### PR TITLE
bulk-cdk: fix bugs surfaced by CAT tests

### DIFF
--- a/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/read/FeedReader.kt
+++ b/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/read/FeedReader.kt
@@ -41,6 +41,9 @@ class FeedReader(
                 log.info {
                     "no more partitions to read for '${feed.label}' in round $partitionsCreatorID"
                 }
+                // Publish a checkpoint if applicable.
+                maybeCheckpoint()
+                // Publish stream completion.
                 emitStreamStatus(AirbyteStreamStatusTraceMessage.AirbyteStreamStatus.COMPLETE)
                 break
             }
@@ -279,17 +282,24 @@ class FeedReader(
                 }
             } finally {
                 // Publish a checkpoint if applicable.
-                val stateMessages: List<AirbyteStateMessage> = root.stateManager.checkpoint()
-                if (stateMessages.isNotEmpty()) {
-                    log.info { "checkpoint of ${stateMessages.size} state message(s)" }
-                    stateMessages.forEach(root.outputConsumer::accept)
-                }
+                maybeCheckpoint()
             }
         }
     }
 
     private suspend fun ctx(nameSuffix: String): CoroutineContext =
         coroutineContext + ThreadRenamingCoroutineName("${feed.label}-$nameSuffix") + Dispatchers.IO
