### PR TITLE
Update private key generation steps in snowflake.md

### DIFF
--- a/docs/integrations/destinations/snowflake.md
+++ b/docs/integrations/destinations/snowflake.md
@@ -171,7 +171,7 @@ username/password or key pair authentication:
 
     Alternatively, use this command to generate an encrypted private key file:
 
-      `openssl genrsa 2048 | openssl pkcs8 -topk8 -inform PEM -v1 PBE-SHA1-RC4-128 -out rsa_key.p8`
+      `openssl genrsa 2048 | openssl pkcs8 -topk8 -inform PEM -v2 aes-256-cbc -out rsa_key.p8`
 
     Once you have your private key, you need to generate a matching public key.
     You can do so with the following command:


### PR DESCRIPTION


## What
openssl now deems -v1 PBE-SHA1-RC4-128 insecure, and will no longer generate keys of this class. s

```yaml
openssl genrsa 2048 | openssl pkcs8 -topk8 -inform PEM -v1 PBE-SHA1-RC4-128 -out rsa_key.p8                                                        
Enter Encryption Password:
Verifying - Enter Encryption Password:
Error encrypting key
409C4FE201000000:error:0308010C:digital envelope routines:inner_evp_generic_fetch:unsupported:crypto/evp/evp_fetch.c:355:Global default library context, Algorithm (RC4 : 27), Properties ()
409C4FE201000000:error:11800067:PKCS12 routines:PKCS12_item_i2d_encrypt_ex:encrypt error:crypto/pkcs12/p12_decr.c:199:
409C4FE201000000:error:11800067:PKCS12 routines:PKCS8_set0_pbe_ex:encrypt error:crypto/pkcs12/p12_p8e.c:80:

OpenSSL 3.3.1 4 Jun 2024 (Library: OpenSSL 3.3.1 4 Jun 2024)
```

## How
suggest updating our documentation to instead suggest using -v2 aes-256-cbc

e.g

`openssl genrsa 2048 | openssl pkcs8 -topk8 -inform PEM -v2 aes-256-cbc -out rsa_key.p8`

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
