### PR TITLE
[ISSUE 9173] add ERD files for source-stripe

### DIFF
--- a/airbyte-integrations/connectors/source-stripe/erd/discovered_catalog.json
+++ b/airbyte-integrations/connectors/source-stripe/erd/discovered_catalog.json
@@ -1,0 +1,12912 @@
+{
+  "streams": [
+    {
+      "name": "checkout_sessions",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "type": ["null", "object"],
+        "properties": {
+          "id": {
+            "description": "Unique identifier for the session.",
+            "type": ["null", "string"]
+          },
+          "object": {
+            "description": "Type of object.",
+            "type": ["null", "string"]
+          },
+          "after_expiration": {
+            "description": "Information related to the recovery options after the session expiration.",
+            "type": ["null", "object"],
+            "properties": {
+              "recovery": {
+                "description": "Details about the recovery process.",
+                "type": ["null", "object"],
+                "properties": {
+                  "allow_promotion_codes": {
+                    "description": "Flag indicating whether to allow promotion codes during recovery.",
+                    "type": ["null", "boolean"]
+                  },
+                  "enabled": {
+                    "description": "Flag indicating whether recovery is enabled.",
+                    "type": ["null", "boolean"]
+                  },
+                  "expires_at": {
+                    "description": "Timestamp indicating the expiration time for recovery.",
+                    "type": ["null", "integer"]
+                  },
+                  "url": {
+                    "description": "URL for the recovery process.",
+                    "type": ["null", "string"]
+                  }
+                }
+              }
+            }
+          },
+          "allow_promotion_codes": {
+            "description": "Flag indicating whether promotion codes are allowed.",
+            "type": ["null", "boolean"]
+          },
+          "amount_subtotal": {
+            "description": "Subtotal amount for the session.",
+            "type": ["null", "integer"]
+          },
+          "amount_total": {
+            "description": "Total amount for the session.",
+            "type": ["null", "integer"]
+          },
+          "automatic_tax": {
+            "description": "Configuration for automatic tax calculation.",
+            "type": ["null", "object"],
+            "properties": {
+              "enabled": {
+                "description": "Flag indicating whether automatic tax calculation is enabled.",
+                "type": ["null", "boolean"]
+              },
+              "liability": {
+                "description": "Details about tax liability.",
+                "type": ["null", "object"],
+                "properties": {
+                  "account": {
+                    "description": "Account associated with tax liability.",
+                    "type": ["null", "string"]
+                  },
+                  "type": {
+                    "description": "Type of tax liability.",
+                    "type": ["null", "string"]
+                  }
+                }
+              },
+              "status": {
+                "description": "Status of automatic tax calculation.",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "billing_address_collection": {
+            "description": "Configuration for collecting billing address information.",
+            "type": ["null", "string"]
+          },
+          "cancel_url": {
+            "description": "URL to redirect to if the session is canceled.",
+            "type": ["null", "string"]
+          },
+          "client_reference_id": {
+            "description": "Client reference ID for the session.",
+            "type": ["null", "string"]
+          },
+          "consent": {
+            "description": "Consent information for the session.",
+            "type": ["null", "object"],
+            "properties": {
+              "promotions": {
+                "description": "Consent for receiving promotions.",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "consent_collection": {
+            "description": "Configuration for collecting consent information.",
+            "type": ["null", "object"],
+            "properties": {
+              "promotions": {
+                "description": "Consent for receiving promotions.",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "currency": {
+            "description": "Currency used for the session.",
+            "type": ["null", "string"]
+          },
+          "customer": {
+            "description": "Customer information associated with the session.",
+            "type": ["null", "string"]
+          },
+          "customer_details": {
+            "description": "Details of the customer associated with the session.",
+            "type": ["null", "object"],
+            "properties": {
+              "email": {
+                "description": "Customer's email address.",
+                "type": ["null", "string"]
+              },
+              "phone": {
+                "description": "Customer's phone number.",
+                "type": ["null", "string"]
+              },
+              "tax_exempt": {
+                "description": "Flag indicating if the customer is tax exempt.",
+                "type": ["null", "string"]
+              },
+              "tax_ids": {
+                "description": "Tax IDs associated with the customer.",
+                "type": ["null", "array"],
+                "items": {
+                  "type": ["null", "object"],
+                  "properties": {
+                    "type": {
+                      "description": "Type of tax ID.",
+                      "type": ["null", "string"]
+                    },
+                    "value": {
+                      "description": "Value of tax ID.",
+                      "type": ["null", "string"]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "customer_email": {
+            "description": "Customer's email address.",
+            "type": ["null", "string"]
+          },
+          "expires_at": {
+            "description": "Timestamp indicating the expiration time of the session.",
+            "type": ["null", "integer"]
+          },
+          "livemode": {
+            "description": "Flag indicating if the session is in live mode.",
+            "type": ["null", "boolean"]
+          },
+          "locale": {
+            "description": "Locale settings for the session.",
+            "type": ["null", "string"]
+          },
+          "metadata": {
+            "description": "Additional metadata for the session.",
+            "type": ["null", "object"],
+            "properties": {}
+          },
+          "mode": {
+            "description": "Mode of the session.",
+            "type": ["null", "string"]
+          },
+          "payment_intent": {
+            "description": "Payment intent associated with the session.",
+            "type": ["null", "string"]
+          },
+          "payment_method_options": {
+            "description": "Options for different payment methods.",
+            "type": ["null", "object"],
+            "properties": {
+              "acss_debit": {
+                "description": "Options for ACSS debit payments.",
+                "type": ["null", "object"],
+                "properties": {
+                  "currency": {
+                    "description": "Currency for the payment.",
+                    "type": ["null", "string"]
+                  },
+                  "mandate_options": {
+                    "description": "Options for mandate setup.",
+                    "type": ["null", "object"],
+                    "properties": {
+                      "custom_mandate_url": {
+                        "description": "Custom URL for mandate setup.",
+                        "type": ["null", "string"]
+                      },
+                      "default_for": {
+                        "type": ["null", "array"],
+                        "items": { "type": ["null", "string"] }
+                      },
+                      "interval_description": {
+                        "description": "Description of payment interval.",
+                        "type": ["null", "string"]
+                      },
+                      "payment_schedule": {
+                        "description": "Schedule for payments.",
+                        "type": ["null", "string"]
+                      },
+                      "transaction_type": {
+                        "description": "Type of transaction.",
+                        "type": ["null", "string"]
+                      }
+                    }
+                  },
+                  "verification_method": {
+                    "description": "Verification method for the payment.",
+                    "type": ["null", "string"]
+                  }
+                }
+              },
+              "boleto": {
+                "description": "Options for Boleto payments.",
+                "type": ["null", "object"],
+                "properties": {
+                  "expires_after_days": {
+                    "description": "Expiration period for the Boleto.",
+                    "type": ["null", "integer"]
+                  }
+                }
+              },
+              "oxxo": {
+                "description": "Options for OXXO payments.",
+                "type": ["null", "object"],
+                "properties": {
+                  "expires_after_days": {
+                    "description": "Expiration period for the OXXO.",
+                    "type": ["null", "integer"]
+                  }
+                }
+              }
+            }
+          },
+          "payment_method_types": {
+            "description": "Types of payment methods accepted.",
+            "type": ["null", "array"],
+            "items": {
+              "card": {
+                "description": "Credit card payment method.",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "payment_status": {
+            "description": "Status of the payment.",
+            "type": ["null", "string"]
+          },
+          "phone_number_collection": {
+            "description": "Configuration for collecting phone numbers.",
+            "type": ["null", "object"],
+            "properties": {
+              "enabled": {
+                "description": "Flag indicating if phone number collection is enabled.",
+                "type": ["null", "boolean"]
+              }
+            }
+          },
+          "recovered_from": {
+            "description": "Information about the recovery source.",
+            "type": ["null", "string"]
+          },
+          "setup_intent": {
+            "description": "Setup intent associated with the session.",
+            "type": ["null", "string"]
+          },
+          "shipping": {
+            "description": "Shipping information for the session.",
+            "type": ["null", "object"],
+            "properties": {
+              "address": {
+                "type": ["null", "object"],
+                "properties": {
+                  "city": { "type": ["null", "string"] },
+                  "country": { "type": ["null", "string"] },
+                  "line1": { "type": ["null", "string"] },
+                  "line2": { "type": ["null", "string"] },
+                  "postal_code": { "type": ["null", "string"] },
+                  "state": { "type": ["null", "string"] }
+                }
+              },
+              "name": {
+                "description": "Recipient name.",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "shipping_address_collection": {
+            "description": "Configuration for collecting shipping address information.",
+            "type": ["null", "object"],
+            "properties": {
+              "allowed_countries": {
+                "type": ["null", "array"],
+                "items": { "type": ["null", "string"] }
+              }
+            }
+          },
+          "submit_type": {
+            "description": "Type of submission.",
+            "type": ["null", "string"]
+          },
+          "subscription": {
+            "description": "Subscription associated with the session.",
+            "type": ["null", "string"]
+          },
+          "success_url": {
+            "description": "URL to redirect to upon successful completion.",
+            "type": ["null", "string"]
+          },
+          "tax_id_collection": {
+            "description": "Configuration for collecting tax IDs.",
+            "type": ["null", "object"],
+            "properties": {
+              "enabled": {
+                "description": "Flag indicating if tax ID collection is enabled.",
+                "type": ["null", "boolean"]
+              }
+            }
+          },
+          "total_details": {
+            "description": "Details about the total amount.",
+            "type": ["null", "object"],
+            "properties": {
+              "amount_discount": {
+                "description": "Discount amount.",
+                "type": ["null", "integer"]
+              },
+              "amount_shipping": {
+                "description": "Shipping amount.",
+                "type": ["null", "integer"]
+              },
+              "amount_tax": {
+                "description": "Tax amount.",
+                "type": ["null", "integer"]
+              },
+              "breakdown": {
+                "description": "Breakdown of total amount.",
+                "type": ["null", "object"],
+                "properties": {
+                  "discounts": {
+                    "description": "Details of discounts applied.",
+                    "type": ["null", "array"],
+                    "items": {
+                      "type": ["null", "object"],
+                      "properties": {
+                        "amount": {
+                          "description": "Discount amount.",
+                          "type": ["null", "integer"]
+                        },
+                        "discount": {
+                          "description": "Details of discount.",
+                          "type": ["null", "object"],
+                          "properties": {}
+                        }
+                      }
+                    }
+                  },
+                  "taxes": {
+                    "description": "Details of taxes applied.",
+                    "type": ["null", "array"],
+                    "items": {
+                      "type": ["null", "object"],
+                      "properties": {
+                        "amount": {
+                          "description": "Tax amount.",
+                          "type": ["null", "integer"]
+                        },
+                        "rate": {
+                          "description": "Tax rate details.",
+                          "type": ["null", "object"],
+                          "properties": {
+                            "id": {
+                              "description": "Unique identifier for tax rate.",
+                              "type": ["null", "string"]
+                            },
+                            "object": {
+                              "description": "Type of object.",
+                              "type": ["null", "string"]
+                            },
+                            "active": {
+                              "description": "Flag indicating if tax rate is active.",
+                              "type": ["null", "boolean"]
+                            },
+                            "country": {
+                              "description": "Country for the tax rate.",
+                              "type": ["null", "string"]
+                            },
+                            "created": {
+                              "description": "Timestamp indicating creation time.",
+                              "type": ["null", "integer"]
+                            },
+                            "description": {
+                              "description": "Description of tax rate.",
+                              "type": ["null", "string"]
+                            },
+                            "display_name": {
+                              "description": "Display name of tax rate.",
+                              "type": ["null", "string"]
+                            },
+                            "inclusive": {
+                              "description": "Flag indicating if tax is inclusive.",
+                              "type": ["null", "boolean"]
+                            },
+                            "jurisdiction": {
+                              "description": "Jurisdiction of the tax rate.",
+                              "type": ["null", "string"]
+                            },
+                            "livemode": {
+                              "description": "Flag indicating if tax rate is in live mode.",
+                              "type": ["null", "boolean"]
+                            },
+                            "metadata": {
+                              "description": "Additional metadata for the tax rate.",
+                              "type": ["null", "object"],
+                              "properties": {}
+                            },
+                            "percentage": {
+                              "description": "Percentage of the tax rate.",
+                              "type": ["null", "number"]
+                            },
+                            "state": {
+                              "description": "State of the tax rate.",
+                              "type": ["null", "string"]
+                            },
+                            "tax_type": {
+                              "description": "Type of tax.",
+                              "type": ["null", "string"]
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "url": {
+            "description": "URL for the session.",
+            "type": ["null", "string"]
+          },
+          "updated": {
+            "description": "Timestamp indicating the last update time.",
+            "type": ["null", "integer"]
+          },
+          "created": {
+            "description": "Timestamp indicating the creation time of the session.",
+            "type": ["null", "integer"]
+          },
+          "currency_conversion": {
+            "description": "Details of currency conversion for the session.",
+            "type": ["null", "object"],
+            "properties": {
+              "amount_subtotal": {
+                "description": "Subtotal amount after currency conversion.",
+                "type": ["null", "integer"]
+              },
+              "amount_total": {
+                "description": "Total amount after currency conversion.",
+                "type": ["null", "integer"]
+              },
+              "fix_rate": {
+                "description": "Fixed exchange rate used for conversion.",
+                "type": ["null", "string"]
+              },
+              "source_currency": {
+                "description": "Source currency before conversion.",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "custom_fields": {
+            "description": "Custom fields configured for the session.",
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "dropdown": {
+                  "description": "Dropdown field configuration.",
+                  "type": ["null", "object"],
+                  "properties": {
+                    "options": {
+                      "description": "Dropdown options.",
+                      "type": ["null", "array"],
+                      "items": { "type": ["null", "object"] }
+                    },
+                    "value": {
+                      "description": "Selected value.",
+                      "type": ["null", "string"]
+                    }
+                  }
+                },
+                "key": {
+                  "description": "Key for the custom field.",
+                  "type": ["null", "string"]
+                },
+                "label": {
+                  "description": "Label field configuration.",
+                  "type": ["null", "object"],
+                  "properties": {
+                    "custom": {
+                      "description": "Custom label.",
+                      "type": ["null", "string"]
+                    },
+                    "type": {
+                      "description": "Type of label.",
+                      "type": ["null", "string"]
+                    }
+                  }
+                },
+                "numeric": {
+                  "description": "Numeric field configuration.",
+                  "type": ["null", "object"],
+                  "properties": {
+                    "maximum_length": {
+                      "description": "Maximum length for numeric value.",
+                      "type": ["null", "integer"]
+                    },
+                    "minimum_length": {
+                      "description": "Minimum length for numeric value.",
+                      "type": ["null", "integer"]
+                    },
+                    "value": {
+                      "description": "Numeric value.",
+                      "type": ["null", "string"]
+                    }
+                  }
+                },
+                "optional": {
+                  "description": "Flag indicating if the field is optional.",
+                  "type": ["null", "boolean"]
+                },
+                "text": {
+                  "description": "Text field configuration.",
+                  "type": ["null", "object"],
+                  "properties": {
+                    "maximum_length": {
+                      "description": "Maximum length for text value.",
+                      "type": ["null", "integer"]
+                    },
+                    "minimum_length": {
+                      "description": "Minimum length for text value.",
+                      "type": ["null", "integer"]
+                    },
+                    "value": {
+                      "description": "Text value.",
+                      "type": ["null", "string"]
+                    }
+                  }
+                },
+                "type": {
+                  "description": "Type of custom field.",
+                  "type": ["null", "string"]
+                }
+              }
+            }
+          },
+          "custom_text": {
+            "description": "Custom text configurations for different sections.",
+            "type": ["null", "object"],
+            "properties": {
+              "shipping_address": {
+                "description": "Custom text for shipping address section.",
+                "type": ["null", "object"],
+                "properties": {
+                  "message": {
+                    "description": "Message for shipping address section.",
+                    "type": ["null", "string"]
+                  }
+                }
+              },
+              "submit": {
+                "description": "Custom text for submit button.",
+                "type": ["null", "string"],
+                "properties": {
+                  "message": {
+                    "description": "Message for submit button.",
+                    "type": ["null", "string"]
+                  }
+                }
+              },
+              "terms_of_service": {
+                "description": "Custom text for terms of service section.",
+                "type": ["null", "object"],
+                "properties": {
+                  "message": {
+                    "description": "Message for terms of service section.",
+                    "type": ["null", "string"]
+                  }
+                }
+              }
+            }
+          },
+          "customer_creation": {
+            "description": "Configuration for customer creation during the session.",
+            "type": ["null", "string"]
+          },
+          "invoice": {
+            "description": "Invoice associated with the session.",
+            "type": ["null", "string"]
+          },
+          "invoice_creation": {
+            "description": "Configuration for invoice creation.",
+            "type": ["null", "object"],
+            "properties": {
+              "enabled": {
+                "description": "Flag indicating if invoice creation is enabled.",
+                "type": ["null", "boolean"]
+              },
+              "invoice_data": {
+                "description": "Data related to invoice generation.",
+                "type": ["null", "object"],
+                "properties": {
+                  "account_tax_ids": {
+                    "type": ["null", "array"],
+                    "items": { "type": ["null", "string"] }
+                  },
+                  "custom_fields": {
+                    "description": "Custom fields for the invoice.",
+                    "type": ["null", "array"],
+                    "items": {
+                      "type": ["null", "object"],
+                      "properties": {
+                        "name": {
+                          "description": "Name of custom field.",
+                          "type": ["null", "string"]
+                        },
+                        "value": {
+                          "description": "Value of custom field.",
+                          "type": ["null", "string"]
+                        }
+                      }
+                    }
+                  },
+                  "description": {
+                    "description": "Description for the invoice.",
+                    "type": ["null", "string"]
+                  },
+                  "footer": {
+                    "description": "Footer content for the invoice.",
+                    "type": ["null", "string"]
+                  },
+                  "issuer": {
+                    "description": "Details of the entity issuing the invoice.",
+                    "type": ["null", "object"],
+                    "properties": {
+                      "account": {
+                        "description": "Account associated with the issuer.",
+                        "type": ["null", "string"]
+                      },
+                      "type": {
+                        "description": "Type of issuer.",
+                        "type": ["null", "string"]
+                      }
+                    }
+                  },
+                  "metadata": {
+                    "description": "Additional metadata for the invoice.",
+                    "type": ["null", "object"]
+                  },
+                  "rendering_options": {
+                    "description": "Options for rendering the invoice.",
+                    "type": ["null", "object"],
+                    "properties": {
+                      "amount_tax_display": {
+                        "description": "Display format for tax amount.",
+                        "type": ["null", "string"]
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "payment_link": {
+            "description": "Payment link for the session.",
+            "type": ["null", "string"]
+          },
+          "payment_method_collection": {
+            "description": "Configuration for collecting payment methods.",
+            "type": ["null", "string"]
+          },
+          "shipping_cost": {
+            "description": "Cost details for shipping.",
+            "type": ["null", "object"],
+            "properties": {
+              "amount_total": {
+                "description": "Total amount for shipping.",
+                "type": ["null", "integer"]
+              },
+              "amount_subtotal": {
+                "description": "Subtotal amount for shipping.",
+                "type": ["null", "integer"]
+              },
+              "amount_tax": {
+                "description": "Tax amount for shipping.",
+                "type": ["null", "integer"]
+              },
+              "shipping_rate": {
+                "description": "Rate for shipping.",
+                "type": ["null", "string"]
+              },
+              "taxes": {
+                "description": "Tax details for shipping.",
+                "type": ["null", "array"],
+                "items": {
+                  "type": ["null", "object"],
+                  "properties": {
+                    "amount": {
+                      "description": "Tax amount.",
+                      "type": ["null", "integer"]
+                    },
+                    "rate": {
+                      "type": ["null", "object"],
+                      "properties": {
+                        "id": { "type": ["null", "string"] },
+                        "object": { "type": ["null", "string"] },
+                        "active": { "type": ["null", "boolean"] },
+                        "country": { "type": ["null", "string"] },
+                        "created": { "type": ["null", "integer"] },
+                        "description": { "type": ["null", "string"] },
+                        "display_name": { "type": ["null", "string"] },
+                        "effective_percentage": { "type": ["null", "number"] },
+                        "inclusive": { "type": ["null", "boolean"] },
+                        "jurisdiction": { "type": ["null", "string"] },
+                        "livemode": { "type": ["null", "boolean"] },
+                        "metadata": { "type": ["null", "object"] },
+                        "percentage": { "type": ["null", "number"] },
+                        "state": { "type": ["null", "string"] },
+                        "tax_type": { "type": ["null", "string"] }
+                      }
+                    },
+                    "taxability_reason": {
+                      "description": "Reason for taxability.",
+                      "type": ["null", "string"]
+                    },
+                    "taxable_amount": {
+                      "description": "Taxable amount.",
+                      "type": ["null", "integer"]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "shipping_details": {
+            "description": "Details of shipping information.",
+            "type": ["null", "object"],
+            "properties": {
+              "address": {
+                "type": ["null", "object"],
+                "properties": {
+                  "city": { "type": ["null", "string"] },
+                  "country": { "type": ["null", "string"] },
+                  "line1": { "type": ["null", "string"] },
+                  "line2": { "type": ["null", "string"] },
+                  "postal_code": { "type": ["null", "string"] },
+                  "state": { "type": ["null", "string"] }
+                }
+              },
+              "name": {
+                "description": "Recipient name.",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "shipping_options": {
+            "description": "Available shipping options.",
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "shipping_amount": {
+                  "description": "Shipping amount.",
+                  "type": ["null", "integer"]
+                },
+                "shipping_rate": {
+                  "description": "Rate for shipping.",
+                  "type": ["null", "string"]
+                }
+              }
+            }
+          },
+          "status": {
+            "description": "Overall status of the session.",
+            "type": ["null", "string"]
+          },
+          "payment_method_configuration_details": {
+            "type": ["null", "object"],
+            "properties": {
+              "id": { "type": ["null", "string"] },
+              "parent": { "type": ["null", "string"] }
+            }
+          },
+          "client_secret": {
+            "description": "Client secret used for authentication.",
+            "type": ["null", "string"]
+          },
+          "ui_mode": {
+            "description": "UI mode for displaying the session.",
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "customer_balance_transactions",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "type": ["null", "object"],
+        "properties": {
+          "id": {
+            "description": "Unique identifier of the balance transaction",
+            "type": ["null", "string"]
+          },
+          "object": {
+            "description": "Type of object, in this case, 'balance_transaction'",
+            "type": ["null", "string"]
+          },
+          "amount": {
+            "description": "The transaction amount in the smallest currency unit",
+            "type": ["null", "number"]
+          },
+          "created": {
+            "description": "The date and time when the transaction was created",
+            "type": ["null", "integer"]
+          },
+          "credit_note": {
+            "description": "Credit note related to the balance transaction",
+            "type": ["null", "string"]
+          },
+          "currency": {
+            "description": "The currency code of the transaction amount",
+            "type": ["null", "string"]
+          },
+          "customer": {
+            "description": "ID of the customer associated with the transaction",
+            "type": ["null", "string"]
+          },
+          "description": {
+            "description": "Description of the balance transaction",
+            "type": ["null", "string"]
+          },
+          "ending_balance": {
+            "description": "The ending balance after the transaction",
+            "type": ["null", "number"]
+          },
+          "invoice": {
+            "description": "ID of the invoice associated with the transaction",
+            "type": ["null", "string"]
+          },
+          "livemode": {
+            "description": "Boolean indicating whether the balance transaction is in live mode",
+            "type": ["null", "boolean"]
+          },
+          "metadata": {
+            "description": "Custom metadata attached to the balance transaction",
+            "type": ["null", "object"],
+            "additionalProperties": true
+          },
+          "type": {
+            "description": "Type of the balance transaction (e.g., charge, refund, adjustment)",
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "events",
+      "json_schema": {
+        "type": "object",
+        "properties": {
+          "created": {
+            "description": "The timestamp representing when the event was created.",
+            "type": ["null", "integer"]
+          },
+          "data": {
+            "description": "Additional data related to the event, specific to the event type.",
+            "type": ["null", "object"],
+            "properties": {}
+          },
+          "id": {
+            "description": "The unique identifier of the event.",
+            "type": ["null", "string"]
+          },
+          "api_version": {
+            "description": "The version of the Stripe API that generated the event.",
+            "type": ["null", "string"]
+          },
+          "object": {
+            "description": "The object type representing the event.",
+            "type": ["null", "string"]
+          },
+          "livemode": {
+            "description": "Indicates whether the event occurred in live mode or test mode.",
+            "type": ["null", "boolean"]
+          },
+          "pending_webhooks": {
+            "description": "The number of webhooks pending to be sent related to the event.",
+            "type": ["null", "integer"]
+          },
+          "request": {
+            "description": "The API request information associated with the event.",
+            "oneOf": [
+              { "type": ["null", "string"] },
+              {
+                "type": ["null", "object"],
+                "properties": {
+                  "id": { "type": ["null", "string"] },
+                  "idempotency_key": { "type": ["null", "string"] }
+                }
+              }
+            ]
+          },
+          "type": {
+            "description": "The type of event that occurred.",
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["created"],
+      "source_defined_primary_key": [["id"]]
+    },
+    {
+      "name": "external_account_cards",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "type": "object",
+        "properties": {
+          "id": {
+            "description": "The unique identifier for the card.",
+            "type": "string"
+          },
+          "object": {
+            "description": "Indicates the object type such as 'card'.",
+            "type": ["string", "null"]
+          },
+          "address_city": {
+            "description": "The city part of the cardholder's billing address.",
+            "type": ["string", "null"]
+          },
+          "address_country": {
+            "description": "The country part of the cardholder's billing address.",
+            "type": ["string", "null"]
+          },
+          "address_line1": {
+            "description": "The first line of the cardholder's billing address.",
+            "type": ["string", "null"]
+          },
+          "address_line1_check": {
+            "description": "If `address_line1` was provided, indicates if it has been checked for address_line1 true/false.",
+            "type": ["string", "null"]
+          },
+          "address_line2": {
+            "description": "The second line of the cardholder's billing address.",
+            "type": ["string", "null"]
+          },
+          "address_state": {
+            "description": "The state part of the cardholder's billing address.",
+            "type": ["string", "null"]
+          },
+          "address_zip": {
+            "description": "The ZIP or postal code of the cardholder's billing address.",
+            "type": ["string", "null"]
+          },
+          "address_zip_check": {
+            "description": "If `address_zip` was provided, indicates if it has been checked for address_zip true/false.",
+            "type": ["string", "null"]
+          },
+          "brand": {
+            "description": "The card brand such as Visa, Mastercard, etc.",
+            "type": ["string", "null"]
+          },
+          "country": {
+            "description": "The country where the card was issued.",
+            "type": ["string", "null"]
+          },
+          "cvc_check": {
+            "description": "If `cvc` was provided, indicates if it has been checked for cvc_check true/false.",
+            "type": ["string", "null"]
+          },
+          "dynamic_last4": {
+            "description": "The last 4 digits of the card number.",
+            "type": ["string", "null"]
+          },
+          "exp_month": {
+            "description": "The expiration month of the card.",
+            "type": ["integer", "null"]
+          },
+          "exp_year": {
+            "description": "The expiration year of the card.",
+            "type": ["integer", "null"]
+          },
+          "fingerprint": {
+            "description": "A unique identifier for the card created by Stripe.",
+            "type": ["string", "null"]
+          },
+          "funding": {
+            "description": "The funding source such as credit, debit, etc.",
+            "type": ["string", "null"]
+          },
+          "last4": {
+            "description": "The last 4 digits of the card number.",
+            "type": ["string", "null"]
+          },
+          "metadata": {
+            "description": "Additional information about the card.",
+            "type": ["object", "null"]
+          },
+          "name": {
+            "description": "The cardholder's name as it appears on the card.",
+            "type": ["string", "null"]
+          },
+          "redaction": {
+            "description": "Indicates if the card has been redacted for security purposes true/false.",
+            "type": ["string", "null"]
+          },
+          "tokenization_method": {
+            "description": "The method used to tokenize the card such as apple_pay, google_pay, etc.",
+            "type": ["string", "null"]
+          },
+          "account": {
+            "description": "The ID of the Stripe account the card belongs to.",
+            "type": ["string", "null"]
+          },
+          "updated": {
+            "description": "Timestamp indicating when the card details were last updated.",
+            "type": ["null", "integer"]
+          },
+          "is_deleted": {
+            "description": "Indicates if the card has been deleted true/false.",
+            "type": ["null", "boolean"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "external_account_bank_accounts",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "type": "object",
+        "properties": {
+          "id": {
+            "description": "The unique identifier for the bank account.",
+            "type": "string"
+          },
+          "object": {
+            "description": "The object type, which is typically 'bank_account'.",
+            "type": ["string", "null"]
+          },
+          "account_holder_name": {
+            "description": "The name of the account holder.",
+            "type": ["string", "null"]
+          },
+          "account_holder_type": {
+            "description": "The type of account holder, such as individual or company.",
+            "type": ["string", "null"]
+          },
+          "account_type": {
+            "description": "The type of bank account, such as checking or savings.",
+            "type": ["string", "null"]
+          },
+          "bank_name": {
+            "description": "The name of the bank.",
+            "type": ["string", "null"]
+          },
+          "country": {
+            "description": "The country where the bank account is located.",
+            "type": ["string", "null"]
+          },
+          "currency": {
+            "description": "The currency of the bank account.",
+            "type": ["string", "null"]
+          },
+          "fingerprint": {
+            "description": "A unique identifier for the bank account.",
+            "type": ["string", "null"]
+          },
+          "last4": {
+            "description": "The last 4 digits of the bank account number.",
+            "type": ["string", "null"]
+          },
+          "metadata": {
+            "description": "Additional information or attributes associated with the bank account.",
+            "type": ["object", "null"]
+          },
+          "routing_number": {
+            "description": "The routing number of the bank account.",
+            "type": ["string", "null"]
+          },
+          "status": {
+            "description": "The status of the bank account, such as 'verified' or 'pending'.",
+            "type": ["string", "null"]
+          },
+          "account": {
+            "description": "The account number associated with the bank account.",
+            "type": ["string", "null"]
+          },
+          "updated": {
+            "description": "The timestamp for when the bank account was last updated.",
+            "type": ["null", "integer"]
+          },
+          "is_deleted": {
+            "description": "Indicates if the bank account has been deleted.",
+            "type": ["null", "boolean"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "persons",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "Persons Schema",
+        "additionalProperties": true,
+        "type": ["null", "object"],
+        "properties": {
+          "id": {
+            "description": "Unique identifier for the person",
+            "type": ["null", "string"]
+          },
+          "object": {
+            "description": "Object type for the person data",
+            "type": ["null", "string"]
+          },
+          "phone": {
+            "description": "Phone number",
+            "type": ["null", "string"]
+          },
+          "email": {
+            "description": "Email address",
+            "type": ["null", "string"]
+          },
+          "address_kana": {
+            "description": "Japanese Kana writing for address",
+            "type": ["null", "string"]
+          },
+          "address_kanji": {
+            "description": "Japanese Kanji writing for address",
+            "type": ["null", "string"]
+          },
+          "first_name_kana": {
+            "description": "Japanese Kana writing for first name",
+            "type": ["null", "string"]
+          },
+          "gender": {
+            "description": "Gender of the person",
+            "type": ["null", "string"]
+          },
+          "full_name_aliases": {
+            "description": "Alternate full name entries",
+            "type": ["null", "string"]
+          },
+          "id_number_secondary_provided": {
+            "description": "Flag indicating if secondary ID number is provided",
+            "type": ["null", "string"]
+          },
+          "first_name_kanji": {
+            "description": "Japanese Kanji writing for first name",
+            "type": ["null", "string"]
+          },
+          "nationality": {
+            "description": "Nationality of the person",
+            "type": ["null", "string"]
+          },
+          "political_exposure": {
+            "description": "Information on political exposure",
+            "type": ["null", "string"]
+          },
+          "registered_address": {
+            "description": "Registered address details",
+            "type": ["null", "string"]
+          },
+          "account": {
+            "description": "Information related to the person's account",
+            "type": ["null", "string"]
+          },
+          "address": {
+            "description": "Physical address details",
+            "type": ["null", "object"],
+            "properties": {
+              "city": {
+                "description": "City name",
+                "type": ["null", "string"]
+              },
+              "country": {
+                "description": "Country name",
+                "type": ["null", "string"]
+              },
+              "line1": {
+                "description": "First line of the address",
+                "type": ["null", "string"]
+              },
+              "line2": {
+                "description": "Second line of the address",
+                "type": ["null", "string"]
+              },
+              "postal_code": {
+                "description": "Postal code",
+                "type": ["null", "string"]
+              },
+              "state": {
+                "description": "State or region",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "created": {
+            "description": "Timestamp for when the person data was created",
+            "type": ["null", "integer"]
+          },
+          "updated": {
+            "description": "Timestamp for when the person data was last updated",
+            "type": ["null", "integer"]
+          },
+          "dob": {
+            "description": "Date of birth details",
+            "type": ["null", "object"],
+            "properties": {
+              "day": {
+                "description": "Day of birth",
+                "type": ["null", "integer"]
+              },
+              "month": {
+                "description": "Month of birth",
+                "type": ["null", "integer"]
+              },
+              "year": {
+                "description": "Year of birth",
+                "type": ["null", "integer"]
+              }
+            }
+          },
+          "first_name": {
+            "description": "First name of the person",
+            "type": ["null", "string"]
+          },
+          "future_requirements": {
+            "description": "Future requirements for the person",
+            "type": ["null", "object"],
+            "properties": {
+              "alternatives": {
+                "description": "Alternative fields that may be required",
+                "type": ["null", "array"],
+                "items": {
+                  "type": ["null", "string", "object"],
+                  "properties": {
+                    "flat_amount": {
+                      "description": "Flat amount required",
+                      "type": ["null", "integer"]
+                    },
+                    "unit_amount": {
+                      "description": "Unit amount required",
+                      "type": ["null", "integer"]
+                    },
+                    "up_to": {
+                      "description": "Up to the specified limit",
+                      "type": ["null", "integer"]
+                    },
+                    "alternative_fields_due": {
+                      "description": "Fields due for alternative verification",
+                      "type": ["null", "array"],
+                      "items": { "type": ["null", "string"] }
+                    },
+                    "original_fields_due": {
+                      "description": "Original fields due for verification",
+                      "type": ["null", "array"],
+                      "items": { "type": ["null", "string"] }
+                    }
+                  }
+                }
+              },
+              "currently_due": {
+                "description": "Fields currently due for verification",
+                "type": ["null", "array"],
+                "items": {
+                  "type": ["null", "string", "object"],
+                  "properties": {
+                    "flat_amount": {
+                      "description": "Flat amount required",
+                      "type": ["null", "integer"]
+                    },
+                    "unit_amount": {
+                      "description": "Unit amount required",
+                      "type": ["null", "integer"]
+                    },
+                    "up_to": {
+                      "description": "Up to the specified limit",
+                      "type": ["null", "integer"]
+                    }
+                  }
+                }
+              },
+              "errors": {
+                "description": "Errors related to verification",
+                "type": ["null", "array"],
+                "items": {
+                  "type": ["null", "string", "object"],
+                  "properties": {
+                    "flat_amount": {
+                      "description": "Flat amount causing error",
+                      "type": ["null", "integer"]
+                    },
+                    "unit_amount": {
+                      "description": "Unit amount causing error",
+                      "type": ["null", "integer"]
+                    },
+                    "up_to": {
+                      "description": "Specific limit causing error",
+                      "type": ["null", "integer"]
+                    }
+                  }
+                }
+              },
+              "eventually_due": {
+                "description": "Fields to be due eventually for verification",
+                "type": ["null", "array"],
+                "items": {
+                  "type": ["null", "string", "object"],
+                  "properties": {
+                    "flat_amount": {
+                      "description": "Flat amount to be due",
+                      "type": ["null", "integer"]
+                    },
+                    "unit_amount": {
+                      "description": "Unit amount to be due",
+                      "type": ["null", "integer"]
+                    },
+                    "up_to": {
+                      "description": "Up to the specified limit",
+                      "type": ["null", "integer"]
+                    }
+                  }
+                }
+              },
+              "past_due": {
+                "description": "Fields that are past due for verification",
+                "type": ["null", "array"],
+                "items": {
+                  "type": ["null", "string", "object"],
+                  "properties": {
+                    "flat_amount": {
+                      "description": "Past due flat amount",
+                      "type": ["null", "integer"]
+                    },
+                    "unit_amount": {
+                      "description": "Past due unit amount",
+                      "type": ["null", "integer"]
+                    },
+                    "up_to": {
+                      "description": "Specific limit past due",
+                      "type": ["null", "integer"]
+                    }
+                  }
+                }
+              },
+              "pending_verification": {
+                "description": "Fields pending verification",
+                "type": ["null", "array"],
+                "items": {
+                  "type": ["null", "string", "object"],
+                  "properties": {
+                    "flat_amount": {
+                      "description": "Flat amount pending verification",
+                      "type": ["null", "integer"]
+                    },
+                    "unit_amount": {
+                      "description": "Unit amount pending verification",
+                      "type": ["null", "integer"]
+                    },
+                    "up_to": {
+                      "description": "Up to the specific limit pending verification",
+                      "type": ["null", "integer"]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "id_number_provided": {
+            "description": "Flag indicating if ID number is provided",
+            "type": ["null", "boolean"]
+          },
+          "last_name": {
+            "description": "Last name of the person",
+            "type": ["null", "string"]
+          },
+          "metadata": {
+            "description": "Additional metadata related to the person",
+            "type": ["null", "object"],
+            "properties": {
+              "id_number_provided": {
+                "description": "Flag indicating if ID number is provided in metadata",
+                "type": ["null", "boolean"]
+              }
+            }
+          },
+          "relationship": {
+            "description": "Relationship details of the person",
+            "type": ["null", "object"],
+            "properties": {
+              "director": {
+                "description": "Director relationship status",
+                "type": ["null", "boolean"]
+              },
+              "executive": {
+                "description": "Executive relationship status",
+                "type": ["null", "boolean"]
+              },
+              "owner": {
+                "description": "Owner relationship status",
+                "type": ["null", "boolean"]
+              },
+              "percent_ownership": {
+                "description": "Percentage of ownership",
+                "type": ["null", "string"]
+              },
+              "representative": {
+                "description": "Representative relationship status",
+                "type": ["null", "boolean"]
+              },
+              "title": {
+                "description": "Title of the relationship",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "requirements": {
+            "description": "Verification requirements for the person",
+            "type": ["null", "object"],
+            "properties": {
+              "alternatives": {
+                "description": "Alternative verification fields required",
+                "type": ["null", "array"],
+                "items": {
+                  "type": ["null", "string", "object"],
+                  "properties": {
+                    "flat_amount": {
+                      "description": "Flat amount required",
+                      "type": ["null", "integer"]
+                    },
+                    "unit_amount": {
+                      "description": "Unit amount required",
+                      "type": ["null", "integer"]
+                    },
+                    "up_to": {
+                      "description": "Up to the specified limit",
+                      "type": ["null", "integer"]
+                    },
+                    "alternative_fields_due": {
+                      "description": "Fields due for alternative verification",
+                      "type": ["null", "array"],
+                      "items": { "type": ["null", "string"] }
+                    },
+                    "original_fields_due": {
+                      "description": "Original fields due for verification",
+                      "type": ["null", "array"],
+                      "items": { "type": ["null", "string"] }
+                    }
+                  }
+                }
+              },
+              "currently_due": {
+                "description": "Fields currently due for verification",
+                "type": ["null", "array"],
+                "items": {
+                  "type": ["null", "string", "object"],
+                  "properties": {
+                    "flat_amount": {
+                      "description": "Flat amount required",
+                      "type": ["null", "integer"]
+                    },
+                    "unit_amount": {
+                      "description": "Unit amount required",
+                      "type": ["null", "integer"]
+                    },
+                    "up_to": {
+                      "description": "Up to the specified limit",
+                      "type": ["null", "integer"]
+                    }
+                  }
+                }
+              },
+              "errors": {
+                "description": "Errors related to verification",
+                "type": ["null", "array"],
+                "items": {
+                  "type": ["null", "string", "object"],
+                  "properties": {
+                    "flat_amount": {
+                      "description": "Flat amount causing error",
+                      "type": ["null", "integer"]
+                    },
+                    "unit_amount": {
+                      "description": "Unit amount causing error",
+                      "type": ["null", "integer"]
+                    },
+                    "up_to": {
+                      "description": "Specific limit causing error",
+                      "type": ["null", "integer"]
+                    }
+                  }
+                }
+              },
+              "eventually_due": {
+                "description": "Fields to be due eventually for verification",
+                "type": ["null", "array"],
+                "items": {
+                  "type": ["null", "string", "object"],
+                  "properties": {
+                    "flat_amount": {
+                      "description": "Flat amount to be due",
+                      "type": ["null", "integer"]
+                    },
+                    "unit_amount": {
+                      "description": "Unit amount to be due",
+                      "type": ["null", "integer"]
+                    },
+                    "up_to": {
+                      "description": "Up to the specified limit",
+                      "type": ["null", "integer"]
+                    }
+                  }
+                }
+              },
+              "past_due": {
+                "description": "Fields that are past due for verification",
+                "type": ["null", "array"],
+                "items": {
+                  "type": ["null", "string", "object"],
+                  "properties": {
+                    "flat_amount": {
+                      "description": "Past due flat amount",
+                      "type": ["null", "integer"]
+                    },
+                    "unit_amount": {
+                      "description": "Past due unit amount",
+                      "type": ["null", "integer"]
+                    },
+                    "up_to": {
+                      "description": "Specific limit past due",
+                      "type": ["null", "integer"]
+                    }
+                  }
+                }
+              },
+              "pending_verification": {
+                "description": "Fields pending verification",
+                "type": ["null", "array"],
+                "items": {
+                  "type": ["null", "string", "object"],
+                  "properties": {
+                    "flat_amount": {
+                      "description": "Flat amount pending verification",
+                      "type": ["null", "integer"]
+                    },
+                    "unit_amount": {
+                      "description": "Unit amount pending verification",
+                      "type": ["null", "integer"]
+                    },
+                    "up_to": {
+                      "description": "Up to the specific limit pending verification",
+                      "type": ["null", "integer"]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "ssn_last_4_provided": {
+            "description": "Flag indicating if last 4 SSN digits are provided",
+            "type": ["null", "boolean"]
+          },
+          "verification": {
+            "description": "Details related to verification status",
+            "type": ["null", "object"],
+            "properties": {
+              "additional_document": {
+                "description": "Additional document verification details",
+                "type": ["null", "object"],
+                "properties": {
+                  "back": {
+                    "description": "Back side of the document",
+                    "type": ["null", "string"]
+                  },
+                  "details": {
+                    "description": "Additional verification details",
+                    "type": ["null", "string"]
+                  },
+                  "details_code": {
+                    "description": "Verification details code",
+                    "type": ["null", "string"]
+                  },
+                  "front": {
+                    "description": "Front side of the document",
+                    "type": ["null", "string"]
+                  }
+                }
+              },
+              "details": {
+                "description": "General verification details",
+                "type": ["null", "string"]
+              },
+              "details_code": {
+                "description": "General verification details code",
+                "type": ["null", "string"]
+              },
+              "document": {
+                "description": "Document verification details",
+                "type": ["null", "object"],
+                "properties": {
+                  "back": {
+                    "description": "Back side of the document",
+                    "type": ["null", "string"]
+                  },
+                  "details": {
+                    "description": "Verification details",
+                    "type": ["null", "string"]
+                  },
+                  "details_code": {
+                    "description": "Verification details code",
+                    "type": ["null", "string"]
+                  },
+                  "front": {
+                    "description": "Front side of the document",
+                    "type": ["null", "string"]
+                  }
+                }
+              },
+              "status": {
+                "description": "Verification status",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "is_deleted": {
+            "description": "Flag indicating if the person data is deleted",
+            "type": ["null", "boolean"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "setup_attempts",
+      "json_schema": {
+        "$schema": "https://json-schema.org/draft-07/schema#",
+        "additionalProperties": true,
+        "type": ["null", "object"],
+        "properties": {
+          "application": {
+            "description": "The application associated with the setup attempt.",
+            "type": ["null", "string"]
+          },
+          "created": {
+            "description": "The timestamp when the setup attempt was created.",
+            "type": ["null", "integer"]
+          },
+          "customer": {
+            "description": "The customer associated with the setup attempt.",
+            "type": ["null", "string"]
+          },
+          "id": {
+            "description": "The unique identifier for the setup attempt.",
+            "type": ["null", "string"]
+          },
+          "livemode": {
+            "description": "Indicates if the setup attempt is in live mode.",
+            "type": ["null", "boolean"]
+          },
+          "object": {
+            "description": "The object type, typically 'setup_attempt'.",
+            "type": ["null", "string"]
+          },
+          "on_behalf_of": {
+            "description": "The entity on whose behalf the setup attempt is being made.",
+            "type": ["null", "string"]
+          },
+          "payment_method": {
+            "description": "The payment method associated with the setup attempt.",
+            "type": ["null", "string"]
+          },
+          "payment_method_details": {
+            "description": "Detailed information about the payment method associated with the setup attempt.",
+            "type": ["null", "object"],
+            "properties": {
+              "au_becs_debit": {
+                "description": "Details specific to an AU BECS Debit payment method.",
+                "type": ["null", "object"],
+                "additional_properties": true,
+                "properties": {}
+              },
+              "bacs_debit": {
+                "description": "Details specific to a BACS Debit payment method.",
+                "type": ["null", "object"],
+                "additional_properties": true,
+                "properties": {}
+              },
+              "bancontact": {
+                "description": "Details specific to a Bancontact payment method.",
+                "type": ["null", "object"],
+                "properties": {
+                  "bank_code": {
+                    "description": "The bank code associated with the Bancontact payment method.",
+                    "type": ["null", "string"]
+                  },
+                  "bank_name": {
+                    "description": "The name of the bank associated with the Bancontact payment method.",
+                    "type": ["null", "string"]
+                  },
+                  "bic": {
+                    "description": "The BIC of the Bancontact payment method.",
+                    "type": ["null", "string"]
+                  },
+                  "generated_sepa_debit": {
+                    "description": "Indicates if a SEPA debit was generated.",
+                    "type": ["null", "string"]
+                  },
+                  "generated_sepa_debit_mandate": {
+                    "description": "Indicates if a SEPA debit mandate was generated.",
+                    "type": ["null", "string"]
+                  },
+                  "iban_last4": {
+                    "description": "The last 4 digits of the IBAN associated with the Bancontact payment method.",
+                    "type": ["null", "string"]
+                  },
+                  "preferred_language": {
+                    "description": "The preferred language for the Bancontact payment method.",
+                    "type": ["null", "string"]
+                  },
+                  "verified_name": {
+                    "description": "The verified name associated with the Bancontact payment method.",
+                    "type": ["null", "string"]
+                  }
+                }
+              },
+              "card": {
+                "description": "Details specific to a card payment method.",
+                "type": ["null", "object"],
+                "properties": {
+                  "three_d_secure": {
+                    "description": "Details related to 3D Secure authentication.",
+                    "type": ["null", "object"],
+                    "properties": {
+                      "authentication_flow": {
+                        "description": "The authentication flow for 3D Secure.",
+                        "type": ["null", "string"]
+                      },
+                      "result": {
+                        "description": "The authentication result for 3D Secure.",
+                        "type": ["null", "string"]
+                      },
+                      "result_reason": {
+                        "description": "The reason for the authentication result.",
+                        "type": ["null", "string"]
+                      },
+                      "version": {
+                        "description": "The version of 3D Secure used.",
+                        "type": ["null", "string"]
+                      }
+                    }
+                  }
+                }
+              },
+              "card_present": {
+                "description": "Details specific to a card-present payment method.",
+                "type": ["null", "object"],
+                "properties": {
+                  "generated_card": {
+                    "description": "Indicates if a card was generated.",
+                    "type": ["null", "string"]
+                  }
+                }
+              },
+              "ideal": {
+                "description": "Details specific to an iDEAL payment method.",
+                "type": ["null", "object"],
+                "properties": {
+                  "bank": {
+                    "description": "The bank associated with the iDEAL payment method.",
+                    "type": ["null", "string"]
+                  },
+                  "bic": {
+                    "description": "The BIC of the iDEAL payment method.",
+                    "type": ["null", "string"]
+                  },
+                  "generated_sepa_debit": {
+                    "description": "Indicates if a SEPA debit was generated.",
+                    "type": ["null", "string"]
+                  },
+                  "generated_sepa_debit_mandate": {
+                    "description": "Indicates if a SEPA debit mandate was generated.",
+                    "type": ["null", "string"]
+                  },
+                  "iban_last4": {
+                    "description": "The last 4 digits of the IBAN associated with the iDEAL payment method.",
+                    "type": ["null", "string"]
+                  },
+                  "verified_name": {
+                    "description": "The verified name associated with the iDEAL payment method.",
+                    "type": ["null", "string"]
+                  }
+                }
+              },
+              "sepa_debit": {
+                "description": "Details specific to a SEPA debit payment method.",
+                "type": ["null", "object"],
+                "additional_properties": true,
+                "properties": {}
+              },
+              "sofort": {
+                "description": "Details specific to a Sofort payment method.",
+                "type": ["null", "object"],
+                "properties": {
+                  "bank_code": {
+                    "description": "The bank code associated with the Sofort payment method.",
+                    "type": ["null", "string"]
+                  },
+                  "bank_name": {
+                    "description": "The name of the bank associated with the Sofort payment method.",
+                    "type": ["null", "string"]
+                  },
+                  "bic": {
+                    "description": "The BIC of the Sofort payment method.",
+                    "type": ["null", "string"]
+                  },
+                  "generated_sepa_debit": {
+                    "description": "Indicates if a SEPA debit was generated.",
+                    "type": ["null", "string"]
+                  },
+                  "generated_sepa_debit_mandate": {
+                    "description": "Indicates if a SEPA debit mandate was generated.",
+                    "type": ["null", "string"]
+                  },
+                  "iban_last4": {
+                    "description": "The last 4 digits of the IBAN associated with the Sofort payment method.",
+                    "type": ["null", "string"]
+                  },
+                  "preferred_language": {
+                    "description": "The preferred language for the Sofort payment method.",
+                    "type": ["null", "string"]
+                  },
+                  "verified_name": {
+                    "description": "The verified name associated with the Sofort payment method.",
+                    "type": ["null", "string"]
+                  }
+                }
+              },
+              "type": {
+                "description": "The type of payment method.",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "setup_error": {
+            "description": "Details about any setup errors encountered.",
+            "type": ["null", "object"],
+            "properties": {
+              "charge": {
+                "description": "The charge associated with the setup error.",
+                "type": ["null", "string"]
+              },
+              "code": {
+                "description": "The error code.",
+                "type": ["null", "string"]
+              },
+              "decline_code": {
+                "description": "The decline code if applicable.",
+                "type": ["null", "string"]
+              },
+              "doc_url": {
+                "description": "The URL to documentation related to the error.",
+                "type": ["null", "string"]
+              },
+              "message": {
+                "description": "The error message.",
+                "type": ["null", "string"]
+              },
+              "param": {
+                "description": "The parameter related to the error.",
+                "type": ["null", "string"]
+              },
+              "payment_intent": {
+                "type": ["null", "object"],
+                "properties": {
+                  "id": { "type": ["null", "string"] },
+                  "object": { "type": ["null", "string"] },
+                  "amount": { "type": ["null", "integer"] },
+                  "amount_capturable": { "type": ["null", "integer"] },
+                  "amount_received": { "type": ["null", "integer"] },
+                  "application": { "type": ["null", "string"] },
+                  "application_fee_amount": { "type": ["null", "integer"] },
+                  "canceled_at": { "type": ["null", "integer"] },
+                  "cancellation_reason": { "type": ["null", "string"] },
+                  "capture_method": { "type": ["null", "string"] },
+                  "charges": {
+                    "type": ["null", "object"],
+                    "properties": {
+                      "object": { "type": ["null", "string"] },
+                      "data": { "type": ["null", "array"] },
+                      "has_more": { "type": ["null", "boolean"] },
+                      "total_count": { "type": ["null", "integer"] },
+                      "url": { "type": ["null", "string"] }
+                    }
+                  },
+                  "client_secret": { "type": ["null", "string"] },
+                  "confirmation_method": { "type": ["null", "string"] },
+                  "created": { "type": ["null", "integer"] },
+                  "updated": { "type": ["null", "integer"] },
+                  "currency": { "type": ["null", "string"] },
+                  "customer": { "type": ["null", "string"] },
+                  "description": { "type": ["null", "string"] },
+                  "invoice": { "type": ["null", "string"] },
+                  "last_payment_error": {
+                    "type": ["null", "object"],
+                    "properties": {
+                      "charge": { "type": ["null", "string"] },
+                      "code": { "type": ["null", "string"] },
+                      "decline_code": { "type": ["null", "string"] },
+                      "doc_url": { "type": ["null", "string"] },
+                      "message": { "type": ["null", "string"] },
+                      "param": { "type": ["null", "string"] },
+                      "payment_method": {
+                        "type": ["null", "object"],
+                        "properties": {
+                          "id": { "type": ["null", "string"] },
+                          "object": { "type": ["null", "string"] },
+                          "acss_debit": {
+                            "type": ["null", "object"],
+                            "properties": {
+                              "bank_name": { "type": ["null", "string"] },
+                              "fingerprint": { "type": ["null", "string"] },
+                              "institution_number": {
+                                "type": ["null", "string"]
+                              },
+                              "last4": { "type": ["null", "string"] },
+                              "transit_number": { "type": ["null", "string"] }
+                            }
+                          },
+                          "afterpay_clearpay": { "type": ["null", "string"] },
+                          "alipay": { "type": ["null", "string"] },
+                          "au_becs_debit": {
+                            "type": ["null", "object"],
+                            "properties": {
+                              "bsb_number": { "type": ["null", "string"] },
+                              "fingerprint": { "type": ["null", "string"] },
+                              "last4": { "type": ["null", "string"] }
+                            }
+                          },
+                          "bacs_debit": {
+                            "type": ["null", "object"],
+                            "properties": {
+                              "fingerprint": { "type": ["null", "string"] },
+                              "last4": { "type": ["null", "string"] },
+                              "sort_code": { "type": ["null", "string"] }
+                            }
+                          },
+                          "bancontact": { "type": ["null", "string"] },
+                          "billing_details": {
+                            "type": ["null", "object"],
+                            "properties": {
+                              "address": {
+                                "type": ["null", "object"],
+                                "properties": {
+                                  "city": { "type": ["null", "string"] },
+                                  "country": { "type": ["null", "string"] },
+                                  "line1": { "type": ["null", "string"] },
+                                  "line2": { "type": ["null", "string"] },
+                                  "postal_code": { "type": ["null", "string"] },
+                                  "state": { "type": ["null", "string"] }
+                                }
+                              },
+                              "email": { "type": ["null", "string"] },
+                              "name": { "type": ["null", "string"] },
+                              "phone": { "type": ["null", "string"] }
+                            }
+                          },
+                          "boleto": {
+                            "type": ["null", "object"],
+                            "properties": {
+                              "tax_id": { "type": ["null", "string"] }
+                            }
+                          },
+                          "card": {
+                            "type": ["null", "object"],
+                            "properties": {
+                              "brand": { "type": ["null", "string"] },
+                              "checks": {
+                                "type": ["null", "object"],
+                                "properties": {
+                                  "address_line1_check": {
+                                    "type": ["null", "string"]
+                                  },
+                                  "address_postal_code_check": {
+                                    "type": ["null", "string"]
+                                  },
+                                  "cvc_check": { "type": ["null", "string"] }
+                                }
+                              },
+                              "country": { "type": ["null", "string"] },
+                              "exp_month": { "type": ["null", "integer"] },
+                              "exp_year": { "type": ["null", "integer"] },
+                              "fingerprint": { "type": ["null", "string"] },
+                              "funding": { "type": ["null", "string"] },
+                              "generated_from": {
+                                "type": ["null", "object"],
+                                "properties": {
+                                  "charge": { "type": ["null", "string"] },
+                                  "payment_method_details": {
+                                    "type": ["null", "object"],
+                                    "properties": {
+                                      "card_present": {
+                                        "type": ["null", "object"],
+                                        "properties": {
+                                          "brand": {
+                                            "type": ["null", "string"]
+                                          },
+                                          "cardholder_name": {
+                                            "type": ["null", "string"]
+                                          },
+                                          "country": {
+                                            "type": ["null", "string"]
+                                          },
+                                          "emv_auth_data": {
+                                            "type": ["null", "string"]
+                                          },
+                                          "exp_month": {
+                                            "type": ["null", "integer"]
+                                          },
+                                          "exp_year": {
+                                            "type": ["null", "integer"]
+                                          },
+                                          "fingerprint": {
+                                            "type": ["null", "string"]
+                                          },
+                                          "funding": {
+                                            "type": ["null", "string"]
+                                          },
+                                          "generated_card": {
+                                            "type": ["null", "string"]
+                                          },
+                                          "lsat4": {
+                                            "type": ["null", "string"]
+                                          },
+                                          "network": {
+                                            "type": ["null", "string"]
+                                          },
+                                          "read_method": {
+                                            "type": ["null", "string"]
+                                          },
+                                          "receipt": {
+                                            "type": ["null", "object"],
+                                            "properties": {
+                                              "account_type": {
+                                                "type": ["null", "string"]
+                                              },
+                                              "application_cryptogram": {
+                                                "type": ["null", "string"]
+                                              },
+                                              "application_preferred_name": {
+                                                "type": ["null", "string"]
+                                              },
+                                              "authorization_code": {
+                                                "type": ["null", "string"]
+                                              },
+                                              "authorization_response_code": {
+                                                "type": ["null", "string"]
+                                              },
+                                              "cardholder_verification_method": {
+                                                "type": ["null", "string"]
+                                              },
+                                              "dedicated_file_name": {
+                                                "type": ["null", "string"]
+                                              },
+                                              "terminal_verification_results": {
+                                                "type": ["null", "string"]
+                                              },
+                                              "transaction_status_information": {
+                                                "type": ["null", "string"]
+                                              }
+                                            }
+                                          },
+                                          "type": { "type": ["null", "string"] }
+                                        }
+                                      },
+                                      "type": { "type": ["null", "string"] }
+                                    }
+                                  },
+                                  "setup_attempt": {
+                                    "type": ["null", "string"]
+                                  }
+                                }
+                              },
+                              "last4": { "type": ["null", "string"] },
+                              "networks": {
+                                "type": ["null", "object"],
+                                "properties": {
+                                  "available": {
+                                    "type": ["null", "array"],
+                                    "items": { "type": ["null", "string"] }
+                                  },
+                                  "preferred": { "type": ["null", "string"] }
+                                }
+                              },
+                              "three_d_secure_usage": {
+                                "type": ["null", "object"],
+                                "properties": {
+                                  "supported": { "type": ["null", "boolean"] }
+                                }
+                              },
+                              "wallet": {
+                                "type": ["null", "object"],
+                                "properties": {
+                                  "amex_express_checkout": {
+                                    "type": ["null", "string"]
+                                  },
+                                  "apple_pay": { "type": ["null", "string"] },
+                                  "dynamic_last4": {
+                                    "type": ["null", "string"]
+                                  },
+                                  "google_pay": { "type": ["null", "string"] },
+                                  "masterpass": {
+                                    "type": ["null", "object"],
+                                    "properties": {
+                                      "billing_address": {
+                                        "type": ["null", "object"],
+                                        "properties": {
+                                          "city": {
+                                            "type": ["null", "string"]
+                                          },
+                                          "country": {
+                                            "type": ["null", "string"]
+                                          },
+                                          "line1": {
+                                            "type": ["null", "string"]
+                                          },
+                                          "line2": {
+                                            "type": ["null", "string"]
+                                          },
+                                          "postal_code": {
+                                            "type": ["null", "string"]
+                                          },
+                                          "state": {
+                                            "type": ["null", "string"]
+                                          }
+                                        }
+                                      },
+                                      "email": { "type": ["null", "string"] },
+                                      "name": { "type": ["null", "string"] },
+                                      "shipping_address": {
+                                        "type": ["null", "object"],
+                                        "properties": {
+                                          "city": {
+                                            "type": ["null", "string"]
+                                          },
+                                          "country": {
+                                            "type": ["null", "string"]
+                                          },
+                                          "line1": {
+                                            "type": ["null", "string"]
+                                          },
+                                          "line2": {
+                                            "type": ["null", "string"]
+                                          },
+                                          "postal_code": {
+                                            "type": ["null", "string"]
+                                          },
+                                          "state": {
+                                            "type": ["null", "string"]
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "samsung_pay": { "type": ["null", "string"] },
+                                  "type": { "type": ["null", "string"] },
+                                  "visa_checkout": {
+                                    "type": ["null", "object"],
+                                    "properties": {
+                                      "billing_address": {
+                                        "type": ["null", "object"],
+                                        "properties": {
+                                          "city": {
+                                            "type": ["null", "string"]
+                                          },
+                                          "country": {
+                                            "type": ["null", "string"]
+                                          },
+                                          "line1": {
+                                            "type": ["null", "string"]
+                                          },
+                                          "line2": {
+                                            "type": ["null", "string"]
+                                          },
+                                          "postal_code": {
+                                            "type": ["null", "string"]
+                                          },
+                                          "state": {
+                                            "type": ["null", "string"]
+                                          }
+                                        }
+                                      },
+                                      "email": { "type": ["null", "string"] },
+                                      "name": { "type": ["null", "string"] },
+                                      "shipping_address": {
+                                        "type": ["null", "object"],
+                                        "properties": {
+                                          "city": {
+                                            "type": ["null", "string"]
+                                          },
+                                          "country": {
+                                            "type": ["null", "string"]
+                                          },
+                                          "line1": {
+                                            "type": ["null", "string"]
+                                          },
+                                          "line2": {
+                                            "type": ["null", "string"]
+                                          },
+                                          "postal_code": {
+                                            "type": ["null", "string"]
+                                          },
+                                          "state": {
+                                            "type": ["null", "string"]
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "card_present": {
+                            "type": ["null", "object"],
+                            "properties": {}
+                          },
+                          "created": { "type": ["null", "integer"] },
+                          "customer": { "type": ["null", "string"] },
+                          "eps": {
+                            "type": ["null", "object"],
+                            "properties": {
+                              "bank": { "type": ["null", "string"] }
+                            }
+                          },
+                          "fpx": {
+                            "type": ["null", "object"],
+                            "properties": {
+                              "bank": { "type": ["null", "string"] }
+                            }
+                          },
+                          "giropay": {
+                            "type": ["null", "object"],
+                            "properties": {}
+                          },
+                          "grabpay": {
+                            "type": ["null", "object"],
+                            "properties": {}
+                          },
+                          "ideal": {
+                            "type": ["null", "object"],
+                            "properties": {
+                              "bank": { "type": ["null", "string"] }
+                            }
+                          },
+                          "interac_present": {
+                            "type": ["null", "object"],
+                            "properties": {}
+                          },
+                          "livemode": { "type": ["null", "boolean"] },
+                          "metadata": {
+                            "type": ["null", "object"],
+                            "properties": {}
+                          },
+                          "oxxo": {
+                            "type": ["null", "object"],
+                            "properties": {}
+                          },
+                          "p24": {
+                            "type": ["null", "object"],
+                            "properties": {
+                              "bank": { "type": ["null", "string"] }
+                            }
+                          },
+                          "sepa_debit": {
+                            "type": ["null", "object"],
+                            "properties": {
+                              "bank_code": { "type": ["null", "string"] },
+                              "branch_code": { "type": ["null", "string"] },
+                              "country": { "type": ["null", "string"] },
+                              "fingerprint": { "type": ["null", "string"] },
+                              "generated_from": {
+                                "type": ["null", "object"],
+                                "properties": {
+                                  "charge": { "type": ["null", "string"] },
+                                  "setup_attempt": {
+                                    "type": ["null", "string"]
+                                  }
+                                }
+                              },
+                              "last4": { "type": ["null", "string"] }
+                            }
+                          },
+                          "sofort": {
+                            "type": ["null", "object"],
+                            "properties": {
+                              "country": { "type": ["null", "string"] }
+                            }
+                          },
+                          "type": { "type": ["null", "string"] },
+                          "wechat_pay": {
+                            "type": ["null", "object"],
+                            "properties": {}
+                          }
+                        }
+                      },
+                      "payment_method_type": { "type": ["null", "string"] },
+                      "type": { "type": ["null", "string"] }
+                    }
+                  },
+                  "livemode": { "type": ["null", "boolean"] },
+                  "metadata": { "type": ["null", "object"], "properties": {} },
+                  "next_action": {
+                    "type": ["null", "object"],
+                    "properties": {
+                      "alipay_handle_redirect": {
+                        "type": ["null", "object"],
+                        "properties": {
+                          "native_data": { "type": ["null", "string"] },
+                          "native_url": { "type": ["null", "string"] },
+                          "return_url": { "type": ["null", "string"] },
+                          "url": { "type": ["null", "string"] }
+                        }
+                      },
+                      "boleto_display_details": {
+                        "type": ["null", "object"],
+                        "properties": {
+                          "expires_at": { "type": ["null", "integer"] },
+                          "hosted_voucher_url": { "type": ["null", "string"] },
+                          "number": { "type": ["null", "string"] },
+                          "pdf": { "type": ["null", "string"] }
+                        }
+                      },
+                      "oxxo_display_details": {
+                        "type": ["null", "object"],
+                        "properties": {
+                          "expires_after": { "type": ["null", "integer"] },
+                          "hosted_voucher_url": { "type": ["null", "string"] },
+                          "number": { "type": ["null", "string"] }
+                        }
+                      },
+                      "redirect_to_url": {
+                        "type": ["null", "object"],
+                        "properties": {
+                          "return_url": { "type": ["null", "string"] },
+                          "url": { "type": ["null", "string"] }
+                        }
+                      },
+                      "type": { "type": ["null", "string"] },
+                      "use_stripe_sdk": {
+                        "type": ["null", "object"],
+                        "properties": {}
+                      },
+                      "verify_with_microdeposits": {
+                        "type": ["null", "object"],
+                        "properties": {
+                          "arrival_date": { "type": ["null", "integer"] },
+                          "hosted_verification_url": {
+                            "type": ["null", "string"]
+                          }
+                        }
+                      },
+                      "wechat_pay_display_qr_code": {
+                        "type": ["null", "object"],
+                        "properties": {
+                          "data": { "type": ["null", "string"] },
+                          "image_data_url": { "type": ["null", "string"] }
+                        }
+                      },
+                      "wechat_pay_redirect_to_android_app": {
+                        "type": ["null", "object"],
+                        "properties": {
+                          "app_id": { "type": ["null", "string"] },
+                          "nonce_str": { "type": ["null", "string"] },
+                          "package": { "type": ["null", "string"] },
+                          "partner_id": { "type": ["null", "string"] },
+                          "prepay_id": { "type": ["null", "string"] },
+                          "sign": { "type": ["null", "string"] },
+                          "timestamp": { "type": ["null", "string"] }
+                        }
+                      },
+                      "wechat_pay_redirect_to_ios_app": {
+                        "type": ["null", "object"],
+                        "properties": {
+                          "native_url": { "type": ["null", "string"] }
+                        }
+                      }
+                    }
+                  },
+                  "on_behalf_of": { "type": ["null", "string"] },
+                  "payment_method": { "type": ["null", "string"] },
+                  "payment_method_options": {
+                    "type": ["null", "object"],
+                    "properties": {}
+                  },
+                  "payment_method_types": {
+                    "type": ["null", "array"],
+                    "items": { "type": ["null", "string"] }
+                  },
+                  "receipt_email": { "type": ["null", "string"] },
+                  "review": { "type": ["null", "string"] },
+                  "setup_future_usage": { "type": ["null", "string"] },
+                  "shipping": {
+                    "type": ["null", "object"],
+                    "properties": {
+                      "address": {
+                        "type": ["null", "object"],
+                        "properties": {
+                          "city": { "type": ["null", "string"] },
+                          "country": { "type": ["null", "string"] },
+                          "line1": { "type": ["null", "string"] },
+                          "line2": { "type": ["null", "string"] },
+                          "postal_code": { "type": ["null", "string"] },
+                          "state": { "type": ["null", "string"] }
+                        }
+                      },
+                      "carrier": { "type": ["null", "string"] },
+                      "name": { "type": ["null", "string"] },
+                      "phone": { "type": ["null", "string"] },
+                      "tracking_number": { "type": ["null", "string"] }
+                    }
+                  },
+                  "source": { "type": ["null", "string"] },
+                  "statement_description": { "type": ["null", "string"] },
+                  "statement_descriptor_suffix": { "type": ["null", "string"] },
+                  "status": { "type": ["null", "string"] },
+                  "transfer_data": {
+                    "type": ["null", "object"],
+                    "properties": {
+                      "amount": { "type": ["null", "integer"] },
+                      "destination": { "type": ["null", "string"] }
+                    }
+                  },
+                  "transfer_group": { "type": ["null", "string"] },
+                  "latest_charge": { "type": ["null", "string"] },
+                  "statement_descriptor": { "type": ["null", "string"] },
+                  "amount_details": {
+                    "type": ["null", "object"],
+                    "properties": {
+                      "tip": {
+                        "type": ["null", "object"],
+                        "properties": {
+                          "amount": { "type": ["null", "integer"] }
+                        }
+                      }
+                    }
+                  },
+                  "processing": {
+                    "type": ["null", "object"],
+                    "properties": {
+                      "type": { "type": ["null", "string"] },
+                      "card": {
+                        "type": ["null", "object"],
+                        "properties": {
+                          "customer_notification": {
+                            "type": ["null", "object"],
+                            "properties": {
+                              "approval_requested": {
+                                "type": ["null", "boolean"]
+                              },
+                              "completes_at": { "type": ["null", "integer"] }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "automatic_payment_methods": {
+                    "type": ["null", "object"],
+                    "properties": {
+                      "allow_redirects": { "type": ["null", "string"] },
+                      "enabled": { "type": ["null", "boolean"] }
+                    }
+                  },
+                  "payment_method_configuration_details": {
+                    "type": ["null", "object"],
+                    "properties": {
+                      "id": { "type": ["null", "string"] },
+                      "parent": { "type": ["null", "string"] }
+                    }
+                  }
+                }
+              },
+              "payment_method": {
+                "description": "The payment method associated with the setup error.",
+                "type": ["null", "object"],
+                "properties": {
+                  "afterpay_clearpay": {
+                    "description": "Details specific to an Afterpay Clearpay payment method.",
+                    "additionalProperties": true,
+                    "type": ["null", "object"]
+                  },
+                  "alipay": {
+                    "description": "Details specific to an Alipay payment method.",
+                    "additionalProperties": true,
+                    "type": ["null", "object"]
+                  },
+                  "au_becs_debit": {
+                    "description": "Details specific to an AU BECS Debit payment method.",
+                    "additionalProperties": true,
+                    "type": ["null", "object"],
+                    "properties": {
+                      "bsb_number": {
+                        "description": "The BSB number associated with the AU BECS Debit payment method.",
+                        "type": ["null", "string"]
+                      },
+                      "fingerprint": {
+                        "description": "The fingerprint of the AU BECS Debit payment method.",
+                        "type": ["null", "string"]
+                      },
+                      "last4": {
+                        "description": "The last 4 digits of the account number.",
+                        "type": ["null", "string"]
+                      }
+                    }
+                  },
+                  "bacs_debit": {
+                    "description": "Details specific to a BACS Debit payment method.",
+                    "additionalProperties": true,
+                    "type": ["null", "object"],
+                    "properties": {
+                      "fingerprint": {
+                        "description": "The fingerprint of the BACS Debit payment method.",
+                        "type": ["null", "string"]
+                      },
+                      "last4": {
+                        "description": "The last 4 digits of the account number.",
+                        "type": ["null", "string"]
+                      },
+                      "sort_code": {
+                        "description": "The sort code associated with the BACS Debit payment method.",
+                        "type": ["null", "string"]
+                      }
+                    }
+                  },
+                  "bancontact": {
+                    "description": "Details specific to a Bancontact payment method.",
+                    "additionalProperties": true,
+                    "type": ["null", "object"]
+                  },
+                  "billing_details": {
+                    "description": "Details about the billing information associated with the payment method.",
+                    "additionalProperties": true,
+                    "type": ["null", "object"],
+                    "properties": {
+                      "address": {
+                        "type": ["null", "object"],
+                        "properties": {
+                          "city": { "type": ["null", "string"] },
+                          "country": { "type": ["null", "string"] },
+                          "line1": { "type": ["null", "string"] },
+                          "line2": { "type": ["null", "string"] },
+                          "postal_code": { "type": ["null", "string"] },
+                          "state": { "type": ["null", "string"] }
+                        }
+                      },
+                      "email": {
+                        "description": "The email address associated with the billing details.",
+                        "type": ["null", "string"]
+                      },
+                      "name": {
+                        "description": "The name associated with the billing details.",
+                        "type": ["null", "string"]
+                      },
+                      "phone": {
+                        "description": "The phone number associated with the billing details.",
+                        "type": ["null", "string"]
+                      }
+                    }
+                  },
+                  "card": {
+                    "description": "Details specific to a card payment method.",
+                    "additionalProperties": true,
+                    "type": ["null", "object"],
+                    "properties": {
+                      "brand": {
+                        "description": "The brand of the card.",
+                        "type": ["null", "string"]
+                      },
+                      "checks": {
+                        "description": "The various card checks performed.",
+                        "additionalProperties": true,
+                        "type": ["null", "object"],
+                        "properties": {
+                          "address_line1_check": {
+                            "description": "The result of the address line 1 check.",
+                            "type": ["null", "string"]
+                          },
+                          "address_postal_code_check": {
+                            "description": "The result of the address postal code check.",
+                            "type": ["null", "string"]
+                          },
+                          "cvc_check": {
+                            "description": "The result of the CVC check.",
+                            "type": ["null", "string"]
+                          }
+                        }
+                      },
+                      "country": {
+                        "description": "The country associated with the card.",
+                        "type": ["null", "string"]
+                      },
+                      "exp_month": {
+                        "description": "The expiration month of the card.",
+                        "type": ["null", "integer"]
+                      },
+                      "exp_year": {
+                        "description": "The expiration year of the card.",
+                        "type": ["null", "integer"]
+                      },
+                      "fingerprint": {
+                        "description": "The fingerprint of the card.",
+                        "type": ["null", "string"]
+                      },
+                      "funding": {
+                        "description": "The funding source of the card.",
+                        "type": ["null", "string"]
+                      },
+                      "generated_from": {
+                        "description": "Indicates the origin of the card generation.",
+                        "additionalProperties": true,
+                        "type": ["null", "object"]
+                      },
+                      "last4": {
+                        "description": "The last 4 digits of the card number.",
+                        "type": ["null", "string"]
+                      },
+                      "networks": {
+                        "description": "Details about card networks.",
+                        "additionalProperties": true,
+                        "type": ["null", "object"],
+                        "properties": {
+                          "available": {
+                            "description": "Available card networks.",
+                            "type": ["null", "array"],
+                            "items": {
+                              "description": "Available card network item.",
+                              "type": ["null", "string"]
+                            }
+                          },
+                          "preferred": {
+                            "description": "Preferred card network.",
+                            "type": ["null", "string"]
+                          }
+                        }
+                      },
+                      "three_d_secure_usage": {
+                        "description": "Details about 3D Secure usage.",
+                        "additionalProperties": true,
+                        "type": ["null", "object"],
+                        "properties": {
+                          "supported": {
+                            "description": "Indicates if 3D Secure is supported.",
+                            "type": ["null", "boolean"]
+                          }
+                        }
+                      },
+                      "wallet": {
+                        "description": "The wallet associated with the card.",
+                        "additionalProperties": true,
+                        "type": ["null", "object"]
+                      }
+                    }
+                  },
+                  "card_present": {
+                    "description": "Details specific to a card-present payment method.",
+                    "additionalProperties": true,
+                    "type": ["null", "object"]
+                  },
+                  "created": {
+                    "description": "The timestamp when the payment method was created.",
+                    "type": ["null", "integer"]
+                  },
+                  "updated": {
+                    "description": "The timestamp when the payment method was last updated.",
+                    "type": ["null", "integer"]
+                  },
+                  "customer": {
+                    "description": "The customer associated with the payment method.",
+                    "type": ["null", "string"]
+                  },
+                  "eps": {
+                    "description": "Details specific to an EPS payment method.",
+                    "additionalProperties": true,
+                    "type": ["null", "object"],
+                    "properties": {
+                      "bank": {
+                        "description": "The bank associated with the EPS payment method.",
+                        "type": ["null", "string"]
+                      }
+                    }
+                  },
+                  "fpx": {
+                    "description": "Details specific to an FPX payment method.",
+                    "additionalProperties": true,
+                    "type": ["null", "object"],
+                    "properties": {
+                      "bank": {
+                        "description": "The bank associated with the FPX payment method.",
+                        "type": ["null", "string"]
+                      }
+                    }
+                  },
+                  "giropay": {
+                    "description": "Details specific to a Giropay payment method.",
+                    "additionalProperties": true,
+                    "type": ["null", "object"]
+                  },
+                  "grabpay": {
+                    "description": "Details specific to a Grabpay payment method.",
+                    "additionalProperties": true,
+                    "type": ["null", "object"]
+                  },
+                  "id": {
+                    "description": "The unique identifier for the payment method.",
+                    "type": ["null", "string"]
+                  },
+                  "ideal": {
+                    "description": "Details specific to an iDEAL payment method.",
+                    "additionalProperties": true,
+                    "type": ["null", "object"],
+                    "properties": {
+                      "bank": {
+                        "description": "The bank associated with the iDEAL payment method.",
+                        "type": ["null", "string"]
+                      },
+                      "bic": {
+                        "description": "The BIC of the iDEAL payment method.",
+                        "type": ["null", "string"]
+                      }
+                    }
+                  },
+                  "interac_present": {
+                    "description": "Details specific to an Interac Present payment method.",
+                    "additionalProperties": true,
+                    "type": ["null", "object"]
+                  },
+                  "livemode": {
+                    "description": "Indicates if the payment method is in live mode.",
+                    "type": ["null", "boolean"]
+                  },
+                  "metadata": {
+                    "description": "Metadata associated with the payment method.",
+                    "additionalProperties": true,
+                    "type": ["null", "object"]
+                  },
+                  "object": {
+                    "description": "The object type, typically 'payment_method'.",
+                    "type": ["null", "string"]
+                  },
+                  "oxxo": {
+                    "description": "Details specific to an OXXO payment method.",
+                    "additionalProperties": true,
+                    "type": ["null", "object"]
+                  },
+                  "p24": {
+                    "description": "Details specific to a P24 payment method.",
+                    "type": ["null", "object"],
+                    "additionalProperties": true,
+                    "properties": {
+                      "bank": {
+                        "description": "The bank associated with the P24 payment method.",
+                        "type": ["null", "string"]
+                      }
+                    }
+                  },
+                  "sepa_debit": {
+                    "description": "Details specific to a SEPA debit payment method.",
+                    "type": ["null", "object"],
+                    "additionalProperties": true,
+                    "properties": {
+                      "bank_code": {
+                        "description": "The bank code associated with the SEPA debit payment method.",
+                        "type": ["null", "string"]
+                      },
+                      "branch_code": {
+                        "description": "The branch code associated with the SEPA debit payment method.",
+                        "type": ["null", "string"]
+                      },
+                      "country": {
+                        "description": "The country associated with the SEPA debit payment method.",
+                        "type": ["null", "string"]
+                      },
+                      "fingerprint": {
+                        "description": "The fingerprint of the SEPA debit payment method.",
+                        "type": ["null", "string"]
+                      },
+                      "generated_from": {
+                        "description": "Indicates the origin of the SEPA debit generation.",
+                        "type": ["null", "object"],
+                        "properties": {
+                          "charge": {
+                            "description": "The charge associated with the SEPA debit generation.",
+                            "type": ["null", "string"]
+                          },
+                          "setup_attempt": {
+                            "description": "The setup attempt associated with the SEPA debit generation.",
+                            "type": ["null", "string"]
+                          }
+                        }
+                      },
+                      "last4": {
+                        "description": "The last 4 digits of the account number.",
+                        "type": ["null", "string"]
+                      }
+                    }
+                  },
+                  "sofort": {
+                    "description": "Details specific to a Sofort payment method.",
+                    "type": ["null", "object"],
+                    "additionalProperties": true,
+                    "properties": {
+                      "country": {
+                        "description": "The country associated with the Sofort payment method.",
+                        "type": ["null", "string"]
+                      }
+                    }
+                  },
+                  "type": {
+                    "description": "The type of payment method.",
+                    "type": ["null", "string"]
+                  }
+                }
+              },
+              "payment_method_type": {
+                "description": "The type of payment method.",
+                "type": ["null", "string"]
+              },
+              "setup_intent": {
+                "type": ["null", "object"],
+                "properties": {
+                  "id": { "type": ["string"] },
+                  "object": { "type": ["string"], "enum": ["setup_intent"] },
+                  "application": { "type": ["null", "string"] },
+                  "cancellation_reason": { "type": ["null", "string"] },
+                  "created": { "type": ["integer"] },
+                  "updated": { "type": ["null", "integer"] },
+                  "customer": { "type": ["null", "string"] },
+                  "description": { "type": ["null", "string"] },
+                  "flow_directions": {
+                    "type": ["null", "array"],
+                    "items": { "type": ["null", "string"] }
+                  },
+                  "last_setup_error": { "type": ["null", "string"] },
+                  "latest_attempt": { "type": ["null", "string"] },
+                  "livemode": { "type": ["null", "boolean"] },
+                  "mandate": { "type": ["null", "string"] },
+                  "metadata": { "type": ["null", "object"] },
+                  "next_action": { "type": ["null", "string"] },
+                  "on_behalf_of": { "type": ["null", "string"] },
+                  "payment_method": { "type": ["null", "string"] },
+                  "payment_method_options": {
+                    "type": ["null", "object"],
+                    "additionalProperties": true
+                  },
+                  "payment_method_types": {
+                    "type": ["null", "array"],
+                    "items": { "type": ["null", "string"] }
+                  },
+                  "single_use_mandate": { "type": ["null", "string"] },
+                  "status": { "type": ["string"] },
+                  "usage": {
+                    "type": ["string"],
+                    "enum": ["on_session", "off_session"]
+                  },
+                  "client_secret": { "type": ["null", "string"] },
+                  "automatic_payment_methods": {
+                    "type": ["null", "object"],
+                    "properties": {
+                      "allow_redirects": { "type": ["null", "string"] },
+                      "enabled": { "type": ["null", "boolean"] }
+                    }
+                  },
+                  "payment_method_configuration_details": {
+                    "type": ["null", "object"],
+                    "properties": {
+                      "id": { "type": ["null", "string"] },
+                      "parent": { "type": ["null", "string"] }
+                    }
+                  }
+                }
+              },
+              "source": {
+                "description": "The source of the error.",
+                "type": ["null", "object"],
+                "properties": {}
+              },
+              "type": {
+                "description": "The type of error.",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "setup_intent": {
+            "description": "The setup intent associated with the setup attempt.",
+            "type": ["null", "string"]
+          },
+          "status": {
+            "description": "The status of the setup attempt.",
+            "type": ["null", "string"]
+          },
+          "usage": {
+            "description": "The usage of the setup attempt.",
+            "type": ["null", "string"]
+          },
+          "flow_directions": {
+            "description": "The flow directions for the setup attempt.",
+            "type": ["null", "array"],
+            "items": {
+              "description": "Flow direction item.",
+              "type": ["null", "string"]
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["created"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "accounts",
+      "json_schema": {
+        "$schema": "https://json-schema.org/draft-07/schema#",
+        "additionalProperties": true,
+        "type": "object",
+        "properties": {
+          "business_profile": {
+            "description": "Business profile information for the account",
+            "type": ["null", "object"],
+            "properties": {
+              "annual_revenue": {
+                "description": "Annual revenue of the business",
+                "type": ["null", "object"],
+                "additionalProperties": true,
+                "properties": {
+                  "amount": {
+                    "description": "The annual revenue amount.",
+                    "type": ["null", "integer"]
+                  },
+                  "currency": {
+                    "description": "The currency in which the annual revenue is denominated.",
+                    "type": ["null", "string"]
+                  },
+                  "fiscal_year_end": {
+                    "description": "The fiscal year end date for the annual revenue.",
+                    "type": ["null", "string"]
+                  }
+                }
+              },
+              "estimated_worker_count": {
+                "description": "The estimated number of workers in the business.",
+                "type": ["null", "integer"]
+              },
+              "mcc": {
+                "description": "Merchant Category Code representing the type of business.",
+                "type": ["null", "string"]
+              },
+              "name": {
+                "description": "The name of the business.",
+                "type": ["null", "string"]
+              },
+              "product_description": {
+                "description": "Description of the products/services offered by the business.",
+                "type": ["null", "string"]
+              },
+              "support_address": {
+                "type": ["null", "object"],
+                "properties": {
+                  "city": { "type": ["null", "string"] },
+                  "country": { "type": ["null", "string"] },
+                  "line1": { "type": ["null", "string"] },
+                  "line2": { "type": ["null", "string"] },
+                  "postal_code": { "type": ["null", "string"] },
+                  "state": { "type": ["null", "string"] }
+                }
+              },
+              "support_email": {
+                "description": "Support email for the business.",
+                "type": ["null", "string"]
+              },
+              "support_phone": {
+                "description": "Support phone number for the business.",
+                "type": ["null", "string"]
+              },
+              "support_url": {
+                "description": "Support URL for the business.",
+                "type": ["null", "string"]
+              },
+              "url": {
+                "description": "URL of the business.",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "business_type": {
+            "description": "The type of business the account belongs to.",
+            "type": ["null", "string"]
+          },
+          "capabilities": {
+            "description": "Capabilities of the account",
+            "type": ["null", "object"],
+            "additionalProperties": true,
+            "properties": {
+              "afterpay_clearpay_payments": {
+                "description": "Capability for Afterpay Clearpay payments.",
+                "type": ["null", "string"]
+              },
+              "au_becs_debit_payments": {
+                "description": "Capability for AU BECS debit payments.",
+                "type": ["null", "string"]
+              },
+              "bacs_debit_payments": {
+                "description": "Capability for BACS debit payments.",
+                "type": ["null", "string"]
+              },
+              "bancontact_payments": {
+                "description": "Capability for Bancontact payments.",
+                "type": ["null", "string"]
+              },
+              "card_issuing": {
+                "description": "Capability for card issuing.",
+                "type": ["null", "string"]
+              },
+              "card_payments": {
+                "description": "Capability for card payments.",
+                "type": ["null", "string"]
+              },
+              "cartes_bancaires_payments": {
+                "description": "Capability for Cartes Bancaires payments.",
+                "type": ["null", "string"]
+              },
+              "eps_payments": {
+                "description": "Capability for EPS payments.",
+                "type": ["null", "string"]
+              },
+              "fpx_payments": {
+                "description": "Capability for FPX payments.",
+                "type": ["null", "string"]
+              },
+              "giropay_payments": {
+                "description": "Capability for Giropay payments.",
+                "type": ["null", "string"]
+              },
+              "grabpay_payments": {
+                "description": "Capability for Grabpay payments.",
+                "type": ["null", "string"]
+              },
+              "ideal_payments": {
+                "description": "Capability for iDEAL payments.",
+                "type": ["null", "string"]
+              },
+              "jcb_payments": {
+                "description": "Capability for JCB payments.",
+                "type": ["null", "string"]
+              },
+              "legacy_payments": {
+                "description": "Capability for legacy payments.",
+                "type": ["null", "string"]
+              },
+              "oxxo_payments": {
+                "description": "Capability for OXXO payments.",
+                "type": ["null", "string"]
+              },
+              "p24_payments": {
+                "description": "Capability for P24 payments.",
+                "type": ["null", "string"]
+              },
+              "sepa_debit_payments": {
+                "description": "Capability for SEPA debit payments.",
+                "type": ["null", "string"]
+              },
+              "sofort_payments": {
+                "description": "Capability for SOFORT payments.",
+                "type": ["null", "string"]
+              },
+              "tax_reporting_us_1099_k": {
+                "description": "Capability for tax reporting US 1099-K.",
+                "type": ["null", "string"]
+              },
+              "tax_reporting_us_1099_misc": {
+                "description": "Capability for tax reporting US 1099-MISC.",
+                "type": ["null", "string"]
+              },
+              "transfers": {
+                "description": "Capability for transfers.",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "charges_enabled": {
+            "description": "Indicates if charges can be made on this account.",
+            "type": ["null", "boolean"]
+          },
+          "company": {
+            "description": "Company information associated with the account",
+            "type": ["null", "object"],
+            "additionalProperties": true,
+            "properties": {
+              "address": {
+                "type": ["null", "object"],
+                "properties": {
+                  "city": { "type": ["null", "string"] },
+                  "country": { "type": ["null", "string"] },
+                  "line1": { "type": ["null", "string"] },
+                  "line2": { "type": ["null", "string"] },
+                  "postal_code": { "type": ["null", "string"] },
+                  "state": { "type": ["null", "string"] }
+                }
+              },
+              "address_kana": {
+                "description": "Japanese Kana address information of the company.",
+                "type": ["null", "object"],
+                "additionalProperties": true,
+                "properties": {
+                  "city": { "type": ["null", "string"] },
+                  "country": { "type": ["null", "string"] },
+                  "line1": { "type": ["null", "string"] },
+                  "line2": { "type": ["null", "string"] },
+                  "postal_code": { "type": ["null", "string"] },
+                  "state": { "type": ["null", "string"] },
+                  "town": { "type": ["null", "string"] }
+                }
+              },
+              "address_kanji": {
+                "description": "Japanese Kanji address information of the company.",
+                "type": ["null", "object"],
+                "additionalProperties": true,
+                "properties": {
+                  "city": { "type": ["null", "string"] },
+                  "country": { "type": ["null", "string"] },
+                  "line1": { "type": ["null", "string"] },
+                  "line2": { "type": ["null", "string"] },
+                  "postal_code": { "type": ["null", "string"] },
+                  "state": { "type": ["null", "string"] },
+                  "town": { "type": ["null", "string"] }
+                }
+              },
+              "directors_provided": {
+                "description": "Flag indicating whether director information is provided.",
+                "type": ["null", "boolean"]
+              },
+              "executives_provided": {
+                "description": "Flag indicating whether executive information is provided.",
+                "type": ["null", "boolean"]
+              },
+              "export_license_id": {
+                "description": "Export license ID of the company.",
+                "type": ["null", "string"]
+              },
+              "export_purpose_code": {
+                "description": "Export purpose code of the company.",
+                "type": ["null", "string"]
+              },
+              "name": {
+                "description": "The name of the company.",
+                "type": ["null", "string"]
+              },
+              "name_kana": {
+                "description": "Japanese Kana name of the company.",
+                "type": ["null", "string"]
+              },
+              "name_kanji": {
+                "description": "Japanese Kanji name of the company.",
+                "type": ["null", "string"]
+              },
+              "owners_provided": {
+                "description": "Flag indicating whether owner information is provided.",
+                "type": ["null", "boolean"]
+              },
+              "ownership_declaration": {
+                "description": "Information related to ownership declaration.",
+                "type": ["null", "object"],
+                "additionalProperties": true,
+                "properties": {
+                  "date": {
+                    "description": "Date of ownership declaration.",
+                    "type": ["null", "string"]
+                  },
+                  "ip": {
+                    "description": "IP address of the owner declaring ownership.",
+                    "type": ["null", "string"]
+                  },
+                  "user_agent": {
+                    "description": "User agent information of the owner declaring ownership.",
+                    "type": ["null", "string"]
+                  }
+                }
+              },
+              "phone": {
+                "description": "The phone number of the company.",
+                "type": ["null", "string"]
+              },
+              "structure": {
+                "description": "Legal structure of the company.",
+                "type": ["null", "string"]
+              },
+              "tax_id_provided": {
+                "description": "Flag indicating whether tax ID is provided.",
+                "type": ["null", "boolean"]
+              },
+              "tax_id_registrar": {
+                "description": "Registrar of the tax ID provided.",
+                "type": ["null", "string"]
+              },
+              "vat_id_provided": {
+                "description": "Flag indicating whether VAT ID is provided.",
+                "type": ["null", "boolean"]
+              },
+              "verification": {
+                "description": "Verification status and details.",
+                "type": ["null", "object"],
+                "additionalProperties": true,
+                "properties": {
+                  "document": {
+                    "description": "Verification document details.",
+                    "type": ["null", "object"],
+                    "additionalProperties": true,
+                    "properties": {
+                      "back": { "type": ["null", "string"] },
+                      "details": { "type": ["null", "string"] },
+                      "details_code": { "type": ["null", "string"] }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "country": {
+            "description": "The country of the account.",
+            "type": ["null", "string"]
+          },
+          "created": {
+            "description": "The timestamp when the account was created.",
+            "type": ["null", "integer"]
+          },
+          "default_currency": {
+            "description": "The default currency used for transactions.",
+            "type": ["null", "string"]
+          },
+          "details_submitted": {
+            "description": "Specifies if details have been submitted for the account.",
+            "type": ["null", "boolean"]
+          },
+          "email": {
+            "description": "The email associated with the account.",
+            "type": ["null", "string"]
+          },
+          "external_accounts": {
+            "description": "External accounts information of the entity.",
+            "type": ["null", "object"],
+            "additionalProperties": true,
+            "properties": {
+              "data": { "type": ["null", "array"] },
+              "has_more": { "type": ["null", "boolean"] },
+              "object": { "enum": ["list"], "type": ["null", "string"] },
+              "url": { "type": ["null", "string"] }
+            }
+          },
+          "id": {
+            "description": "The unique identifier of the account.",
+            "type": ["null", "string"]
+          },
+          "individual": {
+            "description": "Information about an individual associated with the entity.",
+            "type": ["null", "object"],
+            "additionalProperties": true,
+            "properties": {
+              "id": {
+                "description": "Unique identifier of the individual.",
+                "type": ["null", "string"]
+              },
+              "object": {
+                "description": "Object type representing the individual.",
+                "type": ["null", "string"],
+                "enum": ["person"]
+              },
+              "account": {
+                "description": "Associated account information of the individual.",
+                "type": ["null", "string"]
+              },
+              "address": {
+                "type": ["null", "object"],
+                "properties": {
+                  "city": { "type": ["null", "string"] },
+                  "country": { "type": ["null", "string"] },
+                  "line1": { "type": ["null", "string"] },
+                  "line2": { "type": ["null", "string"] },
+                  "postal_code": { "type": ["null", "string"] },
+                  "state": { "type": ["null", "string"] }
+                }
+              },
+              "address_kana": {
+                "description": "Japanese Kana address information of the individual.",
+                "type": ["null", "object"],
+                "additionalProperties": true,
+                "properties": {
+                  "city": { "type": ["null", "string"] },
+                  "country": { "type": ["null", "string"] },
+                  "line1": { "type": ["null", "string"] },
+                  "line2": { "type": ["null", "string"] },
+                  "postal_code": { "type": ["null", "string"] },
+                  "state": { "type": ["null", "string"] },
+                  "town": { "type": ["null", "string"] }
+                }
+              },
+              "address_kanji": {
+                "description": "Japanese Kanji address information of the individual.",
+                "type": ["null", "object"],
+                "additionalProperties": true,
+                "properties": {
+                  "city": { "type": ["null", "string"] },
+                  "country": { "type": ["null", "string"] },
+                  "line1": { "type": ["null", "string"] },
+                  "line2": { "type": ["null", "string"] },
+                  "postal_code": { "type": ["null", "string"] },
+                  "state": { "type": ["null", "string"] },
+                  "town": { "type": ["null", "string"] }
+                }
+              },
+              "created": {
+                "description": "Creation date of the individual profile.",
+                "type": ["null", "string"]
+              },
+              "dob": {
+                "description": "Date of birth of the individual.",
+                "type": ["null", "object"],
+                "additionalProperties": true,
+                "properties": {
+                  "day": { "type": ["null", "number"] },
+                  "month": { "type": ["null", "number"] },
+                  "year": { "type": ["null", "number"] }
+                }
+              },
+              "email": {
+                "description": "Email address of the individual.",
+                "type": ["null", "string"]
+              },
+              "first_name": {
+                "description": "First name of the individual.",
+                "type": ["null", "string"]
+              },
+              "first_name_kane": {
+                "description": "Phonetic Kana first name of the individual.",
+                "type": ["null", "string"]
+              },
+              "first_name_kanji": {
+                "description": "Phonetic Kanji first name of the individual.",
+                "type": ["null", "string"]
+              },
+              "full_name_aliases": {
+                "description": "Aliases of the full name of the individual.",
+                "type": ["null", "array"],
+                "items": { "type": ["null", "string"] }
+              },
+              "full_requirements": {
+                "description": "Full requirements status and details for the individual.",
+                "type": ["null", "object"],
+                "additionalProperties": true,
+                "properties": {
+                  "alternatives": {
+                    "description": "Alternative fields due for full requirements.",
+                    "type": ["null", "object"],
+                    "additionalProperties": true,
+                    "properties": {
+                      "alternative_fields_due": {
+                        "description": "Fields alternative to those currently due.",
+                        "type": ["null", "array"],
+                        "items": { "type": ["null", "string"] }
+                      },
+                      "original_fields_due": {
+                        "description": "Original fields initially due.",
+                        "type": ["null", "array"],
+                        "items": { "type": ["null", "string"] }
+                      }
+                    }
+                  },
+                  "currently_due": {
+                    "description": "Fields currently due for full requirements.",
+                    "type": ["null", "string"]
+                  },
+                  "errors": {
+                    "description": "Errors related to full requirements.",
+                    "type": ["null", "array"],
+                    "items": {
+                      "type": ["null", "object"],
+                      "additionalProperties": true,
+                      "properties": {
+                        "code": { "type": ["null", "string"] },
+                        "reason": { "type": ["null", "string"] },
+                        "requirement": { "type": ["null", "string"] }
+                      }
+                    }
+                  },
+                  "eventually_due": {
+                    "description": "Fields eventually due for full requirements.",
+                    "type": ["null", "array"],
+                    "items": { "type": ["null", "string"] }
+                  },
+                  "past_due": {
+                    "description": "Fields past due for full requirements.",
+                    "type": ["null", "array"],
+                    "items": { "type": ["null", "string"] }
+                  },
+                  "pending_verification": {
+                    "description": "Fields pending verification for full requirements.",
+                    "type": ["null", "array"],
+                    "items": { "type": ["null", "string"] }
+                  }
+                }
+              },
+              "gender": {
+                "description": "Gender of the individual.",
+                "type": ["null", "string"]
+              },
+              "id_number_provided": {
+                "description": "Flag indicating whether ID number is provided.",
+                "type": ["null", "boolean"]
+              },
+              "id_number_secondary_provided": {
+                "description": "Flag indicating whether secondary ID number is provided.",
+                "type": ["null", "boolean"]
+              },
+              "last_name": {
+                "description": "Last name of the individual.",
+                "type": ["null", "string"]
+              },
+              "last_name_kana": {
+                "description": "Phonetic Kana last name of the individual.",
+                "type": ["null", "string"]
+              },
+              "last_name_kanji": {
+                "description": "Phonetic Kanji last name of the individual.",
+                "type": ["null", "string"]
+              },
+              "maiden_name": {
+                "description": "Maiden name of the individual.",
+                "type": ["null", "string"]
+              },
+              "metadata": {
+                "description": "Additional metadata about the individual.",
+                "type": ["null", "object"],
+                "additionalProperties": true
+              },
+              "nationality": {
+                "description": "Nationality of the individual.",
+                "type": ["null", "string"]
+              },
+              "phone": {
+                "description": "Phone number of the individual.",
+                "type": ["null", "string"]
+              },
+              "political_exposure": {
+                "description": "Political exposure status of the individual.",
+                "type": ["null", "string"]
+              },
+              "registered_address": {
+                "type": ["null", "object"],
+                "properties": {
+                  "city": { "type": ["null", "string"] },
+                  "country": { "type": ["null", "string"] },
+                  "line1": { "type": ["null", "string"] },
+                  "line2": { "type": ["null", "string"] },
+                  "postal_code": { "type": ["null", "string"] },
+                  "state": { "type": ["null", "string"] }
+                }
+              },
+              "relationship": {
+                "description": "Relationship information of the individual with the entity.",
+                "type": ["null", "object"],
+                "additionalProperties": true,
+                "properties": {
+                  "director": {
+                    "description": "Indicator if the individual is a director.",
+                    "type": ["null", "boolean"]
+                  },
+                  "executive": {
+                    "description": "Indicator if the individual is an executive.",
+                    "type": ["null", "boolean"]
+                  },
+                  "owner": {
+                    "description": "Indicator if the individual is an owner.",
+                    "type": ["null", "boolean"]
+                  },
+                  "percent_ownership": {
+                    "description": "Percentage ownership of the individual.",
+                    "type": ["null", "number"]
+                  },
+                  "representative": {
+                    "description": "Indicator if the individual is a representative.",
+                    "type": ["null", "boolean"]
+                  },
+                  "title": {
+                    "description": "Title/Role of the individual.",
+                    "type": ["null", "string"]
+                  }
+                }
+              },
+              "requirements": {
+                "description": "Requirements status and details for the individual.",
+                "type": ["null", "object"],
+                "additionalProperties": true,
+                "properties": {
+                  "alternatives": {
+                    "description": "Alternative fields due for individual requirements.",
+                    "type": ["null", "object"],
+                    "additionalProperties": true,
+                    "properties": {
+                      "alternative_fields_due": {
+                        "description": "Fields alternative to those currently due.",
+                        "type": ["null", "array"],
+                        "items": { "type": ["null", "string"] }
+                      },
+                      "original_fields_due": {
+                        "description": "Original fields initially due.",
+                        "type": ["null", "array"],
+                        "items": { "type": ["null", "string"] }
+                      }
+                    }
+                  },
+                  "currently_due": {
+                    "description": "Fields currently due for individual requirements.",
+                    "type": ["null", "array"],
+                    "items": { "type": ["null", "string"] }
+                  },
+                  "errors": {
+                    "description": "Errors related to individual requirements.",
+                    "type": ["null", "array"],
+                    "items": {
+                      "type": ["null", "object"],
+                      "additionalProperties": true,
+                      "properties": {
+                        "code": { "type": ["null", "string"] },
+                        "reason": { "type": ["null", "string"] },
+                        "requirement": { "type": ["null", "string"] }
+                      }
+                    }
+                  },
+                  "eventually_due": {
+                    "description": "Fields eventually due for individual requirements.",
+                    "type": ["null", "array"],
+                    "items": { "type": ["null", "string"] }
+                  },
+                  "past_due": {
+                    "description": "Fields past due for individual requirements.",
+                    "type": ["null", "array"],
+                    "items": { "type": ["null", "string"] }
+                  },
+                  "pending_verification": {
+                    "description": "Fields pending verification for individual requirements.",
+                    "type": ["null", "array"],
+                    "items": { "type": ["null", "string"] }
+                  }
+                }
+              },
+              "ssn_last_4_provided": {
+                "description": "Flag indicating whether the last 4 digits of SSN are provided.",
+                "type": ["null", "boolean"]
+              },
+              "verification": {
+                "description": "Verification status and details for the individual.",
+                "type": ["null", "object"],
+                "additionalProperties": true,
+                "properties": {
+                  "additional_document": {
+                    "description": "Additional document verification details.",
+                    "type": ["null", "object"],
+                    "additionalProperties": true,
+                    "properties": {
+                      "back": { "type": ["null", "string"] },
+                      "details": { "type": ["null", "string"] },
+                      "details_code": { "type": ["null", "string"] }
+                    }
+                  },
+                  "details": { "type": ["null", "string"] },
+                  "details_code": { "type": ["null", "string"] },
+                  "document": {
+                    "description": "Base document verification details.",
+                    "type": ["null", "object"],
+                    "additionalProperties": true,
+                    "properties": {
+                      "back": { "type": ["null", "string"] },
+                      "details": { "type": ["null", "string"] },
+                      "details_code": { "type": ["null", "string"] },
+                      "front": { "type": ["null", "string"] }
+                    }
+                  },
+                  "status": {
+                    "description": "Verification status of the individual.",
+                    "type": ["null", "string"]
+                  }
+                }
+              }
+            }
+          },
+          "metadata": {
+            "description": "Additional information associated with the account.",
+            "type": ["null", "object"],
+            "additionalProperties": true
+          },
+          "object": {
+            "description": "The object type representing the account.",
+            "enum": ["account"],
+            "type": ["null", "string"]
+          },
+          "payouts_enabled": {
+            "description": "Indicates if payouts are enabled for the account.",
+            "type": ["null", "boolean"]
+          },
+          "requirements": {
+            "description": "Requirements status and details for the entity.",
+            "type": ["null", "object"],
+            "additionalProperties": true,
+            "properties": {
+              "alternatives": {
+                "description": "Alternative fields due for entity requirements.",
+                "type": ["null", "array"],
+                "items": {
+                  "additionalProperties": true,
+                  "properties": {
+                    "alternative_fields_due": {
+                      "description": "Fields alternative to those currently due.",
+                      "type": ["null", "array"],
+                      "items": { "type": ["null", "string"] }
+                    },
+                    "original_fields_due": {
+                      "description": "Original fields initially due.",
+                      "type": ["null", "array"],
+                      "items": { "type": ["null", "string"] }
+                    }
+                  }
+                }
+              },
+              "currently_due": {
+                "description": "Fields currently due for entity requirements.",
+                "type": ["null", "array"],
+                "items": { "type": ["null", "string"] }
+              },
+              "disabled_reason": {
+                "description": "Reason for entity requirements being disabled.",
+                "type": ["null", "string"]
+              },
+              "errors": {
+                "description": "Errors related to entity requirements.",
+                "type": ["null", "array"],
+                "items": {
+                  "type": ["null", "object"],
+                  "additionalProperties": true,
+                  "properties": {
+                    "code": { "type": ["null", "string"] },
+                    "reason": { "type": ["null", "string"] },
+                    "requirement": { "type": ["null", "string"] }
+                  }
+                }
+              },
+              "eventually_due": {
+                "description": "Fields eventually due for entity requirements.",
+                "type": ["null", "array"],
+                "items": { "type": ["null", "string"] }
+              },
+              "past_due": {
+                "description": "Fields past due for entity requirements.",
+                "type": ["null", "array"],
+                "items": { "type": ["null", "string"] }
+              },
+              "pending_verification": {
+                "description": "Fields pending verification for entity requirements.",
+                "type": ["null", "array"],
+                "items": { "type": ["null", "string"] }
+              }
+            }
+          },
+          "settings": {
+            "description": "Settings specific to the account.",
+            "type": ["null", "object"],
+            "additionalProperties": true
+          },
+          "tos_acceptance": {
+            "description": "Details related to terms of service acceptance for the account.",
+            "type": ["null", "object"],
+            "additionalProperties": true,
+            "properties": {
+              "date": {
+                "description": "The date on which the terms of service were accepted.",
+                "type": ["null", "string"]
+              },
+              "ip": {
+                "description": "The IP address of the user who accepted the terms of service.",
+                "type": ["null", "string"]
+              },
+              "service_agreement": {
+                "description": "Specifies the agreement to the service terms.",
+                "type": ["null", "string"]
+              },
+              "user_agent": {
+                "description": "The user agent used when accepting the terms of service.",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "type": {
+            "description": "The type of account.",
+            "enum": ["custom", "express", "standard"],
+            "type": ["null", "string"]
+          },
+          "future_requirements": {
+            "description": "Details about future requirements for the entity.",
+            "type": ["null", "object"],
+            "properties": {
+              "alternatives": {
+                "description": "Alternative fields due for future requirements.",
+                "type": ["null", "array"],
+                "items": {
+                  "type": ["null", "object"],
+                  "properties": {
+                    "alternative_fields_due": {
+                      "description": "Fields alternative to those currently due.",
+                      "type": ["null", "array"],
+                      "items": { "type": ["null", "string"] }
+                    },
+                    "original_fields_due": {
+                      "description": "Original fields initially due.",
+                      "type": ["null", "array"],
+                      "items": { "type": ["null", "string"] }
+                    }
+                  }
+                }
+              },
+              "current_deadline": {
+                "description": "Deadline for current requirements.",
+                "type": ["null", "integer"]
+              },
+              "currently_due": {
+                "description": "Fields currently due for future requirements.",
+                "type": ["null", "array"],
+                "items": { "type": ["null", "string"] }
+              },
+              "disabled_reason": {
+                "description": "Reason for future requirements being disabled.",
+                "type": ["null", "string"]
+              },
+              "errors": {
+                "description": "Errors related to future requirements.",
+                "type": ["null", "array"],
+                "items": {
+                  "type": ["null", "object"],
+                  "properties": {
+                    "code": { "type": ["null", "string"] },
+                    "reason": { "type": ["null", "string"] },
+                    "requirement": { "type": ["null", "string"] }
+                  }
+                }
+              },
+              "eventually_due": {
+                "description": "Fields eventually due for future requirements.",
+                "type": ["null", "array"],
+                "items": { "type": ["null", "string"] }
+              },
+              "past_due": {
+                "description": "Fields past due for future requirements.",
+                "type": ["null", "array"],
+                "items": { "type": ["null", "string"] }
+              },
+              "pending_verification": {
+                "description": "Fields pending verification for future requirements.",
+                "type": ["null", "array"],
+                "items": { "type": ["null", "string"] }
+              }
+            }
+          },
+          "controller": {
+            "description": "Information about the controller.",
+            "type": ["null", "object"],
+            "properties": {
+              "is_controller": {
+                "description": "Flag indicating whether the entity is a controller.",
+                "type": ["null", "boolean"]
+              },
+              "type": {
+                "description": "Type of controller entity.",
+                "type": ["null", "string"]
+              }
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "shipping_rates",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "Shipping Rates Schema",
+        "additionalProperties": true,
+        "type": ["null", "object"],
+        "properties": {
+          "id": {
+            "description": "Unique identifier for the shipping rate",
+            "type": ["null", "string"]
+          },
+          "object": {
+            "description": "Type of object, in this case, it will always be 'shipping_rate'",
+            "type": ["null", "string"]
+          },
+          "active": {
+            "description": "Specifies if the shipping rate is currently active or not",
+            "type": ["null", "boolean"]
+          },
+          "created": {
+            "description": "Timestamp indicating when the shipping rate was created",
+            "type": ["null", "integer"]
+          },
+          "delivery_estimate": {
+            "description": "Estimated delivery time for the shipping rate",
+            "type": ["null", "string"]
+          },
+          "display_name": {
+            "description": "Name displayed for the shipping rate",
+            "type": ["null", "string"]
+          },
+          "fixed_amount": {
+            "description": "Details about the fixed shipping amount associated with a shipping rate.",
+            "type": ["null", "object"],
+            "properties": {
+              "amount": {
+                "description": "Fixed amount for the shipping rate",
+                "type": ["null", "integer"]
+              },
+              "currency": {
+                "description": "Currency of the fixed amount",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "livemode": {
+            "description": "Indicates if the shipping rate is in live mode",
+            "type": ["null", "boolean"]
+          },
+          "metadata": {
+            "description": "Any additional data related to the shipping rate that is not directly represented by other fields.",
+            "type": ["null", "object"],
+            "properties": {
+              "amount": {
+                "description": "Metadata amount associated with the shipping rate",
+                "type": ["null", "integer"]
+              },
+              "currency": {
+                "description": "Currency of the metadata amount",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "tax_behavior": {
+            "description": "Specifies tax behavior for the shipping rate",
+            "type": ["null", "string"]
+          },
+          "tax_code": {
+            "description": "Tax code related to the shipping rate",
+            "type": ["null", "string"]
+          },
+          "type": {
+            "description": "Type of shipping rate, e.g., international, domestic, etc.",
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["created"],
+      "source_defined_primary_key": [["id"]]
+    },
+    {
+      "name": "balance_transactions",
+      "json_schema": {
+        "type": ["null", "object"],
+        "properties": {
+          "fee": { "type": ["null", "integer"] },
+          "currency": { "type": ["null", "string"] },
+          "source": { "type": ["null", "string"] },
+          "fee_details": {
+            "type": ["null", "array"],
+            "items": {
+              "properties": {
+                "application": { "type": ["null", "string"] },
+                "type": { "type": ["null", "string"] },
+                "description": { "type": ["null", "string"] },
+                "amount": { "type": ["null", "integer"] },
+                "currency": { "type": ["null", "string"] }
+              },
+              "type": ["null", "object"]
+            }
+          },
+          "available_on": { "type": ["null", "integer"] },
+          "status": { "type": ["null", "string"] },
+          "description": { "type": ["null", "string"] },
+          "net": { "type": ["null", "integer"] },
+          "exchange_rate": { "type": ["null", "number"] },
+          "type": { "type": ["null", "string"] },
+          "sourced_transfers": { "items": {}, "type": ["null", "array"] },
+          "id": { "type": ["null", "string"] },
+          "object": { "type": ["null", "string"] },
+          "created": { "type": ["null", "integer"] },
+          "amount": { "type": ["null", "integer"] },
+          "reporting_category": { "type": ["null", "string"] }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["created"],
+      "source_defined_primary_key": [["id"]]
+    },
+    {
+      "name": "files",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": true,
+        "type": "object",
+        "properties": {
+          "id": {
+            "description": "Unique identifier for the file",
+            "type": ["null", "string"]
+          },
+          "purpose": {
+            "description": "Purpose of the file",
+            "type": ["null", "string"]
+          },
+          "type": {
+            "description": "Type of the file",
+            "type": ["null", "string"]
+          },
+          "object": {
+            "description": "Type of object represented by the file",
+            "type": ["null", "string"]
+          },
+          "created": {
+            "description": "Timestamp indicating when the file was created",
+            "type": ["null", "integer"]
+          },
+          "expires_at": {
+            "description": "Timestamp indicating when the file will expire",
+            "type": ["null", "integer"]
+          },
+          "filename": {
+            "description": "Name of the file",
+            "type": ["null", "string"]
+          },
+          "links": {
+            "description": "Object containing links data",
+            "type": ["null", "object"],
+            "properties": {
+              "object": {
+                "description": "Type of object containing the linked data entries",
+                "type": ["null", "string"]
+              },
+              "data": {
+                "description": "Array containing file data",
+                "type": ["null", "array"],
+                "items": {
+                  "description": "Properties of the file object",
+                  "type": ["null", "object"],
+                  "properties": {
+                    "id": {
+                      "description": "Unique identifier for the linked data entry",
+                      "type": ["null", "string"]
+                    },
+                    "object": {
+                      "description": "Type of object linked to the file",
+                      "type": ["null", "string"]
+                    },
+                    "created": {
+                      "description": "Timestamp indicating when the linked data entry was created",
+                      "type": ["null", "integer"]
+                    },
+                    "expired": {
+                      "description": "Boolean indicating whether the linked data entry is expired",
+                      "type": ["null", "integer"]
+                    },
+                    "expires_at": {
+                      "description": "Timestamp indicating when the linked data entry will expire",
+                      "type": ["null", "integer"]
+                    },
+                    "file": {
+                      "description": "Related file identifier",
+                      "type": ["null", "string"]
+                    },
+                    "livemode": {
+                      "description": "Boolean indicating if the linked data entry is in live mode",
+                      "type": ["null", "boolean"]
+                    },
+                    "metadata": {
+                      "description": "Additional information associated with the linked data entry",
+                      "type": ["null", "object"]
+                    },
+                    "url": {
+                      "description": "URL to access the linked data entry",
+                      "type": ["null", "string"]
+                    }
+                  }
+                }
+              },
+              "has_more": {
+                "description": "Boolean indicating whether there are more linked data entries",
+                "type": ["null", "boolean"]
+              },
+              "url": {
+                "description": "URL to access the linked data entries",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "size": {
+            "description": "Size of the file in bytes",
+            "type": ["null", "integer"]
+          },
+          "title": {
+            "description": "Title of the file",
+            "type": ["null", "string"]
+          },
+          "url": {
+            "description": "URL to access the file",
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["created"],
+      "source_defined_primary_key": [["id"]]
+    },
+    {
+      "name": "file_links",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": true,
+        "type": "object",
+        "properties": {
+          "id": {
+            "description": "Unique identifier for the file link.",
+            "type": ["null", "string"]
+          },
+          "expires_at": {
+            "description": "Timestamp indicating the date and time when the file link will expire.",
+            "type": ["null", "integer"]
+          },
+          "file": {
+            "description": "Information about the file linked.",
+            "type": ["null", "string"]
+          },
+          "metadata": {
+            "description": "Key-value pairs associated with the file link for storing additional information.",
+            "type": ["null", "object"]
+          },
+          "url": {
+            "description": "The URL that can be used to access/download the file linked.",
+            "type": ["null", "string"]
+          },
+          "object": {
+            "description": "Indicates the object type, which should be 'file_link'.",
+            "type": ["null", "string"]
+          },
+          "created": {
+            "description": "Timestamp representing the date and time when the file link was created.",
+            "type": ["null", "integer"]
+          },
+          "expired": {
+            "description": "Boolean indicating whether the file link is expired or not.",
+            "type": ["null", "boolean"]
+          },
+          "livemode": {
+            "description": "Boolean indicating whether the file link is in live mode or test mode.",
+            "type": ["null", "boolean"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["created"],
+      "source_defined_primary_key": [["id"]]
+    },
+    {
+      "name": "refunds",
+      "json_schema": {
+        "type": ["null", "object"],
+        "properties": {
+          "id": {
+            "description": "Unique identifier for the refund.",
+            "type": ["null", "string"]
+          },
+          "object": {
+            "description": "Indicates the type of object, which should be 'refund'.",
+            "type": ["null", "string"]
+          },
+          "amount": {
+            "description": "The amount refunded in the smallest currency unit (e.g. cents).",
+            "type": ["null", "integer"]
+          },
+          "balance_transaction": {
+            "description": "ID of the balance transaction that describes the impact on your account balance.",
+            "type": ["null", "string"]
+          },
+          "charge": {
+            "description": "ID of the charge that was refunded.",
+            "type": ["null", "string"]
+          },
+          "created": {
+            "description": "Timestamp representing when the refund was created.",
+            "type": ["null", "integer"]
+          },
+          "updated": {
+            "description": "Timestamp representing when the refund was last updated.",
+            "type": ["null", "integer"]
+          },
+          "currency": {
+            "description": "The currency of the refund.",
+            "type": ["null", "string"]
+          },
+          "metadata": {
+            "description": "Any additional data or information associated with the refund.",
+            "type": ["null", "object"],
+            "properties": {}
+          },
+          "payment_intent": {
+            "description": "ID of the payment intent associated with the refund.",
+            "type": ["null", "string"]
+          },
+          "reason": {
+            "description": "The reason for the refund (e.g. duplicate, fraudulent).",
+            "type": ["null", "string"]
+          },
+          "receipt_number": {
+            "description": "Unique identifier for the refund receipt.",
+            "type": ["null", "string"]
+          },
+          "source_transfer_reversal": {
+            "description": "Details of any transfer reversal associated with the refund source.",
+            "type": ["null", "string"]
+          },
+          "status": {
+            "description": "The status of the refund (e.g. succeeded, pending).",
+            "type": ["null", "string"]
+          },
+          "transfer_reversal": {
+            "description": "Details of any transfer reversal associated with the refund.",
+            "type": ["null", "string"]
+          },
+          "destination_details": {
+            "description": "Details about the destination of the refunded amount.",
+            "type": ["null", "object"],
+            "properties": {
+              "type": {
+                "description": "The type of destination.",
+                "type": ["null", "string"]
+              },
+              "card": {
+                "description": "Information related to the card used for the refund.",
+                "type": ["null", "object"],
+                "properties": {
+                  "reference": {
+                    "description": "ID of the payment method used for the refund.",
+                    "type": ["null", "string"]
+                  },
+                  "reference_status": {
+                    "description": "The status of the payment method reference.",
+                    "type": ["null", "string"]
+                  },
+                  "reference_type": {
+                    "description": "The type of payment method reference (e.g. card).",
+                    "type": ["null", "string"]
+                  },
+                  "type": {
+                    "description": "Type of payment method (e.g. card).",
+                    "type": ["null", "string"]
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "payment_methods",
+      "json_schema": {
+        "type": ["object", "null"],
+        "properties": {
+          "afterpay_clearpay": {
+            "additionalProperties": true,
+            "type": ["null", "object"]
+          },
+          "alipay": {
+            "additionalProperties": true,
+            "type": ["null", "object"]
+          },
+          "au_becs_debit": {
+            "additionalProperties": true,
+            "type": ["null", "object"],
+            "properties": {
+              "bsb_number": { "type": ["null", "string"] },
+              "fingerprint": { "type": ["null", "string"] },
+              "last4": { "type": ["null", "string"] }
+            }
+          },
+          "bacs_debit": {
+            "additionalProperties": true,
+            "type": ["null", "object"],
+            "properties": {
+              "fingerprint": { "type": ["null", "string"] },
+              "last4": { "type": ["null", "string"] },
+              "sort_code": { "type": ["null", "string"] }
+            }
+          },
+          "bancontact": {
+            "additionalProperties": true,
+            "type": ["null", "object"]
+          },
+          "billing_details": {
+            "additionalProperties": true,
+            "type": ["null", "object"],
+            "properties": {
+              "address": {
+                "type": ["null", "object"],
+                "properties": {
+                  "city": { "type": ["null", "string"] },
+                  "country": { "type": ["null", "string"] },
+                  "line1": { "type": ["null", "string"] },
+                  "line2": { "type": ["null", "string"] },
+                  "postal_code": { "type": ["null", "string"] },
+                  "state": { "type": ["null", "string"] }
+                }
+              },
+              "email": { "type": ["null", "string"] },
+              "name": { "type": ["null", "string"] },
+              "phone": { "type": ["null", "string"] }
+            }
+          },
+          "card": {
+            "additionalProperties": true,
+            "type": ["null", "object"],
+            "properties": {
+              "brand": { "type": ["null", "string"] },
+              "checks": {
+                "additionalProperties": true,
+                "type": ["null", "object"],
+                "properties": {
+                  "address_line1_check": { "type": ["null", "string"] },
+                  "address_postal_code_check": { "type": ["null", "string"] },
+                  "cvc_check": { "type": ["null", "string"] }
+                }
+              },
+              "country": { "type": ["null", "string"] },
+              "exp_month": { "type": ["null", "integer"] },
+              "exp_year": { "type": ["null", "integer"] },
+              "fingerprint": { "type": ["null", "string"] },
+              "funding": { "type": ["null", "string"] },
+              "generated_from": {
+                "additionalProperties": true,
+                "type": ["null", "object"]
+              },
+              "last4": { "type": ["null", "string"] },
+              "networks": {
+                "additionalProperties": true,
+                "type": ["null", "object"],
+                "properties": {
+                  "available": {
+                    "type": ["null", "array"],
+                    "items": { "type": ["null", "string"] }
+                  },
+                  "preferred": { "type": ["null", "string"] }
+                }
+              },
+              "three_d_secure_usage": {
+                "additionalProperties": true,
+                "type": ["null", "object"],
+                "properties": { "supported": { "type": ["null", "boolean"] } }
+              },
+              "wallet": {
+                "additionalProperties": true,
+                "type": ["null", "object"]
+              }
+            }
+          },
+          "card_present": {
+            "additionalProperties": true,
+            "type": ["null", "object"]
+          },
+          "created": { "type": ["null", "integer"] },
+          "updated": { "type": ["null", "integer"] },
+          "customer": {
+            "type": ["null", "object"],
+            "properties": {
+              "metadata": { "type": ["null", "object"], "properties": {} },
+              "preferred_locales": {
+                "type": ["null", "array"],
+                "items": { "type": ["null", "string"] }
+              },
+              "invoice_settings": {
+                "type": ["null", "object"],
+                "properties": {
+                  "custom_fields": {
+                    "type": ["null", "array"],
+                    "items": { "type": ["null", "string"] }
+                  },
+                  "default_payment_method": { "type": ["null", "string"] },
+                  "footer": { "type": ["null", "string"] }
+                }
+              },
+              "name": { "type": ["null", "string"] },
+              "tax_exempt": { "type": ["null", "string"] },
+              "next_invoice_sequence": { "type": ["null", "integer"] },
+              "balance": { "type": ["null", "integer"] },
+              "phone": { "type": ["null", "string"] },
+              "address": {
+                "type": ["null", "object"],
+                "properties": {
+                  "city": { "type": ["null", "string"] },
+                  "country": { "type": ["null", "string"] },
+                  "line1": { "type": ["null", "string"] },
+                  "line2": { "type": ["null", "string"] },
+                  "postal_code": { "type": ["null", "string"] },
+                  "state": { "type": ["null", "string"] }
+                }
+              },
+              "shipping": {
+                "type": ["null", "object"],
+                "properties": {
+                  "address": {
+                    "type": ["null", "object"],
+                    "properties": {
+                      "city": { "type": ["null", "string"] },
+                      "country": { "type": ["null", "string"] },
+                      "line1": { "type": ["null", "string"] },
+                      "line2": { "type": ["null", "string"] },
+                      "postal_code": { "type": ["null", "string"] },
+                      "state": { "type": ["null", "string"] }
+                    }
+                  },
+                  "name": { "type": ["null", "string"] },
+                  "phone": { "type": ["null", "string"] }
+                }
+              },
+              "sources": {
+                "anyOf": [
+                  {
+                    "type": ["null", "array"],
+                    "items": {
+                      "type": ["null", "object"],
+                      "properties": {
+                        "metadata": {
+                          "type": ["null", "object"],
+                          "properties": {}
+                        },
+                        "type": { "type": ["null", "string"] },
+                        "address_zip": { "type": ["null", "string"] },
+                        "livemode": { "type": ["null", "boolean"] },
+                        "card": {
+                          "type": ["null", "object"],
+                          "properties": {
+                            "fingerprint": { "type": ["null", "string"] },
+                            "last4": { "type": ["null", "string"] },
+                            "dynamic_last4": { "type": ["null", "string"] },
+                            "address_line1_check": {
+                              "type": ["null", "string"]
+                            },
+                            "exp_month": { "type": ["null", "integer"] },
+                            "tokenization_method": {
+                              "type": ["null", "string"]
+                            },
+                            "name": { "type": ["null", "string"] },
+                            "exp_year": { "type": ["null", "integer"] },
+                            "three_d_secure": { "type": ["null", "string"] },
+                            "funding": { "type": ["null", "string"] },
+                            "brand": { "type": ["null", "string"] },
+                            "cvc_check": { "type": ["null", "string"] },
+                            "country": { "type": ["null", "string"] },
+                            "address_zip_check": { "type": ["null", "string"] },
+                            "type": { "type": ["null", "string"] }
+                          }
+                        },
+                        "statement_descriptor": { "type": ["null", "string"] },
+                        "id": { "type": ["null", "string"] },
+                        "address_country": { "type": ["null", "string"] },
+                        "funding": { "type": ["null", "string"] },
+                        "dynamic_last4": { "type": ["null", "string"] },
+                        "exp_year": { "type": ["null", "integer"] },
+                        "last4": { "type": ["null", "string"] },
+                        "exp_month": { "type": ["null", "integer"] },
+                        "brand": { "type": ["null", "string"] },
+                        "address_line2": { "type": ["null", "string"] },
+                        "country": { "type": ["null", "string"] },
+                        "object": { "type": ["null", "string"] },
+                        "amount": { "type": ["null", "integer"] },
+                        "cvc_check": { "type": ["null", "string"] },
+                        "usage": { "type": ["null", "string"] },
+                        "address_line1": { "type": ["null", "string"] },
+                        "owner": {
+                          "type": ["null", "object"],
+                          "properties": {
+                            "verified_address": { "type": ["null", "string"] },
+                            "email": { "type": ["null", "string"] },
+                            "address": {
+                              "type": ["null", "object"],
+                              "properties": {
+                                "city": { "type": ["null", "string"] },
+                                "country": { "type": ["null", "string"] },
+                                "line1": { "type": ["null", "string"] },
+                                "line2": { "type": ["null", "string"] },
+                                "postal_code": { "type": ["null", "string"] },
+                                "state": { "type": ["null", "string"] }
+                              }
+                            },
+                            "verified_email": { "type": ["null", "string"] },
+                            "name": { "type": ["null", "string"] },
+                            "phone": { "type": ["null", "string"] },
+                            "verified_name": { "type": ["null", "string"] },
+                            "verified_phone": { "type": ["null", "string"] }
+                          }
+                        },
+                        "tokenization_method": { "type": ["null", "string"] },
+                        "client_secret": { "type": ["null", "string"] },
+                        "fingerprint": { "type": ["null", "string"] },
+                        "address_city": { "type": ["null", "string"] },
+                        "currency": { "type": ["null", "string"] },
+                        "address_line1_check": { "type": ["null", "string"] },
+                        "receiver": {
+                          "type": ["null", "object"],
+                          "properties": {
+                            "refund_attributes_method": {
+                              "type": ["null", "string"]
+                            },
+                            "amount_returned": { "type": ["null", "integer"] },
+                            "amount_received": { "type": ["null", "integer"] },
+                            "refund_attributes_status": {
+                              "type": ["null", "string"]
+                            },
+                            "address": { "type": ["null", "string"] },
+                            "amount_charged": { "type": ["null", "integer"] }
+                          }
+                        },
+                        "flow": { "type": ["null", "string"] },
+                        "name": { "type": ["null", "string"] },
+                        "ach_credit_transfer": {
+                          "type": ["null", "object"],
+                          "properties": {
+                            "bank_name": { "type": ["null", "string"] },
+                            "fingerprint": { "type": ["null", "string"] },
+                            "routing_number": { "type": ["null", "string"] },
+                            "swift_code": { "type": ["null", "string"] },
+                            "refund_account_holder_type": {
+                              "type": ["null", "string"]
+                            },
+                            "refund_account_holder_name": {
+                              "type": ["null", "string"]
+                            },
+                            "refund_account_number": {
+                              "type": ["null", "string"]
+                            },
+                            "refund_routing_number": {
+                              "type": ["null", "string"]
+                            },
+                            "account_number": { "type": ["null", "string"] }
+                          }
+                        },
+                        "customer": { "type": ["null", "string"] },
+                        "address_zip_check": { "type": ["null", "string"] },
+                        "status": { "type": ["null", "string"] },
+                        "created": { "type": ["null", "integer"] },
+                        "address_state": { "type": ["null", "string"] },
+                        "alipay": {
+                          "type": ["null", "object"],
+                          "properties": {}
+                        },
+                        "bancontact": {
+                          "type": ["null", "object"],
+                          "properties": {}
+                        },
+                        "eps": { "type": ["null", "object"], "properties": {} },
+                        "ideal": {
+                          "type": ["null", "object"],
+                          "properties": {}
+                        },
+                        "multibanco": {
+                          "type": ["null", "object"],
+                          "properties": {}
+                        },
+                        "redirect": {
+                          "type": ["null", "object"],
+                          "properties": {
+                            "failure_reason": { "type": ["null", "string"] },
+                            "return_url": { "type": ["null", "string"] },
+                            "status": { "type": ["null", "string"] },
+                            "url": { "type": ["null", "string"] }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "type": ["null", "object"],
+                    "properties": {
+                      "metadata": {
+                        "type": ["null", "object"],
+                        "properties": {}
+                      },
+                      "type": { "type": ["null", "string"] },
+                      "address_zip": { "type": ["null", "string"] },
+                      "livemode": { "type": ["null", "boolean"] },
+                      "card": {
+                        "type": ["null", "object"],
+                        "properties": {
+                          "fingerprint": { "type": ["null", "string"] },
+                          "last4": { "type": ["null", "string"] },
+                          "dynamic_last4": { "type": ["null", "string"] },
+                          "address_line1_check": { "type": ["null", "string"] },
+                          "exp_month": { "type": ["null", "integer"] },
+                          "tokenization_method": { "type": ["null", "string"] },
+                          "name": { "type": ["null", "string"] },
+                          "exp_year": { "type": ["null", "integer"] },
+                          "three_d_secure": { "type": ["null", "string"] },
+                          "funding": { "type": ["null", "string"] },
+                          "brand": { "type": ["null", "string"] },
+                          "cvc_check": { "type": ["null", "string"] },
+                          "country": { "type": ["null", "string"] },
+                          "address_zip_check": { "type": ["null", "string"] },
+                          "type": { "type": ["null", "string"] }
+                        }
+                      },
+                      "statement_descriptor": { "type": ["null", "string"] },
+                      "id": { "type": ["null", "string"] },
+                      "address_country": { "type": ["null", "string"] },
+                      "funding": { "type": ["null", "string"] },
+                      "dynamic_last4": { "type": ["null", "string"] },
+                      "exp_year": { "type": ["null", "integer"] },
+                      "last4": { "type": ["null", "string"] },
+                      "exp_month": { "type": ["null", "integer"] },
+                      "brand": { "type": ["null", "string"] },
+                      "address_line2": { "type": ["null", "string"] },
+                      "country": { "type": ["null", "string"] },
+                      "object": { "type": ["null", "string"] },
+                      "amount": { "type": ["null", "integer"] },
+                      "cvc_check": { "type": ["null", "string"] },
+                      "usage": { "type": ["null", "string"] },
+                      "address_line1": { "type": ["null", "string"] },
+                      "owner": {
+                        "type": ["null", "object"],
+                        "properties": {
+                          "verified_address": { "type": ["null", "string"] },
+                          "email": { "type": ["null", "string"] },
+                          "address": {
+                            "type": ["null", "object"],
+                            "properties": {
+                              "city": { "type": ["null", "string"] },
+                              "country": { "type": ["null", "string"] },
+                              "line1": { "type": ["null", "string"] },
+                              "line2": { "type": ["null", "string"] },
+                              "postal_code": { "type": ["null", "string"] },
+                              "state": { "type": ["null", "string"] }
+                            }
+                          },
+                          "verified_email": { "type": ["null", "string"] },
+                          "name": { "type": ["null", "string"] },
+                          "phone": { "type": ["null", "string"] },
+                          "verified_name": { "type": ["null", "string"] },
+                          "verified_phone": { "type": ["null", "string"] }
+                        }
+                      },
+                      "tokenization_method": { "type": ["null", "string"] },
+                      "client_secret": { "type": ["null", "string"] },
+                      "fingerprint": { "type": ["null", "string"] },
+                      "address_city": { "type": ["null", "string"] },
+                      "currency": { "type": ["null", "string"] },
+                      "address_line1_check": { "type": ["null", "string"] },
+                      "receiver": {
+                        "type": ["null", "object"],
+                        "properties": {
+                          "refund_attributes_method": {
+                            "type": ["null", "string"]
+                          },
+                          "amount_returned": { "type": ["null", "integer"] },
+                          "amount_received": { "type": ["null", "integer"] },
+                          "refund_attributes_status": {
+                            "type": ["null", "string"]
+                          },
+                          "address": { "type": ["null", "string"] },
+                          "amount_charged": { "type": ["null", "integer"] }
+                        }
+                      },
+                      "flow": { "type": ["null", "string"] },
+                      "name": { "type": ["null", "string"] },
+                      "ach_credit_transfer": {
+                        "type": ["null", "object"],
+                        "properties": {
+                          "bank_name": { "type": ["null", "string"] },
+                          "fingerprint": { "type": ["null", "string"] },
+                          "routing_number": { "type": ["null", "string"] },
+                          "swift_code": { "type": ["null", "string"] },
+                          "refund_account_holder_type": {
+                            "type": ["null", "string"]
+                          },
+                          "refund_account_holder_name": {
+                            "type": ["null", "string"]
+                          },
+                          "refund_account_number": {
+                            "type": ["null", "string"]
+                          },
+                          "refund_routing_number": {
+                            "type": ["null", "string"]
+                          },
+                          "account_number": { "type": ["null", "string"] }
+                        }
+                      },
+                      "customer": { "type": ["null", "string"] },
+                      "address_zip_check": { "type": ["null", "string"] },
+                      "status": { "type": ["null", "string"] },
+                      "created": { "type": ["null", "integer"] },
+                      "address_state": { "type": ["null", "string"] },
+                      "alipay": {
+                        "type": ["null", "object"],
+                        "properties": {}
+                      },
+                      "bancontact": {
+                        "type": ["null", "object"],
+                        "properties": {}
+                      },
+                      "eps": { "type": ["null", "object"], "properties": {} },
+                      "ideal": { "type": ["null", "object"], "properties": {} },
+                      "multibanco": {
+                        "type": ["null", "object"],
+                        "properties": {}
+                      },
+                      "redirect": {
+                        "type": ["null", "object"],
+                        "properties": {
+                          "failure_reason": { "type": ["null", "string"] },
+                          "return_url": { "type": ["null", "string"] },
+                          "status": { "type": ["null", "string"] },
+                          "url": { "type": ["null", "string"] }
+                        }
+                      }
+                    }
+                  }
+                ]
+              },
+              "delinquent": { "type": ["null", "boolean"] },
+              "description": { "type": ["null", "string"] },
+              "livemode": { "type": ["null", "boolean"] },
+              "default_source": { "type": ["null", "string"] },
+              "cards": {
+                "type": ["null", "array"],
+                "items": {
+                  "type": ["null", "object"],
+                  "properties": {
+                    "metadata": {
+                      "type": ["null", "object"],
+                      "properties": {}
+                    },
+                    "object": { "type": ["null", "string"] },
+                    "id": { "type": ["null", "string"] },
+                    "exp_month": { "type": ["null", "integer"] },
+                    "dynamic_last4": { "type": ["null", "string"] },
+                    "exp_year": { "type": ["null", "integer"] },
+                    "last4": { "type": ["null", "string"] },
+                    "funding": { "type": ["null", "string"] },
+                    "brand": { "type": ["null", "string"] },
+                    "country": { "type": ["null", "string"] },
+                    "customer": { "type": ["null", "string"] },
+                    "cvc_check": { "type": ["null", "string"] },
+                    "address_line2": { "type": ["null", "string"] },
+                    "address_line1": { "type": ["null", "string"] },
+                    "fingerprint": { "type": ["null", "string"] },
+                    "address_zip": { "type": ["null", "string"] },
+                    "address_city": { "type": ["null", "string"] },
+                    "address_country": { "type": ["null", "string"] },
+                    "address_line1_check": { "type": ["null", "string"] },
+                    "tokenization_method": { "type": ["null", "string"] },
+                    "name": { "type": ["null", "string"] },
+                    "address_state": { "type": ["null", "string"] },
+                    "address_zip_check": { "type": ["null", "string"] },
+                    "type": { "type": ["null", "string"] }
+                  }
+                }
+              },
+              "email": { "type": ["null", "string"] },
+              "default_card": { "type": ["null", "string"] },
+              "subscriptions": {
+                "type": ["null", "object"],
+                "properties": {
+                  "object": { "type": ["null", "string"] },
+                  "data": { "type": ["null", "array"] },
+                  "has_more": { "type": ["null", "boolean"] },
+                  "total_count": { "type": ["null", "number"] },
+                  "url": { "type": ["null", "string"] }
+                }
+              },
+              "discount": {
+                "type": ["null", "object"],
+                "properties": {
+                  "end": { "type": ["null", "integer"] },
+                  "coupon": {
+                    "type": ["null", "object"],
+                    "properties": {
+                      "metadata": {
+                        "type": ["null", "object"],
+                        "properties": {}
+                      },
+                      "valid": { "type": ["null", "boolean"] },
+                      "livemode": { "type": ["null", "boolean"] },
+                      "amount_off": { "type": ["null", "integer"] },
+                      "redeem_by": { "type": ["null", "integer"] },
+                      "duration_in_months": { "type": ["null", "integer"] },
+                      "percent_off_precise": { "type": ["null", "number"] },
+                      "max_redemptions": { "type": ["null", "integer"] },
+                      "currency": { "type": ["null", "string"] },
+                      "name": { "type": ["null", "string"] },
+                      "times_redeemed": { "type": ["null", "integer"] },
+                      "id": { "type": ["null", "string"] },
+                      "duration": { "type": ["null", "string"] },
+                      "object": { "type": ["null", "string"] },
+                      "percent_off": { "type": ["null", "number"] },
+                      "created": { "type": ["null", "integer"] }
+                    }
+                  },
+                  "customer": { "type": ["null", "string"] },
+                  "start": { "type": ["null", "integer"] },
+                  "object": { "type": ["null", "string"] },
+                  "subscription": { "type": ["null", "string"] }
+                }
+              },
+              "account_balance": { "type": ["null", "integer"] },
+              "currency": { "type": ["null", "string"] },
+              "id": { "type": ["null", "string"] },
+              "invoice_prefix": { "type": ["null", "string"] },
+              "tax_info_verification": { "type": ["null", "string"] },
+              "object": { "type": ["null", "string"] },
+              "created": { "type": ["null", "integer"] },
+              "updated": { "type": ["null", "integer"] },
+              "tax_info": { "type": ["null", "string"] },
+              "test_clock": { "type": ["null", "string"] },
+              "is_deleted": { "type": ["null", "boolean"] }
+            }
+          },
+          "eps": {
+            "additionalProperties": true,
+            "type": ["null", "object"],
+            "properties": { "bank": { "type": ["null", "string"] } }
+          },
+          "fpx": {
+            "additionalProperties": true,
+            "type": ["null", "object"],
+            "properties": { "bank": { "type": ["null", "string"] } }
+          },
+          "giropay": {
+            "additionalProperties": true,
+            "type": ["null", "object"]
+          },
+          "grabpay": {
+            "additionalProperties": true,
+            "type": ["null", "object"]
+          },
+          "id": { "type": ["null", "string"] },
+          "ideal": {
+            "additionalProperties": true,
+            "type": ["null", "object"],
+            "properties": {
+              "bank": { "type": ["null", "string"] },
+              "bic": { "type": ["null", "string"] }
+            }
+          },
+          "interac_present": {
+            "additionalProperties": true,
+            "type": ["null", "object"]
+          },
+          "livemode": { "type": ["null", "boolean"] },
+          "metadata": {
+            "additionalProperties": true,
+            "type": ["null", "object"]
+          },
+          "object": { "type": ["null", "string"] },
+          "oxxo": { "additionalProperties": true, "type": ["null", "object"] },
+          "p24": {
+            "type": ["null", "object"],
+            "additionalProperties": true,
+            "properties": { "bank": { "type": ["null", "string"] } }
+          },
+          "sepa_debit": {
+            "type": ["null", "object"],
+            "additionalProperties": true,
+            "properties": {
+              "bank_code": { "type": ["null", "string"] },
+              "branch_code": { "type": ["null", "string"] },
+              "country": { "type": ["null", "string"] },
+              "fingerprint": { "type": ["null", "string"] },
+              "generated_from": {
+                "type": ["null", "object"],
+                "properties": {
+                  "charge": { "type": ["null", "string"] },
+                  "setup_attempt": { "type": ["null", "string"] }
+                }
+              },
+              "last4": { "type": ["null", "string"] }
+            }
+          },
+          "sofort": {
+            "type": ["null", "object"],
+            "additionalProperties": true,
+            "properties": { "country": { "type": ["null", "string"] } }
+          },
+          "type": { "type": ["null", "string"] }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "credit_notes",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": true,
+        "type": ["null", "object"],
+        "properties": {
+          "id": {
+            "description": "The unique identifier of the credit note.",
+            "type": ["null", "string"]
+          },
+          "object": {
+            "description": "The object type.",
+            "type": ["null", "string"]
+          },
+          "amount": {
+            "description": "The total amount of the credit note.",
+            "type": ["null", "integer"]
+          },
+          "amount_shipping": {
+            "description": "The amount charged for shipping.",
+            "type": ["null", "integer"]
+          },
+          "created": {
+            "description": "The timestamp when the credit note was created.",
+            "type": ["null", "integer"]
+          },
+          "updated": {
+            "description": "The timestamp when the credit note was last updated.",
+            "type": ["null", "integer"]
+          },
+          "currency": {
+            "description": "The currency of the credit note.",
+            "type": ["null", "string"]
+          },
+          "customer": {
+            "description": "The customer associated with the credit note.",
+            "type": ["null", "string"]
+          },
+          "customer_balance_transaction": {
+            "description": "The balance transaction associated with the customer.",
+            "type": ["null", "string"]
+          },
+          "discount_amount": {
+            "description": "The amount of discount applied.",
+            "type": ["null", "string"]
+          },
+          "discount_amounts": {
+            "description": "Details of discount amounts.",
+            "type": ["null", "array"]
+          },
+          "invoice": {
+            "description": "The invoice associated with the credit note.",
+            "type": ["null", "string"]
+          },
+          "lines": {
+            "description": "An array of line items associated with the credit note",
+            "type": ["null", "object"],
+            "properties": {
+              "object": {
+                "description": "The object type.",
+                "type": ["null", "string"]
+              },
+              "data": {
+                "description": "An array of line item objects containing discount amounts, tax amounts, and tax rates",
+                "type": ["null", "array"],
+                "items": {
+                  "type": ["null", "object"],
+                  "properties": {
+                    "id": {
+                      "description": "The unique identifier of the line item.",
+                      "type": ["null", "string"]
+                    },
+                    "object": {
+                      "description": "The object type.",
+                      "type": ["null", "string"]
+                    },
+                    "amount": {
+                      "description": "The total amount for the line item.",
+                      "type": ["null", "integer"]
+                    },
+                    "amount_excluding_tax": {
+                      "description": "The amount excluding tax for the line item.",
+                      "type": ["null", "integer"]
+                    },
+                    "description": {
+                      "description": "The description of the line item.",
+                      "type": ["null", "string"]
+                    },
+                    "discount_amount": {
+                      "description": "The discount amount applied to the line item.",
+                      "type": ["null", "integer"]
+                    },
+                    "discount_amounts": {
+                      "description": "An array of discount amounts applied to the line item",
+                      "type": ["null", "array"],
+                      "items": {
+                        "type": ["null", "object"],
+                        "properties": {
+                          "amount": {
+                            "description": "The amount of discount applied.",
+                            "type": ["null", "integer"]
+                          },
+                          "discount": {
+                            "description": "The discount details.",
+                            "type": ["null", "string"]
+                          }
+                        }
+                      }
+                    },
+                    "invoice_line_item": {
+                      "description": "The invoice line item associated with the line.",
+                      "type": ["null", "string"]
+                    },
+                    "livemode": {
+                      "description": "Indicates if the transaction is in live mode.",
+                      "type": ["null", "boolean"]
+                    },
+                    "quantity": {
+                      "description": "The quantity of the line item.",
+                      "type": ["null", "integer"]
+                    },
+                    "tax_amounts": {
+                      "description": "An array of tax amounts applied to the line item",
+                      "type": ["null", "array"],
+                      "items": {
+                        "type": ["null", "object"],
+                        "properties": {
+                          "amount": {
+                            "description": "The tax amount.",
+                            "type": ["null", "integer"]
+                          },
+                          "inclusive": {
+                            "description": "Indicates if tax is inclusive.",
+                            "type": ["null", "boolean"]
+                          },
+                          "tax_rate": {
+                            "description": "The tax rate applied.",
+                            "type": ["null", "string"]
+                          },
+                          "taxability_reason": {
+                            "description": "The reason for taxability.",
+                            "type": ["null", "string"]
+                          },
+                          "taxable_amount": {
+                            "description": "The taxable amount.",
+                            "type": ["null", "integer"]
+                          }
+                        }
+                      }
+                    },
+                    "tax_rates": {
+                      "description": "An array of tax rates applied to the line item",
+                      "type": ["null", "array"],
+                      "items": {
+                        "type": ["null", "object"],
+                        "properties": {
+                          "id": {
+                            "description": "The unique identifier of the tax rate.",
+                            "type": ["null", "string"]
+                          },
+                          "object": {
+                            "description": "The object type.",
+                            "type": ["null", "string"]
+                          },
+                          "active": {
+                            "description": "Indicates if the tax rate is active.",
+                            "type": ["null", "boolean"]
+                          },
+                          "country": {
+                            "description": "The country for the tax rate.",
+                            "type": ["null", "string"]
+                          },
+                          "created": {
+                            "description": "The timestamp when the tax rate was created.",
+                            "type": ["null", "integer"]
+                          },
+                          "description": {
+                            "description": "The description of the tax rate.",
+                            "type": ["null", "string"]
+                          },
+                          "display_name": {
+                            "description": "The display name of the tax rate.",
+                            "type": ["null", "string"]
+                          },
+                          "effective_percentage": {
+                            "description": "The effective percentage of the tax rate.",
+                            "type": ["null", "number"]
+                          },
+                          "inclusive": {
+                            "description": "Indicates if tax is inclusive.",
+                            "type": ["null", "boolean"]
+                          },
+                          "jurisdiction": {
+                            "description": "The jurisdiction of the tax rate.",
+                            "type": ["null", "string"]
+                          },
+                          "livemode": {
+                            "description": "Indicates if the tax rate is in live mode.",
+                            "type": ["null", "boolean"]
+                          },
+                          "metadata": {
+                            "description": "Additional metadata for the tax rate.",
+                            "type": ["null", "object"]
+                          },
+                          "percentage": {
+                            "description": "The percentage of the tax rate.",
+                            "type": ["null", "number"]
+                          },
+                          "state": {
+                            "description": "The state of the tax rate.",
+                            "type": ["null", "string"]
+                          },
+                          "tax_type": {
+                            "description": "The type of tax.",
+                            "type": ["null", "string"]
+                          }
+                        }
+                      }
+                    },
+                    "type": {
+                      "description": "The type of line item.",
+                      "type": ["null", "string"]
+                    },
+                    "unit_amount": {
+                      "description": "The unit amount of the line item.",
+                      "type": ["null", "integer"]
+                    },
+                    "unit_amount_decimal": {
+                      "description": "The unit amount in decimal format.",
+                      "type": ["null", "number"]
+                    },
+                    "unit_amount_excluding_tax": {
+                      "description": "The unit amount excluding tax.",
+                      "type": ["null", "number"]
+                    }
+                  }
+                }
+              }
+            },
+            "has_more": {
+              "description": "Indicates if there are more line items.",
+              "type": ["null", "boolean"]
+            },
+            "url": {
+              "description": "The URL for the line items.",
+              "type": ["null", "string"]
+            }
+          },
+          "livemode": {
+            "description": "Indicates if the transaction is in live mode.",
+            "type": ["null", "boolean"]
+          },
+          "memo": {
+            "description": "Additional information or notes.",
+            "type": ["null", "string"]
+          },
+          "metadata": {
+            "description": "Additional metadata for the credit note.",
+            "type": ["null", "object"]
+          },
+          "number": {
+            "description": "The unique number of the credit note.",
+            "type": ["null", "string"]
+          },
+          "out_of_band_amount": {
+            "description": "The out of band amount.",
+            "type": ["null", "integer"]
+          },
+          "pdf": {
+            "description": "The URL for the PDF of the credit note.",
+            "type": ["null", "string"]
+          },
+          "reason": {
+            "description": "The reason for the credit note.",
+            "type": ["null", "string"]
+          },
+          "refund": {
+            "description": "Indicates if the credit note is a refund.",
+            "type": ["null", "string"]
+          },
+          "shipping_cost": {
+            "description": "Shipping cost details associated with the credit note",
+            "type": ["null", "object"],
+            "properties": {
+              "amount_subtotal": {
+                "description": "The subtotal amount of shipping.",
+                "type": ["null", "integer"]
+              },
+              "amount_tax": {
+                "description": "The tax amount for shipping.",
+                "type": ["null", "integer"]
+              },
+              "amount_total": {
+                "description": "The total amount including tax for shipping.",
+                "type": ["null", "integer"]
+              },
+              "shipping_rate": {
+                "description": "The shipping rate details.",
+                "type": ["null", "string"]
+              },
+              "taxes": {
+                "description": "An array of tax objects applied to the shipping cost",
+                "type": ["null", "array"],
+                "items": {
+                  "type": ["null", "object"],
+                  "properties": {
+                    "amount": {
+                      "description": "The tax amount.",
+                      "type": ["null", "integer"]
+                    },
+                    "rate": {
+                      "description": "Tax rate applied to the shipping cost",
+                      "type": ["null", "object"],
+                      "properties": {
+                        "id": {
+                          "description": "The unique identifier of the tax rate.",
+                          "type": ["null", "string"]
+                        },
+                        "object": {
+                          "description": "The object type.",
+                          "type": ["null", "string"]
+                        },
+                        "active": {
+                          "description": "Indicates if the tax rate is active.",
+                          "type": ["null", "boolean"]
+                        },
+                        "country": {
+                          "description": "The country for the tax rate.",
+                          "type": ["null", "boolean"]
+                        },
+                        "created": {
+                          "description": "The timestamp when the tax rate was created.",
+                          "type": ["null", "integer"]
+                        },
+                        "description": {
+                          "description": "The description of the tax rate.",
+                          "type": ["null", "string"]
+                        },
+                        "display_name": {
+                          "description": "The display name of the tax rate.",
+                          "type": ["null", "string"]
+                        },
+                        "effective_percentage": {
+                          "description": "The effective percentage of the tax rate.",
+                          "type": ["null", "number"]
+                        },
+                        "inclusive": {
+                          "description": "Indicates if tax is inclusive.",
+                          "type": ["null", "boolean"]
+                        },
+                        "jurisdiction": {
+                          "description": "The jurisdiction of the tax rate.",
+                          "type": ["null", "string"]
+                        },
+                        "livemode": {
+                          "description": "Indicates if the tax rate is in live mode.",
+                          "type": ["null", "boolean"]
+                        },
+                        "metadata": {
+                          "description": "Additional metadata for the tax rate.",
+                          "type": ["null", "boolean"]
+                        },
+                        "percentage": {
+                          "description": "The percentage of the tax rate.",
+                          "type": ["null", "number"]
+                        },
+                        "state": {
+                          "description": "The state of the tax rate.",
+                          "type": ["null", "string"]
+                        },
+                        "tax_type": {
+                          "description": "The type of tax.",
+                          "type": ["null", "string"]
+                        }
+                      }
+                    },
+                    "taxability_reason": {
+                      "description": "The reason for taxability.",
+                      "type": ["null", "string"]
+                    },
+                    "taxable_amount": {
+                      "description": "The taxable amount.",
+                      "type": ["null", "integer"]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "status": {
+            "description": "The status of the credit note.",
+            "type": ["null", "string"]
+          },
+          "subtotal": {
+            "description": "The subtotal amount excluding tax.",
+            "type": ["null", "integer"]
+          },
+          "subtotal_excluding_tax": {
+            "description": "The subtotal amount excluding tax.",
+            "type": ["null", "integer"]
+          },
+          "tax_amounts": {
+            "description": "An array of total tax amounts applied to the credit note",
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "amount": {
+                  "description": "The tax amount.",
+                  "type": ["null", "integer"]
+                },
+                "inclusive": {
+                  "description": "Indicates if tax is inclusive.",
+                  "type": ["null", "boolean"]
+                },
+                "tax_rate": {
+                  "description": "The tax rate applied.",
+                  "type": ["null", "string"]
+                },
+                "taxability_reason": {
+                  "description": "The reason for taxability.",
+                  "type": ["null", "string"]
+                },
+                "taxable_amount": {
+                  "description": "The taxable amount.",
+                  "type": ["null", "integer"]
+                }
+              }
+            }
+          },
+          "total": {
+            "description": "The total amount including tax.",
+            "type": ["null", "integer"]
+          },
+          "total_excluding_tax": {
+            "description": "The total amount excluding tax.",
+            "type": ["null", "integer"]
+          },
+          "type": {
+            "description": "The type of the credit note.",
+            "type": ["null", "string"]
+          },
+          "voided_at": {
+            "description": "The timestamp when the credit note was voided.",
+            "type": ["null", "integer"]
+          },
+          "effective_at": {
+            "description": "The effective date of the credit note.",
+            "type": ["null", "integer"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "early_fraud_warnings",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "Early Fraud Warnings Schema",
+        "additionalProperties": true,
+        "type": ["null", "object"],
+        "properties": {
+          "id": {
+            "description": "Unique identifier for the fraud warning.",
+            "type": ["null", "string"]
+          },
+          "object": {
+            "description": "Defines the object type as 'early_fraud_warning'.",
+            "type": ["null", "string"]
+          },
+          "actionable": {
+            "description": "Boolean indicating if action is required based on the fraud warning.",
+            "type": ["null", "boolean"]
+          },
+          "charge": {
+            "description": "ID of the charge associated with the fraud warning.",
+            "type": ["null", "string"]
+          },
+          "created": {
+            "description": "Timestamp when the fraud warning was created.",
+            "type": ["null", "number"]
+          },
+          "updated": {
+            "description": "Timestamp when the fraud warning was last updated.",
+            "type": ["null", "integer"]
+          },
+          "fraud_type": {
+            "description": "Type of fraud warning detected.",
+            "type": ["null", "string"]
+          },
+          "livemode": {
+            "description": "Boolean indicating if the fraud warning is in live mode.",
+            "type": ["null", "boolean"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "authorizations",
+      "json_schema": {
+        "$schema": "https://json-schema.org/draft-07/schema#",
+        "additionalProperties": true,
+        "type": "object",
+        "properties": {
+          "amount": {
+            "description": "The amount of the authorization.",
+            "type": ["null", "integer"]
+          },
+          "amount_details": {
+            "description": "Details about the authorization amount.",
+            "type": ["null", "object"],
+            "properties": {
+              "atm_fee": {
+                "description": "The ATM fee included in the authorization amount.",
+                "type": ["null", "integer"]
+              }
+            }
+          },
+          "approved": {
+            "description": "Indicates if the authorization is approved.",
+            "type": ["null", "boolean"]
+          },
+          "authorization_method": {
+            "description": "The method used for authorization.",
+            "type": ["null", "string"]
+          },
+          "balance_transactions": {
+            "description": "Balance transactions associated with the authorization.",
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "fee": { "type": ["null", "integer"] },
+                "currency": { "type": ["null", "string"] },
+                "source": { "type": ["null", "string"] },
+                "fee_details": {
+                  "type": ["null", "array"],
+                  "items": {
+                    "properties": {
+                      "application": { "type": ["null", "string"] },
+                      "type": { "type": ["null", "string"] },
+                      "description": { "type": ["null", "string"] },
+                      "amount": { "type": ["null", "integer"] },
+                      "currency": { "type": ["null", "string"] }
+                    },
+                    "type": ["null", "object"]
+                  }
+                },
+                "available_on": { "type": ["null", "integer"] },
+                "status": { "type": ["null", "string"] },
+                "description": { "type": ["null", "string"] },
+                "net": { "type": ["null", "integer"] },
+                "exchange_rate": { "type": ["null", "number"] },
+                "type": { "type": ["null", "string"] },
+                "sourced_transfers": { "items": {}, "type": ["null", "array"] },
+                "id": { "type": ["null", "string"] },
+                "object": { "type": ["null", "string"] },
+                "created": { "type": ["null", "integer"] },
+                "amount": { "type": ["null", "integer"] },
+                "reporting_category": { "type": ["null", "string"] }
+              }
+            },
+            "type": ["null", "array"]
+          },
+          "card": {
+            "type": ["null", "object"],
+            "properties": {
+              "brand": { "type": ["null", "string"] },
+              "cancellation_reason": { "type": ["null", "string"] },
+              "cardholder": {
+                "type": ["null", "object"],
+                "properties": {
+                  "billing": {
+                    "type": ["null", "object"],
+                    "properties": {
+                      "address": {
+                        "type": ["null", "object"],
+                        "properties": {
+                          "city": { "type": ["null", "string"] },
+                          "country": { "type": ["null", "string"] },
+                          "line1": { "type": ["null", "string"] },
+                          "line2": { "type": ["null", "string"] },
+                          "postal_code": { "type": ["null", "string"] },
+                          "state": { "type": ["null", "string"] }
+                        }
+                      }
+                    }
+                  },
+                  "company": {
+                    "type": ["null", "object"],
+                    "properties": { "tax_id_provided": { "type": "boolean" } }
+                  },
+                  "created": { "type": ["null", "integer"] },
+                  "updated": { "type": ["null", "integer"] },
+                  "email": { "type": ["null", "string"] },
+                  "id": { "type": ["null", "string"] },
+                  "individual": {
+                    "type": ["null", "object"],
+                    "properties": {
+                      "dob": {
+                        "type": ["null", "object"],
+                        "properties": {
+                          "day": { "type": ["null", "integer"] },
+                          "month": { "type": ["null", "integer"] },
+                          "year": { "type": ["null", "integer"] }
+                        }
+                      },
+                      "first_name": { "type": ["null", "string"] },
+                      "last_name": { "type": ["null", "string"] },
+                      "verification": {
+                        "type": ["null", "object"],
+                        "properties": {
+                          "document": {
+                            "type": ["null", "object"],
+                            "properties": {
+                              "back": { "type": ["null", "string"] },
+                              "front": { "type": ["null", "string"] }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "livemode": { "type": ["null", "boolean"] },
+                  "metadata": { "type": ["null", "object"] },
+                  "name": { "type": ["null", "string"] },
+                  "object": { "type": ["null", "string"] },
+                  "phone_number": { "type": ["null", "string"] },
+                  "requirements": {
+                    "type": ["null", "object"],
+                    "properties": {
+                      "disabled_reason": { "type": ["null", "string"] },
+                      "past_due": {
+                        "type": ["null", "array"],
+                        "items": { "type": ["null", "string"] }
+                      }
+                    }
+                  },
+                  "spending_controls": {
+                    "type": ["null", "object"],
+                    "properties": {
+                      "allowed_categories": {
+                        "type": ["null", "array"],
+                        "items": { "type": ["null", "string"] }
+                      },
+                      "blocked_categories": {
+                        "type": ["null", "array"],
+                        "items": { "type": ["null", "string"] }
+                      },
+                      "spending_limits": {
+                        "type": ["null", "array"],
+                        "items": { "type": ["null", "object"] }
+                      },
+                      "spending_limits_currency": { "type": ["null", "string"] }
+                    }
+                  },
+                  "status": { "type": ["null", "string"] },
+                  "type": { "type": ["null", "string"] },
+                  "preferred_locales": {
+                    "type": ["null", "array"],
+                    "items": { "type": ["null", "string"] }
+                  }
+                }
+              },
+              "created": { "type": ["null", "integer"] },
+              "updated": { "type": ["null", "integer"] },
+              "currency": { "type": ["null", "string"] },
+              "cvc": { "type": ["null", "string"] },
+              "exp_month": { "type": ["null", "integer"] },
+              "exp_year": { "type": ["null", "integer"] },
+              "id": { "type": ["null", "string"] },
+              "last4": { "type": ["null", "string"] },
+              "livemode": { "type": ["null", "boolean"] },
+              "metadata": {
+                "type": ["null", "object"],
+                "additionalProperties": true
+              },
+              "number": { "type": ["null", "string"] },
+              "object": { "type": ["null", "string"] },
+              "replaced_by": {
+                "type": ["null", "object"],
+                "additionalProperties": true
+              },
+              "replacement_for": {
+                "type": ["null", "object"],
+                "additionalProperties": true
+              },
+              "replacement_reason": { "type": ["null", "string"] },
+              "shipping": {
+                "type": ["null", "object"],
+                "additionalProperties": true,
+                "properties": {
+                  "address": {
+                    "type": ["null", "object"],
+                    "properties": {
+                      "city": { "type": ["null", "string"] },
+                      "country": { "type": ["null", "string"] },
+                      "line1": { "type": ["null", "string"] },
+                      "line2": { "type": ["null", "string"] },
+                      "postal_code": { "type": ["null", "string"] },
+                      "state": { "type": ["null", "string"] }
+                    }
+                  },
+                  "carrier": { "type": ["null", "string"] },
+                  "eta": { "type": ["null", "integer"] },
+                  "name": { "type": ["null", "string"] },
+                  "service": { "type": ["null", "string"] },
+                  "status": { "type": ["null", "string"] },
+                  "tracking_number": { "type": ["null", "string"] },
+                  "tracking_url": { "type": ["null", "string"] },
+                  "type": { "type": ["null", "string"] }
+                }
+              },
+              "spending_controls": {
+                "type": ["null", "object"],
+                "properties": {
+                  "allowed_categories": {
+                    "type": ["null", "array"],
+                    "items": { "type": ["null", "string"] }
+                  },
+                  "blocked_categories": {
+                    "type": ["null", "array"],
+                    "items": { "type": ["null", "string"] }
+                  },
+                  "spending_limits": {
+                    "type": ["null", "array"],
+                    "items": { "type": ["null", "object"] }
+                  },
+                  "spending_limits_currency": { "type": ["null", "string"] }
+                }
+              },
+              "status": { "type": ["null", "string"] },
+              "type": { "type": ["null", "string"] }
+            }
+          },
+          "cardholder": {
+            "description": "Details about the cardholder.",
+            "type": ["null", "string"]
+          },
+          "created": {
+            "description": "Timestamp for when the authorization was created.",
+            "type": ["null", "integer"]
+          },
+          "updated": {
+            "description": "Timestamp for when the authorization was last updated.",
+            "type": ["null", "integer"]
+          },
+          "currency": {
+            "description": "The currency of the authorization.",
+            "type": ["null", "string"]
+          },
+          "id": {
+            "description": "The unique identifier for the authorization.",
+            "type": ["null", "string"]
+          },
+          "livemode": {
+            "description": "Indicates if the authorization is in live mode.",
+            "type": ["null", "boolean"]
+          },
+          "merchant_amount": {
+            "description": "The amount in merchant's currency.",
+            "type": ["null", "integer"]
+          },
+          "merchant_currency": {
+            "description": "The currency used by the merchant.",
+            "type": ["null", "string"]
+          },
+          "merchant_data": {
+            "description": "Data about the merchant.",
+            "type": ["null", "object"],
+            "properties": {
+              "category": {
+                "description": "The category of the merchant.",
+                "type": ["null", "string"]
+              },
+              "city": {
+                "description": "City where the merchant is located.",
+                "type": ["null", "string"]
+              },
+              "country": {
+                "description": "Country where the merchant is located.",
+                "type": ["null", "string"]
+              },
+              "name": {
+                "description": "Name of the merchant.",
+                "type": ["null", "string"]
+              },
+              "network_id": {
+                "description": "Network ID of the merchant.",
+                "type": ["null", "string"]
+              },
+              "postal_code": {
+                "description": "Postal code of the merchant.",
+                "type": ["null", "string"]
+              },
+              "state": {
+                "description": "State where the merchant is located.",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "metadata": {
+            "description": "Additional metadata related to the authorization.",
+            "type": ["null", "object"],
+            "additionalProperties": true
+          },
+          "object": {
+            "description": "Type of object, in this case, always 'authorization'.",
+            "type": ["null", "string"]
+          },
+          "pending_request": {
+            "description": "Details of a pending request for authorization.",
+            "type": ["null", "object"],
+            "properties": {
+              "amount": {
+                "description": "The amount requested in the pending request.",
+                "type": ["null", "integer"]
+              },
+              "amount_details": {
+                "description": "Details about the amount in the pending request.",
+                "type": ["null", "object"],
+                "properties": {
+                  "atm_fee": {
+                    "description": "The ATM fee included in the pending request amount.",
+                    "type": ["null", "integer"]
+                  }
+                }
+              },
+              "currency": {
+                "description": "The currency of the pending request.",
+                "type": ["null", "string"]
+              },
+              "is_amount_controllable": {
+                "description": "Indicates if the amount in the pending request is controllable.",
+                "type": ["null", "boolean"]
+              },
+              "merchant_amount": {
+                "description": "The amount in merchant's currency for the pending request.",
+                "type": ["null", "integer"]
+              },
+              "merchant_currency": {
+                "description": "The currency used by the merchant for the pending request.",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "request_history": {
+            "description": "History of previous authorization requests.",
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "amount": {
+                  "description": "The amount of the authorization request.",
+                  "type": ["null", "integer"]
+                },
+                "amount_details": {
+                  "description": "Details about the authorization request amount.",
+                  "type": ["null", "object"],
+                  "properties": {
+                    "atm_fee": {
+                      "description": "The ATM fee included in the authorization request amount.",
+                      "type": ["null", "integer"]
+                    }
+                  }
+                },
+                "approved": {
+                  "description": "Indicates if the authorization request was approved.",
+                  "type": ["null", "boolean"]
+                },
+                "created": {
+                  "description": "Timestamp for when the authorization request was created.",
+                  "type": ["null", "integer"]
+                },
+                "currency": {
+                  "description": "The currency of the authorization request.",
+                  "type": ["null", "string"]
+                },
+                "merchant_amount": {
+                  "description": "The amount in merchant's currency for the authorization request.",
+                  "type": ["null", "integer"]
+                },
+                "merchant_currency": {
+                  "description": "The currency used by the merchant for the authorization request.",
+                  "type": ["null", "string"]
+                },
+                "reason": {
+                  "description": "Reason for the authorization request.",
+                  "type": ["null", "string"]
+                }
+              }
+            }
+          },
+          "status": {
+            "description": "Status of the authorization.",
+            "type": ["null", "string"]
+          },
+          "transactions": {
+            "description": "Transactions related to the authorization.",
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "amount": {
+                  "description": "The amount of the transaction.",
+                  "type": ["null", "integer"]
+                },
+                "amount_details": {
+                  "description": "Details about the transaction amount.",
+                  "type": ["null", "object"],
+                  "properties": {
+                    "atm_fee": {
+                      "description": "The ATM fee included in the transaction amount.",
+                      "type": ["null", "integer"]
+                    }
+                  }
+                },
+                "authorization": {
+                  "description": "The authorization for the transaction.",
+                  "type": ["null", "string"]
+                },
+                "balance_transaction": {
+                  "description": "Balance transaction associated with the transaction.",
+                  "type": ["null", "string"]
+                },
+                "card": {
+                  "description": "The card used for the transaction.",
+                  "type": ["null", "string"]
+                },
+                "cardholder": {
+                  "description": "Details about the cardholder for the transaction.",
+                  "type": ["null", "string"]
+                },
+                "created": {
+                  "description": "Timestamp for when the transaction was created.",
+                  "type": ["null", "integer"]
+                },
+                "currency": {
+                  "description": "The currency of the transaction.",
+                  "type": ["null", "string"]
+                },
+                "dispute": {
+                  "description": "Any dispute related to the transaction.",
+                  "type": ["null", "string"]
+                },
+                "id": {
+                  "description": "The unique identifier for the transaction.",
+                  "type": ["null", "string"]
+                },
+                "livemode": {
+                  "description": "Indicates if the transaction is in live mode.",
+                  "type": ["null", "boolean"]
+                },
+                "merchant_amount": {
+                  "description": "The amount in merchant's currency for the transaction.",
+                  "type": ["null", "integer"]
+                },
+                "merchant_currency": {
+                  "description": "The currency used by the merchant for the transaction.",
+                  "type": ["null", "string"]
+                },
+                "merchant_data": {
+                  "description": "Data about the merchant for the transaction.",
+                  "type": ["null", "object"],
+                  "properties": {
+                    "category": {
+                      "description": "The category of the merchant for the transaction.",
+                      "type": ["null", "string"]
+                    },
+                    "city": {
+                      "description": "City where the merchant is located for the transaction.",
+                      "type": ["null", "string"]
+                    },
+                    "country": {
+                      "description": "Country where the merchant is located for the transaction.",
+                      "type": ["null", "string"]
+                    },
+                    "name": {
+                      "description": "Name of the merchant for the transaction.",
+                      "type": ["null", "string"]
+                    },
+                    "network_id": {
+                      "description": "Network ID of the merchant for the transaction.",
+                      "type": ["null", "string"]
+                    },
+                    "postal_code": {
+                      "description": "Postal code of the merchant for the transaction.",
+                      "type": ["null", "string"]
+                    },
+                    "state": {
+                      "description": "State where the merchant is located for the transaction.",
+                      "type": ["null", "string"]
+                    }
+                  }
+                },
+                "metadata": {
+                  "description": "Additional metadata related to the transaction.",
+                  "type": ["null", "object"],
+                  "additionalProperties": true
+                },
+                "object": {
+                  "description": "Type of object, in this case, always 'transaction'.",
+                  "type": ["null", "string"]
+                },
+                "purchase_details": {
+                  "type": ["null", "object"],
+                  "properties": {
+                    "flight": {
+                      "type": ["null", "object"],
+                      "properties": {
+                        "departure_at": { "type": ["null", "integer"] },
+                        "passenger_name": { "type": ["null", "string"] },
+                        "refundable": { "type": ["null", "boolean"] },
+                        "segments": {
+                          "type": ["null", "array"],
+                          "items": {
+                            "type": ["null", "object"],
+                            "properties": {
+                              "arrival_airport_code": {
+                                "type": ["null", "string"]
+                              },
+                              "carrier": { "type": ["null", "string"] },
+                              "departure_airport_code": {
+                                "type": ["null", "string"]
+                              },
+                              "flight_number": { "type": ["null", "string"] },
+                              "service_class": { "type": ["null", "string"] },
+                              "stopover_allowed": {
+                                "type": ["null", "boolean"]
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "travel_agency": { "type": ["null", "string"] }
+                    }
+                  },
+                  "fuel": {
+                    "type": ["null", "object"],
+                    "properties": {
+                      "type": { "type": ["null", "string"] },
+                      "unit": { "type": ["null", "string"] },
+                      "unit_cost_decimal": { "type": ["null", "string"] },
+                      "volume_decimal": { "type": ["null", "string"] }
+                    }
+                  },
+                  "lodging": {
+                    "type": ["null", "object"],
+                    "properties": {
+                      "check_in_at": { "type": ["null", "integer"] },
+                      "nights": { "type": ["null", "integer"] }
+                    }
+                  },
+                  "receipt": {
+                    "items": {
+                      "type": ["null", "object"],
+                      "properties": {
+                        "description": { "type": ["null", "string"] },
+                        "quantity": { "type": ["null", "number"] },
+                        "total": { "type": ["null", "integer"] },
+                        "unit_cost": { "type": ["null", "integer"] }
+                      }
+                    },
+                    "type": ["null", "array"]
+                  },
+                  "reference": { "type": ["null", "string"] }
+                }
+              }
+            }
+          },
+          "verification_data": {
+            "description": "Data related to verification of the authorization.",
+            "type": ["null", "object"],
+            "properties": {
+              "address_line1_check": {
+                "description": "Result of address line 1 check during verification.",
+                "type": ["null", "string"]
+              },
+              "address_postal_code_check": {
+                "description": "Result of postal code check during verification.",
+                "type": ["null", "string"]
+              },
+              "cvc_check": {
+                "description": "Result of CVC check during verification.",
+                "type": ["null", "string"]
+              },
+              "expiry_check": {
+                "description": "Result of expiry check during verification.",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "wallet": {
+            "description": "Information about the wallet used for the authorization.",
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "customers",
+      "json_schema": {
+        "type": ["null", "object"],
+        "properties": {
+          "metadata": { "type": ["null", "object"], "properties": {} },
+          "preferred_locales": {
+            "type": ["null", "array"],
+            "items": { "type": ["null", "string"] }
+          },
+          "invoice_settings": {
+            "type": ["null", "object"],
+            "properties": {
+              "custom_fields": {
+                "type": ["null", "array"],
+                "items": { "type": ["null", "string"] }
+              },
+              "default_payment_method": { "type": ["null", "string"] },
+              "footer": { "type": ["null", "string"] }
+            }
+          },
+          "name": { "type": ["null", "string"] },
+          "tax_exempt": { "type": ["null", "string"] },
+          "next_invoice_sequence": { "type": ["null", "integer"] },
+          "balance": { "type": ["null", "integer"] },
+          "phone": { "type": ["null", "string"] },
+          "address": {
+            "type": ["null", "object"],
+            "properties": {
+              "city": { "type": ["null", "string"] },
+              "country": { "type": ["null", "string"] },
+              "line1": { "type": ["null", "string"] },
+              "line2": { "type": ["null", "string"] },
+              "postal_code": { "type": ["null", "string"] },
+              "state": { "type": ["null", "string"] }
+            }
+          },
+          "shipping": {
+            "type": ["null", "object"],
+            "properties": {
+              "address": {
+                "type": ["null", "object"],
+                "properties": {
+                  "city": { "type": ["null", "string"] },
+                  "country": { "type": ["null", "string"] },
+                  "line1": { "type": ["null", "string"] },
+                  "line2": { "type": ["null", "string"] },
+                  "postal_code": { "type": ["null", "string"] },
+                  "state": { "type": ["null", "string"] }
+                }
+              },
+              "name": { "type": ["null", "string"] },
+              "phone": { "type": ["null", "string"] }
+            }
+          },
+          "sources": {
+            "anyOf": [
+              {
+                "type": ["null", "array"],
+                "items": {
+                  "type": ["null", "object"],
+                  "properties": {
+                    "metadata": {
+                      "type": ["null", "object"],
+                      "properties": {}
+                    },
+                    "type": { "type": ["null", "string"] },
+                    "address_zip": { "type": ["null", "string"] },
+                    "livemode": { "type": ["null", "boolean"] },
+                    "card": {
+                      "type": ["null", "object"],
+                      "properties": {
+                        "fingerprint": { "type": ["null", "string"] },
+                        "last4": { "type": ["null", "string"] },
+                        "dynamic_last4": { "type": ["null", "string"] },
+                        "address_line1_check": { "type": ["null", "string"] },
+                        "exp_month": { "type": ["null", "integer"] },
+                        "tokenization_method": { "type": ["null", "string"] },
+                        "name": { "type": ["null", "string"] },
+                        "exp_year": { "type": ["null", "integer"] },
+                        "three_d_secure": { "type": ["null", "string"] },
+                        "funding": { "type": ["null", "string"] },
+                        "brand": { "type": ["null", "string"] },
+                        "cvc_check": { "type": ["null", "string"] },
+                        "country": { "type": ["null", "string"] },
+                        "address_zip_check": { "type": ["null", "string"] },
+                        "type": { "type": ["null", "string"] }
+                      }
+                    },
+                    "statement_descriptor": { "type": ["null", "string"] },
+                    "id": { "type": ["null", "string"] },
+                    "address_country": { "type": ["null", "string"] },
+                    "funding": { "type": ["null", "string"] },
+                    "dynamic_last4": { "type": ["null", "string"] },
+                    "exp_year": { "type": ["null", "integer"] },
+                    "last4": { "type": ["null", "string"] },
+                    "exp_month": { "type": ["null", "integer"] },
+                    "brand": { "type": ["null", "string"] },
+                    "address_line2": { "type": ["null", "string"] },
+                    "country": { "type": ["null", "string"] },
+                    "object": { "type": ["null", "string"] },
+                    "amount": { "type": ["null", "integer"] },
+                    "cvc_check": { "type": ["null", "string"] },
+                    "usage": { "type": ["null", "string"] },
+                    "address_line1": { "type": ["null", "string"] },
+                    "owner": {
+                      "type": ["null", "object"],
+                      "properties": {
+                        "verified_address": { "type": ["null", "string"] },
+                        "email": { "type": ["null", "string"] },
+                        "address": {
+                          "type": ["null", "object"],
+                          "properties": {
+                            "city": { "type": ["null", "string"] },
+                            "country": { "type": ["null", "string"] },
+                            "line1": { "type": ["null", "string"] },
+                            "line2": { "type": ["null", "string"] },
+                            "postal_code": { "type": ["null", "string"] },
+                            "state": { "type": ["null", "string"] }
+                          }
+                        },
+                        "verified_email": { "type": ["null", "string"] },
+                        "name": { "type": ["null", "string"] },
+                        "phone": { "type": ["null", "string"] },
+                        "verified_name": { "type": ["null", "string"] },
+                        "verified_phone": { "type": ["null", "string"] }
+                      }
+                    },
+                    "tokenization_method": { "type": ["null", "string"] },
+                    "client_secret": { "type": ["null", "string"] },
+                    "fingerprint": { "type": ["null", "string"] },
+                    "address_city": { "type": ["null", "string"] },
+                    "currency": { "type": ["null", "string"] },
+                    "address_line1_check": { "type": ["null", "string"] },
+                    "receiver": {
+                      "type": ["null", "object"],
+                      "properties": {
+                        "refund_attributes_method": {
+                          "type": ["null", "string"]
+                        },
+                        "amount_returned": { "type": ["null", "integer"] },
+                        "amount_received": { "type": ["null", "integer"] },
+                        "refund_attributes_status": {
+                          "type": ["null", "string"]
+                        },
+                        "address": { "type": ["null", "string"] },
+                        "amount_charged": { "type": ["null", "integer"] }
+                      }
+                    },
+                    "flow": { "type": ["null", "string"] },
+                    "name": { "type": ["null", "string"] },
+                    "ach_credit_transfer": {
+                      "type": ["null", "object"],
+                      "properties": {
+                        "bank_name": { "type": ["null", "string"] },
+                        "fingerprint": { "type": ["null", "string"] },
+                        "routing_number": { "type": ["null", "string"] },
+                        "swift_code": { "type": ["null", "string"] },
+                        "refund_account_holder_type": {
+                          "type": ["null", "string"]
+                        },
+                        "refund_account_holder_name": {
+                          "type": ["null", "string"]
+                        },
+                        "refund_account_number": { "type": ["null", "string"] },
+                        "refund_routing_number": { "type": ["null", "string"] },
+                        "account_number": { "type": ["null", "string"] }
+                      }
+                    },
+                    "customer": { "type": ["null", "string"] },
+                    "address_zip_check": { "type": ["null", "string"] },
+                    "status": { "type": ["null", "string"] },
+                    "created": { "type": ["null", "integer"] },
+                    "address_state": { "type": ["null", "string"] },
+                    "alipay": { "type": ["null", "object"], "properties": {} },
+                    "bancontact": {
+                      "type": ["null", "object"],
+                      "properties": {}
+                    },
+                    "eps": { "type": ["null", "object"], "properties": {} },
+                    "ideal": { "type": ["null", "object"], "properties": {} },
+                    "multibanco": {
+                      "type": ["null", "object"],
+                      "properties": {}
+                    },
+                    "redirect": {
+                      "type": ["null", "object"],
+                      "properties": {
+                        "failure_reason": { "type": ["null", "string"] },
+                        "return_url": { "type": ["null", "string"] },
+                        "status": { "type": ["null", "string"] },
+                        "url": { "type": ["null", "string"] }
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "type": ["null", "object"],
+                "properties": {
+                  "metadata": { "type": ["null", "object"], "properties": {} },
+                  "type": { "type": ["null", "string"] },
+                  "address_zip": { "type": ["null", "string"] },
+                  "livemode": { "type": ["null", "boolean"] },
+                  "card": {
+                    "type": ["null", "object"],
+                    "properties": {
+                      "fingerprint": { "type": ["null", "string"] },
+                      "last4": { "type": ["null", "string"] },
+                      "dynamic_last4": { "type": ["null", "string"] },
+                      "address_line1_check": { "type": ["null", "string"] },
+                      "exp_month": { "type": ["null", "integer"] },
+                      "tokenization_method": { "type": ["null", "string"] },
+                      "name": { "type": ["null", "string"] },
+                      "exp_year": { "type": ["null", "integer"] },
+                      "three_d_secure": { "type": ["null", "string"] },
+                      "funding": { "type": ["null", "string"] },
+                      "brand": { "type": ["null", "string"] },
+                      "cvc_check": { "type": ["null", "string"] },
+                      "country": { "type": ["null", "string"] },
+                      "address_zip_check": { "type": ["null", "string"] },
+                      "type": { "type": ["null", "string"] }
+                    }
+                  },
+                  "statement_descriptor": { "type": ["null", "string"] },
+                  "id": { "type": ["null", "string"] },
+                  "address_country": { "type": ["null", "string"] },
+                  "funding": { "type": ["null", "string"] },
+                  "dynamic_last4": { "type": ["null", "string"] },
+                  "exp_year": { "type": ["null", "integer"] },
+                  "last4": { "type": ["null", "string"] },
+                  "exp_month": { "type": ["null", "integer"] },
+                  "brand": { "type": ["null", "string"] },
+                  "address_line2": { "type": ["null", "string"] },
+                  "country": { "type": ["null", "string"] },
+                  "object": { "type": ["null", "string"] },
+                  "amount": { "type": ["null", "integer"] },
+                  "cvc_check": { "type": ["null", "string"] },
+                  "usage": { "type": ["null", "string"] },
+                  "address_line1": { "type": ["null", "string"] },
+                  "owner": {
+                    "type": ["null", "object"],
+                    "properties": {
+                      "verified_address": { "type": ["null", "string"] },
+                      "email": { "type": ["null", "string"] },
+                      "address": {
+                        "type": ["null", "object"],
+                        "properties": {
+                          "city": { "type": ["null", "string"] },
+                          "country": { "type": ["null", "string"] },
+                          "line1": { "type": ["null", "string"] },
+                          "line2": { "type": ["null", "string"] },
+                          "postal_code": { "type": ["null", "string"] },
+                          "state": { "type": ["null", "string"] }
+                        }
+                      },
+                      "verified_email": { "type": ["null", "string"] },
+                      "name": { "type": ["null", "string"] },
+                      "phone": { "type": ["null", "string"] },
+                      "verified_name": { "type": ["null", "string"] },
+                      "verified_phone": { "type": ["null", "string"] }
+                    }
+                  },
+                  "tokenization_method": { "type": ["null", "string"] },
+                  "client_secret": { "type": ["null", "string"] },
+                  "fingerprint": { "type": ["null", "string"] },
+                  "address_city": { "type": ["null", "string"] },
+                  "currency": { "type": ["null", "string"] },
+                  "address_line1_check": { "type": ["null", "string"] },
+                  "receiver": {
+                    "type": ["null", "object"],
+                    "properties": {
+                      "refund_attributes_method": {
+                        "type": ["null", "string"]
+                      },
+                      "amount_returned": { "type": ["null", "integer"] },
+                      "amount_received": { "type": ["null", "integer"] },
+                      "refund_attributes_status": {
+                        "type": ["null", "string"]
+                      },
+                      "address": { "type": ["null", "string"] },
+                      "amount_charged": { "type": ["null", "integer"] }
+                    }
+                  },
+                  "flow": { "type": ["null", "string"] },
+                  "name": { "type": ["null", "string"] },
+                  "ach_credit_transfer": {
+                    "type": ["null", "object"],
+                    "properties": {
+                      "bank_name": { "type": ["null", "string"] },
+                      "fingerprint": { "type": ["null", "string"] },
+                      "routing_number": { "type": ["null", "string"] },
+                      "swift_code": { "type": ["null", "string"] },
+                      "refund_account_holder_type": {
+                        "type": ["null", "string"]
+                      },
+                      "refund_account_holder_name": {
+                        "type": ["null", "string"]
+                      },
+                      "refund_account_number": { "type": ["null", "string"] },
+                      "refund_routing_number": { "type": ["null", "string"] },
+                      "account_number": { "type": ["null", "string"] }
+                    }
+                  },
+                  "customer": { "type": ["null", "string"] },
+                  "address_zip_check": { "type": ["null", "string"] },
+                  "status": { "type": ["null", "string"] },
+                  "created": { "type": ["null", "integer"] },
+                  "address_state": { "type": ["null", "string"] },
+                  "alipay": { "type": ["null", "object"], "properties": {} },
+                  "bancontact": {
+                    "type": ["null", "object"],
+                    "properties": {}
+                  },
+                  "eps": { "type": ["null", "object"], "properties": {} },
+                  "ideal": { "type": ["null", "object"], "properties": {} },
+                  "multibanco": {
+                    "type": ["null", "object"],
+                    "properties": {}
+                  },
+                  "redirect": {
+                    "type": ["null", "object"],
+                    "properties": {
+                      "failure_reason": { "type": ["null", "string"] },
+                      "return_url": { "type": ["null", "string"] },
+                      "status": { "type": ["null", "string"] },
+                      "url": { "type": ["null", "string"] }
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          "delinquent": { "type": ["null", "boolean"] },
+          "description": { "type": ["null", "string"] },
+          "livemode": { "type": ["null", "boolean"] },
+          "default_source": { "type": ["null", "string"] },
+          "cards": {
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "metadata": { "type": ["null", "object"], "properties": {} },
+                "object": { "type": ["null", "string"] },
+                "id": { "type": ["null", "string"] },
+                "exp_month": { "type": ["null", "integer"] },
+                "dynamic_last4": { "type": ["null", "string"] },
+                "exp_year": { "type": ["null", "integer"] },
+                "last4": { "type": ["null", "string"] },
+                "funding": { "type": ["null", "string"] },
+                "brand": { "type": ["null", "string"] },
+                "country": { "type": ["null", "string"] },
+                "customer": { "type": ["null", "string"] },
+                "cvc_check": { "type": ["null", "string"] },
+                "address_line2": { "type": ["null", "string"] },
+                "address_line1": { "type": ["null", "string"] },
+                "fingerprint": { "type": ["null", "string"] },
+                "address_zip": { "type": ["null", "string"] },
+                "address_city": { "type": ["null", "string"] },
+                "address_country": { "type": ["null", "string"] },
+                "address_line1_check": { "type": ["null", "string"] },
+                "tokenization_method": { "type": ["null", "string"] },
+                "name": { "type": ["null", "string"] },
+                "address_state": { "type": ["null", "string"] },
+                "address_zip_check": { "type": ["null", "string"] },
+                "type": { "type": ["null", "string"] }
+              }
+            }
+          },
+          "email": { "type": ["null", "string"] },
+          "default_card": { "type": ["null", "string"] },
+          "subscriptions": {
+            "type": ["null", "object"],
+            "properties": {
+              "object": { "type": ["null", "string"] },
+              "data": { "type": ["null", "array"] },
+              "has_more": { "type": ["null", "boolean"] },
+              "total_count": { "type": ["null", "number"] },
+              "url": { "type": ["null", "string"] }
+            }
+          },
+          "discount": {
+            "type": ["null", "object"],
+            "properties": {
+              "end": { "type": ["null", "integer"] },
+              "coupon": {
+                "type": ["null", "object"],
+                "properties": {
+                  "metadata": { "type": ["null", "object"], "properties": {} },
+                  "valid": { "type": ["null", "boolean"] },
+                  "livemode": { "type": ["null", "boolean"] },
+                  "amount_off": { "type": ["null", "integer"] },
+                  "redeem_by": { "type": ["null", "integer"] },
+                  "duration_in_months": { "type": ["null", "integer"] },
+                  "percent_off_precise": { "type": ["null", "number"] },
+                  "max_redemptions": { "type": ["null", "integer"] },
+                  "currency": { "type": ["null", "string"] },
+                  "name": { "type": ["null", "string"] },
+                  "times_redeemed": { "type": ["null", "integer"] },
+                  "id": { "type": ["null", "string"] },
+                  "duration": { "type": ["null", "string"] },
+                  "object": { "type": ["null", "string"] },
+                  "percent_off": { "type": ["null", "number"] },
+                  "created": { "type": ["null", "integer"] }
+                }
+              },
+              "customer": { "type": ["null", "string"] },
+              "start": { "type": ["null", "integer"] },
+              "object": { "type": ["null", "string"] },
+              "subscription": { "type": ["null", "string"] }
+            }
+          },
+          "account_balance": { "type": ["null", "integer"] },
+          "currency": { "type": ["null", "string"] },
+          "id": { "type": ["null", "string"] },
+          "invoice_prefix": { "type": ["null", "string"] },
+          "tax_info_verification": { "type": ["null", "string"] },
+          "object": { "type": ["null", "string"] },
+          "created": { "type": ["null", "integer"] },
+          "updated": { "type": ["null", "integer"] },
+          "tax_info": { "type": ["null", "string"] },
+          "test_clock": { "type": ["null", "string"] },
+          "is_deleted": { "type": ["null", "boolean"] }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "cardholders",
+      "json_schema": {
+        "type": ["null", "object"],
+        "properties": {
+          "billing": {
+            "type": ["null", "object"],
+            "properties": {
+              "address": {
+                "type": ["null", "object"],
+                "properties": {
+                  "city": { "type": ["null", "string"] },
+                  "country": { "type": ["null", "string"] },
+                  "line1": { "type": ["null", "string"] },
+                  "line2": { "type": ["null", "string"] },
+                  "postal_code": { "type": ["null", "string"] },
+                  "state": { "type": ["null", "string"] }
+                }
+              }
+            }
+          },
+          "company": {
+            "type": ["null", "object"],
+            "properties": { "tax_id_provided": { "type": "boolean" } }
+          },
+          "created": { "type": ["null", "integer"] },
+          "updated": { "type": ["null", "integer"] },
+          "email": { "type": ["null", "string"] },
+          "id": { "type": ["null", "string"] },
+          "individual": {
+            "type": ["null", "object"],
+            "properties": {
+              "dob": {
+                "type": ["null", "object"],
+                "properties": {
+                  "day": { "type": ["null", "integer"] },
+                  "month": { "type": ["null", "integer"] },
+                  "year": { "type": ["null", "integer"] }
+                }
+              },
+              "first_name": { "type": ["null", "string"] },
+              "last_name": { "type": ["null", "string"] },
+              "verification": {
+                "type": ["null", "object"],
+                "properties": {
+                  "document": {
+                    "type": ["null", "object"],
+                    "properties": {
+                      "back": { "type": ["null", "string"] },
+                      "front": { "type": ["null", "string"] }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "livemode": { "type": ["null", "boolean"] },
+          "metadata": { "type": ["null", "object"] },
+          "name": { "type": ["null", "string"] },
+          "object": { "type": ["null", "string"] },
+          "phone_number": { "type": ["null", "string"] },
+          "requirements": {
+            "type": ["null", "object"],
+            "properties": {
+              "disabled_reason": { "type": ["null", "string"] },
+              "past_due": {
+                "type": ["null", "array"],
+                "items": { "type": ["null", "string"] }
+              }
+            }
+          },
+          "spending_controls": {
+            "type": ["null", "object"],
+            "properties": {
+              "allowed_categories": {
+                "type": ["null", "array"],
+                "items": { "type": ["null", "string"] }
+              },
+              "blocked_categories": {
+                "type": ["null", "array"],
+                "items": { "type": ["null", "string"] }
+              },
+              "spending_limits": {
+                "type": ["null", "array"],
+                "items": { "type": ["null", "object"] }
+              },
+              "spending_limits_currency": { "type": ["null", "string"] }
+            }
+          },
+          "status": { "type": ["null", "string"] },
+          "type": { "type": ["null", "string"] },
+          "preferred_locales": {
+            "type": ["null", "array"],
+            "items": { "type": ["null", "string"] }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "charges",
+      "json_schema": {
+        "type": ["null", "object"],
+        "properties": {
+          "metadata": {
+            "description": "Additional metadata associated with the charge.",
+            "type": ["null", "object"],
+            "properties": {}
+          },
+          "fraud_details": {
+            "description": "Details of fraud reports.",
+            "type": ["null", "object"],
+            "properties": {
+              "stripe_report": {
+                "description": "The ID of the fraud report from Stripe.",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "transfer_group": {
+            "description": "The transfer group of the charge.",
+            "type": ["null", "string"]
+          },
+          "on_behalf_of": {
+            "description": "The ID of the account on behalf of which the charge is made.",
+            "type": ["null", "string"]
+          },
+          "review": {
+            "description": "A boolean indicating if the charge is under review.",
+            "type": ["null", "string"]
+          },
+          "failure_message": {
+            "description": "The failure error message for the charge.",
+            "type": ["null", "string"]
+          },
+          "receipt_email": {
+            "description": "The email address to send receipt of the charge.",
+            "type": ["null", "string"]
+          },
+          "statement_descriptor": {
+            "description": "The statement descriptor for the charge.",
+            "type": ["null", "string"]
+          },
+          "source": {
+            "description": "Details of the payment source for the charge.",
+            "type": ["null", "object"],
+            "properties": {
+              "metadata": {
+                "description": "Metadata related to the payment source.",
+                "type": ["null", "object"],
+                "properties": {}
+              },
+              "type": { "type": ["null", "string"] },
+              "address_zip": { "type": ["null", "string"] },
+              "livemode": { "type": ["null", "boolean"] },
+              "card": {
+                "description": "Details of the credit/debit card source.",
+                "type": ["null", "object"],
+                "properties": {
+                  "fingerprint": { "type": ["null", "string"] },
+                  "last4": { "type": ["null", "string"] },
+                  "dynamic_last4": { "type": ["null", "string"] },
+                  "address_line1_check": { "type": ["null", "string"] },
+                  "exp_month": { "type": ["null", "integer"] },
+                  "tokenization_method": { "type": ["null", "string"] },
+                  "name": { "type": ["null", "string"] },
+                  "exp_year": { "type": ["null", "integer"] },
+                  "three_d_secure": { "type": ["null", "string"] },
+                  "funding": { "type": ["null", "string"] },
+                  "brand": { "type": ["null", "string"] },
+                  "cvc_check": { "type": ["null", "string"] },
+                  "country": { "type": ["null", "string"] },
+                  "address_zip_check": { "type": ["null", "string"] },
+                  "type": { "type": ["null", "string"] }
+                }
+              },
+              "statement_descriptor": { "type": ["null", "string"] },
+              "id": { "type": ["null", "string"] },
+              "address_country": { "type": ["null", "string"] },
+              "funding": { "type": ["null", "string"] },
+              "dynamic_last4": { "type": ["null", "string"] },
+              "exp_year": { "type": ["null", "integer"] },
+              "last4": { "type": ["null", "string"] },
+              "exp_month": { "type": ["null", "integer"] },
+              "brand": { "type": ["null", "string"] },
+              "address_line2": { "type": ["null", "string"] },
+              "country": { "type": ["null", "string"] },
+              "object": { "type": ["null", "string"] },
+              "amount": { "type": ["null", "integer"] },
+              "cvc_check": { "type": ["null", "string"] },
+              "usage": { "type": ["null", "string"] },
+              "address_line1": { "type": ["null", "string"] },
+              "owner": {
+                "description": "Details of the owner of the payment source.",
+                "type": ["null", "object"],
+                "properties": {
+                  "verified_address": { "type": ["null", "string"] },
+                  "email": { "type": ["null", "string"] },
+                  "address": {
+                    "type": ["null", "object"],
+                    "properties": {
+                      "city": { "type": ["null", "string"] },
+                      "country": { "type": ["null", "string"] },
+                      "line1": { "type": ["null", "string"] },
+                      "line2": { "type": ["null", "string"] },
+                      "postal_code": { "type": ["null", "string"] },
+                      "state": { "type": ["null", "string"] }
+                    }
+                  },
+                  "verified_email": { "type": ["null", "string"] },
+                  "name": { "type": ["null", "string"] },
+                  "phone": { "type": ["null", "string"] },
+                  "verified_name": { "type": ["null", "string"] },
+                  "verified_phone": { "type": ["null", "string"] }
+                }
+              },
+              "tokenization_method": { "type": ["null", "string"] },
+              "client_secret": { "type": ["null", "string"] },
+              "fingerprint": { "type": ["null", "string"] },
+              "address_city": { "type": ["null", "string"] },
+              "currency": { "type": ["null", "string"] },
+              "address_line1_check": { "type": ["null", "string"] },
+              "receiver": {
+                "description": "Details of the receiver of the payment source.",
+                "type": ["null", "object"],
+                "properties": {
+                  "refund_attributes_method": { "type": ["null", "string"] },
+                  "amount_returned": { "type": ["null", "integer"] },
+                  "amount_received": { "type": ["null", "integer"] },
+                  "refund_attributes_status": { "type": ["null", "string"] },
+                  "address": { "type": ["null", "string"] },
+                  "amount_charged": { "type": ["null", "integer"] }
+                }
+              },
+              "flow": { "type": ["null", "string"] },
+              "name": { "type": ["null", "string"] },
+              "ach_credit_transfer": {
+                "description": "Details of the ACH credit transfer source.",
+                "type": ["null", "object"],
+                "properties": {
+                  "bank_name": { "type": ["null", "string"] },
+                  "fingerprint": { "type": ["null", "string"] },
+                  "routing_number": { "type": ["null", "string"] },
+                  "swift_code": { "type": ["null", "string"] },
+                  "refund_account_holder_type": { "type": ["null", "string"] },
+                  "refund_account_holder_name": { "type": ["null", "string"] },
+                  "refund_account_number": { "type": ["null", "string"] },
+                  "refund_routing_number": { "type": ["null", "string"] },
+                  "account_number": { "type": ["null", "string"] }
+                }
+              },
+              "customer": { "type": ["null", "string"] },
+              "address_zip_check": { "type": ["null", "string"] },
+              "status": { "type": ["null", "string"] },
+              "created": { "type": ["null", "integer"] },
+              "address_state": { "type": ["null", "string"] },
+              "alipay": {
+                "description": "Details of the Alipay source.",
+                "type": ["null", "object"],
+                "properties": {}
+              },
+              "bancontact": {
+                "description": "Details of the Bancontact source.",
+                "type": ["null", "object"],
+                "properties": {}
+              },
+              "eps": {
+                "description": "Details of the EPS source.",
+                "type": ["null", "object"],
+                "properties": {}
+              },
+              "ideal": {
+                "description": "Details of the iDeal source.",
+                "type": ["null", "object"],
+                "properties": {}
+              },
+              "multibanco": {
+                "description": "Details of the Multibanco source.",
+                "type": ["null", "object"],
+                "properties": {}
+              },
+              "redirect": {
+                "description": "Details of the redirect setup for the payment source.",
+                "type": ["null", "object"],
+                "properties": {
+                  "failure_reason": { "type": ["null", "string"] },
+                  "return_url": { "type": ["null", "string"] },
+                  "status": { "type": ["null", "string"] },
+                  "url": { "type": ["null", "string"] }
+                }
+              }
+            }
+          },
+          "destination": {
+            "description": "The ID of the destination on account to which funds are to be transferred.",
+            "type": ["null", "string"]
+          },
+          "id": {
+            "description": "The unique ID of the charge instance.",
+            "type": ["string"]
+          },
+          "object": {
+            "description": "Object type, always set to 'charge'.",
+            "type": ["null", "string"]
+          },
+          "outcome": {
+            "description": "Details of the outcome of the charge.",
+            "type": ["null", "object"],
+            "properties": {
+              "type": { "type": ["null", "string"] },
+              "seller_message": { "type": ["null", "string"] },
+              "reason": { "type": ["null", "string"] },
+              "risk_level": { "type": ["null", "string"] },
+              "network_status": { "type": ["null", "string"] },
+              "risk_score": { "type": ["null", "integer"] }
+            }
+          },
+          "status": {
+            "description": "The status of the charge.",
+            "type": ["null", "string"]
+          },
+          "currency": {
+            "description": "The currency in which the charge was made.",
+            "type": ["null", "string"]
+          },
+          "created": {
+            "description": "The timestamp when the charge was created.",
+            "type": ["null", "integer"]
+          },
+          "updated": {
+            "description": "The timestamp when the charge was last updated.",
+            "type": ["null", "integer"]
+          },
+          "order": {
+            "description": "The ID of the order associated with the charge.",
+            "type": ["null", "string"]
+          },
+          "application": {
+            "description": "The ID of the application associated with the charge.",
+            "type": ["null", "string"]
+          },
+          "refunded": {
+            "description": "A boolean indicating if the charge has been refunded.",
+            "type": ["null", "boolean"]
+          },
+          "receipt_number": {
+            "description": "The receipt number associated with the charge.",
+            "type": ["null", "string"]
+          },
+          "livemode": {
+            "description": "A boolean indicating if the charge is in live mode.",
+            "type": ["null", "boolean"]
+          },
+          "captured": {
+            "description": "A boolean indicating if the charge has been captured.",
+            "type": ["null", "boolean"]
+          },
+          "paid": {
+            "description": "A boolean indicating if the charge has been paid.",
+            "type": ["null", "boolean"]
+          },
+          "shipping": {
+            "description": "Details of shipping information for the charge.",
+            "type": ["null", "object"],
+            "properties": {}
+          },
+          "invoice": {
+            "description": "The ID of the invoice associated with the charge.",
+            "type": ["null", "string"]
+          },
+          "amount": {
+            "description": "The total amount in cents that was charged.",
+            "type": ["null", "integer"]
+          },
+          "customer": {
+            "description": "The ID of the customer associated with the charge.",
+            "type": ["null", "string"]
+          },
+          "payment_intent": {
+            "description": "The ID of the payment intent associated with the charge.",
+            "type": ["null", "string"]
+          },
+          "source_transfer": {
+            "description": "The ID of the source transfer associated with the charge.",
+            "type": ["null", "string"]
+          },
+          "statement_description": {
+            "description": "The statement description for the charge.",
+            "type": ["null", "string"]
+          },
+          "refunds": {
+            "description": "Details of refunds against the charge.",
+            "type": ["null", "object"],
+            "properties": {
+              "object": { "type": ["null", "string"] },
+              "data": { "type": ["null", "array"] },
+              "has_more": { "type": ["null", "boolean"] },
+              "total_count": { "type": ["null", "number"] },
+              "url": { "type": ["null", "string"] }
+            }
+          },
+          "application_fee": {
+            "description": "The ID of the application fee if the charge is an application fee.",
+            "type": ["null", "string"]
+          },
+          "card": {
+            "description": "Details of the credit/debit card used for the charge.",
+            "type": ["null", "object"],
+            "properties": {
+              "metadata": {
+                "description": "Metadata related to the card.",
+                "type": ["null", "object"],
+                "properties": {}
+              },
+              "exp_month": { "type": ["null", "integer"] },
+              "address_state": { "type": ["null", "string"] },
+              "id": { "type": ["null", "string"] },
+              "object": { "type": ["null", "string"] },
+              "address_line1_check": { "type": ["null", "string"] },
+              "address_line1": { "type": ["null", "string"] },
+              "exp_year": { "type": ["null", "integer"] },
+              "tokenization_method": { "type": ["null", "string"] },
+              "address_country": { "type": ["null", "string"] },
+              "fingerprint": { "type": ["null", "string"] },
+              "address_city": { "type": ["null", "string"] },
+              "last4": { "type": ["null", "string"] },
+              "address_line2": { "type": ["null", "string"] },
+              "customer": { "type": ["null", "string"] },
+              "brand": { "type": ["null", "string"] },
+              "country": { "type": ["null", "string"] },
+              "dynamic_last4": { "type": ["null", "string"] },
+              "name": { "type": ["null", "string"] },
+              "funding": { "type": ["null", "string"] },
+              "address_zip": { "type": ["null", "string"] },
+              "address_zip_check": { "type": ["null", "string"] },
+              "cvc_check": { "type": ["null", "string"] },
+              "type": { "type": ["null", "string"] }
+            }
+          },
+          "payment_method_details": {
+            "description": "Details of the payment method used for the charge.",
+            "type": ["null", "object"],
+            "properties": {
+              "ach_credit_transfer": {
+                "description": "Details of the ACH credit transfer payment method.",
+                "type": ["null", "object"],
+                "properties": {
+                  "account_number": { "type": ["null", "string"] },
+                  "bank_name": { "type": ["null", "string"] },
+                  "routing_number": { "type": ["null", "string"] },
+                  "swift_code": { "type": ["null", "string"] }
+                }
+              },
+              "ach_debit": {
+                "description": "Details of the ACH debit payment method.",
+                "type": ["null", "object"],
+                "properties": {
+                  "account_holder_type": { "type": ["null", "string"] },
+                  "bank_name": { "type": ["null", "string"] },
+                  "country": { "type": ["null", "string"] },
+                  "fingerprint": { "type": ["null", "string"] },
+                  "last4": { "type": ["null", "string"] },
+                  "routing_number": { "type": ["null", "string"] }
+                }
+              },
+              "alipay": { "type": ["null", "object"] },
+              "bancontact": {
+                "description": "Details of the Bancontact payment method.",
+                "type": ["null", "object"],
+                "properties": {
+                  "bank_code": { "type": ["null", "string"] },
+                  "bank_name": { "type": ["null", "string"] },
+                  "bic": { "type": ["null", "string"] },
+                  "iban_last4": { "type": ["null", "string"] },
+                  "preferred_language": { "type": ["null", "string"] },
+                  "verified_name": { "type": ["null", "string"] }
+                }
+              },
+              "card": {
+                "description": "Details of the credit/debit card payment method.",
+                "type": ["null", "object"],
+                "properties": {
+                  "brand": { "type": ["null", "string"] },
+                  "checks": {
+                    "description": "Check details for the card payment.",
+                    "type": ["null", "object"],
+                    "properties": {
+                      "address_line1_check": { "type": ["null", "string"] },
+                      "address_postal_code_check": {
+                        "type": ["null", "string"]
+                      },
+                      "cvc_check": { "type": ["null", "string"] }
+                    }
+                  },
+                  "country": { "type": ["null", "string"] },
+                  "exp_month": { "type": ["null", "integer"] },
+                  "exp_year": { "type": ["null", "integer"] },
+                  "fingerprint": { "type": ["null", "string"] },
+                  "funding": { "type": ["null", "string"] },
+                  "installments": {
+                    "description": "Details of the installments plan for payment.",
+                    "type": ["null", "object"],
+                    "properties": {
+                      "plan": {
+                        "description": "Details of the installment plan.",
+                        "type": ["null", "object"],
+                        "properties": {
+                          "count": { "type": ["null", "integer"] },
+                          "interval": { "type": ["null", "string"] },
+                          "type": { "type": ["null", "string"] }
+                        }
+                      }
+                    }
+                  },
+                  "last4": { "type": ["null", "string"] },
+                  "network": { "type": ["null", "string"] },
+                  "three_d_secure": {
+                    "description": "Details of the 3D Secure authentication for payment.",
+                    "type": ["null", "object"],
+                    "properties": {
+                      "authenticated": { "type": ["null", "boolean"] },
+                      "succeeded": { "type": ["null", "boolean"] },
+                      "version": { "type": ["null", "string"] }
+                    }
+                  },
+                  "wallet": {
+                    "description": "Details of wallet payment methods.",
+                    "type": ["null", "object"],
+                    "properties": {
+                      "amex_express_checkout": {
+                        "description": "Details of the Amex Express Checkout wallet.",
+                        "type": ["null", "object"],
+                        "properties": {}
+                      },
+                      "apple_pay": {
+                        "description": "Details of the Apple Pay wallet.",
+                        "type": ["null", "object"],
+                        "properties": {}
+                      },
+                      "dynamic_last4": { "type": ["null", "string"] },
+                      "google_pay": {
+                        "description": "Details of the Google Pay wallet.",
+                        "type": ["null", "object"],
+                        "properties": {}
+                      },
+                      "masterpass": {
+                        "description": "Details of the Masterpass wallet.",
+                        "type": ["null", "object"],
+                        "properties": {
+                          "billing_address": {
+                            "type": ["null", "object"],
+                            "properties": {
+                              "city": { "type": ["null", "string"] },
+                              "country": { "type": ["null", "string"] },
+                              "line1": { "type": ["null", "string"] },
+                              "line2": { "type": ["null", "string"] },
+                              "postal_code": { "type": ["null", "string"] },
+                              "state": { "type": ["null", "string"] }
+                            }
+                          },
+                          "email": { "type": ["null", "string"] },
+                          "name": { "type": ["null", "string"] },
+                          "shipping_address": {
+                            "type": ["null", "object"],
+                            "properties": {
+                              "city": { "type": ["null", "string"] },
+                              "country": { "type": ["null", "string"] },
+                              "line1": { "type": ["null", "string"] },
+                              "line2": { "type": ["null", "string"] },
+                              "postal_code": { "type": ["null", "string"] },
+                              "state": { "type": ["null", "string"] }
+                            }
+                          }
+                        }
+                      },
+                      "samsung_pay": {
+                        "description": "Details of the Samsung Pay wallet.",
+                        "type": ["null", "object"],
+                        "properties": {}
+                      },
+                      "type": { "type": ["null", "string"] },
+                      "visa_checkout": {
+                        "description": "Details of the Visa Checkout wallet.",
+                        "type": ["null", "object"],
+                        "properties": {
+                          "billing_address": {
+                            "type": ["null", "object"],
+                            "properties": {
+                              "city": { "type": ["null", "string"] },
+                              "country": { "type": ["null", "string"] },
+                              "line1": { "type": ["null", "string"] },
+                              "line2": { "type": ["null", "string"] },
+                              "postal_code": { "type": ["null", "string"] },
+                              "state": { "type": ["null", "string"] }
+                            }
+                          },
+                          "email": { "type": ["null", "string"] },
+                          "name": { "type": ["null", "string"] },
+                          "shipping_address": {
+                            "type": ["null", "object"],
+                            "properties": {
+                              "city": { "type": ["null", "string"] },
+                              "country": { "type": ["null", "string"] },
+                              "line1": { "type": ["null", "string"] },
+                              "line2": { "type": ["null", "string"] },
+                              "postal_code": { "type": ["null", "string"] },
+                              "state": { "type": ["null", "string"] }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "card_present": {
+                    "description": "Details of the card present during payment.",
+                    "type": ["null", "object"],
+                    "properties": {
+                      "brand": { "type": ["null", "string"] },
+                      "country": { "type": ["null", "string"] },
+                      "emv_auth_data": { "type": ["null", "string"] },
+                      "exp_month": { "type": ["null", "integer"] },
+                      "exp_year": { "type": ["null", "integer"] },
+                      "fingerprint": { "type": ["null", "string"] },
+                      "funding": { "type": ["null", "string"] },
+                      "generated_card": { "type": ["null", "string"] },
+                      "last4": { "type": ["null", "string"] },
+                      "network": { "type": ["null", "string"] },
+                      "read_method": { "type": ["null", "string"] },
+                      "receipt": {
+                        "description": "Receipt information related to the card payment.",
+                        "type": ["null", "object"],
+                        "properties": {
+                          "application_cryptogram": {
+                            "type": ["null", "string"]
+                          },
+                          "application_preferred_name": {
+                            "type": ["null", "string"]
+                          },
+                          "authorization_code": { "type": ["null", "string"] },
+                          "authorization_response_code": {
+                            "type": ["null", "string"]
+                          },
+                          "cardholder_verification_method": {
+                            "type": ["null", "string"]
+                          },
+                          "dedicated_file_name": { "type": ["null", "string"] },
+                          "terminal_verification_results": {
+                            "type": ["null", "string"]
+                          },
+                          "transaction_status_information": {
+                            "type": ["null", "string"]
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "eps": {
+                    "description": "Details of the EPS payment method.",
+                    "type": ["null", "object"],
+                    "properties": {
+                      "verified_name": { "type": ["null", "string"] }
+                    }
+                  },
+                  "giropay": {
+                    "description": "Details of the Giropay payment method.",
+                    "type": ["null", "object"],
+                    "properties": {
+                      "bank_code": { "type": ["null", "string"] },
+                      "bank_name": { "type": ["null", "string"] },
+                      "bic": { "type": ["null", "string"] },
+                      "verified_name": { "type": ["null", "string"] }
+                    }
+                  },
+                  "ideal": {
+                    "description": "Details of the iDeal payment method.",
+                    "type": ["null", "object"],
+                    "properties": {
+                      "bank": { "type": ["null", "string"] },
+                      "bic": { "type": ["null", "string"] },
+                      "iban_last4": { "type": ["null", "string"] },
+                      "verified_name": { "type": ["null", "string"] }
+                    }
+                  },
+                  "klarna": {
+                    "description": "Details of the Klarna payment method.",
+                    "type": ["null", "object"],
+                    "properties": {}
+                  },
+                  "multibanco": {
+                    "description": "Details of the Multibanco payment method.",
+                    "type": ["null", "object"],
+                    "properties": {
+                      "entity": { "type": ["null", "string"] },
+                      "reference": { "type": ["null", "string"] }
+                    }
+                  },
+                  "p24": {
+                    "description": "Details of the Przelewy24 payment method.",
+                    "type": ["null", "object"],
+                    "properties": {
+                      "reference": { "type": ["null", "string"] },
+                      "verified_name": { "type": ["null", "string"] }
+                    }
+                  },
+                  "sepa_debit": {
+                    "description": "Details of the SEPA Direct Debit payment method.",
+                    "type": ["null", "object"],
+                    "properties": {
+                      "bank_code": { "type": ["null", "string"] },
+                      "branch_code": { "type": ["null", "string"] },
+                      "country": { "type": ["null", "string"] },
+                      "fingerprint": { "type": ["null", "string"] },
+                      "last4": { "type": ["null", "string"] },
+                      "mandate": { "type": ["null", "string"] }
+                    }
+                  },
+                  "sofort": {
+                    "description": "Details of the SOFORT payment method.",
+                    "type": ["null", "object"],
+                    "properties": {
+                      "bank_code": { "type": ["null", "string"] },
+                      "bank_name": { "type": ["null", "string"] },
+                      "bic": { "type": ["null", "string"] },
+                      "country": { "type": ["null", "string"] },
+                      "iban_last4": { "type": ["null", "string"] },
+                      "verified_name": { "type": ["null", "string"] }
+                    }
+                  },
+                  "stripe_account": {
+                    "description": "Details of the Stripe account used for payment.",
+                    "type": ["null", "object"],
+                    "properties": {}
+                  },
+                  "type": { "type": ["null", "string"] },
+                  "wechat": {
+                    "description": "Details of the WeChat Pay payment method.",
+                    "type": ["null", "object"],
+                    "properties": {}
+                  },
+                  "metadata": {
+                    "description": "Metadata related to the card payment method.",
+                    "type": ["null", "object"],
+                    "properties": {}
+                  },
+                  "address_state": { "type": ["null", "string"] },
+                  "id": { "type": ["null", "string"] },
+                  "object": { "type": ["null", "string"] },
+                  "address_line1_check": { "type": ["null", "string"] },
+                  "address_line1": { "type": ["null", "string"] },
+                  "tokenization_method": { "type": ["null", "string"] },
+                  "address_country": { "type": ["null", "string"] },
+                  "address_city": { "type": ["null", "string"] },
+                  "address_line2": { "type": ["null", "string"] },
+                  "customer": { "type": ["null", "string"] },
+                  "dynamic_last4": { "type": ["null", "string"] },
+                  "name": { "type": ["null", "string"] },
+                  "address_zip": { "type": ["null", "string"] },
+                  "address_zip_check": { "type": ["null", "string"] },
+                  "cvc_check": { "type": ["null", "string"] }
+                }
+              },
+              "type": { "type": ["null", "string"] }
+            }
+          },
+          "balance_transaction": {
+            "description": "The ID of the balance transaction related to the charge.",
+            "type": ["null", "string"]
+          },
+          "amount_refunded": {
+            "description": "The total amount in cents that has been refunded back.",
+            "type": ["null", "integer"]
+          },
+          "failure_code": {
+            "description": "The failure error code for the charge.",
+            "type": ["null", "string"]
+          },
+          "dispute": {
+            "description": "The ID of the dispute associated with the charge.",
+            "type": ["null", "string"]
+          },
+          "description": {
+            "description": "A description of the charge.",
+            "type": ["null", "string"]
+          },
+          "statement_descriptor_suffix": {
+            "description": "The statement descriptor suffix for the charge.",
+            "type": ["null", "string"]
+          },
+          "calculated_statement_descriptor": {
+            "description": "The calculated statement descriptor for the charge.",
+            "type": ["null", "string"]
+          },
+          "receipt_url": {
+            "description": "The URL of the receipt for the charge.",
+            "type": ["null", "string"]
+          },
+          "transfer_data": {
+            "description": "Details of the transfer associated with the charge.",
+            "type": ["null", "object"],
+            "properties": {
+              "amount": { "type": ["null", "integer"] },
+              "destination": { "type": ["null", "string"] }
+            }
+          },
+          "billing_details": {
+            "description": "Details of the billing address and contact information of the customer.",
+            "type": ["null", "object"],
+            "properties": {
+              "address": {
+                "description": "The address details of the customer.",
+                "type": ["null", "object"],
+                "properties": {
+                  "city": { "type": ["null", "string"] },
+                  "country": { "type": ["null", "string"] },
+                  "line1": { "type": ["null", "string"] },
+                  "line2": { "type": ["null", "string"] },
+                  "postal_code": { "type": ["null", "string"] },
+                  "state": { "type": ["null", "string"] }
+                }
+              },
+              "email": {
+                "description": "The email address of the customer.",
+                "type": ["null", "string"]
+              },
+              "name": {
+                "description": "The name of the customer.",
+                "type": ["null", "string"]
+              },
+              "phone": {
+                "description": "The phone number of the customer.",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "failure_balance_transaction": {
+            "description": "The ID of the balance transaction related to the failed charge.",
+            "type": ["null", "string"]
+          },
+          "amount_captured": {
+            "description": "The total amount in cents that has been successfully captured.",
+            "type": ["null", "integer"]
+          },
+          "application_fee_amount": {
+            "description": "The amount in cents of the application fee.",
+            "type": ["null", "integer"]
+          },
+          "amount_updates": {
+            "description": "Additional items related to changes in the amount.",
+            "type": ["null", "array"],
+            "items": { "type": ["null", "string"] }
+          },
+          "payment_method": {
+            "description": "The ID of the payment method used for the charge.",
+            "type": ["null", "string"]
+          },
+          "disputed": {
+            "description": "A boolean indicating if the charge has been disputed.",
+            "type": ["null", "boolean"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "coupons",
+      "json_schema": {
+        "type": ["null", "object"],
+        "properties": {
+          "metadata": {
+            "description": "Additional information associated with the coupon.",
+            "type": ["null", "object"],
+            "properties": {}
+          },
+          "times_redeemed": {
+            "description": "Number of times the coupon has been redeemed.",
+            "type": ["null", "integer"]
+          },
+          "percent_off_precise": {
+            "description": "Precise percentage discount value.",
+            "type": ["null", "number"]
+          },
+          "livemode": {
+            "description": "Indicates if the coupon is in live mode.",
+            "type": ["null", "boolean"]
+          },
+          "object": {
+            "description": "Type of object, in this case, 'coupon'.",
+            "type": ["null", "string"]
+          },
+          "redeem_by": {
+            "description": "Timestamp by which the coupon must be redeemed.",
+            "type": ["null", "string"]
+          },
+          "duration": {
+            "description": "Specifies the duration that the coupon remains valid for, e.g., once, repeating.",
+            "type": ["null", "string"]
+          },
+          "id": {
+            "description": "Unique identifier for the coupon.",
+            "type": ["null", "string"]
+          },
+          "valid": {
+            "description": "Indicates if the coupon is currently valid for use.",
+            "type": ["null", "boolean"]
+          },
+          "currency": {
+            "description": "Currency of the amount_off value.",
+            "type": ["null", "string"]
+          },
+          "duration_in_months": {
+            "description": "The number of months the coupon is valid for.",
+            "type": ["null", "integer"]
+          },
+          "name": {
+            "description": "Name of the coupon for identification purposes.",
+            "type": ["null", "string"]
+          },
+          "max_redemptions": {
+            "description": "Maximum number of times the coupon can be redeemed.",
+            "type": ["null", "integer"]
+          },
+          "amount_off": {
+            "description": "The amount deducted from the total cost when the coupon is applied.",
+            "type": ["null", "integer"]
+          },
+          "created": {
+            "description": "Timestamp when the coupon was created.",
+            "type": ["null", "integer"]
+          },
+          "updated": {
+            "description": "Timestamp when the coupon was last updated.",
+            "type": ["null", "integer"]
+          },
+          "percent_off": {
+            "description": "Percentage discount applied when coupon is used.",
+            "type": ["null", "number"]
+          },
+          "is_deleted": {
+            "description": "Indicates if the coupon has been marked as deleted.",
+            "type": ["null", "boolean"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "disputes",
+      "json_schema": {
+        "type": ["null", "object"],
+        "properties": {
+          "id": { "description": "The ID of the dispute.", "type": ["string"] },
+          "object": {
+            "description": "Type of object being returned.",
+            "type": ["null", "string"]
+          },
+          "amount": {
+            "description": "The amount of the dispute.",
+            "type": ["null", "integer"]
+          },
+          "balance_transactions": {
+            "description": "List of balance transactions associated with the dispute",
+            "type": ["null", "array"],
+            "items": {
+              "description": "Details of each balance transaction",
+              "type": ["null", "object"],
+              "properties": {
+                "id": {
+                  "description": "The ID of the balance transaction related to the dispute.",
+                  "type": ["string"]
+                }
+              }
+            }
+          },
+          "charge": {
+            "description": "The charge ID associated with the dispute.",
+            "type": ["null", "string"]
+          },
+          "created": {
+            "description": "The timestamp when the dispute was created.",
+            "type": ["null", "integer"]
+          },
+          "updated": {
+            "description": "The timestamp when the dispute was last updated.",
+            "type": ["null", "integer"]
+          },
+          "currency": {
+            "description": "The currency of the dispute amount.",
+            "type": ["null", "string"]
+          },
+          "evidence": {
+            "description": "Evidence provided for the dispute.",
+            "type": ["null", "string", "object"],
+            "properties": {
+              "refund_policy": { "type": ["null", "string"] },
+              "shipping_address": { "type": ["null", "string"] },
+              "duplicate_charge_explanation": { "type": ["null", "string"] },
+              "shipping_tracking_number": { "type": ["null", "string"] },
+              "customer_signature": { "type": ["null", "string"] },
+              "uncategorized_text": { "type": ["null", "string"] },
+              "cancellation_policy_disclosure": { "type": ["null", "string"] },
+              "refund_policy_disclosure": { "type": ["null", "string"] },
+              "receipt": { "type": ["null", "string"] },
+              "customer_name": { "type": ["null", "string"] },
+              "refund_refusal_explanation": { "type": ["null", "string"] },
+              "cancellation_rebuttal": { "type": ["null", "string"] },
+              "product_description": { "type": ["null", "string"] },
+              "shipping_date": { "type": ["null", "string"] },
+              "customer_email_address": { "type": ["null", "string"] },
+              "duplicate_charge_id": { "type": ["null", "string"] },
+              "shipping_documentation": { "type": ["null", "string"] },
+              "access_activity_log": { "type": ["null", "string"] },
+              "customer_purchase_ip": { "type": ["null", "string"] },
+              "service_date": { "type": ["null", "string"] },
+              "shipping_carrier": { "type": ["null", "string"] },
+              "service_documentation": { "type": ["null", "string"] },
+              "duplicate_charge_documentation": { "type": ["null", "string"] },
+              "cancellation_policy": { "type": ["null", "string"] },
+              "customer_communication": { "type": ["null", "string"] },
+              "uncategorized_file": { "type": ["null", "string"] },
+              "billing_address": { "type": ["null", "string"] }
+            }
+          },
+          "evidence_details": {
+            "description": "Details about the evidence provided for the dispute.",
+            "type": ["null", "object"],
+            "properties": {
+              "due_by": { "type": ["null", "number"] },
+              "has_evidence": { "type": ["null", "boolean"] },
+              "past_due": { "type": ["null", "boolean"] },
+              "submission_count": { "type": ["null", "integer"] }
+            }
+          },
+          "is_charge_refundable": {
+            "description": "Flag indicating if the charge is refundable.",
+            "type": ["null", "boolean"]
+          },
+          "livemode": {
+            "description": "Indicates if the dispute is in live mode.",
+            "type": ["null", "boolean"]
+          },
+          "metadata": {
+            "description": "Additional metadata related to the dispute.",
+            "type": ["null", "object"],
+            "properties": {}
+          },
+          "reason": {
+            "description": "The reason for the dispute.",
+            "type": ["null", "string"]
+          },
+          "status": {
+            "description": "The current status of the dispute.",
+            "type": ["null", "string"]
+          },
+          "payment_intent": {
+            "description": "The payment intent associated with the dispute.",
+            "type": ["null", "string"]
+          },
+          "balance_transaction": {
+            "description": "The balance transaction ID related to the dispute.",
+            "type": ["null", "string"]
+          },
+          "payment_method_details": {
+            "description": "Details of the payment method associated with the dispute.",
+            "type": ["null", "object"],
+            "properties": {
+              "card": {
+                "description": "Details of the card used for payment.",
+                "type": ["null", "object"],
+                "properties": {
+                  "brand": { "type": ["null", "string"] },
+                  "network_reason_code": { "type": ["null", "string"] }
+                }
+              },
+              "type": {
+                "description": "Type of payment method used.",
+                "type": ["null", "string"]
+              }
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "application_fees",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "Application Fees Schema",
+        "additionalProperties": true,
+        "type": ["null", "object"],
+        "properties": {
+          "id": {
+            "description": "The unique identifier for the application fee.",
+            "type": ["null", "string"]
+          },
+          "object": {
+            "description": "Type of object, which should have a value of 'application_fee'.",
+            "type": ["null", "string"]
+          },
+          "account": {
+            "description": "The ID of the Stripe account that received the application fee.",
+            "type": ["null", "string"]
+          },
+          "amount": {
+            "description": "The total amount in cents that was collected by the application fee.",
+            "type": ["null", "number"]
+          },
+          "amount_refunded": {
+            "description": "The total amount in cents that was refunded for the application fee.",
+            "type": ["null", "number"]
+          },
+          "application": {
+            "description": "The ID of the application that the fee was collected for.",
+            "type": ["null", "string"]
+          },
+          "balance_transaction": {
+            "description": "The ID of the balance transaction associated with the application fee.",
+            "type": ["null", "string"]
+          },
+          "charge": {
+            "description": "The ID of the charge that the application fee was collected from.",
+            "type": ["null", "string"]
+          },
+          "created": {
+            "description": "The timestamp when the application fee was created.",
+            "type": ["null", "number"]
+          },
+          "updated": {
+            "description": "The timestamp when the application fee was last updated.",
+            "type": ["null", "integer"]
+          },
+          "currency": {
+            "description": "The currency of the amount collected for the application fee.",
+            "type": ["null", "string"]
+          },
+          "livemode": {
+            "description": "Indicates whether it was collected in live mode or test mode.",
+            "type": "boolean"
+          },
+          "originating_transaction": {
+            "description": "The ID of the transaction that originated the application fee.",
+            "type": ["null", "string"]
+          },
+          "refunded": {
+            "description": "Indicates whether the application fee has been fully refunded.",
+            "type": "boolean"
+          },
+          "refunds": {
+            "description": "Contains information about any refunds associated with the application fees.",
+            "type": ["null", "object"],
+            "properties": {
+              "object": {
+                "description": "Type of object, which should have a value of 'list'.",
+                "type": ["null", "string"]
+              },
+              "data": {
+                "description": "An array of objects representing refunds issued for this application fee.",
+                "type": "array",
+                "items": {}
+              },
+              "has_more": {
+                "description": "Indicates whether there are more refunds to be fetched.",
+                "type": "boolean"
+              },
+              "url": {
+                "description": "The URL from which additional refunds can be fetched.",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "source": {
+            "description": "Contains details about the source of the application fee payment.",
+            "type": ["null", "object"],
+            "properties": {
+              "fee_type": {
+                "description": "The type of the fee that was collected.",
+                "type": ["null", "string"]
+              },
+              "resource": {
+                "description": "Contains information about the resource used for the payment of the application fee.",
+                "type": ["null", "object"],
+                "properties": {
+                  "charge": {
+                    "description": "The ID of the charge associated with the application fee.",
+                    "type": ["null", "string"]
+                  },
+                  "type": {
+                    "description": "The type of the resource that was charged.",
+                    "type": ["null", "string"]
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "invoices",
+      "json_schema": {
+        "type": ["null", "object"],
+        "properties": {
+          "created": {
+            "description": "The timestamp when the invoice was created",
+            "type": ["null", "integer"]
+          },
+          "updated": {
+            "description": "Timestamp for when the invoice was last updated",
+            "type": ["null", "integer"]
+          },
+          "next_payment_attempt": {
+            "description": "Timestamp for the next payment attempt",
+            "type": ["null", "number"]
+          },
+          "tax": {
+            "description": "The total tax amount on the invoice",
+            "type": ["null", "integer"]
+          },
+          "metadata": {
+            "description": "Additional metadata associated with the invoice",
+            "type": ["null", "object"],
+            "properties": {}
+          },
+          "charge": {
+            "description": "The charge associated with the invoice",
+            "type": ["null", "string"]
+          },
+          "description": {
+            "description": "The description of the invoice",
+            "type": ["null", "string"]
+          },
+          "customer_tax_ids": {
+            "description": "The tax IDs associated with the customer",
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "additionalProperties": true,
+              "properties": {
+                "type": { "type": ["null", "string"] },
+                "value": { "type": ["null", "string"] }
+              }
+            }
+          },
+          "receipt_number": {
+            "description": "The receipt number associated with the invoice",
+            "type": ["null", "string"]
+          },
+          "attempt_count": {
+            "description": "The number of attempts made to pay the invoice",
+            "type": ["null", "integer"]
+          },
+          "payment": {
+            "description": "The payment details associated with the invoice",
+            "type": ["null", "string"]
+          },
+          "amount_paid": {
+            "description": "The total amount paid on the invoice",
+            "type": ["null", "integer"]
+          },
+          "due_date": {
+            "description": "The due date for the invoice payment",
+            "type": ["null", "number"]
+          },
+          "id": {
+            "description": "The unique identifier of the invoice",
+            "type": ["null", "string"]
+          },
+          "webhooks_delivered_at": {
+            "description": "Timestamp for when webhooks were delivered related to the invoice",
+            "type": ["null", "number"]
+          },
+          "statement_descriptor": {
+            "description": "The descriptor that appears on the customer's statement",
+            "type": ["null", "string"]
+          },
+          "hosted_invoice_url": {
+            "description": "The URL for the hosted invoice page",
+            "type": ["null", "string"]
+          },
+          "period_end": {
+            "description": "The end date of the billing period",
+            "type": ["null", "number"]
+          },
+          "amount_remaining": {
+            "description": "The remaining amount to be paid on the invoice",
+            "type": ["null", "integer"]
+          },
+          "tax_percent": {
+            "description": "The tax percentage applied to the invoice",
+            "type": ["null", "number"]
+          },
+          "billing": {
+            "description": "The billing details associated with the invoice",
+            "type": ["null", "string"]
+          },
+          "auto_advance": {
+            "description": "Flag indicating if the invoice will be automatically advanced to the next status",
+            "type": ["null", "boolean"]
+          },
+          "paid": {
+            "description": "Whether the invoice has been paid",
+            "type": ["null", "boolean"]
+          },
+          "discounts": {
+            "description": "Any discounts applied to the invoice",
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "additionalProperties": true,
+              "properties": {
+                "id": { "type": ["null", "string"] },
+                "object": { "type": ["null", "string"] },
+                "checkout_session": { "type": ["null", "string"] },
+                "coupon": {
+                  "type": ["null", "object"],
+                  "properties": {
+                    "metadata": {
+                      "type": ["null", "object"],
+                      "additionalProperties": true,
+                      "properties": {}
+                    },
+                    "valid": { "type": ["null", "boolean"] },
+                    "livemode": { "type": ["null", "boolean"] },
+                    "amount_off": { "type": ["null", "integer"] },
+                    "redeem_by": { "type": ["null", "integer"] },
+                    "duration_in_months": { "type": ["null", "integer"] },
+                    "max_redemptions": { "type": ["null", "integer"] },
+                    "currency": { "type": ["null", "string"] },
+                    "name": { "type": ["null", "string"] },
+                    "times_redeemed": { "type": ["null", "integer"] },
+                    "id": { "type": ["null", "string"] },
+                    "duration": { "type": ["null", "string"] },
+                    "object": { "type": ["null", "string"] },
+                    "percent_off": { "type": ["null", "number"] },
+                    "created": { "type": ["null", "integer"] }
+                  }
+                }
+              }
+            }
+          },
+          "discount": {
+            "description": "Details about any discounts applied to the invoice",
+            "type": ["null", "object"],
+            "properties": {
+              "id": { "type": ["null", "string"] },
+              "object": { "type": ["null", "string"] },
+              "checkout_session": { "type": ["null", "string"] },
+              "coupon": {
+                "type": ["null", "object"],
+                "properties": {
+                  "metadata": { "type": ["null", "object"], "properties": {} },
+                  "valid": { "type": ["null", "boolean"] },
+                  "livemode": { "type": ["null", "boolean"] },
+                  "amount_off": { "type": ["null", "integer"] },
+                  "redeem_by": { "type": ["null", "integer"] },
+                  "duration_in_months": { "type": ["null", "integer"] },
+                  "max_redemptions": { "type": ["null", "integer"] },
+                  "currency": { "type": ["null", "string"] },
+                  "name": { "type": ["null", "string"] },
+                  "times_redeemed": { "type": ["null", "integer"] },
+                  "id": { "type": ["null", "string"] },
+                  "duration": { "type": ["null", "string"] },
+                  "object": { "type": ["null", "string"] },
+                  "percent_off": { "type": ["null", "number"] },
+                  "created": { "type": ["null", "integer"] }
+                }
+              },
+              "customer": { "type": ["null", "string"] },
+              "end": { "type": ["null", "integer"] },
+              "invoice": { "type": ["null", "string"] },
+              "invoice_item": { "type": ["null", "string"] },
+              "promotion_code": { "type": ["null", "string"] },
+              "start": { "type": ["null", "integer"] },
+              "subscription": { "type": ["null", "string"] }
+            }
+          },
+          "number": {
+            "description": "The invoice number",
+            "type": ["null", "string"]
+          },
+          "billing_reason": {
+            "description": "The reason for the billing of the invoice",
+            "type": ["null", "string"]
+          },
+          "ending_balance": {
+            "description": "The balance remaining at the end of the billing period",
+            "type": ["null", "integer"]
+          },
+          "livemode": {
+            "description": "Whether the data is in live mode",
+            "type": ["null", "boolean"]
+          },
+          "period_start": {
+            "description": "The start date of the billing period",
+            "type": ["null", "number"]
+          },
+          "attempted": {
+            "description": "Whether the invoice has been attempted to be paid",
+            "type": ["null", "boolean"]
+          },
+          "closed": {
+            "description": "Whether the invoice has been closed",
+            "type": ["null", "boolean"]
+          },
+          "invoice_pdf": {
+            "description": "The URL for the PDF version of the invoice",
+            "type": ["null", "string"]
+          },
+          "customer": {
+            "description": "The customer associated with the invoice",
+            "type": ["null", "string"]
+          },
+          "subtotal": {
+            "description": "The subtotal amount on the invoice",
+            "type": ["null", "integer"]
+          },
+          "application_fee": {
+            "description": "The application fee amount",
+            "type": ["null", "integer"]
+          },
+          "lines": {
+            "description": "Details of individual line items included in the invoice",
+            "type": ["null", "object"]
+          },
+          "forgiven": {
+            "description": "Whether the invoice has been forgiven",
+            "type": ["null", "boolean"]
+          },
+          "object": {
+            "description": "Object type, should be 'invoice'",
+            "type": ["null", "string"]
+          },
+          "starting_balance": {
+            "description": "The starting balance at the beginning of the billing period",
+            "type": ["null", "integer"]
+          },
+          "amount_due": {
+            "description": "The total amount due on the invoice",
+            "type": ["null", "integer"]
+          },
+          "currency": {
+            "description": "The currency used for the invoice",
+            "type": ["null", "string"]
+          },
+          "total": {
+            "description": "The total amount on the invoice, including tax",
+            "type": ["null", "integer"]
+          },
+          "statement_description": {
+            "description": "The description that appears on the customer's statement",
+            "type": ["null", "string"]
+          },
+          "subscription": {
+            "description": "Details of any subscription associated with the invoice",
+            "type": ["null", "string"]
+          },
+          "subscription_details": {
+            "description": "Details about the subscription associated with the invoice",
+            "type": ["null", "object"],
+            "properties": { "metadata": { "type": ["null", "object"] } }
+          },
+          "status": {
+            "description": "The current status of the invoice",
+            "type": ["null", "string"]
+          },
+          "status_transitions": {
+            "description": "Timestamps for status transitions of the invoice",
+            "type": "object",
+            "properties": {
+              "finalized_at": { "type": ["null", "integer"] },
+              "marked_uncollectible_at": { "type": ["null", "integer"] },
+              "paid_at": { "type": ["null", "integer"] },
+              "voided_at": { "type": ["null", "integer"] }
+            }
+          },
+          "post_payment_credit_notes_amount": {
+            "description": "The amount credited post payment",
+            "type": ["null", "integer"]
+          },
+          "paid_out_of_band": {
+            "description": "Whether the payment was made outside the platform",
+            "type": ["null", "boolean"]
+          },
+          "total_discount_amounts": {
+            "description": "Total amounts of discounts applied to the invoice",
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "amount": { "type": ["null", "integer"] },
+                "discount": { "type": ["null", "string"] }
+              }
+            }
+          },
+          "customer_name": {
+            "description": "The name of the customer",
+            "type": ["null", "string"]
+          },
+          "shipping_cost": {
+            "description": "The cost details associated with shipping",
+            "type": ["null", "object"],
+            "properties": {
+              "amount_subtotal": { "type": ["null", "integer"] },
+              "amount_tax": { "type": ["null", "integer"] },
+              "amount_total": { "type": ["null", "integer"] },
+              "shipping_rate": { "type": ["null", "string"] },
+              "taxes": {
+                "type": ["null", "array"],
+                "items": { "type": ["null", "string"] }
+              }
+            }
+          },
+          "custom_fields": {
+            "description": "Custom fields associated with the invoice",
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "name": { "type": ["null", "string"] },
+                "value": { "type": ["null", "string"] }
+              }
+            }
+          },
+          "transfer_data": {
+            "description": "Details about transfer of funds related to the invoice",
+            "type": ["null", "object"],
+            "properties": {
+              "amount": { "type": ["null", "integer"] },
+              "destination": { "type": ["null", "string"] }
+            }
+          },
+          "application_fee_amount": {
+            "description": "The fee amount to be paid to the application",
+            "type": ["null", "integer"]
+          },
+          "customer_shipping": {
+            "description": "The shipping details of the customer",
+            "type": ["null", "object"],
+            "additionalProperties": true,
+            "properties": {
+              "address": {
+                "type": ["null", "object"],
+                "properties": {
+                  "city": { "type": ["null", "string"] },
+                  "country": { "type": ["null", "string"] },
+                  "line1": { "type": ["null", "string"] },
+                  "line2": { "type": ["null", "string"] },
+                  "postal_code": { "type": ["null", "string"] },
+                  "state": { "type": ["null", "string"] }
+                }
+              },
+              "name": { "type": ["null", "string"] },
+              "phone": { "type": ["null", "string"] }
+            }
+          },
+          "application": {
+            "description": "The application associated with the invoice",
+            "type": ["null", "string"]
+          },
+          "amount_shipping": {
+            "description": "The amount charged for shipping",
+            "type": ["null", "integer"]
+          },
+          "from_invoice": {
+            "description": "Details about the previous invoice",
+            "type": ["null", "object"],
+            "properties": {
+              "actions": { "type": ["null", "string"] },
+              "invoice": { "type": ["null", "string"] }
+            }
+          },
+          "customer_tax_exempt": {
+            "description": "Whether the customer is tax exempt",
+            "type": ["null", "string"]
+          },
+          "total_tax_amounts": {
+            "description": "Details about total tax amounts applied to the invoice",
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "amount": { "type": ["null", "integer"] },
+                "inclusive": { "type": ["null", "boolean"] },
+                "tax_rate": {
+                  "type": ["null", "object"],
+                  "properties": {
+                    "id": { "type": ["null", "string"] },
+                    "object": { "type": ["null", "string"] },
+                    "active": { "type": ["null", "boolean"] },
+                    "country": { "type": ["null", "string"] },
+                    "created": { "type": ["null", "integer"] },
+                    "description": { "type": ["null", "string"] },
+                    "display_name": { "type": ["null", "string"] },
+                    "effective_percentage": { "type": ["null", "number"] },
+                    "inclusive": { "type": ["null", "boolean"] },
+                    "jurisdiction": { "type": ["null", "string"] },
+                    "livemode": { "type": ["null", "boolean"] },
+                    "metadata": { "type": ["null", "object"] },
+                    "percentage": { "type": ["null", "number"] },
+                    "state": { "type": ["null", "string"] },
+                    "tax_type": { "type": ["null", "string"] }
+                  }
+                },
+                "taxability_reason": { "type": ["null", "string"] },
+                "taxable_amount": { "type": ["null", "integer"] }
+              }
+            }
+          },
+          "footer": {
+            "description": "The footer content of the invoice",
+            "type": ["null", "string"]
+          },
+          "test_clock": {
+            "description": "Timestamp for testing purposes",
+            "type": ["null", "string"]
+          },
+          "automatic_tax": {
+            "description": "Details about automatic tax calculation",
+            "type": ["null", "object"],
+            "properties": {
+              "enabled": { "type": ["null", "boolean"] },
+              "status": { "type": ["null", "string"] }
+            }
+          },
+          "payment_settings": {
+            "description": "Settings related to payment on the invoice",
+            "type": ["null", "object"],
+            "properties": {
+              "default_mandate": { "type": ["null", "string"] },
+              "payment_method_options": { "type": ["null", "object"] },
+              "payment_method_types": {
+                "type": ["null", "array"],
+                "items": { "type": ["null", "string"] }
+              }
+            }
+          },
+          "default_source": {
+            "description": "The default payment source for the invoice",
+            "type": ["null", "string"]
+          },
+          "payment_intent": {
+            "description": "The payment intent associated with the invoice",
+            "type": ["null", "string"]
+          },
+          "default_payment_method": {
+            "description": "The default payment method for the invoice",
+            "type": ["null", "string"]
+          },
+          "shipping_details": {
+            "description": "The details of shipping associated with the invoice",
+            "type": ["null", "object"],
+            "properties": {
+              "address": {
+                "type": ["null", "object"],
+                "properties": {
+                  "city": { "type": ["null", "string"] },
+                  "country": { "type": ["null", "string"] },
+                  "line1": { "type": ["null", "string"] },
+                  "line2": { "type": ["null", "string"] },
+                  "postal_code": { "type": ["null", "string"] },
+                  "state": { "type": ["null", "string"] }
+                }
+              },
+              "name": { "type": ["null", "string"] },
+              "phone": { "type": ["null", "string"] }
+            }
+          },
+          "collection_method": {
+            "description": "The method used for collecting payment on the invoice",
+            "type": ["null", "string"]
+          },
+          "effective_at": {
+            "description": "Timestamp for when the invoice becomes effective",
+            "type": ["null", "integer"]
+          },
+          "default_tax_rates": {
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "id": { "type": ["null", "string"] },
+                "object": { "type": ["null", "string"] },
+                "active": { "type": ["null", "boolean"] },
+                "country": { "type": ["null", "string"] },
+                "created": { "type": ["null", "integer"] },
+                "description": { "type": ["null", "string"] },
+                "display_name": { "type": ["null", "string"] },
+                "effective_percentage": { "type": ["null", "number"] },
+                "inclusive": { "type": ["null", "boolean"] },
+                "jurisdiction": { "type": ["null", "string"] },
+                "livemode": { "type": ["null", "boolean"] },
+                "metadata": { "type": ["null", "object"] },
+                "percentage": { "type": ["null", "number"] },
+                "state": { "type": ["null", "string"] },
+                "tax_type": { "type": ["null", "string"] }
+              }
+            }
+          },
+          "total_excluding_tax": {
+            "description": "The total amount excluding tax",
+            "type": ["null", "integer"]
+          },
+          "subtotal_excluding_tax": {
+            "description": "The subtotal amount excluding tax",
+            "type": ["null", "integer"]
+          },
+          "last_finalization_error": {
+            "description": "Details about the last finalization error associated with the invoice",
+            "type": ["null", "object"],
+            "properties": {
+              "type": { "type": ["null", "string"] },
+              "code": { "type": ["null", "string"] },
+              "doc_url": { "type": ["null", "string"] },
+              "message": { "type": ["null", "string"] },
+              "param": { "type": ["null", "string"] },
+              "payment_method_type": { "type": ["null", "string"] }
+            }
+          },
+          "issuer": {
+            "description": "Details about the issuer of the invoice",
+            "type": ["null", "object"],
+            "properties": { "type": { "type": ["null", "string"] } }
+          },
+          "latest_revision": {
+            "description": "The latest revision number of the invoice",
+            "type": ["null", "string"]
+          },
+          "rendering_options": {
+            "description": "Rendering options for the invoice",
+            "type": ["null", "object"],
+            "properties": {
+              "amount_tax_display": { "type": ["null", "string"] }
+            }
+          },
+          "quote": {
+            "description": "The associated quote for the invoice",
+            "type": ["null", "string"]
+          },
+          "pre_payment_credit_notes_amount": {
+            "description": "The amount credited pre payment",
+            "type": ["null", "integer"]
+          },
+          "customer_phone": {
+            "description": "The phone number of the customer",
+            "type": ["null", "string"]
+          },
+          "on_behalf_of": {
+            "description": "The account on behalf of which the invoice is raised",
+            "type": ["null", "string"]
+          },
+          "account_tax_ids": {
+            "description": "The tax IDs associated with the account",
+            "type": ["null", "array"],
+            "items": { "type": ["null", "string"] }
+          },
+          "customer_email": {
+            "description": "The email address of the customer",
+            "type": ["null", "string"]
+          },
+          "customer_address": {
+            "description": "The address details of the customer",
+            "type": ["null", "object"],
+            "properties": {
+              "city": { "type": ["null", "string"] },
+              "country": { "type": ["null", "string"] },
+              "line1": { "type": ["null", "string"] },
+              "line2": { "type": ["null", "string"] },
+              "postal_code": { "type": ["null", "string"] },
+              "state": { "type": ["null", "string"] }
+            }
+          },
+          "account_name": {
+            "description": "The name of the account",
+            "type": ["null", "string"]
+          },
+          "account_country": {
+            "description": "The country associated with the account",
+            "type": ["null", "string"]
+          },
+          "is_deleted": {
+            "description": "Whether the invoice has been deleted",
+            "type": ["null", "boolean"]
+          },
+          "rendering": {
+            "description": "Rendering details for the invoice",
+            "type": ["object", "null"],
+            "properties": {
+              "amount_tax_display": { "type": ["null", "string"] },
+              "pdf": {
+                "type": ["null", "object"],
+                "properties": { "page_size": { "type": ["null", "string"] } }
+              }
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "invoice_items",
+      "json_schema": {
+        "type": ["null", "object"],
+        "properties": {
+          "amount": {
+            "description": "The amount associated with the invoice item",
+            "type": ["null", "integer"]
+          },
+          "metadata": {
+            "description": "Custom metadata associated with the invoice item.",
+            "type": ["null", "object"],
+            "properties": {}
+          },
+          "plan": {
+            "description": "Information about the subscription plan associated with the invoice item.",
+            "type": ["null", "object", "string"],
+            "properties": {
+              "nickname": {
+                "description": "The nickname of the plan",
+                "type": ["null", "string"]
+              },
+              "tiers": {
+                "description": "Tiers within the plan that affect the pricing of the invoice item.",
+                "type": ["null", "array"],
+                "items": {
+                  "type": ["null", "string", "object"],
+                  "properties": {
+                    "flat_amount": {
+                      "description": "The flat amount for the tier",
+                      "type": ["null", "integer"]
+                    },
+                    "unit_amount": {
+                      "description": "The unit amount for the tier",
+                      "type": ["null", "integer"]
+                    },
+                    "up_to": {
+                      "description": "The maximum value of the tier",
+                      "type": ["null", "integer"]
+                    }
+                  }
+                }
+              },
+              "object": {
+                "description": "The object type of the plan",
+                "type": ["null", "string"]
+              },
+              "aggregate_usage": {
+                "description": "The usage aggregation rule for the plan",
+                "type": ["null", "string"]
+              },
+              "created": {
+                "description": "The creation timestamp of the plan",
+                "type": ["null", "integer"]
+              },
+              "statement_description": {
+                "description": "The description on customer's statement for the plan",
+                "type": ["null", "string"]
+              },
+              "product": {
+                "description": "The product associated with the plan",
+                "type": ["null", "string"]
+              },
+              "statement_descriptor": {
+                "description": "The statement descriptor of the plan",
+                "type": ["null", "string"]
+              },
+              "interval_count": {
+                "description": "The number of intervals between plan charges",
+                "type": ["null", "integer"]
+              },
+              "transform_usage": {
+                "description": "The transformation rules for usage allowed",
+                "type": ["null", "string"]
+              },
+              "name": {
+                "description": "The name of the plan",
+                "type": ["null", "string"]
+              },
+              "amount": {
+                "description": "The amount of the plan",
+                "type": ["null", "integer"]
+              },
+              "interval": {
+                "description": "The billing interval of the plan",
+                "type": ["null", "string"]
+              },
+              "id": {
+                "description": "The unique identifier of the plan",
+                "type": ["null", "string"]
+              },
+              "trial_period_days": {
+                "description": "The trial period days for the plan",
+                "type": ["null", "integer"]
+              },
+              "usage_type": {
+                "description": "The usage type allowed for the plan",
+                "type": ["null", "string"]
+              },
+              "active": {
+                "description": "Indicates if the plan is active",
+                "type": ["null", "boolean"]
+              },
+              "tiers_mode": {
+                "description": "The pricing mode for the tiers",
+                "type": ["null", "string"]
+              },
+              "billing_scheme": {
+                "description": "The billing scheme of the plan",
+                "type": ["null", "string"]
+              },
+              "livemode": {
+                "description": "Indicates if the plan is in live mode",
+                "type": ["null", "boolean"]
+              },
+              "currency": {
+                "description": "The currency code of the plan",
+                "type": ["null", "string"]
+              },
+              "metadata": {
+                "description": "Custom metadata associated with the plan.",
+                "type": ["null", "object"],
+                "properties": {}
+              },
+              "updated": {
+                "description": "The last update timestamp of the plan",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "invoice": {
+            "description": "The invoice associated with the item",
+            "type": ["null", "string"]
+          },
+          "period": {
+            "description": "Period during which the invoice item applies.",
+            "type": ["null", "object"],
+            "properties": {
+              "end": {
+                "description": "The end date of the billing period",
+                "type": ["null", "integer"]
+              },
+              "start": {
+                "description": "The start date of the billing period",
+                "type": ["null", "integer"]
+              }
+            }
+          },
+          "quantity": {
+            "description": "The quantity of the item",
+            "type": ["null", "integer"]
+          },
+          "description": {
+            "description": "A description of the invoice item",
+            "type": ["null", "string"]
+          },
+          "date": {
+            "description": "The date of the invoice item",
+            "type": ["null", "integer"]
+          },
+          "updated": {
+            "description": "The last update timestamp of the invoice item",
+            "type": ["null", "integer"]
+          },
+          "object": {
+            "description": "The object type of the item",
+            "type": ["null", "string"]
+          },
+          "subscription": {
+            "description": "The subscription associated with the item",
+            "type": ["null", "string"]
+          },
+          "id": {
+            "description": "The unique identifier of the invoice item",
+            "type": ["null", "string"]
+          },
+          "livemode": {
+            "description": "Indicates if the item is in live mode",
+            "type": ["null", "boolean"]
+          },
+          "discountable": {
+            "description": "Indicates if the item can be discounted",
+            "type": ["null", "boolean"]
+          },
+          "unit_amount": {
+            "description": "The unit amount of the invoice item",
+            "type": ["null", "integer"]
+          },
+          "currency": {
+            "description": "The currency code of the amount",
+            "type": ["null", "string"]
+          },
+          "customer": {
+            "description": "The customer associated with the invoice item",
+            "type": ["null", "string"]
+          },
+          "proration": {
+            "description": "Indicates if the item is prorated",
+            "type": ["null", "boolean"]
+          },
+          "subscription_item": {
+            "description": "The subscription item related to the invoice item",
+            "type": ["null", "string"]
+          },
+          "price": {
+            "type": ["null", "object"],
+            "properties": {
+              "id": { "type": ["null", "string"] },
+              "object": { "type": ["null", "string"] },
+              "active": { "type": ["null", "boolean"] },
+              "billing_scheme": { "type": ["null", "string"] },
+              "created": { "type": ["null", "integer"] },
+              "currency": { "type": ["null", "string"] },
+              "currency_options": { "type": ["null", "string"] },
+              "custom_unit_amount": {
+                "type": ["null", "object"],
+                "properties": {
+                  "maximum": { "type": ["null", "integer"] },
+                  "minimum": { "type": ["null", "integer"] },
+                  "preset": { "type": ["null", "integer"] }
+                }
+              },
+              "livemode": { "type": ["null", "boolean"] },
+              "lookup_key": { "type": ["null", "string"] },
+              "metadata": { "type": ["null", "object"] },
+              "nickname": { "type": ["null", "string"] },
+              "product": { "type": ["null", "string"] },
+              "recurring": {
+                "type": ["null", "object"],
+                "properties": {
+                  "aggregate_usage": { "type": ["null", "string"] },
+                  "interval": { "type": ["null", "string"] },
+                  "interval_count": { "type": ["null", "integer"] },
+                  "usage_type": { "type": ["null", "string"] }
+                }
+              },
+              "tax_behavior": { "type": ["null", "string"] },
+              "tiers": {
+                "type": ["null", "array"],
+                "items": { "type": ["null", "string"] }
+              },
+              "tiers_mode": { "type": ["null", "string"] },
+              "transform_quantity": {
+                "type": ["null", "object"],
+                "properties": {
+                  "divide_by": { "type": ["null", "integer"] },
+                  "round": { "type": ["null", "string"] }
+                }
+              },
+              "type": { "type": ["null", "string"] },
+              "unit_amount": { "type": ["null", "integer"] },
+              "unit_amount_decimal": { "type": ["null", "string"] }
+            }
+          },
+          "test_clock": {
+            "description": "A test clock for the item",
+            "type": ["null", "string"]
+          },
+          "discounts": {
+            "description": "Discount details applied to the invoice item.",
+            "type": ["null", "array"],
+            "items": {
+              "description": "Discount items applied to the invoice item",
+              "type": ["null", "string"]
+            }
+          },
+          "tax_rates": {
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "id": { "type": ["null", "string"] },
+                "object": { "type": ["null", "string"] },
+                "active": { "type": ["null", "boolean"] },
+                "country": { "type": ["null", "string"] },
+                "created": { "type": ["null", "integer"] },
+                "description": { "type": ["null", "string"] },
+                "display_name": { "type": ["null", "string"] },
+                "effective_percentage": { "type": ["null", "number"] },
+                "inclusive": { "type": ["null", "boolean"] },
+                "jurisdiction": { "type": ["null", "string"] },
+                "livemode": { "type": ["null", "boolean"] },
+                "metadata": { "type": ["null", "object"] },
+                "percentage": { "type": ["null", "number"] },
+                "state": { "type": ["null", "string"] },
+                "tax_type": { "type": ["null", "string"] }
+              }
+            }
+          },
+          "unit_amount_decimal": {
+            "description": "The decimal unit amount of the invoice item",
+            "type": ["null", "string"]
+          },
+          "is_deleted": {
+            "description": "Indicates if the item is deleted",
+            "type": ["null", "boolean"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "payouts",
+      "json_schema": {
+        "properties": {
+          "metadata": {
+            "description": "Additional data about the payout.",
+            "type": ["null", "object"],
+            "properties": {}
+          },
+          "failure_code": {
+            "description": "The failure code for a failed payout.",
+            "type": ["null", "string"]
+          },
+          "id": {
+            "description": "The ID of the payout.",
+            "type": ["null", "string"]
+          },
+          "statement_description": {
+            "description": "The description that will appear on the bank statement.",
+            "type": ["null", "string"]
+          },
+          "amount": {
+            "description": "The amount of the payout in the smallest currency unit.",
+            "type": ["null", "integer"]
+          },
+          "balance_transaction": {
+            "description": "The ID of the balance transaction that describes the impact on your account balance.",
+            "type": ["null", "string"]
+          },
+          "created": {
+            "description": "The date the payout was created.",
+            "type": ["null", "integer"]
+          },
+          "updated": {
+            "description": "The date the payout was last updated.",
+            "type": ["null", "integer"]
+          },
+          "amount_reversed": {
+            "description": "The amount that was reversed (negative) from this payout.",
+            "type": ["null", "integer"]
+          },
+          "source_type": {
+            "description": "The type of the source transaction (charge, payment, refund).",
+            "type": ["null", "string"]
+          },
+          "bank_account": {
+            "description": "Details of the bank account associated with the payout",
+            "properties": {
+              "metadata": {
+                "description": "Additional data about the bank account.",
+                "type": ["null", "object"],
+                "properties": {}
+              },
+              "routing_number": {
+                "description": "The routing number of the bank account.",
+                "type": ["null", "string"]
+              },
+              "account_holder_type": {
+                "description": "The type of account holder (individual or company).",
+                "type": ["null", "string"]
+              },
+              "name": {
+                "description": "The name of the bank account.",
+                "type": ["null", "string"]
+              },
+              "id": {
+                "description": "The ID of the bank account.",
+                "type": ["null", "string"]
+              },
+              "bank_name": {
+                "description": "The name of the bank.",
+                "type": ["null", "string"]
+              },
+              "last4": {
+                "description": "The last 4 digits of the bank account number.",
+                "type": ["null", "string"]
+              },
+              "fingerprint": {
+                "description": "A unique identifier for the bank account.",
+                "type": ["null", "string"]
+              },
+              "account_holder_name": {
+                "description": "The name of the account holder.",
+                "type": ["null", "string"]
+              },
+              "object": {
+                "description": "Type of object that represents the bank account.",
+                "type": ["null", "string"]
+              },
+              "status": {
+                "description": "The status of the bank account (verified, unverified).",
+                "type": ["null", "string"]
+              },
+              "currency": {
+                "description": "The currency of the bank account.",
+                "type": ["null", "string"]
+              },
+              "country": {
+                "description": "The country code of the bank account.",
+                "type": ["null", "string"]
+              }
+            },
+            "type": ["null", "object"]
+          },
+          "date": {
+            "description": "The date when the payout was initiated.",
+            "type": ["null", "integer"]
+          },
+          "method": {
+            "description": "The method used for the payout (standard, instant).",
+            "type": ["null", "string"]
+          },
+          "livemode": {
+            "description": "Indicates if the payout was created in live mode.",
+            "type": ["null", "boolean"]
+          },
+          "statement_descriptor": {
+            "description": "The statement descriptor that appears on the recipient's bank statement.",
+            "type": ["null", "string"]
+          },
+          "failure_message": {
+            "description": "The failure message for a failed payout.",
+            "type": ["null", "string"]
+          },
+          "failure_balance_transaction": {
+            "description": "The ID of the balance transaction when the payout failed.",
+            "type": ["null", "string"]
+          },
+          "recipient": {
+            "description": "The recipient of the funds for the payout.",
+            "type": ["null", "string"]
+          },
+          "destination": {
+            "description": "The destination of the payout (e.g., bank account).",
+            "type": ["null", "string"]
+          },
+          "automatic": {
+            "description": "Indicates if the payout was done automatically by Stripe.",
+            "type": ["null", "boolean"]
+          },
+          "object": {
+            "description": "Type of object that represents the payout.",
+            "type": ["null", "string"]
+          },
+          "status": {
+            "description": "The status of the payout (paid, pending, failed).",
+            "type": ["null", "string"]
+          },
+          "currency": {
+            "description": "The currency of the payout.",
+            "type": ["null", "string"]
+          },
+          "transfer_group": {
+            "description": "A unique identifier for the transfer group.",
+            "type": ["null", "string"]
+          },
+          "type": {
+            "description": "The type of the payout (bank_account, card).",
+            "type": ["null", "string"]
+          },
+          "arrival_date": {
+            "description": "The date the payout is expected to arrive in the bank account.",
+            "type": ["null", "integer"]
+          },
+          "description": {
+            "description": "A description of the payout.",
+            "type": ["null", "string"]
+          },
+          "source_transaction": {
+            "description": "The ID of the transaction that generated the payout.",
+            "type": ["null", "string"]
+          },
+          "original_payout": {
+            "description": "The original payout that was reversed.",
+            "type": ["null", "string"]
+          },
+          "reconciliation_status": {
+            "description": "The reconciliation status of the payout.",
+            "type": ["null", "string"]
+          },
+          "source_balance": {
+            "description": "The balance amount from which the payout was sourced.",
+            "type": ["null", "string"]
+          },
+          "reversed_by": {
+            "description": "The ID of the payout that initiated the reversal.",
+            "type": ["null", "string"]
+          }
+        },
+        "type": ["null", "object"]
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "plans",
+      "json_schema": {
+        "type": ["null", "object"],
+        "properties": {
+          "nickname": {
+            "description": "A short phrase used to identify the plan.",
+            "type": ["null", "string"]
+          },
+          "tiers": {
+            "description": "Details of the pricing tiers if the plan uses tiered pricing.",
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "string", "object"],
+              "properties": {
+                "flat_amount": { "type": ["null", "integer"] },
+                "flat_amount_decimal": { "type": ["null", "string"] },
+                "unit_amount": { "type": ["null", "integer"] },
+                "unit_amount_decimal": { "type": ["null", "string"] },
+                "up_to": { "type": ["null", "integer"] }
+              }
+            }
+          },
+          "object": {
+            "description": "Type of object. Value is 'plan'.",
+            "type": ["null", "string"]
+          },
+          "aggregate_usage": {
+            "description": "Determines how usage is calculated for the subscription.",
+            "type": ["null", "string"]
+          },
+          "created": {
+            "description": "Timestamp representing the creation date of the plan.",
+            "type": ["null", "integer"]
+          },
+          "updated": {
+            "description": "Timestamp representing the last update of the plan.",
+            "type": ["null", "integer"]
+          },
+          "statement_description": {
+            "description": "Description to be shown on customer statements.",
+            "type": ["null", "string"]
+          },
+          "product": {
+            "description": "The product associated with the plan.",
+            "type": ["null", "string"]
+          },
+          "statement_descriptor": {
+            "description": "The statement descriptor to be shown on credit card statements.",
+            "type": ["null", "string"]
+          },
+          "interval_count": {
+            "description": "Number of intervals between each subscription billing.",
+            "type": ["null", "integer"]
+          },
+          "transform_usage": {
+            "description": "Specifies billing behavior for subscription within a few hours of cycle-end.",
+            "type": ["null", "string"]
+          },
+          "name": {
+            "description": "The name of the plan.",
+            "type": ["null", "string"]
+          },
+          "amount": {
+            "description": "The amount in the smallest currency unit representing the price of the plan.",
+            "type": ["null", "integer"]
+          },
+          "interval": {
+            "description": "Specifies the duration between billing periods.",
+            "type": ["null", "string"]
+          },
+          "id": {
+            "description": "Unique identifier for the plan.",
+            "type": ["null", "string"]
+          },
+          "trial_period_days": {
+            "description": "Number of days in the trial period for new subscribers.",
+            "type": ["null", "integer"]
+          },
+          "usage_type": {
+            "description": "Specifies metered billing or licensed billing.",
+            "type": ["null", "string"]
+          },
+          "active": {
+            "description": "Indicates if the plan is currently active or not.",
+            "type": ["null", "boolean"]
+          },
+          "tiers_mode": {
+            "description": "Determines how to interpret the pricing tiers.",
+            "type": ["null", "string"]
+          },
+          "billing_scheme": {
+            "description": "Specifies how the subscription interacts with proration.",
+            "type": ["null", "string"]
+          },
+          "livemode": {
+            "description": "Indicates if the plan is in livemode or testmode.",
+            "type": ["null", "boolean"]
+          },
+          "currency": {
+            "description": "The currency in which the plan amount is specified.",
+            "type": ["null", "string"]
+          },
+          "metadata": {
+            "description": "Set of key-value pairs associated with the plan.",
+            "type": ["null", "object"],
+            "properties": {}
+          },
+          "amount_decimal": {
+            "description": "The decimal equivalent of the amount field.",
+            "type": ["null", "string"]
+          },
+          "is_deleted": {
+            "description": "Indicates if the plan has been marked as deleted.",
+            "type": ["null", "boolean"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "prices",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "Prices Schema",
+        "additionalProperties": true,
+        "type": ["null", "object"],
+        "properties": {
+          "id": {
+            "description": "Unique identifier for the price.",
+            "type": ["null", "string"]
+          },
+          "object": {
+            "description": "Type of object, in this case, 'price'.",
+            "type": ["null", "string"]
+          },
+          "active": {
+            "description": "Indicates if the price is currently active or not.",
+            "type": ["null", "boolean"]
+          },
+          "billing_scheme": {
+            "description": "Defines how the price interacts with the subscription's billing periods.",
+            "type": ["null", "string"]
+          },
+          "created": {
+            "description": "Timestamp representing when the price was created.",
+            "type": ["null", "integer"]
+          },
+          "updated": {
+            "description": "Timestamp representing when the price was last updated.",
+            "type": ["null", "integer"]
+          },
+          "currency": {
+            "description": "The currency of the price.",
+            "type": ["null", "string"]
+          },
+          "custom_unit_amount": {
+            "description": "Custom unit amount for the price if set.",
+            "type": ["null", "string"]
+          },
+          "livemode": {
+            "description": "Indicates if the price is in live mode.",
+            "type": ["null", "boolean"]
+          },
+          "lookup_key": {
+            "description": "A reference key for the price used in lookup.",
+            "type": ["null", "string"]
+          },
+          "metadata": {
+            "description": "Custom metadata associated with the price.",
+            "type": ["null", "object"],
+            "properties": {
+              "nickname": {
+                "description": "User-defined nickname for the price.",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "nickname": {
+            "description": "User-defined nickname for the price.",
+            "type": ["null", "string"]
+          },
+          "product": {
+            "description": "The product associated with the price.",
+            "type": ["null", "string"]
+          },
+          "recurring": {
+            "description": "Recurring billing details for the price.",
+            "type": ["null", "object"],
+            "properties": {
+              "aggregate_usage": {
+                "description": "Specifies usage aggregation for the price if multiple subscriptions exist.",
+                "type": ["null", "string"]
+              },
+              "interval": {
+                "description": "Specifies how often the price should be billed.",
+                "type": ["null", "string"]
+              },
+              "interval_count": {
+                "description": "The number of intervals between each subscription billing.",
+                "type": ["null", "number"]
+              },
+              "trial_period_days": {
+                "description": "Number of days of trial period for the price.",
+                "type": ["null", "string"]
+              },
+              "usage_type": {
+                "description": "Specifies usage type for the price.",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "tax_behavior": {
+            "description": "Specifies the tax behavior for the price.",
+            "type": ["null", "string"]
+          },
+          "tiers_mode": {
+            "description": "Specifies pricing tiers mode for the price.",
+            "type": ["null", "string"]
+          },
+          "transform_quantity": {
+            "description": "Specifies how the quantity should be transformed before calculating the price.",
+            "type": ["null", "string"]
+          },
+          "type": {
+            "description": "Indicates the type of the price.",
+            "type": ["null", "string"]
+          },
+          "unit_amount": {
+            "description": "Unit amount for the price.",
+            "type": ["null", "number"]
+          },
+          "unit_amount_decimal": {
+            "description": "Unit amount in decimal format for the price.",
+            "type": ["null", "string"]
+          },
+          "is_deleted": {
+            "description": "Indicates if the price has been deleted.",
+            "type": ["null", "boolean"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "products",
+      "json_schema": {
+        "type": ["null", "object"],
+        "properties": {
+          "id": {
+            "description": "Unique identifier for the product.",
+            "type": ["null", "string"]
+          },
+          "object": {
+            "description": "Indicates the type of object, in this case, a product.",
+            "type": ["null", "string"]
+          },
+          "active": {
+            "description": "Indicates if the product is active or not.",
+            "type": ["null", "boolean"]
+          },
+          "attributes": {
+            "description": "Details about the attributes of the product.",
+            "type": ["null", "array"],
+            "items": {
+              "description": "List of custom attributes associated with the product.",
+              "type": ["null", "string"]
+            }
+          },
+          "caption": {
+            "description": "A short description or title for the product.",
+            "type": ["null", "string"]
+          },
+          "created": {
+            "description": "Timestamp indicating the creation date of the product.",
+            "type": ["null", "integer"]
+          },
+          "deactivate_on": {
+            "description": "The date on which the product will be deactivated.",
+            "type": ["null", "array"],
+            "items": {
+              "description": "List of reasons or events that might lead to product deactivation.",
+              "type": ["null", "string"]
+            }
+          },
+          "description": {
+            "description": "A detailed description of the product.",
+            "type": ["null", "string"]
+          },
+          "images": {
+            "description": "Images related to the product.",
+            "type": ["null", "array"],
+            "items": {
+              "description": "List of images associated with the product.",
+              "type": ["null", "string"]
+            }
+          },
+          "livemode": {
+            "description": "Indicates if the product is in live mode or test mode.",
+            "type": ["null", "boolean"]
+          },
+          "metadata": {
+            "description": "Additional information or custom data related to the product.",
+            "type": ["null", "object"],
+            "properties": {}
+          },
+          "name": {
+            "description": "Name of the product.",
+            "type": ["null", "string"]
+          },
+          "package_dimensions": {
+            "description": "Dimensions of the package in which the product is shipped.",
+            "type": ["null", "object"],
+            "properties": {
+              "width": {
+                "description": "Width dimension of the product package.",
+                "type": ["null", "number"]
+              },
+              "length": {
+                "description": "Length dimension of the product package.",
+                "type": ["null", "number"]
+              },
+              "weight": {
+                "description": "Weight of the product package.",
+                "type": ["null", "number"]
+              },
+              "height": {
+                "description": "Height dimension of the product package.",
+                "type": ["null", "number"]
+              }
+            }
+          },
+          "shippable": {
+            "description": "Indicates if the product is shippable or not.",
+            "type": ["null", "boolean"]
+          },
+          "statement_descriptor": {
+            "description": "Descriptor displayed in the customer's statement for this product.",
+            "type": ["null", "string"]
+          },
+          "type": {
+            "description": "Type or category of the product.",
+            "type": ["null", "string"]
+          },
+          "unit_label": {
+            "description": "Label representing the unit of the product.",
+            "type": ["null", "string"]
+          },
+          "updated": {
+            "description": "Timestamp indicating the last update date of the product.",
+            "type": ["null", "integer"]
+          },
+          "url": {
+            "description": "URL pointing to more details or information about the product.",
+            "type": ["null", "string"]
+          },
+          "default_price": {
+            "description": "The default price set for the product.",
+            "type": ["null", "string"]
+          },
+          "tax_code": {
+            "description": "Tax code associated with the product.",
+            "type": ["null", "string"]
+          },
+          "features": {
+            "description": "List of features offered by the product.",
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "name": {
+                  "description": "Name of a specific feature associated with the product.",
+                  "type": ["null", "string"]
+                }
+              }
+            }
+          },
+          "is_deleted": {
+            "description": "Indicates if the product has been deleted.",
+            "type": ["null", "boolean"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "reviews",
+      "json_schema": {
+        "$schema": "https://json-schema.org/draft-07/schema#",
+        "additionalProperties": true,
+        "type": ["null", "object"],
+        "properties": {
+          "billing_zip": {
+            "description": "The ZIP code associated with the billing address.",
+            "type": ["null", "string"]
+          },
+          "charge": {
+            "description": "The charge associated with the payment.",
+            "type": ["null", "string"]
+          },
+          "closed_reason": {
+            "description": "The reason for closing the transaction.",
+            "type": ["null", "string"]
+          },
+          "created": {
+            "description": "The timestamp when the review was created.",
+            "type": ["null", "integer"]
+          },
+          "updated": {
+            "description": "The timestamp when the review was last updated.",
+            "type": ["null", "integer"]
+          },
+          "id": {
+            "description": "The unique identifier for the review.",
+            "type": ["null", "string"]
+          },
+          "ip_address": {
+            "description": "The IP address of the reviewer.",
+            "type": ["null", "string"]
+          },
+          "ip_address_location": {
+            "description": "Location details of the reviewer's IP address.",
+            "type": ["null", "object"],
+            "properties": {
+              "city": {
+                "description": "The city of the reviewer's IP address location.",
+                "type": ["null", "string"]
+              },
+              "country": {
+                "description": "The country of the reviewer's IP address location.",
+                "type": ["null", "string"]
+              },
+              "latitude": {
+                "description": "The latitude coordinate of the reviewer's IP address location.",
+                "type": ["null", "number"]
+              },
+              "longitude": {
+                "description": "The longitude coordinate of the reviewer's IP address location.",
+                "type": ["null", "number"]
+              },
+              "region": {
+                "description": "The region of the reviewer's IP address location.",
+                "type": ["null", "number"]
+              }
+            }
+          },
+          "livemode": {
+            "description": "Indicates if the review is in live mode.",
+            "type": ["null", "string"]
+          },
+          "object": {
+            "description": "The type of object being reviewed.",
+            "type": ["null", "string"]
+          },
+          "open": {
+            "description": "Indicates if the review is open.",
+            "type": ["null", "boolean"]
+          },
+          "opened_reason": {
+            "description": "The reason for opening the review.",
+            "type": ["null", "string"]
+          },
+          "payment_intent": {
+            "description": "The payment intent associated with the review.",
+            "type": ["null", "string"]
+          },
+          "reason": {
+            "description": "The reason for the review being conducted.",
+            "type": ["null", "string"]
+          },
+          "session": {
+            "description": "Details of the reviewer's session.",
+            "type": ["null", "object"],
+            "properties": {
+              "browser": {
+                "description": "The browser used by the reviewer.",
+                "type": ["null", "string"]
+              },
+              "device": {
+                "description": "The device used by the reviewer.",
+                "type": ["null", "string"]
+              },
+              "platform": {
+                "description": "The platform used by the reviewer.",
+                "type": ["null", "string"]
+              },
+              "version": {
+                "description": "The version of the platform used by the reviewer.",
+                "type": ["null", "string"]
+              }
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "subscriptions",
+      "json_schema": {
+        "type": ["null", "object"],
+        "properties": {
+          "metadata": {
+            "description": "Additional metadata associated with the subscription.",
+            "type": ["null", "object"],
+            "properties": {}
+          },
+          "canceled_at": {
+            "description": "The timestamp at which the subscription was canceled.",
+            "type": ["null", "number"]
+          },
+          "cancel_at": {
+            "description": "The timestamp at which the subscription will be canceled.",
+            "type": ["null", "number"]
+          },
+          "livemode": {
+            "description": "Indicates if the subscription is in live mode.",
+            "type": ["null", "boolean"]
+          },
+          "start_date": {
+            "description": "The start date of the subscription.",
+            "type": ["null", "integer"]
+          },
+          "items": {
+            "description": "Items included in the subscription.",
+            "type": ["null", "object"],
+            "properties": {
+              "object": {
+                "description": "Type of object, in this case, 'items'.",
+                "type": ["null", "string"]
+              },
+              "data": {
+                "description": "Data related to the subscription items.",
+                "type": ["null", "array"]
+              },
+              "has_more": {
+                "description": "Indicates if there are more items in the subscription.",
+                "type": ["null", "boolean"]
+              },
+              "total_count": {
+                "description": "The total count of items in the subscription.",
+                "type": ["null", "number"]
+              },
+              "url": {
+                "description": "The URL to access the subscription items.",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "id": {
+            "description": "The unique identifier of the subscription.",
+            "type": ["null", "string"]
+          },
+          "trial_start": {
+            "description": "The start date of the trial period for the subscription.",
+            "type": ["null", "integer"]
+          },
+          "application_fee_percent": {
+            "description": "The percentage of the subscription fee that goes to the application.",
+            "type": ["null", "number"]
+          },
+          "billing_cycle_anchor": {
+            "description": "The anchor point for determining the billing cycle.",
+            "type": ["null", "number"]
+          },
+          "billing_cycle_anchor_config": {
+            "description": "Configuration for the billing cycle anchor.",
+            "type": ["null", "object"]
+          },
+          "invoice_settings": {
+            "description": "Settings related to invoicing for the subscription.",
+            "type": ["null", "object"]
+          },
+          "cancel_at_period_end": {
+            "description": "Indicates if the subscription should be canceled at the end of the current period.",
+            "type": ["null", "boolean"]
+          },
+          "tax_percent": {
+            "description": "The percentage of tax applied to the subscription.",
+            "type": ["null", "number"]
+          },
+          "discount": {
+            "description": "Information about any discounts applied to the subscription.",
+            "type": ["null", "object"],
+            "properties": {
+              "end": {
+                "description": "The end date of the discount.",
+                "type": ["null", "integer"]
+              },
+              "coupon": {
+                "description": "Details of the coupon discount applied to the subscription.",
+                "type": ["null", "object"],
+                "properties": {
+                  "metadata": {
+                    "description": "Additional metadata associated with the coupon.",
+                    "type": ["null", "object"],
+                    "properties": {}
+                  },
+                  "valid": {
+                    "description": "Indicates if the coupon is valid.",
+                    "type": ["null", "boolean"]
+                  },
+                  "livemode": {
+                    "description": "Indicates if the coupon is in live mode.",
+                    "type": ["null", "boolean"]
+                  },
+                  "amount_off": {
+                    "description": "The amount discounted by the coupon.",
+                    "type": ["null", "number"]
+                  },
+                  "redeem_by": {
+                    "description": "The date by which the coupon must be redeemed.",
+                    "type": ["null", "string"]
+                  },
+                  "duration_in_months": {
+                    "description": "The duration in months for which the coupon is valid.",
+                    "type": ["null", "number"]
+                  },
+                  "percent_off_precise": {
+                    "description": "Precise percentage off applied by the coupon.",
+                    "type": ["null", "number"]
+                  },
+                  "max_redemptions": {
+                    "description": "The maximum number of times the coupon can be redeemed.",
+                    "type": ["null", "number"]
+                  },
+                  "currency": {
+                    "description": "The currency of the coupon.",
+                    "type": ["null", "string"]
+                  },
+                  "name": {
+                    "description": "The name of the coupon.",
+                    "type": ["null", "string"]
+                  },
+                  "times_redeemed": {
+                    "description": "The number of times the coupon has been redeemed.",
+                    "type": ["null", "number"]
+                  },
+                  "id": {
+                    "description": "The ID of the coupon.",
+                    "type": ["null", "string"]
+                  },
+                  "duration": {
+                    "description": "The duration of the coupon redemption.",
+                    "type": ["null", "string"]
+                  },
+                  "object": {
+                    "description": "Type of object, in this case, 'coupon'.",
+                    "type": ["null", "string"]
+                  },
+                  "percent_off": {
+                    "description": "The percentage off applied by the coupon.",
+                    "type": ["null", "number"]
+                  },
+                  "created": {
+                    "description": "The timestamp when the coupon was created.",
+                    "type": ["null", "integer"]
+                  }
+                }
+              },
+              "customer": {
+                "description": "The customer associated with the discount.",
+                "type": ["null", "string"]
+              },
+              "start": {
+                "description": "The start date of the discount.",
+                "type": ["null", "integer"]
+              },
+              "object": {
+                "description": "Type of object, in this case, 'discount'.",
+                "type": ["null", "string"]
+              },
+              "subscription": {
+                "description": "The subscription to which the discount is applied.",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "current_period_end": {
+            "description": "The timestamp at which the current period ends.",
+            "type": ["null", "number"]
+          },
+          "plan": {
+            "description": "Details of the plan associated with the subscription.",
+            "type": ["null", "object"],
+            "properties": {
+              "metadata": {
+                "description": "Additional metadata associated with the plan.",
+                "type": ["null", "object"],
+                "properties": {}
+              },
+              "product": {
+                "description": "The product associated with the plan.",
+                "type": ["null", "string"]
+              },
+              "statement_description": {
+                "description": "The statement description of the plan.",
+                "type": ["null", "string"]
+              },
+              "currency": {
+                "description": "The currency of the plan.",
+                "type": ["null", "string"]
+              },
+              "livemode": {
+                "description": "Indicates if the plan is in live mode.",
+                "type": ["null", "boolean"]
+              },
+              "tiers_mode": {
+                "description": "The mode of tiers for the plan.",
+                "type": ["null", "string"]
+              },
+              "active": {
+                "description": "Indicates if the plan is active.",
+                "type": ["null", "boolean"]
+              },
+              "id": {
+                "description": "The unique identifier of the plan.",
+                "type": ["null", "string"]
+              },
+              "tiers": {
+                "description": "Tiers associated with the plan.",
+                "type": ["null", "array"],
+                "items": {
+                  "type": ["null", "integer", "object"],
+                  "properties": {
+                    "flat_amount": {
+                      "description": "The flat amount applied in the tier.",
+                      "type": ["null", "integer"]
+                    },
+                    "unit_amount": {
+                      "description": "The unit amount applied in the tier.",
+                      "type": ["null", "integer"]
+                    },
+                    "up_to": {
+                      "description": "The upper limit for the tier.",
+                      "type": ["null", "integer"]
+                    }
+                  }
+                }
+              },
+              "created": {
+                "description": "The timestamp at which the plan was created.",
+                "type": ["null", "integer"]
+              },
+              "nickname": {
+                "description": "The nickname of the plan.",
+                "type": ["null", "string"]
+              },
+              "transform_usage": {
+                "description": "Transformation applied to usage for the plan.",
+                "type": ["null", "string"]
+              },
+              "interval_count": {
+                "description": "The count of intervals for the plan.",
+                "type": ["null", "integer"]
+              },
+              "name": {
+                "description": "The name of the plan.",
+                "type": ["null", "string"]
+              },
+              "amount": {
+                "description": "The amount of the plan.",
+                "type": ["null", "integer"]
+              },
+              "interval": {
+                "description": "The interval of the plan.",
+                "type": ["null", "string"]
+              },
+              "aggregate_usage": {
+                "description": "The type of usage aggregation for the plan.",
+                "type": ["null", "string"]
+              },
+              "trial_period_days": {
+                "description": "The number of trial period days for the plan.",
+                "type": ["null", "integer"]
+              },
+              "billing_scheme": {
+                "description": "The billing scheme of the plan.",
+                "type": ["null", "string"]
+              },
+              "statement_descriptor": {
+                "description": "The statement descriptor of the plan.",
+                "type": ["null", "string"]
+              },
+              "usage_type": {
+                "description": "The type of usage for the plan.",
+                "type": ["null", "string"]
+              },
+              "object": {
+                "description": "Type of object, in this case, 'plan'.",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "billing": {
+            "description": "The billing method for the subscription.",
+            "type": ["null", "string"]
+          },
+          "quantity": {
+            "description": "The quantity of the subscription.",
+            "type": ["null", "integer"]
+          },
+          "days_until_due": {
+            "description": "The number of days until payment is due for the subscription.",
+            "type": ["null", "integer"]
+          },
+          "status": {
+            "description": "The status of the subscription.",
+            "type": ["null", "string"]
+          },
+          "created": {
+            "description": "The timestamp at which the subscription was created.",
+            "type": ["null", "integer"]
+          },
+          "updated": {
+            "description": "The timestamp at which the subscription was last updated.",
+            "type": ["null", "integer"]
+          },
+          "ended_at": {
+            "description": "The timestamp at which the subscription ended.",
+            "type": ["null", "number"]
+          },
+          "customer": {
+            "description": "The customer associated with the subscription.",
+            "type": ["null", "string"]
+          },
+          "current_period_start": {
+            "description": "The timestamp at which the current period started.",
+            "type": ["null", "integer"]
+          },
+          "trial_end": {
+            "description": "The end date of the trial period for the subscription.",
+            "type": ["null", "number"]
+          },
+          "object": {
+            "description": "Type of object, in this case, 'subscription'.",
+            "type": ["null", "string"]
+          },
+          "pending_setup_intent": {
+            "description": "The pending setup intent for the subscription.",
+            "type": ["null", "string"]
+          },
+          "currency": {
+            "description": "The currency used for the subscription.",
+            "type": ["null", "string"]
+          },
+          "transfer_data": {
+            "description": "Data related to transfers for the subscription.",
+            "type": ["null", "object"],
+            "properties": {
+              "amount_percent": {
+                "description": "The percentage amount for transfers.",
+                "type": ["null", "number"]
+              },
+              "destination": {
+                "description": "The destination for transfers.",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "application": {
+            "description": "The application linked to the subscription.",
+            "type": ["null", "string"]
+          },
+          "test_clock": {
+            "description": "The test clock for subscription testing purposes.",
+            "type": ["null", "string"]
+          },
+          "automatic_tax": {
+            "description": "Data related to automatic tax calculations for the subscription.",
+            "type": ["null", "object"],
+            "properties": {
+              "enabled": {
+                "description": "Indicates if automatic tax calculation is enabled for the subscription.",
+                "type": ["null", "boolean"]
+              }
+            }
+          },
+          "payment_settings": {
+            "description": "Settings related to payment for the subscription.",
+            "type": ["null", "object"],
+            "properties": {
+              "payment_method_options": {
+                "description": "Options for the payment method.",
+                "type": ["null", "object"]
+              },
+              "payment_method_types": {
+                "description": "Supported payment method types.",
+                "type": ["null", "array"],
+                "items": { "type": ["null", "string"] }
+              },
+              "save_default_payment_method": {
+                "description": "Indicates if the default payment method should be saved.",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "next_pending_invoice_item_invoice": {
+            "description": "The next pending invoice item invoice.",
+            "type": ["null", "integer"]
+          },
+          "default_source": {
+            "description": "The default payment source for the subscription.",
+            "type": ["null", "string"]
+          },
+          "default_payment_method": {
+            "description": "The default payment method for the subscription.",
+            "type": ["null", "string"]
+          },
+          "collection_method": {
+            "description": "The method of collection for the subscription.",
+            "type": ["null", "string"]
+          },
+          "pending_invoice_item_interval": {
+            "description": "Interval settings for pending invoice items.",
+            "type": ["null", "object"],
+            "properties": {
+              "interval": {
+                "description": "The interval for pending invoice items.",
+                "type": ["null", "string"]
+              },
+              "interval_count": {
+                "description": "The count of intervals for pending invoice items.",
+                "type": ["null", "integer"]
+              }
+            }
+          },
+          "default_tax_rates": {
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "id": { "type": ["null", "string"] },
+                "object": { "type": ["null", "string"] },
+                "active": { "type": ["null", "boolean"] },
+                "country": { "type": ["null", "string"] },
+                "created": { "type": ["null", "integer"] },
+                "description": { "type": ["null", "string"] },
+                "display_name": { "type": ["null", "string"] },
+                "effective_percentage": { "type": ["null", "number"] },
+                "inclusive": { "type": ["null", "boolean"] },
+                "jurisdiction": { "type": ["null", "string"] },
+                "livemode": { "type": ["null", "boolean"] },
+                "metadata": { "type": ["null", "object"] },
+                "percentage": { "type": ["null", "number"] },
+                "state": { "type": ["null", "string"] },
+                "tax_type": { "type": ["null", "string"] }
+              }
+            }
+          },
+          "pause_collection": {
+            "description": "Details related to pausing the collection for the subscription.",
+            "type": ["null", "object"],
+            "properties": {
+              "behavior": {
+                "description": "The behavior when pausing collection.",
+                "type": ["null", "string"]
+              },
+              "resumes_at": {
+                "description": "The timestamp at which collection resumes.",
+                "type": ["null", "integer"]
+              }
+            }
+          },
+          "cancellation_details": {
+            "description": "Details related to the cancellation of the subscription.",
+            "type": ["null", "object"],
+            "properties": {
+              "comment": {
+                "description": "Any comments provided during the cancellation.",
+                "type": ["null", "string"]
+              },
+              "feedback": {
+                "description": "Feedback related to the cancellation.",
+                "type": ["null", "string"]
+              },
+              "reason": {
+                "description": "The reason for canceling the subscription.",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "latest_invoice": {
+            "description": "Details of the latest invoice generated for the subscription.",
+            "type": ["null", "string"]
+          },
+          "pending_update": {
+            "description": "Details of any pending updates for the subscription.",
+            "type": ["null", "object"],
+            "properties": {
+              "billing_cycle_anchor": {
+                "description": "The anchor point for any pending billing cycle update.",
+                "type": ["null", "integer"]
+              },
+              "expires_at": {
+                "description": "The timestamp at which the pending update expires.",
+                "type": ["null", "integer"]
+              },
+              "subscription_items": {
+                "description": "Items included in the subscription update.",
+                "type": ["null", "array"],
+                "items": {
+                  "type": ["null", "object"],
+                  "properties": {
+                    "id": {
+                      "description": "The unique identifier of the updated subscription item.",
+                      "type": ["null", "string"]
+                    },
+                    "object": {
+                      "description": "Type of object, in this case, 'subscription item'.",
+                      "type": ["null", "string"]
+                    },
+                    "billing_thresholds": {
+                      "description": "Thresholds for billing in the updated subscription item.",
+                      "type": ["null", "object"],
+                      "properties": {
+                        "usage_gte": {
+                          "description": "The usage threshold for billing.",
+                          "type": ["null", "integer"]
+                        }
+                      }
+                    },
+                    "created": {
+                      "description": "The timestamp at which the updated subscription item was created.",
+                      "type": ["null", "integer"]
+                    },
+                    "metadata": {
+                      "description": "Additional metadata associated with the updated subscription item.",
+                      "type": ["null", "object"]
+                    },
+                    "price": {
+                      "type": ["null", "object"],
+                      "properties": {
+                        "id": { "type": ["null", "string"] },
+                        "object": { "type": ["null", "string"] },
+                        "active": { "type": ["null", "boolean"] },
+                        "billing_scheme": { "type": ["null", "string"] },
+                        "created": { "type": ["null", "integer"] },
+                        "currency": { "type": ["null", "string"] },
+                        "currency_options": { "type": ["null", "string"] },
+                        "custom_unit_amount": {
+                          "type": ["null", "object"],
+                          "properties": {
+                            "maximum": { "type": ["null", "integer"] },
+                            "minimum": { "type": ["null", "integer"] },
+                            "preset": { "type": ["null", "integer"] }
+                          }
+                        },
+                        "livemode": { "type": ["null", "boolean"] },
+                        "lookup_key": { "type": ["null", "string"] },
+                        "metadata": { "type": ["null", "object"] },
+                        "nickname": { "type": ["null", "string"] },
+                        "product": { "type": ["null", "string"] },
+                        "recurring": {
+                          "type": ["null", "object"],
+                          "properties": {
+                            "aggregate_usage": { "type": ["null", "string"] },
+                            "interval": { "type": ["null", "string"] },
+                            "interval_count": { "type": ["null", "integer"] },
+                            "usage_type": { "type": ["null", "string"] }
+                          }
+                        },
+                        "tax_behavior": { "type": ["null", "string"] },
+                        "tiers": {
+                          "type": ["null", "array"],
+                          "items": { "type": ["null", "string"] }
+                        },
+                        "tiers_mode": { "type": ["null", "string"] },
+                        "transform_quantity": {
+                          "type": ["null", "object"],
+                          "properties": {
+                            "divide_by": { "type": ["null", "integer"] },
+                            "round": { "type": ["null", "string"] }
+                          }
+                        },
+                        "type": { "type": ["null", "string"] },
+                        "unit_amount": { "type": ["null", "integer"] },
+                        "unit_amount_decimal": { "type": ["null", "string"] }
+                      }
+                    },
+                    "quantity": {
+                      "description": "The quantity of the updated subscription item.",
+                      "type": ["null", "integer"]
+                    },
+                    "subscription": {
+                      "description": "The subscription to which the item is updated.",
+                      "type": ["null", "string"]
+                    },
+                    "tax_rates": {
+                      "type": ["null", "array"],
+                      "items": {
+                        "type": ["null", "object"],
+                        "properties": {
+                          "id": { "type": ["null", "string"] },
+                          "object": { "type": ["null", "string"] },
+                          "active": { "type": ["null", "boolean"] },
+                          "country": { "type": ["null", "string"] },
+                          "created": { "type": ["null", "integer"] },
+                          "description": { "type": ["null", "string"] },
+                          "display_name": { "type": ["null", "string"] },
+                          "effective_percentage": {
+                            "type": ["null", "number"]
+                          },
+                          "inclusive": { "type": ["null", "boolean"] },
+                          "jurisdiction": { "type": ["null", "string"] },
+                          "livemode": { "type": ["null", "boolean"] },
+                          "metadata": { "type": ["null", "object"] },
+                          "percentage": { "type": ["null", "number"] },
+                          "state": { "type": ["null", "string"] },
+                          "tax_type": { "type": ["null", "string"] }
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "trial_end": {
+                "description": "The end date of the trial period for the pending update.",
+                "type": ["null", "integer"]
+              },
+              "trial_from_plan": {
+                "description": "Indicates if the trial period is based on the plan for the pending update.",
+                "type": ["null", "boolean"]
+              }
+            }
+          },
+          "description": {
+            "description": "A brief description of the subscription.",
+            "type": ["null", "string"]
+          },
+          "schedule": {
+            "description": "The schedule associated with the subscription.",
+            "type": ["null", "string"]
+          },
+          "trial_settings": {
+            "description": "Settings related to the trial period of the subscription.",
+            "type": ["null", "object"],
+            "properties": {
+              "end_behavior": {
+                "description": "Behavior at the end of the trial period.",
+                "type": ["null", "object"],
+                "properties": {
+                  "missing_payment_method": {
+                    "description": "Handling of missing payment method at the end of the trial.",
+                    "type": ["null", "string"]
+                  }
+                }
+              }
+            }
+          },
+          "on_behalf_of": {
+            "description": "The entity on whose behalf the subscription is made.",
+            "type": ["null", "string"]
+          },
+          "billing_thresholds": {
+            "description": "Settings for billing thresholds such as usage-based pricing or limit enforcement.",
+            "type": ["null", "object"],
+            "properties": {
+              "amount_gte": {
+                "description": "The threshold amount for triggering a billing cycle anchor reset.",
+                "type": ["null", "integer"]
+              },
+              "reset_billing_cycle_anchor": {
+                "description": "Indicates if the billing cycle anchor should be reset based on the threshold.",
+                "type": ["null", "boolean"]
+              }
+            }
+          },
+          "is_deleted": {
+            "description": "Indicates if the subscription has been deleted.",
+            "type": ["null", "boolean"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "subscription_schedule",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": ["null", "object"],
+        "additionalProperties": true,
+        "properties": {
+          "id": {
+            "description": "The unique ID of the subscription schedule.",
+            "type": ["null", "string"]
+          },
+          "object": {
+            "description": "The object type, which is 'subscription_schedule'.",
+            "type": ["null", "string"]
+          },
+          "application": {
+            "description": "The ID of the application associated with the subscription schedule.",
+            "type": ["null", "string"]
+          },
+          "canceled_at": {
+            "description": "The date and time when the subscription schedule was canceled.",
+            "type": ["null", "string"]
+          },
+          "completed_at": {
+            "description": "The date and time when the subscription schedule was completed.",
+            "type": ["null", "string"]
+          },
+          "created": {
+            "description": "The date and time when the subscription schedule was created.",
+            "type": ["null", "integer"]
+          },
+          "updated": {
+            "description": "The date and time when the subscription schedule was last updated.",
+            "type": ["null", "integer"]
+          },
+          "current_phase": {
+            "description": "Information about the current phase of the subscription schedule.",
+            "type": ["null", "object"],
+            "additionalProperties": true,
+            "properties": {
+              "end_date": {
+                "description": "The end date of the current phase.",
+                "type": ["null", "integer"]
+              },
+              "start_date": {
+                "description": "The start date of the current phase.",
+                "type": ["null", "integer"]
+              }
+            }
+          },
+          "customer": {
+            "description": "The ID of the customer associated with the subscription schedule.",
+            "type": ["null", "string"]
+          },
+          "default_settings": {
+            "description": "Default settings for the subscription schedule.",
+            "type": ["null", "object"],
+            "properties": {
+              "application_fee_percent": {
+                "description": "The application fee percent.",
+                "type": ["null", "string"]
+              },
+              "automatic_tax": {
+                "description": "Automatic tax settings.",
+                "type": ["null", "object"],
+                "properties": {
+                  "enabled": {
+                    "description": "Indicates if automatic tax calculation is enabled.",
+                    "type": ["null", "boolean"]
+                  }
+                }
+              },
+              "billing_cycle_anchor": {
+                "description": "The billing cycle anchor date.",
+                "type": ["null", "string"]
+              },
+              "billing_thresholds": {
+                "description": "Billing thresholds for the subscription schedule.",
+                "type": ["null", "string"]
+              },
+              "collection_method": {
+                "description": "The collection method used for payments.",
+                "type": ["null", "string"]
+              },
+              "default_payment_method": {
+                "description": "The ID of the default payment method.",
+                "type": ["null", "string"]
+              },
+              "description": {
+                "description": "A description for the subscription schedule.",
+                "type": ["null", "string"]
+              },
+              "invoice_settings": {
+                "description": "Settings for invoices.",
+                "type": ["null", "string"]
+              },
+              "on_behalf_of": {
+                "description": "The ID of the account on whose behalf the subscription schedule operates.",
+                "type": ["null", "string"]
+              },
+              "transfer_data": {
+                "description": "Information about transfers linked to the subscription schedule.",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "end_behavior": {
+            "description": "The behavior after the subscription schedule ends.",
+            "type": ["null", "string"]
+          },
+          "livemode": {
+            "description": "Indicates if the subscription schedule is in live mode.",
+            "type": ["null", "boolean"]
+          },
+          "metadata": {
+            "description": "Additional metadata related to the subscription schedule.",
+            "type": ["null", "object"]
+          },
+          "phases": {
+            "description": "Information about the phases within the subscription schedule.",
+            "type": ["null", "array"],
+            "items": {
+              "description": "Details of each phase.",
+              "type": ["null", "object"],
+              "additionalProperties": true,
+              "properties": {
+                "add_invoice_items": {
+                  "description": "Additional invoice items to add in this phase.",
+                  "type": ["null", "array"],
+                  "items": {
+                    "description": "Details of each item to be added to the invoice.",
+                    "type": ["null", "object"],
+                    "additionalProperties": true,
+                    "properties": {
+                      "price": {
+                        "description": "The ID of the price that should be added to the invoice.",
+                        "type": ["null", "string"]
+                      },
+                      "quantity": {
+                        "description": "The quantity of the item to be added.",
+                        "type": ["null", "string"]
+                      },
+                      "tax_rates": {
+                        "type": ["null", "array"],
+                        "items": {
+                          "type": ["null", "object"],
+                          "properties": {
+                            "id": { "type": ["null", "string"] },
+                            "object": { "type": ["null", "string"] },
+                            "active": { "type": ["null", "boolean"] },
+                            "country": { "type": ["null", "string"] },
+                            "created": { "type": ["null", "integer"] },
+                            "description": { "type": ["null", "string"] },
+                            "display_name": { "type": ["null", "string"] },
+                            "effective_percentage": {
+                              "type": ["null", "number"]
+                            },
+                            "inclusive": { "type": ["null", "boolean"] },
+                            "jurisdiction": { "type": ["null", "string"] },
+                            "livemode": { "type": ["null", "boolean"] },
+                            "metadata": { "type": ["null", "object"] },
+                            "percentage": { "type": ["null", "number"] },
+                            "state": { "type": ["null", "string"] },
+                            "tax_type": { "type": ["null", "string"] }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "application_fee_percent": {
+                  "description": "The application fee percent for this phase.",
+                  "type": ["null", "string"]
+                },
+                "billing_cycle_anchor": {
+                  "description": "The billing cycle anchor date for this phase.",
+                  "type": ["null", "string"]
+                },
+                "billing_thresholds": {
+                  "description": "Billing thresholds for this phase.",
+                  "type": ["null", "string"]
+                },
+                "collection_method": {
+                  "description": "The collection method used for payments in this phase.",
+                  "type": ["null", "string"]
+                },
+                "coupon": {
+                  "description": "The coupon code applied in this phase.",
+                  "type": ["null", "string"]
+                },
+                "currency": {
+                  "description": "The currency used for payments in this phase.",
+                  "type": ["null", "string"]
+                },
+                "default_payment_method": {
+                  "description": "The default payment method for this phase.",
+                  "type": ["null", "string"]
+                },
+                "default_tax_rates": {
+                  "type": ["null", "array"],
+                  "items": {
+                    "type": ["null", "object"],
+                    "properties": {
+                      "id": { "type": ["null", "string"] },
+                      "object": { "type": ["null", "string"] },
+                      "active": { "type": ["null", "boolean"] },
+                      "country": { "type": ["null", "string"] },
+                      "created": { "type": ["null", "integer"] },
+                      "description": { "type": ["null", "string"] },
+                      "display_name": { "type": ["null", "string"] },
+                      "effective_percentage": { "type": ["null", "number"] },
+                      "inclusive": { "type": ["null", "boolean"] },
+                      "jurisdiction": { "type": ["null", "string"] },
+                      "livemode": { "type": ["null", "boolean"] },
+                      "metadata": { "type": ["null", "object"] },
+                      "percentage": { "type": ["null", "number"] },
+                      "state": { "type": ["null", "string"] },
+                      "tax_type": { "type": ["null", "string"] }
+                    }
+                  }
+                },
+                "description": {
+                  "description": "A description for this phase.",
+                  "type": ["null", "string"]
+                },
+                "end_date": {
+                  "description": "The end date of this phase.",
+                  "type": ["null", "integer"]
+                },
+                "invoice_settings": {
+                  "description": "Invoice settings specific to this phase.",
+                  "type": ["null", "string"]
+                },
+                "items": {
+                  "description": "Invoice items included in this phase.",
+                  "type": ["null", "array"],
+                  "items": {
+                    "description": "Details of each item included in the invoice.",
+                    "type": ["null", "object"],
+                    "additionalProperties": true,
+                    "properties": {
+                      "billing_thresholds": {
+                        "description": "Billing thresholds specific to this item.",
+                        "type": ["null", "string"]
+                      },
+                      "metadata": {
+                        "description": "Additional metadata related to this item.",
+                        "type": ["null", "object"],
+                        "additionalProperties": true
+                      },
+                      "price": {
+                        "description": "The ID of the price for this item.",
+                        "type": ["null", "string"]
+                      },
+                      "quantity": {
+                        "description": "The quantity of this item.",
+                        "type": ["null", "integer"]
+                      },
+                      "tax_rates": {
+                        "description": "Tax rates applied to this item.",
+                        "type": ["null", "array"],
+                        "items": {
+                          "description": "Details of each tax rate applied.",
+                          "type": ["null", "object"],
+                          "additionalProperties": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "metadata": {
+                  "description": "Additional metadata related to this phase.",
+                  "type": ["null", "object"],
+                  "additionalProperties": true
+                },
+                "on_behalf_of": {
+                  "description": "The ID of the account on whose behalf this phase operates.",
+                  "type": ["null", "string"]
+                },
+                "proration_behavior": {
+                  "description": "The proration behavior for this phase.",
+                  "type": ["null", "string"]
+                },
+                "start_date": {
+                  "description": "The start date of this phase.",
+                  "type": ["null", "integer"]
+                },
+                "transfer_data": {
+                  "description": "Information about transfers linked to this phase.",
+                  "type": ["null", "string"]
+                },
+                "trial_end": {
+                  "description": "The trial end date for this phase.",
+                  "type": ["null", "string"]
+                }
+              }
+            }
+          },
+          "released_at": {
+            "description": "The date and time when the subscription schedule was released.",
+            "type": ["null", "string"]
+          },
+          "released_subscription": {
+            "description": "The released subscription that resulted from the schedule.",
+            "type": ["null", "string"]
+          },
+          "status": {
+            "description": "The current status of the subscription schedule.",
+            "type": ["null", "string"]
+          },
+          "subscription": {
+            "description": "The subscription ID associated with the schedule.",
+            "type": ["null", "string"]
+          },
+          "test_clock": {
+            "description": "Indicates if the test clock is active.",
+            "type": ["null", "string"]
+          },
+          "renewal_interval": {
+            "description": "The renewal interval for the subscription schedule.",
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "transfers",
+      "json_schema": {
+        "properties": {
+          "metadata": {
+            "description": "Additional information related to the transfer",
+            "type": ["null", "object"],
+            "properties": {}
+          },
+          "reversals": {
+            "description": "Details of any reversals associated with the transfer",
+            "type": ["null", "object"],
+            "properties": {
+              "object": {
+                "description": "The object type, in this case, 'list'",
+                "type": ["null", "string"]
+              },
+              "data": {
+                "description": "An array of reversal objects",
+                "type": ["null", "array"]
+              },
+              "has_more": {
+                "description": "Indicates if there are more reversals to retrieve",
+                "type": ["null", "boolean"]
+              },
+              "total_count": {
+                "description": "Total count of reversals",
+                "type": ["null", "number"]
+              },
+              "url": {
+                "description": "URL to retrieve all reversals for the transfer",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "id": {
+            "description": "The unique identifier of the transfer",
+            "type": ["null", "string"]
+          },
+          "statement_description": {
+            "description": "The description appearing on the recipient's bank statement",
+            "type": ["null", "string"]
+          },
+          "amount": {
+            "description": "The amount of the transfer",
+            "type": ["null", "integer"]
+          },
+          "balance_transaction": {
+            "description": "The balance transaction associated with the transfer",
+            "type": ["null", "string"]
+          },
+          "reversed": {
+            "description": "Indicates if the transfer was fully or partially reversed",
+            "type": ["null", "boolean"]
+          },
+          "created": {
+            "description": "The timestamp when the transfer was created",
+            "type": ["null", "integer"]
+          },
+          "updated": {
+            "description": "The timestamp when the transfer was last updated",
+            "type": ["null", "integer"]
+          },
+          "amount_reversed": {
+            "description": "The amount that was reversed from the transfer",
+            "type": ["null", "integer"]
+          },
+          "source_type": {
+            "description": "The type of the transfer source, e.g., card, bank account",
+            "type": ["null", "string"]
+          },
+          "source_transaction": {
+            "description": "The source transaction that funded the transfer",
+            "type": ["null", "string"]
+          },
+          "date": {
+            "description": "The date the transfer was initiated",
+            "type": ["null", "integer"]
+          },
+          "livemode": {
+            "description": "Indicates if the transfer was made in live mode",
+            "type": ["null", "boolean"]
+          },
+          "statement_descriptor": {
+            "description": "An optional statement descriptor appended to the recipient's bank statement",
+            "type": ["null", "string"]
+          },
+          "failure_balance_transaction": {
+            "description": "The balance transaction information for a failed transfer",
+            "type": ["null", "string"]
+          },
+          "recipient": {
+            "description": "The recipient of the transfer, usually a connected account",
+            "type": ["null", "string"]
+          },
+          "destination": {
+            "description": "The destination bank account or card where the funds are transferred",
+            "type": ["null", "string"]
+          },
+          "automatic": {
+            "description": "Indicates if the transfer was processed automatically",
+            "type": ["null", "boolean"]
+          },
+          "object": {
+            "description": "The object type, in this case, 'transfer'",
+            "type": ["null", "string"]
+          },
+          "currency": {
+            "description": "The currency of the transfer amount",
+            "type": ["null", "string"]
+          },
+          "transfer_group": {
+            "description": "A unique identifier for the transfer group if multiple transfers are linked",
+            "type": ["null", "string"]
+          },
+          "arrival_date": {
+            "description": "The date the funds are expected to arrive in the destination bank account",
+            "type": ["null", "integer"]
+          },
+          "description": {
+            "description": "A description of the transfer",
+            "type": ["null", "string"]
+          },
+          "destination_payment": {
+            "description": "The destination payment id if applicable",
+            "type": ["null", "string"]
+          }
+        },
+        "type": ["null", "object"]
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "payment_intents",
+      "json_schema": {
+        "type": ["null", "object"],
+        "properties": {
+          "id": { "type": ["null", "string"] },
+          "object": { "type": ["null", "string"] },
+          "amount": { "type": ["null", "integer"] },
+          "amount_capturable": { "type": ["null", "integer"] },
+          "amount_received": { "type": ["null", "integer"] },
+          "application": { "type": ["null", "string"] },
+          "application_fee_amount": { "type": ["null", "integer"] },
+          "canceled_at": { "type": ["null", "integer"] },
+          "cancellation_reason": { "type": ["null", "string"] },
+          "capture_method": { "type": ["null", "string"] },
+          "charges": {
+            "type": ["null", "object"],
+            "properties": {
+              "object": { "type": ["null", "string"] },
+              "data": { "type": ["null", "array"] },
+              "has_more": { "type": ["null", "boolean"] },
+              "total_count": { "type": ["null", "integer"] },
+              "url": { "type": ["null", "string"] }
+            }
+          },
+          "client_secret": { "type": ["null", "string"] },
+          "confirmation_method": { "type": ["null", "string"] },
+          "created": { "type": ["null", "integer"] },
+          "updated": { "type": ["null", "integer"] },
+          "currency": { "type": ["null", "string"] },
+          "customer": { "type": ["null", "string"] },
+          "description": { "type": ["null", "string"] },
+          "invoice": { "type": ["null", "string"] },
+          "last_payment_error": {
+            "type": ["null", "object"],
+            "properties": {
+              "charge": { "type": ["null", "string"] },
+              "code": { "type": ["null", "string"] },
+              "decline_code": { "type": ["null", "string"] },
+              "doc_url": { "type": ["null", "string"] },
+              "message": { "type": ["null", "string"] },
+              "param": { "type": ["null", "string"] },
+              "payment_method": {
+                "type": ["null", "object"],
+                "properties": {
+                  "id": { "type": ["null", "string"] },
+                  "object": { "type": ["null", "string"] },
+                  "acss_debit": {
+                    "type": ["null", "object"],
+                    "properties": {
+                      "bank_name": { "type": ["null", "string"] },
+                      "fingerprint": { "type": ["null", "string"] },
+                      "institution_number": { "type": ["null", "string"] },
+                      "last4": { "type": ["null", "string"] },
+                      "transit_number": { "type": ["null", "string"] }
+                    }
+                  },
+                  "afterpay_clearpay": { "type": ["null", "string"] },
+                  "alipay": { "type": ["null", "string"] },
+                  "au_becs_debit": {
+                    "type": ["null", "object"],
+                    "properties": {
+                      "bsb_number": { "type": ["null", "string"] },
+                      "fingerprint": { "type": ["null", "string"] },
+                      "last4": { "type": ["null", "string"] }
+                    }
+                  },
+                  "bacs_debit": {
+                    "type": ["null", "object"],
+                    "properties": {
+                      "fingerprint": { "type": ["null", "string"] },
+                      "last4": { "type": ["null", "string"] },
+                      "sort_code": { "type": ["null", "string"] }
+                    }
+                  },
+                  "bancontact": { "type": ["null", "string"] },
+                  "billing_details": {
+                    "type": ["null", "object"],
+                    "properties": {
+                      "address": {
+                        "type": ["null", "object"],
+                        "properties": {
+                          "city": { "type": ["null", "string"] },
+                          "country": { "type": ["null", "string"] },
+                          "line1": { "type": ["null", "string"] },
+                          "line2": { "type": ["null", "string"] },
+                          "postal_code": { "type": ["null", "string"] },
+                          "state": { "type": ["null", "string"] }
+                        }
+                      },
+                      "email": { "type": ["null", "string"] },
+                      "name": { "type": ["null", "string"] },
+                      "phone": { "type": ["null", "string"] }
+                    }
+                  },
+                  "boleto": {
+                    "type": ["null", "object"],
+                    "properties": { "tax_id": { "type": ["null", "string"] } }
+                  },
+                  "card": {
+                    "type": ["null", "object"],
+                    "properties": {
+                      "brand": { "type": ["null", "string"] },
+                      "checks": {
+                        "type": ["null", "object"],
+                        "properties": {
+                          "address_line1_check": { "type": ["null", "string"] },
+                          "address_postal_code_check": {
+                            "type": ["null", "string"]
+                          },
+                          "cvc_check": { "type": ["null", "string"] }
+                        }
+                      },
+                      "country": { "type": ["null", "string"] },
+                      "exp_month": { "type": ["null", "integer"] },
+                      "exp_year": { "type": ["null", "integer"] },
+                      "fingerprint": { "type": ["null", "string"] },
+                      "funding": { "type": ["null", "string"] },
+                      "generated_from": {
+                        "type": ["null", "object"],
+                        "properties": {
+                          "charge": { "type": ["null", "string"] },
+                          "payment_method_details": {
+                            "type": ["null", "object"],
+                            "properties": {
+                              "card_present": {
+                                "type": ["null", "object"],
+                                "properties": {
+                                  "brand": { "type": ["null", "string"] },
+                                  "cardholder_name": {
+                                    "type": ["null", "string"]
+                                  },
+                                  "country": { "type": ["null", "string"] },
+                                  "emv_auth_data": {
+                                    "type": ["null", "string"]
+                                  },
+                                  "exp_month": { "type": ["null", "integer"] },
+                                  "exp_year": { "type": ["null", "integer"] },
+                                  "fingerprint": { "type": ["null", "string"] },
+                                  "funding": { "type": ["null", "string"] },
+                                  "generated_card": {
+                                    "type": ["null", "string"]
+                                  },
+                                  "lsat4": { "type": ["null", "string"] },
+                                  "network": { "type": ["null", "string"] },
+                                  "read_method": { "type": ["null", "string"] },
+                                  "receipt": {
+                                    "type": ["null", "object"],
+                                    "properties": {
+                                      "account_type": {
+                                        "type": ["null", "string"]
+                                      },
+                                      "application_cryptogram": {
+                                        "type": ["null", "string"]
+                                      },
+                                      "application_preferred_name": {
+                                        "type": ["null", "string"]
+                                      },
+                                      "authorization_code": {
+                                        "type": ["null", "string"]
+                                      },
+                                      "authorization_response_code": {
+                                        "type": ["null", "string"]
+                                      },
+                                      "cardholder_verification_method": {
+                                        "type": ["null", "string"]
+                                      },
+                                      "dedicated_file_name": {
+                                        "type": ["null", "string"]
+                                      },
+                                      "terminal_verification_results": {
+                                        "type": ["null", "string"]
+                                      },
+                                      "transaction_status_information": {
+                                        "type": ["null", "string"]
+                                      }
+                                    }
+                                  },
+                                  "type": { "type": ["null", "string"] }
+                                }
+                              },
+                              "type": { "type": ["null", "string"] }
+                            }
+                          },
+                          "setup_attempt": { "type": ["null", "string"] }
+                        }
+                      },
+                      "last4": { "type": ["null", "string"] },
+                      "networks": {
+                        "type": ["null", "object"],
+                        "properties": {
+                          "available": {
+                            "type": ["null", "array"],
+                            "items": { "type": ["null", "string"] }
+                          },
+                          "preferred": { "type": ["null", "string"] }
+                        }
+                      },
+                      "three_d_secure_usage": {
+                        "type": ["null", "object"],
+                        "properties": {
+                          "supported": { "type": ["null", "boolean"] }
+                        }
+                      },
+                      "wallet": {
+                        "type": ["null", "object"],
+                        "properties": {
+                          "amex_express_checkout": {
+                            "type": ["null", "string"]
+                          },
+                          "apple_pay": { "type": ["null", "string"] },
+                          "dynamic_last4": { "type": ["null", "string"] },
+                          "google_pay": { "type": ["null", "string"] },
+                          "masterpass": {
+                            "type": ["null", "object"],
+                            "properties": {
+                              "billing_address": {
+                                "type": ["null", "object"],
+                                "properties": {
+                                  "city": { "type": ["null", "string"] },
+                                  "country": { "type": ["null", "string"] },
+                                  "line1": { "type": ["null", "string"] },
+                                  "line2": { "type": ["null", "string"] },
+                                  "postal_code": { "type": ["null", "string"] },
+                                  "state": { "type": ["null", "string"] }
+                                }
+                              },
+                              "email": { "type": ["null", "string"] },
+                              "name": { "type": ["null", "string"] },
+                              "shipping_address": {
+                                "type": ["null", "object"],
+                                "properties": {
+                                  "city": { "type": ["null", "string"] },
+                                  "country": { "type": ["null", "string"] },
+                                  "line1": { "type": ["null", "string"] },
+                                  "line2": { "type": ["null", "string"] },
+                                  "postal_code": { "type": ["null", "string"] },
+                                  "state": { "type": ["null", "string"] }
+                                }
+                              }
+                            }
+                          },
+                          "samsung_pay": { "type": ["null", "string"] },
+                          "type": { "type": ["null", "string"] },
+                          "visa_checkout": {
+                            "type": ["null", "object"],
+                            "properties": {
+                              "billing_address": {
+                                "type": ["null", "object"],
+                                "properties": {
+                                  "city": { "type": ["null", "string"] },
+                                  "country": { "type": ["null", "string"] },
+                                  "line1": { "type": ["null", "string"] },
+                                  "line2": { "type": ["null", "string"] },
+                                  "postal_code": { "type": ["null", "string"] },
+                                  "state": { "type": ["null", "string"] }
+                                }
+                              },
+                              "email": { "type": ["null", "string"] },
+                              "name": { "type": ["null", "string"] },
+                              "shipping_address": {
+                                "type": ["null", "object"],
+                                "properties": {
+                                  "city": { "type": ["null", "string"] },
+                                  "country": { "type": ["null", "string"] },
+                                  "line1": { "type": ["null", "string"] },
+                                  "line2": { "type": ["null", "string"] },
+                                  "postal_code": { "type": ["null", "string"] },
+                                  "state": { "type": ["null", "string"] }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "card_present": {
+                    "type": ["null", "object"],
+                    "properties": {}
+                  },
+                  "created": { "type": ["null", "integer"] },
+                  "customer": { "type": ["null", "string"] },
+                  "eps": {
+                    "type": ["null", "object"],
+                    "properties": { "bank": { "type": ["null", "string"] } }
+                  },
+                  "fpx": {
+                    "type": ["null", "object"],
+                    "properties": { "bank": { "type": ["null", "string"] } }
+                  },
+                  "giropay": { "type": ["null", "object"], "properties": {} },
+                  "grabpay": { "type": ["null", "object"], "properties": {} },
+                  "ideal": {
+                    "type": ["null", "object"],
+                    "properties": { "bank": { "type": ["null", "string"] } }
+                  },
+                  "interac_present": {
+                    "type": ["null", "object"],
+                    "properties": {}
+                  },
+                  "livemode": { "type": ["null", "boolean"] },
+                  "metadata": { "type": ["null", "object"], "properties": {} },
+                  "oxxo": { "type": ["null", "object"], "properties": {} },
+                  "p24": {
+                    "type": ["null", "object"],
+                    "properties": { "bank": { "type": ["null", "string"] } }
+                  },
+                  "sepa_debit": {
+                    "type": ["null", "object"],
+                    "properties": {
+                      "bank_code": { "type": ["null", "string"] },
+                      "branch_code": { "type": ["null", "string"] },
+                      "country": { "type": ["null", "string"] },
+                      "fingerprint": { "type": ["null", "string"] },
+                      "generated_from": {
+                        "type": ["null", "object"],
+                        "properties": {
+                          "charge": { "type": ["null", "string"] },
+                          "setup_attempt": { "type": ["null", "string"] }
+                        }
+                      },
+                      "last4": { "type": ["null", "string"] }
+                    }
+                  },
+                  "sofort": {
+                    "type": ["null", "object"],
+                    "properties": { "country": { "type": ["null", "string"] } }
+                  },
+                  "type": { "type": ["null", "string"] },
+                  "wechat_pay": { "type": ["null", "object"], "properties": {} }
+                }
+              },
+              "payment_method_type": { "type": ["null", "string"] },
+              "type": { "type": ["null", "string"] }
+            }
+          },
+          "livemode": { "type": ["null", "boolean"] },
+          "metadata": { "type": ["null", "object"], "properties": {} },
+          "next_action": {
+            "type": ["null", "object"],
+            "properties": {
+              "alipay_handle_redirect": {
+                "type": ["null", "object"],
+                "properties": {
+                  "native_data": { "type": ["null", "string"] },
+                  "native_url": { "type": ["null", "string"] },
+                  "return_url": { "type": ["null", "string"] },
+                  "url": { "type": ["null", "string"] }
+                }
+              },
+              "boleto_display_details": {
+                "type": ["null", "object"],
+                "properties": {
+                  "expires_at": { "type": ["null", "integer"] },
+                  "hosted_voucher_url": { "type": ["null", "string"] },
+                  "number": { "type": ["null", "string"] },
+                  "pdf": { "type": ["null", "string"] }
+                }
+              },
+              "oxxo_display_details": {
+                "type": ["null", "object"],
+                "properties": {
+                  "expires_after": { "type": ["null", "integer"] },
+                  "hosted_voucher_url": { "type": ["null", "string"] },
+                  "number": { "type": ["null", "string"] }
+                }
+              },
+              "redirect_to_url": {
+                "type": ["null", "object"],
+                "properties": {
+                  "return_url": { "type": ["null", "string"] },
+                  "url": { "type": ["null", "string"] }
+                }
+              },
+              "type": { "type": ["null", "string"] },
+              "use_stripe_sdk": {
+                "type": ["null", "object"],
+                "properties": {}
+              },
+              "verify_with_microdeposits": {
+                "type": ["null", "object"],
+                "properties": {
+                  "arrival_date": { "type": ["null", "integer"] },
+                  "hosted_verification_url": { "type": ["null", "string"] }
+                }
+              },
+              "wechat_pay_display_qr_code": {
+                "type": ["null", "object"],
+                "properties": {
+                  "data": { "type": ["null", "string"] },
+                  "image_data_url": { "type": ["null", "string"] }
+                }
+              },
+              "wechat_pay_redirect_to_android_app": {
+                "type": ["null", "object"],
+                "properties": {
+                  "app_id": { "type": ["null", "string"] },
+                  "nonce_str": { "type": ["null", "string"] },
+                  "package": { "type": ["null", "string"] },
+                  "partner_id": { "type": ["null", "string"] },
+                  "prepay_id": { "type": ["null", "string"] },
+                  "sign": { "type": ["null", "string"] },
+                  "timestamp": { "type": ["null", "string"] }
+                }
+              },
+              "wechat_pay_redirect_to_ios_app": {
+                "type": ["null", "object"],
+                "properties": { "native_url": { "type": ["null", "string"] } }
+              }
+            }
+          },
+          "on_behalf_of": { "type": ["null", "string"] },
+          "payment_method": { "type": ["null", "string"] },
+          "payment_method_options": {
+            "type": ["null", "object"],
+            "properties": {}
+          },
+          "payment_method_types": {
+            "type": ["null", "array"],
+            "items": { "type": ["null", "string"] }
+          },
+          "receipt_email": { "type": ["null", "string"] },
+          "review": { "type": ["null", "string"] },
+          "setup_future_usage": { "type": ["null", "string"] },
+          "shipping": {
+            "type": ["null", "object"],
+            "properties": {
+              "address": {
+                "type": ["null", "object"],
+                "properties": {
+                  "city": { "type": ["null", "string"] },
+                  "country": { "type": ["null", "string"] },
+                  "line1": { "type": ["null", "string"] },
+                  "line2": { "type": ["null", "string"] },
+                  "postal_code": { "type": ["null", "string"] },
+                  "state": { "type": ["null", "string"] }
+                }
+              },
+              "carrier": { "type": ["null", "string"] },
+              "name": { "type": ["null", "string"] },
+              "phone": { "type": ["null", "string"] },
+              "tracking_number": { "type": ["null", "string"] }
+            }
+          },
+          "source": { "type": ["null", "string"] },
+          "statement_description": { "type": ["null", "string"] },
+          "statement_descriptor_suffix": { "type": ["null", "string"] },
+          "status": { "type": ["null", "string"] },
+          "transfer_data": {
+            "type": ["null", "object"],
+            "properties": {
+              "amount": { "type": ["null", "integer"] },
+              "destination": { "type": ["null", "string"] }
+            }
+          },
+          "transfer_group": { "type": ["null", "string"] },
+          "latest_charge": { "type": ["null", "string"] },
+          "statement_descriptor": { "type": ["null", "string"] },
+          "amount_details": {
+            "type": ["null", "object"],
+            "properties": {
+              "tip": {
+                "type": ["null", "object"],
+                "properties": { "amount": { "type": ["null", "integer"] } }
+              }
+            }
+          },
+          "processing": {
+            "type": ["null", "object"],
+            "properties": {
+              "type": { "type": ["null", "string"] },
+              "card": {
+                "type": ["null", "object"],
+                "properties": {
+                  "customer_notification": {
+                    "type": ["null", "object"],
+                    "properties": {
+                      "approval_requested": { "type": ["null", "boolean"] },
+                      "completes_at": { "type": ["null", "integer"] }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "automatic_payment_methods": {
+            "type": ["null", "object"],
+            "properties": {
+              "allow_redirects": { "type": ["null", "string"] },
+              "enabled": { "type": ["null", "boolean"] }
+            }
+          },
+          "payment_method_configuration_details": {
+            "type": ["null", "object"],
+            "properties": {
+              "id": { "type": ["null", "string"] },
+              "parent": { "type": ["null", "string"] }
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "promotion_codes",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "type": ["null", "object"],
+        "properties": {
+          "id": {
+            "description": "The unique identifier for the promotion code.",
+            "type": ["null", "string"]
+          },
+          "code": {
+            "description": "The unique code string associated with the promotion code.",
+            "type": ["null", "string"]
+          },
+          "coupon": {
+            "description": "Information about the coupon associated with the promotion code.",
+            "type": ["null", "object"],
+            "properties": {
+              "id": {
+                "description": "The unique identifier for the coupon.",
+                "type": ["null", "string"]
+              },
+              "amount_off": {
+                "description": "The amount which will be discounted from the total if the coupon is applied.",
+                "type": ["null", "integer"]
+              },
+              "currency": {
+                "description": "The currency in which the discount amount is specified.",
+                "type": ["null", "string"]
+              },
+              "duration": {
+                "description": "Indicates how long the discount will last (e.g, once, forever).",
+                "type": ["null", "string"]
+              },
+              "duration_in_months": {
+                "description": "Optional. The number of months the coupon will last.",
+                "type": ["null", "integer"]
+              },
+              "metadata": {
+                "description": "Additional information attached to the coupon.",
+                "type": ["null", "object"],
+                "properties": {}
+              },
+              "name": {
+                "description": "The name of the coupon.",
+                "type": ["null", "string"]
+              },
+              "percent_off": {
+                "description": "The percentage to be discounted if the coupon is applied.",
+                "type": ["null", "number"]
+              },
+              "object": {
+                "description": "Indicates the object type, typically 'coupon'.",
+                "type": ["null", "string"]
+              },
+              "applies_to": {
+                "description": "Specifies any products to which the coupon can be applied.",
+                "type": ["null", "object"],
+                "properties": {
+                  "products": {
+                    "type": ["null", "array"],
+                    "items": {
+                      "description": "Specify the list of product IDs to which the coupon applies.",
+                      "type": ["null", "string"]
+                    }
+                  }
+                }
+              },
+              "created": {
+                "description": "The date and time when the coupon was created.",
+                "type": ["null", "integer"]
+              },
+              "livemode": {
+                "description": "Indicates if the coupon is in live mode or test mode.",
+                "type": ["null", "boolean"]
+              },
+              "max_redemptions": {
+                "description": "The maximum number of times the coupon can be redeemed.",
+                "type": ["null", "integer"]
+              },
+              "redeem_by": {
+                "description": "The last date and time when the coupon can be redeemed.",
+                "type": ["null", "integer"]
+              },
+              "times_redeemed": {
+                "description": "The number of times the coupon has been redeemed.",
+                "type": ["null", "integer"]
+              },
+              "valid": {
+                "description": "Indicates if the coupon is currently valid for use.",
+                "type": ["null", "boolean"]
+              }
+            }
+          },
+          "metadata": {
+            "description": "Additional information attached to the promotion code.",
+            "type": ["null", "object"],
+            "properties": {}
+          },
+          "object": {
+            "description": "Indicates the object type, typically 'promotion_code'.",
+            "type": ["null", "string"]
+          },
+          "active": {
+            "description": "Indicates if the promotion code is currently active.",
+            "type": ["null", "boolean"]
+          },
+          "created": {
+            "description": "The date and time when the promotion code was created.",
+            "type": ["null", "integer"]
+          },
+          "updated": {
+            "description": "The date and time when the promotion code was last updated.",
+            "type": ["null", "integer"]
+          },
+          "customer": {
+            "description": "The customer associated with the promotion code, if applicable.",
+            "type": ["null", "string"]
+          },
+          "expires_at": {
+            "description": "The date and time when the promotion code expires.",
+            "type": ["null", "integer"]
+          },
+          "livemode": {
+            "description": "Indicates if the promotion code is in live mode or test mode.",
+            "type": ["null", "boolean"]
+          },
+          "max_redemptions": {
+            "description": "The maximum number of times the promotion code can be redeemed.",
+            "type": ["null", "integer"]
+          },
+          "restrictions": {
+            "description": "Any restrictions associated with the promotion code application.",
+            "type": ["null", "object"],
+            "properties": {
+              "first_time_transaction": {
+                "description": "Indicates if the promotion code is applicable only for the first transaction.",
+                "type": ["null", "boolean"]
+              },
+              "minimum_amount": {
+                "description": "The minimum amount required for the promotion code to be valid.",
+                "type": ["null", "integer"]
+              },
+              "minimum_amount_currency": {
+                "description": "The currency in which the minimum amount is specified.",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "times_redeemed": {
+            "description": "The number of times the promotion code has been redeemed.",
+            "type": ["null", "integer"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "setup_intents",
+      "json_schema": {
+        "type": ["null", "object"],
+        "properties": {
+          "id": { "type": ["string"] },
+          "object": { "type": ["string"], "enum": ["setup_intent"] },
+          "application": { "type": ["null", "string"] },
+          "cancellation_reason": { "type": ["null", "string"] },
+          "created": { "type": ["integer"] },
+          "updated": { "type": ["null", "integer"] },
+          "customer": { "type": ["null", "string"] },
+          "description": { "type": ["null", "string"] },
+          "flow_directions": {
+            "type": ["null", "array"],
+            "items": { "type": ["null", "string"] }
+          },
+          "last_setup_error": { "type": ["null", "string"] },
+          "latest_attempt": { "type": ["null", "string"] },
+          "livemode": { "type": ["null", "boolean"] },
+          "mandate": { "type": ["null", "string"] },
+          "metadata": { "type": ["null", "object"] },
+          "next_action": { "type": ["null", "string"] },
+          "on_behalf_of": { "type": ["null", "string"] },
+          "payment_method": { "type": ["null", "string"] },
+          "payment_method_options": {
+            "type": ["null", "object"],
+            "additionalProperties": true
+          },
+          "payment_method_types": {
+            "type": ["null", "array"],
+            "items": { "type": ["null", "string"] }
+          },
+          "single_use_mandate": { "type": ["null", "string"] },
+          "status": { "type": ["string"] },
+          "usage": {
+            "type": ["string"],
+            "enum": ["on_session", "off_session"]
+          },
+          "client_secret": { "type": ["null", "string"] },
+          "automatic_payment_methods": {
+            "type": ["null", "object"],
+            "properties": {
+              "allow_redirects": { "type": ["null", "string"] },
+              "enabled": { "type": ["null", "boolean"] }
+            }
+          },
+          "payment_method_configuration_details": {
+            "type": ["null", "object"],
+            "properties": {
+              "id": { "type": ["null", "string"] },
+              "parent": { "type": ["null", "string"] }
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "cards",
+      "json_schema": {
+        "type": ["null", "object"],
+        "properties": {
+          "brand": { "type": ["null", "string"] },
+          "cancellation_reason": { "type": ["null", "string"] },
+          "cardholder": {
+            "type": ["null", "object"],
+            "properties": {
+              "billing": {
+                "type": ["null", "object"],
+                "properties": {
+                  "address": {
+                    "type": ["null", "object"],
+                    "properties": {
+                      "city": { "type": ["null", "string"] },
+                      "country": { "type": ["null", "string"] },
+                      "line1": { "type": ["null", "string"] },
+                      "line2": { "type": ["null", "string"] },
+                      "postal_code": { "type": ["null", "string"] },
+                      "state": { "type": ["null", "string"] }
+                    }
+                  }
+                }
+              },
+              "company": {
+                "type": ["null", "object"],
+                "properties": { "tax_id_provided": { "type": "boolean" } }
+              },
+              "created": { "type": ["null", "integer"] },
+              "updated": { "type": ["null", "integer"] },
+              "email": { "type": ["null", "string"] },
+              "id": { "type": ["null", "string"] },
+              "individual": {
+                "type": ["null", "object"],
+                "properties": {
+                  "dob": {
+                    "type": ["null", "object"],
+                    "properties": {
+                      "day": { "type": ["null", "integer"] },
+                      "month": { "type": ["null", "integer"] },
+                      "year": { "type": ["null", "integer"] }
+                    }
+                  },
+                  "first_name": { "type": ["null", "string"] },
+                  "last_name": { "type": ["null", "string"] },
+                  "verification": {
+                    "type": ["null", "object"],
+                    "properties": {
+                      "document": {
+                        "type": ["null", "object"],
+                        "properties": {
+                          "back": { "type": ["null", "string"] },
+                          "front": { "type": ["null", "string"] }
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "livemode": { "type": ["null", "boolean"] },
+              "metadata": { "type": ["null", "object"] },
+              "name": { "type": ["null", "string"] },
+              "object": { "type": ["null", "string"] },
+              "phone_number": { "type": ["null", "string"] },
+              "requirements": {
+                "type": ["null", "object"],
+                "properties": {
+                  "disabled_reason": { "type": ["null", "string"] },
+                  "past_due": {
+                    "type": ["null", "array"],
+                    "items": { "type": ["null", "string"] }
+                  }
+                }
+              },
+              "spending_controls": {
+                "type": ["null", "object"],
+                "properties": {
+                  "allowed_categories": {
+                    "type": ["null", "array"],
+                    "items": { "type": ["null", "string"] }
+                  },
+                  "blocked_categories": {
+                    "type": ["null", "array"],
+                    "items": { "type": ["null", "string"] }
+                  },
+                  "spending_limits": {
+                    "type": ["null", "array"],
+                    "items": { "type": ["null", "object"] }
+                  },
+                  "spending_limits_currency": { "type": ["null", "string"] }
+                }
+              },
+              "status": { "type": ["null", "string"] },
+              "type": { "type": ["null", "string"] },
+              "preferred_locales": {
+                "type": ["null", "array"],
+                "items": { "type": ["null", "string"] }
+              }
+            }
+          },
+          "created": { "type": ["null", "integer"] },
+          "updated": { "type": ["null", "integer"] },
+          "currency": { "type": ["null", "string"] },
+          "cvc": { "type": ["null", "string"] },
+          "exp_month": { "type": ["null", "integer"] },
+          "exp_year": { "type": ["null", "integer"] },
+          "id": { "type": ["null", "string"] },
+          "last4": { "type": ["null", "string"] },
+          "livemode": { "type": ["null", "boolean"] },
+          "metadata": {
+            "type": ["null", "object"],
+            "additionalProperties": true
+          },
+          "number": { "type": ["null", "string"] },
+          "object": { "type": ["null", "string"] },
+          "replaced_by": {
+            "type": ["null", "object"],
+            "additionalProperties": true
+          },
+          "replacement_for": {
+            "type": ["null", "object"],
+            "additionalProperties": true
+          },
+          "replacement_reason": { "type": ["null", "string"] },
+          "shipping": {
+            "type": ["null", "object"],
+            "additionalProperties": true,
+            "properties": {
+              "address": {
+                "type": ["null", "object"],
+                "properties": {
+                  "city": { "type": ["null", "string"] },
+                  "country": { "type": ["null", "string"] },
+                  "line1": { "type": ["null", "string"] },
+                  "line2": { "type": ["null", "string"] },
+                  "postal_code": { "type": ["null", "string"] },
+                  "state": { "type": ["null", "string"] }
+                }
+              },
+              "carrier": { "type": ["null", "string"] },
+              "eta": { "type": ["null", "integer"] },
+              "name": { "type": ["null", "string"] },
+              "service": { "type": ["null", "string"] },
+              "status": { "type": ["null", "string"] },
+              "tracking_number": { "type": ["null", "string"] },
+              "tracking_url": { "type": ["null", "string"] },
+              "type": { "type": ["null", "string"] }
+            }
+          },
+          "spending_controls": {
+            "type": ["null", "object"],
+            "properties": {
+              "allowed_categories": {
+                "type": ["null", "array"],
+                "items": { "type": ["null", "string"] }
+              },
+              "blocked_categories": {
+                "type": ["null", "array"],
+                "items": { "type": ["null", "string"] }
+              },
+              "spending_limits": {
+                "type": ["null", "array"],
+                "items": { "type": ["null", "object"] }
+              },
+              "spending_limits_currency": { "type": ["null", "string"] }
+            }
+          },
+          "status": { "type": ["null", "string"] },
+          "type": { "type": ["null", "string"] }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "transactions",
+      "json_schema": {
+        "$schema": "https://json-schema.org/draft-07/schema#",
+        "type": ["null", "object"],
+        "additionalProperties": true,
+        "properties": {
+          "amount": {
+            "description": "The transaction amount in the specified currency.",
+            "type": ["null", "integer"]
+          },
+          "amount_details": {
+            "description": "Additional details about the transaction amount such as currency, fees, and taxes.",
+            "type": ["null", "object"],
+            "properties": {
+              "atm_fee": {
+                "description": "The fee charged by the ATM for the transaction.",
+                "type": ["null", "integer"]
+              }
+            }
+          },
+          "authorization": {
+            "description": "The authorization code for the transaction.",
+            "type": ["null", "string"]
+          },
+          "balance_transaction": {
+            "description": "The ID of the balance transaction associated with this payment.",
+            "type": ["null", "string"]
+          },
+          "card": {
+            "description": "Information about the payment card used for the transaction.",
+            "type": ["null", "string"]
+          },
+          "cardholder": {
+            "description": "Details about the cardholder, such as name and address.",
+            "type": ["null", "string"]
+          },
+          "created": {
+            "description": "The timestamp when the transaction was created.",
+            "type": ["null", "integer"]
+          },
+          "updated": {
+            "description": "The timestamp when the transaction record was last updated.",
+            "type": ["null", "integer"]
+          },
+          "currency": {
+            "description": "The currency in which the transaction was made.",
+            "type": ["null", "string"]
+          },
+          "dispute": {
+            "description": "Information about any disputes related to the transaction.",
+            "type": ["null", "string"]
+          },
+          "id": {
+            "description": "The unique identifier for the transaction.",
+            "type": ["null", "string"]
+          },
+          "livemode": {
+            "description": "A boolean indicating whether the transaction occurred in live mode.",
+            "type": ["null", "boolean"]
+          },
+          "merchant_amount": {
+            "description": "The amount received by the merchant after fees.",
+            "type": ["null", "integer"]
+          },
+          "merchant_currency": {
+            "description": "The currency in which the merchant received the payment.",
+            "type": ["null", "string"]
+          },
+          "merchant_data": {
+            "description": "Information about the merchant involved in the transaction, like the merchant name, location, and ID.",
+            "type": ["null", "object"],
+            "properties": {
+              "category": {
+                "description": "The category of the merchant.",
+                "type": ["null", "string"]
+              },
+              "city": {
+                "description": "The city where the merchant is located.",
+                "type": ["null", "string"]
+              },
+              "country": {
+                "description": "The country where the merchant is located.",
+                "type": ["null", "string"]
+              },
+              "name": {
+                "description": "The name of the merchant.",
+                "type": ["null", "string"]
+              },
+              "network_id": {
+                "description": "The unique network identifier of the merchant.",
+                "type": ["null", "string"]
+              },
+              "postal_code": {
+                "description": "The postal code of the merchant's location.",
+                "type": ["null", "string"]
+              },
+              "state": {
+                "description": "The state or region where the merchant is located.",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "metadata": {
+            "description": "Additional metadata or custom information associated with the transaction.",
+            "type": ["null", "object"],
+            "additionalProperties": true
+          },
+          "object": {
+            "description": "The object type, which in this case is 'transaction'.",
+            "type": ["null", "string"]
+          },
+          "purchase_details": {
+            "type": ["null", "object"],
+            "properties": {
+              "flight": {
+                "type": ["null", "object"],
+                "properties": {
+                  "departure_at": { "type": ["null", "integer"] },
+                  "passenger_name": { "type": ["null", "string"] },
+                  "refundable": { "type": ["null", "boolean"] },
+                  "segments": {
+                    "type": ["null", "array"],
+                    "items": {
+                      "type": ["null", "object"],
+                      "properties": {
+                        "arrival_airport_code": { "type": ["null", "string"] },
+                        "carrier": { "type": ["null", "string"] },
+                        "departure_airport_code": {
+                          "type": ["null", "string"]
+                        },
+                        "flight_number": { "type": ["null", "string"] },
+                        "service_class": { "type": ["null", "string"] },
+                        "stopover_allowed": { "type": ["null", "boolean"] }
+                      }
+                    }
+                  }
+                },
+                "travel_agency": { "type": ["null", "string"] }
+              }
+            },
+            "fuel": {
+              "type": ["null", "object"],
+              "properties": {
+                "type": { "type": ["null", "string"] },
+                "unit": { "type": ["null", "string"] },
+                "unit_cost_decimal": { "type": ["null", "string"] },
+                "volume_decimal": { "type": ["null", "string"] }
+              }
+            },
+            "lodging": {
+              "type": ["null", "object"],
+              "properties": {
+                "check_in_at": { "type": ["null", "integer"] },
+                "nights": { "type": ["null", "integer"] }
+              }
+            },
+            "receipt": {
+              "items": {
+                "type": ["null", "object"],
+                "properties": {
+                  "description": { "type": ["null", "string"] },
+                  "quantity": { "type": ["null", "number"] },
+                  "total": { "type": ["null", "integer"] },
+                  "unit_cost": { "type": ["null", "integer"] }
+                }
+              },
+              "type": ["null", "array"]
+            },
+            "reference": { "type": ["null", "string"] }
+          },
+          "type": {
+            "description": "The type of transaction, e.g., sale, refund, or dispute.",
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "top_ups",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": true,
+        "type": "object",
+        "properties": {
+          "id": {
+            "description": "Unique identifier for the top-up",
+            "type": ["null", "string"]
+          },
+          "amount": {
+            "description": "The amount of the top-up in the smallest currency unit, e.g., 100 cents for $1",
+            "type": ["null", "integer"]
+          },
+          "currency": {
+            "description": "The currency in which the top-up was made, e.g., USD, EUR",
+            "type": ["null", "string"]
+          },
+          "description": {
+            "description": "A brief description of the purpose of the top-up",
+            "type": ["null", "string"]
+          },
+          "metadata": {
+            "description": "Additional information related to the top-up",
+            "type": ["null", "object"],
+            "properties": {}
+          },
+          "status": {
+            "description": "Current status of the top-up, e.g., succeeded, failed",
+            "type": ["null", "string"]
+          },
+          "object": {
+            "description": "Type of object, in this case, 'top-up'",
+            "type": ["null", "string"]
+          },
+          "balance_transaction": {
+            "description": "ID of the balance transaction that describes the impact of this top-up on your account balance",
+            "type": ["null", "string"]
+          },
+          "created": {
+            "description": "Timestamp indicating when the top-up was created",
+            "type": ["null", "integer"]
+          },
+          "updated": {
+            "description": "Timestamp indicating when the top-up was last updated",
+            "type": ["null", "integer"]
+          },
+          "destination_balance": {
+            "description": "ID of the balance that the top-up is ultimately creating",
+            "type": ["null", "string"]
+          },
+          "expected_availability_date": {
+            "description": "Expected date when the funds from the top-up will become available",
+            "type": ["null", "integer"]
+          },
+          "failure_code": {
+            "description": "Error code describing why the top-up failed if it did",
+            "type": ["null", "string"]
+          },
+          "failure_message": {
+            "description": "A message explaining why the top-up failed if it did",
+            "type": ["null", "string"]
+          },
+          "livemode": {
+            "description": "Indicates whether the top-up was made in test/live mode",
+            "type": ["null", "boolean"]
+          },
+          "source": {
+            "description": "Details about the payment source used for the top-up",
+            "type": ["null", "object"],
+            "properties": {}
+          },
+          "statement_descriptor": {
+            "description": "The statement descriptor displayed on customers' statements for the top-up",
+            "type": ["null", "string"]
+          },
+          "transfer_group": {
+            "description": "A unique identifier for the transfer group this top-up is in",
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "application_fees_refunds",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "Application Fees Refunds Schema",
+        "additionalProperties": true,
+        "type": ["null", "object"],
+        "properties": {
+          "id": {
+            "description": "Unique identifier for the application fee refund",
+            "type": ["null", "string"]
+          },
+          "object": {
+            "description": "The object type, which will be 'fee_refund'",
+            "type": ["null", "string"]
+          },
+          "amount": {
+            "description": "The amount refunded in the application fee",
+            "type": ["null", "number"]
+          },
+          "balance_transaction": {
+            "description": "The balance transaction ID associated with the refund",
+            "type": ["null", "string"]
+          },
+          "created": {
+            "description": "Timestamp for when the refund was created",
+            "type": ["null", "number"]
+          },
+          "updated": {
+            "description": "Timestamp for when the refund was last updated",
+            "type": ["null", "integer"]
+          },
+          "currency": {
+            "description": "The currency of the refunded amount",
+            "type": ["null", "string"]
+          },
+          "fee": {
+            "description": "The application fee ID associated with the refund",
+            "type": ["null", "string"]
+          },
+          "metadata": {
+            "description": "Additional information or custom data associated with the application fee refunds.",
+            "type": ["null", "object"],
+            "properties": {
+              "fee": {
+                "description": "Metadata related to the refunded fee",
+                "type": ["null", "string"]
+              }
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "bank_accounts",
+      "json_schema": {
+        "type": ["null", "object"],
+        "properties": {
+          "id": {
+            "description": "Unique identifier for the bank account.",
+            "type": ["null", "string"]
+          },
+          "object": {
+            "description": "Type of object, in this case, 'bank_account'.",
+            "type": ["null", "string"]
+          },
+          "account_holder_name": {
+            "description": "The name of the account holder associated with the bank account.",
+            "type": ["null", "string"]
+          },
+          "account_holder_type": {
+            "description": "The type of account holder (individual or company) for the bank account.",
+            "type": ["null", "string"]
+          },
+          "account_type": {
+            "description": "The type of bank account (checking or savings).",
+            "type": ["null", "string"]
+          },
+          "bank_name": {
+            "description": "The name of the bank associated with the bank account.",
+            "type": ["null", "string"]
+          },
+          "country": {
+            "description": "The country where the bank account is located.",
+            "type": ["null", "string"]
+          },
+          "currency": {
+            "description": "The currency associated with the bank account.",
+            "type": ["null", "string"]
+          },
+          "customer": {
+            "description": "ID of the customer associated with the bank account.",
+            "type": ["null", "string"]
+          },
+          "fingerprint": {
+            "description": "A unique identifier for the bank account.",
+            "type": ["null", "string"]
+          },
+          "last4": {
+            "description": "Last 4 digits of the bank account number.",
+            "type": ["null", "string"]
+          },
+          "metadata": {
+            "description": "Additional data related to the bank account.",
+            "type": ["null", "object"],
+            "properties": {}
+          },
+          "routing_number": {
+            "description": "The routing number of the bank associated with the bank account.",
+            "type": ["null", "string"]
+          },
+          "status": {
+            "description": "Status of the bank account (e.g., verified, unverified).",
+            "type": ["null", "string"]
+          },
+          "updated": {
+            "description": "Timestamp for when the bank account was last updated.",
+            "type": ["null", "integer"]
+          },
+          "is_deleted": {
+            "description": "Indicates if the bank account has been deleted.",
+            "type": ["null", "boolean"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "checkout_sessions_line_items",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "type": ["null", "object"],
+        "properties": {
+          "id": {
+            "description": "The unique identifier of the line item.",
+            "type": ["null", "string"]
+          },
+          "checkout_session_id": {
+            "description": "The unique identifier of the checkout session.",
+            "type": ["null", "string"]
+          },
+          "checkout_session_expires_at": {
+            "description": "The expiration timestamp of the checkout session.",
+            "type": ["null", "integer"]
+          },
+          "checkout_session_created": {
+            "description": "The timestamp when the checkout session was created.",
+            "type": ["null", "integer"]
+          },
+          "checkout_session_updated": {
+            "description": "The timestamp when the checkout session was last updated.",
+            "type": ["null", "integer"]
+          },
+          "object": {
+            "description": "The type of object, in this case, it will be 'checkout_sessions_line_items'.",
+            "type": ["null", "string"]
+          },
+          "amount_subtotal": {
+            "description": "The subtotal amount of the line item before any discounts or taxes.",
+            "type": ["null", "integer"]
+          },
+          "amount_tax": {
+            "description": "The total tax amount applied to the line item.",
+            "type": ["null", "integer"]
+          },
+          "amount_discount": {
+            "description": "The total discount amount applied to the line item.",
+            "type": ["null", "integer"]
+          },
+          "amount_total": {
+            "description": "The total amount of the line item including discounts and taxes.",
+            "type": ["null", "integer"]
+          },
+          "currency": {
+            "description": "The currency code used for the line item.",
+            "type": ["null", "string"]
+          },
+          "description": {
+            "description": "The description of the line item.",
+            "type": ["null", "string"]
+          },
+          "discounts": {
+            "description": "Information about any discounts applied to this checkout session",
+            "type": ["null", "array"],
+            "items": {
+              "description": "Individual discount item",
+              "type": ["null", "object"],
+              "properties": {
+                "amount": {
+                  "description": "The amount of discount applied",
+                  "type": ["null", "integer"]
+                },
+                "discount": {
+                  "description": "Details about the discount applied",
+                  "type": ["null", "object"],
+                  "properties": {
+                    "id": {
+                      "description": "ID of the discount",
+                      "type": ["null", "string"]
+                    },
+                    "coupon": {
+                      "description": "Details of the coupon used for the discount",
+                      "type": ["null", "object"],
+                      "properties": {
+                        "id": {
+                          "description": "ID of the coupon",
+                          "type": ["null", "string"]
+                        },
+                        "amount_off": {
+                          "description": "The amount off provided by the coupon",
+                          "type": ["null", "integer"]
+                        },
+                        "currency": {
+                          "description": "Currency of the coupon",
+                          "type": ["null", "string"]
+                        },
+                        "duration": {
+                          "description": "Duration of the coupon validity",
+                          "type": ["null", "string"]
+                        },
+                        "duration_in_months": {
+                          "description": "Duration in months for which the coupon is valid",
+                          "type": ["null", "integer"]
+                        },
+                        "metadata": {
+                          "description": "Additional information about the coupon",
+                          "type": ["null", "object"],
+                          "properties": {}
+                        },
+                        "name": {
+                          "description": "Name of the coupon",
+                          "type": ["null", "string"]
+                        },
+                        "percent_off": {
+                          "description": "Percentage off provided by the coupon",
+                          "type": ["null", "number"]
+                        },
+                        "object": {
+                          "description": "Type of object, in this case, 'coupon'",
+                          "type": ["null", "string"]
+                        },
+                        "applies_to": {
+                          "description": "Products to which the coupon is applicable",
+                          "type": ["null", "object"],
+                          "properties": {
+                            "products": {
+                              "description": "List of product IDs to which the coupon applies",
+                              "type": ["null", "array"],
+                              "items": { "type": ["null", "string"] }
+                            }
+                          }
+                        },
+                        "created": {
+                          "description": "Timestamp of when the coupon was created",
+                          "type": ["null", "integer"]
+                        },
+                        "livemode": {
+                          "description": "Indicates if the coupon is in live mode",
+                          "type": ["null", "boolean"]
+                        },
+                        "max_redemptions": {
+                          "description": "Maximum number of times the coupon can be redeemed",
+                          "type": ["null", "integer"]
+                        },
+                        "redeem_by": {
+                          "description": "Timestamp until which the coupon can be redeemed",
+                          "type": ["null", "integer"]
+                        },
+                        "times_redeemed": {
+                          "description": "Number of times the coupon has been redeemed",
+                          "type": ["null", "integer"]
+                        },
+                        "valid": {
+                          "description": "Indicates if the coupon is currently valid",
+                          "type": ["null", "boolean"]
+                        }
+                      }
+                    },
+                    "customer": {
+                      "description": "Customer associated with the discount",
+                      "type": ["null", "string"]
+                    },
+                    "end": {
+                      "description": "Timestamp of the discount end time",
+                      "type": ["null", "integer"]
+                    },
+                    "start": {
+                      "description": "Timestamp of the discount start time",
+                      "type": ["null", "integer"]
+                    },
+                    "subscription": {
+                      "description": "Subscription associated with the discount",
+                      "type": ["null", "string"]
+                    },
+                    "object": {
+                      "description": "Type of object, in this case, 'discount'",
+                      "type": ["null", "string"]
+                    },
+                    "checkout_session": {
+                      "description": "The checkout session ID associated with this discount",
+                      "type": ["null", "string"]
+                    },
+                    "invoice": {
+                      "description": "Invoice ID associated with the discount",
+                      "type": ["null", "string"]
+                    },
+                    "invoice_item": {
+                      "description": "Invoice item ID associated with the discount",
+                      "type": ["null", "string"]
+                    },
+                    "promotion_code": {
+                      "description": "Promotion code associated with the discount",
+                      "type": ["null", "string"]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "price": {
+            "description": "Details about the pricing of the products in the checkout session",
+            "type": ["null", "object"],
+            "properties": {
+              "id": {
+                "description": "ID of the price",
+                "type": ["null", "string"]
+              },
+              "object": {
+                "description": "Type of object, in this case, 'price'",
+                "type": ["null", "string"]
+              },
+              "active": {
+                "description": "Indicates if the price is currently active",
+                "type": ["null", "boolean"]
+              },
+              "billing_scheme": {
+                "description": "Billing scheme used for the price",
+                "type": ["null", "string"]
+              },
+              "created": {
+                "description": "Timestamp of when the price was created",
+                "type": ["null", "integer"]
+              },
+              "currency": {
+                "description": "Currency of the price",
+                "type": ["null", "string"]
+              },
+              "livemode": {
+                "description": "Indicates if the price is in live mode",
+                "type": ["null", "boolean"]
+              },
+              "lookup_key": {
+                "description": "Lookup key for the price",
+                "type": ["null", "string"]
+              },
+              "metadata": {
+                "description": "Additional information about the price",
+                "type": ["null", "object"],
+                "properties": {}
+              },
+              "nickname": {
+                "description": "Nickname of the price",
+                "type": ["null", "string"]
+              },
+              "product": {
+                "description": "Product associated with the price",
+                "type": ["null", "string"]
+              },
+              "recurring": {
+                "description": "Details about the recurring nature of the pricing",
+                "type": ["null", "object"],
+                "properties": {
+                  "aggregate_usage": {
+                    "description": "Usage count type for the price",
+                    "type": ["null", "string"]
+                  },
+                  "interval": {
+                    "description": "Interval for the price recurrence",
+                    "type": ["null", "string"]
+                  },
+                  "interval_count": {
+                    "description": "Number of intervals",
+                    "type": ["null", "integer"]
+                  },
+                  "usage_type": {
+                    "description": "Type of usage of the price",
+                    "type": ["null", "string"]
+                  }
+                }
+              },
+              "tax_behavior": {
+                "description": "Tax behavior for the price",
+                "type": ["null", "string"]
+              },
+              "tiers": {
+                "description": "Tiers information for the price",
+                "type": ["null", "object"],
+                "properties": {
+                  "flat_amount": {
+                    "description": "Flat amount for the tier",
+                    "type": ["null", "integer"]
+                  },
+                  "flat_amount_decimal": {
+                    "description": "Flat amount in decimal for the tier",
+                    "type": ["null", "string"]
+                  },
+                  "unit_amount": {
+                    "description": "Unit amount for the tier",
+                    "type": ["null", "integer"]
+                  },
+                  "unit_amount_decimal": {
+                    "description": "Unit amount in decimal for the tier",
+                    "type": ["null", "string"]
+                  },
+                  "up_to": {
+                    "description": "Determines the upper limit of the tier",
+                    "type": ["null", "integer"]
+                  }
+                }
+              },
+              "tiers_mode": {
+                "description": "Tiers mode for the price",
+                "type": ["null", "string"]
+              },
+              "transform_quantity": {
+                "description": "Information on transforming the quantity",
+                "type": ["null", "object"],
+                "properties": {
+                  "divide_by": {
+                    "description": "Value to divide the quantity by",
+                    "type": ["null", "integer"]
+                  },
+                  "round": {
+                    "description": "Rounding behavior for the quantity",
+                    "type": ["null", "string"]
+                  }
+                }
+              },
+              "type": {
+                "description": "Type of price",
+                "type": ["null", "string"]
+              },
+              "unit_amount": {
+                "description": "Unit amount of the price",
+                "type": ["null", "integer"]
+              },
+              "unit_amount_decimal": {
+                "description": "Unit amount in decimal",
+                "type": ["null", "string"]
+              }
+            }
+          },
+          "quantity": {
+            "description": "The quantity of the line item purchased.",
+            "type": ["null", "integer"]
+          },
+          "taxes": {
+            "description": "Information about any taxes applied to this checkout session",
+            "type": ["null", "array"],
+            "items": {
+              "description": "Individual tax item",
+              "type": ["null", "object"],
+              "properties": {
+                "amount": {
+                  "description": "The amount of tax applied",
+                  "types": ["null", "integer"]
+                },
+                "rate": {
+                  "description": "Details about the tax rate",
+                  "type": ["null", "object"],
+                  "properties": {
+                    "id": {
+                      "description": "ID of the tax rate",
+                      "type": ["null", "string"]
+                    },
+                    "object": {
+                      "description": "Type of object, in this case, 'tax_rate'",
+                      "type": ["null", "string"]
+                    },
+                    "active": {
+                      "description": "Indicates if the tax rate is currently active",
+                      "type": ["null", "boolean"]
+                    },
+                    "country": {
+                      "description": "Country for which the tax rate applies",
+                      "type": ["null", "string"]
+                    },
+                    "created": {
+                      "description": "Timestamp of when the tax rate was created",
+                      "type": ["null", "integer"]
+                    },
+                    "description": {
+                      "description": "Description of the tax rate",
+                      "type": ["null", "string"]
+                    },
+                    "display_name": {
+                      "description": "Display name for the tax rate",
+                      "type": ["null", "string"]
+                    },
+                    "inclusive": {
+                      "description": "Indicates if tax is inclusive in the price",
+                      "type": ["null", "boolean"]
+                    },
+                    "jurisdiction": {
+                      "description": "Jurisdiction to which the tax rate applies",
+                      "type": ["null", "string"]
+                    },
+                    "livemode": {
+                      "description": "Indicates if the tax rate is in live mode",
+                      "type": ["null", "boolean"]
+                    },
+                    "metadata": {
+                      "description": "Additional information about the tax rate",
+                      "type": ["null", "object"],
+                      "properties": {}
+                    },
+                    "percentage": {
+                      "description": "Percentage of the tax rate",
+                      "type": ["null", "number"]
+                    },
+                    "state": {
+                      "description": "State for which the tax rate applies",
+                      "type": ["null", "string"]
+                    },
+                    "tax_type": {
+                      "description": "Type of tax rate",
+                      "type": ["null", "string"]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh", "incremental"],
+      "source_defined_cursor": true,
+      "default_cursor_field": ["checkout_session_updated"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": true
+    },
+    {
+      "name": "invoice_line_items",
+      "json_schema": {
+        "type": ["null", "object"],
+        "properties": {
+          "id": {
+            "description": "The unique identifier for the invoice line item.",
+            "type": ["null", "string"]
+          },
+          "invoice": {
+            "description": "The ID of the invoice associated with the line item.",
+            "type": ["null", "string"]
+          },
+          "invoice_id": {
+            "description": "The ID of the invoice associated with the line item.",
+            "type": ["null", "string"]
+          },
+          "subscription_item": {
+            "description": "The item details associated with the subscription.",
+            "type": ["null", "string"]
+          },
+          "metadata": {
+            "description": "Additional information or custom data related to the invoice line items.",
+            "type": ["null", "object"],
+            "properties": {}
+          },
+          "description": {
+            "description": "A brief description of the invoice line item.",
+            "type": ["null", "string"]
+          },
+          "object": {
+            "description": "The object type, which is 'invoiceitem'.",
+            "type": ["null", "string"]
+          },
+          "discountable": {
+            "description": "Indicates whether the item is eligible for discounts.",
+            "type": ["null", "boolean"]
+          },
+          "quantity": {
+            "description": "The quantity of the item being billed.",
+            "type": ["null", "integer"]
+          },
+          "amount": {
+            "description": "The total amount of the invoice line item, including any taxes and discounts.",
+            "type": ["null", "integer"]
+          },
+          "type": {
+            "description": "The type of the invoice line item.",
+            "type": ["null", "string"]
+          },
+          "livemode": {
+            "description": "Indicates if the data is from a live mode.",
+            "type": ["null", "boolean"]
+          },
+          "margins": {
+            "description": "Information about the margins for each item.",
+            "type": ["null", "array"],
+            "items": {
+              "description": "Details about margins.",
+              "type": ["null", "string"]
+            }
+          },
+          "proration": {
+            "description": "Indicates if the amount is prorated.",
+            "type": ["null", "boolean"]
+          },
+          "period": {
+            "description": "The time period for which the invoice line items are applicable.",
+            "type": ["null", "object"],
+            "properties": {
+              "start": {
+                "description": "The start date of the period.",
+                "type": ["null", "integer"]
+              },
+              "end": {
+                "description": "The end date of the period.",
+                "type": ["null", "integer"]
+              }
+            }
+          },
+          "subscription": {
+            "description": "The ID of the subscription associated with the line item.",
+            "type": ["null", "string"]
+          },
+          "plan": {
+            "description": "Details about the plan associated with the invoice line items.",
+            "type": ["null", "object", "string"],
+            "properties": {
+              "nickname": {
+                "description": "The nickname of the plan.",
+                "type": ["null", "string"]
+              },
+              "tiers": {
+                "description": "Information about the tiers of the plan.",
+                "type": ["null", "array"],
+                "items": {
+                  "type": ["null", "string", "object"],
+                  "properties": {
+                    "flat_amount": {
+                      "description": "The flat amount for tiered pricing.",
+                      "type": ["null", "integer"]
+                    },
+                    "unit_amount": {
+                      "description": "The unit amount for tiered pricing.",
+                      "type": ["null", "integer"]
+                    },
+                    "up_to": {
+                      "description": "The upper limit for the tier.",
+                      "type": ["null", "integer"]
+                    }
+                  }
+                }
+              },
+              "object": {
+                "description": "The object type, which is 'plan'.",
+                "type": ["null", "string"]
+              },
+              "aggregate_usage": {
+                "description": "The usage aggregation type for the plan.",
+                "type": ["null", "string"]
+              },
+              "created": {
+                "description": "The creation date of the plan.",
+                "type": ["null", "integer"]
+              },
+              "statement_description": {
+                "description": "The statement description for the plan.",
+                "type": ["null", "string"]
+              },
+              "product": {
+                "description": "The product associated with the plan.",
+                "type": ["null", "string"]
+              },
+              "statement_descriptor": {
+                "description": "The statement descriptor for the plan.",
+                "type": ["null", "string"]
+              },
+              "interval_count": {
+                "description": "The number of intervals between plan billings.",
+                "type": ["null", "integer"]
+              },
+              "transform_usage": {
+                "description": "Indicates if usage is transformed for the plan.",
+                "type": ["null", "string"]
+              },
+              "name": {
+                "description": "The name of the plan.",
+                "type": ["null", "string"]
+              },
+              "amount": {
+                "description": "The amount of the plan.",
+                "type": ["null", "integer"]
+              },
+              "interval": {
+                "description": "The interval for the plan billing.",
+                "type": ["null", "string"]
+              },
+              "id": {
+                "description": "The unique identifier for the plan.",
+                "type": ["null", "string"]
+              },
+              "trial_period_days": {
+                "description": "The number of trial days for the plan.",
+                "type": ["null", "integer"]
+              },
+              "usage_type": {
+                "description": "The usage type for the plan.",
+                "type": ["null", "string"]
+              },
+              "active": {
+                "description": "Indicates if the plan is active.",
+                "type": ["null", "boolean"]
+              },
+              "tiers_mode": {
+                "description": "The mode for applying tiered pricing.",
+                "type": ["null", "string"]
+              },
+              "billing_scheme": {
+                "description": "The billing scheme for the plan.",
+                "type": ["null", "string"]
+              },
+              "livemode": {
+                "description": "Indicates if the plan is in live mode.",
+                "type": ["null", "boolean"]
+              },
+              "currency": {
+                "description": "The currency of the plan amount.",
+                "type": ["null", "string"]
+              },
+              "metadata": {
+                "description": "Metadata specific to the plan.",
+                "type": ["null", "object"],
+                "properties": {}
+              },
+              "updated": {
+                "description": "The last updated date of the plan.",
+                "type": ["null", "number"]
+              }
+            }
+          },
+          "invoice_item": {
+            "description": "The item details on the invoice.",
+            "type": ["null", "string"]
+          },
+          "currency": {
+            "description": "The currency in which the amount is denominated.",
+            "type": ["null", "string"]
+          },
+          "amount_excluding_tax": {
+            "description": "The amount of the invoice line item excluding any taxes.",
+            "type": ["null", "integer"]
+          },
+          "unit_amount_excluding_tax": {
+            "description": "The unit amount of the item excluding tax.",
+            "type": ["null", "string"]
+          },
+          "proration_details": {
+            "description": "Details related to proration on the invoice line items.",
+            "type": ["null", "object"],
+            "properties": {
+              "credited_items": {
+                "description": "Items that were credited in relation to the invoice line items.",
+                "type": ["null", "object"],
+                "properties": {
+                  "invoice": {
+                    "description": "The invoice related to the credited item.",
+                    "type": ["null", "string"]
+                  },
+                  "invoice_line_items": {
+                    "description": "Details of the specific invoice line items that were credited.",
+                    "type": ["null", "array"],
+                    "items": {
+                      "description": "Details of the credited items on the invoice.",
+                      "type": ["null", "string"]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "price": {
+            "type": ["null", "object"],
+            "properties": {
+              "id": { "type": ["null", "string"] },
+              "object": { "type": ["null", "string"] },
+              "active": { "type": ["null", "boolean"] },
+              "billing_scheme": { "type": ["null", "string"] },
+              "created": { "type": ["null", "integer"] },
+              "currency": { "type": ["null", "string"] },
+              "currency_options": { "type": ["null", "string"] },
+              "custom_unit_amount": {
+                "type": ["null", "object"],
+                "properties": {
+                  "maximum": { "type": ["null", "integer"] },
+                  "minimum": { "type": ["null", "integer"] },
+                  "preset": { "type": ["null", "integer"] }
+                }
+              },
+              "livemode": { "type": ["null", "boolean"] },
+              "lookup_key": { "type": ["null", "string"] },
+              "metadata": { "type": ["null", "object"] },
+              "nickname": { "type": ["null", "string"] },
+              "product": { "type": ["null", "string"] },
+              "recurring": {
+                "type": ["null", "object"],
+                "properties": {
+                  "aggregate_usage": { "type": ["null", "string"] },
+                  "interval": { "type": ["null", "string"] },
+                  "interval_count": { "type": ["null", "integer"] },
+                  "usage_type": { "type": ["null", "string"] }
+                }
+              },
+              "tax_behavior": { "type": ["null", "string"] },
+              "tiers": {
+                "type": ["null", "array"],
+                "items": { "type": ["null", "string"] }
+              },
+              "tiers_mode": { "type": ["null", "string"] },
+              "transform_quantity": {
+                "type": ["null", "object"],
+                "properties": {
+                  "divide_by": { "type": ["null", "integer"] },
+                  "round": { "type": ["null", "string"] }
+                }
+              },
+              "type": { "type": ["null", "string"] },
+              "unit_amount": { "type": ["null", "integer"] },
+              "unit_amount_decimal": { "type": ["null", "string"] }
+            }
+          },
+          "discount_amounts": {
+            "description": "The amount of discount applied to each item in the invoice line items.",
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "amount": {
+                  "description": "The amount of discount applied to the item.",
+                  "type": ["null", "integer"]
+                },
+                "discount": {
+                  "description": "The discount information.",
+                  "type": ["null", "string"]
+                }
+              }
+            }
+          },
+          "discounts": {
+            "description": "Any discounts applied to the invoice line items.",
+            "type": ["null", "array"],
+            "items": {
+              "description": "Discount information for the invoice line item.",
+              "type": ["null", "string"]
+            }
+          },
+          "tax_rates": {
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "id": { "type": ["null", "string"] },
+                "object": { "type": ["null", "string"] },
+                "active": { "type": ["null", "boolean"] },
+                "country": { "type": ["null", "string"] },
+                "created": { "type": ["null", "integer"] },
+                "description": { "type": ["null", "string"] },
+                "display_name": { "type": ["null", "string"] },
+                "effective_percentage": { "type": ["null", "number"] },
+                "inclusive": { "type": ["null", "boolean"] },
+                "jurisdiction": { "type": ["null", "string"] },
+                "livemode": { "type": ["null", "boolean"] },
+                "metadata": { "type": ["null", "object"] },
+                "percentage": { "type": ["null", "number"] },
+                "state": { "type": ["null", "string"] },
+                "tax_type": { "type": ["null", "string"] }
+              }
+            }
+          },
+          "tax_amounts": {
+            "description": "The amounts of tax applied to each item in the invoice line items.",
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "amount": {
+                  "description": "The amount of tax applied.",
+                  "type": ["null", "integer"]
+                },
+                "inclusive": {
+                  "description": "Indicates if the tax is inclusive of the item price.",
+                  "type": ["null", "boolean"]
+                },
+                "tax_rate": {
+                  "description": "The tax rate applied.",
+                  "type": ["null", "string"]
+                },
+                "taxability_reason": {
+                  "description": "The reason for taxability.",
+                  "type": ["null", "string"]
+                },
+                "taxable_amount": {
+                  "description": "The taxable amount.",
+                  "type": ["null", "integer"]
+                }
+              }
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": false
+    },
+    {
+      "name": "subscription_items",
+      "json_schema": {
+        "type": ["null", "object"],
+        "properties": {
+          "metadata": {
+            "description": "Additional information attached to the subscription item.",
+            "type": ["null", "object"],
+            "properties": {}
+          },
+          "canceled_at": {
+            "description": "Timestamp indicating when the subscription was canceled.",
+            "type": ["null", "string"]
+          },
+          "current_period_end": {
+            "description": "Timestamp indicating when the current billing period ends.",
+            "type": ["null", "string"]
+          },
+          "plan": {
+            "description": "Details of the plan associated with the subscription item.",
+            "type": ["null", "object", "string"],
+            "properties": {
+              "nickname": {
+                "description": "Nickname of the plan.",
+                "type": ["null", "string"]
+              },
+              "tiers": {
+                "description": "Tiers of pricing for the plan of the subscription item.",
+                "type": ["null", "array"],
+                "items": {
+                  "description": "Individual pricing tiers with specific criteria for the plan.",
+                  "type": ["null", "string", "object"],
+                  "properties": {
+                    "flat_amount": {
+                      "description": "Flat fee amount for this tier.",
+                      "type": ["null", "integer"]
+                    },
+                    "unit_amount": {
+                      "description": "Unit amount for usage within this tier.",
+                      "type": ["null", "integer"]
+                    },
+                    "up_to": {
+                      "description": "Upper usage boundary for this tier.",
+                      "type": ["null", "integer"]
+                    }
+                  }
+                }
+              },
+              "object": {
+                "description": "Type of object, in this case, 'plan'.",
+                "type": ["null", "string"]
+              },
+              "aggregate_usage": {
+                "description": "Type of usage aggregation for the subscription.",
+                "type": ["null", "string"]
+              },
+              "created": {
+                "description": "Timestamp indicating when the plan was created.",
+                "type": ["null", "integer"]
+              },
+              "statement_description": {
+                "description": "Description to be shown on the customer's statement for the plan.",
+                "type": ["null", "string"]
+              },
+              "product": {
+                "description": "ID of the product associated with the plan.",
+                "type": ["null", "string"]
+              },
+              "statement_descriptor": {
+                "description": "Descriptor shown on the customer's credit card statement for the plan.",
+                "type": ["null", "string"]
+              },
+              "interval_count": {
+                "description": "Number of intervals between each billing cycle.",
+                "type": ["null", "integer"]
+              },
+              "transform_usage": {
+                "description": "Transform usage to a new quantity in the subscription.",
+                "type": ["null", "string"]
+              },
+              "name": {
+                "description": "Name of the plan.",
+                "type": ["null", "string"]
+              },
+              "amount": {
+                "description": "Amount in the smallest currency unit representing the plan price.",
+                "type": ["null", "integer"]
+              },
+              "interval": {
+                "description": "Interval at which the plan is billed.",
+                "type": ["null", "string"]
+              },
+              "id": {
+                "description": "Unique identifier for the plan associated with the subscription item.",
+                "type": ["null", "string"]
+              },
+              "trial_period_days": {
+                "description": "Number of days in the trial period for the plan.",
+                "type": ["null", "integer"]
+              },
+              "usage_type": {
+                "description": "Type of usage, either 'licensed' or 'metered'.",
+                "type": ["null", "string"]
+              },
+              "active": {
+                "description": "Flag indicating if the plan associated with the subscription item is active.",
+                "type": ["null", "boolean"]
+              },
+              "tiers_mode": {
+                "description": "Mode to define tiered pricing, either 'graduated' or 'volume'.",
+                "type": ["null", "string"]
+              },
+              "billing_scheme": {
+                "description": "Scheme for how prices will be billed for the plan.",
+                "type": ["null", "string"]
+              },
+              "livemode": {
+                "description": "Flag indicating if the plan is in live mode.",
+                "type": ["null", "boolean"]
+              },
+              "currency": {
+                "description": "The currency of the plan price.",
+                "type": ["null", "string"]
+              },
+              "metadata": {
+                "description": "Additional information specific to the plan of the subscription item.",
+                "type": ["null", "object"],
+                "properties": {}
+              },
+              "updated": {
+                "description": "Timestamp indicating when the plan was last updated.",
+                "type": ["null", "number"]
+              }
+            }
+          },
+          "subscription": {
+            "description": "ID of the subscription to which the subscription item belongs.",
+            "type": ["null", "string"]
+          },
+          "trial_start": {
+            "description": "Timestamp indicating when the trial period for the subscription item starts.",
+            "type": ["null", "integer"]
+          },
+          "created": {
+            "description": "Timestamp indicating when the subscription item was created.",
+            "type": ["null", "integer"]
+          },
+          "cancel_at_period_end": {
+            "description": "Flag indicating if the subscription will be canceled at the end of the current period.",
+            "type": ["null", "boolean"]
+          },
+          "quantity": {
+            "description": "Quantity of the plan to be included in the subscription item.",
+            "type": ["null", "integer"]
+          },
+          "tax_percent": {
+            "description": "Tax percentage applied to the subscription item price.",
+            "type": ["null", "number"]
+          },
+          "current_period_start": {
+            "description": "Timestamp indicating when the current billing period began.",
+            "type": ["null", "integer"]
+          },
+          "start": {
+            "description": "Timestamp indicating when the subscription item starts.",
+            "type": ["null", "integer"]
+          },
+          "discount": {
+            "description": "Any discounts applied to the subscription item.",
+            "type": ["null", "object"],
+            "properties": {}
+          },
+          "application_fee_percent": {
+            "description": "A fee percentage applied to the subscription that will be transferred to the platform owner.",
+            "type": ["null", "number"]
+          },
+          "id": {
+            "description": "Unique identifier for the subscription item.",
+            "type": ["null", "string"]
+          },
+          "status": {
+            "description": "Status of the subscription item, e.g., 'active', 'trialing', 'canceled'.",
+            "type": ["null", "string"]
+          },
+          "customer": {
+            "description": "ID of the customer to whom the subscription item belongs.",
+            "type": ["null", "string"]
+          },
+          "object": {
+            "description": "Type of object, in this case, 'subscription_item'.",
+            "type": ["null", "string"]
+          },
+          "livemode": {
+            "description": "Flag indicating if the subscription item is in live mode.",
+            "type": ["null", "boolean"]
+          },
+          "ended_at": {
+            "description": "Timestamp indicating when the subscription ended.",
+            "type": ["null", "number"]
+          },
+          "trial_end": {
+            "description": "Timestamp indicating when the trial period for the subscription item ends.",
+            "type": ["null", "number"]
+          },
+          "billing_thresholds": {
+            "description": "Threshold rules that trigger billing actions for the subscription item.",
+            "type": ["null", "object"],
+            "properties": {
+              "usage_gte": {
+                "description": "The usage threshold that triggers the billing for metered billing subscriptions.",
+                "type": ["null", "integer"]
+              }
+            }
+          },
+          "tax_rates": {
+            "type": ["null", "array"],
+            "items": {
+              "type": ["null", "object"],
+              "properties": {
+                "id": { "type": ["null", "string"] },
+                "object": { "type": ["null", "string"] },
+                "active": { "type": ["null", "boolean"] },
+                "country": { "type": ["null", "string"] },
+                "created": { "type": ["null", "integer"] },
+                "description": { "type": ["null", "string"] },
+                "display_name": { "type": ["null", "string"] },
+                "effective_percentage": { "type": ["null", "number"] },
+                "inclusive": { "type": ["null", "boolean"] },
+                "jurisdiction": { "type": ["null", "string"] },
+                "livemode": { "type": ["null", "boolean"] },
+                "metadata": { "type": ["null", "object"] },
+                "percentage": { "type": ["null", "number"] },
+                "state": { "type": ["null", "string"] },
+                "tax_type": { "type": ["null", "string"] }
+              }
+            }
+          },
+          "price": {
+            "type": ["null", "object"],
+            "properties": {
+              "id": { "type": ["null", "string"] },
+              "object": { "type": ["null", "string"] },
+              "active": { "type": ["null", "boolean"] },
+              "billing_scheme": { "type": ["null", "string"] },
+              "created": { "type": ["null", "integer"] },
+              "currency": { "type": ["null", "string"] },
+              "currency_options": { "type": ["null", "string"] },
+              "custom_unit_amount": {
+                "type": ["null", "object"],
+                "properties": {
+                  "maximum": { "type": ["null", "integer"] },
+                  "minimum": { "type": ["null", "integer"] },
+                  "preset": { "type": ["null", "integer"] }
+                }
+              },
+              "livemode": { "type": ["null", "boolean"] },
+              "lookup_key": { "type": ["null", "string"] },
+              "metadata": { "type": ["null", "object"] },
+              "nickname": { "type": ["null", "string"] },
+              "product": { "type": ["null", "string"] },
+              "recurring": {
+                "type": ["null", "object"],
+                "properties": {
+                  "aggregate_usage": { "type": ["null", "string"] },
+                  "interval": { "type": ["null", "string"] },
+                  "interval_count": { "type": ["null", "integer"] },
+                  "usage_type": { "type": ["null", "string"] }
+                }
+              },
+              "tax_behavior": { "type": ["null", "string"] },
+              "tiers": {
+                "type": ["null", "array"],
+                "items": { "type": ["null", "string"] }
+              },
+              "tiers_mode": { "type": ["null", "string"] },
+              "transform_quantity": {
+                "type": ["null", "object"],
+                "properties": {
+                  "divide_by": { "type": ["null", "integer"] },
+                  "round": { "type": ["null", "string"] }
+                }
+              },
+              "type": { "type": ["null", "string"] },
+              "unit_amount": { "type": ["null", "integer"] },
+              "unit_amount_decimal": { "type": ["null", "string"] }
+            }
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": false
+    },
+    {
+      "name": "transfer_reversals",
+      "json_schema": {
+        "$schema": "https://json-schema.org/draft-07/schema#",
+        "type": ["null", "object"],
+        "additionalProperties": true,
+        "properties": {
+          "amount": {
+            "description": "The amount of the transfer reversal, in cents.",
+            "type": ["null", "integer"]
+          },
+          "balance_transaction": {
+            "description": "The balance transaction associated with this transfer reversal.",
+            "type": ["null", "string"]
+          },
+          "created": {
+            "description": "Timestamp representing when the transfer reversal was created.",
+            "type": ["null", "integer"]
+          },
+          "currency": {
+            "description": "The currency of the transfer reversal amount.",
+            "type": ["null", "string"]
+          },
+          "destination_payment_refund": {
+            "description": "The ID of the payment refund to which this transfer reversal is linked.",
+            "type": ["null", "string"]
+          },
+          "id": {
+            "description": "Unique identifier for the transfer reversal.",
+            "type": ["null", "string"]
+          },
+          "metadata": {
+            "description": "A set of key-value pairs that you can attach to the transfer reversal.",
+            "additionalProperties": true,
+            "type": ["null", "object"],
+            "properties": {}
+          },
+          "object": {
+            "description": "Indicates the object type, which should be 'transfer_reversal'.",
+            "type": ["null", "string"]
+          },
+          "source_refund": {
+            "description": "The ID of the refund on the source transfer that created this reversal.",
+            "type": ["null", "string"]
+          },
+          "transfer": {
+            "description": "The ID of the transfer for which this is a reversal.",
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "source_defined_primary_key": [["id"]],
+      "is_resumable": false
+    },
+    {
+      "name": "usage_records",
+      "json_schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": ["null", "object"],
+        "additionalProperties": true,
+        "properties": {
+          "id": {
+            "description": "The unique identifier for the usage record",
+            "type": ["null", "string"]
+          },
+          "invoice": {
+            "description": "The ID of the invoice associated with this usage record",
+            "type": ["null", "string"]
+          },
+          "livemode": {
+            "description": "Indicates whether this usage record is in live mode or test mode",
+            "type": ["null", "boolean"]
+          },
+          "object": {
+            "description": "Represents the type of object, in this case, 'usage_record'",
+            "type": ["null", "string"]
+          },
+          "period": {
+            "description": "The period during which the usage occurred",
+            "type": ["null", "object"],
+            "properties": {
+              "start": {
+                "description": "The start date of the usage period",
+                "type": ["null", "integer"]
+              },
+              "end": {
+                "description": "The end date of the usage period",
+                "type": ["null", "integer"]
+              }
+            }
+          },
+          "subscription_item": {
+            "description": "The item within the subscription that this usage record is associated with",
+            "type": ["null", "string"]
+          },
+          "total_usage": {
+            "description": "The total quantity of units used for this usage record",
+            "type": ["null", "integer"]
+          }
+        }
+      },
+      "supported_sync_modes": ["full_refresh"],
+      "is_resumable": false
+    }
+  ]
+}

--- a/airbyte-integrations/connectors/source-stripe/erd/estimated_relationships.json
+++ b/airbyte-integrations/connectors/source-stripe/erd/estimated_relationships.json
@@ -1,0 +1,339 @@
+{
+  "streams": [
+    {
+      "name": "checkout_sessions",
+      "relations": {
+        "customer": "customers.id",
+        "payment_intent": "payment_intents.id",
+        "setup_intent": "setup_intents.id",
+        "subscription": "subscriptions.id",
+        "invoice": "invoices.id",
+        "payment_link": "payment_methods.id",
+        "payment_method_collection": "payment_methods.id"
+      }
+    },
+    {
+      "name": "customer_balance_transactions",
+      "relations": {
+        "customer": "customers.id",
+        "credit_note": "credit_notes.id",
+        "invoice": "invoices.id"
+      }
+    },
+    {
+      "name": "events",
+      "relations": {}
+    },
+    {
+      "name": "external_account_cards",
+      "relations": {
+        "account": "accounts.id"
+      }
+    },
+    {
+      "name": "external_account_bank_accounts",
+      "relations": {
+        "account": "accounts.id"
+      }
+    },
+    {
+      "name": "persons",
+      "relations": {
+        "account": "accounts.id"
+      }
+    },
+    {
+      "name": "setup_attempts",
+      "relations": {
+        "customer": "customers.id",
+        "payment_method": "payment_methods.id",
+        "setup_intent": "setup_intents.id"
+      }
+    },
+    {
+      "name": "accounts",
+      "relations": {}
+    },
+    {
+      "name": "shipping_rates",
+      "relations": {}
+    },
+    {
+      "name": "balance_transactions",
+      "relations": {
+        "source": "charges.id"
+      }
+    },
+    {
+      "name": "files",
+      "relations": {}
+    },
+    {
+      "name": "file_links",
+      "relations": {
+        "file": "files.id"
+      }
+    },
+    {
+      "name": "refunds",
+      "relations": {
+        "charge": "charges.id",
+        "payment_intent": "payment_intents.id"
+      }
+    },
+    {
+      "name": "payment_methods",
+      "relations": {}
+    },
+    {
+      "name": "credit_notes",
+      "relations": {
+        "customer": "customers.id",
+        "invoice": "invoices.id",
+        "customer_balance_transaction": "customer_balance_transactions.id",
+        "refund": "refunds.id"
+      }
+    },
+    {
+      "name": "early_fraud_warnings",
+      "relations": {
+        "charge": "charges.id"
+      }
+    },
+    {
+      "name": "authorizations",
+      "relations": {}
+    },
+    {
+      "name": "customers",
+      "relations": {
+        "default_source": "cards.id",
+        "default_card": "cards.id"
+      }
+    },
+    {
+      "name": "cardholders",
+      "relations": {}
+    },
+    {
+      "name": "charges",
+      "relations": {
+        "customer": "customers.id",
+        "order": "orders.id",
+        "application": "accounts.id",
+        "payment_intent": "payment_intents.id",
+        "source_transfer": "transfers.id",
+        "application_fee": "application_fees.id",
+        "balance_transaction": "balance_transactions.id",
+        "dispute": "disputes.id",
+        "failure_balance_transaction": "balance_transactions.id",
+        "payment_method": "payment_methods.id"
+      }
+    },
+    {
+      "name": "coupons",
+      "relations": {}
+    },
+    {
+      "name": "disputes",
+      "relations": {
+        "charge": "charges.id",
+        "payment_intent": "payment_intents.id",
+        "balance_transaction": "balance_transactions.id"
+      }
+    },
+    {
+      "name": "application_fees",
+      "relations": {
+        "account": "accounts.id",
+        "charge": "charges.id",
+        "balance_transaction": "balance_transactions.id"
+      }
+    },
+    {
+      "name": "invoices",
+      "relations": {
+        "customer": "customers.id",
+        "charge": "charges.id",
+        "payment": "payment_methods.id",
+        "subscription": "subscriptions.id",
+        "application": "accounts.id",
+        "default_source": "cards.id",
+        "default_payment_method": "payment_methods.id",
+        "latest_invoice": "invoices.id",
+        "quote": "quotes.id"
+      }
+    },
+    {
+      "name": "invoice_items",
+      "relations": {
+        "invoice": "invoices.id",
+        "subscription": "subscriptions.id",
+        "subscription_item": "subscription_items.id",
+        "customer": "customers.id"
+      }
+    },
+    {
+      "name": "payouts",
+      "relations": {
+        "balance_transaction": "balance_transactions.id",
+        "recipient": "accounts.id",
+        "destination": "bank_accounts.id",
+        "source_transaction": "charges.id",
+        "original_payout": "payouts.id",
+        "reversed_by": "payouts.id"
+      }
+    },
+    {
+      "name": "plans",
+      "relations": {
+        "product": "products.id"
+      }
+    },
+    {
+      "name": "prices",
+      "relations": {
+        "product": "products.id"
+      }
+    },
+    {
+      "name": "products",
+      "relations": {
+        "default_price": "prices.id"
+      }
+    },
+    {
+      "name": "reviews",
+      "relations": {
+        "charge": "charges.id",
+        "payment_intent": "payment_intents.id"
+      }
+    },
+    {
+      "name": "subscriptions",
+      "relations": {
+        "customer": "customers.id",
+        "application": "accounts.id",
+        "pending_setup_intent": "setup_intents.id",
+        "default_source": "cards.id",
+        "default_payment_method": "payment_methods.id",
+        "latest_invoice": "invoices.id",
+        "schedule": "subscription_schedule.id"
+      }
+    },
+    {
+      "name": "subscription_schedule",
+      "relations": {
+        "application": "accounts.id",
+        "customer": "customers.id",
+        "released_subscription": "subscriptions.id",
+        "subscription": "subscriptions.id"
+      }
+    },
+    {
+      "name": "transfers",
+      "relations": {
+        "balance_transaction": "balance_transactions.id",
+        "recipient": "accounts.id",
+        "destination": "bank_accounts.id",
+        "source_transaction": "charges.id",
+        "failure_balance_transaction": "balance_transactions.id",
+        "destination_payment": "payment_methods.id"
+      }
+    },
+    {
+      "name": "payment_intents",
+      "relations": {
+        "customer": "customers.id",
+        "invoice": "invoices.id",
+        "payment_method": "payment_methods.id",
+        "latest_charge": "charges.id"
+      }
+    },
+    {
+      "name": "promotion_codes",
+      "relations": {
+        "customer": "customers.id"
+      }
+    },
+    {
+      "name": "setup_intents",
+      "relations": {
+        "customer": "customers.id",
+        "payment_method": "payment_methods.id",
+        "latest_attempt": "setup_attempts.id"
+      }
+    },
+    {
+      "name": "cards",
+      "relations": {}
+    },
+    {
+      "name": "transactions",
+      "relations": {
+        "card": "cards.id",
+        "cardholder": "cardholders.id",
+        "dispute": "disputes.id",
+        "balance_transaction": "balance_transactions.id"
+      }
+    },
+    {
+      "name": "top_ups",
+      "relations": {
+        "balance_transaction": "balance_transactions.id",
+        "destination_balance": "balance_transactions.id"
+      }
+    },
+    {
+      "name": "application_fees_refunds",
+      "relations": {
+        "balance_transaction": "balance_transactions.id",
+        "fee": "application_fees.id"
+      }
+    },
+    {
+      "name": "bank_accounts",
+      "relations": {
+        "customer": "customers.id"
+      }
+    },
+    {
+      "name": "checkout_sessions_line_items",
+      "relations": {
+        "checkout_session_id": "checkout_sessions.id"
+      }
+    },
+    {
+      "name": "invoice_line_items",
+      "relations": {
+        "invoice": "invoices.id",
+        "subscription": "subscriptions.id",
+        "subscription_item": "subscription_items.id",
+        "invoice_item": "invoice_items.id"
+      }
+    },
+    {
+      "name": "subscription_items",
+      "relations": {
+        "subscription": "subscriptions.id",
+        "customer": "customers.id"
+      }
+    },
+    {
+      "name": "transfer_reversals",
+      "relations": {
+        "balance_transaction": "balance_transactions.id",
+        "transfer": "transfers.id",
+        "source_refund": "refunds.id",
+        "destination_payment_refund": "refunds.id"
+      }
+    },
+    {
+      "name": "usage_records",
+      "relations": {
+        "invoice": "invoices.id",
+        "subscription_item": "subscription_items.id"
+      }
+    }
+  ]
+}

--- a/airbyte-integrations/connectors/source-stripe/erd/source.dbml
+++ b/airbyte-integrations/connectors/source-stripe/erd/source.dbml
@@ -1,0 +1,1637 @@
+Table "checkout_sessions" {
+    "id" string [pk]
+    "object" string
+    "after_expiration" object
+    "allow_promotion_codes" boolean
+    "amount_subtotal" integer
+    "amount_total" integer
+    "automatic_tax" object
+    "billing_address_collection" string
+    "cancel_url" string
+    "client_reference_id" string
+    "consent" object
+    "consent_collection" object
+    "currency" string
+    "customer" string
+    "customer_details" object
+    "customer_email" string
+    "expires_at" integer
+    "livemode" boolean
+    "locale" string
+    "metadata" object
+    "mode" string
+    "payment_intent" string
+    "payment_method_options" object
+    "payment_method_types" array
+    "payment_status" string
+    "phone_number_collection" object
+    "recovered_from" string
+    "setup_intent" string
+    "shipping" object
+    "shipping_address_collection" object
+    "submit_type" string
+    "subscription" string
+    "success_url" string
+    "tax_id_collection" object
+    "total_details" object
+    "url" string
+    "updated" integer
+    "created" integer
+    "currency_conversion" object
+    "custom_fields" array
+    "custom_text" object
+    "customer_creation" string
+    "invoice" string
+    "invoice_creation" object
+    "payment_link" string
+    "payment_method_collection" string
+    "shipping_cost" object
+    "shipping_details" object
+    "shipping_options" array
+    "status" string
+    "payment_method_configuration_details" object
+    "client_secret" string
+    "ui_mode" string
+}
+
+Table "customer_balance_transactions" {
+    "id" string [pk]
+    "object" string
+    "amount" number
+    "created" integer
+    "credit_note" string
+    "currency" string
+    "customer" string
+    "description" string
+    "ending_balance" number
+    "invoice" string
+    "livemode" boolean
+    "metadata" object
+    "type" string
+}
+
+Table "events" {
+    "created" integer
+    "data" object
+    "id" string [pk]
+    "api_version" string
+    "object" string
+    "livemode" boolean
+    "pending_webhooks" integer
+    "type" string
+}
+
+Table "external_account_cards" {
+    "id" string [pk]
+    "object" string
+    "address_city" string
+    "address_country" string
+    "address_line1" string
+    "address_line1_check" string
+    "address_line2" string
+    "address_state" string
+    "address_zip" string
+    "address_zip_check" string
+    "brand" string
+    "country" string
+    "cvc_check" string
+    "dynamic_last4" string
+    "exp_month" integer
+    "exp_year" integer
+    "fingerprint" string
+    "funding" string
+    "last4" string
+    "metadata" object
+    "name" string
+    "redaction" string
+    "tokenization_method" string
+    "account" string
+    "updated" integer
+    "is_deleted" boolean
+}
+
+Table "external_account_bank_accounts" {
+    "id" string [pk]
+    "object" string
+    "account_holder_name" string
+    "account_holder_type" string
+    "account_type" string
+    "bank_name" string
+    "country" string
+    "currency" string
+    "fingerprint" string
+    "last4" string
+    "metadata" object
+    "routing_number" string
+    "status" string
+    "account" string
+    "updated" integer
+    "is_deleted" boolean
+}
+
+Table "persons" {
+    "id" string [pk]
+    "object" string
+    "phone" string
+    "email" string
+    "address_kana" string
+    "address_kanji" string
+    "first_name_kana" string
+    "gender" string
+    "full_name_aliases" string
+    "id_number_secondary_provided" string
+    "first_name_kanji" string
+    "nationality" string
+    "political_exposure" string
+    "registered_address" string
+    "account" string
+    "address" object
+    "created" integer
+    "updated" integer
+    "dob" object
+    "first_name" string
+    "future_requirements" object
+    "id_number_provided" boolean
+    "last_name" string
+    "metadata" object
+    "relationship" object
+    "requirements" object
+    "ssn_last_4_provided" boolean
+    "verification" object
+    "is_deleted" boolean
+}
+
+Table "setup_attempts" {
+    "application" string
+    "created" integer
+    "customer" string
+    "id" string [pk]
+    "livemode" boolean
+    "object" string
+    "on_behalf_of" string
+    "payment_method" string
+    "payment_method_details" object
+    "setup_error" object
+    "setup_intent" string
+    "status" string
+    "usage" string
+    "flow_directions" array
+}
+
+Table "accounts" {
+    "business_profile" object
+    "business_type" string
+    "capabilities" object
+    "charges_enabled" boolean
+    "company" object
+    "country" string
+    "created" integer
+    "default_currency" string
+    "details_submitted" boolean
+    "email" string
+    "external_accounts" object
+    "id" string [pk]
+    "individual" object
+    "metadata" object
+    "object" string
+    "payouts_enabled" boolean
+    "requirements" object
+    "settings" object
+    "tos_acceptance" object
+    "type" string
+    "future_requirements" object
+    "controller" object
+}
+
+Table "shipping_rates" {
+    "id" string [pk]
+    "object" string
+    "active" boolean
+    "created" integer
+    "delivery_estimate" string
+    "display_name" string
+    "fixed_amount" object
+    "livemode" boolean
+    "metadata" object
+    "tax_behavior" string
+    "tax_code" string
+    "type" string
+}
+
+Table "balance_transactions" {
+    "fee" integer
+    "currency" string
+    "source" string
+    "fee_details" array
+    "available_on" integer
+    "status" string
+    "description" string
+    "net" integer
+    "exchange_rate" number
+    "type" string
+    "sourced_transfers" array
+    "id" string [pk]
+    "object" string
+    "created" integer
+    "amount" integer
+    "reporting_category" string
+}
+
+Table "files" {
+    "id" string [pk]
+    "purpose" string
+    "type" string
+    "object" string
+    "created" integer
+    "expires_at" integer
+    "filename" string
+    "links" object
+    "size" integer
+    "title" string
+    "url" string
+}
+
+Table "file_links" {
+    "id" string [pk]
+    "expires_at" integer
+    "file" string
+    "metadata" object
+    "url" string
+    "object" string
+    "created" integer
+    "expired" boolean
+    "livemode" boolean
+}
+
+Table "refunds" {
+    "id" string [pk]
+    "object" string
+    "amount" integer
+    "balance_transaction" string
+    "charge" string
+    "created" integer
+    "updated" integer
+    "currency" string
+    "metadata" object
+    "payment_intent" string
+    "reason" string
+    "receipt_number" string
+    "source_transfer_reversal" string
+    "status" string
+    "transfer_reversal" string
+    "destination_details" object
+}
+
+Table "payment_methods" {
+    "afterpay_clearpay" object
+    "alipay" object
+    "au_becs_debit" object
+    "bacs_debit" object
+    "bancontact" object
+    "billing_details" object
+    "card" object
+    "card_present" object
+    "created" integer
+    "updated" integer
+    "customer" object
+    "eps" object
+    "fpx" object
+    "giropay" object
+    "grabpay" object
+    "id" string [pk]
+    "ideal" object
+    "interac_present" object
+    "livemode" boolean
+    "metadata" object
+    "object" string
+    "oxxo" object
+    "p24" object
+    "sepa_debit" object
+    "sofort" object
+    "type" string
+}
+
+Table "credit_notes" {
+    "id" string [pk]
+    "object" string
+    "amount" integer
+    "amount_shipping" integer
+    "created" integer
+    "updated" integer
+    "currency" string
+    "customer" string
+    "customer_balance_transaction" string
+    "discount_amount" string
+    "discount_amounts" array
+    "invoice" string
+    "lines" object
+    "livemode" boolean
+    "memo" string
+    "metadata" object
+    "number" string
+    "out_of_band_amount" integer
+    "pdf" string
+    "reason" string
+    "refund" string
+    "shipping_cost" object
+    "status" string
+    "subtotal" integer
+    "subtotal_excluding_tax" integer
+    "tax_amounts" array
+    "total" integer
+    "total_excluding_tax" integer
+    "type" string
+    "voided_at" integer
+    "effective_at" integer
+}
+
+Table "early_fraud_warnings" {
+    "id" string [pk]
+    "object" string
+    "actionable" boolean
+    "charge" string
+    "created" number
+    "updated" integer
+    "fraud_type" string
+    "livemode" boolean
+}
+
+Table "authorizations" {
+    "amount" integer
+    "amount_details" object
+    "approved" boolean
+    "authorization_method" string
+    "balance_transactions" array
+    "card" object
+    "cardholder" string
+    "created" integer
+    "updated" integer
+    "currency" string
+    "id" string [pk]
+    "livemode" boolean
+    "merchant_amount" integer
+    "merchant_currency" string
+    "merchant_data" object
+    "metadata" object
+    "object" string
+    "pending_request" object
+    "request_history" array
+    "status" string
+    "transactions" array
+    "verification_data" object
+    "wallet" string
+}
+
+Table "customers" {
+    "metadata" object
+    "preferred_locales" array
+    "invoice_settings" object
+    "name" string
+    "tax_exempt" string
+    "next_invoice_sequence" integer
+    "balance" integer
+    "phone" string
+    "address" object
+    "shipping" object
+    "delinquent" boolean
+    "description" string
+    "livemode" boolean
+    "default_source" string
+    "cards" array
+    "email" string
+    "default_card" string
+    "subscriptions" object
+    "discount" object
+    "account_balance" integer
+    "currency" string
+    "id" string [pk]
+    "invoice_prefix" string
+    "tax_info_verification" string
+    "object" string
+    "created" integer
+    "updated" integer
+    "tax_info" string
+    "test_clock" string
+    "is_deleted" boolean
+}
+
+Table "cardholders" {
+    "billing" object
+    "company" object
+    "created" integer
+    "updated" integer
+    "email" string
+    "id" string [pk]
+    "individual" object
+    "livemode" boolean
+    "metadata" object
+    "name" string
+    "object" string
+    "phone_number" string
+    "requirements" object
+    "spending_controls" object
+    "status" string
+    "type" string
+    "preferred_locales" array
+}
+
+Table "charges" {
+    "metadata" object
+    "fraud_details" object
+    "transfer_group" string
+    "on_behalf_of" string
+    "review" string
+    "failure_message" string
+    "receipt_email" string
+    "statement_descriptor" string
+    "source" object
+    "destination" string
+    "id" string [pk]
+    "object" string
+    "outcome" object
+    "status" string
+    "currency" string
+    "created" integer
+    "updated" integer
+    "order" string
+    "application" string
+    "refunded" boolean
+    "receipt_number" string
+    "livemode" boolean
+    "captured" boolean
+    "paid" boolean
+    "shipping" object
+    "invoice" string
+    "amount" integer
+    "customer" string
+    "payment_intent" string
+    "source_transfer" string
+    "statement_description" string
+    "refunds" object
+    "application_fee" string
+    "card" object
+    "payment_method_details" object
+    "balance_transaction" string
+    "amount_refunded" integer
+    "failure_code" string
+    "dispute" string
+    "description" string
+    "statement_descriptor_suffix" string
+    "calculated_statement_descriptor" string
+    "receipt_url" string
+    "transfer_data" object
+    "billing_details" object
+    "failure_balance_transaction" string
+    "amount_captured" integer
+    "application_fee_amount" integer
+    "amount_updates" array
+    "payment_method" string
+    "disputed" boolean
+}
+
+Table "coupons" {
+    "metadata" object
+    "times_redeemed" integer
+    "percent_off_precise" number
+    "livemode" boolean
+    "object" string
+    "redeem_by" string
+    "duration" string
+    "id" string [pk]
+    "valid" boolean
+    "currency" string
+    "duration_in_months" integer
+    "name" string
+    "max_redemptions" integer
+    "amount_off" integer
+    "created" integer
+    "updated" integer
+    "percent_off" number
+    "is_deleted" boolean
+}
+
+Table "disputes" {
+    "id" string [pk]
+    "object" string
+    "amount" integer
+    "balance_transactions" array
+    "charge" string
+    "created" integer
+    "updated" integer
+    "currency" string
+    "evidence_details" object
+    "is_charge_refundable" boolean
+    "livemode" boolean
+    "metadata" object
+    "reason" string
+    "status" string
+    "payment_intent" string
+    "balance_transaction" string
+    "payment_method_details" object
+}
+
+Table "application_fees" {
+    "id" string [pk]
+    "object" string
+    "account" string
+    "amount" number
+    "amount_refunded" number
+    "application" string
+    "balance_transaction" string
+    "charge" string
+    "created" number
+    "updated" integer
+    "currency" string
+    "livemode" boolean
+    "originating_transaction" string
+    "refunded" boolean
+    "refunds" object
+    "source" object
+}
+
+Table "invoices" {
+    "created" integer
+    "updated" integer
+    "next_payment_attempt" number
+    "tax" integer
+    "metadata" object
+    "charge" string
+    "description" string
+    "customer_tax_ids" array
+    "receipt_number" string
+    "attempt_count" integer
+    "payment" string
+    "amount_paid" integer
+    "due_date" number
+    "id" string [pk]
+    "webhooks_delivered_at" number
+    "statement_descriptor" string
+    "hosted_invoice_url" string
+    "period_end" number
+    "amount_remaining" integer
+    "tax_percent" number
+    "billing" string
+    "auto_advance" boolean
+    "paid" boolean
+    "discounts" array
+    "discount" object
+    "number" string
+    "billing_reason" string
+    "ending_balance" integer
+    "livemode" boolean
+    "period_start" number
+    "attempted" boolean
+    "closed" boolean
+    "invoice_pdf" string
+    "customer" string
+    "subtotal" integer
+    "application_fee" integer
+    "lines" object
+    "forgiven" boolean
+    "object" string
+    "starting_balance" integer
+    "amount_due" integer
+    "currency" string
+    "total" integer
+    "statement_description" string
+    "subscription" string
+    "subscription_details" object
+    "status" string
+    "status_transitions" object
+    "post_payment_credit_notes_amount" integer
+    "paid_out_of_band" boolean
+    "total_discount_amounts" array
+    "customer_name" string
+    "shipping_cost" object
+    "custom_fields" array
+    "transfer_data" object
+    "application_fee_amount" integer
+    "customer_shipping" object
+    "application" string
+    "amount_shipping" integer
+    "from_invoice" object
+    "customer_tax_exempt" string
+    "total_tax_amounts" array
+    "footer" string
+    "test_clock" string
+    "automatic_tax" object
+    "payment_settings" object
+    "default_source" string
+    "payment_intent" string
+    "default_payment_method" string
+    "shipping_details" object
+    "collection_method" string
+    "effective_at" integer
+    "default_tax_rates" array
+    "total_excluding_tax" integer
+    "subtotal_excluding_tax" integer
+    "last_finalization_error" object
+    "issuer" object
+    "latest_revision" string
+    "rendering_options" object
+    "quote" string
+    "pre_payment_credit_notes_amount" integer
+    "customer_phone" string
+    "on_behalf_of" string
+    "account_tax_ids" array
+    "customer_email" string
+    "customer_address" object
+    "account_name" string
+    "account_country" string
+    "is_deleted" boolean
+    "rendering" object
+}
+
+Table "invoice_items" {
+    "amount" integer
+    "metadata" object
+    "invoice" string
+    "period" object
+    "quantity" integer
+    "description" string
+    "date" integer
+    "updated" integer
+    "object" string
+    "subscription" string
+    "id" string [pk]
+    "livemode" boolean
+    "discountable" boolean
+    "unit_amount" integer
+    "currency" string
+    "customer" string
+    "proration" boolean
+    "subscription_item" string
+    "price" object
+    "test_clock" string
+    "discounts" array
+    "tax_rates" array
+    "unit_amount_decimal" string
+    "is_deleted" boolean
+}
+
+Table "payouts" {
+    "metadata" object
+    "failure_code" string
+    "id" string [pk]
+    "statement_description" string
+    "amount" integer
+    "balance_transaction" string
+    "created" integer
+    "updated" integer
+    "amount_reversed" integer
+    "source_type" string
+    "bank_account" object
+    "date" integer
+    "method" string
+    "livemode" boolean
+    "statement_descriptor" string
+    "failure_message" string
+    "failure_balance_transaction" string
+    "recipient" string
+    "destination" string
+    "automatic" boolean
+    "object" string
+    "status" string
+    "currency" string
+    "transfer_group" string
+    "type" string
+    "arrival_date" integer
+    "description" string
+    "source_transaction" string
+    "original_payout" string
+    "reconciliation_status" string
+    "source_balance" string
+    "reversed_by" string
+}
+
+Table "plans" {
+    "nickname" string
+    "tiers" array
+    "object" string
+    "aggregate_usage" string
+    "created" integer
+    "updated" integer
+    "statement_description" string
+    "product" string
+    "statement_descriptor" string
+    "interval_count" integer
+    "transform_usage" string
+    "name" string
+    "amount" integer
+    "interval" string
+    "id" string [pk]
+    "trial_period_days" integer
+    "usage_type" string
+    "active" boolean
+    "tiers_mode" string
+    "billing_scheme" string
+    "livemode" boolean
+    "currency" string
+    "metadata" object
+    "amount_decimal" string
+    "is_deleted" boolean
+}
+
+Table "prices" {
+    "id" string [pk]
+    "object" string
+    "active" boolean
+    "billing_scheme" string
+    "created" integer
+    "updated" integer
+    "currency" string
+    "custom_unit_amount" string
+    "livemode" boolean
+    "lookup_key" string
+    "metadata" object
+    "nickname" string
+    "product" string
+    "recurring" object
+    "tax_behavior" string
+    "tiers_mode" string
+    "transform_quantity" string
+    "type" string
+    "unit_amount" number
+    "unit_amount_decimal" string
+    "is_deleted" boolean
+}
+
+Table "products" {
+    "id" string [pk]
+    "object" string
+    "active" boolean
+    "attributes" array
+    "caption" string
+    "created" integer
+    "deactivate_on" array
+    "description" string
+    "images" array
+    "livemode" boolean
+    "metadata" object
+    "name" string
+    "package_dimensions" object
+    "shippable" boolean
+    "statement_descriptor" string
+    "type" string
+    "unit_label" string
+    "updated" integer
+    "url" string
+    "default_price" string
+    "tax_code" string
+    "features" array
+    "is_deleted" boolean
+}
+
+Table "reviews" {
+    "billing_zip" string
+    "charge" string
+    "closed_reason" string
+    "created" integer
+    "updated" integer
+    "id" string [pk]
+    "ip_address" string
+    "ip_address_location" object
+    "livemode" string
+    "object" string
+    "open" boolean
+    "opened_reason" string
+    "payment_intent" string
+    "reason" string
+    "session" object
+}
+
+Table "subscriptions" {
+    "metadata" object
+    "canceled_at" number
+    "cancel_at" number
+    "livemode" boolean
+    "start_date" integer
+    "items" object
+    "id" string [pk]
+    "trial_start" integer
+    "application_fee_percent" number
+    "billing_cycle_anchor" number
+    "billing_cycle_anchor_config" object
+    "invoice_settings" object
+    "cancel_at_period_end" boolean
+    "tax_percent" number
+    "discount" object
+    "current_period_end" number
+    "plan" object
+    "billing" string
+    "quantity" integer
+    "days_until_due" integer
+    "status" string
+    "created" integer
+    "updated" integer
+    "ended_at" number
+    "customer" string
+    "current_period_start" integer
+    "trial_end" number
+    "object" string
+    "pending_setup_intent" string
+    "currency" string
+    "transfer_data" object
+    "application" string
+    "test_clock" string
+    "automatic_tax" object
+    "payment_settings" object
+    "next_pending_invoice_item_invoice" integer
+    "default_source" string
+    "default_payment_method" string
+    "collection_method" string
+    "pending_invoice_item_interval" object
+    "default_tax_rates" array
+    "pause_collection" object
+    "cancellation_details" object
+    "latest_invoice" string
+    "pending_update" object
+    "description" string
+    "schedule" string
+    "trial_settings" object
+    "on_behalf_of" string
+    "billing_thresholds" object
+    "is_deleted" boolean
+}
+
+Table "subscription_schedule" {
+    "id" string [pk]
+    "object" string
+    "application" string
+    "canceled_at" string
+    "completed_at" string
+    "created" integer
+    "updated" integer
+    "current_phase" object
+    "customer" string
+    "default_settings" object
+    "end_behavior" string
+    "livemode" boolean
+    "metadata" object
+    "phases" array
+    "released_at" string
+    "released_subscription" string
+    "status" string
+    "subscription" string
+    "test_clock" string
+    "renewal_interval" string
+}
+
+Table "transfers" {
+    "metadata" object
+    "reversals" object
+    "id" string [pk]
+    "statement_description" string
+    "amount" integer
+    "balance_transaction" string
+    "reversed" boolean
+    "created" integer
+    "updated" integer
+    "amount_reversed" integer
+    "source_type" string
+    "source_transaction" string
+    "date" integer
+    "livemode" boolean
+    "statement_descriptor" string
+    "failure_balance_transaction" string
+    "recipient" string
+    "destination" string
+    "automatic" boolean
+    "object" string
+    "currency" string
+    "transfer_group" string
+    "arrival_date" integer
+    "description" string
+    "destination_payment" string
+}
+
+Table "payment_intents" {
+    "id" string [pk]
+    "object" string
+    "amount" integer
+    "amount_capturable" integer
+    "amount_received" integer
+    "application" string
+    "application_fee_amount" integer
+    "canceled_at" integer
+    "cancellation_reason" string
+    "capture_method" string
+    "charges" object
+    "client_secret" string
+    "confirmation_method" string
+    "created" integer
+    "updated" integer
+    "currency" string
+    "customer" string
+    "description" string
+    "invoice" string
+    "last_payment_error" object
+    "livemode" boolean
+    "metadata" object
+    "next_action" object
+    "on_behalf_of" string
+    "payment_method" string
+    "payment_method_options" object
+    "payment_method_types" array
+    "receipt_email" string
+    "review" string
+    "setup_future_usage" string
+    "shipping" object
+    "source" string
+    "statement_description" string
+    "statement_descriptor_suffix" string
+    "status" string
+    "transfer_data" object
+    "transfer_group" string
+    "latest_charge" string
+    "statement_descriptor" string
+    "amount_details" object
+    "processing" object
+    "automatic_payment_methods" object
+    "payment_method_configuration_details" object
+}
+
+Table "promotion_codes" {
+    "id" string [pk]
+    "code" string
+    "coupon" object
+    "metadata" object
+    "object" string
+    "active" boolean
+    "created" integer
+    "updated" integer
+    "customer" string
+    "expires_at" integer
+    "livemode" boolean
+    "max_redemptions" integer
+    "restrictions" object
+    "times_redeemed" integer
+}
+
+Table "setup_intents" {
+    "id" string [pk]
+    "object" string
+    "application" string
+    "cancellation_reason" string
+    "created" integer
+    "updated" integer
+    "customer" string
+    "description" string
+    "flow_directions" array
+    "last_setup_error" string
+    "latest_attempt" string
+    "livemode" boolean
+    "mandate" string
+    "metadata" object
+    "next_action" string
+    "on_behalf_of" string
+    "payment_method" string
+    "payment_method_options" object
+    "payment_method_types" array
+    "single_use_mandate" string
+    "status" string
+    "usage" string
+    "client_secret" string
+    "automatic_payment_methods" object
+    "payment_method_configuration_details" object
+}
+
+Table "cards" {
+    "brand" string
+    "cancellation_reason" string
+    "cardholder" object
+    "created" integer
+    "updated" integer
+    "currency" string
+    "cvc" string
+    "exp_month" integer
+    "exp_year" integer
+    "id" string [pk]
+    "last4" string
+    "livemode" boolean
+    "metadata" object
+    "number" string
+    "object" string
+    "replaced_by" object
+    "replacement_for" object
+    "replacement_reason" string
+    "shipping" object
+    "spending_controls" object
+    "status" string
+    "type" string
+}
+
+Table "transactions" {
+    "amount" integer
+    "amount_details" object
+    "authorization" string
+    "balance_transaction" string
+    "card" string
+    "cardholder" string
+    "created" integer
+    "updated" integer
+    "currency" string
+    "dispute" string
+    "id" string [pk]
+    "livemode" boolean
+    "merchant_amount" integer
+    "merchant_currency" string
+    "merchant_data" object
+    "metadata" object
+    "object" string
+    "purchase_details" object
+    "type" string
+}
+
+Table "top_ups" {
+    "id" string [pk]
+    "amount" integer
+    "currency" string
+    "description" string
+    "metadata" object
+    "status" string
+    "object" string
+    "balance_transaction" string
+    "created" integer
+    "updated" integer
+    "destination_balance" string
+    "expected_availability_date" integer
+    "failure_code" string
+    "failure_message" string
+    "livemode" boolean
+    "source" object
+    "statement_descriptor" string
+    "transfer_group" string
+}
+
+Table "application_fees_refunds" {
+    "id" string [pk]
+    "object" string
+    "amount" number
+    "balance_transaction" string
+    "created" number
+    "updated" integer
+    "currency" string
+    "fee" string
+    "metadata" object
+}
+
+Table "bank_accounts" {
+    "id" string [pk]
+    "object" string
+    "account_holder_name" string
+    "account_holder_type" string
+    "account_type" string
+    "bank_name" string
+    "country" string
+    "currency" string
+    "customer" string
+    "fingerprint" string
+    "last4" string
+    "metadata" object
+    "routing_number" string
+    "status" string
+    "updated" integer
+    "is_deleted" boolean
+}
+
+Table "checkout_sessions_line_items" {
+    "id" string [pk]
+    "checkout_session_id" string
+    "checkout_session_expires_at" integer
+    "checkout_session_created" integer
+    "checkout_session_updated" integer
+    "object" string
+    "amount_subtotal" integer
+    "amount_tax" integer
+    "amount_discount" integer
+    "amount_total" integer
+    "currency" string
+    "description" string
+    "discounts" array
+    "price" object
+    "quantity" integer
+    "taxes" array
+}
+
+Table "invoice_line_items" {
+    "id" string [pk]
+    "invoice" string
+    "invoice_id" string
+    "subscription_item" string
+    "metadata" object
+    "description" string
+    "object" string
+    "discountable" boolean
+    "quantity" integer
+    "amount" integer
+    "type" string
+    "livemode" boolean
+    "margins" array
+    "proration" boolean
+    "period" object
+    "subscription" string
+    "invoice_item" string
+    "currency" string
+    "amount_excluding_tax" integer
+    "unit_amount_excluding_tax" string
+    "proration_details" object
+    "price" object
+    "discount_amounts" array
+    "discounts" array
+    "tax_rates" array
+    "tax_amounts" array
+}
+
+Table "subscription_items" {
+    "metadata" object
+    "canceled_at" string
+    "current_period_end" string
+    "subscription" string
+    "trial_start" integer
+    "created" integer
+    "cancel_at_period_end" boolean
+    "quantity" integer
+    "tax_percent" number
+    "current_period_start" integer
+    "start" integer
+    "discount" object
+    "application_fee_percent" number
+    "id" string [pk]
+    "status" string
+    "customer" string
+    "object" string
+    "livemode" boolean
+    "ended_at" number
+    "trial_end" number
+    "billing_thresholds" object
+    "tax_rates" array
+    "price" object
+}
+
+Table "transfer_reversals" {
+    "amount" integer
+    "balance_transaction" string
+    "created" integer
+    "currency" string
+    "destination_payment_refund" string
+    "id" string [pk]
+    "metadata" object
+    "object" string
+    "source_refund" string
+    "transfer" string
+}
+
+Table "usage_records" {
+    "id" string
+    "invoice" string
+    "livemode" boolean
+    "object" string
+    "period" object
+    "subscription_item" string
+    "total_usage" integer
+}
+
+Ref {
+    "checkout_sessions"."customer" <> "customers"."id"
+}
+
+Ref {
+    "checkout_sessions"."payment_intent" <> "payment_intents"."id"
+}
+
+Ref {
+    "checkout_sessions"."setup_intent" <> "setup_intents"."id"
+}
+
+Ref {
+    "checkout_sessions"."subscription" <> "subscriptions"."id"
+}
+
+Ref {
+    "checkout_sessions"."invoice" <> "invoices"."id"
+}
+
+Ref {
+    "checkout_sessions"."payment_link" <> "payment_methods"."id"
+}
+
+Ref {
+    "checkout_sessions"."payment_method_collection" <> "payment_methods"."id"
+}
+
+Ref {
+    "customer_balance_transactions"."customer" <> "customers"."id"
+}
+
+Ref {
+    "customer_balance_transactions"."credit_note" <> "credit_notes"."id"
+}
+
+Ref {
+    "customer_balance_transactions"."invoice" <> "invoices"."id"
+}
+
+Ref {
+    "external_account_cards"."account" <> "accounts"."id"
+}
+
+Ref {
+    "external_account_bank_accounts"."account" <> "accounts"."id"
+}
+
+Ref {
+    "persons"."account" <> "accounts"."id"
+}
+
+Ref {
+    "setup_attempts"."customer" <> "customers"."id"
+}
+
+Ref {
+    "setup_attempts"."payment_method" <> "payment_methods"."id"
+}
+
+Ref {
+    "setup_attempts"."setup_intent" <> "setup_intents"."id"
+}
+
+Ref {
+    "balance_transactions"."source" <> "charges"."id"
+}
+
+Ref {
+    "file_links"."file" <> "files"."id"
+}
+
+Ref {
+    "refunds"."charge" <> "charges"."id"
+}
+
+Ref {
+    "refunds"."payment_intent" <> "payment_intents"."id"
+}
+
+Ref {
+    "credit_notes"."customer" <> "customers"."id"
+}
+
+Ref {
+    "credit_notes"."invoice" <> "invoices"."id"
+}
+
+Ref {
+    "credit_notes"."customer_balance_transaction" <> "customer_balance_transactions"."id"
+}
+
+Ref {
+    "credit_notes"."refund" <> "refunds"."id"
+}
+
+Ref {
+    "early_fraud_warnings"."charge" <> "charges"."id"
+}
+
+Ref {
+    "customers"."default_source" <> "cards"."id"
+}
+
+Ref {
+    "customers"."default_card" <> "cards"."id"
+}
+
+Ref {
+    "charges"."customer" <> "customers"."id"
+}
+
+Ref {
+    "charges"."application" <> "accounts"."id"
+}
+
+Ref {
+    "charges"."payment_intent" <> "payment_intents"."id"
+}
+
+Ref {
+    "charges"."source_transfer" <> "transfers"."id"
+}
+
+Ref {
+    "charges"."application_fee" <> "application_fees"."id"
+}
+
+Ref {
+    "charges"."balance_transaction" <> "balance_transactions"."id"
+}
+
+Ref {
+    "charges"."dispute" <> "disputes"."id"
+}
+
+Ref {
+    "charges"."failure_balance_transaction" <> "balance_transactions"."id"
+}
+
+Ref {
+    "charges"."payment_method" <> "payment_methods"."id"
+}
+
+Ref {
+    "disputes"."charge" <> "charges"."id"
+}
+
+Ref {
+    "disputes"."payment_intent" <> "payment_intents"."id"
+}
+
+Ref {
+    "disputes"."balance_transaction" <> "balance_transactions"."id"
+}
+
+Ref {
+    "application_fees"."account" <> "accounts"."id"
+}
+
+Ref {
+    "application_fees"."charge" <> "charges"."id"
+}
+
+Ref {
+    "application_fees"."balance_transaction" <> "balance_transactions"."id"
+}
+
+Ref {
+    "invoices"."customer" <> "customers"."id"
+}
+
+Ref {
+    "invoices"."charge" <> "charges"."id"
+}
+
+Ref {
+    "invoices"."payment" <> "payment_methods"."id"
+}
+
+Ref {
+    "invoices"."subscription" <> "subscriptions"."id"
+}
+
+Ref {
+    "invoices"."application" <> "accounts"."id"
+}
+
+Ref {
+    "invoices"."default_source" <> "cards"."id"
+}
+
+Ref {
+    "invoices"."default_payment_method" <> "payment_methods"."id"
+}
+
+Ref {
+    "invoice_items"."invoice" <> "invoices"."id"
+}
+
+Ref {
+    "invoice_items"."subscription" <> "subscriptions"."id"
+}
+
+Ref {
+    "invoice_items"."subscription_item" <> "subscription_items"."id"
+}
+
+Ref {
+    "invoice_items"."customer" <> "customers"."id"
+}
+
+Ref {
+    "payouts"."balance_transaction" <> "balance_transactions"."id"
+}
+
+Ref {
+    "payouts"."recipient" <> "accounts"."id"
+}
+
+Ref {
+    "payouts"."destination" <> "bank_accounts"."id"
+}
+
+Ref {
+    "payouts"."source_transaction" <> "charges"."id"
+}
+
+Ref {
+    "payouts"."original_payout" <> "payouts"."id"
+}
+
+Ref {
+    "payouts"."reversed_by" <> "payouts"."id"
+}
+
+Ref {
+    "plans"."product" <> "products"."id"
+}
+
+Ref {
+    "prices"."product" <> "products"."id"
+}
+
+Ref {
+    "products"."default_price" <> "prices"."id"
+}
+
+Ref {
+    "reviews"."charge" <> "charges"."id"
+}
+
+Ref {
+    "reviews"."payment_intent" <> "payment_intents"."id"
+}
+
+Ref {
+    "subscriptions"."customer" <> "customers"."id"
+}
+
+Ref {
+    "subscriptions"."application" <> "accounts"."id"
+}
+
+Ref {
+    "subscriptions"."pending_setup_intent" <> "setup_intents"."id"
+}
+
+Ref {
+    "subscriptions"."default_source" <> "cards"."id"
+}
+
+Ref {
+    "subscriptions"."default_payment_method" <> "payment_methods"."id"
+}
+
+Ref {
+    "subscriptions"."latest_invoice" <> "invoices"."id"
+}
+
+Ref {
+    "subscriptions"."schedule" <> "subscription_schedule"."id"
+}
+
+Ref {
+    "subscription_schedule"."application" <> "accounts"."id"
+}
+
+Ref {
+    "subscription_schedule"."customer" <> "customers"."id"
+}
+
+Ref {
+    "subscription_schedule"."released_subscription" <> "subscriptions"."id"
+}
+
+Ref {
+    "subscription_schedule"."subscription" <> "subscriptions"."id"
+}
+
+Ref {
+    "transfers"."balance_transaction" <> "balance_transactions"."id"
+}
+
+Ref {
+    "transfers"."recipient" <> "accounts"."id"
+}
+
+Ref {
+    "transfers"."destination" <> "bank_accounts"."id"
+}
+
+Ref {
+    "transfers"."source_transaction" <> "charges"."id"
+}
+
+Ref {
+    "transfers"."failure_balance_transaction" <> "balance_transactions"."id"
+}
+
+Ref {
+    "transfers"."destination_payment" <> "payment_methods"."id"
+}
+
+Ref {
+    "payment_intents"."customer" <> "customers"."id"
+}
+
+Ref {
+    "payment_intents"."invoice" <> "invoices"."id"
+}
+
+Ref {
+    "payment_intents"."payment_method" <> "payment_methods"."id"
+}
+
+Ref {
+    "payment_intents"."latest_charge" <> "charges"."id"
+}
+
+Ref {
+    "promotion_codes"."customer" <> "customers"."id"
+}
+
+Ref {
+    "setup_intents"."customer" <> "customers"."id"
+}
+
+Ref {
+    "setup_intents"."payment_method" <> "payment_methods"."id"
+}
+
+Ref {
+    "setup_intents"."latest_attempt" <> "setup_attempts"."id"
+}
+
+Ref {
+    "transactions"."card" <> "cards"."id"
+}
+
+Ref {
+    "transactions"."cardholder" <> "cardholders"."id"
+}
+
+Ref {
+    "transactions"."dispute" <> "disputes"."id"
+}
+
+Ref {
+    "transactions"."balance_transaction" <> "balance_transactions"."id"
+}
+
+Ref {
+    "top_ups"."balance_transaction" <> "balance_transactions"."id"
+}
+
+Ref {
+    "top_ups"."destination_balance" <> "balance_transactions"."id"
+}
+
+Ref {
+    "application_fees_refunds"."balance_transaction" <> "balance_transactions"."id"
+}
+
+Ref {
+    "application_fees_refunds"."fee" <> "application_fees"."id"
+}
+
+Ref {
+    "bank_accounts"."customer" <> "customers"."id"
+}
+
+Ref {
+    "checkout_sessions_line_items"."checkout_session_id" <> "checkout_sessions"."id"
+}
+
+Ref {
+    "invoice_line_items"."invoice" <> "invoices"."id"
+}
+
+Ref {
+    "invoice_line_items"."subscription" <> "subscriptions"."id"
+}
+
+Ref {
+    "invoice_line_items"."subscription_item" <> "subscription_items"."id"
+}
+
+Ref {
+    "invoice_line_items"."invoice_item" <> "invoice_items"."id"
+}
+
+Ref {
+    "subscription_items"."subscription" <> "subscriptions"."id"
+}
+
+Ref {
+    "subscription_items"."customer" <> "customers"."id"
+}
+
+Ref {
+    "transfer_reversals"."balance_transaction" <> "balance_transactions"."id"
+}
+
+Ref {
+    "transfer_reversals"."transfer" <> "transfers"."id"
+}
+
+Ref {
+    "transfer_reversals"."source_refund" <> "refunds"."id"
+}
+
+Ref {
+    "transfer_reversals"."destination_payment_refund" <> "refunds"."id"
+}
+
+Ref {
+    "usage_records"."invoice" <> "invoices"."id"
+}
+
+Ref {
+    "usage_records"."subscription_item" <> "subscription_items"."id"
+}

--- a/airbyte-integrations/connectors/source-stripe/metadata.yaml
+++ b/airbyte-integrations/connectors/source-stripe/metadata.yaml
@@ -13,6 +13,7 @@ data:
   dockerImageTag: 5.5.1
   dockerRepository: airbyte/source-stripe
   documentationUrl: https://docs.airbyte.com/integrations/sources/stripe
+  erdUrl: https://dbdocs.io/airbyteio/source-stripe?view=relationships
   githubIssueLabel: source-stripe
   icon: stripe.svg
   license: ELv2


### PR DESCRIPTION
## What
Addresses https://github.com/airbytehq/airbyte-internal-issues/issues/9173 for source-stripe

## How
By running `airbyte-ci --name=source-stripe generate-erd`

The publish has been done as part of the airbyte-ci command executed locally.

## User Impact
ERD is now available on https://dbdocs.io/airbyteio/source-stripe

## Can this PR be safely reverted and rolled back?
- [X] YES 💚
- [ ] NO ❌

