### PR TITLE
DATs: nuke references to normalization

### DIFF
--- a/airbyte-cdk/java/airbyte-cdk/gcs-destinations/src/testFixtures/kotlin/io/airbyte/cdk/integrations/destination/gcs/GcsAvroParquetDestinationAcceptanceTest.kt
+++ b/airbyte-cdk/java/airbyte-cdk/gcs-destinations/src/testFixtures/kotlin/io/airbyte/cdk/integrations/destination/gcs/GcsAvroParquetDestinationAcceptanceTest.kt
@@ -37,7 +37,7 @@ abstract class GcsAvroParquetDestinationAcceptanceTest(fileUploadFormat: FileUpl
         val config = this.getConfig()
         val defaultSchema = getDefaultSchema(config)
         val configuredCatalog = CatalogHelpers.toDefaultConfiguredCatalog(catalog)
-        runSyncAndVerifyStateOutput(config, messages, configuredCatalog, false)
+        runSyncAndVerifyStateOutput(config, messages, configuredCatalog)
 
         for (stream in catalog.streams) {
             val streamName = stream.name

--- a/airbyte-cdk/java/airbyte-cdk/s3-destinations/src/testFixtures/kotlin/io/airbyte/cdk/integrations/destination/s3/S3AvroParquetDestinationAcceptanceTest.kt
+++ b/airbyte-cdk/java/airbyte-cdk/s3-destinations/src/testFixtures/kotlin/io/airbyte/cdk/integrations/destination/s3/S3AvroParquetDestinationAcceptanceTest.kt
@@ -45,7 +45,7 @@ protected constructor(
         configuredCatalog.streams.forEach {
             it.withSyncId(42).withGenerationId(12).withMinimumGenerationId(12)
         }
-        runSyncAndVerifyStateOutput(config, messages, configuredCatalog, false)
+        runSyncAndVerifyStateOutput(config, messages, configuredCatalog)
 
         for (stream in catalog.streams) {
             val streamName = stream.name

--- a/airbyte-cdk/java/airbyte-cdk/s3-destinations/src/testFixtures/kotlin/io/airbyte/cdk/integrations/destination/s3/S3DestinationAcceptanceTest.kt
+++ b/airbyte-cdk/java/airbyte-cdk/s3-destinations/src/testFixtures/kotlin/io/airbyte/cdk/integrations/destination/s3/S3DestinationAcceptanceTest.kt
@@ -317,7 +317,6 @@ protected constructor(
             config,
             firstSyncMessages,
             catalogPair.first,
-            runNormalization = false,
             "airbyte/destination-s3:0.6.4",
             verifyIndividualStateAndCounts = false,
         )
@@ -329,7 +328,7 @@ protected constructor(
 
         // Run and verify only second sync messages are present.
         val secondSyncMessages = getSyncMessagesFixture2()
-        runSyncAndVerifyStateOutput(config, secondSyncMessages, catalogPair2.first, false)
+        runSyncAndVerifyStateOutput(config, secondSyncMessages, catalogPair2.first)
 
         val defaultSchema = getDefaultSchema(config)
         retrieveRawRecordsAndAssertSameMessages(
@@ -359,7 +358,7 @@ protected constructor(
             getTestCatalog(SyncMode.FULL_REFRESH, DestinationSyncMode.APPEND, 42, 0, 1)
         val config = getConfig()
         val firstSyncMessages = getSyncMessagesFixture2()
-        runSyncAndVerifyStateOutput(config, firstSyncMessages, catalogPair.first, false)
+        runSyncAndVerifyStateOutput(config, firstSyncMessages, catalogPair.first)
 
         // Run second sync, even though the previous one was incomplete, intentionally incrementing
         // genId and minGenId
@@ -369,7 +368,7 @@ protected constructor(
 
         // Run and verify only second sync messages are present.
         val secondSyncMessages = getSyncMessagesFixture2()
-        runSyncAndVerifyStateOutput(config, secondSyncMessages, catalogPair2.first, false)
+        runSyncAndVerifyStateOutput(config, secondSyncMessages, catalogPair2.first)
 
         // Run third sync.
         val catalogPair3 =
@@ -377,7 +376,7 @@ protected constructor(
 
         // Run and verify only second sync messages are present.
         val thirdSyncMessages = getSyncMessagesFixture2()
-        runSyncAndVerifyStateOutput(config, thirdSyncMessages, catalogPair3.first, false)
+        runSyncAndVerifyStateOutput(config, thirdSyncMessages, catalogPair3.first)
 
         val defaultSchema = getDefaultSchema(config)
         retrieveRawRecordsAndAssertSameMessages(
@@ -404,7 +403,7 @@ protected constructor(
                 catalogPair.first,
                 AirbyteStreamStatusTraceMessage.AirbyteStreamStatus.COMPLETE,
             )
-        runSyncAndVerifyStateOutput(config, firstSyncMessages, catalogPair.first, false)
+        runSyncAndVerifyStateOutput(config, firstSyncMessages, catalogPair.first)
 
         // Change the generationId, we always assume platform sends a monotonically increasing
         // number
@@ -413,7 +412,7 @@ protected constructor(
 
         // Run and verify only second sync messages are present.
         val secondSyncMessages = getSyncMessagesFixture2()
-        runSyncAndVerifyStateOutput(config, secondSyncMessages, catalogPair2.first, false)
+        runSyncAndVerifyStateOutput(config, secondSyncMessages, catalogPair2.first)
 
         val defaultSchema = getDefaultSchema(config)
         retrieveRawRecordsAndAssertSameMessages(
@@ -445,11 +444,11 @@ protected constructor(
             )
         assertThrows<TestHarnessException>(
             "Should not succeed the sync when Trace message is INCOMPLETE"
-        ) { runSyncAndVerifyStateOutput(config, firstSyncMessages, catalogPair.first, false) }
+        ) { runSyncAndVerifyStateOutput(config, firstSyncMessages, catalogPair.first) }
 
         // Run second sync with the same messages from the previous failed sync.
         val secondSyncMessages = getSyncMessagesFixture2()
-        runSyncAndVerifyStateOutput(config, secondSyncMessages, catalogPair.first, false)
+        runSyncAndVerifyStateOutput(config, secondSyncMessages, catalogPair.first)
 
         // verify records are preserved from first failed sync + second sync.
         val defaultSchema = getDefaultSchema(config)
@@ -479,7 +478,7 @@ protected constructor(
             )
         assertThrows<TestHarnessException>(
             "Should not succeed the sync when Trace message is INCOMPLETE"
-        ) { runSyncAndVerifyStateOutput(config, firstSyncMessages, catalogPair.first, false) }
+        ) { runSyncAndVerifyStateOutput(config, firstSyncMessages, catalogPair.first) }
 
         // Run second failed attempt of same generation
         val catalogPair2 =
@@ -492,7 +491,7 @@ protected constructor(
 
         assertThrows<TestHarnessException>(
             "Should not succeed the sync when Trace message is INCOMPLETE"
-        ) { runSyncAndVerifyStateOutput(config, secondSyncMessages, catalogPair2.first, false) }
+        ) { runSyncAndVerifyStateOutput(config, secondSyncMessages, catalogPair2.first) }
 
         // Verify our delayed delete logic creates no data downtime.
         val defaultSchema = getDefaultSchema(config)
@@ -507,7 +506,7 @@ protected constructor(
         val catalogPair3 =
             getTestCatalog(SyncMode.FULL_REFRESH, DestinationSyncMode.OVERWRITE, 43, 13, 13)
         val thirdSyncMessages = getSyncMessagesFixture2()
-        runSyncAndVerifyStateOutput(config, thirdSyncMessages, catalogPair3.first, false)
+        runSyncAndVerifyStateOutput(config, thirdSyncMessages, catalogPair3.first)
 
         retrieveRawRecordsAndAssertSameMessages(
             catalogPair.second,
@@ -539,7 +538,7 @@ protected constructor(
                 catalogPair.first,
                 AirbyteStreamStatusTraceMessage.AirbyteStreamStatus.COMPLETE
             )
-        runSyncAndVerifyStateOutput(config, firstSyncMessages, catalogPair.first, false)
+        runSyncAndVerifyStateOutput(config, firstSyncMessages, catalogPair.first)
 
         // We need to make sure that other streams\tables\files in the same location will not be
         // affected\deleted\overridden by our activities during first, second or any future sync.
@@ -568,11 +567,11 @@ protected constructor(
                 message.trace.streamStatus.streamDescriptor.name = dummyCatalogStream
             }
         // sync dummy data
-        runSyncAndVerifyStateOutput(config, firstSyncMessages, configuredDummyCatalog, false)
+        runSyncAndVerifyStateOutput(config, firstSyncMessages, configuredDummyCatalog)
 
         // Run second sync
         val secondSyncMessages: List<AirbyteMessage> = getSyncMessagesFixture2()
-        runSyncAndVerifyStateOutput(config, secondSyncMessages, catalogPair.first, false)
+        runSyncAndVerifyStateOutput(config, secondSyncMessages, catalogPair.first)
 
         // Verify records of both syncs are preserved.
         val defaultSchema = getDefaultSchema(config)
@@ -610,11 +609,11 @@ protected constructor(
                 catalogPair.first,
                 AirbyteStreamStatusTraceMessage.AirbyteStreamStatus.COMPLETE,
             )
-        runSyncAndVerifyStateOutput(config, firstSyncMessages, catalogPair.first, false)
+        runSyncAndVerifyStateOutput(config, firstSyncMessages, catalogPair.first)
 
         // Second sync
         val secondSyncMessages: List<AirbyteMessage> = getSyncMessagesFixture2()
-        runSyncAndVerifyStateOutput(config, secondSyncMessages, catalogPair.first, false)
+        runSyncAndVerifyStateOutput(config, secondSyncMessages, catalogPair.first)
 
         // Verify records
         val defaultSchema = getDefaultSchema(config)
@@ -650,7 +649,6 @@ protected constructor(
             config,
             firstSyncMessages,
             catalogPair.first,
-            runNormalization = false,
             "airbyte/destination-s3:0.6.4",
             verifyIndividualStateAndCounts = false,
         )
@@ -663,7 +661,7 @@ protected constructor(
 
         // Run and verify only second sync messages are present.
         val secondSyncMessages = getSyncMessagesFixture2()
-        runSyncAndVerifyStateOutput(config, secondSyncMessages, catalogPair2.first, false)
+        runSyncAndVerifyStateOutput(config, secondSyncMessages, catalogPair2.first)
 
         val defaultSchema = getDefaultSchema(config)
         retrieveRawRecordsAndAssertSameMessages(

--- a/airbyte-integrations/connectors/destination-bigquery/build.gradle
+++ b/airbyte-integrations/connectors/destination-bigquery/build.gradle
@@ -11,7 +11,7 @@ airbyteJavaConnector {
             'gcs-destinations',
             'core',
     ]
-    useLocalCdk = false
+    useLocalCdk = true
 }
 
 java {

--- a/airbyte-integrations/connectors/destination-databricks/build.gradle
+++ b/airbyte-integrations/connectors/destination-databricks/build.gradle
@@ -20,7 +20,7 @@ plugins {
 airbyteJavaConnector {
     cdkVersionRequired = '0.44.16'
     features = ['db-destinations', 's3-destinations', 'typing-deduping']
-    useLocalCdk = false
+    useLocalCdk = true
 }
 
 //remove once upgrading the CDK version to 0.4.x or later

--- a/airbyte-integrations/connectors/destination-postgres-strict-encrypt/build.gradle
+++ b/airbyte-integrations/connectors/destination-postgres-strict-encrypt/build.gradle
@@ -5,7 +5,7 @@ plugins {
 airbyteJavaConnector {
     cdkVersionRequired = '0.44.2'
     features = ['db-destinations', 'typing-deduping', 'datastore-postgres']
-    useLocalCdk = false
+    useLocalCdk = true
 }
 
 application {

--- a/airbyte-integrations/connectors/destination-postgres/build.gradle
+++ b/airbyte-integrations/connectors/destination-postgres/build.gradle
@@ -5,7 +5,7 @@ plugins {
 airbyteJavaConnector {
     cdkVersionRequired = '0.44.3'
     features = ['db-destinations', 'datastore-postgres', 'typing-deduping']
-    useLocalCdk = false
+    useLocalCdk = true
 }
 
 compileKotlin {

--- a/airbyte-integrations/connectors/destination-redshift/build.gradle
+++ b/airbyte-integrations/connectors/destination-redshift/build.gradle
@@ -6,7 +6,7 @@ plugins {
 airbyteJavaConnector {
     cdkVersionRequired = '0.44.14'
     features = ['db-destinations', 's3-destinations', 'typing-deduping']
-    useLocalCdk = false
+    useLocalCdk = true
 }
 
 java {

--- a/airbyte-integrations/connectors/destination-s3/build.gradle
+++ b/airbyte-integrations/connectors/destination-s3/build.gradle
@@ -6,7 +6,7 @@ plugins {
 airbyteJavaConnector {
     cdkVersionRequired = '0.44.15'
     features = ['db-destinations', 's3-destinations']
-    useLocalCdk = false
+    useLocalCdk = true
 }
 
 airbyteJavaConnector.addCdkDependencies()

--- a/airbyte-integrations/connectors/destination-snowflake/build.gradle
+++ b/airbyte-integrations/connectors/destination-snowflake/build.gradle
@@ -5,7 +5,7 @@ plugins {
 airbyteJavaConnector {
     cdkVersionRequired = '0.44.14'
     features = ['db-destinations', 's3-destinations', 'typing-deduping']
-    useLocalCdk = false
+    useLocalCdk = true
 }
 
 java {

--- a/airbyte-integrations/connectors/destination-snowflake/src/test-integration/kotlin/io/airbyte/integrations/destination/snowflake/SnowflakeInsertDestinationAcceptanceTest.kt
+++ b/airbyte-integrations/connectors/destination-snowflake/src/test-integration/kotlin/io/airbyte/integrations/destination/snowflake/SnowflakeInsertDestinationAcceptanceTest.kt
@@ -82,10 +82,6 @@ open class SnowflakeInsertDestinationAcceptanceTest : DestinationAcceptanceTest(
         return true
     }
 
-    override fun supportsInDestinationNormalization(): Boolean {
-        return true
-    }
-
     override fun getFailCheckConfig(): JsonNode? {
         val invalidConfig: JsonNode = Jsons.clone<JsonNode>(config)
         (invalidConfig["credentials"] as ObjectNode).put("password", "wrong password")
@@ -283,7 +279,7 @@ open class SnowflakeInsertDestinationAcceptanceTest : DestinationAcceptanceTest(
                 .collect(Collectors.toList())
 
         val config = getConfig()
-        runSyncAndVerifyStateOutput(config, largeNumberRecords, configuredCatalog, false)
+        runSyncAndVerifyStateOutput(config, largeNumberRecords, configuredCatalog)
     }
 
     companion object {

--- a/airbyte-integrations/connectors/destination-snowflake/src/test-integration/kotlin/io/airbyte/integrations/destination/snowflake/SnowflakeInternalStagingDestinationAcceptanceTest.kt
+++ b/airbyte-integrations/connectors/destination-snowflake/src/test-integration/kotlin/io/airbyte/integrations/destination/snowflake/SnowflakeInternalStagingDestinationAcceptanceTest.kt
@@ -100,10 +100,6 @@ class SnowflakeInternalStagingDestinationAcceptanceTest :
         catalogFilename: String,
         configName: String
     ) {
-        if (!normalizationFromDefinition()) {
-            return
-        }
-
         val catalog = deserialize(readResource(catalogFilename), AirbyteCatalog::class.java)
         val configuredCatalog = CatalogHelpers.toDefaultConfiguredCatalog(catalog)
         val messages: List<AirbyteMessage> =
@@ -113,7 +109,7 @@ class SnowflakeInternalStagingDestinationAcceptanceTest :
                 .toList()
 
         val config = deserialize(readFile(Path.of(configName)))
-        runSyncAndVerifyStateOutput(config, messages, configuredCatalog, true)
+        runSyncAndVerifyStateOutput(config, messages, configuredCatalog)
 
         val defaultSchema = getDefaultSchema(config)
         val actualMessages = retrieveNormalizedRecords(catalog, defaultSchema)


### PR DESCRIPTION
I'm _pretty_ sure I've interpreted the existing code correctly? Trying to just replace everything with T+D.

notably:
* we no longer read the `supports_normalization` flag from the destination definition/spec/whatever this was
* we don't need to launch an `airbyte/normalization:dev` container anymore, so wipe all that out
* there was a boolean `runNormalization` param that was getting passed around, delete it
* delete some dead tests (dbt transforms are gone)
* some method renaming (I'm not 100% certain on these? but I'm _pretty_ sure I read it correctly)

also bump all our major destinations to local cdk to make sure they still compile.