### PR TITLE
gradle: add airbyte-bulk-connector plugin

### DIFF
--- a/buildSrc/src/main/groovy/airbyte-bulk-connector.gradle
+++ b/buildSrc/src/main/groovy/airbyte-bulk-connector.gradle
@@ -1,0 +1,150 @@
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+class AirbyteBulkConnectorExtension {
+
+    String core // 'extract' or 'load'
+    List<String> toolkits = []  // 'extract-jdbc', etc...
+    String cdk // 'local' or a specific version
+
+    AirbyteBulkConnectorExtension(Project project) {
+        this.project = project
+    }
+
+    private Project project
+
+    void setCore(String core) {
+        this.core = core
+        if (core != "extract" && core != "load") {
+            throw new IllegalArgumentException("'core' should be either 'extract' or 'load'")
+        }
+        if (cdk != null) {
+            throw new IllegalArgumentException("'core' should be defined before 'cdk'")
+        }
+    }
+
+    void setToolkits(List<String> toolkits) {
+        this.toolkits = toolkits
+        if (cdk != null) {
+            throw new IllegalArgumentException("'toolkits' should be defined before 'cdk'")
+        }
+    }
+
+    void setCdk(String cdk) {
+        this.cdk = cdk
+        if (cdk != "local" && !cdk.matches("^[0-9]+\\.[0-9]+")) {
+            throw new IllegalArgumentException("'cdk' should be either a well-formed version number or 'local'")
+        }
+
+        project.processResources {
+            // The metadata.yaml file is required by Micronaut.
+            from(project.projectDir) {
+                include 'metadata.yaml'
+                duplicatesStrategy DuplicatesStrategy.EXCLUDE
+            }
+        }
+
+        List<Project> fromSource = []
+        List<String> fromJar = []
+        if (cdk == "local") {
+            fromSource = [
+                    project.project(":airbyte-cdk:bulk:core:bulk-cdk-core-base"),
+                    project.project(":airbyte-cdk:bulk:core:bulk-cdk-core-$core"),
+            ]
+            for (toolkit in toolkits) {
+                fromSource << project.project(":airbyte-cdk:bulk:toolkits:bulk-cdk-toolkit-$toolkit")
+            }
+        } else {
+            fromJar = [
+                    "io.airbyte.bulk-cdk:bulk-cdk-core-base:$cdk",
+                    "io.airbyte.bulk-cdk:bulk-cdk-core-$core:$cdk",
+            ]
+            for (toolkit in toolkits) {
+                fromJar << "io.airbyte.bulk-cdk:bulk-cdk-toolkit-$toolkit:$cdk"
+            }
+        }
+
+        String micronautVersion = null
+        {
+            // Use a temporary configuration to find the Micronaut version
+            // in the transitive dependencies of the Bulk CDK base.
+            def tempConfiguration = project.configurations.detachedConfiguration()
+            def baseDependency = (cdk == "local")
+                    ? project.dependencies.create(fromSource.first)
+                    : project.dependencies.create(fromJar.first)
+            tempConfiguration.dependencies.add(baseDependency)
+            tempConfiguration.resolvedConfiguration.firstLevelModuleDependencies.each {resolvedDependency ->
+                resolvedDependency.children.each { transitiveDependency ->
+                    if (micronautVersion == null &&
+                            transitiveDependency.moduleGroup == TARGET_GROUP &&
+                            transitiveDependency.moduleName == TARGET_MODULE) {
+                        micronautVersion = transitiveDependency.moduleVersion
+                    }
+                }
+            }
+            if (micronautVersion == null) {
+                throw new IllegalArgumentException(
+                        "Micronaut version number not found; $TARGET_GROUP:$TARGET_MODULE is not a transitive dependency."
+                )
+            }
+        }
+        final String kspDependency = "io.micronaut:micronaut-inject-kotlin:$micronautVersion"
+
+        project.dependencies {
+
+            ksp kspDependency
+            kspTestFixtures kspDependency
+            kspTest kspDependency
+
+            for (dep in fromSource) {
+                implementation dep
+                testFixturesImplementation dep
+                testFixturesImplementation testFixtures(dep)
+                testImplementation dep
+                testImplementation testFixtures(dep)
+            }
+            for (dep in fromJar) {
+                implementation dep
+                testFixturesImplementation dep
+                testFixturesImplementation testFixtures(dep)
+                testImplementation dep
+                testImplementation testFixtures(dep)
+            }
+        }
+    }
+
+    static private final String TARGET_GROUP = "io.micronaut"
+    static private final String TARGET_MODULE = "micronaut-runtime"
+}
+
+class AirbyteBulkConnectorPlugin implements Plugin<Project> {
+
+    @Override
+    void apply(Project project) {
+
+        project.plugins.apply('application')
+
+        project.application {
+            applicationDefaultJvmArgs = [
+                    '-XX:+ExitOnOutOfMemoryError',
+                    '-XX:InitialRAMPercentage=75.0',
+                    '-XX:MaxRAMPercentage=75.0',
+            ]
+        }
+
+        project.tasks.named('spotbugsTest').configure {
+            enabled = false
+        }
+
+        project.tasks.named('check').configure {
+            dependsOn project.tasks.matching { it.name ==~ /(compile|spotbugs)[a-zA-Z]*Java/ }
+        }
+
+        project.configurations {
+            testFixturesImplementation.extendsFrom implementation
+            testFixturesRuntimeOnly.extendsFrom runtimeOnly
+        }
+
+        project.extensions.create('airbyteBulkConnector', AirbyteBulkConnectorExtension, project)
+    }
+}


### PR DESCRIPTION
## What

This PR adds a gradle plugin which minimizes the gradle boilerplate required for connectors using the Bulk CDK.

## How

I'd never have managed this without ChatGPT. Thanks, AI!

## Review guide

Check out the companion PR in airbyte-enterprise for a usage example: https://github.com/airbytehq/airbyte-enterprise/pull/38

## User Impact

None

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
