### PR TITLE
live-test: improve error message when the selected connection did not run the control version

### DIFF
--- a/airbyte-ci/connectors/live-tests/README.md
+++ b/airbyte-ci/connectors/live-tests/README.md
@@ -279,6 +279,11 @@ The traffic recorded on the control connector is passed to the target connector 
 
 ## Changelog
 
+### 0.18.8
+
+Improve error message when failing to retrieve connection. 
+Ask to double-check that a sync ran with the control version on the selected connection.
+
 ### 0.18.7
 
 Improve error message when failing to retrieve connection.

--- a/airbyte-ci/connectors/live-tests/pyproject.toml
+++ b/airbyte-ci/connectors/live-tests/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "live-tests"
-version = "0.18.7"
+version = "0.18.8"
 description = "Contains utilities for testing connectors against live data."
 authors = ["Airbyte <contact@airbyte.io>"]
 license = "MIT"

--- a/airbyte-ci/connectors/live-tests/src/live_tests/commons/connection_objects_retrieval.py
+++ b/airbyte-ci/connectors/live-tests/src/live_tests/commons/connection_objects_retrieval.py
@@ -240,7 +240,7 @@ def _get_connection_objects_from_retrieved_objects(
         )
     elif retrieved_source_docker_image.split(":")[1] != source_docker_image_tag:
         raise InvalidConnectionError(
-            f"The provided docker image tag ({source_docker_image_tag}) does not match the image tag for connection ID {connection_id}. Please double check that this connection is using the correct image tag. Connection URL: {connection_url}"
+            f"The provided docker image tag ({source_docker_image_tag}) does not match the image tag for connection ID {connection_id}. Please double check that this connection is using the correct image tag and the latest job ran using this version. Connection URL: {connection_url}"
         )
 
     return ConnectionObjects(


### PR DESCRIPTION
## What
The connection retriever fetches connection matching the control version passed by the user.
When the selected connection did not run a job with the control version we raises an `InvalidConnectionError`.
Even if the connection is correctly using the control version the connection might not have run a sync on it yet.
Which causes the error.
The constraint of having the latest job on the control version exists to be sure we run our test suite on not connections which are not pinning a version.
