### PR TITLE
🐛 airbyte-ci: skip archived connectors pre-emptively when using --modified flag

### DIFF
--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -843,6 +843,7 @@ airbyte-ci connectors --language=low-code migrate-to-manifest-only
 
 | Version | PR                                                         | Description                                                                                                                  |
 | ------- | ---------------------------------------------------------- |------------------------------------------------------------------------------------------------------------------------------|
+| 4.34.2  | []() | Pre-emptively skip archived connectors when searching for modified files |
 | 4.34.1  | [#44557](https://github.com/airbytehq/airbyte/pull/44557)  | Conditionally propagate parameters in manifest-only migration                                                                |
 | 4.34.0  | [#44551](https://github.com/airbytehq/airbyte/pull/44551)  | `connectors publish` do not push the `latest` tag when the current version is a release candidate.                           |
 | 4.33.1  | [#44465](https://github.com/airbytehq/airbyte/pull/44465)  | Ignore version check if only erd folder is changed                                                                           |

--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -843,7 +843,7 @@ airbyte-ci connectors --language=low-code migrate-to-manifest-only
 
 | Version | PR                                                         | Description                                                                                                                  |
 | ------- | ---------------------------------------------------------- |------------------------------------------------------------------------------------------------------------------------------|
-| 4.34.2  | []() | Pre-emptively skip archived connectors when searching for modified files |
+| 4.34.2  | [#44786](https://github.com/airbytehq/airbyte/pull/44786)  | Pre-emptively skip archived connectors when searching for modified files                                                     |
 | 4.34.1  | [#44557](https://github.com/airbytehq/airbyte/pull/44557)  | Conditionally propagate parameters in manifest-only migration                                                                |
 | 4.34.0  | [#44551](https://github.com/airbytehq/airbyte/pull/44551)  | `connectors publish` do not push the `latest` tag when the current version is a release candidate.                           |
 | 4.33.1  | [#44465](https://github.com/airbytehq/airbyte/pull/44465)  | Ignore version check if only erd folder is changed                                                                           |

--- a/airbyte-ci/connectors/pipelines/pipelines/helpers/connectors/modifed.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/helpers/connectors/modifed.py
@@ -56,7 +56,9 @@ def get_modified_connectors(modified_files: Set[Path], all_connectors: Set[Conne
     # Ignore files with certain extensions
     modified_connectors = set()
     active_connectors = {conn for conn in all_connectors if conn.support_level != "archived"}
-    main_logger.info(f"Checking for modified files. Skipping {len(all_connectors) - len(active_connectors)} connectors with support level 'archived'.")
+    main_logger.info(
+        f"Checking for modified files. Skipping {len(all_connectors) - len(active_connectors)} connectors with support level 'archived'."
+    )
     for modified_file in modified_files:
         if not _is_ignored_file(modified_file):
             modified_connectors.update(_find_modified_connectors(modified_file, active_connectors, dependency_scanning))

--- a/airbyte-ci/connectors/pipelines/pipelines/helpers/connectors/modifed.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/helpers/connectors/modifed.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 #
 
-import time
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import FrozenSet, Set, Union
@@ -57,12 +56,9 @@ def get_modified_connectors(modified_files: Set[Path], all_connectors: Set[Conne
     """
     # Ignore files with certain extensions
     modified_connectors = set()
-    start_time = time.time()
     for modified_file in modified_files:
         if not _is_ignored_file(modified_file):
             modified_connectors.update(_find_modified_connectors(modified_file, all_connectors, dependency_scanning))
-    end_time = time.time()
-    print(f"Time taken to find modified connectors: {end_time - start_time} seconds")
     return modified_connectors
 
 

--- a/airbyte-ci/connectors/pipelines/pipelines/helpers/connectors/modifed.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/helpers/connectors/modifed.py
@@ -21,10 +21,9 @@ def get_connector_modified_files(connector: Connector, all_modified_files: Set[P
 
 
 def _find_modified_connectors(
-    file_path: Union[str, Path], all_connectors: Set[Connector], dependency_scanning: bool = True
+    file_path: Union[str, Path], active_connectors: Set[Connector], dependency_scanning: bool = True
 ) -> Set[Connector]:
     """Find all connectors impacted by the file change."""
-    active_connectors = {conn for conn in all_connectors if conn.support_level != "archived"}
     modified_connectors = set()
 
     for connector in active_connectors:
@@ -56,9 +55,11 @@ def get_modified_connectors(modified_files: Set[Path], all_connectors: Set[Conne
     """
     # Ignore files with certain extensions
     modified_connectors = set()
+    active_connectors = {conn for conn in all_connectors if conn.support_level != "archived"}
+    main_logger.info(f"Checking for modified files. Skipping {len(all_connectors) - len(active_connectors)} connectors with support level 'archived'.")
     for modified_file in modified_files:
         if not _is_ignored_file(modified_file):
-            modified_connectors.update(_find_modified_connectors(modified_file, all_connectors, dependency_scanning))
+            modified_connectors.update(_find_modified_connectors(modified_file, active_connectors, dependency_scanning))
     return modified_connectors
 
 

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "4.34.1"
+version = "4.34.2"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 


### PR DESCRIPTION
## What
Adds logic to pre-emptively skip `archived` connectors when using the `--modified` flag in airbyte-ci. This should clean up the test logs in CI and make it easier to reach the test reports:

![Screenshot 2024-08-26 at 12 37 49 PM](https://github.com/user-attachments/assets/4a525375-0c41-41be-ab82-7026e6df8390)

Resolves [#9176](https://github.com/airbytehq/airbyte-internal-issues/issues/9176)

## How
- Create a mapping of active connectors (ie, not `archived`) to iterate through when checking for modified connectors.
- Remove conditional logic to verify and log each "archived" connector.

## User Impact
This change is not geared toward improving performance; it is intended to reduce clutter in logs when checking PR test reports.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
