### PR TITLE
Update `abctl version` command in oss-quickstart

### DIFF
--- a/docs/using-airbyte/getting-started/oss-quickstart.md
+++ b/docs/using-airbyte/getting-started/oss-quickstart.md
@@ -109,7 +109,7 @@ sudo mv abctl /usr/local/bin
 **5: Verify the installation**
 
 ```bash
-abctl --version
+abctl version
 ```
 
 If this command prints the installed version of the Airbyte Command Line Tool, it confirm that you are now ready to manage a local Airbyte instance using `abctl`.


### PR DESCRIPTION


## What
It should be `abctl version`, not `abctl --version`

## How
Just update the markdown

## Review guide

## User Impact
Better docs

## Can this PR be safely reverted and rolled back?
- [X] YES 💚
- [ ] NO ❌