+
+    private fun maybeCheckpoint() {
+        val stateMessages: List<AirbyteStateMessage> = root.stateManager.checkpoint()
+        if (stateMessages.isEmpty()) {
+            return
+        }
+        log.info { "checkpoint of ${stateMessages.size} state message(s)" }
+        for (stateMessage in stateMessages) {
+            root.outputConsumer.accept(stateMessage)
+        }
+    }
 
     private fun emitStreamStatus(status: AirbyteStreamStatusTraceMessage.AirbyteStreamStatus) {
         if (feed is Stream) {

--- a/airbyte-cdk/bulk/toolkits/extract-jdbc/src/test/kotlin/io/airbyte/cdk/h2source/H2SourceIntegrationTest.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-jdbc/src/test/kotlin/io/airbyte/cdk/h2source/H2SourceIntegrationTest.kt
@@ -146,6 +146,50 @@ class H2SourceIntegrationTest {
         }
     }
 
+    @Test
+    fun testReadStreamStateTooFarAhead() {
+        H2TestFixture().use { h2: H2TestFixture ->
+            val configPojo =
+                H2SourceConfigurationJsonObject().apply {
+                    port = h2.port
+                    database = h2.database
+                    resumablePreferred = true
+                }
+            SyncsTestFixture.testReads(
+                configPojo,
+                h2::createConnection,
+                Companion::prelude,
+                "h2source/incremental-only-catalog.json",
+                "h2source/state-too-far-ahead.json",
+                SyncsTestFixture.AfterRead.Companion.fromExpectedMessages(
+                    "h2source/expected-messages-stream-too-far-ahead.json",
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun testReadBadCatalog() {
+        H2TestFixture().use { h2: H2TestFixture ->
+            val configPojo =
+                H2SourceConfigurationJsonObject().apply {
+                    port = h2.port
+                    database = h2.database
+                    resumablePreferred = true
+                }
+            SyncsTestFixture.testReads(
+                configPojo,
+                h2::createConnection,
+                Companion::prelude,
+                "h2source/bad-catalog.json",
+                initialStateResource = null,
+                SyncsTestFixture.AfterRead.Companion.fromExpectedMessages(
+                    "h2source/expected-messages-stream-bad-catalog.json",
+                ),
+            )
+        }
+    }
+
     companion object {
         @JvmStatic
         fun prelude(connection: Connection) {

--- a/airbyte-cdk/bulk/toolkits/extract-jdbc/src/test/resources/h2source/bad-catalog.json
+++ b/airbyte-cdk/bulk/toolkits/extract-jdbc/src/test/resources/h2source/bad-catalog.json
@@ -1,0 +1,27 @@
+{
+  "streams": [
+    {
+      "stream": {
+        "name": "FOO",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "BAR": {
+              "type": "string"
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "source_defined_cursor": false,
+        "default_cursor_field": [],
+        "source_defined_primary_key": [],
+        "is_resumable": false,
+        "namespace": "PUBLIC"
+      },
+      "sync_mode": "incremental",
+      "cursor_field": ["BAR"],
+      "destination_sync_mode": "overwrite",
+      "primary_key": []
+    }
+  ]
+}

--- a/airbyte-cdk/bulk/toolkits/extract-jdbc/src/test/resources/h2source/expected-messages-stream-bad-catalog.json
+++ b/airbyte-cdk/bulk/toolkits/extract-jdbc/src/test/resources/h2source/expected-messages-stream-bad-catalog.json
@@ -1,0 +1,24 @@
+[
+  {
+    "type": "LOG",
+    "log": {
+      "level": "WARN",
+      "message": "StreamNotFound(streamName=FOO, streamNamespace=PUBLIC)"
+    }
+  },
+  {
+    "type": "TRACE",
+    "trace": {
+      "type": "ERROR",
+      "emitted_at": 3.1336416e12,
+      "error": {
+        "stream_descriptor": {
+          "name": "FOO",
+          "namespace": "PUBLIC"
+        },
+        "message": "Stream 'PUBLIC_FOO' not found or not accessible in source.",
+        "failure_type": "config_error"
+      }
+    }
+  }
+]

--- a/airbyte-cdk/bulk/toolkits/extract-jdbc/src/test/resources/h2source/expected-messages-stream-too-far-ahead.json
+++ b/airbyte-cdk/bulk/toolkits/extract-jdbc/src/test/resources/h2source/expected-messages-stream-too-far-ahead.json
@@ -14,33 +14,6 @@
     }
   },
   {
-    "type": "TRACE",
-    "trace": {
-      "type": "STREAM_STATUS",
-      "emitted_at": 3.1336416e12,
-      "stream_status": {
-        "stream_descriptor": {
-          "name": "KV",
-          "namespace": "PUBLIC"
-        },
-        "status": "STARTED"
-      }
-    }
-  },
-  {
-    "type": "RECORD",
-    "record": {
-      "namespace": "PUBLIC",
-      "stream": "EVENTS",
-      "data": {
-        "ID": "3VWqE0Hrb7TV5BOEP2wN+g==",
-        "TS": "2024-04-30T00:00:00.000000-04:00",
-        "MSG": null
-      },
-      "emitted_at": 3133641600000
-    }
-  },
-  {
     "type": "STATE",
     "state": {
       "type": "STREAM",
@@ -57,21 +30,7 @@
         }
       },
       "sourceStats": {
-        "recordCount": 1.0
-      }
-    }
-  },
-  {
-    "type": "TRACE",
-    "trace": {
-      "type": "STREAM_STATUS",
-      "emitted_at": 3.1336416e12,
-      "stream_status": {
-        "stream_descriptor": {
-          "name": "KV",
-          "namespace": "PUBLIC"
-        },
-        "status": "COMPLETE"
+        "recordCount": 0.0
       }
     }
   },

--- a/airbyte-cdk/bulk/toolkits/extract-jdbc/src/test/resources/h2source/incremental-only-catalog.json
+++ b/airbyte-cdk/bulk/toolkits/extract-jdbc/src/test/resources/h2source/incremental-only-catalog.json
@@ -1,0 +1,36 @@
+{
+  "streams": [
+    {
+      "stream": {
+        "name": "EVENTS",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "ID": {
+              "type": "string",
+              "contentEncoding": "base64"
+            },
+            "TS": {
+              "type": "string",
+              "format": "date-time",
+              "airbyte_type": "timestamp_with_timezone"
+            },
+            "MSG": {
+              "type": "string"
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "source_defined_cursor": false,
+        "default_cursor_field": [],
+        "source_defined_primary_key": [["ID"]],
+        "is_resumable": true,
+        "namespace": "PUBLIC"
+      },
+      "sync_mode": "incremental",
+      "cursor_field": ["TS"],
+      "destination_sync_mode": "overwrite",
+      "primary_key": [["ID"]]
+    }
+  ]
+}

--- a/airbyte-cdk/bulk/toolkits/extract-jdbc/src/test/resources/h2source/state-too-far-ahead.json
+++ b/airbyte-cdk/bulk/toolkits/extract-jdbc/src/test/resources/h2source/state-too-far-ahead.json
@@ -1,0 +1,17 @@
+[
+  {
+    "type": "STREAM",
+    "stream": {
+      "stream_descriptor": {
+        "name": "EVENTS",
+        "namespace": "PUBLIC"
+      },
+      "stream_state": {
+        "primary_key": {},
+        "cursors": {
+          "TS": "2049-04-30T00:00:00.000000-04:00"
+        }
+      }
+    }
+  }
+]


### PR DESCRIPTION
## What
I tried to get the CAT tests running on airbyte-enterprise today. There were a few failures which surfaced bugs in the Bulk CDK, which doesn't always emit STATE or TRACE ERROR messages when required during a READ.

## How
Emit TRACE ERROR messages if the configured streams are bad.
Emit at least one STATE message for each stream with an input state.

## Review guide
Commit by commit

## User Impact
None

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
