### PR TITLE
[source-hubspot] - Fix `associations` issue with streams that inherit from `CRMSearchStream` class

### DIFF
--- a/airbyte-integrations/connectors/source-hubspot/metadata.yaml
+++ b/airbyte-integrations/connectors/source-hubspot/metadata.yaml
@@ -24,7 +24,6 @@ data:
       packageName: airbyte-source-hubspot
   registryOverrides:
     cloud:
-      dockerImageTag: 4.2.15
       enabled: true
     oss:
       enabled: true

--- a/airbyte-integrations/connectors/source-hubspot/metadata.yaml
+++ b/airbyte-integrations/connectors/source-hubspot/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 36c891d9-4bd9-43ac-bad2-10e12756272c
-  dockerImageTag: 4.2.15
+  dockerImageTag: 4.2.16
   dockerRepository: airbyte/source-hubspot
   documentationUrl: https://docs.airbyte.com/integrations/sources/hubspot
   githubIssueLabel: source-hubspot
@@ -24,6 +24,7 @@ data:
       packageName: airbyte-source-hubspot
   registryOverrides:
     cloud:
+      dockerImageTag: 4.2.15
       enabled: true
     oss:
       enabled: true

--- a/airbyte-integrations/connectors/source-hubspot/metadata.yaml
+++ b/airbyte-integrations/connectors/source-hubspot/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 36c891d9-4bd9-43ac-bad2-10e12756272c
-  dockerImageTag: 4.2.16
+  dockerImageTag: 4.2.17
   dockerRepository: airbyte/source-hubspot
   documentationUrl: https://docs.airbyte.com/integrations/sources/hubspot
   githubIssueLabel: source-hubspot

--- a/airbyte-integrations/connectors/source-hubspot/metadata.yaml
+++ b/airbyte-integrations/connectors/source-hubspot/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 36c891d9-4bd9-43ac-bad2-10e12756272c
-  dockerImageTag: 4.2.16
+  dockerImageTag: 4.2.15
   dockerRepository: airbyte/source-hubspot
   documentationUrl: https://docs.airbyte.com/integrations/sources/hubspot
   githubIssueLabel: source-hubspot

--- a/airbyte-integrations/connectors/source-hubspot/pyproject.toml
+++ b/airbyte-integrations/connectors/source-hubspot/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "4.2.16"
+version = "4.2.17"
 name = "source-hubspot"
 description = "Source implementation for HubSpot."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-hubspot/source_hubspot/streams.py
+++ b/airbyte-integrations/connectors/source-hubspot/source_hubspot/streams.py
@@ -1092,7 +1092,7 @@ class CRMSearchStream(IncrementalStream, ABC):
     state_pk = "updatedAt"
     updated_at_field = "updatedAt"
     last_modified_field: str = None
-    associations: List[str] = None
+    associations: List[str] = []
     fully_qualified_name: str = None
 
     # added to guarantee the data types, declared for the stream's schema

--- a/airbyte-integrations/connectors/source-hubspot/source_hubspot/streams.py
+++ b/airbyte-integrations/connectors/source-hubspot/source_hubspot/streams.py
@@ -1187,7 +1187,8 @@ class CRMSearchStream(IncrementalStream, ABC):
                     stream_state=stream_state,
                     stream_slice=stream_slice,
                 )
