### PR TITLE
connector acceptance tests: fix regression in test_airbyte_trace_message_on_failure

### DIFF
--- a/airbyte-integrations/bases/connector-acceptance-test/CHANGELOG.md
+++ b/airbyte-integrations/bases/connector-acceptance-test/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.9.3
+
+Undo failure trace message test case changes from 3.9.1
+
 ## 3.9.2
 
 Relax test_oneof_usage criteria for constant value definitions.

--- a/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/tests/test_core.py
+++ b/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/tests/test_core.py
@@ -1158,29 +1158,17 @@ class TestBasicRead(BaseTest):
 
         invalid_configured_catalog = ConfiguredAirbyteCatalog(
             streams=[
-                # Create ConfiguredAirbyteStream without validation.
-                #
-                # Care must be taken for the created object to be valid regardless.
-                # Connectors using the Bulk CDK will perform schema validation
-                # https://github.com/airbytehq/airbyte/blob/master/airbyte-cdk/bulk/core/base/src/main/kotlin/io/airbyte/cdk/command/ConfiguredCatalogFactory.kt#L29
+                # Create ConfiguredAirbyteStream which is deliberately invalid
+                # with regard to the Airbyte Protocol.
+                # This should cause the connector to fail.
                 ConfiguredAirbyteStream.construct(
                     stream=AirbyteStream(
                         name="__AIRBYTE__stream_that_does_not_exist",
-                        namespace="__AIRBYTE__namespace_that_does_not_exist",
                         json_schema={"type": "object", "properties": {"f1": {"type": "string"}}},
                         supported_sync_modes=[SyncMode.full_refresh],
-                        source_defined_primary_key=[],
-                        source_defined_cursor=False,
-                        default_cursor_field=[],
-                        is_resumable=False,
                     ),
-                    sync_mode=SyncMode.full_refresh,
-                    destination_sync_mode=DestinationSyncMode.append,
-                    primary_key=[],
-                    cursor_field=[],
-                    minimum_generation_id=1,
-                    generation_id=1,
-                    sync_id=1,
+                    sync_mode="INVALID",
+                    destination_sync_mode="INVALID",
                 )
             ]
         )

--- a/airbyte-integrations/bases/connector-acceptance-test/pyproject.toml
+++ b/airbyte-integrations/bases/connector-acceptance-test/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "connector-acceptance-test"
-version = "3.9.2"
+version = "3.9.3"
 description = "Contains acceptance tests for connectors."
 authors = ["Airbyte <contact@airbyte.io>"]
 license = "MIT"


### PR DESCRIPTION
## What
Context: https://airbytehq-team.slack.com/archives/C02U9R3AF37/p1724417263754139

3.9.1 broke `test_airbyte_trace_message_on_failure`
See https://github.com/airbytehq/airbyte/pull/44529

## How

Undo the changes to `test_airbyte_trace_message_on_failure` in 3.9.1

## User Impact
CAT tests which failed in the last nightly might pass again in the next one.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
