### PR TITLE
fix(sources): registryOverrides indentation on builder-contributed connectors

### DIFF
--- a/airbyte-integrations/connectors/source-basecamp/metadata.yaml
+++ b/airbyte-integrations/connectors/source-basecamp/metadata.yaml
@@ -3,7 +3,7 @@ data:
   allowedHosts:
     hosts:
       - "*"
-    registries:
+  registryOverrides:
     oss:
       enabled: true
     cloud:

--- a/airbyte-integrations/connectors/source-breezy-hr/metadata.yaml
+++ b/airbyte-integrations/connectors/source-breezy-hr/metadata.yaml
@@ -3,7 +3,7 @@ data:
   allowedHosts:
     hosts:
       - "*"
-    registryOverrides:
+  registryOverrides:
     oss:
       enabled: true
     cloud:

--- a/airbyte-integrations/connectors/source-leadfeeder/metadata.yaml
+++ b/airbyte-integrations/connectors/source-leadfeeder/metadata.yaml
@@ -3,7 +3,7 @@ data:
   allowedHosts:
     hosts:
       - "*"
-    registryOverrides:
+  registryOverrides:
     oss:
       enabled: true
     cloud:

--- a/airbyte-integrations/connectors/source-pennylane/metadata.yaml
+++ b/airbyte-integrations/connectors/source-pennylane/metadata.yaml
@@ -3,7 +3,7 @@ data:
   allowedHosts:
     hosts:
       - "*"
-    registryOverrides:
+  registryOverrides:
     oss:
       enabled: true
     cloud:


### PR DESCRIPTION
## What

I've made a few PRs yesterday with sources from Builder, and noticed now that the `registryOverrides` key indentation was broken.
