### PR TITLE
[docs] Filter connectors by suport level tabs

### DIFF
--- a/docusaurus/src/components/ConnectorRegistry.jsx
+++ b/docusaurus/src/components/ConnectorRegistry.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useEffect, useState } from "react";
-import { getSupportLevelDisplay } from "../connector_registry";
-
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
 import styles from "./ConnectorRegistry.module.css";
 import { REGISTRY_URL } from "../connector_registry";
 
@@ -30,35 +30,23 @@ function connectorSort(a, b) {
   if (a.name_oss > b.name_oss) return 1;
 }
 
-export default function ConnectorRegistry({ type }) {
-  const [registry, setRegistry] = useState([]);
-
-  useEffect(() => {
-    fetchCatalog(REGISTRY_URL, setRegistry);
-  }, []);
-
-  if (registry.length === 0) return <div>{`Loading ${type}s...`}</div>;
-
-  const connectors = registry
-    .filter((c) => c.connector_type === type)
-    .filter((c) => c.name_oss)
-    .filter((c) => c.supportLevel_oss); // at lease one connector is missing a support level
-
+function ConnectorTable({ connectors, connectorSupportLevel }) {
   return (
-    <div>
-      <table>
-        <thead>
-          <tr>
-            <th>Connector Name</th>
-            <th>Links</th>
-            <th>Support Level</th>
-            <th>OSS</th>
-            <th>Cloud</th>
-            <th>Docker Image</th>
-          </tr>
-        </thead>
-        <tbody>
-          {connectors.sort(connectorSort).map((connector) => {
+    <table>
+      <thead>
+        <tr>
+          <th>Connector Name</th>
+          <th>Links</th>
+          <th>OSS</th>
+          <th>Cloud</th>
+          <th>Docker Image</th>
+        </tr>
+      </thead>
+      <tbody>
+        {connectors
+          .sort(connectorSort)
+          .filter((c) => c.supportLevel_oss === connectorSupportLevel)
+          .map((connector) => {
             const docsLink = connector.documentationUrl_oss?.replace(
               "https://docs.airbyte.com",
               ""
@@ -86,9 +74,6 @@ export default function ConnectorRegistry({ type }) {
                     <a href={connector.issue_url}>🐛</a>
                   ) : null}
                 </td>
-                <td>
-                  <small>{getSupportLevelDisplay(connector.supportLevel_oss)}</small>
-                </td>
                 <td>{connector.is_oss ? "✅" : "❌"}</td>
                 <td>{connector.is_cloud ? "✅" : "❌"}</td>
                 <td>
@@ -102,8 +87,46 @@ export default function ConnectorRegistry({ type }) {
               </tr>
             );
           })}
-        </tbody>
-      </table>
-    </div>
+      </tbody>
+    </table>
+  );
+}
+
+export default function ConnectorRegistry({ type }) {
+  const [registry, setRegistry] = useState([]);
+
+  useEffect(() => {
+    fetchCatalog(REGISTRY_URL, setRegistry);
+  }, []);
+
+  if (registry.length === 0) return <div>{`Loading ${type}s...`}</div>;
+
+  const connectors = registry
+    .filter((c) => c.connector_type === type)
+    .filter((c) => c.name_oss)
+    .filter((c) => c.supportLevel_oss); // at least one connector is missing a support level
+
+  return (
+    <Tabs>
+      <TabItem value="certified" label="Airbyte Connector" default>
+        <ConnectorTable
+          connectors={connectors}
+          connectorSupportLevel={"certified"}
+        />
+      </TabItem>
+      <TabItem value="community" label="Marketplace" default>
+        <ConnectorTable
+          connectors={connectors}
+          connectorSupportLevel={"community"}
+        />
+      </TabItem>
+      {/* There are no archived connectors to show at the moment, so hiding for now */}
+      {/* <TabItem value="archived" label="Archived" default>
+        <ConnectorTable
+          connectors={connectors}
+          connectorSupportLevel={"archived"}
+        />
+      </TabItem> */}
+    </Tabs>
   );
 }

--- a/docusaurus/src/components/ConnectorRegistry.jsx
+++ b/docusaurus/src/components/ConnectorRegistry.jsx
@@ -108,7 +108,7 @@ export default function ConnectorRegistry({ type }) {
 
   return (
     <Tabs>
-      <TabItem value="certified" label="Airbyte Connector" default>
+      <TabItem value="certified" label="Airbyte Connectors" default>
         <ConnectorTable
           connectors={connectors}
           connectorSupportLevel={"certified"}


### PR DESCRIPTION
Tabs! Just like in-product! 
<img width="1678" alt="Screenshot 2024-09-06 at 3 08 23 PM" src="https://github.com/user-attachments/assets/2b25de1b-631a-4d01-bd39-1c73334c9154">
<img width="1678" alt="Screenshot 2024-09-06 at 3 08 25 PM" src="https://github.com/user-attachments/assets/e6c02fa9-a5c8-4851-890d-03e4132aa9fa">
