### PR TITLE
:zap: Speedup method `PrintBuffer.write` by 73% by disabling periodic flushing as it is slower [codeflash]

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/utils/print_buffer.py
+++ b/airbyte-cdk/python/airbyte_cdk/utils/print_buffer.py
@@ -1,9 +1,8 @@
 # Copyright (c) 2024 Airbyte, Inc., all rights reserved.
 
 import sys
-import time
 from io import StringIO
-from threading import RLock
+from threading import Lock
 from types import TracebackType
 from typing import Optional
 
@@ -19,13 +18,11 @@ class PrintBuffer:
 
     Attributes:
         buffer (StringIO): A buffer to store the messages before flushing.
-        flush_interval (float): The time interval (in seconds) after which the buffer is flushed.
-        last_flush_time (float): The last time the buffer was flushed.
-        lock (RLock): A reentrant lock to ensure thread-safe operations.
+        lock (Lock): A lock to ensure thread-safe operations.
 
     Methods:
         write(message: str) -> None:
-            Writes a message to the buffer and flushes if the interval has passed.
+            Writes a message to the buffer.
 
         flush() -> None:
             Flushes the buffer content to the standard output.
@@ -37,19 +34,13 @@ class PrintBuffer:
             Exits the runtime context and restores the original stdout and stderr.
     """
 
-    def __init__(self, flush_interval: float = 0.1):
+    def __init__(self):
         self.buffer = StringIO()
-        self.flush_interval = flush_interval
-        self.last_flush_time = time.monotonic()
-        self.lock = RLock()
+        self.lock = Lock()
 
     def write(self, message: str) -> None:
         with self.lock:
             self.buffer.write(message)
-            current_time = time.monotonic()
-            if (current_time - self.last_flush_time) >= self.flush_interval:
-                self.flush()
-                self.last_flush_time = current_time
 
     def flush(self) -> None:
         with self.lock:


### PR DESCRIPTION
📈 Performance improved by `73%` (`0.73x` faster)

⏱️ Runtime went down from `0.535 seconds` to `0.309 seconds`
On the airbyte-ci benchmark with 24million records the end-to-end runtime went down from `3m25s` to `3m15s`

PrintBuffer is used in only one part of the codebase at entrypoint.py like 
```python
    with PrintBuffer():
        for message in source_entrypoint.run(parsed_args):
            print(f"{message}\n", end="", flush=True)
```
This results in every print operation using `PrintBuffer`'s `.write` operation and then it is also flushed at each write because print is called with `flush=True`. So the StringIO buffer does not accumulate because it is flushed with every `print`. The logic to dump every 0.1s was essentially unused, and check for 'Should I flush at this write attempt?' caused overhead with every write operation which is very frequent.

This was the performance of write operation of the master branch code. This was measured with pyinstrument for 100,000 source_hardcoded_record entries as config, which generates 300,000 records
```
|     ├─ 3.101 PrintBuffer.flush  airbyte_cdk/utils/print_buffer.py:54
│     │  ├─ 2.767 TextIOWrapper.write  <built-in>
│     │  └─ 0.266 [self]  airbyte_cdk/utils/print_buffer.py
│     ├─ 0.535 PrintBuffer.write  airbyte_cdk/utils/print_buffer.py:46
│     │  └─ 0.376 [self]  airbyte_cdk/utils/print_buffer.py
```
Over here the main focus is `PrintBuffer.write` where the function body denoted by `[self]` takes 0.376 seconds.

The optimization is to remove the following checks with every `.write()` as it was unnecessary.
```
            current_time = time.monotonic()
            if (current_time - self.last_flush_time) >= self.flush_interval:
```
It is probably as good idea to remove the re-entrant lock with a regular lock since `.write()` does not call `.flush()` anymore. And hopefully the normal lock is faster since it needs to do lesser checks.
After applying the following optimizations here is how the time looks like
```
│     ├─ 3.105 PrintBuffer.flush  airbyte_cdk/utils/print_buffer.py:47
│     │  ├─ 2.758 TextIOWrapper.write  <built-in>
│     │  └─ 0.288 [self]  airbyte_cdk/utils/print_buffer.py
│     ├─ 0.309 PrintBuffer.write  airbyte_cdk/utils/print_buffer.py:43
│     │  └─ 0.213 [self]  airbyte_cdk/utils/print_buffer.py
```
We have saved about 0.125 seconds (over a total of 10s workflow), with the savings coming from the `[self]` body which takes only 0.213s now.

Also I found that the alternative of batching print statements and printing every 0.1s slows everything down by a lot. I proved this by using the code at master branch and modifying the outer print to `flush=False`. Here is how that went
```
│     ├─ 6.238 PrintBuffer.write  airbyte_cdk/utils/print_buffer.py:45
│     │  ├─ 5.881 PrintBuffer.flush  airbyte_cdk/utils/print_buffer.py:53
│     │  │  └─ 5.844 TextIOWrapper.write  <built-in>
│     │  └─ 0.242 [self]  airbyte_cdk/utils/print_buffer.py
```
It takes 2x more time now. This proves that for source-hardcoded-records buffering is wasteful, and moreover this flushing behavior was disabled because the print was flushed everytime.

With this analysis, it is a good idea to remove the batched-flush from printing.

Also as an extension for concurrent-cdk another optimization for the `.flush()` function could be the following
```
    def flush(self) -> None:
        with self.lock:
            combined_message = self.buffer.getvalue()
            self.buffer = StringIO()
        sys.__stdout__.write(combined_message)  # type: ignore[union-attr]
```
that is not printing to the real stdout behind a lock. This allows other threads or processes to write into the buffer while another process is printing. At the same time, only one process can write into the real stdout as the stdout write will only run after the lock is acquired. This can be tested if its faster
