### PR TITLE
[ISSUE 9173] add ERD files for source-hubspot

### DIFF
--- a/airbyte-integrations/connectors/source-hubspot/erd/discovered_catalog.json
+++ b/airbyte-integrations/connectors/source-hubspot/erd/discovered_catalog.json
@@ -1,0 +1,15740 @@
+{
+  "streams": [
+    {
+      "name": "campaigns",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": ["null", "object"],
+        "properties": {
+          "appId": {
+            "description": "The unique identifier of the application associated with the campaign data.",
+            "type": ["null", "integer"]
+          },
+          "appName": {
+            "description": "The name of the application associated with the campaign data.",
+            "type": ["null", "string"]
+          },
+          "contentId": {
+            "description": "The unique identifier of the content associated with the campaign.",
+            "type": ["null", "integer"]
+          },
+          "counters": {
+            "description": "Object containing different counters related to the campaign's performance.",
+            "type": ["null", "object"],
+            "properties": {
+              "open": {
+                "description": "Number of email opens.",
+                "type": ["null", "integer"]
+              },
+              "processed": {
+                "description": "Number of emails processed by the campaign.",
+                "type": ["null", "integer"]
+              },
+              "sent": {
+                "description": "Number of emails sent.",
+                "type": ["null", "integer"]
+              },
+              "deferred": {
+                "description": "Number of deferred emails.",
+                "type": ["null", "integer"]
+              },
+              "unsubscribed": {
+                "description": "Number of recipients unsubscribed from the campaign.",
+                "type": ["null", "integer"]
+              },
+              "statuschange": {
+                "description": "Number of status changes related to the campaign.",
+                "type": ["null", "integer"]
+              },
+              "bounce": {
+                "description": "Number of bounced emails.",
+                "type": ["null", "integer"]
+              },
+              "mta_dropped": {
+                "description": "Number of emails dropped at the MTA level.",
+                "type": ["null", "integer"]
+              },
+              "dropped": {
+                "description": "Number of dropped emails.",
+                "type": ["null", "integer"]
+              },
+              "suppressed": {
+                "description": "Number of emails suppressed from sending.",
+                "type": ["null", "integer"]
+              },
+              "click": {
+                "description": "Number of clicks on the campaign.",
+                "type": ["null", "integer"]
+              },
+              "delivered": {
+                "description": "Number of successfully delivered emails.",
+                "type": ["null", "integer"]
+              },
+              "forward": {
+                "description": "Number of emails forwarded by recipients.",
+                "type": ["null", "integer"]
+              },
+              "print": {
+                "description": "Number of emails printed by recipients.",
+                "type": ["null", "integer"]
+              },
+              "reply": {
+                "description": "Number of replies received to the campaign.",
+                "type": ["null", "integer"]
+              },
+              "spamreport": {
+                "description": "Number of spam reports received for the campaign.",
+                "type": ["null", "integer"]
+              }
+            }
+          },
+          "counters_open": {
+            "description": "Alias for the open counter value.",
+            "type": ["null", "integer"]
+          },
+          "counters_processed": {
+            "description": "Alias for the processed counter value.",
+            "type": ["null", "integer"]
+          },
+          "counters_sent": {
+            "description": "Alias for the sent counter value.",
+            "type": ["null", "integer"]
+          },
+          "counters_deferred": {
+            "description": "Alias for the deferred counter value.",
+            "type": ["null", "integer"]
+          },
+          "counters_unsubscribed": {
+            "description": "Alias for the unsubscribed counter value.",
+            "type": ["null", "integer"]
+          },
+          "counters_statuschange": {
+            "description": "Alias for the status change counter value.",
+            "type": ["null", "integer"]
+          },
+          "counters_bounce": {
+            "description": "Alias for the bounce counter value.",
+            "type": ["null", "integer"]
+          },
+          "counters_mta_dropped": {
+            "description": "Alias for the MTA dropped counter value.",
+            "type": ["null", "integer"]
+          },
+          "counters_dropped": {
+            "description": "Alias for the dropped counter value.",
+            "type": ["null", "integer"]
+          },
+          "counters_suppressed": {
+            "description": "Alias for the suppressed counter value.",
+            "type": ["null", "integer"]
+          },
+          "counters_click": {
+            "description": "Alias for the click counter value.",
+            "type": ["null", "integer"]
+          },
+          "counters_delivered": {
+            "description": "Alias for the delivered counter value.",
+            "type": ["null", "integer"]
+          },
+          "counters_forward": {
+            "description": "Alias for the forward counter value.",
+            "type": ["null", "integer"]
+          },
+          "counters_print": {
+            "description": "Alias for the print counter value.",
+            "type": ["null", "integer"]
+          },
+          "counters_reply": {
+            "description": "Alias for the reply counter value.",
+            "type": ["null", "integer"]
+          },
+          "counters_spamreport": {
+            "description": "Alias for the spam report counter value.",
+            "type": ["null", "integer"]
+          },
+          "id": {
+            "description": "The unique identifier of the campaign.",
+            "type": ["null", "integer"]
+          },
+          "lastProcessingFinishedAt": {
+            "description": "Timestamp indicating when the last processing of the campaign was finished.",
+            "type": ["null", "integer"]
+          },
+          "lastProcessingStateChangeAt": {
+            "description": "Timestamp indicating the last state change time of the processing state.",
+            "type": ["null", "integer"]
+          },
+          "lastProcessingStartedAt": {
+            "description": "Timestamp indicating when the last processing of the campaign started.",
+            "type": ["null", "integer"]
+          },
+          "processingState": {
+            "description": "Current processing state of the campaign.",
+            "type": ["null", "string"]
+          },
+          "name": {
+            "description": "The name of the campaign.",
+            "type": ["null", "string"]
+          },
+          "numIncluded": {
+            "description": "Number of recipients included in the campaign.",
+            "type": ["null", "integer"]
+          },
+          "numQueued": {
+            "description": "Number of emails queued for sending.",
+            "type": ["null", "integer"]
+          },
+          "subType": {
+            "description": "Subtype of the campaign.",
+            "type": ["null", "string"]
+          },
+          "subject": {
+            "description": "The subject line of the campaign.",
+            "type": ["null", "string"]
+          },
+          "type": {
+            "description": "Type classification of the campaign.",
+            "type": ["null", "string"]
+          },
+          "lastUpdatedTime": {
+            "description": "Timestamp indicating when the campaign data was last updated.",
+            "type": ["null", "integer"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["lastUpdatedTime"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "companies",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": ["null", "object"],
+        "properties": {
+          "id": {
+            "description": "Unique identifier for the company",
+            "type": ["null", "string"]
+          },
+          "createdAt": {
+            "description": "Date and time when the company was created",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "description": "Date and time when the company was last updated",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "archived": {
+            "description": "Indicates whether the company is archived or active",
+            "type": ["null", "boolean"]
+          },
+          "contacts": {
+            "description": "List of contacts associated with the company",
+            "type": ["null", "array"],
+            "items": {
+              "description": "Details of individual contacts",
+              "type": "string"
+            }
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "about_us": { "type": ["null", "string"] },
+              "address": { "type": ["null", "string"] },
+              "address2": { "type": ["null", "string"] },
+              "annualrevenue": { "type": ["null", "number"] },
+              "city": { "type": ["null", "string"] },
+              "closedate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "closedate_timestamp_earliest_value_a2a17e6e": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "country": { "type": ["null", "string"] },
+              "createdate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "custom_company_property": { "type": ["null", "string"] },
+              "days_to_close": { "type": ["null", "number"] },
+              "description": { "type": ["null", "string"] },
+              "domain": { "type": ["null", "string"] },
+              "engagements_last_meeting_booked": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "engagements_last_meeting_booked_campaign": {
+                "type": ["null", "string"]
+              },
+              "engagements_last_meeting_booked_medium": {
+                "type": ["null", "string"]
+              },
+              "engagements_last_meeting_booked_source": {
+                "type": ["null", "string"]
+              },
+              "facebook_company_page": { "type": ["null", "string"] },
+              "facebookfans": { "type": ["null", "number"] },
+              "first_contact_createdate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "first_contact_createdate_timestamp_earliest_value_78b50eea": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "first_conversion_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "first_conversion_date_timestamp_earliest_value_61f58f2c": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "first_conversion_event_name": { "type": ["null", "string"] },
+              "first_conversion_event_name_timestamp_earliest_value_68ddae0a": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "first_deal_created_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "founded_year": { "type": ["null", "string"] },
+              "googleplus_page": { "type": ["null", "string"] },
+              "hs_additional_domains": { "type": ["null", "string"] },
+              "hs_all_accessible_team_ids": { "type": ["null", "string"] },
+              "hs_all_owner_ids": { "type": ["null", "string"] },
+              "hs_all_team_ids": { "type": ["null", "string"] },
+              "hs_analytics_first_timestamp": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_analytics_first_timestamp_timestamp_earliest_value_11e3a63a": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_analytics_first_touch_converting_campaign": {
+                "type": ["null", "string"]
+              },
+              "hs_analytics_first_touch_converting_campaign_timestamp_earliest_value_4757fe10": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_analytics_first_visit_timestamp": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_analytics_first_visit_timestamp_timestamp_earliest_value_accc17ae": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_analytics_last_timestamp": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_analytics_last_timestamp_timestamp_latest_value_4e16365a": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_analytics_last_touch_converting_campaign": {
+                "type": ["null", "string"]
+              },
+              "hs_analytics_last_touch_converting_campaign_timestamp_latest_value_81a64e30": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_analytics_last_visit_timestamp": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_analytics_last_visit_timestamp_timestamp_latest_value_999a0fce": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_analytics_latest_source": { "type": ["null", "string"] },
+              "hs_analytics_latest_source_data_1": {
+                "type": ["null", "string"]
+              },
+              "hs_analytics_latest_source_data_2": {
+                "type": ["null", "string"]
+              },
+              "hs_analytics_latest_source_timestamp": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_analytics_num_page_views": { "type": ["null", "number"] },
+              "hs_analytics_num_page_views_cardinality_sum_e46e85b0": {
+                "type": ["null", "number"]
+              },
+              "hs_analytics_num_visits": { "type": ["null", "number"] },
+              "hs_analytics_num_visits_cardinality_sum_53d952a6": {
+                "type": ["null", "number"]
+              },
+              "hs_analytics_source": { "type": ["null", "string"] },
+              "hs_analytics_source_data_1": { "type": ["null", "string"] },
+              "hs_analytics_source_data_1_timestamp_earliest_value_9b2f1fa1": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_analytics_source_data_2": { "type": ["null", "string"] },
+              "hs_analytics_source_data_2_timestamp_earliest_value_9b2f9400": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_analytics_source_timestamp_earliest_value_25a3a52c": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_annual_revenue_currency_code": { "type": ["null", "string"] },
+              "hs_avatar_filemanager_key": { "type": ["null", "string"] },
+              "hs_country_code": { "type": ["null", "string"] },
+              "hs_created_by_user_id": { "type": ["null", "number"] },
+              "hs_createdate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_csm_sentiment": { "type": ["null", "string"] },
+              "hs_customer_success_ticket_sentiment": {
+                "type": ["null", "number"]
+              },
+              "hs_date_entered_customer": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_entered_evangelist": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_entered_lead": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_entered_marketingqualifiedlead": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_entered_opportunity": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_entered_other": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_entered_salesqualifiedlead": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_entered_subscriber": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_exited_customer": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_exited_evangelist": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_exited_lead": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_exited_marketingqualifiedlead": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_exited_opportunity": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_exited_other": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_exited_salesqualifiedlead": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_exited_subscriber": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_ideal_customer_profile": { "type": ["null", "string"] },
+              "hs_is_target_account": { "type": ["null", "boolean"] },
+              "hs_last_booked_meeting_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_last_logged_call_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_last_open_task_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_last_sales_activity_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_last_sales_activity_timestamp": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_last_sales_activity_type": { "type": ["null", "string"] },
+              "hs_lastmodifieddate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_latest_createdate_of_active_subscriptions": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_latest_meeting_activity": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_lead_status": { "type": ["null", "string"] },
+              "hs_logo_url": { "type": ["null", "string"] },
+              "hs_merged_object_ids": { "type": ["null", "string"] },
+              "hs_notes_next_activity_type": { "type": ["null", "string"] },
+              "hs_num_blockers": { "type": ["null", "number"] },
+              "hs_num_child_companies": { "type": ["null", "number"] },
+              "hs_num_contacts_with_buying_roles": {
+                "type": ["null", "number"]
+              },
+              "hs_num_decision_makers": { "type": ["null", "number"] },
+              "hs_num_open_deals": { "type": ["null", "number"] },
+              "hs_object_id": { "type": ["null", "number"] },
+              "hs_object_source": { "type": ["null", "string"] },
+              "hs_object_source_detail_1": { "type": ["null", "string"] },
+              "hs_object_source_detail_2": { "type": ["null", "string"] },
+              "hs_object_source_detail_3": { "type": ["null", "string"] },
+              "hs_object_source_id": { "type": ["null", "string"] },
+              "hs_object_source_label": { "type": ["null", "string"] },
+              "hs_object_source_user_id": { "type": ["null", "number"] },
+              "hs_parent_company_id": { "type": ["null", "number"] },
+              "hs_pinned_engagement_id": { "type": ["null", "number"] },
+              "hs_pipeline": { "type": ["null", "string"] },
+              "hs_predictivecontactscore_v2": { "type": ["null", "number"] },
+              "hs_predictivecontactscore_v2_next_max_max_d4e58c1e": {
+                "type": ["null", "number"]
+              },
+              "hs_read_only": { "type": ["null", "boolean"] },
+              "hs_sales_email_last_replied": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_target_account": { "type": ["null", "string"] },
+              "hs_target_account_probability": { "type": ["null", "number"] },
+              "hs_target_account_recommendation_snooze_time": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_target_account_recommendation_state": {
+                "type": ["null", "string"]
+              },
+              "hs_time_in_customer": { "type": ["null", "number"] },
+              "hs_time_in_evangelist": { "type": ["null", "number"] },
+              "hs_time_in_lead": { "type": ["null", "number"] },
+              "hs_time_in_marketingqualifiedlead": {
+                "type": ["null", "number"]
+              },
+              "hs_time_in_opportunity": { "type": ["null", "number"] },
+              "hs_time_in_other": { "type": ["null", "number"] },
+              "hs_time_in_salesqualifiedlead": { "type": ["null", "number"] },
+              "hs_time_in_subscriber": { "type": ["null", "number"] },
+              "hs_total_deal_value": { "type": ["null", "number"] },
+              "hs_unique_creation_key": { "type": ["null", "string"] },
+              "hs_updated_by_user_id": { "type": ["null", "number"] },
+              "hs_user_ids_of_all_notification_followers": {
+                "type": ["null", "string"]
+              },
+              "hs_user_ids_of_all_notification_unfollowers": {
+                "type": ["null", "string"]
+              },
+              "hs_user_ids_of_all_owners": { "type": ["null", "string"] },
+              "hs_was_imported": { "type": ["null", "boolean"] },
+              "hubspot_owner_assigneddate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hubspot_owner_id": { "type": ["null", "string"] },
+              "hubspot_team_id": { "type": ["null", "string"] },
+              "hubspotscore": { "type": ["null", "number"] },
+              "industry": { "type": ["null", "string"] },
+              "is_public": { "type": ["null", "boolean"] },
+              "lifecyclestage": { "type": ["null", "string"] },
+              "linkedin_company_page": { "type": ["null", "string"] },
+              "linkedinbio": { "type": ["null", "string"] },
+              "name": { "type": ["null", "string"] },
+              "notes_last_contacted": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "notes_last_updated": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "notes_next_activity_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "num_associated_contacts": { "type": ["null", "number"] },
+              "num_associated_deals": { "type": ["null", "number"] },
+              "num_contacted_notes": { "type": ["null", "number"] },
+              "num_conversion_events": { "type": ["null", "number"] },
+              "num_conversion_events_cardinality_sum_d095f14b": {
+                "type": ["null", "number"]
+              },
+              "num_notes": { "type": ["null", "number"] },
+              "numberofemployees": { "type": ["null", "number"] },
+              "phone": { "type": ["null", "string"] },
+              "recent_conversion_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "recent_conversion_date_timestamp_latest_value_72856da1": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "recent_conversion_event_name": { "type": ["null", "string"] },
+              "recent_conversion_event_name_timestamp_latest_value_66c820bf": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "recent_deal_amount": { "type": ["null", "number"] },
+              "recent_deal_close_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "state": { "type": ["null", "string"] },
+              "timezone": { "type": ["null", "string"] },
+              "total_money_raised": { "type": ["null", "string"] },
+              "total_revenue": { "type": ["null", "number"] },
+              "twitterbio": { "type": ["null", "string"] },
+              "twitterfollowers": { "type": ["null", "number"] },
+              "twitterhandle": { "type": ["null", "string"] },
+              "type": { "type": ["null", "string"] },
+              "web_technologies": { "type": ["null", "string"] },
+              "website": { "type": ["null", "string"] },
+              "zip": { "type": ["null", "string"] }
+            }
+          },
+          "properties_about_us": { "type": ["null", "string"] },
+          "properties_address": { "type": ["null", "string"] },
+          "properties_address2": { "type": ["null", "string"] },
+          "properties_annualrevenue": { "type": ["null", "number"] },
+          "properties_city": { "type": ["null", "string"] },
+          "properties_closedate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_closedate_timestamp_earliest_value_a2a17e6e": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_country": { "type": ["null", "string"] },
+          "properties_createdate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_custom_company_property": { "type": ["null", "string"] },
+          "properties_days_to_close": { "type": ["null", "number"] },
+          "properties_description": { "type": ["null", "string"] },
+          "properties_domain": { "type": ["null", "string"] },
+          "properties_engagements_last_meeting_booked": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_engagements_last_meeting_booked_campaign": {
+            "type": ["null", "string"]
+          },
+          "properties_engagements_last_meeting_booked_medium": {
+            "type": ["null", "string"]
+          },
+          "properties_engagements_last_meeting_booked_source": {
+            "type": ["null", "string"]
+          },
+          "properties_facebook_company_page": { "type": ["null", "string"] },
+          "properties_facebookfans": { "type": ["null", "number"] },
+          "properties_first_contact_createdate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_first_contact_createdate_timestamp_earliest_value_78b50eea": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_first_conversion_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_first_conversion_date_timestamp_earliest_value_61f58f2c": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_first_conversion_event_name": {
+            "type": ["null", "string"]
+          },
+          "properties_first_conversion_event_name_timestamp_earliest_value_68ddae0a": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_first_deal_created_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_founded_year": { "type": ["null", "string"] },
+          "properties_googleplus_page": { "type": ["null", "string"] },
+          "properties_hs_additional_domains": { "type": ["null", "string"] },
+          "properties_hs_all_accessible_team_ids": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_all_owner_ids": { "type": ["null", "string"] },
+          "properties_hs_all_team_ids": { "type": ["null", "string"] },
+          "properties_hs_analytics_first_timestamp": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_analytics_first_timestamp_timestamp_earliest_value_11e3a63a": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_analytics_first_touch_converting_campaign": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_analytics_first_touch_converting_campaign_timestamp_earliest_value_4757fe10": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_analytics_first_visit_timestamp": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_analytics_first_visit_timestamp_timestamp_earliest_value_accc17ae": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_analytics_last_timestamp": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_analytics_last_timestamp_timestamp_latest_value_4e16365a": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_analytics_last_touch_converting_campaign": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_analytics_last_touch_converting_campaign_timestamp_latest_value_81a64e30": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_analytics_last_visit_timestamp": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_analytics_last_visit_timestamp_timestamp_latest_value_999a0fce": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_analytics_latest_source": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_analytics_latest_source_data_1": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_analytics_latest_source_data_2": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_analytics_latest_source_timestamp": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_analytics_num_page_views": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_analytics_num_page_views_cardinality_sum_e46e85b0": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_analytics_num_visits": { "type": ["null", "number"] },
+          "properties_hs_analytics_num_visits_cardinality_sum_53d952a6": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_analytics_source": { "type": ["null", "string"] },
+          "properties_hs_analytics_source_data_1": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_analytics_source_data_1_timestamp_earliest_value_9b2f1fa1": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_analytics_source_data_2": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_analytics_source_data_2_timestamp_earliest_value_9b2f9400": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_analytics_source_timestamp_earliest_value_25a3a52c": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_annual_revenue_currency_code": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_avatar_filemanager_key": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_country_code": { "type": ["null", "string"] },
+          "properties_hs_created_by_user_id": { "type": ["null", "number"] },
+          "properties_hs_createdate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_csm_sentiment": { "type": ["null", "string"] },
+          "properties_hs_customer_success_ticket_sentiment": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_date_entered_customer": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_entered_evangelist": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_entered_lead": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_entered_marketingqualifiedlead": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_entered_opportunity": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_entered_other": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_entered_salesqualifiedlead": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_entered_subscriber": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_exited_customer": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_exited_evangelist": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_exited_lead": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_exited_marketingqualifiedlead": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_exited_opportunity": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_exited_other": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_exited_salesqualifiedlead": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_exited_subscriber": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_ideal_customer_profile": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_is_target_account": { "type": ["null", "boolean"] },
+          "properties_hs_last_booked_meeting_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_last_logged_call_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_last_open_task_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_last_sales_activity_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_last_sales_activity_timestamp": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_last_sales_activity_type": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_lastmodifieddate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_latest_createdate_of_active_subscriptions": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_latest_meeting_activity": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_lead_status": { "type": ["null", "string"] },
+          "properties_hs_logo_url": { "type": ["null", "string"] },
+          "properties_hs_merged_object_ids": { "type": ["null", "string"] },
+          "properties_hs_notes_next_activity_type": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_num_blockers": { "type": ["null", "number"] },
+          "properties_hs_num_child_companies": { "type": ["null", "number"] },
+          "properties_hs_num_contacts_with_buying_roles": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_num_decision_makers": { "type": ["null", "number"] },
+          "properties_hs_num_open_deals": { "type": ["null", "number"] },
+          "properties_hs_object_id": { "type": ["null", "number"] },
+          "properties_hs_object_source": { "type": ["null", "string"] },
+          "properties_hs_object_source_detail_1": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_object_source_detail_2": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_object_source_detail_3": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_object_source_id": { "type": ["null", "string"] },
+          "properties_hs_object_source_label": { "type": ["null", "string"] },
+          "properties_hs_object_source_user_id": { "type": ["null", "number"] },
+          "properties_hs_parent_company_id": { "type": ["null", "number"] },
+          "properties_hs_pinned_engagement_id": { "type": ["null", "number"] },
+          "properties_hs_pipeline": { "type": ["null", "string"] },
+          "properties_hs_predictivecontactscore_v2": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_predictivecontactscore_v2_next_max_max_d4e58c1e": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_read_only": { "type": ["null", "boolean"] },
+          "properties_hs_sales_email_last_replied": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_target_account": { "type": ["null", "string"] },
+          "properties_hs_target_account_probability": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_target_account_recommendation_snooze_time": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_target_account_recommendation_state": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_time_in_customer": { "type": ["null", "number"] },
+          "properties_hs_time_in_evangelist": { "type": ["null", "number"] },
+          "properties_hs_time_in_lead": { "type": ["null", "number"] },
+          "properties_hs_time_in_marketingqualifiedlead": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_time_in_opportunity": { "type": ["null", "number"] },
+          "properties_hs_time_in_other": { "type": ["null", "number"] },
+          "properties_hs_time_in_salesqualifiedlead": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_time_in_subscriber": { "type": ["null", "number"] },
+          "properties_hs_total_deal_value": { "type": ["null", "number"] },
+          "properties_hs_unique_creation_key": { "type": ["null", "string"] },
+          "properties_hs_updated_by_user_id": { "type": ["null", "number"] },
+          "properties_hs_user_ids_of_all_notification_followers": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_user_ids_of_all_notification_unfollowers": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_user_ids_of_all_owners": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_was_imported": { "type": ["null", "boolean"] },
+          "properties_hubspot_owner_assigneddate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hubspot_owner_id": { "type": ["null", "string"] },
+          "properties_hubspot_team_id": { "type": ["null", "string"] },
+          "properties_hubspotscore": { "type": ["null", "number"] },
+          "properties_industry": { "type": ["null", "string"] },
+          "properties_is_public": { "type": ["null", "boolean"] },
+          "properties_lifecyclestage": { "type": ["null", "string"] },
+          "properties_linkedin_company_page": { "type": ["null", "string"] },
+          "properties_linkedinbio": { "type": ["null", "string"] },
+          "properties_name": { "type": ["null", "string"] },
+          "properties_notes_last_contacted": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_notes_last_updated": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_notes_next_activity_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_num_associated_contacts": { "type": ["null", "number"] },
+          "properties_num_associated_deals": { "type": ["null", "number"] },
+          "properties_num_contacted_notes": { "type": ["null", "number"] },
+          "properties_num_conversion_events": { "type": ["null", "number"] },
+          "properties_num_conversion_events_cardinality_sum_d095f14b": {
+            "type": ["null", "number"]
+          },
+          "properties_num_notes": { "type": ["null", "number"] },
+          "properties_numberofemployees": { "type": ["null", "number"] },
+          "properties_phone": { "type": ["null", "string"] },
+          "properties_recent_conversion_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_recent_conversion_date_timestamp_latest_value_72856da1": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_recent_conversion_event_name": {
+            "type": ["null", "string"]
+          },
+          "properties_recent_conversion_event_name_timestamp_latest_value_66c820bf": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_recent_deal_amount": { "type": ["null", "number"] },
+          "properties_recent_deal_close_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_state": { "type": ["null", "string"] },
+          "properties_timezone": { "type": ["null", "string"] },
+          "properties_total_money_raised": { "type": ["null", "string"] },
+          "properties_total_revenue": { "type": ["null", "number"] },
+          "properties_twitterbio": { "type": ["null", "string"] },
+          "properties_twitterfollowers": { "type": ["null", "number"] },
+          "properties_twitterhandle": { "type": ["null", "string"] },
+          "properties_type": { "type": ["null", "string"] },
+          "properties_web_technologies": { "type": ["null", "string"] },
+          "properties_website": { "type": ["null", "string"] },
+          "properties_zip": { "type": ["null", "string"] }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updatedAt"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "contact_lists",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "parentId": {
+            "description": "The ID of the parent list, if applicable.",
+            "type": ["null", "integer"]
+          },
+          "metaData": {
+            "description": "Additional metadata related to the fetched contact lists",
+            "type": ["null", "object"],
+            "properties": {
+              "processing": {
+                "description": "Indicates if the list is currently being processed.",
+                "type": ["null", "string"]
+              },
+              "size": {
+                "description": "The size of the contact list.",
+                "type": ["null", "integer"]
+              },
+              "error": {
+                "description": "Any error associated with the contact list.",
+                "type": ["null", "string"]
+              },
+              "lastProcessingStateChangeAt": {
+                "description": "The timestamp of the last processing state change.",
+                "type": ["null", "integer"]
+              },
+              "lastSizeChangeAt": {
+                "description": "The timestamp of the last size change.",
+                "type": ["null", "integer"]
+              },
+              "listReferencesCount": {
+                "description": "The count of references to the list.",
+                "type": ["null", "integer"]
+              },
+              "parentFolderId": {
+                "description": "The ID of the parent folder containing the list.",
+                "type": ["null", "integer"]
+              }
+            }
+          },
+          "metaData_processing": {
+            "description": "Processing status related to list metadata.",
+            "type": ["null", "string"]
+          },
+          "metaData_size": {
+            "description": "Size of the list metadata.",
+            "type": ["null", "integer"]
+          },
+          "metaData_error": {
+            "description": "Error information related to list metadata.",
+            "type": ["null", "string"]
+          },
+          "metaData_lastProcessingStateChangeAt": {
+            "description": "Timestamp of the last processing state change for metadata.",
+            "type": ["null", "integer"]
+          },
+          "metaData_lastSizeChangeAt": {
+            "description": "Timestamp of the last size change for metadata.",
+            "type": ["null", "integer"]
+          },
+          "metaData_listReferencesCount": {
+            "description": "References count related to list metadata.",
+            "type": ["null", "integer"]
+          },
+          "metaData_parentFolderId": {
+            "description": "Parent folder ID associated with list metadata.",
+            "type": ["null", "integer"]
+          },
+          "dynamic": {
+            "description": "Identifies if the contact list is dynamic in nature.",
+            "type": ["null", "boolean"]
+          },
+          "name": {
+            "description": "The name or title of the contact list.",
+            "type": ["null", "string"]
+          },
+          "filters": {
+            "description": "Contains filter criteria to fetch contact lists",
+            "type": ["null", "array"],
+            "items": {
+              "description": "Individual filter items",
+              "type": ["null", "array"],
+              "items": {
+                "description": "Properties for each filter item",
+                "type": ["null", "object"],
+                "properties": {
+                  "filterFamily": {
+                    "description": "The family to which the filter belongs.",
+                    "type": ["null", "string"]
+                  },
+                  "withinTimeMode": {
+                    "description": "Specifies the time mode within which the filter operates.",
+                    "type": ["null", "string"]
+                  },
+                  "checkPastVersions": {
+                    "description": "Specifies if past versions of the filter should be checked.",
+                    "type": ["null", "boolean"]
+                  },
+                  "type": {
+                    "description": "The type of filter being used.",
+                    "type": ["null", "string"]
+                  },
+                  "property": {
+                    "description": "The property on which the filter is applied.",
+                    "type": ["null", "string"]
+                  },
+                  "value": {
+                    "description": "The specific value for the filter.",
+                    "type": ["null", "string"]
+                  },
+                  "operator": {
+                    "description": "The operation performed by the filter.",
+                    "type": ["null", "string"]
+                  }
+                }
+              }
+            }
+          },
+          "ilsFilterBranch": {
+            "description": "Indicates the branch of the filter applied.",
+            "type": ["null", "string"]
+          },
+          "internal": {
+            "description": "Specifies if the contact list is internal (not accessible to customers).",
+            "type": ["null", "boolean"]
+          },
+          "authorId": {
+            "description": "The ID of the user who authored or created the contact list.",
+            "type": ["null", "integer"]
+          },
+          "limitExempt": {
+            "description": "Specifies if any limits are exempted for the contact list.",
+            "type": ["null", "boolean"]
+          },
+          "teamIds": {
+            "description": "The IDs of teams that have access to the contact list.",
+            "type": ["null", "array"]
+          },
+          "portalId": {
+            "description": "The ID of the portal to which the contact list belongs.",
+            "type": ["null", "integer"]
+          },
+          "createdAt": {
+            "description": "The timestamp when the contact list was created.",
+            "type": ["null", "integer"]
+          },
+          "listId": {
+            "description": "The unique ID of the contact list.",
+            "type": ["null", "integer"]
+          },
+          "updatedAt": {
+            "description": "The timestamp of the last update to the contact list.",
+            "type": ["null", "integer"]
+          },
+          "internalListId": {
+            "description": "The internal ID of the contact list.",
+            "type": ["null", "integer"]
+          },
+          "readOnly": {
+            "description": "Specifies if the list is read-only or not.",
+            "type": ["null", "boolean"]
+          },
+          "deleteable": {
+            "description": "Specifies if the contact list can be deleted.",
+            "type": ["null", "boolean"]
+          },
+          "listType": {
+            "description": "Specifies the type of list, e.g., static or dynamic.",
+            "type": ["null", "string"]
+          },
+          "archived": {
+            "description": "Indicates if the contact list is archived or not.",
+            "type": ["null", "boolean"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updatedAt"],
+      "source_defined_primary_key": [["listId"]],
+      "is_resumable": true
+    },
+    {
+      "name": "contacts",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": ["null", "object"],
+        "properties": {
+          "id": {
+            "description": "Unique identifier for the contact.",
+            "type": ["null", "string"]
+          },
+          "createdAt": {
+            "description": "Date and time when the contact was created.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "description": "Date and time when the contact was last updated.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "archived": {
+            "description": "Indicates if the contact is archived or not.",
+            "type": ["null", "boolean"]
+          },
+          "companies": {
+            "description": "List of companies associated with the contact.",
+            "type": ["null", "array"],
+            "items": {
+              "description": "Details of a company associated with the contact.",
+              "type": ["null", "string"]
+            }
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "address": { "type": ["null", "string"] },
+              "annualrevenue": { "type": ["null", "string"] },
+              "associatedcompanyid": { "type": ["null", "number"] },
+              "associatedcompanylastupdated": { "type": ["null", "number"] },
+              "city": { "type": ["null", "string"] },
+              "closedate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "company": { "type": ["null", "string"] },
+              "company_size": { "type": ["null", "string"] },
+              "country": { "type": ["null", "string"] },
+              "createdate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "currentlyinworkflow": { "type": ["null", "string"] },
+              "date_of_birth": { "type": ["null", "string"] },
+              "days_to_close": { "type": ["null", "number"] },
+              "degree": { "type": ["null", "string"] },
+              "email": { "type": ["null", "string"] },
+              "engagements_last_meeting_booked": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "engagements_last_meeting_booked_campaign": {
+                "type": ["null", "string"]
+              },
+              "engagements_last_meeting_booked_medium": {
+                "type": ["null", "string"]
+              },
+              "engagements_last_meeting_booked_source": {
+                "type": ["null", "string"]
+              },
+              "fax": { "type": ["null", "string"] },
+              "field_of_study": { "type": ["null", "string"] },
+              "first_conversion_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "first_conversion_event_name": { "type": ["null", "string"] },
+              "first_deal_created_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "firstname": { "type": ["null", "string"] },
+              "gender": { "type": ["null", "string"] },
+              "graduation_date": { "type": ["null", "string"] },
+              "hs_additional_emails": { "type": ["null", "string"] },
+              "hs_all_accessible_team_ids": { "type": ["null", "string"] },
+              "hs_all_contact_vids": { "type": ["null", "string"] },
+              "hs_all_owner_ids": { "type": ["null", "string"] },
+              "hs_all_team_ids": { "type": ["null", "string"] },
+              "hs_analytics_average_page_views": { "type": ["null", "number"] },
+              "hs_analytics_first_referrer": { "type": ["null", "string"] },
+              "hs_analytics_first_timestamp": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_analytics_first_touch_converting_campaign": {
+                "type": ["null", "string"]
+              },
+              "hs_analytics_first_url": { "type": ["null", "string"] },
+              "hs_analytics_first_visit_timestamp": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_analytics_last_referrer": { "type": ["null", "string"] },
+              "hs_analytics_last_timestamp": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_analytics_last_touch_converting_campaign": {
+                "type": ["null", "string"]
+              },
+              "hs_analytics_last_url": { "type": ["null", "string"] },
+              "hs_analytics_last_visit_timestamp": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_analytics_num_event_completions": {
+                "type": ["null", "number"]
+              },
+              "hs_analytics_num_page_views": { "type": ["null", "number"] },
+              "hs_analytics_num_visits": { "type": ["null", "number"] },
+              "hs_analytics_revenue": { "type": ["null", "number"] },
+              "hs_analytics_source": { "type": ["null", "string"] },
+              "hs_analytics_source_data_1": { "type": ["null", "string"] },
+              "hs_analytics_source_data_2": { "type": ["null", "string"] },
+              "hs_associated_target_accounts": { "type": ["null", "number"] },
+              "hs_avatar_filemanager_key": { "type": ["null", "string"] },
+              "hs_buying_role": { "type": ["null", "string"] },
+              "hs_calculated_form_submissions": { "type": ["null", "string"] },
+              "hs_calculated_merged_vids": { "type": ["null", "string"] },
+              "hs_calculated_mobile_number": { "type": ["null", "string"] },
+              "hs_calculated_phone_number": { "type": ["null", "string"] },
+              "hs_calculated_phone_number_area_code": {
+                "type": ["null", "string"]
+              },
+              "hs_calculated_phone_number_country_code": {
+                "type": ["null", "string"]
+              },
+              "hs_calculated_phone_number_region_code": {
+                "type": ["null", "string"]
+              },
+              "hs_clicked_linkedin_ad": { "type": ["null", "string"] },
+              "hs_content_membership_email": { "type": ["null", "string"] },
+              "hs_content_membership_email_confirmed": {
+                "type": ["null", "boolean"]
+              },
+              "hs_content_membership_follow_up_enqueued_at": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_content_membership_notes": { "type": ["null", "string"] },
+              "hs_content_membership_registered_at": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_content_membership_registration_domain_sent_to": {
+                "type": ["null", "string"]
+              },
+              "hs_content_membership_registration_email_sent_at": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_content_membership_status": { "type": ["null", "string"] },
+              "hs_conversations_visitor_email": { "type": ["null", "string"] },
+              "hs_count_is_unworked": { "type": ["null", "number"] },
+              "hs_count_is_worked": { "type": ["null", "number"] },
+              "hs_created_by_conversations": { "type": ["null", "boolean"] },
+              "hs_created_by_user_id": { "type": ["null", "number"] },
+              "hs_createdate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_entered_customer": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_entered_evangelist": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_entered_lead": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_entered_marketingqualifiedlead": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_entered_opportunity": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_entered_other": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_entered_salesqualifiedlead": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_entered_subscriber": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_exited_customer": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_exited_evangelist": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_exited_lead": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_exited_marketingqualifiedlead": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_exited_opportunity": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_exited_other": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_exited_salesqualifiedlead": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_exited_subscriber": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_document_last_revisited": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_email_bad_address": { "type": ["null", "boolean"] },
+              "hs_email_bounce": { "type": ["null", "number"] },
+              "hs_email_click": { "type": ["null", "number"] },
+              "hs_email_customer_quarantined_reason": {
+                "type": ["null", "string"]
+              },
+              "hs_email_delivered": { "type": ["null", "number"] },
+              "hs_email_domain": { "type": ["null", "string"] },
+              "hs_email_first_click_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_email_first_open_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_email_first_reply_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_email_first_send_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_email_hard_bounce_reason": { "type": ["null", "string"] },
+              "hs_email_hard_bounce_reason_enum": {
+                "type": ["null", "string"]
+              },
+              "hs_email_is_ineligible": { "type": ["null", "boolean"] },
+              "hs_email_last_click_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_email_last_email_name": { "type": ["null", "string"] },
+              "hs_email_last_open_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_email_last_reply_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_email_last_send_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_email_open": { "type": ["null", "number"] },
+              "hs_email_optout": { "type": ["null", "boolean"] },
+              "hs_email_optout_10798197": { "type": ["null", "string"] },
+              "hs_email_optout_11890603": { "type": ["null", "string"] },
+              "hs_email_optout_11890831": { "type": ["null", "string"] },
+              "hs_email_optout_23704464": { "type": ["null", "string"] },
+              "hs_email_optout_313921448": { "type": ["null", "string"] },
+              "hs_email_optout_94692364": { "type": ["null", "string"] },
+              "hs_email_quarantined": { "type": ["null", "boolean"] },
+              "hs_email_quarantined_reason": { "type": ["null", "string"] },
+              "hs_email_recipient_fatigue_recovery_time": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_email_replied": { "type": ["null", "number"] },
+              "hs_email_sends_since_last_engagement": {
+                "type": ["null", "number"]
+              },
+              "hs_emailconfirmationstatus": { "type": ["null", "string"] },
+              "hs_facebook_ad_clicked": { "type": ["null", "boolean"] },
+              "hs_facebook_click_id": { "type": ["null", "string"] },
+              "hs_feedback_last_nps_follow_up": { "type": ["null", "string"] },
+              "hs_feedback_last_nps_rating": { "type": ["null", "string"] },
+              "hs_feedback_last_survey_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_feedback_show_nps_web_survey": {
+                "type": ["null", "boolean"]
+              },
+              "hs_first_engagement_object_id": { "type": ["null", "number"] },
+              "hs_first_outreach_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_first_subscription_create_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_google_click_id": { "type": ["null", "string"] },
+              "hs_has_active_subscription": { "type": ["null", "number"] },
+              "hs_ip_timezone": { "type": ["null", "string"] },
+              "hs_is_contact": { "type": ["null", "boolean"] },
+              "hs_is_unworked": { "type": ["null", "boolean"] },
+              "hs_language": { "type": ["null", "string"] },
+              "hs_last_sales_activity_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_last_sales_activity_timestamp": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_last_sales_activity_type": { "type": ["null", "string"] },
+              "hs_lastmodifieddate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_latest_disqualified_lead_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_latest_meeting_activity": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_latest_open_lead_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_latest_qualified_lead_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_latest_sequence_ended_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_latest_sequence_enrolled": { "type": ["null", "number"] },
+              "hs_latest_sequence_enrolled_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_latest_sequence_finished_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_latest_sequence_unenrolled_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_latest_source": { "type": ["null", "string"] },
+              "hs_latest_source_data_1": { "type": ["null", "string"] },
+              "hs_latest_source_data_2": { "type": ["null", "string"] },
+              "hs_latest_source_timestamp": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_latest_subscription_create_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_lead_status": { "type": ["null", "string"] },
+              "hs_legal_basis": { "type": ["null", "string"] },
+              "hs_lifecyclestage_customer_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_lifecyclestage_evangelist_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_lifecyclestage_lead_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_lifecyclestage_marketingqualifiedlead_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_lifecyclestage_opportunity_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_lifecyclestage_other_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_lifecyclestage_salesqualifiedlead_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_lifecyclestage_subscriber_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_linkedin_ad_clicked": { "type": ["null", "string"] },
+              "hs_marketable_reason_id": { "type": ["null", "string"] },
+              "hs_marketable_reason_type": { "type": ["null", "string"] },
+              "hs_marketable_status": { "type": ["null", "string"] },
+              "hs_marketable_until_renewal": { "type": ["null", "string"] },
+              "hs_membership_has_accessed_private_content": {
+                "type": ["null", "number"]
+              },
+              "hs_membership_last_private_content_access_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_merged_object_ids": { "type": ["null", "string"] },
+              "hs_mobile_sdk_push_tokens": { "type": ["null", "string"] },
+              "hs_notes_next_activity_type": { "type": ["null", "string"] },
+              "hs_object_id": { "type": ["null", "number"] },
+              "hs_object_source": { "type": ["null", "string"] },
+              "hs_object_source_detail_1": { "type": ["null", "string"] },
+              "hs_object_source_detail_2": { "type": ["null", "string"] },
+              "hs_object_source_detail_3": { "type": ["null", "string"] },
+              "hs_object_source_id": { "type": ["null", "string"] },
+              "hs_object_source_label": { "type": ["null", "string"] },
+              "hs_object_source_user_id": { "type": ["null", "number"] },
+              "hs_persona": { "type": ["null", "string"] },
+              "hs_pinned_engagement_id": { "type": ["null", "number"] },
+              "hs_pipeline": { "type": ["null", "string"] },
+              "hs_predictivecontactscore": { "type": ["null", "number"] },
+              "hs_predictivecontactscore_v2": { "type": ["null", "number"] },
+              "hs_predictivecontactscorebucket": { "type": ["null", "string"] },
+              "hs_predictivescoringtier": { "type": ["null", "string"] },
+              "hs_quarantined_emails": { "type": ["null", "string"] },
+              "hs_read_only": { "type": ["null", "boolean"] },
+              "hs_registered_member": { "type": ["null", "number"] },
+              "hs_registration_method": { "type": ["null", "string"] },
+              "hs_sa_first_engagement_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_sa_first_engagement_descr": { "type": ["null", "string"] },
+              "hs_sa_first_engagement_object_type": {
+                "type": ["null", "string"]
+              },
+              "hs_sales_email_last_clicked": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_sales_email_last_opened": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_sales_email_last_replied": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_searchable_calculated_international_mobile_number": {
+                "type": ["null", "string"]
+              },
+              "hs_searchable_calculated_international_phone_number": {
+                "type": ["null", "string"]
+              },
+              "hs_searchable_calculated_mobile_number": {
+                "type": ["null", "string"]
+              },
+              "hs_searchable_calculated_phone_number": {
+                "type": ["null", "string"]
+              },
+              "hs_sequences_actively_enrolled_count": {
+                "type": ["null", "number"]
+              },
+              "hs_sequences_enrolled_count": { "type": ["null", "number"] },
+              "hs_sequences_is_enrolled": { "type": ["null", "boolean"] },
+              "hs_testpurge": { "type": ["null", "string"] },
+              "hs_testrollback": { "type": ["null", "string"] },
+              "hs_time_between_contact_creation_and_deal_close": {
+                "type": ["null", "number"]
+              },
+              "hs_time_between_contact_creation_and_deal_creation": {
+                "type": ["null", "number"]
+              },
+              "hs_time_in_customer": { "type": ["null", "number"] },
+              "hs_time_in_evangelist": { "type": ["null", "number"] },
+              "hs_time_in_lead": { "type": ["null", "number"] },
+              "hs_time_in_marketingqualifiedlead": {
+                "type": ["null", "number"]
+              },
+              "hs_time_in_opportunity": { "type": ["null", "number"] },
+              "hs_time_in_other": { "type": ["null", "number"] },
+              "hs_time_in_salesqualifiedlead": { "type": ["null", "number"] },
+              "hs_time_in_subscriber": { "type": ["null", "number"] },
+              "hs_time_to_first_engagement": { "type": ["null", "number"] },
+              "hs_time_to_move_from_lead_to_customer": {
+                "type": ["null", "number"]
+              },
+              "hs_time_to_move_from_marketingqualifiedlead_to_customer": {
+                "type": ["null", "number"]
+              },
+              "hs_time_to_move_from_opportunity_to_customer": {
+                "type": ["null", "number"]
+              },
+              "hs_time_to_move_from_salesqualifiedlead_to_customer": {
+                "type": ["null", "number"]
+              },
+              "hs_time_to_move_from_subscriber_to_customer": {
+                "type": ["null", "number"]
+              },
+              "hs_timezone": { "type": ["null", "string"] },
+              "hs_unique_creation_key": { "type": ["null", "string"] },
+              "hs_updated_by_user_id": { "type": ["null", "number"] },
+              "hs_user_ids_of_all_notification_followers": {
+                "type": ["null", "string"]
+              },
+              "hs_user_ids_of_all_notification_unfollowers": {
+                "type": ["null", "string"]
+              },
+              "hs_user_ids_of_all_owners": { "type": ["null", "string"] },
+              "hs_v2_cumulative_time_in_customer": {
+                "type": ["null", "number"]
+              },
+              "hs_v2_cumulative_time_in_evangelist": {
+                "type": ["null", "number"]
+              },
+              "hs_v2_cumulative_time_in_lead": { "type": ["null", "number"] },
+              "hs_v2_cumulative_time_in_marketingqualifiedlead": {
+                "type": ["null", "number"]
+              },
+              "hs_v2_cumulative_time_in_opportunity": {
+                "type": ["null", "number"]
+              },
+              "hs_v2_cumulative_time_in_other": { "type": ["null", "number"] },
+              "hs_v2_cumulative_time_in_salesqualifiedlead": {
+                "type": ["null", "number"]
+              },
+              "hs_v2_cumulative_time_in_subscriber": {
+                "type": ["null", "number"]
+              },
+              "hs_v2_date_entered_customer": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_entered_evangelist": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_entered_lead": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_entered_marketingqualifiedlead": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_entered_opportunity": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_entered_other": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_entered_salesqualifiedlead": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_entered_subscriber": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_exited_customer": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_exited_evangelist": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_exited_lead": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_exited_marketingqualifiedlead": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_exited_opportunity": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_exited_other": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_exited_salesqualifiedlead": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_exited_subscriber": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_latest_time_in_customer": { "type": ["null", "number"] },
+              "hs_v2_latest_time_in_evangelist": { "type": ["null", "number"] },
+              "hs_v2_latest_time_in_lead": { "type": ["null", "number"] },
+              "hs_v2_latest_time_in_marketingqualifiedlead": {
+                "type": ["null", "number"]
+              },
+              "hs_v2_latest_time_in_opportunity": {
+                "type": ["null", "number"]
+              },
+              "hs_v2_latest_time_in_other": { "type": ["null", "number"] },
+              "hs_v2_latest_time_in_salesqualifiedlead": {
+                "type": ["null", "number"]
+              },
+              "hs_v2_latest_time_in_subscriber": { "type": ["null", "number"] },
+              "hs_was_imported": { "type": ["null", "boolean"] },
+              "hs_whatsapp_phone_number": { "type": ["null", "string"] },
+              "hubspot_owner_assigneddate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hubspot_owner_id": { "type": ["null", "string"] },
+              "hubspot_team_id": { "type": ["null", "string"] },
+              "hubspotscore": { "type": ["null", "number"] },
+              "industry": { "type": ["null", "string"] },
+              "ip_city": { "type": ["null", "string"] },
+              "ip_country": { "type": ["null", "string"] },
+              "ip_country_code": { "type": ["null", "string"] },
+              "ip_latlon": { "type": ["null", "string"] },
+              "ip_state": { "type": ["null", "string"] },
+              "ip_state_code": { "type": ["null", "string"] },
+              "ip_zipcode": { "type": ["null", "string"] },
+              "job_function": { "type": ["null", "string"] },
+              "jobtitle": { "type": ["null", "string"] },
+              "lastmodifieddate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "lastname": { "type": ["null", "string"] },
+              "lifecyclestage": { "type": ["null", "string"] },
+              "marital_status": { "type": ["null", "string"] },
+              "message": { "type": ["null", "string"] },
+              "military_status": { "type": ["null", "string"] },
+              "mobilephone": { "type": ["null", "string"] },
+              "my_custom_test_property": { "type": ["null", "string"] },
+              "notes_last_contacted": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "notes_last_updated": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "notes_next_activity_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "num_associated_deals": { "type": ["null", "number"] },
+              "num_contacted_notes": { "type": ["null", "number"] },
+              "num_conversion_events": { "type": ["null", "number"] },
+              "num_notes": { "type": ["null", "number"] },
+              "num_unique_conversion_events": { "type": ["null", "number"] },
+              "numemployees": { "type": ["null", "string"] },
+              "phone": { "type": ["null", "string"] },
+              "recent_conversion_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "recent_conversion_event_name": { "type": ["null", "string"] },
+              "recent_deal_amount": { "type": ["null", "number"] },
+              "recent_deal_close_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "relationship_status": { "type": ["null", "string"] },
+              "salutation": { "type": ["null", "string"] },
+              "school": { "type": ["null", "string"] },
+              "seniority": { "type": ["null", "string"] },
+              "start_date": { "type": ["null", "string"] },
+              "state": { "type": ["null", "string"] },
+              "surveymonkeyeventlastupdated": { "type": ["null", "number"] },
+              "test": { "type": ["null", "number"] },
+              "total_revenue": { "type": ["null", "number"] },
+              "twitterhandle": { "type": ["null", "string"] },
+              "webinareventlastupdated": { "type": ["null", "number"] },
+              "website": { "type": ["null", "string"] },
+              "work_email": { "type": ["null", "string"] },
+              "zip": { "type": ["null", "string"] }
+            }
+          },
+          "properties_address": { "type": ["null", "string"] },
+          "properties_annualrevenue": { "type": ["null", "string"] },
+          "properties_associatedcompanyid": { "type": ["null", "number"] },
+          "properties_associatedcompanylastupdated": {
+            "type": ["null", "number"]
+          },
+          "properties_city": { "type": ["null", "string"] },
+          "properties_closedate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_company": { "type": ["null", "string"] },
+          "properties_company_size": { "type": ["null", "string"] },
+          "properties_country": { "type": ["null", "string"] },
+          "properties_createdate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_currentlyinworkflow": { "type": ["null", "string"] },
+          "properties_date_of_birth": { "type": ["null", "string"] },
+          "properties_days_to_close": { "type": ["null", "number"] },
+          "properties_degree": { "type": ["null", "string"] },
+          "properties_email": { "type": ["null", "string"] },
+          "properties_engagements_last_meeting_booked": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_engagements_last_meeting_booked_campaign": {
+            "type": ["null", "string"]
+          },
+          "properties_engagements_last_meeting_booked_medium": {
+            "type": ["null", "string"]
+          },
+          "properties_engagements_last_meeting_booked_source": {
+            "type": ["null", "string"]
+          },
+          "properties_fax": { "type": ["null", "string"] },
+          "properties_field_of_study": { "type": ["null", "string"] },
+          "properties_first_conversion_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_first_conversion_event_name": {
+            "type": ["null", "string"]
+          },
+          "properties_first_deal_created_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_firstname": { "type": ["null", "string"] },
+          "properties_gender": { "type": ["null", "string"] },
+          "properties_graduation_date": { "type": ["null", "string"] },
+          "properties_hs_additional_emails": { "type": ["null", "string"] },
+          "properties_hs_all_accessible_team_ids": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_all_contact_vids": { "type": ["null", "string"] },
+          "properties_hs_all_owner_ids": { "type": ["null", "string"] },
+          "properties_hs_all_team_ids": { "type": ["null", "string"] },
+          "properties_hs_analytics_average_page_views": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_analytics_first_referrer": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_analytics_first_timestamp": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_analytics_first_touch_converting_campaign": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_analytics_first_url": { "type": ["null", "string"] },
+          "properties_hs_analytics_first_visit_timestamp": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_analytics_last_referrer": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_analytics_last_timestamp": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_analytics_last_touch_converting_campaign": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_analytics_last_url": { "type": ["null", "string"] },
+          "properties_hs_analytics_last_visit_timestamp": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_analytics_num_event_completions": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_analytics_num_page_views": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_analytics_num_visits": { "type": ["null", "number"] },
+          "properties_hs_analytics_revenue": { "type": ["null", "number"] },
+          "properties_hs_analytics_source": { "type": ["null", "string"] },
+          "properties_hs_analytics_source_data_1": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_analytics_source_data_2": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_associated_target_accounts": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_avatar_filemanager_key": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_buying_role": { "type": ["null", "string"] },
+          "properties_hs_calculated_form_submissions": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_calculated_merged_vids": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_calculated_mobile_number": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_calculated_phone_number": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_calculated_phone_number_area_code": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_calculated_phone_number_country_code": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_calculated_phone_number_region_code": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_clicked_linkedin_ad": { "type": ["null", "string"] },
+          "properties_hs_content_membership_email": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_content_membership_email_confirmed": {
+            "type": ["null", "boolean"]
+          },
+          "properties_hs_content_membership_follow_up_enqueued_at": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_content_membership_notes": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_content_membership_registered_at": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_content_membership_registration_domain_sent_to": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_content_membership_registration_email_sent_at": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_content_membership_status": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_conversations_visitor_email": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_count_is_unworked": { "type": ["null", "number"] },
+          "properties_hs_count_is_worked": { "type": ["null", "number"] },
+          "properties_hs_created_by_conversations": {
+            "type": ["null", "boolean"]
+          },
+          "properties_hs_created_by_user_id": { "type": ["null", "number"] },
+          "properties_hs_createdate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_entered_customer": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_entered_evangelist": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_entered_lead": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_entered_marketingqualifiedlead": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_entered_opportunity": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_entered_other": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_entered_salesqualifiedlead": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_entered_subscriber": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_exited_customer": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_exited_evangelist": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_exited_lead": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_exited_marketingqualifiedlead": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_exited_opportunity": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_exited_other": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_exited_salesqualifiedlead": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_exited_subscriber": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_document_last_revisited": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_email_bad_address": { "type": ["null", "boolean"] },
+          "properties_hs_email_bounce": { "type": ["null", "number"] },
+          "properties_hs_email_click": { "type": ["null", "number"] },
+          "properties_hs_email_customer_quarantined_reason": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_email_delivered": { "type": ["null", "number"] },
+          "properties_hs_email_domain": { "type": ["null", "string"] },
+          "properties_hs_email_first_click_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_email_first_open_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_email_first_reply_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_email_first_send_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_email_hard_bounce_reason": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_email_hard_bounce_reason_enum": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_email_is_ineligible": { "type": ["null", "boolean"] },
+          "properties_hs_email_last_click_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_email_last_email_name": { "type": ["null", "string"] },
+          "properties_hs_email_last_open_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_email_last_reply_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_email_last_send_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_email_open": { "type": ["null", "number"] },
+          "properties_hs_email_optout": { "type": ["null", "boolean"] },
+          "properties_hs_email_optout_10798197": { "type": ["null", "string"] },
+          "properties_hs_email_optout_11890603": { "type": ["null", "string"] },
+          "properties_hs_email_optout_11890831": { "type": ["null", "string"] },
+          "properties_hs_email_optout_23704464": { "type": ["null", "string"] },
+          "properties_hs_email_optout_313921448": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_email_optout_94692364": { "type": ["null", "string"] },
+          "properties_hs_email_quarantined": { "type": ["null", "boolean"] },
+          "properties_hs_email_quarantined_reason": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_email_recipient_fatigue_recovery_time": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_email_replied": { "type": ["null", "number"] },
+          "properties_hs_email_sends_since_last_engagement": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_emailconfirmationstatus": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_facebook_ad_clicked": { "type": ["null", "boolean"] },
+          "properties_hs_facebook_click_id": { "type": ["null", "string"] },
+          "properties_hs_feedback_last_nps_follow_up": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_feedback_last_nps_rating": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_feedback_last_survey_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_feedback_show_nps_web_survey": {
+            "type": ["null", "boolean"]
+          },
+          "properties_hs_first_engagement_object_id": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_first_outreach_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_first_subscription_create_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_google_click_id": { "type": ["null", "string"] },
+          "properties_hs_has_active_subscription": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_ip_timezone": { "type": ["null", "string"] },
+          "properties_hs_is_contact": { "type": ["null", "boolean"] },
+          "properties_hs_is_unworked": { "type": ["null", "boolean"] },
+          "properties_hs_language": { "type": ["null", "string"] },
+          "properties_hs_last_sales_activity_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_last_sales_activity_timestamp": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_last_sales_activity_type": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_lastmodifieddate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_latest_disqualified_lead_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_latest_meeting_activity": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_latest_open_lead_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_latest_qualified_lead_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_latest_sequence_ended_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_latest_sequence_enrolled": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_latest_sequence_enrolled_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_latest_sequence_finished_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_latest_sequence_unenrolled_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_latest_source": { "type": ["null", "string"] },
+          "properties_hs_latest_source_data_1": { "type": ["null", "string"] },
+          "properties_hs_latest_source_data_2": { "type": ["null", "string"] },
+          "properties_hs_latest_source_timestamp": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_latest_subscription_create_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_lead_status": { "type": ["null", "string"] },
+          "properties_hs_legal_basis": { "type": ["null", "string"] },
+          "properties_hs_lifecyclestage_customer_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_lifecyclestage_evangelist_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_lifecyclestage_lead_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_lifecyclestage_marketingqualifiedlead_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_lifecyclestage_opportunity_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_lifecyclestage_other_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_lifecyclestage_salesqualifiedlead_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_lifecyclestage_subscriber_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_linkedin_ad_clicked": { "type": ["null", "string"] },
+          "properties_hs_marketable_reason_id": { "type": ["null", "string"] },
+          "properties_hs_marketable_reason_type": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_marketable_status": { "type": ["null", "string"] },
+          "properties_hs_marketable_until_renewal": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_membership_has_accessed_private_content": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_membership_last_private_content_access_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_merged_object_ids": { "type": ["null", "string"] },
+          "properties_hs_mobile_sdk_push_tokens": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_notes_next_activity_type": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_object_id": { "type": ["null", "number"] },
+          "properties_hs_object_source": { "type": ["null", "string"] },
+          "properties_hs_object_source_detail_1": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_object_source_detail_2": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_object_source_detail_3": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_object_source_id": { "type": ["null", "string"] },
+          "properties_hs_object_source_label": { "type": ["null", "string"] },
+          "properties_hs_object_source_user_id": { "type": ["null", "number"] },
+          "properties_hs_persona": { "type": ["null", "string"] },
+          "properties_hs_pinned_engagement_id": { "type": ["null", "number"] },
+          "properties_hs_pipeline": { "type": ["null", "string"] },
+          "properties_hs_predictivecontactscore": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_predictivecontactscore_v2": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_predictivecontactscorebucket": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_predictivescoringtier": { "type": ["null", "string"] },
+          "properties_hs_quarantined_emails": { "type": ["null", "string"] },
+          "properties_hs_read_only": { "type": ["null", "boolean"] },
+          "properties_hs_registered_member": { "type": ["null", "number"] },
+          "properties_hs_registration_method": { "type": ["null", "string"] },
+          "properties_hs_sa_first_engagement_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_sa_first_engagement_descr": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_sa_first_engagement_object_type": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_sales_email_last_clicked": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_sales_email_last_opened": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_sales_email_last_replied": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_searchable_calculated_international_mobile_number": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_searchable_calculated_international_phone_number": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_searchable_calculated_mobile_number": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_searchable_calculated_phone_number": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_sequences_actively_enrolled_count": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_sequences_enrolled_count": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_sequences_is_enrolled": {
+            "type": ["null", "boolean"]
+          },
+          "properties_hs_testpurge": { "type": ["null", "string"] },
+          "properties_hs_testrollback": { "type": ["null", "string"] },
+          "properties_hs_time_between_contact_creation_and_deal_close": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_time_between_contact_creation_and_deal_creation": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_time_in_customer": { "type": ["null", "number"] },
+          "properties_hs_time_in_evangelist": { "type": ["null", "number"] },
+          "properties_hs_time_in_lead": { "type": ["null", "number"] },
+          "properties_hs_time_in_marketingqualifiedlead": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_time_in_opportunity": { "type": ["null", "number"] },
+          "properties_hs_time_in_other": { "type": ["null", "number"] },
+          "properties_hs_time_in_salesqualifiedlead": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_time_in_subscriber": { "type": ["null", "number"] },
+          "properties_hs_time_to_first_engagement": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_time_to_move_from_lead_to_customer": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_time_to_move_from_marketingqualifiedlead_to_customer": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_time_to_move_from_opportunity_to_customer": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_time_to_move_from_salesqualifiedlead_to_customer": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_time_to_move_from_subscriber_to_customer": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_timezone": { "type": ["null", "string"] },
+          "properties_hs_unique_creation_key": { "type": ["null", "string"] },
+          "properties_hs_updated_by_user_id": { "type": ["null", "number"] },
+          "properties_hs_user_ids_of_all_notification_followers": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_user_ids_of_all_notification_unfollowers": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_user_ids_of_all_owners": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_v2_cumulative_time_in_customer": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_cumulative_time_in_evangelist": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_cumulative_time_in_lead": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_cumulative_time_in_marketingqualifiedlead": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_cumulative_time_in_opportunity": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_cumulative_time_in_other": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_cumulative_time_in_salesqualifiedlead": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_cumulative_time_in_subscriber": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_date_entered_customer": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_entered_evangelist": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_entered_lead": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_entered_marketingqualifiedlead": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_entered_opportunity": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_entered_other": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_entered_salesqualifiedlead": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_entered_subscriber": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_exited_customer": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_exited_evangelist": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_exited_lead": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_exited_marketingqualifiedlead": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_exited_opportunity": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_exited_other": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_exited_salesqualifiedlead": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_exited_subscriber": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_latest_time_in_customer": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_latest_time_in_evangelist": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_latest_time_in_lead": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_latest_time_in_marketingqualifiedlead": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_latest_time_in_opportunity": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_latest_time_in_other": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_latest_time_in_salesqualifiedlead": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_latest_time_in_subscriber": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_was_imported": { "type": ["null", "boolean"] },
+          "properties_hs_whatsapp_phone_number": { "type": ["null", "string"] },
+          "properties_hubspot_owner_assigneddate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hubspot_owner_id": { "type": ["null", "string"] },
+          "properties_hubspot_team_id": { "type": ["null", "string"] },
+          "properties_hubspotscore": { "type": ["null", "number"] },
+          "properties_industry": { "type": ["null", "string"] },
+          "properties_ip_city": { "type": ["null", "string"] },
+          "properties_ip_country": { "type": ["null", "string"] },
+          "properties_ip_country_code": { "type": ["null", "string"] },
+          "properties_ip_latlon": { "type": ["null", "string"] },
+          "properties_ip_state": { "type": ["null", "string"] },
+          "properties_ip_state_code": { "type": ["null", "string"] },
+          "properties_ip_zipcode": { "type": ["null", "string"] },
+          "properties_job_function": { "type": ["null", "string"] },
+          "properties_jobtitle": { "type": ["null", "string"] },
+          "properties_lastmodifieddate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_lastname": { "type": ["null", "string"] },
+          "properties_lifecyclestage": { "type": ["null", "string"] },
+          "properties_marital_status": { "type": ["null", "string"] },
+          "properties_message": { "type": ["null", "string"] },
+          "properties_military_status": { "type": ["null", "string"] },
+          "properties_mobilephone": { "type": ["null", "string"] },
+          "properties_my_custom_test_property": { "type": ["null", "string"] },
+          "properties_notes_last_contacted": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_notes_last_updated": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_notes_next_activity_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_num_associated_deals": { "type": ["null", "number"] },
+          "properties_num_contacted_notes": { "type": ["null", "number"] },
+          "properties_num_conversion_events": { "type": ["null", "number"] },
+          "properties_num_notes": { "type": ["null", "number"] },
+          "properties_num_unique_conversion_events": {
+            "type": ["null", "number"]
+          },
+          "properties_numemployees": { "type": ["null", "string"] },
+          "properties_phone": { "type": ["null", "string"] },
+          "properties_recent_conversion_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_recent_conversion_event_name": {
+            "type": ["null", "string"]
+          },
+          "properties_recent_deal_amount": { "type": ["null", "number"] },
+          "properties_recent_deal_close_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_relationship_status": { "type": ["null", "string"] },
+          "properties_salutation": { "type": ["null", "string"] },
+          "properties_school": { "type": ["null", "string"] },
+          "properties_seniority": { "type": ["null", "string"] },
+          "properties_start_date": { "type": ["null", "string"] },
+          "properties_state": { "type": ["null", "string"] },
+          "properties_surveymonkeyeventlastupdated": {
+            "type": ["null", "number"]
+          },
+          "properties_test": { "type": ["null", "number"] },
+          "properties_total_revenue": { "type": ["null", "number"] },
+          "properties_twitterhandle": { "type": ["null", "string"] },
+          "properties_webinareventlastupdated": { "type": ["null", "number"] },
+          "properties_website": { "type": ["null", "string"] },
+          "properties_work_email": { "type": ["null", "string"] },
+          "properties_zip": { "type": ["null", "string"] }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updatedAt"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "contacts_form_submissions",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "canonical-vid": {
+            "description": "The canonical VID associated with the submission",
+            "type": ["null", "integer"]
+          },
+          "canonical-url": {
+            "description": "The canonical URL of the submitted form",
+            "type": ["null", "string"]
+          },
+          "conversion-id": {
+            "description": "The conversion ID related to the form submission",
+            "type": ["null", "string"]
+          },
+          "page-title": {
+            "description": "The title of the page where the form submission occurred",
+            "type": ["null", "string"]
+          },
+          "timestamp": {
+            "description": "The timestamp of when the form submission occurred",
+            "type": ["null", "integer"]
+          },
+          "form-id": {
+            "description": "The unique ID of the form submitted",
+            "type": ["null", "string"]
+          },
+          "portal-id": {
+            "description": "The ID of the portal where the form submission was made",
+            "type": ["null", "integer"]
+          },
+          "title": {
+            "description": "The title of the form submitted",
+            "type": ["null", "string"]
+          },
+          "page-url": {
+            "description": "The URL of the page where the form was submitted",
+            "type": ["null", "string"]
+          },
+          "form-type": {
+            "description": "The type of form that was submitted",
+            "type": ["null", "string"]
+          },
+          "contact-associated-by": {
+            "description": "The specific contacts associated with the submission",
+            "type": ["null", "array"],
+            "items": {
+              "description": "Individual contact details",
+              "type": ["null", "string"]
+            }
+          },
+          "meta-data": {
+            "description": "Additional metadata associated with the submission",
+            "type": ["null", "array"],
+            "items": { "description": "Specific metadata details" }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "source_defined_primary_key": [["canonical-vid"]],
+      "is_resumable": true
+    },
+    {
+      "name": "contacts_list_memberships",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "canonical-vid": {
+            "description": "The unique ID associated with the contact in the HubSpot CRM",
+            "type": ["null", "integer"]
+          },
+          "static-list-id": {
+            "description": "The static ID assigned to the list of contacts within the HubSpot CRM",
+            "type": ["null", "integer"]
+          },
+          "internal-list-id": {
+            "description": "The internal ID assigned to the list of contacts within the HubSpot CRM",
+            "type": ["null", "integer"]
+          },
+          "timestamp": {
+            "description": "The timestamp when the contact was added to or removed from the list",
+            "type": ["null", "integer"]
+          },
+          "vid": {
+            "description": "The ID associated with the contact in the HubSpot CRM",
+            "type": ["null", "integer"]
+          },
+          "is-member": {
+            "description": "Flag indicating whether the contact is a member of the list or not",
+            "type": ["null", "boolean"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["timestamp"],
+      "source_defined_primary_key": [["canonical-vid"]],
+      "is_resumable": true
+    },
+    {
+      "name": "contacts_merged_audit",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": ["null", "object"],
+        "additionalProperties": true,
+        "properties": {
+          "canonical-vid": {
+            "description": "The unique identifier for the merged contact in HubSpot's CRM.",
+            "type": ["null", "integer"]
+          },
+          "vid-to-merge": {
+            "description": "The contact\u2019s unique identifier to be merged.",
+            "type": ["null", "integer"]
+          },
+          "timestamp": {
+            "description": "The timestamp of when the merge operation occurred.",
+            "type": ["null", "integer"]
+          },
+          "entity-id": {
+            "description": "The entity identifier for the merged contact.",
+            "type": ["null", "string"]
+          },
+          "user-id": {
+            "description": "The user ID responsible for the merge operation.",
+            "type": ["null", "integer"]
+          },
+          "num-properties-moved": {
+            "description": "The number of properties moved during the merge process.",
+            "type": ["null", "integer"]
+          },
+          "merged_from_email": {
+            "description": "Details of the email address from which the contact was merged from.",
+            "type": ["null", "object"],
+            "additionalProperties": true,
+            "properties": {
+              "source-vids": {
+                "description": "Array of unique identifiers of video sources.",
+                "type": ["null", "array"],
+                "items": { "type": ["null", "integer"] }
+              },
+              "updated-by-user-id": {
+                "description": "The user ID of the user who updated the email address.",
+                "type": ["null", "integer"]
+              },
+              "source-label": {
+                "description": "The label of the source of the email address.",
+                "type": ["null", "string"]
+              },
+              "source-type": {
+                "description": "The type of the source of the email address.",
+                "type": ["null", "string"]
+              },
+              "value": {
+                "description": "The email address value.",
+                "type": ["null", "string"]
+              },
+              "source-id": {
+                "description": "The unique identifier of the source of the email address.",
+                "type": ["null", "string"]
+              },
+              "selected": {
+                "description": "Indicates if this email address was selected during the merge process.",
+                "type": ["null", "boolean"]
+              },
+              "timestamp": {
+                "description": "The timestamp of when the merge occurred.",
+                "type": ["null", "integer"]
+              }
+            }
+          },
+          "merged_from_email_source-vids": {
+            "description": "Array of unique identifiers of video sources.",
+            "type": ["null", "array"],
+            "items": { "type": ["null", "integer"] }
+          },
+          "merged_from_email_updated-by-user-id": {
+            "description": "The user ID of the user who updated the email address from which the contact was merged from.",
+            "type": ["null", "integer"]
+          },
+          "merged_from_email_source-label": {
+            "description": "The source label of the email address from which the contact was merged from.",
+            "type": ["null", "string"]
+          },
+          "merged_from_email_source-type": {
+            "description": "The source type of the email address from which the contact was merged from.",
+            "type": ["null", "string"]
+          },
+          "merged_from_email_value": {
+            "description": "The email address value from which the contact was merged from.",
+            "type": ["null", "string"]
+          },
+          "merged_from_email_source-id": {
+            "description": "The source ID of the email address from which the contact was merged from.",
+            "type": ["null", "string"]
+          },
+          "merged_from_email_selected": {
+            "description": "Indicates if the email address from which the contact was merged from was selected.",
+            "type": ["null", "boolean"]
+          },
+          "merged_from_email_timestamp": {
+            "description": "The timestamp of the email address merge.",
+            "type": ["null", "integer"]
+          },
+          "merged_to_email": {
+            "description": "Details of the email address to which the contact was merged to.",
+            "type": ["null", "object"],
+            "additionalProperties": true,
+            "properties": {
+              "updated-by-user-id": {
+                "description": "The user ID of the user who updated the email address.",
+                "type": ["null", "integer"]
+              },
+              "source-label": {
+                "description": "The label of the source of the email address.",
+                "type": ["null", "string"]
+              },
+              "source-type": {
+                "description": "The type of the source of the email address.",
+                "type": ["null", "string"]
+              },
+              "value": {
+                "description": "The email address value.",
+                "type": ["null", "string"]
+              },
+              "source-id": {
+                "description": "The unique identifier of the source of the email address.",
+                "type": ["null", "string"]
+              },
+              "selected": {
+                "description": "Indicates if this email address was selected during the merge process.",
+                "type": ["null", "boolean"]
+              },
+              "timestamp": {
+                "description": "The timestamp of when the merge occurred.",
+                "type": ["null", "integer"]
+              }
+            }
+          },
+          "merged_to_email_updated-by-user-id": {
+            "description": "The user ID of the user who updated the email address to which the contact was merged to.",
+            "type": ["null", "integer"]
+          },
+          "merged_to_email_source-label": {
+            "description": "The source label of the email address to which the contact was merged to.",
+            "type": ["null", "string"]
+          },
+          "merged_to_email_source-type": {
+            "description": "The source type of the email address to which the contact was merged to.",
+            "type": ["null", "string"]
+          },
+          "merged_to_email_value": {
+            "description": "The email address value to which the contact was merged to.",
+            "type": ["null", "string"]
+          },
+          "merged_to_email_source-id": {
+            "description": "The source ID of the email address to which the contact was merged to.",
+            "type": ["null", "string"]
+          },
+          "merged_to_email_selected": {
+            "description": "Indicates if the email address to which the contact was merged to was selected.",
+            "type": ["null", "boolean"]
+          },
+          "merged_to_email_timestamp": {
+            "description": "The timestamp of the email address merge.",
+            "type": ["null", "integer"]
+          },
+          "first-name": {
+            "description": "The first name of the merged contact.",
+            "type": ["null", "string"]
+          },
+          "last-name": {
+            "description": "The last name of the merged contact.",
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "source_defined_primary_key": [["canonical-vid"]],
+      "is_resumable": true
+    },
+    {
+      "name": "deal_pipelines",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": ["null", "object"],
+        "properties": {
+          "label": {
+            "description": "The label or name of the deal pipeline.",
+            "type": ["null", "string"]
+          },
+          "displayOrder": {
+            "description": "The ordering of the deal pipeline for display.",
+            "type": ["null", "integer"]
+          },
+          "active": {
+            "description": "Indicates if the deal pipeline is currently active or not.",
+            "type": ["null", "boolean"]
+          },
+          "stages": {
+            "description": "List of deal stages within the pipeline.",
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "label": {
+                  "description": "The label or name of the deal stage.",
+                  "type": ["null", "string"]
+                },
+                "displayOrder": {
+                  "description": "The ordering of the deal stage for display within the pipeline.",
+                  "type": ["null", "integer"]
+                },
+                "metadata": {
+                  "description": "Additional information related to the deal stage.",
+                  "type": ["null", "object"],
+                  "properties": {
+                    "isClosed": {
+                      "description": "Indicates if the deal stage is considered closed or not.",
+                      "type": ["null", "string"]
+                    },
+                    "probability": {
+                      "description": "The probability of closing a deal at this stage.",
+                      "type": ["null", "string"]
+                    }
+                  }
+                },
+                "stageId": {
+                  "description": "The unique identifier of the deal stage.",
+                  "type": ["null", "string"]
+                },
+                "createdAt": {
+                  "description": "Timestamp for the creation date of the deal stage.",
+                  "type": ["null", "integer"]
+                },
+                "updatedAt": {
+                  "description": "Timestamp for the last update to the deal stage.",
+                  "type": ["null", "integer"]
+                },
+                "active": {
+                  "description": "Indicates if the deal stage is currently active or not.",
+                  "type": ["null", "boolean"]
+                }
+              }
+            }
+          },
+          "objectType": {
+            "description": "The type of object this deal pipeline is associated with.",
+            "type": ["null", "string"]
+          },
+          "objectTypeId": {
+            "description": "The ID of the object type this deal pipeline is associated with.",
+            "type": ["null", "string"]
+          },
+          "pipelineId": {
+            "description": "The unique identifier of the deal pipeline.",
+            "type": ["null", "string"]
+          },
+          "createdAt": {
+            "description": "Timestamp for the creation date of the deal pipeline.",
+            "type": ["null", "integer"]
+          },
+          "updatedAt": {
+            "description": "Timestamp for the last update to the deal pipeline.",
+            "type": ["null", "integer"]
+          },
+          "default": {
+            "description": "Indicates if this pipeline is the default one in the system.",
+            "type": ["null", "boolean"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updatedAt"],
+      "source_defined_primary_key": [["pipelineId"]],
+      "is_resumable": true
+    },
+    {
+      "name": "deals",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": ["null", "object"],
+        "properties": {
+          "id": {
+            "description": "Unique identifier for the deal",
+            "type": ["null", "string"]
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "amount": { "type": ["null", "number"] },
+              "amount_in_home_currency": { "type": ["null", "number"] },
+              "closed_lost_reason": { "type": ["null", "string"] },
+              "closed_won_reason": { "type": ["null", "string"] },
+              "closedate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "createdate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "days_to_close": { "type": ["null", "number"] },
+              "dealname": { "type": ["null", "string"] },
+              "dealstage": { "type": ["null", "string"] },
+              "dealtype": { "type": ["null", "string"] },
+              "description": { "type": ["null", "string"] },
+              "engagements_last_meeting_booked": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "engagements_last_meeting_booked_campaign": {
+                "type": ["null", "string"]
+              },
+              "engagements_last_meeting_booked_medium": {
+                "type": ["null", "string"]
+              },
+              "engagements_last_meeting_booked_source": {
+                "type": ["null", "string"]
+              },
+              "hs_acv": { "type": ["null", "number"] },
+              "hs_all_accessible_team_ids": { "type": ["null", "string"] },
+              "hs_all_collaborator_owner_ids": { "type": ["null", "string"] },
+              "hs_all_deal_split_owner_ids": { "type": ["null", "string"] },
+              "hs_all_owner_ids": { "type": ["null", "string"] },
+              "hs_all_team_ids": { "type": ["null", "string"] },
+              "hs_analytics_latest_source": { "type": ["null", "string"] },
+              "hs_analytics_latest_source_company": {
+                "type": ["null", "string"]
+              },
+              "hs_analytics_latest_source_contact": {
+                "type": ["null", "string"]
+              },
+              "hs_analytics_latest_source_data_1": {
+                "type": ["null", "string"]
+              },
+              "hs_analytics_latest_source_data_1_company": {
+                "type": ["null", "string"]
+              },
+              "hs_analytics_latest_source_data_1_contact": {
+                "type": ["null", "string"]
+              },
+              "hs_analytics_latest_source_data_2": {
+                "type": ["null", "string"]
+              },
+              "hs_analytics_latest_source_data_2_company": {
+                "type": ["null", "string"]
+              },
+              "hs_analytics_latest_source_data_2_contact": {
+                "type": ["null", "string"]
+              },
+              "hs_analytics_latest_source_timestamp": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_analytics_latest_source_timestamp_company": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_analytics_latest_source_timestamp_contact": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_analytics_source": { "type": ["null", "string"] },
+              "hs_analytics_source_data_1": { "type": ["null", "string"] },
+              "hs_analytics_source_data_2": { "type": ["null", "string"] },
+              "hs_arr": { "type": ["null", "number"] },
+              "hs_campaign": { "type": ["null", "string"] },
+              "hs_closed_amount": { "type": ["null", "number"] },
+              "hs_closed_amount_in_home_currency": {
+                "type": ["null", "number"]
+              },
+              "hs_closed_deal_close_date": { "type": ["null", "number"] },
+              "hs_closed_deal_create_date": { "type": ["null", "number"] },
+              "hs_closed_won_count": { "type": ["null", "number"] },
+              "hs_closed_won_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_created_by_user_id": { "type": ["null", "number"] },
+              "hs_createdate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_entered_66894120": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_entered_9567448": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_entered_9567449": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_entered_appointmentscheduled": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_entered_closedlost": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_entered_closedwon": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_entered_contractsent": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_entered_customclosedwonstage": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_entered_decisionmakerboughtin": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_entered_presentationscheduled": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_entered_qualifiedtobuy": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_exited_66894120": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_exited_9567448": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_exited_9567449": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_exited_appointmentscheduled": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_exited_closedlost": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_exited_closedwon": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_exited_contractsent": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_exited_customclosedwonstage": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_exited_decisionmakerboughtin": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_exited_presentationscheduled": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_exited_qualifiedtobuy": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_days_to_close_raw": { "type": ["null", "number"] },
+              "hs_deal_amount_calculation_preference": {
+                "type": ["null", "string"]
+              },
+              "hs_deal_score": { "type": ["null", "number"] },
+              "hs_deal_stage_probability": { "type": ["null", "number"] },
+              "hs_deal_stage_probability_shadow": {
+                "type": ["null", "number"]
+              },
+              "hs_exchange_rate": { "type": ["null", "number"] },
+              "hs_forecast_amount": { "type": ["null", "number"] },
+              "hs_forecast_probability": { "type": ["null", "number"] },
+              "hs_has_empty_conditional_stage_properties": {
+                "type": ["null", "boolean"]
+              },
+              "hs_is_closed": { "type": ["null", "boolean"] },
+              "hs_is_closed_count": { "type": ["null", "number"] },
+              "hs_is_closed_won": { "type": ["null", "boolean"] },
+              "hs_is_deal_split": { "type": ["null", "boolean"] },
+              "hs_is_in_first_deal_stage": { "type": ["null", "boolean"] },
+              "hs_is_open_count": { "type": ["null", "number"] },
+              "hs_lastmodifieddate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_latest_approval_status": { "type": ["null", "string"] },
+              "hs_latest_approval_status_approval_id": {
+                "type": ["null", "number"]
+              },
+              "hs_latest_meeting_activity": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_likelihood_to_close": { "type": ["null", "number"] },
+              "hs_line_item_global_term_hs_discount_percentage": {
+                "type": ["null", "string"]
+              },
+              "hs_line_item_global_term_hs_discount_percentage_enabled": {
+                "type": ["null", "boolean"]
+              },
+              "hs_line_item_global_term_hs_recurring_billing_period": {
+                "type": ["null", "string"]
+              },
+              "hs_line_item_global_term_hs_recurring_billing_period_enabled": {
+                "type": ["null", "boolean"]
+              },
+              "hs_line_item_global_term_hs_recurring_billing_start_date": {
+                "type": ["null", "string"]
+              },
+              "hs_line_item_global_term_hs_recurring_billing_start_date_enabled": {
+                "type": ["null", "boolean"]
+              },
+              "hs_line_item_global_term_recurringbillingfrequency": {
+                "type": ["null", "string"]
+              },
+              "hs_line_item_global_term_recurringbillingfrequency_enabled": {
+                "type": ["null", "boolean"]
+              },
+              "hs_manual_forecast_category": { "type": ["null", "string"] },
+              "hs_merged_object_ids": { "type": ["null", "string"] },
+              "hs_mrr": { "type": ["null", "number"] },
+              "hs_next_step": { "type": ["null", "string"] },
+              "hs_next_step_updated_at": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_notes_next_activity_type": { "type": ["null", "string"] },
+              "hs_num_associated_deal_splits": { "type": ["null", "number"] },
+              "hs_num_of_associated_line_items": { "type": ["null", "number"] },
+              "hs_num_target_accounts": { "type": ["null", "number"] },
+              "hs_object_id": { "type": ["null", "number"] },
+              "hs_object_source": { "type": ["null", "string"] },
+              "hs_object_source_detail_1": { "type": ["null", "string"] },
+              "hs_object_source_detail_2": { "type": ["null", "string"] },
+              "hs_object_source_detail_3": { "type": ["null", "string"] },
+              "hs_object_source_id": { "type": ["null", "string"] },
+              "hs_object_source_label": { "type": ["null", "string"] },
+              "hs_object_source_user_id": { "type": ["null", "number"] },
+              "hs_open_deal_create_date": { "type": ["null", "number"] },
+              "hs_pinned_engagement_id": { "type": ["null", "number"] },
+              "hs_predicted_amount": { "type": ["null", "number"] },
+              "hs_predicted_amount_in_home_currency": {
+                "type": ["null", "number"]
+              },
+              "hs_priority": { "type": ["null", "string"] },
+              "hs_projected_amount": { "type": ["null", "number"] },
+              "hs_projected_amount_in_home_currency": {
+                "type": ["null", "number"]
+              },
+              "hs_read_only": { "type": ["null", "boolean"] },
+              "hs_sales_email_last_replied": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_tag_ids": { "type": ["null", "string"] },
+              "hs_tcv": { "type": ["null", "number"] },
+              "hs_time_in_66894120": { "type": ["null", "number"] },
+              "hs_time_in_9567448": { "type": ["null", "number"] },
+              "hs_time_in_9567449": { "type": ["null", "number"] },
+              "hs_time_in_appointmentscheduled": { "type": ["null", "number"] },
+              "hs_time_in_closedlost": { "type": ["null", "number"] },
+              "hs_time_in_closedwon": { "type": ["null", "number"] },
+              "hs_time_in_contractsent": { "type": ["null", "number"] },
+              "hs_time_in_customclosedwonstage": { "type": ["null", "number"] },
+              "hs_time_in_decisionmakerboughtin": {
+                "type": ["null", "number"]
+              },
+              "hs_time_in_presentationscheduled": {
+                "type": ["null", "number"]
+              },
+              "hs_time_in_qualifiedtobuy": { "type": ["null", "number"] },
+              "hs_unique_creation_key": { "type": ["null", "string"] },
+              "hs_updated_by_user_id": { "type": ["null", "number"] },
+              "hs_user_ids_of_all_notification_followers": {
+                "type": ["null", "string"]
+              },
+              "hs_user_ids_of_all_notification_unfollowers": {
+                "type": ["null", "string"]
+              },
+              "hs_user_ids_of_all_owners": { "type": ["null", "string"] },
+              "hs_v2_cumulative_time_in_66894120": {
+                "type": ["null", "number"]
+              },
+              "hs_v2_cumulative_time_in_9567448": {
+                "type": ["null", "number"]
+              },
+              "hs_v2_cumulative_time_in_9567449": {
+                "type": ["null", "number"]
+              },
+              "hs_v2_cumulative_time_in_appointmentscheduled": {
+                "type": ["null", "number"]
+              },
+              "hs_v2_cumulative_time_in_closedlost": {
+                "type": ["null", "number"]
+              },
+              "hs_v2_cumulative_time_in_closedwon": {
+                "type": ["null", "number"]
+              },
+              "hs_v2_cumulative_time_in_contractsent": {
+                "type": ["null", "number"]
+              },
+              "hs_v2_cumulative_time_in_customclosedwonstage": {
+                "type": ["null", "number"]
+              },
+              "hs_v2_cumulative_time_in_decisionmakerboughtin": {
+                "type": ["null", "number"]
+              },
+              "hs_v2_cumulative_time_in_presentationscheduled": {
+                "type": ["null", "number"]
+              },
+              "hs_v2_cumulative_time_in_qualifiedtobuy": {
+                "type": ["null", "number"]
+              },
+              "hs_v2_date_entered_66894120": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_entered_9567448": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_entered_9567449": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_entered_appointmentscheduled": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_entered_closedlost": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_entered_closedwon": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_entered_contractsent": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_entered_customclosedwonstage": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_entered_decisionmakerboughtin": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_entered_presentationscheduled": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_entered_qualifiedtobuy": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_exited_66894120": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_exited_9567448": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_exited_9567449": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_exited_appointmentscheduled": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_exited_closedlost": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_exited_closedwon": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_exited_contractsent": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_exited_customclosedwonstage": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_exited_decisionmakerboughtin": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_exited_presentationscheduled": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_exited_qualifiedtobuy": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_latest_time_in_66894120": { "type": ["null", "number"] },
+              "hs_v2_latest_time_in_9567448": { "type": ["null", "number"] },
+              "hs_v2_latest_time_in_9567449": { "type": ["null", "number"] },
+              "hs_v2_latest_time_in_appointmentscheduled": {
+                "type": ["null", "number"]
+              },
+              "hs_v2_latest_time_in_closedlost": { "type": ["null", "number"] },
+              "hs_v2_latest_time_in_closedwon": { "type": ["null", "number"] },
+              "hs_v2_latest_time_in_contractsent": {
+                "type": ["null", "number"]
+              },
+              "hs_v2_latest_time_in_customclosedwonstage": {
+                "type": ["null", "number"]
+              },
+              "hs_v2_latest_time_in_decisionmakerboughtin": {
+                "type": ["null", "number"]
+              },
+              "hs_v2_latest_time_in_presentationscheduled": {
+                "type": ["null", "number"]
+              },
+              "hs_v2_latest_time_in_qualifiedtobuy": {
+                "type": ["null", "number"]
+              },
+              "hs_was_imported": { "type": ["null", "boolean"] },
+              "hubspot_owner_assigneddate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hubspot_owner_id": { "type": ["null", "string"] },
+              "hubspot_team_id": { "type": ["null", "string"] },
+              "notes_last_contacted": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "notes_last_updated": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "notes_next_activity_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "num_associated_contacts": { "type": ["null", "number"] },
+              "num_contacted_notes": { "type": ["null", "number"] },
+              "num_notes": { "type": ["null", "number"] },
+              "pipeline": { "type": ["null", "string"] }
+            }
+          },
+          "properties_amount": { "type": ["null", "number"] },
+          "properties_amount_in_home_currency": { "type": ["null", "number"] },
+          "properties_closed_lost_reason": { "type": ["null", "string"] },
+          "properties_closed_won_reason": { "type": ["null", "string"] },
+          "properties_closedate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_createdate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_days_to_close": { "type": ["null", "number"] },
+          "properties_dealname": { "type": ["null", "string"] },
+          "properties_dealstage": { "type": ["null", "string"] },
+          "properties_dealtype": { "type": ["null", "string"] },
+          "properties_description": { "type": ["null", "string"] },
+          "properties_engagements_last_meeting_booked": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_engagements_last_meeting_booked_campaign": {
+            "type": ["null", "string"]
+          },
+          "properties_engagements_last_meeting_booked_medium": {
+            "type": ["null", "string"]
+          },
+          "properties_engagements_last_meeting_booked_source": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_acv": { "type": ["null", "number"] },
+          "properties_hs_all_accessible_team_ids": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_all_assigned_business_unit_ids": {
+            "description": "IDs of all assigned business units for the deal",
+            "type": ["null", "string"]
+          },
+          "properties_hs_all_owner_ids": { "type": ["null", "string"] },
+          "properties_hs_all_team_ids": { "type": ["null", "string"] },
+          "properties_hs_analytics_source": { "type": ["null", "string"] },
+          "properties_hs_analytics_source_data_1": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_analytics_source_data_2": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_arr": { "type": ["null", "number"] },
+          "properties_hs_closed_amount": { "type": ["null", "number"] },
+          "properties_hs_closed_amount_in_home_currency": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_created_by_user_id": { "type": ["null", "number"] },
+          "properties_hs_createdate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_entered_9567448": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_entered_9567449": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_entered_appointmentscheduled": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_entered_closedlost": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_entered_closedwon": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_entered_contractsent": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_entered_customclosedwonstage": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_entered_decisionmakerboughtin": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_entered_presentationscheduled": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_entered_qualifiedtobuy": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_exited_9567448": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_exited_9567449": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_exited_appointmentscheduled": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_exited_closedlost": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_exited_closedwon": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_exited_contractsent": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_exited_customclosedwonstage": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_exited_decisionmakerboughtin": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_exited_presentationscheduled": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_exited_qualifiedtobuy": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_deal_amount_calculation_preference": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_deal_stage_probability": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_deal_stage_probability_shadow": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_forecast_amount": { "type": ["null", "number"] },
+          "properties_hs_forecast_probability": { "type": ["null", "number"] },
+          "properties_hs_is_closed": { "type": ["null", "boolean"] },
+          "properties_hs_is_closed_won": { "type": ["null", "boolean"] },
+          "properties_hs_lastmodifieddate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_latest_meeting_activity": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_likelihood_to_close": { "type": ["null", "number"] },
+          "properties_hs_line_item_global_term_hs_discount_percentage": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_line_item_global_term_hs_discount_percentage_enabled": {
+            "type": ["null", "boolean"]
+          },
+          "properties_hs_line_item_global_term_hs_recurring_billing_period": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_line_item_global_term_hs_recurring_billing_period_enabled": {
+            "type": ["null", "boolean"]
+          },
+          "properties_hs_line_item_global_term_hs_recurring_billing_start_date": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_line_item_global_term_hs_recurring_billing_start_date_enabled": {
+            "type": ["null", "boolean"]
+          },
+          "properties_hs_line_item_global_term_recurringbillingfrequency": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_line_item_global_term_recurringbillingfrequency_enabled": {
+            "type": ["null", "boolean"]
+          },
+          "properties_hs_manual_forecast_category": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_merged_object_ids": { "type": ["null", "string"] },
+          "properties_hs_mrr": { "type": ["null", "number"] },
+          "properties_hs_next_step": { "type": ["null", "string"] },
+          "properties_hs_num_target_accounts": { "type": ["null", "number"] },
+          "properties_hs_object_id": { "type": ["null", "number"] },
+          "properties_hs_predicted_amount": { "type": ["null", "number"] },
+          "properties_hs_predicted_amount_in_home_currency": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_priority": { "type": ["null", "string"] },
+          "properties_hs_projected_amount": { "type": ["null", "number"] },
+          "properties_hs_projected_amount_in_home_currency": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_sales_email_last_replied": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_tcv": { "type": ["null", "number"] },
+          "properties_hs_unique_creation_key": { "type": ["null", "string"] },
+          "properties_hs_updated_by_user_id": { "type": ["null", "number"] },
+          "properties_hs_user_ids_of_all_notification_followers": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_user_ids_of_all_notification_unfollowers": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_user_ids_of_all_owners": {
+            "type": ["null", "string"]
+          },
+          "properties_hubspot_owner_assigneddate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hubspot_owner_id": { "type": ["null", "string"] },
+          "properties_hubspot_team_id": { "type": ["null", "string"] },
+          "properties_notes_last_contacted": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_notes_last_updated": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_notes_next_activity_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_num_associated_contacts": { "type": ["null", "number"] },
+          "properties_num_contacted_notes": { "type": ["null", "number"] },
+          "properties_num_notes": { "type": ["null", "number"] },
+          "properties_pipeline": { "type": ["null", "string"] },
+          "createdAt": {
+            "description": "The date and time when the deal was created",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "description": "The date and time when the deal was last updated",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "archived": {
+            "description": "Indicates if the deal is archived",
+            "type": ["null", "boolean"]
+          },
+          "companies": {
+            "description": "Information about companies associated with the deal",
+            "type": ["null", "array"],
+            "items": { "type": ["null", "string"] }
+          },
+          "contacts": {
+            "description": "Information about contacts associated with the deal",
+            "type": ["null", "array"],
+            "items": { "type": ["null", "string"] }
+          },
+          "line_items": {
+            "description": "Details of line items associated with the deal",
+            "type": ["null", "array"],
+            "items": { "type": ["null", "string"] }
+          },
+          "properties_hs_all_collaborator_owner_ids": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_all_deal_split_owner_ids": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_analytics_latest_source": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_analytics_latest_source_company": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_analytics_latest_source_contact": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_analytics_latest_source_data_1": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_analytics_latest_source_data_1_company": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_analytics_latest_source_data_1_contact": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_analytics_latest_source_data_2": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_analytics_latest_source_data_2_company": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_analytics_latest_source_data_2_contact": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_analytics_latest_source_timestamp": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_analytics_latest_source_timestamp_company": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_analytics_latest_source_timestamp_contact": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_campaign": { "type": ["null", "string"] },
+          "properties_hs_closed_deal_close_date": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_closed_deal_create_date": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_closed_won_count": { "type": ["null", "number"] },
+          "properties_hs_closed_won_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_entered_66894120": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_exited_66894120": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_days_to_close_raw": { "type": ["null", "number"] },
+          "properties_hs_deal_score": { "type": ["null", "number"] },
+          "properties_hs_exchange_rate": { "type": ["null", "number"] },
+          "properties_hs_has_empty_conditional_stage_properties": {
+            "type": ["null", "boolean"]
+          },
+          "properties_hs_is_closed_count": { "type": ["null", "number"] },
+          "properties_hs_is_deal_split": { "type": ["null", "boolean"] },
+          "properties_hs_is_in_first_deal_stage": {
+            "type": ["null", "boolean"]
+          },
+          "properties_hs_is_open_count": { "type": ["null", "number"] },
+          "properties_hs_latest_approval_status": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_latest_approval_status_approval_id": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_next_step_updated_at": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_notes_next_activity_type": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_num_associated_deal_splits": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_num_of_associated_line_items": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_object_source": { "type": ["null", "string"] },
+          "properties_hs_object_source_detail_1": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_object_source_detail_2": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_object_source_detail_3": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_object_source_id": { "type": ["null", "string"] },
+          "properties_hs_object_source_label": { "type": ["null", "string"] },
+          "properties_hs_object_source_user_id": { "type": ["null", "number"] },
+          "properties_hs_open_deal_create_date": { "type": ["null", "number"] },
+          "properties_hs_pinned_engagement_id": { "type": ["null", "number"] },
+          "properties_hs_read_only": { "type": ["null", "boolean"] },
+          "properties_hs_tag_ids": { "type": ["null", "string"] },
+          "properties_hs_time_in_66894120": { "type": ["null", "number"] },
+          "properties_hs_time_in_9567448": { "type": ["null", "number"] },
+          "properties_hs_time_in_9567449": { "type": ["null", "number"] },
+          "properties_hs_time_in_appointmentscheduled": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_time_in_closedlost": { "type": ["null", "number"] },
+          "properties_hs_time_in_closedwon": { "type": ["null", "number"] },
+          "properties_hs_time_in_contractsent": { "type": ["null", "number"] },
+          "properties_hs_time_in_customclosedwonstage": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_time_in_decisionmakerboughtin": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_time_in_presentationscheduled": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_time_in_qualifiedtobuy": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_cumulative_time_in_66894120": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_cumulative_time_in_9567448": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_cumulative_time_in_9567449": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_cumulative_time_in_appointmentscheduled": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_cumulative_time_in_closedlost": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_cumulative_time_in_closedwon": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_cumulative_time_in_contractsent": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_cumulative_time_in_customclosedwonstage": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_cumulative_time_in_decisionmakerboughtin": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_cumulative_time_in_presentationscheduled": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_cumulative_time_in_qualifiedtobuy": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_date_entered_66894120": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_entered_9567448": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_entered_9567449": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_entered_appointmentscheduled": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_entered_closedlost": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_entered_closedwon": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_entered_contractsent": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_entered_customclosedwonstage": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_entered_decisionmakerboughtin": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_entered_presentationscheduled": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_entered_qualifiedtobuy": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_exited_66894120": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_exited_9567448": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_exited_9567449": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_exited_appointmentscheduled": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_exited_closedlost": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_exited_closedwon": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_exited_contractsent": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_exited_customclosedwonstage": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_exited_decisionmakerboughtin": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_exited_presentationscheduled": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_exited_qualifiedtobuy": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_latest_time_in_66894120": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_latest_time_in_9567448": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_latest_time_in_9567449": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_latest_time_in_appointmentscheduled": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_latest_time_in_closedlost": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_latest_time_in_closedwon": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_latest_time_in_contractsent": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_latest_time_in_customclosedwonstage": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_latest_time_in_decisionmakerboughtin": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_latest_time_in_presentationscheduled": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_latest_time_in_qualifiedtobuy": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_was_imported": { "type": ["null", "boolean"] }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updatedAt"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "deals_archived",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": ["null", "object"],
+        "properties": {
+          "id": { "type": ["null", "string"] },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "amount": { "type": ["null", "number"] },
+              "amount_in_home_currency": { "type": ["null", "number"] },
+              "closed_lost_reason": { "type": ["null", "string"] },
+              "closed_won_reason": { "type": ["null", "string"] },
+              "closedate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "createdate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "days_to_close": { "type": ["null", "number"] },
+              "dealname": { "type": ["null", "string"] },
+              "dealstage": { "type": ["null", "string"] },
+              "dealtype": { "type": ["null", "string"] },
+              "description": { "type": ["null", "string"] },
+              "engagements_last_meeting_booked": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "engagements_last_meeting_booked_campaign": {
+                "type": ["null", "string"]
+              },
+              "engagements_last_meeting_booked_medium": {
+                "type": ["null", "string"]
+              },
+              "engagements_last_meeting_booked_source": {
+                "type": ["null", "string"]
+              },
+              "hs_acv": { "type": ["null", "number"] },
+              "hs_all_accessible_team_ids": { "type": ["null", "string"] },
+              "hs_all_collaborator_owner_ids": { "type": ["null", "string"] },
+              "hs_all_deal_split_owner_ids": { "type": ["null", "string"] },
+              "hs_all_owner_ids": { "type": ["null", "string"] },
+              "hs_all_team_ids": { "type": ["null", "string"] },
+              "hs_analytics_latest_source": { "type": ["null", "string"] },
+              "hs_analytics_latest_source_company": {
+                "type": ["null", "string"]
+              },
+              "hs_analytics_latest_source_contact": {
+                "type": ["null", "string"]
+              },
+              "hs_analytics_latest_source_data_1": {
+                "type": ["null", "string"]
+              },
+              "hs_analytics_latest_source_data_1_company": {
+                "type": ["null", "string"]
+              },
+              "hs_analytics_latest_source_data_1_contact": {
+                "type": ["null", "string"]
+              },
+              "hs_analytics_latest_source_data_2": {
+                "type": ["null", "string"]
+              },
+              "hs_analytics_latest_source_data_2_company": {
+                "type": ["null", "string"]
+              },
+              "hs_analytics_latest_source_data_2_contact": {
+                "type": ["null", "string"]
+              },
+              "hs_analytics_latest_source_timestamp": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_analytics_latest_source_timestamp_company": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_analytics_latest_source_timestamp_contact": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_analytics_source": { "type": ["null", "string"] },
+              "hs_analytics_source_data_1": { "type": ["null", "string"] },
+              "hs_analytics_source_data_2": { "type": ["null", "string"] },
+              "hs_arr": { "type": ["null", "number"] },
+              "hs_campaign": { "type": ["null", "string"] },
+              "hs_closed_amount": { "type": ["null", "number"] },
+              "hs_closed_amount_in_home_currency": {
+                "type": ["null", "number"]
+              },
+              "hs_closed_deal_close_date": { "type": ["null", "number"] },
+              "hs_closed_deal_create_date": { "type": ["null", "number"] },
+              "hs_closed_won_count": { "type": ["null", "number"] },
+              "hs_closed_won_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_created_by_user_id": { "type": ["null", "number"] },
+              "hs_createdate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_entered_66894120": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_entered_9567448": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_entered_9567449": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_entered_appointmentscheduled": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_entered_closedlost": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_entered_closedwon": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_entered_contractsent": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_entered_customclosedwonstage": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_entered_decisionmakerboughtin": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_entered_presentationscheduled": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_entered_qualifiedtobuy": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_exited_66894120": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_exited_9567448": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_exited_9567449": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_exited_appointmentscheduled": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_exited_closedlost": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_exited_closedwon": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_exited_contractsent": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_exited_customclosedwonstage": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_exited_decisionmakerboughtin": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_exited_presentationscheduled": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_exited_qualifiedtobuy": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_days_to_close_raw": { "type": ["null", "number"] },
+              "hs_deal_amount_calculation_preference": {
+                "type": ["null", "string"]
+              },
+              "hs_deal_score": { "type": ["null", "number"] },
+              "hs_deal_stage_probability": { "type": ["null", "number"] },
+              "hs_deal_stage_probability_shadow": {
+                "type": ["null", "number"]
+              },
+              "hs_exchange_rate": { "type": ["null", "number"] },
+              "hs_forecast_amount": { "type": ["null", "number"] },
+              "hs_forecast_probability": { "type": ["null", "number"] },
+              "hs_has_empty_conditional_stage_properties": {
+                "type": ["null", "boolean"]
+              },
+              "hs_is_closed": { "type": ["null", "boolean"] },
+              "hs_is_closed_count": { "type": ["null", "number"] },
+              "hs_is_closed_won": { "type": ["null", "boolean"] },
+              "hs_is_deal_split": { "type": ["null", "boolean"] },
+              "hs_is_in_first_deal_stage": { "type": ["null", "boolean"] },
+              "hs_is_open_count": { "type": ["null", "number"] },
+              "hs_lastmodifieddate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_latest_approval_status": { "type": ["null", "string"] },
+              "hs_latest_approval_status_approval_id": {
+                "type": ["null", "number"]
+              },
+              "hs_latest_meeting_activity": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_likelihood_to_close": { "type": ["null", "number"] },
+              "hs_line_item_global_term_hs_discount_percentage": {
+                "type": ["null", "string"]
+              },
+              "hs_line_item_global_term_hs_discount_percentage_enabled": {
+                "type": ["null", "boolean"]
+              },
+              "hs_line_item_global_term_hs_recurring_billing_period": {
+                "type": ["null", "string"]
+              },
+              "hs_line_item_global_term_hs_recurring_billing_period_enabled": {
+                "type": ["null", "boolean"]
+              },
+              "hs_line_item_global_term_hs_recurring_billing_start_date": {
+                "type": ["null", "string"]
+              },
+              "hs_line_item_global_term_hs_recurring_billing_start_date_enabled": {
+                "type": ["null", "boolean"]
+              },
+              "hs_line_item_global_term_recurringbillingfrequency": {
+                "type": ["null", "string"]
+              },
+              "hs_line_item_global_term_recurringbillingfrequency_enabled": {
+                "type": ["null", "boolean"]
+              },
+              "hs_manual_forecast_category": { "type": ["null", "string"] },
+              "hs_merged_object_ids": { "type": ["null", "string"] },
+              "hs_mrr": { "type": ["null", "number"] },
+              "hs_next_step": { "type": ["null", "string"] },
+              "hs_next_step_updated_at": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_notes_next_activity_type": { "type": ["null", "string"] },
+              "hs_num_associated_deal_splits": { "type": ["null", "number"] },
+              "hs_num_of_associated_line_items": { "type": ["null", "number"] },
+              "hs_num_target_accounts": { "type": ["null", "number"] },
+              "hs_object_id": { "type": ["null", "number"] },
+              "hs_object_source": { "type": ["null", "string"] },
+              "hs_object_source_detail_1": { "type": ["null", "string"] },
+              "hs_object_source_detail_2": { "type": ["null", "string"] },
+              "hs_object_source_detail_3": { "type": ["null", "string"] },
+              "hs_object_source_id": { "type": ["null", "string"] },
+              "hs_object_source_label": { "type": ["null", "string"] },
+              "hs_object_source_user_id": { "type": ["null", "number"] },
+              "hs_open_deal_create_date": { "type": ["null", "number"] },
+              "hs_pinned_engagement_id": { "type": ["null", "number"] },
+              "hs_predicted_amount": { "type": ["null", "number"] },
+              "hs_predicted_amount_in_home_currency": {
+                "type": ["null", "number"]
+              },
+              "hs_priority": { "type": ["null", "string"] },
+              "hs_projected_amount": { "type": ["null", "number"] },
+              "hs_projected_amount_in_home_currency": {
+                "type": ["null", "number"]
+              },
+              "hs_read_only": { "type": ["null", "boolean"] },
+              "hs_sales_email_last_replied": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_tag_ids": { "type": ["null", "string"] },
+              "hs_tcv": { "type": ["null", "number"] },
+              "hs_time_in_66894120": { "type": ["null", "number"] },
+              "hs_time_in_9567448": { "type": ["null", "number"] },
+              "hs_time_in_9567449": { "type": ["null", "number"] },
+              "hs_time_in_appointmentscheduled": { "type": ["null", "number"] },
+              "hs_time_in_closedlost": { "type": ["null", "number"] },
+              "hs_time_in_closedwon": { "type": ["null", "number"] },
+              "hs_time_in_contractsent": { "type": ["null", "number"] },
+              "hs_time_in_customclosedwonstage": { "type": ["null", "number"] },
+              "hs_time_in_decisionmakerboughtin": {
+                "type": ["null", "number"]
+              },
+              "hs_time_in_presentationscheduled": {
+                "type": ["null", "number"]
+              },
+              "hs_time_in_qualifiedtobuy": { "type": ["null", "number"] },
+              "hs_unique_creation_key": { "type": ["null", "string"] },
+              "hs_updated_by_user_id": { "type": ["null", "number"] },
+              "hs_user_ids_of_all_notification_followers": {
+                "type": ["null", "string"]
+              },
+              "hs_user_ids_of_all_notification_unfollowers": {
+                "type": ["null", "string"]
+              },
+              "hs_user_ids_of_all_owners": { "type": ["null", "string"] },
+              "hs_v2_cumulative_time_in_66894120": {
+                "type": ["null", "number"]
+              },
+              "hs_v2_cumulative_time_in_9567448": {
+                "type": ["null", "number"]
+              },
+              "hs_v2_cumulative_time_in_9567449": {
+                "type": ["null", "number"]
+              },
+              "hs_v2_cumulative_time_in_appointmentscheduled": {
+                "type": ["null", "number"]
+              },
+              "hs_v2_cumulative_time_in_closedlost": {
+                "type": ["null", "number"]
+              },
+              "hs_v2_cumulative_time_in_closedwon": {
+                "type": ["null", "number"]
+              },
+              "hs_v2_cumulative_time_in_contractsent": {
+                "type": ["null", "number"]
+              },
+              "hs_v2_cumulative_time_in_customclosedwonstage": {
+                "type": ["null", "number"]
+              },
+              "hs_v2_cumulative_time_in_decisionmakerboughtin": {
+                "type": ["null", "number"]
+              },
+              "hs_v2_cumulative_time_in_presentationscheduled": {
+                "type": ["null", "number"]
+              },
+              "hs_v2_cumulative_time_in_qualifiedtobuy": {
+                "type": ["null", "number"]
+              },
+              "hs_v2_date_entered_66894120": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_entered_9567448": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_entered_9567449": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_entered_appointmentscheduled": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_entered_closedlost": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_entered_closedwon": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_entered_contractsent": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_entered_customclosedwonstage": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_entered_decisionmakerboughtin": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_entered_presentationscheduled": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_entered_qualifiedtobuy": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_exited_66894120": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_exited_9567448": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_exited_9567449": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_exited_appointmentscheduled": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_exited_closedlost": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_exited_closedwon": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_exited_contractsent": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_exited_customclosedwonstage": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_exited_decisionmakerboughtin": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_exited_presentationscheduled": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_exited_qualifiedtobuy": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_latest_time_in_66894120": { "type": ["null", "number"] },
+              "hs_v2_latest_time_in_9567448": { "type": ["null", "number"] },
+              "hs_v2_latest_time_in_9567449": { "type": ["null", "number"] },
+              "hs_v2_latest_time_in_appointmentscheduled": {
+                "type": ["null", "number"]
+              },
+              "hs_v2_latest_time_in_closedlost": { "type": ["null", "number"] },
+              "hs_v2_latest_time_in_closedwon": { "type": ["null", "number"] },
+              "hs_v2_latest_time_in_contractsent": {
+                "type": ["null", "number"]
+              },
+              "hs_v2_latest_time_in_customclosedwonstage": {
+                "type": ["null", "number"]
+              },
+              "hs_v2_latest_time_in_decisionmakerboughtin": {
+                "type": ["null", "number"]
+              },
+              "hs_v2_latest_time_in_presentationscheduled": {
+                "type": ["null", "number"]
+              },
+              "hs_v2_latest_time_in_qualifiedtobuy": {
+                "type": ["null", "number"]
+              },
+              "hs_was_imported": { "type": ["null", "boolean"] },
+              "hubspot_owner_assigneddate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hubspot_owner_id": { "type": ["null", "string"] },
+              "hubspot_team_id": { "type": ["null", "string"] },
+              "notes_last_contacted": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "notes_last_updated": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "notes_next_activity_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "num_associated_contacts": { "type": ["null", "number"] },
+              "num_contacted_notes": { "type": ["null", "number"] },
+              "num_notes": { "type": ["null", "number"] },
+              "pipeline": { "type": ["null", "string"] }
+            }
+          },
+          "properties_amount": { "type": ["null", "number"] },
+          "properties_amount_in_home_currency": { "type": ["null", "number"] },
+          "properties_closed_lost_reason": { "type": ["null", "string"] },
+          "properties_closed_won_reason": { "type": ["null", "string"] },
+          "properties_closedate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_createdate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_days_to_close": { "type": ["null", "number"] },
+          "properties_dealname": { "type": ["null", "string"] },
+          "properties_dealstage": { "type": ["null", "string"] },
+          "properties_dealtype": { "type": ["null", "string"] },
+          "properties_description": { "type": ["null", "string"] },
+          "properties_engagements_last_meeting_booked": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_engagements_last_meeting_booked_campaign": {
+            "type": ["null", "string"]
+          },
+          "properties_engagements_last_meeting_booked_medium": {
+            "type": ["null", "string"]
+          },
+          "properties_engagements_last_meeting_booked_source": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_acv": { "type": ["null", "number"] },
+          "properties_hs_all_accessible_team_ids": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_all_assigned_business_unit_ids": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_all_owner_ids": { "type": ["null", "string"] },
+          "properties_hs_all_team_ids": { "type": ["null", "string"] },
+          "properties_hs_analytics_source": { "type": ["null", "string"] },
+          "properties_hs_analytics_source_data_1": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_analytics_source_data_2": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_arr": { "type": ["null", "number"] },
+          "properties_hs_closed_amount": { "type": ["null", "number"] },
+          "properties_hs_closed_amount_in_home_currency": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_created_by_user_id": { "type": ["null", "number"] },
+          "properties_hs_createdate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_entered_9567448": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_entered_9567449": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_entered_appointmentscheduled": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_entered_closedlost": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_entered_closedwon": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_entered_contractsent": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_entered_customclosedwonstage": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_entered_decisionmakerboughtin": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_entered_presentationscheduled": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_entered_qualifiedtobuy": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_exited_9567448": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_exited_9567449": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_exited_appointmentscheduled": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_exited_closedlost": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_exited_closedwon": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_exited_contractsent": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_exited_customclosedwonstage": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_exited_decisionmakerboughtin": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_exited_presentationscheduled": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_exited_qualifiedtobuy": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_deal_amount_calculation_preference": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_deal_stage_probability": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_deal_stage_probability_shadow": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_forecast_amount": { "type": ["null", "number"] },
+          "properties_hs_forecast_probability": { "type": ["null", "number"] },
+          "properties_hs_is_closed": { "type": ["null", "boolean"] },
+          "properties_hs_is_closed_won": { "type": ["null", "boolean"] },
+          "properties_hs_lastmodifieddate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_latest_meeting_activity": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_likelihood_to_close": { "type": ["null", "number"] },
+          "properties_hs_line_item_global_term_hs_discount_percentage": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_line_item_global_term_hs_discount_percentage_enabled": {
+            "type": ["null", "boolean"]
+          },
+          "properties_hs_line_item_global_term_hs_recurring_billing_period": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_line_item_global_term_hs_recurring_billing_period_enabled": {
+            "type": ["null", "boolean"]
+          },
+          "properties_hs_line_item_global_term_hs_recurring_billing_start_date": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_line_item_global_term_hs_recurring_billing_start_date_enabled": {
+            "type": ["null", "boolean"]
+          },
+          "properties_hs_line_item_global_term_recurringbillingfrequency": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_line_item_global_term_recurringbillingfrequency_enabled": {
+            "type": ["null", "boolean"]
+          },
+          "properties_hs_manual_forecast_category": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_merged_object_ids": { "type": ["null", "string"] },
+          "properties_hs_mrr": { "type": ["null", "number"] },
+          "properties_hs_next_step": { "type": ["null", "string"] },
+          "properties_hs_num_target_accounts": { "type": ["null", "number"] },
+          "properties_hs_object_id": { "type": ["null", "number"] },
+          "properties_hs_predicted_amount": { "type": ["null", "number"] },
+          "properties_hs_predicted_amount_in_home_currency": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_priority": { "type": ["null", "string"] },
+          "properties_hs_projected_amount": { "type": ["null", "number"] },
+          "properties_hs_projected_amount_in_home_currency": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_sales_email_last_replied": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_tcv": { "type": ["null", "number"] },
+          "properties_hs_unique_creation_key": { "type": ["null", "string"] },
+          "properties_hs_updated_by_user_id": { "type": ["null", "number"] },
+          "properties_hs_user_ids_of_all_notification_followers": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_user_ids_of_all_notification_unfollowers": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_user_ids_of_all_owners": {
+            "type": ["null", "string"]
+          },
+          "properties_hubspot_owner_assigneddate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hubspot_owner_id": { "type": ["null", "string"] },
+          "properties_hubspot_team_id": { "type": ["null", "string"] },
+          "properties_notes_last_contacted": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_notes_last_updated": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_notes_next_activity_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_num_associated_contacts": { "type": ["null", "number"] },
+          "properties_num_contacted_notes": { "type": ["null", "number"] },
+          "properties_num_notes": { "type": ["null", "number"] },
+          "properties_pipeline": { "type": ["null", "string"] },
+          "createdAt": { "type": ["null", "string"], "format": "date-time" },
+          "updatedAt": { "type": ["null", "string"], "format": "date-time" },
+          "archived": { "type": ["null", "boolean"] },
+          "archivedAt": {
+            "description": "The date and time when the deal was archived",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "companies": {
+            "type": ["null", "array"],
+            "items": { "type": ["null", "string"] }
+          },
+          "contacts": {
+            "type": ["null", "array"],
+            "items": { "type": ["null", "string"] }
+          },
+          "line_items": {
+            "type": ["null", "array"],
+            "items": { "type": ["null", "string"] }
+          },
+          "properties_hs_all_collaborator_owner_ids": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_all_deal_split_owner_ids": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_analytics_latest_source": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_analytics_latest_source_company": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_analytics_latest_source_contact": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_analytics_latest_source_data_1": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_analytics_latest_source_data_1_company": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_analytics_latest_source_data_1_contact": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_analytics_latest_source_data_2": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_analytics_latest_source_data_2_company": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_analytics_latest_source_data_2_contact": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_analytics_latest_source_timestamp": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_analytics_latest_source_timestamp_company": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_analytics_latest_source_timestamp_contact": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_campaign": { "type": ["null", "string"] },
+          "properties_hs_closed_deal_close_date": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_closed_deal_create_date": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_closed_won_count": { "type": ["null", "number"] },
+          "properties_hs_closed_won_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_entered_66894120": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_exited_66894120": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_days_to_close_raw": { "type": ["null", "number"] },
+          "properties_hs_deal_score": { "type": ["null", "number"] },
+          "properties_hs_exchange_rate": { "type": ["null", "number"] },
+          "properties_hs_has_empty_conditional_stage_properties": {
+            "type": ["null", "boolean"]
+          },
+          "properties_hs_is_closed_count": { "type": ["null", "number"] },
+          "properties_hs_is_deal_split": { "type": ["null", "boolean"] },
+          "properties_hs_is_in_first_deal_stage": {
+            "type": ["null", "boolean"]
+          },
+          "properties_hs_is_open_count": { "type": ["null", "number"] },
+          "properties_hs_latest_approval_status": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_latest_approval_status_approval_id": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_next_step_updated_at": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_notes_next_activity_type": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_num_associated_deal_splits": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_num_of_associated_line_items": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_object_source": { "type": ["null", "string"] },
+          "properties_hs_object_source_detail_1": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_object_source_detail_2": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_object_source_detail_3": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_object_source_id": { "type": ["null", "string"] },
+          "properties_hs_object_source_label": { "type": ["null", "string"] },
+          "properties_hs_object_source_user_id": { "type": ["null", "number"] },
+          "properties_hs_open_deal_create_date": { "type": ["null", "number"] },
+          "properties_hs_pinned_engagement_id": { "type": ["null", "number"] },
+          "properties_hs_read_only": { "type": ["null", "boolean"] },
+          "properties_hs_tag_ids": { "type": ["null", "string"] },
+          "properties_hs_time_in_66894120": { "type": ["null", "number"] },
+          "properties_hs_time_in_9567448": { "type": ["null", "number"] },
+          "properties_hs_time_in_9567449": { "type": ["null", "number"] },
+          "properties_hs_time_in_appointmentscheduled": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_time_in_closedlost": { "type": ["null", "number"] },
+          "properties_hs_time_in_closedwon": { "type": ["null", "number"] },
+          "properties_hs_time_in_contractsent": { "type": ["null", "number"] },
+          "properties_hs_time_in_customclosedwonstage": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_time_in_decisionmakerboughtin": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_time_in_presentationscheduled": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_time_in_qualifiedtobuy": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_cumulative_time_in_66894120": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_cumulative_time_in_9567448": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_cumulative_time_in_9567449": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_cumulative_time_in_appointmentscheduled": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_cumulative_time_in_closedlost": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_cumulative_time_in_closedwon": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_cumulative_time_in_contractsent": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_cumulative_time_in_customclosedwonstage": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_cumulative_time_in_decisionmakerboughtin": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_cumulative_time_in_presentationscheduled": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_cumulative_time_in_qualifiedtobuy": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_date_entered_66894120": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_entered_9567448": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_entered_9567449": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_entered_appointmentscheduled": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_entered_closedlost": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_entered_closedwon": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_entered_contractsent": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_entered_customclosedwonstage": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_entered_decisionmakerboughtin": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_entered_presentationscheduled": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_entered_qualifiedtobuy": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_exited_66894120": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_exited_9567448": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_exited_9567449": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_exited_appointmentscheduled": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_exited_closedlost": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_exited_closedwon": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_exited_contractsent": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_exited_customclosedwonstage": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_exited_decisionmakerboughtin": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_exited_presentationscheduled": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_exited_qualifiedtobuy": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_latest_time_in_66894120": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_latest_time_in_9567448": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_latest_time_in_9567449": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_latest_time_in_appointmentscheduled": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_latest_time_in_closedlost": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_latest_time_in_closedwon": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_latest_time_in_contractsent": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_latest_time_in_customclosedwonstage": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_latest_time_in_decisionmakerboughtin": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_latest_time_in_presentationscheduled": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_latest_time_in_qualifiedtobuy": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_was_imported": { "type": ["null", "boolean"] }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["archivedAt"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "email_events",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": ["null", "object"],
+        "properties": {
+          "appId": {
+            "description": "The unique identifier of the application associated with the email event.",
+            "type": ["null", "integer"]
+          },
+          "appName": {
+            "description": "The name of the application associated with the email event.",
+            "type": ["null", "string"]
+          },
+          "bcc": {
+            "description": "The blind carbon copy recipients of the email.",
+            "type": ["null", "array"]
+          },
+          "cc": {
+            "description": "The carbon copy recipients of the email.",
+            "type": ["null", "array"]
+          },
+          "attempt": {
+            "description": "The number of attempts made to send the email.",
+            "type": ["null", "integer"]
+          },
+          "bounced": {
+            "description": "Indicates if the email bounced.",
+            "type": ["null", "boolean"]
+          },
+          "browser": {
+            "description": "Details about the email event recipient's browser.",
+            "type": ["null", "object"],
+            "properties": {
+              "family": {
+                "description": "The family of the browser used by the recipient.",
+                "type": ["null", "string"]
+              },
+              "name": {
+                "description": "The name of the browser.",
+                "type": ["null", "string"]
+              },
+              "producer": {
+                "description": "The producer of the browser.",
+                "type": ["null", "string"]
+              },
+              "producerUrl": {
+                "description": "The URL of the producer's website.",
+                "type": ["null", "string"]
+              },
+              "type": {
+                "description": "The type of the browser.",
+                "type": ["null", "string"]
+              },
+              "url": {
+                "description": "The URL of the browser.",
+                "type": ["null", "string"]
+              },
+              "version": {
+                "description": "The version of the browser used by the recipient.",
+                "type": ["null", "array"],
+                "items": {
+                  "description": "The version of the browser.",
+                  "type": ["null", "string"]
+                }
+              }
+            }
+          },
+          "category": {
+            "description": "The category of the email event.",
+            "type": ["null", "string"]
+          },
+          "causedBy": {
+            "description": "Information about the action that caused the email event.",
+            "type": ["null", "object"],
+            "properties": {
+              "created": {
+                "description": "The timestamp of when the event was created.",
+                "type": ["null", "integer"]
+              },
+              "id": {
+                "description": "The unique identifier of the event causing this event.",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "created": {
+            "description": "The timestamp of when the email event was created.",
+            "type": ["null", "integer"]
+          },
+          "deviceType": {
+            "description": "The type of device used by the recipient.",
+            "type": ["null", "string"]
+          },
+          "dropMessage": {
+            "description": "The message associated with dropped email.",
+            "type": ["null", "string"]
+          },
+          "dropReason": {
+            "description": "The reason for dropping the email.",
+            "type": ["null", "string"]
+          },
+          "duration": {
+            "description": "The duration of the email event.",
+            "type": ["null", "integer"]
+          },
+          "emailCampaignId": {
+            "description": "The ID of the email campaign associated with the event.",
+            "type": ["null", "integer"]
+          },
+          "emailCampaignGroupId": {
+            "description": "The group ID of the email campaign associated with the event.",
+            "type": ["null", "integer"]
+          },
+          "filteredEvent": {
+            "description": "Indicates if the event is filtered.",
+            "type": ["null", "boolean"]
+          },
+          "from": {
+            "description": "The sender of the email.",
+            "type": ["null", "string"]
+          },
+          "hmid": {
+            "description": "The HubSpot Marketing ID.",
+            "type": ["null", "string"]
+          },
+          "id": {
+            "description": "The unique identifier of the email event.",
+            "type": ["null", "string"]
+          },
+          "ipAddress": {
+            "description": "The IP address of the recipient.",
+            "type": ["null", "string"]
+          },
+          "linkId": {
+            "description": "The ID of the link in the email.",
+            "type": ["null", "integer"]
+          },
+          "location": {
+            "description": "Details about the geographical location associated with the email event.",
+            "type": ["null", "object"],
+            "properties": {
+              "city": {
+                "description": "The city of the recipient's location.",
+                "type": ["null", "string"]
+              },
+              "country": {
+                "description": "The country of the recipient's location.",
+                "type": ["null", "string"]
+              },
+              "latitude": {
+                "description": "The latitude coordinate of the recipient's location.",
+                "type": ["null", "number"]
+              },
+              "longitude": {
+                "description": "The longitude coordinate of the recipient's location.",
+                "type": ["null", "number"]
+              },
+              "state": {
+                "description": "The state of the recipient's location.",
+                "type": ["null", "string"]
+              },
+              "zipcode": {
+                "description": "The zipcode of the recipient's location.",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "obsoletedBy": {
+            "description": "Information about any email event that this event has made obsolete.",
+            "type": ["null", "object"],
+            "properties": {
+              "created": {
+                "description": "The timestamp of when the event was obsoleted.",
+                "type": ["null", "integer"]
+              },
+              "id": {
+                "description": "The ID of the event that obsoleted this event.",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "portalId": {
+            "description": "The ID of the HubSpot portal.",
+            "type": ["null", "integer"]
+          },
+          "portalSubscriptionStatus": {
+            "description": "The subscription status of the portal.",
+            "type": ["null", "string"]
+          },
+          "recipient": {
+            "description": "The recipient of the email.",
+            "type": ["null", "string"]
+          },
+          "referer": {
+            "description": "The referer URL of the email.",
+            "type": ["null", "string"]
+          },
+          "replyTo": {
+            "description": "The email address to which replies should be directed.",
+            "type": ["null", "array"],
+            "items": {
+              "description": "The email address for replying to the email.",
+              "type": ["null", "string"]
+            }
+          },
+          "requestedBy": {
+            "description": "The entity that requested the email event.",
+            "type": ["null", "string"]
+          },
+          "requestedByUserId": {
+            "description": "The ID of the user who requested the email event.",
+            "type": ["null", "integer"]
+          },
+          "response": {
+            "description": "The response code related to the email event.",
+            "type": ["null", "string"]
+          },
+          "sentBy": {
+            "description": "Details about the entity that sent the email event.",
+            "type": ["null", "object"],
+            "properties": {
+              "created": {
+                "description": "The timestamp of when the email was sent.",
+                "type": ["null", "integer"]
+              },
+              "id": {
+                "description": "The ID of the sender of the email.",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "smtpId": {
+            "description": "The SMTP ID associated with email event.",
+            "type": ["null", "string"]
+          },
+          "source": {
+            "description": "The source of the email event.",
+            "type": ["null", "string"]
+          },
+          "sourceId": {
+            "description": "The unique identifier of the email event source.",
+            "type": ["null", "string"]
+          },
+          "subscriptions": {
+            "description": "Information about the subscriptions associated with the email event.",
+            "type": ["null", "array"],
+            "items": {
+              "description": "Details about a specific subscription.",
+              "type": ["null", "object"],
+              "properties": {
+                "id": {
+                  "description": "The ID of the subscription.",
+                  "type": ["null", "integer"]
+                },
+                "legalBasisChange": {
+                  "description": "Information about any changes in legal basis related to the subscription.",
+                  "type": ["null", "object"],
+                  "properties": {
+                    "legalBasisExplanation": {
+                      "description": "Explanation for legal basis change.",
+                      "type": ["null", "string"]
+                    },
+                    "legalBasisType": {
+                      "description": "The type of legal basis for subscription change.",
+                      "type": ["null", "string"]
+                    },
+                    "optState": {
+                      "description": "The state of opt-in.",
+                      "type": ["null", "string"]
+                    }
+                  }
+                },
+                "status": {
+                  "description": "The status of the subscription.",
+                  "type": ["null", "string"]
+                }
+              }
+            }
+          },
+          "status": {
+            "description": "The status of the email event.",
+            "type": ["null", "string"]
+          },
+          "subject": {
+            "description": "The subject of the email.",
+            "type": ["null", "string"]
+          },
+          "type": {
+            "description": "The type of email event.",
+            "type": ["null", "string"]
+          },
+          "url": {
+            "description": "The URL associated with the email event.",
+            "type": ["null", "string"]
+          },
+          "userAgent": {
+            "description": "The user agent of the recipient.",
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["created"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "email_subscriptions",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": ["null", "object"],
+        "additionalProperties": true,
+        "properties": {
+          "active": {
+            "description": "Indicates whether the subscription is currently active or not",
+            "type": ["null", "boolean"]
+          },
+          "portalId": {
+            "description": "The unique identifier for the portal associated with the subscription",
+            "type": ["null", "integer"]
+          },
+          "description": {
+            "description": "Additional information or details about the subscription",
+            "type": ["null", "string"]
+          },
+          "id": {
+            "description": "The unique identifier for the subscription",
+            "type": ["null", "integer"]
+          },
+          "name": {
+            "description": "The display name of the subscription",
+            "type": ["null", "string"]
+          },
+          "order": {
+            "description": "The order in which the subscription is displayed or processed",
+            "type": ["null", "integer"]
+          },
+          "businessUnitId": {
+            "description": "The unique identifier for the business unit associated with the subscription",
+            "type": ["null", "integer"]
+          },
+          "internal": {
+            "description": "Indicates whether the subscription is for internal use only",
+            "type": ["null", "boolean"]
+          },
+          "internalName": {
+            "description": "The internal name for the subscription",
+            "type": ["null", "string"]
+          },
+          "category": {
+            "description": "The category to which the subscription belongs",
+            "type": ["null", "string"]
+          },
+          "channel": {
+            "description": "The communication channel through which the subscription is managed",
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": false
+    },
+    {
+      "name": "engagements",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": ["null", "object"],
+        "properties": {
+          "id": {
+            "description": "Unique ID of the engagement.",
+            "type": ["null", "integer"]
+          },
+          "uid": {
+            "description": "Unique identifier of the engagement.",
+            "type": ["null", "string"]
+          },
+          "teamId": {
+            "description": "ID of the team associated with the engagement.",
+            "type": ["null", "integer"]
+          },
+          "portalId": {
+            "description": "ID of the portal associated with the engagement.",
+            "type": ["null", "integer"]
+          },
+          "queueMembershipIds": {
+            "description": "IDs of queue memberships related to the engagement.",
+            "type": ["null", "array"]
+          },
+          "scheduledTasks": {
+            "description": "Scheduled tasks related to the engagement.",
+            "type": ["null", "array"]
+          },
+          "active": {
+            "description": "Indicates if the engagement is currently active or not.",
+            "type": ["null", "boolean"]
+          },
+          "createdAt": {
+            "description": "Timestamp indicating when the engagement was created.",
+            "type": ["null", "integer"]
+          },
+          "createdBy": {
+            "description": "ID of the user who created the engagement.",
+            "type": ["null", "integer"]
+          },
+          "modifiedBy": {
+            "description": "ID of the user who last modified the engagement.",
+            "type": ["null", "integer"]
+          },
+          "lastUpdated": {
+            "description": "Timestamp indicating when the engagement was last updated.",
+            "type": ["null", "integer"]
+          },
+          "ownerId": {
+            "description": "ID of the owner of the engagement.",
+            "type": ["null", "integer"]
+          },
+          "type": {
+            "description": "Type of the engagement.",
+            "type": ["null", "string"]
+          },
+          "timestamp": {
+            "description": "Timestamp related to the engagement.",
+            "type": ["null", "integer"]
+          },
+          "bodyPreview": {
+            "description": "Preview of the body content.",
+            "type": ["null", "string"]
+          },
+          "bodyPreviewHtml": {
+            "description": "HTML preview of the body content.",
+            "type": ["null", "string"]
+          },
+          "bodyPreviewIsTruncated": {
+            "description": "Indicates if the body preview is truncated.",
+            "type": ["null", "boolean"]
+          },
+          "allAccessibleTeamIds": {
+            "description": "IDs of all teams with access to this engagement.",
+            "type": ["null", "array"],
+            "items": { "type": ["null", "integer"] }
+          },
+          "activityType": {
+            "description": "Type of activity associated with the engagement.",
+            "type": ["null", "string"]
+          },
+          "gdprDeleted": {
+            "description": "Indicates if the engagement is deleted due to GDPR compliance.",
+            "type": ["null", "boolean"]
+          },
+          "source": {
+            "description": "Source of the engagement data.",
+            "type": ["null", "string"]
+          },
+          "sourceId": {
+            "description": "ID of the source associated with the engagement.",
+            "type": ["null", "string"]
+          },
+          "associations": {
+            "description": "Associations related to the engagement.",
+            "type": ["null", "object"],
+            "properties": {
+              "contactIds": {
+                "description": "IDs of associated contacts.",
+                "type": ["null", "array"],
+                "items": { "type": ["null", "integer"] }
+              },
+              "companyIds": {
+                "description": "IDs of associated companies.",
+                "type": ["null", "array"],
+                "items": { "type": ["null", "integer"] }
+              },
+              "dealIds": {
+                "description": "IDs of associated deals.",
+                "type": ["null", "array"],
+                "items": { "type": ["null", "integer"] }
+              },
+              "ownerIds": {
+                "description": "IDs of owners associated with the engagement.",
+                "type": ["null", "array"],
+                "items": { "type": ["null", "integer"] }
+              },
+              "workflowIds": {
+                "description": "IDs of associated workflow.",
+                "type": ["null", "array"],
+                "items": { "type": ["null", "integer"] }
+              },
+              "ticketIds": {
+                "description": "IDs of associated tickets.",
+                "type": ["null", "array"],
+                "items": { "type": ["null", "integer"] }
+              },
+              "contentIds": {
+                "description": "IDs of associated content.",
+                "type": ["null", "array"],
+                "items": { "type": ["null", "integer"] }
+              },
+              "quoteIds": {
+                "description": "IDs of associated quotes.",
+                "type": ["null", "array"],
+                "items": { "type": ["null", "integer"] }
+              },
+              "marketingEventIds": {
+                "description": "IDs of associated marketing events.",
+                "type": ["null", "array"],
+                "items": { "type": ["null", "integer"] }
+              }
+            }
+          },
+          "associations_contactIds": {
+            "description": "List of contact IDs associated with the engagement",
+            "type": ["null", "array"],
+            "items": { "type": ["null", "integer"] }
+          },
+          "associations_contentIds": {
+            "description": "List of content IDs associated with the engagement",
+            "type": ["null", "array"],
+            "items": { "type": ["null", "integer"] }
+          },
+          "associations_companyIds": {
+            "description": "List of company IDs associated with the engagement",
+            "type": ["null", "array"],
+            "items": { "type": ["null", "integer"] }
+          },
+          "associations_dealIds": {
+            "description": "List of deal IDs associated with the engagement",
+            "type": ["null", "array"],
+            "items": { "type": ["null", "integer"] }
+          },
+          "associations_marketingEventIds": {
+            "description": "List of marketing event IDs associated with the engagement",
+            "type": ["null", "array"],
+            "items": { "type": ["null", "integer"] }
+          },
+          "associations_ownerIds": {
+            "description": "List of owner IDs associated with the engagement",
+            "type": ["null", "array"],
+            "items": { "type": ["null", "integer"] }
+          },
+          "associations_quoteIds": {
+            "description": "List of quote IDs associated with the engagement",
+            "type": ["null", "array"],
+            "items": { "type": ["null", "integer"] }
+          },
+          "associations_workflowIds": {
+            "description": "List of workflow IDs associated with the engagement",
+            "type": ["null", "array"],
+            "items": { "type": ["null", "integer"] }
+          },
+          "associations_ticketIds": {
+            "description": "List of ticket IDs associated with the engagement",
+            "type": ["null", "array"],
+            "items": { "type": ["null", "integer"] }
+          },
+          "attachments": {
+            "description": "Attachments included in the engagement.",
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "id": {
+                  "description": "ID of the attachment.",
+                  "type": ["null", "integer"]
+                }
+              }
+            }
+          },
+          "metadata": {
+            "description": "Metadata related to the engagement.",
+            "type": ["null", "object"],
+            "properties": {
+              "body": { "type": ["null", "string"] },
+              "meetingOutcome": { "type": ["null", "string"] },
+              "calendarEventHash": { "type": ["null", "string"] },
+              "createdFromLinkId": { "type": ["null", "integer"] },
+              "meetingChangeId": { "type": ["null", "string"] },
+              "locationType": { "type": ["null", "string"] },
+              "location": { "type": ["null", "string"] },
+              "internalMeetingNotes": { "type": ["null", "string"] },
+              "includeDescriptionInReminder": { "type": ["null", "boolean"] },
+              "iCalUid": { "type": ["null", "string"] },
+              "preMeetingProspectReminders": {
+                "description": "Reminders for pre-meeting prospects.",
+                "type": ["null", "array"],
+                "items": {}
+              },
+              "attendeeOwnerIds": {
+                "description": "IDs of attendees' owners.",
+                "type": ["null", "array"],
+                "items": {}
+              },
+              "guestEmails": {
+                "description": "Emails of guest attendees.",
+                "type": ["null", "array"],
+                "items": {}
+              },
+              "ownerIdsBcc": {
+                "description": "IDs of BCC owners.",
+                "type": ["null", "array"],
+                "items": {}
+              },
+              "ownerIdsCc": {
+                "description": "IDs of CC owners.",
+                "type": ["null", "array"],
+                "items": {}
+              },
+              "ownerIdsFrom": {
+                "description": "IDs of 'from' owners.",
+                "type": ["null", "array"],
+                "items": {}
+              },
+              "ownerIdsTo": {
+                "description": "IDs of 'to' owners.",
+                "type": ["null", "array"],
+                "items": {}
+              },
+              "pendingInlineImageIds": {
+                "description": "IDs of pending inline image attachments.",
+                "type": ["null", "array"],
+                "items": {}
+              },
+              "validationSkipped": {
+                "description": "Validation details skipped.",
+                "type": ["null", "array"],
+                "items": {}
+              },
+              "from": {
+                "description": "Sender information.",
+                "type": ["null", "object"],
+                "properties": {
+                  "email": { "type": ["null", "string"] },
+                  "firstName": { "type": ["null", "string"] },
+                  "lastName": { "type": ["null", "string"] },
+                  "raw": { "type": ["null", "string"] }
+                }
+              },
+              "sender": {
+                "description": "Sender's email information.",
+                "type": ["null", "object"],
+                "properties": {
+                  "email": {
+                    "description": "Email of the sender.",
+                    "type": ["null", "string"]
+                  }
+                }
+              },
+              "to": {
+                "description": "Recipient information.",
+                "type": ["null", "array"],
+                "items": {
+                  "type": ["null", "object"],
+                  "properties": {
+                    "email": { "type": ["null", "string"] },
+                    "firstName": { "type": ["null", "string"] },
+                    "lastName": { "type": ["null", "string"] },
+                    "raw": { "type": ["null", "string"] }
+                  }
+                }
+              },
+              "cc": {
+                "description": "CC recipients of the engagement.",
+                "type": ["null", "array"],
+                "items": {
+                  "type": ["null", "object"],
+                  "properties": {
+                    "email": {
+                      "description": "Email of the CC recipient.",
+                      "type": ["null", "string"]
+                    },
+                    "firstName": {
+                      "description": "First name of the CC recipient.",
+                      "type": ["null", "string"]
+                    },
+                    "lastName": {
+                      "description": "Last name of the CC recipient.",
+                      "type": ["null", "string"]
+                    },
+                    "raw": {
+                      "description": "Raw data of the CC recipient.",
+                      "type": ["null", "string"]
+                    }
+                  }
+                }
+              },
+              "bcc": {
+                "description": "BCC recipients of the engagement.",
+                "type": ["null", "array"],
+                "items": {
+                  "type": ["null", "object"],
+                  "properties": {
+                    "email": {
+                      "description": "Email of the BCC recipient.",
+                      "type": ["null", "string"]
+                    }
+                  }
+                }
+              },
+              "subject": { "type": ["null", "string"] },
+              "html": { "type": ["null", "string"] },
+              "text": { "type": ["null", "string"] },
+              "status": { "type": ["null", "string"] },
+              "forObjectType": { "type": ["null", "string"] },
+              "startTime": { "type": ["null", "integer"] },
+              "endTime": { "type": ["null", "integer"] },
+              "title": { "type": ["null", "string"] },
+              "timezone": { "type": ["null", "string"] },
+              "toNumber": { "type": ["null", "string"] },
+              "fromNumber": { "type": ["null", "string"] },
+              "externalId": { "type": ["null", "string"] },
+              "durationMilliseconds": { "type": ["null", "integer"] },
+              "externalAccountId": { "type": ["null", "string"] },
+              "recordingUrl": { "type": ["null", "string"] },
+              "disposition": { "type": ["null", "string"] },
+              "completionDate": { "type": ["null", "integer"] },
+              "taskType": { "type": ["null", "string"] },
+              "reminders": {
+                "description": "Reminders related to the engagement.",
+                "type": ["null", "array"],
+                "items": { "type": ["null", "integer"] }
+              },
+              "threadId": { "type": ["null", "string"] },
+              "messageId": { "type": ["null", "string"] },
+              "loggedFrom": { "type": ["null", "string"] },
+              "attachedVideoOpened": { "type": ["null", "boolean"] },
+              "bounceErrorDetail": { "type": ["null", "object"] },
+              "emailSendEventId": { "type": ["null", "object"] },
+              "attachedVideoWatched": { "type": ["null", "boolean"] },
+              "trackerKey": { "type": ["null", "string"] },
+              "sendDefaultReminder": { "type": ["null", "boolean"] },
+              "source": { "type": ["null", "string"] },
+              "unknownVisitorConversation": { "type": ["null", "boolean"] },
+              "facsimileSendId": { "type": ["null", "string"] },
+              "sentVia": { "type": ["null", "string"] },
+              "sequenceStepOrder": { "type": ["null", "integer"] },
+              "externalUrl": { "type": ["null", "string"] },
+              "postSendStatus": { "type": ["null", "string"] },
+              "errorMessage": { "type": ["null", "string"] },
+              "recipientDropReasons": { "type": ["null", "string"] },
+              "calleeObjectId": { "type": ["null", "integer"] },
+              "calleeObjectType": { "type": ["null", "string"] },
+              "mediaProcessingStatus": { "type": ["null", "string"] },
+              "sourceId": { "type": ["null", "string"] },
+              "priority": { "type": ["null", "string"] },
+              "isAllDay": { "type": ["null", "boolean"] }
+            }
+          },
+          "metadata_attendeeOwnerIds": {
+            "description": "IDs of attendees' owners in metadata.",
+            "type": ["null", "array"],
+            "items": {}
+          },
+          "metadata_calendarEventHash": {
+            "description": "Hash value for calendar event",
+            "type": ["null", "string"]
+          },
+          "metadata_createdFromLinkId": {
+            "description": "ID from which engagement was created",
+            "type": ["null", "integer"]
+          },
+          "metadata_meetingChangeId": {
+            "description": "ID of the meeting change",
+            "type": ["null", "string"]
+          },
+          "ownerIdsBcc": {
+            "description": "IDs of BCC owners.",
+            "type": ["null", "array"],
+            "items": { "type": ["null", "integer"] }
+          },
+          "ownerIdsFrom": {
+            "description": "IDs of 'from' owners.",
+            "type": ["null", "array"],
+            "items": { "type": ["null", "integer"] }
+          },
+          "ownerIdsTo": {
+            "description": "IDs of 'to' owners.",
+            "type": ["null", "array"],
+            "items": { "type": ["null", "integer"] }
+          },
+          "pendingInlineImageIds": {
+            "description": "IDs of pending inline image attachments.",
+            "type": ["null", "array"],
+            "items": { "type": ["null", "integer"] }
+          },
+          "validationSkipped": {
+            "description": "Validation details skipped.",
+            "type": ["null", "array"],
+            "items": {}
+          },
+          "ownerIdsCc": {
+            "description": "IDs of CC owners.",
+            "type": ["null", "array"],
+            "items": { "type": ["null", "integer"] }
+          },
+          "metadata_guestEmails": {
+            "description": "Guest attendee emails in metadata.",
+            "type": ["null", "array"],
+            "items": {}
+          },
+          "metadata_iCalUid": {
+            "description": "Unique ID for iCal",
+            "type": ["null", "string"]
+          },
+          "metadata_includeDescriptionInReminder": {
+            "description": "Flag indicating if description should be included in reminder",
+            "type": ["null", "boolean"]
+          },
+          "metadata_internalMeetingNotes": {
+            "description": "Internal meeting notes",
+            "type": ["null", "string"]
+          },
+          "metadata_location": {
+            "description": "Location of the engagement",
+            "type": ["null", "string"]
+          },
+          "metadata_locationType": {
+            "description": "Type of location for the engagement",
+            "type": ["null", "string"]
+          },
+          "metadata_meetingOutcome": {
+            "description": "Outcome of the meeting",
+            "type": ["null", "string"]
+          },
+          "metadata_timezone": {
+            "description": "Timezone of the engagement",
+            "type": ["null", "string"]
+          },
+          "metadata_preMeetingProspectReminders": {
+            "description": "Pre-meeting prospect reminders in metadata.",
+            "type": ["null", "array"],
+            "items": {}
+          },
+          "metadata_body": {
+            "description": "Engagement body content",
+            "type": ["null", "string"]
+          },
+          "metadata_from": {
+            "description": "Sender information in metadata.",
+            "type": ["null", "object"],
+            "properties": {
+              "email": { "type": ["null", "string"] },
+              "firstName": { "type": ["null", "string"] },
+              "lastName": { "type": ["null", "string"] },
+              "raw": { "type": ["null", "string"] }
+            }
+          },
+          "metadata_sender": {
+            "description": "Sender's email information in metadata.",
+            "type": ["null", "object"],
+            "properties": {
+              "email": {
+                "description": "Email of the sender in metadata.",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "metadata_to": {
+            "description": "Recipient information in metadata.",
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "email": { "type": ["null", "string"] },
+                "firstName": { "type": ["null", "string"] },
+                "lastName": { "type": ["null", "string"] },
+                "raw": { "type": ["null", "string"] }
+              }
+            }
+          },
+          "metadata_cc": {
+            "description": "CC recipients in metadata.",
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "email": { "type": ["null", "string"] },
+                "firstName": { "type": ["null", "string"] },
+                "lastName": { "type": ["null", "string"] },
+                "raw": { "type": ["null", "string"] }
+              }
+            }
+          },
+          "metadata_bounceErrorDetail": {
+            "description": "Details of bounce errors, if any",
+            "type": ["null", "object"]
+          },
+          "metadata_emailSendEventId": {
+            "description": "ID of the email send event",
+            "type": ["null", "object"]
+          },
+          "metadata_ownerIdsBcc": {
+            "description": "IDs of BCC owners in metadata.",
+            "type": ["null", "array"],
+            "items": {}
+          },
+          "metadata_ownerIdsCc": {
+            "description": "IDs of CC owners in metadata.",
+            "type": ["null", "array"],
+            "items": {}
+          },
+          "metadata_ownerIdsFrom": {
+            "description": "IDs of 'from' owners in metadata.",
+            "type": ["null", "array"],
+            "items": {}
+          },
+          "metadata_ownerIdsTo": {
+            "description": "IDs of 'to' owners in metadata.",
+            "type": ["null", "array"],
+            "items": {}
+          },
+          "metadata_pendingInlineImageIds": {
+            "description": "IDs of pending inline image attachments in metadata.",
+            "type": ["null", "array"],
+            "items": {}
+          },
+          "metadata_validationSkipped": {
+            "description": "Validation details skipped in metadata.",
+            "type": ["null", "array"],
+            "items": {}
+          },
+          "metadata_bcc": {
+            "description": "BCC recipients in metadata.",
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "email": {
+                  "description": "Email of the BCC recipient in metadata.",
+                  "type": ["null", "string"]
+                }
+              }
+            }
+          },
+          "metadata_subject": {
+            "description": "Subject of the engagement",
+            "type": ["null", "string"]
+          },
+          "metadata_html": {
+            "description": "HTML content of the engagement",
+            "type": ["null", "string"]
+          },
+          "metadata_text": {
+            "description": "Text content of the engagement",
+            "type": ["null", "string"]
+          },
+          "metadata_status": {
+            "description": "Status of the engagement",
+            "type": ["null", "string"]
+          },
+          "metadata_forObjectType": {
+            "description": "Type of object for which engagement is associated",
+            "type": ["null", "string"]
+          },
+          "metadata_startTime": {
+            "description": "Start time of the engagement",
+            "type": ["null", "integer"]
+          },
+          "metadata_endTime": {
+            "description": "End time of the engagement",
+            "type": ["null", "integer"]
+          },
+          "metadata_title": {
+            "description": "Title of the engagement",
+            "type": ["null", "string"]
+          },
+          "metadata_toNumber": {
+            "description": "Number to which engagement was sent",
+            "type": ["null", "string"]
+          },
+          "metadata_fromNumber": {
+            "description": "Number from which engagement was sent",
+            "type": ["null", "string"]
+          },
+          "metadata_externalId": {
+            "description": "External ID of the engagement",
+            "type": ["null", "string"]
+          },
+          "metadata_durationMilliseconds": {
+            "description": "Duration of the engagement in milliseconds",
+            "type": ["null", "integer"]
+          },
+          "metadata_externalAccountId": {
+            "description": "External account ID associated with the engagement",
+            "type": ["null", "string"]
+          },
+          "metadata_recordingUrl": {
+            "description": "URL of the recording related to the engagement",
+            "type": ["null", "string"]
+          },
+          "metadata_disposition": {
+            "description": "Engagement disposition",
+            "type": ["null", "string"]
+          },
+          "metadata_completionDate": {
+            "description": "Date when engagement was completed",
+            "type": ["null", "integer"]
+          },
+          "metadata_taskType": {
+            "description": "Type of engagement task",
+            "type": ["null", "string"]
+          },
+          "metadata_reminders": {
+            "description": "Reminders in metadata.",
+            "type": ["null", "array"],
+            "items": { "type": ["null", "integer"] }
+          },
+          "metadata_threadId": {
+            "description": "ID of the thread",
+            "type": ["null", "string"]
+          },
+          "metadata_messageId": {
+            "description": "ID of the message",
+            "type": ["null", "string"]
+          },
+          "metadata_loggedFrom": {
+            "description": "Source from which the engagement was logged",
+            "type": ["null", "string"]
+          },
+          "metadata_attachedVideoOpened": {
+            "description": "Flag indicating if attached videos were opened",
+            "type": ["null", "boolean"]
+          },
+          "metadata_attachedVideoWatched": {
+            "description": "Flag indicating if attached videos were watched",
+            "type": ["null", "boolean"]
+          },
+          "metadata_trackerKey": {
+            "description": "Key for tracking engagement",
+            "type": ["null", "string"]
+          },
+          "metadata_sendDefaultReminder": {
+            "description": "Default reminder settings for the engagement",
+            "type": ["null", "boolean"]
+          },
+          "metadata_source": {
+            "description": "Source of the engagement",
+            "type": ["null", "string"]
+          },
+          "metadata_unknownVisitorConversation": {
+            "description": "Conversation with unknown visitor",
+            "type": ["null", "boolean"]
+          },
+          "metadata_facsimileSendId": {
+            "description": "ID of the facsimile send",
+            "type": ["null", "string"]
+          },
+          "metadata_sentVia": {
+            "description": "Medium through which engagement was sent",
+            "type": ["null", "string"]
+          },
+          "metadata_sequenceStepOrder": {
+            "description": "Order of sequence step",
+            "type": ["null", "integer"]
+          },
+          "metadata_externalUrl": {
+            "description": "External URL related to the engagement",
+            "type": ["null", "string"]
+          },
+          "metadata_postSendStatus": {
+            "description": "Status of post send operation",
+            "type": ["null", "string"]
+          },
+          "metadata_errorMessage": {
+            "description": "Error message associated with the engagement",
+            "type": ["null", "string"]
+          },
+          "metadata_recipientDropReasons": {
+            "description": "Reasons for recipient drop",
+            "type": ["null", "string"]
+          },
+          "metadata_calleeObjectId": {
+            "description": "ID of the callee object",
+            "type": ["null", "integer"]
+          },
+          "metadata_calleeObjectType": {
+            "description": "Type of the callee object",
+            "type": ["null", "string"]
+          },
+          "metadata_mediaProcessingStatus": {
+            "description": "Status of media processing for the engagement",
+            "type": ["null", "string"]
+          },
+          "metadata_sourceId": {
+            "description": "Source ID of the engagement",
+            "type": ["null", "string"]
+          },
+          "metadata_priority": {
+            "description": "Priority of the engagement",
+            "type": ["null", "string"]
+          },
+          "metadata_isAllDay": {
+            "description": "Flag indicating if engagement is for the whole day",
+            "type": ["null", "boolean"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["lastUpdated"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "engagements_calls",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": ["null", "object"],
+        "properties": {
+          "id": {
+            "description": "Unique identifier for the call engagement.",
+            "type": ["null", "string"]
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "hs_activity_type": { "type": ["null", "string"] },
+              "hs_all_accessible_team_ids": { "type": ["null", "string"] },
+              "hs_all_assigned_business_unit_ids": {
+                "type": ["null", "string"]
+              },
+              "hs_all_owner_ids": { "type": ["null", "string"] },
+              "hs_all_team_ids": { "type": ["null", "string"] },
+              "hs_at_mentioned_owner_ids": { "type": ["null", "string"] },
+              "hs_attachment_ids": { "type": ["null", "string"] },
+              "hs_body_preview": { "type": ["null", "string"] },
+              "hs_body_preview_html": { "type": ["null", "string"] },
+              "hs_body_preview_is_truncated": { "type": ["null", "boolean"] },
+              "hs_call_app_id": { "type": ["null", "number"] },
+              "hs_call_authed_url_provider": { "type": ["null", "string"] },
+              "hs_call_body": { "type": ["null", "string"] },
+              "hs_call_callee_object_id": { "type": ["null", "number"] },
+              "hs_call_callee_object_type": { "type": ["null", "string"] },
+              "hs_call_deal_stage_during_call": { "type": ["null", "string"] },
+              "hs_call_direction": { "type": ["null", "string"] },
+              "hs_call_disposition": { "type": ["null", "string"] },
+              "hs_call_duration": { "type": ["null", "number"] },
+              "hs_call_external_account_id": { "type": ["null", "string"] },
+              "hs_call_external_id": { "type": ["null", "string"] },
+              "hs_call_from_number": { "type": ["null", "string"] },
+              "hs_call_from_number_nickname": { "type": ["null", "string"] },
+              "hs_call_has_transcript": { "type": ["null", "boolean"] },
+              "hs_call_has_voicemail": { "type": ["null", "string"] },
+              "hs_call_ms_teams_payload": { "type": ["null", "string"] },
+              "hs_call_primary_deal": { "type": ["null", "string"] },
+              "hs_call_recording_url": { "type": ["null", "string"] },
+              "hs_call_source": { "type": ["null", "string"] },
+              "hs_call_status": { "type": ["null", "string"] },
+              "hs_call_summary": { "type": ["null", "string"] },
+              "hs_call_summary_execution_id": { "type": ["null", "string"] },
+              "hs_call_title": { "type": ["null", "string"] },
+              "hs_call_to_number": { "type": ["null", "string"] },
+              "hs_call_to_number_nickname": { "type": ["null", "string"] },
+              "hs_call_transcript_audio_num_channels": {
+                "type": ["null", "number"]
+              },
+              "hs_call_transcript_tracked_terms": {
+                "type": ["null", "string"]
+              },
+              "hs_call_transcription_id": { "type": ["null", "number"] },
+              "hs_call_video_meeting_type": { "type": ["null", "string"] },
+              "hs_call_video_recording_url": { "type": ["null", "string"] },
+              "hs_call_zoom_meeting_uuid": { "type": ["null", "string"] },
+              "hs_calls_service_call_id": { "type": ["null", "number"] },
+              "hs_connected_count": { "type": ["null", "number"] },
+              "hs_created_by": { "type": ["null", "number"] },
+              "hs_created_by_user_id": { "type": ["null", "number"] },
+              "hs_createdate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_engagement_source": { "type": ["null", "string"] },
+              "hs_engagement_source_id": { "type": ["null", "string"] },
+              "hs_follow_up_action": { "type": ["null", "string"] },
+              "hs_gdpr_deleted": { "type": ["null", "boolean"] },
+              "hs_lastmodifieddate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_merged_object_ids": { "type": ["null", "string"] },
+              "hs_modified_by": { "type": ["null", "number"] },
+              "hs_object_id": { "type": ["null", "number"] },
+              "hs_object_source": { "type": ["null", "string"] },
+              "hs_object_source_detail_1": { "type": ["null", "string"] },
+              "hs_object_source_detail_2": { "type": ["null", "string"] },
+              "hs_object_source_detail_3": { "type": ["null", "string"] },
+              "hs_object_source_id": { "type": ["null", "string"] },
+              "hs_object_source_label": { "type": ["null", "string"] },
+              "hs_object_source_user_id": { "type": ["null", "number"] },
+              "hs_product_name": { "type": ["null", "string"] },
+              "hs_queue_membership_ids": { "type": ["null", "string"] },
+              "hs_read_only": { "type": ["null", "boolean"] },
+              "hs_shared_team_ids": { "type": ["null", "string"] },
+              "hs_shared_user_ids": { "type": ["null", "string"] },
+              "hs_timestamp": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_unique_creation_key": { "type": ["null", "string"] },
+              "hs_unique_id": { "type": ["null", "string"] },
+              "hs_unknown_visitor_conversation": {
+                "type": ["null", "boolean"]
+              },
+              "hs_updated_by_user_id": { "type": ["null", "number"] },
+              "hs_user_ids_of_all_notification_followers": {
+                "type": ["null", "string"]
+              },
+              "hs_user_ids_of_all_notification_unfollowers": {
+                "type": ["null", "string"]
+              },
+              "hs_user_ids_of_all_owners": { "type": ["null", "string"] },
+              "hs_voicemail_count": { "type": ["null", "number"] },
+              "hs_was_imported": { "type": ["null", "boolean"] },
+              "hubspot_owner_assigneddate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hubspot_owner_id": { "type": ["null", "string"] },
+              "hubspot_team_id": { "type": ["null", "string"] }
+            }
+          },
+          "properties_hs_activity_type": { "type": ["null", "string"] },
+          "properties_hs_all_assigned_business_unit_ids": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_at_mentioned_owner_ids": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_attachment_ids": { "type": ["null", "string"] },
+          "properties_hs_body_preview": { "type": ["null", "string"] },
+          "properties_hs_body_preview_html": { "type": ["null", "string"] },
+          "properties_hs_body_preview_is_truncated": {
+            "type": ["null", "boolean"]
+          },
+          "properties_hs_call_app_id": { "type": ["null", "number"] },
+          "properties_hs_call_authed_url_provider": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_call_body": { "type": ["null", "string"] },
+          "properties_hs_call_callee_object_id": { "type": ["null", "number"] },
+          "properties_hs_call_callee_object_type": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_call_disposition": { "type": ["null", "string"] },
+          "properties_hs_call_duration": { "type": ["null", "number"] },
+          "properties_hs_call_external_account_id": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_call_external_id": { "type": ["null", "string"] },
+          "properties_hs_call_from_number": { "type": ["null", "string"] },
+          "properties_hs_call_has_transcript": { "type": ["null", "boolean"] },
+          "properties_hs_call_recording_url": { "type": ["null", "string"] },
+          "properties_hs_call_source": { "type": ["null", "string"] },
+          "properties_hs_call_status": { "type": ["null", "string"] },
+          "properties_hs_call_title": { "type": ["null", "string"] },
+          "properties_hs_call_to_number": { "type": ["null", "string"] },
+          "properties_hs_call_transcription_id": { "type": ["null", "number"] },
+          "properties_hs_call_video_recording_url": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_call_zoom_meeting_uuid": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_calls_service_call_id": { "type": ["null", "number"] },
+          "properties_hs_created_by": { "type": ["null", "number"] },
+          "properties_hs_created_by_user_id": { "type": ["null", "number"] },
+          "properties_hs_createdate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_engagement_source": { "type": ["null", "string"] },
+          "properties_hs_engagement_source_id": { "type": ["null", "string"] },
+          "properties_hs_follow_up_action": { "type": ["null", "string"] },
+          "properties_hs_gdpr_deleted": { "type": ["null", "boolean"] },
+          "properties_hs_lastmodifieddate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_merged_object_ids": { "type": ["null", "string"] },
+          "properties_hs_modified_by": { "type": ["null", "number"] },
+          "properties_hs_object_id": { "type": ["null", "number"] },
+          "properties_hs_product_name": { "type": ["null", "string"] },
+          "properties_hs_queue_membership_ids": { "type": ["null", "string"] },
+          "properties_hs_timestamp": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_unique_creation_key": { "type": ["null", "string"] },
+          "properties_hs_unique_id": { "type": ["null", "string"] },
+          "properties_hs_unknown_visitor_conversation": {
+            "type": ["null", "boolean"]
+          },
+          "properties_hs_updated_by_user_id": { "type": ["null", "number"] },
+          "properties_hs_user_ids_of_all_notification_followers": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_user_ids_of_all_notification_unfollowers": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_user_ids_of_all_owners": {
+            "type": ["null", "string"]
+          },
+          "properties_hubspot_owner_assigneddate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hubspot_owner_id": { "type": ["null", "string"] },
+          "properties_hubspot_team_id": { "type": ["null", "string"] },
+          "properties_hs_all_owner_ids": { "type": ["null", "string"] },
+          "properties_hs_all_team_ids": { "type": ["null", "string"] },
+          "properties_hs_all_accessible_team_ids": {
+            "type": ["null", "string"]
+          },
+          "createdAt": {
+            "description": "Date and time when the call engagement was created.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "description": "Date and time when the call engagement was last updated.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "archived": {
+            "description": "Indicates if the call engagement is archived or not.",
+            "type": ["null", "boolean"]
+          },
+          "contacts": {
+            "description": "Contacts associated with the call engagement.",
+            "type": ["null", "array"],
+            "items": { "type": ["null", "string"] }
+          },
+          "deals": {
+            "description": "Deals associated with the call engagement.",
+            "type": ["null", "array"],
+            "items": { "type": ["null", "string"] }
+          },
+          "companies": {
+            "description": "Companies associated with the call engagement.",
+            "type": ["null", "array"],
+            "items": { "type": ["null", "string"] }
+          },
+          "tickets": {
+            "description": "Tickets associated with the call engagement.",
+            "type": ["null", "array"],
+            "items": { "type": ["null", "string"] }
+          },
+          "properties_hs_call_deal_stage_during_call": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_call_direction": { "type": ["null", "string"] },
+          "properties_hs_call_from_number_nickname": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_call_has_voicemail": { "type": ["null", "string"] },
+          "properties_hs_call_ms_teams_payload": { "type": ["null", "string"] },
+          "properties_hs_call_primary_deal": { "type": ["null", "string"] },
+          "properties_hs_call_summary": { "type": ["null", "string"] },
+          "properties_hs_call_summary_execution_id": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_call_to_number_nickname": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_call_transcript_audio_num_channels": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_call_transcript_tracked_terms": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_call_video_meeting_type": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_connected_count": { "type": ["null", "number"] },
+          "properties_hs_object_source": { "type": ["null", "string"] },
+          "properties_hs_object_source_detail_1": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_object_source_detail_2": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_object_source_detail_3": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_object_source_id": { "type": ["null", "string"] },
+          "properties_hs_object_source_label": { "type": ["null", "string"] },
+          "properties_hs_object_source_user_id": { "type": ["null", "number"] },
+          "properties_hs_read_only": { "type": ["null", "boolean"] },
+          "properties_hs_shared_team_ids": { "type": ["null", "string"] },
+          "properties_hs_shared_user_ids": { "type": ["null", "string"] },
+          "properties_hs_voicemail_count": { "type": ["null", "number"] },
+          "properties_hs_was_imported": { "type": ["null", "boolean"] }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updatedAt"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "engagements_emails",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": ["null", "object"],
+        "properties": {
+          "id": {
+            "description": "Unique identifier for the engagement email",
+            "type": ["null", "string"]
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "hs_all_accessible_team_ids": { "type": ["null", "string"] },
+              "hs_all_assigned_business_unit_ids": {
+                "type": ["null", "string"]
+              },
+              "hs_all_owner_ids": { "type": ["null", "string"] },
+              "hs_all_team_ids": { "type": ["null", "string"] },
+              "hs_at_mentioned_owner_ids": { "type": ["null", "string"] },
+              "hs_attachment_ids": { "type": ["null", "string"] },
+              "hs_body_preview": { "type": ["null", "string"] },
+              "hs_body_preview_html": { "type": ["null", "string"] },
+              "hs_body_preview_is_truncated": { "type": ["null", "boolean"] },
+              "hs_created_by": { "type": ["null", "string"] },
+              "hs_created_by_user_id": { "type": ["null", "number"] },
+              "hs_createdate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_direction_and_unique_id": { "type": ["null", "string"] },
+              "hs_email_attached_video_id": { "type": ["null", "string"] },
+              "hs_email_attached_video_name": { "type": ["null", "string"] },
+              "hs_email_attached_video_opened": { "type": ["null", "boolean"] },
+              "hs_email_attached_video_watched": {
+                "type": ["null", "boolean"]
+              },
+              "hs_email_bcc_email": { "type": ["null", "string"] },
+              "hs_email_bcc_firstname": { "type": ["null", "string"] },
+              "hs_email_bcc_lastname": { "type": ["null", "string"] },
+              "hs_email_bcc_raw": { "type": ["null", "string"] },
+              "hs_email_bounce_error_detail_message": {
+                "type": ["null", "string"]
+              },
+              "hs_email_bounce_error_detail_status_code": {
+                "type": ["null", "number"]
+              },
+              "hs_email_cc_email": { "type": ["null", "string"] },
+              "hs_email_cc_firstname": { "type": ["null", "string"] },
+              "hs_email_cc_lastname": { "type": ["null", "string"] },
+              "hs_email_cc_raw": { "type": ["null", "string"] },
+              "hs_email_click_count": { "type": ["null", "number"] },
+              "hs_email_direction": { "type": ["null", "string"] },
+              "hs_email_encoded_email_associations_request": {
+                "type": ["null", "string"]
+              },
+              "hs_email_error_message": { "type": ["null", "string"] },
+              "hs_email_facsimile_send_id": { "type": ["null", "string"] },
+              "hs_email_from_email": { "type": ["null", "string"] },
+              "hs_email_from_firstname": { "type": ["null", "string"] },
+              "hs_email_from_lastname": { "type": ["null", "string"] },
+              "hs_email_from_raw": { "type": ["null", "string"] },
+              "hs_email_has_inline_images_stripped": {
+                "type": ["null", "boolean"]
+              },
+              "hs_email_headers": { "type": ["null", "string"] },
+              "hs_email_html": { "type": ["null", "string"] },
+              "hs_email_logged_from": { "type": ["null", "string"] },
+              "hs_email_media_processing_status": {
+                "type": ["null", "string"]
+              },
+              "hs_email_member_of_forwarded_subthread": {
+                "type": ["null", "boolean"]
+              },
+              "hs_email_message_id": { "type": ["null", "string"] },
+              "hs_email_migrated_via_portal_data_migration": {
+                "type": ["null", "string"]
+              },
+              "hs_email_ms_teams_payload": { "type": ["null", "string"] },
+              "hs_email_open_count": { "type": ["null", "number"] },
+              "hs_email_pending_inline_image_ids": {
+                "type": ["null", "string"]
+              },
+              "hs_email_post_send_status": { "type": ["null", "string"] },
+              "hs_email_recipient_drop_reasons": { "type": ["null", "string"] },
+              "hs_email_reply_count": { "type": ["null", "number"] },
+              "hs_email_send_event_id": { "type": ["null", "string"] },
+              "hs_email_send_event_id_created": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_email_sender_email": { "type": ["null", "string"] },
+              "hs_email_sender_firstname": { "type": ["null", "string"] },
+              "hs_email_sender_lastname": { "type": ["null", "string"] },
+              "hs_email_sender_raw": { "type": ["null", "string"] },
+              "hs_email_sent_count": { "type": ["null", "number"] },
+              "hs_email_sent_via": { "type": ["null", "string"] },
+              "hs_email_status": { "type": ["null", "string"] },
+              "hs_email_stripped_attachment_count": {
+                "type": ["null", "number"]
+              },
+              "hs_email_subject": { "type": ["null", "string"] },
+              "hs_email_text": { "type": ["null", "string"] },
+              "hs_email_thread_id": { "type": ["null", "string"] },
+              "hs_email_thread_summary": { "type": ["null", "string"] },
+              "hs_email_to_email": { "type": ["null", "string"] },
+              "hs_email_to_firstname": { "type": ["null", "string"] },
+              "hs_email_to_lastname": { "type": ["null", "string"] },
+              "hs_email_to_raw": { "type": ["null", "string"] },
+              "hs_email_tracker_key": { "type": ["null", "string"] },
+              "hs_email_validation_skipped": { "type": ["null", "string"] },
+              "hs_engagement_source": { "type": ["null", "string"] },
+              "hs_engagement_source_id": { "type": ["null", "string"] },
+              "hs_follow_up_action": { "type": ["null", "string"] },
+              "hs_gdpr_deleted": { "type": ["null", "boolean"] },
+              "hs_lastmodifieddate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_merged_object_ids": { "type": ["null", "string"] },
+              "hs_modified_by": { "type": ["null", "string"] },
+              "hs_object_id": { "type": ["null", "number"] },
+              "hs_object_source": { "type": ["null", "string"] },
+              "hs_object_source_detail_1": { "type": ["null", "string"] },
+              "hs_object_source_detail_2": { "type": ["null", "string"] },
+              "hs_object_source_detail_3": { "type": ["null", "string"] },
+              "hs_object_source_id": { "type": ["null", "string"] },
+              "hs_object_source_label": { "type": ["null", "string"] },
+              "hs_object_source_user_id": { "type": ["null", "number"] },
+              "hs_owner_ids_bcc": { "type": ["null", "string"] },
+              "hs_owner_ids_cc": { "type": ["null", "string"] },
+              "hs_owner_ids_from": { "type": ["null", "string"] },
+              "hs_owner_ids_to": { "type": ["null", "string"] },
+              "hs_product_name": { "type": ["null", "string"] },
+              "hs_queue_membership_ids": { "type": ["null", "string"] },
+              "hs_read_only": { "type": ["null", "boolean"] },
+              "hs_scs_association_status": { "type": ["null", "string"] },
+              "hs_scs_audit_id": { "type": ["null", "string"] },
+              "hs_shared_team_ids": { "type": ["null", "string"] },
+              "hs_shared_user_ids": { "type": ["null", "string"] },
+              "hs_timestamp": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_unique_creation_key": { "type": ["null", "string"] },
+              "hs_unique_id": { "type": ["null", "string"] },
+              "hs_updated_by_user_id": { "type": ["null", "number"] },
+              "hs_user_ids_of_all_notification_followers": {
+                "type": ["null", "string"]
+              },
+              "hs_user_ids_of_all_notification_unfollowers": {
+                "type": ["null", "string"]
+              },
+              "hs_user_ids_of_all_owners": { "type": ["null", "string"] },
+              "hs_was_imported": { "type": ["null", "boolean"] },
+              "hubspot_owner_assigneddate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hubspot_owner_id": { "type": ["null", "string"] },
+              "hubspot_team_id": { "type": ["null", "string"] }
+            }
+          },
+          "properties_hs_all_assigned_business_unit_ids": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_at_mentioned_owner_ids": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_attachment_ids": { "type": ["null", "string"] },
+          "properties_hs_body_preview": { "type": ["null", "string"] },
+          "properties_hs_body_preview_html": { "type": ["null", "string"] },
+          "properties_hs_body_preview_is_truncated": {
+            "type": ["null", "boolean"]
+          },
+          "properties_hs_created_by": { "type": ["null", "string"] },
+          "properties_hs_created_by_user_id": { "type": ["null", "number"] },
+          "properties_hs_createdate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_direction_and_unique_id": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_email_attached_video_id": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_email_attached_video_name": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_email_attached_video_opened": {
+            "type": ["null", "boolean"]
+          },
+          "properties_hs_email_attached_video_watched": {
+            "type": ["null", "boolean"]
+          },
+          "properties_hs_email_bcc_email": { "type": ["null", "string"] },
+          "properties_hs_email_bcc_firstname": { "type": ["null", "string"] },
+          "properties_hs_email_bcc_lastname": { "type": ["null", "string"] },
+          "properties_hs_email_bcc_raw": { "type": ["null", "string"] },
+          "properties_hs_email_cc_email": { "type": ["null", "string"] },
+          "properties_hs_email_cc_firstname": { "type": ["null", "string"] },
+          "properties_hs_email_cc_lastname": { "type": ["null", "string"] },
+          "properties_hs_email_cc_raw": { "type": ["null", "string"] },
+          "properties_hs_email_direction": { "type": ["null", "string"] },
+          "properties_hs_email_encoded_email_associations_request": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_email_error_message": { "type": ["null", "string"] },
+          "properties_hs_email_facsimile_send_id": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_email_from_email": { "type": ["null", "string"] },
+          "properties_hs_email_from_firstname": { "type": ["null", "string"] },
+          "properties_hs_email_from_lastname": { "type": ["null", "string"] },
+          "properties_hs_email_from_raw": { "type": ["null", "string"] },
+          "properties_hs_email_headers": { "type": ["null", "string"] },
+          "properties_hs_email_html": { "type": ["null", "string"] },
+          "properties_hs_email_logged_from": { "type": ["null", "string"] },
+          "properties_hs_email_media_processing_status": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_email_member_of_forwarded_subthread": {
+            "type": ["null", "boolean"]
+          },
+          "properties_hs_email_message_id": { "type": ["null", "string"] },
+          "properties_hs_email_migrated_via_portal_data_migration": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_email_pending_inline_image_ids": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_email_post_send_status": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_email_recipient_drop_reasons": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_email_send_event_id": { "type": ["null", "string"] },
+          "properties_hs_email_send_event_id_created": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_email_sender_email": { "type": ["null", "string"] },
+          "properties_hs_email_sender_firstname": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_email_sender_lastname": { "type": ["null", "string"] },
+          "properties_hs_email_sender_raw": { "type": ["null", "string"] },
+          "properties_hs_email_sent_via": { "type": ["null", "string"] },
+          "properties_hs_email_status": { "type": ["null", "string"] },
+          "properties_hs_email_subject": { "type": ["null", "string"] },
+          "properties_hs_email_text": { "type": ["null", "string"] },
+          "properties_hs_email_thread_id": { "type": ["null", "string"] },
+          "properties_hs_email_to_email": { "type": ["null", "string"] },
+          "properties_hs_email_to_firstname": { "type": ["null", "string"] },
+          "properties_hs_email_to_lastname": { "type": ["null", "string"] },
+          "properties_hs_email_to_raw": { "type": ["null", "string"] },
+          "properties_hs_email_tracker_key": { "type": ["null", "string"] },
+          "properties_hs_email_validation_skipped": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_engagement_source": { "type": ["null", "string"] },
+          "properties_hs_engagement_source_id": { "type": ["null", "string"] },
+          "properties_hs_follow_up_action": { "type": ["null", "string"] },
+          "properties_hs_gdpr_deleted": { "type": ["null", "boolean"] },
+          "properties_hs_lastmodifieddate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_merged_object_ids": { "type": ["null", "string"] },
+          "properties_hs_modified_by": { "type": ["null", "string"] },
+          "properties_hs_object_id": { "type": ["null", "number"] },
+          "properties_hs_product_name": { "type": ["null", "string"] },
+          "properties_hs_queue_membership_ids": { "type": ["null", "string"] },
+          "properties_hs_timestamp": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_unique_creation_key": { "type": ["null", "string"] },
+          "properties_hs_unique_id": { "type": ["null", "string"] },
+          "properties_hs_updated_by_user_id": { "type": ["null", "number"] },
+          "properties_hs_user_ids_of_all_notification_followers": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_user_ids_of_all_notification_unfollowers": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_user_ids_of_all_owners": {
+            "type": ["null", "string"]
+          },
+          "properties_hubspot_owner_assigneddate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hubspot_owner_id": { "type": ["null", "string"] },
+          "properties_hubspot_team_id": { "type": ["null", "string"] },
+          "properties_hs_all_owner_ids": { "type": ["null", "string"] },
+          "properties_hs_all_team_ids": { "type": ["null", "string"] },
+          "properties_hs_all_accessible_team_ids": {
+            "type": ["null", "string"]
+          },
+          "createdAt": {
+            "description": "Date and time when the engagement email was created",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "description": "Date and time when the engagement email was last updated",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "archived": {
+            "description": "Indicates if the engagement email is archived or not",
+            "type": ["null", "boolean"]
+          },
+          "contacts": {
+            "description": "List of contacts associated with the engagement email",
+            "type": ["null", "array"],
+            "items": { "type": ["null", "string"] }
+          },
+          "deals": {
+            "description": "List of deals associated with the engagement email",
+            "type": ["null", "array"],
+            "items": { "type": ["null", "string"] }
+          },
+          "companies": {
+            "description": "List of companies associated with the engagement email",
+            "type": ["null", "array"],
+            "items": { "type": ["null", "string"] }
+          },
+          "tickets": {
+            "description": "List of tickets associated with the engagement email",
+            "type": ["null", "array"],
+            "items": { "type": ["null", "string"] }
+          },
+          "properties_hs_email_bounce_error_detail_message": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_email_bounce_error_detail_status_code": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_email_click_count": { "type": ["null", "number"] },
+          "properties_hs_email_has_inline_images_stripped": {
+            "type": ["null", "boolean"]
+          },
+          "properties_hs_email_ms_teams_payload": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_email_open_count": { "type": ["null", "number"] },
+          "properties_hs_email_reply_count": { "type": ["null", "number"] },
+          "properties_hs_email_sent_count": { "type": ["null", "number"] },
+          "properties_hs_email_stripped_attachment_count": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_email_thread_summary": { "type": ["null", "string"] },
+          "properties_hs_object_source": { "type": ["null", "string"] },
+          "properties_hs_object_source_detail_1": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_object_source_detail_2": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_object_source_detail_3": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_object_source_id": { "type": ["null", "string"] },
+          "properties_hs_object_source_label": { "type": ["null", "string"] },
+          "properties_hs_object_source_user_id": { "type": ["null", "number"] },
+          "properties_hs_owner_ids_bcc": { "type": ["null", "string"] },
+          "properties_hs_owner_ids_cc": { "type": ["null", "string"] },
+          "properties_hs_owner_ids_from": { "type": ["null", "string"] },
+          "properties_hs_owner_ids_to": { "type": ["null", "string"] },
+          "properties_hs_read_only": { "type": ["null", "boolean"] },
+          "properties_hs_scs_association_status": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_scs_audit_id": { "type": ["null", "string"] },
+          "properties_hs_shared_team_ids": { "type": ["null", "string"] },
+          "properties_hs_shared_user_ids": { "type": ["null", "string"] },
+          "properties_hs_was_imported": { "type": ["null", "boolean"] }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updatedAt"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "engagements_meetings",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": ["null", "object"],
+        "properties": {
+          "id": {
+            "description": "Unique identifier for the meeting engagement.",
+            "type": ["null", "string"]
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "hs_activity_type": { "type": ["null", "string"] },
+              "hs_all_accessible_team_ids": { "type": ["null", "string"] },
+              "hs_all_assigned_business_unit_ids": {
+                "type": ["null", "string"]
+              },
+              "hs_all_owner_ids": { "type": ["null", "string"] },
+              "hs_all_team_ids": { "type": ["null", "string"] },
+              "hs_at_mentioned_owner_ids": { "type": ["null", "string"] },
+              "hs_attachment_ids": { "type": ["null", "string"] },
+              "hs_attendee_owner_ids": { "type": ["null", "string"] },
+              "hs_body_preview": { "type": ["null", "string"] },
+              "hs_body_preview_html": { "type": ["null", "string"] },
+              "hs_body_preview_is_truncated": { "type": ["null", "boolean"] },
+              "hs_contact_first_outreach_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_created_by": { "type": ["null", "number"] },
+              "hs_created_by_user_id": { "type": ["null", "number"] },
+              "hs_createdate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_engagement_source": { "type": ["null", "string"] },
+              "hs_engagement_source_id": { "type": ["null", "string"] },
+              "hs_follow_up_action": { "type": ["null", "string"] },
+              "hs_follow_up_tasks_remaining": { "type": ["null", "number"] },
+              "hs_gdpr_deleted": { "type": ["null", "boolean"] },
+              "hs_guest_emails": { "type": ["null", "string"] },
+              "hs_i_cal_uid": { "type": ["null", "string"] },
+              "hs_include_description_in_reminder": {
+                "type": ["null", "boolean"]
+              },
+              "hs_internal_meeting_notes": { "type": ["null", "string"] },
+              "hs_lastmodifieddate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_meeting_body": { "type": ["null", "string"] },
+              "hs_meeting_calendar_event_hash": { "type": ["null", "string"] },
+              "hs_meeting_change_id": { "type": ["null", "string"] },
+              "hs_meeting_created_from_link_id": { "type": ["null", "string"] },
+              "hs_meeting_end_time": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_meeting_external_url": { "type": ["null", "string"] },
+              "hs_meeting_location": { "type": ["null", "string"] },
+              "hs_meeting_location_type": { "type": ["null", "string"] },
+              "hs_meeting_ms_teams_payload": { "type": ["null", "string"] },
+              "hs_meeting_outcome": { "type": ["null", "string"] },
+              "hs_meeting_payments_session_id": { "type": ["null", "string"] },
+              "hs_meeting_pre_meeting_prospect_reminders": {
+                "type": ["null", "string"]
+              },
+              "hs_meeting_source": { "type": ["null", "string"] },
+              "hs_meeting_source_id": { "type": ["null", "string"] },
+              "hs_meeting_start_time": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_meeting_title": { "type": ["null", "string"] },
+              "hs_meeting_web_conference_meeting_id": {
+                "type": ["null", "string"]
+              },
+              "hs_merged_object_ids": { "type": ["null", "string"] },
+              "hs_modified_by": { "type": ["null", "number"] },
+              "hs_object_id": { "type": ["null", "number"] },
+              "hs_object_source": { "type": ["null", "string"] },
+              "hs_object_source_detail_1": { "type": ["null", "string"] },
+              "hs_object_source_detail_2": { "type": ["null", "string"] },
+              "hs_object_source_detail_3": { "type": ["null", "string"] },
+              "hs_object_source_id": { "type": ["null", "string"] },
+              "hs_object_source_label": { "type": ["null", "string"] },
+              "hs_object_source_user_id": { "type": ["null", "number"] },
+              "hs_outcome_canceled_count": { "type": ["null", "number"] },
+              "hs_outcome_completed_count": { "type": ["null", "number"] },
+              "hs_outcome_no_show_count": { "type": ["null", "number"] },
+              "hs_outcome_rescheduled_count": { "type": ["null", "number"] },
+              "hs_outcome_scheduled_count": { "type": ["null", "number"] },
+              "hs_product_name": { "type": ["null", "string"] },
+              "hs_queue_membership_ids": { "type": ["null", "string"] },
+              "hs_read_only": { "type": ["null", "boolean"] },
+              "hs_roster_object_coordinates": { "type": ["null", "string"] },
+              "hs_scheduled_tasks": { "type": ["null", "string"] },
+              "hs_shared_team_ids": { "type": ["null", "string"] },
+              "hs_shared_user_ids": { "type": ["null", "string"] },
+              "hs_time_to_book_meeting_from_first_contact": {
+                "type": ["null", "number"]
+              },
+              "hs_timestamp": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_timezone": { "type": ["null", "string"] },
+              "hs_unique_creation_key": { "type": ["null", "string"] },
+              "hs_unique_id": { "type": ["null", "string"] },
+              "hs_updated_by_user_id": { "type": ["null", "number"] },
+              "hs_user_ids_of_all_notification_followers": {
+                "type": ["null", "string"]
+              },
+              "hs_user_ids_of_all_notification_unfollowers": {
+                "type": ["null", "string"]
+              },
+              "hs_user_ids_of_all_owners": { "type": ["null", "string"] },
+              "hs_video_conference_url": { "type": ["null", "string"] },
+              "hs_was_imported": { "type": ["null", "boolean"] },
+              "hubspot_owner_assigneddate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hubspot_owner_id": { "type": ["null", "string"] },
+              "hubspot_team_id": { "type": ["null", "string"] }
+            }
+          },
+          "properties_hs_activity_type": { "type": ["null", "string"] },
+          "properties_hs_all_assigned_business_unit_ids": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_at_mentioned_owner_ids": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_attachment_ids": { "type": ["null", "string"] },
+          "properties_hs_attendee_owner_ids": { "type": ["null", "string"] },
+          "properties_hs_body_preview": { "type": ["null", "string"] },
+          "properties_hs_body_preview_html": { "type": ["null", "string"] },
+          "properties_hs_body_preview_is_truncated": {
+            "type": ["null", "boolean"]
+          },
+          "properties_hs_created_by": { "type": ["null", "number"] },
+          "properties_hs_created_by_user_id": { "type": ["null", "number"] },
+          "properties_hs_createdate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_engagement_source": { "type": ["null", "string"] },
+          "properties_hs_engagement_source_id": { "type": ["null", "string"] },
+          "properties_hs_follow_up_action": { "type": ["null", "string"] },
+          "properties_hs_gdpr_deleted": { "type": ["null", "boolean"] },
+          "properties_hs_i_cal_uid": { "type": ["null", "string"] },
+          "properties_hs_internal_meeting_notes": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_lastmodifieddate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_meeting_body": { "type": ["null", "string"] },
+          "properties_hs_meeting_calendar_event_hash": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_meeting_change_id": { "type": ["null", "string"] },
+          "properties_hs_meeting_created_from_link_id": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_meeting_end_time": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_meeting_external_url": { "type": ["null", "string"] },
+          "properties_hs_meeting_location": { "type": ["null", "string"] },
+          "properties_hs_meeting_location_type": { "type": ["null", "string"] },
+          "properties_hs_meeting_outcome": { "type": ["null", "string"] },
+          "properties_hs_meeting_pre_meeting_prospect_reminders": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_meeting_source": { "type": ["null", "string"] },
+          "properties_hs_meeting_source_id": { "type": ["null", "string"] },
+          "properties_hs_meeting_start_time": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_meeting_title": { "type": ["null", "string"] },
+          "properties_hs_meeting_web_conference_meeting_id": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_merged_object_ids": { "type": ["null", "string"] },
+          "properties_hs_modified_by": { "type": ["null", "number"] },
+          "properties_hs_object_id": { "type": ["null", "number"] },
+          "properties_hs_product_name": { "type": ["null", "string"] },
+          "properties_hs_queue_membership_ids": { "type": ["null", "string"] },
+          "properties_hs_scheduled_tasks": { "type": ["null", "string"] },
+          "properties_hs_timestamp": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_unique_creation_key": { "type": ["null", "string"] },
+          "properties_hs_unique_id": { "type": ["null", "string"] },
+          "properties_hs_updated_by_user_id": { "type": ["null", "number"] },
+          "properties_hs_user_ids_of_all_notification_followers": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_user_ids_of_all_notification_unfollowers": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_user_ids_of_all_owners": {
+            "type": ["null", "string"]
+          },
+          "properties_hubspot_owner_assigneddate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hubspot_owner_id": { "type": ["null", "string"] },
+          "properties_hubspot_team_id": { "type": ["null", "string"] },
+          "properties_hs_all_owner_ids": { "type": ["null", "string"] },
+          "properties_hs_all_team_ids": { "type": ["null", "string"] },
+          "properties_hs_all_accessible_team_ids": {
+            "type": ["null", "string"]
+          },
+          "createdAt": {
+            "description": "Timestamp indicating when the meeting engagement was created.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "description": "Timestamp indicating when the meeting engagement was last updated.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "archived": {
+            "description": "Indicates whether the meeting engagement is archived or not.",
+            "type": ["null", "boolean"]
+          },
+          "contacts": {
+            "description": "Information about the contacts associated with the meeting engagement.",
+            "type": ["null", "array"],
+            "items": { "type": ["null", "string"] }
+          },
+          "deals": {
+            "description": "Information about the deals associated with the meeting engagement.",
+            "type": ["null", "array"],
+            "items": { "type": ["null", "string"] }
+          },
+          "companies": {
+            "description": "Information about the companies associated with the meeting engagement.",
+            "type": ["null", "array"],
+            "items": { "type": ["null", "string"] }
+          },
+          "tickets": {
+            "description": "Information about the tickets associated with the meeting engagement.",
+            "type": ["null", "array"],
+            "items": { "type": ["null", "string"] }
+          },
+          "properties_hs_contact_first_outreach_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_follow_up_tasks_remaining": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_guest_emails": { "type": ["null", "string"] },
+          "properties_hs_include_description_in_reminder": {
+            "type": ["null", "boolean"]
+          },
+          "properties_hs_meeting_ms_teams_payload": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_meeting_payments_session_id": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_object_source": { "type": ["null", "string"] },
+          "properties_hs_object_source_detail_1": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_object_source_detail_2": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_object_source_detail_3": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_object_source_id": { "type": ["null", "string"] },
+          "properties_hs_object_source_label": { "type": ["null", "string"] },
+          "properties_hs_object_source_user_id": { "type": ["null", "number"] },
+          "properties_hs_outcome_canceled_count": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_outcome_completed_count": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_outcome_no_show_count": { "type": ["null", "number"] },
+          "properties_hs_outcome_rescheduled_count": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_outcome_scheduled_count": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_read_only": { "type": ["null", "boolean"] },
+          "properties_hs_roster_object_coordinates": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_shared_team_ids": { "type": ["null", "string"] },
+          "properties_hs_shared_user_ids": { "type": ["null", "string"] },
+          "properties_hs_time_to_book_meeting_from_first_contact": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_timezone": { "type": ["null", "string"] },
+          "properties_hs_video_conference_url": { "type": ["null", "string"] },
+          "properties_hs_was_imported": { "type": ["null", "boolean"] }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updatedAt"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "engagements_notes",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": ["null", "object"],
+        "properties": {
+          "id": {
+            "description": "Unique identifier for the engagement note",
+            "type": ["null", "string"]
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "hs_all_accessible_team_ids": { "type": ["null", "string"] },
+              "hs_all_assigned_business_unit_ids": {
+                "type": ["null", "string"]
+              },
+              "hs_all_owner_ids": { "type": ["null", "string"] },
+              "hs_all_team_ids": { "type": ["null", "string"] },
+              "hs_at_mentioned_owner_ids": { "type": ["null", "string"] },
+              "hs_attachment_ids": { "type": ["null", "string"] },
+              "hs_body_preview": { "type": ["null", "string"] },
+              "hs_body_preview_html": { "type": ["null", "string"] },
+              "hs_body_preview_is_truncated": { "type": ["null", "boolean"] },
+              "hs_created_by": { "type": ["null", "number"] },
+              "hs_created_by_user_id": { "type": ["null", "number"] },
+              "hs_createdate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_engagement_source": { "type": ["null", "string"] },
+              "hs_engagement_source_id": { "type": ["null", "string"] },
+              "hs_follow_up_action": { "type": ["null", "string"] },
+              "hs_gdpr_deleted": { "type": ["null", "boolean"] },
+              "hs_lastmodifieddate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_merged_object_ids": { "type": ["null", "string"] },
+              "hs_modified_by": { "type": ["null", "number"] },
+              "hs_note_body": { "type": ["null", "string"] },
+              "hs_note_ms_teams_payload": { "type": ["null", "string"] },
+              "hs_object_id": { "type": ["null", "number"] },
+              "hs_object_source": { "type": ["null", "string"] },
+              "hs_object_source_detail_1": { "type": ["null", "string"] },
+              "hs_object_source_detail_2": { "type": ["null", "string"] },
+              "hs_object_source_detail_3": { "type": ["null", "string"] },
+              "hs_object_source_id": { "type": ["null", "string"] },
+              "hs_object_source_label": { "type": ["null", "string"] },
+              "hs_object_source_user_id": { "type": ["null", "number"] },
+              "hs_product_name": { "type": ["null", "string"] },
+              "hs_queue_membership_ids": { "type": ["null", "string"] },
+              "hs_read_only": { "type": ["null", "boolean"] },
+              "hs_shared_team_ids": { "type": ["null", "string"] },
+              "hs_shared_user_ids": { "type": ["null", "string"] },
+              "hs_timestamp": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_unique_creation_key": { "type": ["null", "string"] },
+              "hs_unique_id": { "type": ["null", "string"] },
+              "hs_updated_by_user_id": { "type": ["null", "number"] },
+              "hs_user_ids_of_all_notification_followers": {
+                "type": ["null", "string"]
+              },
+              "hs_user_ids_of_all_notification_unfollowers": {
+                "type": ["null", "string"]
+              },
+              "hs_user_ids_of_all_owners": { "type": ["null", "string"] },
+              "hs_was_imported": { "type": ["null", "boolean"] },
+              "hubspot_owner_assigneddate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hubspot_owner_id": { "type": ["null", "string"] },
+              "hubspot_team_id": { "type": ["null", "string"] }
+            }
+          },
+          "properties_hs_all_assigned_business_unit_ids": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_at_mentioned_owner_ids": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_attachment_ids": { "type": ["null", "string"] },
+          "properties_hs_body_preview": { "type": ["null", "string"] },
+          "properties_hs_body_preview_html": { "type": ["null", "string"] },
+          "properties_hs_body_preview_is_truncated": {
+            "type": ["null", "boolean"]
+          },
+          "properties_hs_created_by": { "type": ["null", "number"] },
+          "properties_hs_created_by_user_id": { "type": ["null", "number"] },
+          "properties_hs_createdate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_engagement_source": { "type": ["null", "string"] },
+          "properties_hs_engagement_source_id": { "type": ["null", "string"] },
+          "properties_hs_follow_up_action": { "type": ["null", "string"] },
+          "properties_hs_gdpr_deleted": { "type": ["null", "boolean"] },
+          "properties_hs_lastmodifieddate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_merged_object_ids": { "type": ["null", "string"] },
+          "properties_hs_modified_by": { "type": ["null", "number"] },
+          "properties_hs_note_body": { "type": ["null", "string"] },
+          "properties_hs_object_id": { "type": ["null", "number"] },
+          "properties_hs_product_name": { "type": ["null", "string"] },
+          "properties_hs_queue_membership_ids": { "type": ["null", "string"] },
+          "properties_hs_timestamp": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_unique_creation_key": { "type": ["null", "string"] },
+          "properties_hs_unique_id": { "type": ["null", "string"] },
+          "properties_hs_updated_by_user_id": { "type": ["null", "number"] },
+          "properties_hs_user_ids_of_all_notification_followers": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_user_ids_of_all_notification_unfollowers": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_user_ids_of_all_owners": {
+            "type": ["null", "string"]
+          },
+          "properties_hubspot_owner_assigneddate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hubspot_owner_id": { "type": ["null", "string"] },
+          "properties_hubspot_team_id": { "type": ["null", "string"] },
+          "properties_hs_all_owner_ids": { "type": ["null", "string"] },
+          "properties_hs_all_team_ids": { "type": ["null", "string"] },
+          "properties_hs_all_accessible_team_ids": {
+            "type": ["null", "string"]
+          },
+          "createdAt": {
+            "description": "The date and time when the note was created",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "description": "Date and time when the note was last updated",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "archived": {
+            "description": "Indicates if the note has been archived",
+            "type": ["null", "boolean"]
+          },
+          "contacts": {
+            "description": "Contacts associated with the engagement note",
+            "type": ["null", "array"],
+            "items": { "type": ["null", "string"] }
+          },
+          "deals": {
+            "description": "Deals associated with the engagement note",
+            "type": ["null", "array"],
+            "items": { "type": ["null", "string"] }
+          },
+          "companies": {
+            "description": "Companies associated with the engagement note",
+            "type": ["null", "array"],
+            "items": { "type": ["null", "string"] }
+          },
+          "tickets": {
+            "description": "Tickets associated with the engagement note",
+            "type": ["null", "array"],
+            "items": { "type": ["null", "string"] }
+          },
+          "properties_hs_note_ms_teams_payload": { "type": ["null", "string"] },
+          "properties_hs_object_source": { "type": ["null", "string"] },
+          "properties_hs_object_source_detail_1": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_object_source_detail_2": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_object_source_detail_3": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_object_source_id": { "type": ["null", "string"] },
+          "properties_hs_object_source_label": { "type": ["null", "string"] },
+          "properties_hs_object_source_user_id": { "type": ["null", "number"] },
+          "properties_hs_read_only": { "type": ["null", "boolean"] },
+          "properties_hs_shared_team_ids": { "type": ["null", "string"] },
+          "properties_hs_shared_user_ids": { "type": ["null", "string"] },
+          "properties_hs_was_imported": { "type": ["null", "boolean"] }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updatedAt"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "engagements_tasks",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": ["null", "object"],
+        "properties": {
+          "id": {
+            "description": "Unique identifier for the task",
+            "type": ["null", "string"]
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "hs_all_accessible_team_ids": { "type": ["null", "string"] },
+              "hs_all_assigned_business_unit_ids": {
+                "type": ["null", "string"]
+              },
+              "hs_all_owner_ids": { "type": ["null", "string"] },
+              "hs_all_team_ids": { "type": ["null", "string"] },
+              "hs_at_mentioned_owner_ids": { "type": ["null", "string"] },
+              "hs_attachment_ids": { "type": ["null", "string"] },
+              "hs_body_preview": { "type": ["null", "string"] },
+              "hs_body_preview_html": { "type": ["null", "string"] },
+              "hs_body_preview_is_truncated": { "type": ["null", "boolean"] },
+              "hs_calendar_event_id": { "type": ["null", "string"] },
+              "hs_created_by": { "type": ["null", "number"] },
+              "hs_created_by_user_id": { "type": ["null", "number"] },
+              "hs_createdate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_entered_60b5c368_04c4_4d32_9b4a_457e159f49b7_13292096": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_entered_61bafb31_e7fa_46ed_aaa9_1322438d6e67_1866552342": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_entered_af0e6a5c_2ea3_4c72_b69f_7c6cb3fdb591_1652950531": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_entered_dd5826e4_c976_4654_a527_b59ada542e52_2144133616": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_entered_fc8148fb_3a2d_4b59_834e_69b7859347cb_1813133675": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_exited_60b5c368_04c4_4d32_9b4a_457e159f49b7_13292096": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_exited_61bafb31_e7fa_46ed_aaa9_1322438d6e67_1866552342": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_exited_af0e6a5c_2ea3_4c72_b69f_7c6cb3fdb591_1652950531": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_exited_dd5826e4_c976_4654_a527_b59ada542e52_2144133616": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_exited_fc8148fb_3a2d_4b59_834e_69b7859347cb_1813133675": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_engagement_source": { "type": ["null", "string"] },
+              "hs_engagement_source_id": { "type": ["null", "string"] },
+              "hs_follow_up_action": { "type": ["null", "string"] },
+              "hs_gdpr_deleted": { "type": ["null", "boolean"] },
+              "hs_lastmodifieddate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_merged_object_ids": { "type": ["null", "string"] },
+              "hs_modified_by": { "type": ["null", "number"] },
+              "hs_msteams_message_id": { "type": ["null", "string"] },
+              "hs_object_id": { "type": ["null", "number"] },
+              "hs_object_source": { "type": ["null", "string"] },
+              "hs_object_source_detail_1": { "type": ["null", "string"] },
+              "hs_object_source_detail_2": { "type": ["null", "string"] },
+              "hs_object_source_detail_3": { "type": ["null", "string"] },
+              "hs_object_source_id": { "type": ["null", "string"] },
+              "hs_object_source_label": { "type": ["null", "string"] },
+              "hs_object_source_user_id": { "type": ["null", "number"] },
+              "hs_product_name": { "type": ["null", "string"] },
+              "hs_queue_membership_ids": { "type": ["null", "string"] },
+              "hs_read_only": { "type": ["null", "boolean"] },
+              "hs_repeat_status": { "type": ["null", "string"] },
+              "hs_scheduled_tasks": { "type": ["null", "string"] },
+              "hs_shared_team_ids": { "type": ["null", "string"] },
+              "hs_shared_user_ids": { "type": ["null", "string"] },
+              "hs_task_body": { "type": ["null", "string"] },
+              "hs_task_completion_count": { "type": ["null", "number"] },
+              "hs_task_completion_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_task_contact_timezone": { "type": ["null", "string"] },
+              "hs_task_family": { "type": ["null", "string"] },
+              "hs_task_for_object_type": { "type": ["null", "string"] },
+              "hs_task_is_all_day": { "type": ["null", "boolean"] },
+              "hs_task_is_completed": { "type": ["null", "number"] },
+              "hs_task_is_completed_call": { "type": ["null", "number"] },
+              "hs_task_is_completed_email": { "type": ["null", "number"] },
+              "hs_task_is_completed_linked_in": { "type": ["null", "number"] },
+              "hs_task_is_completed_sequence": { "type": ["null", "number"] },
+              "hs_task_is_overdue": { "type": ["null", "boolean"] },
+              "hs_task_is_past_due_date": { "type": ["null", "boolean"] },
+              "hs_task_last_contact_outreach": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_task_last_sales_activity_timestamp": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_task_missed_due_date": { "type": ["null", "boolean"] },
+              "hs_task_missed_due_date_count": { "type": ["null", "number"] },
+              "hs_task_ms_teams_payload": { "type": ["null", "string"] },
+              "hs_task_priority": { "type": ["null", "string"] },
+              "hs_task_probability_to_complete": { "type": ["null", "number"] },
+              "hs_task_relative_reminders": { "type": ["null", "string"] },
+              "hs_task_reminders": { "type": ["null", "string"] },
+              "hs_task_repeat_interval": { "type": ["null", "string"] },
+              "hs_task_send_default_reminder": { "type": ["null", "boolean"] },
+              "hs_task_sequence_enrollment_active": {
+                "type": ["null", "boolean"]
+              },
+              "hs_task_sequence_step_enrollment_id": {
+                "type": ["null", "string"]
+              },
+              "hs_task_sequence_step_order": { "type": ["null", "number"] },
+              "hs_task_status": { "type": ["null", "string"] },
+              "hs_task_subject": { "type": ["null", "string"] },
+              "hs_task_template_id": { "type": ["null", "number"] },
+              "hs_task_type": { "type": ["null", "string"] },
+              "hs_time_in_60b5c368_04c4_4d32_9b4a_457e159f49b7_13292096": {
+                "type": ["null", "number"]
+              },
+              "hs_time_in_61bafb31_e7fa_46ed_aaa9_1322438d6e67_1866552342": {
+                "type": ["null", "number"]
+              },
+              "hs_time_in_af0e6a5c_2ea3_4c72_b69f_7c6cb3fdb591_1652950531": {
+                "type": ["null", "number"]
+              },
+              "hs_time_in_dd5826e4_c976_4654_a527_b59ada542e52_2144133616": {
+                "type": ["null", "number"]
+              },
+              "hs_time_in_fc8148fb_3a2d_4b59_834e_69b7859347cb_1813133675": {
+                "type": ["null", "number"]
+              },
+              "hs_timestamp": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_unique_creation_key": { "type": ["null", "string"] },
+              "hs_unique_id": { "type": ["null", "string"] },
+              "hs_updated_by_user_id": { "type": ["null", "number"] },
+              "hs_user_ids_of_all_notification_followers": {
+                "type": ["null", "string"]
+              },
+              "hs_user_ids_of_all_notification_unfollowers": {
+                "type": ["null", "string"]
+              },
+              "hs_user_ids_of_all_owners": { "type": ["null", "string"] },
+              "hs_was_imported": { "type": ["null", "boolean"] },
+              "hubspot_owner_assigneddate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hubspot_owner_id": { "type": ["null", "string"] },
+              "hubspot_team_id": { "type": ["null", "string"] }
+            }
+          },
+          "properties_hs_all_assigned_business_unit_ids": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_at_mentioned_owner_ids": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_attachment_ids": { "type": ["null", "string"] },
+          "properties_hs_body_preview": { "type": ["null", "string"] },
+          "properties_hs_body_preview_html": { "type": ["null", "string"] },
+          "properties_hs_body_preview_is_truncated": {
+            "type": ["null", "boolean"]
+          },
+          "properties_hs_calendar_event_id": { "type": ["null", "string"] },
+          "properties_hs_created_by": { "type": ["null", "number"] },
+          "properties_hs_created_by_user_id": { "type": ["null", "number"] },
+          "properties_hs_createdate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_engagement_source": { "type": ["null", "string"] },
+          "properties_hs_engagement_source_id": { "type": ["null", "string"] },
+          "properties_hs_follow_up_action": { "type": ["null", "string"] },
+          "properties_hs_gdpr_deleted": { "type": ["null", "boolean"] },
+          "properties_hs_lastmodifieddate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_merged_object_ids": { "type": ["null", "string"] },
+          "properties_hs_modified_by": { "type": ["null", "number"] },
+          "properties_hs_msteams_message_id": { "type": ["null", "string"] },
+          "properties_hs_num_associated_companies": {
+            "description": "Number of companies associated with the task.",
+            "type": ["null", "number"]
+          },
+          "properties_hs_num_associated_contacts": {
+            "description": "Number of contacts associated with the task.",
+            "type": ["null", "number"]
+          },
+          "properties_hs_num_associated_deals": {
+            "description": "Number of deals associated with the task.",
+            "type": ["null", "number"]
+          },
+          "properties_hs_num_associated_queue_objects": {
+            "description": "Number of queue objects associated with the task.",
+            "type": ["null", "number"]
+          },
+          "properties_hs_num_associated_tickets": {
+            "description": "Number of tickets associated with the task.",
+            "type": ["null", "number"]
+          },
+          "properties_hs_object_id": { "type": ["null", "number"] },
+          "properties_hs_product_name": { "type": ["null", "string"] },
+          "properties_hs_queue_membership_ids": { "type": ["null", "string"] },
+          "properties_hs_scheduled_tasks": { "type": ["null", "string"] },
+          "properties_hs_task_body": { "type": ["null", "string"] },
+          "properties_hs_task_completion_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_task_contact_timezone": { "type": ["null", "string"] },
+          "properties_hs_task_for_object_type": { "type": ["null", "string"] },
+          "properties_hs_task_is_all_day": { "type": ["null", "boolean"] },
+          "properties_hs_task_last_contact_outreach": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_task_last_sales_activity_timestamp": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_task_priority": { "type": ["null", "string"] },
+          "properties_hs_task_probability_to_complete": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_task_relative_reminders": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_task_reminders": { "type": ["null", "string"] },
+          "properties_hs_task_repeat_interval": { "type": ["null", "string"] },
+          "properties_hs_task_send_default_reminder": {
+            "type": ["null", "boolean"]
+          },
+          "properties_hs_task_sequence_enrollment_active": {
+            "type": ["null", "boolean"]
+          },
+          "properties_hs_task_sequence_step_enrollment_id": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_task_sequence_step_order": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_task_status": { "type": ["null", "string"] },
+          "properties_hs_task_subject": { "type": ["null", "string"] },
+          "properties_hs_task_template_id": { "type": ["null", "number"] },
+          "properties_hs_task_type": { "type": ["null", "string"] },
+          "properties_hs_timestamp": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_unique_creation_key": { "type": ["null", "string"] },
+          "properties_hs_unique_id": { "type": ["null", "string"] },
+          "properties_hs_updated_by_user_id": { "type": ["null", "number"] },
+          "properties_hs_user_ids_of_all_notification_followers": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_user_ids_of_all_notification_unfollowers": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_user_ids_of_all_owners": {
+            "type": ["null", "string"]
+          },
+          "properties_hubspot_owner_assigneddate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hubspot_owner_id": { "type": ["null", "string"] },
+          "properties_hubspot_team_id": { "type": ["null", "string"] },
+          "properties_hs_all_owner_ids": { "type": ["null", "string"] },
+          "properties_hs_all_team_ids": { "type": ["null", "string"] },
+          "properties_hs_all_accessible_team_ids": {
+            "type": ["null", "string"]
+          },
+          "createdAt": {
+            "description": "The date and time when the task was created",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "description": "The date and time when the task was last updated",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "archived": {
+            "description": "Indicates if the task has been archived",
+            "type": ["null", "boolean"]
+          },
+          "contacts": {
+            "description": "List of contacts associated with the task",
+            "type": ["null", "array"],
+            "items": { "type": ["null", "string"] }
+          },
+          "deals": {
+            "description": "List of deals associated with the task",
+            "type": ["null", "array"],
+            "items": { "type": ["null", "string"] }
+          },
+          "companies": {
+            "description": "List of companies associated with the task",
+            "type": ["null", "array"],
+            "items": { "type": ["null", "string"] }
+          },
+          "tickets": {
+            "description": "List of tickets associated with the task",
+            "type": ["null", "array"],
+            "items": { "type": ["null", "string"] }
+          },
+          "properties_hs_date_entered_60b5c368_04c4_4d32_9b4a_457e159f49b7_13292096": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_entered_61bafb31_e7fa_46ed_aaa9_1322438d6e67_1866552342": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_entered_af0e6a5c_2ea3_4c72_b69f_7c6cb3fdb591_1652950531": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_entered_dd5826e4_c976_4654_a527_b59ada542e52_2144133616": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_entered_fc8148fb_3a2d_4b59_834e_69b7859347cb_1813133675": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_exited_60b5c368_04c4_4d32_9b4a_457e159f49b7_13292096": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_exited_61bafb31_e7fa_46ed_aaa9_1322438d6e67_1866552342": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_exited_af0e6a5c_2ea3_4c72_b69f_7c6cb3fdb591_1652950531": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_exited_dd5826e4_c976_4654_a527_b59ada542e52_2144133616": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_exited_fc8148fb_3a2d_4b59_834e_69b7859347cb_1813133675": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_object_source": { "type": ["null", "string"] },
+          "properties_hs_object_source_detail_1": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_object_source_detail_2": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_object_source_detail_3": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_object_source_id": { "type": ["null", "string"] },
+          "properties_hs_object_source_label": { "type": ["null", "string"] },
+          "properties_hs_object_source_user_id": { "type": ["null", "number"] },
+          "properties_hs_read_only": { "type": ["null", "boolean"] },
+          "properties_hs_repeat_status": { "type": ["null", "string"] },
+          "properties_hs_shared_team_ids": { "type": ["null", "string"] },
+          "properties_hs_shared_user_ids": { "type": ["null", "string"] },
+          "properties_hs_task_completion_count": { "type": ["null", "number"] },
+          "properties_hs_task_family": { "type": ["null", "string"] },
+          "properties_hs_task_is_completed": { "type": ["null", "number"] },
+          "properties_hs_task_is_completed_call": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_task_is_completed_email": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_task_is_completed_linked_in": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_task_is_completed_sequence": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_task_is_overdue": { "type": ["null", "boolean"] },
+          "properties_hs_task_is_past_due_date": {
+            "type": ["null", "boolean"]
+          },
+          "properties_hs_task_missed_due_date": { "type": ["null", "boolean"] },
+          "properties_hs_task_missed_due_date_count": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_task_ms_teams_payload": { "type": ["null", "string"] },
+          "properties_hs_time_in_60b5c368_04c4_4d32_9b4a_457e159f49b7_13292096": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_time_in_61bafb31_e7fa_46ed_aaa9_1322438d6e67_1866552342": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_time_in_af0e6a5c_2ea3_4c72_b69f_7c6cb3fdb591_1652950531": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_time_in_dd5826e4_c976_4654_a527_b59ada542e52_2144133616": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_time_in_fc8148fb_3a2d_4b59_834e_69b7859347cb_1813133675": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_was_imported": { "type": ["null", "boolean"] }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updatedAt"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "forms",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": ["null", "object"],
+        "properties": {
+          "id": {
+            "description": "Unique identifier for the form.",
+            "type": ["null", "string"]
+          },
+          "name": {
+            "description": "Name of the form.",
+            "type": ["null", "string"]
+          },
+          "formType": {
+            "description": "Type of the form.",
+            "type": ["null", "string"]
+          },
+          "createdAt": {
+            "description": "Date and time when the form was created.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "description": "Date and time when the form was last updated.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "archived": {
+            "description": "Indicates whether the form is archived.",
+            "type": ["null", "boolean"]
+          },
+          "deletedAt": {
+            "description": "Date and time when the form was deleted.",
+            "type": ["null", "string"]
+          },
+          "fieldGroups": {
+            "description": "Groups containing fields of a form.",
+            "type": ["null", "array"],
+            "items": {
+              "description": "Field groups in the form.",
+              "type": ["null", "object"],
+              "properties": {
+                "fields": {
+                  "type": ["null", "array"],
+                  "items": {
+                    "description": "Properties of each field.",
+                    "type": ["null", "object"],
+                    "properties": {
+                      "objectTypeId": {
+                        "description": "Object type ID for the field.",
+                        "type": ["null", "string"]
+                      },
+                      "name": {
+                        "description": "Name of the field.",
+                        "type": ["null", "string"]
+                      },
+                      "label": {
+                        "description": "Label for the field.",
+                        "type": ["null", "string"]
+                      },
+                      "required": {
+                        "description": "Indicates whether the field is required.",
+                        "type": ["null", "boolean"]
+                      },
+                      "hidden": {
+                        "description": "Indicates whether the field is hidden.",
+                        "type": ["null", "boolean"]
+                      },
+                      "fieldType": {
+                        "description": "Type of the field.",
+                        "type": ["null", "string"]
+                      },
+                      "validation": {
+                        "description": "Validation settings for the field.",
+                        "type": ["null", "object"],
+                        "properties": {
+                          "blockedEmailDomains": {
+                            "description": "List of blocked email domains for validation.",
+                            "type": ["null", "array"],
+                            "items": { "type": ["null", "string"] }
+                          },
+                          "useDefaultBlockList": {
+                            "description": "Indicates whether to use the default block list for validation.",
+                            "type": ["null", "boolean"]
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "groupType": {
+                  "description": "Type of field group.",
+                  "type": ["null", "string"]
+                },
+                "richTextType": {
+                  "description": "Type of rich text.",
+                  "type": ["null", "string"]
+                }
+              }
+            }
+          },
+          "configuration": {
+            "description": "Configuration settings for the form.",
+            "type": ["null", "object"],
+            "properties": {
+              "language": {
+                "description": "Language setting for the form.",
+                "type": ["null", "string"]
+              },
+              "cloneable": {
+                "description": "Indicates whether the form is cloneable.",
+                "type": ["null", "boolean"]
+              },
+              "postSubmitAction": {
+                "description": "Action to be taken after form submission.",
+                "type": ["null", "object"],
+                "properties": {
+                  "type": {
+                    "description": "Type of post-submit action.",
+                    "type": ["null", "string"]
+                  },
+                  "value": {
+                    "description": "Value of post-submit action.",
+                    "type": ["null", "string"]
+                  }
+                }
+              },
+              "editable": {
+                "description": "Indicates whether the form is editable.",
+                "type": ["null", "boolean"]
+              },
+              "archivable": {
+                "description": "Indicates whether the form is archivable.",
+                "type": ["null", "boolean"]
+              },
+              "recaptchaEnabled": {
+                "description": "Indicates whether reCAPTCHA is enabled.",
+                "type": ["null", "boolean"]
+              },
+              "notifyContactOwner": {
+                "description": "Notification setting for contacting the owner.",
+                "type": ["null", "boolean"]
+              },
+              "notifyRecipients": {
+                "description": "Notification setting for recipients.",
+                "type": ["null", "array"]
+              },
+              "createNewContactForNewEmail": {
+                "description": "Creates a new contact for a new email.",
+                "type": ["null", "boolean"]
+              },
+              "prePopulateKnownValues": {
+                "description": "Pre-populates known values in the form.",
+                "type": ["null", "boolean"]
+              },
+              "allowLinkToResetKnownValues": {
+                "description": "Allows resetting known values through a link.",
+                "type": ["null", "boolean"]
+              },
+              "lifecycleStages": {
+                "description": "List of lifecycle stages.",
+                "type": ["null", "array"],
+                "items": { "type": ["null", "string"] }
+              }
+            }
+          },
+          "displayOptions": {
+            "description": "Display options for the form.",
+            "type": ["null", "object"],
+            "properties": {
+              "renderRawHtml": {
+                "description": "Indicates whether to render raw HTML.",
+                "type": ["null", "boolean"]
+              },
+              "theme": {
+                "description": "Theme setting for the form.",
+                "type": ["null", "string"]
+              },
+              "submitButtonText": {
+                "description": "Text for the submit button.",
+                "type": ["null", "string"]
+              },
+              "style": {
+                "description": "Style settings for the form.",
+                "type": ["null", "object"],
+                "properties": {
+                  "fontFamily": {
+                    "description": "Font family style.",
+                    "type": ["null", "string"]
+                  },
+                  "backgroundWidth": {
+                    "description": "Background width style.",
+                    "type": ["null", "string"]
+                  },
+                  "labelTextColor": {
+                    "description": "Label text color style.",
+                    "type": ["null", "string"]
+                  },
+                  "labelTextSize": {
+                    "description": "Label text font size.",
+                    "type": ["null", "string"]
+                  },
+                  "helpTextColor": {
+                    "description": "Help text color style.",
+                    "type": ["null", "string"]
+                  },
+                  "helpTextSize": {
+                    "description": "Help text font size.",
+                    "type": ["null", "string"]
+                  },
+                  "legalConsentTextColor": {
+                    "description": "Legal consent text color style.",
+                    "type": ["null", "string"]
+                  },
+                  "legalConsentTextSize": {
+                    "description": "Legal consent text font size.",
+                    "type": ["null", "string"]
+                  },
+                  "submitColor": {
+                    "description": "Color of submit button.",
+                    "type": ["null", "string"]
+                  },
+                  "submitAlignment": {
+                    "description": "Alignment of submit button.",
+                    "type": ["null", "string"]
+                  },
+                  "submitFontColor": {
+                    "description": "Font color of submit button.",
+                    "type": ["null", "string"]
+                  },
+                  "submitSize": {
+                    "description": "Size of submit button.",
+                    "type": ["null", "string"]
+                  }
+                }
+              },
+              "cssClass": {
+                "description": "CSS class for styling the form.",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "legalConsentOptions": {
+            "description": "Legal consent options for the form.",
+            "type": ["null", "object"]
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "hs_all_accessible_team_ids": { "type": ["null", "string"] },
+              "hs_all_assigned_business_unit_ids": {
+                "type": ["null", "string"]
+              },
+              "hs_all_owner_ids": { "type": ["null", "string"] },
+              "hs_all_team_ids": { "type": ["null", "string"] },
+              "hs_cloneable": { "type": ["null", "string"] },
+              "hs_created_at": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_created_by_user_id": { "type": ["null", "number"] },
+              "hs_createdate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_deletable": { "type": ["null", "string"] },
+              "hs_editable": { "type": ["null", "string"] },
+              "hs_embed_version": { "type": ["null", "string"] },
+              "hs_folder_id": { "type": ["null", "number"] },
+              "hs_form_id": { "type": ["null", "string"] },
+              "hs_form_interactions": { "type": ["null", "number"] },
+              "hs_form_submissions": { "type": ["null", "number"] },
+              "hs_form_submissions_per_form_interaction": {
+                "type": ["null", "number"]
+              },
+              "hs_form_submissions_per_form_view": {
+                "type": ["null", "number"]
+              },
+              "hs_form_submissions_per_page_view": {
+                "type": ["null", "number"]
+              },
+              "hs_form_submissions_per_pop_up_cta_view": {
+                "type": ["null", "number"]
+              },
+              "hs_form_type": { "type": ["null", "string"] },
+              "hs_form_views": { "type": ["null", "number"] },
+              "hs_lastmodifieddate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_marketing_campaign_guid": { "type": ["null", "string"] },
+              "hs_merged_object_ids": { "type": ["null", "string"] },
+              "hs_name": { "type": ["null", "string"] },
+              "hs_object_id": { "type": ["null", "number"] },
+              "hs_object_source": { "type": ["null", "string"] },
+              "hs_object_source_detail_1": { "type": ["null", "string"] },
+              "hs_object_source_detail_2": { "type": ["null", "string"] },
+              "hs_object_source_detail_3": { "type": ["null", "string"] },
+              "hs_object_source_id": { "type": ["null", "string"] },
+              "hs_object_source_label": { "type": ["null", "string"] },
+              "hs_object_source_user_id": { "type": ["null", "number"] },
+              "hs_page_views": { "type": ["null", "number"] },
+              "hs_pop_up_cta_views": { "type": ["null", "number"] },
+              "hs_read_only": { "type": ["null", "boolean"] },
+              "hs_shared_team_ids": { "type": ["null", "string"] },
+              "hs_shared_user_ids": { "type": ["null", "string"] },
+              "hs_spam_submissions": { "type": ["null", "number"] },
+              "hs_status": { "type": ["null", "string"] },
+              "hs_unique_creation_key": { "type": ["null", "string"] },
+              "hs_updated_at": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_updated_by_user_id": { "type": ["null", "number"] },
+              "hs_user_ids_of_all_notification_followers": {
+                "type": ["null", "string"]
+              },
+              "hs_user_ids_of_all_notification_unfollowers": {
+                "type": ["null", "string"]
+              },
+              "hs_user_ids_of_all_owners": { "type": ["null", "string"] },
+              "hs_was_imported": { "type": ["null", "boolean"] },
+              "hubspot_owner_assigneddate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hubspot_owner_id": { "type": ["null", "string"] },
+              "hubspot_team_id": { "type": ["null", "string"] }
+            }
+          },
+          "properties_hs_all_accessible_team_ids": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_all_assigned_business_unit_ids": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_all_owner_ids": { "type": ["null", "string"] },
+          "properties_hs_all_team_ids": { "type": ["null", "string"] },
+          "properties_hs_cloneable": { "type": ["null", "string"] },
+          "properties_hs_created_at": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_created_by_user_id": { "type": ["null", "number"] },
+          "properties_hs_createdate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_deletable": { "type": ["null", "string"] },
+          "properties_hs_editable": { "type": ["null", "string"] },
+          "properties_hs_embed_version": { "type": ["null", "string"] },
+          "properties_hs_folder_id": { "type": ["null", "number"] },
+          "properties_hs_form_id": { "type": ["null", "string"] },
+          "properties_hs_form_interactions": { "type": ["null", "number"] },
+          "properties_hs_form_submissions": { "type": ["null", "number"] },
+          "properties_hs_form_submissions_per_form_interaction": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_form_submissions_per_form_view": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_form_submissions_per_page_view": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_form_submissions_per_pop_up_cta_view": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_form_type": { "type": ["null", "string"] },
+          "properties_hs_form_views": { "type": ["null", "number"] },
+          "properties_hs_lastmodifieddate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_marketing_campaign_guid": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_merged_object_ids": { "type": ["null", "string"] },
+          "properties_hs_name": { "type": ["null", "string"] },
+          "properties_hs_object_id": { "type": ["null", "number"] },
+          "properties_hs_object_source": { "type": ["null", "string"] },
+          "properties_hs_object_source_detail_1": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_object_source_detail_2": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_object_source_detail_3": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_object_source_id": { "type": ["null", "string"] },
+          "properties_hs_object_source_label": { "type": ["null", "string"] },
+          "properties_hs_object_source_user_id": { "type": ["null", "number"] },
+          "properties_hs_page_views": { "type": ["null", "number"] },
+          "properties_hs_pop_up_cta_views": { "type": ["null", "number"] },
+          "properties_hs_read_only": { "type": ["null", "boolean"] },
+          "properties_hs_shared_team_ids": { "type": ["null", "string"] },
+          "properties_hs_shared_user_ids": { "type": ["null", "string"] },
+          "properties_hs_spam_submissions": { "type": ["null", "number"] },
+          "properties_hs_status": { "type": ["null", "string"] },
+          "properties_hs_unique_creation_key": { "type": ["null", "string"] },
+          "properties_hs_updated_at": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_updated_by_user_id": { "type": ["null", "number"] },
+          "properties_hs_user_ids_of_all_notification_followers": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_user_ids_of_all_notification_unfollowers": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_user_ids_of_all_owners": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_was_imported": { "type": ["null", "boolean"] },
+          "properties_hubspot_owner_assigneddate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hubspot_owner_id": { "type": ["null", "string"] },
+          "properties_hubspot_team_id": { "type": ["null", "string"] }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updatedAt"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "form_submissions",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema",
+        "type": ["null", "object"],
+        "properties": {
+          "submittedAt": {
+            "description": "The timestamp when the form was submitted.",
+            "type": ["null", "integer"]
+          },
+          "updatedAt": {
+            "description": "The timestamp when the form submission data was last updated.",
+            "type": ["null", "integer"]
+          },
+          "values": {
+            "description": "An array of form field values submitted in the form.",
+            "type": ["null", "array"],
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "description": "The name or identifier of the form field.",
+                  "type": ["null", "string"]
+                },
+                "value": {
+                  "description": "The actual value submitted for the form field.",
+                  "type": ["null", "string"]
+                },
+                "objectTypeId": {
+                  "description": "The type identifier of the form field value.",
+                  "type": ["null", "string"]
+                }
+              }
+            }
+          },
+          "pageUrl": {
+            "description": "The URL of the web page where the form was submitted.",
+            "type": ["null", "string"]
+          },
+          "formId": {
+            "description": "The unique identifier of the form associated with the submission.",
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updatedAt"],
+      "is_resumable": true
+    },
+    {
+      "name": "goals",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": ["null", "object"],
+        "properties": {
+          "id": {
+            "description": "Unique identifier for the goal.",
+            "type": ["null", "string"]
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "hs__migration_soft_delete": { "type": ["null", "string"] },
+              "hs_ad_account_asset_ids": { "type": ["null", "string"] },
+              "hs_ad_campaign_asset_ids": { "type": ["null", "string"] },
+              "hs_all_accessible_team_ids": { "type": ["null", "string"] },
+              "hs_all_assigned_business_unit_ids": {
+                "type": ["null", "string"]
+              },
+              "hs_all_owner_ids": { "type": ["null", "string"] },
+              "hs_all_team_ids": { "type": ["null", "string"] },
+              "hs_assignee_team_id": { "type": ["null", "number"] },
+              "hs_assignee_user_id": { "type": ["null", "number"] },
+              "hs_contact_lifecycle_stage": { "type": ["null", "string"] },
+              "hs_created_by_user_id": { "type": ["null", "number"] },
+              "hs_createdate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_currency": { "type": ["null", "string"] },
+              "hs_deal_pipeline_ids": { "type": ["null", "string"] },
+              "hs_edit_updates_notification_frequency": {
+                "type": ["null", "string"]
+              },
+              "hs_end_date": { "type": ["null", "string"], "format": "date" },
+              "hs_end_datetime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_fiscal_year_offset": { "type": ["null", "number"] },
+              "hs_forecast_type_id": { "type": ["null", "number"] },
+              "hs_goal_definition_key": { "type": ["null", "string"] },
+              "hs_goal_definition_key_with_team": {
+                "type": ["null", "string"]
+              },
+              "hs_goal_definition_key_with_user": {
+                "type": ["null", "string"]
+              },
+              "hs_goal_name": { "type": ["null", "string"] },
+              "hs_goal_target_group_id": { "type": ["null", "number"] },
+              "hs_goal_type": { "type": ["null", "string"] },
+              "hs_group_correlation_uuid": { "type": ["null", "string"] },
+              "hs_is_forecastable": { "type": ["null", "string"] },
+              "hs_is_legacy": { "type": ["null", "string"] },
+              "hs_kpi_display_unit": { "type": ["null", "string"] },
+              "hs_kpi_filter_groups": { "type": ["null", "string"] },
+              "hs_kpi_filter_groups_for_key_grouping": {
+                "type": ["null", "string"]
+              },
+              "hs_kpi_filter_groups_for_key_team_grouping": {
+                "type": ["null", "string"]
+              },
+              "hs_kpi_is_team_rollup": { "type": ["null", "boolean"] },
+              "hs_kpi_metric_type": { "type": ["null", "string"] },
+              "hs_kpi_object_type": { "type": ["null", "string"] },
+              "hs_kpi_object_type_id": { "type": ["null", "string"] },
+              "hs_kpi_progress_percent": { "type": ["null", "number"] },
+              "hs_kpi_property_name": { "type": ["null", "string"] },
+              "hs_kpi_single_object_custom_goal_type_name": {
+                "type": ["null", "string"]
+              },
+              "hs_kpi_time_period_property": { "type": ["null", "string"] },
+              "hs_kpi_tracking_method": { "type": ["null", "string"] },
+              "hs_kpi_unit_type": { "type": ["null", "string"] },
+              "hs_kpi_value": { "type": ["null", "number"] },
+              "hs_kpi_value_calculated_at": { "type": ["null", "number"] },
+              "hs_kpi_value_last_calculated_at": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_lastmodifieddate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_legacy_active": { "type": ["null", "string"] },
+              "hs_legacy_created_at": { "type": ["null", "number"] },
+              "hs_legacy_created_by": { "type": ["null", "number"] },
+              "hs_legacy_quarterly_target_composite_id": {
+                "type": ["null", "string"]
+              },
+              "hs_legacy_sql_id": { "type": ["null", "number"] },
+              "hs_legacy_unique_sql_id": { "type": ["null", "number"] },
+              "hs_legacy_updated_at": { "type": ["null", "number"] },
+              "hs_legacy_updated_by": { "type": ["null", "number"] },
+              "hs_marketing_campaign_object_ids": {
+                "type": ["null", "number"]
+              },
+              "hs_merged_object_ids": { "type": ["null", "string"] },
+              "hs_migration_soft_delete": { "type": ["null", "string"] },
+              "hs_milestone": { "type": ["null", "string"] },
+              "hs_object_id": { "type": ["null", "number"] },
+              "hs_object_source": { "type": ["null", "string"] },
+              "hs_object_source_detail_1": { "type": ["null", "string"] },
+              "hs_object_source_detail_2": { "type": ["null", "string"] },
+              "hs_object_source_detail_3": { "type": ["null", "string"] },
+              "hs_object_source_id": { "type": ["null", "string"] },
+              "hs_object_source_label": { "type": ["null", "string"] },
+              "hs_object_source_user_id": { "type": ["null", "number"] },
+              "hs_outcome": { "type": ["null", "string"] },
+              "hs_owner_ids_of_all_owners": { "type": ["null", "string"] },
+              "hs_pipelines": { "type": ["null", "string"] },
+              "hs_progress_updates_notification_frequency": {
+                "type": ["null", "string"]
+              },
+              "hs_read_only": { "type": ["null", "boolean"] },
+              "hs_shared_team_ids": { "type": ["null", "string"] },
+              "hs_shared_user_ids": { "type": ["null", "string"] },
+              "hs_should_notify_on_achieved": { "type": ["null", "string"] },
+              "hs_should_notify_on_edit_updates": {
+                "type": ["null", "string"]
+              },
+              "hs_should_notify_on_exceeded": { "type": ["null", "string"] },
+              "hs_should_notify_on_kickoff": { "type": ["null", "string"] },
+              "hs_should_notify_on_missed": { "type": ["null", "string"] },
+              "hs_should_notify_on_progress_updates": {
+                "type": ["null", "string"]
+              },
+              "hs_should_recalculate": { "type": ["null", "string"] },
+              "hs_start_date": { "type": ["null", "string"], "format": "date" },
+              "hs_start_datetime": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_static_kpi_filter_groups": { "type": ["null", "string"] },
+              "hs_status": { "type": ["null", "string"] },
+              "hs_status_display_order": { "type": ["null", "number"] },
+              "hs_target_amount": { "type": ["null", "number"] },
+              "hs_target_amount_in_home_currency": {
+                "type": ["null", "number"]
+              },
+              "hs_team_id": { "type": ["null", "number"] },
+              "hs_template_id": { "type": ["null", "number"] },
+              "hs_ticket_pipeline_ids": { "type": ["null", "string"] },
+              "hs_unique_creation_key": { "type": ["null", "string"] },
+              "hs_updated_by_user_id": { "type": ["null", "number"] },
+              "hs_user_id": { "type": ["null", "number"] },
+              "hs_user_ids_of_all_notification_followers": {
+                "type": ["null", "string"]
+              },
+              "hs_user_ids_of_all_notification_unfollowers": {
+                "type": ["null", "string"]
+              },
+              "hs_user_ids_of_all_owners": { "type": ["null", "string"] },
+              "hs_was_imported": { "type": ["null", "boolean"] },
+              "hubspot_owner_assigneddate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hubspot_owner_id": { "type": ["null", "string"] },
+              "hubspot_team_id": { "type": ["null", "string"] }
+            }
+          },
+          "properties_hs_created_by_user_id": { "type": ["null", "number"] },
+          "properties_hs_createdate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_start_datetime": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_end_datetime": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_goal_name": { "type": ["null", "string"] },
+          "properties_hs_lastmodifieddate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_kpi_value_last_calculated_at": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_object_id": { "type": ["null", "number"] },
+          "properties_hs_target_amount": { "type": ["null", "number"] },
+          "createdAt": {
+            "description": "Date and time when the goal was created.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "description": "Date and time when the goal was last updated.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "archived": {
+            "description": "Indicates if the goal is archived or not.",
+            "type": ["null", "boolean"]
+          },
+          "properties_hs__migration_soft_delete": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_ad_account_asset_ids": { "type": ["null", "string"] },
+          "properties_hs_ad_campaign_asset_ids": { "type": ["null", "string"] },
+          "properties_hs_all_accessible_team_ids": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_all_assigned_business_unit_ids": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_all_owner_ids": { "type": ["null", "string"] },
+          "properties_hs_all_team_ids": { "type": ["null", "string"] },
+          "properties_hs_assignee_team_id": { "type": ["null", "number"] },
+          "properties_hs_assignee_user_id": { "type": ["null", "number"] },
+          "properties_hs_contact_lifecycle_stage": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_currency": { "type": ["null", "string"] },
+          "properties_hs_deal_pipeline_ids": { "type": ["null", "string"] },
+          "properties_hs_edit_updates_notification_frequency": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_end_date": {
+            "type": ["null", "string"],
+            "format": "date"
+          },
+          "properties_hs_fiscal_year_offset": { "type": ["null", "number"] },
+          "properties_hs_forecast_type_id": { "type": ["null", "number"] },
+          "properties_hs_goal_definition_key": { "type": ["null", "string"] },
+          "properties_hs_goal_definition_key_with_team": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_goal_definition_key_with_user": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_goal_target_group_id": { "type": ["null", "number"] },
+          "properties_hs_goal_type": { "type": ["null", "string"] },
+          "properties_hs_group_correlation_uuid": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_is_forecastable": { "type": ["null", "string"] },
+          "properties_hs_is_legacy": { "type": ["null", "string"] },
+          "properties_hs_kpi_display_unit": { "type": ["null", "string"] },
+          "properties_hs_kpi_filter_groups": { "type": ["null", "string"] },
+          "properties_hs_kpi_filter_groups_for_key_grouping": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_kpi_filter_groups_for_key_team_grouping": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_kpi_is_team_rollup": { "type": ["null", "boolean"] },
+          "properties_hs_kpi_metric_type": { "type": ["null", "string"] },
+          "properties_hs_kpi_object_type": { "type": ["null", "string"] },
+          "properties_hs_kpi_object_type_id": { "type": ["null", "string"] },
+          "properties_hs_kpi_progress_percent": { "type": ["null", "number"] },
+          "properties_hs_kpi_property_name": { "type": ["null", "string"] },
+          "properties_hs_kpi_single_object_custom_goal_type_name": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_kpi_time_period_property": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_kpi_tracking_method": { "type": ["null", "string"] },
+          "properties_hs_kpi_unit_type": { "type": ["null", "string"] },
+          "properties_hs_kpi_value": { "type": ["null", "number"] },
+          "properties_hs_kpi_value_calculated_at": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_legacy_active": { "type": ["null", "string"] },
+          "properties_hs_legacy_created_at": { "type": ["null", "number"] },
+          "properties_hs_legacy_created_by": { "type": ["null", "number"] },
+          "properties_hs_legacy_quarterly_target_composite_id": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_legacy_sql_id": { "type": ["null", "number"] },
+          "properties_hs_legacy_unique_sql_id": { "type": ["null", "number"] },
+          "properties_hs_legacy_updated_at": { "type": ["null", "number"] },
+          "properties_hs_legacy_updated_by": { "type": ["null", "number"] },
+          "properties_hs_marketing_campaign_object_ids": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_merged_object_ids": { "type": ["null", "string"] },
+          "properties_hs_migration_soft_delete": { "type": ["null", "string"] },
+          "properties_hs_milestone": { "type": ["null", "string"] },
+          "properties_hs_object_source": { "type": ["null", "string"] },
+          "properties_hs_object_source_detail_1": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_object_source_detail_2": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_object_source_detail_3": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_object_source_id": { "type": ["null", "string"] },
+          "properties_hs_object_source_label": { "type": ["null", "string"] },
+          "properties_hs_object_source_user_id": { "type": ["null", "number"] },
+          "properties_hs_outcome": { "type": ["null", "string"] },
+          "properties_hs_owner_ids_of_all_owners": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_pipelines": { "type": ["null", "string"] },
+          "properties_hs_progress_updates_notification_frequency": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_read_only": { "type": ["null", "boolean"] },
+          "properties_hs_shared_team_ids": { "type": ["null", "string"] },
+          "properties_hs_shared_user_ids": { "type": ["null", "string"] },
+          "properties_hs_should_notify_on_achieved": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_should_notify_on_edit_updates": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_should_notify_on_exceeded": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_should_notify_on_kickoff": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_should_notify_on_missed": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_should_notify_on_progress_updates": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_should_recalculate": { "type": ["null", "string"] },
+          "properties_hs_start_date": {
+            "type": ["null", "string"],
+            "format": "date"
+          },
+          "properties_hs_static_kpi_filter_groups": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_status": { "type": ["null", "string"] },
+          "properties_hs_status_display_order": { "type": ["null", "number"] },
+          "properties_hs_target_amount_in_home_currency": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_team_id": { "type": ["null", "number"] },
+          "properties_hs_template_id": { "type": ["null", "number"] },
+          "properties_hs_ticket_pipeline_ids": { "type": ["null", "string"] },
+          "properties_hs_unique_creation_key": { "type": ["null", "string"] },
+          "properties_hs_updated_by_user_id": { "type": ["null", "number"] },
+          "properties_hs_user_id": { "type": ["null", "number"] },
+          "properties_hs_user_ids_of_all_notification_followers": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_user_ids_of_all_notification_unfollowers": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_user_ids_of_all_owners": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_was_imported": { "type": ["null", "boolean"] },
+          "properties_hubspot_owner_assigneddate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hubspot_owner_id": { "type": ["null", "string"] },
+          "properties_hubspot_team_id": { "type": ["null", "string"] }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updatedAt"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "line_items",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": ["null", "object"],
+        "properties": {
+          "id": {
+            "description": "The unique identifier for the line item.",
+            "type": ["null", "string"]
+          },
+          "createdAt": {
+            "description": "The date and time when the line item was created.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "description": "The date and time when the line item was last updated.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "archived": {
+            "description": "Indicates whether the line item is archived or not.",
+            "type": ["null", "boolean"]
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "amount": { "type": ["null", "number"] },
+              "createdate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "description": { "type": ["null", "string"] },
+              "discount": { "type": ["null", "number"] },
+              "hs_acv": { "type": ["null", "number"] },
+              "hs_all_accessible_team_ids": { "type": ["null", "string"] },
+              "hs_all_assigned_business_unit_ids": {
+                "type": ["null", "string"]
+              },
+              "hs_all_owner_ids": { "type": ["null", "string"] },
+              "hs_all_team_ids": { "type": ["null", "string"] },
+              "hs_allow_buyer_selected_quantity": {
+                "type": ["null", "string"]
+              },
+              "hs_arr": { "type": ["null", "number"] },
+              "hs_billing_period_end_date": {
+                "type": ["null", "string"],
+                "format": "date"
+              },
+              "hs_billing_period_start_date": {
+                "type": ["null", "string"],
+                "format": "date"
+              },
+              "hs_billing_start_delay_days": { "type": ["null", "number"] },
+              "hs_billing_start_delay_months": { "type": ["null", "number"] },
+              "hs_billing_start_delay_type": { "type": ["null", "string"] },
+              "hs_buyer_selected_quantity_max": { "type": ["null", "number"] },
+              "hs_buyer_selected_quantity_min": { "type": ["null", "number"] },
+              "hs_cost_of_goods_sold": { "type": ["null", "number"] },
+              "hs_created_by_user_id": { "type": ["null", "number"] },
+              "hs_createdate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_discount_percentage": { "type": ["null", "number"] },
+              "hs_external_id": { "type": ["null", "number"] },
+              "hs_images": { "type": ["null", "string"] },
+              "hs_is_editable_price": { "type": ["null", "boolean"] },
+              "hs_is_optional": { "type": ["null", "boolean"] },
+              "hs_lastmodifieddate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_line_item_currency_code": { "type": ["null", "string"] },
+              "hs_margin": { "type": ["null", "number"] },
+              "hs_margin_acv": { "type": ["null", "number"] },
+              "hs_margin_arr": { "type": ["null", "number"] },
+              "hs_margin_mrr": { "type": ["null", "number"] },
+              "hs_margin_tcv": { "type": ["null", "number"] },
+              "hs_merged_object_ids": { "type": ["null", "string"] },
+              "hs_mrr": { "type": ["null", "number"] },
+              "hs_object_id": { "type": ["null", "number"] },
+              "hs_object_source": { "type": ["null", "string"] },
+              "hs_object_source_detail_1": { "type": ["null", "string"] },
+              "hs_object_source_detail_2": { "type": ["null", "string"] },
+              "hs_object_source_detail_3": { "type": ["null", "string"] },
+              "hs_object_source_id": { "type": ["null", "string"] },
+              "hs_object_source_label": { "type": ["null", "string"] },
+              "hs_object_source_user_id": { "type": ["null", "number"] },
+              "hs_position_on_quote": { "type": ["null", "number"] },
+              "hs_post_tax_amount": { "type": ["null", "number"] },
+              "hs_pre_discount_amount": { "type": ["null", "number"] },
+              "hs_product_id": { "type": ["null", "number"] },
+              "hs_product_type": { "type": ["null", "string"] },
+              "hs_read_only": { "type": ["null", "boolean"] },
+              "hs_recurring_billing_end_date": {
+                "type": ["null", "string"],
+                "format": "date"
+              },
+              "hs_recurring_billing_number_of_payments": {
+                "type": ["null", "number"]
+              },
+              "hs_recurring_billing_period": { "type": ["null", "string"] },
+              "hs_recurring_billing_start_date": {
+                "type": ["null", "string"],
+                "format": "date"
+              },
+              "hs_recurring_billing_terms": { "type": ["null", "string"] },
+              "hs_shared_team_ids": { "type": ["null", "string"] },
+              "hs_shared_user_ids": { "type": ["null", "string"] },
+              "hs_sku": { "type": ["null", "string"] },
+              "hs_sync_amount": { "type": ["null", "number"] },
+              "hs_tax_label": { "type": ["null", "string"] },
+              "hs_tax_rate": { "type": ["null", "number"] },
+              "hs_tax_rate_group_id": { "type": ["null", "string"] },
+              "hs_tcv": { "type": ["null", "number"] },
+              "hs_term_in_months": { "type": ["null", "number"] },
+              "hs_total_discount": { "type": ["null", "number"] },
+              "hs_unique_creation_key": { "type": ["null", "string"] },
+              "hs_updated_by_user_id": { "type": ["null", "number"] },
+              "hs_url": { "type": ["null", "string"] },
+              "hs_user_ids_of_all_notification_followers": {
+                "type": ["null", "string"]
+              },
+              "hs_user_ids_of_all_notification_unfollowers": {
+                "type": ["null", "string"]
+              },
+              "hs_user_ids_of_all_owners": { "type": ["null", "string"] },
+              "hs_variant_id": { "type": ["null", "number"] },
+              "hs_was_imported": { "type": ["null", "boolean"] },
+              "hubspot_owner_assigneddate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hubspot_owner_id": { "type": ["null", "string"] },
+              "hubspot_team_id": { "type": ["null", "string"] },
+              "name": { "type": ["null", "string"] },
+              "price": { "type": ["null", "number"] },
+              "quantity": { "type": ["null", "number"] },
+              "recurringbillingfrequency": { "type": ["null", "string"] },
+              "tax": { "type": ["null", "number"] },
+              "test": { "type": ["null", "string"], "format": "date" },
+              "test_product_price": {
+                "type": ["null", "string"],
+                "format": "date"
+              }
+            }
+          },
+          "properties_amount": { "type": ["null", "number"] },
+          "properties_createdate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_description": { "type": ["null", "string"] },
+          "properties_discount": { "type": ["null", "number"] },
+          "properties_hs_acv": { "type": ["null", "number"] },
+          "properties_hs_all_accessible_team_ids": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_all_assigned_business_unit_ids": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_all_owner_ids": { "type": ["null", "string"] },
+          "properties_hs_all_team_ids": { "type": ["null", "string"] },
+          "properties_hs_allow_buyer_selected_quantity": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_arr": { "type": ["null", "number"] },
+          "properties_hs_billing_period_end_date": {
+            "type": ["null", "string"],
+            "format": "date"
+          },
+          "properties_hs_billing_period_start_date": {
+            "type": ["null", "string"],
+            "format": "date"
+          },
+          "properties_hs_billing_start_delay_days": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_billing_start_delay_months": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_billing_start_delay_type": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_buyer_selected_quantity_max": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_buyer_selected_quantity_min": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_cost_of_goods_sold": { "type": ["null", "number"] },
+          "properties_hs_created_by_user_id": { "type": ["null", "number"] },
+          "properties_hs_createdate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_discount_percentage": { "type": ["null", "number"] },
+          "properties_hs_external_id": { "type": ["null", "number"] },
+          "properties_hs_images": { "type": ["null", "string"] },
+          "properties_hs_is_editable_price": { "type": ["null", "boolean"] },
+          "properties_hs_is_optional": { "type": ["null", "boolean"] },
+          "properties_hs_lastmodifieddate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_line_item_currency_code": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_margin": { "type": ["null", "number"] },
+          "properties_hs_margin_acv": { "type": ["null", "number"] },
+          "properties_hs_margin_arr": { "type": ["null", "number"] },
+          "properties_hs_margin_mrr": { "type": ["null", "number"] },
+          "properties_hs_margin_tcv": { "type": ["null", "number"] },
+          "properties_hs_merged_object_ids": { "type": ["null", "string"] },
+          "properties_hs_mrr": { "type": ["null", "number"] },
+          "properties_hs_object_id": { "type": ["null", "number"] },
+          "properties_hs_object_source": { "type": ["null", "string"] },
+          "properties_hs_object_source_detail_1": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_object_source_detail_2": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_object_source_detail_3": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_object_source_id": { "type": ["null", "string"] },
+          "properties_hs_object_source_label": { "type": ["null", "string"] },
+          "properties_hs_object_source_user_id": { "type": ["null", "number"] },
+          "properties_hs_position_on_quote": { "type": ["null", "number"] },
+          "properties_hs_post_tax_amount": { "type": ["null", "number"] },
+          "properties_hs_pre_discount_amount": { "type": ["null", "number"] },
+          "properties_hs_product_id": { "type": ["null", "number"] },
+          "properties_hs_product_type": { "type": ["null", "string"] },
+          "properties_hs_read_only": { "type": ["null", "boolean"] },
+          "properties_hs_recurring_billing_end_date": {
+            "type": ["null", "string"],
+            "format": "date"
+          },
+          "properties_hs_recurring_billing_number_of_payments": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_recurring_billing_period": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_recurring_billing_start_date": {
+            "type": ["null", "string"],
+            "format": "date"
+          },
+          "properties_hs_recurring_billing_terms": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_shared_team_ids": { "type": ["null", "string"] },
+          "properties_hs_shared_user_ids": { "type": ["null", "string"] },
+          "properties_hs_sku": { "type": ["null", "string"] },
+          "properties_hs_sync_amount": { "type": ["null", "number"] },
+          "properties_hs_tax_label": { "type": ["null", "string"] },
+          "properties_hs_tax_rate": { "type": ["null", "number"] },
+          "properties_hs_tax_rate_group_id": { "type": ["null", "string"] },
+          "properties_hs_tcv": { "type": ["null", "number"] },
+          "properties_hs_term_in_months": { "type": ["null", "number"] },
+          "properties_hs_total_discount": { "type": ["null", "number"] },
+          "properties_hs_unique_creation_key": { "type": ["null", "string"] },
+          "properties_hs_updated_by_user_id": { "type": ["null", "number"] },
+          "properties_hs_url": { "type": ["null", "string"] },
+          "properties_hs_user_ids_of_all_notification_followers": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_user_ids_of_all_notification_unfollowers": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_user_ids_of_all_owners": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_variant_id": { "type": ["null", "number"] },
+          "properties_hs_was_imported": { "type": ["null", "boolean"] },
+          "properties_hubspot_owner_assigneddate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hubspot_owner_id": { "type": ["null", "string"] },
+          "properties_hubspot_team_id": { "type": ["null", "string"] },
+          "properties_name": { "type": ["null", "string"] },
+          "properties_price": { "type": ["null", "number"] },
+          "properties_quantity": { "type": ["null", "number"] },
+          "properties_recurringbillingfrequency": {
+            "type": ["null", "string"]
+          },
+          "properties_tax": { "type": ["null", "number"] },
+          "properties_test": { "type": ["null", "string"], "format": "date" },
+          "properties_test_product_price": {
+            "type": ["null", "string"],
+            "format": "date"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updatedAt"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "marketing_emails",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": ["null", "object"],
+        "properties": {
+          "id": { "type": ["null", "integer"] },
+          "ab": { "type": ["null", "boolean"] },
+          "abHoursToWait": { "type": ["null", "integer"] },
+          "abSampleSizeDefault": { "type": ["null", "string"] },
+          "abSamplingDefault": { "type": ["null", "string"] },
+          "abStatus": { "type": ["null", "string"] },
+          "abSuccessMetric": { "type": ["null", "string"] },
+          "abTestPercentage": { "type": ["null", "integer"] },
+          "abVariation": { "type": ["null", "boolean"] },
+          "absoluteUrl": { "type": ["null", "string"] },
+          "aifeatures": { "type": ["null", "object"] },
+          "allEmailCampaignIds": {
+            "type": ["null", "array"],
+            "items": { "type": ["null", "integer"] }
+          },
+          "analyticsPageId": { "type": ["null", "string"] },
+          "analyticsPageType": { "type": ["null", "string"] },
+          "archived": { "type": ["null", "boolean"] },
+          "authorAt": { "type": ["null", "integer"] },
+          "authorName": { "type": ["null", "string"] },
+          "authorUserId": { "type": ["null", "integer"] },
+          "blogEmailType": { "type": ["null", "string"] },
+          "campaign": { "type": ["null", "string"] },
+          "campaignName": { "type": ["null", "string"] },
+          "canSpamSettingsId": { "type": ["null", "integer"] },
+          "categoryId": { "type": ["null", "integer"] },
+          "clonedFrom": { "type": ["null", "integer"] },
+          "contentTypeCategory": { "type": ["null", "integer"] },
+          "createPage": { "type": ["null", "boolean"] },
+          "created": { "type": ["null", "integer"] },
+          "createdById": { "type": ["null", "integer"] },
+          "currentState": { "type": ["null", "string"] },
+          "currentlyPublished": { "type": ["null", "boolean"] },
+          "customReplyTo": { "type": ["null", "string"] },
+          "customReplyToEnabled": { "type": ["null", "boolean"] },
+          "domain": { "type": ["null", "string"] },
+          "emailBody": { "type": ["null", "string"] },
+          "emailNote": { "type": ["null", "string"] },
+          "emailTemplateMode": { "type": ["null", "string"] },
+          "emailType": { "type": ["null", "string"] },
+          "emailbodyPlaintext": {
+            "description": "Plain text version of the email body",
+            "type": ["null", "string"]
+          },
+          "feedbackEmailCategory": {
+            "description": "Category for feedback related to the email",
+            "type": ["null", "string"]
+          },
+          "feedbackSurveyId": {
+            "description": "ID of the feedback survey linked to the email",
+            "type": ["null", "integer"]
+          },
+          "folderId": {
+            "description": "ID of the folder where the email is stored",
+            "type": ["null", "integer"]
+          },
+          "freezeDate": {
+            "description": "Date when the email content was finalized",
+            "type": ["null", "integer"]
+          },
+          "fromName": {
+            "description": "Name of the sender displayed in the email",
+            "type": ["null", "string"]
+          },
+          "htmlTitle": {
+            "description": "HTML title of the email",
+            "type": ["null", "string"]
+          },
+          "isGraymailSuppressionEnabled": {
+            "description": "Flag indicating if graymail suppression is enabled for the email",
+            "type": ["null", "boolean"]
+          },
+          "isLocalTimezoneSend": {
+            "description": "Flag indicating if the email is sent based on the local timezone",
+            "type": ["null", "boolean"]
+          },
+          "isPublished": {
+            "description": "Flag indicating if the email is published",
+            "type": ["null", "boolean"]
+          },
+          "isRecipientFatigueSuppressionEnabled": {
+            "description": "Flag indicating if recipient fatigue suppression is enabled",
+            "type": ["null", "boolean"]
+          },
+          "leadFlowId": {
+            "description": "ID of the lead flow associated with the email",
+            "type": ["null", "integer"]
+          },
+          "liveDomain": {
+            "description": "Domain where the live version of the email is hosted",
+            "type": ["null", "string"]
+          },
+          "mailingListsExcluded": {
+            "type": ["null", "array"],
+            "items": { "type": ["null", "integer"] }
+          },
+          "mailingListsIncluded": {
+            "type": ["null", "array"],
+            "items": { "type": ["null", "integer"] }
+          },
+          "maxRssEntries": {
+            "description": "Maximum number of RSS entries to include in the email",
+            "type": ["null", "integer"]
+          },
+          "metaDescription": {
+            "description": "Meta description of the email content",
+            "type": ["null", "string"]
+          },
+          "name": {
+            "description": "Name of the email",
+            "type": ["null", "string"]
+          },
+          "pageExpiryEnabled": {
+            "description": "Flag indicating if page expiry is enabled for the email",
+            "type": ["null", "boolean"]
+          },
+          "pageRedirected": {
+            "description": "Information about page redirection",
+            "type": ["null", "boolean"]
+          },
+          "portalId": {
+            "description": "ID of the HubSpot portal associated with the email",
+            "type": ["null", "integer"]
+          },
+          "previewKey": {
+            "description": "Key used for email preview",
+            "type": ["null", "string"]
+          },
+          "primaryEmailCampaignId": {
+            "description": "ID of the primary email campaign associated with the email",
+            "type": ["null", "integer"]
+          },
+          "processingStatus": {
+            "description": "Status of the email processing",
+            "type": ["null", "string"]
+          },
+          "publishDate": {
+            "description": "Date when the email is scheduled to be published",
+            "type": ["null", "integer"]
+          },
+          "publishedById": {
+            "description": "ID of the user who published the email",
+            "type": ["null", "integer"]
+          },
+          "publishedByName": {
+            "description": "Name of the user who published the email",
+            "type": ["null", "string"]
+          },
+          "publishImmediately": {
+            "description": "Flag indicating if the email should be published immediately",
+            "type": ["null", "boolean"]
+          },
+          "publishedUrl": {
+            "description": "URL where the published email can be accessed",
+            "type": ["null", "string"]
+          },
+          "replyTo": {
+            "description": "Email address for replies to the email",
+            "type": ["null", "string"]
+          },
+          "resolvedDomain": {
+            "description": "Domain resolved for the email",
+            "type": ["null", "string"]
+          },
+          "rootMicId": {
+            "description": "Root MIC ID associated with the email",
+            "type": ["null", "string"]
+          },
+          "selected": {
+            "description": "Flag indicating if the email is selected",
+            "type": ["null", "integer"]
+          },
+          "slug": {
+            "description": "Slug associated with the email",
+            "type": ["null", "string"]
+          },
+          "smartEmailFields": {
+            "description": "Fields related to smart email features",
+            "type": ["null", "object"]
+          },
+          "state": {
+            "description": "Current state of the email",
+            "type": ["null", "string"]
+          },
+          "stats": {
+            "type": ["null", "object"],
+            "properties": {
+              "counters": {
+                "type": ["null", "object"],
+                "properties": {
+                  "sent": { "type": ["null", "integer"] },
+                  "open": { "type": ["null", "integer"] },
+                  "delivered": { "type": ["null", "integer"] },
+                  "bounce": { "type": ["null", "integer"] },
+                  "unsubscribed": { "type": ["null", "integer"] },
+                  "click": { "type": ["null", "integer"] },
+                  "reply": { "type": ["null", "integer"] },
+                  "dropped": { "type": ["null", "integer"] },
+                  "selected": { "type": ["null", "integer"] },
+                  "spamreport": { "type": ["null", "integer"] },
+                  "suppressed": { "type": ["null", "integer"] },
+                  "hardbounced": { "type": ["null", "integer"] },
+                  "softbounced": { "type": ["null", "integer"] },
+                  "pending": { "type": ["null", "integer"] },
+                  "contactslost": { "type": ["null", "integer"] },
+                  "notsent": { "type": ["null", "integer"] }
+                }
+              },
+              "deviceBreakdown": {
+                "type": ["null", "object"],
+                "properties": {
+                  "open_device_type": {
+                    "type": ["null", "object"],
+                    "properties": {
+                      "computer": { "type": ["null", "integer"] },
+                      "mobile": { "type": ["null", "integer"] },
+                      "unknown": { "type": ["null", "integer"] }
+                    }
+                  },
+                  "click_device_type": {
+                    "type": ["null", "object"],
+                    "properties": {
+                      "computer": { "type": ["null", "integer"] },
+                      "mobile": { "type": ["null", "integer"] },
+                      "unknown": { "type": ["null", "integer"] }
+                    }
+                  }
+                }
+              },
+              "failedToLoad": { "type": ["null", "boolean"] },
+              "qualifierStats": { "type": ["null", "object"] },
+              "ratios": {
+                "type": ["null", "object"],
+                "properties": {
+                  "clickratio": { "type": ["null", "number"] },
+                  "clickthroughratio": { "type": ["null", "number"] },
+                  "deliveredratio": { "type": ["null", "number"] },
+                  "openratio": { "type": ["null", "number"] },
+                  "replyratio": { "type": ["null", "number"] },
+                  "unsubscribedratio": { "type": ["null", "number"] },
+                  "spamreportratio": { "type": ["null", "number"] },
+                  "bounceratio": { "type": ["null", "number"] },
+                  "hardbounceratio": { "type": ["null", "number"] },
+                  "softbounceratio": { "type": ["null", "number"] },
+                  "contactslostratio": { "type": ["null", "number"] },
+                  "pendingratio": { "type": ["null", "number"] },
+                  "notsentratio": { "type": ["null", "number"] }
+                }
+              }
+            }
+          },
+          "subcategory": {
+            "description": "Subcategory to which the email belongs",
+            "type": ["null", "string"]
+          },
+          "subject": {
+            "description": "Subject line of the email",
+            "type": ["null", "string"]
+          },
+          "subscription": {
+            "description": "Information about email subscription",
+            "type": ["null", "integer"]
+          },
+          "subscriptionName": {
+            "description": "Name of the email subscription",
+            "type": ["null", "string"]
+          },
+          "templatePath": {
+            "description": "Path of the email template",
+            "type": ["null", "string"]
+          },
+          "transactional": {
+            "description": "Flag indicating if the email is transactional",
+            "type": ["null", "boolean"]
+          },
+          "unpublishedAt": {
+            "description": "Timestamp when the email was unpublished",
+            "type": ["null", "integer"]
+          },
+          "updated": {
+            "description": "Timestamp of the last update to the email",
+            "type": ["null", "integer"]
+          },
+          "updatedById": {
+            "description": "ID of the user who last updated the email",
+            "type": ["null", "integer"]
+          },
+          "url": {
+            "description": "URL associated with the email",
+            "type": ["null", "string"]
+          },
+          "useRssHeadlineAsSubject": {
+            "description": "Flag indicating if the RSS headline should be used as the subject",
+            "type": ["null", "boolean"]
+          },
+          "vidsExcluded": {
+            "type": ["null", "array"],
+            "items": { "type": ["null", "integer"] }
+          },
+          "vidsIncluded": {
+            "type": ["null", "array"],
+            "items": { "type": ["null", "integer"] }
+          },
+          "publishedByEmail": {
+            "description": "Email address of the user who published the email",
+            "type": ["null", "string"]
+          },
+          "sections": {
+            "description": "Sections within the email",
+            "type": ["null", "object"]
+          },
+          "author": {
+            "description": "Author of the email",
+            "type": ["null", "string"]
+          },
+          "isCreatedFomSandboxSync": {
+            "description": "Flag indicating if the email was created from a sandbox sync",
+            "type": ["null", "boolean"]
+          },
+          "rssEmailUrl": {
+            "description": "URL for RSS emails",
+            "type": ["null", "string"]
+          },
+          "teamPerms": {
+            "type": ["null", "array"],
+            "items": { "type": ["null", "string"] }
+          },
+          "securityState": {
+            "description": "Security state of the email",
+            "type": ["null", "string"]
+          },
+          "isInstanceLayoutPage": {
+            "description": "Flag indicating if the email is a layout page in an instance",
+            "type": ["null", "boolean"]
+          },
+          "audienceAccess": {
+            "description": "Information about who has access to view the email",
+            "type": ["null", "string"]
+          },
+          "campaignUtm": {
+            "description": "UTM parameters for campaign tracking",
+            "type": ["null", "string"]
+          },
+          "contentAccessRuleTypes": {
+            "type": ["null", "array"],
+            "items": { "type": ["null", "string"] }
+          },
+          "pastMabExperimentIds": {
+            "type": ["null", "array"],
+            "items": { "type": ["null", "string"] }
+          },
+          "rssEmailClickThroughText": {
+            "description": "Text for click-through actions in RSS emails",
+            "type": ["null", "string"]
+          },
+          "rssEmailImageMaxWidth": {
+            "description": "Maximum width of images in RSS emails",
+            "type": ["null", "integer"]
+          },
+          "flexAreas": {
+            "type": ["null", "object"],
+            "properties": {
+              "main": {
+                "type": ["null", "object"],
+                "properties": {
+                  "boxed": { "type": ["null", "boolean"] },
+                  "isSingleColumnFullWidth": { "type": ["null", "boolean"] },
+                  "sections": {
+                    "type": ["null", "array"],
+                    "items": {
+                      "type": ["null", "object"],
+                      "properties": {
+                        "columns": {
+                          "type": ["null", "array"],
+                          "items": {
+                            "type": ["null", "object"],
+                            "properties": {
+                              "id": { "type": ["null", "string"] },
+                              "widgets": {
+                                "type": ["null", "array"],
+                                "items": { "type": ["null", "string"] }
+                              },
+                              "width": { "type": ["null", "integer"] }
+                            }
+                          }
+                        },
+                        "id": { "type": ["null", "string"] },
+                        "style": {
+                          "type": ["null", "object"],
+                          "properties": {
+                            "backgroundColor": { "type": ["null", "string"] },
+                            "backgroundType": { "type": ["null", "string"] },
+                            "paddingBottom": { "type": ["null", "string"] },
+                            "paddingTop": { "type": ["null", "string"] }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "emailCampaignGroupId": {
+            "description": "Group ID associated with the email campaign",
+            "type": ["null", "integer"]
+          },
+          "layoutSections": {
+            "description": "Sections within the email layout",
+            "type": ["null", "object"]
+          },
+          "blogRssSettings": {
+            "description": "Settings related to blog RSS integration",
+            "type": ["null", "string"]
+          },
+          "archivedInDashboard": {
+            "description": "Flag indicating if the email was archived in the dashboard",
+            "type": ["null", "boolean"]
+          },
+          "publishedAt": {
+            "description": "Timestamp when the email was published",
+            "type": ["null", "integer"]
+          },
+          "lastEditUpdateId": {
+            "description": "Update ID of the last edit made to the email",
+            "type": ["null", "integer"]
+          },
+          "lastEditSessionId": {
+            "description": "Session ID of the last edit made to the email",
+            "type": ["null", "integer"]
+          },
+          "styleSettings": {
+            "type": ["null", "object"],
+            "properties": {
+              "background_color": { "type": ["null", "string"] },
+              "background_image": { "type": ["null", "string"] },
+              "background_image_type": { "type": ["null", "string"] },
+              "body_border_color": { "type": ["null", "string"] },
+              "body_border_color_choice": { "type": ["null", "string"] },
+              "body_border_width": { "type": ["null", "string"] },
+              "body_color": { "type": ["null", "string"] },
+              "color_picker_favorite1": { "type": ["null", "string"] },
+              "color_picker_favorite2": { "type": ["null", "string"] },
+              "color_picker_favorite3": { "type": ["null", "string"] },
+              "color_picker_favorite4": { "type": ["null", "string"] },
+              "color_picker_favorite5": { "type": ["null", "string"] },
+              "color_picker_favorite6": { "type": ["null", "string"] },
+              "email_body_padding": { "type": ["null", "string"] },
+              "email_body_width": { "type": ["null", "string"] },
+              "heading_one_font": {
+                "type": ["null", "object"],
+                "properties": {
+                  "bold": { "type": ["null", "boolean"] },
+                  "color": { "type": ["null", "string"] },
+                  "font": { "type": ["null", "string"] },
+                  "font_style": { "type": ["null", "object"] },
+                  "italic": { "type": ["null", "boolean"] },
+                  "size": { "type": ["null", "string"] },
+                  "underline": { "type": ["null", "boolean"] }
+                }
+              },
+              "heading_two_font": {
+                "type": ["null", "object"],
+                "properties": {
+                  "bold": { "type": ["null", "boolean"] },
+                  "color": { "type": ["null", "string"] },
+                  "font": { "type": ["null", "string"] },
+                  "font_style": { "type": ["null", "object"] },
+                  "italic": { "type": ["null", "boolean"] },
+                  "size": { "type": ["null", "string"] },
+                  "underline": { "type": ["null", "boolean"] }
+                }
+              },
+              "links_font": {
+                "type": ["null", "object"],
+                "properties": {
+                  "bold": { "type": ["null", "boolean"] },
+                  "color": { "type": ["null", "string"] },
+                  "font": { "type": ["null", "string"] },
+                  "font_style": { "type": ["null", "object"] },
+                  "italic": { "type": ["null", "boolean"] },
+                  "size": { "type": ["null", "string"] },
+                  "underline": { "type": ["null", "boolean"] }
+                }
+              },
+              "primary_accent_color": { "type": ["null", "string"] },
+              "primary_font": { "type": ["null", "string"] },
+              "primary_font_color": { "type": ["null", "string"] },
+              "primary_font_line_height": { "type": ["null", "string"] },
+              "primary_font_size": { "type": ["null", "string"] },
+              "secondary_accent_color": { "type": ["null", "string"] },
+              "secondary_font": { "type": ["null", "string"] },
+              "secondary_font_color": { "type": ["null", "string"] },
+              "secondary_font_line_height": { "type": ["null", "string"] },
+              "secondary_font_size": { "type": ["null", "string"] },
+              "use_email_client_default_settings": {
+                "type": ["null", "boolean"]
+              },
+              "user_module_defaults": {
+                "type": ["null", "object"],
+                "properties": {
+                  "button_email": {
+                    "type": ["null", "object"],
+                    "properties": {
+                      "background_color": { "type": ["null", "string"] },
+                      "corner_radius": { "type": ["null", "integer"] },
+                      "font": { "type": ["null", "string"] },
+                      "font_color": { "type": ["null", "string"] },
+                      "font_size": { "type": ["null", "integer"] },
+                      "font_style": { "type": ["null", "object"] }
+                    }
+                  },
+                  "email_divider": {
+                    "type": ["null", "object"],
+                    "properties": {
+                      "color": { "type": ["null", "object"] },
+                      "height": { "type": ["null", "integer"] },
+                      "line_type": { "type": ["null", "string"] }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "visibleToAll": {
+            "description": "Flag indicating if the email is visible to all users",
+            "type": ["null", "boolean"]
+          },
+          "language": {
+            "description": "Language in which the email is written",
+            "type": ["null", "string"]
+          },
+          "rssEmailByText": {
+            "description": "Text content related to RSS emails",
+            "type": ["null", "string"]
+          },
+          "rssEmailCommentText": {
+            "description": "Text for comments in RSS emails",
+            "type": ["null", "string"]
+          },
+          "hasContentAccessRules": {
+            "description": "Indicates if the email has content access rules applied",
+            "type": ["null", "boolean"]
+          },
+          "archivedAt": {
+            "description": "Timestamp when the email was archived",
+            "type": ["null", "integer"]
+          },
+          "translations": {
+            "description": "Translations available for the email",
+            "type": ["null", "object"]
+          },
+          "userPerms": {
+            "type": ["null", "array"],
+            "items": { "type": ["null", "integer"] }
+          },
+          "contentAccessRuleIds": {
+            "type": ["null", "array"],
+            "items": { "type": ["null", "integer"] }
+          },
+          "rssEmailEntryTemplateEnabled": {
+            "description": "Flag indicating if the RSS email entry template is enabled",
+            "type": ["null", "boolean"]
+          },
+          "mailingIlsListsExcluded": {
+            "type": ["null", "array"],
+            "items": { "type": ["null", "integer"] }
+          },
+          "mailingIlsListsIncluded": {
+            "type": ["null", "array"],
+            "items": { "type": ["null", "integer"] }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": false
+    },
+    {
+      "name": "owners",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": ["null", "object"],
+        "properties": {
+          "id": {
+            "description": "The unique identifier of the owner.",
+            "type": ["null", "string"]
+          },
+          "email": {
+            "description": "The email address of the owner.",
+            "type": ["null", "string"]
+          },
+          "firstName": {
+            "description": "The first name of the owner.",
+            "type": ["null", "string"]
+          },
+          "lastName": {
+            "description": "The last name of the owner.",
+            "type": ["null", "string"]
+          },
+          "userId": {
+            "description": "The unique identifier of the user associated with the owner.",
+            "type": ["null", "integer"]
+          },
+          "createdAt": {
+            "description": "The date and time when the owner was created.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "description": "The date and time when the owner was last updated.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "archived": {
+            "description": "Indicates if the owner is archived or not.",
+            "type": ["null", "boolean"]
+          },
+          "teams": {
+            "description": "An array of teams the owner belongs to.",
+            "type": ["null", "array"],
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "description": "The unique identifier of the team.",
+                  "type": ["null", "string"]
+                },
+                "name": {
+                  "description": "The name of the team.",
+                  "type": ["null", "string"]
+                },
+                "membership": {
+                  "description": "The membership status of the owner in the team.",
+                  "type": ["null", "string"]
+                }
+              }
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updatedAt"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "owners_archived",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": ["null", "object"],
+        "properties": {
+          "id": {
+            "description": "The unique identifier of the owner.",
+            "type": ["null", "string"]
+          },
+          "email": {
+            "description": "The email address of the owner.",
+            "type": ["null", "string"]
+          },
+          "firstName": {
+            "description": "The first name of the owner.",
+            "type": ["null", "string"]
+          },
+          "lastName": {
+            "description": "The last name of the owner.",
+            "type": ["null", "string"]
+          },
+          "userId": {
+            "description": "The user ID associated with the owner.",
+            "type": ["null", "integer"]
+          },
+          "createdAt": {
+            "description": "The date and time the owner was created.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "description": "The date and time the owner was last updated.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "archived": {
+            "description": "Indicates if the owner is archived or not.",
+            "type": ["null", "boolean"]
+          },
+          "teams": {
+            "description": "A list of teams the owner belongs to.",
+            "type": ["null", "array"],
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "description": "The unique identifier of the team.",
+                  "type": ["null", "string"]
+                },
+                "name": {
+                  "description": "The name of the team.",
+                  "type": ["null", "string"]
+                },
+                "membership": {
+                  "description": "The membership status of the owner within the team.",
+                  "type": ["null", "string"]
+                }
+              }
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updatedAt"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "products",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": ["null", "object"],
+        "properties": {
+          "id": {
+            "description": "The unique identifier of the product.",
+            "type": ["null", "string"]
+          },
+          "createdAt": {
+            "description": "The datetime when the product was created.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "description": "The datetime when the product was last updated.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "archived": {
+            "description": "Indicates whether the product is archived or active.",
+            "type": ["null", "boolean"]
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "amount": { "type": ["null", "number"] },
+              "createdate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "description": { "type": ["null", "string"] },
+              "discount": { "type": ["null", "number"] },
+              "hs_all_accessible_team_ids": { "type": ["null", "string"] },
+              "hs_all_assigned_business_unit_ids": {
+                "type": ["null", "string"]
+              },
+              "hs_all_owner_ids": { "type": ["null", "string"] },
+              "hs_all_team_ids": { "type": ["null", "string"] },
+              "hs_avatar_filemanager_key": { "type": ["null", "string"] },
+              "hs_cost_of_goods_sold": { "type": ["null", "number"] },
+              "hs_created_by_user_id": { "type": ["null", "number"] },
+              "hs_createdate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_discount_percentage": { "type": ["null", "number"] },
+              "hs_folder": { "type": ["null", "string"] },
+              "hs_folder_id": { "type": ["null", "number"] },
+              "hs_folder_name": { "type": ["null", "string"] },
+              "hs_images": { "type": ["null", "string"] },
+              "hs_lastmodifieddate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_merged_object_ids": { "type": ["null", "string"] },
+              "hs_object_id": { "type": ["null", "number"] },
+              "hs_object_source": { "type": ["null", "string"] },
+              "hs_object_source_detail_1": { "type": ["null", "string"] },
+              "hs_object_source_detail_2": { "type": ["null", "string"] },
+              "hs_object_source_detail_3": { "type": ["null", "string"] },
+              "hs_object_source_id": { "type": ["null", "string"] },
+              "hs_object_source_label": { "type": ["null", "string"] },
+              "hs_object_source_user_id": { "type": ["null", "number"] },
+              "hs_product_type": { "type": ["null", "string"] },
+              "hs_read_only": { "type": ["null", "boolean"] },
+              "hs_recurring_billing_period": { "type": ["null", "string"] },
+              "hs_recurring_billing_start_date": {
+                "type": ["null", "string"],
+                "format": "date"
+              },
+              "hs_shared_team_ids": { "type": ["null", "string"] },
+              "hs_shared_user_ids": { "type": ["null", "string"] },
+              "hs_sku": { "type": ["null", "string"] },
+              "hs_unique_creation_key": { "type": ["null", "string"] },
+              "hs_updated_by_user_id": { "type": ["null", "number"] },
+              "hs_url": { "type": ["null", "string"] },
+              "hs_user_ids_of_all_notification_followers": {
+                "type": ["null", "string"]
+              },
+              "hs_user_ids_of_all_notification_unfollowers": {
+                "type": ["null", "string"]
+              },
+              "hs_user_ids_of_all_owners": { "type": ["null", "string"] },
+              "hs_was_imported": { "type": ["null", "boolean"] },
+              "hubspot_owner_assigneddate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hubspot_owner_id": { "type": ["null", "string"] },
+              "hubspot_team_id": { "type": ["null", "string"] },
+              "name": { "type": ["null", "string"] },
+              "price": { "type": ["null", "number"] },
+              "quantity": { "type": ["null", "number"] },
+              "recurringbillingfrequency": { "type": ["null", "string"] },
+              "tax": { "type": ["null", "number"] },
+              "test": { "type": ["null", "string"], "format": "date" },
+              "test_product_price": {
+                "type": ["null", "string"],
+                "format": "date"
+              }
+            }
+          },
+          "properties_amount": { "type": ["null", "number"] },
+          "properties_createdate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_description": { "type": ["null", "string"] },
+          "properties_discount": { "type": ["null", "number"] },
+          "properties_hs_all_accessible_team_ids": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_all_assigned_business_unit_ids": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_all_owner_ids": { "type": ["null", "string"] },
+          "properties_hs_all_team_ids": { "type": ["null", "string"] },
+          "properties_hs_avatar_filemanager_key": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_cost_of_goods_sold": { "type": ["null", "number"] },
+          "properties_hs_created_by_user_id": { "type": ["null", "number"] },
+          "properties_hs_createdate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_discount_percentage": { "type": ["null", "number"] },
+          "properties_hs_folder": { "type": ["null", "string"] },
+          "properties_hs_folder_id": { "type": ["null", "number"] },
+          "properties_hs_folder_name": { "type": ["null", "string"] },
+          "properties_hs_images": { "type": ["null", "string"] },
+          "properties_hs_lastmodifieddate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_merged_object_ids": { "type": ["null", "string"] },
+          "properties_hs_object_id": { "type": ["null", "number"] },
+          "properties_hs_object_source": { "type": ["null", "string"] },
+          "properties_hs_object_source_detail_1": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_object_source_detail_2": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_object_source_detail_3": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_object_source_id": { "type": ["null", "string"] },
+          "properties_hs_object_source_label": { "type": ["null", "string"] },
+          "properties_hs_object_source_user_id": { "type": ["null", "number"] },
+          "properties_hs_product_type": { "type": ["null", "string"] },
+          "properties_hs_read_only": { "type": ["null", "boolean"] },
+          "properties_hs_recurring_billing_period": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_recurring_billing_start_date": {
+            "type": ["null", "string"],
+            "format": "date"
+          },
+          "properties_hs_shared_team_ids": { "type": ["null", "string"] },
+          "properties_hs_shared_user_ids": { "type": ["null", "string"] },
+          "properties_hs_sku": { "type": ["null", "string"] },
+          "properties_hs_unique_creation_key": { "type": ["null", "string"] },
+          "properties_hs_updated_by_user_id": { "type": ["null", "number"] },
+          "properties_hs_url": { "type": ["null", "string"] },
+          "properties_hs_user_ids_of_all_notification_followers": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_user_ids_of_all_notification_unfollowers": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_user_ids_of_all_owners": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_was_imported": { "type": ["null", "boolean"] },
+          "properties_hubspot_owner_assigneddate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hubspot_owner_id": { "type": ["null", "string"] },
+          "properties_hubspot_team_id": { "type": ["null", "string"] },
+          "properties_name": { "type": ["null", "string"] },
+          "properties_price": { "type": ["null", "number"] },
+          "properties_quantity": { "type": ["null", "number"] },
+          "properties_recurringbillingfrequency": {
+            "type": ["null", "string"]
+          },
+          "properties_tax": { "type": ["null", "number"] },
+          "properties_test": { "type": ["null", "string"], "format": "date" },
+          "properties_test_product_price": {
+            "type": ["null", "string"],
+            "format": "date"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updatedAt"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "contacts_property_history",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema",
+        "type": ["null", "object"],
+        "additionalProperties": true,
+        "properties": {
+          "value": {
+            "description": "The value of the property at the specified timestamp.",
+            "type": ["null", "string"]
+          },
+          "source-type": {
+            "description": "The type or category of the data source.",
+            "type": ["null", "string"]
+          },
+          "source-id": {
+            "description": "The identifier of the data source that generated this historical entry.",
+            "type": ["null", "string"]
+          },
+          "source-label": {
+            "description": "The label representing the source of the data.",
+            "type": ["null", "string"]
+          },
+          "updated-by-user-id": {
+            "description": "The identifier of the user who last updated the property value.",
+            "type": ["null", "integer"]
+          },
+          "timestamp": {
+            "description": "The timestamp when the property value was last updated.",
+            "type": ["null", "integer"]
+          },
+          "selected": {
+            "description": "Indicates whether this property is currently selected or not.",
+            "type": ["null", "boolean"]
+          },
+          "is-contact": {
+            "description": "Indicates whether the data is associated with a contact record.",
+            "type": ["null", "boolean"]
+          },
+          "property": {
+            "description": "The specific property whose history is being tracked.",
+            "type": ["null", "string"]
+          },
+          "vid": {
+            "description": "The unique identifier for this historical data entry.",
+            "type": ["null", "integer"]
+          },
+          "canonical-vid": {
+            "description": "The unique identifier for the contact record that this historical data belongs to.",
+            "type": ["null", "integer"]
+          },
+          "portal-id": {
+            "description": "The identifier for the HubSpot portal that the data belongs to.",
+            "type": ["null", "integer"]
+          },
+          "source-vids": {
+            "description": "List of unique identifiers of the sources associated with this historical data.",
+            "type": ["array", "null"],
+            "items": { "type": ["null", "integer"] }
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "address": { "type": ["null", "string"] },
+              "annualrevenue": { "type": ["null", "string"] },
+              "associatedcompanyid": { "type": ["null", "number"] },
+              "associatedcompanylastupdated": { "type": ["null", "number"] },
+              "city": { "type": ["null", "string"] },
+              "closedate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "company": { "type": ["null", "string"] },
+              "company_size": { "type": ["null", "string"] },
+              "country": { "type": ["null", "string"] },
+              "createdate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "currentlyinworkflow": { "type": ["null", "string"] },
+              "date_of_birth": { "type": ["null", "string"] },
+              "days_to_close": { "type": ["null", "number"] },
+              "degree": { "type": ["null", "string"] },
+              "email": { "type": ["null", "string"] },
+              "engagements_last_meeting_booked": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "engagements_last_meeting_booked_campaign": {
+                "type": ["null", "string"]
+              },
+              "engagements_last_meeting_booked_medium": {
+                "type": ["null", "string"]
+              },
+              "engagements_last_meeting_booked_source": {
+                "type": ["null", "string"]
+              },
+              "fax": { "type": ["null", "string"] },
+              "field_of_study": { "type": ["null", "string"] },
+              "first_conversion_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "first_conversion_event_name": { "type": ["null", "string"] },
+              "first_deal_created_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "firstname": { "type": ["null", "string"] },
+              "gender": { "type": ["null", "string"] },
+              "graduation_date": { "type": ["null", "string"] },
+              "hs_additional_emails": { "type": ["null", "string"] },
+              "hs_all_accessible_team_ids": { "type": ["null", "string"] },
+              "hs_all_contact_vids": { "type": ["null", "string"] },
+              "hs_all_owner_ids": { "type": ["null", "string"] },
+              "hs_all_team_ids": { "type": ["null", "string"] },
+              "hs_analytics_average_page_views": { "type": ["null", "number"] },
+              "hs_analytics_first_referrer": { "type": ["null", "string"] },
+              "hs_analytics_first_timestamp": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_analytics_first_touch_converting_campaign": {
+                "type": ["null", "string"]
+              },
+              "hs_analytics_first_url": { "type": ["null", "string"] },
+              "hs_analytics_first_visit_timestamp": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_analytics_last_referrer": { "type": ["null", "string"] },
+              "hs_analytics_last_timestamp": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_analytics_last_touch_converting_campaign": {
+                "type": ["null", "string"]
+              },
+              "hs_analytics_last_url": { "type": ["null", "string"] },
+              "hs_analytics_last_visit_timestamp": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_analytics_num_event_completions": {
+                "type": ["null", "number"]
+              },
+              "hs_analytics_num_page_views": { "type": ["null", "number"] },
+              "hs_analytics_num_visits": { "type": ["null", "number"] },
+              "hs_analytics_revenue": { "type": ["null", "number"] },
+              "hs_analytics_source": { "type": ["null", "string"] },
+              "hs_analytics_source_data_1": { "type": ["null", "string"] },
+              "hs_analytics_source_data_2": { "type": ["null", "string"] },
+              "hs_associated_target_accounts": { "type": ["null", "number"] },
+              "hs_avatar_filemanager_key": { "type": ["null", "string"] },
+              "hs_buying_role": { "type": ["null", "string"] },
+              "hs_calculated_form_submissions": { "type": ["null", "string"] },
+              "hs_calculated_merged_vids": { "type": ["null", "string"] },
+              "hs_calculated_mobile_number": { "type": ["null", "string"] },
+              "hs_calculated_phone_number": { "type": ["null", "string"] },
+              "hs_calculated_phone_number_area_code": {
+                "type": ["null", "string"]
+              },
+              "hs_calculated_phone_number_country_code": {
+                "type": ["null", "string"]
+              },
+              "hs_calculated_phone_number_region_code": {
+                "type": ["null", "string"]
+              },
+              "hs_clicked_linkedin_ad": { "type": ["null", "string"] },
+              "hs_content_membership_email": { "type": ["null", "string"] },
+              "hs_content_membership_email_confirmed": {
+                "type": ["null", "boolean"]
+              },
+              "hs_content_membership_follow_up_enqueued_at": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_content_membership_notes": { "type": ["null", "string"] },
+              "hs_content_membership_registered_at": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_content_membership_registration_domain_sent_to": {
+                "type": ["null", "string"]
+              },
+              "hs_content_membership_registration_email_sent_at": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_content_membership_status": { "type": ["null", "string"] },
+              "hs_conversations_visitor_email": { "type": ["null", "string"] },
+              "hs_count_is_unworked": { "type": ["null", "number"] },
+              "hs_count_is_worked": { "type": ["null", "number"] },
+              "hs_created_by_conversations": { "type": ["null", "boolean"] },
+              "hs_created_by_user_id": { "type": ["null", "number"] },
+              "hs_createdate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_entered_customer": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_entered_evangelist": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_entered_lead": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_entered_marketingqualifiedlead": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_entered_opportunity": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_entered_other": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_entered_salesqualifiedlead": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_entered_subscriber": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_exited_customer": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_exited_evangelist": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_exited_lead": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_exited_marketingqualifiedlead": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_exited_opportunity": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_exited_other": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_exited_salesqualifiedlead": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_exited_subscriber": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_document_last_revisited": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_email_bad_address": { "type": ["null", "boolean"] },
+              "hs_email_bounce": { "type": ["null", "number"] },
+              "hs_email_click": { "type": ["null", "number"] },
+              "hs_email_customer_quarantined_reason": {
+                "type": ["null", "string"]
+              },
+              "hs_email_delivered": { "type": ["null", "number"] },
+              "hs_email_domain": { "type": ["null", "string"] },
+              "hs_email_first_click_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_email_first_open_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_email_first_reply_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_email_first_send_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_email_hard_bounce_reason": { "type": ["null", "string"] },
+              "hs_email_hard_bounce_reason_enum": {
+                "type": ["null", "string"]
+              },
+              "hs_email_is_ineligible": { "type": ["null", "boolean"] },
+              "hs_email_last_click_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_email_last_email_name": { "type": ["null", "string"] },
+              "hs_email_last_open_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_email_last_reply_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_email_last_send_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_email_open": { "type": ["null", "number"] },
+              "hs_email_optout": { "type": ["null", "boolean"] },
+              "hs_email_optout_10798197": { "type": ["null", "string"] },
+              "hs_email_optout_11890603": { "type": ["null", "string"] },
+              "hs_email_optout_11890831": { "type": ["null", "string"] },
+              "hs_email_optout_23704464": { "type": ["null", "string"] },
+              "hs_email_optout_313921448": { "type": ["null", "string"] },
+              "hs_email_optout_94692364": { "type": ["null", "string"] },
+              "hs_email_quarantined": { "type": ["null", "boolean"] },
+              "hs_email_quarantined_reason": { "type": ["null", "string"] },
+              "hs_email_recipient_fatigue_recovery_time": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_email_replied": { "type": ["null", "number"] },
+              "hs_email_sends_since_last_engagement": {
+                "type": ["null", "number"]
+              },
+              "hs_emailconfirmationstatus": { "type": ["null", "string"] },
+              "hs_facebook_ad_clicked": { "type": ["null", "boolean"] },
+              "hs_facebook_click_id": { "type": ["null", "string"] },
+              "hs_feedback_last_nps_follow_up": { "type": ["null", "string"] },
+              "hs_feedback_last_nps_rating": { "type": ["null", "string"] },
+              "hs_feedback_last_survey_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_feedback_show_nps_web_survey": {
+                "type": ["null", "boolean"]
+              },
+              "hs_first_engagement_object_id": { "type": ["null", "number"] },
+              "hs_first_outreach_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_first_subscription_create_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_google_click_id": { "type": ["null", "string"] },
+              "hs_has_active_subscription": { "type": ["null", "number"] },
+              "hs_ip_timezone": { "type": ["null", "string"] },
+              "hs_is_contact": { "type": ["null", "boolean"] },
+              "hs_is_unworked": { "type": ["null", "boolean"] },
+              "hs_language": { "type": ["null", "string"] },
+              "hs_last_sales_activity_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_last_sales_activity_timestamp": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_last_sales_activity_type": { "type": ["null", "string"] },
+              "hs_lastmodifieddate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_latest_disqualified_lead_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_latest_meeting_activity": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_latest_open_lead_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_latest_qualified_lead_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_latest_sequence_ended_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_latest_sequence_enrolled": { "type": ["null", "number"] },
+              "hs_latest_sequence_enrolled_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_latest_sequence_finished_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_latest_sequence_unenrolled_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_latest_source": { "type": ["null", "string"] },
+              "hs_latest_source_data_1": { "type": ["null", "string"] },
+              "hs_latest_source_data_2": { "type": ["null", "string"] },
+              "hs_latest_source_timestamp": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_latest_subscription_create_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_lead_status": { "type": ["null", "string"] },
+              "hs_legal_basis": { "type": ["null", "string"] },
+              "hs_lifecyclestage_customer_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_lifecyclestage_evangelist_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_lifecyclestage_lead_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_lifecyclestage_marketingqualifiedlead_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_lifecyclestage_opportunity_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_lifecyclestage_other_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_lifecyclestage_salesqualifiedlead_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_lifecyclestage_subscriber_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_linkedin_ad_clicked": { "type": ["null", "string"] },
+              "hs_marketable_reason_id": { "type": ["null", "string"] },
+              "hs_marketable_reason_type": { "type": ["null", "string"] },
+              "hs_marketable_status": { "type": ["null", "string"] },
+              "hs_marketable_until_renewal": { "type": ["null", "string"] },
+              "hs_membership_has_accessed_private_content": {
+                "type": ["null", "number"]
+              },
+              "hs_membership_last_private_content_access_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_merged_object_ids": { "type": ["null", "string"] },
+              "hs_mobile_sdk_push_tokens": { "type": ["null", "string"] },
+              "hs_notes_next_activity_type": { "type": ["null", "string"] },
+              "hs_object_id": { "type": ["null", "number"] },
+              "hs_object_source": { "type": ["null", "string"] },
+              "hs_object_source_detail_1": { "type": ["null", "string"] },
+              "hs_object_source_detail_2": { "type": ["null", "string"] },
+              "hs_object_source_detail_3": { "type": ["null", "string"] },
+              "hs_object_source_id": { "type": ["null", "string"] },
+              "hs_object_source_label": { "type": ["null", "string"] },
+              "hs_object_source_user_id": { "type": ["null", "number"] },
+              "hs_persona": { "type": ["null", "string"] },
+              "hs_pinned_engagement_id": { "type": ["null", "number"] },
+              "hs_pipeline": { "type": ["null", "string"] },
+              "hs_predictivecontactscore": { "type": ["null", "number"] },
+              "hs_predictivecontactscore_v2": { "type": ["null", "number"] },
+              "hs_predictivecontactscorebucket": { "type": ["null", "string"] },
+              "hs_predictivescoringtier": { "type": ["null", "string"] },
+              "hs_quarantined_emails": { "type": ["null", "string"] },
+              "hs_read_only": { "type": ["null", "boolean"] },
+              "hs_registered_member": { "type": ["null", "number"] },
+              "hs_registration_method": { "type": ["null", "string"] },
+              "hs_sa_first_engagement_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_sa_first_engagement_descr": { "type": ["null", "string"] },
+              "hs_sa_first_engagement_object_type": {
+                "type": ["null", "string"]
+              },
+              "hs_sales_email_last_clicked": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_sales_email_last_opened": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_sales_email_last_replied": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_searchable_calculated_international_mobile_number": {
+                "type": ["null", "string"]
+              },
+              "hs_searchable_calculated_international_phone_number": {
+                "type": ["null", "string"]
+              },
+              "hs_searchable_calculated_mobile_number": {
+                "type": ["null", "string"]
+              },
+              "hs_searchable_calculated_phone_number": {
+                "type": ["null", "string"]
+              },
+              "hs_sequences_actively_enrolled_count": {
+                "type": ["null", "number"]
+              },
+              "hs_sequences_enrolled_count": { "type": ["null", "number"] },
+              "hs_sequences_is_enrolled": { "type": ["null", "boolean"] },
+              "hs_testpurge": { "type": ["null", "string"] },
+              "hs_testrollback": { "type": ["null", "string"] },
+              "hs_time_between_contact_creation_and_deal_close": {
+                "type": ["null", "number"]
+              },
+              "hs_time_between_contact_creation_and_deal_creation": {
+                "type": ["null", "number"]
+              },
+              "hs_time_in_customer": { "type": ["null", "number"] },
+              "hs_time_in_evangelist": { "type": ["null", "number"] },
+              "hs_time_in_lead": { "type": ["null", "number"] },
+              "hs_time_in_marketingqualifiedlead": {
+                "type": ["null", "number"]
+              },
+              "hs_time_in_opportunity": { "type": ["null", "number"] },
+              "hs_time_in_other": { "type": ["null", "number"] },
+              "hs_time_in_salesqualifiedlead": { "type": ["null", "number"] },
+              "hs_time_in_subscriber": { "type": ["null", "number"] },
+              "hs_time_to_first_engagement": { "type": ["null", "number"] },
+              "hs_time_to_move_from_lead_to_customer": {
+                "type": ["null", "number"]
+              },
+              "hs_time_to_move_from_marketingqualifiedlead_to_customer": {
+                "type": ["null", "number"]
+              },
+              "hs_time_to_move_from_opportunity_to_customer": {
+                "type": ["null", "number"]
+              },
+              "hs_time_to_move_from_salesqualifiedlead_to_customer": {
+                "type": ["null", "number"]
+              },
+              "hs_time_to_move_from_subscriber_to_customer": {
+                "type": ["null", "number"]
+              },
+              "hs_timezone": { "type": ["null", "string"] },
+              "hs_unique_creation_key": { "type": ["null", "string"] },
+              "hs_updated_by_user_id": { "type": ["null", "number"] },
+              "hs_user_ids_of_all_notification_followers": {
+                "type": ["null", "string"]
+              },
+              "hs_user_ids_of_all_notification_unfollowers": {
+                "type": ["null", "string"]
+              },
+              "hs_user_ids_of_all_owners": { "type": ["null", "string"] },
+              "hs_v2_cumulative_time_in_customer": {
+                "type": ["null", "number"]
+              },
+              "hs_v2_cumulative_time_in_evangelist": {
+                "type": ["null", "number"]
+              },
+              "hs_v2_cumulative_time_in_lead": { "type": ["null", "number"] },
+              "hs_v2_cumulative_time_in_marketingqualifiedlead": {
+                "type": ["null", "number"]
+              },
+              "hs_v2_cumulative_time_in_opportunity": {
+                "type": ["null", "number"]
+              },
+              "hs_v2_cumulative_time_in_other": { "type": ["null", "number"] },
+              "hs_v2_cumulative_time_in_salesqualifiedlead": {
+                "type": ["null", "number"]
+              },
+              "hs_v2_cumulative_time_in_subscriber": {
+                "type": ["null", "number"]
+              },
+              "hs_v2_date_entered_customer": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_entered_evangelist": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_entered_lead": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_entered_marketingqualifiedlead": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_entered_opportunity": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_entered_other": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_entered_salesqualifiedlead": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_entered_subscriber": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_exited_customer": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_exited_evangelist": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_exited_lead": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_exited_marketingqualifiedlead": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_exited_opportunity": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_exited_other": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_exited_salesqualifiedlead": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_exited_subscriber": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_latest_time_in_customer": { "type": ["null", "number"] },
+              "hs_v2_latest_time_in_evangelist": { "type": ["null", "number"] },
+              "hs_v2_latest_time_in_lead": { "type": ["null", "number"] },
+              "hs_v2_latest_time_in_marketingqualifiedlead": {
+                "type": ["null", "number"]
+              },
+              "hs_v2_latest_time_in_opportunity": {
+                "type": ["null", "number"]
+              },
+              "hs_v2_latest_time_in_other": { "type": ["null", "number"] },
+              "hs_v2_latest_time_in_salesqualifiedlead": {
+                "type": ["null", "number"]
+              },
+              "hs_v2_latest_time_in_subscriber": { "type": ["null", "number"] },
+              "hs_was_imported": { "type": ["null", "boolean"] },
+              "hs_whatsapp_phone_number": { "type": ["null", "string"] },
+              "hubspot_owner_assigneddate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hubspot_owner_id": { "type": ["null", "string"] },
+              "hubspot_team_id": { "type": ["null", "string"] },
+              "hubspotscore": { "type": ["null", "number"] },
+              "industry": { "type": ["null", "string"] },
+              "ip_city": { "type": ["null", "string"] },
+              "ip_country": { "type": ["null", "string"] },
+              "ip_country_code": { "type": ["null", "string"] },
+              "ip_latlon": { "type": ["null", "string"] },
+              "ip_state": { "type": ["null", "string"] },
+              "ip_state_code": { "type": ["null", "string"] },
+              "ip_zipcode": { "type": ["null", "string"] },
+              "job_function": { "type": ["null", "string"] },
+              "jobtitle": { "type": ["null", "string"] },
+              "lastmodifieddate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "lastname": { "type": ["null", "string"] },
+              "lifecyclestage": { "type": ["null", "string"] },
+              "marital_status": { "type": ["null", "string"] },
+              "message": { "type": ["null", "string"] },
+              "military_status": { "type": ["null", "string"] },
+              "mobilephone": { "type": ["null", "string"] },
+              "my_custom_test_property": { "type": ["null", "string"] },
+              "notes_last_contacted": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "notes_last_updated": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "notes_next_activity_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "num_associated_deals": { "type": ["null", "number"] },
+              "num_contacted_notes": { "type": ["null", "number"] },
+              "num_conversion_events": { "type": ["null", "number"] },
+              "num_notes": { "type": ["null", "number"] },
+              "num_unique_conversion_events": { "type": ["null", "number"] },
+              "numemployees": { "type": ["null", "string"] },
+              "phone": { "type": ["null", "string"] },
+              "recent_conversion_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "recent_conversion_event_name": { "type": ["null", "string"] },
+              "recent_deal_amount": { "type": ["null", "number"] },
+              "recent_deal_close_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "relationship_status": { "type": ["null", "string"] },
+              "salutation": { "type": ["null", "string"] },
+              "school": { "type": ["null", "string"] },
+              "seniority": { "type": ["null", "string"] },
+              "start_date": { "type": ["null", "string"] },
+              "state": { "type": ["null", "string"] },
+              "surveymonkeyeventlastupdated": { "type": ["null", "number"] },
+              "test": { "type": ["null", "number"] },
+              "total_revenue": { "type": ["null", "number"] },
+              "twitterhandle": { "type": ["null", "string"] },
+              "webinareventlastupdated": { "type": ["null", "number"] },
+              "website": { "type": ["null", "string"] },
+              "work_email": { "type": ["null", "string"] },
+              "zip": { "type": ["null", "string"] }
+            }
+          },
+          "properties_address": { "type": ["null", "string"] },
+          "properties_annualrevenue": { "type": ["null", "string"] },
+          "properties_associatedcompanyid": { "type": ["null", "number"] },
+          "properties_associatedcompanylastupdated": {
+            "type": ["null", "number"]
+          },
+          "properties_city": { "type": ["null", "string"] },
+          "properties_closedate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_company": { "type": ["null", "string"] },
+          "properties_company_size": { "type": ["null", "string"] },
+          "properties_country": { "type": ["null", "string"] },
+          "properties_createdate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_currentlyinworkflow": { "type": ["null", "string"] },
+          "properties_date_of_birth": { "type": ["null", "string"] },
+          "properties_days_to_close": { "type": ["null", "number"] },
+          "properties_degree": { "type": ["null", "string"] },
+          "properties_email": { "type": ["null", "string"] },
+          "properties_engagements_last_meeting_booked": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_engagements_last_meeting_booked_campaign": {
+            "type": ["null", "string"]
+          },
+          "properties_engagements_last_meeting_booked_medium": {
+            "type": ["null", "string"]
+          },
+          "properties_engagements_last_meeting_booked_source": {
+            "type": ["null", "string"]
+          },
+          "properties_fax": { "type": ["null", "string"] },
+          "properties_field_of_study": { "type": ["null", "string"] },
+          "properties_first_conversion_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_first_conversion_event_name": {
+            "type": ["null", "string"]
+          },
+          "properties_first_deal_created_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_firstname": { "type": ["null", "string"] },
+          "properties_gender": { "type": ["null", "string"] },
+          "properties_graduation_date": { "type": ["null", "string"] },
+          "properties_hs_additional_emails": { "type": ["null", "string"] },
+          "properties_hs_all_accessible_team_ids": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_all_contact_vids": { "type": ["null", "string"] },
+          "properties_hs_all_owner_ids": { "type": ["null", "string"] },
+          "properties_hs_all_team_ids": { "type": ["null", "string"] },
+          "properties_hs_analytics_average_page_views": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_analytics_first_referrer": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_analytics_first_timestamp": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_analytics_first_touch_converting_campaign": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_analytics_first_url": { "type": ["null", "string"] },
+          "properties_hs_analytics_first_visit_timestamp": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_analytics_last_referrer": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_analytics_last_timestamp": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_analytics_last_touch_converting_campaign": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_analytics_last_url": { "type": ["null", "string"] },
+          "properties_hs_analytics_last_visit_timestamp": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_analytics_num_event_completions": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_analytics_num_page_views": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_analytics_num_visits": { "type": ["null", "number"] },
+          "properties_hs_analytics_revenue": { "type": ["null", "number"] },
+          "properties_hs_analytics_source": { "type": ["null", "string"] },
+          "properties_hs_analytics_source_data_1": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_analytics_source_data_2": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_associated_target_accounts": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_avatar_filemanager_key": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_buying_role": { "type": ["null", "string"] },
+          "properties_hs_calculated_form_submissions": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_calculated_merged_vids": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_calculated_mobile_number": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_calculated_phone_number": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_calculated_phone_number_area_code": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_calculated_phone_number_country_code": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_calculated_phone_number_region_code": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_clicked_linkedin_ad": { "type": ["null", "string"] },
+          "properties_hs_content_membership_email": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_content_membership_email_confirmed": {
+            "type": ["null", "boolean"]
+          },
+          "properties_hs_content_membership_follow_up_enqueued_at": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_content_membership_notes": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_content_membership_registered_at": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_content_membership_registration_domain_sent_to": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_content_membership_registration_email_sent_at": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_content_membership_status": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_conversations_visitor_email": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_count_is_unworked": { "type": ["null", "number"] },
+          "properties_hs_count_is_worked": { "type": ["null", "number"] },
+          "properties_hs_created_by_conversations": {
+            "type": ["null", "boolean"]
+          },
+          "properties_hs_created_by_user_id": { "type": ["null", "number"] },
+          "properties_hs_createdate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_entered_customer": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_entered_evangelist": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_entered_lead": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_entered_marketingqualifiedlead": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_entered_opportunity": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_entered_other": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_entered_salesqualifiedlead": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_entered_subscriber": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_exited_customer": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_exited_evangelist": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_exited_lead": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_exited_marketingqualifiedlead": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_exited_opportunity": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_exited_other": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_exited_salesqualifiedlead": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_exited_subscriber": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_document_last_revisited": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_email_bad_address": { "type": ["null", "boolean"] },
+          "properties_hs_email_bounce": { "type": ["null", "number"] },
+          "properties_hs_email_click": { "type": ["null", "number"] },
+          "properties_hs_email_customer_quarantined_reason": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_email_delivered": { "type": ["null", "number"] },
+          "properties_hs_email_domain": { "type": ["null", "string"] },
+          "properties_hs_email_first_click_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_email_first_open_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_email_first_reply_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_email_first_send_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_email_hard_bounce_reason": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_email_hard_bounce_reason_enum": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_email_is_ineligible": { "type": ["null", "boolean"] },
+          "properties_hs_email_last_click_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_email_last_email_name": { "type": ["null", "string"] },
+          "properties_hs_email_last_open_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_email_last_reply_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_email_last_send_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_email_open": { "type": ["null", "number"] },
+          "properties_hs_email_optout": { "type": ["null", "boolean"] },
+          "properties_hs_email_optout_10798197": { "type": ["null", "string"] },
+          "properties_hs_email_optout_11890603": { "type": ["null", "string"] },
+          "properties_hs_email_optout_11890831": { "type": ["null", "string"] },
+          "properties_hs_email_optout_23704464": { "type": ["null", "string"] },
+          "properties_hs_email_optout_313921448": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_email_optout_94692364": { "type": ["null", "string"] },
+          "properties_hs_email_quarantined": { "type": ["null", "boolean"] },
+          "properties_hs_email_quarantined_reason": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_email_recipient_fatigue_recovery_time": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_email_replied": { "type": ["null", "number"] },
+          "properties_hs_email_sends_since_last_engagement": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_emailconfirmationstatus": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_facebook_ad_clicked": { "type": ["null", "boolean"] },
+          "properties_hs_facebook_click_id": { "type": ["null", "string"] },
+          "properties_hs_feedback_last_nps_follow_up": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_feedback_last_nps_rating": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_feedback_last_survey_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_feedback_show_nps_web_survey": {
+            "type": ["null", "boolean"]
+          },
+          "properties_hs_first_engagement_object_id": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_first_outreach_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_first_subscription_create_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_google_click_id": { "type": ["null", "string"] },
+          "properties_hs_has_active_subscription": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_ip_timezone": { "type": ["null", "string"] },
+          "properties_hs_is_contact": { "type": ["null", "boolean"] },
+          "properties_hs_is_unworked": { "type": ["null", "boolean"] },
+          "properties_hs_language": { "type": ["null", "string"] },
+          "properties_hs_last_sales_activity_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_last_sales_activity_timestamp": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_last_sales_activity_type": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_lastmodifieddate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_latest_disqualified_lead_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_latest_meeting_activity": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_latest_open_lead_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_latest_qualified_lead_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_latest_sequence_ended_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_latest_sequence_enrolled": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_latest_sequence_enrolled_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_latest_sequence_finished_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_latest_sequence_unenrolled_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_latest_source": { "type": ["null", "string"] },
+          "properties_hs_latest_source_data_1": { "type": ["null", "string"] },
+          "properties_hs_latest_source_data_2": { "type": ["null", "string"] },
+          "properties_hs_latest_source_timestamp": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_latest_subscription_create_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_lead_status": { "type": ["null", "string"] },
+          "properties_hs_legal_basis": { "type": ["null", "string"] },
+          "properties_hs_lifecyclestage_customer_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_lifecyclestage_evangelist_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_lifecyclestage_lead_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_lifecyclestage_marketingqualifiedlead_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_lifecyclestage_opportunity_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_lifecyclestage_other_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_lifecyclestage_salesqualifiedlead_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_lifecyclestage_subscriber_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_linkedin_ad_clicked": { "type": ["null", "string"] },
+          "properties_hs_marketable_reason_id": { "type": ["null", "string"] },
+          "properties_hs_marketable_reason_type": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_marketable_status": { "type": ["null", "string"] },
+          "properties_hs_marketable_until_renewal": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_membership_has_accessed_private_content": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_membership_last_private_content_access_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_merged_object_ids": { "type": ["null", "string"] },
+          "properties_hs_mobile_sdk_push_tokens": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_notes_next_activity_type": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_object_id": { "type": ["null", "number"] },
+          "properties_hs_object_source": { "type": ["null", "string"] },
+          "properties_hs_object_source_detail_1": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_object_source_detail_2": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_object_source_detail_3": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_object_source_id": { "type": ["null", "string"] },
+          "properties_hs_object_source_label": { "type": ["null", "string"] },
+          "properties_hs_object_source_user_id": { "type": ["null", "number"] },
+          "properties_hs_persona": { "type": ["null", "string"] },
+          "properties_hs_pinned_engagement_id": { "type": ["null", "number"] },
+          "properties_hs_pipeline": { "type": ["null", "string"] },
+          "properties_hs_predictivecontactscore": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_predictivecontactscore_v2": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_predictivecontactscorebucket": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_predictivescoringtier": { "type": ["null", "string"] },
+          "properties_hs_quarantined_emails": { "type": ["null", "string"] },
+          "properties_hs_read_only": { "type": ["null", "boolean"] },
+          "properties_hs_registered_member": { "type": ["null", "number"] },
+          "properties_hs_registration_method": { "type": ["null", "string"] },
+          "properties_hs_sa_first_engagement_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_sa_first_engagement_descr": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_sa_first_engagement_object_type": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_sales_email_last_clicked": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_sales_email_last_opened": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_sales_email_last_replied": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_searchable_calculated_international_mobile_number": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_searchable_calculated_international_phone_number": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_searchable_calculated_mobile_number": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_searchable_calculated_phone_number": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_sequences_actively_enrolled_count": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_sequences_enrolled_count": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_sequences_is_enrolled": {
+            "type": ["null", "boolean"]
+          },
+          "properties_hs_testpurge": { "type": ["null", "string"] },
+          "properties_hs_testrollback": { "type": ["null", "string"] },
+          "properties_hs_time_between_contact_creation_and_deal_close": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_time_between_contact_creation_and_deal_creation": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_time_in_customer": { "type": ["null", "number"] },
+          "properties_hs_time_in_evangelist": { "type": ["null", "number"] },
+          "properties_hs_time_in_lead": { "type": ["null", "number"] },
+          "properties_hs_time_in_marketingqualifiedlead": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_time_in_opportunity": { "type": ["null", "number"] },
+          "properties_hs_time_in_other": { "type": ["null", "number"] },
+          "properties_hs_time_in_salesqualifiedlead": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_time_in_subscriber": { "type": ["null", "number"] },
+          "properties_hs_time_to_first_engagement": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_time_to_move_from_lead_to_customer": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_time_to_move_from_marketingqualifiedlead_to_customer": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_time_to_move_from_opportunity_to_customer": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_time_to_move_from_salesqualifiedlead_to_customer": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_time_to_move_from_subscriber_to_customer": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_timezone": { "type": ["null", "string"] },
+          "properties_hs_unique_creation_key": { "type": ["null", "string"] },
+          "properties_hs_updated_by_user_id": { "type": ["null", "number"] },
+          "properties_hs_user_ids_of_all_notification_followers": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_user_ids_of_all_notification_unfollowers": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_user_ids_of_all_owners": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_v2_cumulative_time_in_customer": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_cumulative_time_in_evangelist": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_cumulative_time_in_lead": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_cumulative_time_in_marketingqualifiedlead": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_cumulative_time_in_opportunity": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_cumulative_time_in_other": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_cumulative_time_in_salesqualifiedlead": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_cumulative_time_in_subscriber": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_date_entered_customer": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_entered_evangelist": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_entered_lead": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_entered_marketingqualifiedlead": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_entered_opportunity": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_entered_other": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_entered_salesqualifiedlead": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_entered_subscriber": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_exited_customer": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_exited_evangelist": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_exited_lead": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_exited_marketingqualifiedlead": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_exited_opportunity": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_exited_other": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_exited_salesqualifiedlead": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_exited_subscriber": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_latest_time_in_customer": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_latest_time_in_evangelist": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_latest_time_in_lead": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_latest_time_in_marketingqualifiedlead": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_latest_time_in_opportunity": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_latest_time_in_other": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_latest_time_in_salesqualifiedlead": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_latest_time_in_subscriber": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_was_imported": { "type": ["null", "boolean"] },
+          "properties_hs_whatsapp_phone_number": { "type": ["null", "string"] },
+          "properties_hubspot_owner_assigneddate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hubspot_owner_id": { "type": ["null", "string"] },
+          "properties_hubspot_team_id": { "type": ["null", "string"] },
+          "properties_hubspotscore": { "type": ["null", "number"] },
+          "properties_industry": { "type": ["null", "string"] },
+          "properties_ip_city": { "type": ["null", "string"] },
+          "properties_ip_country": { "type": ["null", "string"] },
+          "properties_ip_country_code": { "type": ["null", "string"] },
+          "properties_ip_latlon": { "type": ["null", "string"] },
+          "properties_ip_state": { "type": ["null", "string"] },
+          "properties_ip_state_code": { "type": ["null", "string"] },
+          "properties_ip_zipcode": { "type": ["null", "string"] },
+          "properties_job_function": { "type": ["null", "string"] },
+          "properties_jobtitle": { "type": ["null", "string"] },
+          "properties_lastmodifieddate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_lastname": { "type": ["null", "string"] },
+          "properties_lifecyclestage": { "type": ["null", "string"] },
+          "properties_marital_status": { "type": ["null", "string"] },
+          "properties_message": { "type": ["null", "string"] },
+          "properties_military_status": { "type": ["null", "string"] },
+          "properties_mobilephone": { "type": ["null", "string"] },
+          "properties_my_custom_test_property": { "type": ["null", "string"] },
+          "properties_notes_last_contacted": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_notes_last_updated": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_notes_next_activity_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_num_associated_deals": { "type": ["null", "number"] },
+          "properties_num_contacted_notes": { "type": ["null", "number"] },
+          "properties_num_conversion_events": { "type": ["null", "number"] },
+          "properties_num_notes": { "type": ["null", "number"] },
+          "properties_num_unique_conversion_events": {
+            "type": ["null", "number"]
+          },
+          "properties_numemployees": { "type": ["null", "string"] },
+          "properties_phone": { "type": ["null", "string"] },
+          "properties_recent_conversion_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_recent_conversion_event_name": {
+            "type": ["null", "string"]
+          },
+          "properties_recent_deal_amount": { "type": ["null", "number"] },
+          "properties_recent_deal_close_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_relationship_status": { "type": ["null", "string"] },
+          "properties_salutation": { "type": ["null", "string"] },
+          "properties_school": { "type": ["null", "string"] },
+          "properties_seniority": { "type": ["null", "string"] },
+          "properties_start_date": { "type": ["null", "string"] },
+          "properties_state": { "type": ["null", "string"] },
+          "properties_surveymonkeyeventlastupdated": {
+            "type": ["null", "number"]
+          },
+          "properties_test": { "type": ["null", "number"] },
+          "properties_total_revenue": { "type": ["null", "number"] },
+          "properties_twitterhandle": { "type": ["null", "string"] },
+          "properties_webinareventlastupdated": { "type": ["null", "number"] },
+          "properties_website": { "type": ["null", "string"] },
+          "properties_work_email": { "type": ["null", "string"] },
+          "properties_zip": { "type": ["null", "string"] }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["timestamp"],
+      "source_defined_primary_key": [["vid"], ["property"], ["timestamp"]],
+      "is_resumable": true
+    },
+    {
+      "name": "companies_property_history",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema",
+        "type": ["null", "object"],
+        "additionalProperties": true,
+        "properties": {
+          "updatedByUserId": {
+            "description": "The user ID of the user who initiated the property update.",
+            "type": ["null", "number"]
+          },
+          "timestamp": {
+            "description": "The date and time when the property update occurred.",
+            "type": ["null", "string"],
+            "format": "date-time",
+            "airbyte_type": "timestamp_with_timezone"
+          },
+          "property": {
+            "description": "The specific property that was updated in the company record.",
+            "type": ["null", "string"]
+          },
+          "companyId": {
+            "description": "The unique identifier of the company to which the property history record belongs.",
+            "type": ["null", "string"]
+          },
+          "sourceType": {
+            "description": "The type of the source that updated the property in the company record.",
+            "type": ["null", "string"]
+          },
+          "sourceId": {
+            "description": "The identifier of the source that updated the property in the company record.",
+            "type": ["null", "string"]
+          },
+          "value": {
+            "description": "The new value of the property after the update.",
+            "type": ["null", "string"]
+          },
+          "archived": {
+            "description": "Flag indicating if the company property history record is archived or not.",
+            "type": ["null", "boolean"]
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "about_us": { "type": ["null", "string"] },
+              "address": { "type": ["null", "string"] },
+              "address2": { "type": ["null", "string"] },
+              "annualrevenue": { "type": ["null", "number"] },
+              "city": { "type": ["null", "string"] },
+              "closedate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "closedate_timestamp_earliest_value_a2a17e6e": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "country": { "type": ["null", "string"] },
+              "createdate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "custom_company_property": { "type": ["null", "string"] },
+              "days_to_close": { "type": ["null", "number"] },
+              "description": { "type": ["null", "string"] },
+              "domain": { "type": ["null", "string"] },
+              "engagements_last_meeting_booked": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "engagements_last_meeting_booked_campaign": {
+                "type": ["null", "string"]
+              },
+              "engagements_last_meeting_booked_medium": {
+                "type": ["null", "string"]
+              },
+              "engagements_last_meeting_booked_source": {
+                "type": ["null", "string"]
+              },
+              "facebook_company_page": { "type": ["null", "string"] },
+              "facebookfans": { "type": ["null", "number"] },
+              "first_contact_createdate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "first_contact_createdate_timestamp_earliest_value_78b50eea": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "first_conversion_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "first_conversion_date_timestamp_earliest_value_61f58f2c": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "first_conversion_event_name": { "type": ["null", "string"] },
+              "first_conversion_event_name_timestamp_earliest_value_68ddae0a": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "first_deal_created_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "founded_year": { "type": ["null", "string"] },
+              "googleplus_page": { "type": ["null", "string"] },
+              "hs_additional_domains": { "type": ["null", "string"] },
+              "hs_all_accessible_team_ids": { "type": ["null", "string"] },
+              "hs_all_owner_ids": { "type": ["null", "string"] },
+              "hs_all_team_ids": { "type": ["null", "string"] },
+              "hs_analytics_first_timestamp": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_analytics_first_timestamp_timestamp_earliest_value_11e3a63a": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_analytics_first_touch_converting_campaign": {
+                "type": ["null", "string"]
+              },
+              "hs_analytics_first_touch_converting_campaign_timestamp_earliest_value_4757fe10": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_analytics_first_visit_timestamp": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_analytics_first_visit_timestamp_timestamp_earliest_value_accc17ae": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_analytics_last_timestamp": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_analytics_last_timestamp_timestamp_latest_value_4e16365a": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_analytics_last_touch_converting_campaign": {
+                "type": ["null", "string"]
+              },
+              "hs_analytics_last_touch_converting_campaign_timestamp_latest_value_81a64e30": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_analytics_last_visit_timestamp": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_analytics_last_visit_timestamp_timestamp_latest_value_999a0fce": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_analytics_latest_source": { "type": ["null", "string"] },
+              "hs_analytics_latest_source_data_1": {
+                "type": ["null", "string"]
+              },
+              "hs_analytics_latest_source_data_2": {
+                "type": ["null", "string"]
+              },
+              "hs_analytics_latest_source_timestamp": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_analytics_num_page_views": { "type": ["null", "number"] },
+              "hs_analytics_num_page_views_cardinality_sum_e46e85b0": {
+                "type": ["null", "number"]
+              },
+              "hs_analytics_num_visits": { "type": ["null", "number"] },
+              "hs_analytics_num_visits_cardinality_sum_53d952a6": {
+                "type": ["null", "number"]
+              },
+              "hs_analytics_source": { "type": ["null", "string"] },
+              "hs_analytics_source_data_1": { "type": ["null", "string"] },
+              "hs_analytics_source_data_1_timestamp_earliest_value_9b2f1fa1": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_analytics_source_data_2": { "type": ["null", "string"] },
+              "hs_analytics_source_data_2_timestamp_earliest_value_9b2f9400": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_analytics_source_timestamp_earliest_value_25a3a52c": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_annual_revenue_currency_code": { "type": ["null", "string"] },
+              "hs_avatar_filemanager_key": { "type": ["null", "string"] },
+              "hs_country_code": { "type": ["null", "string"] },
+              "hs_created_by_user_id": { "type": ["null", "number"] },
+              "hs_createdate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_csm_sentiment": { "type": ["null", "string"] },
+              "hs_customer_success_ticket_sentiment": {
+                "type": ["null", "number"]
+              },
+              "hs_date_entered_customer": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_entered_evangelist": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_entered_lead": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_entered_marketingqualifiedlead": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_entered_opportunity": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_entered_other": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_entered_salesqualifiedlead": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_entered_subscriber": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_exited_customer": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_exited_evangelist": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_exited_lead": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_exited_marketingqualifiedlead": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_exited_opportunity": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_exited_other": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_exited_salesqualifiedlead": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_exited_subscriber": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_ideal_customer_profile": { "type": ["null", "string"] },
+              "hs_is_target_account": { "type": ["null", "boolean"] },
+              "hs_last_booked_meeting_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_last_logged_call_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_last_open_task_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_last_sales_activity_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_last_sales_activity_timestamp": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_last_sales_activity_type": { "type": ["null", "string"] },
+              "hs_lastmodifieddate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_latest_createdate_of_active_subscriptions": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_latest_meeting_activity": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_lead_status": { "type": ["null", "string"] },
+              "hs_logo_url": { "type": ["null", "string"] },
+              "hs_merged_object_ids": { "type": ["null", "string"] },
+              "hs_notes_next_activity_type": { "type": ["null", "string"] },
+              "hs_num_blockers": { "type": ["null", "number"] },
+              "hs_num_child_companies": { "type": ["null", "number"] },
+              "hs_num_contacts_with_buying_roles": {
+                "type": ["null", "number"]
+              },
+              "hs_num_decision_makers": { "type": ["null", "number"] },
+              "hs_num_open_deals": { "type": ["null", "number"] },
+              "hs_object_id": { "type": ["null", "number"] },
+              "hs_object_source": { "type": ["null", "string"] },
+              "hs_object_source_detail_1": { "type": ["null", "string"] },
+              "hs_object_source_detail_2": { "type": ["null", "string"] },
+              "hs_object_source_detail_3": { "type": ["null", "string"] },
+              "hs_object_source_id": { "type": ["null", "string"] },
+              "hs_object_source_label": { "type": ["null", "string"] },
+              "hs_object_source_user_id": { "type": ["null", "number"] },
+              "hs_parent_company_id": { "type": ["null", "number"] },
+              "hs_pinned_engagement_id": { "type": ["null", "number"] },
+              "hs_pipeline": { "type": ["null", "string"] },
+              "hs_predictivecontactscore_v2": { "type": ["null", "number"] },
+              "hs_predictivecontactscore_v2_next_max_max_d4e58c1e": {
+                "type": ["null", "number"]
+              },
+              "hs_read_only": { "type": ["null", "boolean"] },
+              "hs_sales_email_last_replied": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_target_account": { "type": ["null", "string"] },
+              "hs_target_account_probability": { "type": ["null", "number"] },
+              "hs_target_account_recommendation_snooze_time": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_target_account_recommendation_state": {
+                "type": ["null", "string"]
+              },
+              "hs_time_in_customer": { "type": ["null", "number"] },
+              "hs_time_in_evangelist": { "type": ["null", "number"] },
+              "hs_time_in_lead": { "type": ["null", "number"] },
+              "hs_time_in_marketingqualifiedlead": {
+                "type": ["null", "number"]
+              },
+              "hs_time_in_opportunity": { "type": ["null", "number"] },
+              "hs_time_in_other": { "type": ["null", "number"] },
+              "hs_time_in_salesqualifiedlead": { "type": ["null", "number"] },
+              "hs_time_in_subscriber": { "type": ["null", "number"] },
+              "hs_total_deal_value": { "type": ["null", "number"] },
+              "hs_unique_creation_key": { "type": ["null", "string"] },
+              "hs_updated_by_user_id": { "type": ["null", "number"] },
+              "hs_user_ids_of_all_notification_followers": {
+                "type": ["null", "string"]
+              },
+              "hs_user_ids_of_all_notification_unfollowers": {
+                "type": ["null", "string"]
+              },
+              "hs_user_ids_of_all_owners": { "type": ["null", "string"] },
+              "hs_was_imported": { "type": ["null", "boolean"] },
+              "hubspot_owner_assigneddate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hubspot_owner_id": { "type": ["null", "string"] },
+              "hubspot_team_id": { "type": ["null", "string"] },
+              "hubspotscore": { "type": ["null", "number"] },
+              "industry": { "type": ["null", "string"] },
+              "is_public": { "type": ["null", "boolean"] },
+              "lifecyclestage": { "type": ["null", "string"] },
+              "linkedin_company_page": { "type": ["null", "string"] },
+              "linkedinbio": { "type": ["null", "string"] },
+              "name": { "type": ["null", "string"] },
+              "notes_last_contacted": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "notes_last_updated": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "notes_next_activity_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "num_associated_contacts": { "type": ["null", "number"] },
+              "num_associated_deals": { "type": ["null", "number"] },
+              "num_contacted_notes": { "type": ["null", "number"] },
+              "num_conversion_events": { "type": ["null", "number"] },
+              "num_conversion_events_cardinality_sum_d095f14b": {
+                "type": ["null", "number"]
+              },
+              "num_notes": { "type": ["null", "number"] },
+              "numberofemployees": { "type": ["null", "number"] },
+              "phone": { "type": ["null", "string"] },
+              "recent_conversion_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "recent_conversion_date_timestamp_latest_value_72856da1": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "recent_conversion_event_name": { "type": ["null", "string"] },
+              "recent_conversion_event_name_timestamp_latest_value_66c820bf": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "recent_deal_amount": { "type": ["null", "number"] },
+              "recent_deal_close_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "state": { "type": ["null", "string"] },
+              "timezone": { "type": ["null", "string"] },
+              "total_money_raised": { "type": ["null", "string"] },
+              "total_revenue": { "type": ["null", "number"] },
+              "twitterbio": { "type": ["null", "string"] },
+              "twitterfollowers": { "type": ["null", "number"] },
+              "twitterhandle": { "type": ["null", "string"] },
+              "type": { "type": ["null", "string"] },
+              "web_technologies": { "type": ["null", "string"] },
+              "website": { "type": ["null", "string"] },
+              "zip": { "type": ["null", "string"] }
+            }
+          },
+          "properties_about_us": { "type": ["null", "string"] },
+          "properties_address": { "type": ["null", "string"] },
+          "properties_address2": { "type": ["null", "string"] },
+          "properties_annualrevenue": { "type": ["null", "number"] },
+          "properties_city": { "type": ["null", "string"] },
+          "properties_closedate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_closedate_timestamp_earliest_value_a2a17e6e": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_country": { "type": ["null", "string"] },
+          "properties_createdate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_custom_company_property": { "type": ["null", "string"] },
+          "properties_days_to_close": { "type": ["null", "number"] },
+          "properties_description": { "type": ["null", "string"] },
+          "properties_domain": { "type": ["null", "string"] },
+          "properties_engagements_last_meeting_booked": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_engagements_last_meeting_booked_campaign": {
+            "type": ["null", "string"]
+          },
+          "properties_engagements_last_meeting_booked_medium": {
+            "type": ["null", "string"]
+          },
+          "properties_engagements_last_meeting_booked_source": {
+            "type": ["null", "string"]
+          },
+          "properties_facebook_company_page": { "type": ["null", "string"] },
+          "properties_facebookfans": { "type": ["null", "number"] },
+          "properties_first_contact_createdate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_first_contact_createdate_timestamp_earliest_value_78b50eea": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_first_conversion_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_first_conversion_date_timestamp_earliest_value_61f58f2c": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_first_conversion_event_name": {
+            "type": ["null", "string"]
+          },
+          "properties_first_conversion_event_name_timestamp_earliest_value_68ddae0a": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_first_deal_created_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_founded_year": { "type": ["null", "string"] },
+          "properties_googleplus_page": { "type": ["null", "string"] },
+          "properties_hs_additional_domains": { "type": ["null", "string"] },
+          "properties_hs_all_accessible_team_ids": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_all_owner_ids": { "type": ["null", "string"] },
+          "properties_hs_all_team_ids": { "type": ["null", "string"] },
+          "properties_hs_analytics_first_timestamp": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_analytics_first_timestamp_timestamp_earliest_value_11e3a63a": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_analytics_first_touch_converting_campaign": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_analytics_first_touch_converting_campaign_timestamp_earliest_value_4757fe10": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_analytics_first_visit_timestamp": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_analytics_first_visit_timestamp_timestamp_earliest_value_accc17ae": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_analytics_last_timestamp": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_analytics_last_timestamp_timestamp_latest_value_4e16365a": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_analytics_last_touch_converting_campaign": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_analytics_last_touch_converting_campaign_timestamp_latest_value_81a64e30": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_analytics_last_visit_timestamp": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_analytics_last_visit_timestamp_timestamp_latest_value_999a0fce": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_analytics_latest_source": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_analytics_latest_source_data_1": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_analytics_latest_source_data_2": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_analytics_latest_source_timestamp": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_analytics_num_page_views": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_analytics_num_page_views_cardinality_sum_e46e85b0": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_analytics_num_visits": { "type": ["null", "number"] },
+          "properties_hs_analytics_num_visits_cardinality_sum_53d952a6": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_analytics_source": { "type": ["null", "string"] },
+          "properties_hs_analytics_source_data_1": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_analytics_source_data_1_timestamp_earliest_value_9b2f1fa1": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_analytics_source_data_2": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_analytics_source_data_2_timestamp_earliest_value_9b2f9400": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_analytics_source_timestamp_earliest_value_25a3a52c": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_annual_revenue_currency_code": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_avatar_filemanager_key": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_country_code": { "type": ["null", "string"] },
+          "properties_hs_created_by_user_id": { "type": ["null", "number"] },
+          "properties_hs_createdate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_csm_sentiment": { "type": ["null", "string"] },
+          "properties_hs_customer_success_ticket_sentiment": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_date_entered_customer": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_entered_evangelist": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_entered_lead": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_entered_marketingqualifiedlead": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_entered_opportunity": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_entered_other": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_entered_salesqualifiedlead": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_entered_subscriber": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_exited_customer": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_exited_evangelist": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_exited_lead": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_exited_marketingqualifiedlead": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_exited_opportunity": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_exited_other": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_exited_salesqualifiedlead": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_exited_subscriber": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_ideal_customer_profile": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_is_target_account": { "type": ["null", "boolean"] },
+          "properties_hs_last_booked_meeting_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_last_logged_call_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_last_open_task_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_last_sales_activity_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_last_sales_activity_timestamp": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_last_sales_activity_type": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_lastmodifieddate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_latest_createdate_of_active_subscriptions": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_latest_meeting_activity": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_lead_status": { "type": ["null", "string"] },
+          "properties_hs_logo_url": { "type": ["null", "string"] },
+          "properties_hs_merged_object_ids": { "type": ["null", "string"] },
+          "properties_hs_notes_next_activity_type": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_num_blockers": { "type": ["null", "number"] },
+          "properties_hs_num_child_companies": { "type": ["null", "number"] },
+          "properties_hs_num_contacts_with_buying_roles": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_num_decision_makers": { "type": ["null", "number"] },
+          "properties_hs_num_open_deals": { "type": ["null", "number"] },
+          "properties_hs_object_id": { "type": ["null", "number"] },
+          "properties_hs_object_source": { "type": ["null", "string"] },
+          "properties_hs_object_source_detail_1": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_object_source_detail_2": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_object_source_detail_3": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_object_source_id": { "type": ["null", "string"] },
+          "properties_hs_object_source_label": { "type": ["null", "string"] },
+          "properties_hs_object_source_user_id": { "type": ["null", "number"] },
+          "properties_hs_parent_company_id": { "type": ["null", "number"] },
+          "properties_hs_pinned_engagement_id": { "type": ["null", "number"] },
+          "properties_hs_pipeline": { "type": ["null", "string"] },
+          "properties_hs_predictivecontactscore_v2": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_predictivecontactscore_v2_next_max_max_d4e58c1e": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_read_only": { "type": ["null", "boolean"] },
+          "properties_hs_sales_email_last_replied": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_target_account": { "type": ["null", "string"] },
+          "properties_hs_target_account_probability": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_target_account_recommendation_snooze_time": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_target_account_recommendation_state": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_time_in_customer": { "type": ["null", "number"] },
+          "properties_hs_time_in_evangelist": { "type": ["null", "number"] },
+          "properties_hs_time_in_lead": { "type": ["null", "number"] },
+          "properties_hs_time_in_marketingqualifiedlead": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_time_in_opportunity": { "type": ["null", "number"] },
+          "properties_hs_time_in_other": { "type": ["null", "number"] },
+          "properties_hs_time_in_salesqualifiedlead": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_time_in_subscriber": { "type": ["null", "number"] },
+          "properties_hs_total_deal_value": { "type": ["null", "number"] },
+          "properties_hs_unique_creation_key": { "type": ["null", "string"] },
+          "properties_hs_updated_by_user_id": { "type": ["null", "number"] },
+          "properties_hs_user_ids_of_all_notification_followers": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_user_ids_of_all_notification_unfollowers": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_user_ids_of_all_owners": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_was_imported": { "type": ["null", "boolean"] },
+          "properties_hubspot_owner_assigneddate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hubspot_owner_id": { "type": ["null", "string"] },
+          "properties_hubspot_team_id": { "type": ["null", "string"] },
+          "properties_hubspotscore": { "type": ["null", "number"] },
+          "properties_industry": { "type": ["null", "string"] },
+          "properties_is_public": { "type": ["null", "boolean"] },
+          "properties_lifecyclestage": { "type": ["null", "string"] },
+          "properties_linkedin_company_page": { "type": ["null", "string"] },
+          "properties_linkedinbio": { "type": ["null", "string"] },
+          "properties_name": { "type": ["null", "string"] },
+          "properties_notes_last_contacted": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_notes_last_updated": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_notes_next_activity_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_num_associated_contacts": { "type": ["null", "number"] },
+          "properties_num_associated_deals": { "type": ["null", "number"] },
+          "properties_num_contacted_notes": { "type": ["null", "number"] },
+          "properties_num_conversion_events": { "type": ["null", "number"] },
+          "properties_num_conversion_events_cardinality_sum_d095f14b": {
+            "type": ["null", "number"]
+          },
+          "properties_num_notes": { "type": ["null", "number"] },
+          "properties_numberofemployees": { "type": ["null", "number"] },
+          "properties_phone": { "type": ["null", "string"] },
+          "properties_recent_conversion_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_recent_conversion_date_timestamp_latest_value_72856da1": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_recent_conversion_event_name": {
+            "type": ["null", "string"]
+          },
+          "properties_recent_conversion_event_name_timestamp_latest_value_66c820bf": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_recent_deal_amount": { "type": ["null", "number"] },
+          "properties_recent_deal_close_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_state": { "type": ["null", "string"] },
+          "properties_timezone": { "type": ["null", "string"] },
+          "properties_total_money_raised": { "type": ["null", "string"] },
+          "properties_total_revenue": { "type": ["null", "number"] },
+          "properties_twitterbio": { "type": ["null", "string"] },
+          "properties_twitterfollowers": { "type": ["null", "number"] },
+          "properties_twitterhandle": { "type": ["null", "string"] },
+          "properties_type": { "type": ["null", "string"] },
+          "properties_web_technologies": { "type": ["null", "string"] },
+          "properties_website": { "type": ["null", "string"] },
+          "properties_zip": { "type": ["null", "string"] }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["timestamp"],
+      "source_defined_primary_key": [
+        ["companyId"],
+        ["property"],
+        ["timestamp"]
+      ],
+      "is_resumable": true
+    },
+    {
+      "name": "deals_property_history",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema",
+        "type": ["null", "object"],
+        "additionalProperties": true,
+        "properties": {
+          "updatedByUserId": {
+            "description": "The unique identifier of the user who made the update",
+            "type": ["null", "number"]
+          },
+          "timestamp": {
+            "description": "The date and time when the property was updated",
+            "type": ["null", "string"],
+            "format": "date-time",
+            "airbyte_type": "timestamp_with_timezone"
+          },
+          "property": {
+            "description": "The name of the property that was updated",
+            "type": ["null", "string"]
+          },
+          "dealId": {
+            "description": "The unique identifier of the deal associated with this property history",
+            "type": ["null", "string"]
+          },
+          "sourceType": {
+            "description": "The type of source that triggered this update",
+            "type": ["null", "string"]
+          },
+          "sourceId": {
+            "description": "The unique identifier of the source of this update",
+            "type": ["null", "string"]
+          },
+          "value": {
+            "description": "The new value of the property",
+            "type": ["null", "string"]
+          },
+          "archived": {
+            "description": "Indicates if the deal property history is archived",
+            "type": ["null", "boolean"]
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "amount": { "type": ["null", "number"] },
+              "amount_in_home_currency": { "type": ["null", "number"] },
+              "closed_lost_reason": { "type": ["null", "string"] },
+              "closed_won_reason": { "type": ["null", "string"] },
+              "closedate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "createdate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "days_to_close": { "type": ["null", "number"] },
+              "dealname": { "type": ["null", "string"] },
+              "dealstage": { "type": ["null", "string"] },
+              "dealtype": { "type": ["null", "string"] },
+              "description": { "type": ["null", "string"] },
+              "engagements_last_meeting_booked": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "engagements_last_meeting_booked_campaign": {
+                "type": ["null", "string"]
+              },
+              "engagements_last_meeting_booked_medium": {
+                "type": ["null", "string"]
+              },
+              "engagements_last_meeting_booked_source": {
+                "type": ["null", "string"]
+              },
+              "hs_acv": { "type": ["null", "number"] },
+              "hs_all_accessible_team_ids": { "type": ["null", "string"] },
+              "hs_all_collaborator_owner_ids": { "type": ["null", "string"] },
+              "hs_all_deal_split_owner_ids": { "type": ["null", "string"] },
+              "hs_all_owner_ids": { "type": ["null", "string"] },
+              "hs_all_team_ids": { "type": ["null", "string"] },
+              "hs_analytics_latest_source": { "type": ["null", "string"] },
+              "hs_analytics_latest_source_company": {
+                "type": ["null", "string"]
+              },
+              "hs_analytics_latest_source_contact": {
+                "type": ["null", "string"]
+              },
+              "hs_analytics_latest_source_data_1": {
+                "type": ["null", "string"]
+              },
+              "hs_analytics_latest_source_data_1_company": {
+                "type": ["null", "string"]
+              },
+              "hs_analytics_latest_source_data_1_contact": {
+                "type": ["null", "string"]
+              },
+              "hs_analytics_latest_source_data_2": {
+                "type": ["null", "string"]
+              },
+              "hs_analytics_latest_source_data_2_company": {
+                "type": ["null", "string"]
+              },
+              "hs_analytics_latest_source_data_2_contact": {
+                "type": ["null", "string"]
+              },
+              "hs_analytics_latest_source_timestamp": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_analytics_latest_source_timestamp_company": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_analytics_latest_source_timestamp_contact": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_analytics_source": { "type": ["null", "string"] },
+              "hs_analytics_source_data_1": { "type": ["null", "string"] },
+              "hs_analytics_source_data_2": { "type": ["null", "string"] },
+              "hs_arr": { "type": ["null", "number"] },
+              "hs_campaign": { "type": ["null", "string"] },
+              "hs_closed_amount": { "type": ["null", "number"] },
+              "hs_closed_amount_in_home_currency": {
+                "type": ["null", "number"]
+              },
+              "hs_closed_deal_close_date": { "type": ["null", "number"] },
+              "hs_closed_deal_create_date": { "type": ["null", "number"] },
+              "hs_closed_won_count": { "type": ["null", "number"] },
+              "hs_closed_won_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_created_by_user_id": { "type": ["null", "number"] },
+              "hs_createdate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_entered_66894120": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_entered_9567448": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_entered_9567449": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_entered_appointmentscheduled": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_entered_closedlost": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_entered_closedwon": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_entered_contractsent": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_entered_customclosedwonstage": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_entered_decisionmakerboughtin": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_entered_presentationscheduled": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_entered_qualifiedtobuy": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_exited_66894120": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_exited_9567448": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_exited_9567449": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_exited_appointmentscheduled": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_exited_closedlost": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_exited_closedwon": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_exited_contractsent": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_exited_customclosedwonstage": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_exited_decisionmakerboughtin": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_exited_presentationscheduled": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_exited_qualifiedtobuy": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_days_to_close_raw": { "type": ["null", "number"] },
+              "hs_deal_amount_calculation_preference": {
+                "type": ["null", "string"]
+              },
+              "hs_deal_score": { "type": ["null", "number"] },
+              "hs_deal_stage_probability": { "type": ["null", "number"] },
+              "hs_deal_stage_probability_shadow": {
+                "type": ["null", "number"]
+              },
+              "hs_exchange_rate": { "type": ["null", "number"] },
+              "hs_forecast_amount": { "type": ["null", "number"] },
+              "hs_forecast_probability": { "type": ["null", "number"] },
+              "hs_has_empty_conditional_stage_properties": {
+                "type": ["null", "boolean"]
+              },
+              "hs_is_closed": { "type": ["null", "boolean"] },
+              "hs_is_closed_count": { "type": ["null", "number"] },
+              "hs_is_closed_won": { "type": ["null", "boolean"] },
+              "hs_is_deal_split": { "type": ["null", "boolean"] },
+              "hs_is_in_first_deal_stage": { "type": ["null", "boolean"] },
+              "hs_is_open_count": { "type": ["null", "number"] },
+              "hs_lastmodifieddate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_latest_approval_status": { "type": ["null", "string"] },
+              "hs_latest_approval_status_approval_id": {
+                "type": ["null", "number"]
+              },
+              "hs_latest_meeting_activity": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_likelihood_to_close": { "type": ["null", "number"] },
+              "hs_line_item_global_term_hs_discount_percentage": {
+                "type": ["null", "string"]
+              },
+              "hs_line_item_global_term_hs_discount_percentage_enabled": {
+                "type": ["null", "boolean"]
+              },
+              "hs_line_item_global_term_hs_recurring_billing_period": {
+                "type": ["null", "string"]
+              },
+              "hs_line_item_global_term_hs_recurring_billing_period_enabled": {
+                "type": ["null", "boolean"]
+              },
+              "hs_line_item_global_term_hs_recurring_billing_start_date": {
+                "type": ["null", "string"]
+              },
+              "hs_line_item_global_term_hs_recurring_billing_start_date_enabled": {
+                "type": ["null", "boolean"]
+              },
+              "hs_line_item_global_term_recurringbillingfrequency": {
+                "type": ["null", "string"]
+              },
+              "hs_line_item_global_term_recurringbillingfrequency_enabled": {
+                "type": ["null", "boolean"]
+              },
+              "hs_manual_forecast_category": { "type": ["null", "string"] },
+              "hs_merged_object_ids": { "type": ["null", "string"] },
+              "hs_mrr": { "type": ["null", "number"] },
+              "hs_next_step": { "type": ["null", "string"] },
+              "hs_next_step_updated_at": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_notes_next_activity_type": { "type": ["null", "string"] },
+              "hs_num_associated_deal_splits": { "type": ["null", "number"] },
+              "hs_num_of_associated_line_items": { "type": ["null", "number"] },
+              "hs_num_target_accounts": { "type": ["null", "number"] },
+              "hs_object_id": { "type": ["null", "number"] },
+              "hs_object_source": { "type": ["null", "string"] },
+              "hs_object_source_detail_1": { "type": ["null", "string"] },
+              "hs_object_source_detail_2": { "type": ["null", "string"] },
+              "hs_object_source_detail_3": { "type": ["null", "string"] },
+              "hs_object_source_id": { "type": ["null", "string"] },
+              "hs_object_source_label": { "type": ["null", "string"] },
+              "hs_object_source_user_id": { "type": ["null", "number"] },
+              "hs_open_deal_create_date": { "type": ["null", "number"] },
+              "hs_pinned_engagement_id": { "type": ["null", "number"] },
+              "hs_predicted_amount": { "type": ["null", "number"] },
+              "hs_predicted_amount_in_home_currency": {
+                "type": ["null", "number"]
+              },
+              "hs_priority": { "type": ["null", "string"] },
+              "hs_projected_amount": { "type": ["null", "number"] },
+              "hs_projected_amount_in_home_currency": {
+                "type": ["null", "number"]
+              },
+              "hs_read_only": { "type": ["null", "boolean"] },
+              "hs_sales_email_last_replied": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_tag_ids": { "type": ["null", "string"] },
+              "hs_tcv": { "type": ["null", "number"] },
+              "hs_time_in_66894120": { "type": ["null", "number"] },
+              "hs_time_in_9567448": { "type": ["null", "number"] },
+              "hs_time_in_9567449": { "type": ["null", "number"] },
+              "hs_time_in_appointmentscheduled": { "type": ["null", "number"] },
+              "hs_time_in_closedlost": { "type": ["null", "number"] },
+              "hs_time_in_closedwon": { "type": ["null", "number"] },
+              "hs_time_in_contractsent": { "type": ["null", "number"] },
+              "hs_time_in_customclosedwonstage": { "type": ["null", "number"] },
+              "hs_time_in_decisionmakerboughtin": {
+                "type": ["null", "number"]
+              },
+              "hs_time_in_presentationscheduled": {
+                "type": ["null", "number"]
+              },
+              "hs_time_in_qualifiedtobuy": { "type": ["null", "number"] },
+              "hs_unique_creation_key": { "type": ["null", "string"] },
+              "hs_updated_by_user_id": { "type": ["null", "number"] },
+              "hs_user_ids_of_all_notification_followers": {
+                "type": ["null", "string"]
+              },
+              "hs_user_ids_of_all_notification_unfollowers": {
+                "type": ["null", "string"]
+              },
+              "hs_user_ids_of_all_owners": { "type": ["null", "string"] },
+              "hs_v2_cumulative_time_in_66894120": {
+                "type": ["null", "number"]
+              },
+              "hs_v2_cumulative_time_in_9567448": {
+                "type": ["null", "number"]
+              },
+              "hs_v2_cumulative_time_in_9567449": {
+                "type": ["null", "number"]
+              },
+              "hs_v2_cumulative_time_in_appointmentscheduled": {
+                "type": ["null", "number"]
+              },
+              "hs_v2_cumulative_time_in_closedlost": {
+                "type": ["null", "number"]
+              },
+              "hs_v2_cumulative_time_in_closedwon": {
+                "type": ["null", "number"]
+              },
+              "hs_v2_cumulative_time_in_contractsent": {
+                "type": ["null", "number"]
+              },
+              "hs_v2_cumulative_time_in_customclosedwonstage": {
+                "type": ["null", "number"]
+              },
+              "hs_v2_cumulative_time_in_decisionmakerboughtin": {
+                "type": ["null", "number"]
+              },
+              "hs_v2_cumulative_time_in_presentationscheduled": {
+                "type": ["null", "number"]
+              },
+              "hs_v2_cumulative_time_in_qualifiedtobuy": {
+                "type": ["null", "number"]
+              },
+              "hs_v2_date_entered_66894120": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_entered_9567448": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_entered_9567449": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_entered_appointmentscheduled": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_entered_closedlost": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_entered_closedwon": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_entered_contractsent": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_entered_customclosedwonstage": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_entered_decisionmakerboughtin": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_entered_presentationscheduled": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_entered_qualifiedtobuy": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_exited_66894120": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_exited_9567448": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_exited_9567449": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_exited_appointmentscheduled": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_exited_closedlost": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_exited_closedwon": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_exited_contractsent": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_exited_customclosedwonstage": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_exited_decisionmakerboughtin": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_exited_presentationscheduled": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_date_exited_qualifiedtobuy": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_v2_latest_time_in_66894120": { "type": ["null", "number"] },
+              "hs_v2_latest_time_in_9567448": { "type": ["null", "number"] },
+              "hs_v2_latest_time_in_9567449": { "type": ["null", "number"] },
+              "hs_v2_latest_time_in_appointmentscheduled": {
+                "type": ["null", "number"]
+              },
+              "hs_v2_latest_time_in_closedlost": { "type": ["null", "number"] },
+              "hs_v2_latest_time_in_closedwon": { "type": ["null", "number"] },
+              "hs_v2_latest_time_in_contractsent": {
+                "type": ["null", "number"]
+              },
+              "hs_v2_latest_time_in_customclosedwonstage": {
+                "type": ["null", "number"]
+              },
+              "hs_v2_latest_time_in_decisionmakerboughtin": {
+                "type": ["null", "number"]
+              },
+              "hs_v2_latest_time_in_presentationscheduled": {
+                "type": ["null", "number"]
+              },
+              "hs_v2_latest_time_in_qualifiedtobuy": {
+                "type": ["null", "number"]
+              },
+              "hs_was_imported": { "type": ["null", "boolean"] },
+              "hubspot_owner_assigneddate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hubspot_owner_id": { "type": ["null", "string"] },
+              "hubspot_team_id": { "type": ["null", "string"] },
+              "notes_last_contacted": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "notes_last_updated": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "notes_next_activity_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "num_associated_contacts": { "type": ["null", "number"] },
+              "num_contacted_notes": { "type": ["null", "number"] },
+              "num_notes": { "type": ["null", "number"] },
+              "pipeline": { "type": ["null", "string"] }
+            }
+          },
+          "properties_amount": { "type": ["null", "number"] },
+          "properties_amount_in_home_currency": { "type": ["null", "number"] },
+          "properties_closed_lost_reason": { "type": ["null", "string"] },
+          "properties_closed_won_reason": { "type": ["null", "string"] },
+          "properties_closedate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_createdate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_days_to_close": { "type": ["null", "number"] },
+          "properties_dealname": { "type": ["null", "string"] },
+          "properties_dealstage": { "type": ["null", "string"] },
+          "properties_dealtype": { "type": ["null", "string"] },
+          "properties_description": { "type": ["null", "string"] },
+          "properties_engagements_last_meeting_booked": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_engagements_last_meeting_booked_campaign": {
+            "type": ["null", "string"]
+          },
+          "properties_engagements_last_meeting_booked_medium": {
+            "type": ["null", "string"]
+          },
+          "properties_engagements_last_meeting_booked_source": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_acv": { "type": ["null", "number"] },
+          "properties_hs_all_accessible_team_ids": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_all_collaborator_owner_ids": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_all_deal_split_owner_ids": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_all_owner_ids": { "type": ["null", "string"] },
+          "properties_hs_all_team_ids": { "type": ["null", "string"] },
+          "properties_hs_analytics_latest_source": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_analytics_latest_source_company": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_analytics_latest_source_contact": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_analytics_latest_source_data_1": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_analytics_latest_source_data_1_company": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_analytics_latest_source_data_1_contact": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_analytics_latest_source_data_2": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_analytics_latest_source_data_2_company": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_analytics_latest_source_data_2_contact": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_analytics_latest_source_timestamp": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_analytics_latest_source_timestamp_company": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_analytics_latest_source_timestamp_contact": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_analytics_source": { "type": ["null", "string"] },
+          "properties_hs_analytics_source_data_1": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_analytics_source_data_2": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_arr": { "type": ["null", "number"] },
+          "properties_hs_campaign": { "type": ["null", "string"] },
+          "properties_hs_closed_amount": { "type": ["null", "number"] },
+          "properties_hs_closed_amount_in_home_currency": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_closed_deal_close_date": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_closed_deal_create_date": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_closed_won_count": { "type": ["null", "number"] },
+          "properties_hs_closed_won_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_created_by_user_id": { "type": ["null", "number"] },
+          "properties_hs_createdate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_entered_66894120": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_entered_9567448": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_entered_9567449": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_entered_appointmentscheduled": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_entered_closedlost": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_entered_closedwon": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_entered_contractsent": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_entered_customclosedwonstage": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_entered_decisionmakerboughtin": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_entered_presentationscheduled": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_entered_qualifiedtobuy": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_exited_66894120": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_exited_9567448": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_exited_9567449": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_exited_appointmentscheduled": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_exited_closedlost": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_exited_closedwon": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_exited_contractsent": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_exited_customclosedwonstage": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_exited_decisionmakerboughtin": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_exited_presentationscheduled": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_exited_qualifiedtobuy": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_days_to_close_raw": { "type": ["null", "number"] },
+          "properties_hs_deal_amount_calculation_preference": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_deal_score": { "type": ["null", "number"] },
+          "properties_hs_deal_stage_probability": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_deal_stage_probability_shadow": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_exchange_rate": { "type": ["null", "number"] },
+          "properties_hs_forecast_amount": { "type": ["null", "number"] },
+          "properties_hs_forecast_probability": { "type": ["null", "number"] },
+          "properties_hs_has_empty_conditional_stage_properties": {
+            "type": ["null", "boolean"]
+          },
+          "properties_hs_is_closed": { "type": ["null", "boolean"] },
+          "properties_hs_is_closed_count": { "type": ["null", "number"] },
+          "properties_hs_is_closed_won": { "type": ["null", "boolean"] },
+          "properties_hs_is_deal_split": { "type": ["null", "boolean"] },
+          "properties_hs_is_in_first_deal_stage": {
+            "type": ["null", "boolean"]
+          },
+          "properties_hs_is_open_count": { "type": ["null", "number"] },
+          "properties_hs_lastmodifieddate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_latest_approval_status": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_latest_approval_status_approval_id": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_latest_meeting_activity": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_likelihood_to_close": { "type": ["null", "number"] },
+          "properties_hs_line_item_global_term_hs_discount_percentage": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_line_item_global_term_hs_discount_percentage_enabled": {
+            "type": ["null", "boolean"]
+          },
+          "properties_hs_line_item_global_term_hs_recurring_billing_period": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_line_item_global_term_hs_recurring_billing_period_enabled": {
+            "type": ["null", "boolean"]
+          },
+          "properties_hs_line_item_global_term_hs_recurring_billing_start_date": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_line_item_global_term_hs_recurring_billing_start_date_enabled": {
+            "type": ["null", "boolean"]
+          },
+          "properties_hs_line_item_global_term_recurringbillingfrequency": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_line_item_global_term_recurringbillingfrequency_enabled": {
+            "type": ["null", "boolean"]
+          },
+          "properties_hs_manual_forecast_category": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_merged_object_ids": { "type": ["null", "string"] },
+          "properties_hs_mrr": { "type": ["null", "number"] },
+          "properties_hs_next_step": { "type": ["null", "string"] },
+          "properties_hs_next_step_updated_at": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_notes_next_activity_type": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_num_associated_deal_splits": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_num_of_associated_line_items": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_num_target_accounts": { "type": ["null", "number"] },
+          "properties_hs_object_id": { "type": ["null", "number"] },
+          "properties_hs_object_source": { "type": ["null", "string"] },
+          "properties_hs_object_source_detail_1": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_object_source_detail_2": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_object_source_detail_3": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_object_source_id": { "type": ["null", "string"] },
+          "properties_hs_object_source_label": { "type": ["null", "string"] },
+          "properties_hs_object_source_user_id": { "type": ["null", "number"] },
+          "properties_hs_open_deal_create_date": { "type": ["null", "number"] },
+          "properties_hs_pinned_engagement_id": { "type": ["null", "number"] },
+          "properties_hs_predicted_amount": { "type": ["null", "number"] },
+          "properties_hs_predicted_amount_in_home_currency": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_priority": { "type": ["null", "string"] },
+          "properties_hs_projected_amount": { "type": ["null", "number"] },
+          "properties_hs_projected_amount_in_home_currency": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_read_only": { "type": ["null", "boolean"] },
+          "properties_hs_sales_email_last_replied": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_tag_ids": { "type": ["null", "string"] },
+          "properties_hs_tcv": { "type": ["null", "number"] },
+          "properties_hs_time_in_66894120": { "type": ["null", "number"] },
+          "properties_hs_time_in_9567448": { "type": ["null", "number"] },
+          "properties_hs_time_in_9567449": { "type": ["null", "number"] },
+          "properties_hs_time_in_appointmentscheduled": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_time_in_closedlost": { "type": ["null", "number"] },
+          "properties_hs_time_in_closedwon": { "type": ["null", "number"] },
+          "properties_hs_time_in_contractsent": { "type": ["null", "number"] },
+          "properties_hs_time_in_customclosedwonstage": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_time_in_decisionmakerboughtin": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_time_in_presentationscheduled": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_time_in_qualifiedtobuy": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_unique_creation_key": { "type": ["null", "string"] },
+          "properties_hs_updated_by_user_id": { "type": ["null", "number"] },
+          "properties_hs_user_ids_of_all_notification_followers": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_user_ids_of_all_notification_unfollowers": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_user_ids_of_all_owners": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_v2_cumulative_time_in_66894120": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_cumulative_time_in_9567448": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_cumulative_time_in_9567449": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_cumulative_time_in_appointmentscheduled": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_cumulative_time_in_closedlost": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_cumulative_time_in_closedwon": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_cumulative_time_in_contractsent": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_cumulative_time_in_customclosedwonstage": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_cumulative_time_in_decisionmakerboughtin": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_cumulative_time_in_presentationscheduled": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_cumulative_time_in_qualifiedtobuy": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_date_entered_66894120": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_entered_9567448": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_entered_9567449": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_entered_appointmentscheduled": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_entered_closedlost": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_entered_closedwon": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_entered_contractsent": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_entered_customclosedwonstage": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_entered_decisionmakerboughtin": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_entered_presentationscheduled": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_entered_qualifiedtobuy": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_exited_66894120": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_exited_9567448": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_exited_9567449": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_exited_appointmentscheduled": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_exited_closedlost": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_exited_closedwon": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_exited_contractsent": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_exited_customclosedwonstage": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_exited_decisionmakerboughtin": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_exited_presentationscheduled": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_date_exited_qualifiedtobuy": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_v2_latest_time_in_66894120": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_latest_time_in_9567448": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_latest_time_in_9567449": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_latest_time_in_appointmentscheduled": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_latest_time_in_closedlost": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_latest_time_in_closedwon": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_latest_time_in_contractsent": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_latest_time_in_customclosedwonstage": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_latest_time_in_decisionmakerboughtin": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_latest_time_in_presentationscheduled": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_v2_latest_time_in_qualifiedtobuy": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_was_imported": { "type": ["null", "boolean"] },
+          "properties_hubspot_owner_assigneddate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hubspot_owner_id": { "type": ["null", "string"] },
+          "properties_hubspot_team_id": { "type": ["null", "string"] },
+          "properties_notes_last_contacted": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_notes_last_updated": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_notes_next_activity_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_num_associated_contacts": { "type": ["null", "number"] },
+          "properties_num_contacted_notes": { "type": ["null", "number"] },
+          "properties_num_notes": { "type": ["null", "number"] },
+          "properties_pipeline": { "type": ["null", "string"] }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["timestamp"],
+      "source_defined_primary_key": [["dealId"], ["property"], ["timestamp"]],
+      "is_resumable": true
+    },
+    {
+      "name": "subscription_changes",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": ["null", "object"],
+        "properties": {
+          "timestamp": {
+            "description": "Timestamp when the subscription change data was fetched",
+            "type": ["null", "integer"]
+          },
+          "portalId": {
+            "description": "ID of the portal related to the subscription changes",
+            "type": ["null", "integer"]
+          },
+          "recipient": {
+            "description": "Recipient of the subscription change notification",
+            "type": ["null", "string"]
+          },
+          "normalizedEmailId": {
+            "description": "Normalized email identifier associated with the subscription",
+            "type": ["null", "string"]
+          },
+          "changes": {
+            "description": "List of all subscription changes",
+            "type": ["null", "array"],
+            "items": {
+              "description": "Details of each subscription change",
+              "type": ["null", "object"],
+              "properties": {
+                "change": {
+                  "description": "Details of the change that occurred",
+                  "type": ["null", "string"]
+                },
+                "timestamp": {
+                  "description": "Timestamp when the subscription change occurred",
+                  "type": ["null", "integer"]
+                },
+                "source": {
+                  "description": "Source of the subscription change",
+                  "type": ["null", "string"]
+                },
+                "portalId": {
+                  "description": "ID of the portal associated with the subscription change",
+                  "type": ["null", "integer"]
+                },
+                "subscriptionId": {
+                  "description": "Unique identifier for the subscription affected by the change",
+                  "type": ["null", "integer"]
+                },
+                "changeType": {
+                  "description": "Type of change (e.g., add, remove, update)",
+                  "type": ["null", "string"]
+                },
+                "causedByEvent": {
+                  "description": "Event that triggered the subscription change",
+                  "type": ["null", "object"],
+                  "properties": {
+                    "id": {
+                      "description": "Unique identifier for the event that caused the change",
+                      "type": ["null", "string"]
+                    },
+                    "created": {
+                      "description": "Timestamp when the event that caused the change occurred",
+                      "type": ["null", "integer"]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["timestamp"],
+      "is_resumable": true
+    },
+    {
+      "name": "tickets",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": ["null", "object"],
+        "properties": {
+          "id": {
+            "description": "Unique identifier for the ticket",
+            "type": ["null", "string"]
+          },
+          "createdAt": {
+            "description": "Date and time when the ticket was created",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "description": "Date and time when the ticket was last updated",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "archived": {
+            "description": "Indicates if the ticket is archived or not",
+            "type": ["null", "boolean"]
+          },
+          "contacts": {
+            "description": "Contacts associated with the ticket",
+            "type": ["null", "array"],
+            "items": {
+              "description": "Contact data",
+              "type": ["null", "integer"]
+            }
+          },
+          "companies": {
+            "description": "Companies associated with the ticket",
+            "type": ["null", "array"],
+            "items": {
+              "description": "Company data",
+              "type": ["null", "string"]
+            }
+          },
+          "deals": {
+            "description": "Deals associated with the ticket",
+            "type": ["null", "array"],
+            "items": { "description": "Deal data", "type": ["null", "string"] }
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "closed_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "content": { "type": ["null", "string"] },
+              "created_by": { "type": ["null", "number"] },
+              "createdate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "first_agent_reply_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_all_accessible_team_ids": { "type": ["null", "string"] },
+              "hs_all_associated_contact_companies": {
+                "type": ["null", "string"]
+              },
+              "hs_all_associated_contact_emails": {
+                "type": ["null", "string"]
+              },
+              "hs_all_associated_contact_firstnames": {
+                "type": ["null", "string"]
+              },
+              "hs_all_associated_contact_lastnames": {
+                "type": ["null", "string"]
+              },
+              "hs_all_associated_contact_mobilephones": {
+                "type": ["null", "string"]
+              },
+              "hs_all_associated_contact_phones": {
+                "type": ["null", "string"]
+              },
+              "hs_all_conversation_mentions": { "type": ["null", "string"] },
+              "hs_all_owner_ids": { "type": ["null", "string"] },
+              "hs_all_team_ids": { "type": ["null", "string"] },
+              "hs_applied_sla_rule_config_at": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_assigned_team_ids": { "type": ["null", "string"] },
+              "hs_assignment_method": { "type": ["null", "string"] },
+              "hs_auto_generated_from_thread_id": {
+                "type": ["null", "number"]
+              },
+              "hs_conversations_originating_message_id": {
+                "type": ["null", "string"]
+              },
+              "hs_conversations_originating_thread_id": {
+                "type": ["null", "number"]
+              },
+              "hs_created_by_user_id": { "type": ["null", "number"] },
+              "hs_createdate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_custom_inbox": { "type": ["null", "number"] },
+              "hs_date_entered_1": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_entered_151692305": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_entered_151692306": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_entered_151692307": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_entered_151692308": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_entered_2": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_entered_3": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_entered_4": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_exited_1": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_exited_151692305": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_exited_151692306": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_exited_151692307": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_exited_151692308": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_exited_2": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_exited_3": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_date_exited_4": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_email_subject": { "type": ["null", "string"] },
+              "hs_external_object_ids": { "type": ["null", "string"] },
+              "hs_feedback_last_ces_follow_up": { "type": ["null", "string"] },
+              "hs_feedback_last_ces_rating": { "type": ["null", "string"] },
+              "hs_feedback_last_survey_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_file_upload": { "type": ["null", "string"] },
+              "hs_first_agent_message_sent_at": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_helpdesk_sort_timestamp": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_in_helpdesk": { "type": ["null", "boolean"] },
+              "hs_inbox_id": { "type": ["null", "number"] },
+              "hs_is_latest_message_failed": { "type": ["null", "boolean"] },
+              "hs_is_visible_in_help_desk": { "type": ["null", "boolean"] },
+              "hs_last_email_activity": { "type": ["null", "string"] },
+              "hs_last_email_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_last_message_from_visitor": { "type": ["null", "boolean"] },
+              "hs_last_message_received_at": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_last_message_sent_at": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_lastactivitydate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_lastcontacted": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_lastmodifieddate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_latest_message_attachment_types": {
+                "type": ["null", "string"]
+              },
+              "hs_latest_message_is_forwarded_email": {
+                "type": ["null", "boolean"]
+              },
+              "hs_latest_message_is_thread_comment": {
+                "type": ["null", "boolean"]
+              },
+              "hs_latest_message_seen_by_agent_ids": {
+                "type": ["null", "string"]
+              },
+              "hs_latest_message_text": { "type": ["null", "string"] },
+              "hs_latest_message_visible_to_visitor": {
+                "type": ["null", "string"]
+              },
+              "hs_merged_object_ids": { "type": ["null", "string"] },
+              "hs_most_relevant_sla_status": { "type": ["null", "string"] },
+              "hs_most_relevant_sla_type": { "type": ["null", "string"] },
+              "hs_msteams_message_id": { "type": ["null", "string"] },
+              "hs_nextactivitydate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_notes_next_activity_type": { "type": ["null", "string"] },
+              "hs_num_associated_companies": { "type": ["null", "number"] },
+              "hs_num_associated_conversations": { "type": ["null", "number"] },
+              "hs_num_times_contacted": { "type": ["null", "number"] },
+              "hs_object_id": { "type": ["null", "number"] },
+              "hs_object_source": { "type": ["null", "string"] },
+              "hs_object_source_detail_1": { "type": ["null", "string"] },
+              "hs_object_source_detail_2": { "type": ["null", "string"] },
+              "hs_object_source_detail_3": { "type": ["null", "string"] },
+              "hs_object_source_id": { "type": ["null", "string"] },
+              "hs_object_source_label": { "type": ["null", "string"] },
+              "hs_object_source_user_id": { "type": ["null", "number"] },
+              "hs_originating_channel_instance_id": {
+                "type": ["null", "string"]
+              },
+              "hs_originating_email_engagement_id": {
+                "type": ["null", "number"]
+              },
+              "hs_originating_generic_channel_id": {
+                "type": ["null", "string"]
+              },
+              "hs_pinned_engagement_id": { "type": ["null", "number"] },
+              "hs_pipeline": { "type": ["null", "string"] },
+              "hs_pipeline_stage": { "type": ["null", "string"] },
+              "hs_primary_company": { "type": ["null", "string"] },
+              "hs_primary_company_id": { "type": ["null", "number"] },
+              "hs_primary_company_name": { "type": ["null", "string"] },
+              "hs_read_only": { "type": ["null", "boolean"] },
+              "hs_resolution": { "type": ["null", "string"] },
+              "hs_sales_email_last_replied": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_seen_by_agent_ids": { "type": ["null", "string"] },
+              "hs_tag_ids": { "type": ["null", "string"] },
+              "hs_thread_ids_to_restore": { "type": ["null", "string"] },
+              "hs_ticket_category": { "type": ["null", "string"] },
+              "hs_ticket_id": { "type": ["null", "number"] },
+              "hs_ticket_priority": { "type": ["null", "string"] },
+              "hs_time_in_1": { "type": ["null", "number"] },
+              "hs_time_in_151692305": { "type": ["null", "number"] },
+              "hs_time_in_151692306": { "type": ["null", "number"] },
+              "hs_time_in_151692307": { "type": ["null", "number"] },
+              "hs_time_in_151692308": { "type": ["null", "number"] },
+              "hs_time_in_2": { "type": ["null", "number"] },
+              "hs_time_in_3": { "type": ["null", "number"] },
+              "hs_time_in_4": { "type": ["null", "number"] },
+              "hs_time_to_close_sla_at": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_time_to_close_sla_status": { "type": ["null", "string"] },
+              "hs_time_to_first_response_sla_at": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_time_to_first_response_sla_status": {
+                "type": ["null", "string"]
+              },
+              "hs_time_to_next_response_sla_at": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_time_to_next_response_sla_status": {
+                "type": ["null", "string"]
+              },
+              "hs_unique_creation_key": { "type": ["null", "string"] },
+              "hs_updated_by_user_id": { "type": ["null", "number"] },
+              "hs_user_ids_of_all_notification_followers": {
+                "type": ["null", "string"]
+              },
+              "hs_user_ids_of_all_notification_unfollowers": {
+                "type": ["null", "string"]
+              },
+              "hs_user_ids_of_all_owners": { "type": ["null", "string"] },
+              "hs_was_imported": { "type": ["null", "boolean"] },
+              "hubspot_owner_assigneddate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hubspot_owner_id": { "type": ["null", "string"] },
+              "hubspot_team_id": { "type": ["null", "string"] },
+              "last_engagement_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "last_reply_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "notes_last_contacted": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "notes_last_updated": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "notes_next_activity_date": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "nps_follow_up_answer": { "type": ["null", "string"] },
+              "nps_follow_up_question_version": { "type": ["null", "number"] },
+              "nps_score": { "type": ["null", "string"] },
+              "num_contacted_notes": { "type": ["null", "number"] },
+              "num_notes": { "type": ["null", "number"] },
+              "source_ref": { "type": ["null", "string"] },
+              "source_thread_id": { "type": ["null", "string"] },
+              "source_type": { "type": ["null", "string"] },
+              "subject": { "type": ["null", "string"] },
+              "tags": { "type": ["null", "string"] },
+              "time_to_close": { "type": ["null", "number"] },
+              "time_to_first_agent_reply": { "type": ["null", "number"] }
+            }
+          },
+          "properties_closed_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_content": { "type": ["null", "string"] },
+          "properties_created_by": { "type": ["null", "number"] },
+          "properties_createdate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_first_agent_reply_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_all_accessible_team_ids": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_all_associated_contact_companies": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_all_associated_contact_emails": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_all_associated_contact_firstnames": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_all_associated_contact_lastnames": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_all_associated_contact_mobilephones": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_all_associated_contact_phones": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_all_conversation_mentions": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_all_owner_ids": { "type": ["null", "string"] },
+          "properties_hs_all_team_ids": { "type": ["null", "string"] },
+          "properties_hs_applied_sla_rule_config_at": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_assigned_team_ids": { "type": ["null", "string"] },
+          "properties_hs_assignment_method": { "type": ["null", "string"] },
+          "properties_hs_auto_generated_from_thread_id": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_conversations_originating_message_id": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_conversations_originating_thread_id": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_created_by_user_id": { "type": ["null", "number"] },
+          "properties_hs_createdate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_custom_inbox": { "type": ["null", "number"] },
+          "properties_hs_date_entered_1": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_entered_151692305": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_entered_151692306": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_entered_151692307": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_entered_151692308": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_entered_2": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_entered_3": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_entered_4": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_exited_1": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_exited_151692305": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_exited_151692306": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_exited_151692307": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_exited_151692308": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_exited_2": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_exited_3": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_date_exited_4": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_email_subject": { "type": ["null", "string"] },
+          "properties_hs_external_object_ids": { "type": ["null", "string"] },
+          "properties_hs_feedback_last_ces_follow_up": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_feedback_last_ces_rating": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_feedback_last_survey_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_file_upload": { "type": ["null", "string"] },
+          "properties_hs_first_agent_message_sent_at": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_helpdesk_sort_timestamp": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_in_helpdesk": { "type": ["null", "boolean"] },
+          "properties_hs_inbox_id": { "type": ["null", "number"] },
+          "properties_hs_is_latest_message_failed": {
+            "type": ["null", "boolean"]
+          },
+          "properties_hs_is_visible_in_help_desk": {
+            "type": ["null", "boolean"]
+          },
+          "properties_hs_last_email_activity": { "type": ["null", "string"] },
+          "properties_hs_last_email_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_last_message_from_visitor": {
+            "type": ["null", "boolean"]
+          },
+          "properties_hs_last_message_received_at": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_last_message_sent_at": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_lastactivitydate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_lastcontacted": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_lastmodifieddate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_latest_message_attachment_types": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_latest_message_is_forwarded_email": {
+            "type": ["null", "boolean"]
+          },
+          "properties_hs_latest_message_is_thread_comment": {
+            "type": ["null", "boolean"]
+          },
+          "properties_hs_latest_message_seen_by_agent_ids": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_latest_message_text": { "type": ["null", "string"] },
+          "properties_hs_latest_message_visible_to_visitor": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_merged_object_ids": { "type": ["null", "string"] },
+          "properties_hs_most_relevant_sla_status": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_most_relevant_sla_type": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_msteams_message_id": { "type": ["null", "string"] },
+          "properties_hs_nextactivitydate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_notes_next_activity_type": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_num_associated_companies": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_num_associated_conversations": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_num_times_contacted": { "type": ["null", "number"] },
+          "properties_hs_object_id": { "type": ["null", "number"] },
+          "properties_hs_object_source": { "type": ["null", "string"] },
+          "properties_hs_object_source_detail_1": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_object_source_detail_2": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_object_source_detail_3": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_object_source_id": { "type": ["null", "string"] },
+          "properties_hs_object_source_label": { "type": ["null", "string"] },
+          "properties_hs_object_source_user_id": { "type": ["null", "number"] },
+          "properties_hs_originating_channel_instance_id": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_originating_email_engagement_id": {
+            "type": ["null", "number"]
+          },
+          "properties_hs_originating_generic_channel_id": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_pinned_engagement_id": { "type": ["null", "number"] },
+          "properties_hs_pipeline": { "type": ["null", "string"] },
+          "properties_hs_pipeline_stage": { "type": ["null", "string"] },
+          "properties_hs_primary_company": { "type": ["null", "string"] },
+          "properties_hs_primary_company_id": { "type": ["null", "number"] },
+          "properties_hs_primary_company_name": { "type": ["null", "string"] },
+          "properties_hs_read_only": { "type": ["null", "boolean"] },
+          "properties_hs_resolution": { "type": ["null", "string"] },
+          "properties_hs_sales_email_last_replied": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_seen_by_agent_ids": { "type": ["null", "string"] },
+          "properties_hs_tag_ids": { "type": ["null", "string"] },
+          "properties_hs_thread_ids_to_restore": { "type": ["null", "string"] },
+          "properties_hs_ticket_category": { "type": ["null", "string"] },
+          "properties_hs_ticket_id": { "type": ["null", "number"] },
+          "properties_hs_ticket_priority": { "type": ["null", "string"] },
+          "properties_hs_time_in_1": { "type": ["null", "number"] },
+          "properties_hs_time_in_151692305": { "type": ["null", "number"] },
+          "properties_hs_time_in_151692306": { "type": ["null", "number"] },
+          "properties_hs_time_in_151692307": { "type": ["null", "number"] },
+          "properties_hs_time_in_151692308": { "type": ["null", "number"] },
+          "properties_hs_time_in_2": { "type": ["null", "number"] },
+          "properties_hs_time_in_3": { "type": ["null", "number"] },
+          "properties_hs_time_in_4": { "type": ["null", "number"] },
+          "properties_hs_time_to_close_sla_at": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_time_to_close_sla_status": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_time_to_first_response_sla_at": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_time_to_first_response_sla_status": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_time_to_next_response_sla_at": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_time_to_next_response_sla_status": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_unique_creation_key": { "type": ["null", "string"] },
+          "properties_hs_updated_by_user_id": { "type": ["null", "number"] },
+          "properties_hs_user_ids_of_all_notification_followers": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_user_ids_of_all_notification_unfollowers": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_user_ids_of_all_owners": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_was_imported": { "type": ["null", "boolean"] },
+          "properties_hubspot_owner_assigneddate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hubspot_owner_id": { "type": ["null", "string"] },
+          "properties_hubspot_team_id": { "type": ["null", "string"] },
+          "properties_last_engagement_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_last_reply_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_notes_last_contacted": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_notes_last_updated": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_notes_next_activity_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_nps_follow_up_answer": { "type": ["null", "string"] },
+          "properties_nps_follow_up_question_version": {
+            "type": ["null", "number"]
+          },
+          "properties_nps_score": { "type": ["null", "string"] },
+          "properties_num_contacted_notes": { "type": ["null", "number"] },
+          "properties_num_notes": { "type": ["null", "number"] },
+          "properties_source_ref": { "type": ["null", "string"] },
+          "properties_source_thread_id": { "type": ["null", "string"] },
+          "properties_source_type": { "type": ["null", "string"] },
+          "properties_subject": { "type": ["null", "string"] },
+          "properties_tags": { "type": ["null", "string"] },
+          "properties_time_to_close": { "type": ["null", "number"] },
+          "properties_time_to_first_agent_reply": { "type": ["null", "number"] }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updatedAt"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "ticket_pipelines",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": ["null", "object"],
+        "properties": {
+          "label": {
+            "description": "The label or name of the ticket pipeline.",
+            "type": ["null", "string"]
+          },
+          "displayOrder": {
+            "description": "The order in which the ticket pipeline is displayed.",
+            "type": ["null", "integer"]
+          },
+          "id": {
+            "description": "The unique identifier of the ticket pipeline.",
+            "type": ["null", "string"]
+          },
+          "archived": {
+            "description": "Indicates if the ticket pipeline is archived or not.",
+            "type": ["null", "boolean"]
+          },
+          "stages": {
+            "description": "List of stages within the ticket pipeline.",
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "label": {
+                  "description": "The label or name of the stage.",
+                  "type": ["null", "string"]
+                },
+                "displayOrder": {
+                  "description": "The order in which the stage is displayed.",
+                  "type": ["null", "integer"]
+                },
+                "metadata": {
+                  "description": "Additional metadata related to the stage.",
+                  "type": ["null", "object"],
+                  "properties": {
+                    "ticketState": {
+                      "description": "The state of the ticket within this stage.",
+                      "type": ["null", "string"]
+                    },
+                    "isClosed": {
+                      "description": "Indicates if the stage is closed or not.",
+                      "type": ["null", "string"]
+                    }
+                  }
+                },
+                "id": {
+                  "description": "The unique identifier of the stage.",
+                  "type": ["null", "string"]
+                },
+                "createdAt": {
+                  "description": "The date and time when the stage was created.",
+                  "type": ["null", "string"],
+                  "format": "date-time"
+                },
+                "updatedAt": {
+                  "description": "The date and time when the stage was last updated.",
+                  "type": ["null", "string"],
+                  "format": "date-time"
+                },
+                "active": {
+                  "description": "Indicates if the stage is actively being used.",
+                  "type": ["null", "boolean"]
+                },
+                "archived": {
+                  "description": "Indicates if the stage is archived or not.",
+                  "type": ["null", "boolean"]
+                },
+                "writePermissions": {
+                  "description": "Permissions for writing/modifying the stage.",
+                  "type": ["null", "string"]
+                }
+              }
+            }
+          },
+          "createdAt": {
+            "description": "The date and time when the ticket pipeline was created.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "description": "The date and time when the ticket pipeline was last updated.",
+            "type": ["null", "string"],
+            "format": "date-time"
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updatedAt"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "workflows",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": ["null", "object"],
+        "properties": {
+          "name": {
+            "description": "Name of the workflow",
+            "type": ["null", "string"]
+          },
+          "id": {
+            "description": "Unique identifier of the workflow",
+            "type": ["null", "integer"]
+          },
+          "type": {
+            "description": "Type of the workflow",
+            "type": ["null", "string"]
+          },
+          "enabled": {
+            "description": "Flag indicating if the workflow is enabled",
+            "type": ["null", "boolean"]
+          },
+          "insertedAt": {
+            "description": "Timestamp when the workflow was inserted",
+            "type": ["null", "integer"]
+          },
+          "updatedAt": {
+            "description": "Timestamp when the workflow was last updated",
+            "type": ["null", "integer"]
+          },
+          "personaTagIds": {
+            "description": "IDs of persona tags associated with the workflow",
+            "type": ["null", "array"],
+            "items": {
+              "description": "Individual persona tag ID",
+              "type": ["null", "integer"]
+            }
+          },
+          "contactListIds": {
+            "description": "IDs of contact lists associated with the workflow",
+            "type": ["null", "object"],
+            "properties": {
+              "enrolled": {
+                "description": "ID of the contact list containing enrolled contacts",
+                "type": ["null", "integer"]
+              },
+              "active": {
+                "description": "ID of the contact list containing active contacts",
+                "type": ["null", "integer"]
+              },
+              "steps": {
+                "description": "List of steps within the workflow",
+                "type": ["null", "array"],
+                "items": {
+                  "description": "Individual step details",
+                  "type": ["null", "string"]
+                }
+              },
+              "completed": {
+                "description": "ID of the contact list containing completed contacts",
+                "type": ["null", "integer"]
+              },
+              "succeeded": {
+                "description": "ID of the contact list containing succeeded contacts",
+                "type": ["null", "integer"]
+              }
+            }
+          },
+          "contactListIds_enrolled": {
+            "description": "ID of the contact list containing enrolled contacts",
+            "type": ["null", "integer"]
+          },
+          "contactListIds_active": {
+            "description": "ID of the contact list containing active contacts",
+            "type": ["null", "integer"]
+          },
+          "contactListIds_completed": {
+            "description": "ID of the contact list containing completed contacts",
+            "type": ["null", "integer"]
+          },
+          "contactListIds_succeeded": {
+            "description": "ID of the contact list containing succeeded contacts",
+            "type": ["null", "integer"]
+          },
+          "contactListIds_steps": {
+            "description": "List of steps within the workflow",
+            "type": ["null", "array"],
+            "items": {
+              "description": "Individual step details",
+              "type": ["null", "string"]
+            }
+          },
+          "lastUpdatedByUserId": {
+            "description": "ID of the user who last updated the workflow",
+            "type": ["null", "integer"]
+          },
+          "contactCounts": {
+            "description": "Counts of contacts in various stages within the workflow",
+            "type": ["null", "object"],
+            "properties": {
+              "active": {
+                "description": "Count of contacts currently active in the workflow",
+                "type": ["null", "integer"]
+              },
+              "enrolled": {
+                "description": "Count of contacts enrolled in the workflow",
+                "type": ["null", "integer"]
+              }
+            }
+          },
+          "description": {
+            "description": "Description of the workflow",
+            "type": ["null", "string"]
+          },
+          "originalAuthorUserId": {
+            "description": "ID of the original author of the workflow",
+            "type": ["null", "integer"]
+          },
+          "migrationStatus": {
+            "description": "Status and details of workflow migration",
+            "type": ["null", "object"],
+            "properties": {
+              "enrollmentMigrationStatus": {
+                "description": "Enrollment migration status",
+                "type": ["null", "string"]
+              },
+              "enrollmentMigrationTimestamp": {
+                "description": "Timestamp of enrollment migration",
+                "type": ["null", "integer"]
+              },
+              "flowId": {
+                "description": "ID of the flow",
+                "type": ["null", "integer"]
+              },
+              "lastSuccessfulMigrationTimestamp": {
+                "description": "Timestamp of last successful migration",
+                "type": ["null", "integer"]
+              },
+              "migrationStatus": {
+                "description": "Overall migration status",
+                "type": ["null", "string"]
+              },
+              "platformOwnsActions": {
+                "description": "Flag indicating if the platform owns actions",
+                "type": ["null", "boolean"]
+              },
+              "portalId": {
+                "description": "ID of the portal",
+                "type": ["null", "integer"]
+              },
+              "workflowId": {
+                "description": "ID of the workflow",
+                "type": ["null", "integer"]
+              }
+            }
+          },
+          "updateSource": {
+            "description": "Details of the workflow update source",
+            "type": ["null", "object"],
+            "properties": {
+              "sourceApplication": {
+                "description": "Application details of the workflow update source",
+                "type": ["null", "object"],
+                "properties": {
+                  "serviceName": {
+                    "description": "Name of the service",
+                    "type": ["null", "string"]
+                  },
+                  "source": {
+                    "description": "Source details",
+                    "type": ["null", "string"]
+                  }
+                }
+              },
+              "updatedAt": {
+                "description": "Timestamp of workflow update",
+                "type": ["null", "integer"]
+              },
+              "updatedByUser": {
+                "description": "Details of the user who updated the workflow",
+                "type": ["null", "object"],
+                "properties": {
+                  "userEmail": {
+                    "description": "Email address of the user",
+                    "type": ["null", "string"]
+                  },
+                  "userId": {
+                    "description": "ID of the user",
+                    "type": ["null", "integer"]
+                  }
+                }
+              }
+            }
+          },
+          "creationSource": {
+            "description": "Details of the workflow creation source",
+            "type": ["null", "object"],
+            "properties": {
+              "clonedFromWorkflowId": {
+                "description": "ID of the workflow that was cloned",
+                "type": ["null", "integer"]
+              },
+              "createdAt": {
+                "description": "Timestamp of workflow creation",
+                "type": ["null", "integer"]
+              },
+              "createdByUser": {
+                "description": "Details of the user who created the workflow",
+                "type": ["null", "object"],
+                "properties": {
+                  "userEmail": {
+                    "description": "Email address of the user",
+                    "type": ["null", "string"]
+                  },
+                  "userId": {
+                    "description": "ID of the user",
+                    "type": ["null", "integer"]
+                  }
+                }
+              },
+              "sourceApplication": {
+                "description": "Application details of the workflow source",
+                "type": ["null", "object"],
+                "properties": {
+                  "serviceName": {
+                    "description": "Name of the service",
+                    "type": ["null", "string"]
+                  },
+                  "source": {
+                    "description": "Source details",
+                    "type": ["null", "string"]
+                  }
+                }
+              }
+            }
+          },
+          "portalId": {
+            "description": "ID of the portal associated with the workflow",
+            "type": ["null", "integer"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updatedAt"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "contacts_web_analytics",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": ["null", "object"],
+        "additionalProperties": true,
+        "properties": {
+          "properties_hs_asset_description": { "type": ["null", "string"] },
+          "properties_hs_asset_type": { "type": ["null", "string"] },
+          "properties_hs_browser": { "type": ["null", "string"] },
+          "properties_hs_campaign_id": { "type": ["null", "string"] },
+          "properties_hs_city": { "type": ["null", "string"] },
+          "properties_hs_country": { "type": ["null", "string"] },
+          "properties_hs_device_name": { "type": ["null", "string"] },
+          "properties_hs_device_type": { "type": ["null", "string"] },
+          "properties_hs_title": { "type": ["null", "string"] },
+          "properties_hs_form_correlation_id": { "type": ["null", "string"] },
+          "properties_hs_element_class": { "type": ["null", "string"] },
+          "properties_hs_element_id": { "type": ["null", "string"] },
+          "properties_hs_element_text": { "type": ["null", "string"] },
+          "properties_hs_language": { "type": ["null", "string"] },
+          "properties_hs_document_id": { "type": ["null", "string"] },
+          "properties_hs_presentation_id": { "type": ["null", "string"] },
+          "properties_hs_user_id": { "type": ["null", "string"] },
+          "properties_hs_link_href": { "type": ["null", "string"] },
+          "properties_hs_operating_system": { "type": ["null", "string"] },
+          "properties_hs_operating_version": { "type": ["null", "string"] },
+          "properties_hs_page_content_type": { "type": ["null", "string"] },
+          "properties_hs_page_id": { "type": ["null", "string"] },
+          "properties_hs_page_title": { "type": ["null", "string"] },
+          "properties_hs_page_url": { "type": ["null", "string"] },
+          "properties_hs_parent_module_id": { "type": ["null", "string"] },
+          "properties_hs_referrer": { "type": ["null", "string"] },
+          "properties_hs_region": { "type": ["null", "string"] },
+          "properties_hs_url": { "type": ["null", "string"] },
+          "properties_hs_screen_height": { "type": ["null", "string"] },
+          "properties_hs_screen_width": { "type": ["null", "string"] },
+          "properties_hs_touchpoint_source": { "type": ["null", "string"] },
+          "properties_hs_tracking_name": { "type": ["null", "string"] },
+          "properties_hs_user_agent": { "type": ["null", "string"] },
+          "properties_hs_utm_campaign": { "type": ["null", "string"] },
+          "properties_hs_utm_content": { "type": ["null", "string"] },
+          "properties_hs_utm_medium": { "type": ["null", "string"] },
+          "properties_hs_utm_source": { "type": ["null", "string"] },
+          "properties_hs_utm_term": { "type": ["null", "string"] },
+          "id": { "type": ["null", "string"] },
+          "properties_hs_base_url": { "type": ["null", "string"] },
+          "properties_hs_form_id": { "type": ["null", "string"] },
+          "properties_hs_form_type": { "type": ["null", "string"] },
+          "properties_hs_url_domain": { "type": ["null", "string"] },
+          "properties_hs_url_path": { "type": ["null", "string"] },
+          "properties_hs_visitor_type": { "type": ["null", "string"] },
+          "objectId": { "type": ["null", "string"] },
+          "objectType": { "type": ["null", "string"] },
+          "eventType": { "type": ["null", "string"] },
+          "occurredAt": { "type": ["null", "string"], "format": "date-time" }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["occurredAt"],
+      "is_resumable": true
+    },
+    {
+      "name": "companies_web_analytics",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": ["null", "object"],
+        "additionalProperties": true,
+        "properties": {
+          "properties_hs_asset_description": { "type": ["null", "string"] },
+          "properties_hs_asset_type": { "type": ["null", "string"] },
+          "properties_hs_browser": { "type": ["null", "string"] },
+          "properties_hs_campaign_id": { "type": ["null", "string"] },
+          "properties_hs_city": { "type": ["null", "string"] },
+          "properties_hs_country": { "type": ["null", "string"] },
+          "properties_hs_device_name": { "type": ["null", "string"] },
+          "properties_hs_device_type": { "type": ["null", "string"] },
+          "properties_hs_title": { "type": ["null", "string"] },
+          "properties_hs_form_correlation_id": { "type": ["null", "string"] },
+          "properties_hs_element_class": { "type": ["null", "string"] },
+          "properties_hs_element_id": { "type": ["null", "string"] },
+          "properties_hs_element_text": { "type": ["null", "string"] },
+          "properties_hs_language": { "type": ["null", "string"] },
+          "properties_hs_document_id": { "type": ["null", "string"] },
+          "properties_hs_presentation_id": { "type": ["null", "string"] },
+          "properties_hs_user_id": { "type": ["null", "string"] },
+          "properties_hs_link_href": { "type": ["null", "string"] },
+          "properties_hs_operating_system": { "type": ["null", "string"] },
+          "properties_hs_operating_version": { "type": ["null", "string"] },
+          "properties_hs_page_content_type": { "type": ["null", "string"] },
+          "properties_hs_page_id": { "type": ["null", "string"] },
+          "properties_hs_page_title": { "type": ["null", "string"] },
+          "properties_hs_page_url": { "type": ["null", "string"] },
+          "properties_hs_parent_module_id": { "type": ["null", "string"] },
+          "properties_hs_referrer": { "type": ["null", "string"] },
+          "properties_hs_region": { "type": ["null", "string"] },
+          "properties_hs_url": { "type": ["null", "string"] },
+          "properties_hs_screen_height": { "type": ["null", "string"] },
+          "properties_hs_screen_width": { "type": ["null", "string"] },
+          "properties_hs_touchpoint_source": { "type": ["null", "string"] },
+          "properties_hs_tracking_name": { "type": ["null", "string"] },
+          "properties_hs_user_agent": { "type": ["null", "string"] },
+          "properties_hs_utm_campaign": { "type": ["null", "string"] },
+          "properties_hs_utm_content": { "type": ["null", "string"] },
+          "properties_hs_utm_medium": { "type": ["null", "string"] },
+          "properties_hs_utm_source": { "type": ["null", "string"] },
+          "properties_hs_utm_term": { "type": ["null", "string"] },
+          "id": { "type": ["null", "string"] },
+          "properties_hs_base_url": { "type": ["null", "string"] },
+          "properties_hs_form_id": { "type": ["null", "string"] },
+          "properties_hs_form_type": { "type": ["null", "string"] },
+          "properties_hs_url_domain": { "type": ["null", "string"] },
+          "properties_hs_url_path": { "type": ["null", "string"] },
+          "properties_hs_visitor_type": { "type": ["null", "string"] },
+          "objectId": { "type": ["null", "string"] },
+          "objectType": { "type": ["null", "string"] },
+          "eventType": { "type": ["null", "string"] },
+          "occurredAt": { "type": ["null", "string"], "format": "date-time" }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["occurredAt"],
+      "is_resumable": true
+    },
+    {
+      "name": "deals_web_analytics",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": ["null", "object"],
+        "additionalProperties": true,
+        "properties": {
+          "properties_hs_asset_description": { "type": ["null", "string"] },
+          "properties_hs_asset_type": { "type": ["null", "string"] },
+          "properties_hs_browser": { "type": ["null", "string"] },
+          "properties_hs_campaign_id": { "type": ["null", "string"] },
+          "properties_hs_city": { "type": ["null", "string"] },
+          "properties_hs_country": { "type": ["null", "string"] },
+          "properties_hs_device_name": { "type": ["null", "string"] },
+          "properties_hs_device_type": { "type": ["null", "string"] },
+          "properties_hs_title": { "type": ["null", "string"] },
+          "properties_hs_form_correlation_id": { "type": ["null", "string"] },
+          "properties_hs_element_class": { "type": ["null", "string"] },
+          "properties_hs_element_id": { "type": ["null", "string"] },
+          "properties_hs_element_text": { "type": ["null", "string"] },
+          "properties_hs_language": { "type": ["null", "string"] },
+          "properties_hs_document_id": { "type": ["null", "string"] },
+          "properties_hs_presentation_id": { "type": ["null", "string"] },
+          "properties_hs_user_id": { "type": ["null", "string"] },
+          "properties_hs_link_href": { "type": ["null", "string"] },
+          "properties_hs_operating_system": { "type": ["null", "string"] },
+          "properties_hs_operating_version": { "type": ["null", "string"] },
+          "properties_hs_page_content_type": { "type": ["null", "string"] },
+          "properties_hs_page_id": { "type": ["null", "string"] },
+          "properties_hs_page_title": { "type": ["null", "string"] },
+          "properties_hs_page_url": { "type": ["null", "string"] },
+          "properties_hs_parent_module_id": { "type": ["null", "string"] },
+          "properties_hs_referrer": { "type": ["null", "string"] },
+          "properties_hs_region": { "type": ["null", "string"] },
+          "properties_hs_url": { "type": ["null", "string"] },
+          "properties_hs_screen_height": { "type": ["null", "string"] },
+          "properties_hs_screen_width": { "type": ["null", "string"] },
+          "properties_hs_touchpoint_source": { "type": ["null", "string"] },
+          "properties_hs_tracking_name": { "type": ["null", "string"] },
+          "properties_hs_user_agent": { "type": ["null", "string"] },
+          "properties_hs_utm_campaign": { "type": ["null", "string"] },
+          "properties_hs_utm_content": { "type": ["null", "string"] },
+          "properties_hs_utm_medium": { "type": ["null", "string"] },
+          "properties_hs_utm_source": { "type": ["null", "string"] },
+          "properties_hs_utm_term": { "type": ["null", "string"] },
+          "id": { "type": ["null", "string"] },
+          "properties_hs_base_url": { "type": ["null", "string"] },
+          "properties_hs_form_id": { "type": ["null", "string"] },
+          "properties_hs_form_type": { "type": ["null", "string"] },
+          "properties_hs_url_domain": { "type": ["null", "string"] },
+          "properties_hs_url_path": { "type": ["null", "string"] },
+          "properties_hs_visitor_type": { "type": ["null", "string"] },
+          "objectId": { "type": ["null", "string"] },
+          "objectType": { "type": ["null", "string"] },
+          "eventType": { "type": ["null", "string"] },
+          "occurredAt": { "type": ["null", "string"], "format": "date-time" }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["occurredAt"],
+      "is_resumable": true
+    },
+    {
+      "name": "tickets_web_analytics",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": ["null", "object"],
+        "additionalProperties": true,
+        "properties": {
+          "properties_hs_asset_description": { "type": ["null", "string"] },
+          "properties_hs_asset_type": { "type": ["null", "string"] },
+          "properties_hs_browser": { "type": ["null", "string"] },
+          "properties_hs_campaign_id": { "type": ["null", "string"] },
+          "properties_hs_city": { "type": ["null", "string"] },
+          "properties_hs_country": { "type": ["null", "string"] },
+          "properties_hs_device_name": { "type": ["null", "string"] },
+          "properties_hs_device_type": { "type": ["null", "string"] },
+          "properties_hs_title": { "type": ["null", "string"] },
+          "properties_hs_form_correlation_id": { "type": ["null", "string"] },
+          "properties_hs_element_class": { "type": ["null", "string"] },
+          "properties_hs_element_id": { "type": ["null", "string"] },
+          "properties_hs_element_text": { "type": ["null", "string"] },
+          "properties_hs_language": { "type": ["null", "string"] },
+          "properties_hs_document_id": { "type": ["null", "string"] },
+          "properties_hs_presentation_id": { "type": ["null", "string"] },
+          "properties_hs_user_id": { "type": ["null", "string"] },
+          "properties_hs_link_href": { "type": ["null", "string"] },
+          "properties_hs_operating_system": { "type": ["null", "string"] },
+          "properties_hs_operating_version": { "type": ["null", "string"] },
+          "properties_hs_page_content_type": { "type": ["null", "string"] },
+          "properties_hs_page_id": { "type": ["null", "string"] },
+          "properties_hs_page_title": { "type": ["null", "string"] },
+          "properties_hs_page_url": { "type": ["null", "string"] },
+          "properties_hs_parent_module_id": { "type": ["null", "string"] },
+          "properties_hs_referrer": { "type": ["null", "string"] },
+          "properties_hs_region": { "type": ["null", "string"] },
+          "properties_hs_url": { "type": ["null", "string"] },
+          "properties_hs_screen_height": { "type": ["null", "string"] },
+          "properties_hs_screen_width": { "type": ["null", "string"] },
+          "properties_hs_touchpoint_source": { "type": ["null", "string"] },
+          "properties_hs_tracking_name": { "type": ["null", "string"] },
+          "properties_hs_user_agent": { "type": ["null", "string"] },
+          "properties_hs_utm_campaign": { "type": ["null", "string"] },
+          "properties_hs_utm_content": { "type": ["null", "string"] },
+          "properties_hs_utm_medium": { "type": ["null", "string"] },
+          "properties_hs_utm_source": { "type": ["null", "string"] },
+          "properties_hs_utm_term": { "type": ["null", "string"] },
+          "id": { "type": ["null", "string"] },
+          "properties_hs_base_url": { "type": ["null", "string"] },
+          "properties_hs_form_id": { "type": ["null", "string"] },
+          "properties_hs_form_type": { "type": ["null", "string"] },
+          "properties_hs_url_domain": { "type": ["null", "string"] },
+          "properties_hs_url_path": { "type": ["null", "string"] },
+          "properties_hs_visitor_type": { "type": ["null", "string"] },
+          "objectId": { "type": ["null", "string"] },
+          "objectType": { "type": ["null", "string"] },
+          "eventType": { "type": ["null", "string"] },
+          "occurredAt": { "type": ["null", "string"], "format": "date-time" }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["occurredAt"],
+      "is_resumable": true
+    },
+    {
+      "name": "engagements_calls_web_analytics",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": ["null", "object"],
+        "additionalProperties": true,
+        "properties": {
+          "properties_hs_asset_description": { "type": ["null", "string"] },
+          "properties_hs_asset_type": { "type": ["null", "string"] },
+          "properties_hs_browser": { "type": ["null", "string"] },
+          "properties_hs_campaign_id": { "type": ["null", "string"] },
+          "properties_hs_city": { "type": ["null", "string"] },
+          "properties_hs_country": { "type": ["null", "string"] },
+          "properties_hs_device_name": { "type": ["null", "string"] },
+          "properties_hs_device_type": { "type": ["null", "string"] },
+          "properties_hs_title": { "type": ["null", "string"] },
+          "properties_hs_form_correlation_id": { "type": ["null", "string"] },
+          "properties_hs_element_class": { "type": ["null", "string"] },
+          "properties_hs_element_id": { "type": ["null", "string"] },
+          "properties_hs_element_text": { "type": ["null", "string"] },
+          "properties_hs_language": { "type": ["null", "string"] },
+          "properties_hs_document_id": { "type": ["null", "string"] },
+          "properties_hs_presentation_id": { "type": ["null", "string"] },
+          "properties_hs_user_id": { "type": ["null", "string"] },
+          "properties_hs_link_href": { "type": ["null", "string"] },
+          "properties_hs_operating_system": { "type": ["null", "string"] },
+          "properties_hs_operating_version": { "type": ["null", "string"] },
+          "properties_hs_page_content_type": { "type": ["null", "string"] },
+          "properties_hs_page_id": { "type": ["null", "string"] },
+          "properties_hs_page_title": { "type": ["null", "string"] },
+          "properties_hs_page_url": { "type": ["null", "string"] },
+          "properties_hs_parent_module_id": { "type": ["null", "string"] },
+          "properties_hs_referrer": { "type": ["null", "string"] },
+          "properties_hs_region": { "type": ["null", "string"] },
+          "properties_hs_url": { "type": ["null", "string"] },
+          "properties_hs_screen_height": { "type": ["null", "string"] },
+          "properties_hs_screen_width": { "type": ["null", "string"] },
+          "properties_hs_touchpoint_source": { "type": ["null", "string"] },
+          "properties_hs_tracking_name": { "type": ["null", "string"] },
+          "properties_hs_user_agent": { "type": ["null", "string"] },
+          "properties_hs_utm_campaign": { "type": ["null", "string"] },
+          "properties_hs_utm_content": { "type": ["null", "string"] },
+          "properties_hs_utm_medium": { "type": ["null", "string"] },
+          "properties_hs_utm_source": { "type": ["null", "string"] },
+          "properties_hs_utm_term": { "type": ["null", "string"] },
+          "id": { "type": ["null", "string"] },
+          "properties_hs_base_url": { "type": ["null", "string"] },
+          "properties_hs_form_id": { "type": ["null", "string"] },
+          "properties_hs_form_type": { "type": ["null", "string"] },
+          "properties_hs_url_domain": { "type": ["null", "string"] },
+          "properties_hs_url_path": { "type": ["null", "string"] },
+          "properties_hs_visitor_type": { "type": ["null", "string"] },
+          "objectId": { "type": ["null", "string"] },
+          "objectType": { "type": ["null", "string"] },
+          "eventType": { "type": ["null", "string"] },
+          "occurredAt": { "type": ["null", "string"], "format": "date-time" }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["occurredAt"],
+      "is_resumable": true
+    },
+    {
+      "name": "engagements_emails_web_analytics",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": ["null", "object"],
+        "additionalProperties": true,
+        "properties": {
+          "properties_hs_asset_description": { "type": ["null", "string"] },
+          "properties_hs_asset_type": { "type": ["null", "string"] },
+          "properties_hs_browser": { "type": ["null", "string"] },
+          "properties_hs_campaign_id": { "type": ["null", "string"] },
+          "properties_hs_city": { "type": ["null", "string"] },
+          "properties_hs_country": { "type": ["null", "string"] },
+          "properties_hs_device_name": { "type": ["null", "string"] },
+          "properties_hs_device_type": { "type": ["null", "string"] },
+          "properties_hs_title": { "type": ["null", "string"] },
+          "properties_hs_form_correlation_id": { "type": ["null", "string"] },
+          "properties_hs_element_class": { "type": ["null", "string"] },
+          "properties_hs_element_id": { "type": ["null", "string"] },
+          "properties_hs_element_text": { "type": ["null", "string"] },
+          "properties_hs_language": { "type": ["null", "string"] },
+          "properties_hs_document_id": { "type": ["null", "string"] },
+          "properties_hs_presentation_id": { "type": ["null", "string"] },
+          "properties_hs_user_id": { "type": ["null", "string"] },
+          "properties_hs_link_href": { "type": ["null", "string"] },
+          "properties_hs_operating_system": { "type": ["null", "string"] },
+          "properties_hs_operating_version": { "type": ["null", "string"] },
+          "properties_hs_page_content_type": { "type": ["null", "string"] },
+          "properties_hs_page_id": { "type": ["null", "string"] },
+          "properties_hs_page_title": { "type": ["null", "string"] },
+          "properties_hs_page_url": { "type": ["null", "string"] },
+          "properties_hs_parent_module_id": { "type": ["null", "string"] },
+          "properties_hs_referrer": { "type": ["null", "string"] },
+          "properties_hs_region": { "type": ["null", "string"] },
+          "properties_hs_url": { "type": ["null", "string"] },
+          "properties_hs_screen_height": { "type": ["null", "string"] },
+          "properties_hs_screen_width": { "type": ["null", "string"] },
+          "properties_hs_touchpoint_source": { "type": ["null", "string"] },
+          "properties_hs_tracking_name": { "type": ["null", "string"] },
+          "properties_hs_user_agent": { "type": ["null", "string"] },
+          "properties_hs_utm_campaign": { "type": ["null", "string"] },
+          "properties_hs_utm_content": { "type": ["null", "string"] },
+          "properties_hs_utm_medium": { "type": ["null", "string"] },
+          "properties_hs_utm_source": { "type": ["null", "string"] },
+          "properties_hs_utm_term": { "type": ["null", "string"] },
+          "id": { "type": ["null", "string"] },
+          "properties_hs_base_url": { "type": ["null", "string"] },
+          "properties_hs_form_id": { "type": ["null", "string"] },
+          "properties_hs_form_type": { "type": ["null", "string"] },
+          "properties_hs_url_domain": { "type": ["null", "string"] },
+          "properties_hs_url_path": { "type": ["null", "string"] },
+          "properties_hs_visitor_type": { "type": ["null", "string"] },
+          "objectId": { "type": ["null", "string"] },
+          "objectType": { "type": ["null", "string"] },
+          "eventType": { "type": ["null", "string"] },
+          "occurredAt": { "type": ["null", "string"], "format": "date-time" }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["occurredAt"],
+      "is_resumable": true
+    },
+    {
+      "name": "engagements_meetings_web_analytics",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": ["null", "object"],
+        "additionalProperties": true,
+        "properties": {
+          "properties_hs_asset_description": { "type": ["null", "string"] },
+          "properties_hs_asset_type": { "type": ["null", "string"] },
+          "properties_hs_browser": { "type": ["null", "string"] },
+          "properties_hs_campaign_id": { "type": ["null", "string"] },
+          "properties_hs_city": { "type": ["null", "string"] },
+          "properties_hs_country": { "type": ["null", "string"] },
+          "properties_hs_device_name": { "type": ["null", "string"] },
+          "properties_hs_device_type": { "type": ["null", "string"] },
+          "properties_hs_title": { "type": ["null", "string"] },
+          "properties_hs_form_correlation_id": { "type": ["null", "string"] },
+          "properties_hs_element_class": { "type": ["null", "string"] },
+          "properties_hs_element_id": { "type": ["null", "string"] },
+          "properties_hs_element_text": { "type": ["null", "string"] },
+          "properties_hs_language": { "type": ["null", "string"] },
+          "properties_hs_document_id": { "type": ["null", "string"] },
+          "properties_hs_presentation_id": { "type": ["null", "string"] },
+          "properties_hs_user_id": { "type": ["null", "string"] },
+          "properties_hs_link_href": { "type": ["null", "string"] },
+          "properties_hs_operating_system": { "type": ["null", "string"] },
+          "properties_hs_operating_version": { "type": ["null", "string"] },
+          "properties_hs_page_content_type": { "type": ["null", "string"] },
+          "properties_hs_page_id": { "type": ["null", "string"] },
+          "properties_hs_page_title": { "type": ["null", "string"] },
+          "properties_hs_page_url": { "type": ["null", "string"] },
+          "properties_hs_parent_module_id": { "type": ["null", "string"] },
+          "properties_hs_referrer": { "type": ["null", "string"] },
+          "properties_hs_region": { "type": ["null", "string"] },
+          "properties_hs_url": { "type": ["null", "string"] },
+          "properties_hs_screen_height": { "type": ["null", "string"] },
+          "properties_hs_screen_width": { "type": ["null", "string"] },
+          "properties_hs_touchpoint_source": { "type": ["null", "string"] },
+          "properties_hs_tracking_name": { "type": ["null", "string"] },
+          "properties_hs_user_agent": { "type": ["null", "string"] },
+          "properties_hs_utm_campaign": { "type": ["null", "string"] },
+          "properties_hs_utm_content": { "type": ["null", "string"] },
+          "properties_hs_utm_medium": { "type": ["null", "string"] },
+          "properties_hs_utm_source": { "type": ["null", "string"] },
+          "properties_hs_utm_term": { "type": ["null", "string"] },
+          "id": { "type": ["null", "string"] },
+          "properties_hs_base_url": { "type": ["null", "string"] },
+          "properties_hs_form_id": { "type": ["null", "string"] },
+          "properties_hs_form_type": { "type": ["null", "string"] },
+          "properties_hs_url_domain": { "type": ["null", "string"] },
+          "properties_hs_url_path": { "type": ["null", "string"] },
+          "properties_hs_visitor_type": { "type": ["null", "string"] },
+          "objectId": { "type": ["null", "string"] },
+          "objectType": { "type": ["null", "string"] },
+          "eventType": { "type": ["null", "string"] },
+          "occurredAt": { "type": ["null", "string"], "format": "date-time" }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["occurredAt"],
+      "is_resumable": true
+    },
+    {
+      "name": "engagements_notes_web_analytics",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": ["null", "object"],
+        "additionalProperties": true,
+        "properties": {
+          "properties_hs_asset_description": { "type": ["null", "string"] },
+          "properties_hs_asset_type": { "type": ["null", "string"] },
+          "properties_hs_browser": { "type": ["null", "string"] },
+          "properties_hs_campaign_id": { "type": ["null", "string"] },
+          "properties_hs_city": { "type": ["null", "string"] },
+          "properties_hs_country": { "type": ["null", "string"] },
+          "properties_hs_device_name": { "type": ["null", "string"] },
+          "properties_hs_device_type": { "type": ["null", "string"] },
+          "properties_hs_title": { "type": ["null", "string"] },
+          "properties_hs_form_correlation_id": { "type": ["null", "string"] },
+          "properties_hs_element_class": { "type": ["null", "string"] },
+          "properties_hs_element_id": { "type": ["null", "string"] },
+          "properties_hs_element_text": { "type": ["null", "string"] },
+          "properties_hs_language": { "type": ["null", "string"] },
+          "properties_hs_document_id": { "type": ["null", "string"] },
+          "properties_hs_presentation_id": { "type": ["null", "string"] },
+          "properties_hs_user_id": { "type": ["null", "string"] },
+          "properties_hs_link_href": { "type": ["null", "string"] },
+          "properties_hs_operating_system": { "type": ["null", "string"] },
+          "properties_hs_operating_version": { "type": ["null", "string"] },
+          "properties_hs_page_content_type": { "type": ["null", "string"] },
+          "properties_hs_page_id": { "type": ["null", "string"] },
+          "properties_hs_page_title": { "type": ["null", "string"] },
+          "properties_hs_page_url": { "type": ["null", "string"] },
+          "properties_hs_parent_module_id": { "type": ["null", "string"] },
+          "properties_hs_referrer": { "type": ["null", "string"] },
+          "properties_hs_region": { "type": ["null", "string"] },
+          "properties_hs_url": { "type": ["null", "string"] },
+          "properties_hs_screen_height": { "type": ["null", "string"] },
+          "properties_hs_screen_width": { "type": ["null", "string"] },
+          "properties_hs_touchpoint_source": { "type": ["null", "string"] },
+          "properties_hs_tracking_name": { "type": ["null", "string"] },
+          "properties_hs_user_agent": { "type": ["null", "string"] },
+          "properties_hs_utm_campaign": { "type": ["null", "string"] },
+          "properties_hs_utm_content": { "type": ["null", "string"] },
+          "properties_hs_utm_medium": { "type": ["null", "string"] },
+          "properties_hs_utm_source": { "type": ["null", "string"] },
+          "properties_hs_utm_term": { "type": ["null", "string"] },
+          "id": { "type": ["null", "string"] },
+          "properties_hs_base_url": { "type": ["null", "string"] },
+          "properties_hs_form_id": { "type": ["null", "string"] },
+          "properties_hs_form_type": { "type": ["null", "string"] },
+          "properties_hs_url_domain": { "type": ["null", "string"] },
+          "properties_hs_url_path": { "type": ["null", "string"] },
+          "properties_hs_visitor_type": { "type": ["null", "string"] },
+          "objectId": { "type": ["null", "string"] },
+          "objectType": { "type": ["null", "string"] },
+          "eventType": { "type": ["null", "string"] },
+          "occurredAt": { "type": ["null", "string"], "format": "date-time" }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["occurredAt"],
+      "is_resumable": true
+    },
+    {
+      "name": "engagements_tasks_web_analytics",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": ["null", "object"],
+        "additionalProperties": true,
+        "properties": {
+          "properties_hs_asset_description": { "type": ["null", "string"] },
+          "properties_hs_asset_type": { "type": ["null", "string"] },
+          "properties_hs_browser": { "type": ["null", "string"] },
+          "properties_hs_campaign_id": { "type": ["null", "string"] },
+          "properties_hs_city": { "type": ["null", "string"] },
+          "properties_hs_country": { "type": ["null", "string"] },
+          "properties_hs_device_name": { "type": ["null", "string"] },
+          "properties_hs_device_type": { "type": ["null", "string"] },
+          "properties_hs_title": { "type": ["null", "string"] },
+          "properties_hs_form_correlation_id": { "type": ["null", "string"] },
+          "properties_hs_element_class": { "type": ["null", "string"] },
+          "properties_hs_element_id": { "type": ["null", "string"] },
+          "properties_hs_element_text": { "type": ["null", "string"] },
+          "properties_hs_language": { "type": ["null", "string"] },
+          "properties_hs_document_id": { "type": ["null", "string"] },
+          "properties_hs_presentation_id": { "type": ["null", "string"] },
+          "properties_hs_user_id": { "type": ["null", "string"] },
+          "properties_hs_link_href": { "type": ["null", "string"] },
+          "properties_hs_operating_system": { "type": ["null", "string"] },
+          "properties_hs_operating_version": { "type": ["null", "string"] },
+          "properties_hs_page_content_type": { "type": ["null", "string"] },
+          "properties_hs_page_id": { "type": ["null", "string"] },
+          "properties_hs_page_title": { "type": ["null", "string"] },
+          "properties_hs_page_url": { "type": ["null", "string"] },
+          "properties_hs_parent_module_id": { "type": ["null", "string"] },
+          "properties_hs_referrer": { "type": ["null", "string"] },
+          "properties_hs_region": { "type": ["null", "string"] },
+          "properties_hs_url": { "type": ["null", "string"] },
+          "properties_hs_screen_height": { "type": ["null", "string"] },
+          "properties_hs_screen_width": { "type": ["null", "string"] },
+          "properties_hs_touchpoint_source": { "type": ["null", "string"] },
+          "properties_hs_tracking_name": { "type": ["null", "string"] },
+          "properties_hs_user_agent": { "type": ["null", "string"] },
+          "properties_hs_utm_campaign": { "type": ["null", "string"] },
+          "properties_hs_utm_content": { "type": ["null", "string"] },
+          "properties_hs_utm_medium": { "type": ["null", "string"] },
+          "properties_hs_utm_source": { "type": ["null", "string"] },
+          "properties_hs_utm_term": { "type": ["null", "string"] },
+          "id": { "type": ["null", "string"] },
+          "properties_hs_base_url": { "type": ["null", "string"] },
+          "properties_hs_form_id": { "type": ["null", "string"] },
+          "properties_hs_form_type": { "type": ["null", "string"] },
+          "properties_hs_url_domain": { "type": ["null", "string"] },
+          "properties_hs_url_path": { "type": ["null", "string"] },
+          "properties_hs_visitor_type": { "type": ["null", "string"] },
+          "objectId": { "type": ["null", "string"] },
+          "objectType": { "type": ["null", "string"] },
+          "eventType": { "type": ["null", "string"] },
+          "occurredAt": { "type": ["null", "string"], "format": "date-time" }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["occurredAt"],
+      "is_resumable": true
+    },
+    {
+      "name": "goals_web_analytics",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": ["null", "object"],
+        "additionalProperties": true,
+        "properties": {
+          "properties_hs_asset_description": { "type": ["null", "string"] },
+          "properties_hs_asset_type": { "type": ["null", "string"] },
+          "properties_hs_browser": { "type": ["null", "string"] },
+          "properties_hs_campaign_id": { "type": ["null", "string"] },
+          "properties_hs_city": { "type": ["null", "string"] },
+          "properties_hs_country": { "type": ["null", "string"] },
+          "properties_hs_device_name": { "type": ["null", "string"] },
+          "properties_hs_device_type": { "type": ["null", "string"] },
+          "properties_hs_title": { "type": ["null", "string"] },
+          "properties_hs_form_correlation_id": { "type": ["null", "string"] },
+          "properties_hs_element_class": { "type": ["null", "string"] },
+          "properties_hs_element_id": { "type": ["null", "string"] },
+          "properties_hs_element_text": { "type": ["null", "string"] },
+          "properties_hs_language": { "type": ["null", "string"] },
+          "properties_hs_document_id": { "type": ["null", "string"] },
+          "properties_hs_presentation_id": { "type": ["null", "string"] },
+          "properties_hs_user_id": { "type": ["null", "string"] },
+          "properties_hs_link_href": { "type": ["null", "string"] },
+          "properties_hs_operating_system": { "type": ["null", "string"] },
+          "properties_hs_operating_version": { "type": ["null", "string"] },
+          "properties_hs_page_content_type": { "type": ["null", "string"] },
+          "properties_hs_page_id": { "type": ["null", "string"] },
+          "properties_hs_page_title": { "type": ["null", "string"] },
+          "properties_hs_page_url": { "type": ["null", "string"] },
+          "properties_hs_parent_module_id": { "type": ["null", "string"] },
+          "properties_hs_referrer": { "type": ["null", "string"] },
+          "properties_hs_region": { "type": ["null", "string"] },
+          "properties_hs_url": { "type": ["null", "string"] },
+          "properties_hs_screen_height": { "type": ["null", "string"] },
+          "properties_hs_screen_width": { "type": ["null", "string"] },
+          "properties_hs_touchpoint_source": { "type": ["null", "string"] },
+          "properties_hs_tracking_name": { "type": ["null", "string"] },
+          "properties_hs_user_agent": { "type": ["null", "string"] },
+          "properties_hs_utm_campaign": { "type": ["null", "string"] },
+          "properties_hs_utm_content": { "type": ["null", "string"] },
+          "properties_hs_utm_medium": { "type": ["null", "string"] },
+          "properties_hs_utm_source": { "type": ["null", "string"] },
+          "properties_hs_utm_term": { "type": ["null", "string"] },
+          "id": { "type": ["null", "string"] },
+          "properties_hs_base_url": { "type": ["null", "string"] },
+          "properties_hs_form_id": { "type": ["null", "string"] },
+          "properties_hs_form_type": { "type": ["null", "string"] },
+          "properties_hs_url_domain": { "type": ["null", "string"] },
+          "properties_hs_url_path": { "type": ["null", "string"] },
+          "properties_hs_visitor_type": { "type": ["null", "string"] },
+          "objectId": { "type": ["null", "string"] },
+          "objectType": { "type": ["null", "string"] },
+          "eventType": { "type": ["null", "string"] },
+          "occurredAt": { "type": ["null", "string"], "format": "date-time" }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["occurredAt"],
+      "is_resumable": true
+    },
+    {
+      "name": "line_items_web_analytics",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": ["null", "object"],
+        "additionalProperties": true,
+        "properties": {
+          "properties_hs_asset_description": { "type": ["null", "string"] },
+          "properties_hs_asset_type": { "type": ["null", "string"] },
+          "properties_hs_browser": { "type": ["null", "string"] },
+          "properties_hs_campaign_id": { "type": ["null", "string"] },
+          "properties_hs_city": { "type": ["null", "string"] },
+          "properties_hs_country": { "type": ["null", "string"] },
+          "properties_hs_device_name": { "type": ["null", "string"] },
+          "properties_hs_device_type": { "type": ["null", "string"] },
+          "properties_hs_title": { "type": ["null", "string"] },
+          "properties_hs_form_correlation_id": { "type": ["null", "string"] },
+          "properties_hs_element_class": { "type": ["null", "string"] },
+          "properties_hs_element_id": { "type": ["null", "string"] },
+          "properties_hs_element_text": { "type": ["null", "string"] },
+          "properties_hs_language": { "type": ["null", "string"] },
+          "properties_hs_document_id": { "type": ["null", "string"] },
+          "properties_hs_presentation_id": { "type": ["null", "string"] },
+          "properties_hs_user_id": { "type": ["null", "string"] },
+          "properties_hs_link_href": { "type": ["null", "string"] },
+          "properties_hs_operating_system": { "type": ["null", "string"] },
+          "properties_hs_operating_version": { "type": ["null", "string"] },
+          "properties_hs_page_content_type": { "type": ["null", "string"] },
+          "properties_hs_page_id": { "type": ["null", "string"] },
+          "properties_hs_page_title": { "type": ["null", "string"] },
+          "properties_hs_page_url": { "type": ["null", "string"] },
+          "properties_hs_parent_module_id": { "type": ["null", "string"] },
+          "properties_hs_referrer": { "type": ["null", "string"] },
+          "properties_hs_region": { "type": ["null", "string"] },
+          "properties_hs_url": { "type": ["null", "string"] },
+          "properties_hs_screen_height": { "type": ["null", "string"] },
+          "properties_hs_screen_width": { "type": ["null", "string"] },
+          "properties_hs_touchpoint_source": { "type": ["null", "string"] },
+          "properties_hs_tracking_name": { "type": ["null", "string"] },
+          "properties_hs_user_agent": { "type": ["null", "string"] },
+          "properties_hs_utm_campaign": { "type": ["null", "string"] },
+          "properties_hs_utm_content": { "type": ["null", "string"] },
+          "properties_hs_utm_medium": { "type": ["null", "string"] },
+          "properties_hs_utm_source": { "type": ["null", "string"] },
+          "properties_hs_utm_term": { "type": ["null", "string"] },
+          "id": { "type": ["null", "string"] },
+          "properties_hs_base_url": { "type": ["null", "string"] },
+          "properties_hs_form_id": { "type": ["null", "string"] },
+          "properties_hs_form_type": { "type": ["null", "string"] },
+          "properties_hs_url_domain": { "type": ["null", "string"] },
+          "properties_hs_url_path": { "type": ["null", "string"] },
+          "properties_hs_visitor_type": { "type": ["null", "string"] },
+          "objectId": { "type": ["null", "string"] },
+          "objectType": { "type": ["null", "string"] },
+          "eventType": { "type": ["null", "string"] },
+          "occurredAt": { "type": ["null", "string"], "format": "date-time" }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["occurredAt"],
+      "is_resumable": true
+    },
+    {
+      "name": "products_web_analytics",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": ["null", "object"],
+        "additionalProperties": true,
+        "properties": {
+          "properties_hs_asset_description": { "type": ["null", "string"] },
+          "properties_hs_asset_type": { "type": ["null", "string"] },
+          "properties_hs_browser": { "type": ["null", "string"] },
+          "properties_hs_campaign_id": { "type": ["null", "string"] },
+          "properties_hs_city": { "type": ["null", "string"] },
+          "properties_hs_country": { "type": ["null", "string"] },
+          "properties_hs_device_name": { "type": ["null", "string"] },
+          "properties_hs_device_type": { "type": ["null", "string"] },
+          "properties_hs_title": { "type": ["null", "string"] },
+          "properties_hs_form_correlation_id": { "type": ["null", "string"] },
+          "properties_hs_element_class": { "type": ["null", "string"] },
+          "properties_hs_element_id": { "type": ["null", "string"] },
+          "properties_hs_element_text": { "type": ["null", "string"] },
+          "properties_hs_language": { "type": ["null", "string"] },
+          "properties_hs_document_id": { "type": ["null", "string"] },
+          "properties_hs_presentation_id": { "type": ["null", "string"] },
+          "properties_hs_user_id": { "type": ["null", "string"] },
+          "properties_hs_link_href": { "type": ["null", "string"] },
+          "properties_hs_operating_system": { "type": ["null", "string"] },
+          "properties_hs_operating_version": { "type": ["null", "string"] },
+          "properties_hs_page_content_type": { "type": ["null", "string"] },
+          "properties_hs_page_id": { "type": ["null", "string"] },
+          "properties_hs_page_title": { "type": ["null", "string"] },
+          "properties_hs_page_url": { "type": ["null", "string"] },
+          "properties_hs_parent_module_id": { "type": ["null", "string"] },
+          "properties_hs_referrer": { "type": ["null", "string"] },
+          "properties_hs_region": { "type": ["null", "string"] },
+          "properties_hs_url": { "type": ["null", "string"] },
+          "properties_hs_screen_height": { "type": ["null", "string"] },
+          "properties_hs_screen_width": { "type": ["null", "string"] },
+          "properties_hs_touchpoint_source": { "type": ["null", "string"] },
+          "properties_hs_tracking_name": { "type": ["null", "string"] },
+          "properties_hs_user_agent": { "type": ["null", "string"] },
+          "properties_hs_utm_campaign": { "type": ["null", "string"] },
+          "properties_hs_utm_content": { "type": ["null", "string"] },
+          "properties_hs_utm_medium": { "type": ["null", "string"] },
+          "properties_hs_utm_source": { "type": ["null", "string"] },
+          "properties_hs_utm_term": { "type": ["null", "string"] },
+          "id": { "type": ["null", "string"] },
+          "properties_hs_base_url": { "type": ["null", "string"] },
+          "properties_hs_form_id": { "type": ["null", "string"] },
+          "properties_hs_form_type": { "type": ["null", "string"] },
+          "properties_hs_url_domain": { "type": ["null", "string"] },
+          "properties_hs_url_path": { "type": ["null", "string"] },
+          "properties_hs_visitor_type": { "type": ["null", "string"] },
+          "objectId": { "type": ["null", "string"] },
+          "objectType": { "type": ["null", "string"] },
+          "eventType": { "type": ["null", "string"] },
+          "occurredAt": { "type": ["null", "string"], "format": "date-time" }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["occurredAt"],
+      "is_resumable": true
+    },
+    {
+      "name": "pets",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": ["null", "object"],
+        "additionalProperties": true,
+        "properties": {
+          "id": { "type": ["null", "string"] },
+          "createdAt": { "type": ["null", "string"], "format": "date-time" },
+          "updatedAt": { "type": ["null", "string"], "format": "date-time" },
+          "archived": { "type": ["null", "boolean"] },
+          "properties": {
+            "type": ["null", "object"],
+            "properties": {
+              "hs_all_accessible_team_ids": { "type": ["null", "string"] },
+              "hs_all_assigned_business_unit_ids": {
+                "type": ["null", "string"]
+              },
+              "hs_all_owner_ids": { "type": ["null", "string"] },
+              "hs_all_team_ids": { "type": ["null", "string"] },
+              "hs_created_by_user_id": { "type": ["null", "number"] },
+              "hs_createdate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_lastmodifieddate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_merged_object_ids": { "type": ["null", "string"] },
+              "hs_object_id": { "type": ["null", "number"] },
+              "hs_object_source": { "type": ["null", "string"] },
+              "hs_object_source_detail_1": { "type": ["null", "string"] },
+              "hs_object_source_detail_2": { "type": ["null", "string"] },
+              "hs_object_source_detail_3": { "type": ["null", "string"] },
+              "hs_object_source_id": { "type": ["null", "string"] },
+              "hs_object_source_label": { "type": ["null", "string"] },
+              "hs_object_source_user_id": { "type": ["null", "number"] },
+              "hs_pinned_engagement_id": { "type": ["null", "number"] },
+              "hs_read_only": { "type": ["null", "boolean"] },
+              "hs_shared_team_ids": { "type": ["null", "string"] },
+              "hs_shared_user_ids": { "type": ["null", "string"] },
+              "hs_unique_creation_key": { "type": ["null", "string"] },
+              "hs_updated_by_user_id": { "type": ["null", "number"] },
+              "hs_user_ids_of_all_notification_followers": {
+                "type": ["null", "string"]
+              },
+              "hs_user_ids_of_all_notification_unfollowers": {
+                "type": ["null", "string"]
+              },
+              "hs_user_ids_of_all_owners": { "type": ["null", "string"] },
+              "hs_was_imported": { "type": ["null", "boolean"] },
+              "hubspot_owner_assigneddate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hubspot_owner_id": { "type": ["null", "string"] },
+              "hubspot_team_id": { "type": ["null", "string"] },
+              "pet_name": { "type": ["null", "string"] },
+              "pet_type": { "type": ["null", "string"] }
+            }
+          },
+          "properties_hs_all_accessible_team_ids": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_all_assigned_business_unit_ids": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_all_owner_ids": { "type": ["null", "string"] },
+          "properties_hs_all_team_ids": { "type": ["null", "string"] },
+          "properties_hs_created_by_user_id": { "type": ["null", "number"] },
+          "properties_hs_createdate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_lastmodifieddate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_merged_object_ids": { "type": ["null", "string"] },
+          "properties_hs_object_id": { "type": ["null", "number"] },
+          "properties_hs_object_source": { "type": ["null", "string"] },
+          "properties_hs_object_source_detail_1": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_object_source_detail_2": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_object_source_detail_3": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_object_source_id": { "type": ["null", "string"] },
+          "properties_hs_object_source_label": { "type": ["null", "string"] },
+          "properties_hs_object_source_user_id": { "type": ["null", "number"] },
+          "properties_hs_pinned_engagement_id": { "type": ["null", "number"] },
+          "properties_hs_read_only": { "type": ["null", "boolean"] },
+          "properties_hs_shared_team_ids": { "type": ["null", "string"] },
+          "properties_hs_shared_user_ids": { "type": ["null", "string"] },
+          "properties_hs_unique_creation_key": { "type": ["null", "string"] },
+          "properties_hs_updated_by_user_id": { "type": ["null", "number"] },
+          "properties_hs_user_ids_of_all_notification_followers": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_user_ids_of_all_notification_unfollowers": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_user_ids_of_all_owners": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_was_imported": { "type": ["null", "boolean"] },
+          "properties_hubspot_owner_assigneddate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hubspot_owner_id": { "type": ["null", "string"] },
+          "properties_hubspot_team_id": { "type": ["null", "string"] },
+          "properties_pet_name": { "type": ["null", "string"] },
+          "properties_pet_type": { "type": ["null", "string"] }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updatedAt"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "cars",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": ["null", "object"],
+        "additionalProperties": true,
+        "properties": {
+          "id": { "type": ["null", "string"] },
+          "createdAt": { "type": ["null", "string"], "format": "date-time" },
+          "updatedAt": { "type": ["null", "string"], "format": "date-time" },
+          "archived": { "type": ["null", "boolean"] },
+          "properties": {
+            "type": ["null", "object"],
+            "properties": {
+              "car_id": { "type": ["null", "number"] },
+              "car_name": { "type": ["null", "number"] },
+              "hs_all_accessible_team_ids": { "type": ["null", "string"] },
+              "hs_all_assigned_business_unit_ids": {
+                "type": ["null", "string"]
+              },
+              "hs_all_owner_ids": { "type": ["null", "string"] },
+              "hs_all_team_ids": { "type": ["null", "string"] },
+              "hs_created_by_user_id": { "type": ["null", "number"] },
+              "hs_createdate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_lastmodifieddate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hs_merged_object_ids": { "type": ["null", "string"] },
+              "hs_object_id": { "type": ["null", "number"] },
+              "hs_object_source": { "type": ["null", "string"] },
+              "hs_object_source_detail_1": { "type": ["null", "string"] },
+              "hs_object_source_detail_2": { "type": ["null", "string"] },
+              "hs_object_source_detail_3": { "type": ["null", "string"] },
+              "hs_object_source_id": { "type": ["null", "string"] },
+              "hs_object_source_label": { "type": ["null", "string"] },
+              "hs_object_source_user_id": { "type": ["null", "number"] },
+              "hs_pinned_engagement_id": { "type": ["null", "number"] },
+              "hs_read_only": { "type": ["null", "boolean"] },
+              "hs_shared_team_ids": { "type": ["null", "string"] },
+              "hs_shared_user_ids": { "type": ["null", "string"] },
+              "hs_unique_creation_key": { "type": ["null", "string"] },
+              "hs_updated_by_user_id": { "type": ["null", "number"] },
+              "hs_user_ids_of_all_notification_followers": {
+                "type": ["null", "string"]
+              },
+              "hs_user_ids_of_all_notification_unfollowers": {
+                "type": ["null", "string"]
+              },
+              "hs_user_ids_of_all_owners": { "type": ["null", "string"] },
+              "hs_was_imported": { "type": ["null", "boolean"] },
+              "hubspot_owner_assigneddate": {
+                "type": ["null", "string"],
+                "format": "date-time"
+              },
+              "hubspot_owner_id": { "type": ["null", "string"] },
+              "hubspot_team_id": { "type": ["null", "string"] }
+            }
+          },
+          "properties_car_id": { "type": ["null", "number"] },
+          "properties_car_name": { "type": ["null", "number"] },
+          "properties_hs_all_accessible_team_ids": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_all_assigned_business_unit_ids": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_all_owner_ids": { "type": ["null", "string"] },
+          "properties_hs_all_team_ids": { "type": ["null", "string"] },
+          "properties_hs_created_by_user_id": { "type": ["null", "number"] },
+          "properties_hs_createdate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_lastmodifieddate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hs_merged_object_ids": { "type": ["null", "string"] },
+          "properties_hs_object_id": { "type": ["null", "number"] },
+          "properties_hs_object_source": { "type": ["null", "string"] },
+          "properties_hs_object_source_detail_1": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_object_source_detail_2": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_object_source_detail_3": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_object_source_id": { "type": ["null", "string"] },
+          "properties_hs_object_source_label": { "type": ["null", "string"] },
+          "properties_hs_object_source_user_id": { "type": ["null", "number"] },
+          "properties_hs_pinned_engagement_id": { "type": ["null", "number"] },
+          "properties_hs_read_only": { "type": ["null", "boolean"] },
+          "properties_hs_shared_team_ids": { "type": ["null", "string"] },
+          "properties_hs_shared_user_ids": { "type": ["null", "string"] },
+          "properties_hs_unique_creation_key": { "type": ["null", "string"] },
+          "properties_hs_updated_by_user_id": { "type": ["null", "number"] },
+          "properties_hs_user_ids_of_all_notification_followers": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_user_ids_of_all_notification_unfollowers": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_user_ids_of_all_owners": {
+            "type": ["null", "string"]
+          },
+          "properties_hs_was_imported": { "type": ["null", "boolean"] },
+          "properties_hubspot_owner_assigneddate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "properties_hubspot_owner_id": { "type": ["null", "string"] },
+          "properties_hubspot_team_id": { "type": ["null", "string"] }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updatedAt"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "pets_web_analytics",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": ["null", "object"],
+        "additionalProperties": true,
+        "properties": {
+          "properties_hs_asset_description": { "type": ["null", "string"] },
+          "properties_hs_asset_type": { "type": ["null", "string"] },
+          "properties_hs_browser": { "type": ["null", "string"] },
+          "properties_hs_campaign_id": { "type": ["null", "string"] },
+          "properties_hs_city": { "type": ["null", "string"] },
+          "properties_hs_country": { "type": ["null", "string"] },
+          "properties_hs_device_name": { "type": ["null", "string"] },
+          "properties_hs_device_type": { "type": ["null", "string"] },
+          "properties_hs_title": { "type": ["null", "string"] },
+          "properties_hs_form_correlation_id": { "type": ["null", "string"] },
+          "properties_hs_element_class": { "type": ["null", "string"] },
+          "properties_hs_element_id": { "type": ["null", "string"] },
+          "properties_hs_element_text": { "type": ["null", "string"] },
+          "properties_hs_language": { "type": ["null", "string"] },
+          "properties_hs_document_id": { "type": ["null", "string"] },
+          "properties_hs_presentation_id": { "type": ["null", "string"] },
+          "properties_hs_user_id": { "type": ["null", "string"] },
+          "properties_hs_link_href": { "type": ["null", "string"] },
+          "properties_hs_operating_system": { "type": ["null", "string"] },
+          "properties_hs_operating_version": { "type": ["null", "string"] },
+          "properties_hs_page_content_type": { "type": ["null", "string"] },
+          "properties_hs_page_id": { "type": ["null", "string"] },
+          "properties_hs_page_title": { "type": ["null", "string"] },
+          "properties_hs_page_url": { "type": ["null", "string"] },
+          "properties_hs_parent_module_id": { "type": ["null", "string"] },
+          "properties_hs_referrer": { "type": ["null", "string"] },
+          "properties_hs_region": { "type": ["null", "string"] },
+          "properties_hs_url": { "type": ["null", "string"] },
+          "properties_hs_screen_height": { "type": ["null", "string"] },
+          "properties_hs_screen_width": { "type": ["null", "string"] },
+          "properties_hs_touchpoint_source": { "type": ["null", "string"] },
+          "properties_hs_tracking_name": { "type": ["null", "string"] },
+          "properties_hs_user_agent": { "type": ["null", "string"] },
+          "properties_hs_utm_campaign": { "type": ["null", "string"] },
+          "properties_hs_utm_content": { "type": ["null", "string"] },
+          "properties_hs_utm_medium": { "type": ["null", "string"] },
+          "properties_hs_utm_source": { "type": ["null", "string"] },
+          "properties_hs_utm_term": { "type": ["null", "string"] },
+          "id": { "type": ["null", "string"] },
+          "properties_hs_base_url": { "type": ["null", "string"] },
+          "properties_hs_form_id": { "type": ["null", "string"] },
+          "properties_hs_form_type": { "type": ["null", "string"] },
+          "properties_hs_url_domain": { "type": ["null", "string"] },
+          "properties_hs_url_path": { "type": ["null", "string"] },
+          "properties_hs_visitor_type": { "type": ["null", "string"] },
+          "objectId": { "type": ["null", "string"] },
+          "objectType": { "type": ["null", "string"] },
+          "eventType": { "type": ["null", "string"] },
+          "occurredAt": { "type": ["null", "string"], "format": "date-time" }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["occurredAt"],
+      "is_resumable": true
+    },
+    {
+      "name": "cars_web_analytics",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": ["null", "object"],
+        "additionalProperties": true,
+        "properties": {
+          "properties_hs_asset_description": { "type": ["null", "string"] },
+          "properties_hs_asset_type": { "type": ["null", "string"] },
+          "properties_hs_browser": { "type": ["null", "string"] },
+          "properties_hs_campaign_id": { "type": ["null", "string"] },
+          "properties_hs_city": { "type": ["null", "string"] },
+          "properties_hs_country": { "type": ["null", "string"] },
+          "properties_hs_device_name": { "type": ["null", "string"] },
+          "properties_hs_device_type": { "type": ["null", "string"] },
+          "properties_hs_title": { "type": ["null", "string"] },
+          "properties_hs_form_correlation_id": { "type": ["null", "string"] },
+          "properties_hs_element_class": { "type": ["null", "string"] },
+          "properties_hs_element_id": { "type": ["null", "string"] },
+          "properties_hs_element_text": { "type": ["null", "string"] },
+          "properties_hs_language": { "type": ["null", "string"] },
+          "properties_hs_document_id": { "type": ["null", "string"] },
+          "properties_hs_presentation_id": { "type": ["null", "string"] },
+          "properties_hs_user_id": { "type": ["null", "string"] },
+          "properties_hs_link_href": { "type": ["null", "string"] },
+          "properties_hs_operating_system": { "type": ["null", "string"] },
+          "properties_hs_operating_version": { "type": ["null", "string"] },
+          "properties_hs_page_content_type": { "type": ["null", "string"] },
+          "properties_hs_page_id": { "type": ["null", "string"] },
+          "properties_hs_page_title": { "type": ["null", "string"] },
+          "properties_hs_page_url": { "type": ["null", "string"] },
+          "properties_hs_parent_module_id": { "type": ["null", "string"] },
+          "properties_hs_referrer": { "type": ["null", "string"] },
+          "properties_hs_region": { "type": ["null", "string"] },
+          "properties_hs_url": { "type": ["null", "string"] },
+          "properties_hs_screen_height": { "type": ["null", "string"] },
+          "properties_hs_screen_width": { "type": ["null", "string"] },
+          "properties_hs_touchpoint_source": { "type": ["null", "string"] },
+          "properties_hs_tracking_name": { "type": ["null", "string"] },
+          "properties_hs_user_agent": { "type": ["null", "string"] },
+          "properties_hs_utm_campaign": { "type": ["null", "string"] },
+          "properties_hs_utm_content": { "type": ["null", "string"] },
+          "properties_hs_utm_medium": { "type": ["null", "string"] },
+          "properties_hs_utm_source": { "type": ["null", "string"] },
+          "properties_hs_utm_term": { "type": ["null", "string"] },
+          "id": { "type": ["null", "string"] },
+          "properties_hs_base_url": { "type": ["null", "string"] },
+          "properties_hs_form_id": { "type": ["null", "string"] },
+          "properties_hs_form_type": { "type": ["null", "string"] },
+          "properties_hs_url_domain": { "type": ["null", "string"] },
+          "properties_hs_url_path": { "type": ["null", "string"] },
+          "properties_hs_visitor_type": { "type": ["null", "string"] },
+          "objectId": { "type": ["null", "string"] },
+          "objectType": { "type": ["null", "string"] },
+          "eventType": { "type": ["null", "string"] },
+          "occurredAt": { "type": ["null", "string"], "format": "date-time" }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["occurredAt"],
+      "is_resumable": true
+    }
+  ]
+}

--- a/airbyte-integrations/connectors/source-hubspot/erd/estimated_relationships.json
+++ b/airbyte-integrations/connectors/source-hubspot/erd/estimated_relationships.json
@@ -1,0 +1,398 @@
+{
+  "streams": [
+    {
+      "name": "campaigns",
+      "relations": {
+        "appId": "applications.id",
+        "contentId": "contents.id",
+        "emailCampaignGroupId": "marketing_emails.emailCampaignGroupId"
+      }
+    },
+    {
+      "name": "companies",
+      "relations": {
+        "properties_hs_created_by_user_id": "owners.userId",
+        "properties_hs_updated_by_user_id": "owners.userId",
+        "properties_hubspot_owner_id": "owners.userId",
+        "properties_hubspot_team_id": "teams.id",
+        "properties_hs_parent_company_id": "companies.id"
+      }
+    },
+    {
+      "name": "contact_lists",
+      "relations": {
+        "parentId": "contact_lists.listId",
+        "authorId": "owners.userId",
+        "portalId": "portals.id"
+      }
+    },
+    {
+      "name": "contacts",
+      "relations": {
+        "properties_associatedcompanyid": "companies.id",
+        "properties_hs_created_by_user_id": "owners.userId",
+        "properties_hs_updated_by_user_id": "owners.userId",
+        "properties_hubspot_owner_id": "owners.userId",
+        "properties_hubspot_team_id": "teams.id"
+      }
+    },
+    {
+      "name": "contacts_form_submissions",
+      "relations": {
+        "canonical-vid": "contacts.id",
+        "portal-id": "portals.id"
+      }
+    },
+    {
+      "name": "contacts_list_memberships",
+      "relations": {
+        "canonical-vid": "contacts.id",
+        "static-list-id": "contact_lists.listId"
+      }
+    },
+    {
+      "name": "contacts_merged_audit",
+      "relations": {
+        "canonical-vid": "contacts.id",
+        "vid-to-merge": "contacts.id",
+        "user-id": "owners.userId"
+      }
+    },
+    {
+      "name": "deal_pipelines",
+      "relations": {
+        "objectTypeId": "object_types.id"
+      }
+    },
+    {
+      "name": "deals",
+      "relations": {
+        "properties_hs_created_by_user_id": "owners.userId",
+        "properties_hs_updated_by_user_id": "owners.userId",
+        "properties_hubspot_owner_id": "owners.userId",
+        "properties_hubspot_team_id": "teams.id",
+        "properties_hs_primary_company_id": "companies.id"
+      }
+    },
+    {
+      "name": "deals_archived",
+      "relations": {
+        "properties_hs_created_by_user_id": "owners.userId",
+        "properties_hs_updated_by_user_id": "owners.userId",
+        "properties_hubspot_owner_id": "owners.userId",
+        "properties_hubspot_team_id": "teams.id",
+        "properties_hs_primary_company_id": "companies.id"
+      }
+    },
+    {
+      "name": "email_events",
+      "relations": {
+        "emailCampaignId": "campaigns.id",
+        "emailCampaignGroupId": "marketing_emails.emailCampaignGroupId",
+        "portalId": "portals.id",
+        "requestedByUserId": "owners.userId"
+      }
+    },
+    {
+      "name": "email_subscriptions",
+      "relations": {
+        "portalId": "portals.id",
+        "businessUnitId": "business_units.id"
+      }
+    },
+    {
+      "name": "engagements",
+      "relations": {
+        "teamId": "teams.id",
+        "portalId": "portals.id",
+        "createdBy": "owners.userId",
+        "modifiedBy": "owners.userId",
+        "ownerId": "owners.userId",
+        "metadata_createdFromLinkId": "links.id",
+        "metadata_calleeObjectId": "contacts.id",
+        "metadata_externalAccountId": "external_accounts.id",
+        "metadata_facsimileSendId": "engagements_emails.id",
+        "metadata_sourceId": "engagements_emails.id"
+      }
+    },
+    {
+      "name": "engagements_calls",
+      "relations": {
+        "properties_hs_created_by_user_id": "owners.userId",
+        "properties_hs_updated_by_user_id": "owners.userId",
+        "properties_hubspot_owner_id": "owners.userId",
+        "properties_hubspot_team_id": "teams.id",
+        "properties_hs_call_callee_object_id": "contacts.id",
+        "properties_hs_call_external_account_id": "external_accounts.id"
+      }
+    },
+    {
+      "name": "engagements_emails",
+      "relations": {
+        "properties_hs_created_by_user_id": "owners.userId",
+        "properties_hs_updated_by_user_id": "owners.userId",
+        "properties_hubspot_owner_id": "owners.userId",
+        "properties_hubspot_team_id": "teams.id"
+      }
+    },
+    {
+      "name": "engagements_meetings",
+      "relations": {
+        "properties_hs_created_by_user_id": "owners.userId",
+        "properties_hs_updated_by_user_id": "owners.userId",
+        "properties_hubspot_owner_id": "owners.userId",
+        "properties_hubspot_team_id": "teams.id",
+        "properties_hs_meeting_created_from_link_id": "links.id"
+      }
+    },
+    {
+      "name": "engagements_notes",
+      "relations": {
+        "properties_hs_created_by_user_id": "owners.userId",
+        "properties_hs_updated_by_user_id": "owners.userId",
+        "properties_hubspot_owner_id": "owners.userId",
+        "properties_hubspot_team_id": "teams.id"
+      }
+    },
+    {
+      "name": "engagements_tasks",
+      "relations": {
+        "properties_hs_created_by_user_id": "owners.userId",
+        "properties_hs_updated_by_user_id": "owners.userId",
+        "properties_hubspot_owner_id": "owners.userId",
+        "properties_hubspot_team_id": "teams.id"
+      }
+    },
+    {
+      "name": "forms",
+      "relations": {
+        "properties_hs_created_by_user_id": "owners.userId",
+        "properties_hs_updated_by_user_id": "owners.userId",
+        "properties_hubspot_owner_id": "owners.userId",
+        "properties_hubspot_team_id": "teams.id",
+        "properties_hs_folder_id": "folders.id",
+        "properties_hs_feedback_survey_id": "feedback_surveys.id"
+      }
+    },
+    {
+      "name": "form_submissions",
+      "relations": {
+        "formId": "forms.id"
+      }
+    },
+    {
+      "name": "goals",
+      "relations": {
+        "properties_hs_created_by_user_id": "owners.userId",
+        "properties_hs_updated_by_user_id": "owners.userId",
+        "properties_hubspot_owner_id": "owners.userId",
+        "properties_hubspot_team_id": "teams.id",
+        "properties_hs_assignee_team_id": "teams.id",
+        "properties_hs_assignee_user_id": "owners.userId",
+        "properties_hs_goal_target_group_id": "goal_target_groups.id",
+        "properties_hs_team_id": "teams.id",
+        "properties_hs_user_id": "owners.userId"
+      }
+    },
+    {
+      "name": "line_items",
+      "relations": {
+        "properties_hs_created_by_user_id": "owners.userId",
+        "properties_hs_updated_by_user_id": "owners.userId",
+        "properties_hubspot_owner_id": "owners.userId",
+        "properties_hubspot_team_id": "teams.id"
+      }
+    },
+    {
+      "name": "marketing_emails",
+      "relations": {
+        "authorUserId": "owners.userId",
+        "createdById": "owners.userId",
+        "folderId": "folders.id",
+        "leadFlowId": "lead_flows.id",
+        "primaryEmailCampaignId": "campaigns.id",
+        "publishedById": "owners.userId",
+        "subscription": "email_subscriptions.id",
+        "emailCampaignGroupId": "campaigns.emailCampaignGroupId"
+      }
+    },
+    {
+      "name": "owners",
+      "relations": {
+        "userId": "users.id"
+      }
+    },
+    {
+      "name": "owners_archived",
+      "relations": {
+        "userId": "users.id"
+      }
+    },
+    {
+      "name": "products",
+      "relations": {
+        "properties_hs_created_by_user_id": "owners.userId",
+        "properties_hs_updated_by_user_id": "owners.userId",
+        "properties_hubspot_owner_id": "owners.userId",
+        "properties_hubspot_team_id": "teams.id",
+        "properties_hs_folder_id": "folders.id"
+      }
+    },
+    {
+      "name": "contacts_property_history",
+      "relations": {
+        "updated-by-user-id": "owners.userId",
+        "canonical-vid": "contacts.id",
+        "portal-id": "portals.id"
+      }
+    },
+    {
+      "name": "companies_property_history",
+      "relations": {
+        "updatedByUserId": "owners.userId",
+        "companyId": "companies.id"
+      }
+    },
+    {
+      "name": "deals_property_history",
+      "relations": {
+        "updatedByUserId": "owners.userId",
+        "dealId": "deals.id"
+      }
+    },
+    {
+      "name": "subscription_changes",
+      "relations": {
+        "portalId": "portals.id"
+      }
+    },
+    {
+      "name": "tickets",
+      "relations": {
+        "properties_hs_created_by_user_id": "owners.userId",
+        "properties_hs_updated_by_user_id": "owners.userId",
+        "properties_hubspot_owner_id": "owners.userId",
+        "properties_hubspot_team_id": "teams.id",
+        "properties_hs_custom_inbox": "inboxes.id",
+        "properties_hs_inbox_id": "inboxes.id",
+        "properties_hs_originating_email_engagement_id": "engagements_emails.id",
+        "properties_hs_primary_company_id": "companies.id",
+        "properties_hs_ticket_id": "tickets.id"
+      }
+    },
+    {
+      "name": "ticket_pipelines",
+      "relations": {}
+    },
+    {
+      "name": "workflows",
+      "relations": {
+        "lastUpdatedByUserId": "owners.userId",
+        "originalAuthorUserId": "owners.userId",
+        "portalId": "portals.id"
+      }
+    },
+    {
+      "name": "contacts_web_analytics",
+      "relations": {
+        "properties_hs_user_id": "owners.userId"
+      }
+    },
+    {
+      "name": "companies_web_analytics",
+      "relations": {
+        "properties_hs_user_id": "owners.userId"
+      }
+    },
+    {
+      "name": "deals_web_analytics",
+      "relations": {
+        "properties_hs_user_id": "owners.userId"
+      }
+    },
+    {
+      "name": "tickets_web_analytics",
+      "relations": {
+        "properties_hs_user_id": "owners.userId"
+      }
+    },
+    {
+      "name": "engagements_calls_web_analytics",
+      "relations": {
+        "properties_hs_user_id": "owners.userId"
+      }
+    },
+    {
+      "name": "engagements_emails_web_analytics",
+      "relations": {
+        "properties_hs_user_id": "owners.userId"
+      }
+    },
+    {
+      "name": "engagements_meetings_web_analytics",
+      "relations": {
+        "properties_hs_user_id": "owners.userId"
+      }
+    },
+    {
+      "name": "engagements_notes_web_analytics",
+      "relations": {
+        "properties_hs_user_id": "owners.userId"
+      }
+    },
+    {
+      "name": "engagements_tasks_web_analytics",
+      "relations": {
+        "properties_hs_user_id": "owners.userId"
+      }
+    },
+    {
+      "name": "goals_web_analytics",
+      "relations": {
+        "properties_hs_user_id": "owners.userId"
+      }
+    },
+    {
+      "name": "line_items_web_analytics",
+      "relations": {
+        "properties_hs_user_id": "owners.userId"
+      }
+    },
+    {
+      "name": "products_web_analytics",
+      "relations": {
+        "properties_hs_user_id": "owners.userId"
+      }
+    },
+    {
+      "name": "pets",
+      "relations": {
+        "properties_hs_created_by_user_id": "owners.userId",
+        "properties_hs_updated_by_user_id": "owners.userId",
+        "properties_hubspot_owner_id": "owners.userId",
+        "properties_hubspot_team_id": "teams.id"
+      }
+    },
+    {
+      "name": "cars",
+      "relations": {
+        "properties_hs_created_by_user_id": "owners.userId",
+        "properties_hs_updated_by_user_id": "owners.userId",
+        "properties_hubspot_owner_id": "owners.userId",
+        "properties_hubspot_team_id": "teams.id"
+      }
+    },
+    {
+      "name": "pets_web_analytics",
+      "relations": {
+        "properties_hs_user_id": "owners.userId"
+      }
+    },
+    {
+      "name": "cars_web_analytics",
+      "relations": {
+        "properties_hs_user_id": "owners.userId"
+      }
+    }
+  ]
+}

--- a/airbyte-integrations/connectors/source-hubspot/erd/source.dbml
+++ b/airbyte-integrations/connectors/source-hubspot/erd/source.dbml
@@ -1,0 +1,3423 @@
+Table "campaigns" {
+    "appId" integer
+    "appName" string
+    "contentId" integer
+    "counters" object
+    "counters_open" integer
+    "counters_processed" integer
+    "counters_sent" integer
+    "counters_deferred" integer
+    "counters_unsubscribed" integer
+    "counters_statuschange" integer
+    "counters_bounce" integer
+    "counters_mta_dropped" integer
+    "counters_dropped" integer
+    "counters_suppressed" integer
+    "counters_click" integer
+    "counters_delivered" integer
+    "counters_forward" integer
+    "counters_print" integer
+    "counters_reply" integer
+    "counters_spamreport" integer
+    "id" integer [pk]
+    "lastProcessingFinishedAt" integer
+    "lastProcessingStateChangeAt" integer
+    "lastProcessingStartedAt" integer
+    "processingState" string
+    "name" string
+    "numIncluded" integer
+    "numQueued" integer
+    "subType" string
+    "subject" string
+    "type" string
+    "lastUpdatedTime" integer
+}
+
+Table "companies" {
+    "id" string [pk]
+    "createdAt" string
+    "updatedAt" string
+    "archived" boolean
+    "contacts" array
+    "properties" object
+    "properties_about_us" string
+    "properties_address" string
+    "properties_address2" string
+    "properties_annualrevenue" number
+    "properties_city" string
+    "properties_closedate" string
+    "properties_closedate_timestamp_earliest_value_a2a17e6e" string
+    "properties_country" string
+    "properties_createdate" string
+    "properties_custom_company_property" string
+    "properties_days_to_close" number
+    "properties_description" string
+    "properties_domain" string
+    "properties_engagements_last_meeting_booked" string
+    "properties_engagements_last_meeting_booked_campaign" string
+    "properties_engagements_last_meeting_booked_medium" string
+    "properties_engagements_last_meeting_booked_source" string
+    "properties_facebook_company_page" string
+    "properties_facebookfans" number
+    "properties_first_contact_createdate" string
+    "properties_first_contact_createdate_timestamp_earliest_value_78b50eea" string
+    "properties_first_conversion_date" string
+    "properties_first_conversion_date_timestamp_earliest_value_61f58f2c" string
+    "properties_first_conversion_event_name" string
+    "properties_first_conversion_event_name_timestamp_earliest_value_68ddae0a" string
+    "properties_first_deal_created_date" string
+    "properties_founded_year" string
+    "properties_googleplus_page" string
+    "properties_hs_additional_domains" string
+    "properties_hs_all_accessible_team_ids" string
+    "properties_hs_all_owner_ids" string
+    "properties_hs_all_team_ids" string
+    "properties_hs_analytics_first_timestamp" string
+    "properties_hs_analytics_first_timestamp_timestamp_earliest_value_11e3a63a" string
+    "properties_hs_analytics_first_touch_converting_campaign" string
+    "properties_hs_analytics_first_touch_converting_campaign_timestamp_earliest_value_4757fe10" string
+    "properties_hs_analytics_first_visit_timestamp" string
+    "properties_hs_analytics_first_visit_timestamp_timestamp_earliest_value_accc17ae" string
+    "properties_hs_analytics_last_timestamp" string
+    "properties_hs_analytics_last_timestamp_timestamp_latest_value_4e16365a" string
+    "properties_hs_analytics_last_touch_converting_campaign" string
+    "properties_hs_analytics_last_touch_converting_campaign_timestamp_latest_value_81a64e30" string
+    "properties_hs_analytics_last_visit_timestamp" string
+    "properties_hs_analytics_last_visit_timestamp_timestamp_latest_value_999a0fce" string
+    "properties_hs_analytics_latest_source" string
+    "properties_hs_analytics_latest_source_data_1" string
+    "properties_hs_analytics_latest_source_data_2" string
+    "properties_hs_analytics_latest_source_timestamp" string
+    "properties_hs_analytics_num_page_views" number
+    "properties_hs_analytics_num_page_views_cardinality_sum_e46e85b0" number
+    "properties_hs_analytics_num_visits" number
+    "properties_hs_analytics_num_visits_cardinality_sum_53d952a6" number
+    "properties_hs_analytics_source" string
+    "properties_hs_analytics_source_data_1" string
+    "properties_hs_analytics_source_data_1_timestamp_earliest_value_9b2f1fa1" string
+    "properties_hs_analytics_source_data_2" string
+    "properties_hs_analytics_source_data_2_timestamp_earliest_value_9b2f9400" string
+    "properties_hs_analytics_source_timestamp_earliest_value_25a3a52c" string
+    "properties_hs_annual_revenue_currency_code" string
+    "properties_hs_avatar_filemanager_key" string
+    "properties_hs_country_code" string
+    "properties_hs_created_by_user_id" number
+    "properties_hs_createdate" string
+    "properties_hs_csm_sentiment" string
+    "properties_hs_customer_success_ticket_sentiment" number
+    "properties_hs_date_entered_customer" string
+    "properties_hs_date_entered_evangelist" string
+    "properties_hs_date_entered_lead" string
+    "properties_hs_date_entered_marketingqualifiedlead" string
+    "properties_hs_date_entered_opportunity" string
+    "properties_hs_date_entered_other" string
+    "properties_hs_date_entered_salesqualifiedlead" string
+    "properties_hs_date_entered_subscriber" string
+    "properties_hs_date_exited_customer" string
+    "properties_hs_date_exited_evangelist" string
+    "properties_hs_date_exited_lead" string
+    "properties_hs_date_exited_marketingqualifiedlead" string
+    "properties_hs_date_exited_opportunity" string
+    "properties_hs_date_exited_other" string
+    "properties_hs_date_exited_salesqualifiedlead" string
+    "properties_hs_date_exited_subscriber" string
+    "properties_hs_ideal_customer_profile" string
+    "properties_hs_is_target_account" boolean
+    "properties_hs_last_booked_meeting_date" string
+    "properties_hs_last_logged_call_date" string
+    "properties_hs_last_open_task_date" string
+    "properties_hs_last_sales_activity_date" string
+    "properties_hs_last_sales_activity_timestamp" string
+    "properties_hs_last_sales_activity_type" string
+    "properties_hs_lastmodifieddate" string
+    "properties_hs_latest_createdate_of_active_subscriptions" string
+    "properties_hs_latest_meeting_activity" string
+    "properties_hs_lead_status" string
+    "properties_hs_logo_url" string
+    "properties_hs_merged_object_ids" string
+    "properties_hs_notes_next_activity_type" string
+    "properties_hs_num_blockers" number
+    "properties_hs_num_child_companies" number
+    "properties_hs_num_contacts_with_buying_roles" number
+    "properties_hs_num_decision_makers" number
+    "properties_hs_num_open_deals" number
+    "properties_hs_object_id" number
+    "properties_hs_object_source" string
+    "properties_hs_object_source_detail_1" string
+    "properties_hs_object_source_detail_2" string
+    "properties_hs_object_source_detail_3" string
+    "properties_hs_object_source_id" string
+    "properties_hs_object_source_label" string
+    "properties_hs_object_source_user_id" number
+    "properties_hs_parent_company_id" number
+    "properties_hs_pinned_engagement_id" number
+    "properties_hs_pipeline" string
+    "properties_hs_predictivecontactscore_v2" number
+    "properties_hs_predictivecontactscore_v2_next_max_max_d4e58c1e" number
+    "properties_hs_read_only" boolean
+    "properties_hs_sales_email_last_replied" string
+    "properties_hs_target_account" string
+    "properties_hs_target_account_probability" number
+    "properties_hs_target_account_recommendation_snooze_time" string
+    "properties_hs_target_account_recommendation_state" string
+    "properties_hs_time_in_customer" number
+    "properties_hs_time_in_evangelist" number
+    "properties_hs_time_in_lead" number
+    "properties_hs_time_in_marketingqualifiedlead" number
+    "properties_hs_time_in_opportunity" number
+    "properties_hs_time_in_other" number
+    "properties_hs_time_in_salesqualifiedlead" number
+    "properties_hs_time_in_subscriber" number
+    "properties_hs_total_deal_value" number
+    "properties_hs_unique_creation_key" string
+    "properties_hs_updated_by_user_id" number
+    "properties_hs_user_ids_of_all_notification_followers" string
+    "properties_hs_user_ids_of_all_notification_unfollowers" string
+    "properties_hs_user_ids_of_all_owners" string
+    "properties_hs_was_imported" boolean
+    "properties_hubspot_owner_assigneddate" string
+    "properties_hubspot_owner_id" string
+    "properties_hubspot_team_id" string
+    "properties_hubspotscore" number
+    "properties_industry" string
+    "properties_is_public" boolean
+    "properties_lifecyclestage" string
+    "properties_linkedin_company_page" string
+    "properties_linkedinbio" string
+    "properties_name" string
+    "properties_notes_last_contacted" string
+    "properties_notes_last_updated" string
+    "properties_notes_next_activity_date" string
+    "properties_num_associated_contacts" number
+    "properties_num_associated_deals" number
+    "properties_num_contacted_notes" number
+    "properties_num_conversion_events" number
+    "properties_num_conversion_events_cardinality_sum_d095f14b" number
+    "properties_num_notes" number
+    "properties_numberofemployees" number
+    "properties_phone" string
+    "properties_recent_conversion_date" string
+    "properties_recent_conversion_date_timestamp_latest_value_72856da1" string
+    "properties_recent_conversion_event_name" string
+    "properties_recent_conversion_event_name_timestamp_latest_value_66c820bf" string
+    "properties_recent_deal_amount" number
+    "properties_recent_deal_close_date" string
+    "properties_state" string
+    "properties_timezone" string
+    "properties_total_money_raised" string
+    "properties_total_revenue" number
+    "properties_twitterbio" string
+    "properties_twitterfollowers" number
+    "properties_twitterhandle" string
+    "properties_type" string
+    "properties_web_technologies" string
+    "properties_website" string
+    "properties_zip" string
+}
+
+Table "contact_lists" {
+    "parentId" integer
+    "metaData" object
+    "metaData_processing" string
+    "metaData_size" integer
+    "metaData_error" string
+    "metaData_lastProcessingStateChangeAt" integer
+    "metaData_lastSizeChangeAt" integer
+    "metaData_listReferencesCount" integer
+    "metaData_parentFolderId" integer
+    "dynamic" boolean
+    "name" string
+    "filters" array
+    "ilsFilterBranch" string
+    "internal" boolean
+    "authorId" integer
+    "limitExempt" boolean
+    "teamIds" array
+    "portalId" integer
+    "createdAt" integer
+    "listId" integer [pk]
+    "updatedAt" integer
+    "internalListId" integer
+    "readOnly" boolean
+    "deleteable" boolean
+    "listType" string
+    "archived" boolean
+}
+
+Table "contacts" {
+    "id" string [pk]
+    "createdAt" string
+    "updatedAt" string
+    "archived" boolean
+    "companies" array
+    "properties" object
+    "properties_address" string
+    "properties_annualrevenue" string
+    "properties_associatedcompanyid" number
+    "properties_associatedcompanylastupdated" number
+    "properties_city" string
+    "properties_closedate" string
+    "properties_company" string
+    "properties_company_size" string
+    "properties_country" string
+    "properties_createdate" string
+    "properties_currentlyinworkflow" string
+    "properties_date_of_birth" string
+    "properties_days_to_close" number
+    "properties_degree" string
+    "properties_email" string
+    "properties_engagements_last_meeting_booked" string
+    "properties_engagements_last_meeting_booked_campaign" string
+    "properties_engagements_last_meeting_booked_medium" string
+    "properties_engagements_last_meeting_booked_source" string
+    "properties_fax" string
+    "properties_field_of_study" string
+    "properties_first_conversion_date" string
+    "properties_first_conversion_event_name" string
+    "properties_first_deal_created_date" string
+    "properties_firstname" string
+    "properties_gender" string
+    "properties_graduation_date" string
+    "properties_hs_additional_emails" string
+    "properties_hs_all_accessible_team_ids" string
+    "properties_hs_all_contact_vids" string
+    "properties_hs_all_owner_ids" string
+    "properties_hs_all_team_ids" string
+    "properties_hs_analytics_average_page_views" number
+    "properties_hs_analytics_first_referrer" string
+    "properties_hs_analytics_first_timestamp" string
+    "properties_hs_analytics_first_touch_converting_campaign" string
+    "properties_hs_analytics_first_url" string
+    "properties_hs_analytics_first_visit_timestamp" string
+    "properties_hs_analytics_last_referrer" string
+    "properties_hs_analytics_last_timestamp" string
+    "properties_hs_analytics_last_touch_converting_campaign" string
+    "properties_hs_analytics_last_url" string
+    "properties_hs_analytics_last_visit_timestamp" string
+    "properties_hs_analytics_num_event_completions" number
+    "properties_hs_analytics_num_page_views" number
+    "properties_hs_analytics_num_visits" number
+    "properties_hs_analytics_revenue" number
+    "properties_hs_analytics_source" string
+    "properties_hs_analytics_source_data_1" string
+    "properties_hs_analytics_source_data_2" string
+    "properties_hs_associated_target_accounts" number
+    "properties_hs_avatar_filemanager_key" string
+    "properties_hs_buying_role" string
+    "properties_hs_calculated_form_submissions" string
+    "properties_hs_calculated_merged_vids" string
+    "properties_hs_calculated_mobile_number" string
+    "properties_hs_calculated_phone_number" string
+    "properties_hs_calculated_phone_number_area_code" string
+    "properties_hs_calculated_phone_number_country_code" string
+    "properties_hs_calculated_phone_number_region_code" string
+    "properties_hs_clicked_linkedin_ad" string
+    "properties_hs_content_membership_email" string
+    "properties_hs_content_membership_email_confirmed" boolean
+    "properties_hs_content_membership_follow_up_enqueued_at" string
+    "properties_hs_content_membership_notes" string
+    "properties_hs_content_membership_registered_at" string
+    "properties_hs_content_membership_registration_domain_sent_to" string
+    "properties_hs_content_membership_registration_email_sent_at" string
+    "properties_hs_content_membership_status" string
+    "properties_hs_conversations_visitor_email" string
+    "properties_hs_count_is_unworked" number
+    "properties_hs_count_is_worked" number
+    "properties_hs_created_by_conversations" boolean
+    "properties_hs_created_by_user_id" number
+    "properties_hs_createdate" string
+    "properties_hs_date_entered_customer" string
+    "properties_hs_date_entered_evangelist" string
+    "properties_hs_date_entered_lead" string
+    "properties_hs_date_entered_marketingqualifiedlead" string
+    "properties_hs_date_entered_opportunity" string
+    "properties_hs_date_entered_other" string
+    "properties_hs_date_entered_salesqualifiedlead" string
+    "properties_hs_date_entered_subscriber" string
+    "properties_hs_date_exited_customer" string
+    "properties_hs_date_exited_evangelist" string
+    "properties_hs_date_exited_lead" string
+    "properties_hs_date_exited_marketingqualifiedlead" string
+    "properties_hs_date_exited_opportunity" string
+    "properties_hs_date_exited_other" string
+    "properties_hs_date_exited_salesqualifiedlead" string
+    "properties_hs_date_exited_subscriber" string
+    "properties_hs_document_last_revisited" string
+    "properties_hs_email_bad_address" boolean
+    "properties_hs_email_bounce" number
+    "properties_hs_email_click" number
+    "properties_hs_email_customer_quarantined_reason" string
+    "properties_hs_email_delivered" number
+    "properties_hs_email_domain" string
+    "properties_hs_email_first_click_date" string
+    "properties_hs_email_first_open_date" string
+    "properties_hs_email_first_reply_date" string
+    "properties_hs_email_first_send_date" string
+    "properties_hs_email_hard_bounce_reason" string
+    "properties_hs_email_hard_bounce_reason_enum" string
+    "properties_hs_email_is_ineligible" boolean
+    "properties_hs_email_last_click_date" string
+    "properties_hs_email_last_email_name" string
+    "properties_hs_email_last_open_date" string
+    "properties_hs_email_last_reply_date" string
+    "properties_hs_email_last_send_date" string
+    "properties_hs_email_open" number
+    "properties_hs_email_optout" boolean
+    "properties_hs_email_optout_10798197" string
+    "properties_hs_email_optout_11890603" string
+    "properties_hs_email_optout_11890831" string
+    "properties_hs_email_optout_23704464" string
+    "properties_hs_email_optout_313921448" string
+    "properties_hs_email_optout_94692364" string
+    "properties_hs_email_quarantined" boolean
+    "properties_hs_email_quarantined_reason" string
+    "properties_hs_email_recipient_fatigue_recovery_time" string
+    "properties_hs_email_replied" number
+    "properties_hs_email_sends_since_last_engagement" number
+    "properties_hs_emailconfirmationstatus" string
+    "properties_hs_facebook_ad_clicked" boolean
+    "properties_hs_facebook_click_id" string
+    "properties_hs_feedback_last_nps_follow_up" string
+    "properties_hs_feedback_last_nps_rating" string
+    "properties_hs_feedback_last_survey_date" string
+    "properties_hs_feedback_show_nps_web_survey" boolean
+    "properties_hs_first_engagement_object_id" number
+    "properties_hs_first_outreach_date" string
+    "properties_hs_first_subscription_create_date" string
+    "properties_hs_google_click_id" string
+    "properties_hs_has_active_subscription" number
+    "properties_hs_ip_timezone" string
+    "properties_hs_is_contact" boolean
+    "properties_hs_is_unworked" boolean
+    "properties_hs_language" string
+    "properties_hs_last_sales_activity_date" string
+    "properties_hs_last_sales_activity_timestamp" string
+    "properties_hs_last_sales_activity_type" string
+    "properties_hs_lastmodifieddate" string
+    "properties_hs_latest_disqualified_lead_date" string
+    "properties_hs_latest_meeting_activity" string
+    "properties_hs_latest_open_lead_date" string
+    "properties_hs_latest_qualified_lead_date" string
+    "properties_hs_latest_sequence_ended_date" string
+    "properties_hs_latest_sequence_enrolled" number
+    "properties_hs_latest_sequence_enrolled_date" string
+    "properties_hs_latest_sequence_finished_date" string
+    "properties_hs_latest_sequence_unenrolled_date" string
+    "properties_hs_latest_source" string
+    "properties_hs_latest_source_data_1" string
+    "properties_hs_latest_source_data_2" string
+    "properties_hs_latest_source_timestamp" string
+    "properties_hs_latest_subscription_create_date" string
+    "properties_hs_lead_status" string
+    "properties_hs_legal_basis" string
+    "properties_hs_lifecyclestage_customer_date" string
+    "properties_hs_lifecyclestage_evangelist_date" string
+    "properties_hs_lifecyclestage_lead_date" string
+    "properties_hs_lifecyclestage_marketingqualifiedlead_date" string
+    "properties_hs_lifecyclestage_opportunity_date" string
+    "properties_hs_lifecyclestage_other_date" string
+    "properties_hs_lifecyclestage_salesqualifiedlead_date" string
+    "properties_hs_lifecyclestage_subscriber_date" string
+    "properties_hs_linkedin_ad_clicked" string
+    "properties_hs_marketable_reason_id" string
+    "properties_hs_marketable_reason_type" string
+    "properties_hs_marketable_status" string
+    "properties_hs_marketable_until_renewal" string
+    "properties_hs_membership_has_accessed_private_content" number
+    "properties_hs_membership_last_private_content_access_date" string
+    "properties_hs_merged_object_ids" string
+    "properties_hs_mobile_sdk_push_tokens" string
+    "properties_hs_notes_next_activity_type" string
+    "properties_hs_object_id" number
+    "properties_hs_object_source" string
+    "properties_hs_object_source_detail_1" string
+    "properties_hs_object_source_detail_2" string
+    "properties_hs_object_source_detail_3" string
+    "properties_hs_object_source_id" string
+    "properties_hs_object_source_label" string
+    "properties_hs_object_source_user_id" number
+    "properties_hs_persona" string
+    "properties_hs_pinned_engagement_id" number
+    "properties_hs_pipeline" string
+    "properties_hs_predictivecontactscore" number
+    "properties_hs_predictivecontactscore_v2" number
+    "properties_hs_predictivecontactscorebucket" string
+    "properties_hs_predictivescoringtier" string
+    "properties_hs_quarantined_emails" string
+    "properties_hs_read_only" boolean
+    "properties_hs_registered_member" number
+    "properties_hs_registration_method" string
+    "properties_hs_sa_first_engagement_date" string
+    "properties_hs_sa_first_engagement_descr" string
+    "properties_hs_sa_first_engagement_object_type" string
+    "properties_hs_sales_email_last_clicked" string
+    "properties_hs_sales_email_last_opened" string
+    "properties_hs_sales_email_last_replied" string
+    "properties_hs_searchable_calculated_international_mobile_number" string
+    "properties_hs_searchable_calculated_international_phone_number" string
+    "properties_hs_searchable_calculated_mobile_number" string
+    "properties_hs_searchable_calculated_phone_number" string
+    "properties_hs_sequences_actively_enrolled_count" number
+    "properties_hs_sequences_enrolled_count" number
+    "properties_hs_sequences_is_enrolled" boolean
+    "properties_hs_testpurge" string
+    "properties_hs_testrollback" string
+    "properties_hs_time_between_contact_creation_and_deal_close" number
+    "properties_hs_time_between_contact_creation_and_deal_creation" number
+    "properties_hs_time_in_customer" number
+    "properties_hs_time_in_evangelist" number
+    "properties_hs_time_in_lead" number
+    "properties_hs_time_in_marketingqualifiedlead" number
+    "properties_hs_time_in_opportunity" number
+    "properties_hs_time_in_other" number
+    "properties_hs_time_in_salesqualifiedlead" number
+    "properties_hs_time_in_subscriber" number
+    "properties_hs_time_to_first_engagement" number
+    "properties_hs_time_to_move_from_lead_to_customer" number
+    "properties_hs_time_to_move_from_marketingqualifiedlead_to_customer" number
+    "properties_hs_time_to_move_from_opportunity_to_customer" number
+    "properties_hs_time_to_move_from_salesqualifiedlead_to_customer" number
+    "properties_hs_time_to_move_from_subscriber_to_customer" number
+    "properties_hs_timezone" string
+    "properties_hs_unique_creation_key" string
+    "properties_hs_updated_by_user_id" number
+    "properties_hs_user_ids_of_all_notification_followers" string
+    "properties_hs_user_ids_of_all_notification_unfollowers" string
+    "properties_hs_user_ids_of_all_owners" string
+    "properties_hs_v2_cumulative_time_in_customer" number
+    "properties_hs_v2_cumulative_time_in_evangelist" number
+    "properties_hs_v2_cumulative_time_in_lead" number
+    "properties_hs_v2_cumulative_time_in_marketingqualifiedlead" number
+    "properties_hs_v2_cumulative_time_in_opportunity" number
+    "properties_hs_v2_cumulative_time_in_other" number
+    "properties_hs_v2_cumulative_time_in_salesqualifiedlead" number
+    "properties_hs_v2_cumulative_time_in_subscriber" number
+    "properties_hs_v2_date_entered_customer" string
+    "properties_hs_v2_date_entered_evangelist" string
+    "properties_hs_v2_date_entered_lead" string
+    "properties_hs_v2_date_entered_marketingqualifiedlead" string
+    "properties_hs_v2_date_entered_opportunity" string
+    "properties_hs_v2_date_entered_other" string
+    "properties_hs_v2_date_entered_salesqualifiedlead" string
+    "properties_hs_v2_date_entered_subscriber" string
+    "properties_hs_v2_date_exited_customer" string
+    "properties_hs_v2_date_exited_evangelist" string
+    "properties_hs_v2_date_exited_lead" string
+    "properties_hs_v2_date_exited_marketingqualifiedlead" string
+    "properties_hs_v2_date_exited_opportunity" string
+    "properties_hs_v2_date_exited_other" string
+    "properties_hs_v2_date_exited_salesqualifiedlead" string
+    "properties_hs_v2_date_exited_subscriber" string
+    "properties_hs_v2_latest_time_in_customer" number
+    "properties_hs_v2_latest_time_in_evangelist" number
+    "properties_hs_v2_latest_time_in_lead" number
+    "properties_hs_v2_latest_time_in_marketingqualifiedlead" number
+    "properties_hs_v2_latest_time_in_opportunity" number
+    "properties_hs_v2_latest_time_in_other" number
+    "properties_hs_v2_latest_time_in_salesqualifiedlead" number
+    "properties_hs_v2_latest_time_in_subscriber" number
+    "properties_hs_was_imported" boolean
+    "properties_hs_whatsapp_phone_number" string
+    "properties_hubspot_owner_assigneddate" string
+    "properties_hubspot_owner_id" string
+    "properties_hubspot_team_id" string
+    "properties_hubspotscore" number
+    "properties_industry" string
+    "properties_ip_city" string
+    "properties_ip_country" string
+    "properties_ip_country_code" string
+    "properties_ip_latlon" string
+    "properties_ip_state" string
+    "properties_ip_state_code" string
+    "properties_ip_zipcode" string
+    "properties_job_function" string
+    "properties_jobtitle" string
+    "properties_lastmodifieddate" string
+    "properties_lastname" string
+    "properties_lifecyclestage" string
+    "properties_marital_status" string
+    "properties_message" string
+    "properties_military_status" string
+    "properties_mobilephone" string
+    "properties_my_custom_test_property" string
+    "properties_notes_last_contacted" string
+    "properties_notes_last_updated" string
+    "properties_notes_next_activity_date" string
+    "properties_num_associated_deals" number
+    "properties_num_contacted_notes" number
+    "properties_num_conversion_events" number
+    "properties_num_notes" number
+    "properties_num_unique_conversion_events" number
+    "properties_numemployees" string
+    "properties_phone" string
+    "properties_recent_conversion_date" string
+    "properties_recent_conversion_event_name" string
+    "properties_recent_deal_amount" number
+    "properties_recent_deal_close_date" string
+    "properties_relationship_status" string
+    "properties_salutation" string
+    "properties_school" string
+    "properties_seniority" string
+    "properties_start_date" string
+    "properties_state" string
+    "properties_surveymonkeyeventlastupdated" number
+    "properties_test" number
+    "properties_total_revenue" number
+    "properties_twitterhandle" string
+    "properties_webinareventlastupdated" number
+    "properties_website" string
+    "properties_work_email" string
+    "properties_zip" string
+}
+
+Table "contacts_form_submissions" {
+    "canonical-vid" integer [pk]
+    "canonical-url" string
+    "conversion-id" string
+    "page-title" string
+    "timestamp" integer
+    "form-id" string
+    "portal-id" integer
+    "title" string
+    "page-url" string
+    "form-type" string
+    "contact-associated-by" array
+    "meta-data" array
+}
+
+Table "contacts_list_memberships" {
+    "canonical-vid" integer [pk]
+    "static-list-id" integer
+    "internal-list-id" integer
+    "timestamp" integer
+    "vid" integer
+    "is-member" boolean
+}
+
+Table "contacts_merged_audit" {
+    "canonical-vid" integer [pk]
+    "vid-to-merge" integer
+    "timestamp" integer
+    "entity-id" string
+    "user-id" integer
+    "num-properties-moved" integer
+    "merged_from_email" object
+    "merged_from_email_source-vids" array
+    "merged_from_email_updated-by-user-id" integer
+    "merged_from_email_source-label" string
+    "merged_from_email_source-type" string
+    "merged_from_email_value" string
+    "merged_from_email_source-id" string
+    "merged_from_email_selected" boolean
+    "merged_from_email_timestamp" integer
+    "merged_to_email" object
+    "merged_to_email_updated-by-user-id" integer
+    "merged_to_email_source-label" string
+    "merged_to_email_source-type" string
+    "merged_to_email_value" string
+    "merged_to_email_source-id" string
+    "merged_to_email_selected" boolean
+    "merged_to_email_timestamp" integer
+    "first-name" string
+    "last-name" string
+}
+
+Table "deal_pipelines" {
+    "label" string
+    "displayOrder" integer
+    "active" boolean
+    "stages" array
+    "objectType" string
+    "objectTypeId" string
+    "pipelineId" string [pk]
+    "createdAt" integer
+    "updatedAt" integer
+    "default" boolean
+}
+
+Table "deals" {
+    "id" string [pk]
+    "properties" object
+    "properties_amount" number
+    "properties_amount_in_home_currency" number
+    "properties_closed_lost_reason" string
+    "properties_closed_won_reason" string
+    "properties_closedate" string
+    "properties_createdate" string
+    "properties_days_to_close" number
+    "properties_dealname" string
+    "properties_dealstage" string
+    "properties_dealtype" string
+    "properties_description" string
+    "properties_engagements_last_meeting_booked" string
+    "properties_engagements_last_meeting_booked_campaign" string
+    "properties_engagements_last_meeting_booked_medium" string
+    "properties_engagements_last_meeting_booked_source" string
+    "properties_hs_acv" number
+    "properties_hs_all_accessible_team_ids" string
+    "properties_hs_all_assigned_business_unit_ids" string
+    "properties_hs_all_owner_ids" string
+    "properties_hs_all_team_ids" string
+    "properties_hs_analytics_source" string
+    "properties_hs_analytics_source_data_1" string
+    "properties_hs_analytics_source_data_2" string
+    "properties_hs_arr" number
+    "properties_hs_closed_amount" number
+    "properties_hs_closed_amount_in_home_currency" number
+    "properties_hs_created_by_user_id" number
+    "properties_hs_createdate" string
+    "properties_hs_date_entered_9567448" string
+    "properties_hs_date_entered_9567449" string
+    "properties_hs_date_entered_appointmentscheduled" string
+    "properties_hs_date_entered_closedlost" string
+    "properties_hs_date_entered_closedwon" string
+    "properties_hs_date_entered_contractsent" string
+    "properties_hs_date_entered_customclosedwonstage" string
+    "properties_hs_date_entered_decisionmakerboughtin" string
+    "properties_hs_date_entered_presentationscheduled" string
+    "properties_hs_date_entered_qualifiedtobuy" string
+    "properties_hs_date_exited_9567448" string
+    "properties_hs_date_exited_9567449" string
+    "properties_hs_date_exited_appointmentscheduled" string
+    "properties_hs_date_exited_closedlost" string
+    "properties_hs_date_exited_closedwon" string
+    "properties_hs_date_exited_contractsent" string
+    "properties_hs_date_exited_customclosedwonstage" string
+    "properties_hs_date_exited_decisionmakerboughtin" string
+    "properties_hs_date_exited_presentationscheduled" string
+    "properties_hs_date_exited_qualifiedtobuy" string
+    "properties_hs_deal_amount_calculation_preference" string
+    "properties_hs_deal_stage_probability" number
+    "properties_hs_deal_stage_probability_shadow" number
+    "properties_hs_forecast_amount" number
+    "properties_hs_forecast_probability" number
+    "properties_hs_is_closed" boolean
+    "properties_hs_is_closed_won" boolean
+    "properties_hs_lastmodifieddate" string
+    "properties_hs_latest_meeting_activity" string
+    "properties_hs_likelihood_to_close" number
+    "properties_hs_line_item_global_term_hs_discount_percentage" string
+    "properties_hs_line_item_global_term_hs_discount_percentage_enabled" boolean
+    "properties_hs_line_item_global_term_hs_recurring_billing_period" string
+    "properties_hs_line_item_global_term_hs_recurring_billing_period_enabled" boolean
+    "properties_hs_line_item_global_term_hs_recurring_billing_start_date" string
+    "properties_hs_line_item_global_term_hs_recurring_billing_start_date_enabled" boolean
+    "properties_hs_line_item_global_term_recurringbillingfrequency" string
+    "properties_hs_line_item_global_term_recurringbillingfrequency_enabled" boolean
+    "properties_hs_manual_forecast_category" string
+    "properties_hs_merged_object_ids" string
+    "properties_hs_mrr" number
+    "properties_hs_next_step" string
+    "properties_hs_num_target_accounts" number
+    "properties_hs_object_id" number
+    "properties_hs_predicted_amount" number
+    "properties_hs_predicted_amount_in_home_currency" number
+    "properties_hs_priority" string
+    "properties_hs_projected_amount" number
+    "properties_hs_projected_amount_in_home_currency" number
+    "properties_hs_sales_email_last_replied" string
+    "properties_hs_tcv" number
+    "properties_hs_unique_creation_key" string
+    "properties_hs_updated_by_user_id" number
+    "properties_hs_user_ids_of_all_notification_followers" string
+    "properties_hs_user_ids_of_all_notification_unfollowers" string
+    "properties_hs_user_ids_of_all_owners" string
+    "properties_hubspot_owner_assigneddate" string
+    "properties_hubspot_owner_id" string
+    "properties_hubspot_team_id" string
+    "properties_notes_last_contacted" string
+    "properties_notes_last_updated" string
+    "properties_notes_next_activity_date" string
+    "properties_num_associated_contacts" number
+    "properties_num_contacted_notes" number
+    "properties_num_notes" number
+    "properties_pipeline" string
+    "createdAt" string
+    "updatedAt" string
+    "archived" boolean
+    "companies" array
+    "contacts" array
+    "line_items" array
+    "properties_hs_all_collaborator_owner_ids" string
+    "properties_hs_all_deal_split_owner_ids" string
+    "properties_hs_analytics_latest_source" string
+    "properties_hs_analytics_latest_source_company" string
+    "properties_hs_analytics_latest_source_contact" string
+    "properties_hs_analytics_latest_source_data_1" string
+    "properties_hs_analytics_latest_source_data_1_company" string
+    "properties_hs_analytics_latest_source_data_1_contact" string
+    "properties_hs_analytics_latest_source_data_2" string
+    "properties_hs_analytics_latest_source_data_2_company" string
+    "properties_hs_analytics_latest_source_data_2_contact" string
+    "properties_hs_analytics_latest_source_timestamp" string
+    "properties_hs_analytics_latest_source_timestamp_company" string
+    "properties_hs_analytics_latest_source_timestamp_contact" string
+    "properties_hs_campaign" string
+    "properties_hs_closed_deal_close_date" number
+    "properties_hs_closed_deal_create_date" number
+    "properties_hs_closed_won_count" number
+    "properties_hs_closed_won_date" string
+    "properties_hs_date_entered_66894120" string
+    "properties_hs_date_exited_66894120" string
+    "properties_hs_days_to_close_raw" number
+    "properties_hs_deal_score" number
+    "properties_hs_exchange_rate" number
+    "properties_hs_has_empty_conditional_stage_properties" boolean
+    "properties_hs_is_closed_count" number
+    "properties_hs_is_deal_split" boolean
+    "properties_hs_is_in_first_deal_stage" boolean
+    "properties_hs_is_open_count" number
+    "properties_hs_latest_approval_status" string
+    "properties_hs_latest_approval_status_approval_id" number
+    "properties_hs_next_step_updated_at" string
+    "properties_hs_notes_next_activity_type" string
+    "properties_hs_num_associated_deal_splits" number
+    "properties_hs_num_of_associated_line_items" number
+    "properties_hs_object_source" string
+    "properties_hs_object_source_detail_1" string
+    "properties_hs_object_source_detail_2" string
+    "properties_hs_object_source_detail_3" string
+    "properties_hs_object_source_id" string
+    "properties_hs_object_source_label" string
+    "properties_hs_object_source_user_id" number
+    "properties_hs_open_deal_create_date" number
+    "properties_hs_pinned_engagement_id" number
+    "properties_hs_read_only" boolean
+    "properties_hs_tag_ids" string
+    "properties_hs_time_in_66894120" number
+    "properties_hs_time_in_9567448" number
+    "properties_hs_time_in_9567449" number
+    "properties_hs_time_in_appointmentscheduled" number
+    "properties_hs_time_in_closedlost" number
+    "properties_hs_time_in_closedwon" number
+    "properties_hs_time_in_contractsent" number
+    "properties_hs_time_in_customclosedwonstage" number
+    "properties_hs_time_in_decisionmakerboughtin" number
+    "properties_hs_time_in_presentationscheduled" number
+    "properties_hs_time_in_qualifiedtobuy" number
+    "properties_hs_v2_cumulative_time_in_66894120" number
+    "properties_hs_v2_cumulative_time_in_9567448" number
+    "properties_hs_v2_cumulative_time_in_9567449" number
+    "properties_hs_v2_cumulative_time_in_appointmentscheduled" number
+    "properties_hs_v2_cumulative_time_in_closedlost" number
+    "properties_hs_v2_cumulative_time_in_closedwon" number
+    "properties_hs_v2_cumulative_time_in_contractsent" number
+    "properties_hs_v2_cumulative_time_in_customclosedwonstage" number
+    "properties_hs_v2_cumulative_time_in_decisionmakerboughtin" number
+    "properties_hs_v2_cumulative_time_in_presentationscheduled" number
+    "properties_hs_v2_cumulative_time_in_qualifiedtobuy" number
+    "properties_hs_v2_date_entered_66894120" string
+    "properties_hs_v2_date_entered_9567448" string
+    "properties_hs_v2_date_entered_9567449" string
+    "properties_hs_v2_date_entered_appointmentscheduled" string
+    "properties_hs_v2_date_entered_closedlost" string
+    "properties_hs_v2_date_entered_closedwon" string
+    "properties_hs_v2_date_entered_contractsent" string
+    "properties_hs_v2_date_entered_customclosedwonstage" string
+    "properties_hs_v2_date_entered_decisionmakerboughtin" string
+    "properties_hs_v2_date_entered_presentationscheduled" string
+    "properties_hs_v2_date_entered_qualifiedtobuy" string
+    "properties_hs_v2_date_exited_66894120" string
+    "properties_hs_v2_date_exited_9567448" string
+    "properties_hs_v2_date_exited_9567449" string
+    "properties_hs_v2_date_exited_appointmentscheduled" string
+    "properties_hs_v2_date_exited_closedlost" string
+    "properties_hs_v2_date_exited_closedwon" string
+    "properties_hs_v2_date_exited_contractsent" string
+    "properties_hs_v2_date_exited_customclosedwonstage" string
+    "properties_hs_v2_date_exited_decisionmakerboughtin" string
+    "properties_hs_v2_date_exited_presentationscheduled" string
+    "properties_hs_v2_date_exited_qualifiedtobuy" string
+    "properties_hs_v2_latest_time_in_66894120" number
+    "properties_hs_v2_latest_time_in_9567448" number
+    "properties_hs_v2_latest_time_in_9567449" number
+    "properties_hs_v2_latest_time_in_appointmentscheduled" number
+    "properties_hs_v2_latest_time_in_closedlost" number
+    "properties_hs_v2_latest_time_in_closedwon" number
+    "properties_hs_v2_latest_time_in_contractsent" number
+    "properties_hs_v2_latest_time_in_customclosedwonstage" number
+    "properties_hs_v2_latest_time_in_decisionmakerboughtin" number
+    "properties_hs_v2_latest_time_in_presentationscheduled" number
+    "properties_hs_v2_latest_time_in_qualifiedtobuy" number
+    "properties_hs_was_imported" boolean
+}
+
+Table "deals_archived" {
+    "id" string [pk]
+    "properties" object
+    "properties_amount" number
+    "properties_amount_in_home_currency" number
+    "properties_closed_lost_reason" string
+    "properties_closed_won_reason" string
+    "properties_closedate" string
+    "properties_createdate" string
+    "properties_days_to_close" number
+    "properties_dealname" string
+    "properties_dealstage" string
+    "properties_dealtype" string
+    "properties_description" string
+    "properties_engagements_last_meeting_booked" string
+    "properties_engagements_last_meeting_booked_campaign" string
+    "properties_engagements_last_meeting_booked_medium" string
+    "properties_engagements_last_meeting_booked_source" string
+    "properties_hs_acv" number
+    "properties_hs_all_accessible_team_ids" string
+    "properties_hs_all_assigned_business_unit_ids" string
+    "properties_hs_all_owner_ids" string
+    "properties_hs_all_team_ids" string
+    "properties_hs_analytics_source" string
+    "properties_hs_analytics_source_data_1" string
+    "properties_hs_analytics_source_data_2" string
+    "properties_hs_arr" number
+    "properties_hs_closed_amount" number
+    "properties_hs_closed_amount_in_home_currency" number
+    "properties_hs_created_by_user_id" number
+    "properties_hs_createdate" string
+    "properties_hs_date_entered_9567448" string
+    "properties_hs_date_entered_9567449" string
+    "properties_hs_date_entered_appointmentscheduled" string
+    "properties_hs_date_entered_closedlost" string
+    "properties_hs_date_entered_closedwon" string
+    "properties_hs_date_entered_contractsent" string
+    "properties_hs_date_entered_customclosedwonstage" string
+    "properties_hs_date_entered_decisionmakerboughtin" string
+    "properties_hs_date_entered_presentationscheduled" string
+    "properties_hs_date_entered_qualifiedtobuy" string
+    "properties_hs_date_exited_9567448" string
+    "properties_hs_date_exited_9567449" string
+    "properties_hs_date_exited_appointmentscheduled" string
+    "properties_hs_date_exited_closedlost" string
+    "properties_hs_date_exited_closedwon" string
+    "properties_hs_date_exited_contractsent" string
+    "properties_hs_date_exited_customclosedwonstage" string
+    "properties_hs_date_exited_decisionmakerboughtin" string
+    "properties_hs_date_exited_presentationscheduled" string
+    "properties_hs_date_exited_qualifiedtobuy" string
+    "properties_hs_deal_amount_calculation_preference" string
+    "properties_hs_deal_stage_probability" number
+    "properties_hs_deal_stage_probability_shadow" number
+    "properties_hs_forecast_amount" number
+    "properties_hs_forecast_probability" number
+    "properties_hs_is_closed" boolean
+    "properties_hs_is_closed_won" boolean
+    "properties_hs_lastmodifieddate" string
+    "properties_hs_latest_meeting_activity" string
+    "properties_hs_likelihood_to_close" number
+    "properties_hs_line_item_global_term_hs_discount_percentage" string
+    "properties_hs_line_item_global_term_hs_discount_percentage_enabled" boolean
+    "properties_hs_line_item_global_term_hs_recurring_billing_period" string
+    "properties_hs_line_item_global_term_hs_recurring_billing_period_enabled" boolean
+    "properties_hs_line_item_global_term_hs_recurring_billing_start_date" string
+    "properties_hs_line_item_global_term_hs_recurring_billing_start_date_enabled" boolean
+    "properties_hs_line_item_global_term_recurringbillingfrequency" string
+    "properties_hs_line_item_global_term_recurringbillingfrequency_enabled" boolean
+    "properties_hs_manual_forecast_category" string
+    "properties_hs_merged_object_ids" string
+    "properties_hs_mrr" number
+    "properties_hs_next_step" string
+    "properties_hs_num_target_accounts" number
+    "properties_hs_object_id" number
+    "properties_hs_predicted_amount" number
+    "properties_hs_predicted_amount_in_home_currency" number
+    "properties_hs_priority" string
+    "properties_hs_projected_amount" number
+    "properties_hs_projected_amount_in_home_currency" number
+    "properties_hs_sales_email_last_replied" string
+    "properties_hs_tcv" number
+    "properties_hs_unique_creation_key" string
+    "properties_hs_updated_by_user_id" number
+    "properties_hs_user_ids_of_all_notification_followers" string
+    "properties_hs_user_ids_of_all_notification_unfollowers" string
+    "properties_hs_user_ids_of_all_owners" string
+    "properties_hubspot_owner_assigneddate" string
+    "properties_hubspot_owner_id" string
+    "properties_hubspot_team_id" string
+    "properties_notes_last_contacted" string
+    "properties_notes_last_updated" string
+    "properties_notes_next_activity_date" string
+    "properties_num_associated_contacts" number
+    "properties_num_contacted_notes" number
+    "properties_num_notes" number
+    "properties_pipeline" string
+    "createdAt" string
+    "updatedAt" string
+    "archived" boolean
+    "archivedAt" string
+    "companies" array
+    "contacts" array
+    "line_items" array
+    "properties_hs_all_collaborator_owner_ids" string
+    "properties_hs_all_deal_split_owner_ids" string
+    "properties_hs_analytics_latest_source" string
+    "properties_hs_analytics_latest_source_company" string
+    "properties_hs_analytics_latest_source_contact" string
+    "properties_hs_analytics_latest_source_data_1" string
+    "properties_hs_analytics_latest_source_data_1_company" string
+    "properties_hs_analytics_latest_source_data_1_contact" string
+    "properties_hs_analytics_latest_source_data_2" string
+    "properties_hs_analytics_latest_source_data_2_company" string
+    "properties_hs_analytics_latest_source_data_2_contact" string
+    "properties_hs_analytics_latest_source_timestamp" string
+    "properties_hs_analytics_latest_source_timestamp_company" string
+    "properties_hs_analytics_latest_source_timestamp_contact" string
+    "properties_hs_campaign" string
+    "properties_hs_closed_deal_close_date" number
+    "properties_hs_closed_deal_create_date" number
+    "properties_hs_closed_won_count" number
+    "properties_hs_closed_won_date" string
+    "properties_hs_date_entered_66894120" string
+    "properties_hs_date_exited_66894120" string
+    "properties_hs_days_to_close_raw" number
+    "properties_hs_deal_score" number
+    "properties_hs_exchange_rate" number
+    "properties_hs_has_empty_conditional_stage_properties" boolean
+    "properties_hs_is_closed_count" number
+    "properties_hs_is_deal_split" boolean
+    "properties_hs_is_in_first_deal_stage" boolean
+    "properties_hs_is_open_count" number
+    "properties_hs_latest_approval_status" string
+    "properties_hs_latest_approval_status_approval_id" number
+    "properties_hs_next_step_updated_at" string
+    "properties_hs_notes_next_activity_type" string
+    "properties_hs_num_associated_deal_splits" number
+    "properties_hs_num_of_associated_line_items" number
+    "properties_hs_object_source" string
+    "properties_hs_object_source_detail_1" string
+    "properties_hs_object_source_detail_2" string
+    "properties_hs_object_source_detail_3" string
+    "properties_hs_object_source_id" string
+    "properties_hs_object_source_label" string
+    "properties_hs_object_source_user_id" number
+    "properties_hs_open_deal_create_date" number
+    "properties_hs_pinned_engagement_id" number
+    "properties_hs_read_only" boolean
+    "properties_hs_tag_ids" string
+    "properties_hs_time_in_66894120" number
+    "properties_hs_time_in_9567448" number
+    "properties_hs_time_in_9567449" number
+    "properties_hs_time_in_appointmentscheduled" number
+    "properties_hs_time_in_closedlost" number
+    "properties_hs_time_in_closedwon" number
+    "properties_hs_time_in_contractsent" number
+    "properties_hs_time_in_customclosedwonstage" number
+    "properties_hs_time_in_decisionmakerboughtin" number
+    "properties_hs_time_in_presentationscheduled" number
+    "properties_hs_time_in_qualifiedtobuy" number
+    "properties_hs_v2_cumulative_time_in_66894120" number
+    "properties_hs_v2_cumulative_time_in_9567448" number
+    "properties_hs_v2_cumulative_time_in_9567449" number
+    "properties_hs_v2_cumulative_time_in_appointmentscheduled" number
+    "properties_hs_v2_cumulative_time_in_closedlost" number
+    "properties_hs_v2_cumulative_time_in_closedwon" number
+    "properties_hs_v2_cumulative_time_in_contractsent" number
+    "properties_hs_v2_cumulative_time_in_customclosedwonstage" number
+    "properties_hs_v2_cumulative_time_in_decisionmakerboughtin" number
+    "properties_hs_v2_cumulative_time_in_presentationscheduled" number
+    "properties_hs_v2_cumulative_time_in_qualifiedtobuy" number
+    "properties_hs_v2_date_entered_66894120" string
+    "properties_hs_v2_date_entered_9567448" string
+    "properties_hs_v2_date_entered_9567449" string
+    "properties_hs_v2_date_entered_appointmentscheduled" string
+    "properties_hs_v2_date_entered_closedlost" string
+    "properties_hs_v2_date_entered_closedwon" string
+    "properties_hs_v2_date_entered_contractsent" string
+    "properties_hs_v2_date_entered_customclosedwonstage" string
+    "properties_hs_v2_date_entered_decisionmakerboughtin" string
+    "properties_hs_v2_date_entered_presentationscheduled" string
+    "properties_hs_v2_date_entered_qualifiedtobuy" string
+    "properties_hs_v2_date_exited_66894120" string
+    "properties_hs_v2_date_exited_9567448" string
+    "properties_hs_v2_date_exited_9567449" string
+    "properties_hs_v2_date_exited_appointmentscheduled" string
+    "properties_hs_v2_date_exited_closedlost" string
+    "properties_hs_v2_date_exited_closedwon" string
+    "properties_hs_v2_date_exited_contractsent" string
+    "properties_hs_v2_date_exited_customclosedwonstage" string
+    "properties_hs_v2_date_exited_decisionmakerboughtin" string
+    "properties_hs_v2_date_exited_presentationscheduled" string
+    "properties_hs_v2_date_exited_qualifiedtobuy" string
+    "properties_hs_v2_latest_time_in_66894120" number
+    "properties_hs_v2_latest_time_in_9567448" number
+    "properties_hs_v2_latest_time_in_9567449" number
+    "properties_hs_v2_latest_time_in_appointmentscheduled" number
+    "properties_hs_v2_latest_time_in_closedlost" number
+    "properties_hs_v2_latest_time_in_closedwon" number
+    "properties_hs_v2_latest_time_in_contractsent" number
+    "properties_hs_v2_latest_time_in_customclosedwonstage" number
+    "properties_hs_v2_latest_time_in_decisionmakerboughtin" number
+    "properties_hs_v2_latest_time_in_presentationscheduled" number
+    "properties_hs_v2_latest_time_in_qualifiedtobuy" number
+    "properties_hs_was_imported" boolean
+}
+
+Table "email_events" {
+    "appId" integer
+    "appName" string
+    "bcc" array
+    "cc" array
+    "attempt" integer
+    "bounced" boolean
+    "browser" object
+    "category" string
+    "causedBy" object
+    "created" integer
+    "deviceType" string
+    "dropMessage" string
+    "dropReason" string
+    "duration" integer
+    "emailCampaignId" integer
+    "emailCampaignGroupId" integer
+    "filteredEvent" boolean
+    "from" string
+    "hmid" string
+    "id" string [pk]
+    "ipAddress" string
+    "linkId" integer
+    "location" object
+    "obsoletedBy" object
+    "portalId" integer
+    "portalSubscriptionStatus" string
+    "recipient" string
+    "referer" string
+    "replyTo" array
+    "requestedBy" string
+    "requestedByUserId" integer
+    "response" string
+    "sentBy" object
+    "smtpId" string
+    "source" string
+    "sourceId" string
+    "subscriptions" array
+    "status" string
+    "subject" string
+    "type" string
+    "url" string
+    "userAgent" string
+}
+
+Table "email_subscriptions" {
+    "active" boolean
+    "portalId" integer
+    "description" string
+    "id" integer [pk]
+    "name" string
+    "order" integer
+    "businessUnitId" integer
+    "internal" boolean
+    "internalName" string
+    "category" string
+    "channel" string
+}
+
+Table "engagements" {
+    "id" integer [pk]
+    "uid" string
+    "teamId" integer
+    "portalId" integer
+    "queueMembershipIds" array
+    "scheduledTasks" array
+    "active" boolean
+    "createdAt" integer
+    "createdBy" integer
+    "modifiedBy" integer
+    "lastUpdated" integer
+    "ownerId" integer
+    "type" string
+    "timestamp" integer
+    "bodyPreview" string
+    "bodyPreviewHtml" string
+    "bodyPreviewIsTruncated" boolean
+    "allAccessibleTeamIds" array
+    "activityType" string
+    "gdprDeleted" boolean
+    "source" string
+    "sourceId" string
+    "associations" object
+    "associations_contactIds" array
+    "associations_contentIds" array
+    "associations_companyIds" array
+    "associations_dealIds" array
+    "associations_marketingEventIds" array
+    "associations_ownerIds" array
+    "associations_quoteIds" array
+    "associations_workflowIds" array
+    "associations_ticketIds" array
+    "attachments" array
+    "metadata" object
+    "metadata_attendeeOwnerIds" array
+    "metadata_calendarEventHash" string
+    "metadata_createdFromLinkId" integer
+    "metadata_meetingChangeId" string
+    "ownerIdsBcc" array
+    "ownerIdsFrom" array
+    "ownerIdsTo" array
+    "pendingInlineImageIds" array
+    "validationSkipped" array
+    "ownerIdsCc" array
+    "metadata_guestEmails" array
+    "metadata_iCalUid" string
+    "metadata_includeDescriptionInReminder" boolean
+    "metadata_internalMeetingNotes" string
+    "metadata_location" string
+    "metadata_locationType" string
+    "metadata_meetingOutcome" string
+    "metadata_timezone" string
+    "metadata_preMeetingProspectReminders" array
+    "metadata_body" string
+    "metadata_from" object
+    "metadata_sender" object
+    "metadata_to" array
+    "metadata_cc" array
+    "metadata_bounceErrorDetail" object
+    "metadata_emailSendEventId" object
+    "metadata_ownerIdsBcc" array
+    "metadata_ownerIdsCc" array
+    "metadata_ownerIdsFrom" array
+    "metadata_ownerIdsTo" array
+    "metadata_pendingInlineImageIds" array
+    "metadata_validationSkipped" array
+    "metadata_bcc" array
+    "metadata_subject" string
+    "metadata_html" string
+    "metadata_text" string
+    "metadata_status" string
+    "metadata_forObjectType" string
+    "metadata_startTime" integer
+    "metadata_endTime" integer
+    "metadata_title" string
+    "metadata_toNumber" string
+    "metadata_fromNumber" string
+    "metadata_externalId" string
+    "metadata_durationMilliseconds" integer
+    "metadata_externalAccountId" string
+    "metadata_recordingUrl" string
+    "metadata_disposition" string
+    "metadata_completionDate" integer
+    "metadata_taskType" string
+    "metadata_reminders" array
+    "metadata_threadId" string
+    "metadata_messageId" string
+    "metadata_loggedFrom" string
+    "metadata_attachedVideoOpened" boolean
+    "metadata_attachedVideoWatched" boolean
+    "metadata_trackerKey" string
+    "metadata_sendDefaultReminder" boolean
+    "metadata_source" string
+    "metadata_unknownVisitorConversation" boolean
+    "metadata_facsimileSendId" string
+    "metadata_sentVia" string
+    "metadata_sequenceStepOrder" integer
+    "metadata_externalUrl" string
+    "metadata_postSendStatus" string
+    "metadata_errorMessage" string
+    "metadata_recipientDropReasons" string
+    "metadata_calleeObjectId" integer
+    "metadata_calleeObjectType" string
+    "metadata_mediaProcessingStatus" string
+    "metadata_sourceId" string
+    "metadata_priority" string
+    "metadata_isAllDay" boolean
+}
+
+Table "engagements_calls" {
+    "id" string [pk]
+    "properties" object
+    "properties_hs_activity_type" string
+    "properties_hs_all_assigned_business_unit_ids" string
+    "properties_hs_at_mentioned_owner_ids" string
+    "properties_hs_attachment_ids" string
+    "properties_hs_body_preview" string
+    "properties_hs_body_preview_html" string
+    "properties_hs_body_preview_is_truncated" boolean
+    "properties_hs_call_app_id" number
+    "properties_hs_call_authed_url_provider" string
+    "properties_hs_call_body" string
+    "properties_hs_call_callee_object_id" number
+    "properties_hs_call_callee_object_type" string
+    "properties_hs_call_disposition" string
+    "properties_hs_call_duration" number
+    "properties_hs_call_external_account_id" string
+    "properties_hs_call_external_id" string
+    "properties_hs_call_from_number" string
+    "properties_hs_call_has_transcript" boolean
+    "properties_hs_call_recording_url" string
+    "properties_hs_call_source" string
+    "properties_hs_call_status" string
+    "properties_hs_call_title" string
+    "properties_hs_call_to_number" string
+    "properties_hs_call_transcription_id" number
+    "properties_hs_call_video_recording_url" string
+    "properties_hs_call_zoom_meeting_uuid" string
+    "properties_hs_calls_service_call_id" number
+    "properties_hs_created_by" number
+    "properties_hs_created_by_user_id" number
+    "properties_hs_createdate" string
+    "properties_hs_engagement_source" string
+    "properties_hs_engagement_source_id" string
+    "properties_hs_follow_up_action" string
+    "properties_hs_gdpr_deleted" boolean
+    "properties_hs_lastmodifieddate" string
+    "properties_hs_merged_object_ids" string
+    "properties_hs_modified_by" number
+    "properties_hs_object_id" number
+    "properties_hs_product_name" string
+    "properties_hs_queue_membership_ids" string
+    "properties_hs_timestamp" string
+    "properties_hs_unique_creation_key" string
+    "properties_hs_unique_id" string
+    "properties_hs_unknown_visitor_conversation" boolean
+    "properties_hs_updated_by_user_id" number
+    "properties_hs_user_ids_of_all_notification_followers" string
+    "properties_hs_user_ids_of_all_notification_unfollowers" string
+    "properties_hs_user_ids_of_all_owners" string
+    "properties_hubspot_owner_assigneddate" string
+    "properties_hubspot_owner_id" string
+    "properties_hubspot_team_id" string
+    "properties_hs_all_owner_ids" string
+    "properties_hs_all_team_ids" string
+    "properties_hs_all_accessible_team_ids" string
+    "createdAt" string
+    "updatedAt" string
+    "archived" boolean
+    "contacts" array
+    "deals" array
+    "companies" array
+    "tickets" array
+    "properties_hs_call_deal_stage_during_call" string
+    "properties_hs_call_direction" string
+    "properties_hs_call_from_number_nickname" string
+    "properties_hs_call_has_voicemail" string
+    "properties_hs_call_ms_teams_payload" string
+    "properties_hs_call_primary_deal" string
+    "properties_hs_call_summary" string
+    "properties_hs_call_summary_execution_id" string
+    "properties_hs_call_to_number_nickname" string
+    "properties_hs_call_transcript_audio_num_channels" number
+    "properties_hs_call_transcript_tracked_terms" string
+    "properties_hs_call_video_meeting_type" string
+    "properties_hs_connected_count" number
+    "properties_hs_object_source" string
+    "properties_hs_object_source_detail_1" string
+    "properties_hs_object_source_detail_2" string
+    "properties_hs_object_source_detail_3" string
+    "properties_hs_object_source_id" string
+    "properties_hs_object_source_label" string
+    "properties_hs_object_source_user_id" number
+    "properties_hs_read_only" boolean
+    "properties_hs_shared_team_ids" string
+    "properties_hs_shared_user_ids" string
+    "properties_hs_voicemail_count" number
+    "properties_hs_was_imported" boolean
+}
+
+Table "engagements_emails" {
+    "id" string [pk]
+    "properties" object
+    "properties_hs_all_assigned_business_unit_ids" string
+    "properties_hs_at_mentioned_owner_ids" string
+    "properties_hs_attachment_ids" string
+    "properties_hs_body_preview" string
+    "properties_hs_body_preview_html" string
+    "properties_hs_body_preview_is_truncated" boolean
+    "properties_hs_created_by" string
+    "properties_hs_created_by_user_id" number
+    "properties_hs_createdate" string
+    "properties_hs_direction_and_unique_id" string
+    "properties_hs_email_attached_video_id" string
+    "properties_hs_email_attached_video_name" string
+    "properties_hs_email_attached_video_opened" boolean
+    "properties_hs_email_attached_video_watched" boolean
+    "properties_hs_email_bcc_email" string
+    "properties_hs_email_bcc_firstname" string
+    "properties_hs_email_bcc_lastname" string
+    "properties_hs_email_bcc_raw" string
+    "properties_hs_email_cc_email" string
+    "properties_hs_email_cc_firstname" string
+    "properties_hs_email_cc_lastname" string
+    "properties_hs_email_cc_raw" string
+    "properties_hs_email_direction" string
+    "properties_hs_email_encoded_email_associations_request" string
+    "properties_hs_email_error_message" string
+    "properties_hs_email_facsimile_send_id" string
+    "properties_hs_email_from_email" string
+    "properties_hs_email_from_firstname" string
+    "properties_hs_email_from_lastname" string
+    "properties_hs_email_from_raw" string
+    "properties_hs_email_headers" string
+    "properties_hs_email_html" string
+    "properties_hs_email_logged_from" string
+    "properties_hs_email_media_processing_status" string
+    "properties_hs_email_member_of_forwarded_subthread" boolean
+    "properties_hs_email_message_id" string
+    "properties_hs_email_migrated_via_portal_data_migration" string
+    "properties_hs_email_pending_inline_image_ids" string
+    "properties_hs_email_post_send_status" string
+    "properties_hs_email_recipient_drop_reasons" string
+    "properties_hs_email_send_event_id" string
+    "properties_hs_email_send_event_id_created" string
+    "properties_hs_email_sender_email" string
+    "properties_hs_email_sender_firstname" string
+    "properties_hs_email_sender_lastname" string
+    "properties_hs_email_sender_raw" string
+    "properties_hs_email_sent_via" string
+    "properties_hs_email_status" string
+    "properties_hs_email_subject" string
+    "properties_hs_email_text" string
+    "properties_hs_email_thread_id" string
+    "properties_hs_email_to_email" string
+    "properties_hs_email_to_firstname" string
+    "properties_hs_email_to_lastname" string
+    "properties_hs_email_to_raw" string
+    "properties_hs_email_tracker_key" string
+    "properties_hs_email_validation_skipped" string
+    "properties_hs_engagement_source" string
+    "properties_hs_engagement_source_id" string
+    "properties_hs_follow_up_action" string
+    "properties_hs_gdpr_deleted" boolean
+    "properties_hs_lastmodifieddate" string
+    "properties_hs_merged_object_ids" string
+    "properties_hs_modified_by" string
+    "properties_hs_object_id" number
+    "properties_hs_product_name" string
+    "properties_hs_queue_membership_ids" string
+    "properties_hs_timestamp" string
+    "properties_hs_unique_creation_key" string
+    "properties_hs_unique_id" string
+    "properties_hs_updated_by_user_id" number
+    "properties_hs_user_ids_of_all_notification_followers" string
+    "properties_hs_user_ids_of_all_notification_unfollowers" string
+    "properties_hs_user_ids_of_all_owners" string
+    "properties_hubspot_owner_assigneddate" string
+    "properties_hubspot_owner_id" string
+    "properties_hubspot_team_id" string
+    "properties_hs_all_owner_ids" string
+    "properties_hs_all_team_ids" string
+    "properties_hs_all_accessible_team_ids" string
+    "createdAt" string
+    "updatedAt" string
+    "archived" boolean
+    "contacts" array
+    "deals" array
+    "companies" array
+    "tickets" array
+    "properties_hs_email_bounce_error_detail_message" string
+    "properties_hs_email_bounce_error_detail_status_code" number
+    "properties_hs_email_click_count" number
+    "properties_hs_email_has_inline_images_stripped" boolean
+    "properties_hs_email_ms_teams_payload" string
+    "properties_hs_email_open_count" number
+    "properties_hs_email_reply_count" number
+    "properties_hs_email_sent_count" number
+    "properties_hs_email_stripped_attachment_count" number
+    "properties_hs_email_thread_summary" string
+    "properties_hs_object_source" string
+    "properties_hs_object_source_detail_1" string
+    "properties_hs_object_source_detail_2" string
+    "properties_hs_object_source_detail_3" string
+    "properties_hs_object_source_id" string
+    "properties_hs_object_source_label" string
+    "properties_hs_object_source_user_id" number
+    "properties_hs_owner_ids_bcc" string
+    "properties_hs_owner_ids_cc" string
+    "properties_hs_owner_ids_from" string
+    "properties_hs_owner_ids_to" string
+    "properties_hs_read_only" boolean
+    "properties_hs_scs_association_status" string
+    "properties_hs_scs_audit_id" string
+    "properties_hs_shared_team_ids" string
+    "properties_hs_shared_user_ids" string
+    "properties_hs_was_imported" boolean
+}
+
+Table "engagements_meetings" {
+    "id" string [pk]
+    "properties" object
+    "properties_hs_activity_type" string
+    "properties_hs_all_assigned_business_unit_ids" string
+    "properties_hs_at_mentioned_owner_ids" string
+    "properties_hs_attachment_ids" string
+    "properties_hs_attendee_owner_ids" string
+    "properties_hs_body_preview" string
+    "properties_hs_body_preview_html" string
+    "properties_hs_body_preview_is_truncated" boolean
+    "properties_hs_created_by" number
+    "properties_hs_created_by_user_id" number
+    "properties_hs_createdate" string
+    "properties_hs_engagement_source" string
+    "properties_hs_engagement_source_id" string
+    "properties_hs_follow_up_action" string
+    "properties_hs_gdpr_deleted" boolean
+    "properties_hs_i_cal_uid" string
+    "properties_hs_internal_meeting_notes" string
+    "properties_hs_lastmodifieddate" string
+    "properties_hs_meeting_body" string
+    "properties_hs_meeting_calendar_event_hash" string
+    "properties_hs_meeting_change_id" string
+    "properties_hs_meeting_created_from_link_id" string
+    "properties_hs_meeting_end_time" string
+    "properties_hs_meeting_external_url" string
+    "properties_hs_meeting_location" string
+    "properties_hs_meeting_location_type" string
+    "properties_hs_meeting_outcome" string
+    "properties_hs_meeting_pre_meeting_prospect_reminders" string
+    "properties_hs_meeting_source" string
+    "properties_hs_meeting_source_id" string
+    "properties_hs_meeting_start_time" string
+    "properties_hs_meeting_title" string
+    "properties_hs_meeting_web_conference_meeting_id" string
+    "properties_hs_merged_object_ids" string
+    "properties_hs_modified_by" number
+    "properties_hs_object_id" number
+    "properties_hs_product_name" string
+    "properties_hs_queue_membership_ids" string
+    "properties_hs_scheduled_tasks" string
+    "properties_hs_timestamp" string
+    "properties_hs_unique_creation_key" string
+    "properties_hs_unique_id" string
+    "properties_hs_updated_by_user_id" number
+    "properties_hs_user_ids_of_all_notification_followers" string
+    "properties_hs_user_ids_of_all_notification_unfollowers" string
+    "properties_hs_user_ids_of_all_owners" string
+    "properties_hubspot_owner_assigneddate" string
+    "properties_hubspot_owner_id" string
+    "properties_hubspot_team_id" string
+    "properties_hs_all_owner_ids" string
+    "properties_hs_all_team_ids" string
+    "properties_hs_all_accessible_team_ids" string
+    "createdAt" string
+    "updatedAt" string
+    "archived" boolean
+    "contacts" array
+    "deals" array
+    "companies" array
+    "tickets" array
+    "properties_hs_contact_first_outreach_date" string
+    "properties_hs_follow_up_tasks_remaining" number
+    "properties_hs_guest_emails" string
+    "properties_hs_include_description_in_reminder" boolean
+    "properties_hs_meeting_ms_teams_payload" string
+    "properties_hs_meeting_payments_session_id" string
+    "properties_hs_object_source" string
+    "properties_hs_object_source_detail_1" string
+    "properties_hs_object_source_detail_2" string
+    "properties_hs_object_source_detail_3" string
+    "properties_hs_object_source_id" string
+    "properties_hs_object_source_label" string
+    "properties_hs_object_source_user_id" number
+    "properties_hs_outcome_canceled_count" number
+    "properties_hs_outcome_completed_count" number
+    "properties_hs_outcome_no_show_count" number
+    "properties_hs_outcome_rescheduled_count" number
+    "properties_hs_outcome_scheduled_count" number
+    "properties_hs_read_only" boolean
+    "properties_hs_roster_object_coordinates" string
+    "properties_hs_shared_team_ids" string
+    "properties_hs_shared_user_ids" string
+    "properties_hs_time_to_book_meeting_from_first_contact" number
+    "properties_hs_timezone" string
+    "properties_hs_video_conference_url" string
+    "properties_hs_was_imported" boolean
+}
+
+Table "engagements_notes" {
+    "id" string [pk]
+    "properties" object
+    "properties_hs_all_assigned_business_unit_ids" string
+    "properties_hs_at_mentioned_owner_ids" string
+    "properties_hs_attachment_ids" string
+    "properties_hs_body_preview" string
+    "properties_hs_body_preview_html" string
+    "properties_hs_body_preview_is_truncated" boolean
+    "properties_hs_created_by" number
+    "properties_hs_created_by_user_id" number
+    "properties_hs_createdate" string
+    "properties_hs_engagement_source" string
+    "properties_hs_engagement_source_id" string
+    "properties_hs_follow_up_action" string
+    "properties_hs_gdpr_deleted" boolean
+    "properties_hs_lastmodifieddate" string
+    "properties_hs_merged_object_ids" string
+    "properties_hs_modified_by" number
+    "properties_hs_note_body" string
+    "properties_hs_object_id" number
+    "properties_hs_product_name" string
+    "properties_hs_queue_membership_ids" string
+    "properties_hs_timestamp" string
+    "properties_hs_unique_creation_key" string
+    "properties_hs_unique_id" string
+    "properties_hs_updated_by_user_id" number
+    "properties_hs_user_ids_of_all_notification_followers" string
+    "properties_hs_user_ids_of_all_notification_unfollowers" string
+    "properties_hs_user_ids_of_all_owners" string
+    "properties_hubspot_owner_assigneddate" string
+    "properties_hubspot_owner_id" string
+    "properties_hubspot_team_id" string
+    "properties_hs_all_owner_ids" string
+    "properties_hs_all_team_ids" string
+    "properties_hs_all_accessible_team_ids" string
+    "createdAt" string
+    "updatedAt" string
+    "archived" boolean
+    "contacts" array
+    "deals" array
+    "companies" array
+    "tickets" array
+    "properties_hs_note_ms_teams_payload" string
+    "properties_hs_object_source" string
+    "properties_hs_object_source_detail_1" string
+    "properties_hs_object_source_detail_2" string
+    "properties_hs_object_source_detail_3" string
+    "properties_hs_object_source_id" string
+    "properties_hs_object_source_label" string
+    "properties_hs_object_source_user_id" number
+    "properties_hs_read_only" boolean
+    "properties_hs_shared_team_ids" string
+    "properties_hs_shared_user_ids" string
+    "properties_hs_was_imported" boolean
+}
+
+Table "engagements_tasks" {
+    "id" string [pk]
+    "properties" object
+    "properties_hs_all_assigned_business_unit_ids" string
+    "properties_hs_at_mentioned_owner_ids" string
+    "properties_hs_attachment_ids" string
+    "properties_hs_body_preview" string
+    "properties_hs_body_preview_html" string
+    "properties_hs_body_preview_is_truncated" boolean
+    "properties_hs_calendar_event_id" string
+    "properties_hs_created_by" number
+    "properties_hs_created_by_user_id" number
+    "properties_hs_createdate" string
+    "properties_hs_engagement_source" string
+    "properties_hs_engagement_source_id" string
+    "properties_hs_follow_up_action" string
+    "properties_hs_gdpr_deleted" boolean
+    "properties_hs_lastmodifieddate" string
+    "properties_hs_merged_object_ids" string
+    "properties_hs_modified_by" number
+    "properties_hs_msteams_message_id" string
+    "properties_hs_num_associated_companies" number
+    "properties_hs_num_associated_contacts" number
+    "properties_hs_num_associated_deals" number
+    "properties_hs_num_associated_queue_objects" number
+    "properties_hs_num_associated_tickets" number
+    "properties_hs_object_id" number
+    "properties_hs_product_name" string
+    "properties_hs_queue_membership_ids" string
+    "properties_hs_scheduled_tasks" string
+    "properties_hs_task_body" string
+    "properties_hs_task_completion_date" string
+    "properties_hs_task_contact_timezone" string
+    "properties_hs_task_for_object_type" string
+    "properties_hs_task_is_all_day" boolean
+    "properties_hs_task_last_contact_outreach" string
+    "properties_hs_task_last_sales_activity_timestamp" string
+    "properties_hs_task_priority" string
+    "properties_hs_task_probability_to_complete" number
+    "properties_hs_task_relative_reminders" string
+    "properties_hs_task_reminders" string
+    "properties_hs_task_repeat_interval" string
+    "properties_hs_task_send_default_reminder" boolean
+    "properties_hs_task_sequence_enrollment_active" boolean
+    "properties_hs_task_sequence_step_enrollment_id" string
+    "properties_hs_task_sequence_step_order" number
+    "properties_hs_task_status" string
+    "properties_hs_task_subject" string
+    "properties_hs_task_template_id" number
+    "properties_hs_task_type" string
+    "properties_hs_timestamp" string
+    "properties_hs_unique_creation_key" string
+    "properties_hs_unique_id" string
+    "properties_hs_updated_by_user_id" number
+    "properties_hs_user_ids_of_all_notification_followers" string
+    "properties_hs_user_ids_of_all_notification_unfollowers" string
+    "properties_hs_user_ids_of_all_owners" string
+    "properties_hubspot_owner_assigneddate" string
+    "properties_hubspot_owner_id" string
+    "properties_hubspot_team_id" string
+    "properties_hs_all_owner_ids" string
+    "properties_hs_all_team_ids" string
+    "properties_hs_all_accessible_team_ids" string
+    "createdAt" string
+    "updatedAt" string
+    "archived" boolean
+    "contacts" array
+    "deals" array
+    "companies" array
+    "tickets" array
+    "properties_hs_date_entered_60b5c368_04c4_4d32_9b4a_457e159f49b7_13292096" string
+    "properties_hs_date_entered_61bafb31_e7fa_46ed_aaa9_1322438d6e67_1866552342" string
+    "properties_hs_date_entered_af0e6a5c_2ea3_4c72_b69f_7c6cb3fdb591_1652950531" string
+    "properties_hs_date_entered_dd5826e4_c976_4654_a527_b59ada542e52_2144133616" string
+    "properties_hs_date_entered_fc8148fb_3a2d_4b59_834e_69b7859347cb_1813133675" string
+    "properties_hs_date_exited_60b5c368_04c4_4d32_9b4a_457e159f49b7_13292096" string
+    "properties_hs_date_exited_61bafb31_e7fa_46ed_aaa9_1322438d6e67_1866552342" string
+    "properties_hs_date_exited_af0e6a5c_2ea3_4c72_b69f_7c6cb3fdb591_1652950531" string
+    "properties_hs_date_exited_dd5826e4_c976_4654_a527_b59ada542e52_2144133616" string
+    "properties_hs_date_exited_fc8148fb_3a2d_4b59_834e_69b7859347cb_1813133675" string
+    "properties_hs_object_source" string
+    "properties_hs_object_source_detail_1" string
+    "properties_hs_object_source_detail_2" string
+    "properties_hs_object_source_detail_3" string
+    "properties_hs_object_source_id" string
+    "properties_hs_object_source_label" string
+    "properties_hs_object_source_user_id" number
+    "properties_hs_read_only" boolean
+    "properties_hs_repeat_status" string
+    "properties_hs_shared_team_ids" string
+    "properties_hs_shared_user_ids" string
+    "properties_hs_task_completion_count" number
+    "properties_hs_task_family" string
+    "properties_hs_task_is_completed" number
+    "properties_hs_task_is_completed_call" number
+    "properties_hs_task_is_completed_email" number
+    "properties_hs_task_is_completed_linked_in" number
+    "properties_hs_task_is_completed_sequence" number
+    "properties_hs_task_is_overdue" boolean
+    "properties_hs_task_is_past_due_date" boolean
+    "properties_hs_task_missed_due_date" boolean
+    "properties_hs_task_missed_due_date_count" number
+    "properties_hs_task_ms_teams_payload" string
+    "properties_hs_time_in_60b5c368_04c4_4d32_9b4a_457e159f49b7_13292096" number
+    "properties_hs_time_in_61bafb31_e7fa_46ed_aaa9_1322438d6e67_1866552342" number
+    "properties_hs_time_in_af0e6a5c_2ea3_4c72_b69f_7c6cb3fdb591_1652950531" number
+    "properties_hs_time_in_dd5826e4_c976_4654_a527_b59ada542e52_2144133616" number
+    "properties_hs_time_in_fc8148fb_3a2d_4b59_834e_69b7859347cb_1813133675" number
+    "properties_hs_was_imported" boolean
+}
+
+Table "forms" {
+    "id" string [pk]
+    "name" string
+    "formType" string
+    "createdAt" string
+    "updatedAt" string
+    "archived" boolean
+    "deletedAt" string
+    "fieldGroups" array
+    "configuration" object
+    "displayOptions" object
+    "legalConsentOptions" object
+    "properties" object
+    "properties_hs_all_accessible_team_ids" string
+    "properties_hs_all_assigned_business_unit_ids" string
+    "properties_hs_all_owner_ids" string
+    "properties_hs_all_team_ids" string
+    "properties_hs_cloneable" string
+    "properties_hs_created_at" string
+    "properties_hs_created_by_user_id" number
+    "properties_hs_createdate" string
+    "properties_hs_deletable" string
+    "properties_hs_editable" string
+    "properties_hs_embed_version" string
+    "properties_hs_folder_id" number
+    "properties_hs_form_id" string
+    "properties_hs_form_interactions" number
+    "properties_hs_form_submissions" number
+    "properties_hs_form_submissions_per_form_interaction" number
+    "properties_hs_form_submissions_per_form_view" number
+    "properties_hs_form_submissions_per_page_view" number
+    "properties_hs_form_submissions_per_pop_up_cta_view" number
+    "properties_hs_form_type" string
+    "properties_hs_form_views" number
+    "properties_hs_lastmodifieddate" string
+    "properties_hs_marketing_campaign_guid" string
+    "properties_hs_merged_object_ids" string
+    "properties_hs_name" string
+    "properties_hs_object_id" number
+    "properties_hs_object_source" string
+    "properties_hs_object_source_detail_1" string
+    "properties_hs_object_source_detail_2" string
+    "properties_hs_object_source_detail_3" string
+    "properties_hs_object_source_id" string
+    "properties_hs_object_source_label" string
+    "properties_hs_object_source_user_id" number
+    "properties_hs_page_views" number
+    "properties_hs_pop_up_cta_views" number
+    "properties_hs_read_only" boolean
+    "properties_hs_shared_team_ids" string
+    "properties_hs_shared_user_ids" string
+    "properties_hs_spam_submissions" number
+    "properties_hs_status" string
+    "properties_hs_unique_creation_key" string
+    "properties_hs_updated_at" string
+    "properties_hs_updated_by_user_id" number
+    "properties_hs_user_ids_of_all_notification_followers" string
+    "properties_hs_user_ids_of_all_notification_unfollowers" string
+    "properties_hs_user_ids_of_all_owners" string
+    "properties_hs_was_imported" boolean
+    "properties_hubspot_owner_assigneddate" string
+    "properties_hubspot_owner_id" string
+    "properties_hubspot_team_id" string
+}
+
+Table "form_submissions" {
+    "submittedAt" integer
+    "updatedAt" integer
+    "values" array
+    "pageUrl" string
+    "formId" string
+}
+
+Table "goals" {
+    "id" string [pk]
+    "properties" object
+    "properties_hs_created_by_user_id" number
+    "properties_hs_createdate" string
+    "properties_hs_start_datetime" string
+    "properties_hs_end_datetime" string
+    "properties_hs_goal_name" string
+    "properties_hs_lastmodifieddate" string
+    "properties_hs_kpi_value_last_calculated_at" string
+    "properties_hs_object_id" number
+    "properties_hs_target_amount" number
+    "createdAt" string
+    "updatedAt" string
+    "archived" boolean
+    "properties_hs__migration_soft_delete" string
+    "properties_hs_ad_account_asset_ids" string
+    "properties_hs_ad_campaign_asset_ids" string
+    "properties_hs_all_accessible_team_ids" string
+    "properties_hs_all_assigned_business_unit_ids" string
+    "properties_hs_all_owner_ids" string
+    "properties_hs_all_team_ids" string
+    "properties_hs_assignee_team_id" number
+    "properties_hs_assignee_user_id" number
+    "properties_hs_contact_lifecycle_stage" string
+    "properties_hs_currency" string
+    "properties_hs_deal_pipeline_ids" string
+    "properties_hs_edit_updates_notification_frequency" string
+    "properties_hs_end_date" string
+    "properties_hs_fiscal_year_offset" number
+    "properties_hs_forecast_type_id" number
+    "properties_hs_goal_definition_key" string
+    "properties_hs_goal_definition_key_with_team" string
+    "properties_hs_goal_definition_key_with_user" string
+    "properties_hs_goal_target_group_id" number
+    "properties_hs_goal_type" string
+    "properties_hs_group_correlation_uuid" string
+    "properties_hs_is_forecastable" string
+    "properties_hs_is_legacy" string
+    "properties_hs_kpi_display_unit" string
+    "properties_hs_kpi_filter_groups" string
+    "properties_hs_kpi_filter_groups_for_key_grouping" string
+    "properties_hs_kpi_filter_groups_for_key_team_grouping" string
+    "properties_hs_kpi_is_team_rollup" boolean
+    "properties_hs_kpi_metric_type" string
+    "properties_hs_kpi_object_type" string
+    "properties_hs_kpi_object_type_id" string
+    "properties_hs_kpi_progress_percent" number
+    "properties_hs_kpi_property_name" string
+    "properties_hs_kpi_single_object_custom_goal_type_name" string
+    "properties_hs_kpi_time_period_property" string
+    "properties_hs_kpi_tracking_method" string
+    "properties_hs_kpi_unit_type" string
+    "properties_hs_kpi_value" number
+    "properties_hs_kpi_value_calculated_at" number
+    "properties_hs_legacy_active" string
+    "properties_hs_legacy_created_at" number
+    "properties_hs_legacy_created_by" number
+    "properties_hs_legacy_quarterly_target_composite_id" string
+    "properties_hs_legacy_sql_id" number
+    "properties_hs_legacy_unique_sql_id" number
+    "properties_hs_legacy_updated_at" number
+    "properties_hs_legacy_updated_by" number
+    "properties_hs_marketing_campaign_object_ids" number
+    "properties_hs_merged_object_ids" string
+    "properties_hs_migration_soft_delete" string
+    "properties_hs_milestone" string
+    "properties_hs_object_source" string
+    "properties_hs_object_source_detail_1" string
+    "properties_hs_object_source_detail_2" string
+    "properties_hs_object_source_detail_3" string
+    "properties_hs_object_source_id" string
+    "properties_hs_object_source_label" string
+    "properties_hs_object_source_user_id" number
+    "properties_hs_outcome" string
+    "properties_hs_owner_ids_of_all_owners" string
+    "properties_hs_pipelines" string
+    "properties_hs_progress_updates_notification_frequency" string
+    "properties_hs_read_only" boolean
+    "properties_hs_shared_team_ids" string
+    "properties_hs_shared_user_ids" string
+    "properties_hs_should_notify_on_achieved" string
+    "properties_hs_should_notify_on_edit_updates" string
+    "properties_hs_should_notify_on_exceeded" string
+    "properties_hs_should_notify_on_kickoff" string
+    "properties_hs_should_notify_on_missed" string
+    "properties_hs_should_notify_on_progress_updates" string
+    "properties_hs_should_recalculate" string
+    "properties_hs_start_date" string
+    "properties_hs_static_kpi_filter_groups" string
+    "properties_hs_status" string
+    "properties_hs_status_display_order" number
+    "properties_hs_target_amount_in_home_currency" number
+    "properties_hs_team_id" number
+    "properties_hs_template_id" number
+    "properties_hs_ticket_pipeline_ids" string
+    "properties_hs_unique_creation_key" string
+    "properties_hs_updated_by_user_id" number
+    "properties_hs_user_id" number
+    "properties_hs_user_ids_of_all_notification_followers" string
+    "properties_hs_user_ids_of_all_notification_unfollowers" string
+    "properties_hs_user_ids_of_all_owners" string
+    "properties_hs_was_imported" boolean
+    "properties_hubspot_owner_assigneddate" string
+    "properties_hubspot_owner_id" string
+    "properties_hubspot_team_id" string
+}
+
+Table "line_items" {
+    "id" string [pk]
+    "createdAt" string
+    "updatedAt" string
+    "archived" boolean
+    "properties" object
+    "properties_amount" number
+    "properties_createdate" string
+    "properties_description" string
+    "properties_discount" number
+    "properties_hs_acv" number
+    "properties_hs_all_accessible_team_ids" string
+    "properties_hs_all_assigned_business_unit_ids" string
+    "properties_hs_all_owner_ids" string
+    "properties_hs_all_team_ids" string
+    "properties_hs_allow_buyer_selected_quantity" string
+    "properties_hs_arr" number
+    "properties_hs_billing_period_end_date" string
+    "properties_hs_billing_period_start_date" string
+    "properties_hs_billing_start_delay_days" number
+    "properties_hs_billing_start_delay_months" number
+    "properties_hs_billing_start_delay_type" string
+    "properties_hs_buyer_selected_quantity_max" number
+    "properties_hs_buyer_selected_quantity_min" number
+    "properties_hs_cost_of_goods_sold" number
+    "properties_hs_created_by_user_id" number
+    "properties_hs_createdate" string
+    "properties_hs_discount_percentage" number
+    "properties_hs_external_id" number
+    "properties_hs_images" string
+    "properties_hs_is_editable_price" boolean
+    "properties_hs_is_optional" boolean
+    "properties_hs_lastmodifieddate" string
+    "properties_hs_line_item_currency_code" string
+    "properties_hs_margin" number
+    "properties_hs_margin_acv" number
+    "properties_hs_margin_arr" number
+    "properties_hs_margin_mrr" number
+    "properties_hs_margin_tcv" number
+    "properties_hs_merged_object_ids" string
+    "properties_hs_mrr" number
+    "properties_hs_object_id" number
+    "properties_hs_object_source" string
+    "properties_hs_object_source_detail_1" string
+    "properties_hs_object_source_detail_2" string
+    "properties_hs_object_source_detail_3" string
+    "properties_hs_object_source_id" string
+    "properties_hs_object_source_label" string
+    "properties_hs_object_source_user_id" number
+    "properties_hs_position_on_quote" number
+    "properties_hs_post_tax_amount" number
+    "properties_hs_pre_discount_amount" number
+    "properties_hs_product_id" number
+    "properties_hs_product_type" string
+    "properties_hs_read_only" boolean
+    "properties_hs_recurring_billing_end_date" string
+    "properties_hs_recurring_billing_number_of_payments" number
+    "properties_hs_recurring_billing_period" string
+    "properties_hs_recurring_billing_start_date" string
+    "properties_hs_recurring_billing_terms" string
+    "properties_hs_shared_team_ids" string
+    "properties_hs_shared_user_ids" string
+    "properties_hs_sku" string
+    "properties_hs_sync_amount" number
+    "properties_hs_tax_label" string
+    "properties_hs_tax_rate" number
+    "properties_hs_tax_rate_group_id" string
+    "properties_hs_tcv" number
+    "properties_hs_term_in_months" number
+    "properties_hs_total_discount" number
+    "properties_hs_unique_creation_key" string
+    "properties_hs_updated_by_user_id" number
+    "properties_hs_url" string
+    "properties_hs_user_ids_of_all_notification_followers" string
+    "properties_hs_user_ids_of_all_notification_unfollowers" string
+    "properties_hs_user_ids_of_all_owners" string
+    "properties_hs_variant_id" number
+    "properties_hs_was_imported" boolean
+    "properties_hubspot_owner_assigneddate" string
+    "properties_hubspot_owner_id" string
+    "properties_hubspot_team_id" string
+    "properties_name" string
+    "properties_price" number
+    "properties_quantity" number
+    "properties_recurringbillingfrequency" string
+    "properties_tax" number
+    "properties_test" string
+    "properties_test_product_price" string
+}
+
+Table "marketing_emails" {
+    "id" integer [pk]
+    "ab" boolean
+    "abHoursToWait" integer
+    "abSampleSizeDefault" string
+    "abSamplingDefault" string
+    "abStatus" string
+    "abSuccessMetric" string
+    "abTestPercentage" integer
+    "abVariation" boolean
+    "absoluteUrl" string
+    "aifeatures" object
+    "allEmailCampaignIds" array
+    "analyticsPageId" string
+    "analyticsPageType" string
+    "archived" boolean
+    "authorAt" integer
+    "authorName" string
+    "authorUserId" integer
+    "blogEmailType" string
+    "campaign" string
+    "campaignName" string
+    "canSpamSettingsId" integer
+    "categoryId" integer
+    "clonedFrom" integer
+    "contentTypeCategory" integer
+    "createPage" boolean
+    "created" integer
+    "createdById" integer
+    "currentState" string
+    "currentlyPublished" boolean
+    "customReplyTo" string
+    "customReplyToEnabled" boolean
+    "domain" string
+    "emailBody" string
+    "emailNote" string
+    "emailTemplateMode" string
+    "emailType" string
+    "emailbodyPlaintext" string
+    "feedbackEmailCategory" string
+    "feedbackSurveyId" integer
+    "folderId" integer
+    "freezeDate" integer
+    "fromName" string
+    "htmlTitle" string
+    "isGraymailSuppressionEnabled" boolean
+    "isLocalTimezoneSend" boolean
+    "isPublished" boolean
+    "isRecipientFatigueSuppressionEnabled" boolean
+    "leadFlowId" integer
+    "liveDomain" string
+    "mailingListsExcluded" array
+    "mailingListsIncluded" array
+    "maxRssEntries" integer
+    "metaDescription" string
+    "name" string
+    "pageExpiryEnabled" boolean
+    "pageRedirected" boolean
+    "portalId" integer
+    "previewKey" string
+    "primaryEmailCampaignId" integer
+    "processingStatus" string
+    "publishDate" integer
+    "publishedById" integer
+    "publishedByName" string
+    "publishImmediately" boolean
+    "publishedUrl" string
+    "replyTo" string
+    "resolvedDomain" string
+    "rootMicId" string
+    "selected" integer
+    "slug" string
+    "smartEmailFields" object
+    "state" string
+    "stats" object
+    "subcategory" string
+    "subject" string
+    "subscription" integer
+    "subscriptionName" string
+    "templatePath" string
+    "transactional" boolean
+    "unpublishedAt" integer
+    "updated" integer
+    "updatedById" integer
+    "url" string
+    "useRssHeadlineAsSubject" boolean
+    "vidsExcluded" array
+    "vidsIncluded" array
+    "publishedByEmail" string
+    "sections" object
+    "author" string
+    "isCreatedFomSandboxSync" boolean
+    "rssEmailUrl" string
+    "teamPerms" array
+    "securityState" string
+    "isInstanceLayoutPage" boolean
+    "audienceAccess" string
+    "campaignUtm" string
+    "contentAccessRuleTypes" array
+    "pastMabExperimentIds" array
+    "rssEmailClickThroughText" string
+    "rssEmailImageMaxWidth" integer
+    "flexAreas" object
+    "emailCampaignGroupId" integer
+    "layoutSections" object
+    "blogRssSettings" string
+    "archivedInDashboard" boolean
+    "publishedAt" integer
+    "lastEditUpdateId" integer
+    "lastEditSessionId" integer
+    "styleSettings" object
+    "visibleToAll" boolean
+    "language" string
+    "rssEmailByText" string
+    "rssEmailCommentText" string
+    "hasContentAccessRules" boolean
+    "archivedAt" integer
+    "translations" object
+    "userPerms" array
+    "contentAccessRuleIds" array
+    "rssEmailEntryTemplateEnabled" boolean
+    "mailingIlsListsExcluded" array
+    "mailingIlsListsIncluded" array
+}
+
+Table "owners" {
+    "id" string [pk]
+    "email" string
+    "firstName" string
+    "lastName" string
+    "userId" integer
+    "createdAt" string
+    "updatedAt" string
+    "archived" boolean
+    "teams" array
+}
+
+Table "owners_archived" {
+    "id" string [pk]
+    "email" string
+    "firstName" string
+    "lastName" string
+    "userId" integer
+    "createdAt" string
+    "updatedAt" string
+    "archived" boolean
+    "teams" array
+}
+
+Table "products" {
+    "id" string [pk]
+    "createdAt" string
+    "updatedAt" string
+    "archived" boolean
+    "properties" object
+    "properties_amount" number
+    "properties_createdate" string
+    "properties_description" string
+    "properties_discount" number
+    "properties_hs_all_accessible_team_ids" string
+    "properties_hs_all_assigned_business_unit_ids" string
+    "properties_hs_all_owner_ids" string
+    "properties_hs_all_team_ids" string
+    "properties_hs_avatar_filemanager_key" string
+    "properties_hs_cost_of_goods_sold" number
+    "properties_hs_created_by_user_id" number
+    "properties_hs_createdate" string
+    "properties_hs_discount_percentage" number
+    "properties_hs_folder" string
+    "properties_hs_folder_id" number
+    "properties_hs_folder_name" string
+    "properties_hs_images" string
+    "properties_hs_lastmodifieddate" string
+    "properties_hs_merged_object_ids" string
+    "properties_hs_object_id" number
+    "properties_hs_object_source" string
+    "properties_hs_object_source_detail_1" string
+    "properties_hs_object_source_detail_2" string
+    "properties_hs_object_source_detail_3" string
+    "properties_hs_object_source_id" string
+    "properties_hs_object_source_label" string
+    "properties_hs_object_source_user_id" number
+    "properties_hs_product_type" string
+    "properties_hs_read_only" boolean
+    "properties_hs_recurring_billing_period" string
+    "properties_hs_recurring_billing_start_date" string
+    "properties_hs_shared_team_ids" string
+    "properties_hs_shared_user_ids" string
+    "properties_hs_sku" string
+    "properties_hs_unique_creation_key" string
+    "properties_hs_updated_by_user_id" number
+    "properties_hs_url" string
+    "properties_hs_user_ids_of_all_notification_followers" string
+    "properties_hs_user_ids_of_all_notification_unfollowers" string
+    "properties_hs_user_ids_of_all_owners" string
+    "properties_hs_was_imported" boolean
+    "properties_hubspot_owner_assigneddate" string
+    "properties_hubspot_owner_id" string
+    "properties_hubspot_team_id" string
+    "properties_name" string
+    "properties_price" number
+    "properties_quantity" number
+    "properties_recurringbillingfrequency" string
+    "properties_tax" number
+    "properties_test" string
+    "properties_test_product_price" string
+}
+
+Table "contacts_property_history" {
+    "value" string
+    "source-type" string
+    "source-id" string
+    "source-label" string
+    "updated-by-user-id" integer
+    "timestamp" integer
+    "selected" boolean
+    "is-contact" boolean
+    "property" string
+    "vid" integer
+    "canonical-vid" integer
+    "portal-id" integer
+    "source-vids" array
+    "properties" object
+    "properties_address" string
+    "properties_annualrevenue" string
+    "properties_associatedcompanyid" number
+    "properties_associatedcompanylastupdated" number
+    "properties_city" string
+    "properties_closedate" string
+    "properties_company" string
+    "properties_company_size" string
+    "properties_country" string
+    "properties_createdate" string
+    "properties_currentlyinworkflow" string
+    "properties_date_of_birth" string
+    "properties_days_to_close" number
+    "properties_degree" string
+    "properties_email" string
+    "properties_engagements_last_meeting_booked" string
+    "properties_engagements_last_meeting_booked_campaign" string
+    "properties_engagements_last_meeting_booked_medium" string
+    "properties_engagements_last_meeting_booked_source" string
+    "properties_fax" string
+    "properties_field_of_study" string
+    "properties_first_conversion_date" string
+    "properties_first_conversion_event_name" string
+    "properties_first_deal_created_date" string
+    "properties_firstname" string
+    "properties_gender" string
+    "properties_graduation_date" string
+    "properties_hs_additional_emails" string
+    "properties_hs_all_accessible_team_ids" string
+    "properties_hs_all_contact_vids" string
+    "properties_hs_all_owner_ids" string
+    "properties_hs_all_team_ids" string
+    "properties_hs_analytics_average_page_views" number
+    "properties_hs_analytics_first_referrer" string
+    "properties_hs_analytics_first_timestamp" string
+    "properties_hs_analytics_first_touch_converting_campaign" string
+    "properties_hs_analytics_first_url" string
+    "properties_hs_analytics_first_visit_timestamp" string
+    "properties_hs_analytics_last_referrer" string
+    "properties_hs_analytics_last_timestamp" string
+    "properties_hs_analytics_last_touch_converting_campaign" string
+    "properties_hs_analytics_last_url" string
+    "properties_hs_analytics_last_visit_timestamp" string
+    "properties_hs_analytics_num_event_completions" number
+    "properties_hs_analytics_num_page_views" number
+    "properties_hs_analytics_num_visits" number
+    "properties_hs_analytics_revenue" number
+    "properties_hs_analytics_source" string
+    "properties_hs_analytics_source_data_1" string
+    "properties_hs_analytics_source_data_2" string
+    "properties_hs_associated_target_accounts" number
+    "properties_hs_avatar_filemanager_key" string
+    "properties_hs_buying_role" string
+    "properties_hs_calculated_form_submissions" string
+    "properties_hs_calculated_merged_vids" string
+    "properties_hs_calculated_mobile_number" string
+    "properties_hs_calculated_phone_number" string
+    "properties_hs_calculated_phone_number_area_code" string
+    "properties_hs_calculated_phone_number_country_code" string
+    "properties_hs_calculated_phone_number_region_code" string
+    "properties_hs_clicked_linkedin_ad" string
+    "properties_hs_content_membership_email" string
+    "properties_hs_content_membership_email_confirmed" boolean
+    "properties_hs_content_membership_follow_up_enqueued_at" string
+    "properties_hs_content_membership_notes" string
+    "properties_hs_content_membership_registered_at" string
+    "properties_hs_content_membership_registration_domain_sent_to" string
+    "properties_hs_content_membership_registration_email_sent_at" string
+    "properties_hs_content_membership_status" string
+    "properties_hs_conversations_visitor_email" string
+    "properties_hs_count_is_unworked" number
+    "properties_hs_count_is_worked" number
+    "properties_hs_created_by_conversations" boolean
+    "properties_hs_created_by_user_id" number
+    "properties_hs_createdate" string
+    "properties_hs_date_entered_customer" string
+    "properties_hs_date_entered_evangelist" string
+    "properties_hs_date_entered_lead" string
+    "properties_hs_date_entered_marketingqualifiedlead" string
+    "properties_hs_date_entered_opportunity" string
+    "properties_hs_date_entered_other" string
+    "properties_hs_date_entered_salesqualifiedlead" string
+    "properties_hs_date_entered_subscriber" string
+    "properties_hs_date_exited_customer" string
+    "properties_hs_date_exited_evangelist" string
+    "properties_hs_date_exited_lead" string
+    "properties_hs_date_exited_marketingqualifiedlead" string
+    "properties_hs_date_exited_opportunity" string
+    "properties_hs_date_exited_other" string
+    "properties_hs_date_exited_salesqualifiedlead" string
+    "properties_hs_date_exited_subscriber" string
+    "properties_hs_document_last_revisited" string
+    "properties_hs_email_bad_address" boolean
+    "properties_hs_email_bounce" number
+    "properties_hs_email_click" number
+    "properties_hs_email_customer_quarantined_reason" string
+    "properties_hs_email_delivered" number
+    "properties_hs_email_domain" string
+    "properties_hs_email_first_click_date" string
+    "properties_hs_email_first_open_date" string
+    "properties_hs_email_first_reply_date" string
+    "properties_hs_email_first_send_date" string
+    "properties_hs_email_hard_bounce_reason" string
+    "properties_hs_email_hard_bounce_reason_enum" string
+    "properties_hs_email_is_ineligible" boolean
+    "properties_hs_email_last_click_date" string
+    "properties_hs_email_last_email_name" string
+    "properties_hs_email_last_open_date" string
+    "properties_hs_email_last_reply_date" string
+    "properties_hs_email_last_send_date" string
+    "properties_hs_email_open" number
+    "properties_hs_email_optout" boolean
+    "properties_hs_email_optout_10798197" string
+    "properties_hs_email_optout_11890603" string
+    "properties_hs_email_optout_11890831" string
+    "properties_hs_email_optout_23704464" string
+    "properties_hs_email_optout_313921448" string
+    "properties_hs_email_optout_94692364" string
+    "properties_hs_email_quarantined" boolean
+    "properties_hs_email_quarantined_reason" string
+    "properties_hs_email_recipient_fatigue_recovery_time" string
+    "properties_hs_email_replied" number
+    "properties_hs_email_sends_since_last_engagement" number
+    "properties_hs_emailconfirmationstatus" string
+    "properties_hs_facebook_ad_clicked" boolean
+    "properties_hs_facebook_click_id" string
+    "properties_hs_feedback_last_nps_follow_up" string
+    "properties_hs_feedback_last_nps_rating" string
+    "properties_hs_feedback_last_survey_date" string
+    "properties_hs_feedback_show_nps_web_survey" boolean
+    "properties_hs_first_engagement_object_id" number
+    "properties_hs_first_outreach_date" string
+    "properties_hs_first_subscription_create_date" string
+    "properties_hs_google_click_id" string
+    "properties_hs_has_active_subscription" number
+    "properties_hs_ip_timezone" string
+    "properties_hs_is_contact" boolean
+    "properties_hs_is_unworked" boolean
+    "properties_hs_language" string
+    "properties_hs_last_sales_activity_date" string
+    "properties_hs_last_sales_activity_timestamp" string
+    "properties_hs_last_sales_activity_type" string
+    "properties_hs_lastmodifieddate" string
+    "properties_hs_latest_disqualified_lead_date" string
+    "properties_hs_latest_meeting_activity" string
+    "properties_hs_latest_open_lead_date" string
+    "properties_hs_latest_qualified_lead_date" string
+    "properties_hs_latest_sequence_ended_date" string
+    "properties_hs_latest_sequence_enrolled" number
+    "properties_hs_latest_sequence_enrolled_date" string
+    "properties_hs_latest_sequence_finished_date" string
+    "properties_hs_latest_sequence_unenrolled_date" string
+    "properties_hs_latest_source" string
+    "properties_hs_latest_source_data_1" string
+    "properties_hs_latest_source_data_2" string
+    "properties_hs_latest_source_timestamp" string
+    "properties_hs_latest_subscription_create_date" string
+    "properties_hs_lead_status" string
+    "properties_hs_legal_basis" string
+    "properties_hs_lifecyclestage_customer_date" string
+    "properties_hs_lifecyclestage_evangelist_date" string
+    "properties_hs_lifecyclestage_lead_date" string
+    "properties_hs_lifecyclestage_marketingqualifiedlead_date" string
+    "properties_hs_lifecyclestage_opportunity_date" string
+    "properties_hs_lifecyclestage_other_date" string
+    "properties_hs_lifecyclestage_salesqualifiedlead_date" string
+    "properties_hs_lifecyclestage_subscriber_date" string
+    "properties_hs_linkedin_ad_clicked" string
+    "properties_hs_marketable_reason_id" string
+    "properties_hs_marketable_reason_type" string
+    "properties_hs_marketable_status" string
+    "properties_hs_marketable_until_renewal" string
+    "properties_hs_membership_has_accessed_private_content" number
+    "properties_hs_membership_last_private_content_access_date" string
+    "properties_hs_merged_object_ids" string
+    "properties_hs_mobile_sdk_push_tokens" string
+    "properties_hs_notes_next_activity_type" string
+    "properties_hs_object_id" number
+    "properties_hs_object_source" string
+    "properties_hs_object_source_detail_1" string
+    "properties_hs_object_source_detail_2" string
+    "properties_hs_object_source_detail_3" string
+    "properties_hs_object_source_id" string
+    "properties_hs_object_source_label" string
+    "properties_hs_object_source_user_id" number
+    "properties_hs_persona" string
+    "properties_hs_pinned_engagement_id" number
+    "properties_hs_pipeline" string
+    "properties_hs_predictivecontactscore" number
+    "properties_hs_predictivecontactscore_v2" number
+    "properties_hs_predictivecontactscorebucket" string
+    "properties_hs_predictivescoringtier" string
+    "properties_hs_quarantined_emails" string
+    "properties_hs_read_only" boolean
+    "properties_hs_registered_member" number
+    "properties_hs_registration_method" string
+    "properties_hs_sa_first_engagement_date" string
+    "properties_hs_sa_first_engagement_descr" string
+    "properties_hs_sa_first_engagement_object_type" string
+    "properties_hs_sales_email_last_clicked" string
+    "properties_hs_sales_email_last_opened" string
+    "properties_hs_sales_email_last_replied" string
+    "properties_hs_searchable_calculated_international_mobile_number" string
+    "properties_hs_searchable_calculated_international_phone_number" string
+    "properties_hs_searchable_calculated_mobile_number" string
+    "properties_hs_searchable_calculated_phone_number" string
+    "properties_hs_sequences_actively_enrolled_count" number
+    "properties_hs_sequences_enrolled_count" number
+    "properties_hs_sequences_is_enrolled" boolean
+    "properties_hs_testpurge" string
+    "properties_hs_testrollback" string
+    "properties_hs_time_between_contact_creation_and_deal_close" number
+    "properties_hs_time_between_contact_creation_and_deal_creation" number
+    "properties_hs_time_in_customer" number
+    "properties_hs_time_in_evangelist" number
+    "properties_hs_time_in_lead" number
+    "properties_hs_time_in_marketingqualifiedlead" number
+    "properties_hs_time_in_opportunity" number
+    "properties_hs_time_in_other" number
+    "properties_hs_time_in_salesqualifiedlead" number
+    "properties_hs_time_in_subscriber" number
+    "properties_hs_time_to_first_engagement" number
+    "properties_hs_time_to_move_from_lead_to_customer" number
+    "properties_hs_time_to_move_from_marketingqualifiedlead_to_customer" number
+    "properties_hs_time_to_move_from_opportunity_to_customer" number
+    "properties_hs_time_to_move_from_salesqualifiedlead_to_customer" number
+    "properties_hs_time_to_move_from_subscriber_to_customer" number
+    "properties_hs_timezone" string
+    "properties_hs_unique_creation_key" string
+    "properties_hs_updated_by_user_id" number
+    "properties_hs_user_ids_of_all_notification_followers" string
+    "properties_hs_user_ids_of_all_notification_unfollowers" string
+    "properties_hs_user_ids_of_all_owners" string
+    "properties_hs_v2_cumulative_time_in_customer" number
+    "properties_hs_v2_cumulative_time_in_evangelist" number
+    "properties_hs_v2_cumulative_time_in_lead" number
+    "properties_hs_v2_cumulative_time_in_marketingqualifiedlead" number
+    "properties_hs_v2_cumulative_time_in_opportunity" number
+    "properties_hs_v2_cumulative_time_in_other" number
+    "properties_hs_v2_cumulative_time_in_salesqualifiedlead" number
+    "properties_hs_v2_cumulative_time_in_subscriber" number
+    "properties_hs_v2_date_entered_customer" string
+    "properties_hs_v2_date_entered_evangelist" string
+    "properties_hs_v2_date_entered_lead" string
+    "properties_hs_v2_date_entered_marketingqualifiedlead" string
+    "properties_hs_v2_date_entered_opportunity" string
+    "properties_hs_v2_date_entered_other" string
+    "properties_hs_v2_date_entered_salesqualifiedlead" string
+    "properties_hs_v2_date_entered_subscriber" string
+    "properties_hs_v2_date_exited_customer" string
+    "properties_hs_v2_date_exited_evangelist" string
+    "properties_hs_v2_date_exited_lead" string
+    "properties_hs_v2_date_exited_marketingqualifiedlead" string
+    "properties_hs_v2_date_exited_opportunity" string
+    "properties_hs_v2_date_exited_other" string
+    "properties_hs_v2_date_exited_salesqualifiedlead" string
+    "properties_hs_v2_date_exited_subscriber" string
+    "properties_hs_v2_latest_time_in_customer" number
+    "properties_hs_v2_latest_time_in_evangelist" number
+    "properties_hs_v2_latest_time_in_lead" number
+    "properties_hs_v2_latest_time_in_marketingqualifiedlead" number
+    "properties_hs_v2_latest_time_in_opportunity" number
+    "properties_hs_v2_latest_time_in_other" number
+    "properties_hs_v2_latest_time_in_salesqualifiedlead" number
+    "properties_hs_v2_latest_time_in_subscriber" number
+    "properties_hs_was_imported" boolean
+    "properties_hs_whatsapp_phone_number" string
+    "properties_hubspot_owner_assigneddate" string
+    "properties_hubspot_owner_id" string
+    "properties_hubspot_team_id" string
+    "properties_hubspotscore" number
+    "properties_industry" string
+    "properties_ip_city" string
+    "properties_ip_country" string
+    "properties_ip_country_code" string
+    "properties_ip_latlon" string
+    "properties_ip_state" string
+    "properties_ip_state_code" string
+    "properties_ip_zipcode" string
+    "properties_job_function" string
+    "properties_jobtitle" string
+    "properties_lastmodifieddate" string
+    "properties_lastname" string
+    "properties_lifecyclestage" string
+    "properties_marital_status" string
+    "properties_message" string
+    "properties_military_status" string
+    "properties_mobilephone" string
+    "properties_my_custom_test_property" string
+    "properties_notes_last_contacted" string
+    "properties_notes_last_updated" string
+    "properties_notes_next_activity_date" string
+    "properties_num_associated_deals" number
+    "properties_num_contacted_notes" number
+    "properties_num_conversion_events" number
+    "properties_num_notes" number
+    "properties_num_unique_conversion_events" number
+    "properties_numemployees" string
+    "properties_phone" string
+    "properties_recent_conversion_date" string
+    "properties_recent_conversion_event_name" string
+    "properties_recent_deal_amount" number
+    "properties_recent_deal_close_date" string
+    "properties_relationship_status" string
+    "properties_salutation" string
+    "properties_school" string
+    "properties_seniority" string
+    "properties_start_date" string
+    "properties_state" string
+    "properties_surveymonkeyeventlastupdated" number
+    "properties_test" number
+    "properties_total_revenue" number
+    "properties_twitterhandle" string
+    "properties_webinareventlastupdated" number
+    "properties_website" string
+    "properties_work_email" string
+    "properties_zip" string
+
+    indexes {
+        (vid, property, timestamp) [pk]
+    }
+}
+
+Table "companies_property_history" {
+    "updatedByUserId" number
+    "timestamp" string
+    "property" string
+    "companyId" string
+    "sourceType" string
+    "sourceId" string
+    "value" string
+    "archived" boolean
+    "properties" object
+    "properties_about_us" string
+    "properties_address" string
+    "properties_address2" string
+    "properties_annualrevenue" number
+    "properties_city" string
+    "properties_closedate" string
+    "properties_closedate_timestamp_earliest_value_a2a17e6e" string
+    "properties_country" string
+    "properties_createdate" string
+    "properties_custom_company_property" string
+    "properties_days_to_close" number
+    "properties_description" string
+    "properties_domain" string
+    "properties_engagements_last_meeting_booked" string
+    "properties_engagements_last_meeting_booked_campaign" string
+    "properties_engagements_last_meeting_booked_medium" string
+    "properties_engagements_last_meeting_booked_source" string
+    "properties_facebook_company_page" string
+    "properties_facebookfans" number
+    "properties_first_contact_createdate" string
+    "properties_first_contact_createdate_timestamp_earliest_value_78b50eea" string
+    "properties_first_conversion_date" string
+    "properties_first_conversion_date_timestamp_earliest_value_61f58f2c" string
+    "properties_first_conversion_event_name" string
+    "properties_first_conversion_event_name_timestamp_earliest_value_68ddae0a" string
+    "properties_first_deal_created_date" string
+    "properties_founded_year" string
+    "properties_googleplus_page" string
+    "properties_hs_additional_domains" string
+    "properties_hs_all_accessible_team_ids" string
+    "properties_hs_all_owner_ids" string
+    "properties_hs_all_team_ids" string
+    "properties_hs_analytics_first_timestamp" string
+    "properties_hs_analytics_first_timestamp_timestamp_earliest_value_11e3a63a" string
+    "properties_hs_analytics_first_touch_converting_campaign" string
+    "properties_hs_analytics_first_touch_converting_campaign_timestamp_earliest_value_4757fe10" string
+    "properties_hs_analytics_first_visit_timestamp" string
+    "properties_hs_analytics_first_visit_timestamp_timestamp_earliest_value_accc17ae" string
+    "properties_hs_analytics_last_timestamp" string
+    "properties_hs_analytics_last_timestamp_timestamp_latest_value_4e16365a" string
+    "properties_hs_analytics_last_touch_converting_campaign" string
+    "properties_hs_analytics_last_touch_converting_campaign_timestamp_latest_value_81a64e30" string
+    "properties_hs_analytics_last_visit_timestamp" string
+    "properties_hs_analytics_last_visit_timestamp_timestamp_latest_value_999a0fce" string
+    "properties_hs_analytics_latest_source" string
+    "properties_hs_analytics_latest_source_data_1" string
+    "properties_hs_analytics_latest_source_data_2" string
+    "properties_hs_analytics_latest_source_timestamp" string
+    "properties_hs_analytics_num_page_views" number
+    "properties_hs_analytics_num_page_views_cardinality_sum_e46e85b0" number
+    "properties_hs_analytics_num_visits" number
+    "properties_hs_analytics_num_visits_cardinality_sum_53d952a6" number
+    "properties_hs_analytics_source" string
+    "properties_hs_analytics_source_data_1" string
+    "properties_hs_analytics_source_data_1_timestamp_earliest_value_9b2f1fa1" string
+    "properties_hs_analytics_source_data_2" string
+    "properties_hs_analytics_source_data_2_timestamp_earliest_value_9b2f9400" string
+    "properties_hs_analytics_source_timestamp_earliest_value_25a3a52c" string
+    "properties_hs_annual_revenue_currency_code" string
+    "properties_hs_avatar_filemanager_key" string
+    "properties_hs_country_code" string
+    "properties_hs_created_by_user_id" number
+    "properties_hs_createdate" string
+    "properties_hs_csm_sentiment" string
+    "properties_hs_customer_success_ticket_sentiment" number
+    "properties_hs_date_entered_customer" string
+    "properties_hs_date_entered_evangelist" string
+    "properties_hs_date_entered_lead" string
+    "properties_hs_date_entered_marketingqualifiedlead" string
+    "properties_hs_date_entered_opportunity" string
+    "properties_hs_date_entered_other" string
+    "properties_hs_date_entered_salesqualifiedlead" string
+    "properties_hs_date_entered_subscriber" string
+    "properties_hs_date_exited_customer" string
+    "properties_hs_date_exited_evangelist" string
+    "properties_hs_date_exited_lead" string
+    "properties_hs_date_exited_marketingqualifiedlead" string
+    "properties_hs_date_exited_opportunity" string
+    "properties_hs_date_exited_other" string
+    "properties_hs_date_exited_salesqualifiedlead" string
+    "properties_hs_date_exited_subscriber" string
+    "properties_hs_ideal_customer_profile" string
+    "properties_hs_is_target_account" boolean
+    "properties_hs_last_booked_meeting_date" string
+    "properties_hs_last_logged_call_date" string
+    "properties_hs_last_open_task_date" string
+    "properties_hs_last_sales_activity_date" string
+    "properties_hs_last_sales_activity_timestamp" string
+    "properties_hs_last_sales_activity_type" string
+    "properties_hs_lastmodifieddate" string
+    "properties_hs_latest_createdate_of_active_subscriptions" string
+    "properties_hs_latest_meeting_activity" string
+    "properties_hs_lead_status" string
+    "properties_hs_logo_url" string
+    "properties_hs_merged_object_ids" string
+    "properties_hs_notes_next_activity_type" string
+    "properties_hs_num_blockers" number
+    "properties_hs_num_child_companies" number
+    "properties_hs_num_contacts_with_buying_roles" number
+    "properties_hs_num_decision_makers" number
+    "properties_hs_num_open_deals" number
+    "properties_hs_object_id" number
+    "properties_hs_object_source" string
+    "properties_hs_object_source_detail_1" string
+    "properties_hs_object_source_detail_2" string
+    "properties_hs_object_source_detail_3" string
+    "properties_hs_object_source_id" string
+    "properties_hs_object_source_label" string
+    "properties_hs_object_source_user_id" number
+    "properties_hs_parent_company_id" number
+    "properties_hs_pinned_engagement_id" number
+    "properties_hs_pipeline" string
+    "properties_hs_predictivecontactscore_v2" number
+    "properties_hs_predictivecontactscore_v2_next_max_max_d4e58c1e" number
+    "properties_hs_read_only" boolean
+    "properties_hs_sales_email_last_replied" string
+    "properties_hs_target_account" string
+    "properties_hs_target_account_probability" number
+    "properties_hs_target_account_recommendation_snooze_time" string
+    "properties_hs_target_account_recommendation_state" string
+    "properties_hs_time_in_customer" number
+    "properties_hs_time_in_evangelist" number
+    "properties_hs_time_in_lead" number
+    "properties_hs_time_in_marketingqualifiedlead" number
+    "properties_hs_time_in_opportunity" number
+    "properties_hs_time_in_other" number
+    "properties_hs_time_in_salesqualifiedlead" number
+    "properties_hs_time_in_subscriber" number
+    "properties_hs_total_deal_value" number
+    "properties_hs_unique_creation_key" string
+    "properties_hs_updated_by_user_id" number
+    "properties_hs_user_ids_of_all_notification_followers" string
+    "properties_hs_user_ids_of_all_notification_unfollowers" string
+    "properties_hs_user_ids_of_all_owners" string
+    "properties_hs_was_imported" boolean
+    "properties_hubspot_owner_assigneddate" string
+    "properties_hubspot_owner_id" string
+    "properties_hubspot_team_id" string
+    "properties_hubspotscore" number
+    "properties_industry" string
+    "properties_is_public" boolean
+    "properties_lifecyclestage" string
+    "properties_linkedin_company_page" string
+    "properties_linkedinbio" string
+    "properties_name" string
+    "properties_notes_last_contacted" string
+    "properties_notes_last_updated" string
+    "properties_notes_next_activity_date" string
+    "properties_num_associated_contacts" number
+    "properties_num_associated_deals" number
+    "properties_num_contacted_notes" number
+    "properties_num_conversion_events" number
+    "properties_num_conversion_events_cardinality_sum_d095f14b" number
+    "properties_num_notes" number
+    "properties_numberofemployees" number
+    "properties_phone" string
+    "properties_recent_conversion_date" string
+    "properties_recent_conversion_date_timestamp_latest_value_72856da1" string
+    "properties_recent_conversion_event_name" string
+    "properties_recent_conversion_event_name_timestamp_latest_value_66c820bf" string
+    "properties_recent_deal_amount" number
+    "properties_recent_deal_close_date" string
+    "properties_state" string
+    "properties_timezone" string
+    "properties_total_money_raised" string
+    "properties_total_revenue" number
+    "properties_twitterbio" string
+    "properties_twitterfollowers" number
+    "properties_twitterhandle" string
+    "properties_type" string
+    "properties_web_technologies" string
+    "properties_website" string
+    "properties_zip" string
+
+    indexes {
+        (companyId, property, timestamp) [pk]
+    }
+}
+
+Table "deals_property_history" {
+    "updatedByUserId" number
+    "timestamp" string
+    "property" string
+    "dealId" string
+    "sourceType" string
+    "sourceId" string
+    "value" string
+    "archived" boolean
+    "properties" object
+    "properties_amount" number
+    "properties_amount_in_home_currency" number
+    "properties_closed_lost_reason" string
+    "properties_closed_won_reason" string
+    "properties_closedate" string
+    "properties_createdate" string
+    "properties_days_to_close" number
+    "properties_dealname" string
+    "properties_dealstage" string
+    "properties_dealtype" string
+    "properties_description" string
+    "properties_engagements_last_meeting_booked" string
+    "properties_engagements_last_meeting_booked_campaign" string
+    "properties_engagements_last_meeting_booked_medium" string
+    "properties_engagements_last_meeting_booked_source" string
+    "properties_hs_acv" number
+    "properties_hs_all_accessible_team_ids" string
+    "properties_hs_all_collaborator_owner_ids" string
+    "properties_hs_all_deal_split_owner_ids" string
+    "properties_hs_all_owner_ids" string
+    "properties_hs_all_team_ids" string
+    "properties_hs_analytics_latest_source" string
+    "properties_hs_analytics_latest_source_company" string
+    "properties_hs_analytics_latest_source_contact" string
+    "properties_hs_analytics_latest_source_data_1" string
+    "properties_hs_analytics_latest_source_data_1_company" string
+    "properties_hs_analytics_latest_source_data_1_contact" string
+    "properties_hs_analytics_latest_source_data_2" string
+    "properties_hs_analytics_latest_source_data_2_company" string
+    "properties_hs_analytics_latest_source_data_2_contact" string
+    "properties_hs_analytics_latest_source_timestamp" string
+    "properties_hs_analytics_latest_source_timestamp_company" string
+    "properties_hs_analytics_latest_source_timestamp_contact" string
+    "properties_hs_analytics_source" string
+    "properties_hs_analytics_source_data_1" string
+    "properties_hs_analytics_source_data_2" string
+    "properties_hs_arr" number
+    "properties_hs_campaign" string
+    "properties_hs_closed_amount" number
+    "properties_hs_closed_amount_in_home_currency" number
+    "properties_hs_closed_deal_close_date" number
+    "properties_hs_closed_deal_create_date" number
+    "properties_hs_closed_won_count" number
+    "properties_hs_closed_won_date" string
+    "properties_hs_created_by_user_id" number
+    "properties_hs_createdate" string
+    "properties_hs_date_entered_66894120" string
+    "properties_hs_date_entered_9567448" string
+    "properties_hs_date_entered_9567449" string
+    "properties_hs_date_entered_appointmentscheduled" string
+    "properties_hs_date_entered_closedlost" string
+    "properties_hs_date_entered_closedwon" string
+    "properties_hs_date_entered_contractsent" string
+    "properties_hs_date_entered_customclosedwonstage" string
+    "properties_hs_date_entered_decisionmakerboughtin" string
+    "properties_hs_date_entered_presentationscheduled" string
+    "properties_hs_date_entered_qualifiedtobuy" string
+    "properties_hs_date_exited_66894120" string
+    "properties_hs_date_exited_9567448" string
+    "properties_hs_date_exited_9567449" string
+    "properties_hs_date_exited_appointmentscheduled" string
+    "properties_hs_date_exited_closedlost" string
+    "properties_hs_date_exited_closedwon" string
+    "properties_hs_date_exited_contractsent" string
+    "properties_hs_date_exited_customclosedwonstage" string
+    "properties_hs_date_exited_decisionmakerboughtin" string
+    "properties_hs_date_exited_presentationscheduled" string
+    "properties_hs_date_exited_qualifiedtobuy" string
+    "properties_hs_days_to_close_raw" number
+    "properties_hs_deal_amount_calculation_preference" string
+    "properties_hs_deal_score" number
+    "properties_hs_deal_stage_probability" number
+    "properties_hs_deal_stage_probability_shadow" number
+    "properties_hs_exchange_rate" number
+    "properties_hs_forecast_amount" number
+    "properties_hs_forecast_probability" number
+    "properties_hs_has_empty_conditional_stage_properties" boolean
+    "properties_hs_is_closed" boolean
+    "properties_hs_is_closed_count" number
+    "properties_hs_is_closed_won" boolean
+    "properties_hs_is_deal_split" boolean
+    "properties_hs_is_in_first_deal_stage" boolean
+    "properties_hs_is_open_count" number
+    "properties_hs_lastmodifieddate" string
+    "properties_hs_latest_approval_status" string
+    "properties_hs_latest_approval_status_approval_id" number
+    "properties_hs_latest_meeting_activity" string
+    "properties_hs_likelihood_to_close" number
+    "properties_hs_line_item_global_term_hs_discount_percentage" string
+    "properties_hs_line_item_global_term_hs_discount_percentage_enabled" boolean
+    "properties_hs_line_item_global_term_hs_recurring_billing_period" string
+    "properties_hs_line_item_global_term_hs_recurring_billing_period_enabled" boolean
+    "properties_hs_line_item_global_term_hs_recurring_billing_start_date" string
+    "properties_hs_line_item_global_term_hs_recurring_billing_start_date_enabled" boolean
+    "properties_hs_line_item_global_term_recurringbillingfrequency" string
+    "properties_hs_line_item_global_term_recurringbillingfrequency_enabled" boolean
+    "properties_hs_manual_forecast_category" string
+    "properties_hs_merged_object_ids" string
+    "properties_hs_mrr" number
+    "properties_hs_next_step" string
+    "properties_hs_next_step_updated_at" string
+    "properties_hs_notes_next_activity_type" string
+    "properties_hs_num_associated_deal_splits" number
+    "properties_hs_num_of_associated_line_items" number
+    "properties_hs_num_target_accounts" number
+    "properties_hs_object_id" number
+    "properties_hs_object_source" string
+    "properties_hs_object_source_detail_1" string
+    "properties_hs_object_source_detail_2" string
+    "properties_hs_object_source_detail_3" string
+    "properties_hs_object_source_id" string
+    "properties_hs_object_source_label" string
+    "properties_hs_object_source_user_id" number
+    "properties_hs_open_deal_create_date" number
+    "properties_hs_pinned_engagement_id" number
+    "properties_hs_predicted_amount" number
+    "properties_hs_predicted_amount_in_home_currency" number
+    "properties_hs_priority" string
+    "properties_hs_projected_amount" number
+    "properties_hs_projected_amount_in_home_currency" number
+    "properties_hs_read_only" boolean
+    "properties_hs_sales_email_last_replied" string
+    "properties_hs_tag_ids" string
+    "properties_hs_tcv" number
+    "properties_hs_time_in_66894120" number
+    "properties_hs_time_in_9567448" number
+    "properties_hs_time_in_9567449" number
+    "properties_hs_time_in_appointmentscheduled" number
+    "properties_hs_time_in_closedlost" number
+    "properties_hs_time_in_closedwon" number
+    "properties_hs_time_in_contractsent" number
+    "properties_hs_time_in_customclosedwonstage" number
+    "properties_hs_time_in_decisionmakerboughtin" number
+    "properties_hs_time_in_presentationscheduled" number
+    "properties_hs_time_in_qualifiedtobuy" number
+    "properties_hs_unique_creation_key" string
+    "properties_hs_updated_by_user_id" number
+    "properties_hs_user_ids_of_all_notification_followers" string
+    "properties_hs_user_ids_of_all_notification_unfollowers" string
+    "properties_hs_user_ids_of_all_owners" string
+    "properties_hs_v2_cumulative_time_in_66894120" number
+    "properties_hs_v2_cumulative_time_in_9567448" number
+    "properties_hs_v2_cumulative_time_in_9567449" number
+    "properties_hs_v2_cumulative_time_in_appointmentscheduled" number
+    "properties_hs_v2_cumulative_time_in_closedlost" number
+    "properties_hs_v2_cumulative_time_in_closedwon" number
+    "properties_hs_v2_cumulative_time_in_contractsent" number
+    "properties_hs_v2_cumulative_time_in_customclosedwonstage" number
+    "properties_hs_v2_cumulative_time_in_decisionmakerboughtin" number
+    "properties_hs_v2_cumulative_time_in_presentationscheduled" number
+    "properties_hs_v2_cumulative_time_in_qualifiedtobuy" number
+    "properties_hs_v2_date_entered_66894120" string
+    "properties_hs_v2_date_entered_9567448" string
+    "properties_hs_v2_date_entered_9567449" string
+    "properties_hs_v2_date_entered_appointmentscheduled" string
+    "properties_hs_v2_date_entered_closedlost" string
+    "properties_hs_v2_date_entered_closedwon" string
+    "properties_hs_v2_date_entered_contractsent" string
+    "properties_hs_v2_date_entered_customclosedwonstage" string
+    "properties_hs_v2_date_entered_decisionmakerboughtin" string
+    "properties_hs_v2_date_entered_presentationscheduled" string
+    "properties_hs_v2_date_entered_qualifiedtobuy" string
+    "properties_hs_v2_date_exited_66894120" string
+    "properties_hs_v2_date_exited_9567448" string
+    "properties_hs_v2_date_exited_9567449" string
+    "properties_hs_v2_date_exited_appointmentscheduled" string
+    "properties_hs_v2_date_exited_closedlost" string
+    "properties_hs_v2_date_exited_closedwon" string
+    "properties_hs_v2_date_exited_contractsent" string
+    "properties_hs_v2_date_exited_customclosedwonstage" string
+    "properties_hs_v2_date_exited_decisionmakerboughtin" string
+    "properties_hs_v2_date_exited_presentationscheduled" string
+    "properties_hs_v2_date_exited_qualifiedtobuy" string
+    "properties_hs_v2_latest_time_in_66894120" number
+    "properties_hs_v2_latest_time_in_9567448" number
+    "properties_hs_v2_latest_time_in_9567449" number
+    "properties_hs_v2_latest_time_in_appointmentscheduled" number
+    "properties_hs_v2_latest_time_in_closedlost" number
+    "properties_hs_v2_latest_time_in_closedwon" number
+    "properties_hs_v2_latest_time_in_contractsent" number
+    "properties_hs_v2_latest_time_in_customclosedwonstage" number
+    "properties_hs_v2_latest_time_in_decisionmakerboughtin" number
+    "properties_hs_v2_latest_time_in_presentationscheduled" number
+    "properties_hs_v2_latest_time_in_qualifiedtobuy" number
+    "properties_hs_was_imported" boolean
+    "properties_hubspot_owner_assigneddate" string
+    "properties_hubspot_owner_id" string
+    "properties_hubspot_team_id" string
+    "properties_notes_last_contacted" string
+    "properties_notes_last_updated" string
+    "properties_notes_next_activity_date" string
+    "properties_num_associated_contacts" number
+    "properties_num_contacted_notes" number
+    "properties_num_notes" number
+    "properties_pipeline" string
+
+    indexes {
+        (dealId, property, timestamp) [pk]
+    }
+}
+
+Table "subscription_changes" {
+    "timestamp" integer
+    "portalId" integer
+    "recipient" string
+    "normalizedEmailId" string
+    "changes" array
+}
+
+Table "tickets" {
+    "id" string [pk]
+    "createdAt" string
+    "updatedAt" string
+    "archived" boolean
+    "contacts" array
+    "companies" array
+    "deals" array
+    "properties" object
+    "properties_closed_date" string
+    "properties_content" string
+    "properties_created_by" number
+    "properties_createdate" string
+    "properties_first_agent_reply_date" string
+    "properties_hs_all_accessible_team_ids" string
+    "properties_hs_all_associated_contact_companies" string
+    "properties_hs_all_associated_contact_emails" string
+    "properties_hs_all_associated_contact_firstnames" string
+    "properties_hs_all_associated_contact_lastnames" string
+    "properties_hs_all_associated_contact_mobilephones" string
+    "properties_hs_all_associated_contact_phones" string
+    "properties_hs_all_conversation_mentions" string
+    "properties_hs_all_owner_ids" string
+    "properties_hs_all_team_ids" string
+    "properties_hs_applied_sla_rule_config_at" string
+    "properties_hs_assigned_team_ids" string
+    "properties_hs_assignment_method" string
+    "properties_hs_auto_generated_from_thread_id" number
+    "properties_hs_conversations_originating_message_id" string
+    "properties_hs_conversations_originating_thread_id" number
+    "properties_hs_created_by_user_id" number
+    "properties_hs_createdate" string
+    "properties_hs_custom_inbox" number
+    "properties_hs_date_entered_1" string
+    "properties_hs_date_entered_151692305" string
+    "properties_hs_date_entered_151692306" string
+    "properties_hs_date_entered_151692307" string
+    "properties_hs_date_entered_151692308" string
+    "properties_hs_date_entered_2" string
+    "properties_hs_date_entered_3" string
+    "properties_hs_date_entered_4" string
+    "properties_hs_date_exited_1" string
+    "properties_hs_date_exited_151692305" string
+    "properties_hs_date_exited_151692306" string
+    "properties_hs_date_exited_151692307" string
+    "properties_hs_date_exited_151692308" string
+    "properties_hs_date_exited_2" string
+    "properties_hs_date_exited_3" string
+    "properties_hs_date_exited_4" string
+    "properties_hs_email_subject" string
+    "properties_hs_external_object_ids" string
+    "properties_hs_feedback_last_ces_follow_up" string
+    "properties_hs_feedback_last_ces_rating" string
+    "properties_hs_feedback_last_survey_date" string
+    "properties_hs_file_upload" string
+    "properties_hs_first_agent_message_sent_at" string
+    "properties_hs_helpdesk_sort_timestamp" string
+    "properties_hs_in_helpdesk" boolean
+    "properties_hs_inbox_id" number
+    "properties_hs_is_latest_message_failed" boolean
+    "properties_hs_is_visible_in_help_desk" boolean
+    "properties_hs_last_email_activity" string
+    "properties_hs_last_email_date" string
+    "properties_hs_last_message_from_visitor" boolean
+    "properties_hs_last_message_received_at" string
+    "properties_hs_last_message_sent_at" string
+    "properties_hs_lastactivitydate" string
+    "properties_hs_lastcontacted" string
+    "properties_hs_lastmodifieddate" string
+    "properties_hs_latest_message_attachment_types" string
+    "properties_hs_latest_message_is_forwarded_email" boolean
+    "properties_hs_latest_message_is_thread_comment" boolean
+    "properties_hs_latest_message_seen_by_agent_ids" string
+    "properties_hs_latest_message_text" string
+    "properties_hs_latest_message_visible_to_visitor" string
+    "properties_hs_merged_object_ids" string
+    "properties_hs_most_relevant_sla_status" string
+    "properties_hs_most_relevant_sla_type" string
+    "properties_hs_msteams_message_id" string
+    "properties_hs_nextactivitydate" string
+    "properties_hs_notes_next_activity_type" string
+    "properties_hs_num_associated_companies" number
+    "properties_hs_num_associated_conversations" number
+    "properties_hs_num_times_contacted" number
+    "properties_hs_object_id" number
+    "properties_hs_object_source" string
+    "properties_hs_object_source_detail_1" string
+    "properties_hs_object_source_detail_2" string
+    "properties_hs_object_source_detail_3" string
+    "properties_hs_object_source_id" string
+    "properties_hs_object_source_label" string
+    "properties_hs_object_source_user_id" number
+    "properties_hs_originating_channel_instance_id" string
+    "properties_hs_originating_email_engagement_id" number
+    "properties_hs_originating_generic_channel_id" string
+    "properties_hs_pinned_engagement_id" number
+    "properties_hs_pipeline" string
+    "properties_hs_pipeline_stage" string
+    "properties_hs_primary_company" string
+    "properties_hs_primary_company_id" number
+    "properties_hs_primary_company_name" string
+    "properties_hs_read_only" boolean
+    "properties_hs_resolution" string
+    "properties_hs_sales_email_last_replied" string
+    "properties_hs_seen_by_agent_ids" string
+    "properties_hs_tag_ids" string
+    "properties_hs_thread_ids_to_restore" string
+    "properties_hs_ticket_category" string
+    "properties_hs_ticket_id" number
+    "properties_hs_ticket_priority" string
+    "properties_hs_time_in_1" number
+    "properties_hs_time_in_151692305" number
+    "properties_hs_time_in_151692306" number
+    "properties_hs_time_in_151692307" number
+    "properties_hs_time_in_151692308" number
+    "properties_hs_time_in_2" number
+    "properties_hs_time_in_3" number
+    "properties_hs_time_in_4" number
+    "properties_hs_time_to_close_sla_at" string
+    "properties_hs_time_to_close_sla_status" string
+    "properties_hs_time_to_first_response_sla_at" string
+    "properties_hs_time_to_first_response_sla_status" string
+    "properties_hs_time_to_next_response_sla_at" string
+    "properties_hs_time_to_next_response_sla_status" string
+    "properties_hs_unique_creation_key" string
+    "properties_hs_updated_by_user_id" number
+    "properties_hs_user_ids_of_all_notification_followers" string
+    "properties_hs_user_ids_of_all_notification_unfollowers" string
+    "properties_hs_user_ids_of_all_owners" string
+    "properties_hs_was_imported" boolean
+    "properties_hubspot_owner_assigneddate" string
+    "properties_hubspot_owner_id" string
+    "properties_hubspot_team_id" string
+    "properties_last_engagement_date" string
+    "properties_last_reply_date" string
+    "properties_notes_last_contacted" string
+    "properties_notes_last_updated" string
+    "properties_notes_next_activity_date" string
+    "properties_nps_follow_up_answer" string
+    "properties_nps_follow_up_question_version" number
+    "properties_nps_score" string
+    "properties_num_contacted_notes" number
+    "properties_num_notes" number
+    "properties_source_ref" string
+    "properties_source_thread_id" string
+    "properties_source_type" string
+    "properties_subject" string
+    "properties_tags" string
+    "properties_time_to_close" number
+    "properties_time_to_first_agent_reply" number
+}
+
+Table "ticket_pipelines" {
+    "label" string
+    "displayOrder" integer
+    "id" string [pk]
+    "archived" boolean
+    "stages" array
+    "createdAt" string
+    "updatedAt" string
+}
+
+Table "workflows" {
+    "name" string
+    "id" integer [pk]
+    "type" string
+    "enabled" boolean
+    "insertedAt" integer
+    "updatedAt" integer
+    "personaTagIds" array
+    "contactListIds" object
+    "contactListIds_enrolled" integer
+    "contactListIds_active" integer
+    "contactListIds_completed" integer
+    "contactListIds_succeeded" integer
+    "contactListIds_steps" array
+    "lastUpdatedByUserId" integer
+    "contactCounts" object
+    "description" string
+    "originalAuthorUserId" integer
+    "migrationStatus" object
+    "updateSource" object
+    "creationSource" object
+    "portalId" integer
+}
+
+Ref {
+    "companies"."properties_hs_created_by_user_id" <> "owners"."userId"
+}
+
+Ref {
+    "companies"."properties_hs_updated_by_user_id" <> "owners"."userId"
+}
+
+Ref {
+    "companies"."properties_hubspot_owner_id" <> "owners"."userId"
+}
+
+Ref {
+    "companies"."properties_hs_parent_company_id" <> "companies"."id"
+}
+
+Ref {
+    "contact_lists"."parentId" <> "contact_lists"."listId"
+}
+
+Ref {
+    "contact_lists"."authorId" <> "owners"."userId"
+}
+
+Ref {
+    "contacts"."properties_associatedcompanyid" <> "companies"."id"
+}
+
+Ref {
+    "contacts"."properties_hs_created_by_user_id" <> "owners"."userId"
+}
+
+Ref {
+    "contacts"."properties_hs_updated_by_user_id" <> "owners"."userId"
+}
+
+Ref {
+    "contacts"."properties_hubspot_owner_id" <> "owners"."userId"
+}
+
+Ref {
+    "contacts_form_submissions"."canonical-vid" <> "contacts"."id"
+}
+
+Ref {
+    "contacts_list_memberships"."canonical-vid" <> "contacts"."id"
+}
+
+Ref {
+    "contacts_list_memberships"."static-list-id" <> "contact_lists"."listId"
+}
+
+Ref {
+    "contacts_merged_audit"."canonical-vid" <> "contacts"."id"
+}
+
+Ref {
+    "contacts_merged_audit"."vid-to-merge" <> "contacts"."id"
+}
+
+Ref {
+    "contacts_merged_audit"."user-id" <> "owners"."userId"
+}
+
+Ref {
+    "deals"."properties_hs_created_by_user_id" <> "owners"."userId"
+}
+
+Ref {
+    "deals"."properties_hs_updated_by_user_id" <> "owners"."userId"
+}
+
+Ref {
+    "deals"."properties_hubspot_owner_id" <> "owners"."userId"
+}
+
+Ref {
+    "deals_archived"."properties_hs_created_by_user_id" <> "owners"."userId"
+}
+
+Ref {
+    "deals_archived"."properties_hs_updated_by_user_id" <> "owners"."userId"
+}
+
+Ref {
+    "deals_archived"."properties_hubspot_owner_id" <> "owners"."userId"
+}
+
+Ref {
+    "email_events"."emailCampaignId" <> "campaigns"."id"
+}
+
+Ref {
+    "email_events"."emailCampaignGroupId" <> "marketing_emails"."emailCampaignGroupId"
+}
+
+Ref {
+    "email_events"."requestedByUserId" <> "owners"."userId"
+}
+
+Ref {
+    "engagements"."createdBy" <> "owners"."userId"
+}
+
+Ref {
+    "engagements"."modifiedBy" <> "owners"."userId"
+}
+
+Ref {
+    "engagements"."ownerId" <> "owners"."userId"
+}
+
+Ref {
+    "engagements"."metadata_calleeObjectId" <> "contacts"."id"
+}
+
+Ref {
+    "engagements"."metadata_facsimileSendId" <> "engagements_emails"."id"
+}
+
+Ref {
+    "engagements"."metadata_sourceId" <> "engagements_emails"."id"
+}
+
+Ref {
+    "engagements_calls"."properties_hs_created_by_user_id" <> "owners"."userId"
+}
+
+Ref {
+    "engagements_calls"."properties_hs_updated_by_user_id" <> "owners"."userId"
+}
+
+Ref {
+    "engagements_calls"."properties_hubspot_owner_id" <> "owners"."userId"
+}
+
+Ref {
+    "engagements_calls"."properties_hs_call_callee_object_id" <> "contacts"."id"
+}
+
+Ref {
+    "engagements_emails"."properties_hs_created_by_user_id" <> "owners"."userId"
+}
+
+Ref {
+    "engagements_emails"."properties_hs_updated_by_user_id" <> "owners"."userId"
+}
+
+Ref {
+    "engagements_emails"."properties_hubspot_owner_id" <> "owners"."userId"
+}
+
+Ref {
+    "engagements_meetings"."properties_hs_created_by_user_id" <> "owners"."userId"
+}
+
+Ref {
+    "engagements_meetings"."properties_hs_updated_by_user_id" <> "owners"."userId"
+}
+
+Ref {
+    "engagements_meetings"."properties_hubspot_owner_id" <> "owners"."userId"
+}
+
+Ref {
+    "engagements_notes"."properties_hs_created_by_user_id" <> "owners"."userId"
+}
+
+Ref {
+    "engagements_notes"."properties_hs_updated_by_user_id" <> "owners"."userId"
+}
+
+Ref {
+    "engagements_notes"."properties_hubspot_owner_id" <> "owners"."userId"
+}
+
+Ref {
+    "engagements_tasks"."properties_hs_created_by_user_id" <> "owners"."userId"
+}
+
+Ref {
+    "engagements_tasks"."properties_hs_updated_by_user_id" <> "owners"."userId"
+}
+
+Ref {
+    "engagements_tasks"."properties_hubspot_owner_id" <> "owners"."userId"
+}
+
+Ref {
+    "forms"."properties_hs_created_by_user_id" <> "owners"."userId"
+}
+
+Ref {
+    "forms"."properties_hs_updated_by_user_id" <> "owners"."userId"
+}
+
+Ref {
+    "forms"."properties_hubspot_owner_id" <> "owners"."userId"
+}
+
+Ref {
+    "form_submissions"."formId" <> "forms"."id"
+}
+
+Ref {
+    "goals"."properties_hs_created_by_user_id" <> "owners"."userId"
+}
+
+Ref {
+    "goals"."properties_hs_updated_by_user_id" <> "owners"."userId"
+}
+
+Ref {
+    "goals"."properties_hubspot_owner_id" <> "owners"."userId"
+}
+
+Ref {
+    "goals"."properties_hs_assignee_user_id" <> "owners"."userId"
+}
+
+Ref {
+    "goals"."properties_hs_user_id" <> "owners"."userId"
+}
+
+Ref {
+    "line_items"."properties_hs_created_by_user_id" <> "owners"."userId"
+}
+
+Ref {
+    "line_items"."properties_hs_updated_by_user_id" <> "owners"."userId"
+}
+
+Ref {
+    "line_items"."properties_hubspot_owner_id" <> "owners"."userId"
+}
+
+Ref {
+    "marketing_emails"."authorUserId" <> "owners"."userId"
+}
+
+Ref {
+    "marketing_emails"."createdById" <> "owners"."userId"
+}
+
+Ref {
+    "marketing_emails"."primaryEmailCampaignId" <> "campaigns"."id"
+}
+
+Ref {
+    "marketing_emails"."publishedById" <> "owners"."userId"
+}
+
+Ref {
+    "marketing_emails"."subscription" <> "email_subscriptions"."id"
+}
+
+Ref {
+    "products"."properties_hs_created_by_user_id" <> "owners"."userId"
+}
+
+Ref {
+    "products"."properties_hs_updated_by_user_id" <> "owners"."userId"
+}
+
+Ref {
+    "products"."properties_hubspot_owner_id" <> "owners"."userId"
+}
+
+Ref {
+    "contacts_property_history"."updated-by-user-id" <> "owners"."userId"
+}
+
+Ref {
+    "contacts_property_history"."canonical-vid" <> "contacts"."id"
+}
+
+Ref {
+    "companies_property_history"."updatedByUserId" <> "owners"."userId"
+}
+
+Ref {
+    "companies_property_history"."companyId" <> "companies"."id"
+}
+
+Ref {
+    "deals_property_history"."updatedByUserId" <> "owners"."userId"
+}
+
+Ref {
+    "deals_property_history"."dealId" <> "deals"."id"
+}
+
+Ref {
+    "tickets"."properties_hs_created_by_user_id" <> "owners"."userId"
+}
+
+Ref {
+    "tickets"."properties_hs_updated_by_user_id" <> "owners"."userId"
+}
+
+Ref {
+    "tickets"."properties_hubspot_owner_id" <> "owners"."userId"
+}
+
+Ref {
+    "tickets"."properties_hs_originating_email_engagement_id" <> "engagements_emails"."id"
+}
+
+Ref {
+    "tickets"."properties_hs_primary_company_id" <> "companies"."id"
+}
+
+Ref {
+    "tickets"."properties_hs_ticket_id" <> "tickets"."id"
+}
+
+Ref {
+    "workflows"."lastUpdatedByUserId" <> "owners"."userId"
+}
+
+Ref {
+    "workflows"."originalAuthorUserId" <> "owners"."userId"
+}

--- a/airbyte-integrations/connectors/source-hubspot/metadata.yaml
+++ b/airbyte-integrations/connectors/source-hubspot/metadata.yaml
@@ -13,6 +13,7 @@ data:
   dockerImageTag: 4.2.16
   dockerRepository: airbyte/source-hubspot
   documentationUrl: https://docs.airbyte.com/integrations/sources/hubspot
+  erdUrl: https://dbdocs.io/airbyteio/source-hubspot?view=relationships
   githubIssueLabel: source-hubspot
   icon: hubspot.svg
   license: ELv2


### PR DESCRIPTION
## What
Addresses https://github.com/airbytehq/airbyte-internal-issues/issues/9173 for source-hubspot

## How
By running `airbyte-ci --name=source-hubspot generate-erd`

The publish has been done as part of the airbyte-ci command executed locally.

## User Impact
ERD is now available on https://dbdocs.io/airbyteio/source-hubspot

## Can this PR be safely reverted and rolled back?
- [X] YES 💚
- [ ] NO ❌

