### PR TITLE
patch version bump for aws-java-sdk

### DIFF
--- a/airbyte-cdk/java/airbyte-cdk/s3-destinations/build.gradle
+++ b/airbyte-cdk/java/airbyte-cdk/s3-destinations/build.gradle
@@ -20,8 +20,8 @@ dependencies {
     implementation project(':airbyte-cdk:java:airbyte-cdk:airbyte-cdk-db-destinations')
 
     // Re-export dependencies for gcs-destinations.
-    api 'com.amazonaws:aws-java-sdk-s3:1.12.647'
-    api 'com.amazonaws:aws-java-sdk-sts:1.12.647'
+    api 'com.amazonaws:aws-java-sdk-s3:1.12.746'
+    api 'com.amazonaws:aws-java-sdk-sts:1.12.746'
     api ('com.github.airbytehq:json-avro-converter:1.1.3') { exclude group: 'ch.qos.logback', module: 'logback-classic'}
     api 'com.github.alexmojaki:s3-stream-upload:2.2.4'
     api 'org.apache.avro:avro:1.11.3'

--- a/airbyte-integrations/connectors/destination-dynamodb/build.gradle
+++ b/airbyte-integrations/connectors/destination-dynamodb/build.gradle
@@ -24,5 +24,5 @@ application {
 }
 
 dependencies {
-    implementation 'com.amazonaws:aws-java-sdk-dynamodb:1.12.47'
+    implementation 'com.amazonaws:aws-java-sdk-dynamodb:1.12.746'
 }

--- a/airbyte-integrations/connectors/destination-dynamodb/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-dynamodb/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: 8ccd8909-4e99-4141-b48d-4984b70b2d89
-  dockerImageTag: 0.1.8
+  dockerImageTag: 0.1.9
   dockerRepository: airbyte/destination-dynamodb
   githubIssueLabel: destination-dynamodb
   icon: dynamodb.svg

--- a/airbyte-integrations/connectors/destination-redshift/build.gradle
+++ b/airbyte-integrations/connectors/destination-redshift/build.gradle
@@ -32,7 +32,7 @@ application {
 
 dependencies {
 
-    implementation 'com.amazonaws:aws-java-sdk-s3:1.11.978'
+    implementation 'com.amazonaws:aws-java-sdk-s3:1.12.746'
     // TODO: Verify no aws sdk code is pulled by this dependency causing classpath conflicts
     // https://docs.aws.amazon.com/redshift/latest/mgmt/jdbc20-jdbc10-driver-differences.html
     implementation 'com.amazon.redshift:redshift-jdbc42:2.1.0.26'

--- a/airbyte-integrations/connectors/destination-s3-glue/build.gradle
+++ b/airbyte-integrations/connectors/destination-s3-glue/build.gradle
@@ -25,7 +25,7 @@ application {
 dependencies {
 
     // https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-glue
-    implementation 'com.amazonaws:aws-java-sdk-glue:1.12.334'
+    implementation 'com.amazonaws:aws-java-sdk-glue:1.12.746'
 
     implementation libs.aws.java.sdk.s3
     implementation libs.s3

--- a/airbyte-integrations/connectors/destination-s3-glue/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-s3-glue/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: file
   connectorType: destination
   definitionId: 471e5cab-8ed1-49f3-ba11-79c687784737
-  dockerImageTag: 0.1.8
+  dockerImageTag: 0.1.9
   dockerRepository: airbyte/destination-s3-glue
   githubIssueLabel: destination-s3-glue
   icon: s3-glue.svg

--- a/airbyte-integrations/connectors/destination-s3/build.gradle
+++ b/airbyte-integrations/connectors/destination-s3/build.gradle
@@ -27,7 +27,7 @@ application {
 dependencies {
 
     // csv
-    implementation 'com.amazonaws:aws-java-sdk-s3:1.11.978'
+    implementation 'com.amazonaws:aws-java-sdk-s3:1.12.746'
     implementation 'org.apache.commons:commons-csv:1.4'
     implementation 'com.github.alexmojaki:s3-stream-upload:2.2.2'
 

--- a/airbyte-integrations/connectors/destination-s3/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-s3/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: file
   connectorType: destination
   definitionId: 4816b78f-1489-44c1-9060-4b19d5fa9362
-  dockerImageTag: 1.0.2
+  dockerImageTag: 1.0.5
   dockerRepository: airbyte/destination-s3
   githubIssueLabel: destination-s3
   icon: s3.svg

--- a/airbyte-integrations/connectors/destination-s3/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-s3/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: file
   connectorType: destination
   definitionId: 4816b78f-1489-44c1-9060-4b19d5fa9362
-  dockerImageTag: 1.0.5
+  dockerImageTag: 1.0.6
   dockerRepository: airbyte/destination-s3
   githubIssueLabel: destination-s3
   icon: s3.svg

--- a/deps.toml
+++ b/deps.toml
@@ -27,7 +27,7 @@ apache-commons = { module = "org.apache.commons:commons-compress", version = "1.
 apache-commons-lang = { module = "org.apache.commons:commons-lang3", version = "3.11" }
 appender-log4j2 = { module = "com.therealvan:appender-log4j2", version = "3.6.0" }
 assertj-core = { module = "org.assertj:assertj-core", version = "3.21.0" }
-aws-java-sdk-s3 = { module = "com.amazonaws:aws-java-sdk-s3", version = "1.12.6" }
+aws-java-sdk-s3 = { module = "com.amazonaws:aws-java-sdk-s3", version = "1.12.746" }
 commons-io = { module = "commons-io:commons-io", version.ref = "commons_io" }
 testcontainers = { module = "org.testcontainers:testcontainers", version.ref = "testcontainers" }
 testcontainers-cassandra = { module = "org.testcontainers:cassandra", version.ref = "testcontainers" }

--- a/docs/integrations/destinations/dynamodb.md
+++ b/docs/integrations/destinations/dynamodb.md
@@ -79,6 +79,7 @@ provision more capacity units in the DynamoDB console when there are performance
 
 | Version | Date       | Pull Request                                               | Subject                                                     |
 | :------ | :--------- | :--------------------------------------------------------- | :---------------------------------------------------------- |
+| 0.1.9   | 2024-09-13 | [#44603](https://github.com/airbytehq/airbyte/pull/44603)  | Update AWS SDK version to support EKS Pod Identity           |
 | 0.1.8   | 2024-01-03 | [#33924](https://github.com/airbytehq/airbyte/pull/33924)  | Add new ap-southeast-3 AWS region                           |
 | 0.1.7   | 2022-11-03 | [\#18672](https://github.com/airbytehq/airbyte/pull/18672) | Added strict-encrypt cloud runner                           |
 | 0.1.6   | 2022-11-01 | [\#18672](https://github.com/airbytehq/airbyte/pull/18672) | Enforce to use ssl connection                               |

--- a/docs/integrations/destinations/s3-glue.md
+++ b/docs/integrations/destinations/s3-glue.md
@@ -306,6 +306,7 @@ the output filename will have an extra extension (GZIP: `.jsonl.gz`).
 
 | Version | Date       | Pull Request                                              | Subject                                                                                 |
 | :------ | :--------- | :-------------------------------------------------------- | :-------------------------------------------------------------------------------------- |
+| 0.1.9   | 2024-09-13 | [#44603](https://github.com/airbytehq/airbyte/pull/44603)  | Update AWS SDK version to support EKS Pod Identity           |
 | 0.1.8   | 2024-01-03 | [#33924](https://github.com/airbytehq/airbyte/pull/33924) | Add new ap-southeast-3 AWS region                                                       |
 | 0.1.7   | 2023-05-01 | [25724](https://github.com/airbytehq/airbyte/pull/25724)  | Fix decimal type creation syntax to avoid overflow                                      |
 | 0.1.6   | 2023-04-13 | [25178](https://github.com/airbytehq/airbyte/pull/25178)  | Fix decimal precision and scale to allow for a wider range of numeric values            |

--- a/docs/integrations/destinations/s3.md
+++ b/docs/integrations/destinations/s3.md
@@ -537,6 +537,7 @@ To see connector limitations, or troubleshoot your S3 connector, see more [in ou
 
 | Version | Date       | Pull Request                                               | Subject                                                                                                                                              |
 |:--------|:-----------|:-----------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| 1.0.6  | 2024-09-13 | [44603](https://github.com/airbytehq/airbyte/pull/44603)  | Update AWS SDK version to support EKS Pod Identity           |
 | 1.0.2   | 2024-08-19 | [44401](https://github.com/airbytehq/airbyte/pull/44401)   | Fix: S3 Avro/Parquet: handle nullable top-level schema                                                                                               |
 | 1.0.1   | 2024-08-14 | [42579](https://github.com/airbytehq/airbyte/pull/42579)   | OVERWRITE MODE: Deletes deferred until successful sync.                                                                                              |
 | 1.0.0   | 2024-08-08 | [42409](https://github.com/airbytehq/airbyte/pull/42409)   | Major breaking changes: new destination schema, change capture, Avro/Parquet improvements, bugfixes                                                  |


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving.
* It helps to add screenshots if it affects the frontend.
-->
[This GitHub Issue](https://github.com/aws/aws-sdk-java/issues/3062) for the aws java sdk discusses how version 1.12.746 of the sdk is the first version that supports the EKS pod identity add-on. Seeing how airbyte is moving to kubernetes deployment of it's open source platform, it makes sense for this sdk version to be updated to support EKS pod identity deployments.
## How
<!--
* Describe how code changes achieve the solution.
-->
Simply updating the aws-java-sdk dependency to be on version `1.12.746` will enable support for EKS pod identity to work. 
This [page](https://docs.aws.amazon.com/eks/latest/userguide/pod-id-minimum-sdk.html) shows which AWS SDKs and versions support EKS pod identity.

## Recommended reading order

## User Impact
Based on the information provided in (this GitHub issue)[https://github.com/aws/aws-sdk-java/issues/3062] I don't believe there to be any user impact. 

## Can this PR be safely reverted and rolled back?
<!--
* If you know that your be safely rolled back, check YES.*
* If that is not the case (e.g. a database migration), check NO.
* If unsure, leave it blank.*
-->
- [x] YES 💚
- [ ] NO ❌