### PR TITLE
Revert "docs: add SBOM url to metadata state in connector documentation (#44386)

### DIFF
--- a/docusaurus/src/components/ConnectorRegistry.jsx
+++ b/docusaurus/src/components/ConnectorRegistry.jsx
@@ -55,7 +55,6 @@ export default function ConnectorRegistry({ type }) {
             <th>OSS</th>
             <th>Cloud</th>
             <th>Docker Image</th>
-            <th>SBOM</th>
           </tr>
         </thead>
         <tbody>
@@ -98,13 +97,6 @@ export default function ConnectorRegistry({ type }) {
                       {connector.dockerRepository_oss}:
                       {connector.dockerImageTag_oss}
                     </code>
-                  </small>
-                </td>
-                <td>
-                  <small>
-                    {connector.generated_oss?.sbomUrl ? (
-                      <a target="_blank" href={connector.generated_oss.sbomUrl}>SPDX JSON</a>
-                    ) : "No SBOM"}
                   </small>
                 </td>
               </tr>

--- a/docusaurus/src/components/HeaderDecoration.jsx
+++ b/docusaurus/src/components/HeaderDecoration.jsx
@@ -236,7 +236,6 @@ const ConnectorMetadataCallout = ({
   syncSuccessRate,
   usageRate,
   lastUpdated,
-  sbomUrl,
 }) => (
   <Callout className={styles.connectorMetadataCallout}>
     <dl className={styles.connectorMetadata}>
@@ -282,7 +281,6 @@ const ConnectorMetadataCallout = ({
               lastUpdated
             ).fromNow()})`}</span>
           )}
-
         </MetadataStat>
       )}
       {cdkVersion && (
@@ -293,13 +291,6 @@ const ConnectorMetadataCallout = ({
           {isLatestCDK && (
             <span className={styles.deemphasizeText}>{"(Latest)"}</span>
           )}
-        </MetadataStat>
-      )}
-      {sbomUrl && (
-        <MetadataStat label="SBOM">
-          <a target="_blank" href={sbomUrl}>
-            SPDX JSON
-          </a>
         </MetadataStat>
       )}
       {syncSuccessRate && (
@@ -348,7 +339,6 @@ export const HeaderDecoration = ({
   syncSuccessRate,
   usageRate,
   lastUpdated,
-  sbomUrl,
 }) => {
   const isOss = boolStringToBool(isOssString);
   const isCloud = boolStringToBool(isCloudString);
@@ -379,7 +369,6 @@ export const HeaderDecoration = ({
         syncSuccessRate={syncSuccessRate}
         usageRate={usageRate}
         lastUpdated={lastUpdated}
-        sbomUrl={sbomUrl}
       />
     </>
   );

--- a/docusaurus/src/remark/docsHeaderDecoration.js
+++ b/docusaurus/src/remark/docsHeaderDecoration.js
@@ -48,11 +48,6 @@ const plugin = () => {
           "generated_[oss|cloud].source_file_info.metadata_last_modified"
         );
 
-        const sbomUrl = getFromPaths(
-          registryEntry,
-          "generated_[oss|cloud].sbomUrl"
-        )
-
         const { version, isLatest, url } = parseCDKVersion(
           rawCDKVersion,
           latestPythonCdkVersion
@@ -75,7 +70,6 @@ const plugin = () => {
           syncSuccessRate,
           usageRate,
           lastUpdated,
-          sbomUrl,
         };
 
         firstHeading = false;


### PR DESCRIPTION
## What
Given discussions [here](https://airbytehq-team.slack.com/archives/C032Y32T065/p1724230613701809) I prefer to revert this doc change until the product teams decide on how to expose SBOMs URLs to our users.
