### PR TITLE
🐛 Source Klaviyo: have region also be a number

### DIFF
--- a/airbyte-integrations/connectors/source-klaviyo/metadata.yaml
+++ b/airbyte-integrations/connectors/source-klaviyo/metadata.yaml
@@ -8,7 +8,7 @@ data:
   definitionId: 95e8cffd-b8c4-4039-968e-d32fb4a69bde
   connectorBuildOptions:
     baseImage: docker.io/airbyte/python-connector-base:2.0.0@sha256:c44839ba84406116e8ba68722a0f30e8f6e7056c726f447681bb9e9ece8bd916
-  dockerImageTag: 2.10.1
+  dockerImageTag: 2.10.2
   dockerRepository: airbyte/source-klaviyo
   githubIssueLabel: source-klaviyo
   icon: klaviyo.svg

--- a/airbyte-integrations/connectors/source-klaviyo/pyproject.toml
+++ b/airbyte-integrations/connectors/source-klaviyo/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "2.10.1"
+version = "2.10.2"
 name = "source-klaviyo"
 description = "Source implementation for Klaviyo."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-klaviyo/source_klaviyo/manifest.yaml
+++ b/airbyte-integrations/connectors/source-klaviyo/source_klaviyo/manifest.yaml
@@ -135,7 +135,11 @@ definitions:
     schema_loader:
       type: InlineSchemaLoader
       schema: "#/definitions/profiles_schema"
-    retriever: "#/definitions/profiles_retriever"
+    retriever:
+      $ref: "#/definitions/profiles_retriever"
+      record_selector:
+        $ref: "#/definitions/selector"
+        schema_normalization: Default
     $parameters:
       path: "profiles"
 
@@ -466,10 +470,7 @@ definitions:
                   - type: number
                   - type: string
               region:
-                oneOf:
-                  - type: "null"
-                  - type: number
-                  - type: string
+                type: ["null", string]
               zip:
                 type: ["null", string]
               timezone:

--- a/airbyte-integrations/connectors/source-klaviyo/source_klaviyo/manifest.yaml
+++ b/airbyte-integrations/connectors/source-klaviyo/source_klaviyo/manifest.yaml
@@ -466,7 +466,10 @@ definitions:
                   - type: number
                   - type: string
               region:
-                type: ["null", string]
+                oneOf:
+                  - type: "null"
+                  - type: number
+                  - type: string
               zip:
                 type: ["null", string]
               timezone:

--- a/airbyte-integrations/connectors/source-klaviyo/unit_tests/integration/config.py
+++ b/airbyte-integrations/connectors/source-klaviyo/unit_tests/integration/config.py
@@ -1,0 +1,11 @@
+# Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+
+from typing import Any, Dict
+
+
+class KlaviyoConfigBuilder:
+    def __init__(self) -> None:
+        self._config = {"api_key":"an_api_key","start_date":"2021-01-01T00:00:00Z"}
+
+    def build(self) -> Dict[str, Any]:
+        return self._config

