### PR TITLE
fix: db2 source privilege query

### DIFF
--- a/airbyte-integrations/connectors/source-db2/src/main/java/io.airbyte.integrations.source.db2/Db2Source.java
+++ b/airbyte-integrations/connectors/source-db2/src/main/java/io.airbyte.integrations.source.db2/Db2Source.java
@@ -118,8 +118,46 @@ public class Db2Source extends AbstractJdbcSource<JDBCType> implements Source {
   }
 
   private CheckedFunction<Connection, PreparedStatement, SQLException> getPrivileges() {
+    // Get user, group and role SELECT privileges from the information schema
     return connection -> connection.prepareStatement(
-        "SELECT DISTINCT OBJECTNAME, OBJECTSCHEMA FROM SYSIBMADM.PRIVILEGES WHERE OBJECTTYPE = 'TABLE' AND PRIVILEGE = 'SELECT' AND AUTHID = SESSION_USER");
+        """
+          SELECT DISTINCT 
+          OBJECTNAME, 
+          OBJECTSCHEMA 
+          FROM SYSIBMADM.PRIVILEGES WHERE OBJECTTYPE = 'TABLE' 
+          		AND PRIVILEGE = 'SELECT' 
+          		AND AUTHID = SESSION_USER
+          		AND AUTHIDTYPE = 'U'
+          UNION
+          SELECT DISTINCT 
+          OBJECTNAME, 
+          OBJECTSCHEMA 
+          FROM SYSIBMADM.PRIVILEGES WHERE OBJECTTYPE = 'TABLE' AND PRIVILEGE = 'SELECT'
+          		AND AUTHID IN (
+                  SELECT GROUP 
+                  FROM TABLE (SYSPROC.AUTH_LIST_GROUPS_FOR_AUTHID(SESSION_USER))
+                  )
+                  AND AUTHIDTYPE = 'G'
+          UNION		
+          SELECT DISTINCT
+          TABNAME AS OBJECTNAME,
+          TABSCHEMA AS OBJECTSCHEMA
+          FROM 
+              SYSCAT.TABAUTH
+          WHERE 
+              GRANTEETYPE = 'R'  
+              AND SELECTAUTH = 'Y'
+              AND TABSCHEMA NOT IN ('SYSCAT', 'SYSFUN', 'SYSIBM', 'SYSIBMADM', 'SYSIBMINTERNAL', 'SYSIBMTS', 'SYSPROC', 'SYSPUBLIC', 'SYSSTAT', 'SYSTOOLS')
+              AND GRANTEE IN (
+                  SELECT ROLENAME FROM SYSCAT.ROLEAUTH WHERE 
+                  (GRANTEE IN (
+                  SELECT GROUP 
+                  FROM TABLE (SYSPROC.AUTH_LIST_GROUPS_FOR_AUTHID(SESSION_USER)))
+                  AND GRANTEETYPE = 'G')
+                  OR
+                  (GRANTEE = SESSION_USER AND GRANTEETYPE= 'U')            
+              )
+        """);
   }
 
   private JdbcPrivilegeDto getPrivilegeDto(final JsonNode jsonNode) {


### PR DESCRIPTION
## What
Fixes https://github.com/airbytehq/airbyte/issues/14920

## How
The query has been extended to check also group and role grants and not only user grants.

## Review guide
airbyte-integrations/connectors/source-db2/src/main/java/io.airbyte.integrations.source.db2/Db2Source.java

## User Impact
There are no negative effects. Users will eventually see more table objects displayed in the connection panel in case they have group or role based SELECT grants.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌
