### PR TITLE
airbyte-ci GHA: temporary disable dagger cache

### DIFF
--- a/.github/actions/run-airbyte-ci/action.yml
+++ b/.github/actions/run-airbyte-ci/action.yml
@@ -136,7 +136,7 @@ runs:
         CI_GITHUB_ACCESS_TOKEN: ${{ inputs.github_token }}
         CI_JOB_KEY: ${{ inputs.ci_job_key }}
         CI_REPORT_BUCKET_NAME: ${{ inputs.report_bucket_name }}
-        DAGGER_CLOUD_TOKEN: "${{ inputs.dagger_cloud_token }}"
+        #DAGGER_CLOUD_TOKEN: "${{ inputs.dagger_cloud_token }}"
         DOCKER_HUB_PASSWORD: ${{ inputs.docker_hub_password }}
         DOCKER_HUB_USERNAME: ${{ inputs.docker_hub_username }}
         GCP_GSM_CREDENTIALS: ${{ inputs.gcp_gsm_credentials }}


### PR DESCRIPTION
## What
Globally but temporarily disable the dagger cache / telemetry to not be impacted by SSL errors which happen on cache syncs:

```
dagger.QueryError: host directory tools/bin/: failed to extract ref: failed to copy: Get "https://dagger-cloud-cache-data-cf-enam.02d0b3944c439b04174710962bb10330.r2.cloudflarestorage.com/0479606a-502a-46dd-97dd-6832f93da9a8/layers/sha256%3Add7e583b8ef7923b842609058df2fba291e90e791a0252c8cb19c71197547293?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=418213caa838bf5e309498a869e8650a%2F20240829%2Fenam%2Fs3%2Faws4_request&X-Amz-Date=20240829T173327Z&X-Amz-Expires=600&X-Amz-SignedHeaders=host&x-id=GetObject&X-Amz-Signature=727599aa9bcbc882a6dd1c67cd2820c6324ddd72d2b240c419099136e075295e": net/http: TLS handshake timeout
```

I reached out to the Dagger team to check if they've an ongoing incident.