### PR TITLE
Fix version on cloud

### DIFF
--- a/airbyte-integrations/connectors/source-stripe/metadata.yaml
+++ b/airbyte-integrations/connectors/source-stripe/metadata.yaml
@@ -26,6 +26,7 @@ data:
   registryOverrides:
     cloud:
       enabled: true
+      dockerImageTag: 5.5.1
     oss:
       enabled: true
   releaseStage: generally_available


### PR DESCRIPTION
## What
We're seen some regression on the latest Stripe changes. We will revert the change in cursor. This implies that we might will see the pagination issue mentioned [here](https://github.com/airbytehq/airbyte/pull/44862) but it seems like a lesser problem for now that will be addressed in a later PR.

## How
Fixing the version on cloud

## User Impact
Users that were seeing the sync fails should see them pass now

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [X] YES 💚
- [ ] NO ❌
