### PR TITLE
live-test: disable SortQueryParams addon

### DIFF
--- a/airbyte-ci/connectors/live-tests/README.md
+++ b/airbyte-ci/connectors/live-tests/README.md
@@ -279,6 +279,10 @@ The traffic recorded on the control connector is passed to the target connector 
 
 ## Changelog
 
+### 0.18.6
+
+Disable the `SortQueryParams` MITM proxy addon to avoid double URL encoding.
+
 ### 0.18.5
 
 Relax test_oneof_usage criteria for constant value definitions in connector SPEC output.

--- a/airbyte-ci/connectors/live-tests/pyproject.toml
+++ b/airbyte-ci/connectors/live-tests/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "live-tests"
-version = "0.18.5"
+version = "0.18.6"
 description = "Contains utilities for testing connectors against live data."
 authors = ["Airbyte <contact@airbyte.io>"]
 license = "MIT"

--- a/airbyte-ci/connectors/live-tests/src/live_tests/commons/mitm_addons.py
+++ b/airbyte-ci/connectors/live-tests/src/live_tests/commons/mitm_addons.py
@@ -25,4 +25,9 @@ class SortQueryParams:
             flow.request.url = sorted_url
 
 
-addons = [SortQueryParams()]
+# Disabling the addon.
+# It can alter the request URL when some connector URL are already encoded.
+# See discussion here https://github.com/airbytehq/airbyte-internal-issues/issues/9302#issuecomment-2311854334
+
+# addons = [SortQueryParams()]
+addons = []


### PR DESCRIPTION
## What
Closes https://github.com/airbytehq/airbyte-internal-issues/issues/9302

Disable the `SortQueryParams` addon we use in the MITM proxy of regression testing.
This addon sorts query parameters in the request URL.
I disable it because in some scenario it incorrectly re-encodes URLs which can alter the original behavior of a connector. See discussion here https://github.com/airbytehq/airbyte-internal-issues/issues/9302#issuecomment-2311854334

I opened https://github.com/airbytehq/airbyte-internal-issues/issues/9519 to fix and re-enable it later.