-                records = self._read_associations(records)
+                if self.associations:
+                    records = self._read_associations(records)
             else:
                 records, raw_response = self._read_stream_records(
                     stream_slice=stream_slice,

--- a/airbyte-integrations/connectors/source-hubspot/source_hubspot/streams.py
+++ b/airbyte-integrations/connectors/source-hubspot/source_hubspot/streams.py
@@ -2250,7 +2250,6 @@ class Tickets(CRMSearchStream):
 
 class CustomObject(CRMSearchStream, ABC):
     last_modified_field = "hs_lastmodifieddate"
-    associations = []
     primary_key = "id"
     scopes = {"crm.schemas.custom.read", "crm.objects.custom.read"}
 

--- a/airbyte-integrations/connectors/source-hubspot/unit_tests/test_streams.py
+++ b/airbyte-integrations/connectors/source-hubspot/unit_tests/test_streams.py
@@ -191,6 +191,58 @@ def test_streams_read(stream, endpoint, cursor_value, requests_mock, common_para
     records = read_full_refresh(stream)
     assert records
 
+@pytest.mark.parametrize("sync_mode", [SyncMode.full_refresh, SyncMode.incremental])
+def test_crm_search_streams_with_no_associations(sync_mode, common_params,  requests_mock, fake_properties_list):
+    stream = DealSplits(**common_params)
+    stream_state = {
+        "type": "STREAM",
+        "stream": {
+            "stream_descriptor": { "name": "deal_splits" },
+            "stream_state": { "updatedAt": "2021-01-01T00:00:00.000000Z" }
+        }
+    }
+    cursor_value = {"updatedAt": "2022-02-25T16:43:11Z"}
+    responses = [
+        {
+            "json": {
+                stream.data_field: [
+                    {
+                        "id": "test_id",
+                        "created": "2022-02-25T16:43:11Z",
+                    }
+                    | cursor_value
+                ],
+            }
+        }
+    ]
+    if sync_mode == SyncMode.full_refresh:
+        stream.set_sync(SyncMode.full_refresh, stream_state=None)
+        endpoint_path = f"/crm/v3/objects/{stream.entity}"
+        requests_mock.register_uri("GET", endpoint_path, responses)
+    else:
+        stream.set_sync(SyncMode.incremental, stream_state)
+        endpoint_path = f"/crm/v3/objects/{stream.entity}/search"
+        requests_mock.register_uri("POST", endpoint_path, responses)
+    properties_path = f"/properties/v2/{stream.entity}/properties"
+    properties_response = [
+        {
+            "json": [
+                {"name": property_name, "type": "string", "updatedAt": 1571085954360, "createdAt": 1565059306048}
+                for property_name in fake_properties_list
+            ],
+            "status_code": 200,
+        }
+    ]
+    stream._sync_mode = sync_mode
+    requests_mock.register_uri("POST", endpoint_path, responses)
+    requests_mock.register_uri("GET", properties_path, properties_response)
+    if sync_mode == SyncMode.incremental:
+        records, state = read_incremental(stream, stream_state=stream_state)
+        assert state
+    else:
+        records = read_full_refresh(stream)
+    assert records
+
 
 @pytest.mark.parametrize(
     "error_response",

--- a/docs/integrations/sources/hubspot.md
+++ b/docs/integrations/sources/hubspot.md
@@ -332,7 +332,7 @@ The connector is restricted by normal HubSpot [rate limitations](https://legacyd
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                                                                          |
 |:--------|:-----------|:---------------------------------------------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 4.2.17  | 2024-08-21 | [XXXXX](https://github.com/airbytehq/airbyte/pull/XXXXX) | Fix issue with CRM search streams when they have no `associations`  |
+| 4.2.17  | 2024-08-21 | [44538](https://github.com/airbytehq/airbyte/pull/44538) | Fix issue with CRM search streams when they have no `associations`  |
 | 4.2.16  | 2024-08-20 | [42919](https://github.com/airbytehq/airbyte/pull/42919) | Add support for Deal Splits |
 | 4.2.15  | 2024-08-08 | [43381](https://github.com/airbytehq/airbyte/pull/43381) | Fix associations retrieval for Engagements streams (calls, meetings, notes, tasks, emails) in Incremental with existing state |
 | 4.2.14  | 2024-07-27 | [42688](https://github.com/airbytehq/airbyte/pull/42688) | Update dependencies |

--- a/docs/integrations/sources/hubspot.md
+++ b/docs/integrations/sources/hubspot.md
@@ -104,7 +104,7 @@ To set up a Private App, you must manually configure scopes to ensure Airbyte ca
 
 <FieldAnchor field="start_date">
 
-6. For **Start date**, use the provided datepicker or enter the date in the following format: `yyyy-mm-ddThh:mm:ssZ`. Data added on and after this date will be replicated. If this is not set, "2006-06-01T00:00:00Z" (the date Hubspot was created) will be used as a start date. 
+6. For **Start date**, use the provided datepicker or enter the date in the following format: `yyyy-mm-ddThh:mm:ssZ`. Data added on and after this date will be replicated. If this is not set, "2006-06-01T00:00:00Z" (the date Hubspot was created) will be used as a start date.
 
 </FieldAnchor>
 
@@ -276,9 +276,9 @@ The connector is restricted by normal HubSpot [rate limitations](https://legacyd
   }
   ```
 
-- **Hubspot object labels** In Hubspot, a label can be applied to a stream that differs from the original API name of the stream. Hubspot's UI shows the label of the stream, whereas Airbyte shows the name of the stream. If you are having issues seeing a particular stream your user should have access to, search for the `name` of the Hubspot object instead. 
+- **Hubspot object labels** In Hubspot, a label can be applied to a stream that differs from the original API name of the stream. Hubspot's UI shows the label of the stream, whereas Airbyte shows the name of the stream. If you are having issues seeing a particular stream your user should have access to, search for the `name` of the Hubspot object instead.
 
-- **Unnesting top level properties**: Since version 1.5.0, in order to offer users access to nested fields, we also denest the top-level fields into individual fields in the destination. This is most commonly observed in the `properties` field, which is now split into each attribute in the destination. 
+- **Unnesting top level properties**: Since version 1.5.0, in order to offer users access to nested fields, we also denest the top-level fields into individual fields in the destination. This is most commonly observed in the `properties` field, which is now split into each attribute in the destination.
 
   For instance:
 
@@ -332,6 +332,7 @@ The connector is restricted by normal HubSpot [rate limitations](https://legacyd
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                                                                          |
 |:--------|:-----------|:---------------------------------------------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 4.2.17  | 2024-08-21 | [XXXXX](https://github.com/airbytehq/airbyte/pull/XXXXX) | Fix issue with CRM search streams when they have no `associations`  |
 | 4.2.16  | 2024-08-20 | [42919](https://github.com/airbytehq/airbyte/pull/42919) | Add support for Deal Splits |
 | 4.2.15  | 2024-08-08 | [43381](https://github.com/airbytehq/airbyte/pull/43381) | Fix associations retrieval for Engagements streams (calls, meetings, notes, tasks, emails) in Incremental with existing state |
 | 4.2.14  | 2024-07-27 | [42688](https://github.com/airbytehq/airbyte/pull/42688) | Update dependencies |


### PR DESCRIPTION
## What
- OC Issue: https://github.com/airbytehq/oncall/issues/6316
- `CRMSearchStream`:
    - Update default associations value `associations = []`
    - Add conditional to check if stream has `associations` prior to invoking `self._read_associations`

## User Impact
- Successful `deal_splits` syncs

## Can this PR be safely reverted and rolled back?
- [X] YES 💚
- [ ] NO ❌
