### PR TITLE
Migrate ssh tunneling and source config out of core config

### DIFF
--- a/airbyte-cdk/bulk/core/base/src/main/kotlin/io/airbyte/cdk/command/Configuration.kt
+++ b/airbyte-cdk/bulk/core/base/src/main/kotlin/io/airbyte/cdk/command/Configuration.kt
@@ -1,22 +1,10 @@
 /* Copyright (c) 2024 Airbyte, Inc., all rights reserved. */
 package io.airbyte.cdk.command
 
-import io.airbyte.cdk.ssh.SshConnectionOptions
-import io.airbyte.cdk.ssh.SshTunnelMethodConfiguration
-import java.time.Duration
-
 /**
  * Interface that defines a typed connector configuration.
  *
  * Prefer this or its implementations over the corresponding configuration POJOs; i.e.
  * [ConfigurationJsonObjectBase] subclasses.
  */
-interface Configuration {
-    val realHost: String
-    val realPort: Int
-    val sshTunnel: SshTunnelMethodConfiguration
-    val sshConnectionOptions: SshConnectionOptions
-
-    val maxConcurrency: Int
-    val resourceAcquisitionHeartbeat: Duration
-}
+interface Configuration

--- a/airbyte-cdk/bulk/core/base/src/main/kotlin/io/airbyte/cdk/command/SshTunnelConfiguration.kt
+++ b/airbyte-cdk/bulk/core/base/src/main/kotlin/io/airbyte/cdk/command/SshTunnelConfiguration.kt
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.command
+
+import io.airbyte.cdk.ssh.SshConnectionOptions
+import io.airbyte.cdk.ssh.SshTunnelMethodConfiguration
+
+interface SshTunnelConfiguration {
+    val realHost: String
+    val realPort: Int
+    val sshTunnel: SshTunnelMethodConfiguration
+    val sshConnectionOptions: SshConnectionOptions
+}

--- a/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/command/SourceConfiguration.kt
+++ b/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/command/SourceConfiguration.kt
@@ -6,12 +6,16 @@ import jakarta.inject.Singleton
 import java.time.Duration
 
 /** Subtype of [Configuration] for sources. */
-interface SourceConfiguration : Configuration {
+interface SourceConfiguration : Configuration, SshTunnelConfiguration {
     /** Does READ generate states of type GLOBAL? */
     val global: Boolean
 
     /** During the READ operation, how often a feed should checkpoint, ideally. */
     val checkpointTargetInterval: Duration
+
+    /** Reader concurrency configuration. */
+    val maxConcurrency: Int
+    val resourceAcquisitionHeartbeat: Duration
 
     /**
      * Micronaut factory which glues [ConfigurationJsonObjectSupplier] and


### PR DESCRIPTION
Only some destinations have any use for this. I'd prefer to be able to mix it in as needed.

Also: a good future improvement would be to make corresponding user-facing json spec mixins for these, maybe with dedicated factory methods, so that implementors only have to grab what they need. 