### PR TITLE
community-ci: support regression tests on forks

### DIFF
--- a/.github/actions/run-airbyte-ci/action.yml
+++ b/.github/actions/run-airbyte-ci/action.yml
@@ -34,6 +34,10 @@ inputs:
     description: "GCP credentials for GCP Secret Manager"
     required: false
     default: ""
+  gcp_integration_tester_credentials:
+    description: "GCP credentials for integration tests"
+    required: false
+    default: ""
   git_repo_url:
     description: "Git repository URL"
     default: https://github.com/airbytehq/airbyte.git

--- a/.github/workflows/community_ci.yml
+++ b/.github/workflows/community_ci.yml
@@ -230,11 +230,12 @@ jobs:
           docker_hub_password: ${{ secrets.DOCKER_HUB_PASSWORD }}
           docker_hub_username: ${{ secrets.DOCKER_HUB_USERNAME }}
           gcp_gsm_credentials: ${{ secrets.GCP_GSM_CREDENTIALS }}
+          gcp_integration_tester_credentials: ${{ secrets.GCLOUD_INTEGRATION_TESTER }}
           sentry_dsn: ${{ secrets.SENTRY_AIRBYTE_CI_DSN }}
           git_repo_url: ${{ github.event.pull_request.head.repo.clone_url }}
           git_branch: ${{ github.head_ref }}
           git_revision: ${{ github.event.pull_request.head.sha }}
-          github_token: ${{ github.token }}
+          github_token: ${{ secrets.GH_PAT_MAINTENANCE_OSS }}
           s3_build_cache_access_key_id: ${{ secrets.SELF_RUNNER_AWS_ACCESS_KEY_ID }}
           s3_build_cache_secret_key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
           subcommand: "connectors --modified test"

--- a/airbyte-integrations/connectors/source-faker/metadata.yaml
+++ b/airbyte-integrations/connectors/source-faker/metadata.yaml
@@ -55,8 +55,6 @@ data:
   connectorTestSuitesOptions:
     - suite: liveTests
       testConnections:
-        - name: faker_ben_test_config_dev_null
-          id: 64b8f520-d7c1-4328-9451-c88ce03fc771
         - name: faker_config_dev_null
           id: 73abc3a9-3fea-4e7c-b58d-2c8236464a95
     - suite: unitTests


### PR DESCRIPTION
## What
Closes https://github.com/airbytehq/airbyte-internal-issues/issues/9288

[Succesful workflow run on fork
](https://github.com/airbytehq/airbyte/actions/runs/10582607948/job/29322725087)

The community CI workflow did not have the correct credentials required to run regression tests.