### PR TITLE
fix(source-iterable): reduce stream step size

### DIFF
--- a/airbyte-integrations/connectors/source-iterable/source_iterable/manifest.yaml
+++ b/airbyte-integrations/connectors/source-iterable/source_iterable/manifest.yaml
@@ -298,7 +298,7 @@ streams:
       partition_router: []
     primary_key: []
     incremental_sync:
-      step: P90D
+      step: P7D
       type: DatetimeBasedCursor
       cursor_field: profileUpdatedAt
       end_datetime:

--- a/airbyte-integrations/connectors/source-iterable/source_iterable/slice_generators.py
+++ b/airbyte-integrations/connectors/source-iterable/source_iterable/slice_generators.py
@@ -38,11 +38,11 @@ class SliceGenerator:
 
 class RangeSliceGenerator(SliceGenerator):
     """
-    Split slices into event ranges of 90 days (or less for final slice) from
+    Split slices into event ranges of 7 days (or less for final slice) from
     start_date up to current date.
     """
 
-    RANGE_LENGTH_DAYS: int = 90
+    RANGE_LENGTH_DAYS: int = 7
     _slices: List[StreamSlice] = []
 
     def __init__(self, start_date: DateTime, end_date: Optional[DateTime] = None):
@@ -103,13 +103,13 @@ class AdjustableSliceGenerator(SliceGenerator):
 
     In case if range havent been adjusted before getting next slice (it could
     happend if there were no records for given date range), next slice would
-    have MAX_RANGE_DAYS (180) length.
+    have MAX_RANGE_DAYS (90) length.
     """
 
     REQUEST_PER_MINUTE_LIMIT = 4
-    INITIAL_RANGE_DAYS: int = 30
-    DEFAULT_RANGE_DAYS: int = 90
-    MAX_RANGE_DAYS: int = 180
+    INITIAL_RANGE_DAYS: int = 7
+    DEFAULT_RANGE_DAYS: int = 7
+    MAX_RANGE_DAYS: int = 90
     RANGE_REDUCE_FACTOR = 2
 
     # This variable play important roles: stores length of previos range before

--- a/airbyte-integrations/connectors/source-iterable/source_iterable/streams.py
+++ b/airbyte-integrations/connectors/source-iterable/source_iterable/streams.py
@@ -258,7 +258,7 @@ class IterableExportStream(IterableStream, CheckpointMixin, ABC):
 class IterableExportStreamRanged(IterableExportStream, ABC):
     """
     This class use RangeSliceGenerator class to break single request into
-    ranges with same (or less for final range) number of days. By default it 90
+    ranges with same (or less for final range) number of days. By default it 7
     days.
     """
 
@@ -328,10 +328,12 @@ class IterableExportStreamAdjustableRange(IterableExportStream, ABC):
                     stream_slice=stream_slice,
                     stream_state=stream_state,
                 ):
-                    now = pendulum.now()
-                    self._adjustable_generator.adjust_range(now - start_time)
                     yield record
-                    start_time = now
+
+                now = pendulum.now()
+                self._adjustable_generator.adjust_range(now - start_time)
+                start_time = now
+
                 break
             except ChunkedEncodingError:
                 self.logger.warn("ChunkedEncodingError occurred, decrease days range and try again")


### PR DESCRIPTION
## What
For large datasets in Iterable, it may take a long time to export using Iterable's export API endpoint which is what the source uses. Oftentimes the connection will be closed before the file has finished transferring, resulting in errors such as 'Response ended prematurely'.

The source connector is already slicing the users and events streams into 90-day ranges, but that may still be too large for non-trivial datasets.

## How
This patch reduces the stream step size from 90 days to 7 days for both the users and events streams. This should greatly cut down the response size and time.

## Review guide
Small changes, so should be reviewable in one go.

## User Impact
For users with large datasets, this should result in much fewer errors. But it may introduce more API calls which in some cases may run into the 4 requests/minute rate limit more often, but they will be retried.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
