### PR TITLE
airbyte-ci: promote and rollback publish pipeline for RC

### DIFF
--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -460,6 +460,8 @@ Publish all connectors modified in the head commit: `airbyte-ci connectors --mod
 | `--python-registry-token`            | False    |                                 | `PYTHON_REGISTRY_TOKEN`            | The API token to authenticate with the registry. For pypi, the `pypi-` prefix needs to be specified                                                                                       |
 | `--python-registry-url`              | False    | https://upload.pypi.org/legacy/ | `PYTHON_REGISTRY_URL`              | The python registry to publish to. Defaults to main pypi                                                                                                                                  |
 | `--python-registry-check-url`        | False    | https://pypi.org/pypi           | `PYTHON_REGISTRY_CHECK_URL`        | The python registry url to check whether a package is published already                                                                                                                   |
+| `--promote-release-candidate`        | False    | False                           |                                    | Promote the release candidate version of selected connectors as main version.                                                                                                             |
+| `--rollback-release-candidate`       | False    | False                           |                                    | Rollback the release candidate version of the selector connectors.                                                                                                                        |
 
 I've added an empty "Default" column, and you can fill in the default values as needed.
 
@@ -842,7 +844,8 @@ airbyte-ci connectors --language=low-code migrate-to-manifest-only
 ## Changelog
 
 | Version | PR                                                         | Description                                                                                                                  |
-| ------- | ---------------------------------------------------------- |------------------------------------------------------------------------------------------------------------------------------|
+| ------- | ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| 4.35.0  | [#44877](https://github.com/airbytehq/airbyte/pull/44877)  | Implement `--promote/rollback-release-candidate` in `connectors publish`.                                                    |
 | 4.34.2  | [#44786](https://github.com/airbytehq/airbyte/pull/44786)  | Pre-emptively skip archived connectors when searching for modified files                                                     |
 | 4.34.1  | [#44557](https://github.com/airbytehq/airbyte/pull/44557)  | Conditionally propagate parameters in manifest-only migration                                                                |
 | 4.34.0  | [#44551](https://github.com/airbytehq/airbyte/pull/44551)  | `connectors publish` do not push the `latest` tag when the current version is a release candidate.                           |

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/publish/context.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/publish/context.py
@@ -4,6 +4,7 @@
 
 """Module declaring context related classes."""
 
+from enum import Enum
 from typing import List, Optional
 
 import asyncclick as click
@@ -14,6 +15,12 @@ from pipelines.helpers.connectors.modifed import ConnectorWithModifiedFiles
 from pipelines.helpers.github import AIRBYTE_GITHUB_REPO_URL_PREFIX
 from pipelines.helpers.utils import format_duration
 from pipelines.models.secrets import Secret
+
+
+class RolloutMode(Enum):
+    ROLLBACK = "Rollback"
+    PUBLISH = "Publish"
+    PROMOTE = "Promote"
 
 
 class PublishConnectorContext(ConnectorContext):
@@ -38,6 +45,7 @@ class PublishConnectorContext(ConnectorContext):
         git_repo_url: str,
         python_registry_url: str,
         python_registry_check_url: str,
+        rollout_mode: RolloutMode,
         gha_workflow_run_url: Optional[str] = None,
         dagger_logs_url: Optional[str] = None,
         pipeline_start_timestamp: Optional[int] = None,
@@ -56,7 +64,9 @@ class PublishConnectorContext(ConnectorContext):
         self.python_registry_token = python_registry_token
         self.python_registry_url = python_registry_url
         self.python_registry_check_url = python_registry_check_url
-        pipeline_name = f"Publish {connector.technical_name}"
+        self.rollout_mode = rollout_mode
+
+        pipeline_name = f"{rollout_mode.value} {connector.technical_name}"
         pipeline_name = pipeline_name + " (pre-release)" if pre_release else pipeline_name
 
         if use_local_cdk and not self.pre_release:
@@ -124,7 +134,7 @@ class PublishConnectorContext(ConnectorContext):
     def create_slack_message(self) -> str:
 
         docker_hub_url = f"https://hub.docker.com/r/{self.connector.metadata['dockerRepository']}/tags"
-        message = f"*Publish <{docker_hub_url}|{self.docker_image}>*\n"
+        message = f"*{self.rollout_mode.value} <{docker_hub_url}|{self.docker_image}>*\n"
         if self.is_ci:
             message += f"🤖 <{self.gha_workflow_run_url}|GitHub Action workflow>\n"
         else:

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "4.34.2"
+version = "4.35.0"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 


### PR DESCRIPTION
## What 
Relates to https://github.com/airbytehq/airbyte-internal-issues/issues/9254

In #44876 we introduce new metadata service command to promote and rollback a connector release candidate.
This PR orchestrate these commands in `airbyte-ci connectors publish` by declaring three rollout modes and related pipelines:
`RolloutMode.PUBLISH`: The original publish pipeline
`RolloutMode.ROLLBACK`: Calls the metadata service `rollback-release-candidate` command
`RolloutMode.PROMOTE`: Calls the metadata service `promote-release-candidate` command AND push the `latest` image tag to DockerHub.


