### PR TITLE
feat(airbyte-ci): include handling of components.py in manifest-only migrations

### DIFF
--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/migrate_to_manifest_only/manifest_component_transformer.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/migrate_to_manifest_only/manifest_component_transformer.py
@@ -161,6 +161,8 @@ class ManifestComponentTransformer:
             # have no low-code connectors that use class_name except for custom components.
             if "class_name" in propagated_component:
                 found_type = CUSTOM_COMPONENTS_MAPPING.get(parent_field_identifier)
+                fully_qualified_class_name = propagated_component["class_name"]
+                propagated_component["class_name"] = self._simplify_class_name(fully_qualified_class_name)
             else:
                 found_type = DEFAULT_MODEL_TYPES.get(parent_field_identifier)
             if found_type:
@@ -216,4 +218,12 @@ class ManifestComponentTransformer:
 
     @staticmethod
     def _is_json_schema_object(propagated_component: Mapping[str, Any]) -> bool:
+        component_type = propagated_component.get("type")
+        if isinstance(component_type, list):
+            return "object" in component_type
         return propagated_component.get("type") == "object"
+    
+    @staticmethod
+    def _simplify_class_name(class_name: str) -> str:
+        class_name_parts = class_name.split(".")        
+        return ".".join(class_name_parts[1:])

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/migrate_to_manifest_only/pipeline.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/migrate_to_manifest_only/pipeline.py
@@ -28,8 +28,8 @@ from pipelines.models.steps import Step, StepResult, StepStatus
 ## GLOBAL VARIABLES ##
 
 # spec.yaml and spec.json will be removed as part of the conversion. But if they are present, it's fine to convert still.
-MANIFEST_ONLY_COMPATIBLE_FILES = ["manifest.yaml", "run.py", "__init__.py", "source.py", "spec.json", "spec.yaml"]
-MANIFEST_ONLY_KEEP_FILES = ["manifest.yaml", "metadata.yaml", "icon.svg", "integration_tests", "acceptance-test-config.yml", "secrets"]
+MANIFEST_ONLY_COMPATIBLE_FILES = ["manifest.yaml", "run.py", "__init__.py", "source.py", "spec.json", "spec.yaml", "components.py", "__pycache__"]
+MANIFEST_ONLY_KEEP_FILES = ["manifest.yaml", "metadata.yaml", "icon.svg", "integration_tests", "acceptance-test-config.yml", "secrets", "components.py"]
 
 
 ## STEPS ##
@@ -151,10 +151,16 @@ class StripConnector(Step):
     async def _run(self) -> StepResult:
         connector = self.context.connector
 
-        ## 1. Move manifest.yaml to the root level of the directory
+        ## 1. Move manifest.yaml and components.py to the root level of the directory
         self.logger.info("Moving manifest to the root level of the directory")
         root_manifest_path = connector.code_directory / "manifest.yaml"
         connector.manifest_path.rename(root_manifest_path)
+
+        components_path = connector.python_source_dir_path / "components.py"
+        if components_path.exists():
+            self.logger.info("Connector contains custom components. Moving components.py to the root level of the directory")
+            root_components_path = connector.code_directory / "components.py"
+            components_path.rename(root_components_path)
 
         ## 2. Update the version in manifest.yaml
         try:


### PR DESCRIPTION
# WIP
## What
Updates the `migrate-to-manifest-only` pipeline to handle connectors with custom components listed in `components.py`

Resolves [#9528](https://github.com/airbytehq/airbyte-internal-issues/issues/9528)

## How
- Moves components.py to the root level of the connector's directory
- When resolving the connector's manifest, updates custom component `class_names` by removing the main module name, ie:
 
```
source_pokeapi.components.CustomComponent -> components.CustomComponent
```

This change is reliant on [merging an update to the CDK to handle the new format](https://github.com/airbytehq/airbyte/pull/44881)

## Review guide
[Link to loom](https://www.loom.com/share/d3e0f65a064541dfadaa8ff301fe4aaf?sid=0847263f-6b87-450c-ab06-22ce1bc57781)

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
