### PR TITLE
feat(source-apify-dataset): add option to specify dataset by its name

### DIFF
--- a/airbyte-integrations/connectors/source-apify-dataset/source_apify_dataset/manifest.yaml
+++ b/airbyte-integrations/connectors/source-apify-dataset/source_apify_dataset/manifest.yaml
@@ -10,7 +10,6 @@ spec:
     type: object
     required:
       - token
-      - dataset_id
     properties:
       token:
         type: string
@@ -39,6 +38,25 @@ spec:
           for more information.
         examples:
           - rHuMdwm6xCFt6WiGU
+      username:
+        type: string
+        title: Username
+        description: >-
+          Username of the owner of the dataset collection. In Apify Console, you can find your username in the
+          <a href="https://console.apify.com/settings/account">Settings section under the Account tab</a>
+          after you login.
+        examples:
+          - satoshi_nakamoto
+      dataset_name:
+        type: string
+        title: Dataset Name
+        description: >-
+          Unique name of the dataset you would like to load to Airbyte. In Apify Console, you can view your datasets
+          in the <a href="https://console.apify.com/storage/datasets">Storage section under the Datasets tab</a>
+          after you login. See the <a href="https://docs.apify.com/platform/storage/dataset">Apify Docs</a> for more
+          information. If both `dataset_id` and `dataset_name` are provided, `dataset_name` will take precedence.
+        examples:
+          - my-unique-dataset-name
     additionalProperties: true
 
 definitions:


### PR DESCRIPTION
## What

- Introduce a new feature to specify an Apify dataset by its name.
- Closes: #43321

## How

- Added two new properties: `username` and `dataset_name`. These are necessary to identify the dataset by its name.
- Implemented logic to handle dataset resolution based on the provided inputs. If `dataset_id` is provided, the dataset will be resolved using it. If `username` and `dataset_name` are provided, the dataset will be resolved using those instead. Fail otherwise.
  - This logic is a work in progress - any guidance or feedback would be appreciated (see `## Todo`). 
  - Tagging @flash1293 directly, as he helped me in the last updates of the connector (#30428, #31333, #31397), thanks.

## Todo

- This PR is still under development, and I'm seeking assistance with the following challenge:

### Logic for dataset resolution in `DeclarativeStreams`

- There should be two distinct branches for resolving the dataset path:

1. Using `dataset_id`:

```
path: "datasets/{{ config['dataset_id'] }}"
```

2. Using `username` and `dataset_name`:

```
path: "datasets/{{ config['username'] }}~{{ config['dataset_name'] }}"
```

If neither or both of these options are provided, the process should fail.

- **Question**: How can this conditional logic be defined in the manifest? Is there a way to enforce this directly?

## User Impact

- This update introduces an alternative way to reference a dataset, but the existing method (using `dataset_id`) remains fully functional.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
