### PR TITLE
[ISSUE 9173] add ERD files for source-github

### DIFF
--- a/airbyte-integrations/connectors/source-github/erd/discovered_catalog.json
+++ b/airbyte-integrations/connectors/source-github/erd/discovered_catalog.json
@@ -1,0 +1,10171 @@
+{
+  "streams": [
+    {
+      "name": "issue_timeline_events",
+      "json_schema": {
+        "definitions": {
+          "base_event": {
+            "id": { "type": ["null", "integer"] },
+            "node_id": { "type": ["null", "string"] },
+            "url": { "type": ["null", "string"] },
+            "actor": {
+              "title": "Simple User",
+              "description": "A GitHub user.",
+              "type": ["null", "object"],
+              "properties": {
+                "name": { "type": ["string", "null"] },
+                "email": { "type": ["string", "null"] },
+                "login": { "type": "string" },
+                "id": { "type": "integer" },
+                "node_id": { "type": "string" },
+                "avatar_url": { "type": "string" },
+                "gravatar_id": { "type": ["string", "null"] },
+                "url": { "type": "string" },
+                "html_url": { "type": "string" },
+                "followers_url": { "type": "string" },
+                "following_url": { "type": "string" },
+                "gists_url": { "type": "string" },
+                "starred_url": { "type": "string" },
+                "subscriptions_url": { "type": "string" },
+                "organizations_url": { "type": "string" },
+                "repos_url": { "type": "string" },
+                "events_url": { "type": "string" },
+                "received_events_url": { "type": "string" },
+                "type": { "type": "string" },
+                "site_admin": { "type": "boolean" },
+                "starred_at": { "type": "string", "format": "date-time" }
+              }
+            },
+            "event": { "type": ["null", "string"] },
+            "commit_id": { "type": ["string", "null"] },
+            "commit_url": { "type": ["string", "null"] },
+            "created_at": { "type": ["null", "string"], "format": "date-time" },
+            "performed_via_github_app": {
+              "anyOf": [
+                { "type": "null" },
+                {
+                  "type": "object",
+                  "properties": {
+                    "id": { "type": "integer" },
+                    "slug": { "type": "string" },
+                    "node_id": { "type": "string" },
+                    "owner": {
+                      "anyOf": [
+                        { "type": "null" },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "name": { "type": ["string", "null"] },
+                            "email": { "type": ["string", "null"] },
+                            "login": { "type": "string" },
+                            "id": { "type": "integer" },
+                            "node_id": { "type": "string" },
+                            "avatar_url": { "type": "string" },
+                            "gravatar_id": { "type": ["string", "null"] },
+                            "url": { "type": "string" },
+                            "html_url": { "type": "string" },
+                            "followers_url": { "type": "string" },
+                            "following_url": { "type": "string" },
+                            "gists_url": { "type": "string" },
+                            "starred_url": { "type": "string" },
+                            "subscriptions_url": { "type": "string" },
+                            "organizations_url": { "type": "string" },
+                            "repos_url": { "type": "string" },
+                            "events_url": { "type": "string" },
+                            "received_events_url": { "type": "string" },
+                            "type": { "type": "string" },
+                            "site_admin": { "type": "boolean" },
+                            "starred_at": {
+                              "type": "string",
+                              "format": "date-time"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "name": { "type": "string" },
+                    "description": { "type": ["string", "null"] },
+                    "external_url": { "type": "string" },
+                    "html_url": { "type": "string" },
+                    "created_at": { "type": "string", "format": "date-time" },
+                    "updated_at": { "type": "string", "format": "date-time" },
+                    "permissions": {
+                      "type": "object",
+                      "properties": {
+                        "issues": { "type": "string" },
+                        "checks": { "type": "string" },
+                        "metadata": { "type": "string" },
+                        "contents": { "type": "string" },
+                        "deployments": { "type": "string" }
+                      },
+                      "additionalProperties": true
+                    },
+                    "events": {
+                      "type": "array",
+                      "items": { "type": "string" }
+                    },
+                    "installations_count": { "type": "integer" },
+                    "client_id": { "type": "string" },
+                    "client_secret": { "type": "string" },
+                    "webhook_secret": { "type": ["string", "null"] },
+                    "pem": { "type": "string" }
+                  }
+                }
+              ]
+            }
+          }
+        },
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "repository": {
+            "description": "The repository associated with the issue",
+            "type": "string"
+          },
+          "issue_number": {
+            "description": "The number of the issue",
+            "type": "integer"
+          },
+          "labeled": {
+            "id": { "type": ["null", "integer"] },
+            "node_id": { "type": ["null", "string"] },
+            "url": { "type": ["null", "string"] },
+            "actor": {
+              "title": "Simple User",
+              "description": "A GitHub user.",
+              "type": ["null", "object"],
+              "properties": {
+                "name": { "type": ["string", "null"] },
+                "email": { "type": ["string", "null"] },
+                "login": { "type": "string" },
+                "id": { "type": "integer" },
+                "node_id": { "type": "string" },
+                "avatar_url": { "type": "string" },
+                "gravatar_id": { "type": ["string", "null"] },
+                "url": { "type": "string" },
+                "html_url": { "type": "string" },
+                "followers_url": { "type": "string" },
+                "following_url": { "type": "string" },
+                "gists_url": { "type": "string" },
+                "starred_url": { "type": "string" },
+                "subscriptions_url": { "type": "string" },
+                "organizations_url": { "type": "string" },
+                "repos_url": { "type": "string" },
+                "events_url": { "type": "string" },
+                "received_events_url": { "type": "string" },
+                "type": { "type": "string" },
+                "site_admin": { "type": "boolean" },
+                "starred_at": { "type": "string", "format": "date-time" }
+              }
+            },
+            "event": { "type": ["null", "string"] },
+            "commit_id": { "type": ["string", "null"] },
+            "commit_url": { "type": ["string", "null"] },
+            "created_at": { "type": ["null", "string"], "format": "date-time" },
+            "performed_via_github_app": {
+              "anyOf": [
+                { "type": "null" },
+                {
+                  "type": "object",
+                  "properties": {
+                    "id": { "type": "integer" },
+                    "slug": { "type": "string" },
+                    "node_id": { "type": "string" },
+                    "owner": {
+                      "anyOf": [
+                        { "type": "null" },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "name": { "type": ["string", "null"] },
+                            "email": { "type": ["string", "null"] },
+                            "login": { "type": "string" },
+                            "id": { "type": "integer" },
+                            "node_id": { "type": "string" },
+                            "avatar_url": { "type": "string" },
+                            "gravatar_id": { "type": ["string", "null"] },
+                            "url": { "type": "string" },
+                            "html_url": { "type": "string" },
+                            "followers_url": { "type": "string" },
+                            "following_url": { "type": "string" },
+                            "gists_url": { "type": "string" },
+                            "starred_url": { "type": "string" },
+                            "subscriptions_url": { "type": "string" },
+                            "organizations_url": { "type": "string" },
+                            "repos_url": { "type": "string" },
+                            "events_url": { "type": "string" },
+                            "received_events_url": { "type": "string" },
+                            "type": { "type": "string" },
+                            "site_admin": { "type": "boolean" },
+                            "starred_at": {
+                              "type": "string",
+                              "format": "date-time"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "name": { "type": "string" },
+                    "description": { "type": ["string", "null"] },
+                    "external_url": { "type": "string" },
+                    "html_url": { "type": "string" },
+                    "created_at": { "type": "string", "format": "date-time" },
+                    "updated_at": { "type": "string", "format": "date-time" },
+                    "permissions": {
+                      "type": "object",
+                      "properties": {
+                        "issues": { "type": "string" },
+                        "checks": { "type": "string" },
+                        "metadata": { "type": "string" },
+                        "contents": { "type": "string" },
+                        "deployments": { "type": "string" }
+                      },
+                      "additionalProperties": true
+                    },
+                    "events": {
+                      "type": "array",
+                      "items": { "type": "string" }
+                    },
+                    "installations_count": { "type": "integer" },
+                    "client_id": { "type": "string" },
+                    "client_secret": { "type": "string" },
+                    "webhook_secret": { "type": ["string", "null"] },
+                    "pem": { "type": "string" }
+                  }
+                }
+              ]
+            }
+          },
+          "unlabeled": {
+            "id": { "type": ["null", "integer"] },
+            "node_id": { "type": ["null", "string"] },
+            "url": { "type": ["null", "string"] },
+            "actor": {
+              "title": "Simple User",
+              "description": "A GitHub user.",
+              "type": ["null", "object"],
+              "properties": {
+                "name": { "type": ["string", "null"] },
+                "email": { "type": ["string", "null"] },
+                "login": { "type": "string" },
+                "id": { "type": "integer" },
+                "node_id": { "type": "string" },
+                "avatar_url": { "type": "string" },
+                "gravatar_id": { "type": ["string", "null"] },
+                "url": { "type": "string" },
+                "html_url": { "type": "string" },
+                "followers_url": { "type": "string" },
+                "following_url": { "type": "string" },
+                "gists_url": { "type": "string" },
+                "starred_url": { "type": "string" },
+                "subscriptions_url": { "type": "string" },
+                "organizations_url": { "type": "string" },
+                "repos_url": { "type": "string" },
+                "events_url": { "type": "string" },
+                "received_events_url": { "type": "string" },
+                "type": { "type": "string" },
+                "site_admin": { "type": "boolean" },
+                "starred_at": { "type": "string", "format": "date-time" }
+              }
+            },
+            "event": { "type": ["null", "string"] },
+            "commit_id": { "type": ["string", "null"] },
+            "commit_url": { "type": ["string", "null"] },
+            "created_at": { "type": ["null", "string"], "format": "date-time" },
+            "performed_via_github_app": {
+              "anyOf": [
+                { "type": "null" },
+                {
+                  "type": "object",
+                  "properties": {
+                    "id": { "type": "integer" },
+                    "slug": { "type": "string" },
+                    "node_id": { "type": "string" },
+                    "owner": {
+                      "anyOf": [
+                        { "type": "null" },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "name": { "type": ["string", "null"] },
+                            "email": { "type": ["string", "null"] },
+                            "login": { "type": "string" },
+                            "id": { "type": "integer" },
+                            "node_id": { "type": "string" },
+                            "avatar_url": { "type": "string" },
+                            "gravatar_id": { "type": ["string", "null"] },
+                            "url": { "type": "string" },
+                            "html_url": { "type": "string" },
+                            "followers_url": { "type": "string" },
+                            "following_url": { "type": "string" },
+                            "gists_url": { "type": "string" },
+                            "starred_url": { "type": "string" },
+                            "subscriptions_url": { "type": "string" },
+                            "organizations_url": { "type": "string" },
+                            "repos_url": { "type": "string" },
+                            "events_url": { "type": "string" },
+                            "received_events_url": { "type": "string" },
+                            "type": { "type": "string" },
+                            "site_admin": { "type": "boolean" },
+                            "starred_at": {
+                              "type": "string",
+                              "format": "date-time"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "name": { "type": "string" },
+                    "description": { "type": ["string", "null"] },
+                    "external_url": { "type": "string" },
+                    "html_url": { "type": "string" },
+                    "created_at": { "type": "string", "format": "date-time" },
+                    "updated_at": { "type": "string", "format": "date-time" },
+                    "permissions": {
+                      "type": "object",
+                      "properties": {
+                        "issues": { "type": "string" },
+                        "checks": { "type": "string" },
+                        "metadata": { "type": "string" },
+                        "contents": { "type": "string" },
+                        "deployments": { "type": "string" }
+                      },
+                      "additionalProperties": true
+                    },
+                    "events": {
+                      "type": "array",
+                      "items": { "type": "string" }
+                    },
+                    "installations_count": { "type": "integer" },
+                    "client_id": { "type": "string" },
+                    "client_secret": { "type": "string" },
+                    "webhook_secret": { "type": ["string", "null"] },
+                    "pem": { "type": "string" }
+                  }
+                }
+              ]
+            }
+          },
+          "milestoned": {
+            "id": { "type": ["null", "integer"] },
+            "node_id": { "type": ["null", "string"] },
+            "url": { "type": ["null", "string"] },
+            "actor": {
+              "title": "Simple User",
+              "description": "A GitHub user.",
+              "type": ["null", "object"],
+              "properties": {
+                "name": { "type": ["string", "null"] },
+                "email": { "type": ["string", "null"] },
+                "login": { "type": "string" },
+                "id": { "type": "integer" },
+                "node_id": { "type": "string" },
+                "avatar_url": { "type": "string" },
+                "gravatar_id": { "type": ["string", "null"] },
+                "url": { "type": "string" },
+                "html_url": { "type": "string" },
+                "followers_url": { "type": "string" },
+                "following_url": { "type": "string" },
+                "gists_url": { "type": "string" },
+                "starred_url": { "type": "string" },
+                "subscriptions_url": { "type": "string" },
+                "organizations_url": { "type": "string" },
+                "repos_url": { "type": "string" },
+                "events_url": { "type": "string" },
+                "received_events_url": { "type": "string" },
+                "type": { "type": "string" },
+                "site_admin": { "type": "boolean" },
+                "starred_at": { "type": "string", "format": "date-time" }
+              }
+            },
+            "event": { "type": ["null", "string"] },
+            "commit_id": { "type": ["string", "null"] },
+            "commit_url": { "type": ["string", "null"] },
+            "created_at": { "type": ["null", "string"], "format": "date-time" },
+            "performed_via_github_app": {
+              "anyOf": [
+                { "type": "null" },
+                {
+                  "type": "object",
+                  "properties": {
+                    "id": { "type": "integer" },
+                    "slug": { "type": "string" },
+                    "node_id": { "type": "string" },
+                    "owner": {
+                      "anyOf": [
+                        { "type": "null" },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "name": { "type": ["string", "null"] },
+                            "email": { "type": ["string", "null"] },
+                            "login": { "type": "string" },
+                            "id": { "type": "integer" },
+                            "node_id": { "type": "string" },
+                            "avatar_url": { "type": "string" },
+                            "gravatar_id": { "type": ["string", "null"] },
+                            "url": { "type": "string" },
+                            "html_url": { "type": "string" },
+                            "followers_url": { "type": "string" },
+                            "following_url": { "type": "string" },
+                            "gists_url": { "type": "string" },
+                            "starred_url": { "type": "string" },
+                            "subscriptions_url": { "type": "string" },
+                            "organizations_url": { "type": "string" },
+                            "repos_url": { "type": "string" },
+                            "events_url": { "type": "string" },
+                            "received_events_url": { "type": "string" },
+                            "type": { "type": "string" },
+                            "site_admin": { "type": "boolean" },
+                            "starred_at": {
+                              "type": "string",
+                              "format": "date-time"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "name": { "type": "string" },
+                    "description": { "type": ["string", "null"] },
+                    "external_url": { "type": "string" },
+                    "html_url": { "type": "string" },
+                    "created_at": { "type": "string", "format": "date-time" },
+                    "updated_at": { "type": "string", "format": "date-time" },
+                    "permissions": {
+                      "type": "object",
+                      "properties": {
+                        "issues": { "type": "string" },
+                        "checks": { "type": "string" },
+                        "metadata": { "type": "string" },
+                        "contents": { "type": "string" },
+                        "deployments": { "type": "string" }
+                      },
+                      "additionalProperties": true
+                    },
+                    "events": {
+                      "type": "array",
+                      "items": { "type": "string" }
+                    },
+                    "installations_count": { "type": "integer" },
+                    "client_id": { "type": "string" },
+                    "client_secret": { "type": "string" },
+                    "webhook_secret": { "type": ["string", "null"] },
+                    "pem": { "type": "string" }
+                  }
+                }
+              ]
+            }
+          },
+          "demilestoned": {
+            "id": { "type": ["null", "integer"] },
+            "node_id": { "type": ["null", "string"] },
+            "url": { "type": ["null", "string"] },
+            "actor": {
+              "title": "Simple User",
+              "description": "A GitHub user.",
+              "type": ["null", "object"],
+              "properties": {
+                "name": { "type": ["string", "null"] },
+                "email": { "type": ["string", "null"] },
+                "login": { "type": "string" },
+                "id": { "type": "integer" },
+                "node_id": { "type": "string" },
+                "avatar_url": { "type": "string" },
+                "gravatar_id": { "type": ["string", "null"] },
+                "url": { "type": "string" },
+                "html_url": { "type": "string" },
+                "followers_url": { "type": "string" },
+                "following_url": { "type": "string" },
+                "gists_url": { "type": "string" },
+                "starred_url": { "type": "string" },
+                "subscriptions_url": { "type": "string" },
+                "organizations_url": { "type": "string" },
+                "repos_url": { "type": "string" },
+                "events_url": { "type": "string" },
+                "received_events_url": { "type": "string" },
+                "type": { "type": "string" },
+                "site_admin": { "type": "boolean" },
+                "starred_at": { "type": "string", "format": "date-time" }
+              }
+            },
+            "event": { "type": ["null", "string"] },
+            "commit_id": { "type": ["string", "null"] },
+            "commit_url": { "type": ["string", "null"] },
+            "created_at": { "type": ["null", "string"], "format": "date-time" },
+            "performed_via_github_app": {
+              "anyOf": [
+                { "type": "null" },
+                {
+                  "type": "object",
+                  "properties": {
+                    "id": { "type": "integer" },
+                    "slug": { "type": "string" },
+                    "node_id": { "type": "string" },
+                    "owner": {
+                      "anyOf": [
+                        { "type": "null" },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "name": { "type": ["string", "null"] },
+                            "email": { "type": ["string", "null"] },
+                            "login": { "type": "string" },
+                            "id": { "type": "integer" },
+                            "node_id": { "type": "string" },
+                            "avatar_url": { "type": "string" },
+                            "gravatar_id": { "type": ["string", "null"] },
+                            "url": { "type": "string" },
+                            "html_url": { "type": "string" },
+                            "followers_url": { "type": "string" },
+                            "following_url": { "type": "string" },
+                            "gists_url": { "type": "string" },
+                            "starred_url": { "type": "string" },
+                            "subscriptions_url": { "type": "string" },
+                            "organizations_url": { "type": "string" },
+                            "repos_url": { "type": "string" },
+                            "events_url": { "type": "string" },
+                            "received_events_url": { "type": "string" },
+                            "type": { "type": "string" },
+                            "site_admin": { "type": "boolean" },
+                            "starred_at": {
+                              "type": "string",
+                              "format": "date-time"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "name": { "type": "string" },
+                    "description": { "type": ["string", "null"] },
+                    "external_url": { "type": "string" },
+                    "html_url": { "type": "string" },
+                    "created_at": { "type": "string", "format": "date-time" },
+                    "updated_at": { "type": "string", "format": "date-time" },
+                    "permissions": {
+                      "type": "object",
+                      "properties": {
+                        "issues": { "type": "string" },
+                        "checks": { "type": "string" },
+                        "metadata": { "type": "string" },
+                        "contents": { "type": "string" },
+                        "deployments": { "type": "string" }
+                      },
+                      "additionalProperties": true
+                    },
+                    "events": {
+                      "type": "array",
+                      "items": { "type": "string" }
+                    },
+                    "installations_count": { "type": "integer" },
+                    "client_id": { "type": "string" },
+                    "client_secret": { "type": "string" },
+                    "webhook_secret": { "type": ["string", "null"] },
+                    "pem": { "type": "string" }
+                  }
+                }
+              ]
+            }
+          },
+          "renamed": {
+            "id": { "type": ["null", "integer"] },
+            "node_id": { "type": ["null", "string"] },
+            "url": { "type": ["null", "string"] },
+            "actor": {
+              "title": "Simple User",
+              "description": "A GitHub user.",
+              "type": ["null", "object"],
+              "properties": {
+                "name": { "type": ["string", "null"] },
+                "email": { "type": ["string", "null"] },
+                "login": { "type": "string" },
+                "id": { "type": "integer" },
+                "node_id": { "type": "string" },
+                "avatar_url": { "type": "string" },
+                "gravatar_id": { "type": ["string", "null"] },
+                "url": { "type": "string" },
+                "html_url": { "type": "string" },
+                "followers_url": { "type": "string" },
+                "following_url": { "type": "string" },
+                "gists_url": { "type": "string" },
+                "starred_url": { "type": "string" },
+                "subscriptions_url": { "type": "string" },
+                "organizations_url": { "type": "string" },
+                "repos_url": { "type": "string" },
+                "events_url": { "type": "string" },
+                "received_events_url": { "type": "string" },
+                "type": { "type": "string" },
+                "site_admin": { "type": "boolean" },
+                "starred_at": { "type": "string", "format": "date-time" }
+              }
+            },
+            "event": { "type": ["null", "string"] },
+            "commit_id": { "type": ["string", "null"] },
+            "commit_url": { "type": ["string", "null"] },
+            "created_at": { "type": ["null", "string"], "format": "date-time" },
+            "performed_via_github_app": {
+              "anyOf": [
+                { "type": "null" },
+                {
+                  "type": "object",
+                  "properties": {
+                    "id": { "type": "integer" },
+                    "slug": { "type": "string" },
+                    "node_id": { "type": "string" },
+                    "owner": {
+                      "anyOf": [
+                        { "type": "null" },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "name": { "type": ["string", "null"] },
+                            "email": { "type": ["string", "null"] },
+                            "login": { "type": "string" },
+                            "id": { "type": "integer" },
+                            "node_id": { "type": "string" },
+                            "avatar_url": { "type": "string" },
+                            "gravatar_id": { "type": ["string", "null"] },
+                            "url": { "type": "string" },
+                            "html_url": { "type": "string" },
+                            "followers_url": { "type": "string" },
+                            "following_url": { "type": "string" },
+                            "gists_url": { "type": "string" },
+                            "starred_url": { "type": "string" },
+                            "subscriptions_url": { "type": "string" },
+                            "organizations_url": { "type": "string" },
+                            "repos_url": { "type": "string" },
+                            "events_url": { "type": "string" },
+                            "received_events_url": { "type": "string" },
+                            "type": { "type": "string" },
+                            "site_admin": { "type": "boolean" },
+                            "starred_at": {
+                              "type": "string",
+                              "format": "date-time"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "name": { "type": "string" },
+                    "description": { "type": ["string", "null"] },
+                    "external_url": { "type": "string" },
+                    "html_url": { "type": "string" },
+                    "created_at": { "type": "string", "format": "date-time" },
+                    "updated_at": { "type": "string", "format": "date-time" },
+                    "permissions": {
+                      "type": "object",
+                      "properties": {
+                        "issues": { "type": "string" },
+                        "checks": { "type": "string" },
+                        "metadata": { "type": "string" },
+                        "contents": { "type": "string" },
+                        "deployments": { "type": "string" }
+                      },
+                      "additionalProperties": true
+                    },
+                    "events": {
+                      "type": "array",
+                      "items": { "type": "string" }
+                    },
+                    "installations_count": { "type": "integer" },
+                    "client_id": { "type": "string" },
+                    "client_secret": { "type": "string" },
+                    "webhook_secret": { "type": ["string", "null"] },
+                    "pem": { "type": "string" }
+                  }
+                }
+              ]
+            }
+          },
+          "review_requested": {
+            "id": { "type": ["null", "integer"] },
+            "node_id": { "type": ["null", "string"] },
+            "url": { "type": ["null", "string"] },
+            "actor": {
+              "title": "Simple User",
+              "description": "A GitHub user.",
+              "type": ["null", "object"],
+              "properties": {
+                "name": { "type": ["string", "null"] },
+                "email": { "type": ["string", "null"] },
+                "login": { "type": "string" },
+                "id": { "type": "integer" },
+                "node_id": { "type": "string" },
+                "avatar_url": { "type": "string" },
+                "gravatar_id": { "type": ["string", "null"] },
+                "url": { "type": "string" },
+                "html_url": { "type": "string" },
+                "followers_url": { "type": "string" },
+                "following_url": { "type": "string" },
+                "gists_url": { "type": "string" },
+                "starred_url": { "type": "string" },
+                "subscriptions_url": { "type": "string" },
+                "organizations_url": { "type": "string" },
+                "repos_url": { "type": "string" },
+                "events_url": { "type": "string" },
+                "received_events_url": { "type": "string" },
+                "type": { "type": "string" },
+                "site_admin": { "type": "boolean" },
+                "starred_at": { "type": "string", "format": "date-time" }
+              }
+            },
+            "event": { "type": ["null", "string"] },
+            "commit_id": { "type": ["string", "null"] },
+            "commit_url": { "type": ["string", "null"] },
+            "created_at": { "type": ["null", "string"], "format": "date-time" },
+            "performed_via_github_app": {
+              "anyOf": [
+                { "type": "null" },
+                {
+                  "type": "object",
+                  "properties": {
+                    "id": { "type": "integer" },
+                    "slug": { "type": "string" },
+                    "node_id": { "type": "string" },
+                    "owner": {
+                      "anyOf": [
+                        { "type": "null" },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "name": { "type": ["string", "null"] },
+                            "email": { "type": ["string", "null"] },
+                            "login": { "type": "string" },
+                            "id": { "type": "integer" },
+                            "node_id": { "type": "string" },
+                            "avatar_url": { "type": "string" },
+                            "gravatar_id": { "type": ["string", "null"] },
+                            "url": { "type": "string" },
+                            "html_url": { "type": "string" },
+                            "followers_url": { "type": "string" },
+                            "following_url": { "type": "string" },
+                            "gists_url": { "type": "string" },
+                            "starred_url": { "type": "string" },
+                            "subscriptions_url": { "type": "string" },
+                            "organizations_url": { "type": "string" },
+                            "repos_url": { "type": "string" },
+                            "events_url": { "type": "string" },
+                            "received_events_url": { "type": "string" },
+                            "type": { "type": "string" },
+                            "site_admin": { "type": "boolean" },
+                            "starred_at": {
+                              "type": "string",
+                              "format": "date-time"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "name": { "type": "string" },
+                    "description": { "type": ["string", "null"] },
+                    "external_url": { "type": "string" },
+                    "html_url": { "type": "string" },
+                    "created_at": { "type": "string", "format": "date-time" },
+                    "updated_at": { "type": "string", "format": "date-time" },
+                    "permissions": {
+                      "type": "object",
+                      "properties": {
+                        "issues": { "type": "string" },
+                        "checks": { "type": "string" },
+                        "metadata": { "type": "string" },
+                        "contents": { "type": "string" },
+                        "deployments": { "type": "string" }
+                      },
+                      "additionalProperties": true
+                    },
+                    "events": {
+                      "type": "array",
+                      "items": { "type": "string" }
+                    },
+                    "installations_count": { "type": "integer" },
+                    "client_id": { "type": "string" },
+                    "client_secret": { "type": "string" },
+                    "webhook_secret": { "type": ["string", "null"] },
+                    "pem": { "type": "string" }
+                  }
+                }
+              ]
+            }
+          },
+          "review_request_removed": {
+            "id": { "type": ["null", "integer"] },
+            "node_id": { "type": ["null", "string"] },
+            "url": { "type": ["null", "string"] },
+            "actor": {
+              "title": "Simple User",
+              "description": "A GitHub user.",
+              "type": ["null", "object"],
+              "properties": {
+                "name": { "type": ["string", "null"] },
+                "email": { "type": ["string", "null"] },
+                "login": { "type": "string" },
+                "id": { "type": "integer" },
+                "node_id": { "type": "string" },
+                "avatar_url": { "type": "string" },
+                "gravatar_id": { "type": ["string", "null"] },
+                "url": { "type": "string" },
+                "html_url": { "type": "string" },
+                "followers_url": { "type": "string" },
+                "following_url": { "type": "string" },
+                "gists_url": { "type": "string" },
+                "starred_url": { "type": "string" },
+                "subscriptions_url": { "type": "string" },
+                "organizations_url": { "type": "string" },
+                "repos_url": { "type": "string" },
+                "events_url": { "type": "string" },
+                "received_events_url": { "type": "string" },
+                "type": { "type": "string" },
+                "site_admin": { "type": "boolean" },
+                "starred_at": { "type": "string", "format": "date-time" }
+              }
+            },
+            "event": { "type": ["null", "string"] },
+            "commit_id": { "type": ["string", "null"] },
+            "commit_url": { "type": ["string", "null"] },
+            "created_at": { "type": ["null", "string"], "format": "date-time" },
+            "performed_via_github_app": {
+              "anyOf": [
+                { "type": "null" },
+                {
+                  "type": "object",
+                  "properties": {
+                    "id": { "type": "integer" },
+                    "slug": { "type": "string" },
+                    "node_id": { "type": "string" },
+                    "owner": {
+                      "anyOf": [
+                        { "type": "null" },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "name": { "type": ["string", "null"] },
+                            "email": { "type": ["string", "null"] },
+                            "login": { "type": "string" },
+                            "id": { "type": "integer" },
+                            "node_id": { "type": "string" },
+                            "avatar_url": { "type": "string" },
+                            "gravatar_id": { "type": ["string", "null"] },
+                            "url": { "type": "string" },
+                            "html_url": { "type": "string" },
+                            "followers_url": { "type": "string" },
+                            "following_url": { "type": "string" },
+                            "gists_url": { "type": "string" },
+                            "starred_url": { "type": "string" },
+                            "subscriptions_url": { "type": "string" },
+                            "organizations_url": { "type": "string" },
+                            "repos_url": { "type": "string" },
+                            "events_url": { "type": "string" },
+                            "received_events_url": { "type": "string" },
+                            "type": { "type": "string" },
+                            "site_admin": { "type": "boolean" },
+                            "starred_at": {
+                              "type": "string",
+                              "format": "date-time"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "name": { "type": "string" },
+                    "description": { "type": ["string", "null"] },
+                    "external_url": { "type": "string" },
+                    "html_url": { "type": "string" },
+                    "created_at": { "type": "string", "format": "date-time" },
+                    "updated_at": { "type": "string", "format": "date-time" },
+                    "permissions": {
+                      "type": "object",
+                      "properties": {
+                        "issues": { "type": "string" },
+                        "checks": { "type": "string" },
+                        "metadata": { "type": "string" },
+                        "contents": { "type": "string" },
+                        "deployments": { "type": "string" }
+                      },
+                      "additionalProperties": true
+                    },
+                    "events": {
+                      "type": "array",
+                      "items": { "type": "string" }
+                    },
+                    "installations_count": { "type": "integer" },
+                    "client_id": { "type": "string" },
+                    "client_secret": { "type": "string" },
+                    "webhook_secret": { "type": ["string", "null"] },
+                    "pem": { "type": "string" }
+                  }
+                }
+              ]
+            }
+          },
+          "review_dismissed": {
+            "id": { "type": ["null", "integer"] },
+            "node_id": { "type": ["null", "string"] },
+            "url": { "type": ["null", "string"] },
+            "actor": {
+              "title": "Simple User",
+              "description": "A GitHub user.",
+              "type": ["null", "object"],
+              "properties": {
+                "name": { "type": ["string", "null"] },
+                "email": { "type": ["string", "null"] },
+                "login": { "type": "string" },
+                "id": { "type": "integer" },
+                "node_id": { "type": "string" },
+                "avatar_url": { "type": "string" },
+                "gravatar_id": { "type": ["string", "null"] },
+                "url": { "type": "string" },
+                "html_url": { "type": "string" },
+                "followers_url": { "type": "string" },
+                "following_url": { "type": "string" },
+                "gists_url": { "type": "string" },
+                "starred_url": { "type": "string" },
+                "subscriptions_url": { "type": "string" },
+                "organizations_url": { "type": "string" },
+                "repos_url": { "type": "string" },
+                "events_url": { "type": "string" },
+                "received_events_url": { "type": "string" },
+                "type": { "type": "string" },
+                "site_admin": { "type": "boolean" },
+                "starred_at": { "type": "string", "format": "date-time" }
+              }
+            },
+            "event": { "type": ["null", "string"] },
+            "commit_id": { "type": ["string", "null"] },
+            "commit_url": { "type": ["string", "null"] },
+            "created_at": { "type": ["null", "string"], "format": "date-time" },
+            "performed_via_github_app": {
+              "anyOf": [
+                { "type": "null" },
+                {
+                  "type": "object",
+                  "properties": {
+                    "id": { "type": "integer" },
+                    "slug": { "type": "string" },
+                    "node_id": { "type": "string" },
+                    "owner": {
+                      "anyOf": [
+                        { "type": "null" },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "name": { "type": ["string", "null"] },
+                            "email": { "type": ["string", "null"] },
+                            "login": { "type": "string" },
+                            "id": { "type": "integer" },
+                            "node_id": { "type": "string" },
+                            "avatar_url": { "type": "string" },
+                            "gravatar_id": { "type": ["string", "null"] },
+                            "url": { "type": "string" },
+                            "html_url": { "type": "string" },
+                            "followers_url": { "type": "string" },
+                            "following_url": { "type": "string" },
+                            "gists_url": { "type": "string" },
+                            "starred_url": { "type": "string" },
+                            "subscriptions_url": { "type": "string" },
+                            "organizations_url": { "type": "string" },
+                            "repos_url": { "type": "string" },
+                            "events_url": { "type": "string" },
+                            "received_events_url": { "type": "string" },
+                            "type": { "type": "string" },
+                            "site_admin": { "type": "boolean" },
+                            "starred_at": {
+                              "type": "string",
+                              "format": "date-time"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "name": { "type": "string" },
+                    "description": { "type": ["string", "null"] },
+                    "external_url": { "type": "string" },
+                    "html_url": { "type": "string" },
+                    "created_at": { "type": "string", "format": "date-time" },
+                    "updated_at": { "type": "string", "format": "date-time" },
+                    "permissions": {
+                      "type": "object",
+                      "properties": {
+                        "issues": { "type": "string" },
+                        "checks": { "type": "string" },
+                        "metadata": { "type": "string" },
+                        "contents": { "type": "string" },
+                        "deployments": { "type": "string" }
+                      },
+                      "additionalProperties": true
+                    },
+                    "events": {
+                      "type": "array",
+                      "items": { "type": "string" }
+                    },
+                    "installations_count": { "type": "integer" },
+                    "client_id": { "type": "string" },
+                    "client_secret": { "type": "string" },
+                    "webhook_secret": { "type": ["string", "null"] },
+                    "pem": { "type": "string" }
+                  }
+                }
+              ]
+            }
+          },
+          "locked": {
+            "id": { "type": ["null", "integer"] },
+            "node_id": { "type": ["null", "string"] },
+            "url": { "type": ["null", "string"] },
+            "actor": {
+              "title": "Simple User",
+              "description": "A GitHub user.",
+              "type": ["null", "object"],
+              "properties": {
+                "name": { "type": ["string", "null"] },
+                "email": { "type": ["string", "null"] },
+                "login": { "type": "string" },
+                "id": { "type": "integer" },
+                "node_id": { "type": "string" },
+                "avatar_url": { "type": "string" },
+                "gravatar_id": { "type": ["string", "null"] },
+                "url": { "type": "string" },
+                "html_url": { "type": "string" },
+                "followers_url": { "type": "string" },
+                "following_url": { "type": "string" },
+                "gists_url": { "type": "string" },
+                "starred_url": { "type": "string" },
+                "subscriptions_url": { "type": "string" },
+                "organizations_url": { "type": "string" },
+                "repos_url": { "type": "string" },
+                "events_url": { "type": "string" },
+                "received_events_url": { "type": "string" },
+                "type": { "type": "string" },
+                "site_admin": { "type": "boolean" },
+                "starred_at": { "type": "string", "format": "date-time" }
+              }
+            },
+            "event": { "type": ["null", "string"] },
+            "commit_id": { "type": ["string", "null"] },
+            "commit_url": { "type": ["string", "null"] },
+            "created_at": { "type": ["null", "string"], "format": "date-time" },
+            "performed_via_github_app": {
+              "anyOf": [
+                { "type": "null" },
+                {
+                  "type": "object",
+                  "properties": {
+                    "id": { "type": "integer" },
+                    "slug": { "type": "string" },
+                    "node_id": { "type": "string" },
+                    "owner": {
+                      "anyOf": [
+                        { "type": "null" },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "name": { "type": ["string", "null"] },
+                            "email": { "type": ["string", "null"] },
+                            "login": { "type": "string" },
+                            "id": { "type": "integer" },
+                            "node_id": { "type": "string" },
+                            "avatar_url": { "type": "string" },
+                            "gravatar_id": { "type": ["string", "null"] },
+                            "url": { "type": "string" },
+                            "html_url": { "type": "string" },
+                            "followers_url": { "type": "string" },
+                            "following_url": { "type": "string" },
+                            "gists_url": { "type": "string" },
+                            "starred_url": { "type": "string" },
+                            "subscriptions_url": { "type": "string" },
+                            "organizations_url": { "type": "string" },
+                            "repos_url": { "type": "string" },
+                            "events_url": { "type": "string" },
+                            "received_events_url": { "type": "string" },
+                            "type": { "type": "string" },
+                            "site_admin": { "type": "boolean" },
+                            "starred_at": {
+                              "type": "string",
+                              "format": "date-time"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "name": { "type": "string" },
+                    "description": { "type": ["string", "null"] },
+                    "external_url": { "type": "string" },
+                    "html_url": { "type": "string" },
+                    "created_at": { "type": "string", "format": "date-time" },
+                    "updated_at": { "type": "string", "format": "date-time" },
+                    "permissions": {
+                      "type": "object",
+                      "properties": {
+                        "issues": { "type": "string" },
+                        "checks": { "type": "string" },
+                        "metadata": { "type": "string" },
+                        "contents": { "type": "string" },
+                        "deployments": { "type": "string" }
+                      },
+                      "additionalProperties": true
+                    },
+                    "events": {
+                      "type": "array",
+                      "items": { "type": "string" }
+                    },
+                    "installations_count": { "type": "integer" },
+                    "client_id": { "type": "string" },
+                    "client_secret": { "type": "string" },
+                    "webhook_secret": { "type": ["string", "null"] },
+                    "pem": { "type": "string" }
+                  }
+                }
+              ]
+            }
+          },
+          "added_to_project": {
+            "id": { "type": ["null", "integer"] },
+            "node_id": { "type": ["null", "string"] },
+            "url": { "type": ["null", "string"] },
+            "actor": {
+              "title": "Simple User",
+              "description": "A GitHub user.",
+              "type": ["null", "object"],
+              "properties": {
+                "name": { "type": ["string", "null"] },
+                "email": { "type": ["string", "null"] },
+                "login": { "type": "string" },
+                "id": { "type": "integer" },
+                "node_id": { "type": "string" },
+                "avatar_url": { "type": "string" },
+                "gravatar_id": { "type": ["string", "null"] },
+                "url": { "type": "string" },
+                "html_url": { "type": "string" },
+                "followers_url": { "type": "string" },
+                "following_url": { "type": "string" },
+                "gists_url": { "type": "string" },
+                "starred_url": { "type": "string" },
+                "subscriptions_url": { "type": "string" },
+                "organizations_url": { "type": "string" },
+                "repos_url": { "type": "string" },
+                "events_url": { "type": "string" },
+                "received_events_url": { "type": "string" },
+                "type": { "type": "string" },
+                "site_admin": { "type": "boolean" },
+                "starred_at": { "type": "string", "format": "date-time" }
+              }
+            },
+            "event": { "type": ["null", "string"] },
+            "commit_id": { "type": ["string", "null"] },
+            "commit_url": { "type": ["string", "null"] },
+            "created_at": { "type": ["null", "string"], "format": "date-time" },
+            "performed_via_github_app": {
+              "anyOf": [
+                { "type": "null" },
+                {
+                  "type": "object",
+                  "properties": {
+                    "id": { "type": "integer" },
+                    "slug": { "type": "string" },
+                    "node_id": { "type": "string" },
+                    "owner": {
+                      "anyOf": [
+                        { "type": "null" },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "name": { "type": ["string", "null"] },
+                            "email": { "type": ["string", "null"] },
+                            "login": { "type": "string" },
+                            "id": { "type": "integer" },
+                            "node_id": { "type": "string" },
+                            "avatar_url": { "type": "string" },
+                            "gravatar_id": { "type": ["string", "null"] },
+                            "url": { "type": "string" },
+                            "html_url": { "type": "string" },
+                            "followers_url": { "type": "string" },
+                            "following_url": { "type": "string" },
+                            "gists_url": { "type": "string" },
+                            "starred_url": { "type": "string" },
+                            "subscriptions_url": { "type": "string" },
+                            "organizations_url": { "type": "string" },
+                            "repos_url": { "type": "string" },
+                            "events_url": { "type": "string" },
+                            "received_events_url": { "type": "string" },
+                            "type": { "type": "string" },
+                            "site_admin": { "type": "boolean" },
+                            "starred_at": {
+                              "type": "string",
+                              "format": "date-time"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "name": { "type": "string" },
+                    "description": { "type": ["string", "null"] },
+                    "external_url": { "type": "string" },
+                    "html_url": { "type": "string" },
+                    "created_at": { "type": "string", "format": "date-time" },
+                    "updated_at": { "type": "string", "format": "date-time" },
+                    "permissions": {
+                      "type": "object",
+                      "properties": {
+                        "issues": { "type": "string" },
+                        "checks": { "type": "string" },
+                        "metadata": { "type": "string" },
+                        "contents": { "type": "string" },
+                        "deployments": { "type": "string" }
+                      },
+                      "additionalProperties": true
+                    },
+                    "events": {
+                      "type": "array",
+                      "items": { "type": "string" }
+                    },
+                    "installations_count": { "type": "integer" },
+                    "client_id": { "type": "string" },
+                    "client_secret": { "type": "string" },
+                    "webhook_secret": { "type": ["string", "null"] },
+                    "pem": { "type": "string" }
+                  }
+                }
+              ]
+            }
+          },
+          "moved_columns_in_project": {
+            "id": { "type": ["null", "integer"] },
+            "node_id": { "type": ["null", "string"] },
+            "url": { "type": ["null", "string"] },
+            "actor": {
+              "title": "Simple User",
+              "description": "A GitHub user.",
+              "type": ["null", "object"],
+              "properties": {
+                "name": { "type": ["string", "null"] },
+                "email": { "type": ["string", "null"] },
+                "login": { "type": "string" },
+                "id": { "type": "integer" },
+                "node_id": { "type": "string" },
+                "avatar_url": { "type": "string" },
+                "gravatar_id": { "type": ["string", "null"] },
+                "url": { "type": "string" },
+                "html_url": { "type": "string" },
+                "followers_url": { "type": "string" },
+                "following_url": { "type": "string" },
+                "gists_url": { "type": "string" },
+                "starred_url": { "type": "string" },
+                "subscriptions_url": { "type": "string" },
+                "organizations_url": { "type": "string" },
+                "repos_url": { "type": "string" },
+                "events_url": { "type": "string" },
+                "received_events_url": { "type": "string" },
+                "type": { "type": "string" },
+                "site_admin": { "type": "boolean" },
+                "starred_at": { "type": "string", "format": "date-time" }
+              }
+            },
+            "event": { "type": ["null", "string"] },
+            "commit_id": { "type": ["string", "null"] },
+            "commit_url": { "type": ["string", "null"] },
+            "created_at": { "type": ["null", "string"], "format": "date-time" },
+            "performed_via_github_app": {
+              "anyOf": [
+                { "type": "null" },
+                {
+                  "type": "object",
+                  "properties": {
+                    "id": { "type": "integer" },
+                    "slug": { "type": "string" },
+                    "node_id": { "type": "string" },
+                    "owner": {
+                      "anyOf": [
+                        { "type": "null" },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "name": { "type": ["string", "null"] },
+                            "email": { "type": ["string", "null"] },
+                            "login": { "type": "string" },
+                            "id": { "type": "integer" },
+                            "node_id": { "type": "string" },
+                            "avatar_url": { "type": "string" },
+                            "gravatar_id": { "type": ["string", "null"] },
+                            "url": { "type": "string" },
+                            "html_url": { "type": "string" },
+                            "followers_url": { "type": "string" },
+                            "following_url": { "type": "string" },
+                            "gists_url": { "type": "string" },
+                            "starred_url": { "type": "string" },
+                            "subscriptions_url": { "type": "string" },
+                            "organizations_url": { "type": "string" },
+                            "repos_url": { "type": "string" },
+                            "events_url": { "type": "string" },
+                            "received_events_url": { "type": "string" },
+                            "type": { "type": "string" },
+                            "site_admin": { "type": "boolean" },
+                            "starred_at": {
+                              "type": "string",
+                              "format": "date-time"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "name": { "type": "string" },
+                    "description": { "type": ["string", "null"] },
+                    "external_url": { "type": "string" },
+                    "html_url": { "type": "string" },
+                    "created_at": { "type": "string", "format": "date-time" },
+                    "updated_at": { "type": "string", "format": "date-time" },
+                    "permissions": {
+                      "type": "object",
+                      "properties": {
+                        "issues": { "type": "string" },
+                        "checks": { "type": "string" },
+                        "metadata": { "type": "string" },
+                        "contents": { "type": "string" },
+                        "deployments": { "type": "string" }
+                      },
+                      "additionalProperties": true
+                    },
+                    "events": {
+                      "type": "array",
+                      "items": { "type": "string" }
+                    },
+                    "installations_count": { "type": "integer" },
+                    "client_id": { "type": "string" },
+                    "client_secret": { "type": "string" },
+                    "webhook_secret": { "type": ["string", "null"] },
+                    "pem": { "type": "string" }
+                  }
+                }
+              ]
+            }
+          },
+          "removed_from_project": {
+            "id": { "type": ["null", "integer"] },
+            "node_id": { "type": ["null", "string"] },
+            "url": { "type": ["null", "string"] },
+            "actor": {
+              "title": "Simple User",
+              "description": "A GitHub user.",
+              "type": ["null", "object"],
+              "properties": {
+                "name": { "type": ["string", "null"] },
+                "email": { "type": ["string", "null"] },
+                "login": { "type": "string" },
+                "id": { "type": "integer" },
+                "node_id": { "type": "string" },
+                "avatar_url": { "type": "string" },
+                "gravatar_id": { "type": ["string", "null"] },
+                "url": { "type": "string" },
+                "html_url": { "type": "string" },
+                "followers_url": { "type": "string" },
+                "following_url": { "type": "string" },
+                "gists_url": { "type": "string" },
+                "starred_url": { "type": "string" },
+                "subscriptions_url": { "type": "string" },
+                "organizations_url": { "type": "string" },
+                "repos_url": { "type": "string" },
+                "events_url": { "type": "string" },
+                "received_events_url": { "type": "string" },
+                "type": { "type": "string" },
+                "site_admin": { "type": "boolean" },
+                "starred_at": { "type": "string", "format": "date-time" }
+              }
+            },
+            "event": { "type": ["null", "string"] },
+            "commit_id": { "type": ["string", "null"] },
+            "commit_url": { "type": ["string", "null"] },
+            "created_at": { "type": ["null", "string"], "format": "date-time" },
+            "performed_via_github_app": {
+              "anyOf": [
+                { "type": "null" },
+                {
+                  "type": "object",
+                  "properties": {
+                    "id": { "type": "integer" },
+                    "slug": { "type": "string" },
+                    "node_id": { "type": "string" },
+                    "owner": {
+                      "anyOf": [
+                        { "type": "null" },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "name": { "type": ["string", "null"] },
+                            "email": { "type": ["string", "null"] },
+                            "login": { "type": "string" },
+                            "id": { "type": "integer" },
+                            "node_id": { "type": "string" },
+                            "avatar_url": { "type": "string" },
+                            "gravatar_id": { "type": ["string", "null"] },
+                            "url": { "type": "string" },
+                            "html_url": { "type": "string" },
+                            "followers_url": { "type": "string" },
+                            "following_url": { "type": "string" },
+                            "gists_url": { "type": "string" },
+                            "starred_url": { "type": "string" },
+                            "subscriptions_url": { "type": "string" },
+                            "organizations_url": { "type": "string" },
+                            "repos_url": { "type": "string" },
+                            "events_url": { "type": "string" },
+                            "received_events_url": { "type": "string" },
+                            "type": { "type": "string" },
+                            "site_admin": { "type": "boolean" },
+                            "starred_at": {
+                              "type": "string",
+                              "format": "date-time"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "name": { "type": "string" },
+                    "description": { "type": ["string", "null"] },
+                    "external_url": { "type": "string" },
+                    "html_url": { "type": "string" },
+                    "created_at": { "type": "string", "format": "date-time" },
+                    "updated_at": { "type": "string", "format": "date-time" },
+                    "permissions": {
+                      "type": "object",
+                      "properties": {
+                        "issues": { "type": "string" },
+                        "checks": { "type": "string" },
+                        "metadata": { "type": "string" },
+                        "contents": { "type": "string" },
+                        "deployments": { "type": "string" }
+                      },
+                      "additionalProperties": true
+                    },
+                    "events": {
+                      "type": "array",
+                      "items": { "type": "string" }
+                    },
+                    "installations_count": { "type": "integer" },
+                    "client_id": { "type": "string" },
+                    "client_secret": { "type": "string" },
+                    "webhook_secret": { "type": ["string", "null"] },
+                    "pem": { "type": "string" }
+                  }
+                }
+              ]
+            }
+          },
+          "converted_note_to_issue": {
+            "id": { "type": ["null", "integer"] },
+            "node_id": { "type": ["null", "string"] },
+            "url": { "type": ["null", "string"] },
+            "actor": {
+              "title": "Simple User",
+              "description": "A GitHub user.",
+              "type": ["null", "object"],
+              "properties": {
+                "name": { "type": ["string", "null"] },
+                "email": { "type": ["string", "null"] },
+                "login": { "type": "string" },
+                "id": { "type": "integer" },
+                "node_id": { "type": "string" },
+                "avatar_url": { "type": "string" },
+                "gravatar_id": { "type": ["string", "null"] },
+                "url": { "type": "string" },
+                "html_url": { "type": "string" },
+                "followers_url": { "type": "string" },
+                "following_url": { "type": "string" },
+                "gists_url": { "type": "string" },
+                "starred_url": { "type": "string" },
+                "subscriptions_url": { "type": "string" },
+                "organizations_url": { "type": "string" },
+                "repos_url": { "type": "string" },
+                "events_url": { "type": "string" },
+                "received_events_url": { "type": "string" },
+                "type": { "type": "string" },
+                "site_admin": { "type": "boolean" },
+                "starred_at": { "type": "string", "format": "date-time" }
+              }
+            },
+            "event": { "type": ["null", "string"] },
+            "commit_id": { "type": ["string", "null"] },
+            "commit_url": { "type": ["string", "null"] },
+            "created_at": { "type": ["null", "string"], "format": "date-time" },
+            "performed_via_github_app": {
+              "anyOf": [
+                { "type": "null" },
+                {
+                  "type": "object",
+                  "properties": {
+                    "id": { "type": "integer" },
+                    "slug": { "type": "string" },
+                    "node_id": { "type": "string" },
+                    "owner": {
+                      "anyOf": [
+                        { "type": "null" },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "name": { "type": ["string", "null"] },
+                            "email": { "type": ["string", "null"] },
+                            "login": { "type": "string" },
+                            "id": { "type": "integer" },
+                            "node_id": { "type": "string" },
+                            "avatar_url": { "type": "string" },
+                            "gravatar_id": { "type": ["string", "null"] },
+                            "url": { "type": "string" },
+                            "html_url": { "type": "string" },
+                            "followers_url": { "type": "string" },
+                            "following_url": { "type": "string" },
+                            "gists_url": { "type": "string" },
+                            "starred_url": { "type": "string" },
+                            "subscriptions_url": { "type": "string" },
+                            "organizations_url": { "type": "string" },
+                            "repos_url": { "type": "string" },
+                            "events_url": { "type": "string" },
+                            "received_events_url": { "type": "string" },
+                            "type": { "type": "string" },
+                            "site_admin": { "type": "boolean" },
+                            "starred_at": {
+                              "type": "string",
+                              "format": "date-time"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "name": { "type": "string" },
+                    "description": { "type": ["string", "null"] },
+                    "external_url": { "type": "string" },
+                    "html_url": { "type": "string" },
+                    "created_at": { "type": "string", "format": "date-time" },
+                    "updated_at": { "type": "string", "format": "date-time" },
+                    "permissions": {
+                      "type": "object",
+                      "properties": {
+                        "issues": { "type": "string" },
+                        "checks": { "type": "string" },
+                        "metadata": { "type": "string" },
+                        "contents": { "type": "string" },
+                        "deployments": { "type": "string" }
+                      },
+                      "additionalProperties": true
+                    },
+                    "events": {
+                      "type": "array",
+                      "items": { "type": "string" }
+                    },
+                    "installations_count": { "type": "integer" },
+                    "client_id": { "type": "string" },
+                    "client_secret": { "type": "string" },
+                    "webhook_secret": { "type": ["string", "null"] },
+                    "pem": { "type": "string" }
+                  }
+                }
+              ]
+            }
+          },
+          "comment": {
+            "title": "Timeline Comment Event",
+            "description": "Timeline Comment Event",
+            "type": "object",
+            "properties": {
+              "event": { "type": "string" },
+              "actor": {
+                "title": "Simple User",
+                "description": "A GitHub user.",
+                "type": "object",
+                "properties": {
+                  "name": { "type": ["string", "null"] },
+                  "email": { "type": ["string", "null"] },
+                  "login": { "type": "string" },
+                  "id": { "type": "integer" },
+                  "node_id": { "type": "string" },
+                  "avatar_url": { "type": "string" },
+                  "gravatar_id": { "type": ["string", "null"] },
+                  "url": { "type": "string" },
+                  "html_url": { "type": "string" },
+                  "followers_url": { "type": "string" },
+                  "following_url": { "type": "string" },
+                  "gists_url": { "type": "string" },
+                  "starred_url": { "type": "string" },
+                  "subscriptions_url": { "type": "string" },
+                  "organizations_url": { "type": "string" },
+                  "repos_url": { "type": "string" },
+                  "events_url": { "type": "string" },
+                  "received_events_url": { "type": "string" },
+                  "type": { "type": "string" },
+                  "site_admin": { "type": "boolean" },
+                  "starred_at": { "type": "string", "format": "date-time" }
+                }
+              },
+              "id": {
+                "description": "Unique identifier of the issue comment",
+                "type": "integer"
+              },
+              "node_id": { "type": "string" },
+              "url": {
+                "description": "URL for the issue comment",
+                "type": "string"
+              },
+              "body": {
+                "description": "Contents of the issue comment",
+                "type": "string"
+              },
+              "body_text": { "type": "string" },
+              "body_html": { "type": "string" },
+              "html_url": { "type": "string" },
+              "user": {
+                "title": "Simple User",
+                "description": "A GitHub user.",
+                "type": "object",
+                "properties": {
+                  "name": { "type": ["string", "null"] },
+                  "email": { "type": ["string", "null"] },
+                  "login": { "type": "string" },
+                  "id": { "type": "integer" },
+                  "node_id": { "type": "string" },
+                  "avatar_url": { "type": "string" },
+                  "gravatar_id": { "type": ["string", "null"] },
+                  "url": { "type": "string" },
+                  "html_url": { "type": "string" },
+                  "followers_url": { "type": "string" },
+                  "following_url": { "type": "string" },
+                  "gists_url": { "type": "string" },
+                  "starred_url": { "type": "string" },
+                  "subscriptions_url": { "type": "string" },
+                  "organizations_url": { "type": "string" },
+                  "repos_url": { "type": "string" },
+                  "events_url": { "type": "string" },
+                  "received_events_url": { "type": "string" },
+                  "type": { "type": "string" },
+                  "site_admin": { "type": "boolean" },
+                  "starred_at": { "type": "string", "format": "date-time" }
+                }
+              },
+              "created_at": { "type": "string", "format": "date-time" },
+              "updated_at": { "type": "string", "format": "date-time" },
+              "issue_url": { "type": "string" },
+              "author_association": { "type": "string" },
+              "performed_via_github_app": {
+                "anyOf": [
+                  { "type": "null" },
+                  {
+                    "title": "GitHub app",
+                    "description": "GitHub apps are a new way to extend GitHub. They can be installed directly on organizations and user accounts and granted access to specific repositories. They come with granular permissions and built-in webhooks. GitHub apps are first class actors within GitHub.",
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "description": "Unique identifier of the GitHub app",
+                        "type": "integer"
+                      },
+                      "slug": {
+                        "description": "The slug name of the GitHub app",
+                        "type": "string"
+                      },
+                      "node_id": { "type": "string" },
+                      "owner": {
+                        "anyOf": [
+                          { "type": "null" },
+                          {
+                            "title": "Simple User",
+                            "description": "A GitHub user.",
+                            "type": "object",
+                            "properties": {
+                              "name": { "type": ["string", "null"] },
+                              "email": { "type": ["string", "null"] },
+                              "login": { "type": "string" },
+                              "id": { "type": "integer" },
+                              "node_id": { "type": "string" },
+                              "avatar_url": { "type": "string" },
+                              "gravatar_id": { "type": ["string", "null"] },
+                              "url": { "type": "string" },
+                              "html_url": { "type": "string" },
+                              "followers_url": { "type": "string" },
+                              "following_url": { "type": "string" },
+                              "gists_url": { "type": "string" },
+                              "starred_url": { "type": "string" },
+                              "subscriptions_url": { "type": "string" },
+                              "organizations_url": { "type": "string" },
+                              "repos_url": { "type": "string" },
+                              "events_url": { "type": "string" },
+                              "received_events_url": { "type": "string" },
+                              "type": { "type": "string" },
+                              "site_admin": { "type": "boolean" },
+                              "starred_at": {
+                                "type": "string",
+                                "format": "date-time"
+                              }
+                            }
+                          }
+                        ]
+                      },
+                      "name": {
+                        "description": "The name of the GitHub app",
+                        "type": "string"
+                      },
+                      "description": { "type": ["string", "null"] },
+                      "external_url": { "type": "string" },
+                      "html_url": { "type": "string" },
+                      "created_at": { "type": "string", "format": "date-time" },
+                      "updated_at": { "type": "string", "format": "date-time" },
+                      "permissions": {
+                        "description": "The set of permissions for the GitHub app",
+                        "type": "object",
+                        "properties": {
+                          "issues": { "type": "string" },
+                          "checks": { "type": "string" },
+                          "metadata": { "type": "string" },
+                          "contents": { "type": "string" },
+                          "deployments": { "type": "string" }
+                        }
+                      },
+                      "events": {
+                        "description": "The list of events for the GitHub app",
+                        "type": "array",
+                        "items": { "type": "string" }
+                      },
+                      "installations_count": {
+                        "description": "The number of installations associated with the GitHub app",
+                        "type": "integer"
+                      },
+                      "client_id": { "type": "string" },
+                      "client_secret": { "type": "string" },
+                      "webhook_secret": { "type": ["string", "null"] },
+                      "pem": { "type": "string" }
+                    }
+                  }
+                ]
+              },
+              "reactions": {
+                "title": "Reaction Rollup",
+                "type": "object",
+                "properties": {
+                  "url": { "type": "string" },
+                  "total_count": { "type": "integer" },
+                  "+1": { "type": "integer" },
+                  "-1": { "type": "integer" },
+                  "laugh": { "type": "integer" },
+                  "confused": { "type": "integer" },
+                  "heart": { "type": "integer" },
+                  "hooray": { "type": "integer" },
+                  "eyes": { "type": "integer" },
+                  "rocket": { "type": "integer" }
+                }
+              }
+            }
+          },
+          "cross-referenced": {
+            "title": "Timeline Cross Referenced Event",
+            "description": "Timeline Cross Referenced Event",
+            "type": "object",
+            "properties": {
+              "event": { "type": "string" },
+              "actor": {
+                "type": "object",
+                "properties": {
+                  "name": { "type": ["string", "null"] },
+                  "email": { "type": ["string", "null"] },
+                  "login": { "type": "string" },
+                  "id": { "type": "integer" },
+                  "node_id": { "type": "string" },
+                  "avatar_url": { "type": "string" },
+                  "gravatar_id": { "type": ["string", "null"] },
+                  "url": { "type": "string" },
+                  "html_url": { "type": "string" },
+                  "followers_url": { "type": "string" },
+                  "following_url": { "type": "string" },
+                  "gists_url": { "type": "string" },
+                  "starred_url": { "type": "string" },
+                  "subscriptions_url": { "type": "string" },
+                  "organizations_url": { "type": "string" },
+                  "repos_url": { "type": "string" },
+                  "events_url": { "type": "string" },
+                  "received_events_url": { "type": "string" },
+                  "type": { "type": "string" },
+                  "site_admin": { "type": "boolean" },
+                  "starred_at": { "type": "string", "format": "date-time" }
+                }
+              },
+              "created_at": { "type": "string", "format": "date-time" },
+              "updated_at": { "type": "string", "format": "date-time" },
+              "source": {
+                "type": "object",
+                "properties": {
+                  "type": { "type": "string" },
+                  "issue": {
+                    "title": "Issue",
+                    "description": "Issues are a great way to keep track of tasks, enhancements, and bugs for your projects.",
+                    "type": "object",
+                    "properties": {
+                      "author_association": { "type": ["string", "null"] },
+                      "performed_via_github_app": {
+                        "type": ["object", "null"]
+                      },
+                      "id": { "type": "integer" },
+                      "node_id": { "type": "string" },
+                      "url": { "type": "string" },
+                      "repository_url": { "type": "string" },
+                      "labels_url": { "type": "string" },
+                      "comments_url": { "type": "string" },
+                      "events_url": { "type": "string" },
+                      "html_url": { "type": "string" },
+                      "number": { "type": "integer" },
+                      "state": { "type": "string" },
+                      "state_reason": { "type": ["string", "null"] },
+                      "title": { "type": "string" },
+                      "body": { "type": ["string", "null"] },
+                      "user": {
+                        "anyOf": [
+                          { "type": "null" },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "name": { "type": ["string", "null"] },
+                              "email": { "type": ["string", "null"] },
+                              "login": { "type": "string" },
+                              "id": { "type": "integer" },
+                              "node_id": { "type": "string" },
+                              "avatar_url": { "type": "string" },
+                              "gravatar_id": { "type": ["string", "null"] },
+                              "url": { "type": "string" },
+                              "html_url": { "type": "string" },
+                              "followers_url": { "type": "string" },
+                              "following_url": { "type": "string" },
+                              "gists_url": { "type": "string" },
+                              "starred_url": { "type": "string" },
+                              "subscriptions_url": { "type": "string" },
+                              "organizations_url": { "type": "string" },
+                              "repos_url": { "type": "string" },
+                              "events_url": { "type": "string" },
+                              "received_events_url": { "type": "string" },
+                              "type": { "type": "string" },
+                              "site_admin": { "type": "boolean" },
+                              "starred_at": {
+                                "type": "string",
+                                "format": "date-time"
+                              }
+                            }
+                          }
+                        ]
+                      },
+                      "labels": {
+                        "type": "array",
+                        "items": {
+                          "oneOf": [
+                            { "type": "string" },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "id": { "type": "integer" },
+                                "node_id": { "type": "string" },
+                                "url": { "type": "string" },
+                                "name": { "type": "string" },
+                                "description": { "type": ["string", "null"] },
+                                "color": { "type": ["string", "null"] },
+                                "default": { "type": "boolean" }
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      "assignee": {
+                        "anyOf": [
+                          { "type": "null" },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "name": { "type": ["string", "null"] },
+                              "email": { "type": ["string", "null"] },
+                              "login": { "type": "string" },
+                              "id": { "type": "integer" },
+                              "node_id": { "type": "string" },
+                              "avatar_url": { "type": "string" },
+                              "gravatar_id": { "type": ["string", "null"] },
+                              "url": { "type": "string" },
+                              "html_url": { "type": "string" },
+                              "followers_url": { "type": "string" },
+                              "following_url": { "type": "string" },
+                              "gists_url": { "type": "string" },
+                              "starred_url": { "type": "string" },
+                              "subscriptions_url": { "type": "string" },
+                              "organizations_url": { "type": "string" },
+                              "repos_url": { "type": "string" },
+                              "events_url": { "type": "string" },
+                              "received_events_url": { "type": "string" },
+                              "type": { "type": "string" },
+                              "site_admin": { "type": "boolean" },
+                              "starred_at": {
+                                "type": "string",
+                                "format": "date-time"
+                              }
+                            }
+                          }
+                        ]
+                      },
+                      "assignees": {
+                        "type": ["array", "null"],
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "name": { "type": ["string", "null"] },
+                            "email": { "type": ["string", "null"] },
+                            "login": { "type": "string" },
+                            "id": { "type": "integer" },
+                            "node_id": { "type": "string" },
+                            "avatar_url": { "type": "string" },
+                            "gravatar_id": { "type": ["string", "null"] },
+                            "url": { "type": "string" },
+                            "html_url": { "type": "string" },
+                            "followers_url": { "type": "string" },
+                            "following_url": { "type": "string" },
+                            "gists_url": { "type": "string" },
+                            "starred_url": { "type": "string" },
+                            "subscriptions_url": { "type": "string" },
+                            "organizations_url": { "type": "string" },
+                            "repos_url": { "type": "string" },
+                            "events_url": { "type": "string" },
+                            "received_events_url": { "type": "string" },
+                            "type": { "type": "string" },
+                            "site_admin": { "type": "boolean" },
+                            "starred_at": {
+                              "type": "string",
+                              "format": "date-time"
+                            }
+                          }
+                        }
+                      },
+                      "milestone": {
+                        "anyOf": [
+                          { "type": "null" },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "url": { "type": "string" },
+                              "html_url": { "type": "string" },
+                              "labels_url": { "type": "string" },
+                              "id": { "type": "integer" },
+                              "node_id": { "type": "string" },
+                              "number": { "type": "integer" },
+                              "state": { "type": "string" },
+                              "title": { "type": "string" },
+                              "description": { "type": ["string", "null"] },
+                              "creator": {
+                                "anyOf": [
+                                  { "type": "null" },
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "name": { "type": ["string", "null"] },
+                                      "email": { "type": ["string", "null"] },
+                                      "login": { "type": "string" },
+                                      "id": { "type": "integer" },
+                                      "node_id": { "type": "string" },
+                                      "avatar_url": { "type": "string" },
+                                      "gravatar_id": {
+                                        "type": ["string", "null"]
+                                      },
+                                      "url": { "type": "string" },
+                                      "html_url": { "type": "string" },
+                                      "followers_url": { "type": "string" },
+                                      "following_url": { "type": "string" },
+                                      "gists_url": { "type": "string" },
+                                      "starred_url": { "type": "string" },
+                                      "subscriptions_url": { "type": "string" },
+                                      "organizations_url": { "type": "string" },
+                                      "repos_url": { "type": "string" },
+                                      "events_url": { "type": "string" },
+                                      "received_events_url": {
+                                        "type": "string"
+                                      },
+                                      "type": { "type": "string" },
+                                      "site_admin": { "type": "boolean" },
+                                      "starred_at": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                      }
+                                    }
+                                  }
+                                ]
+                              },
+                              "open_issues": { "type": "integer" },
+                              "closed_issues": { "type": "integer" },
+                              "created_at": {
+                                "type": "string",
+                                "format": "date-time"
+                              },
+                              "updated_at": {
+                                "type": "string",
+                                "format": "date-time"
+                              },
+                              "closed_at": {
+                                "type": ["string", "null"],
+                                "format": "date-time"
+                              },
+                              "due_on": {
+                                "type": ["string", "null"],
+                                "format": "date-time"
+                              }
+                            }
+                          }
+                        ]
+                      },
+                      "locked": { "type": "boolean" },
+                      "active_lock_reason": { "type": ["string", "null"] },
+                      "comments": { "type": "integer" },
+                      "draft": { "type": "boolean" },
+                      "pull_request": {
+                        "type": "object",
+                        "properties": {
+                          "merged_at": {
+                            "type": ["string", "null"],
+                            "format": "date-time"
+                          },
+                          "diff_url": { "type": ["string", "null"] },
+                          "html_url": { "type": ["string", "null"] },
+                          "patch_url": { "type": ["string", "null"] },
+                          "url": { "type": ["string", "null"] }
+                        }
+                      },
+                      "closed_at": {
+                        "type": ["string", "null"],
+                        "format": "date-time"
+                      },
+                      "created_at": { "type": "string", "format": "date-time" },
+                      "updated_at": { "type": "string", "format": "date-time" },
+                      "closed_by": {
+                        "anyOf": [
+                          { "type": "null" },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "name": { "type": ["string", "null"] },
+                              "email": { "type": ["string", "null"] },
+                              "login": {
+                                "type": "string",
+                                "examples": ["octocat"]
+                              },
+                              "id": { "type": "integer" },
+                              "node_id": { "type": "string" },
+                              "avatar_url": { "type": "string" },
+                              "gravatar_id": { "type": ["string", "null"] },
+                              "url": { "type": "string" },
+                              "html_url": { "type": "string" },
+                              "followers_url": { "type": "string" },
+                              "following_url": { "type": "string" },
+                              "gists_url": { "type": "string" },
+                              "starred_url": { "type": "string" },
+                              "subscriptions_url": { "type": "string" },
+                              "organizations_url": { "type": "string" },
+                              "repos_url": { "type": "string" },
+                              "events_url": { "type": "string" },
+                              "received_events_url": { "type": "string" },
+                              "type": { "type": "string" },
+                              "site_admin": { "type": "boolean" },
+                              "starred_at": {
+                                "type": "string",
+                                "format": "date-time"
+                              }
+                            }
+                          }
+                        ]
+                      },
+                      "body_html": { "type": "string" },
+                      "body_text": { "type": "string" },
+                      "timeline_url": { "type": "string" },
+                      "repository": {
+                        "type": "object",
+                        "properties": {
+                          "id": { "type": "integer" },
+                          "node_id": { "type": "string" },
+                          "name": { "type": "string" },
+                          "full_name": { "type": "string" },
+                          "license": {
+                            "anyOf": [
+                              { "type": "null" },
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "key": { "type": "string" },
+                                  "name": { "type": "string" },
+                                  "url": { "type": ["string", "null"] },
+                                  "spdx_id": { "type": ["string", "null"] },
+                                  "node_id": { "type": "string" },
+                                  "html_url": { "type": "string" }
+                                }
+                              }
+                            ]
+                          },
+                          "organization": {
+                            "anyOf": [
+                              { "type": "null" },
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "name": { "type": ["string", "null"] },
+                                  "email": { "type": ["string", "null"] },
+                                  "login": { "type": "string" },
+                                  "id": { "type": "integer" },
+                                  "node_id": { "type": "string" },
+                                  "avatar_url": { "type": "string" },
+                                  "gravatar_id": { "type": ["string", "null"] },
+                                  "url": { "type": "string" },
+                                  "html_url": { "type": "string" },
+                                  "followers_url": { "type": "string" },
+                                  "following_url": { "type": "string" },
+                                  "gists_url": { "type": "string" },
+                                  "starred_url": { "type": "string" },
+                                  "subscriptions_url": { "type": "string" },
+                                  "organizations_url": { "type": "string" },
+                                  "repos_url": { "type": "string" },
+                                  "events_url": { "type": "string" },
+                                  "received_events_url": { "type": "string" },
+                                  "type": { "type": "string" },
+                                  "site_admin": { "type": "boolean" },
+                                  "starred_at": {
+                                    "type": "string",
+                                    "format": "date-time"
+                                  }
+                                }
+                              }
+                            ]
+                          },
+                          "forks": { "type": "integer" },
+                          "permissions": {
+                            "type": "object",
+                            "properties": {
+                              "admin": { "type": "boolean" },
+                              "pull": { "type": "boolean" },
+                              "triage": { "type": "boolean" },
+                              "push": { "type": "boolean" },
+                              "maintain": { "type": "boolean" }
+                            }
+                          },
+                          "owner": {
+                            "type": "object",
+                            "properties": {
+                              "name": { "type": ["string", "null"] },
+                              "email": { "type": ["string", "null"] },
+                              "login": { "type": "string" },
+                              "id": { "type": "integer" },
+                              "node_id": { "type": "string" },
+                              "avatar_url": { "type": "string" },
+                              "gravatar_id": { "type": ["string", "null"] },
+                              "url": { "type": "string" },
+                              "html_url": { "type": "string" },
+                              "followers_url": { "type": "string" },
+                              "following_url": { "type": "string" },
+                              "gists_url": { "type": "string" },
+                              "starred_url": { "type": "string" },
+                              "subscriptions_url": { "type": "string" },
+                              "organizations_url": { "type": "string" },
+                              "repos_url": { "type": "string" },
+                              "events_url": { "type": "string" },
+                              "received_events_url": { "type": "string" },
+                              "type": { "type": "string" },
+                              "site_admin": { "type": "boolean" },
+                              "starred_at": {
+                                "type": "string",
+                                "format": "date-time"
+                              }
+                            }
+                          },
+                          "private": { "type": "boolean" },
+                          "html_url": { "type": "string" },
+                          "description": { "type": ["string", "null"] },
+                          "fork": { "type": "boolean" },
+                          "url": { "type": "string" },
+                          "archive_url": { "type": "string" },
+                          "assignees_url": { "type": "string" },
+                          "blobs_url": { "type": "string" },
+                          "branches_url": { "type": "string" },
+                          "collaborators_url": { "type": "string" },
+                          "comments_url": { "type": "string" },
+                          "commits_url": { "type": "string" },
+                          "compare_url": { "type": "string" },
+                          "contents_url": { "type": "string" },
+                          "contributors_url": { "type": "string" },
+                          "deployments_url": { "type": "string" },
+                          "downloads_url": { "type": "string" },
+                          "events_url": { "type": "string" },
+                          "forks_url": { "type": "string" },
+                          "git_commits_url": { "type": "string" },
+                          "git_refs_url": { "type": "string" },
+                          "git_tags_url": { "type": "string" },
+                          "git_url": { "type": "string" },
+                          "issue_comment_url": { "type": "string" },
+                          "issue_events_url": { "type": "string" },
+                          "issues_url": { "type": "string" },
+                          "keys_url": { "type": "string" },
+                          "labels_url": { "type": "string" },
+                          "languages_url": { "type": "string" },
+                          "merges_url": { "type": "string" },
+                          "milestones_url": { "type": "string" },
+                          "notifications_url": { "type": "string" },
+                          "pulls_url": { "type": "string" },
+                          "releases_url": { "type": "string" },
+                          "ssh_url": { "type": "string" },
+                          "stargazers_url": { "type": "string" },
+                          "statuses_url": { "type": "string" },
+                          "subscribers_url": { "type": "string" },
+                          "subscription_url": { "type": "string" },
+                          "tags_url": { "type": "string" },
+                          "teams_url": { "type": "string" },
+                          "trees_url": { "type": "string" },
+                          "clone_url": { "type": "string" },
+                          "mirror_url": { "type": ["string", "null"] },
+                          "hooks_url": { "type": "string" },
+                          "svn_url": { "type": "string" },
+                          "homepage": { "type": ["string", "null"] },
+                          "language": { "type": ["string", "null"] },
+                          "forks_count": { "type": "integer" },
+                          "stargazers_count": { "type": "integer" },
+                          "watchers_count": { "type": "integer" },
+                          "size": { "type": "integer" },
+                          "default_branch": { "type": "string" },
+                          "open_issues_count": { "type": "integer" },
+                          "is_template": { "type": "boolean" },
+                          "topics": {
+                            "type": "array",
+                            "items": { "type": "string" }
+                          },
+                          "has_issues": { "type": "boolean" },
+                          "has_projects": { "type": "boolean" },
+                          "has_wiki": { "type": "boolean" },
+                          "has_pages": { "type": "boolean" },
+                          "has_downloads": { "type": "boolean" },
+                          "has_discussions": { "type": "boolean" },
+                          "archived": { "type": "boolean" },
+                          "disabled": { "type": "boolean" },
+                          "visibility": { "type": "string" },
+                          "pushed_at": {
+                            "type": ["string", "null"],
+                            "format": "date-time"
+                          },
+                          "created_at": {
+                            "type": ["string", "null"],
+                            "format": "date-time"
+                          },
+                          "updated_at": {
+                            "type": ["string", "null"],
+                            "format": "date-time"
+                          },
+                          "allow_rebase_merge": { "type": "boolean" },
+                          "template_repository": {
+                            "type": ["object", "null"],
+                            "properties": {
+                              "id": { "type": "integer" },
+                              "node_id": { "type": "string" },
+                              "name": { "type": "string" },
+                              "full_name": { "type": "string" },
+                              "owner": {
+                                "type": "object",
+                                "properties": {
+                                  "login": { "type": "string" },
+                                  "id": { "type": "integer" },
+                                  "node_id": { "type": "string" },
+                                  "avatar_url": { "type": "string" },
+                                  "gravatar_id": { "type": "string" },
+                                  "url": { "type": "string" },
+                                  "html_url": { "type": "string" },
+                                  "followers_url": { "type": "string" },
+                                  "following_url": { "type": "string" },
+                                  "gists_url": { "type": "string" },
+                                  "starred_url": { "type": "string" },
+                                  "subscriptions_url": { "type": "string" },
+                                  "organizations_url": { "type": "string" },
+                                  "repos_url": { "type": "string" },
+                                  "events_url": { "type": "string" },
+                                  "received_events_url": { "type": "string" },
+                                  "type": { "type": "string" },
+                                  "site_admin": { "type": "boolean" }
+                                }
+                              },
+                              "private": { "type": "boolean" },
+                              "html_url": { "type": "string" },
+                              "description": { "type": "string" },
+                              "fork": { "type": "boolean" },
+                              "url": { "type": "string" },
+                              "archive_url": { "type": "string" },
+                              "assignees_url": { "type": "string" },
+                              "blobs_url": { "type": "string" },
+                              "branches_url": { "type": "string" },
+                              "collaborators_url": { "type": "string" },
+                              "comments_url": { "type": "string" },
+                              "commits_url": { "type": "string" },
+                              "compare_url": { "type": "string" },
+                              "contents_url": { "type": "string" },
+                              "contributors_url": { "type": "string" },
+                              "deployments_url": { "type": "string" },
+                              "downloads_url": { "type": "string" },
+                              "events_url": { "type": "string" },
+                              "forks_url": { "type": "string" },
+                              "git_commits_url": { "type": "string" },
+                              "git_refs_url": { "type": "string" },
+                              "git_tags_url": { "type": "string" },
+                              "git_url": { "type": "string" },
+                              "issue_comment_url": { "type": "string" },
+                              "issue_events_url": { "type": "string" },
+                              "issues_url": { "type": "string" },
+                              "keys_url": { "type": "string" },
+                              "labels_url": { "type": "string" },
+                              "languages_url": { "type": "string" },
+                              "merges_url": { "type": "string" },
+                              "milestones_url": { "type": "string" },
+                              "notifications_url": { "type": "string" },
+                              "pulls_url": { "type": "string" },
+                              "releases_url": { "type": "string" },
+                              "ssh_url": { "type": "string" },
+                              "stargazers_url": { "type": "string" },
+                              "statuses_url": { "type": "string" },
+                              "subscribers_url": { "type": "string" },
+                              "subscription_url": { "type": "string" },
+                              "tags_url": { "type": "string" },
+                              "teams_url": { "type": "string" },
+                              "trees_url": { "type": "string" },
+                              "clone_url": { "type": "string" },
+                              "mirror_url": { "type": "string" },
+                              "hooks_url": { "type": "string" },
+                              "svn_url": { "type": "string" },
+                              "homepage": { "type": "string" },
+                              "language": { "type": "string" },
+                              "forks_count": { "type": "integer" },
+                              "stargazers_count": { "type": "integer" },
+                              "watchers_count": { "type": "integer" },
+                              "size": { "type": "integer" },
+                              "default_branch": { "type": "string" },
+                              "open_issues_count": { "type": "integer" },
+                              "is_template": { "type": "boolean" },
+                              "topics": {
+                                "type": "array",
+                                "items": { "type": "string" }
+                              },
+                              "has_issues": { "type": "boolean" },
+                              "has_projects": { "type": "boolean" },
+                              "has_wiki": { "type": "boolean" },
+                              "has_pages": { "type": "boolean" },
+                              "has_downloads": { "type": "boolean" },
+                              "archived": { "type": "boolean" },
+                              "disabled": { "type": "boolean" },
+                              "visibility": { "type": "string" },
+                              "pushed_at": {
+                                "type": "string",
+                                "format": "date-time"
+                              },
+                              "created_at": {
+                                "type": "string",
+                                "format": "date-time"
+                              },
+                              "updated_at": {
+                                "type": "string",
+                                "format": "date-time"
+                              },
+                              "permissions": {
+                                "type": "object",
+                                "properties": {
+                                  "admin": { "type": "boolean" },
+                                  "maintain": { "type": "boolean" },
+                                  "push": { "type": "boolean" },
+                                  "triage": { "type": "boolean" },
+                                  "pull": { "type": "boolean" }
+                                }
+                              },
+                              "allow_rebase_merge": { "type": "boolean" },
+                              "temp_clone_token": { "type": "string" },
+                              "allow_squash_merge": { "type": "boolean" },
+                              "allow_auto_merge": { "type": "boolean" },
+                              "delete_branch_on_merge": { "type": "boolean" },
+                              "allow_update_branch": { "type": "boolean" },
+                              "use_squash_pr_title_as_default": {
+                                "type": "boolean"
+                              },
+                              "squash_merge_commit_title": { "type": "string" },
+                              "squash_merge_commit_message": {
+                                "type": "string"
+                              },
+                              "merge_commit_title": { "type": "string" },
+                              "merge_commit_message": { "type": "string" },
+                              "allow_merge_commit": { "type": "boolean" },
+                              "subscribers_count": { "type": "integer" },
+                              "network_count": { "type": "integer" }
+                            }
+                          },
+                          "temp_clone_token": { "type": "string" },
+                          "allow_squash_merge": { "type": "boolean" },
+                          "allow_auto_merge": { "type": "boolean" },
+                          "delete_branch_on_merge": { "type": "boolean" },
+                          "allow_update_branch": { "type": "boolean" },
+                          "use_squash_pr_title_as_default": {
+                            "type": "boolean"
+                          },
+                          "squash_merge_commit_title": { "type": "string" },
+                          "squash_merge_commit_message": { "type": "string" },
+                          "merge_commit_title": { "type": "string" },
+                          "merge_commit_message": { "type": "string" },
+                          "allow_merge_commit": { "type": "boolean" },
+                          "allow_forking": { "type": "boolean" },
+                          "web_commit_signoff_required": { "type": "boolean" },
+                          "subscribers_count": { "type": "integer" },
+                          "network_count": { "type": "integer" },
+                          "open_issues": { "type": "integer" },
+                          "watchers": { "type": "integer" },
+                          "master_branch": { "type": "string" },
+                          "starred_at": {
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          "anonymous_access_enabled": { "type": "boolean" }
+                        },
+                        "performed_via_github_app": {
+                          "anyOf": [
+                            { "type": "null" },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "id": { "type": "integer" },
+                                "slug": { "type": "string" },
+                                "node_id": { "type": "string" },
+                                "owner": {
+                                  "anyOf": [
+                                    { "type": "null" },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "name": { "type": ["string", "null"] },
+                                        "email": { "type": ["string", "null"] },
+                                        "login": { "type": "string" },
+                                        "id": { "type": "integer" },
+                                        "node_id": { "type": "string" },
+                                        "avatar_url": { "type": "string" },
+                                        "gravatar_id": {
+                                          "type": ["string", "null"]
+                                        },
+                                        "url": { "type": "string" },
+                                        "html_url": { "type": "string" },
+                                        "followers_url": { "type": "string" },
+                                        "following_url": { "type": "string" },
+                                        "gists_url": { "type": "string" },
+                                        "starred_url": { "type": "string" },
+                                        "subscriptions_url": {
+                                          "type": "string"
+                                        },
+                                        "organizations_url": {
+                                          "type": "string"
+                                        },
+                                        "repos_url": { "type": "string" },
+                                        "events_url": { "type": "string" },
+                                        "received_events_url": {
+                                          "type": "string"
+                                        },
+                                        "type": { "type": "string" },
+                                        "site_admin": { "type": "boolean" },
+                                        "starred_at": {
+                                          "type": "string",
+                                          "format": "date-time"
+                                        }
+                                      }
+                                    }
+                                  ]
+                                },
+                                "name": { "type": "string" },
+                                "description": { "type": ["string", "null"] },
+                                "external_url": { "type": "string" },
+                                "html_url": { "type": "string" },
+                                "created_at": {
+                                  "type": "string",
+                                  "format": "date-time"
+                                },
+                                "updated_at": {
+                                  "type": "string",
+                                  "format": "date-time"
+                                },
+                                "permissions": {
+                                  "type": "object",
+                                  "properties": {
+                                    "issues": { "type": "string" },
+                                    "checks": { "type": "string" },
+                                    "metadata": { "type": "string" },
+                                    "contents": { "type": "string" },
+                                    "deployments": { "type": "string" }
+                                  },
+                                  "additionalProperties": true
+                                },
+                                "events": {
+                                  "type": "array",
+                                  "items": { "type": "string" },
+                                  "examples": ["label", "deployment"]
+                                },
+                                "installations_count": {
+                                  "type": "integer",
+                                  "examples": [5]
+                                },
+                                "client_id": { "type": "string" },
+                                "client_secret": { "type": "string" },
+                                "webhook_secret": {
+                                  "type": ["string", "null"]
+                                },
+                                "pem": { "type": "string" }
+                              }
+                            }
+                          ]
+                        },
+                        "author_association": { "type": "string" },
+                        "reactions": {
+                          "type": "object",
+                          "properties": {
+                            "url": { "type": "string" },
+                            "total_count": { "type": "integer" },
+                            "+1": { "type": "integer" },
+                            "-1": { "type": "integer" },
+                            "laugh": { "type": "integer" },
+                            "confused": { "type": "integer" },
+                            "heart": { "type": "integer" },
+                            "hooray": { "type": "integer" },
+                            "eyes": { "type": "integer" },
+                            "rocket": { "type": "integer" }
+                          }
+                        }
+                      },
+                      "reactions": {
+                        "type": "object",
+                        "properties": {
+                          "url": { "type": "string" },
+                          "total_count": { "type": "integer" },
+                          "+1": { "type": "integer" },
+                          "-1": { "type": "integer" },
+                          "laugh": { "type": "integer" },
+                          "confused": { "type": "integer" },
+                          "heart": { "type": "integer" },
+                          "hooray": { "type": "integer" },
+                          "eyes": { "type": "integer" },
+                          "rocket": { "type": "integer" }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "committed": {
+            "title": "Timeline Committed Event",
+            "description": "Timeline Committed Event",
+            "type": "object",
+            "properties": {
+              "event": { "type": "string" },
+              "sha": { "type": "string" },
+              "node_id": { "type": "string" },
+              "url": { "type": "string" },
+              "author": {
+                "type": "object",
+                "properties": {
+                  "date": { "format": "date-time", "type": "string" },
+                  "email": { "type": "string" },
+                  "name": { "type": "string" }
+                }
+              },
+              "committer": {
+                "type": "object",
+                "properties": {
+                  "date": { "format": "date-time", "type": "string" },
+                  "email": { "type": "string" },
+                  "name": { "type": "string" }
+                }
+              },
+              "message": { "type": "string" },
+              "tree": {
+                "type": "object",
+                "properties": {
+                  "sha": { "type": "string" },
+                  "url": { "type": "string" }
+                }
+              },
+              "parents": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "sha": { "type": "string" },
+                    "url": { "type": "string" },
+                    "html_url": { "type": "string" }
+                  }
+                }
+              },
+              "verification": {
+                "type": "object",
+                "properties": {
+                  "verified": { "type": "boolean" },
+                  "reason": { "type": "string" },
+                  "signature": { "type": ["string", "null"] },
+                  "payload": { "type": ["string", "null"] }
+                }
+              },
+              "html_url": { "type": "string" }
+            }
+          },
+          "closed": {
+            "id": { "type": ["null", "integer"] },
+            "node_id": { "type": ["null", "string"] },
+            "url": { "type": ["null", "string"] },
+            "actor": {
+              "title": "Simple User",
+              "description": "A GitHub user.",
+              "type": ["null", "object"],
+              "properties": {
+                "name": { "type": ["string", "null"] },
+                "email": { "type": ["string", "null"] },
+                "login": { "type": "string" },
+                "id": { "type": "integer" },
+                "node_id": { "type": "string" },
+                "avatar_url": { "type": "string" },
+                "gravatar_id": { "type": ["string", "null"] },
+                "url": { "type": "string" },
+                "html_url": { "type": "string" },
+                "followers_url": { "type": "string" },
+                "following_url": { "type": "string" },
+                "gists_url": { "type": "string" },
+                "starred_url": { "type": "string" },
+                "subscriptions_url": { "type": "string" },
+                "organizations_url": { "type": "string" },
+                "repos_url": { "type": "string" },
+                "events_url": { "type": "string" },
+                "received_events_url": { "type": "string" },
+                "type": { "type": "string" },
+                "site_admin": { "type": "boolean" },
+                "starred_at": { "type": "string", "format": "date-time" }
+              }
+            },
+            "event": { "type": ["null", "string"] },
+            "commit_id": { "type": ["string", "null"] },
+            "commit_url": { "type": ["string", "null"] },
+            "created_at": { "type": ["null", "string"], "format": "date-time" },
+            "performed_via_github_app": {
+              "anyOf": [
+                { "type": "null" },
+                {
+                  "type": "object",
+                  "properties": {
+                    "id": { "type": "integer" },
+                    "slug": { "type": "string" },
+                    "node_id": { "type": "string" },
+                    "owner": {
+                      "anyOf": [
+                        { "type": "null" },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "name": { "type": ["string", "null"] },
+                            "email": { "type": ["string", "null"] },
+                            "login": { "type": "string" },
+                            "id": { "type": "integer" },
+                            "node_id": { "type": "string" },
+                            "avatar_url": { "type": "string" },
+                            "gravatar_id": { "type": ["string", "null"] },
+                            "url": { "type": "string" },
+                            "html_url": { "type": "string" },
+                            "followers_url": { "type": "string" },
+                            "following_url": { "type": "string" },
+                            "gists_url": { "type": "string" },
+                            "starred_url": { "type": "string" },
+                            "subscriptions_url": { "type": "string" },
+                            "organizations_url": { "type": "string" },
+                            "repos_url": { "type": "string" },
+                            "events_url": { "type": "string" },
+                            "received_events_url": { "type": "string" },
+                            "type": { "type": "string" },
+                            "site_admin": { "type": "boolean" },
+                            "starred_at": {
+                              "type": "string",
+                              "format": "date-time"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "name": { "type": "string" },
+                    "description": { "type": ["string", "null"] },
+                    "external_url": { "type": "string" },
+                    "html_url": { "type": "string" },
+                    "created_at": { "type": "string", "format": "date-time" },
+                    "updated_at": { "type": "string", "format": "date-time" },
+                    "permissions": {
+                      "type": "object",
+                      "properties": {
+                        "issues": { "type": "string" },
+                        "checks": { "type": "string" },
+                        "metadata": { "type": "string" },
+                        "contents": { "type": "string" },
+                        "deployments": { "type": "string" }
+                      },
+                      "additionalProperties": true
+                    },
+                    "events": {
+                      "type": "array",
+                      "items": { "type": "string" }
+                    },
+                    "installations_count": { "type": "integer" },
+                    "client_id": { "type": "string" },
+                    "client_secret": { "type": "string" },
+                    "webhook_secret": { "type": ["string", "null"] },
+                    "pem": { "type": "string" }
+                  }
+                }
+              ]
+            }
+          },
+          "head_ref_deleted": {
+            "id": { "type": ["null", "integer"] },
+            "node_id": { "type": ["null", "string"] },
+            "url": { "type": ["null", "string"] },
+            "actor": {
+              "title": "Simple User",
+              "description": "A GitHub user.",
+              "type": ["null", "object"],
+              "properties": {
+                "name": { "type": ["string", "null"] },
+                "email": { "type": ["string", "null"] },
+                "login": { "type": "string" },
+                "id": { "type": "integer" },
+                "node_id": { "type": "string" },
+                "avatar_url": { "type": "string" },
+                "gravatar_id": { "type": ["string", "null"] },
+                "url": { "type": "string" },
+                "html_url": { "type": "string" },
+                "followers_url": { "type": "string" },
+                "following_url": { "type": "string" },
+                "gists_url": { "type": "string" },
+                "starred_url": { "type": "string" },
+                "subscriptions_url": { "type": "string" },
+                "organizations_url": { "type": "string" },
+                "repos_url": { "type": "string" },
+                "events_url": { "type": "string" },
+                "received_events_url": { "type": "string" },
+                "type": { "type": "string" },
+                "site_admin": { "type": "boolean" },
+                "starred_at": { "type": "string", "format": "date-time" }
+              }
+            },
+            "event": { "type": ["null", "string"] },
+            "commit_id": { "type": ["string", "null"] },
+            "commit_url": { "type": ["string", "null"] },
+            "created_at": { "type": ["null", "string"], "format": "date-time" },
+            "performed_via_github_app": {
+              "anyOf": [
+                { "type": "null" },
+                {
+                  "type": "object",
+                  "properties": {
+                    "id": { "type": "integer" },
+                    "slug": { "type": "string" },
+                    "node_id": { "type": "string" },
+                    "owner": {
+                      "anyOf": [
+                        { "type": "null" },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "name": { "type": ["string", "null"] },
+                            "email": { "type": ["string", "null"] },
+                            "login": { "type": "string" },
+                            "id": { "type": "integer" },
+                            "node_id": { "type": "string" },
+                            "avatar_url": { "type": "string" },
+                            "gravatar_id": { "type": ["string", "null"] },
+                            "url": { "type": "string" },
+                            "html_url": { "type": "string" },
+                            "followers_url": { "type": "string" },
+                            "following_url": { "type": "string" },
+                            "gists_url": { "type": "string" },
+                            "starred_url": { "type": "string" },
+                            "subscriptions_url": { "type": "string" },
+                            "organizations_url": { "type": "string" },
+                            "repos_url": { "type": "string" },
+                            "events_url": { "type": "string" },
+                            "received_events_url": { "type": "string" },
+                            "type": { "type": "string" },
+                            "site_admin": { "type": "boolean" },
+                            "starred_at": {
+                              "type": "string",
+                              "format": "date-time"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "name": { "type": "string" },
+                    "description": { "type": ["string", "null"] },
+                    "external_url": { "type": "string" },
+                    "html_url": { "type": "string" },
+                    "created_at": { "type": "string", "format": "date-time" },
+                    "updated_at": { "type": "string", "format": "date-time" },
+                    "permissions": {
+                      "type": "object",
+                      "properties": {
+                        "issues": { "type": "string" },
+                        "checks": { "type": "string" },
+                        "metadata": { "type": "string" },
+                        "contents": { "type": "string" },
+                        "deployments": { "type": "string" }
+                      },
+                      "additionalProperties": true
+                    },
+                    "events": {
+                      "type": "array",
+                      "items": { "type": "string" }
+                    },
+                    "installations_count": { "type": "integer" },
+                    "client_id": { "type": "string" },
+                    "client_secret": { "type": "string" },
+                    "webhook_secret": { "type": ["string", "null"] },
+                    "pem": { "type": "string" }
+                  }
+                }
+              ]
+            }
+          },
+          "head_ref_restored": {
+            "id": { "type": ["null", "integer"] },
+            "node_id": { "type": ["null", "string"] },
+            "url": { "type": ["null", "string"] },
+            "actor": {
+              "title": "Simple User",
+              "description": "A GitHub user.",
+              "type": ["null", "object"],
+              "properties": {
+                "name": { "type": ["string", "null"] },
+                "email": { "type": ["string", "null"] },
+                "login": { "type": "string" },
+                "id": { "type": "integer" },
+                "node_id": { "type": "string" },
+                "avatar_url": { "type": "string" },
+                "gravatar_id": { "type": ["string", "null"] },
+                "url": { "type": "string" },
+                "html_url": { "type": "string" },
+                "followers_url": { "type": "string" },
+                "following_url": { "type": "string" },
+                "gists_url": { "type": "string" },
+                "starred_url": { "type": "string" },
+                "subscriptions_url": { "type": "string" },
+                "organizations_url": { "type": "string" },
+                "repos_url": { "type": "string" },
+                "events_url": { "type": "string" },
+                "received_events_url": { "type": "string" },
+                "type": { "type": "string" },
+                "site_admin": { "type": "boolean" },
+                "starred_at": { "type": "string", "format": "date-time" }
+              }
+            },
+            "event": { "type": ["null", "string"] },
+            "commit_id": { "type": ["string", "null"] },
+            "commit_url": { "type": ["string", "null"] },
+            "created_at": { "type": ["null", "string"], "format": "date-time" },
+            "performed_via_github_app": {
+              "anyOf": [
+                { "type": "null" },
+                {
+                  "type": "object",
+                  "properties": {
+                    "id": { "type": "integer" },
+                    "slug": { "type": "string" },
+                    "node_id": { "type": "string" },
+                    "owner": {
+                      "anyOf": [
+                        { "type": "null" },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "name": { "type": ["string", "null"] },
+                            "email": { "type": ["string", "null"] },
+                            "login": { "type": "string" },
+                            "id": { "type": "integer" },
+                            "node_id": { "type": "string" },
+                            "avatar_url": { "type": "string" },
+                            "gravatar_id": { "type": ["string", "null"] },
+                            "url": { "type": "string" },
+                            "html_url": { "type": "string" },
+                            "followers_url": { "type": "string" },
+                            "following_url": { "type": "string" },
+                            "gists_url": { "type": "string" },
+                            "starred_url": { "type": "string" },
+                            "subscriptions_url": { "type": "string" },
+                            "organizations_url": { "type": "string" },
+                            "repos_url": { "type": "string" },
+                            "events_url": { "type": "string" },
+                            "received_events_url": { "type": "string" },
+                            "type": { "type": "string" },
+                            "site_admin": { "type": "boolean" },
+                            "starred_at": {
+                              "type": "string",
+                              "format": "date-time"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "name": { "type": "string" },
+                    "description": { "type": ["string", "null"] },
+                    "external_url": { "type": "string" },
+                    "html_url": { "type": "string" },
+                    "created_at": { "type": "string", "format": "date-time" },
+                    "updated_at": { "type": "string", "format": "date-time" },
+                    "permissions": {
+                      "type": "object",
+                      "properties": {
+                        "issues": { "type": "string" },
+                        "checks": { "type": "string" },
+                        "metadata": { "type": "string" },
+                        "contents": { "type": "string" },
+                        "deployments": { "type": "string" }
+                      },
+                      "additionalProperties": true
+                    },
+                    "events": {
+                      "type": "array",
+                      "items": { "type": "string" }
+                    },
+                    "installations_count": { "type": "integer" },
+                    "client_id": { "type": "string" },
+                    "client_secret": { "type": "string" },
+                    "webhook_secret": { "type": ["string", "null"] },
+                    "pem": { "type": "string" }
+                  }
+                }
+              ]
+            }
+          },
+          "reopened": {
+            "id": { "type": ["null", "integer"] },
+            "node_id": { "type": ["null", "string"] },
+            "url": { "type": ["null", "string"] },
+            "actor": {
+              "title": "Simple User",
+              "description": "A GitHub user.",
+              "type": ["null", "object"],
+              "properties": {
+                "name": { "type": ["string", "null"] },
+                "email": { "type": ["string", "null"] },
+                "login": { "type": "string" },
+                "id": { "type": "integer" },
+                "node_id": { "type": "string" },
+                "avatar_url": { "type": "string" },
+                "gravatar_id": { "type": ["string", "null"] },
+                "url": { "type": "string" },
+                "html_url": { "type": "string" },
+                "followers_url": { "type": "string" },
+                "following_url": { "type": "string" },
+                "gists_url": { "type": "string" },
+                "starred_url": { "type": "string" },
+                "subscriptions_url": { "type": "string" },
+                "organizations_url": { "type": "string" },
+                "repos_url": { "type": "string" },
+                "events_url": { "type": "string" },
+                "received_events_url": { "type": "string" },
+                "type": { "type": "string" },
+                "site_admin": { "type": "boolean" },
+                "starred_at": { "type": "string", "format": "date-time" }
+              }
+            },
+            "event": { "type": ["null", "string"] },
+            "commit_id": { "type": ["string", "null"] },
+            "commit_url": { "type": ["string", "null"] },
+            "created_at": { "type": ["null", "string"], "format": "date-time" },
+            "performed_via_github_app": {
+              "anyOf": [
+                { "type": "null" },
+                {
+                  "type": "object",
+                  "properties": {
+                    "id": { "type": "integer" },
+                    "slug": { "type": "string" },
+                    "node_id": { "type": "string" },
+                    "owner": {
+                      "anyOf": [
+                        { "type": "null" },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "name": { "type": ["string", "null"] },
+                            "email": { "type": ["string", "null"] },
+                            "login": { "type": "string" },
+                            "id": { "type": "integer" },
+                            "node_id": { "type": "string" },
+                            "avatar_url": { "type": "string" },
+                            "gravatar_id": { "type": ["string", "null"] },
+                            "url": { "type": "string" },
+                            "html_url": { "type": "string" },
+                            "followers_url": { "type": "string" },
+                            "following_url": { "type": "string" },
+                            "gists_url": { "type": "string" },
+                            "starred_url": { "type": "string" },
+                            "subscriptions_url": { "type": "string" },
+                            "organizations_url": { "type": "string" },
+                            "repos_url": { "type": "string" },
+                            "events_url": { "type": "string" },
+                            "received_events_url": { "type": "string" },
+                            "type": { "type": "string" },
+                            "site_admin": { "type": "boolean" },
+                            "starred_at": {
+                              "type": "string",
+                              "format": "date-time"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "name": { "type": "string" },
+                    "description": { "type": ["string", "null"] },
+                    "external_url": { "type": "string" },
+                    "html_url": { "type": "string" },
+                    "created_at": { "type": "string", "format": "date-time" },
+                    "updated_at": { "type": "string", "format": "date-time" },
+                    "permissions": {
+                      "type": "object",
+                      "properties": {
+                        "issues": { "type": "string" },
+                        "checks": { "type": "string" },
+                        "metadata": { "type": "string" },
+                        "contents": { "type": "string" },
+                        "deployments": { "type": "string" }
+                      },
+                      "additionalProperties": true
+                    },
+                    "events": {
+                      "type": "array",
+                      "items": { "type": "string" }
+                    },
+                    "installations_count": { "type": "integer" },
+                    "client_id": { "type": "string" },
+                    "client_secret": { "type": "string" },
+                    "webhook_secret": { "type": ["string", "null"] },
+                    "pem": { "type": "string" }
+                  }
+                }
+              ]
+            }
+          },
+          "reviewed": {
+            "title": "Timeline Reviewed Event",
+            "description": "Timeline Reviewed Event",
+            "type": "object",
+            "properties": {
+              "event": { "type": "string" },
+              "id": { "type": "integer" },
+              "node_id": { "type": "string" },
+              "user": {
+                "title": "Simple User",
+                "description": "A GitHub user.",
+                "type": "object",
+                "properties": {
+                  "name": { "type": ["string", "null"] },
+                  "email": { "type": ["string", "null"] },
+                  "login": { "type": "string" },
+                  "id": { "type": "integer" },
+                  "node_id": { "type": "string" },
+                  "avatar_url": { "type": "string" },
+                  "gravatar_id": { "type": ["string", "null"] },
+                  "url": { "type": "string" },
+                  "html_url": { "type": "string" },
+                  "followers_url": { "type": "string" },
+                  "following_url": { "type": "string" },
+                  "gists_url": { "type": "string" },
+                  "starred_url": { "type": "string" },
+                  "subscriptions_url": { "type": "string" },
+                  "organizations_url": { "type": "string" },
+                  "repos_url": { "type": "string" },
+                  "events_url": { "type": "string" },
+                  "received_events_url": { "type": "string" },
+                  "type": { "type": "string" },
+                  "site_admin": { "type": "boolean" },
+                  "starred_at": { "type": "string", "format": "date-time" }
+                }
+              },
+              "body": { "type": ["string", "null"] },
+              "state": { "type": "string" },
+              "html_url": { "type": "string" },
+              "pull_request_url": { "type": "string" },
+              "_links": {
+                "type": "object",
+                "properties": {
+                  "html": {
+                    "type": "object",
+                    "properties": { "href": { "type": "string" } },
+                    "required": ["href"]
+                  },
+                  "pull_request": {
+                    "type": "object",
+                    "properties": { "href": { "type": "string" } },
+                    "required": ["href"]
+                  }
+                },
+                "required": ["html", "pull_request"]
+              },
+              "submitted_at": { "type": "string", "format": "date-time" },
+              "commit_id": { "type": "string" },
+              "body_html": { "type": "string" },
+              "body_text": { "type": "string" },
+              "author_association": { "type": "string" }
+            }
+          },
+          "commented": {
+            "title": "Timeline Comment Event",
+            "description": "Timeline Comment Event",
+            "type": "object",
+            "properties": {
+              "event": { "type": "string" },
+              "actor": {
+                "title": "Simple User",
+                "description": "A GitHub user.",
+                "type": "object",
+                "properties": {
+                  "name": { "type": ["string", "null"] },
+                  "email": { "type": ["string", "null"] },
+                  "login": { "type": "string" },
+                  "id": { "type": "integer" },
+                  "node_id": { "type": "string" },
+                  "avatar_url": { "type": "string" },
+                  "gravatar_id": { "type": ["string", "null"] },
+                  "url": { "type": "string" },
+                  "html_url": { "type": "string" },
+                  "followers_url": { "type": "string" },
+                  "following_url": { "type": "string" },
+                  "gists_url": { "type": "string" },
+                  "starred_url": { "type": "string" },
+                  "subscriptions_url": { "type": "string" },
+                  "organizations_url": { "type": "string" },
+                  "repos_url": { "type": "string" },
+                  "events_url": { "type": "string" },
+                  "received_events_url": { "type": "string" },
+                  "type": { "type": "string" },
+                  "site_admin": { "type": "boolean" },
+                  "starred_at": { "type": "string", "format": "date-time" }
+                }
+              },
+              "id": {
+                "description": "Unique identifier of the issue comment",
+                "type": "integer"
+              },
+              "node_id": { "type": "string" },
+              "url": {
+                "description": "URL for the issue comment",
+                "type": "string"
+              },
+              "body": {
+                "description": "Contents of the issue comment",
+                "type": "string"
+              },
+              "body_text": { "type": "string" },
+              "body_html": { "type": "string" },
+              "html_url": { "type": "string" },
+              "user": {
+                "title": "Simple User",
+                "description": "A GitHub user.",
+                "type": "object",
+                "properties": {
+                  "name": { "type": ["string", "null"] },
+                  "email": { "type": ["string", "null"] },
+                  "login": { "type": "string" },
+                  "id": { "type": "integer" },
+                  "node_id": { "type": "string" },
+                  "avatar_url": { "type": "string" },
+                  "gravatar_id": { "type": ["string", "null"] },
+                  "url": { "type": "string" },
+                  "html_url": { "type": "string" },
+                  "followers_url": { "type": "string" },
+                  "following_url": { "type": "string" },
+                  "gists_url": { "type": "string" },
+                  "starred_url": { "type": "string" },
+                  "subscriptions_url": { "type": "string" },
+                  "organizations_url": { "type": "string" },
+                  "repos_url": { "type": "string" },
+                  "events_url": { "type": "string" },
+                  "received_events_url": { "type": "string" },
+                  "type": { "type": "string" },
+                  "site_admin": { "type": "boolean" },
+                  "starred_at": { "type": "string", "format": "date-time" }
+                }
+              },
+              "created_at": { "type": "string", "format": "date-time" },
+              "updated_at": { "type": "string", "format": "date-time" },
+              "issue_url": { "type": "string" },
+              "author_association": { "type": "string" },
+              "performed_via_github_app": {
+                "anyOf": [
+                  { "type": "null" },
+                  {
+                    "title": "GitHub app",
+                    "description": "GitHub apps are a new way to extend GitHub. They can be installed directly on organizations and user accounts and granted access to specific repositories. They come with granular permissions and built-in webhooks. GitHub apps are first class actors within GitHub.",
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "description": "Unique identifier of the GitHub app",
+                        "type": "integer"
+                      },
+                      "slug": {
+                        "description": "The slug name of the GitHub app",
+                        "type": "string"
+                      },
+                      "node_id": { "type": "string" },
+                      "owner": {
+                        "anyOf": [
+                          { "type": "null" },
+                          {
+                            "title": "Simple User",
+                            "description": "A GitHub user.",
+                            "type": "object",
+                            "properties": {
+                              "name": { "type": ["string", "null"] },
+                              "email": { "type": ["string", "null"] },
+                              "login": { "type": "string" },
+                              "id": { "type": "integer" },
+                              "node_id": { "type": "string" },
+                              "avatar_url": { "type": "string" },
+                              "gravatar_id": { "type": ["string", "null"] },
+                              "url": { "type": "string" },
+                              "html_url": { "type": "string" },
+                              "followers_url": { "type": "string" },
+                              "following_url": { "type": "string" },
+                              "gists_url": { "type": "string" },
+                              "starred_url": { "type": "string" },
+                              "subscriptions_url": { "type": "string" },
+                              "organizations_url": { "type": "string" },
+                              "repos_url": { "type": "string" },
+                              "events_url": { "type": "string" },
+                              "received_events_url": { "type": "string" },
+                              "type": { "type": "string" },
+                              "site_admin": { "type": "boolean" },
+                              "starred_at": {
+                                "type": "string",
+                                "format": "date-time"
+                              }
+                            }
+                          }
+                        ]
+                      },
+                      "name": {
+                        "description": "The name of the GitHub app",
+                        "type": "string"
+                      },
+                      "description": { "type": ["string", "null"] },
+                      "external_url": { "type": "string" },
+                      "html_url": { "type": "string" },
+                      "created_at": { "type": "string", "format": "date-time" },
+                      "updated_at": { "type": "string", "format": "date-time" },
+                      "permissions": {
+                        "description": "The set of permissions for the GitHub app",
+                        "type": "object",
+                        "properties": {
+                          "issues": { "type": "string" },
+                          "checks": { "type": "string" },
+                          "metadata": { "type": "string" },
+                          "contents": { "type": "string" },
+                          "deployments": { "type": "string" }
+                        }
+                      },
+                      "events": {
+                        "description": "The list of events for the GitHub app",
+                        "type": "array",
+                        "items": { "type": "string" }
+                      },
+                      "installations_count": {
+                        "description": "The number of installations associated with the GitHub app",
+                        "type": "integer"
+                      },
+                      "client_id": { "type": "string" },
+                      "client_secret": { "type": "string" },
+                      "webhook_secret": { "type": ["string", "null"] },
+                      "pem": { "type": "string" }
+                    }
+                  }
+                ]
+              },
+              "reactions": {
+                "title": "Reaction Rollup",
+                "type": "object",
+                "properties": {
+                  "url": { "type": "string" },
+                  "total_count": { "type": "integer" },
+                  "+1": { "type": "integer" },
+                  "-1": { "type": "integer" },
+                  "laugh": { "type": "integer" },
+                  "confused": { "type": "integer" },
+                  "heart": { "type": "integer" },
+                  "hooray": { "type": "integer" },
+                  "eyes": { "type": "integer" },
+                  "rocket": { "type": "integer" }
+                }
+              }
+            }
+          },
+          "commit_commented": {
+            "title": "Timeline Line Commented Event",
+            "description": "Timeline Line Commented Event",
+            "type": "object",
+            "properties": {
+              "event": { "type": "string" },
+              "node_id": { "type": "string" },
+              "comments": {
+                "type": "array",
+                "items": {
+                  "title": "Pull Request Review Comment",
+                  "type": "object",
+                  "properties": {
+                    "url": { "type": "string" },
+                    "pull_request_review_id": { "type": ["integer", "null"] },
+                    "id": { "type": "integer" },
+                    "node_id": { "type": "string" },
+                    "diff_hunk": { "type": "string" },
+                    "path": { "type": "string" },
+                    "position": { "type": "integer" },
+                    "original_position": { "type": "integer" },
+                    "commit_id": { "type": "string" },
+                    "original_commit_id": { "type": "string" },
+                    "in_reply_to_id": { "type": "integer" },
+                    "user": {
+                      "type": "object",
+                      "properties": {
+                        "name": { "type": ["string", "null"] },
+                        "email": { "type": ["string", "null"] },
+                        "login": { "type": "string" },
+                        "id": { "type": "integer" },
+                        "node_id": { "type": "string" },
+                        "avatar_url": { "type": "string" },
+                        "gravatar_id": { "type": ["string", "null"] },
+                        "url": { "type": "string" },
+                        "html_url": { "type": "string" },
+                        "followers_url": { "type": "string" },
+                        "following_url": { "type": "string" },
+                        "gists_url": { "type": "string" },
+                        "starred_url": { "type": "string" },
+                        "subscriptions_url": { "type": "string" },
+                        "organizations_url": { "type": "string" },
+                        "repos_url": { "type": "string" },
+                        "events_url": { "type": "string" },
+                        "received_events_url": { "type": "string" },
+                        "type": { "type": "string" },
+                        "site_admin": { "type": "boolean" },
+                        "starred_at": {
+                          "type": "string",
+                          "format": "date-time"
+                        }
+                      }
+                    },
+                    "body": { "type": "string" },
+                    "created_at": { "type": "string", "format": "date-time" },
+                    "updated_at": { "type": "string", "format": "date-time" },
+                    "html_url": { "type": "string" },
+                    "pull_request_url": { "type": "string" },
+                    "author_association": { "type": "string" },
+                    "_links": {
+                      "type": "object",
+                      "properties": {
+                        "self": {
+                          "type": "object",
+                          "properties": { "href": { "type": "string" } }
+                        },
+                        "html": {
+                          "type": "object",
+                          "properties": { "href": { "type": "string" } }
+                        },
+                        "pull_request": {
+                          "type": "object",
+                          "properties": { "href": { "type": "string" } }
+                        }
+                      }
+                    },
+                    "start_line": { "type": ["integer", "null"] },
+                    "original_start_line": { "type": ["integer", "null"] },
+                    "start_side": { "type": ["string", "null"] },
+                    "line": { "type": "integer" },
+                    "original_line": { "type": "integer" },
+                    "side": { "type": "string" },
+                    "subject_type": { "type": "string" },
+                    "reactions": {
+                      "type": "object",
+                      "properties": {
+                        "url": { "type": "string" },
+                        "total_count": { "type": "integer" },
+                        "+1": { "type": "integer" },
+                        "-1": { "type": "integer" },
+                        "laugh": { "type": "integer" },
+                        "confused": { "type": "integer" },
+                        "heart": { "type": "integer" },
+                        "hooray": { "type": "integer" },
+                        "eyes": { "type": "integer" },
+                        "rocket": { "type": "integer" }
+                      }
+                    },
+                    "body_html": { "type": "string" },
+                    "body_text": { "type": "string" }
+                  }
+                }
+              }
+            }
+          },
+          "assigned": {
+            "id": { "type": ["null", "integer"] },
+            "node_id": { "type": ["null", "string"] },
+            "url": { "type": ["null", "string"] },
+            "actor": {
+              "title": "Simple User",
+              "description": "A GitHub user.",
+              "type": ["null", "object"],
+              "properties": {
+                "name": { "type": ["string", "null"] },
+                "email": { "type": ["string", "null"] },
+                "login": { "type": "string" },
+                "id": { "type": "integer" },
+                "node_id": { "type": "string" },
+                "avatar_url": { "type": "string" },
+                "gravatar_id": { "type": ["string", "null"] },
+                "url": { "type": "string" },
+                "html_url": { "type": "string" },
+                "followers_url": { "type": "string" },
+                "following_url": { "type": "string" },
+                "gists_url": { "type": "string" },
+                "starred_url": { "type": "string" },
+                "subscriptions_url": { "type": "string" },
+                "organizations_url": { "type": "string" },
+                "repos_url": { "type": "string" },
+                "events_url": { "type": "string" },
+                "received_events_url": { "type": "string" },
+                "type": { "type": "string" },
+                "site_admin": { "type": "boolean" },
+                "starred_at": { "type": "string", "format": "date-time" }
+              }
+            },
+            "event": { "type": ["null", "string"] },
+            "commit_id": { "type": ["string", "null"] },
+            "commit_url": { "type": ["string", "null"] },
+            "created_at": { "type": ["null", "string"], "format": "date-time" },
+            "performed_via_github_app": {
+              "anyOf": [
+                { "type": "null" },
+                {
+                  "type": "object",
+                  "properties": {
+                    "id": { "type": "integer" },
+                    "slug": { "type": "string" },
+                    "node_id": { "type": "string" },
+                    "owner": {
+                      "anyOf": [
+                        { "type": "null" },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "name": { "type": ["string", "null"] },
+                            "email": { "type": ["string", "null"] },
+                            "login": { "type": "string" },
+                            "id": { "type": "integer" },
+                            "node_id": { "type": "string" },
+                            "avatar_url": { "type": "string" },
+                            "gravatar_id": { "type": ["string", "null"] },
+                            "url": { "type": "string" },
+                            "html_url": { "type": "string" },
+                            "followers_url": { "type": "string" },
+                            "following_url": { "type": "string" },
+                            "gists_url": { "type": "string" },
+                            "starred_url": { "type": "string" },
+                            "subscriptions_url": { "type": "string" },
+                            "organizations_url": { "type": "string" },
+                            "repos_url": { "type": "string" },
+                            "events_url": { "type": "string" },
+                            "received_events_url": { "type": "string" },
+                            "type": { "type": "string" },
+                            "site_admin": { "type": "boolean" },
+                            "starred_at": {
+                              "type": "string",
+                              "format": "date-time"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "name": { "type": "string" },
+                    "description": { "type": ["string", "null"] },
+                    "external_url": { "type": "string" },
+                    "html_url": { "type": "string" },
+                    "created_at": { "type": "string", "format": "date-time" },
+                    "updated_at": { "type": "string", "format": "date-time" },
+                    "permissions": {
+                      "type": "object",
+                      "properties": {
+                        "issues": { "type": "string" },
+                        "checks": { "type": "string" },
+                        "metadata": { "type": "string" },
+                        "contents": { "type": "string" },
+                        "deployments": { "type": "string" }
+                      },
+                      "additionalProperties": true
+                    },
+                    "events": {
+                      "type": "array",
+                      "items": { "type": "string" }
+                    },
+                    "installations_count": { "type": "integer" },
+                    "client_id": { "type": "string" },
+                    "client_secret": { "type": "string" },
+                    "webhook_secret": { "type": ["string", "null"] },
+                    "pem": { "type": "string" }
+                  }
+                }
+              ]
+            }
+          },
+          "unassigned": {
+            "id": { "type": ["null", "integer"] },
+            "node_id": { "type": ["null", "string"] },
+            "url": { "type": ["null", "string"] },
+            "actor": {
+              "title": "Simple User",
+              "description": "A GitHub user.",
+              "type": ["null", "object"],
+              "properties": {
+                "name": { "type": ["string", "null"] },
+                "email": { "type": ["string", "null"] },
+                "login": { "type": "string" },
+                "id": { "type": "integer" },
+                "node_id": { "type": "string" },
+                "avatar_url": { "type": "string" },
+                "gravatar_id": { "type": ["string", "null"] },
+                "url": { "type": "string" },
+                "html_url": { "type": "string" },
+                "followers_url": { "type": "string" },
+                "following_url": { "type": "string" },
+                "gists_url": { "type": "string" },
+                "starred_url": { "type": "string" },
+                "subscriptions_url": { "type": "string" },
+                "organizations_url": { "type": "string" },
+                "repos_url": { "type": "string" },
+                "events_url": { "type": "string" },
+                "received_events_url": { "type": "string" },
+                "type": { "type": "string" },
+                "site_admin": { "type": "boolean" },
+                "starred_at": { "type": "string", "format": "date-time" }
+              }
+            },
+            "event": { "type": ["null", "string"] },
+            "commit_id": { "type": ["string", "null"] },
+            "commit_url": { "type": ["string", "null"] },
+            "created_at": { "type": ["null", "string"], "format": "date-time" },
+            "performed_via_github_app": {
+              "anyOf": [
+                { "type": "null" },
+                {
+                  "type": "object",
+                  "properties": {
+                    "id": { "type": "integer" },
+                    "slug": { "type": "string" },
+                    "node_id": { "type": "string" },
+                    "owner": {
+                      "anyOf": [
+                        { "type": "null" },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "name": { "type": ["string", "null"] },
+                            "email": { "type": ["string", "null"] },
+                            "login": { "type": "string" },
+                            "id": { "type": "integer" },
+                            "node_id": { "type": "string" },
+                            "avatar_url": { "type": "string" },
+                            "gravatar_id": { "type": ["string", "null"] },
+                            "url": { "type": "string" },
+                            "html_url": { "type": "string" },
+                            "followers_url": { "type": "string" },
+                            "following_url": { "type": "string" },
+                            "gists_url": { "type": "string" },
+                            "starred_url": { "type": "string" },
+                            "subscriptions_url": { "type": "string" },
+                            "organizations_url": { "type": "string" },
+                            "repos_url": { "type": "string" },
+                            "events_url": { "type": "string" },
+                            "received_events_url": { "type": "string" },
+                            "type": { "type": "string" },
+                            "site_admin": { "type": "boolean" },
+                            "starred_at": {
+                              "type": "string",
+                              "format": "date-time"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "name": { "type": "string" },
+                    "description": { "type": ["string", "null"] },
+                    "external_url": { "type": "string" },
+                    "html_url": { "type": "string" },
+                    "created_at": { "type": "string", "format": "date-time" },
+                    "updated_at": { "type": "string", "format": "date-time" },
+                    "permissions": {
+                      "type": "object",
+                      "properties": {
+                        "issues": { "type": "string" },
+                        "checks": { "type": "string" },
+                        "metadata": { "type": "string" },
+                        "contents": { "type": "string" },
+                        "deployments": { "type": "string" }
+                      },
+                      "additionalProperties": true
+                    },
+                    "events": {
+                      "type": "array",
+                      "items": { "type": "string" }
+                    },
+                    "installations_count": { "type": "integer" },
+                    "client_id": { "type": "string" },
+                    "client_secret": { "type": "string" },
+                    "webhook_secret": { "type": ["string", "null"] },
+                    "pem": { "type": "string" }
+                  }
+                }
+              ]
+            }
+          },
+          "state_change": {
+            "id": { "type": ["null", "integer"] },
+            "node_id": { "type": ["null", "string"] },
+            "url": { "type": ["null", "string"] },
+            "actor": {
+              "title": "Simple User",
+              "description": "A GitHub user.",
+              "type": ["null", "object"],
+              "properties": {
+                "name": { "type": ["string", "null"] },
+                "email": { "type": ["string", "null"] },
+                "login": { "type": "string" },
+                "id": { "type": "integer" },
+                "node_id": { "type": "string" },
+                "avatar_url": { "type": "string" },
+                "gravatar_id": { "type": ["string", "null"] },
+                "url": { "type": "string" },
+                "html_url": { "type": "string" },
+                "followers_url": { "type": "string" },
+                "following_url": { "type": "string" },
+                "gists_url": { "type": "string" },
+                "starred_url": { "type": "string" },
+                "subscriptions_url": { "type": "string" },
+                "organizations_url": { "type": "string" },
+                "repos_url": { "type": "string" },
+                "events_url": { "type": "string" },
+                "received_events_url": { "type": "string" },
+                "type": { "type": "string" },
+                "site_admin": { "type": "boolean" },
+                "starred_at": { "type": "string", "format": "date-time" }
+              }
+            },
+            "event": { "type": ["null", "string"] },
+            "commit_id": { "type": ["string", "null"] },
+            "commit_url": { "type": ["string", "null"] },
+            "created_at": { "type": ["null", "string"], "format": "date-time" },
+            "performed_via_github_app": {
+              "anyOf": [
+                { "type": "null" },
+                {
+                  "type": "object",
+                  "properties": {
+                    "id": { "type": "integer" },
+                    "slug": { "type": "string" },
+                    "node_id": { "type": "string" },
+                    "owner": {
+                      "anyOf": [
+                        { "type": "null" },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "name": { "type": ["string", "null"] },
+                            "email": { "type": ["string", "null"] },
+                            "login": { "type": "string" },
+                            "id": { "type": "integer" },
+                            "node_id": { "type": "string" },
+                            "avatar_url": { "type": "string" },
+                            "gravatar_id": { "type": ["string", "null"] },
+                            "url": { "type": "string" },
+                            "html_url": { "type": "string" },
+                            "followers_url": { "type": "string" },
+                            "following_url": { "type": "string" },
+                            "gists_url": { "type": "string" },
+                            "starred_url": { "type": "string" },
+                            "subscriptions_url": { "type": "string" },
+                            "organizations_url": { "type": "string" },
+                            "repos_url": { "type": "string" },
+                            "events_url": { "type": "string" },
+                            "received_events_url": { "type": "string" },
+                            "type": { "type": "string" },
+                            "site_admin": { "type": "boolean" },
+                            "starred_at": {
+                              "type": "string",
+                              "format": "date-time"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "name": { "type": "string" },
+                    "description": { "type": ["string", "null"] },
+                    "external_url": { "type": "string" },
+                    "html_url": { "type": "string" },
+                    "created_at": { "type": "string", "format": "date-time" },
+                    "updated_at": { "type": "string", "format": "date-time" },
+                    "permissions": {
+                      "type": "object",
+                      "properties": {
+                        "issues": { "type": "string" },
+                        "checks": { "type": "string" },
+                        "metadata": { "type": "string" },
+                        "contents": { "type": "string" },
+                        "deployments": { "type": "string" }
+                      },
+                      "additionalProperties": true
+                    },
+                    "events": {
+                      "type": "array",
+                      "items": { "type": "string" }
+                    },
+                    "installations_count": { "type": "integer" },
+                    "client_id": { "type": "string" },
+                    "client_secret": { "type": "string" },
+                    "webhook_secret": { "type": ["string", "null"] },
+                    "pem": { "type": "string" }
+                  }
+                }
+              ]
+            }
+          },
+          "connected": {
+            "id": { "type": ["null", "integer"] },
+            "node_id": { "type": ["null", "string"] },
+            "url": { "type": ["null", "string"] },
+            "actor": {
+              "title": "Simple User",
+              "description": "A GitHub user.",
+              "type": ["null", "object"],
+              "properties": {
+                "name": { "type": ["string", "null"] },
+                "email": { "type": ["string", "null"] },
+                "login": { "type": "string" },
+                "id": { "type": "integer" },
+                "node_id": { "type": "string" },
+                "avatar_url": { "type": "string" },
+                "gravatar_id": { "type": ["string", "null"] },
+                "url": { "type": "string" },
+                "html_url": { "type": "string" },
+                "followers_url": { "type": "string" },
+                "following_url": { "type": "string" },
+                "gists_url": { "type": "string" },
+                "starred_url": { "type": "string" },
+                "subscriptions_url": { "type": "string" },
+                "organizations_url": { "type": "string" },
+                "repos_url": { "type": "string" },
+                "events_url": { "type": "string" },
+                "received_events_url": { "type": "string" },
+                "type": { "type": "string" },
+                "site_admin": { "type": "boolean" },
+                "starred_at": { "type": "string", "format": "date-time" }
+              }
+            },
+            "event": { "type": ["null", "string"] },
+            "commit_id": { "type": ["string", "null"] },
+            "commit_url": { "type": ["string", "null"] },
+            "created_at": { "type": ["null", "string"], "format": "date-time" },
+            "performed_via_github_app": {
+              "anyOf": [
+                { "type": "null" },
+                {
+                  "type": "object",
+                  "properties": {
+                    "id": { "type": "integer" },
+                    "slug": { "type": "string" },
+                    "node_id": { "type": "string" },
+                    "owner": {
+                      "anyOf": [
+                        { "type": "null" },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "name": { "type": ["string", "null"] },
+                            "email": { "type": ["string", "null"] },
+                            "login": { "type": "string" },
+                            "id": { "type": "integer" },
+                            "node_id": { "type": "string" },
+                            "avatar_url": { "type": "string" },
+                            "gravatar_id": { "type": ["string", "null"] },
+                            "url": { "type": "string" },
+                            "html_url": { "type": "string" },
+                            "followers_url": { "type": "string" },
+                            "following_url": { "type": "string" },
+                            "gists_url": { "type": "string" },
+                            "starred_url": { "type": "string" },
+                            "subscriptions_url": { "type": "string" },
+                            "organizations_url": { "type": "string" },
+                            "repos_url": { "type": "string" },
+                            "events_url": { "type": "string" },
+                            "received_events_url": { "type": "string" },
+                            "type": { "type": "string" },
+                            "site_admin": { "type": "boolean" },
+                            "starred_at": {
+                              "type": "string",
+                              "format": "date-time"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "name": { "type": "string" },
+                    "description": { "type": ["string", "null"] },
+                    "external_url": { "type": "string" },
+                    "html_url": { "type": "string" },
+                    "created_at": { "type": "string", "format": "date-time" },
+                    "updated_at": { "type": "string", "format": "date-time" },
+                    "permissions": {
+                      "type": "object",
+                      "properties": {
+                        "issues": { "type": "string" },
+                        "checks": { "type": "string" },
+                        "metadata": { "type": "string" },
+                        "contents": { "type": "string" },
+                        "deployments": { "type": "string" }
+                      },
+                      "additionalProperties": true
+                    },
+                    "events": {
+                      "type": "array",
+                      "items": { "type": "string" }
+                    },
+                    "installations_count": { "type": "integer" },
+                    "client_id": { "type": "string" },
+                    "client_secret": { "type": "string" },
+                    "webhook_secret": { "type": ["string", "null"] },
+                    "pem": { "type": "string" }
+                  }
+                }
+              ]
+            }
+          },
+          "auto_squash_enabled": {
+            "id": { "type": ["null", "integer"] },
+            "node_id": { "type": ["null", "string"] },
+            "url": { "type": ["null", "string"] },
+            "actor": {
+              "title": "Simple User",
+              "description": "A GitHub user.",
+              "type": ["null", "object"],
+              "properties": {
+                "name": { "type": ["string", "null"] },
+                "email": { "type": ["string", "null"] },
+                "login": { "type": "string" },
+                "id": { "type": "integer" },
+                "node_id": { "type": "string" },
+                "avatar_url": { "type": "string" },
+                "gravatar_id": { "type": ["string", "null"] },
+                "url": { "type": "string" },
+                "html_url": { "type": "string" },
+                "followers_url": { "type": "string" },
+                "following_url": { "type": "string" },
+                "gists_url": { "type": "string" },
+                "starred_url": { "type": "string" },
+                "subscriptions_url": { "type": "string" },
+                "organizations_url": { "type": "string" },
+                "repos_url": { "type": "string" },
+                "events_url": { "type": "string" },
+                "received_events_url": { "type": "string" },
+                "type": { "type": "string" },
+                "site_admin": { "type": "boolean" },
+                "starred_at": { "type": "string", "format": "date-time" }
+              }
+            },
+            "event": { "type": ["null", "string"] },
+            "commit_id": { "type": ["string", "null"] },
+            "commit_url": { "type": ["string", "null"] },
+            "created_at": { "type": ["null", "string"], "format": "date-time" },
+            "performed_via_github_app": {
+              "anyOf": [
+                { "type": "null" },
+                {
+                  "type": "object",
+                  "properties": {
+                    "id": { "type": "integer" },
+                    "slug": { "type": "string" },
+                    "node_id": { "type": "string" },
+                    "owner": {
+                      "anyOf": [
+                        { "type": "null" },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "name": { "type": ["string", "null"] },
+                            "email": { "type": ["string", "null"] },
+                            "login": { "type": "string" },
+                            "id": { "type": "integer" },
+                            "node_id": { "type": "string" },
+                            "avatar_url": { "type": "string" },
+                            "gravatar_id": { "type": ["string", "null"] },
+                            "url": { "type": "string" },
+                            "html_url": { "type": "string" },
+                            "followers_url": { "type": "string" },
+                            "following_url": { "type": "string" },
+                            "gists_url": { "type": "string" },
+                            "starred_url": { "type": "string" },
+                            "subscriptions_url": { "type": "string" },
+                            "organizations_url": { "type": "string" },
+                            "repos_url": { "type": "string" },
+                            "events_url": { "type": "string" },
+                            "received_events_url": { "type": "string" },
+                            "type": { "type": "string" },
+                            "site_admin": { "type": "boolean" },
+                            "starred_at": {
+                              "type": "string",
+                              "format": "date-time"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "name": { "type": "string" },
+                    "description": { "type": ["string", "null"] },
+                    "external_url": { "type": "string" },
+                    "html_url": { "type": "string" },
+                    "created_at": { "type": "string", "format": "date-time" },
+                    "updated_at": { "type": "string", "format": "date-time" },
+                    "permissions": {
+                      "type": "object",
+                      "properties": {
+                        "issues": { "type": "string" },
+                        "checks": { "type": "string" },
+                        "metadata": { "type": "string" },
+                        "contents": { "type": "string" },
+                        "deployments": { "type": "string" }
+                      },
+                      "additionalProperties": true
+                    },
+                    "events": {
+                      "type": "array",
+                      "items": { "type": "string" }
+                    },
+                    "installations_count": { "type": "integer" },
+                    "client_id": { "type": "string" },
+                    "client_secret": { "type": "string" },
+                    "webhook_secret": { "type": ["string", "null"] },
+                    "pem": { "type": "string" }
+                  }
+                }
+              ]
+            }
+          },
+          "merged": {
+            "id": { "type": ["null", "integer"] },
+            "node_id": { "type": ["null", "string"] },
+            "url": { "type": ["null", "string"] },
+            "actor": {
+              "title": "Simple User",
+              "description": "A GitHub user.",
+              "type": ["null", "object"],
+              "properties": {
+                "name": { "type": ["string", "null"] },
+                "email": { "type": ["string", "null"] },
+                "login": { "type": "string" },
+                "id": { "type": "integer" },
+                "node_id": { "type": "string" },
+                "avatar_url": { "type": "string" },
+                "gravatar_id": { "type": ["string", "null"] },
+                "url": { "type": "string" },
+                "html_url": { "type": "string" },
+                "followers_url": { "type": "string" },
+                "following_url": { "type": "string" },
+                "gists_url": { "type": "string" },
+                "starred_url": { "type": "string" },
+                "subscriptions_url": { "type": "string" },
+                "organizations_url": { "type": "string" },
+                "repos_url": { "type": "string" },
+                "events_url": { "type": "string" },
+                "received_events_url": { "type": "string" },
+                "type": { "type": "string" },
+                "site_admin": { "type": "boolean" },
+                "starred_at": { "type": "string", "format": "date-time" }
+              }
+            },
+            "event": { "type": ["null", "string"] },
+            "commit_id": { "type": ["string", "null"] },
+            "commit_url": { "type": ["string", "null"] },
+            "created_at": { "type": ["null", "string"], "format": "date-time" },
+            "performed_via_github_app": {
+              "anyOf": [
+                { "type": "null" },
+                {
+                  "type": "object",
+                  "properties": {
+                    "id": { "type": "integer" },
+                    "slug": { "type": "string" },
+                    "node_id": { "type": "string" },
+                    "owner": {
+                      "anyOf": [
+                        { "type": "null" },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "name": { "type": ["string", "null"] },
+                            "email": { "type": ["string", "null"] },
+                            "login": { "type": "string" },
+                            "id": { "type": "integer" },
+                            "node_id": { "type": "string" },
+                            "avatar_url": { "type": "string" },
+                            "gravatar_id": { "type": ["string", "null"] },
+                            "url": { "type": "string" },
+                            "html_url": { "type": "string" },
+                            "followers_url": { "type": "string" },
+                            "following_url": { "type": "string" },
+                            "gists_url": { "type": "string" },
+                            "starred_url": { "type": "string" },
+                            "subscriptions_url": { "type": "string" },
+                            "organizations_url": { "type": "string" },
+                            "repos_url": { "type": "string" },
+                            "events_url": { "type": "string" },
+                            "received_events_url": { "type": "string" },
+                            "type": { "type": "string" },
+                            "site_admin": { "type": "boolean" },
+                            "starred_at": {
+                              "type": "string",
+                              "format": "date-time"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "name": { "type": "string" },
+                    "description": { "type": ["string", "null"] },
+                    "external_url": { "type": "string" },
+                    "html_url": { "type": "string" },
+                    "created_at": { "type": "string", "format": "date-time" },
+                    "updated_at": { "type": "string", "format": "date-time" },
+                    "permissions": {
+                      "type": "object",
+                      "properties": {
+                        "issues": { "type": "string" },
+                        "checks": { "type": "string" },
+                        "metadata": { "type": "string" },
+                        "contents": { "type": "string" },
+                        "deployments": { "type": "string" }
+                      },
+                      "additionalProperties": true
+                    },
+                    "events": {
+                      "type": "array",
+                      "items": { "type": "string" }
+                    },
+                    "installations_count": { "type": "integer" },
+                    "client_id": { "type": "string" },
+                    "client_secret": { "type": "string" },
+                    "webhook_secret": { "type": ["string", "null"] },
+                    "pem": { "type": "string" }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "source_defined_primary_key": [["repository"], ["issue_number"]],
+      "is_resumable": true
+    },
+    {
+      "name": "assignees",
+      "json_schema": {
+        "$schema": "https://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "repository": {
+            "description": "Repository where the assignee is assigned",
+            "type": "string"
+          },
+          "login": {
+            "description": "Username of the assignee",
+            "type": ["null", "string"]
+          },
+          "id": {
+            "description": "Unique identifier of the assignee",
+            "type": ["null", "integer"]
+          },
+          "node_id": {
+            "description": "Node ID of the assignee",
+            "type": ["null", "string"]
+          },
+          "avatar_url": {
+            "description": "URL of the assignee's avatar image",
+            "type": ["null", "string"]
+          },
+          "gravatar_id": {
+            "description": "Gravatar ID of the assignee",
+            "type": ["null", "string"]
+          },
+          "url": {
+            "description": "URL of the assignee's account",
+            "type": ["null", "string"]
+          },
+          "html_url": {
+            "description": "URL of the assignee's GitHub profile",
+            "type": ["null", "string"]
+          },
+          "followers_url": {
+            "description": "URL of the assignee's followers",
+            "type": ["null", "string"]
+          },
+          "following_url": {
+            "description": "URL of the assignee's following",
+            "type": ["null", "string"]
+          },
+          "gists_url": {
+            "description": "URL of the assignee's gists",
+            "type": ["null", "string"]
+          },
+          "starred_url": {
+            "description": "URL of the assignee's starred items",
+            "type": ["null", "string"]
+          },
+          "subscriptions_url": {
+            "description": "URL of the assignee's subscriptions",
+            "type": ["null", "string"]
+          },
+          "organizations_url": {
+            "description": "URL of the assignee's organizations",
+            "type": ["null", "string"]
+          },
+          "repos_url": {
+            "description": "URL of the assignee's repositories",
+            "type": ["null", "string"]
+          },
+          "events_url": {
+            "description": "URL of the assignee's events",
+            "type": ["null", "string"]
+          },
+          "received_events_url": {
+            "description": "URL of the assignee's received events",
+            "type": ["null", "string"]
+          },
+          "type": {
+            "description": "Type of the assignee's account",
+            "type": ["null", "string"]
+          },
+          "site_admin": {
+            "description": "Boolean indicating if the assignee is a site administrator",
+            "type": ["null", "boolean"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "branches",
+      "json_schema": {
+        "$schema": "https://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "repository": {
+            "description": "Details about the repository associated with the branch.",
+            "type": "string"
+          },
+          "name": {
+            "description": "The name of the branch.",
+            "type": ["null", "string"]
+          },
+          "commit": {
+            "description": "Details about the commit associated with the branch.",
+            "type": ["null", "object"],
+            "properties": {
+              "sha": {
+                "description": "The unique identifier of the commit.",
+                "type": ["null", "string"]
+              },
+              "url": {
+                "description": "The URL to view details of the commit.",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "protected": {
+            "description": "Indicates if the branch is protected.",
+            "type": ["null", "boolean"]
+          },
+          "protection": {
+            "description": "Details about the protection settings of the branch.",
+            "type": ["null", "object"],
+            "properties": {
+              "enabled": {
+                "description": "Indicates if protection is enabled for the branch.",
+                "type": ["null", "boolean"]
+              },
+              "required_status_checks": {
+                "description": "Settings for required status checks on the branch.",
+                "type": ["null", "object"],
+                "properties": {
+                  "enforcement_level": {
+                    "description": "Level of enforcement for required status checks.",
+                    "type": ["null", "string"]
+                  },
+                  "contexts": {
+                    "description": "List of contexts required for status checks to pass.",
+                    "type": ["null", "array"],
+                    "items": {
+                      "description": "Name of a context.",
+                      "type": ["null", "string"]
+                    }
+                  },
+                  "checks": {
+                    "description": "List of status checks that are required.",
+                    "type": ["null", "array"],
+                    "items": {
+                      "description": "Details about a specific status check.",
+                      "type": "object",
+                      "properties": {
+                        "context": {
+                          "description": "Context information of the status check.",
+                          "type": ["null", "string"]
+                        },
+                        "app_id": {
+                          "description": "ID of the application associated with the status check.",
+                          "type": ["null", "integer"]
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "protection_url": {
+            "description": "URL to manage protection settings for the branch.",
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "source_defined_primary_key": [["repository"], ["name"]],
+      "is_resumable": true
+    },
+    {
+      "name": "collaborators",
+      "json_schema": {
+        "$schema": "https://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "repository": {
+            "description": "Repository information related to the collaborator",
+            "type": "string"
+          },
+          "login": {
+            "description": "Username of the collaborator",
+            "type": ["null", "string"]
+          },
+          "id": {
+            "description": "Unique identifier of the collaborator",
+            "type": ["null", "integer"]
+          },
+          "node_id": {
+            "description": "Node ID of the collaborator",
+            "type": ["null", "string"]
+          },
+          "avatar_url": {
+            "description": "URL of the collaborator's avatar image",
+            "type": ["null", "string"]
+          },
+          "gravatar_id": {
+            "description": "Gravatar ID of the collaborator",
+            "type": ["null", "string"]
+          },
+          "url": {
+            "description": "URL of the collaborator's GitHub API endpoint",
+            "type": ["null", "string"]
+          },
+          "html_url": {
+            "description": "HTML URL of the collaborator's profile",
+            "type": ["null", "string"]
+          },
+          "followers_url": {
+            "description": "URL of the followers of the collaborator",
+            "type": ["null", "string"]
+          },
+          "following_url": {
+            "description": "URL of the users followed by the collaborator",
+            "type": ["null", "string"]
+          },
+          "gists_url": {
+            "description": "URL of gists created by the collaborator",
+            "type": ["null", "string"]
+          },
+          "starred_url": {
+            "description": "URL of the repositories starred by the collaborator",
+            "type": ["null", "string"]
+          },
+          "subscriptions_url": {
+            "description": "URL of the repositories subscribed to by the collaborator",
+            "type": ["null", "string"]
+          },
+          "organizations_url": {
+            "description": "URL of organizations the collaborator is associated with",
+            "type": ["null", "string"]
+          },
+          "repos_url": {
+            "description": "URL of the repositories of the collaborator",
+            "type": ["null", "string"]
+          },
+          "events_url": {
+            "description": "URL of the events related to the collaborator",
+            "type": ["null", "string"]
+          },
+          "received_events_url": {
+            "description": "URL of events received by the collaborator",
+            "type": ["null", "string"]
+          },
+          "type": {
+            "description": "Type of the collaborator (e.g., User)",
+            "type": ["null", "string"]
+          },
+          "site_admin": {
+            "description": "Indicates if the collaborator is a site administrator",
+            "type": ["null", "boolean"]
+          },
+          "role_name": {
+            "description": "Name of the collaborator's role",
+            "type": ["null", "string"]
+          },
+          "permissions": {
+            "description": "The permissions assigned to the collaborators",
+            "type": ["null", "object"],
+            "properties": {
+              "admin": {
+                "description": "Indicates if the collaborator has admin access",
+                "type": ["null", "boolean"]
+              },
+              "maintain": {
+                "description": "Indicates if the collaborator has maintain access",
+                "type": ["null", "boolean"]
+              },
+              "push": {
+                "description": "Indicates if the collaborator has push access",
+                "type": ["null", "boolean"]
+              },
+              "pull": {
+                "description": "Indicates if the collaborator has pull access",
+                "type": ["null", "boolean"]
+              },
+              "triage": {
+                "description": "Indicates if the collaborator has triage access",
+                "type": ["null", "boolean"]
+              }
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "comments",
+      "json_schema": {
+        "$schema": "https://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "repository": {
+            "description": "Details about the repository to which the comment belongs",
+            "type": "string"
+          },
+          "id": {
+            "description": "The unique identifier of the comment",
+            "type": ["null", "integer"]
+          },
+          "node_id": {
+            "description": "The unique identifier of the node",
+            "type": ["null", "string"]
+          },
+          "user": {
+            "type": ["null", "object"],
+            "properties": {
+              "login": { "type": ["null", "string"] },
+              "id": { "type": ["null", "integer"] },
+              "node_id": { "type": ["null", "string"] },
+              "avatar_url": { "type": ["null", "string"] },
+              "gravatar_id": { "type": ["null", "string"] },
+              "url": { "type": ["null", "string"] },
+              "html_url": { "type": ["null", "string"] },
+              "followers_url": { "type": ["null", "string"] },
+              "following_url": { "type": ["null", "string"] },
+              "gists_url": { "type": ["null", "string"] },
+              "starred_url": { "type": ["null", "string"] },
+              "subscriptions_url": { "type": ["null", "string"] },
+              "organizations_url": { "type": ["null", "string"] },
+              "repos_url": { "type": ["null", "string"] },
+              "events_url": { "type": ["null", "string"] },
+              "received_events_url": { "type": ["null", "string"] },
+              "type": { "type": ["null", "string"] },
+              "site_admin": { "type": ["null", "boolean"] }
+            }
+          },
+          "url": {
+            "description": "The URL of the comment",
+            "type": ["null", "string"]
+          },
+          "html_url": {
+            "description": "The URL of the comment on GitHub",
+            "type": ["null", "string"]
+          },
+          "body": {
+            "description": "The content of the comment",
+            "type": ["null", "string"]
+          },
+          "user_id": {
+            "description": "The unique identifier of the user",
+            "type": ["null", "integer"]
+          },
+          "created_at": {
+            "description": "The date and time the comment was created",
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "description": "The date and time the comment was last updated",
+            "type": "string",
+            "format": "date-time"
+          },
+          "issue_url": {
+            "description": "The URL of the issue to which the comment belongs",
+            "type": ["null", "string"]
+          },
+          "author_association": {
+            "description": "The association of the comment author to the repository (e.g., owner, member, collaborator, contributor, etc.)",
+            "type": ["null", "string"]
+          },
+          "reactions": {
+            "type": ["null", "object"],
+            "properties": {
+              "url": { "type": ["null", "string"] },
+              "total_count": { "type": ["null", "integer"] },
+              "+1": { "type": ["null", "integer"] },
+              "-1": { "type": ["null", "integer"] },
+              "laugh": { "type": ["null", "integer"] },
+              "hooray": { "type": ["null", "integer"] },
+              "confused": { "type": ["null", "integer"] },
+              "heart": { "type": ["null", "integer"] },
+              "rocket": { "type": ["null", "integer"] },
+              "eyes": { "type": ["null", "integer"] }
+            }
+          },
+          "performed_via_github_app": {
+            "description": "Details about the GitHub App that performed the action",
+            "type": ["null", "object"],
+            "properties": {
+              "id": {
+                "description": "The unique identifier of the GitHub App",
+                "type": ["null", "integer"]
+              },
+              "slug": {
+                "description": "The slug associated with the GitHub App",
+                "type": ["null", "string"]
+              },
+              "node_id": {
+                "description": "The unique identifier of the node for the GitHub App",
+                "type": ["null", "string"]
+              },
+              "owner": {
+                "type": ["null", "object"],
+                "properties": {
+                  "login": { "type": ["null", "string"] },
+                  "id": { "type": ["null", "integer"] },
+                  "node_id": { "type": ["null", "string"] },
+                  "avatar_url": { "type": ["null", "string"] },
+                  "gravatar_id": { "type": ["null", "string"] },
+                  "url": { "type": ["null", "string"] },
+                  "html_url": { "type": ["null", "string"] },
+                  "followers_url": { "type": ["null", "string"] },
+                  "following_url": { "type": ["null", "string"] },
+                  "gists_url": { "type": ["null", "string"] },
+                  "starred_url": { "type": ["null", "string"] },
+                  "subscriptions_url": { "type": ["null", "string"] },
+                  "organizations_url": { "type": ["null", "string"] },
+                  "repos_url": { "type": ["null", "string"] },
+                  "events_url": { "type": ["null", "string"] },
+                  "received_events_url": { "type": ["null", "string"] },
+                  "type": { "type": ["null", "string"] },
+                  "site_admin": { "type": ["null", "boolean"] }
+                }
+              },
+              "name": {
+                "description": "The name of the GitHub App",
+                "type": ["null", "string"]
+              },
+              "description": {
+                "description": "A description of the GitHub App",
+                "type": ["null", "string"]
+              },
+              "external_url": {
+                "description": "The external URL of the GitHub App",
+                "type": ["null", "string"]
+              },
+              "html_url": {
+                "description": "The HTML URL of the GitHub App",
+                "type": ["null", "string"]
+              },
+              "created_at": {
+                "description": "The date and time the GitHub App was created",
+                "type": "string",
+                "format": "date-time"
+              },
+              "updated_at": {
+                "description": "The date and time the GitHub App was last updated",
+                "type": "string",
+                "format": "date-time"
+              },
+              "permissions": {
+                "description": "Permissions granted to the GitHub App",
+                "type": "object",
+                "properties": {
+                  "issues": {
+                    "description": "Permission for accessing issues",
+                    "type": ["null", "string"]
+                  },
+                  "metadata": {
+                    "description": "Permission for accessing metadata",
+                    "type": ["null", "string"]
+                  },
+                  "pull_requests": {
+                    "description": "Permission for accessing pull requests",
+                    "type": ["null", "string"]
+                  }
+                }
+              },
+              "events": {
+                "description": "Events associated with the GitHub App",
+                "type": "array",
+                "items": { "type": ["null", "string"] }
+              }
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated_at"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "commit_comment_reactions",
+      "json_schema": {
+        "type": ["null", "object"],
+        "properties": {
+          "id": { "type": ["null", "integer"] },
+          "node_id": { "type": ["null", "string"] },
+          "content": { "type": ["null", "string"] },
+          "created_at": { "type": "string", "format": "date-time" },
+          "user": {
+            "type": ["null", "object"],
+            "properties": {
+              "login": { "type": ["null", "string"] },
+              "id": { "type": ["null", "integer"] },
+              "node_id": { "type": ["null", "string"] },
+              "avatar_url": { "type": ["null", "string"] },
+              "gravatar_id": { "type": ["null", "string"] },
+              "url": { "type": ["null", "string"] },
+              "html_url": { "type": ["null", "string"] },
+              "followers_url": { "type": ["null", "string"] },
+              "following_url": { "type": ["null", "string"] },
+              "gists_url": { "type": ["null", "string"] },
+              "starred_url": { "type": ["null", "string"] },
+              "subscriptions_url": { "type": ["null", "string"] },
+              "organizations_url": { "type": ["null", "string"] },
+              "repos_url": { "type": ["null", "string"] },
+              "events_url": { "type": ["null", "string"] },
+              "received_events_url": { "type": ["null", "string"] },
+              "type": { "type": ["null", "string"] },
+              "site_admin": { "type": ["null", "boolean"] }
+            }
+          },
+          "repository": { "type": "string" },
+          "comment_id": { "type": "integer" }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["created_at"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "commit_comments",
+      "json_schema": {
+        "$schema": "https://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "repository": {
+            "description": "Details of the repository to which the comment belongs",
+            "type": "string"
+          },
+          "html_url": {
+            "description": "The URL to view the comment on GitHub's web interface",
+            "type": ["null", "string"]
+          },
+          "url": {
+            "description": "The API URL to fetch the details of the comment",
+            "type": ["null", "string"]
+          },
+          "id": {
+            "description": "The unique identifier of the comment",
+            "type": ["null", "integer"]
+          },
+          "node_id": {
+            "description": "The globally unique identifier for the comment",
+            "type": ["null", "string"]
+          },
+          "body": {
+            "description": "The content of the comment",
+            "type": ["null", "string"]
+          },
+          "path": {
+            "description": "The file path to which the comment is associated",
+            "type": ["null", "string"]
+          },
+          "position": {
+            "description": "The position in the file at which the comment is located",
+            "type": ["null", "integer"]
+          },
+          "line": {
+            "description": "The line number in the file at which the comment is located",
+            "type": ["null", "integer"]
+          },
+          "commit_id": {
+            "description": "The identifier of the commit to which the comment is associated",
+            "type": ["null", "string"]
+          },
+          "user": {
+            "type": ["null", "object"],
+            "properties": {
+              "login": { "type": ["null", "string"] },
+              "id": { "type": ["null", "integer"] },
+              "node_id": { "type": ["null", "string"] },
+              "avatar_url": { "type": ["null", "string"] },
+              "gravatar_id": { "type": ["null", "string"] },
+              "url": { "type": ["null", "string"] },
+              "html_url": { "type": ["null", "string"] },
+              "followers_url": { "type": ["null", "string"] },
+              "following_url": { "type": ["null", "string"] },
+              "gists_url": { "type": ["null", "string"] },
+              "starred_url": { "type": ["null", "string"] },
+              "subscriptions_url": { "type": ["null", "string"] },
+              "organizations_url": { "type": ["null", "string"] },
+              "repos_url": { "type": ["null", "string"] },
+              "events_url": { "type": ["null", "string"] },
+              "received_events_url": { "type": ["null", "string"] },
+              "type": { "type": ["null", "string"] },
+              "site_admin": { "type": ["null", "boolean"] }
+            }
+          },
+          "created_at": {
+            "description": "The date and time when the comment was created",
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "description": "The date and time when the comment was last updated",
+            "type": "string",
+            "format": "date-time"
+          },
+          "author_association": {
+            "description": "The association of the user who made the comment with the repository (e.g., owner, collaborator, member, contributor)",
+            "type": ["null", "string"]
+          },
+          "reactions": {
+            "type": ["null", "object"],
+            "properties": {
+              "url": { "type": ["null", "string"] },
+              "total_count": { "type": ["null", "integer"] },
+              "+1": { "type": ["null", "integer"] },
+              "-1": { "type": ["null", "integer"] },
+              "laugh": { "type": ["null", "integer"] },
+              "hooray": { "type": ["null", "integer"] },
+              "confused": { "type": ["null", "integer"] },
+              "heart": { "type": ["null", "integer"] },
+              "rocket": { "type": ["null", "integer"] },
+              "eyes": { "type": ["null", "integer"] }
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated_at"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "commits",
+      "json_schema": {
+        "$schema": "https://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "repository": {
+            "description": "The repository where the commit was made.",
+            "type": "string"
+          },
+          "branch": {
+            "description": "The branch name where the commit was made.",
+            "type": ["null", "string"]
+          },
+          "created_at": {
+            "description": "The creation date and time of the commit.",
+            "type": "string",
+            "format": "date-time"
+          },
+          "url": {
+            "description": "URL for accessing the commit data.",
+            "type": ["null", "string"]
+          },
+          "sha": {
+            "description": "The SHA of the commit.",
+            "type": ["null", "string"]
+          },
+          "node_id": {
+            "description": "The unique identifier of the commit node.",
+            "type": ["null", "string"]
+          },
+          "html_url": {
+            "description": "URL for viewing the commit on GitHub.",
+            "type": ["null", "string"]
+          },
+          "comments_url": {
+            "description": "URL for accessing comments on the commit.",
+            "type": ["null", "string"]
+          },
+          "commit": {
+            "description": "Information about the commit including author, committer, tree, and verification details.",
+            "type": ["null", "object"],
+            "properties": {
+              "author": {
+                "description": "Information about the author of the commit.",
+                "type": ["null", "object"],
+                "properties": {
+                  "name": {
+                    "description": "Name of the author of the commit.",
+                    "type": ["null", "string"]
+                  },
+                  "email": {
+                    "description": "Email of the author of the commit.",
+                    "type": ["null", "string"]
+                  },
+                  "date": {
+                    "description": "The date and time of the commit authored.",
+                    "type": "string",
+                    "format": "date-time"
+                  }
+                }
+              },
+              "committer": {
+                "description": "Information about the committer who applied the commit.",
+                "type": ["null", "object"],
+                "properties": {
+                  "name": {
+                    "description": "Name of the committer of the commit.",
+                    "type": ["null", "string"]
+                  },
+                  "email": {
+                    "description": "Email of the committer of the commit.",
+                    "type": ["null", "string"]
+                  },
+                  "date": {
+                    "description": "The date and time of the commit committed.",
+                    "type": "string",
+                    "format": "date-time"
+                  }
+                }
+              },
+              "message": {
+                "description": "The commit message.",
+                "type": ["null", "string"]
+              },
+              "tree": {
+                "description": "Details about the tree object associated with the commit.",
+                "type": ["null", "object"],
+                "properties": {
+                  "sha": {
+                    "description": "SHA of the commit tree.",
+                    "type": ["null", "string"]
+                  },
+                  "url": {
+                    "description": "URL for accessing the commit tree.",
+                    "type": ["null", "string"]
+                  }
+                }
+              },
+              "url": {
+                "description": "URL for accessing the commit details.",
+                "type": ["null", "string"]
+              },
+              "comment_count": {
+                "description": "Number of comments on the commit.",
+                "type": ["null", "integer"]
+              },
+              "verification": {
+                "description": "Verification status of the commit.",
+                "type": ["null", "object"],
+                "properties": {
+                  "verified": {
+                    "description": "Indicates if the commit is verified.",
+                    "type": ["null", "boolean"]
+                  },
+                  "reason": {
+                    "description": "Reason for the verification result.",
+                    "type": ["null", "string"]
+                  },
+                  "signature": {
+                    "description": "The signature used for verification.",
+                    "type": ["null", "string"]
+                  },
+                  "payload": {
+                    "description": "The payload used for verification.",
+                    "type": ["null", "string"]
+                  }
+                }
+              }
+            }
+          },
+          "author": {
+            "type": ["null", "object"],
+            "properties": {
+              "login": { "type": ["null", "string"] },
+              "id": { "type": ["null", "integer"] },
+              "node_id": { "type": ["null", "string"] },
+              "avatar_url": { "type": ["null", "string"] },
+              "gravatar_id": { "type": ["null", "string"] },
+              "url": { "type": ["null", "string"] },
+              "html_url": { "type": ["null", "string"] },
+              "followers_url": { "type": ["null", "string"] },
+              "following_url": { "type": ["null", "string"] },
+              "gists_url": { "type": ["null", "string"] },
+              "starred_url": { "type": ["null", "string"] },
+              "subscriptions_url": { "type": ["null", "string"] },
+              "organizations_url": { "type": ["null", "string"] },
+              "repos_url": { "type": ["null", "string"] },
+              "events_url": { "type": ["null", "string"] },
+              "received_events_url": { "type": ["null", "string"] },
+              "type": { "type": ["null", "string"] },
+              "site_admin": { "type": ["null", "boolean"] }
+            }
+          },
+          "committer": {
+            "type": ["null", "object"],
+            "properties": {
+              "login": { "type": ["null", "string"] },
+              "id": { "type": ["null", "integer"] },
+              "node_id": { "type": ["null", "string"] },
+              "avatar_url": { "type": ["null", "string"] },
+              "gravatar_id": { "type": ["null", "string"] },
+              "url": { "type": ["null", "string"] },
+              "html_url": { "type": ["null", "string"] },
+              "followers_url": { "type": ["null", "string"] },
+              "following_url": { "type": ["null", "string"] },
+              "gists_url": { "type": ["null", "string"] },
+              "starred_url": { "type": ["null", "string"] },
+              "subscriptions_url": { "type": ["null", "string"] },
+              "organizations_url": { "type": ["null", "string"] },
+              "repos_url": { "type": ["null", "string"] },
+              "events_url": { "type": ["null", "string"] },
+              "received_events_url": { "type": ["null", "string"] },
+              "type": { "type": ["null", "string"] },
+              "site_admin": { "type": ["null", "boolean"] }
+            }
+          },
+          "parents": {
+            "description": "List of parent commits of the current commit.",
+            "type": ["null", "array"],
+            "items": {
+              "description": "Details about each parent commit.",
+              "type": ["null", "object"],
+              "properties": {
+                "sha": {
+                  "description": "SHA of the parent commit.",
+                  "type": ["null", "string"]
+                },
+                "url": {
+                  "description": "URL for accessing the parent commit details.",
+                  "type": ["null", "string"]
+                },
+                "html_url": {
+                  "description": "URL for viewing the parent commit on GitHub.",
+                  "type": ["null", "string"]
+                }
+              }
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["created_at"],
+      "source_defined_primary_key": [["sha"]],
+      "is_resumable": true
+    },
+    {
+      "name": "contributor_activity",
+      "json_schema": {
+        "$schema": "https://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "title": "Contributor Activity",
+        "properties": {
+          "name": {
+            "description": "Name of the contributor",
+            "type": ["null", "string"]
+          },
+          "email": {
+            "description": "Email address of the contributor",
+            "type": ["string", "null"]
+          },
+          "login": {
+            "description": "GitHub username of the contributor",
+            "type": ["null", "string"]
+          },
+          "id": {
+            "description": "Unique identifier for the contributor",
+            "type": ["null", "integer"]
+          },
+          "node_id": {
+            "description": "Node ID of the contributor",
+            "type": ["null", "string"]
+          },
+          "avatar_url": {
+            "description": "URL of the contributor's avatar image",
+            "type": ["null", "string"],
+            "format": "uri"
+          },
+          "gravatar_id": {
+            "description": "ID associated with the contributor's Gravatar image",
+            "type": ["string", "null"]
+          },
+          "url": {
+            "description": "URL of the contributor's profile",
+            "type": ["null", "string"],
+            "format": "uri"
+          },
+          "html_url": {
+            "description": "URL of the contributor's profile page on GitHub",
+            "type": ["null", "string"],
+            "format": "uri"
+          },
+          "followers_url": {
+            "description": "URL of the contributor's followers",
+            "type": ["null", "string"],
+            "format": "uri"
+          },
+          "following_url": {
+            "description": "URL of the contributor's following",
+            "type": ["null", "string"]
+          },
+          "gists_url": {
+            "description": "URL of the contributor's gists",
+            "type": ["null", "string"]
+          },
+          "starred_url": {
+            "description": "URL of the starred repository",
+            "type": ["null", "string"]
+          },
+          "subscriptions_url": {
+            "description": "URL of the contributor's subscriptions",
+            "type": ["null", "string"],
+            "format": "uri"
+          },
+          "organizations_url": {
+            "description": "URL of the contributor's organizations",
+            "type": ["null", "string"],
+            "format": "uri"
+          },
+          "repos_url": {
+            "description": "URL of the contributor's repositories",
+            "type": ["null", "string"],
+            "format": "uri"
+          },
+          "events_url": {
+            "description": "URL of the contributor's events",
+            "type": ["null", "string"]
+          },
+          "repository": {
+            "description": "Repository the contributor is associated with",
+            "type": ["null", "string"]
+          },
+          "received_events_url": {
+            "description": "URL of the events received by the contributor",
+            "type": ["null", "string"],
+            "format": "uri"
+          },
+          "type": {
+            "description": "Type of the contributor (e.g., User, Organization)",
+            "type": ["null", "string"]
+          },
+          "site_admin": {
+            "description": "Boolean value indicating if the contributor is a site admin",
+            "type": ["null", "boolean"]
+          },
+          "starred_at": {
+            "description": "Date and time when the repository was starred by the contributor",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "total": {
+            "description": "Total activity count of the contributor",
+            "type": ["null", "integer"]
+          },
+          "weeks": {
+            "description": "Activity data of the contributor per week",
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "w": {
+                  "description": "Start of the week represented as a Unix timestamp",
+                  "type": ["null", "integer"]
+                },
+                "a": {
+                  "description": "Number of additions made by the contributor",
+                  "type": ["null", "integer"]
+                },
+                "d": {
+                  "description": "Number of deletions made by the contributor",
+                  "type": ["null", "integer"]
+                },
+                "c": {
+                  "description": "Number of commits made by the contributor",
+                  "type": ["null", "integer"]
+                }
+              }
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "deployments",
+      "json_schema": {
+        "$schema": "https://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "url": {
+            "description": "URL to access more details about the deployment.",
+            "type": ["null", "string"]
+          },
+          "id": {
+            "description": "Unique identifier for the deployment.",
+            "type": ["null", "integer"]
+          },
+          "node_id": {
+            "description": "Node identifier for the deployment.",
+            "type": ["null", "string"]
+          },
+          "task": {
+            "description": "Indicates the type of task being performed in the deployment.",
+            "type": ["null", "string"]
+          },
+          "original_environment": {
+            "description": "Original environment name before promotion or changes.",
+            "type": ["null", "string"]
+          },
+          "environment": {
+            "description": "The deployment environment (e.g., staging, production).",
+            "type": ["null", "string"]
+          },
+          "description": {
+            "description": "Description provided for the deployment.",
+            "type": ["null", "string"]
+          },
+          "created_at": {
+            "description": "The timestamp when the deployment was created.",
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "description": "The timestamp when the deployment was last updated.",
+            "type": "string",
+            "format": "date-time"
+          },
+          "statuses_url": {
+            "description": "URL to retrieve the statuses of the deployment.",
+            "type": ["null", "string"]
+          },
+          "repository_url": {
+            "description": "URL of the repository where the deployment originated.",
+            "type": ["null", "string"]
+          },
+          "creator": {
+            "type": ["null", "object"],
+            "properties": {
+              "login": { "type": ["null", "string"] },
+              "id": { "type": ["null", "integer"] },
+              "node_id": { "type": ["null", "string"] },
+              "avatar_url": { "type": ["null", "string"] },
+              "gravatar_id": { "type": ["null", "string"] },
+              "url": { "type": ["null", "string"] },
+              "html_url": { "type": ["null", "string"] },
+              "followers_url": { "type": ["null", "string"] },
+              "following_url": { "type": ["null", "string"] },
+              "gists_url": { "type": ["null", "string"] },
+              "starred_url": { "type": ["null", "string"] },
+              "subscriptions_url": { "type": ["null", "string"] },
+              "organizations_url": { "type": ["null", "string"] },
+              "repos_url": { "type": ["null", "string"] },
+              "events_url": { "type": ["null", "string"] },
+              "received_events_url": { "type": ["null", "string"] },
+              "type": { "type": ["null", "string"] },
+              "site_admin": { "type": ["null", "boolean"] }
+            }
+          },
+          "sha": {
+            "description": "The SHA hash of the deployment.",
+            "type": ["null", "string"]
+          },
+          "ref": {
+            "description": "The Git ref that was deployed.",
+            "type": ["null", "string"]
+          },
+          "payload": {
+            "description": "Additional information or data associated with the deployment.",
+            "oneOf": [
+              {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": true
+              },
+              { "type": "string" },
+              { "type": "null" }
+            ]
+          },
+          "transient_environment": {
+            "description": "Indicates if the environment is temporary or not persistent.",
+            "type": ["null", "boolean"]
+          },
+          "production_environment": {
+            "description": "Indicates if the deployment is in a production environment.",
+            "type": ["null", "boolean"]
+          },
+          "performed_via_github_app": {
+            "description": "Indicates if the deployment was performed via a GitHub App.",
+            "type": ["null", "string"]
+          },
+          "repository": {
+            "description": "Details about the repository where the deployment originated.",
+            "type": "string"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated_at"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "events",
+      "json_schema": {
+        "$schema": "https://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "repository": {
+            "description": "Deprecated. Use 'repo' field instead.",
+            "type": "string"
+          },
+          "type": {
+            "description": "Type of event that occurred.",
+            "type": ["null", "string"]
+          },
+          "public": {
+            "description": "Indicates whether the event is public or not.",
+            "type": ["null", "boolean"]
+          },
+          "payload": {
+            "description": "Additional event-specific data.",
+            "type": ["null", "object"],
+            "properties": {}
+          },
+          "repo": {
+            "description": "Information about the repository where the event occurred.",
+            "type": ["null", "object"],
+            "properties": {
+              "id": {
+                "description": "Unique identifier for the repository.",
+                "type": ["null", "integer"]
+              },
+              "name": {
+                "description": "Name of the repository.",
+                "type": ["null", "string"]
+              },
+              "url": {
+                "description": "URL of the repository.",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "actor": {
+            "type": ["null", "object"],
+            "properties": {
+              "login": { "type": ["null", "string"] },
+              "id": { "type": ["null", "integer"] },
+              "node_id": { "type": ["null", "string"] },
+              "avatar_url": { "type": ["null", "string"] },
+              "gravatar_id": { "type": ["null", "string"] },
+              "url": { "type": ["null", "string"] },
+              "html_url": { "type": ["null", "string"] },
+              "followers_url": { "type": ["null", "string"] },
+              "following_url": { "type": ["null", "string"] },
+              "gists_url": { "type": ["null", "string"] },
+              "starred_url": { "type": ["null", "string"] },
+              "subscriptions_url": { "type": ["null", "string"] },
+              "organizations_url": { "type": ["null", "string"] },
+              "repos_url": { "type": ["null", "string"] },
+              "events_url": { "type": ["null", "string"] },
+              "received_events_url": { "type": ["null", "string"] },
+              "type": { "type": ["null", "string"] },
+              "site_admin": { "type": ["null", "boolean"] }
+            }
+          },
+          "org": {
+            "description": "Information about the organization associated with the event.",
+            "type": ["null", "object"],
+            "properties": {
+              "id": {
+                "description": "Unique identifier for the organization.",
+                "type": ["null", "integer"]
+              },
+              "login": {
+                "description": "Login of the organization.",
+                "type": ["null", "string"]
+              },
+              "gravatar_id": {
+                "description": "Gravatar ID of the organization.",
+                "type": ["null", "string"]
+              },
+              "url": {
+                "description": "URL of the organization.",
+                "type": ["null", "string"]
+              },
+              "avatar_url": {
+                "description": "URL of the organization's avatar.",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "created_at": {
+            "description": "The timestamp when the event occurred.",
+            "type": "string",
+            "format": "date-time"
+          },
+          "id": {
+            "description": "Unique identifier for the event.",
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["created_at"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "issue_comment_reactions",
+      "json_schema": {
+        "type": ["null", "object"],
+        "properties": {
+          "id": { "type": ["null", "integer"] },
+          "node_id": { "type": ["null", "string"] },
+          "content": { "type": ["null", "string"] },
+          "created_at": { "type": "string", "format": "date-time" },
+          "user": {
+            "type": ["null", "object"],
+            "properties": {
+              "login": { "type": ["null", "string"] },
+              "id": { "type": ["null", "integer"] },
+              "node_id": { "type": ["null", "string"] },
+              "avatar_url": { "type": ["null", "string"] },
+              "gravatar_id": { "type": ["null", "string"] },
+              "url": { "type": ["null", "string"] },
+              "html_url": { "type": ["null", "string"] },
+              "followers_url": { "type": ["null", "string"] },
+              "following_url": { "type": ["null", "string"] },
+              "gists_url": { "type": ["null", "string"] },
+              "starred_url": { "type": ["null", "string"] },
+              "subscriptions_url": { "type": ["null", "string"] },
+              "organizations_url": { "type": ["null", "string"] },
+              "repos_url": { "type": ["null", "string"] },
+              "events_url": { "type": ["null", "string"] },
+              "received_events_url": { "type": ["null", "string"] },
+              "type": { "type": ["null", "string"] },
+              "site_admin": { "type": ["null", "boolean"] }
+            }
+          },
+          "repository": { "type": "string" },
+          "comment_id": { "type": "integer" }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["created_at"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "issue_events",
+      "json_schema": {
+        "$schema": "https://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "repository": {
+            "description": "Details about a repository",
+            "type": "string"
+          },
+          "id": {
+            "description": "The unique ID of the event",
+            "type": ["null", "integer"]
+          },
+          "node_id": {
+            "description": "The unique node ID of the event",
+            "type": ["null", "string"]
+          },
+          "url": {
+            "description": "The URL of the event",
+            "type": ["null", "string"]
+          },
+          "actor": {
+            "type": ["null", "object"],
+            "properties": {
+              "login": { "type": ["null", "string"] },
+              "id": { "type": ["null", "integer"] },
+              "node_id": { "type": ["null", "string"] },
+              "avatar_url": { "type": ["null", "string"] },
+              "gravatar_id": { "type": ["null", "string"] },
+              "url": { "type": ["null", "string"] },
+              "html_url": { "type": ["null", "string"] },
+              "followers_url": { "type": ["null", "string"] },
+              "following_url": { "type": ["null", "string"] },
+              "gists_url": { "type": ["null", "string"] },
+              "starred_url": { "type": ["null", "string"] },
+              "subscriptions_url": { "type": ["null", "string"] },
+              "organizations_url": { "type": ["null", "string"] },
+              "repos_url": { "type": ["null", "string"] },
+              "events_url": { "type": ["null", "string"] },
+              "received_events_url": { "type": ["null", "string"] },
+              "type": { "type": ["null", "string"] },
+              "site_admin": { "type": ["null", "boolean"] }
+            }
+          },
+          "event": {
+            "description": "The type of event that occurred",
+            "type": ["null", "string"]
+          },
+          "commit_id": {
+            "description": "The ID of the commit related to the event",
+            "type": ["null", "string"]
+          },
+          "commit_url": {
+            "description": "The URL to the commit related to the event",
+            "type": ["null", "string"]
+          },
+          "created_at": {
+            "description": "The timestamp when the event was created",
+            "type": "string",
+            "format": "date-time"
+          },
+          "state_reason": {
+            "description": "The reason associated with the change in state of the issue event.",
+            "type": ["null", "string"]
+          },
+          "label": {
+            "description": "Details about a label",
+            "type": ["null", "object"],
+            "properties": {
+              "name": { "type": ["null", "string"] },
+              "color": { "type": ["null", "string"] }
+            }
+          },
+          "review_requester": {
+            "type": ["null", "object"],
+            "properties": {
+              "login": { "type": ["null", "string"] },
+              "id": { "type": ["null", "integer"] },
+              "node_id": { "type": ["null", "string"] },
+              "avatar_url": { "type": ["null", "string"] },
+              "gravatar_id": { "type": ["null", "string"] },
+              "url": { "type": ["null", "string"] },
+              "html_url": { "type": ["null", "string"] },
+              "followers_url": { "type": ["null", "string"] },
+              "following_url": { "type": ["null", "string"] },
+              "gists_url": { "type": ["null", "string"] },
+              "starred_url": { "type": ["null", "string"] },
+              "subscriptions_url": { "type": ["null", "string"] },
+              "organizations_url": { "type": ["null", "string"] },
+              "repos_url": { "type": ["null", "string"] },
+              "events_url": { "type": ["null", "string"] },
+              "received_events_url": { "type": ["null", "string"] },
+              "type": { "type": ["null", "string"] },
+              "site_admin": { "type": ["null", "boolean"] }
+            }
+          },
+          "issue": {
+            "description": "Information about the associated issue",
+            "type": ["null", "object"],
+            "properties": {
+              "active_lock_reason": {
+                "description": "The reason the issue is locked",
+                "type": ["null", "string"]
+              },
+              "assignee": {
+                "type": ["null", "object"],
+                "properties": {
+                  "login": { "type": ["null", "string"] },
+                  "id": { "type": ["null", "integer"] },
+                  "node_id": { "type": ["null", "string"] },
+                  "avatar_url": { "type": ["null", "string"] },
+                  "gravatar_id": { "type": ["null", "string"] },
+                  "url": { "type": ["null", "string"] },
+                  "html_url": { "type": ["null", "string"] },
+                  "followers_url": { "type": ["null", "string"] },
+                  "following_url": { "type": ["null", "string"] },
+                  "gists_url": { "type": ["null", "string"] },
+                  "starred_url": { "type": ["null", "string"] },
+                  "subscriptions_url": { "type": ["null", "string"] },
+                  "organizations_url": { "type": ["null", "string"] },
+                  "repos_url": { "type": ["null", "string"] },
+                  "events_url": { "type": ["null", "string"] },
+                  "received_events_url": { "type": ["null", "string"] },
+                  "type": { "type": ["null", "string"] },
+                  "site_admin": { "type": ["null", "boolean"] }
+                }
+              },
+              "assignees": {
+                "description": "List of users assigned to the issue",
+                "type": ["null", "array"],
+                "items": {
+                  "type": ["null", "object"],
+                  "properties": {
+                    "login": { "type": ["null", "string"] },
+                    "id": { "type": ["null", "integer"] },
+                    "node_id": { "type": ["null", "string"] },
+                    "avatar_url": { "type": ["null", "string"] },
+                    "gravatar_id": { "type": ["null", "string"] },
+                    "url": { "type": ["null", "string"] },
+                    "html_url": { "type": ["null", "string"] },
+                    "followers_url": { "type": ["null", "string"] },
+                    "following_url": { "type": ["null", "string"] },
+                    "gists_url": { "type": ["null", "string"] },
+                    "starred_url": { "type": ["null", "string"] },
+                    "subscriptions_url": { "type": ["null", "string"] },
+                    "organizations_url": { "type": ["null", "string"] },
+                    "repos_url": { "type": ["null", "string"] },
+                    "events_url": { "type": ["null", "string"] },
+                    "received_events_url": { "type": ["null", "string"] },
+                    "type": { "type": ["null", "string"] },
+                    "site_admin": { "type": ["null", "boolean"] }
+                  }
+                }
+              },
+              "author_association": {
+                "description": "The association of the event creator to the issue",
+                "type": ["null", "string"]
+              },
+              "closed_at": {
+                "description": "The timestamp when the issue was closed",
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "updated_at": {
+                "description": "The timestamp when the issue was last updated",
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "comments": {
+                "description": "Number of comments on the issue",
+                "type": ["null", "integer"]
+              },
+              "draft": {
+                "description": "Indicates if the issue is a draft",
+                "type": ["null", "boolean"]
+              },
+              "created_at": {
+                "description": "The timestamp when the issue was created",
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "labels": {
+                "description": "List of labels attached to the issue",
+                "type": ["null", "array"],
+                "items": {
+                  "type": ["null", "object"],
+                  "properties": {
+                    "id": { "type": ["null", "integer"] },
+                    "node_id": { "type": ["null", "string"] },
+                    "url": { "type": ["null", "string"] },
+                    "name": { "type": ["null", "string"] },
+                    "description": { "type": ["null", "string"] },
+                    "color": { "type": ["null", "string"] },
+                    "default": { "type": ["null", "boolean"] }
+                  }
+                }
+              },
+              "locked": {
+                "description": "Indicates if the issue is locked",
+                "type": ["null", "boolean"]
+              },
+              "milestone": { "type": ["null", "object"] },
+              "performed_via_github_app": { "type": ["null", "object"] },
+              "state_reason": { "type": ["null", "string"] },
+              "pull_request": {
+                "description": "Details of the pull request linked to the issue",
+                "type": ["null", "object"],
+                "properties": {
+                  "merged_at": {
+                    "description": "The timestamp when the pull request was merged",
+                    "type": ["string", "null"],
+                    "format": "date-time"
+                  },
+                  "diff_url": { "type": ["string", "null"] },
+                  "html_url": { "type": ["string", "null"] },
+                  "patch_url": { "type": ["string", "null"] },
+                  "url": { "type": ["string", "null"] }
+                }
+              },
+              "timeline_url": {
+                "description": "The URL to view the issue timeline",
+                "type": ["null", "string"]
+              },
+              "reactions": {
+                "type": ["null", "object"],
+                "properties": {
+                  "url": { "type": ["null", "string"] },
+                  "total_count": { "type": ["null", "integer"] },
+                  "+1": { "type": ["null", "integer"] },
+                  "-1": { "type": ["null", "integer"] },
+                  "laugh": { "type": ["null", "integer"] },
+                  "hooray": { "type": ["null", "integer"] },
+                  "confused": { "type": ["null", "integer"] },
+                  "heart": { "type": ["null", "integer"] },
+                  "rocket": { "type": ["null", "integer"] },
+                  "eyes": { "type": ["null", "integer"] }
+                }
+              },
+              "id": {
+                "description": "The unique ID of the issue",
+                "type": ["null", "integer"]
+              },
+              "node_id": {
+                "description": "The unique node ID of the issue",
+                "type": ["null", "string"]
+              },
+              "url": {
+                "description": "The URL of the issue",
+                "type": ["null", "string"]
+              },
+              "repository_url": {
+                "description": "The URL of the repository the issue is in",
+                "type": ["null", "string"]
+              },
+              "labels_url": {
+                "description": "The URL to view labels on the issue",
+                "type": ["null", "string"]
+              },
+              "comments_url": {
+                "description": "The URL to view comments on the issue",
+                "type": ["null", "string"]
+              },
+              "events_url": {
+                "description": "The URL to view events related to the issue",
+                "type": ["null", "string"]
+              },
+              "html_url": {
+                "description": "The URL to view the issue on GitHub",
+                "type": ["null", "string"]
+              },
+              "number": {
+                "description": "The issue number",
+                "type": ["null", "integer"]
+              },
+              "state": {
+                "description": "The state of the issue (open, closed, etc.)",
+                "type": ["null", "string"]
+              },
+              "title": {
+                "description": "The title of the issue",
+                "type": ["null", "string"]
+              },
+              "body": {
+                "description": "The body content of the issue",
+                "type": ["null", "string"]
+              },
+              "user": {
+                "type": ["null", "object"],
+                "properties": {
+                  "login": { "type": ["null", "string"] },
+                  "id": { "type": ["null", "integer"] },
+                  "node_id": { "type": ["null", "string"] },
+                  "avatar_url": { "type": ["null", "string"] },
+                  "gravatar_id": { "type": ["null", "string"] },
+                  "url": { "type": ["null", "string"] },
+                  "html_url": { "type": ["null", "string"] },
+                  "followers_url": { "type": ["null", "string"] },
+                  "following_url": { "type": ["null", "string"] },
+                  "gists_url": { "type": ["null", "string"] },
+                  "starred_url": { "type": ["null", "string"] },
+                  "subscriptions_url": { "type": ["null", "string"] },
+                  "organizations_url": { "type": ["null", "string"] },
+                  "repos_url": { "type": ["null", "string"] },
+                  "events_url": { "type": ["null", "string"] },
+                  "received_events_url": { "type": ["null", "string"] },
+                  "type": { "type": ["null", "string"] },
+                  "site_admin": { "type": ["null", "boolean"] }
+                }
+              }
+            }
+          },
+          "performed_via_github_app": {
+            "description": "Information about the GitHub App that triggered the event",
+            "type": ["null", "object"],
+            "properties": {
+              "id": { "type": ["null", "integer"] },
+              "slug": { "type": ["null", "string"] },
+              "node_id": { "type": ["null", "string"] },
+              "owner": {
+                "type": ["null", "object"],
+                "properties": {
+                  "login": { "type": ["null", "string"] },
+                  "id": { "type": ["null", "integer"] },
+                  "node_id": { "type": ["null", "string"] },
+                  "avatar_url": { "type": ["null", "string"] },
+                  "gravatar_id": { "type": ["null", "string"] },
+                  "url": { "type": ["null", "string"] },
+                  "html_url": { "type": ["null", "string"] },
+                  "followers_url": { "type": ["null", "string"] },
+                  "following_url": { "type": ["null", "string"] },
+                  "gists_url": { "type": ["null", "string"] },
+                  "starred_url": { "type": ["null", "string"] },
+                  "subscriptions_url": { "type": ["null", "string"] },
+                  "organizations_url": { "type": ["null", "string"] },
+                  "repos_url": { "type": ["null", "string"] },
+                  "events_url": { "type": ["null", "string"] },
+                  "received_events_url": { "type": ["null", "string"] },
+                  "type": { "type": ["null", "string"] },
+                  "site_admin": { "type": ["null", "boolean"] }
+                }
+              },
+              "name": { "type": ["null", "string"] },
+              "description": { "type": ["null", "string"] },
+              "external_url": { "type": ["null", "string"] },
+              "html_url": {
+                "description": "The URL to view the app on GitHub",
+                "type": ["null", "string"]
+              },
+              "created_at": {
+                "description": "The timestamp when the app was created",
+                "type": "string",
+                "format": "date-time"
+              },
+              "updated_at": {
+                "description": "The timestamp when the app was last updated",
+                "type": "string",
+                "format": "date-time"
+              },
+              "permissions": {
+                "description": "Permissions of the app",
+                "type": ["null", "object"],
+                "properties": {
+                  "actions": { "type": ["null", "string"] },
+                  "administration": { "type": ["null", "string"] },
+                  "checks": { "type": ["null", "string"] },
+                  "contents": { "type": ["null", "string"] },
+                  "deployments": { "type": ["null", "string"] },
+                  "discussions": { "type": ["null", "string"] },
+                  "issues": { "type": ["null", "string"] },
+                  "merge_queues": { "type": ["null", "string"] },
+                  "metadata": { "type": ["null", "string"] },
+                  "packages": { "type": ["null", "string"] },
+                  "pages": { "type": ["null", "string"] },
+                  "pull_requests": { "type": ["null", "string"] },
+                  "repository_hooks": { "type": ["null", "string"] },
+                  "repository_projects": { "type": ["null", "string"] },
+                  "security_events": { "type": ["null", "string"] },
+                  "statuses": { "type": ["null", "string"] },
+                  "vulnerability_alerts": { "type": ["null", "string"] }
+                }
+              },
+              "events": {
+                "description": "List of events related to the app",
+                "type": "array",
+                "items": { "type": ["null", "string"] }
+              }
+            }
+          },
+          "milestone": {
+            "description": "Details about a milestone",
+            "type": ["null", "object"],
+            "properties": { "title": { "type": ["null", "string"] } }
+          },
+          "assignee": {
+            "type": ["null", "object"],
+            "properties": {
+              "login": { "type": ["null", "string"] },
+              "id": { "type": ["null", "integer"] },
+              "node_id": { "type": ["null", "string"] },
+              "avatar_url": { "type": ["null", "string"] },
+              "gravatar_id": { "type": ["null", "string"] },
+              "url": { "type": ["null", "string"] },
+              "html_url": { "type": ["null", "string"] },
+              "followers_url": { "type": ["null", "string"] },
+              "following_url": { "type": ["null", "string"] },
+              "gists_url": { "type": ["null", "string"] },
+              "starred_url": { "type": ["null", "string"] },
+              "subscriptions_url": { "type": ["null", "string"] },
+              "organizations_url": { "type": ["null", "string"] },
+              "repos_url": { "type": ["null", "string"] },
+              "events_url": { "type": ["null", "string"] },
+              "received_events_url": { "type": ["null", "string"] },
+              "type": { "type": ["null", "string"] },
+              "site_admin": { "type": ["null", "boolean"] }
+            }
+          },
+          "assigner": {
+            "type": ["null", "object"],
+            "properties": {
+              "login": { "type": ["null", "string"] },
+              "id": { "type": ["null", "integer"] },
+              "node_id": { "type": ["null", "string"] },
+              "avatar_url": { "type": ["null", "string"] },
+              "gravatar_id": { "type": ["null", "string"] },
+              "url": { "type": ["null", "string"] },
+              "html_url": { "type": ["null", "string"] },
+              "followers_url": { "type": ["null", "string"] },
+              "following_url": { "type": ["null", "string"] },
+              "gists_url": { "type": ["null", "string"] },
+              "starred_url": { "type": ["null", "string"] },
+              "subscriptions_url": { "type": ["null", "string"] },
+              "organizations_url": { "type": ["null", "string"] },
+              "repos_url": { "type": ["null", "string"] },
+              "events_url": { "type": ["null", "string"] },
+              "received_events_url": { "type": ["null", "string"] },
+              "type": { "type": ["null", "string"] },
+              "site_admin": { "type": ["null", "boolean"] }
+            }
+          },
+          "project_card": {
+            "description": "Details about a project card",
+            "type": ["null", "object"],
+            "properties": {
+              "id": { "type": ["null", "integer"] },
+              "url": { "type": ["null", "string"] },
+              "project_id": { "type": ["null", "integer"] },
+              "project_url": { "type": ["null", "string"] },
+              "column_name": { "type": ["null", "string"] },
+              "previous_column_name": { "type": ["null", "string"] }
+            }
+          },
+          "dismissed_review": {
+            "description": "Details about a dismissed review",
+            "type": ["null", "object"],
+            "properties": {
+              "state": {
+                "description": "The state of the review dismissal",
+                "type": ["null", "string"]
+              },
+              "review_id": {
+                "description": "The ID of the review that was dismissed",
+                "type": ["null", "integer"]
+              },
+              "dismissal_message": {
+                "description": "The message explaining the dismissal of the review",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "requested_team": {
+            "description": "Details about a team requested for review",
+            "type": ["null", "object"],
+            "properties": {
+              "name": { "type": ["null", "string"] },
+              "id": { "type": ["null", "integer"] },
+              "node_id": { "type": ["null", "string"] },
+              "slug": { "type": ["null", "string"] },
+              "description": { "type": ["null", "string"] },
+              "privacy": { "type": ["null", "string"] },
+              "url": { "type": ["null", "string"] },
+              "html_url": { "type": ["null", "string"] },
+              "members_url": { "type": ["null", "string"] },
+              "repositories_url": { "type": ["null", "string"] },
+              "permission": { "type": ["null", "string"] },
+              "parent": {
+                "description": "Details about the parent team",
+                "type": ["null", "object"],
+                "properties": {
+                  "name": { "type": ["null", "string"] },
+                  "id": { "type": ["null", "integer"] },
+                  "node_id": { "type": ["null", "string"] },
+                  "slug": { "type": ["null", "string"] },
+                  "description": { "type": ["null", "string"] },
+                  "privacy": { "type": ["null", "string"] },
+                  "url": { "type": ["null", "string"] },
+                  "html_url": { "type": ["null", "string"] },
+                  "members_url": { "type": ["null", "string"] },
+                  "repositories_url": { "type": ["null", "string"] },
+                  "permission": { "type": ["null", "string"] }
+                }
+              }
+            }
+          },
+          "rename": {
+            "description": "Details about a rename action",
+            "type": ["null", "object"],
+            "properties": {
+              "from": { "type": ["null", "string"] },
+              "to": { "type": ["null", "string"] }
+            }
+          },
+          "requested_reviewer": {
+            "type": ["null", "object"],
+            "properties": {
+              "login": { "type": ["null", "string"] },
+              "id": { "type": ["null", "integer"] },
+              "node_id": { "type": ["null", "string"] },
+              "avatar_url": { "type": ["null", "string"] },
+              "gravatar_id": { "type": ["null", "string"] },
+              "url": { "type": ["null", "string"] },
+              "html_url": { "type": ["null", "string"] },
+              "followers_url": { "type": ["null", "string"] },
+              "following_url": { "type": ["null", "string"] },
+              "gists_url": { "type": ["null", "string"] },
+              "starred_url": { "type": ["null", "string"] },
+              "subscriptions_url": { "type": ["null", "string"] },
+              "organizations_url": { "type": ["null", "string"] },
+              "repos_url": { "type": ["null", "string"] },
+              "events_url": { "type": ["null", "string"] },
+              "received_events_url": { "type": ["null", "string"] },
+              "type": { "type": ["null", "string"] },
+              "site_admin": { "type": ["null", "boolean"] }
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["created_at"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "issue_labels",
+      "json_schema": {
+        "$schema": "https://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "repository": {
+            "description": "Information about the repository to which the label belongs.",
+            "type": "string"
+          },
+          "id": {
+            "description": "Unique identifier for the label.",
+            "type": ["null", "integer"]
+          },
+          "node_id": {
+            "description": "A unique identifier for the label at the GitHub API level.",
+            "type": ["null", "string"]
+          },
+          "url": {
+            "description": "URL that provides direct access to the label resource.",
+            "type": ["null", "string"]
+          },
+          "name": {
+            "description": "The name of the label used for identification.",
+            "type": ["null", "string"]
+          },
+          "description": {
+            "description": "Descriptive text providing additional information about the label.",
+            "type": ["null", "string"]
+          },
+          "color": {
+            "description": "The color associated with the label, typically used for visual representation.",
+            "type": ["null", "string"]
+          },
+          "default": {
+            "description": "Indicates if the label is the default label for the repository.",
+            "type": ["null", "boolean"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "issue_milestones",
+      "json_schema": {
+        "$schema": "https://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "repository": {
+            "description": "Repository to which the milestone belongs",
+            "type": "string"
+          },
+          "url": {
+            "description": "API endpoint URL for the milestone",
+            "type": ["null", "string"]
+          },
+          "html_url": {
+            "description": "URL to view the milestone in a web browser",
+            "type": ["null", "string"]
+          },
+          "labels_url": {
+            "description": "URL to fetch labels associated with the milestone",
+            "type": ["null", "string"]
+          },
+          "id": {
+            "description": "Unique identifier for the milestone",
+            "type": ["null", "integer"]
+          },
+          "node_id": {
+            "description": "Unique identifier for the milestone node",
+            "type": ["null", "string"]
+          },
+          "number": {
+            "description": "Numeric identifier for the milestone",
+            "type": ["null", "integer"]
+          },
+          "state": {
+            "description": "Current state of the milestone (open/closed)",
+            "type": ["null", "string"]
+          },
+          "title": {
+            "description": "Title or name of the milestone",
+            "type": ["null", "string"]
+          },
+          "description": {
+            "description": "Brief description of the milestone",
+            "type": ["null", "string"]
+          },
+          "creator": {
+            "type": ["null", "object"],
+            "properties": {
+              "login": { "type": ["null", "string"] },
+              "id": { "type": ["null", "integer"] },
+              "node_id": { "type": ["null", "string"] },
+              "avatar_url": { "type": ["null", "string"] },
+              "gravatar_id": { "type": ["null", "string"] },
+              "url": { "type": ["null", "string"] },
+              "html_url": { "type": ["null", "string"] },
+              "followers_url": { "type": ["null", "string"] },
+              "following_url": { "type": ["null", "string"] },
+              "gists_url": { "type": ["null", "string"] },
+              "starred_url": { "type": ["null", "string"] },
+              "subscriptions_url": { "type": ["null", "string"] },
+              "organizations_url": { "type": ["null", "string"] },
+              "repos_url": { "type": ["null", "string"] },
+              "events_url": { "type": ["null", "string"] },
+              "received_events_url": { "type": ["null", "string"] },
+              "type": { "type": ["null", "string"] },
+              "site_admin": { "type": ["null", "boolean"] }
+            }
+          },
+          "open_issues": {
+            "description": "Total number of open issues within the milestone",
+            "type": ["null", "integer"]
+          },
+          "closed_issues": {
+            "description": "Total number of issues closed within the milestone",
+            "type": ["null", "integer"]
+          },
+          "created_at": {
+            "description": "Timestamp indicating when the milestone was created",
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "description": "Timestamp indicating when the milestone was last updated",
+            "type": "string",
+            "format": "date-time"
+          },
+          "closed_at": {
+            "description": "Timestamp indicating when the milestone was closed",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "due_on": {
+            "description": "Timestamp indicating when the milestone is due",
+            "type": ["null", "string"],
+            "format": "date-time"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated_at"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "issue_reactions",
+      "json_schema": {
+        "$schema": "https://json-schema.org/draft-07/schema#",
+        "type": ["null", "object"],
+        "properties": {
+          "id": {
+            "description": "The unique identifier of the reaction",
+            "type": ["null", "integer"]
+          },
+          "node_id": {
+            "description": "The unique identifier of the reaction node",
+            "type": ["null", "string"]
+          },
+          "content": {
+            "description": "The type of reaction (e.g., thumbs up, thumbs down, heart)",
+            "type": ["null", "string"]
+          },
+          "created_at": {
+            "description": "The date and time when the reaction was created",
+            "type": "string",
+            "format": "date-time"
+          },
+          "user": {
+            "type": ["null", "object"],
+            "properties": {
+              "login": { "type": ["null", "string"] },
+              "id": { "type": ["null", "integer"] },
+              "node_id": { "type": ["null", "string"] },
+              "avatar_url": { "type": ["null", "string"] },
+              "html_url": { "type": ["null", "string"] },
+              "type": { "type": ["null", "string"] },
+              "site_admin": { "type": ["null", "boolean"] }
+            }
+          },
+          "repository": {
+            "description": "The repository to which the reaction belongs",
+            "type": "string"
+          },
+          "issue_number": {
+            "description": "The issue number to which the reaction belongs",
+            "type": "integer"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["created_at"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "issues",
+      "json_schema": {
+        "$schema": "https://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "repository": {
+            "description": "Repository where the issue is located.",
+            "type": "string"
+          },
+          "id": {
+            "description": "Unique identifier for the issue.",
+            "type": ["null", "integer"]
+          },
+          "node_id": {
+            "description": "Unique identifier for the issue node.",
+            "type": ["null", "string"]
+          },
+          "url": {
+            "description": "URL to retrieve more details about the issue.",
+            "type": ["null", "string"]
+          },
+          "repository_url": {
+            "description": "URL to retrieve more details about the repository.",
+            "type": ["null", "string"]
+          },
+          "labels_url": {
+            "description": "URL to retrieve labels associated with the issue.",
+            "type": ["null", "string"]
+          },
+          "comments_url": {
+            "description": "URL to retrieve comments on the issue.",
+            "type": ["null", "string"]
+          },
+          "events_url": {
+            "description": "URL to retrieve events related to the issue.",
+            "type": ["null", "string"]
+          },
+          "html_url": {
+            "description": "URL to view the issue on GitHub.",
+            "type": ["null", "string"]
+          },
+          "number": {
+            "description": "Number of the issue.",
+            "type": ["null", "integer"]
+          },
+          "state": {
+            "description": "State of the issue (open/closed).",
+            "type": ["null", "string"]
+          },
+          "title": {
+            "description": "Title of the issue.",
+            "type": ["null", "string"]
+          },
+          "user": {
+            "type": ["null", "object"],
+            "properties": {
+              "login": { "type": ["null", "string"] },
+              "id": { "type": ["null", "integer"] },
+              "node_id": { "type": ["null", "string"] },
+              "avatar_url": { "type": ["null", "string"] },
+              "gravatar_id": { "type": ["null", "string"] },
+              "url": { "type": ["null", "string"] },
+              "html_url": { "type": ["null", "string"] },
+              "followers_url": { "type": ["null", "string"] },
+              "following_url": { "type": ["null", "string"] },
+              "gists_url": { "type": ["null", "string"] },
+              "starred_url": { "type": ["null", "string"] },
+              "subscriptions_url": { "type": ["null", "string"] },
+              "organizations_url": { "type": ["null", "string"] },
+              "repos_url": { "type": ["null", "string"] },
+              "events_url": { "type": ["null", "string"] },
+              "received_events_url": { "type": ["null", "string"] },
+              "type": { "type": ["null", "string"] },
+              "site_admin": { "type": ["null", "boolean"] }
+            }
+          },
+          "body": {
+            "description": "The content of the issue.",
+            "type": ["null", "string"]
+          },
+          "user_id": {
+            "description": "Identifier of the user who opened the issue.",
+            "type": ["null", "integer"]
+          },
+          "labels": {
+            "description": "List of labels attached to the issue.",
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "id": {
+                  "description": "Unique identifier for the label.",
+                  "type": ["null", "integer"]
+                },
+                "node_id": {
+                  "description": "Unique identifier for the label node.",
+                  "type": ["null", "string"]
+                },
+                "url": {
+                  "description": "URL to retrieve more details about the label.",
+                  "type": ["null", "string"]
+                },
+                "name": {
+                  "description": "Name of the label.",
+                  "type": ["null", "string"]
+                },
+                "description": {
+                  "description": "Description of the label.",
+                  "type": ["null", "string"]
+                },
+                "color": {
+                  "description": "Color of the label.",
+                  "type": ["null", "string"]
+                },
+                "default": {
+                  "description": "Flag indicating if the label is a default label.",
+                  "type": ["null", "boolean"]
+                }
+              }
+            }
+          },
+          "assignee": {
+            "type": ["null", "object"],
+            "properties": {
+              "login": { "type": ["null", "string"] },
+              "id": { "type": ["null", "integer"] },
+              "node_id": { "type": ["null", "string"] },
+              "avatar_url": { "type": ["null", "string"] },
+              "gravatar_id": { "type": ["null", "string"] },
+              "url": { "type": ["null", "string"] },
+              "html_url": { "type": ["null", "string"] },
+              "followers_url": { "type": ["null", "string"] },
+              "following_url": { "type": ["null", "string"] },
+              "gists_url": { "type": ["null", "string"] },
+              "starred_url": { "type": ["null", "string"] },
+              "subscriptions_url": { "type": ["null", "string"] },
+              "organizations_url": { "type": ["null", "string"] },
+              "repos_url": { "type": ["null", "string"] },
+              "events_url": { "type": ["null", "string"] },
+              "received_events_url": { "type": ["null", "string"] },
+              "type": { "type": ["null", "string"] },
+              "site_admin": { "type": ["null", "boolean"] }
+            }
+          },
+          "assignees": {
+            "description": "List of users assigned to the issue.",
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "login": { "type": ["null", "string"] },
+                "id": { "type": ["null", "integer"] },
+                "node_id": { "type": ["null", "string"] },
+                "avatar_url": { "type": ["null", "string"] },
+                "gravatar_id": { "type": ["null", "string"] },
+                "url": { "type": ["null", "string"] },
+                "html_url": { "type": ["null", "string"] },
+                "followers_url": { "type": ["null", "string"] },
+                "following_url": { "type": ["null", "string"] },
+                "gists_url": { "type": ["null", "string"] },
+                "starred_url": { "type": ["null", "string"] },
+                "subscriptions_url": { "type": ["null", "string"] },
+                "organizations_url": { "type": ["null", "string"] },
+                "repos_url": { "type": ["null", "string"] },
+                "events_url": { "type": ["null", "string"] },
+                "received_events_url": { "type": ["null", "string"] },
+                "type": { "type": ["null", "string"] },
+                "site_admin": { "type": ["null", "boolean"] }
+              }
+            }
+          },
+          "milestone": {
+            "description": "Details of the milestone associated with the issue.",
+            "type": ["null", "object"],
+            "properties": {
+              "url": {
+                "description": "URL to retrieve more details about the milestone.",
+                "type": ["null", "string"]
+              },
+              "html_url": {
+                "description": "URL to view the milestone on GitHub.",
+                "type": ["null", "string"]
+              },
+              "labels_url": {
+                "description": "URL to retrieve labels associated with the milestone.",
+                "type": ["null", "string"]
+              },
+              "id": {
+                "description": "Unique identifier for the milestone.",
+                "type": ["null", "integer"]
+              },
+              "node_id": {
+                "description": "Unique identifier for the milestone node.",
+                "type": ["null", "string"]
+              },
+              "number": {
+                "description": "Number of the milestone.",
+                "type": ["null", "integer"]
+              },
+              "state": {
+                "description": "State of the milestone (open/closed).",
+                "type": ["null", "string"]
+              },
+              "title": {
+                "description": "Title of the milestone.",
+                "type": ["null", "string"]
+              },
+              "description": {
+                "description": "Description of the milestone.",
+                "type": ["null", "string"]
+              },
+              "creator": {
+                "type": ["null", "object"],
+                "properties": {
+                  "login": { "type": ["null", "string"] },
+                  "id": { "type": ["null", "integer"] },
+                  "node_id": { "type": ["null", "string"] },
+                  "avatar_url": { "type": ["null", "string"] },
+                  "gravatar_id": { "type": ["null", "string"] },
+                  "url": { "type": ["null", "string"] },
+                  "html_url": { "type": ["null", "string"] },
+                  "followers_url": { "type": ["null", "string"] },
+                  "following_url": { "type": ["null", "string"] },
+                  "gists_url": { "type": ["null", "string"] },
+                  "starred_url": { "type": ["null", "string"] },
+                  "subscriptions_url": { "type": ["null", "string"] },
+                  "organizations_url": { "type": ["null", "string"] },
+                  "repos_url": { "type": ["null", "string"] },
+                  "events_url": { "type": ["null", "string"] },
+                  "received_events_url": { "type": ["null", "string"] },
+                  "type": { "type": ["null", "string"] },
+                  "site_admin": { "type": ["null", "boolean"] }
+                }
+              },
+              "open_issues": {
+                "description": "Number of open issues in the milestone.",
+                "type": ["null", "integer"]
+              },
+              "closed_issues": {
+                "description": "Number of closed issues in the milestone.",
+                "type": ["null", "integer"]
+              },
+              "created_at": {
+                "description": "Date and time when the milestone was created.",
+                "type": "string",
+                "format": "date-time"
+              },
+              "updated_at": {
+                "description": "Date and time when the milestone was last updated.",
+                "type": "string",
+                "format": "date-time"
+              },
+              "closed_at": {
+                "description": "Date and time when the milestone was closed.",
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "due_on": {
+                "description": "Date and time when the milestone is due.",
+                "type": ["null", "string"],
+                "format": "date-time"
+              }
+            }
+          },
+          "locked": {
+            "description": "Flag indicating if the issue is locked.",
+            "type": ["null", "boolean"]
+          },
+          "active_lock_reason": {
+            "description": "Reason for the active lock on the issue, if any.",
+            "type": ["null", "string"]
+          },
+          "comments": {
+            "description": "Number of comments on the issue.",
+            "type": ["null", "integer"]
+          },
+          "pull_request": {
+            "description": "Details of a linked pull request, if the issue is a pull request.",
+            "type": ["null", "object"],
+            "properties": {
+              "url": {
+                "description": "URL to retrieve more details about the pull request.",
+                "type": ["null", "string"]
+              },
+              "html_url": {
+                "description": "URL to view the pull request on GitHub.",
+                "type": ["null", "string"]
+              },
+              "diff_url": {
+                "description": "URL to view the diff of the pull request.",
+                "type": ["null", "string"]
+              },
+              "patch_url": {
+                "description": "URL to view the patch of the pull request.",
+                "type": ["null", "string"]
+              },
+              "merged_at": {
+                "description": "Date and time when the pull request was merged.",
+                "type": ["null", "string"],
+                "format": "date-time"
+              }
+            }
+          },
+          "closed_at": {
+            "description": "Date and time when the issue was closed.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "created_at": {
+            "description": "Date and time when the issue was created.",
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "description": "Date and time when the issue was last updated.",
+            "type": "string",
+            "format": "date-time"
+          },
+          "author_association": {
+            "description": "The association of the author with the issue.",
+            "type": ["null", "string"]
+          },
+          "draft": {
+            "description": "Flag indicating if the issue is a draft.",
+            "type": ["null", "boolean"]
+          },
+          "reactions": {
+            "type": ["null", "object"],
+            "properties": {
+              "url": { "type": ["null", "string"] },
+              "total_count": { "type": ["null", "integer"] },
+              "+1": { "type": ["null", "integer"] },
+              "-1": { "type": ["null", "integer"] },
+              "laugh": { "type": ["null", "integer"] },
+              "hooray": { "type": ["null", "integer"] },
+              "confused": { "type": ["null", "integer"] },
+              "heart": { "type": ["null", "integer"] },
+              "rocket": { "type": ["null", "integer"] },
+              "eyes": { "type": ["null", "integer"] }
+            }
+          },
+          "timeline_url": {
+            "description": "URL to retrieve the timeline of the issue.",
+            "type": ["null", "string"]
+          },
+          "performed_via_github_app": {
+            "description": "Information related to the GitHub App that performed actions on the issue.",
+            "type": ["null", "object"],
+            "properties": {
+              "id": {
+                "description": "Unique identifier for the GitHub app.",
+                "type": ["null", "integer"]
+              },
+              "slug": {
+                "description": "Slug of the GitHub app.",
+                "type": ["null", "string"]
+              },
+              "node_id": {
+                "description": "Unique identifier for the GitHub app node.",
+                "type": ["null", "string"]
+              },
+              "owner": {
+                "type": ["null", "object"],
+                "properties": {
+                  "login": { "type": ["null", "string"] },
+                  "id": { "type": ["null", "integer"] },
+                  "node_id": { "type": ["null", "string"] },
+                  "avatar_url": { "type": ["null", "string"] },
+                  "gravatar_id": { "type": ["null", "string"] },
+                  "url": { "type": ["null", "string"] },
+                  "html_url": { "type": ["null", "string"] },
+                  "followers_url": { "type": ["null", "string"] },
+                  "following_url": { "type": ["null", "string"] },
+                  "gists_url": { "type": ["null", "string"] },
+                  "starred_url": { "type": ["null", "string"] },
+                  "subscriptions_url": { "type": ["null", "string"] },
+                  "organizations_url": { "type": ["null", "string"] },
+                  "repos_url": { "type": ["null", "string"] },
+                  "events_url": { "type": ["null", "string"] },
+                  "received_events_url": { "type": ["null", "string"] },
+                  "type": { "type": ["null", "string"] },
+                  "site_admin": { "type": ["null", "boolean"] }
+                }
+              },
+              "name": {
+                "description": "Name of the GitHub app.",
+                "type": ["null", "string"]
+              },
+              "description": {
+                "description": "Description of the GitHub app.",
+                "type": ["null", "string"]
+              },
+              "external_url": {
+                "description": "External URL associated with the GitHub app.",
+                "type": ["null", "string"]
+              },
+              "html_url": {
+                "description": "URL to view the GitHub app on GitHub.",
+                "type": ["null", "string"]
+              },
+              "created_at": {
+                "description": "Date and time when the GitHub app was created.",
+                "type": "string",
+                "format": "date-time"
+              },
+              "updated_at": {
+                "description": "Date and time when the GitHub app was last updated.",
+                "type": "string",
+                "format": "date-time"
+              },
+              "permissions": {
+                "description": "Permissions granted to the GitHub App on the issue.",
+                "type": ["null", "object"],
+                "properties": {
+                  "issues": {
+                    "description": "Permissions related to issues for the GitHub app.",
+                    "type": ["null", "string"]
+                  },
+                  "metadata": {
+                    "description": "Permissions related to metadata for the GitHub app.",
+                    "type": ["null", "string"]
+                  },
+                  "pull_requests": {
+                    "description": "Permissions related to pull requests for the GitHub app.",
+                    "type": ["null", "string"]
+                  },
+                  "actions": {
+                    "description": "Permissions related to actions for the GitHub app.",
+                    "type": ["null", "string"]
+                  },
+                  "checks": {
+                    "description": "Permissions related to checks for the GitHub app.",
+                    "type": ["null", "string"]
+                  },
+                  "contents": {
+                    "description": "Permissions related to contents for the GitHub app.",
+                    "type": ["null", "string"]
+                  },
+                  "deployments": {
+                    "description": "Permissions related to deployments for the GitHub app.",
+                    "type": ["null", "string"]
+                  },
+                  "discussions": {
+                    "description": "Permissions related to discussions for the GitHub app.",
+                    "type": ["null", "string"]
+                  },
+                  "repository_projects": {
+                    "description": "Permissions related to repository projects for the GitHub app.",
+                    "type": ["null", "string"]
+                  },
+                  "statuses": {
+                    "description": "Permissions related to statuses for the GitHub app.",
+                    "type": ["null", "string"]
+                  }
+                }
+              },
+              "events": {
+                "description": "List of events performed by the GitHub App on the issue.",
+                "type": "array",
+                "items": {
+                  "description": "List of events performed by the GitHub app.",
+                  "type": ["null", "string"]
+                }
+              }
+            }
+          },
+          "state_reason": {
+            "description": "Reason for the state of the issue.",
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated_at"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "organizations",
+      "json_schema": {
+        "$schema": "https://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "login": {
+            "description": "Login username of the organization.",
+            "type": ["null", "string"]
+          },
+          "id": {
+            "description": "Unique identifier of the organization.",
+            "type": ["null", "integer"]
+          },
+          "node_id": {
+            "description": "Node ID of the organization.",
+            "type": ["null", "string"]
+          },
+          "url": {
+            "description": "URL to the organization's API endpoint.",
+            "type": ["null", "string"]
+          },
+          "repos_url": {
+            "description": "URL to fetch repositories of the organization.",
+            "type": ["null", "string"]
+          },
+          "events_url": {
+            "description": "URL to fetch events related to the organization.",
+            "type": ["null", "string"]
+          },
+          "hooks_url": {
+            "description": "URL to manage webhooks for the organization.",
+            "type": ["null", "string"]
+          },
+          "issues_url": {
+            "description": "URL to fetch issues related to the organization.",
+            "type": ["null", "string"]
+          },
+          "members_url": {
+            "description": "URL to fetch members of the organization.",
+            "type": ["null", "string"]
+          },
+          "public_members_url": {
+            "description": "URL to fetch public members of the organization.",
+            "type": ["null", "string"]
+          },
+          "avatar_url": {
+            "description": "URL to the avatar image of the organization.",
+            "type": ["null", "string"]
+          },
+          "description": {
+            "description": "Description of the organization.",
+            "type": ["null", "string"]
+          },
+          "name": {
+            "description": "Name of the organization.",
+            "type": ["null", "string"]
+          },
+          "company": {
+            "description": "Name of the company associated with the organization.",
+            "type": ["null", "string"]
+          },
+          "blog": {
+            "description": "URL to the blog of the organization.",
+            "type": ["null", "string"]
+          },
+          "location": {
+            "description": "Physical location of the organization.",
+            "type": ["null", "string"]
+          },
+          "email": {
+            "description": "Email address of the organization.",
+            "type": ["null", "string"]
+          },
+          "twitter_username": {
+            "description": "Twitter username of the organization.",
+            "type": ["null", "string"]
+          },
+          "is_verified": {
+            "description": "Indicates if the organization is verified.",
+            "type": ["null", "boolean"]
+          },
+          "has_organization_projects": {
+            "description": "Indicates if the organization has projects.",
+            "type": ["null", "boolean"]
+          },
+          "has_repository_projects": {
+            "description": "Indicates if the organization has projects tied to repositories.",
+            "type": ["null", "boolean"]
+          },
+          "public_repos": {
+            "description": "Number of public repositories owned by the organization.",
+            "type": ["null", "integer"]
+          },
+          "public_gists": {
+            "description": "Number of public gists created by the organization.",
+            "type": ["null", "integer"]
+          },
+          "followers": {
+            "description": "Number of followers the organization has.",
+            "type": ["null", "integer"]
+          },
+          "following": {
+            "description": "Number of accounts the organization is following.",
+            "type": ["null", "integer"]
+          },
+          "html_url": {
+            "description": "URL to the organization's profile page.",
+            "type": ["null", "string"]
+          },
+          "created_at": {
+            "description": "Timestamp indicating when the organization was created.",
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "description": "Timestamp indicating when the organization was last updated.",
+            "type": "string",
+            "format": "date-time"
+          },
+          "archived_at": {
+            "description": "Timestamp indicating when the organization was archived.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "type": {
+            "description": "Type of the organization.",
+            "type": ["null", "string"]
+          },
+          "total_private_repos": {
+            "description": "Total number of private repositories owned by the organization.",
+            "type": ["null", "integer"]
+          },
+          "owned_private_repos": {
+            "description": "Number of private repositories owned by the organization.",
+            "type": ["null", "integer"]
+          },
+          "private_gists": {
+            "description": "Number of private gists created by the organization.",
+            "type": ["null", "integer"]
+          },
+          "disk_usage": {
+            "description": "Disk space used by the organization.",
+            "type": ["null", "integer"]
+          },
+          "collaborators": {
+            "description": "Number of collaborators the organization has.",
+            "type": ["null", "integer"]
+          },
+          "billing_email": {
+            "description": "Email address associated with the organization's billing.",
+            "type": ["null", "string"]
+          },
+          "default_repository_permission": {
+            "description": "Default permission level for new repositories.",
+            "type": ["null", "string"]
+          },
+          "members_can_create_repositories": {
+            "description": "Indicates if members can create repositories.",
+            "type": ["null", "boolean"]
+          },
+          "two_factor_requirement_enabled": {
+            "description": "Indicates if two-factor authentication is required for the organization.",
+            "type": ["null", "boolean"]
+          },
+          "members_allowed_repository_creation_type": {
+            "description": "Type of repositories members are allowed to create.",
+            "type": ["null", "string"]
+          },
+          "members_can_create_public_repositories": {
+            "description": "Indicates if members can create public repositories.",
+            "type": ["null", "boolean"]
+          },
+          "members_can_create_private_repositories": {
+            "description": "Indicates if members can create private repositories.",
+            "type": ["null", "boolean"]
+          },
+          "members_can_create_internal_repositories": {
+            "description": "Indicates if members can create internal repositories.",
+            "type": ["null", "boolean"]
+          },
+          "members_can_create_pages": {
+            "description": "Indicates if members can create pages.",
+            "type": ["null", "boolean"]
+          },
+          "members_can_fork_private_repositories": {
+            "description": "Indicates if members can fork private repositories.",
+            "type": ["null", "boolean"]
+          },
+          "web_commit_signoff_required": {
+            "description": "Indicates if web commit signoff is required for the organization.",
+            "type": ["null", "boolean"]
+          },
+          "members_can_create_public_pages": {
+            "description": "Indicates if members can create public pages.",
+            "type": ["null", "boolean"]
+          },
+          "members_can_create_private_pages": {
+            "description": "Indicates if members can create private pages.",
+            "type": ["null", "boolean"]
+          },
+          "plan": {
+            "description": "Information about the subscription plan of the organization.",
+            "type": ["null", "object"],
+            "properties": {
+              "name": {
+                "description": "Name of the organization's plan.",
+                "type": ["null", "string"]
+              },
+              "space": {
+                "description": "Space available in the organization's plan.",
+                "type": ["null", "integer"]
+              },
+              "private_repos": {
+                "description": "Number of private repositories allowed in the organization's plan.",
+                "type": ["null", "integer"]
+              },
+              "filled_seats": {
+                "description": "Number of filled seats in the organization's plan.",
+                "type": ["null", "integer"]
+              },
+              "seats": {
+                "description": "Total number of seats in the organization's plan.",
+                "type": ["null", "integer"]
+              }
+            }
+          },
+          "advanced_security_enabled_for_new_repositories": {
+            "description": "Indicates if advanced security features are enabled for new repositories within the organization.",
+            "type": ["null", "boolean"]
+          },
+          "dependabot_alerts_enabled_for_new_repositories": {
+            "description": "Indicates if dependabot alerts are enabled for new repositories within the organization.",
+            "type": ["null", "boolean"]
+          },
+          "dependabot_security_updates_enabled_for_new_repositories": {
+            "description": "Indicates if dependabot security updates are enabled for new repositories within the organization.",
+            "type": ["null", "boolean"]
+          },
+          "dependency_graph_enabled_for_new_repositories": {
+            "description": "Indicates if dependency graph is enabled for new repositories within the organization.",
+            "type": ["null", "boolean"]
+          },
+          "secret_scanning_enabled_for_new_repositories": {
+            "description": "Indicates if secret scanning is enabled for new repositories within the organization.",
+            "type": ["null", "boolean"]
+          },
+          "secret_scanning_push_protection_enabled_for_new_repositories": {
+            "description": "Indicates if secret scanning push protection is enabled for new repositories.",
+            "type": ["null", "boolean"]
+          },
+          "secret_scanning_push_protection_custom_link_enabled": {
+            "description": "Indicates if custom link for secret scanning push protection is enabled.",
+            "type": ["null", "boolean"]
+          },
+          "secret_scanning_push_protection_custom_link": {
+            "description": "Custom link for secret scanning push protection.",
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "project_cards",
+      "json_schema": {
+        "$schema": "https://json-schema.org/schema#",
+        "type": "object",
+        "properties": {
+          "url": {
+            "description": "The URL to access the project card.",
+            "type": ["null", "string"]
+          },
+          "project_url": {
+            "description": "The URL to access the project that includes the project card.",
+            "type": ["null", "string"]
+          },
+          "id": {
+            "description": "The unique identifier of the project card.",
+            "type": ["null", "integer"]
+          },
+          "node_id": {
+            "description": "The unique Node ID of the project card.",
+            "type": ["null", "string"]
+          },
+          "note": {
+            "description": "Any notes associated with the project card.",
+            "type": ["null", "string"]
+          },
+          "archived": {
+            "description": "Indicates whether the project card is archived or not.",
+            "type": ["null", "boolean"]
+          },
+          "creator": {
+            "type": ["null", "object"],
+            "properties": {
+              "login": { "type": ["null", "string"] },
+              "id": { "type": ["null", "integer"] },
+              "node_id": { "type": ["null", "string"] },
+              "avatar_url": { "type": ["null", "string"] },
+              "gravatar_id": { "type": ["null", "string"] },
+              "url": { "type": ["null", "string"] },
+              "html_url": { "type": ["null", "string"] },
+              "followers_url": { "type": ["null", "string"] },
+              "following_url": { "type": ["null", "string"] },
+              "gists_url": { "type": ["null", "string"] },
+              "starred_url": { "type": ["null", "string"] },
+              "subscriptions_url": { "type": ["null", "string"] },
+              "organizations_url": { "type": ["null", "string"] },
+              "repos_url": { "type": ["null", "string"] },
+              "events_url": { "type": ["null", "string"] },
+              "received_events_url": { "type": ["null", "string"] },
+              "type": { "type": ["null", "string"] },
+              "site_admin": { "type": ["null", "boolean"] }
+            }
+          },
+          "created_at": {
+            "description": "The date and time when the project card was created.",
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "description": "The date and time when the project card was last updated.",
+            "type": "string",
+            "format": "date-time"
+          },
+          "column_url": {
+            "description": "The URL to access the project column associated with the project card.",
+            "type": ["null", "string"]
+          },
+          "content_url": {
+            "description": "The URL that provides direct access to the project card's content.",
+            "type": ["null", "string"]
+          },
+          "repository": {
+            "description": "The repository to which the project card is linked.",
+            "type": "string"
+          },
+          "project_id": {
+            "description": "The unique identifier of the project to which the project card belongs.",
+            "type": "integer"
+          },
+          "column_id": {
+            "description": "The unique identifier of the project column that the project card belongs to.",
+            "type": "integer"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated_at"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "project_columns",
+      "json_schema": {
+        "$schema": "https://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "url": {
+            "description": "The API URL to fetch more details about this project column.",
+            "type": ["null", "string"]
+          },
+          "project_url": {
+            "description": "The URL to view the project associated with this column.",
+            "type": ["null", "string"]
+          },
+          "cards_url": {
+            "description": "The API URL to fetch the cards in this project column.",
+            "type": ["null", "string"]
+          },
+          "id": {
+            "description": "The unique identification number of this project column.",
+            "type": ["null", "integer"]
+          },
+          "node_id": {
+            "description": "The node ID of this project column used in the GraphQL API.",
+            "type": ["null", "string"]
+          },
+          "name": {
+            "description": "The name given to this project column.",
+            "type": ["null", "string"]
+          },
+          "created_at": {
+            "description": "The date and time when this project column was created.",
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "description": "The date and time when this project column was last updated.",
+            "type": "string",
+            "format": "date-time"
+          },
+          "repository": {
+            "description": "The repository to which this project column belongs.",
+            "type": "string"
+          },
+          "project_id": {
+            "description": "The ID of the project to which this column belongs.",
+            "type": "integer"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated_at"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "projects",
+      "json_schema": {
+        "$schema": "https://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "repository": {
+            "description": "The repository associated with the project.",
+            "type": "string"
+          },
+          "owner_url": {
+            "description": "The URL to view the owner or creator of the project.",
+            "type": ["null", "string"]
+          },
+          "url": {
+            "description": "The URL for accessing the project.",
+            "type": ["null", "string"]
+          },
+          "html_url": {
+            "description": "The HTML URL for viewing the project.",
+            "type": ["null", "string"]
+          },
+          "columns_url": {
+            "description": "The URL to view the project's columns or categories.",
+            "type": ["null", "string"]
+          },
+          "id": {
+            "description": "The unique identifier for the project.",
+            "type": ["null", "integer"]
+          },
+          "node_id": {
+            "description": "The Node ID associated with the project.",
+            "type": ["null", "string"]
+          },
+          "name": {
+            "description": "The name of the project.",
+            "type": ["null", "string"]
+          },
+          "body": {
+            "description": "The description or main content of the project.",
+            "type": ["null", "string"]
+          },
+          "number": {
+            "description": "The project number or identifier.",
+            "type": ["null", "integer"]
+          },
+          "state": {
+            "description": "The state or status of the project.",
+            "type": ["null", "string"]
+          },
+          "creator": {
+            "type": ["null", "object"],
+            "properties": {
+              "login": { "type": ["null", "string"] },
+              "id": { "type": ["null", "integer"] },
+              "node_id": { "type": ["null", "string"] },
+              "avatar_url": { "type": ["null", "string"] },
+              "gravatar_id": { "type": ["null", "string"] },
+              "url": { "type": ["null", "string"] },
+              "html_url": { "type": ["null", "string"] },
+              "followers_url": { "type": ["null", "string"] },
+              "following_url": { "type": ["null", "string"] },
+              "gists_url": { "type": ["null", "string"] },
+              "starred_url": { "type": ["null", "string"] },
+              "subscriptions_url": { "type": ["null", "string"] },
+              "organizations_url": { "type": ["null", "string"] },
+              "repos_url": { "type": ["null", "string"] },
+              "events_url": { "type": ["null", "string"] },
+              "received_events_url": { "type": ["null", "string"] },
+              "type": { "type": ["null", "string"] },
+              "site_admin": { "type": ["null", "boolean"] }
+            }
+          },
+          "created_at": {
+            "description": "The date and time when the project was created.",
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "description": "The date and time when the project was last updated.",
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated_at"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "pull_request_comment_reactions",
+      "json_schema": {
+        "$schema": "https://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "id": {
+            "description": "The unique identifier for the reaction.",
+            "type": ["null", "integer"]
+          },
+          "node_id": {
+            "description": "A unique identifier for the reaction node.",
+            "type": ["null", "string"]
+          },
+          "content": {
+            "description": "The type of reaction content, e.g., '+1', 'heart', 'laugh', etc.",
+            "type": ["null", "string"]
+          },
+          "created_at": {
+            "description": "The timestamp when the reaction was created.",
+            "type": "string",
+            "format": "date-time"
+          },
+          "user": {
+            "type": ["null", "object"],
+            "properties": {
+              "login": { "type": ["null", "string"] },
+              "id": { "type": ["null", "integer"] },
+              "node_id": { "type": ["null", "string"] },
+              "avatar_url": { "type": ["null", "string"] },
+              "html_url": { "type": ["null", "string"] },
+              "type": { "type": ["null", "string"] },
+              "site_admin": { "type": ["null", "boolean"] }
+            }
+          },
+          "repository": {
+            "description": "The repository associated with the pull request comment.",
+            "type": "string"
+          },
+          "comment_id": {
+            "description": "The ID of the pull request comment to which the reaction belongs.",
+            "type": "integer"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["created_at"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "pull_request_commits",
+      "json_schema": {
+        "$schema": "https://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "sha": {
+            "description": "SHA of the commit.",
+            "type": ["null", "string"]
+          },
+          "node_id": {
+            "description": "Node ID of the commit.",
+            "type": ["null", "string"]
+          },
+          "commit": {
+            "description": "Details about the commit related to the pull request.",
+            "type": "object",
+            "properties": {
+              "author": {
+                "description": "Details about the author of the commit.",
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "description": "Name of the author.",
+                    "type": ["null", "string"]
+                  },
+                  "email": {
+                    "description": "Email address of the author.",
+                    "type": ["null", "string"]
+                  },
+                  "date": {
+                    "description": "Date and time the commit was authored.",
+                    "type": "string",
+                    "format": "date-time"
+                  }
+                }
+              },
+              "committer": {
+                "description": "Details about the committer of the commit.",
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "description": "Name of the committer.",
+                    "type": ["null", "string"]
+                  },
+                  "email": {
+                    "description": "Email address of the committer.",
+                    "type": ["null", "string"]
+                  },
+                  "date": {
+                    "description": "Date and time the commit was committed.",
+                    "type": "string",
+                    "format": "date-time"
+                  }
+                }
+              },
+              "message": {
+                "description": "Commit message.",
+                "type": ["null", "string"]
+              },
+              "tree": {
+                "description": "Information about the tree associated with the commit.",
+                "type": "object",
+                "properties": {
+                  "sha": {
+                    "description": "SHA of the tree.",
+                    "type": ["null", "string"]
+                  },
+                  "url": {
+                    "description": "URL to retrieve more details about the tree.",
+                    "type": ["null", "string"]
+                  }
+                }
+              },
+              "url": {
+                "description": "URL to access more details about the commit.",
+                "type": ["null", "string"]
+              },
+              "comment_count": {
+                "description": "Number of comments on the commit.",
+                "type": ["null", "integer"]
+              },
+              "verification": {
+                "description": "Verification status of the commit.",
+                "type": "object",
+                "properties": {
+                  "verified": {
+                    "description": "Indicates if the commit is verified.",
+                    "type": ["null", "boolean"]
+                  },
+                  "reason": {
+                    "description": "Reason for verification status.",
+                    "type": ["null", "string"]
+                  },
+                  "signature": {
+                    "description": "Signature of the commit for verification.",
+                    "type": ["null", "string"]
+                  },
+                  "payload": {
+                    "description": "Payload data used for verification.",
+                    "type": ["null", "string"]
+                  }
+                }
+              }
+            }
+          },
+          "url": {
+            "description": "URL to access more details about the commit.",
+            "type": ["null", "string"]
+          },
+          "html_url": {
+            "description": "URL to view the commit in a web browser.",
+            "type": ["null", "string"]
+          },
+          "comments_url": {
+            "description": "URL to retrieve comments related to the commit.",
+            "type": ["null", "string"]
+          },
+          "author": {
+            "type": ["null", "object"],
+            "properties": {
+              "login": { "type": ["null", "string"] },
+              "id": { "type": ["null", "integer"] },
+              "node_id": { "type": ["null", "string"] },
+              "avatar_url": { "type": ["null", "string"] },
+              "gravatar_id": { "type": ["null", "string"] },
+              "url": { "type": ["null", "string"] },
+              "html_url": { "type": ["null", "string"] },
+              "followers_url": { "type": ["null", "string"] },
+              "following_url": { "type": ["null", "string"] },
+              "gists_url": { "type": ["null", "string"] },
+              "starred_url": { "type": ["null", "string"] },
+              "subscriptions_url": { "type": ["null", "string"] },
+              "organizations_url": { "type": ["null", "string"] },
+              "repos_url": { "type": ["null", "string"] },
+              "events_url": { "type": ["null", "string"] },
+              "received_events_url": { "type": ["null", "string"] },
+              "type": { "type": ["null", "string"] },
+              "site_admin": { "type": ["null", "boolean"] }
+            }
+          },
+          "committer": {
+            "type": ["null", "object"],
+            "properties": {
+              "login": { "type": ["null", "string"] },
+              "id": { "type": ["null", "integer"] },
+              "node_id": { "type": ["null", "string"] },
+              "avatar_url": { "type": ["null", "string"] },
+              "gravatar_id": { "type": ["null", "string"] },
+              "url": { "type": ["null", "string"] },
+              "html_url": { "type": ["null", "string"] },
+              "followers_url": { "type": ["null", "string"] },
+              "following_url": { "type": ["null", "string"] },
+              "gists_url": { "type": ["null", "string"] },
+              "starred_url": { "type": ["null", "string"] },
+              "subscriptions_url": { "type": ["null", "string"] },
+              "organizations_url": { "type": ["null", "string"] },
+              "repos_url": { "type": ["null", "string"] },
+              "events_url": { "type": ["null", "string"] },
+              "received_events_url": { "type": ["null", "string"] },
+              "type": { "type": ["null", "string"] },
+              "site_admin": { "type": ["null", "boolean"] }
+            }
+          },
+          "parents": {
+            "description": "List of parent commits associated with the commit.",
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "sha": {
+                  "description": "SHA of the parent commit.",
+                  "type": ["null", "string"]
+                },
+                "url": {
+                  "description": "URL to access more details about the parent commit.",
+                  "type": ["null", "string"]
+                },
+                "html_url": {
+                  "description": "URL to view the parent commit in a web browser.",
+                  "type": ["null", "string"]
+                }
+              }
+            }
+          },
+          "repository": {
+            "description": "Details about the repository where the commit was made.",
+            "type": "string"
+          },
+          "pull_number": {
+            "description": "Number associated with the pull request.",
+            "type": "integer"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "source_defined_primary_key": [["sha"]],
+      "is_resumable": true
+    },
+    {
+      "name": "pull_request_stats",
+      "json_schema": {
+        "$schema": "https://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "repository": {
+            "description": "The repository to which the pull request belongs.",
+            "type": "string"
+          },
+          "id": {
+            "description": "The unique identifier of the pull request.",
+            "type": ["null", "integer"]
+          },
+          "node_id": {
+            "description": "The node ID of the pull request.",
+            "type": ["null", "string"]
+          },
+          "number": {
+            "description": "The number of the pull request.",
+            "type": ["null", "integer"]
+          },
+          "merged": {
+            "description": "Indicates if the pull request has been merged.",
+            "type": ["null", "boolean"]
+          },
+          "mergeable": {
+            "description": "Indicates if the pull request is mergeable.",
+            "type": ["null", "string"]
+          },
+          "can_be_rebased": {
+            "description": "Indicates whether the pull request can be rebased onto the base branch.",
+            "type": ["null", "boolean"]
+          },
+          "merge_state_status": {
+            "description": "The status of the merge state for the pull request.",
+            "type": ["null", "string"]
+          },
+          "merged_by": {
+            "description": "The user who merged the pull request.",
+            "type": ["null", "object"],
+            "properties": {
+              "login": {
+                "description": "The username of the user who merged the pull request.",
+                "type": ["null", "string"]
+              },
+              "id": {
+                "description": "The unique identifier of the user who merged the pull request.",
+                "type": ["null", "integer"]
+              },
+              "node_id": {
+                "description": "The node ID of the user who merged the pull request.",
+                "type": ["null", "string"]
+              },
+              "avatar_url": {
+                "description": "The URL of the avatar of the user who merged the pull request.",
+                "type": ["null", "string"]
+              },
+              "html_url": {
+                "description": "The HTML URL of the user who merged the pull request.",
+                "type": ["null", "string"]
+              },
+              "type": {
+                "description": "The type of user who merged the pull request.",
+                "type": ["null", "string"]
+              },
+              "site_admin": {
+                "description": "Indicates if the user who merged the pull request is a site admin.",
+                "type": ["null", "boolean"]
+              }
+            }
+          },
+          "comments": {
+            "description": "The total number of comments on the pull request.",
+            "type": ["null", "integer"]
+          },
+          "review_comments": {
+            "description": "The total number of review comments on the pull request.",
+            "type": ["null", "integer"]
+          },
+          "maintainer_can_modify": {
+            "description": "Indicates if maintainers can modify the pull request.",
+            "type": ["null", "boolean"]
+          },
+          "commits": {
+            "description": "The total number of commits in the pull request.",
+            "type": ["null", "integer"]
+          },
+          "additions": {
+            "description": "The total number of lines added in the pull request.",
+            "type": ["null", "integer"]
+          },
+          "deletions": {
+            "description": "The total number of lines deleted in the pull request.",
+            "type": ["null", "integer"]
+          },
+          "changed_files": {
+            "description": "The number of files changed in the pull request.",
+            "type": ["null", "integer"]
+          },
+          "updated_at": {
+            "description": "The date and time when the pull request was last updated.",
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated_at"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "projects_v2",
+      "json_schema": {
+        "$schema": "https://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "closed": {
+            "description": "Indicates whether the project is closed or not.",
+            "type": ["null", "boolean"]
+          },
+          "created_at": {
+            "description": "The date and time when the project was created.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "creator": {
+            "description": "Information about the user who created the project.",
+            "type": ["null", "object"],
+            "properties": {
+              "avatarUrl": {
+                "description": "The URL to the creator's avatar image.",
+                "type": ["null", "string"]
+              },
+              "login": {
+                "description": "The username of the creator.",
+                "type": ["null", "string"]
+              },
+              "resourcePath": {
+                "description": "The resource path for the creator's profile.",
+                "type": ["null", "string"]
+              },
+              "url": {
+                "description": "The URL to the creator's profile.",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "closed_at": {
+            "description": "The date and time when the project was closed.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "updated_at": {
+            "description": "The date and time when the project was last updated.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "node_id": {
+            "description": "The node ID of the project.",
+            "type": ["null", "string"]
+          },
+          "id": {
+            "description": "The unique identifier of the project.",
+            "type": ["null", "integer"]
+          },
+          "number": {
+            "description": "The project number.",
+            "type": ["null", "integer"]
+          },
+          "public": {
+            "description": "Indicates whether the project is public or private.",
+            "type": ["null", "boolean"]
+          },
+          "readme": {
+            "description": "The README content of the project.",
+            "type": ["null", "string"]
+          },
+          "short_description": {
+            "description": "A brief description of the project.",
+            "type": ["null", "string"]
+          },
+          "template": {
+            "description": "Indicates whether the project is a template or not.",
+            "type": ["null", "boolean"]
+          },
+          "title": {
+            "description": "The title of the project.",
+            "type": ["null", "string"]
+          },
+          "url": {
+            "description": "The URL to access the project.",
+            "type": ["null", "string"]
+          },
+          "viewerCanClose": {
+            "description": "Indicates whether the current viewer can close the project.",
+            "type": ["null", "boolean"]
+          },
+          "viewerCanReopen": {
+            "description": "Indicates whether the current viewer can reopen the project.",
+            "type": ["null", "boolean"]
+          },
+          "viewerCanUpdate": {
+            "description": "Indicates whether the current viewer can update the project.",
+            "type": ["null", "boolean"]
+          },
+          "owner_id": {
+            "description": "The ID of the project owner.",
+            "type": ["null", "string"]
+          },
+          "repository": {
+            "description": "Information about the repository associated with the project.",
+            "type": "string"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated_at"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "pull_requests",
+      "json_schema": {
+        "$schema": "https://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "repository": {
+            "description": "Repository information",
+            "type": "string"
+          },
+          "url": {
+            "description": "URL for fetching detailed information about this pull request",
+            "type": ["null", "string"]
+          },
+          "id": {
+            "description": "Unique identifier for the pull request",
+            "type": ["null", "integer"]
+          },
+          "node_id": {
+            "description": "Node identifier for the pull request",
+            "type": ["null", "string"]
+          },
+          "html_url": {
+            "description": "URL for viewing the pull request on GitHub",
+            "type": ["null", "string"]
+          },
+          "diff_url": {
+            "description": "URL to view the diff for this pull request",
+            "type": ["null", "string"]
+          },
+          "patch_url": {
+            "description": "URL for fetching the patch file for this pull request",
+            "type": ["null", "string"]
+          },
+          "issue_url": {
+            "description": "URL for viewing the issue associated with this pull request",
+            "type": ["null", "string"]
+          },
+          "commits_url": {
+            "description": "URL for fetching commits on this pull request",
+            "type": ["null", "string"]
+          },
+          "review_comments_url": {
+            "description": "URL for fetching review comments on this pull request",
+            "type": ["null", "string"]
+          },
+          "review_comment_url": {
+            "description": "URL for fetching review comments on this pull request",
+            "type": ["null", "string"]
+          },
+          "comments_url": {
+            "description": "URL for fetching comments on this pull request",
+            "type": ["null", "string"]
+          },
+          "statuses_url": {
+            "description": "URL for fetching status information for this pull request",
+            "type": ["null", "string"]
+          },
+          "number": {
+            "description": "Number assigned to the pull request",
+            "type": ["null", "integer"]
+          },
+          "state": {
+            "description": "State of the pull request",
+            "type": ["null", "string"]
+          },
+          "locked": {
+            "description": "Indicates if the pull request is locked",
+            "type": ["null", "boolean"]
+          },
+          "title": {
+            "description": "Title of the pull request",
+            "type": ["null", "string"]
+          },
+          "user": {
+            "type": ["null", "object"],
+            "properties": {
+              "login": { "type": ["null", "string"] },
+              "id": { "type": ["null", "integer"] },
+              "node_id": { "type": ["null", "string"] },
+              "avatar_url": { "type": ["null", "string"] },
+              "gravatar_id": { "type": ["null", "string"] },
+              "url": { "type": ["null", "string"] },
+              "html_url": { "type": ["null", "string"] },
+              "followers_url": { "type": ["null", "string"] },
+              "following_url": { "type": ["null", "string"] },
+              "gists_url": { "type": ["null", "string"] },
+              "starred_url": { "type": ["null", "string"] },
+              "subscriptions_url": { "type": ["null", "string"] },
+              "organizations_url": { "type": ["null", "string"] },
+              "repos_url": { "type": ["null", "string"] },
+              "events_url": { "type": ["null", "string"] },
+              "received_events_url": { "type": ["null", "string"] },
+              "type": { "type": ["null", "string"] },
+              "site_admin": { "type": ["null", "boolean"] }
+            }
+          },
+          "body": {
+            "description": "Body content of the pull request",
+            "type": ["null", "string"]
+          },
+          "labels": {
+            "description": "Labels attached to this pull request",
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "id": { "type": ["null", "integer"] },
+                "node_id": { "type": ["null", "string"] },
+                "url": { "type": ["null", "string"] },
+                "name": { "type": ["null", "string"] },
+                "description": { "type": ["null", "string"] },
+                "color": { "type": ["null", "string"] },
+                "default": { "type": ["null", "boolean"] }
+              }
+            }
+          },
+          "milestone": {
+            "description": "Milestone information for this pull request",
+            "type": ["null", "object"],
+            "properties": {
+              "url": {
+                "description": "URL for fetching milestone information",
+                "type": ["null", "string"]
+              },
+              "html_url": {
+                "description": "URL for viewing the milestone on GitHub",
+                "type": ["null", "string"]
+              },
+              "labels_url": {
+                "description": "URL for fetching labels on the milestone",
+                "type": ["null", "string"]
+              },
+              "id": {
+                "description": "Unique identifier for the milestone",
+                "type": ["null", "integer"]
+              },
+              "node_id": { "type": ["null", "string"] },
+              "number": {
+                "description": "Milestone number",
+                "type": ["null", "integer"]
+              },
+              "state": {
+                "description": "State of the milestone",
+                "type": ["null", "string"]
+              },
+              "title": {
+                "description": "Title of the milestone",
+                "type": ["null", "string"]
+              },
+              "description": {
+                "description": "Description of the milestone",
+                "type": ["null", "string"]
+              },
+              "creator": {
+                "type": ["null", "object"],
+                "properties": {
+                  "login": { "type": ["null", "string"] },
+                  "id": { "type": ["null", "integer"] },
+                  "node_id": { "type": ["null", "string"] },
+                  "avatar_url": { "type": ["null", "string"] },
+                  "gravatar_id": { "type": ["null", "string"] },
+                  "url": { "type": ["null", "string"] },
+                  "html_url": { "type": ["null", "string"] },
+                  "followers_url": { "type": ["null", "string"] },
+                  "following_url": { "type": ["null", "string"] },
+                  "gists_url": { "type": ["null", "string"] },
+                  "starred_url": { "type": ["null", "string"] },
+                  "subscriptions_url": { "type": ["null", "string"] },
+                  "organizations_url": { "type": ["null", "string"] },
+                  "repos_url": { "type": ["null", "string"] },
+                  "events_url": { "type": ["null", "string"] },
+                  "received_events_url": { "type": ["null", "string"] },
+                  "type": { "type": ["null", "string"] },
+                  "site_admin": { "type": ["null", "boolean"] }
+                }
+              },
+              "open_issues": {
+                "description": "Number of open issues in the milestone",
+                "type": ["null", "integer"]
+              },
+              "closed_issues": {
+                "description": "Number of closed issues in the milestone",
+                "type": ["null", "integer"]
+              },
+              "created_at": {
+                "description": "Date and time when the milestone was created",
+                "type": "string",
+                "format": "date-time"
+              },
+              "updated_at": {
+                "description": "Date and time when the milestone was last updated",
+                "type": "string",
+                "format": "date-time"
+              },
+              "closed_at": {
+                "description": "Date and time when the milestone was closed",
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "due_on": {
+                "description": "Date when the milestone is due",
+                "type": ["null", "string"],
+                "format": "date-time"
+              }
+            }
+          },
+          "active_lock_reason": {
+            "description": "Reason this pull request is locked",
+            "type": ["null", "string"]
+          },
+          "created_at": {
+            "description": "Date and time when the pull request was created",
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "description": "Date and time when the pull request was last updated",
+            "type": "string",
+            "format": "date-time"
+          },
+          "closed_at": {
+            "description": "Date and time when the pull request was closed",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "merged_at": {
+            "description": "Date and time when the pull request was merged",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "merge_commit_sha": {
+            "description": "SHA hash of the merged commit",
+            "type": ["null", "string"]
+          },
+          "assignee": {
+            "type": ["null", "object"],
+            "properties": {
+              "login": { "type": ["null", "string"] },
+              "id": { "type": ["null", "integer"] },
+              "node_id": { "type": ["null", "string"] },
+              "avatar_url": { "type": ["null", "string"] },
+              "gravatar_id": { "type": ["null", "string"] },
+              "url": { "type": ["null", "string"] },
+              "html_url": { "type": ["null", "string"] },
+              "followers_url": { "type": ["null", "string"] },
+              "following_url": { "type": ["null", "string"] },
+              "gists_url": { "type": ["null", "string"] },
+              "starred_url": { "type": ["null", "string"] },
+              "subscriptions_url": { "type": ["null", "string"] },
+              "organizations_url": { "type": ["null", "string"] },
+              "repos_url": { "type": ["null", "string"] },
+              "events_url": { "type": ["null", "string"] },
+              "received_events_url": { "type": ["null", "string"] },
+              "type": { "type": ["null", "string"] },
+              "site_admin": { "type": ["null", "boolean"] }
+            }
+          },
+          "assignees": {
+            "description": "Users assigned to this pull request",
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "login": { "type": ["null", "string"] },
+                "id": { "type": ["null", "integer"] },
+                "node_id": { "type": ["null", "string"] },
+                "avatar_url": { "type": ["null", "string"] },
+                "gravatar_id": { "type": ["null", "string"] },
+                "url": { "type": ["null", "string"] },
+                "html_url": { "type": ["null", "string"] },
+                "followers_url": { "type": ["null", "string"] },
+                "following_url": { "type": ["null", "string"] },
+                "gists_url": { "type": ["null", "string"] },
+                "starred_url": { "type": ["null", "string"] },
+                "subscriptions_url": { "type": ["null", "string"] },
+                "organizations_url": { "type": ["null", "string"] },
+                "repos_url": { "type": ["null", "string"] },
+                "events_url": { "type": ["null", "string"] },
+                "received_events_url": { "type": ["null", "string"] },
+                "type": { "type": ["null", "string"] },
+                "site_admin": { "type": ["null", "boolean"] }
+              }
+            }
+          },
+          "requested_reviewers": {
+            "description": "Requested reviewers for this pull request",
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "login": { "type": ["null", "string"] },
+                "id": { "type": ["null", "integer"] },
+                "node_id": { "type": ["null", "string"] },
+                "avatar_url": { "type": ["null", "string"] },
+                "gravatar_id": { "type": ["null", "string"] },
+                "url": { "type": ["null", "string"] },
+                "html_url": { "type": ["null", "string"] },
+                "followers_url": { "type": ["null", "string"] },
+                "following_url": { "type": ["null", "string"] },
+                "gists_url": { "type": ["null", "string"] },
+                "starred_url": { "type": ["null", "string"] },
+                "subscriptions_url": { "type": ["null", "string"] },
+                "organizations_url": { "type": ["null", "string"] },
+                "repos_url": { "type": ["null", "string"] },
+                "events_url": { "type": ["null", "string"] },
+                "received_events_url": { "type": ["null", "string"] },
+                "type": { "type": ["null", "string"] },
+                "site_admin": { "type": ["null", "boolean"] }
+              }
+            }
+          },
+          "requested_teams": {
+            "description": "Requested teams for this pull request",
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "id": { "type": ["null", "integer"] },
+                "node_id": { "type": ["null", "string"] },
+                "url": { "type": ["null", "string"] },
+                "html_url": { "type": ["null", "string"] },
+                "name": { "type": ["null", "string"] },
+                "slug": { "type": ["null", "string"] },
+                "description": { "type": ["null", "string"] },
+                "privacy": { "type": ["null", "string"] },
+                "permission": { "type": ["null", "string"] },
+                "members_url": { "type": ["null", "string"] },
+                "repositories_url": { "type": ["null", "string"] },
+                "parent": { "type": ["null", "object"], "properties": {} }
+              }
+            }
+          },
+          "head": {
+            "description": "Head branch information",
+            "type": ["null", "object"],
+            "properties": {
+              "label": { "type": ["null", "string"] },
+              "ref": { "type": ["null", "string"] },
+              "sha": { "type": ["null", "string"] },
+              "user_id": { "type": ["null", "integer"] },
+              "repo_id": { "type": ["null", "integer"] },
+              "user": {
+                "type": ["null", "object"],
+                "properties": {
+                  "login": { "type": ["null", "string"] },
+                  "id": { "type": ["null", "integer"] },
+                  "node_id": { "type": ["null", "string"] },
+                  "avatar_url": { "type": ["null", "string"] },
+                  "gravatar_id": { "type": ["null", "string"] },
+                  "url": { "type": ["null", "string"] },
+                  "html_url": { "type": ["null", "string"] },
+                  "followers_url": { "type": ["null", "string"] },
+                  "following_url": { "type": ["null", "string"] },
+                  "gists_url": { "type": ["null", "string"] },
+                  "starred_url": { "type": ["null", "string"] },
+                  "subscriptions_url": { "type": ["null", "string"] },
+                  "organizations_url": { "type": ["null", "string"] },
+                  "repos_url": { "type": ["null", "string"] },
+                  "events_url": { "type": ["null", "string"] },
+                  "received_events_url": { "type": ["null", "string"] },
+                  "type": { "type": ["null", "string"] },
+                  "site_admin": { "type": ["null", "boolean"] }
+                }
+              }
+            }
+          },
+          "base": {
+            "description": "Base branch information",
+            "type": ["null", "object"],
+            "properties": {
+              "label": { "type": ["null", "string"] },
+              "ref": { "type": ["null", "string"] },
+              "sha": { "type": ["null", "string"] },
+              "user_id": { "type": ["null", "integer"] },
+              "repo_id": { "type": ["null", "integer"] },
+              "repo": { "type": ["null", "object"] },
+              "user": {
+                "type": ["null", "object"],
+                "properties": {
+                  "login": { "type": ["null", "string"] },
+                  "id": { "type": ["null", "integer"] },
+                  "node_id": { "type": ["null", "string"] },
+                  "avatar_url": { "type": ["null", "string"] },
+                  "gravatar_id": { "type": ["null", "string"] },
+                  "url": { "type": ["null", "string"] },
+                  "html_url": { "type": ["null", "string"] },
+                  "followers_url": { "type": ["null", "string"] },
+                  "following_url": { "type": ["null", "string"] },
+                  "gists_url": { "type": ["null", "string"] },
+                  "starred_url": { "type": ["null", "string"] },
+                  "subscriptions_url": { "type": ["null", "string"] },
+                  "organizations_url": { "type": ["null", "string"] },
+                  "repos_url": { "type": ["null", "string"] },
+                  "events_url": { "type": ["null", "string"] },
+                  "received_events_url": { "type": ["null", "string"] },
+                  "type": { "type": ["null", "string"] },
+                  "site_admin": { "type": ["null", "boolean"] }
+                }
+              }
+            }
+          },
+          "_links": {
+            "description": "Object containing links related to the pull request.",
+            "type": ["null", "object"],
+            "properties": {
+              "self": {
+                "description": "URL for fetching detailed information about this pull request",
+                "type": ["null", "object"],
+                "properties": { "href": { "type": ["null", "string"] } }
+              },
+              "html": {
+                "description": "URL for viewing the pull request on GitHub",
+                "type": ["null", "object"],
+                "properties": { "href": { "type": ["null", "string"] } }
+              },
+              "issue": {
+                "description": "URL for viewing the issue associated with this pull request",
+                "type": ["null", "object"],
+                "properties": { "href": { "type": ["null", "string"] } }
+              },
+              "comments": {
+                "description": "URL for fetching comments related to this pull request",
+                "type": ["null", "object"],
+                "properties": { "href": { "type": ["null", "string"] } }
+              },
+              "review_comments": {
+                "description": "URL for fetching review comments related to this pull request",
+                "type": ["null", "object"],
+                "properties": { "href": { "type": ["null", "string"] } }
+              },
+              "review_comment": {
+                "description": "URL for fetching review comments related to this pull request",
+                "type": ["null", "object"],
+                "properties": { "href": { "type": ["null", "string"] } }
+              },
+              "commits": {
+                "description": "URL for fetching commits related to this pull request",
+                "type": ["null", "object"],
+                "properties": { "href": { "type": ["null", "string"] } }
+              },
+              "statuses": {
+                "description": "URL for fetching status information for this pull request",
+                "type": ["null", "object"],
+                "properties": { "href": { "type": ["null", "string"] } }
+              }
+            }
+          },
+          "author_association": {
+            "description": "Association of the author with this pull request",
+            "type": ["null", "string"]
+          },
+          "auto_merge": {
+            "description": "Details about automatic merging of this pull request",
+            "type": ["null", "object"],
+            "properties": {
+              "enabled_by": {
+                "type": ["null", "object"],
+                "properties": {
+                  "login": { "type": ["null", "string"] },
+                  "id": { "type": ["null", "integer"] },
+                  "node_id": { "type": ["null", "string"] },
+                  "avatar_url": { "type": ["null", "string"] },
+                  "gravatar_id": { "type": ["null", "string"] },
+                  "url": { "type": ["null", "string"] },
+                  "html_url": { "type": ["null", "string"] },
+                  "followers_url": { "type": ["null", "string"] },
+                  "following_url": { "type": ["null", "string"] },
+                  "gists_url": { "type": ["null", "string"] },
+                  "starred_url": { "type": ["null", "string"] },
+                  "subscriptions_url": { "type": ["null", "string"] },
+                  "organizations_url": { "type": ["null", "string"] },
+                  "repos_url": { "type": ["null", "string"] },
+                  "events_url": { "type": ["null", "string"] },
+                  "received_events_url": { "type": ["null", "string"] },
+                  "type": { "type": ["null", "string"] },
+                  "site_admin": { "type": ["null", "boolean"] }
+                }
+              },
+              "commit_title": { "type": ["null", "string"] },
+              "merge_method": { "type": ["null", "string"] },
+              "commit_message": { "type": ["null", "string"] }
+            }
+          },
+          "draft": {
+            "description": "Indicates if the pull request is a draft",
+            "type": ["null", "boolean"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated_at"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "releases",
+      "json_schema": {
+        "$schema": "https://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "repository": {
+            "description": "The repository associated with the release.",
+            "type": "string"
+          },
+          "url": {
+            "description": "The URL for the release.",
+            "type": ["null", "string"]
+          },
+          "html_url": {
+            "description": "The HTML URL for the release.",
+            "type": ["null", "string"]
+          },
+          "assets_url": {
+            "description": "The URL to fetch information about the assets linked to this release.",
+            "type": ["null", "string"]
+          },
+          "upload_url": {
+            "description": "The URL for uploading assets to the release.",
+            "type": ["null", "string"]
+          },
+          "tarball_url": {
+            "description": "The URL for the tarball file of the release.",
+            "type": ["null", "string"]
+          },
+          "zipball_url": {
+            "description": "The URL for the zipball file of the release.",
+            "type": ["null", "string"]
+          },
+          "id": {
+            "description": "The unique identifier for the release",
+            "type": ["null", "integer"]
+          },
+          "node_id": {
+            "description": "The node ID of the release.",
+            "type": ["null", "string"]
+          },
+          "tag_name": {
+            "description": "The tag name of the release.",
+            "type": ["null", "string"]
+          },
+          "target_commitish": {
+            "description": "The commit SHA or branch name for the release.",
+            "type": ["null", "string"]
+          },
+          "name": {
+            "description": "The name of the release.",
+            "type": ["null", "string"]
+          },
+          "body": {
+            "description": "The body of the release.",
+            "type": ["null", "string"]
+          },
+          "draft": {
+            "description": "Indicates if the release is a draft.",
+            "type": ["null", "boolean"]
+          },
+          "prerelease": {
+            "description": "Indicates if the release is a prerelease.",
+            "type": ["null", "boolean"]
+          },
+          "created_at": {
+            "description": "The timestamp of when the release was created.",
+            "type": "string",
+            "format": "date-time"
+          },
+          "published_at": {
+            "description": "The timestamp of when the release was published.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "author": {
+            "type": ["null", "object"],
+            "properties": {
+              "login": { "type": ["null", "string"] },
+              "id": { "type": ["null", "integer"] },
+              "node_id": { "type": ["null", "string"] },
+              "avatar_url": { "type": ["null", "string"] },
+              "gravatar_id": { "type": ["null", "string"] },
+              "url": { "type": ["null", "string"] },
+              "html_url": { "type": ["null", "string"] },
+              "followers_url": { "type": ["null", "string"] },
+              "following_url": { "type": ["null", "string"] },
+              "gists_url": { "type": ["null", "string"] },
+              "starred_url": { "type": ["null", "string"] },
+              "subscriptions_url": { "type": ["null", "string"] },
+              "organizations_url": { "type": ["null", "string"] },
+              "repos_url": { "type": ["null", "string"] },
+              "events_url": { "type": ["null", "string"] },
+              "received_events_url": { "type": ["null", "string"] },
+              "type": { "type": ["null", "string"] },
+              "site_admin": { "type": ["null", "boolean"] }
+            }
+          },
+          "assets": {
+            "description": "List of assets (e.g., downloadable files) associated with the release",
+            "type": ["null", "array"],
+            "items": {
+              "description": "Details of an individual asset",
+              "type": ["null", "object"],
+              "properties": {
+                "url": {
+                  "description": "The URL of the asset.",
+                  "type": ["null", "string"]
+                },
+                "browser_download_url": {
+                  "description": "The URL for downloading the asset linked to this release.",
+                  "type": ["null", "string"]
+                },
+                "id": {
+                  "description": "The unique identifier for the asset.",
+                  "type": ["null", "integer"]
+                },
+                "node_id": {
+                  "description": "The node ID of the asset.",
+                  "type": ["null", "string"]
+                },
+                "name": {
+                  "description": "The name of the asset.",
+                  "type": ["null", "string"]
+                },
+                "label": {
+                  "description": "The label assigned to the asset.",
+                  "type": ["null", "string"]
+                },
+                "state": {
+                  "description": "The state of the asset.",
+                  "type": ["null", "string"]
+                },
+                "content_type": {
+                  "description": "The content type of the asset.",
+                  "type": ["null", "string"]
+                },
+                "size": {
+                  "description": "The size of the asset in bytes.",
+                  "type": ["null", "integer"]
+                },
+                "download_count": {
+                  "description": "The number of times the asset has been downloaded.",
+                  "type": ["null", "integer"]
+                },
+                "created_at": {
+                  "description": "The timestamp of when the asset was created.",
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "updated_at": {
+                  "description": "The timestamp of when the asset was last updated.",
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "uploader_id": {
+                  "description": "The ID of the user who uploaded the asset.",
+                  "type": ["null", "integer"]
+                }
+              }
+            }
+          },
+          "body_html": {
+            "description": "The HTML body of the release.",
+            "type": ["null", "string"]
+          },
+          "body_text": {
+            "description": "The text body of the release.",
+            "type": ["null", "string"]
+          },
+          "mentions_count": {
+            "description": "The count of mentions in the release.",
+            "type": ["null", "integer"]
+          },
+          "discussion_url": {
+            "description": "The URL for the discussion related to the release.",
+            "type": ["null", "string"]
+          },
+          "reactions": {
+            "type": ["null", "object"],
+            "properties": {
+              "url": { "type": ["null", "string"] },
+              "total_count": { "type": ["null", "integer"] },
+              "+1": { "type": ["null", "integer"] },
+              "-1": { "type": ["null", "integer"] },
+              "laugh": { "type": ["null", "integer"] },
+              "hooray": { "type": ["null", "integer"] },
+              "confused": { "type": ["null", "integer"] },
+              "heart": { "type": ["null", "integer"] },
+              "rocket": { "type": ["null", "integer"] },
+              "eyes": { "type": ["null", "integer"] }
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["created_at"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "repositories",
+      "json_schema": {
+        "$schema": "https://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "id": {
+            "description": "Unique identifier of the repository.",
+            "type": ["null", "integer"]
+          },
+          "node_id": {
+            "description": "Node ID of the repository.",
+            "type": ["null", "string"]
+          },
+          "name": {
+            "description": "Name of the repository.",
+            "type": ["null", "string"]
+          },
+          "full_name": {
+            "description": "Full name of the repository.",
+            "type": ["null", "string"]
+          },
+          "owner": {
+            "type": ["null", "object"],
+            "properties": {
+              "login": { "type": ["null", "string"] },
+              "id": { "type": ["null", "integer"] },
+              "node_id": { "type": ["null", "string"] },
+              "avatar_url": { "type": ["null", "string"] },
+              "gravatar_id": { "type": ["null", "string"] },
+              "url": { "type": ["null", "string"] },
+              "html_url": { "type": ["null", "string"] },
+              "followers_url": { "type": ["null", "string"] },
+              "following_url": { "type": ["null", "string"] },
+              "gists_url": { "type": ["null", "string"] },
+              "starred_url": { "type": ["null", "string"] },
+              "subscriptions_url": { "type": ["null", "string"] },
+              "organizations_url": { "type": ["null", "string"] },
+              "repos_url": { "type": ["null", "string"] },
+              "events_url": { "type": ["null", "string"] },
+              "received_events_url": { "type": ["null", "string"] },
+              "type": { "type": ["null", "string"] },
+              "site_admin": { "type": ["null", "boolean"] }
+            }
+          },
+          "private": {
+            "description": "Indicates if the repository is private.",
+            "type": ["null", "boolean"]
+          },
+          "html_url": {
+            "description": "URL of the repository's GitHub page.",
+            "type": ["null", "string"]
+          },
+          "description": {
+            "description": "Brief description of the repository.",
+            "type": ["null", "string"]
+          },
+          "fork": {
+            "description": "Indicates if the repository is a fork.",
+            "type": ["null", "boolean"]
+          },
+          "url": {
+            "description": "URL of the repository.",
+            "type": ["null", "string"]
+          },
+          "archive_url": {
+            "description": "URL to archive the repository.",
+            "type": ["null", "string"]
+          },
+          "assignees_url": {
+            "description": "URL to fetch assignees for issues in the repository.",
+            "type": ["null", "string"]
+          },
+          "blobs_url": {
+            "description": "URL to fetch blobs within the repository.",
+            "type": ["null", "string"]
+          },
+          "branches_url": {
+            "description": "URL to fetch branches within the repository.",
+            "type": ["null", "string"]
+          },
+          "collaborators_url": {
+            "description": "URL to fetch collaborators of the repository.",
+            "type": ["null", "string"]
+          },
+          "comments_url": {
+            "description": "URL to fetch comments within the repository.",
+            "type": ["null", "string"]
+          },
+          "commits_url": {
+            "description": "URL to fetch commits within the repository.",
+            "type": ["null", "string"]
+          },
+          "compare_url": {
+            "description": "URL to compare references within the repository.",
+            "type": ["null", "string"]
+          },
+          "contents_url": {
+            "description": "URL to fetch contents within the repository.",
+            "type": ["null", "string"]
+          },
+          "contributors_url": {
+            "description": "URL to fetch contributors to the repository.",
+            "type": ["null", "string"]
+          },
+          "deployments_url": {
+            "description": "URL to fetch deployments related to the repository.",
+            "type": ["null", "string"]
+          },
+          "downloads_url": {
+            "description": "URL to fetch downloads linked to the repository.",
+            "type": ["null", "string"]
+          },
+          "events_url": {
+            "description": "URL to fetch events related to the repository.",
+            "type": ["null", "string"]
+          },
+          "forks_url": {
+            "description": "URL to fetch forks of the repository.",
+            "type": ["null", "string"]
+          },
+          "git_commits_url": {
+            "description": "URL to fetch git commits within the repository.",
+            "type": ["null", "string"]
+          },
+          "git_refs_url": {
+            "description": "URL to fetch git references within the repository.",
+            "type": ["null", "string"]
+          },
+          "git_tags_url": {
+            "description": "URL to fetch git tags within the repository.",
+            "type": ["null", "string"]
+          },
+          "git_url": {
+            "description": "URL for Git protocol to interact with the repository.",
+            "type": ["null", "string"]
+          },
+          "issue_comment_url": {
+            "description": "URL to fetch issue comments within the repository.",
+            "type": ["null", "string"]
+          },
+          "issue_events_url": {
+            "description": "URL to fetch issue events within the repository.",
+            "type": ["null", "string"]
+          },
+          "issues_url": {
+            "description": "URL to fetch issues within the repository.",
+            "type": ["null", "string"]
+          },
+          "keys_url": {
+            "description": "URL to fetch keys associated with the repository.",
+            "type": ["null", "string"]
+          },
+          "labels_url": {
+            "description": "URL to fetch labels associated with the repository.",
+            "type": ["null", "string"]
+          },
+          "languages_url": {
+            "description": "URL to fetch languages used in the repository.",
+            "type": ["null", "string"]
+          },
+          "merges_url": {
+            "description": "URL to fetch merges related to the repository.",
+            "type": ["null", "string"]
+          },
+          "milestones_url": {
+            "description": "URL to fetch milestones within the repository.",
+            "type": ["null", "string"]
+          },
+          "notifications_url": {
+            "description": "URL to manage notifications for the repository.",
+            "type": ["null", "string"]
+          },
+          "pulls_url": {
+            "description": "URL to fetch pull requests within the repository.",
+            "type": ["null", "string"]
+          },
+          "releases_url": {
+            "description": "URL to fetch releases related to the repository.",
+            "type": ["null", "string"]
+          },
+          "ssh_url": {
+            "description": "SSH URL of the repository.",
+            "type": ["null", "string"]
+          },
+          "stargazers_url": {
+            "description": "URL to fetch users who starred the repository.",
+            "type": ["null", "string"]
+          },
+          "statuses_url": {
+            "description": "URL to fetch commit statuses within the repository.",
+            "type": ["null", "string"]
+          },
+          "subscribers_url": {
+            "description": "URL to fetch subscribers of the repository.",
+            "type": ["null", "string"]
+          },
+          "subscription_url": {
+            "description": "URL to manage subscriptions to notifications for the repository.",
+            "type": ["null", "string"]
+          },
+          "tags_url": {
+            "description": "URL to fetch tags within the repository.",
+            "type": ["null", "string"]
+          },
+          "teams_url": {
+            "description": "URL to manage repository teams.",
+            "type": ["null", "string"]
+          },
+          "trees_url": {
+            "description": "URL to fetch trees within the repository.",
+            "type": ["null", "string"]
+          },
+          "clone_url": {
+            "description": "URL to clone the repository.",
+            "type": ["null", "string"]
+          },
+          "mirror_url": {
+            "description": "URL of the mirror repository.",
+            "type": ["null", "string"]
+          },
+          "hooks_url": {
+            "description": "URL to manage webhooks for the repository.",
+            "type": ["null", "string"]
+          },
+          "svn_url": {
+            "description": "SVN URL of the repository.",
+            "type": ["null", "string"]
+          },
+          "homepage": {
+            "description": "URL of the repository's homepage.",
+            "type": ["null", "string"]
+          },
+          "language": {
+            "description": "Main programming language used in the repository.",
+            "type": ["null", "string"]
+          },
+          "forks_count": {
+            "description": "Count of forks for the repository.",
+            "type": ["null", "integer"]
+          },
+          "stargazers_count": {
+            "description": "Number of stars the repository has received.",
+            "type": ["null", "integer"]
+          },
+          "watchers_count": {
+            "description": "Count of watchers for the repository.",
+            "type": ["null", "integer"]
+          },
+          "size": {
+            "description": "Size of the repository in kilobytes.",
+            "type": ["null", "integer"]
+          },
+          "default_branch": {
+            "description": "Default branch of the repository.",
+            "type": ["null", "string"]
+          },
+          "open_issues_count": {
+            "description": "Count of open issues in the repository.",
+            "type": ["null", "integer"]
+          },
+          "is_template": {
+            "description": "Indicates if the repository is a template.",
+            "type": ["null", "boolean"]
+          },
+          "topics": {
+            "description": "Topics associated with the repository.",
+            "type": ["null", "array"],
+            "items": {
+              "description": "Individual topic related to the repository.",
+              "type": ["null", "string"]
+            }
+          },
+          "license": {
+            "description": "License information of the repository.",
+            "type": ["null", "object"],
+            "properties": {
+              "key": {
+                "description": "Key identifier of the license.",
+                "type": ["null", "string"]
+              },
+              "name": {
+                "description": "Name of the license.",
+                "type": ["null", "string"]
+              },
+              "url": {
+                "description": "URL to access license details.",
+                "type": ["null", "string"]
+              },
+              "spdx_id": {
+                "description": "SPDX identifier of the license.",
+                "type": ["null", "string"]
+              },
+              "node_id": {
+                "description": "Node ID of the license.",
+                "type": ["null", "string"]
+              },
+              "html_url": {
+                "description": "URL to view license details on the web.",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "has_issues": {
+            "description": "Indicates if the repository has issues enabled.",
+            "type": ["null", "boolean"]
+          },
+          "has_projects": {
+            "description": "Indicates if the repository has projects enabled.",
+            "type": ["null", "boolean"]
+          },
+          "has_wiki": {
+            "description": "Indicates if the repository has a wiki enabled.",
+            "type": ["null", "boolean"]
+          },
+          "has_pages": {
+            "description": "Indicates if the repository has GitHub Pages enabled.",
+            "type": ["null", "boolean"]
+          },
+          "has_downloads": {
+            "description": "Indicates if the repository has downloads available.",
+            "type": ["null", "boolean"]
+          },
+          "archived": {
+            "description": "Indicates if the repository is archived.",
+            "type": ["null", "boolean"]
+          },
+          "disabled": {
+            "description": "Indicates if the repository is disabled.",
+            "type": ["null", "boolean"]
+          },
+          "visibility": {
+            "description": "Visibility status of the repository.",
+            "type": ["null", "string"]
+          },
+          "pushed_at": {
+            "description": "Date and time when the repository was last pushed to.",
+            "type": "string",
+            "format": "date-time"
+          },
+          "created_at": {
+            "description": "Date and time when the repository was created.",
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "description": "Date and time when the repository was last updated.",
+            "type": "string",
+            "format": "date-time"
+          },
+          "permissions": {
+            "description": "Permissions granted to different roles for the repository.",
+            "type": ["null", "object"],
+            "properties": {
+              "admin": {
+                "description": "Admin permission level.",
+                "type": ["null", "boolean"]
+              },
+              "push": {
+                "description": "Push permission level.",
+                "type": ["null", "boolean"]
+              },
+              "pull": {
+                "description": "Pull permission level.",
+                "type": ["null", "boolean"]
+              },
+              "maintain": {
+                "description": "Maintain permission level.",
+                "type": ["null", "boolean"]
+              },
+              "triage": {
+                "description": "Triage permission level.",
+                "type": ["null", "boolean"]
+              }
+            }
+          },
+          "allow_forking": {
+            "description": "Indicates if forking is allowed for the repository.",
+            "type": ["null", "boolean"]
+          },
+          "forks": {
+            "description": "Forks information related to the repository.",
+            "type": ["null", "integer"]
+          },
+          "has_discussions": {
+            "description": "Indicates if the repository has discussions.",
+            "type": ["null", "boolean"]
+          },
+          "open_issues": {
+            "description": "Number of open issues in the repository.",
+            "type": ["null", "integer"]
+          },
+          "organization": {
+            "description": "Organization the repository belongs to.",
+            "type": ["null", "string"]
+          },
+          "watchers": {
+            "description": "Watchers of the repository.",
+            "type": ["null", "integer"]
+          },
+          "web_commit_signoff_required": {
+            "description": "Indicates if web commit sign-off is required for contributions.",
+            "type": ["null", "boolean"]
+          },
+          "security_and_analysis": {
+            "description": "Security and analysis settings of the repository.",
+            "type": ["null", "object"],
+            "properties": {
+              "secret_scanning": {
+                "description": "Secret scanning status.",
+                "type": ["null", "object"],
+                "properties": { "status": { "type": ["null", "string"] } }
+              },
+              "secret_scanning_push_protection": {
+                "description": "Secret scanning push protection status.",
+                "type": ["null", "object"],
+                "properties": { "status": { "type": ["null", "string"] } }
+              },
+              "secret_scanning_validity_checks": {
+                "description": "Secret scanning validity checks status.",
+                "type": ["null", "object"],
+                "properties": { "status": { "type": ["null", "string"] } }
+              },
+              "dependabot_security_updates": {
+                "description": "Dependabot security updates status.",
+                "type": ["null", "object"],
+                "properties": { "status": { "type": ["null", "string"] } }
+              }
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated_at"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "review_comments",
+      "json_schema": {
+        "$schema": "https://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "repository": {
+            "description": "Information about the repository where the comment was made",
+            "type": "string"
+          },
+          "url": {
+            "description": "The URL of the API resource for the comment",
+            "type": ["null", "string"]
+          },
+          "pull_request_review_id": {
+            "description": "The ID of the pull request review to which the comment belongs",
+            "type": ["null", "integer"]
+          },
+          "id": {
+            "description": "The unique identifier of the comment",
+            "type": ["null", "integer"]
+          },
+          "node_id": {
+            "description": "The unique identifier for the comment node",
+            "type": ["null", "string"]
+          },
+          "diff_hunk": {
+            "description": "A snippet of the diff where the comment was made",
+            "type": ["null", "string"]
+          },
+          "path": {
+            "description": "The file path where the comment was made",
+            "type": ["null", "string"]
+          },
+          "position": {
+            "description": "The position of the comment relative to the diff",
+            "type": ["null", "integer"]
+          },
+          "original_position": {
+            "description": "The original position of the comment relative to the diff",
+            "type": ["null", "integer"]
+          },
+          "commit_id": {
+            "description": "The ID of the commit the comment is associated with",
+            "type": ["null", "string"]
+          },
+          "original_commit_id": {
+            "description": "The original commit ID associated with the comment",
+            "type": ["null", "string"]
+          },
+          "in_reply_to_id": {
+            "description": "The ID of the comment being replied to",
+            "type": ["null", "integer"]
+          },
+          "user": {
+            "type": ["null", "object"],
+            "properties": {
+              "login": { "type": ["null", "string"] },
+              "id": { "type": ["null", "integer"] },
+              "node_id": { "type": ["null", "string"] },
+              "avatar_url": { "type": ["null", "string"] },
+              "gravatar_id": { "type": ["null", "string"] },
+              "url": { "type": ["null", "string"] },
+              "html_url": { "type": ["null", "string"] },
+              "followers_url": { "type": ["null", "string"] },
+              "following_url": { "type": ["null", "string"] },
+              "gists_url": { "type": ["null", "string"] },
+              "starred_url": { "type": ["null", "string"] },
+              "subscriptions_url": { "type": ["null", "string"] },
+              "organizations_url": { "type": ["null", "string"] },
+              "repos_url": { "type": ["null", "string"] },
+              "events_url": { "type": ["null", "string"] },
+              "received_events_url": { "type": ["null", "string"] },
+              "type": { "type": ["null", "string"] },
+              "site_admin": { "type": ["null", "boolean"] }
+            }
+          },
+          "body": {
+            "description": "The content of the comment",
+            "type": ["null", "string"]
+          },
+          "created_at": {
+            "description": "The timestamp when the comment was created",
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "description": "The timestamp when the comment was last updated",
+            "type": "string",
+            "format": "date-time"
+          },
+          "html_url": {
+            "description": "The URL for viewing the comment on GitHub",
+            "type": ["null", "string"]
+          },
+          "pull_request_url": {
+            "description": "The URL of the pull request to which the comment belongs",
+            "type": ["null", "string"]
+          },
+          "author_association": {
+            "description": "The association of the author of the comment with the repository",
+            "type": ["null", "string"]
+          },
+          "_links": {
+            "description": "Contains links to related resources for the review comment",
+            "type": ["null", "object"],
+            "properties": {
+              "self": {
+                "description": "URL for the review comment itself",
+                "type": ["null", "object"],
+                "properties": {
+                  "href": {
+                    "description": "The URL of the comment itself",
+                    "type": ["null", "string"]
+                  }
+                }
+              },
+              "html": {
+                "description": "URL for the HTML representation of the review comment",
+                "type": ["null", "object"],
+                "properties": {
+                  "href": {
+                    "description": "The URL for viewing the comment in a browser",
+                    "type": ["null", "string"]
+                  }
+                }
+              },
+              "pull_request": {
+                "description": "URL for the pull request associated with the review comment",
+                "type": ["null", "object"],
+                "properties": {
+                  "href": {
+                    "description": "The URL for the associated pull request",
+                    "type": ["null", "string"]
+                  }
+                }
+              }
+            }
+          },
+          "start_line": {
+            "description": "The starting line of the comment reference",
+            "type": ["null", "integer"]
+          },
+          "original_start_line": {
+            "description": "The original starting line of the comment reference",
+            "type": ["null", "integer"]
+          },
+          "start_side": {
+            "description": "The side in the diff where the comment reference started",
+            "type": ["null", "string"]
+          },
+          "line": {
+            "description": "The line in the diff where the comment was made",
+            "type": ["null", "integer"]
+          },
+          "original_line": {
+            "description": "The original line for the comment reference",
+            "type": ["null", "integer"]
+          },
+          "side": {
+            "description": "The side of the diff where the comment was made (e.g., left or right)",
+            "type": ["null", "string"]
+          },
+          "subject_type": {
+            "description": "The type of subject the comment is associated with",
+            "type": ["null", "string"]
+          },
+          "reactions": {
+            "type": ["null", "object"],
+            "properties": {
+              "url": { "type": ["null", "string"] },
+              "total_count": { "type": ["null", "integer"] },
+              "+1": { "type": ["null", "integer"] },
+              "-1": { "type": ["null", "integer"] },
+              "laugh": { "type": ["null", "integer"] },
+              "hooray": { "type": ["null", "integer"] },
+              "confused": { "type": ["null", "integer"] },
+              "heart": { "type": ["null", "integer"] },
+              "rocket": { "type": ["null", "integer"] },
+              "eyes": { "type": ["null", "integer"] }
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated_at"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "reviews",
+      "json_schema": {
+        "$schema": "https://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "repository": {
+            "description": "Information about the repository where the review is posted.",
+            "type": "string"
+          },
+          "id": {
+            "description": "The unique identifier of the review.",
+            "type": ["null", "integer"]
+          },
+          "node_id": {
+            "description": "The node identifier of the review.",
+            "type": ["null", "string"]
+          },
+          "user": {
+            "type": ["null", "object"],
+            "properties": {
+              "login": { "type": ["null", "string"] },
+              "id": { "type": ["null", "integer"] },
+              "node_id": { "type": ["null", "string"] },
+              "avatar_url": { "type": ["null", "string"] },
+              "html_url": { "type": ["null", "string"] },
+              "type": { "type": ["null", "string"] },
+              "site_admin": { "type": ["null", "boolean"] }
+            }
+          },
+          "body": {
+            "description": "The content of the review comment.",
+            "type": ["null", "string"]
+          },
+          "state": {
+            "description": "The state of the review (e.g., open, closed).",
+            "type": ["null", "string"]
+          },
+          "html_url": {
+            "description": "The URL of the review comment.",
+            "type": ["null", "string"]
+          },
+          "pull_request_url": {
+            "description": "The URL of the pull request associated with the review.",
+            "type": ["null", "string"]
+          },
+          "_links": {
+            "description": "Contains relevant hyperlinks related to the review data.",
+            "type": ["null", "object"],
+            "properties": {
+              "html": {
+                "description": "URL for viewing the review data in HTML format.",
+                "type": ["null", "object"],
+                "properties": {
+                  "href": {
+                    "description": "The URL of the HTML page for the review.",
+                    "type": ["null", "string"]
+                  }
+                }
+              },
+              "pull_request": {
+                "description": "URL for accessing the pull request associated with the review data.",
+                "type": ["null", "object"],
+                "properties": {
+                  "href": {
+                    "description": "The URL of the pull request associated with the review.",
+                    "type": ["null", "string"]
+                  }
+                }
+              }
+            }
+          },
+          "submitted_at": {
+            "description": "The date and time when the review was submitted.",
+            "type": "string",
+            "format": "date-time"
+          },
+          "created_at": {
+            "description": "The date and time when the review was created.",
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "description": "The date and time when the review was last updated.",
+            "type": "string",
+            "format": "date-time"
+          },
+          "commit_id": {
+            "description": "The unique identifier of the commit associated with the review.",
+            "type": ["null", "string"]
+          },
+          "author_association": {
+            "description": "The association of the author of the review with the repository.",
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated_at"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "stargazers",
+      "json_schema": {
+        "$schema": "https://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "repository": {
+            "description": "The repository that was starred by a user.",
+            "type": "string"
+          },
+          "user_id": {
+            "description": "The unique identifier of the user who starred the repository.",
+            "type": ["null", "integer"]
+          },
+          "starred_at": {
+            "description": "The date and time when the user starred the repository.",
+            "type": "string",
+            "format": "date-time"
+          },
+          "user": {
+            "type": ["null", "object"],
+            "properties": {
+              "login": { "type": ["null", "string"] },
+              "id": { "type": ["null", "integer"] },
+              "node_id": { "type": ["null", "string"] },
+              "avatar_url": { "type": ["null", "string"] },
+              "gravatar_id": { "type": ["null", "string"] },
+              "url": { "type": ["null", "string"] },
+              "html_url": { "type": ["null", "string"] },
+              "followers_url": { "type": ["null", "string"] },
+              "following_url": { "type": ["null", "string"] },
+              "gists_url": { "type": ["null", "string"] },
+              "starred_url": { "type": ["null", "string"] },
+              "subscriptions_url": { "type": ["null", "string"] },
+              "organizations_url": { "type": ["null", "string"] },
+              "repos_url": { "type": ["null", "string"] },
+              "events_url": { "type": ["null", "string"] },
+              "received_events_url": { "type": ["null", "string"] },
+              "type": { "type": ["null", "string"] },
+              "site_admin": { "type": ["null", "boolean"] }
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["starred_at"],
+      "source_defined_primary_key": [["user_id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "tags",
+      "json_schema": {
+        "$schema": "https://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "repository": {
+            "description": "Repository information related to the tag",
+            "type": "string"
+          },
+          "name": {
+            "description": "Name of the tag",
+            "type": ["null", "string"]
+          },
+          "commit": {
+            "description": "Information about the commit associated with this tag",
+            "type": ["null", "object"],
+            "properties": {
+              "sha": {
+                "description": "The unique SHA of the commit",
+                "type": ["null", "string"]
+              },
+              "url": {
+                "description": "URL to view details of the commit",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "zipball_url": {
+            "description": "URL to download a zipball archive of the repository at this tag",
+            "type": ["null", "string"]
+          },
+          "tarball_url": {
+            "description": "URL to download a tarball archive of the repository at this tag",
+            "type": ["null", "string"]
+          },
+          "node_id": {
+            "description": "Unique identifier of the tag",
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "source_defined_primary_key": [["repository"], ["name"]],
+      "is_resumable": true
+    },
+    {
+      "name": "teams",
+      "json_schema": {
+        "$schema": "https://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "organization": {
+            "description": "The organization to which the team belongs.",
+            "type": ["null", "string"]
+          },
+          "id": {
+            "description": "The unique identifier of the team.",
+            "type": ["null", "integer"]
+          },
+          "node_id": {
+            "description": "The node identifier of the team.",
+            "type": ["null", "string"]
+          },
+          "url": {
+            "description": "The API URL of the team.",
+            "type": ["null", "string"]
+          },
+          "html_url": {
+            "description": "The URL of the team on GitHub.",
+            "type": ["null", "string"]
+          },
+          "name": {
+            "description": "The name of the team.",
+            "type": ["null", "string"]
+          },
+          "slug": {
+            "description": "The unique URL-friendly name of the team.",
+            "type": ["null", "string"]
+          },
+          "description": {
+            "description": "The description of the team.",
+            "type": ["null", "string"]
+          },
+          "privacy": {
+            "description": "The privacy setting of the team.",
+            "type": ["null", "string"]
+          },
+          "notification_setting": {
+            "description": "The notification setting of the team.",
+            "type": ["null", "string"]
+          },
+          "permission": {
+            "description": "The permission level of the team.",
+            "type": ["null", "string"]
+          },
+          "members_url": {
+            "description": "The URL to fetch members of the team.",
+            "type": ["null", "string"]
+          },
+          "repositories_url": {
+            "description": "The URL to fetch repositories of the team.",
+            "type": ["null", "string"]
+          },
+          "parent": {
+            "description": "The parent team of the team.",
+            "type": ["null", "object"],
+            "properties": {},
+            "additionalProperties": true
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "team_members",
+      "json_schema": {
+        "$schema": "https://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "login": {
+            "description": "Username of the user",
+            "type": ["null", "string"]
+          },
+          "id": {
+            "description": "Unique identifier of the user",
+            "type": "integer"
+          },
+          "node_id": {
+            "description": "Node ID associated with the user",
+            "type": ["null", "string"]
+          },
+          "avatar_url": {
+            "description": "URL of the user's avatar image",
+            "type": ["null", "string"]
+          },
+          "gravatar_id": {
+            "description": "Unique identifier of the user's Gravatar image",
+            "type": ["null", "string"]
+          },
+          "url": {
+            "description": "URL of the user's GitHub API endpoint",
+            "type": ["null", "string"]
+          },
+          "html_url": {
+            "description": "URL of the user's GitHub profile",
+            "type": ["null", "string"]
+          },
+          "followers_url": {
+            "description": "URL of the user's followers",
+            "type": ["null", "string"]
+          },
+          "following_url": {
+            "description": "URL of the users that the user is following",
+            "type": ["null", "string"]
+          },
+          "gists_url": {
+            "description": "URL of the user's gists",
+            "type": ["null", "string"]
+          },
+          "starred_url": {
+            "description": "URL of the repositories starred by the user",
+            "type": ["null", "string"]
+          },
+          "subscriptions_url": {
+            "description": "URL of the repositories the user is subscribed to",
+            "type": ["null", "string"]
+          },
+          "organizations_url": {
+            "description": "URL of the organizations the user belongs to",
+            "type": ["null", "string"]
+          },
+          "repos_url": {
+            "description": "URL of the user's repositories",
+            "type": ["null", "string"]
+          },
+          "events_url": {
+            "description": "URL of the events performed by the user",
+            "type": ["null", "string"]
+          },
+          "received_events_url": {
+            "description": "URL of the received events by the user",
+            "type": ["null", "string"]
+          },
+          "type": {
+            "description": "Type of user account (e.g., User or Organization)",
+            "type": ["null", "string"]
+          },
+          "site_admin": {
+            "description": "Boolean indicating if the user is a site administrator",
+            "type": ["null", "boolean"]
+          },
+          "organization": {
+            "description": "Name of the organization the user is a part of",
+            "type": "string"
+          },
+          "team_slug": {
+            "description": "Slug identifier of the user's team",
+            "type": "string"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "source_defined_primary_key": [["id"], ["team_slug"]],
+      "is_resumable": true
+    },
+    {
+      "name": "users",
+      "json_schema": {
+        "$schema": "https://json-schema.org/draft-07/schema#",
+        "type": ["null", "object"],
+        "properties": {
+          "organization": {
+            "description": "The organization the user belongs to",
+            "type": ["null", "string"]
+          },
+          "login": {
+            "description": "The username of the user",
+            "type": ["null", "string"]
+          },
+          "id": {
+            "description": "The unique identification number of the user",
+            "type": ["null", "integer"]
+          },
+          "node_id": {
+            "description": "The ID assigned to the user in the GraphQL API",
+            "type": ["null", "string"]
+          },
+          "avatar_url": {
+            "description": "The URL of the user's avatar image",
+            "type": ["null", "string"]
+          },
+          "gravatar_id": {
+            "description": "The Gravatar ID associated with the user's email",
+            "type": ["null", "string"]
+          },
+          "url": {
+            "description": "The user's GitHub API URL",
+            "type": ["null", "string"]
+          },
+          "html_url": {
+            "description": "The URL of the user's GitHub page",
+            "type": ["null", "string"]
+          },
+          "followers_url": {
+            "description": "The URL listing the user's followers",
+            "type": ["null", "string"]
+          },
+          "following_url": {
+            "description": "The URL listing the users being followed by the user",
+            "type": ["null", "string"]
+          },
+          "gists_url": {
+            "description": "The URL of the user's gists",
+            "type": ["null", "string"]
+          },
+          "starred_url": {
+            "description": "The URL listing repositories starred by the user",
+            "type": ["null", "string"]
+          },
+          "subscriptions_url": {
+            "description": "The URL listing repositories the user is subscribed to",
+            "type": ["null", "string"]
+          },
+          "organizations_url": {
+            "description": "The URL listing organizations the user belongs to",
+            "type": ["null", "string"]
+          },
+          "repos_url": {
+            "description": "The URL listing repositories owned by the user",
+            "type": ["null", "string"]
+          },
+          "events_url": {
+            "description": "The URL of the events that the user has been involved in",
+            "type": ["null", "string"]
+          },
+          "received_events_url": {
+            "description": "The URL of events received by the user",
+            "type": ["null", "string"]
+          },
+          "type": {
+            "description": "The type of user account (e.g., User or Organization)",
+            "type": ["null", "string"]
+          },
+          "site_admin": {
+            "description": "Specifies if the user is a GitHub site administrator",
+            "type": ["null", "boolean"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "workflows",
+      "json_schema": {
+        "$schema": "https://json-schema.org/draft-04/schema#",
+        "type": ["null", "object"],
+        "properties": {
+          "id": {
+            "description": "Unique identifier for the workflow",
+            "type": "integer"
+          },
+          "node_id": {
+            "description": "Node ID of the workflow",
+            "type": ["null", "string"]
+          },
+          "name": {
+            "description": "Name of the workflow",
+            "type": ["null", "string"]
+          },
+          "path": {
+            "description": "Path to the workflow in the repository",
+            "type": ["null", "string"]
+          },
+          "state": {
+            "description": "Current state of the workflow",
+            "type": ["null", "string"]
+          },
+          "created_at": {
+            "description": "Date and time when the workflow was created",
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "description": "Date and time when the workflow was last updated",
+            "type": "string",
+            "format": "date-time"
+          },
+          "url": {
+            "description": "URL to access detailed information about the workflow",
+            "type": ["null", "string"]
+          },
+          "html_url": {
+            "description": "URL to view the workflow on GitHub's web interface",
+            "type": ["null", "string"]
+          },
+          "badge_url": {
+            "description": "URL for the badge that represents the workflow status",
+            "type": ["null", "string"]
+          },
+          "repository": {
+            "description": "Repository information associated with the workflow",
+            "type": "string"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated_at"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "workflow_runs",
+      "json_schema": {
+        "$schema": "https://json-schema.org/draft-04/schema#",
+        "type": "object",
+        "properties": {
+          "id": {
+            "description": "ID of the workflow run.",
+            "type": ["null", "integer"]
+          },
+          "name": {
+            "description": "Name of the workflow.",
+            "type": ["null", "string"]
+          },
+          "node_id": {
+            "description": "Node ID of the workflow run.",
+            "type": ["null", "string"]
+          },
+          "head_branch": {
+            "description": "The branch associated with the head commit.",
+            "type": ["null", "string"]
+          },
+          "head_sha": {
+            "description": "SHA of the head commit.",
+            "type": ["null", "string"]
+          },
+          "path": {
+            "description": "The path where the workflow file is located.",
+            "type": ["null", "string"]
+          },
+          "display_title": {
+            "description": "Title to display for the workflow run.",
+            "type": ["null", "string"]
+          },
+          "run_number": {
+            "description": "The unique number assigned to the workflow run.",
+            "type": ["null", "integer"]
+          },
+          "event": {
+            "description": "The event that triggered the workflow run.",
+            "type": ["null", "string"]
+          },
+          "status": {
+            "description": "The current status of the workflow run.",
+            "type": ["null", "string"]
+          },
+          "conclusion": {
+            "description": "The outcome or result of the workflow run.",
+            "type": ["null", "string"]
+          },
+          "workflow_id": {
+            "description": "ID of the workflow associated with the run.",
+            "type": ["null", "integer"]
+          },
+          "check_suite_id": {
+            "description": "ID of the associated GitHub check suite.",
+            "type": ["null", "integer"]
+          },
+          "check_suite_node_id": {
+            "description": "Node ID of the associated GitHub check suite.",
+            "type": ["null", "string"]
+          },
+          "url": {
+            "description": "URL to access details of the workflow run.",
+            "type": ["null", "string"]
+          },
+          "html_url": {
+            "description": "URL to view the workflow run on GitHub.",
+            "type": ["null", "string"]
+          },
+          "pull_requests": {
+            "description": "List of all pull requests associated with the workflow run.",
+            "type": "array",
+            "items": {
+              "type": ["null", "object"],
+              "properties": {},
+              "additionalProperties": true
+            }
+          },
+          "created_at": {
+            "description": "The timestamp when the workflow run was created.",
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "description": "The timestamp when the workflow run was last updated.",
+            "type": "string",
+            "format": "date-time"
+          },
+          "run_attempt": {
+            "description": "Specifies the attempt number of the workflow run.",
+            "type": ["null", "integer"]
+          },
+          "referenced_workflows": {
+            "description": "List of workflows referenced by the workflow runs",
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "path": {
+                  "description": "Path of the referenced workflow file",
+                  "type": "string"
+                },
+                "sha": {
+                  "description": "SHA hash of the referenced workflow",
+                  "type": "string"
+                },
+                "ref": {
+                  "description": "Type of reference to the workflow",
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "run_started_at": {
+            "description": "The timestamp when the workflow run started.",
+            "type": "string",
+            "format": "date-time"
+          },
+          "jobs_url": {
+            "description": "URL to access jobs associated with the workflow run.",
+            "type": ["null", "string"]
+          },
+          "logs_url": {
+            "description": "URL to access logs generated by the workflow run.",
+            "type": ["null", "string"]
+          },
+          "check_suite_url": {
+            "description": "URL to access the check suite details.",
+            "type": ["null", "string"]
+          },
+          "artifacts_url": {
+            "description": "URL to access artifacts generated by the workflow run.",
+            "type": ["null", "string"]
+          },
+          "cancel_url": {
+            "description": "URL to cancel the workflow run if supported.",
+            "type": ["null", "string"]
+          },
+          "rerun_url": {
+            "description": "URL to rerun the workflow.",
+            "type": ["null", "string"]
+          },
+          "previous_attempt_url": {
+            "description": "URL to access the previous attempt of the workflow run.",
+            "type": ["null", "string"]
+          },
+          "workflow_url": {
+            "description": "URL to access details of the workflow.",
+            "type": ["null", "string"]
+          },
+          "head_commit": {
+            "description": "Details about the commit associated with the workflow run.",
+            "type": "object",
+            "properties": {
+              "id": {
+                "description": "ID of the head commit.",
+                "type": ["null", "string"]
+              },
+              "tree_id": {
+                "description": "ID of the tree associated with the head commit.",
+                "type": ["null", "string"]
+              },
+              "message": {
+                "description": "The commit message of the head commit.",
+                "type": ["null", "string"]
+              },
+              "timestamp": {
+                "description": "Timestamp of the head commit.",
+                "type": ["null", "string"]
+              },
+              "author": {
+                "description": "The author details of the head commit.",
+                "type": "object",
+                "properties": {
+                  "name": { "type": ["null", "string"] },
+                  "email": { "type": ["null", "string"] }
+                }
+              },
+              "committer": {
+                "description": "The committer details of the head commit.",
+                "type": "object",
+                "properties": {
+                  "name": { "type": ["null", "string"] },
+                  "email": { "type": ["null", "string"] }
+                }
+              }
+            }
+          },
+          "repository": {
+            "description": "Details about the repository where the workflow run is executed.",
+            "type": "object",
+            "properties": {
+              "id": {
+                "description": "ID of the repository.",
+                "type": ["null", "integer"]
+              },
+              "node_id": {
+                "description": "Node ID of the repository.",
+                "type": ["null", "string"]
+              },
+              "name": {
+                "description": "Name of the repository.",
+                "type": ["null", "string"]
+              },
+              "full_name": {
+                "description": "Full name of the repository.",
+                "type": "string"
+              },
+              "private": {
+                "description": "Indicates if the repository is private.",
+                "type": ["null", "boolean"]
+              },
+              "owner": {
+                "type": ["null", "object"],
+                "properties": {
+                  "login": { "type": ["null", "string"] },
+                  "id": { "type": ["null", "integer"] },
+                  "node_id": { "type": ["null", "string"] },
+                  "avatar_url": { "type": ["null", "string"] },
+                  "gravatar_id": { "type": ["null", "string"] },
+                  "url": { "type": ["null", "string"] },
+                  "html_url": { "type": ["null", "string"] },
+                  "followers_url": { "type": ["null", "string"] },
+                  "following_url": { "type": ["null", "string"] },
+                  "gists_url": { "type": ["null", "string"] },
+                  "starred_url": { "type": ["null", "string"] },
+                  "subscriptions_url": { "type": ["null", "string"] },
+                  "organizations_url": { "type": ["null", "string"] },
+                  "repos_url": { "type": ["null", "string"] },
+                  "events_url": { "type": ["null", "string"] },
+                  "received_events_url": { "type": ["null", "string"] },
+                  "type": { "type": ["null", "string"] },
+                  "site_admin": { "type": ["null", "boolean"] }
+                }
+              },
+              "html_url": {
+                "description": "HTML URL of the repository.",
+                "type": ["null", "string"]
+              },
+              "description": {
+                "description": "Description of the repository.",
+                "type": ["null", "string"]
+              },
+              "fork": {
+                "description": "Indicates if the repository is a fork.",
+                "type": ["null", "boolean"]
+              },
+              "url": {
+                "description": "URL of the repository.",
+                "type": ["null", "string"]
+              },
+              "forks_url": {
+                "description": "URL to access forks of the repository.",
+                "type": ["null", "string"]
+              },
+              "keys_url": {
+                "description": "URL to access keys of the repository.",
+                "type": ["null", "string"]
+              },
+              "collaborators_url": {
+                "description": "URL to access collaborators of the repository.",
+                "type": ["null", "string"]
+              },
+              "teams_url": {
+                "description": "URL to access teams in the repository.",
+                "type": ["null", "string"]
+              },
+              "hooks_url": {
+                "description": "URL to access hooks in the repository.",
+                "type": ["null", "string"]
+              },
+              "issue_events_url": {
+                "description": "URL to access issue events in the repository.",
+                "type": ["null", "string"]
+              },
+              "events_url": {
+                "description": "URL to access events associated with the repository.",
+                "type": ["null", "string"]
+              },
+              "assignees_url": {
+                "description": "URL to access assignees of the repository.",
+                "type": ["null", "string"]
+              },
+              "branches_url": {
+                "description": "URL to access branches of the repository.",
+                "type": ["null", "string"]
+              },
+              "tags_url": {
+                "description": "URL to access tags in the repository.",
+                "type": ["null", "string"]
+              },
+              "blobs_url": {
+                "description": "URL to access blobs in the repository.",
+                "type": ["null", "string"]
+              },
+              "git_tags_url": {
+                "description": "URL to access git tags in the repository.",
+                "type": ["null", "string"]
+              },
+              "git_refs_url": {
+                "description": "URL to access git refs in the repository.",
+                "type": ["null", "string"]
+              },
+              "trees_url": {
+                "description": "URL to access trees in the repository.",
+                "type": ["null", "string"]
+              },
+              "statuses_url": {
+                "description": "URL to access commit statuses in the repository.",
+                "type": ["null", "string"]
+              },
+              "languages_url": {
+                "description": "URL to access languages used in the repository.",
+                "type": ["null", "string"]
+              },
+              "stargazers_url": {
+                "description": "URL to access stargazers of the repository.",
+                "type": ["null", "string"]
+              },
+              "contributors_url": {
+                "description": "URL to access contributors of the repository.",
+                "type": ["null", "string"]
+              },
+              "subscribers_url": {
+                "description": "URL to access subscribers of the repository.",
+                "type": ["null", "string"]
+              },
+              "subscription_url": {
+                "description": "URL for subscription to the repository.",
+                "type": ["null", "string"]
+              },
+              "commits_url": {
+                "description": "URL to access commits in the repository.",
+                "type": ["null", "string"]
+              },
+              "git_commits_url": {
+                "description": "URL to access git commits in the repository.",
+                "type": ["null", "string"]
+              },
+              "comments_url": {
+                "description": "URL to access comments in the repository.",
+                "type": ["null", "string"]
+              },
+              "issue_comment_url": {
+                "description": "URL to access issue comments in the repository.",
+                "type": ["null", "string"]
+              },
+              "contents_url": {
+                "description": "URL to access contents of the repository.",
+                "type": ["null", "string"]
+              },
+              "compare_url": {
+                "description": "URL to compare the repository with another ref/commit.",
+                "type": ["null", "string"]
+              },
+              "merges_url": {
+                "description": "URL to access merges in the repository.",
+                "type": ["null", "string"]
+              },
+              "archive_url": {
+                "description": "URL to access the repository's archive.",
+                "type": ["null", "string"]
+              },
+              "downloads_url": {
+                "description": "URL to access downloads in the repository.",
+                "type": ["null", "string"]
+              },
+              "issues_url": {
+                "description": "URL to access issues in the repository.",
+                "type": ["null", "string"]
+              },
+              "pulls_url": {
+                "description": "URL to access pulls in the repository.",
+                "type": ["null", "string"]
+              },
+              "milestones_url": {
+                "description": "URL to access milestones in the repository.",
+                "type": ["null", "string"]
+              },
+              "notifications_url": {
+                "description": "URL to access notifications in the repository.",
+                "type": ["null", "string"]
+              },
+              "labels_url": {
+                "description": "URL to access labels in the repository.",
+                "type": ["null", "string"]
+              },
+              "releases_url": {
+                "description": "URL to access releases in the repository.",
+                "type": ["null", "string"]
+              },
+              "deployments_url": {
+                "description": "URL to access deployments of the repository.",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "head_repository": {
+            "description": "Information about the repository where the workflow was triggered.",
+            "type": ["null", "object"],
+            "properties": {
+              "id": {
+                "description": "ID of the repository.",
+                "type": ["null", "integer"]
+              },
+              "node_id": {
+                "description": "Node ID of the repository.",
+                "type": ["null", "string"]
+              },
+              "name": {
+                "description": "Name of the repository.",
+                "type": ["null", "string"]
+              },
+              "full_name": {
+                "description": "Full name of the repository.",
+                "type": ["null", "string"]
+              },
+              "private": {
+                "description": "Indicates if the repository is private.",
+                "type": ["null", "boolean"]
+              },
+              "owner": {
+                "type": ["null", "object"],
+                "properties": {
+                  "login": { "type": ["null", "string"] },
+                  "id": { "type": ["null", "integer"] },
+                  "node_id": { "type": ["null", "string"] },
+                  "avatar_url": { "type": ["null", "string"] },
+                  "gravatar_id": { "type": ["null", "string"] },
+                  "url": { "type": ["null", "string"] },
+                  "html_url": { "type": ["null", "string"] },
+                  "followers_url": { "type": ["null", "string"] },
+                  "following_url": { "type": ["null", "string"] },
+                  "gists_url": { "type": ["null", "string"] },
+                  "starred_url": { "type": ["null", "string"] },
+                  "subscriptions_url": { "type": ["null", "string"] },
+                  "organizations_url": { "type": ["null", "string"] },
+                  "repos_url": { "type": ["null", "string"] },
+                  "events_url": { "type": ["null", "string"] },
+                  "received_events_url": { "type": ["null", "string"] },
+                  "type": { "type": ["null", "string"] },
+                  "site_admin": { "type": ["null", "boolean"] }
+                }
+              },
+              "html_url": {
+                "description": "HTML URL of the repository.",
+                "type": ["null", "string"]
+              },
+              "description": {
+                "description": "Description of the repository.",
+                "type": ["null", "string"]
+              },
+              "fork": {
+                "description": "Indicates if the repository is a fork.",
+                "type": ["null", "boolean"]
+              },
+              "url": {
+                "description": "URL of the repository.",
+                "type": ["null", "string"]
+              },
+              "forks_url": {
+                "description": "URL to access forks of the repository.",
+                "type": ["null", "string"]
+              },
+              "keys_url": {
+                "description": "URL to access keys of the repository.",
+                "type": ["null", "string"]
+              },
+              "collaborators_url": {
+                "description": "URL to access collaborators of the repository.",
+                "type": ["null", "string"]
+              },
+              "teams_url": {
+                "description": "URL to access teams in the repository.",
+                "type": ["null", "string"]
+              },
+              "hooks_url": {
+                "description": "URL to access hooks in the repository.",
+                "type": ["null", "string"]
+              },
+              "issue_events_url": {
+                "description": "URL to access issue events in the repository.",
+                "type": ["null", "string"]
+              },
+              "events_url": {
+                "description": "URL to access events associated with the repository.",
+                "type": ["null", "string"]
+              },
+              "assignees_url": {
+                "description": "URL to access assignees of the repository.",
+                "type": ["null", "string"]
+              },
+              "branches_url": {
+                "description": "URL to access branches of the repository.",
+                "type": ["null", "string"]
+              },
+              "tags_url": {
+                "description": "URL to access tags in the repository.",
+                "type": ["null", "string"]
+              },
+              "blobs_url": {
+                "description": "URL to access blobs in the repository.",
+                "type": ["null", "string"]
+              },
+              "git_tags_url": {
+                "description": "URL to access git tags in the repository.",
+                "type": ["null", "string"]
+              },
+              "git_refs_url": {
+                "description": "URL to access git refs in the repository.",
+                "type": ["null", "string"]
+              },
+              "trees_url": {
+                "description": "URL to access trees in the repository.",
+                "type": ["null", "string"]
+              },
+              "statuses_url": {
+                "description": "URL to access commit statuses in the repository.",
+                "type": ["null", "string"]
+              },
+              "languages_url": {
+                "description": "URL to access languages used in the repository.",
+                "type": ["null", "string"]
+              },
+              "stargazers_url": {
+                "description": "URL to access stargazers of the repository.",
+                "type": ["null", "string"]
+              },
+              "contributors_url": {
+                "description": "URL to access contributors of the repository.",
+                "type": ["null", "string"]
+              },
+              "subscribers_url": {
+                "description": "URL to access subscribers of the repository.",
+                "type": ["null", "string"]
+              },
+              "subscription_url": {
+                "description": "URL for subscription to the repository.",
+                "type": ["null", "string"]
+              },
+              "commits_url": {
+                "description": "URL to access commits in the repository.",
+                "type": ["null", "string"]
+              },
+              "git_commits_url": {
+                "description": "URL to access git commits in the repository.",
+                "type": ["null", "string"]
+              },
+              "comments_url": {
+                "description": "URL to access comments in the repository.",
+                "type": ["null", "string"]
+              },
+              "issue_comment_url": {
+                "description": "URL to access issue comments in the repository.",
+                "type": ["null", "string"]
+              },
+              "contents_url": {
+                "description": "URL to access contents of the repository.",
+                "type": ["null", "string"]
+              },
+              "compare_url": {
+                "description": "URL to compare the repository with another ref/commit.",
+                "type": ["null", "string"]
+              },
+              "merges_url": {
+                "description": "URL to access merges in the repository.",
+                "type": ["null", "string"]
+              },
+              "archive_url": {
+                "description": "URL to access the repository's archive.",
+                "type": ["null", "string"]
+              },
+              "downloads_url": {
+                "description": "URL to access downloads in the repository.",
+                "type": ["null", "string"]
+              },
+              "issues_url": {
+                "description": "URL to access issues in the repository.",
+                "type": ["null", "string"]
+              },
+              "pulls_url": {
+                "description": "URL to access pulls in the repository.",
+                "type": ["null", "string"]
+              },
+              "milestones_url": {
+                "description": "URL to access milestones in the repository.",
+                "type": ["null", "string"]
+              },
+              "notifications_url": {
+                "description": "URL to access notifications in the repository.",
+                "type": ["null", "string"]
+              },
+              "labels_url": {
+                "description": "URL to access labels in the repository.",
+                "type": ["null", "string"]
+              },
+              "releases_url": {
+                "description": "URL to access releases in the repository.",
+                "type": ["null", "string"]
+              },
+              "deployments_url": {
+                "description": "URL to access deployments of the repository.",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "actor": {
+            "type": ["null", "object"],
+            "properties": {
+              "login": { "type": ["null", "string"] },
+              "id": { "type": ["null", "integer"] },
+              "node_id": { "type": ["null", "string"] },
+              "avatar_url": { "type": ["null", "string"] },
+              "gravatar_id": { "type": ["null", "string"] },
+              "url": { "type": ["null", "string"] },
+              "html_url": { "type": ["null", "string"] },
+              "followers_url": { "type": ["null", "string"] },
+              "following_url": { "type": ["null", "string"] },
+              "gists_url": { "type": ["null", "string"] },
+              "starred_url": { "type": ["null", "string"] },
+              "subscriptions_url": { "type": ["null", "string"] },
+              "organizations_url": { "type": ["null", "string"] },
+              "repos_url": { "type": ["null", "string"] },
+              "events_url": { "type": ["null", "string"] },
+              "received_events_url": { "type": ["null", "string"] },
+              "type": { "type": ["null", "string"] },
+              "site_admin": { "type": ["null", "boolean"] }
+            }
+          },
+          "triggering_actor": {
+            "type": ["null", "object"],
+            "properties": {
+              "login": { "type": ["null", "string"] },
+              "id": { "type": ["null", "integer"] },
+              "node_id": { "type": ["null", "string"] },
+              "avatar_url": { "type": ["null", "string"] },
+              "gravatar_id": { "type": ["null", "string"] },
+              "url": { "type": ["null", "string"] },
+              "html_url": { "type": ["null", "string"] },
+              "followers_url": { "type": ["null", "string"] },
+              "following_url": { "type": ["null", "string"] },
+              "gists_url": { "type": ["null", "string"] },
+              "starred_url": { "type": ["null", "string"] },
+              "subscriptions_url": { "type": ["null", "string"] },
+              "organizations_url": { "type": ["null", "string"] },
+              "repos_url": { "type": ["null", "string"] },
+              "events_url": { "type": ["null", "string"] },
+              "received_events_url": { "type": ["null", "string"] },
+              "type": { "type": ["null", "string"] },
+              "site_admin": { "type": ["null", "boolean"] }
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated_at"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "workflow_jobs",
+      "json_schema": {
+        "$schema": "https://json-schema.org/draft-04/schema#",
+        "type": "object",
+        "properties": {
+          "id": { "description": "Identifier of the job", "type": "integer" },
+          "run_id": {
+            "description": "Identifier of the run associated with the job",
+            "type": "integer"
+          },
+          "workflow_name": {
+            "description": "Name of the workflow associated with the job",
+            "type": ["null", "string"]
+          },
+          "head_branch": {
+            "description": "Name of the branch where the job was triggered",
+            "type": ["null", "string"]
+          },
+          "run_url": {
+            "description": "URL to view the run details associated with the job",
+            "type": "string"
+          },
+          "run_attempt": {
+            "description": "Number of the run attempt for the job",
+            "type": "integer"
+          },
+          "node_id": { "description": "Node ID of the job", "type": "string" },
+          "head_sha": {
+            "description": "Commit SHA associated with the job",
+            "type": "string"
+          },
+          "url": {
+            "description": "URL to fetch the details of the job",
+            "type": "string"
+          },
+          "html_url": {
+            "description": "URL to view the job details in a web browser",
+            "type": ["null", "string"]
+          },
+          "status": {
+            "description": "Status of the job (e.g., in_progress, completed)",
+            "type": "string"
+          },
+          "conclusion": {
+            "description": "Conclusion of the job execution (e.g., success, failure)",
+            "type": ["null", "string"]
+          },
+          "created_at": {
+            "description": "Timestamp when the job was created",
+            "type": "string",
+            "format": "date-time"
+          },
+          "started_at": {
+            "description": "Timestamp when the job was started",
+            "type": "string",
+            "format": "date-time"
+          },
+          "completed_at": {
+            "description": "Timestamp when the job was completed",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "name": { "description": "Name of the job", "type": "string" },
+          "steps": {
+            "description": "List of steps within the job",
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "status": {
+                  "description": "Status of the step (e.g., in_progress, completed)",
+                  "type": "string"
+                },
+                "conclusion": {
+                  "description": "Conclusion of the step execution (e.g., success, failure)",
+                  "type": ["null", "string"]
+                },
+                "name": { "description": "Name of the step", "type": "string" },
+                "number": {
+                  "description": "Number of the step",
+                  "type": "integer"
+                },
+                "started_at": {
+                  "description": "Timestamp when the step was started",
+                  "type": ["null", "string"],
+                  "format": "date-time"
+                },
+                "completed_at": {
+                  "description": "Timestamp when the step was completed",
+                  "type": ["null", "string"],
+                  "format": "date-time"
+                }
+              }
+            }
+          },
+          "check_run_url": {
+            "description": "URL to view the check run associated with the job",
+            "type": "string"
+          },
+          "labels": {
+            "description": "Labels associated with the job",
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "runner_id": {
+            "description": "Identifier of the runner",
+            "type": ["integer", "null"]
+          },
+          "runner_name": {
+            "description": "Name of the runner",
+            "type": ["null", "string"]
+          },
+          "runner_group_id": {
+            "description": "Identifier of the runner group",
+            "type": ["integer", "null"]
+          },
+          "runner_group_name": {
+            "description": "Name of the runner group",
+            "type": ["null", "string"]
+          },
+          "repository": {
+            "description": "Repository information associated with the job",
+            "type": "string"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["completed_at"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "team_memberships",
+      "json_schema": {
+        "$schema": "https://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "state": {
+            "description": "The current state of the team membership (active, pending, etc.).",
+            "type": ["null", "string"]
+          },
+          "role": {
+            "description": "The role or position of the user within the team.",
+            "type": ["null", "string"]
+          },
+          "url": {
+            "description": "The URL link to access more details about the team membership.",
+            "type": "string"
+          },
+          "organization": {
+            "description": "The name of the organization the team membership belongs to.",
+            "type": "string"
+          },
+          "team_slug": {
+            "description": "The unique identifier (slug) of the team the user belongs to.",
+            "type": "string"
+          },
+          "username": {
+            "description": "The username of the user associated with the team membership.",
+            "type": "string"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "source_defined_primary_key": [["url"]],
+      "is_resumable": true
+    }
+  ]
+}

--- a/airbyte-integrations/connectors/source-github/erd/estimated_relationships.json
+++ b/airbyte-integrations/connectors/source-github/erd/estimated_relationships.json
@@ -1,0 +1,242 @@
+{
+  "streams": [
+    {
+      "name": "issue_timeline_events",
+      "relations": {
+        "actor_id": "users.id",
+        "performed_via_github_app_id": "issue_timeline_events.id"
+      }
+    },
+    {
+      "name": "assignees",
+      "relations": {
+        "id": "users.id"
+      }
+    },
+    {
+      "name": "branches",
+      "relations": {}
+    },
+    {
+      "name": "collaborators",
+      "relations": {
+        "id": "users.id"
+      }
+    },
+    {
+      "name": "comments",
+      "relations": {
+        "user_id": "users.id"
+      }
+    },
+    {
+      "name": "commit_comment_reactions",
+      "relations": {
+        "comment_id": "commit_comments.id"
+      }
+    },
+    {
+      "name": "commit_comments",
+      "relations": {}
+    },
+    {
+      "name": "commits",
+      "relations": {}
+    },
+    {
+      "name": "contributor_activity",
+      "relations": {
+        "id": "users.id",
+        "repository": "repositories.full_name"
+      }
+    },
+    {
+      "name": "deployments",
+      "relations": {
+        "repository": "repositories.full_name"
+      }
+    },
+    {
+      "name": "events",
+      "relations": {
+        "repository": "repositories.full_name"
+      }
+    },
+    {
+      "name": "issue_comment_reactions",
+      "relations": {
+        "comment_id": "comments.id"
+      }
+    },
+    {
+      "name": "issue_events",
+      "relations": {
+        "repository": "repositories.full_name"
+      }
+    },
+    {
+      "name": "issue_labels",
+      "relations": {
+        "repository": "repositories.full_name"
+      }
+    },
+    {
+      "name": "issue_milestones",
+      "relations": {
+        "repository": "repositories.full_name"
+      }
+    },
+    {
+      "name": "issue_reactions",
+      "relations": {
+        "repository": "repositories.full_name"
+      }
+    },
+    {
+      "name": "issues",
+      "relations": {
+        "user_id": "users.id",
+        "repository": "repositories.full_name"
+      }
+    },
+    {
+      "name": "organizations",
+      "relations": {}
+    },
+    {
+      "name": "project_cards",
+      "relations": {
+        "repository": "repositories.full_name",
+        "project_id": "projects.id",
+        "column_id": "project_columns.id"
+      }
+    },
+    {
+      "name": "project_columns",
+      "relations": {
+        "repository": "repositories.full_name",
+        "project_id": "projects.id"
+      }
+    },
+    {
+      "name": "projects",
+      "relations": {
+        "repository": "repositories.full_name"
+      }
+    },
+    {
+      "name": "pull_request_comment_reactions",
+      "relations": {
+        "comment_id": "review_comments.id"
+      }
+    },
+    {
+      "name": "pull_request_commits",
+      "relations": {
+        "repository": "repositories.full_name"
+      }
+    },
+    {
+      "name": "pull_request_stats",
+      "relations": {
+        "repository": "repositories.full_name"
+      }
+    },
+    {
+      "name": "projects_v2",
+      "relations": {
+        "owner_id": "organizations.id",
+        "repository": "repositories.full_name"
+      }
+    },
+    {
+      "name": "pull_requests",
+      "relations": {
+        "repository": "repositories.full_name"
+      }
+    },
+    {
+      "name": "releases",
+      "relations": {
+        "repository": "repositories.full_name"
+      }
+    },
+    {
+      "name": "repositories",
+      "relations": {
+        "organization": "organizations.login"
+      }
+    },
+    {
+      "name": "review_comments",
+      "relations": {
+        "repository": "repositories.full_name"
+      }
+    },
+    {
+      "name": "reviews",
+      "relations": {
+        "repository": "repositories.full_name"
+      }
+    },
+    {
+      "name": "stargazers",
+      "relations": {
+        "user_id": "users.id",
+        "repository": "repositories.full_name"
+      }
+    },
+    {
+      "name": "tags",
+      "relations": {
+        "repository": "repositories.full_name"
+      }
+    },
+    {
+      "name": "teams",
+      "relations": {
+        "organization": "organizations.login"
+      }
+    },
+    {
+      "name": "team_members",
+      "relations": {
+        "id": "users.id",
+        "organization": "organizations.login"
+      }
+    },
+    {
+      "name": "users",
+      "relations": {
+        "organization": "organizations.login"
+      }
+    },
+    {
+      "name": "workflows",
+      "relations": {
+        "repository": "repositories.full_name"
+      }
+    },
+    {
+      "name": "workflow_runs",
+      "relations": {
+        "workflow_id": "workflows.id",
+        "repository": "repositories.full_name"
+      }
+    },
+    {
+      "name": "workflow_jobs",
+      "relations": {
+        "repository": "repositories.full_name",
+        "run_id": "workflow_runs.id"
+      }
+    },
+    {
+      "name": "team_memberships",
+      "relations": {
+        "organization": "organizations.login",
+        "username": "users.login"
+      }
+    }
+  ]
+}

--- a/airbyte-integrations/connectors/source-github/erd/source.dbml
+++ b/airbyte-integrations/connectors/source-github/erd/source.dbml
@@ -1,0 +1,1031 @@
+Table "issue_timeline_events" {
+    "repository" string
+    "issue_number" integer
+    "comment" object
+    "cross-referenced" object
+    "committed" object
+    "reviewed" object
+    "commented" object
+    "commit_commented" object
+
+    indexes {
+        (repository, issue_number) [pk]
+    }
+}
+
+Table "assignees" {
+    "repository" string
+    "login" string
+    "id" integer [pk]
+    "node_id" string
+    "avatar_url" string
+    "gravatar_id" string
+    "url" string
+    "html_url" string
+    "followers_url" string
+    "following_url" string
+    "gists_url" string
+    "starred_url" string
+    "subscriptions_url" string
+    "organizations_url" string
+    "repos_url" string
+    "events_url" string
+    "received_events_url" string
+    "type" string
+    "site_admin" boolean
+}
+
+Table "branches" {
+    "repository" string
+    "name" string
+    "commit" object
+    "protected" boolean
+    "protection" object
+    "protection_url" string
+
+    indexes {
+        (repository, name) [pk]
+    }
+}
+
+Table "collaborators" {
+    "repository" string
+    "login" string
+    "id" integer [pk]
+    "node_id" string
+    "avatar_url" string
+    "gravatar_id" string
+    "url" string
+    "html_url" string
+    "followers_url" string
+    "following_url" string
+    "gists_url" string
+    "starred_url" string
+    "subscriptions_url" string
+    "organizations_url" string
+    "repos_url" string
+    "events_url" string
+    "received_events_url" string
+    "type" string
+    "site_admin" boolean
+    "role_name" string
+    "permissions" object
+}
+
+Table "comments" {
+    "repository" string
+    "id" integer [pk]
+    "node_id" string
+    "user" object
+    "url" string
+    "html_url" string
+    "body" string
+    "user_id" integer
+    "created_at" string
+    "updated_at" string
+    "issue_url" string
+    "author_association" string
+    "reactions" object
+    "performed_via_github_app" object
+}
+
+Table "commit_comment_reactions" {
+    "id" integer [pk]
+    "node_id" string
+    "content" string
+    "created_at" string
+    "user" object
+    "repository" string
+    "comment_id" integer
+}
+
+Table "commit_comments" {
+    "repository" string
+    "html_url" string
+    "url" string
+    "id" integer [pk]
+    "node_id" string
+    "body" string
+    "path" string
+    "position" integer
+    "line" integer
+    "commit_id" string
+    "user" object
+    "created_at" string
+    "updated_at" string
+    "author_association" string
+    "reactions" object
+}
+
+Table "commits" {
+    "repository" string
+    "branch" string
+    "created_at" string
+    "url" string
+    "sha" string [pk]
+    "node_id" string
+    "html_url" string
+    "comments_url" string
+    "commit" object
+    "author" object
+    "committer" object
+    "parents" array
+}
+
+Table "contributor_activity" {
+    "name" string
+    "email" string
+    "login" string
+    "id" integer [pk]
+    "node_id" string
+    "avatar_url" string
+    "gravatar_id" string
+    "url" string
+    "html_url" string
+    "followers_url" string
+    "following_url" string
+    "gists_url" string
+    "starred_url" string
+    "subscriptions_url" string
+    "organizations_url" string
+    "repos_url" string
+    "events_url" string
+    "repository" string
+    "received_events_url" string
+    "type" string
+    "site_admin" boolean
+    "starred_at" string
+    "total" integer
+    "weeks" array
+}
+
+Table "deployments" {
+    "url" string
+    "id" integer [pk]
+    "node_id" string
+    "task" string
+    "original_environment" string
+    "environment" string
+    "description" string
+    "created_at" string
+    "updated_at" string
+    "statuses_url" string
+    "repository_url" string
+    "creator" object
+    "sha" string
+    "ref" string
+    "transient_environment" boolean
+    "production_environment" boolean
+    "performed_via_github_app" string
+    "repository" string
+}
+
+Table "events" {
+    "repository" string
+    "type" string
+    "public" boolean
+    "payload" object
+    "repo" object
+    "actor" object
+    "org" object
+    "created_at" string
+    "id" string [pk]
+}
+
+Table "issue_comment_reactions" {
+    "id" integer [pk]
+    "node_id" string
+    "content" string
+    "created_at" string
+    "user" object
+    "repository" string
+    "comment_id" integer
+}
+
+Table "issue_events" {
+    "repository" string
+    "id" integer [pk]
+    "node_id" string
+    "url" string
+    "actor" object
+    "event" string
+    "commit_id" string
+    "commit_url" string
+    "created_at" string
+    "state_reason" string
+    "label" object
+    "review_requester" object
+    "issue" object
+    "performed_via_github_app" object
+    "milestone" object
+    "assignee" object
+    "assigner" object
+    "project_card" object
+    "dismissed_review" object
+    "requested_team" object
+    "rename" object
+    "requested_reviewer" object
+}
+
+Table "issue_labels" {
+    "repository" string
+    "id" integer [pk]
+    "node_id" string
+    "url" string
+    "name" string
+    "description" string
+    "color" string
+    "default" boolean
+}
+
+Table "issue_milestones" {
+    "repository" string
+    "url" string
+    "html_url" string
+    "labels_url" string
+    "id" integer [pk]
+    "node_id" string
+    "number" integer
+    "state" string
+    "title" string
+    "description" string
+    "creator" object
+    "open_issues" integer
+    "closed_issues" integer
+    "created_at" string
+    "updated_at" string
+    "closed_at" string
+    "due_on" string
+}
+
+Table "issue_reactions" {
+    "id" integer [pk]
+    "node_id" string
+    "content" string
+    "created_at" string
+    "user" object
+    "repository" string
+    "issue_number" integer
+}
+
+Table "issues" {
+    "repository" string
+    "id" integer [pk]
+    "node_id" string
+    "url" string
+    "repository_url" string
+    "labels_url" string
+    "comments_url" string
+    "events_url" string
+    "html_url" string
+    "number" integer
+    "state" string
+    "title" string
+    "user" object
+    "body" string
+    "user_id" integer
+    "labels" array
+    "assignee" object
+    "assignees" array
+    "milestone" object
+    "locked" boolean
+    "active_lock_reason" string
+    "comments" integer
+    "pull_request" object
+    "closed_at" string
+    "created_at" string
+    "updated_at" string
+    "author_association" string
+    "draft" boolean
+    "reactions" object
+    "timeline_url" string
+    "performed_via_github_app" object
+    "state_reason" string
+}
+
+Table "organizations" {
+    "login" string
+    "id" integer [pk]
+    "node_id" string
+    "url" string
+    "repos_url" string
+    "events_url" string
+    "hooks_url" string
+    "issues_url" string
+    "members_url" string
+    "public_members_url" string
+    "avatar_url" string
+    "description" string
+    "name" string
+    "company" string
+    "blog" string
+    "location" string
+    "email" string
+    "twitter_username" string
+    "is_verified" boolean
+    "has_organization_projects" boolean
+    "has_repository_projects" boolean
+    "public_repos" integer
+    "public_gists" integer
+    "followers" integer
+    "following" integer
+    "html_url" string
+    "created_at" string
+    "updated_at" string
+    "archived_at" string
+    "type" string
+    "total_private_repos" integer
+    "owned_private_repos" integer
+    "private_gists" integer
+    "disk_usage" integer
+    "collaborators" integer
+    "billing_email" string
+    "default_repository_permission" string
+    "members_can_create_repositories" boolean
+    "two_factor_requirement_enabled" boolean
+    "members_allowed_repository_creation_type" string
+    "members_can_create_public_repositories" boolean
+    "members_can_create_private_repositories" boolean
+    "members_can_create_internal_repositories" boolean
+    "members_can_create_pages" boolean
+    "members_can_fork_private_repositories" boolean
+    "web_commit_signoff_required" boolean
+    "members_can_create_public_pages" boolean
+    "members_can_create_private_pages" boolean
+    "plan" object
+    "advanced_security_enabled_for_new_repositories" boolean
+    "dependabot_alerts_enabled_for_new_repositories" boolean
+    "dependabot_security_updates_enabled_for_new_repositories" boolean
+    "dependency_graph_enabled_for_new_repositories" boolean
+    "secret_scanning_enabled_for_new_repositories" boolean
+    "secret_scanning_push_protection_enabled_for_new_repositories" boolean
+    "secret_scanning_push_protection_custom_link_enabled" boolean
+    "secret_scanning_push_protection_custom_link" string
+}
+
+Table "project_cards" {
+    "url" string
+    "project_url" string
+    "id" integer [pk]
+    "node_id" string
+    "note" string
+    "archived" boolean
+    "creator" object
+    "created_at" string
+    "updated_at" string
+    "column_url" string
+    "content_url" string
+    "repository" string
+    "project_id" integer
+    "column_id" integer
+}
+
+Table "project_columns" {
+    "url" string
+    "project_url" string
+    "cards_url" string
+    "id" integer [pk]
+    "node_id" string
+    "name" string
+    "created_at" string
+    "updated_at" string
+    "repository" string
+    "project_id" integer
+}
+
+Table "projects" {
+    "repository" string
+    "owner_url" string
+    "url" string
+    "html_url" string
+    "columns_url" string
+    "id" integer [pk]
+    "node_id" string
+    "name" string
+    "body" string
+    "number" integer
+    "state" string
+    "creator" object
+    "created_at" string
+    "updated_at" string
+}
+
+Table "pull_request_comment_reactions" {
+    "id" integer [pk]
+    "node_id" string
+    "content" string
+    "created_at" string
+    "user" object
+    "repository" string
+    "comment_id" integer
+}
+
+Table "pull_request_commits" {
+    "sha" string [pk]
+    "node_id" string
+    "commit" object
+    "url" string
+    "html_url" string
+    "comments_url" string
+    "author" object
+    "committer" object
+    "parents" array
+    "repository" string
+    "pull_number" integer
+}
+
+Table "pull_request_stats" {
+    "repository" string
+    "id" integer [pk]
+    "node_id" string
+    "number" integer
+    "merged" boolean
+    "mergeable" string
+    "can_be_rebased" boolean
+    "merge_state_status" string
+    "merged_by" object
+    "comments" integer
+    "review_comments" integer
+    "maintainer_can_modify" boolean
+    "commits" integer
+    "additions" integer
+    "deletions" integer
+    "changed_files" integer
+    "updated_at" string
+}
+
+Table "projects_v2" {
+    "closed" boolean
+    "created_at" string
+    "creator" object
+    "closed_at" string
+    "updated_at" string
+    "node_id" string
+    "id" integer [pk]
+    "number" integer
+    "public" boolean
+    "readme" string
+    "short_description" string
+    "template" boolean
+    "title" string
+    "url" string
+    "viewerCanClose" boolean
+    "viewerCanReopen" boolean
+    "viewerCanUpdate" boolean
+    "owner_id" string
+    "repository" string
+}
+
+Table "pull_requests" {
+    "repository" string
+    "url" string
+    "id" integer [pk]
+    "node_id" string
+    "html_url" string
+    "diff_url" string
+    "patch_url" string
+    "issue_url" string
+    "commits_url" string
+    "review_comments_url" string
+    "review_comment_url" string
+    "comments_url" string
+    "statuses_url" string
+    "number" integer
+    "state" string
+    "locked" boolean
+    "title" string
+    "user" object
+    "body" string
+    "labels" array
+    "milestone" object
+    "active_lock_reason" string
+    "created_at" string
+    "updated_at" string
+    "closed_at" string
+    "merged_at" string
+    "merge_commit_sha" string
+    "assignee" object
+    "assignees" array
+    "requested_reviewers" array
+    "requested_teams" array
+    "head" object
+    "base" object
+    "_links" object
+    "author_association" string
+    "auto_merge" object
+    "draft" boolean
+}
+
+Table "releases" {
+    "repository" string
+    "url" string
+    "html_url" string
+    "assets_url" string
+    "upload_url" string
+    "tarball_url" string
+    "zipball_url" string
+    "id" integer [pk]
+    "node_id" string
+    "tag_name" string
+    "target_commitish" string
+    "name" string
+    "body" string
+    "draft" boolean
+    "prerelease" boolean
+    "created_at" string
+    "published_at" string
+    "author" object
+    "assets" array
+    "body_html" string
+    "body_text" string
+    "mentions_count" integer
+    "discussion_url" string
+    "reactions" object
+}
+
+Table "repositories" {
+    "id" integer [pk]
+    "node_id" string
+    "name" string
+    "full_name" string
+    "owner" object
+    "private" boolean
+    "html_url" string
+    "description" string
+    "fork" boolean
+    "url" string
+    "archive_url" string
+    "assignees_url" string
+    "blobs_url" string
+    "branches_url" string
+    "collaborators_url" string
+    "comments_url" string
+    "commits_url" string
+    "compare_url" string
+    "contents_url" string
+    "contributors_url" string
+    "deployments_url" string
+    "downloads_url" string
+    "events_url" string
+    "forks_url" string
+    "git_commits_url" string
+    "git_refs_url" string
+    "git_tags_url" string
+    "git_url" string
+    "issue_comment_url" string
+    "issue_events_url" string
+    "issues_url" string
+    "keys_url" string
+    "labels_url" string
+    "languages_url" string
+    "merges_url" string
+    "milestones_url" string
+    "notifications_url" string
+    "pulls_url" string
+    "releases_url" string
+    "ssh_url" string
+    "stargazers_url" string
+    "statuses_url" string
+    "subscribers_url" string
+    "subscription_url" string
+    "tags_url" string
+    "teams_url" string
+    "trees_url" string
+    "clone_url" string
+    "mirror_url" string
+    "hooks_url" string
+    "svn_url" string
+    "homepage" string
+    "language" string
+    "forks_count" integer
+    "stargazers_count" integer
+    "watchers_count" integer
+    "size" integer
+    "default_branch" string
+    "open_issues_count" integer
+    "is_template" boolean
+    "topics" array
+    "license" object
+    "has_issues" boolean
+    "has_projects" boolean
+    "has_wiki" boolean
+    "has_pages" boolean
+    "has_downloads" boolean
+    "archived" boolean
+    "disabled" boolean
+    "visibility" string
+    "pushed_at" string
+    "created_at" string
+    "updated_at" string
+    "permissions" object
+    "allow_forking" boolean
+    "forks" integer
+    "has_discussions" boolean
+    "open_issues" integer
+    "organization" string
+    "watchers" integer
+    "web_commit_signoff_required" boolean
+    "security_and_analysis" object
+}
+
+Table "review_comments" {
+    "repository" string
+    "url" string
+    "pull_request_review_id" integer
+    "id" integer [pk]
+    "node_id" string
+    "diff_hunk" string
+    "path" string
+    "position" integer
+    "original_position" integer
+    "commit_id" string
+    "original_commit_id" string
+    "in_reply_to_id" integer
+    "user" object
+    "body" string
+    "created_at" string
+    "updated_at" string
+    "html_url" string
+    "pull_request_url" string
+    "author_association" string
+    "_links" object
+    "start_line" integer
+    "original_start_line" integer
+    "start_side" string
+    "line" integer
+    "original_line" integer
+    "side" string
+    "subject_type" string
+    "reactions" object
+}
+
+Table "reviews" {
+    "repository" string
+    "id" integer [pk]
+    "node_id" string
+    "user" object
+    "body" string
+    "state" string
+    "html_url" string
+    "pull_request_url" string
+    "_links" object
+    "submitted_at" string
+    "created_at" string
+    "updated_at" string
+    "commit_id" string
+    "author_association" string
+}
+
+Table "stargazers" {
+    "repository" string
+    "user_id" integer [pk]
+    "starred_at" string
+    "user" object
+}
+
+Table "tags" {
+    "repository" string
+    "name" string
+    "commit" object
+    "zipball_url" string
+    "tarball_url" string
+    "node_id" string
+
+    indexes {
+        (repository, name) [pk]
+    }
+}
+
+Table "teams" {
+    "organization" string
+    "id" integer [pk]
+    "node_id" string
+    "url" string
+    "html_url" string
+    "name" string
+    "slug" string
+    "description" string
+    "privacy" string
+    "notification_setting" string
+    "permission" string
+    "members_url" string
+    "repositories_url" string
+    "parent" object
+}
+
+Table "team_members" {
+    "login" string
+    "id" integer
+    "node_id" string
+    "avatar_url" string
+    "gravatar_id" string
+    "url" string
+    "html_url" string
+    "followers_url" string
+    "following_url" string
+    "gists_url" string
+    "starred_url" string
+    "subscriptions_url" string
+    "organizations_url" string
+    "repos_url" string
+    "events_url" string
+    "received_events_url" string
+    "type" string
+    "site_admin" boolean
+    "organization" string
+    "team_slug" string
+
+    indexes {
+        (id, team_slug) [pk]
+    }
+}
+
+Table "users" {
+    "organization" string
+    "login" string
+    "id" integer [pk]
+    "node_id" string
+    "avatar_url" string
+    "gravatar_id" string
+    "url" string
+    "html_url" string
+    "followers_url" string
+    "following_url" string
+    "gists_url" string
+    "starred_url" string
+    "subscriptions_url" string
+    "organizations_url" string
+    "repos_url" string
+    "events_url" string
+    "received_events_url" string
+    "type" string
+    "site_admin" boolean
+}
+
+Table "workflows" {
+    "id" integer [pk]
+    "node_id" string
+    "name" string
+    "path" string
+    "state" string
+    "created_at" string
+    "updated_at" string
+    "url" string
+    "html_url" string
+    "badge_url" string
+    "repository" string
+}
+
+Table "workflow_runs" {
+    "id" integer [pk]
+    "name" string
+    "node_id" string
+    "head_branch" string
+    "head_sha" string
+    "path" string
+    "display_title" string
+    "run_number" integer
+    "event" string
+    "status" string
+    "conclusion" string
+    "workflow_id" integer
+    "check_suite_id" integer
+    "check_suite_node_id" string
+    "url" string
+    "html_url" string
+    "pull_requests" array
+    "created_at" string
+    "updated_at" string
+    "run_attempt" integer
+    "referenced_workflows" array
+    "run_started_at" string
+    "jobs_url" string
+    "logs_url" string
+    "check_suite_url" string
+    "artifacts_url" string
+    "cancel_url" string
+    "rerun_url" string
+    "previous_attempt_url" string
+    "workflow_url" string
+    "head_commit" object
+    "repository" object
+    "head_repository" object
+    "actor" object
+    "triggering_actor" object
+}
+
+Table "workflow_jobs" {
+    "id" integer [pk]
+    "run_id" integer
+    "workflow_name" string
+    "head_branch" string
+    "run_url" string
+    "run_attempt" integer
+    "node_id" string
+    "head_sha" string
+    "url" string
+    "html_url" string
+    "status" string
+    "conclusion" string
+    "created_at" string
+    "started_at" string
+    "completed_at" string
+    "name" string
+    "steps" array
+    "check_run_url" string
+    "labels" array
+    "runner_id" integer
+    "runner_name" string
+    "runner_group_id" integer
+    "runner_group_name" string
+    "repository" string
+}
+
+Table "team_memberships" {
+    "state" string
+    "role" string
+    "url" string [pk]
+    "organization" string
+    "team_slug" string
+    "username" string
+}
+
+Ref {
+    "assignees"."id" <> "users"."id"
+}
+
+Ref {
+    "collaborators"."id" <> "users"."id"
+}
+
+Ref {
+    "comments"."user_id" <> "users"."id"
+}
+
+Ref {
+    "commit_comment_reactions"."comment_id" <> "commit_comments"."id"
+}
+
+Ref {
+    "contributor_activity"."id" <> "users"."id"
+}
+
+Ref {
+    "contributor_activity"."repository" <> "repositories"."full_name"
+}
+
+Ref {
+    "deployments"."repository" <> "repositories"."full_name"
+}
+
+Ref {
+    "events"."repository" <> "repositories"."full_name"
+}
+
+Ref {
+    "issue_comment_reactions"."comment_id" <> "comments"."id"
+}
+
+Ref {
+    "issue_events"."repository" <> "repositories"."full_name"
+}
+
+Ref {
+    "issue_labels"."repository" <> "repositories"."full_name"
+}
+
+Ref {
+    "issue_milestones"."repository" <> "repositories"."full_name"
+}
+
+Ref {
+    "issue_reactions"."repository" <> "repositories"."full_name"
+}
+
+Ref {
+    "issues"."user_id" <> "users"."id"
+}
+
+Ref {
+    "issues"."repository" <> "repositories"."full_name"
+}
+
+Ref {
+    "project_cards"."repository" <> "repositories"."full_name"
+}
+
+Ref {
+    "project_cards"."project_id" <> "projects"."id"
+}
+
+Ref {
+    "project_cards"."column_id" <> "project_columns"."id"
+}
+
+Ref {
+    "project_columns"."repository" <> "repositories"."full_name"
+}
+
+Ref {
+    "project_columns"."project_id" <> "projects"."id"
+}
+
+Ref {
+    "projects"."repository" <> "repositories"."full_name"
+}
+
+Ref {
+    "pull_request_comment_reactions"."comment_id" <> "review_comments"."id"
+}
+
+Ref {
+    "pull_request_commits"."repository" <> "repositories"."full_name"
+}
+
+Ref {
+    "pull_request_stats"."repository" <> "repositories"."full_name"
+}
+
+Ref {
+    "projects_v2"."owner_id" <> "organizations"."id"
+}
+
+Ref {
+    "projects_v2"."repository" <> "repositories"."full_name"
+}
+
+Ref {
+    "pull_requests"."repository" <> "repositories"."full_name"
+}
+
+Ref {
+    "releases"."repository" <> "repositories"."full_name"
+}
+
+Ref {
+    "repositories"."organization" <> "organizations"."login"
+}
+
+Ref {
+    "review_comments"."repository" <> "repositories"."full_name"
+}
+
+Ref {
+    "reviews"."repository" <> "repositories"."full_name"
+}
+
+Ref {
+    "stargazers"."user_id" <> "users"."id"
+}
+
+Ref {
+    "stargazers"."repository" <> "repositories"."full_name"
+}
+
+Ref {
+    "tags"."repository" <> "repositories"."full_name"
+}
+
+Ref {
+    "teams"."organization" <> "organizations"."login"
+}
+
+Ref {
+    "team_members"."id" <> "users"."id"
+}
+
+Ref {
+    "team_members"."organization" <> "organizations"."login"
+}
+
+Ref {
+    "users"."organization" <> "organizations"."login"
+}
+
+Ref {
+    "workflows"."repository" <> "repositories"."full_name"
+}
+
+Ref {
+    "workflow_runs"."workflow_id" <> "workflows"."id"
+}
+
+Ref {
+    "workflow_runs"."repository" <> "repositories"."full_name"
+}
+
+Ref {
+    "workflow_jobs"."repository" <> "repositories"."full_name"
+}
+
+Ref {
+    "workflow_jobs"."run_id" <> "workflow_runs"."id"
+}
+
+Ref {
+    "team_memberships"."organization" <> "organizations"."login"
+}
+
+Ref {
+    "team_memberships"."username" <> "users"."login"
+}

--- a/airbyte-integrations/connectors/source-github/metadata.yaml
+++ b/airbyte-integrations/connectors/source-github/metadata.yaml
@@ -13,6 +13,7 @@ data:
   dockerImageTag: 1.8.5
   dockerRepository: airbyte/source-github
   documentationUrl: https://docs.airbyte.com/integrations/sources/github
+  erdUrl: https://dbdocs.io/airbyteio/source-github?view=relationships
   githubIssueLabel: source-github
   icon: github.svg
   license: MIT


### PR DESCRIPTION
## What
Addresses https://github.com/airbytehq/airbyte-internal-issues/issues/9173 for source-github

## How
By running `airbyte-ci --name=source-github generate-erd`

The publish has been done as part of the airbyte-ci command executed locally.

## User Impact
ERD is now available on https://dbdocs.io/airbyteio/source-github

## Can this PR be safely reverted and rolled back?
- [X] YES 💚
- [ ] NO ❌

