### PR TITLE
chore(python-cdk): Skip long-running JSONL decoder test on CI

### DIFF
--- a/airbyte-cdk/python/unit_tests/sources/declarative/decoders/test_json_decoder.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/decoders/test_json_decoder.py
@@ -56,6 +56,7 @@ def large_event_response_fixture():
     os.remove(file_path)
 
 
+@pytest.mark.skipif(os.getenv("GITHUB_ACTIONS"), reason="Skip test due to memory usage and slow execution")
 @pytest.mark.limit_memory("20 MB")
 def test_jsonl_decoder_memory_usage(requests_mock, large_events_response):
     lines_in_response, file_path = large_events_response

--- a/airbyte-cdk/python/unit_tests/sources/declarative/decoders/test_json_decoder.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/decoders/test_json_decoder.py
@@ -56,7 +56,7 @@ def large_event_response_fixture():
     os.remove(file_path)
 
 
-@pytest.mark.skipif(os.getenv("GITHUB_ACTIONS"), reason="Skip test due to memory usage and slow execution")
+@pytest.mark.skipif(os.getenv("GITHUB_ACTIONS"), reason="Skip test due to slow execution")
 @pytest.mark.limit_memory("20 MB")
 def test_jsonl_decoder_memory_usage(requests_mock, large_events_response):
     lines_in_response, file_path = large_events_response


### PR DESCRIPTION
## What
Currently running pytest on the CDK takes more than 70 mins to run on CI. Most CDK changes don't affect the JSONL decoding that is tested in one single long-time test `test_jsonl_decoder_memory_usage`, which takes so long time. With this change, CDK tests finish much faster (about 10x).

## How
Skip long-running test on CI `test_jsonl_decoder_memory_usage` when `GITHUB_ACTIONS` is set true.

## Review guide
1. `test_json_decoder.py`

## User Impact
None

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌
