### PR TITLE
new finalize connector rollout workflow

### DIFF
--- a/.github/workflows/finalize_rollout.yml
+++ b/.github/workflows/finalize_rollout.yml
@@ -1,0 +1,63 @@
+name: Finalize connector rollout
+
+on:
+  repository_dispatch:
+    types: [finalize-connector-rollout]
+  workflow_dispatch:
+    inputs:
+      connector_name:
+        description: "Connector name"
+        required: true
+      action:
+        description: "Action to perform"
+        required: true
+        options: ["promote", "rollback"]
+jobs:
+  finalize_rollout:
+    name: Finalize connector rollout
+    runs-on: connector-publish-large
+    env:
+      ACTION: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.action || github.event.client_payload.action }}
+    steps:
+      - name: Check action value
+        run: |
+          if [[ "${ACTION}" != "promote" && "${ACTION}" != "rollback" ]]; then
+            echo "Invalid action: ${ACTION}"
+            exit 1
+          fi
+        shell: bash
+      - name: Checkout Airbyte
+        uses: actions/checkout@v4
+      - name: Promote {{ github.event.client_payload.connector_name }} release candidate
+        id: promote-release-candidate
+        if: ${{ env.ACTION == 'promote' }}
+        uses: ./.github/actions/run-airbyte-ci
+        with:
+          context: "manual"
+          dagger_cloud_token: ${{ secrets.DAGGER_CLOUD_TOKEN_2 }}
+          docker_hub_password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+          docker_hub_username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          gcp_gsm_credentials: ${{ secrets.GCP_GSM_CREDENTIALS }}
+          gcs_credentials: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          metadata_service_gcs_credentials: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
+          sentry_dsn: ${{ secrets.SENTRY_AIRBYTE_CI_DSN }}
+          slack_webhook_url: ${{ secrets.PUBLISH_ON_MERGE_SLACK_WEBHOOK }}
+          subcommand: "connectors --name=${{ github.event.client_payload.connector_name }} publish --promote-release-candidate"
+      - name: Rollback {{ github.event.client_payload.connector_name }} release candidate
+        id: rollback-release-candidate
+        if: ${{ env.ACTION == 'rollback' }}
+        uses: ./.github/actions/run-airbyte-ci
+        with:
+          context: "manual"
+          dagger_cloud_token: ${{ secrets.DAGGER_CLOUD_TOKEN_2 }}
+          docker_hub_password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+          docker_hub_username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          gcp_gsm_credentials: ${{ secrets.GCP_GSM_CREDENTIALS }}
+          gcs_credentials: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          metadata_service_gcs_credentials: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
+          sentry_dsn: ${{ secrets.SENTRY_AIRBYTE_CI_DSN }}
+          slack_webhook_url: ${{ secrets.PUBLISH_ON_MERGE_SLACK_WEBHOOK }}
+          spec_cache_gcs_credentials: ${{ secrets.SPEC_CACHE_SERVICE_ACCOUNT_KEY_PUBLISH }}
+          subcommand: "connectors --name=${{ github.event.client_payload.connector_name }} publish --rollback-release-candidate"


### PR DESCRIPTION
## What
Close https://github.com/airbytehq/airbyte-internal-issues/issues/9254

Introduce a GHA workflow which will finalize a release candidate rollout.
A RC can either be:
- **promoted**: the workflow calls `airbyte-ci connectors --name=<connector> publish --promote-release-candidate`
- **rolled back**: the workflow calls `airbyte-ci connectors --name=<connector> publish --rollback-release-candidate

This worfklow can be triggered via a classic manual workflow dispatch or via  a webhook (`repository_dispatch`):
```bash
curl -L \
  -X POST \
  -H "Accept: application/vnd.github+json" \
  -H "Authorization: Bearer <YOUR-TOKEN>" \
  -H "X-GitHub-Api-Version: 2022-11-28" \
  https://api.github.com/repos/airbyte-hq/airbyte/dispatches \
  -d '{"event_type":"finalize-connector-rollout","client_payload":{"action": "promote", "connector": "source-faker"}}'
```

*Please note that to call this endpoint the token must be a PAT of an airbytehq org member. We'll probably use something the `GH_PAT_MAINTENANCE_OSS`.*

The plan is to make the gradual rollout orchestrator call this webhook on rollout finalization.

