### PR TITLE
metadata-service[lib]: skip dockerImageTag decrement validation on pre-release

### DIFF
--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/validators/metadata_validator.py
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/validators/metadata_validator.py
@@ -178,6 +178,8 @@ def validate_pypi_only_for_python(
 def validate_docker_image_tag_is_not_decremented(
     metadata_definition: ConnectorMetadataDefinitionV0, _validator_opts: ValidatorOptions
 ) -> ValidationResult:
+    if _validator_opts and _validator_opts.prerelease_tag:
+        return True, None
     docker_image_name = get(metadata_definition, "data.dockerRepository")
     if not docker_image_name:
         return False, "The dockerRepository field is not set"
@@ -193,7 +195,10 @@ def validate_docker_image_tag_is_not_decremented(
     current_semver_version = semver.Version.parse(docker_image_tag)
     latest_released_semver_version = semver.Version.parse(latest_released_version)
     if current_semver_version < latest_released_semver_version:
-        return False, f"The dockerImageTag value can't be decremented: it should be equal to or above {latest_released_version}."
+        return (
+            False,
+            f"The dockerImageTag value ({current_semver_version}) can't be decremented: it should be equal to or above {latest_released_version}.",
+        )
     return True, None
 
 

--- a/airbyte-ci/connectors/metadata_service/lib/pyproject.toml
+++ b/airbyte-ci/connectors/metadata_service/lib/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metadata-service"
-version = "0.13.0"
+version = "0.13.1"
 description = ""
 authors = ["Ben Church <ben@airbyte.io>"]
 readme = "README.md"

--- a/airbyte-ci/connectors/metadata_service/lib/tests/test_validators/test_metadata_validators.py
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/test_validators/test_metadata_validators.py
@@ -71,7 +71,10 @@ def test_validation_fail_on_docker_image_tag_decrement(metadata_definition, decr
     metadata_definition.data.dockerImageTag = decremented_version
     success, error_message = metadata_validator.validate_docker_image_tag_is_not_decremented(metadata_definition, None)
     assert not success
-    assert error_message == f"The dockerImageTag value can't be decremented: it should be equal to or above {current_version}."
+    assert (
+        error_message
+        == f"The dockerImageTag value ({decremented_version}) can't be decremented: it should be equal to or above {current_version}."
+    )
 
 
 def test_validation_pass_on_docker_image_tag_increment(metadata_definition, incremented_version):


### PR DESCRIPTION
## What
On pre-release the process responsible for uploading the metadata patches the `dockerImageTag` with a `.dev<sha> `suffix.
When we run the second metadata validation, before upload, the pre-release version is compared to the latest version.
The semver packages consider this version as lower than the latest one as it considers its a pre-release of the latest version (which should usually be released before the main version). This is logically correct.

This PR bypasses this validation on pre-release as it's useless to have it in a pre-release / testing context.