### PR TITLE
metadata-service[orchestrator]: avoid "too large" errors in generate_registry_reports

### DIFF
--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/utils/dagster_helpers.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/utils/dagster_helpers.py
@@ -17,8 +17,8 @@ def output_dataframe(result_df: pd.DataFrame) -> Output[pd.DataFrame]:
     Returns a Dagster Output object with a dataframe as the result and a markdown preview.
     """
 
-    # Truncate to 100 rows to avoid dagster throwing a "too large" error
-    MAX_PREVIEW_ROWS = 100
+    # Truncate to 10 rows to avoid dagster throwing a "too large" error
+    MAX_PREVIEW_ROWS = 10
     is_truncated = len(result_df) > MAX_PREVIEW_ROWS
     preview_result_df = result_df.head(MAX_PREVIEW_ROWS)
 

--- a/airbyte-ci/connectors/metadata_service/orchestrator/pyproject.toml
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "orchestrator"
-version = "0.5.3"
+version = "0.5.4"
 description = ""
 authors = ["Ben Church <ben@airbyte.io>"]
 readme = "README.md"


### PR DESCRIPTION
## What
We face `errors.DagsterCloudHTTPError: 413 Client Error: Request Entity Too Large for url: https://airbyte-connectors.agent.dagster.cloud/graphql: <` when generating `cloud_sources_dataframe`. [Example](https://airbyte-connectors.dagster.cloud/prod/runs/c38c2556-2634-4567-a985-bc660800adb0)

It means that the markdown preview file we create is too large for Dagster...
Truncating from 100 to 10 lines is solving the problem.