### PR TITLE
connector acceptance tests: bug fixes

### DIFF
--- a/airbyte-integrations/bases/connector-acceptance-test/CHANGELOG.md
+++ b/airbyte-integrations/bases/connector-acceptance-test/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.9.1
+
+Bug fixes for dagger execution caching and for failure trace message test case.
+
 ## 3.9.0
 
 Add support for using `manifest.yaml` as a spec input.

--- a/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/tests/test_core.py
+++ b/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/tests/test_core.py
@@ -31,6 +31,7 @@ from airbyte_protocol.models import (
     ConfiguredAirbyteCatalog,
     ConfiguredAirbyteStream,
     ConnectorSpecification,
+    DestinationSyncMode,
     Status,
     SyncMode,
     TraceType,
@@ -1151,11 +1152,21 @@ class TestBasicRead(BaseTest):
                 ConfiguredAirbyteStream.construct(
                     stream=AirbyteStream(
                         name="__AIRBYTE__stream_that_does_not_exist",
+                        namespace="__AIRBYTE__namespace_that_does_not_exist",
                         json_schema={"type": "object", "properties": {"f1": {"type": "string"}}},
                         supported_sync_modes=[SyncMode.full_refresh],
+                        source_defined_primary_key=[],
+                        source_defined_cursor=False,
+                        default_cursor_field=[],
+                        is_resumable=False,
                     ),
-                    sync_mode="INVALID",
-                    destination_sync_mode="INVALID",
+                    sync_mode=SyncMode.full_refresh,
+                    destination_sync_mode=DestinationSyncMode.append,
+                    primary_key=[],
+                    cursor_field=[],
+                    minimum_generation_id=1,
+                    generation_id=1,
+                    sync_id=1,
                 )
             ]
         )

--- a/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/tests/test_core.py
+++ b/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/tests/test_core.py
@@ -1148,7 +1148,11 @@ class TestBasicRead(BaseTest):
 
         invalid_configured_catalog = ConfiguredAirbyteCatalog(
             streams=[
-                # create ConfiguredAirbyteStream without validation
+                # Create ConfiguredAirbyteStream without validation.
+                #
+                # Care must be taken for the created object to be valid regardless.
+                # Connectors using the Bulk CDK will perform schema validation
+                # https://github.com/airbytehq/airbyte/blob/master/airbyte-cdk/bulk/core/base/src/main/kotlin/io/airbyte/cdk/command/ConfiguredCatalogFactory.kt#L29
                 ConfiguredAirbyteStream.construct(
                     stream=AirbyteStream(
                         name="__AIRBYTE__stream_that_does_not_exist",

--- a/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/utils/client_container_runner.py
+++ b/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/utils/client_container_runner.py
@@ -4,6 +4,7 @@
 
 import json
 import os
+import uuid
 from glob import glob
 from pathlib import Path
 from typing import List
@@ -54,7 +55,7 @@ async def _run_with_config(container: dagger.Container, command: List[str], conf
 
 
 async def _run(container: dagger.Container, command: List[str]) -> dagger.Container:
-    return await container.with_exec(command, skip_entrypoint=True)
+    return await (container.with_env_variable("CACHEBUSTER", str(uuid.uuid4())).with_exec(command, skip_entrypoint=True))
 
 
 async def get_client_container(dagger_client: dagger.Client, connector_path: Path, dockerfile_path: Path):

--- a/airbyte-integrations/bases/connector-acceptance-test/pyproject.toml
+++ b/airbyte-integrations/bases/connector-acceptance-test/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "connector-acceptance-test"
-version = "3.9.0"
+version = "3.9.1"
 description = "Contains acceptance tests for connectors."
 authors = ["Airbyte <contact@airbyte.io>"]
 license = "MIT"


### PR DESCRIPTION
## What
Bug fixes for dagger execution caching and for failure trace message test case in the connector acceptance test suite.

## User Impact
Decreased chance of false positive CAT test runs.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
