### PR TITLE
metadata-service[orchestrator]: fix apply connector releases

### DIFF
--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/registry_entry.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/registry_entry.py
@@ -94,8 +94,8 @@ def calculate_migration_documentation_url(releases_or_breaking_change: dict, doc
 def apply_connector_releases(metadata: dict) -> Optional[pd.DataFrame]:
     documentation_url = metadata.get("documentationUrl")
     final_registry_releases = {}
-
-    if metadata.get("releases", {}).get("breakingChanges"):
+    releases = metadata.get("releases")
+    if releases is not None and releases.get("breakingChanges"):
         # apply defaults for connector releases
         final_registry_releases["migrationDocumentationUrl"] = calculate_migration_documentation_url(
             metadata["releases"], documentation_url

--- a/airbyte-ci/connectors/metadata_service/orchestrator/pyproject.toml
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "orchestrator"
-version = "0.5.2"
+version = "0.5.3"
 description = ""
 authors = ["Ben Church <ben@airbyte.io>"]
 readme = "README.md"


### PR DESCRIPTION
## What
Deserialization of yaml metadata to  metadata defintion object and then to dict leads to the releases field to be set to None.

This is problematic on registry entry generation when we manipulate this field.
