### PR TITLE
metadata-service[orchestrator]: fix missing isReleaseCandidate field

### DIFF
--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/generated/ConnectorRegistryDestinationDefinition.py
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/generated/ConnectorRegistryDestinationDefinition.py
@@ -241,6 +241,7 @@ class ConnectorRegistryReleases(BaseModel):
     class Config:
         extra = Extra.forbid
 
+    isReleaseCandidate: Optional[bool] = Field(None, description="Whether the current version is a release candidate.")
     releaseCandidates: Optional[ConnectorReleaseCandidates] = None
     rolloutConfiguration: Optional[RolloutConfiguration] = None
     breakingChanges: Optional[ConnectorBreakingChanges] = None

--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/generated/ConnectorRegistryReleases.py
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/generated/ConnectorRegistryReleases.py
@@ -202,6 +202,7 @@ class ConnectorRegistryReleases(BaseModel):
     class Config:
         extra = Extra.forbid
 
+    isReleaseCandidate: Optional[bool] = Field(None, description="Whether the current version is a release candidate.")
     releaseCandidates: Optional[ConnectorReleaseCandidates] = None
     rolloutConfiguration: Optional[RolloutConfiguration] = None
     breakingChanges: Optional[ConnectorBreakingChanges] = None

--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/generated/ConnectorRegistrySourceDefinition.py
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/generated/ConnectorRegistrySourceDefinition.py
@@ -238,6 +238,7 @@ class ConnectorRegistryReleases(BaseModel):
     class Config:
         extra = Extra.forbid
 
+    isReleaseCandidate: Optional[bool] = Field(None, description="Whether the current version is a release candidate.")
     releaseCandidates: Optional[ConnectorReleaseCandidates] = None
     rolloutConfiguration: Optional[RolloutConfiguration] = None
     breakingChanges: Optional[ConnectorBreakingChanges] = None

--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/generated/ConnectorRegistryV0.py
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/generated/ConnectorRegistryV0.py
@@ -246,6 +246,7 @@ class ConnectorRegistryReleases(BaseModel):
     class Config:
         extra = Extra.forbid
 
+    isReleaseCandidate: Optional[bool] = Field(None, description="Whether the current version is a release candidate.")
     releaseCandidates: Optional[ConnectorReleaseCandidates] = None
     rolloutConfiguration: Optional[RolloutConfiguration] = None
     breakingChanges: Optional[ConnectorBreakingChanges] = None

--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/src/ConnectorRegistryReleases.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/src/ConnectorRegistryReleases.yaml
@@ -6,6 +6,9 @@ description: Contains information about different types of releases for a connec
 type: object
 additionalProperties: false
 properties:
+  isReleaseCandidate:
+    type: boolean
+    description: Whether the current version is a release candidate.
   releaseCandidates:
     $ref: "#/definitions/ConnectorReleaseCandidates"
   rolloutConfiguration:

--- a/airbyte-ci/connectors/metadata_service/lib/pyproject.toml
+++ b/airbyte-ci/connectors/metadata_service/lib/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metadata-service"
-version = "0.14.0"
+version = "0.14.1"
 description = ""
 authors = ["Ben Church <ben@airbyte.io>"]
 readme = "README.md"

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/registry_entry.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/registry_entry.py
@@ -113,6 +113,7 @@ def apply_connector_releases(metadata: dict) -> Optional[pd.DataFrame]:
 
     if metadata.get("releases", {}).get("rolloutConfiguration"):
         final_registry_releases["rolloutConfiguration"] = metadata["releases"]["rolloutConfiguration"]
+    final_registry_releases["isReleaseCandidate"] = metadata.get("releases", {}).get("isReleaseCandidate", False)
     return final_registry_releases
 
 

--- a/airbyte-ci/connectors/metadata_service/orchestrator/poetry.lock
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/poetry.lock
@@ -1747,7 +1747,7 @@ files = [
 
 [[package]]
 name = "metadata-service"
-version = "0.14.0"
+version = "0.14.1"
 description = ""
 optional = false
 python-versions = "^3.9"

--- a/airbyte-ci/connectors/metadata_service/orchestrator/pyproject.toml
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "orchestrator"
-version = "0.5.0"
+version = "0.5.1"
 description = ""
 authors = ["Ben Church <ben@airbyte.io>"]
 readme = "README.md"


### PR DESCRIPTION
## What
Registry entry declared a `isReleaseCandidate` field that was removed in https://github.com/airbytehq/airbyte/pull/44588 . It means that connector which have set this field now have invalid schemas for the registry entries. This PRs readds the `isReleaseCandidate` field to registry entry as it does not hurt.