### PR TITLE
docs: show manifest-only connectors as available with pyairbyte

### DIFF
--- a/docusaurus/src/components/HeaderDecoration.jsx
+++ b/docusaurus/src/components/HeaderDecoration.jsx
@@ -225,7 +225,7 @@ const EnabledIcon = ({ isEnabled }) => {
 const ConnectorMetadataCallout = ({
   isCloud,
   isOss,
-  isPypiPublished,
+  isPyAirbyteConnector,
   isEnterprise,
   supportLevel,
   github_url,
@@ -257,10 +257,10 @@ const ConnectorMetadataCallout = ({
               </Chip>
               <Chip
                 className={
-                  isPypiPublished ? styles.available : styles.unavailable
+                  isPyAirbyteConnector ? styles.available : styles.unavailable
                 }
               >
-                <EnabledIcon isEnabled={isPypiPublished} /> PyAirbyte
+                <EnabledIcon isEnabled={isPyAirbyteConnector} /> PyAirbyte
               </Chip>
             </>
           )}
@@ -325,7 +325,7 @@ const ConnectorTitle = ({ iconUrl, originalTitle, originalId, isArchived }) => (
 export const HeaderDecoration = ({
   isOss: isOssString,
   isCloud: isCloudString,
-  isPypiPublished: isPypiPublishedString,
+  isPyAirbyteConnector: isPyAirbyteConnectorString,
   isEnterprise: isEnterpriseString,
   dockerImageTag,
   supportLevel,
@@ -342,7 +342,7 @@ export const HeaderDecoration = ({
 }) => {
   const isOss = boolStringToBool(isOssString);
   const isCloud = boolStringToBool(isCloudString);
-  const isPypiPublished = boolStringToBool(isPypiPublishedString);
+  const isPyAirbyteConnector = boolStringToBool(isPyAirbyteConnectorString);
   const isEnterprise = boolStringToBool(isEnterpriseString);
   const isLatestCDK = boolStringToBool(isLatestCDKString);
   const isArchived = supportLevel?.toUpperCase() === "ARCHIVED";
@@ -358,7 +358,7 @@ export const HeaderDecoration = ({
       <ConnectorMetadataCallout
         isCloud={isCloud}
         isOss={isOss}
-        isPypiPublished={isPypiPublished}
+        isPyAirbyteConnector={isPyAirbyteConnector}
         isEnterprise={isEnterprise}
         supportLevel={supportLevel}
         github_url={github_url}

--- a/docusaurus/src/connector_registry.js
+++ b/docusaurus/src/connector_registry.js
@@ -55,7 +55,7 @@ module.exports = {
   REGISTRY_URL,
   catalog: fetchCatalog(),
   isPypiConnector: (connector) => {
-    return Boolean(connector.remoteRegistries_oss?.pypi?.enabled);
+    return Boolean(connector.language_oss == "manifest-only" || connector.remoteRegistries_oss?.pypi?.enabled);
   },
   getLatestPythonCDKVersion,
   parseCDKVersion,

--- a/docusaurus/src/connector_registry.js
+++ b/docusaurus/src/connector_registry.js
@@ -54,7 +54,7 @@ function getSupportLevelDisplay(rawSupportLevel) {
 module.exports = {
   REGISTRY_URL,
   catalog: fetchCatalog(),
-  isPypiConnector: (connector) => {
+  isPyAirbyteConnector: (connector) => {
     return Boolean(connector.language_oss == "manifest-only" || connector.remoteRegistries_oss?.pypi?.enabled);
   },
   getLatestPythonCDKVersion,

--- a/docusaurus/src/remark/connectorList.js
+++ b/docusaurus/src/remark/connectorList.js
@@ -1,5 +1,5 @@
 const visit = require("unist-util-visit").visit;
-const { catalog, isPypiConnector } = require("../connector_registry");
+const { catalog, isPyAirbyteConnector } = require("../connector_registry");
 
 const plugin = () => {
   const transformer = async (ast, vfile) => {
@@ -9,7 +9,7 @@ const plugin = () => {
     visit(ast, "mdxJsxFlowElement", (node) => {
       if (node.name !== "PyAirbyteConnectors") return;
 
-        const connectors = registry.filter(isPypiConnector);
+        const connectors = registry.filter(isPyAirbyteConnector);
 
       node.attributes.push({
         type: "mdxJsxAttribute",

--- a/docusaurus/src/remark/docsHeaderDecoration.js
+++ b/docusaurus/src/remark/docsHeaderDecoration.js
@@ -1,7 +1,7 @@
 const { getFromPaths, toAttributes } = require("../helpers/objects");
 const { isDocsPage, getRegistryEntry } = require("./utils");
 const {
-  isPypiConnector,
+  isPyAirbyteConnector,
   getLatestPythonCDKVersion,
   parseCDKVersion,
 } = require("../connector_registry");
@@ -56,7 +56,7 @@ const plugin = () => {
         const attrDict = {
           isOss: registryEntry.is_oss,
           isCloud: registryEntry.is_cloud,
-          isPypiPublished: isPypiConnector(registryEntry),
+          isPyAirbyteConnector: isPyAirbyteConnector(registryEntry),
           supportLevel: registryEntry.supportLevel_oss,
           dockerImageTag: registryEntry.dockerImageTag_oss,
           iconUrl: registryEntry.iconUrl_oss,

--- a/docusaurus/src/remark/specDecoration.js
+++ b/docusaurus/src/remark/specDecoration.js
@@ -1,5 +1,5 @@
 const visit = require("unist-util-visit").visit;
-const { catalog, isPypiConnector } = require("../connector_registry");
+const { catalog, isPyAirbyteConnector } = require("../connector_registry");
 const { isDocsPage, getRegistryEntry } = require("./utils");
 
 const plugin = () => {
@@ -36,7 +36,7 @@ async function injectDefaultPyAirbyteSection(vfile, ast) {
   if (
     !docsPageInfo.isTrueDocsPage ||
     !registryEntry ||
-    !isPypiConnector(registryEntry) ||
+    !isPyAirbyteConnector(registryEntry) ||
     vfile.value.includes("## Usage with PyAirbyte")
   ) {
     return;


### PR DESCRIPTION
## What

As we migrate connectors to manifest-only format, we pull their pypi packages, and our docs remark plugin shows them as not available on pyairbyte because of that.

This PR should fix it. Pushing up to test, local builds don't seem to actually be fixed =/ 

Closes https://github.com/airbytehq/airbyte-internal-issues/issues/9425