### PR TITLE
patch verison bump for aws-java-sdk

### DIFF
--- a/deps.toml
+++ b/deps.toml
@@ -27,7 +27,7 @@ apache-commons = { module = "org.apache.commons:commons-compress", version = "1.
 apache-commons-lang = { module = "org.apache.commons:commons-lang3", version = "3.11" }
 appender-log4j2 = { module = "com.therealvan:appender-log4j2", version = "3.6.0" }
 assertj-core = { module = "org.assertj:assertj-core", version = "3.21.0" }
-aws-java-sdk-s3 = { module = "com.amazonaws:aws-java-sdk-s3", version = "1.12.6" }
+aws-java-sdk-s3 = { module = "com.amazonaws:aws-java-sdk-s3", version = "1.12.746" }
 commons-io = { module = "commons-io:commons-io", version.ref = "commons_io" }
 testcontainers = { module = "org.testcontainers:testcontainers", version.ref = "testcontainers" }
 testcontainers-cassandra = { module = "org.testcontainers:cassandra", version.ref = "testcontainers" }


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving.
* It helps to add screenshots if it affects the frontend.
-->
[This GitHub Issue] (https://github.com/aws/aws-sdk-java/issues/3062) for the aws java sdk discusses how version 1.12.746 of the sdk is the first version that supports the EKS pod identity add-on. Seeing how airbyte is moving to kubernetes deployment of it's open source platform, it makes sense for this sdk version to be updated to support EKS pod identity deployments.
## How
<!--
* Describe how code changes achieve the solution.
-->
Simply updating the aws-java-sdk dependency to be on version `1.12.746` will enable support for EKS pod identity to work. 
This [page](https://docs.aws.amazon.com/eks/latest/userguide/pod-id-minimum-sdk.html) shows which AWS SDKs and versions support EKS pod identity.

## Recommended reading order

## User Impact
Based on the information provided in {this GItHub issue) [https://github.com/aws/aws-sdk-java/issues/3062] I don't believe there to be any user impact. 

## Can this PR be safely reverted and rolled back?
<!--
* If you know that your be safely rolled back, check YES.*
* If that is not the case (e.g. a database migration), check NO.
* If unsure, leave it blank.*
-->
- [x] YES 💚
- [ ] NO ❌
