### PR TITLE
metadata-service[lib]: add commands to rollback or promote a RC metadata

### DIFF
--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/commands.py
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/commands.py
@@ -5,8 +5,14 @@
 import pathlib
 
 import click
-from metadata_service.constants import METADATA_FILE_NAME
-from metadata_service.gcs_upload import MetadataUploadInfo, upload_metadata_to_gcs
+from metadata_service.constants import METADATA_FILE_NAME, RELEASE_CANDIDATE_GCS_FOLDER_NAME
+from metadata_service.gcs_upload import (
+    MetadataDeleteInfo,
+    MetadataUploadInfo,
+    delete_release_candidate_from_gcs,
+    promote_release_candidate_in_gcs,
+    upload_metadata_to_gcs,
+)
 from metadata_service.validators.metadata_validator import PRE_UPLOAD_VALIDATORS, ValidatorOptions, validate_and_load
 from pydantic import ValidationError
 
@@ -21,6 +27,17 @@ def log_metadata_upload_info(metadata_upload_info: MetadataUploadInfo):
             click.secho(
                 f"The {file.description} file for {metadata_upload_info.metadata_file_path} was not uploaded. Reason: {file.blob_id}",
                 fg="yellow",
+            )
+
+
+def log_metadata_deletion_info(metadata_deletion_info: MetadataDeleteInfo):
+    for remote_file in metadata_deletion_info.deleted_files:
+        if remote_file.deleted:
+            click.secho(f"The {remote_file.description} was deleted ({remote_file.blob_id}).", fg="green")
+        else:
+            click.secho(
+                f"The {remote_file.description} was not deleted ({remote_file.blob_id}).",
+                fg="red",
             )
 
 
@@ -63,3 +80,30 @@ def upload(metadata_file_path: pathlib.Path, docs_path: pathlib.Path, bucket_nam
         exit(0)
     else:
         exit(5)
+
+
+@metadata_service.command(help="Rollback a release candidate by deleting its metadata files from a GCS bucket.")
+@click.argument("connector-docker-repository", type=click.STRING)
+@click.argument("connector-version", type=click.STRING)
+@click.argument("bucket-name", type=click.STRING)
+def rollback_release_candidate(connector_docker_repository: str, connector_version: str, bucket_name: str):
+    try:
+        deletion_info = delete_release_candidate_from_gcs(bucket_name, connector_docker_repository, connector_version)
+        log_metadata_deletion_info(deletion_info)
+    except (FileNotFoundError, ValueError) as e:
+        click.secho(f"The release candidate could not be deleted: {str(e)}", fg="red")
+        exit(1)
+
+
+@metadata_service.command(help="Promote a release candidate by moving its metadata files to the main release folder in a GCS bucket.")
+@click.argument("connector-docker-repository", type=click.STRING)
+@click.argument("connector-version", type=click.STRING)
+@click.argument("bucket-name", type=click.STRING)
+def promote_release_candidate(connector_docker_repository: str, connector_version: str, bucket_name: str):
+    try:
+        upload_info, deletion_info = promote_release_candidate_in_gcs(bucket_name, connector_docker_repository, connector_version)
+        log_metadata_upload_info(upload_info)
+        log_metadata_deletion_info(deletion_info)
+    except (FileNotFoundError, ValueError) as e:
+        click.secho(f"The release candidate could not be promoted: {str(e)}", fg="red")
+        exit(1)

--- a/airbyte-ci/connectors/metadata_service/lib/pyproject.toml
+++ b/airbyte-ci/connectors/metadata_service/lib/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metadata-service"
-version = "0.13.1"
+version = "0.14.0"
 description = ""
 authors = ["Ben Church <ben@airbyte.io>"]
 readme = "README.md"


### PR DESCRIPTION
## What
Relates to https://github.com/airbytehq/airbyte-internal-issues/issues/9254
We want to communicate the finalization of a rollout by modifying metadata files we host on GCS:

Promoting an RC to a main version:
* Move the `release_candidate/metadata.yaml` to `latest/metadata.yaml`

RC Rollback:
* Delete its `<version>/metadata.yaml` and `release_candidate/metadata.yaml` 


## How
Expose two new commands in the metadata service.
They will be called by `airbyte-ci`
