### PR TITLE
bulk-cdk-toolkits-extract-jdbc: noop JdbcCheckQueries when no queries defined 

### DIFF
--- a/airbyte-cdk/bulk/toolkits/extract-jdbc/src/main/kotlin/io/airbyte/cdk/check/JdbcCheckQueries.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-jdbc/src/main/kotlin/io/airbyte/cdk/check/JdbcCheckQueries.kt
@@ -30,7 +30,7 @@ const val CHECK_QUERIES_PREFIX = "airbyte.connector.check.jdbc"
 class JdbcCheckQueries {
 
     // Micronaut configuration objects work better with mutable properties.
-    lateinit var queries: List<String>
+    protected var queries: List<String> = emptyList()
 
     private val log = KotlinLogging.logger {}
 

--- a/airbyte-cdk/bulk/toolkits/extract-jdbc/src/test/kotlin/io/airbyte/cdk/check/JdbcCheckQueriesTest.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-jdbc/src/test/kotlin/io/airbyte/cdk/check/JdbcCheckQueriesTest.kt
@@ -22,6 +22,12 @@ class JdbcCheckQueriesTest {
     @Inject lateinit var checkQueries: JdbcCheckQueries
 
     @Test
+    fun testEmpty() {
+        val empty = JdbcCheckQueries()
+        Assertions.assertDoesNotThrow { h2.createConnection().use { empty.executeAll(it) } }
+    }
+
+    @Test
     @Property(name = "$Q[0]", value = "SELECT DATABASE_PATH() FROM DUAL")
     fun testPass() {
         Assertions.assertDoesNotThrow { h2.createConnection().use { checkQueries.executeAll(it) } }

--- a/airbyte-cdk/bulk/toolkits/extract-jdbc/src/test/kotlin/io/airbyte/cdk/discover/JdbcMetadataQuerierTest.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-jdbc/src/test/kotlin/io/airbyte/cdk/discover/JdbcMetadataQuerierTest.kt
@@ -23,7 +23,7 @@ class JdbcMetadataQuerierTest {
         JdbcMetadataQuerier.Factory(
             selectQueryGenerator = H2SourceOperations(),
             fieldTypeMapper = H2SourceOperations(),
-            checkQueries = JdbcCheckQueries().apply { queries = listOf() },
+            checkQueries = JdbcCheckQueries(),
             constants = DefaultJdbcConstants(),
         )
 


### PR DESCRIPTION
## What

In https://github.com/airbytehq/airbyte/pull/44824 I added `JdbcCheckQueries`. I've since noticed that when the corresponding micronaut property is not set, `JdbcCheckQueries` throws an exception complaining about a lateinit var not being initialized. While not having check queries is an edge case in production, when developing or testing a connector it can be common, making this exception quite annoying. It also prevents the CAT tests from succeeding, since a CHECK will always fail.

## How
Make `JdbcCheckQueries` silently do nothing even when no queries are configured.

## Review guide
I added a regression test.

## User Impact
None

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