--- a/airbyte-integrations/connectors/source-klaviyo/unit_tests/integration/test_profiles.py
+++ b/airbyte-integrations/connectors/source-klaviyo/unit_tests/integration/test_profiles.py
@@ -1,0 +1,89 @@
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+
+from typing import Any, Dict, Optional
+from unittest import TestCase
+
+from airbyte_cdk.test.catalog_builder import CatalogBuilder
+from airbyte_cdk.test.entrypoint_wrapper import EntrypointOutput, read
+from airbyte_cdk.test.mock_http import HttpMocker, HttpRequest
+from airbyte_cdk.test.mock_http.request import ANY_QUERY_PARAMS
+from airbyte_cdk.test.mock_http.response_builder import (
+    FieldPath,
+    HttpResponseBuilder,
+    NestedPath,
+    RecordBuilder,
+    create_record_builder,
+    create_response_builder,
+    find_template,
+)
+from airbyte_protocol.models import ConfiguredAirbyteCatalog, SyncMode
+from integration.config import KlaviyoConfigBuilder
+from source_klaviyo import SourceKlaviyo
+
+_ENDPOINT_TEMPLATE_NAME = "profiles"
+_STREAM_NAME = "profiles"
+_RECORDS_PATH = FieldPath("data")
+
+
+def _config() -> KlaviyoConfigBuilder:
+    return KlaviyoConfigBuilder()
+
+
+def _catalog(sync_mode: SyncMode) -> ConfiguredAirbyteCatalog:
+    return CatalogBuilder().with_stream(_STREAM_NAME, sync_mode).build()
+
+
+def _a_profile_request() -> HttpRequest:
+    return HttpRequest(
+        url=f"https://a.klaviyo.com/api/profiles",
+        query_params=ANY_QUERY_PARAMS
+    )
+
+
+def _a_profile() -> RecordBuilder:
+    return create_record_builder(
+        find_template(_ENDPOINT_TEMPLATE_NAME, __file__),
+        _RECORDS_PATH,
+        record_id_path=FieldPath("id"),
+        record_cursor_path=NestedPath(["attributes", "updated"]),
+    )
+
+
+def _profiles_response() -> HttpResponseBuilder:
+    return create_response_builder(
+        find_template(_ENDPOINT_TEMPLATE_NAME, __file__),
+        _RECORDS_PATH,
+    )
+
+
+def _read(
+    config_builder: KlaviyoConfigBuilder, sync_mode: SyncMode, state: Optional[Dict[str, Any]] = None, expecting_exception: bool = False
+) -> EntrypointOutput:
+    catalog = _catalog(sync_mode)
+    config = config_builder.build()
+    return read(SourceKlaviyo(), config, catalog, state, expecting_exception)
+
+
+class FullRefreshTest(TestCase):
+    @HttpMocker()
+    def test_when_read_then_extract_records(self, http_mocker: HttpMocker) -> None:
+        http_mocker.get(
+            _a_profile_request(),
+            _profiles_response().with_record(_a_profile()).build(),
+        )
+
+        output = _read(_config(), SyncMode.full_refresh)
+
+        assert len(output.records) == 1
+
+    @HttpMocker()
+    def test_given_region_is_number_when_read_then_cast_as_string(self, http_mocker: HttpMocker) -> None:
+        http_mocker.get(
+            _a_profile_request(),
+            _profiles_response().with_record(_a_profile().with_field(NestedPath(["attributes", "location", "region"]), 10)).build(),
+        )
+
+        output = _read(_config(), SyncMode.full_refresh)
+
+        assert len(output.records) == 1
+        assert isinstance(output.records[0].record.data["attributes"]["location"]["region"], str)

