### PR TITLE
live-tests: improve error message on connection retrieval

### DIFF
--- a/airbyte-ci/connectors/live-tests/README.md
+++ b/airbyte-ci/connectors/live-tests/README.md
@@ -279,6 +279,10 @@ The traffic recorded on the control connector is passed to the target connector 
 
 ## Changelog
 
+### 0.18.7
+
+Improve error message when failing to retrieve connection.
+
 ### 0.18.6
 
 Disable the `SortQueryParams` MITM proxy addon to avoid double URL encoding.

--- a/airbyte-ci/connectors/live-tests/pyproject.toml
+++ b/airbyte-ci/connectors/live-tests/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "live-tests"
-version = "0.18.6"
+version = "0.18.7"
 description = "Contains utilities for testing connectors against live data."
 authors = ["Airbyte <contact@airbyte.io>"]
 license = "MIT"

--- a/airbyte-ci/connectors/live-tests/src/live_tests/commons/connection_objects_retrieval.py
+++ b/airbyte-ci/connectors/live-tests/src/live_tests/commons/connection_objects_retrieval.py
@@ -11,11 +11,16 @@ import rich
 from connection_retriever import ConnectionObject, retrieve_objects  # type: ignore
 from connection_retriever.errors import NotPermittedError  # type: ignore
 from live_tests.commons.models import ConnectionSubset
+from live_tests.commons.utils import build_connection_url
 
 from .models import AirbyteCatalog, Command, ConfiguredAirbyteCatalog, ConnectionObjects, SecretDict
 
 LOGGER = logging.getLogger(__name__)
 console = rich.get_console()
+
+
+class InvalidConnectionError(Exception):
+    pass
 
 
 def parse_config(config: dict | str | None) -> Optional[SecretDict]:
@@ -224,11 +229,18 @@ def _get_connection_objects_from_retrieved_objects(
     retrieved_state = parse_state(retrieved_objects.get(ConnectionObject.STATE))
 
     retrieved_source_docker_image = retrieved_objects.get(ConnectionObject.SOURCE_DOCKER_IMAGE)
+    connection_url = build_connection_url(retrieved_objects.get(ConnectionObject.WORKSPACE_ID), connection_id)
     if retrieved_source_docker_image is None:
-        raise ValueError(f"A docker image was not found for connection ID {connection_id}.")
+        raise InvalidConnectionError(
+            f"No docker image was found for connection ID {connection_id}. Please double check that the latest job run used version {source_docker_image_tag}. Connection URL: {connection_url}"
+        )
     elif retrieved_source_docker_image.split(":")[0] != source_docker_repository:
-        raise NotPermittedError(
-            f"The provided docker image ({source_docker_repository}) does not match the image for connection ID {connection_id}."
+        raise InvalidConnectionError(
+            f"The provided docker image ({source_docker_repository}) does not match the image for connection ID {connection_id}. Please double check that this connection is using the correct image. Connection URL: {connection_url}"
+        )
+    elif retrieved_source_docker_image.split(":")[1] != source_docker_image_tag:
+        raise InvalidConnectionError(
+            f"The provided docker image tag ({source_docker_image_tag}) does not match the image tag for connection ID {connection_id}. Please double check that this connection is using the correct image tag. Connection URL: {connection_url}"
         )
 
     return ConnectionObjects(

--- a/airbyte-ci/connectors/live-tests/src/live_tests/conftest.py
+++ b/airbyte-ci/connectors/live-tests/src/live_tests/conftest.py
@@ -16,7 +16,7 @@ from airbyte_protocol.models import AirbyteCatalog, AirbyteStateMessage, Configu
 from connection_retriever.audit_logging import get_user_email  # type: ignore
 from connection_retriever.retrieval import ConnectionNotFoundError, NotPermittedError, get_current_docker_image_tag  # type: ignore
 from live_tests import stash_keys
-from live_tests.commons.connection_objects_retrieval import ConnectionObject, get_connection_objects
+from live_tests.commons.connection_objects_retrieval import ConnectionObject, InvalidConnectionError, get_connection_objects
 from live_tests.commons.connector_runner import ConnectorRunner, Proxy
 from live_tests.commons.evaluation_modes import TestEvaluationMode
 from live_tests.commons.models import (
@@ -176,16 +176,14 @@ def pytest_configure(config: Config) -> None:
             connection_subset=config.stash[stash_keys.CONNECTION_SUBSET],
         )
         config.stash[stash_keys.IS_PERMITTED_BOOL] = True
-    except (ConnectionNotFoundError, NotPermittedError) as exc:
+    except (ConnectionNotFoundError, InvalidConnectionError) as exc:
         clean_up_artifacts(MAIN_OUTPUT_DIRECTORY, LOGGER)
+        LOGGER.error(
+            f"Failed to retrieve a valid a connection which is using the control version {config.stash[stash_keys.CONTROL_VERSION]}."
+        )
         pytest.exit(str(exc))
 
     config.stash[stash_keys.CONNECTION_ID] = config.stash[stash_keys.CONNECTION_OBJECTS].connection_id  # type: ignore
-
-    if config.stash[stash_keys.CONTROL_VERSION] != config.stash[stash_keys.CONNECTION_OBJECTS].source_docker_image.split(":")[-1]:
-        raise ValueError(
-            f"The control version fetched by the connection retriever ({config.stash[stash_keys.CONNECTION_OBJECTS].source_docker_image}) does not match the control version passed by live tests ({config.stash[stash_keys.CONTROL_VERSION]})"
-        )
 
     if config.stash[stash_keys.CONTROL_VERSION] == config.stash[stash_keys.TARGET_VERSION]:
         pytest.exit(f"Control and target versions are the same: {control_version}. Please provide different versions.")


### PR DESCRIPTION
## What
Closes https://github.com/airbytehq/airbyte-internal-issues/issues/9419

The connection retriever is used to fetch live connection from connection ID passed by the test suite:
* The connection ID can be static:
  * Manually passed by a developer
  * Set from the `connectorTestSuitesOptions` in `metadata.yaml`
* It can be dynamic when the connection selection is automatic (when the `--auto-select-connection` suite is passed to the test suite):
  * It's used in manual run of the test suite in workflow dispatch or local run.

The connection retriever can't guarantee it will find a connection whose control version matches the one passed to the test suite. The error messaging was not very helpful for developers to understand what's happening.

This PR centralizes retrieved connection validation and improves error messaging.
