### PR TITLE
Source Facebook Marketing: Update erdUrl

### DIFF
--- a/airbyte-integrations/connectors/source-facebook-marketing/metadata.yaml
+++ b/airbyte-integrations/connectors/source-facebook-marketing/metadata.yaml
@@ -14,7 +14,7 @@ data:
   dockerRepository: airbyte/source-facebook-marketing
   documentationUrl: https://docs.airbyte.com/integrations/sources/facebook-marketing
   githubIssueLabel: source-facebook-marketing
-  erdUrl: https://dbdocs.io/maximec5e237b90b/source-facebook-marketing
+  erdUrl: https://dbdocs.io/airbyteio/source-facebook-marketing?view=relationships
   icon: facebook.svg
   license: ELv2
   maxSecondsBetweenMessages: 86400


### PR DESCRIPTION
## What
The erdUrl for source-facebook-marketing was pointing at my own dbdocs account. This PR updates the URL to use the airbyteio one.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [X] YES 💚
- [ ] NO ❌
