### PR TITLE
cdk connectors test: fix regression test run

### DIFF
--- a/.github/workflows/cdk_connectors_tests.yml
+++ b/.github/workflows/cdk_connectors_tests.yml
@@ -88,6 +88,7 @@ jobs:
           git_branch: ${{ github.head_ref }}
           git_revision: ${{ github.event_name == 'pull_request' && steps.fetch_last_commit_id_pr.outputs.commit_id || steps.fetch_last_commit_id_wd.outputs.commit_id }}
           github_token: ${{ env.PAT }}
+          gcp_integration_tester_credentials: ${{ secrets.GCLOUD_INTEGRATION_TESTER }}
           s3_build_cache_access_key_id: ${{ secrets.SELF_RUNNER_AWS_ACCESS_KEY_ID }}
           s3_build_cache_secret_key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
           # A connector test can't take more than 5 hours to run (5 * 60 * 60 = 18000 seconds)


### PR DESCRIPTION
## What
Closes https://github.com/airbytehq/airbyte-internal-issues/issues/9258

The `cdk_connectors_tests.yml` workflow was missing credentials to run regression tests.

Working workflow example: https://github.com/airbytehq/airbyte/actions/runs/10593420783