### PR TITLE
[source-hubspot] P0 - Pin back to 4.2.15 on Cloud

### DIFF
--- a/airbyte-integrations/connectors/source-hubspot/metadata.yaml
+++ b/airbyte-integrations/connectors/source-hubspot/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 36c891d9-4bd9-43ac-bad2-10e12756272c
-  dockerImageTag: 4.2.15
+  dockerImageTag: 4.2.16
   dockerRepository: airbyte/source-hubspot
   documentationUrl: https://docs.airbyte.com/integrations/sources/hubspot
   githubIssueLabel: source-hubspot
@@ -24,6 +24,7 @@ data:
       packageName: airbyte-source-hubspot
   registryOverrides:
     cloud:
+      dockerImageTag: 4.2.15
       enabled: true
     oss:
       enabled: true

--- a/airbyte-integrations/connectors/source-hubspot/metadata.yaml
+++ b/airbyte-integrations/connectors/source-hubspot/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 36c891d9-4bd9-43ac-bad2-10e12756272c
-  dockerImageTag: 4.2.16
+  dockerImageTag: 4.2.15
   dockerRepository: airbyte/source-hubspot
   documentationUrl: https://docs.airbyte.com/integrations/sources/hubspot
   githubIssueLabel: source-hubspot


### PR DESCRIPTION
## What
OC Issue: https://github.com/airbytehq/oncall/issues/6316
Pin back to previous version before `DealSplit` stream was added.
    - [DealSplit PR](https://github.com/airbytehq/airbyte/pull/42919) that was merged ~10 hours ago

## How
- Updates `dockerImageTag` to 4.2.15

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
