### PR TITLE
bug(airbyte-cdk) Fix extras not being printed

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/logger.py
+++ b/airbyte-cdk/python/airbyte_cdk/logger.py
@@ -53,7 +53,7 @@ class AirbyteLogFormatter(logging.Formatter):
     def format(self, record: logging.LogRecord) -> str:
         """Return a JSON representation of the log message"""
         airbyte_level = self.level_mapping.get(record.levelno, "INFO")
-        if airbyte_level == "DEBUG":
+        if airbyte_level == Level.DEBUG:
             extras = self.extract_extra_args_from_record(record)
             debug_dict = {"type": "DEBUG", "message": record.getMessage(), "data": extras}
             return filter_secrets(json.dumps(debug_dict))

--- a/airbyte-cdk/python/unit_tests/test_logger.py
+++ b/airbyte-cdk/python/unit_tests/test_logger.py
@@ -51,12 +51,15 @@ def test_level_transform(logger, caplog):
 
 def test_debug(logger, caplog):
     # Test debug logger in isolation since the default logger is initialized to TRACE (15) instead of DEBUG (10).
+    formatter = AirbyteLogFormatter()
     debug_logger = logging.getLogger("airbyte.Debuglogger")
     debug_logger.setLevel(logging.DEBUG)
-    debug_logger.debug("Test debug 1")
+    debug_logger.debug("Test debug 1", extra={"extra_field": "extra value"})
     record = caplog.records[0]
-    assert record.levelname == "DEBUG"
-    assert record.message == "Test debug 1"
+    formatted_record = json.loads(formatter.format(record))
+    assert formatted_record["type"] == "DEBUG"
+    assert formatted_record["message"] == "Test debug 1"
+    assert formatted_record["data"]["extra_field"] == "extra value"
 
 
 def test_default_debug_is_ignored(logger, caplog):


### PR DESCRIPTION
## What
Since [this change](https://github.com/airbytehq/airbyte/commit/df34893b63ea944731429cff294c4788c87e62a4#diff-fc454a650e0198b4a2130eff6e4d0f4802f421bd685ae68792a158282f503663R46-R50), extras are not printed anymore

## How
Ensure the comparison on the log level match the type

## User Impact
Devs will be able to see extras in the logs when running on debug mode

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [X] YES 💚
- [ ] NO ❌
