### PR TITLE
Bulk CDK alerts go to the right slack channel

### DIFF
--- a/.github/workflows/publish-bulk-cdk.yml
+++ b/.github/workflows/publish-bulk-cdk.yml
@@ -95,7 +95,7 @@ jobs:
         uses: slackapi/slack-github-action@v1.23.0
         continue-on-error: true
         with:
-          channel-id: C04J1M66D8B
+          channel-id: C07K1P3UL6Q # The `#dev-java-cdk-releases` channel
           payload: |
             {
                 "text": "Error while publishing Bulk CDK!",
@@ -124,7 +124,7 @@ jobs:
         uses: slackapi/slack-github-action@v1.23.0
         continue-on-error: true
         with:
-          channel-id: C04J1M66D8B
+          channel-id: C07K1P3UL6Q # The `#dev-java-cdk-releases` channel
           payload: |
             {
                 "text": "Bulk CDK version 0.${{ env.BUILD_NUMBER }} published successfully!",

--- a/.github/workflows/publish-java-cdk-command.yml
+++ b/.github/workflows/publish-java-cdk-command.yml
@@ -165,7 +165,7 @@ jobs:
         uses: slackapi/slack-github-action@v1.23.0
         continue-on-error: true
         with:
-          channel-id: C04J1M66D8B
+          channel-id: C07K1P3UL6Q # The `#dev-java-cdk-releases` channel
           payload: |
             {
                 "text": "Error during `publish-cdk` while publishing Java CDK!",
@@ -194,7 +194,7 @@ jobs:
         uses: slackapi/slack-github-action@v1.23.0
         continue-on-error: true
         with:
-          channel-id: C04J1M66D8B
+          channel-id: C07K1P3UL6Q # The `#dev-java-cdk-releases` channel
           payload: |
             {
                 "text": "New `${{ env.CDK_VERSION }}` version of Java CDK was successfully published!",


### PR DESCRIPTION
We want the `#dev-java-cdk-releases` channel