### PR TITLE
bulk-cdk-core-base: replace schema validation library

### DIFF
--- a/airbyte-cdk/bulk/core/base/build.gradle
+++ b/airbyte-cdk/bulk/core/base/build.gradle
@@ -22,7 +22,6 @@ dependencies {
     implementation 'com.datadoghq:dd-trace-ot:1.28.0'
     implementation 'com.fasterxml.jackson.module:jackson-module-kotlin'
     implementation 'com.fasterxml.jackson.module:jackson-module-afterburner'
-    implementation 'com.networknt:json-schema-validator:1.4.0'
     implementation 'info.picocli:picocli:4.7.6'
     implementation 'io.micronaut.picocli:micronaut-picocli:5.5.0'
     implementation 'jakarta.validation:jakarta.validation-api:3.0.2'
@@ -33,6 +32,7 @@ dependencies {
     implementation 'org.apache.logging.log4j:log4j-slf4j2-impl'
     implementation 'org.apache.logging.log4j:log4j-layout-template-json:2.17.2'
     implementation 'org.bouncycastle:bcprov-jdk18on:1.77'
+    implementation 'org.openapi4j:openapi-schema-validator:1.0.7'
 
     runtimeOnly 'com.google.guava:guava:33.2.0-jre'
     runtimeOnly 'org.apache.commons:commons-compress:1.26.1'

--- a/airbyte-cdk/bulk/core/base/src/test/kotlin/io/airbyte/cdk/command/ConfiguredAirbyteCatalogTest.kt
+++ b/airbyte-cdk/bulk/core/base/src/test/kotlin/io/airbyte/cdk/command/ConfiguredAirbyteCatalogTest.kt
@@ -1,6 +1,7 @@
 /* Copyright (c) 2024 Airbyte, Inc., all rights reserved. */
 package io.airbyte.cdk.command
 
+import io.airbyte.cdk.ConfigErrorException
 import io.airbyte.cdk.util.Jsons
 import io.airbyte.cdk.util.ResourceUtils
 import io.airbyte.protocol.models.Field
@@ -69,7 +70,35 @@ class ConfiguredAirbyteCatalogTest {
         Assertions.assertEquals(expected, actual)
     }
 
+    @Test
+    fun testSchemaViolation() {
+        // Check that JSON is valid.
+        Assertions.assertDoesNotThrow {
+            Jsons.readTree(ResourceUtils.readResource(INVALID_CATALOG_RESOURCE))
+        }
+        // Check that schema is invalid.
+        Assertions.assertThrows(ConfigErrorException::class.java) {
+            ConfiguredCatalogFactory().makeFromTestResource(INVALID_CATALOG_RESOURCE)
+        }
+    }
+
+    @Test
+    fun testNoNamespace() {
+        // Check that JSON is valid.
+        Assertions.assertDoesNotThrow {
+            Jsons.readTree(ResourceUtils.readResource(NO_NAMESPACE_CATALOG_RESOURCE))
+        }
+        // Check that schema validation is not too strict.
+        // Some validators may believe that the namespace cannot be null,
+        // despite it not being a required field.
+        Assertions.assertDoesNotThrow {
+            ConfiguredCatalogFactory().makeFromTestResource(NO_NAMESPACE_CATALOG_RESOURCE)
+        }
+    }
+
     companion object {
         const val CATALOG_RESOURCE = "command/catalog.json"
+        const val INVALID_CATALOG_RESOURCE = "command/catalog-invalid.json"
+        const val NO_NAMESPACE_CATALOG_RESOURCE = "command/catalog-no-namespace.json"
     }
 }

--- a/airbyte-cdk/bulk/core/base/src/test/resources/command/catalog-invalid.json
+++ b/airbyte-cdk/bulk/core/base/src/test/resources/command/catalog-invalid.json
@@ -1,0 +1,28 @@
+{
+  "streams": [
+    {
+      "stream": {
+        "name": "bar",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "id": {
+              "type": "number"
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "default_cursor_field": [],
+        "source_defined_primary_key": [],
+        "namespace": "foo"
+      },
+      "sync_mode": "BLARGH",
+      "cursor_field": ["id"],
+      "destination_sync_mode": "append",
+      "primary_key": []
+    }
+  ]
+}

--- a/airbyte-cdk/bulk/core/base/src/test/resources/command/catalog-no-namespace.json
+++ b/airbyte-cdk/bulk/core/base/src/test/resources/command/catalog-no-namespace.json
@@ -1,0 +1,27 @@
+{
+  "streams": [
+    {
+      "stream": {
+        "name": "bar",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "id": {
+              "type": "number"
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "default_cursor_field": [],
+        "source_defined_primary_key": []
+      },
+      "sync_mode": "incremental",
+      "cursor_field": ["id"],
+      "destination_sync_mode": "append",
+      "primary_key": []
+    }
+  ]
+}

--- a/airbyte-cdk/bulk/core/extract/src/test/kotlin/io/airbyte/cdk/check/CheckTest.kt
+++ b/airbyte-cdk/bulk/core/extract/src/test/kotlin/io/airbyte/cdk/check/CheckTest.kt
@@ -24,7 +24,7 @@ class CheckTest {
     @Property(name = "airbyte.connector.config.database", value = "testdb")
     @Property(name = "metadata.resource", value = "discover/metadata-valid.json")
     fun testConfigBadPort() {
-        assertFailed(" must have a minimum value of 0".toRegex())
+        assertFailed("port: Minimum is '0', found '-1'. \\(code: 1015\\)".toRegex())
     }
 
     @Test


### PR DESCRIPTION
## What
The schema validation library we were using to validate the CLI inputs was too strict. For instance, it would complain that `namespace` would be `null` in an AirbyteStream, despite that being not a `required` field. 

It turns out that the reason for this is that the old schema validation library was for json-schema v7 whereas the airbyte protocol is defined for openapi. While these schema definition schemes are very similar they're not quite the same! Evidently openapi is a bit more liberal. In any case, openapi is what we care about anyway.

## How
Changed libraries, added regression test case, added more tests.

## Review guide
It's quite straightforward.

## User Impact
None whatsoever.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
