### PR TITLE
bulk-cdk: make exception classifiers recursive

### DIFF
--- a/airbyte-cdk/bulk/core/base/src/main/kotlin/io/airbyte/cdk/output/ExceptionClassifier.kt
+++ b/airbyte-cdk/bulk/core/base/src/main/kotlin/io/airbyte/cdk/output/ExceptionClassifier.kt
@@ -17,9 +17,9 @@ interface ExceptionClassifier : Ordered {
     override fun getOrder(): Int = orderValue
 
     companion object {
-        fun unwind(e: Throwable, test: (Throwable) -> Boolean): Throwable? {
+        fun unwind(e: Throwable, stopUnwind: (Throwable) -> Boolean): Throwable? {
             var unwound = e
-            while (!test(unwound)) {
+            while (!stopUnwind(unwound)) {
                 unwound = unwound.cause ?: return null
             }
             return unwound

--- a/airbyte-cdk/bulk/core/base/src/main/kotlin/io/airbyte/cdk/output/ExceptionClassifier.kt
+++ b/airbyte-cdk/bulk/core/base/src/main/kotlin/io/airbyte/cdk/output/ExceptionClassifier.kt
@@ -15,6 +15,16 @@ interface ExceptionClassifier : Ordered {
     val orderValue: Int
 
     override fun getOrder(): Int = orderValue
+
+    companion object {
+        fun unwind(e: Throwable, test: (Throwable) -> Boolean): Throwable? {
+            var unwound = e
+            while (!test(unwound)) {
+                unwound = unwound.cause ?: return null
+            }
+            return unwound
+        }
+    }
 }
 
 /** Each [ConnectorError] subtype corresponds to a [AirbyteErrorTraceMessage.FailureType]. */
@@ -54,10 +64,8 @@ interface RuleBasedExceptionClassifier<T : RuleBasedExceptionClassifier.Rule> :
 
     override fun classify(e: Throwable): ConnectorError? {
         for (rule in rules) {
-            if (!rule.matches(e)) {
-                continue
-            }
-            val message: String = rule.output ?: e.message ?: e.toString()
+            val match: Throwable = ExceptionClassifier.unwind(e, rule::matches) ?: continue
+            val message: String = rule.output ?: match.message ?: match.toString()
             val firstLine: String = if (rule.group == null) message else "${rule.group}: $message"
             val lines: List<String> = listOf(firstLine) + rule.referenceLinks
             val displayMessage: String = lines.joinToString(separator = "\n")

--- a/airbyte-cdk/bulk/core/base/src/test/kotlin/io/airbyte/cdk/output/RegexExceptionClassifierTest.kt
+++ b/airbyte-cdk/bulk/core/base/src/test/kotlin/io/airbyte/cdk/output/RegexExceptionClassifierTest.kt
@@ -80,4 +80,16 @@ class RegexExceptionClassifierTest {
             classifier.classify(RuntimeException("barbaz")),
         )
     }
+
+    @Test
+    fun testRecursiveRuleOrdering() {
+        Assertions.assertEquals(
+            ConfigError("grouped: has foo\nhttps://www.youtube.com/watch?v=xvFZjo5PgG0"),
+            classifier.classify(RuntimeException("quux", RuntimeException("foobarbaz"))),
+        )
+        Assertions.assertEquals(
+            TransientError("barbaz"),
+            classifier.classify(RuntimeException("quux", RuntimeException("barbaz"))),
+        )
+    }
 }


### PR DESCRIPTION
## What
I forgot to make the `ExceptionClassifier` implementations recursive, in terms of Exception causes. Without this, the `RegexExceptionClassifier` in particular is quite useless; because the interesting exceptions are usually wrapped inside other RuntimeExceptions and whatnot.

## How
Replicate the behaviour of the `ConnectorExceptionHandler` from the legacy CDK. 

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
None as of yet.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