--- a/airbyte-integrations/connectors/source-klaviyo/unit_tests/resource/http/response/profiles.json
+++ b/airbyte-integrations/connectors/source-klaviyo/unit_tests/resource/http/response/profiles.json
@@ -1,0 +1,94 @@
+{
+  "data": [
+    {
+      "type": "profile",
+      "id": "01G4CDTEP140TDXZ0692XSA61K",
+      "attributes": {
+        "email": "tracey.witting@developer-tools.shopifyapps.com",
+        "phone_number": "+13523772689",
+        "external_id": null,
+        "anonymous_id": null,
+        "first_name": "Tracey",
+        "last_name": "Witting",
+        "organization": null,
+        "locale": null,
+        "title": null,
+        "image": null,
+        "created": "2022-05-31T06:46:01+00:00",
+        "updated": "2022-05-31T06:46:01+00:00",
+        "last_event_date": null,
+        "location": {
+          "address1": "2088 Rempel Road",
+          "region": null,
+          "zip": null,
+          "country": "United States",
+          "address2": null,
+          "longitude": null,
+          "city": null,
+          "latitude": null,
+          "timezone": null,
+          "ip": null
+        },
+        "properties": {
+          "Accepts Marketing": false,
+          "Shopify Tags": ["developer-tools-generator"]
+        },
+        "subscriptions": {
+          "email": {
+            "marketing": {
+              "consent": "NEVER_SUBSCRIBED",
+              "timestamp": null,
+              "method": null,
+              "method_detail": null,
+              "custom_method_detail": null,
+              "double_optin": null,
+              "suppressions": [],
+              "list_suppressions": []
+            }
+          },
+          "sms": {
+            "marketing": {
+              "consent": "NEVER_SUBSCRIBED",
+              "timestamp": null,
+              "method": null,
+              "method_detail": null
+            }
+          }
+        },
+        "predictive_analytics": {
+          "historic_clv": null,
+          "predicted_clv": null,
+          "total_clv": null,
+          "historic_number_of_orders": null,
+          "predicted_number_of_orders": null,
+          "average_days_between_orders": null,
+          "average_order_value": null,
+          "churn_probability": null,
+          "expected_date_of_next_order": null
+        }
+      },
+      "relationships": {
+        "lists": {
+          "links": {
+            "self": "https://a.klaviyo.com/api/profiles/01G4CDTEP140TDXZ0692XSA61K/relationships/lists/",
+            "related": "https://a.klaviyo.com/api/profiles/01G4CDTEP140TDXZ0692XSA61K/lists/"
+          }
+        },
+        "segments": {
+          "links": {
+            "self": "https://a.klaviyo.com/api/profiles/01G4CDTEP140TDXZ0692XSA61K/relationships/segments/",
+            "related": "https://a.klaviyo.com/api/profiles/01G4CDTEP140TDXZ0692XSA61K/segments/"
+          }
+        }
+      },
+      "links": {
+        "self": "https://a.klaviyo.com/api/profiles/01G4CDTEP140TDXZ0692XSA61K/"
+      }
+    }
+  ],
+  "links": {
+    "self": "https://a.klaviyo.com/api/profiles?additional-fields%5Bprofile%5D=predictive_analytics&page%5Bsize%5D=100&filter=greater-than%28updated%2C2021-01-01T00%3A00%3A00%2B0000%29&sort=updated&page%5Bcursor%5D=bmV4dDo6dXBkYXRlZDo6MjAyMi0wNS0zMSAwNjo0NjowMSswMDowMDo6aWQ6OjAxRzRDRFRFTTZKMjBHRzVRNU41Q0Q4V0pW",
+    "next": null,
+    "prev": null
+  }
+}

--- a/docs/integrations/sources/klaviyo.md
+++ b/docs/integrations/sources/klaviyo.md
@@ -95,7 +95,7 @@ contain the `predictive_analytics` field and workflows depending on this field w
 
 | Version | Date       | Pull Request                                               | Subject                                                                                                                       |
 |:--------|:-----------|:-----------------------------------------------------------|:------------------------------------------------------------------------------------------------------------------------------|
