### PR TITLE
bulk-cdk: source output performance improvements

### DIFF
--- a/airbyte-cdk/bulk/core/base/src/main/kotlin/io/airbyte/cdk/output/OutputConsumer.kt
+++ b/airbyte-cdk/bulk/core/base/src/main/kotlin/io/airbyte/cdk/output/OutputConsumer.kt
@@ -1,6 +1,7 @@
 /* Copyright (c) 2024 Airbyte, Inc., all rights reserved. */
 package io.airbyte.cdk.output
 
+import com.fasterxml.jackson.databind.SequenceWriter
 import io.airbyte.cdk.ConfigErrorException
 import io.airbyte.cdk.util.Jsons
 import io.airbyte.protocol.models.v0.AirbyteAnalyticsTraceMessage
@@ -112,6 +113,7 @@ private class StdoutOutputConsumer : OutputConsumer {
     override val emittedAt: Instant = Instant.now()
 
     private val buffer = ByteArrayOutputStream()
+    private val sequenceWriter: SequenceWriter = Jsons.writer().writeValues(buffer)
 
     override fun accept(airbyteMessage: AirbyteMessage) {
         // This method effectively println's its JSON-serialized argument.
@@ -121,12 +123,12 @@ private class StdoutOutputConsumer : OutputConsumer {
         // Other Airbyte message types are not buffered, instead they trigger an immediate flush.
         // Such messages should not linger indefinitely in a buffer.
         val isRecord: Boolean = airbyteMessage.type == AirbyteMessage.Type.RECORD
-        val json: ByteArray = Jsons.writeValueAsBytes(airbyteMessage)
         synchronized(this) {
             if (buffer.size() > 0) {
                 buffer.write('\n'.code)
             }
-            buffer.writeBytes(json)
+            sequenceWriter.write(airbyteMessage)
+            sequenceWriter.flush()
             if (!isRecord || buffer.size() >= BUFFER_MAX_SIZE) {
                 withLockFlush()
             }

--- a/airbyte-cdk/bulk/core/base/src/testFixtures/kotlin/io/airbyte/cdk/output/BufferingOutputConsumer.kt
+++ b/airbyte-cdk/bulk/core/base/src/testFixtures/kotlin/io/airbyte/cdk/output/BufferingOutputConsumer.kt
@@ -1,6 +1,7 @@
 /* Copyright (c) 2024 Airbyte, Inc., all rights reserved. */
 package io.airbyte.cdk.output
 
+import io.airbyte.cdk.util.Jsons
 import io.airbyte.protocol.models.v0.AirbyteCatalog
 import io.airbyte.protocol.models.v0.AirbyteConnectionStatus
 import io.airbyte.protocol.models.v0.AirbyteLogMessage
@@ -35,7 +36,10 @@ class BufferingOutputConsumer(
     private val traces = mutableListOf<AirbyteTraceMessage>()
     private val messages = mutableListOf<AirbyteMessage>()
 
-    override fun accept(m: AirbyteMessage) {
+    override fun accept(input: AirbyteMessage) {
+        // Deep copy the input, which may be reused and mutated later on.
+        val m: AirbyteMessage =
+            Jsons.readValue(Jsons.writeValueAsBytes(input), AirbyteMessage::class.java)
         synchronized(this) {
             messages.add(m)
             when (m.type) {

--- a/airbyte-cdk/bulk/core/extract/src/test/kotlin/io/airbyte/cdk/read/RootReaderIntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/extract/src/test/kotlin/io/airbyte/cdk/read/RootReaderIntegrationTest.kt
@@ -335,7 +335,7 @@ data class TestCase(
             )
             for (actualState in actual!!) {
                 Assertions.assertTrue(
-                    actualState in expected,
+                    actualState.toString() in expected.map { it.toString() },
                     "$actualState should be in $expected",
                 )
             }

--- a/airbyte-cdk/bulk/toolkits/extract-jdbc/src/test/kotlin/io/airbyte/cdk/read/JdbcPartitionReaderTest.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-jdbc/src/test/kotlin/io/airbyte/cdk/read/JdbcPartitionReaderTest.kt
@@ -47,7 +47,7 @@ class JdbcPartitionReaderTest {
                                     )
                                 ),
                             ),
-                            SelectQuerier.Parameters(fetchSize = 2),
+                            SelectQuerier.Parameters(reuseResultObject = true, fetchSize = 2),
                             """{"id":1,"ts":"2024-08-01","msg":"hello"}""",
                             """{"id":2,"ts":"2024-08-02","msg":"how"}""",
                             """{"id":3,"ts":"2024-08-03","msg":"are"}""",
@@ -126,7 +126,7 @@ class JdbcPartitionReaderTest {
                                 OrderBy(ts),
                                 Limit(4),
                             ),
-                            SelectQuerier.Parameters(fetchSize = 2),
+                            SelectQuerier.Parameters(reuseResultObject = true, fetchSize = 2),
                             """{"id":1,"ts":"2024-08-01","msg":"hello"}""",
                             """{"id":2,"ts":"2024-08-02","msg":"how"}""",
                             """{"id":3,"ts":"2024-08-03","msg":"are"}""",

--- a/airbyte-cdk/bulk/toolkits/extract-jdbc/src/test/kotlin/io/airbyte/cdk/read/JdbcSelectQuerierTest.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-jdbc/src/test/kotlin/io/airbyte/cdk/read/JdbcSelectQuerierTest.kt
@@ -1,6 +1,7 @@
 /* Copyright (c) 2024 Airbyte, Inc., all rights reserved. */
 package io.airbyte.cdk.read
 
+import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.node.ObjectNode
 import io.airbyte.cdk.discover.Field
 import io.airbyte.cdk.h2.H2TestFixture
@@ -77,7 +78,7 @@ class JdbcSelectQuerierTest {
 
     private fun runTest(
         q: SelectQuery,
-        vararg expected: String,
+        vararg expectedJson: String,
     ) {
         val configPojo: H2SourceConfigurationJsonObject =
             H2SourceConfigurationJsonObject().apply {
@@ -86,7 +87,21 @@ class JdbcSelectQuerierTest {
             }
         val config: H2SourceConfiguration = H2SourceConfigurationFactory().make(configPojo)
         val querier: SelectQuerier = JdbcSelectQuerier(JdbcConnectionFactory(config))
+        // Vanilla query
+        val expected: List<JsonNode> = expectedJson.map(Jsons::readTree)
         val actual: List<ObjectNode> = querier.executeQuery(q).use { it.asSequence().toList() }
-        Assertions.assertIterableEquals(expected.toList().map(Jsons::readTree), actual)
+        Assertions.assertIterableEquals(expected, actual)
+        // Query with reuseResultObject = true
+        querier.executeQuery(q, SelectQuerier.Parameters(reuseResultObject = true)).use {
+            var i = 0
+            var previous: ObjectNode? = null
+            for (record in it) {
+                if (i > 0) {
+                    Assertions.assertTrue(previous === record)
+                }
+                Assertions.assertEquals(expected[i++], record)
+                previous = record
+            }
+        }
     }
 }


### PR DESCRIPTION
## What

Informs https://github.com/airbytehq/airbyte-internal-issues/issues/9461

Performance of source-oracle is currently underwhelming. By running it on a t2.medium EC2 linux box with `cpulimit -l 30` to limit it to 30% of a cpu core, I was able to deduce that CPU usage was the performance bottleneck. 

The linux box was necessary because cpulimit isn't useful on mac for the jvm, it just ignores it! This explains why the connector was so fast on my local airbyte deployment compared to airbyte cloud.

By looking at wall-clock flame graphs collected by async-profiler, I was able to make some educated guesses as to which parts of the code could be improved. This PR contains those improvements.

Here's the before and after, with JDBC-driver stack frames in purple.

Before, only 40% of the time was spent actually fetching data from the source, and the remaining 60% of the time was spent in what's effectively overhead:
<img width="1904" alt="Screenshot 2024-08-28 at 15 42 45" src="https://github.com/user-attachments/assets/2629b8c8-ac99-4c12-88f2-99a92905e50d">

Afterwards, the ratios are inverted:
<img width="1903" alt="Screenshot 2024-08-28 at 15 43 00" src="https://github.com/user-attachments/assets/dce1947a-98f5-49cb-88a8-cfe45398548a">


## How

This PR has two commits.

Firstly, the `SelectQuerier` interface has an inner `data class Parameters` to which `val reuseResultObject: Boolean = false` has been added. When `false` as is the default nothing changes relative to how things are now. When `true` then the `next` method of the `Result` of the `executeQuery` method returns the same instance of `ObjectNode` from one call to the next. Instead of creating a new one it modifies the existing one in-place.

Furthermore, the `JdbcPartitionReader` cuts down on the garbage by re-using the `AirbyteMessage` of type RECORD, including its `ObjectNode` record data object, instead of re-creating those every single time.

This improves performance because it creates less garbage for the GC to collect in the first place, and also because adding entries into an empty object is expensive enough. Under the hood an `ObjectNode` is basically a `LinkedHashMap` and modifying in-place is cheap whereas rebuilding the whole linked list structure isn't as cheap.

Secondly, the `StdoutOutputConsumer` improves its jackson serialization. Instead of calling `ObjectMapper::writeValueAsBytes` which re-creates a `JsonGenerator` (albeit from an object pool) it uses a `SequenceWriter` which is the preferred way of serializing multiple values.


## Review guide
Commit by commit.

## User Impact
Bulk-CDK source connector READs should perform better. We'll see if that proves to be the case in the metabase cloud performance dashboard.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
