### PR TITLE
connector acceptance tests: relax test_oneof_usage const criteria

### DIFF
--- a/airbyte-ci/connectors/live-tests/README.md
+++ b/airbyte-ci/connectors/live-tests/README.md
@@ -279,6 +279,10 @@ The traffic recorded on the control connector is passed to the target connector 
 
 ## Changelog
 
+### 0.18.5
+
+Relax test_oneof_usage criteria for constant value definitions in connector SPEC output.
+
 ### 0.18.4
 
 Bugfix: Use connection-retriever 0.7.2

--- a/airbyte-ci/connectors/live-tests/pyproject.toml
+++ b/airbyte-ci/connectors/live-tests/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "live-tests"
-version = "0.18.4"
+version = "0.18.5"
 description = "Contains utilities for testing connectors against live data."
 authors = ["Airbyte <contact@airbyte.io>"]
 license = "MIT"

--- a/airbyte-integrations/bases/connector-acceptance-test/CHANGELOG.md
+++ b/airbyte-integrations/bases/connector-acceptance-test/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.9.2
+
+Relax test_oneof_usage criteria for constant value definitions.
+
 ## 3.9.1
 
 Bug fixes for dagger execution caching and for failure trace message test case.

--- a/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/tests/test_core.py
+++ b/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/tests/test_core.py
@@ -197,22 +197,32 @@ class TestSpec(BaseTest):
             assert common_props, f"There should be at least one common property for {oneof_path} subobjects. {docs_msg}"
 
             const_common_props = set()
+            enum_common_props = set()
             for common_prop in common_props:
                 if all(["const" in variant["properties"][common_prop] for variant in variants]):
                     const_common_props.add(common_prop)
-            assert (
-                len(const_common_props) == 1
-            ), f"There should be exactly one common property with 'const' keyword for {oneof_path} subobjects. {docs_msg}"
+                if all(["enum" in variant["properties"][common_prop] for variant in variants]):
+                    enum_common_props.add(common_prop)
+            assert len(const_common_props) == 1 or (
+                len(const_common_props) == 0 and len(enum_common_props) == 1
+            ), f"There should be exactly one common property with 'const' keyword (or equivalent) for {oneof_path} subobjects. {docs_msg}"
 
-            const_common_prop = const_common_props.pop()
+            const_common_prop = const_common_props.pop() if const_common_props else enum_common_props.pop()
             for n, variant in enumerate(variants):
                 prop_obj = variant["properties"][const_common_prop]
-                assert (
-                    "default" not in prop_obj or prop_obj["default"] == prop_obj["const"]
-                ), f"'default' needs to be identical to const in common property {oneof_path}[{n}].{const_common_prop}. It's recommended to just use `const`. {docs_msg}"
-                assert "enum" not in prop_obj or (
-                    len(prop_obj["enum"]) == 1 and prop_obj["enum"][0] == prop_obj["const"]
-                ), f"'enum' needs to be an array with a single item identical to const in common property {oneof_path}[{n}].{const_common_prop}. It's recommended to just use `const`. {docs_msg}"
+                prop_info = f"common property {oneof_path}[{n}].{const_common_prop}. It's recommended to just use `const`."
+                if "const" in prop_obj:
+                    const_value = prop_obj["const"]
+                    assert (
+                        "default" not in prop_obj or prop_obj["default"] == const_value
+                    ), f"'default' needs to be identical to 'const' in {prop_info}. {docs_msg}"
+                    assert "enum" not in prop_obj or prop_obj["enum"] == [
+                        const_value
+                    ], f"'enum' needs to be an array with a single item identical to 'const' in {prop_info}. {docs_msg}"
+                else:
+                    assert (
+                        "enum" in prop_obj and "default" in prop_obj and prop_obj["enum"] == [prop_obj["default"]]
+                    ), f"'enum' needs to be an array with a single item identical to 'default' in {prop_info}. {docs_msg}"
 
     def test_required(self):
         """Check that connector will fail if any required field is missing"""

--- a/airbyte-integrations/bases/connector-acceptance-test/pyproject.toml
+++ b/airbyte-integrations/bases/connector-acceptance-test/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "connector-acceptance-test"
-version = "3.9.1"
+version = "3.9.2"
 description = "Contains acceptance tests for connectors."
 authors = ["Airbyte <contact@airbyte.io>"]
 license = "MIT"


### PR DESCRIPTION
## What

The Bulk CDK generates the JSON schema in the SPEC output automatically using a library. This library walks through the config class object recursively using java reflection and transforms certain annotations into json schema properties. In the case of `oneOf`s the libary will generate an `enum` with a singleton value and a `default` set to that value. The UI doesn't seem to mind, but the CAT suite complains that `const` is not present. I get that `const` is preferred, and why, but if it's not strictly necessary it shouldn't fail either.

## How

The assertions in `test_oneof_usage` are too strict.  This PR relaxes them.

## User Impact
None

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