-| 2.10.2  | 2024-09-03 | [44930](https://github.com/airbytehq/airbyte/pull/44930) | Fix typing in profiles stream for field `attributes.location.region`                                                          |
+| 2.10.2  | 2024-08-30 | [44930](https://github.com/airbytehq/airbyte/pull/44930) | Fix typing in profiles stream for field `attributes.location.region`                                                          |
 | 2.10.1  | 2024-08-24 | [44628](https://github.com/airbytehq/airbyte/pull/44628) | Update dependencies                                                                                                           |
 | 2.10.0  | 2024-08-18 | [44366](https://github.com/airbytehq/airbyte/pull/44366) | Add field[metrics] to events stream                                                                                           |
 | 2.9.4   | 2024-08-17 | [44317](https://github.com/airbytehq/airbyte/pull/44317) | Update dependencies                                                                                                           |

--- a/docs/integrations/sources/klaviyo.md
+++ b/docs/integrations/sources/klaviyo.md
@@ -95,49 +95,50 @@ contain the `predictive_analytics` field and workflows depending on this field w
 
 | Version | Date       | Pull Request                                               | Subject                                                                                                                       |
 |:--------|:-----------|:-----------------------------------------------------------|:------------------------------------------------------------------------------------------------------------------------------|
-| 2.10.1 | 2024-08-24 | [44628](https://github.com/airbytehq/airbyte/pull/44628) | Update dependencies |
-| 2.10.0 | 2024-08-18 | [44366](https://github.com/airbytehq/airbyte/pull/44366) | Add field[metrics] to events stream |
-| 2.9.4 | 2024-08-17 | [44317](https://github.com/airbytehq/airbyte/pull/44317) | Update dependencies |
-| 2.9.3 | 2024-08-12 | [43806](https://github.com/airbytehq/airbyte/pull/43806) | Update dependencies |
-| 2.9.2 | 2024-08-10 | [43613](https://github.com/airbytehq/airbyte/pull/43613) | Update dependencies |
-| 2.9.1 | 2024-08-03 | [43247](https://github.com/airbytehq/airbyte/pull/43247) | Update dependencies |
-| 2.9.0 | 2024-08-01 | [42891](https://github.com/airbytehq/airbyte/pull/42891) | Migrate to CDK v4.X and remove custom BackoffStrategy implementation |
-| 2.8.2 | 2024-07-31 | [42895](https://github.com/airbytehq/airbyte/pull/42895) | Add config option disable_fetching_predictive_analytics to prevent 503 Service Unavailable errors |
-| 2.8.1 | 2024-07-27 | [42664](https://github.com/airbytehq/airbyte/pull/42664) | Update dependencies |
-| 2.8.0 | 2024-07-19 | [42121](https://github.com/airbytehq/airbyte/pull/42121) | Migrate to CDK v3.9.0 |
-| 2.7.8 | 2024-07-20 | [42185](https://github.com/airbytehq/airbyte/pull/42185) | Update dependencies |
-| 2.7.7 | 2024-07-08 | [40608](https://github.com/airbytehq/airbyte/pull/40608) | Update the `events_detailed` stream to improve efficiency using the events API |
-| 2.7.6 | 2024-07-13 | [41903](https://github.com/airbytehq/airbyte/pull/41903) | Update dependencies |
-| 2.7.5 | 2024-07-10 | [41548](https://github.com/airbytehq/airbyte/pull/41548) | Update dependencies |
-| 2.7.4 | 2024-07-09 | [41211](https://github.com/airbytehq/airbyte/pull/41211) | Update dependencies |
-| 2.7.3 | 2024-07-06 | [40770](https://github.com/airbytehq/airbyte/pull/40770) | Update dependencies |
-| 2.7.2 | 2024-06-26 | [40401](https://github.com/airbytehq/airbyte/pull/40401) | Update dependencies |
-| 2.7.1 | 2024-06-22 | [40032](https://github.com/airbytehq/airbyte/pull/40032) | Update dependencies |
-| 2.7.0 | 2024-06-08 | [39350](https://github.com/airbytehq/airbyte/pull/39350) | Add `events_detailed` stream |
-| 2.6.4 | 2024-06-06 | [38879](https://github.com/airbytehq/airbyte/pull/38879) | Implement `CheckpointMixin` for handling state in Python streams |
-| 2.6.3 | 2024-06-04 | [38935](https://github.com/airbytehq/airbyte/pull/38935) | [autopull] Upgrade base image to v1.2.1 |
-| 2.6.2 | 2024-05-08 | [37789](https://github.com/airbytehq/airbyte/pull/37789) | Move stream schemas and spec to manifest |
-| 2.6.1 | 2024-05-07 | [38010](https://github.com/airbytehq/airbyte/pull/38010) | Add error handler for `5XX` status codes |
-| 2.6.0 | 2024-04-19 | [37370](https://github.com/airbytehq/airbyte/pull/37370) | Add streams `campaigns_detailed` and `lists_detailed` |
-| 2.5.0 | 2024-04-15 | [36264](https://github.com/airbytehq/airbyte/pull/36264) | Migrate to low-code |
-| 2.4.0 | 2024-04-11 | [36989](https://github.com/airbytehq/airbyte/pull/36989) | Update `Campaigns` schema |
-| 2.3.0 | 2024-03-19 | [36267](https://github.com/airbytehq/airbyte/pull/36267) | Pin airbyte-cdk version to `^0` |
-| 2.2.0 | 2024-02-27 | [35637](https://github.com/airbytehq/airbyte/pull/35637) | Fix `predictive_analytics` field in stream `profiles` |
-| 2.1.3 | 2024-02-15 | [35336](https://github.com/airbytehq/airbyte/pull/35336) | Added type transformer for the `profiles` stream. |
-| 2.1.2 | 2024-02-09 | [35088](https://github.com/airbytehq/airbyte/pull/35088) | Manage dependencies with Poetry. |
-| 2.1.1 | 2024-02-07 | [34998](https://github.com/airbytehq/airbyte/pull/34998) | Add missing fields to stream schemas |
-| 2.1.0 | 2023-12-07 | [33237](https://github.com/airbytehq/airbyte/pull/33237) | Continue syncing streams even when one of the stream fails |
-| 2.0.2 | 2023-12-05 | [33099](https://github.com/airbytehq/airbyte/pull/33099) | Fix filtering for archived records stream |
-| 2.0.1 | 2023-11-08 | [32291](https://github.com/airbytehq/airbyte/pull/32291) | Add logic to have regular checkpointing schedule |
-| 2.0.0 | 2023-11-03 | [32128](https://github.com/airbytehq/airbyte/pull/32128) | Use the latest API for streams `campaigns`, `email_templates`, `events`, `flows`, `global_exclusions`, `lists`, and `metrics` |
-| 1.1.0 | 2023-10-23 | [31710](https://github.com/airbytehq/airbyte/pull/31710) | Make `start_date` config field optional |
-| 1.0.0 | 2023-10-18 | [31565](https://github.com/airbytehq/airbyte/pull/31565) | Add new known fields for 'events' stream |
-| 0.5.0 | 2023-10-19 | [31611](https://github.com/airbytehq/airbyte/pull/31611) | Add `date-time` format for `datetime` field in `Events` stream |
-| 0.4.0 | 2023-10-18 | [31562](https://github.com/airbytehq/airbyte/pull/31562) | Add `archived` field to `Flows` stream |
-| 0.3.3 | 2023-10-13 | [31379](https://github.com/airbytehq/airbyte/pull/31379) | Skip streams that the connector no longer has access to |
-| 0.3.2 | 2023-06-20 | [27498](https://github.com/airbytehq/airbyte/pull/27498) | Do not store state in the future |
-| 0.3.1 | 2023-06-08 | [27162](https://github.com/airbytehq/airbyte/pull/27162) | Anonymize check connection error message |
-| 0.3.0 | 2023-02-18 | [23236](https://github.com/airbytehq/airbyte/pull/23236) | Add ` Email Templates` stream |
+| 2.10.2  | 2024-09-03 | [44930](https://github.com/airbytehq/airbyte/pull/44930) | Fix typing in profiles stream for field `attributes.location.region`                                                          |
+| 2.10.1  | 2024-08-24 | [44628](https://github.com/airbytehq/airbyte/pull/44628) | Update dependencies                                                                                                           |
+| 2.10.0  | 2024-08-18 | [44366](https://github.com/airbytehq/airbyte/pull/44366) | Add field[metrics] to events stream                                                                                           |
+| 2.9.4   | 2024-08-17 | [44317](https://github.com/airbytehq/airbyte/pull/44317) | Update dependencies                                                                                                           |
+| 2.9.3   | 2024-08-12 | [43806](https://github.com/airbytehq/airbyte/pull/43806) | Update dependencies                                                                                                           |
+| 2.9.2   | 2024-08-10 | [43613](https://github.com/airbytehq/airbyte/pull/43613) | Update dependencies                                                                                                           |
+| 2.9.1   | 2024-08-03 | [43247](https://github.com/airbytehq/airbyte/pull/43247) | Update dependencies                                                                                                           |
+| 2.9.0   | 2024-08-01 | [42891](https://github.com/airbytehq/airbyte/pull/42891) | Migrate to CDK v4.X and remove custom BackoffStrategy implementation                                                          |
+| 2.8.2   | 2024-07-31 | [42895](https://github.com/airbytehq/airbyte/pull/42895) | Add config option disable_fetching_predictive_analytics to prevent 503 Service Unavailable errors                             |
+| 2.8.1   | 2024-07-27 | [42664](https://github.com/airbytehq/airbyte/pull/42664) | Update dependencies                                                                                                           |
+| 2.8.0   | 2024-07-19 | [42121](https://github.com/airbytehq/airbyte/pull/42121) | Migrate to CDK v3.9.0                                                                                                         |
+| 2.7.8   | 2024-07-20 | [42185](https://github.com/airbytehq/airbyte/pull/42185) | Update dependencies                                                                                                           |
+| 2.7.7   | 2024-07-08 | [40608](https://github.com/airbytehq/airbyte/pull/40608) | Update the `events_detailed` stream to improve efficiency using the events API                                                |
+| 2.7.6   | 2024-07-13 | [41903](https://github.com/airbytehq/airbyte/pull/41903) | Update dependencies                                                                                                           |
+| 2.7.5   | 2024-07-10 | [41548](https://github.com/airbytehq/airbyte/pull/41548) | Update dependencies                                                                                                           |
+| 2.7.4   | 2024-07-09 | [41211](https://github.com/airbytehq/airbyte/pull/41211) | Update dependencies                                                                                                           |
+| 2.7.3   | 2024-07-06 | [40770](https://github.com/airbytehq/airbyte/pull/40770) | Update dependencies                                                                                                           |
+| 2.7.2   | 2024-06-26 | [40401](https://github.com/airbytehq/airbyte/pull/40401) | Update dependencies                                                                                                           |
+| 2.7.1   | 2024-06-22 | [40032](https://github.com/airbytehq/airbyte/pull/40032) | Update dependencies                                                                                                           |
+| 2.7.0   | 2024-06-08 | [39350](https://github.com/airbytehq/airbyte/pull/39350) | Add `events_detailed` stream                                                                                                  |
+| 2.6.4   | 2024-06-06 | [38879](https://github.com/airbytehq/airbyte/pull/38879) | Implement `CheckpointMixin` for handling state in Python streams                                                              |
+| 2.6.3   | 2024-06-04 | [38935](https://github.com/airbytehq/airbyte/pull/38935) | [autopull] Upgrade base image to v1.2.1                                                                                       |
+| 2.6.2   | 2024-05-08 | [37789](https://github.com/airbytehq/airbyte/pull/37789) | Move stream schemas and spec to manifest                                                                                      |
+| 2.6.1   | 2024-05-07 | [38010](https://github.com/airbytehq/airbyte/pull/38010) | Add error handler for `5XX` status codes                                                                                      |
+| 2.6.0   | 2024-04-19 | [37370](https://github.com/airbytehq/airbyte/pull/37370) | Add streams `campaigns_detailed` and `lists_detailed`                                                                         |
+| 2.5.0   | 2024-04-15 | [36264](https://github.com/airbytehq/airbyte/pull/36264) | Migrate to low-code                                                                                                           |
+| 2.4.0   | 2024-04-11 | [36989](https://github.com/airbytehq/airbyte/pull/36989) | Update `Campaigns` schema                                                                                                     |
+| 2.3.0   | 2024-03-19 | [36267](https://github.com/airbytehq/airbyte/pull/36267) | Pin airbyte-cdk version to `^0`                                                                                               |
+| 2.2.0   | 2024-02-27 | [35637](https://github.com/airbytehq/airbyte/pull/35637) | Fix `predictive_analytics` field in stream `profiles`                                                                         |
+| 2.1.3   | 2024-02-15 | [35336](https://github.com/airbytehq/airbyte/pull/35336) | Added type transformer for the `profiles` stream.                                                                             |
+| 2.1.2   | 2024-02-09 | [35088](https://github.com/airbytehq/airbyte/pull/35088) | Manage dependencies with Poetry.                                                                                              |
+| 2.1.1   | 2024-02-07 | [34998](https://github.com/airbytehq/airbyte/pull/34998) | Add missing fields to stream schemas                                                                                          |
+| 2.1.0   | 2023-12-07 | [33237](https://github.com/airbytehq/airbyte/pull/33237) | Continue syncing streams even when one of the stream fails                                                                    |
+| 2.0.2   | 2023-12-05 | [33099](https://github.com/airbytehq/airbyte/pull/33099) | Fix filtering for archived records stream                                                                                     |
+| 2.0.1   | 2023-11-08 | [32291](https://github.com/airbytehq/airbyte/pull/32291) | Add logic to have regular checkpointing schedule                                                                              |
+| 2.0.0   | 2023-11-03 | [32128](https://github.com/airbytehq/airbyte/pull/32128) | Use the latest API for streams `campaigns`, `email_templates`, `events`, `flows`, `global_exclusions`, `lists`, and `metrics` |
+| 1.1.0   | 2023-10-23 | [31710](https://github.com/airbytehq/airbyte/pull/31710) | Make `start_date` config field optional                                                                                       |
+| 1.0.0   | 2023-10-18 | [31565](https://github.com/airbytehq/airbyte/pull/31565) | Add new known fields for 'events' stream                                                                                      |
+| 0.5.0   | 2023-10-19 | [31611](https://github.com/airbytehq/airbyte/pull/31611) | Add `date-time` format for `datetime` field in `Events` stream                                                                |
+| 0.4.0   | 2023-10-18 | [31562](https://github.com/airbytehq/airbyte/pull/31562) | Add `archived` field to `Flows` stream                                                                                        |
+| 0.3.3   | 2023-10-13 | [31379](https://github.com/airbytehq/airbyte/pull/31379) | Skip streams that the connector no longer has access to                                                                       |
+| 0.3.2   | 2023-06-20 | [27498](https://github.com/airbytehq/airbyte/pull/27498) | Do not store state in the future                                                                                              |
+| 0.3.1   | 2023-06-08 | [27162](https://github.com/airbytehq/airbyte/pull/27162) | Anonymize check connection error message                                                                                      |
+| 0.3.0   | 2023-02-18 | [23236](https://github.com/airbytehq/airbyte/pull/23236) | Add ` Email Templates` stream                                                                                                 |
 | 0.2.0   | 2023-03-13 | [22942](https://github.com/airbytehq/airbyte/pull/23968)   | Add `Profiles` stream                                                                                                         |
 | 0.1.13  | 2023-02-13 | [22942](https://github.com/airbytehq/airbyte/pull/22942)   | Specified date formatting in specification                                                                                    |
 | 0.1.12  | 2023-01-30 | [22071](https://github.com/airbytehq/airbyte/pull/22071)   | Fix `Events` stream schema                                                                                                    |


### PR DESCRIPTION
## What
Addresses https://github.com/airbytehq/oncall/issues/6353

## How
At first, we thought of adding a type to the schema. That being said, this is a breaking change. 

Hence, we decided to add normalization to the profiles stream. This might slow down a bit the connector but we avoid a breaking change. Eventually, we might want to switch to [this solution](https://github.com/airbytehq/airbyte-internal-issues/issues/9607)

## User Impact
The users that have some `attributes.location.region` as a number will now have successful syncs if the destination had typing issues.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [X] YES 💚
- [ ] NO ❌
