### PR TITLE
revert most recent stripe change

### DIFF
--- a/airbyte-integrations/connectors/source-stripe/metadata.yaml
+++ b/airbyte-integrations/connectors/source-stripe/metadata.yaml
@@ -25,6 +25,7 @@ data:
       packageName: airbyte-source-stripe
   registryOverrides:
     cloud:
+      dockerImageTag: 5.5.1
       enabled: true
     oss:
       enabled: true


### PR DESCRIPTION
## What
We're seen some regression on the latest Stripe changes. We will revert the change in cursor. This implies that we might will see the pagination issue mentioned [here](https://github.com/airbytehq/airbyte/pull/44862) but it seems like a lesser problem for now that will be addressed in a later PR.

## How
Fixing the version on cloud

## User Impact
Users that were seeing the sync fails should see them pass now

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [X] YES 💚
- [ ] NO ❌
