### PR TITLE
docs(airbyte-cdk): Fix error in incremental sync docs

### DIFF
--- a/docs/connector-development/config-based/understanding-the-yaml-file/incremental-syncs.md
+++ b/docs/connector-development/config-based/understanding-the-yaml-file/incremental-syncs.md
@@ -220,7 +220,7 @@ The default state format is **per partition**, but there are options to enhance 
   ```
 
 ### Summary
-- **Per Partition**: Default, use for manageable partitions (<10k).
+- **Per Partition**: Default, use for manageable partitions (\<10k).
 - **Incremental Dependency**: Use for incremental parent streams with a dependent child cursor. Ensure API updates parent cursor with child records.
 - **Global Substream Cursor**: Ideal for large-scale parent streams with many partitions to optimize performance.
 


### PR DESCRIPTION
## What
This PR fixes an issue in the incremental sync documentation where a missing escape character caused an failed Vercel build.

## How
Escapes the `<` symbol in the incremental-syncs.md file to prevent a formatting error and correctly display the partition limit (<10k).

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->
The documentation now correctly renders the partition limit as "<10k". No negative side effects.


## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
