### PR TITLE
destination-s3: don't reuse names of existing objects

### DIFF
--- a/airbyte-cdk/java/airbyte-cdk/README.md
+++ b/airbyte-cdk/java/airbyte-cdk/README.md
@@ -174,6 +174,7 @@ corresponds to that version.
 
 | Version    | Date       | Pull Request                                                 | Subject                                                                                                                                                        |
 | :--------- | :--------- | :----------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 0.44.21    | 2024-09-04 | [\#45143](https://github.com/airbytehq/airbyte/pull/45143)  | S3-destination: don't overwrite existing files, skip those file indexes instead                                                                                |
 | 0.44.20    | 2024-08-30 | [\#44933](https://github.com/airbytehq/airbyte/pull/44933)   | Avro/Parquet destinations: handle `{}` schemas inside objects/arrays                                                                                           |
 | 0.44.19    | 2024-08-20 | [\#44476](https://github.com/airbytehq/airbyte/pull/44476)   | Increase Jackson message length limit to 100mb                                                                                                                 |
 | 0.44.18    | 2024-08-22 | [\#44505](https://github.com/airbytehq/airbyte/pull/44505)   | Improve handling of incoming debezium change events                                                                                                            |

--- a/airbyte-cdk/java/airbyte-cdk/core/src/main/resources/version.properties
+++ b/airbyte-cdk/java/airbyte-cdk/core/src/main/resources/version.properties
@@ -1,1 +1,1 @@
-version=0.44.20
+version=0.44.21

--- a/airbyte-cdk/java/airbyte-cdk/s3-destinations/src/main/kotlin/io/airbyte/cdk/integrations/destination/s3/parquet/JsonRecordParquetPreprocessor.kt
+++ b/airbyte-cdk/java/airbyte-cdk/s3-destinations/src/main/kotlin/io/airbyte/cdk/integrations/destination/s3/parquet/JsonRecordParquetPreprocessor.kt
@@ -12,7 +12,7 @@ import io.airbyte.cdk.integrations.destination.s3.jsonschema.JsonRecordIdentityM
 import io.airbyte.commons.jackson.MoreMappers
 
 class JsonRecordParquetPreprocessor : JsonRecordIdentityMapper() {
-    private fun mapCommon(record: JsonNode?, matchingOption: ObjectNode): JsonNode? {
+    private fun mapCommon(record: JsonNode?, matchingOption: ObjectNode): ObjectNode {
         val newObj = MoreMappers.initMapper().createObjectNode()
 
         val propertyName = JsonSchemaParquetPreprocessor.typeFieldName(matchingOption)
@@ -24,7 +24,7 @@ class JsonRecordParquetPreprocessor : JsonRecordIdentityMapper() {
         return newObj
     }
 
-    override fun mapUnion(record: JsonNode?, schema: ObjectNode): JsonNode? {
+    override fun mapUnion(record: JsonNode?, schema: ObjectNode): ObjectNode? {
         if (record == null || record.isNull) {
             return null
         }
@@ -35,7 +35,7 @@ class JsonRecordParquetPreprocessor : JsonRecordIdentityMapper() {
         return mapCommon(record, matchingOption)
     }
 
-    override fun mapCombined(record: JsonNode?, schema: ObjectNode): JsonNode? {
+    override fun mapCombined(record: JsonNode?, schema: ObjectNode): ObjectNode? {
         if (record == null || record.isNull) {
             return null
         }

--- a/airbyte-integrations/connectors/destination-s3/build.gradle
+++ b/airbyte-integrations/connectors/destination-s3/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 airbyteJavaConnector {
-    cdkVersionRequired = '0.44.20'
+    cdkVersionRequired = '0.44.21'
     features = ['db-destinations', 's3-destinations']
     useLocalCdk = false
 }

--- a/airbyte-integrations/connectors/destination-s3/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-s3/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: file
   connectorType: destination
   definitionId: 4816b78f-1489-44c1-9060-4b19d5fa9362
-  dockerImageTag: 1.0.4
+  dockerImageTag: 1.0.5
   dockerRepository: airbyte/destination-s3
   githubIssueLabel: destination-s3
   icon: s3.svg

--- a/docs/integrations/destinations/s3.md
+++ b/docs/integrations/destinations/s3.md
@@ -535,7 +535,8 @@ To see connector limitations, or troubleshoot your S3 connector, see more [in ou
   <summary>Expand to review</summary>
 
 | Version | Date       | Pull Request                                               | Subject                                                                                                                                              |
-| :------ | :--------- | :--------------------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------- |
+|:--------|:-----------|:-----------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| 1.0.5   | 2024-09-05 | [45143](https://github.com/airbytehq/airbyte/pull/45143)   | don't overwrite (and delete) existing files, skip indexes instead                                                                                    |
 | 1.0.4   | 2024-08-30 | [44933](https://github.com/airbytehq/airbyte/pull/44933)   | Fix: Avro/Parquet: handle empty schemas in nested objects/lists                                                                                      |
 | 1.0.3   | 2024-08-20 | [44476](https://github.com/airbytehq/airbyte/pull/44476)   | Increase message parsing limit to 100mb                                                                                                              |
 | 1.0.2   | 2024-08-19 | [44401](https://github.com/airbytehq/airbyte/pull/44401)   | Fix: S3 Avro/Parquet: handle nullable top-level schema                                                                                               |


### PR DESCRIPTION
Instead of counting the number of files and starting creating file based on that counter, we create files starting at 0 and avoid overriding files that were already present.

The problem was that in case of an overwrite sync, the 1st sync would create files `1, 2, 3`. Sync 2 would notice there's 3 files and would create files `4, 5 , 6` and delete `1, 2, 3` at the end of the sync. Sync3 and after would see there's 3 files, would overwrite `4, 5, 6` and delete them because they were here before the sync started, leaving us with no files. 

fixes #6417
