### PR TITLE
airbyte-ci: add 'incubating' support level

### DIFF
--- a/airbyte-ci/connectors/connector_ops/README.md
+++ b/airbyte-ci/connectors/connector_ops/README.md
@@ -37,6 +37,7 @@ poetry run pytest
 ```
 
 ## Changelog
+- 0.10.0: Added an `incubating` value to `SupportLevelEnum`.
 - 0.9.0: Add components path attribute for manifest-only connectors.
 - 0.8.1: Gradle dependency discovery logic supports the Bulk CDK.
 - 0.8.0: Add a `sbom_url` property to `Connector`

--- a/airbyte-ci/connectors/connector_ops/connector_ops/utils.py
+++ b/airbyte-ci/connectors/connector_ops/connector_ops/utils.py
@@ -780,3 +780,4 @@ class SupportLevelEnum(str, Enum):
     certified = "certified"
     community = "community"
     archived = "archived"
+    incubating = "incubating"

--- a/airbyte-ci/connectors/connector_ops/pyproject.toml
+++ b/airbyte-ci/connectors/connector_ops/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "connector_ops"
-version = "0.9.0"
+version = "0.10.0"
 description = "Packaged maintained by the connector operations team to perform CI for connectors"
 authors = ["Airbyte <contact@airbyte.io>"]
 

--- a/airbyte-ci/connectors/connectors_qa/README.md
+++ b/airbyte-ci/connectors/connectors_qa/README.md
@@ -108,6 +108,10 @@ poe lint
 
 ## Changelog
 
+### 1.8.0
+
+Added support for `supportLevel: incubating`, which skips all documentation checks.
+
 ### 1.7.0
 
 Added  `CheckDocumentationLinks`, `CheckDocumentationHeadersOrder`, `CheckPrerequisitesSectionDescribesRequiredFieldsFromSpec`, 

--- a/airbyte-ci/connectors/connectors_qa/pyproject.toml
+++ b/airbyte-ci/connectors/connectors_qa/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "connectors-qa"
-version = "1.7.0"
+version = "1.8.0"
 description = "A package to run QA checks on Airbyte connectors, generate reports and documentation."
 authors = ["Airbyte <contact@airbyte.io>"]
 readme = "README.md"

--- a/airbyte-ci/connectors/connectors_qa/src/connectors_qa/checks/documentation/documentation.py
+++ b/airbyte-ci/connectors/connectors_qa/src/connectors_qa/checks/documentation/documentation.py
@@ -24,6 +24,7 @@ from .models import DocumentationContent, TemplateContent
 
 class DocumentationCheck(Check):
     category = CheckCategory.DOCUMENTATION
+    applies_to_connector_support_levels = ["certified", "community", "archived"]  # all but incubating
 
 
 class CheckMigrationGuide(DocumentationCheck):

--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/generated/ConnectorMetadataDefinitionV0.py
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/generated/ConnectorMetadataDefinitionV0.py
@@ -41,7 +41,7 @@ class ReleaseStage(BaseModel):
 
 
 class SupportLevel(BaseModel):
-    __root__: Literal["community", "certified", "archived"] = Field(
+    __root__: Literal["community", "certified", "archived", "incubating"] = Field(
         ..., description="enum that describes a connector's release stage", title="SupportLevel"
     )
 

--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/generated/ConnectorRegistryDestinationDefinition.py
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/generated/ConnectorRegistryDestinationDefinition.py
@@ -18,7 +18,7 @@ class ReleaseStage(BaseModel):
 
 
 class SupportLevel(BaseModel):
-    __root__: Literal["community", "certified", "archived"] = Field(
+    __root__: Literal["community", "certified", "archived", "incubating"] = Field(
         ..., description="enum that describes a connector's release stage", title="SupportLevel"
     )
 

--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/generated/ConnectorRegistryReleases.py
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/generated/ConnectorRegistryReleases.py
@@ -41,7 +41,7 @@ class ReleaseStage(BaseModel):
 
 
 class SupportLevel(BaseModel):
-    __root__: Literal["community", "certified", "archived"] = Field(
+    __root__: Literal["community", "certified", "archived", "incubating"] = Field(
         ..., description="enum that describes a connector's release stage", title="SupportLevel"
     )
 

--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/generated/ConnectorRegistrySourceDefinition.py
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/generated/ConnectorRegistrySourceDefinition.py
@@ -18,7 +18,7 @@ class ReleaseStage(BaseModel):
 
 
 class SupportLevel(BaseModel):
-    __root__: Literal["community", "certified", "archived"] = Field(
+    __root__: Literal["community", "certified", "archived", "incubating"] = Field(
         ..., description="enum that describes a connector's release stage", title="SupportLevel"
     )
 

--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/generated/ConnectorRegistryV0.py
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/generated/ConnectorRegistryV0.py
@@ -18,7 +18,7 @@ class ReleaseStage(BaseModel):
 
 
 class SupportLevel(BaseModel):
-    __root__: Literal["community", "certified", "archived"] = Field(
+    __root__: Literal["community", "certified", "archived", "incubating"] = Field(
         ..., description="enum that describes a connector's release stage", title="SupportLevel"
     )
 

--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/generated/SupportLevel.py
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/generated/SupportLevel.py
@@ -8,6 +8,6 @@ from typing_extensions import Literal
 
 
 class SupportLevel(BaseModel):
-    __root__: Literal["community", "certified", "archived"] = Field(
+    __root__: Literal["community", "certified", "archived", "incubating"] = Field(
         ..., description="enum that describes a connector's release stage", title="SupportLevel"
     )

--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/src/SupportLevel.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/src/SupportLevel.yaml
@@ -8,3 +8,4 @@ enum:
   - community
   - certified
   - archived
+  - incubating

--- a/airbyte-ci/connectors/metadata_service/lib/pyproject.toml
+++ b/airbyte-ci/connectors/metadata_service/lib/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metadata-service"
-version = "0.14.1"
+version = "0.15.0"
 description = ""
 authors = ["Ben Church <ben@airbyte.io>"]
 readme = "README.md"

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/invalid/metadata_support_level_incubating_version_not_zero.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/invalid/metadata_support_level_incubating_version_not_zero.yaml
@@ -1,0 +1,15 @@
+metadataSpecVersion: 1.0
+data:
+  name: AlloyDB for PostgreSQL
+  definitionId: 1fa90628-2b9e-11ed-a261-0242ac120002
+  connectorType: source
+  dockerRepository: airbyte/image-exists-1
+  githubIssueLabel: source-alloydb-strict-encrypt
+  dockerImageTag: 1.2.3
+  documentationUrl: https://docs.airbyte.com/integrations/sources/existingsource
+  connectorSubtype: database
+  releaseStage: generally_available
+  supportLevel: incubating
+  license: MIT
+  tags:
+    - language:java

--- a/airbyte-ci/connectors/metadata_service/lib/tests/test_validators/test_metadata_validators.py
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/test_validators/test_metadata_validators.py
@@ -71,10 +71,8 @@ def test_validation_fail_on_docker_image_tag_decrement(metadata_definition, decr
     metadata_definition.data.dockerImageTag = decremented_version
     success, error_message = metadata_validator.validate_docker_image_tag_is_not_decremented(metadata_definition, None)
     assert not success
-    assert (
-        error_message
-        == f"The dockerImageTag value ({decremented_version}) can't be decremented: it should be equal to or above {current_version}."
-    )
+    expected_prefix = f"The dockerImageTag value ({decremented_version}) can't be decremented: it should be equal to or above"
+    assert error_message.startswith(expected_prefix), error_message
 
 
 def test_validation_pass_on_docker_image_tag_increment(metadata_definition, incremented_version):

--- a/airbyte-ci/connectors/metadata_service/orchestrator/pyproject.toml
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "orchestrator"
-version = "0.5.4"
+version = "0.6.0"
 description = ""
 authors = ["Ben Church <ben@airbyte.io>"]
 readme = "README.md"

--- a/airbyte-ci/connectors/metadata_service/orchestrator/tests/test_registry.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/tests/test_registry.py
@@ -363,7 +363,7 @@ def test_sbom_url():
 
 def test_support_level_default():
     """
-    Test if supportLevel is defaulted to alpha in the registry entry.
+    Test if supportLevel is defaulted to community in the registry entry.
     """
     metadata = {"data": {"connectorType": "source", "definitionId": "test-id", "registryOverrides": {"oss": {"enabled": True}}}}
 

--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -843,6 +843,7 @@ airbyte-ci connectors --language=low-code migrate-to-manifest-only
 
 | Version | PR                                                         | Description                                                                                                                  |
 | ------- | ---------------------------------------------------------- |------------------------------------------------------------------------------------------------------------------------------|
+| 4.36.0  | [#45339](https://github.com/airbytehq/airbyte/pull/45339)  | Support connectors with `supportLevel: incubating`.                                                                          |
 | 4.35.1  | [#45160](https://github.com/airbytehq/airbyte/pull/45160)  | Remove deps.toml dependency for java connectors.                                                                             |
 | 4.35.0  | [#44879](https://github.com/airbytehq/airbyte/pull/44879)  | Mount `components.py` when building manifest-only connector image                                                            |
 | 4.34.2  | [#44786](https://github.com/airbytehq/airbyte/pull/44786)  | Pre-emptively skip archived connectors when searching for modified files                                                     |

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "4.35.1"
+version = "4.36.0"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 

--- a/docs/contributing-to-airbyte/resources/qa-checks.md
+++ b/docs/contributing-to-airbyte/resources/qa-checks.md
@@ -12,7 +12,7 @@ They are by no mean replacing the need for a manual review of the connector code
 
 _Applies to the following connector types: source, destination_
 _Applies to the following connector languages: java, low-code, python, manifest-only_
-_Applies to connector with any support level_
+_Applies to connector with certified, community, archived support level_
 _Applies to connector with any internal support level_
 _Applies to connector with any Airbyte usage level_
 
@@ -23,7 +23,7 @@ This document should contain a section for each breaking change, in order of the
 
 _Applies to the following connector types: source, destination_
 _Applies to the following connector languages: java, low-code, python, manifest-only_
-_Applies to connector with any support level_
+_Applies to connector with certified, community, archived support level_
 _Applies to connector with any internal support level_
 _Applies to connector with any Airbyte usage level_
 
@@ -33,7 +33,7 @@ The user facing connector documentation should be stored under `./docs/integrati
 
 _Applies to the following connector types: source_
 _Applies to the following connector languages: python, low-code_
-_Applies to connector with any support level_
+_Applies to connector with certified, community, archived support level_
 _Applies to connector with 300 internal support level_
 _Applies to connector with any Airbyte usage level_
 
@@ -43,7 +43,7 @@ The user facing connector documentation should update invalid links in connector
 
 _Applies to the following connector types: source_
 _Applies to the following connector languages: python, low-code_
-_Applies to connector with any support level_
+_Applies to connector with certified, community, archived support level_
 _Applies to connector with 300 internal support level_
 _Applies to connector with any Airbyte usage level_
 
@@ -121,7 +121,7 @@ List of not required headers, which can be not exist in the documentation and th
 
 _Applies to the following connector types: source_
 _Applies to the following connector languages: python, low-code_
-_Applies to connector with any support level_
+_Applies to connector with certified, community, archived support level_
 _Applies to connector with 300 internal support level_
 _Applies to connector with any Airbyte usage level_
 
@@ -132,7 +132,7 @@ If spec has required credentials/access_token/refresh_token etc, check searches 
 
 _Applies to the following connector types: source_
 _Applies to the following connector languages: python, low-code_
-_Applies to connector with any support level_
+_Applies to connector with certified, community, archived support level_
 _Applies to connector with 300 internal support level_
 _Applies to connector with any Airbyte usage level_
 
@@ -155,7 +155,7 @@ This page contains the setup guide and reference information for the [CONNECTOR_
 
 _Applies to the following connector types: source_
 _Applies to the following connector languages: python, low-code_
-_Applies to connector with any support level_
+_Applies to connector with certified, community, archived support level_
 _Applies to connector with 300 internal support level_
 _Applies to connector with any Airbyte usage level_
 
@@ -176,7 +176,7 @@ Check verifies that For Airbyte Cloud: header section content follows standard t
 
 _Applies to the following connector types: source_
 _Applies to the following connector languages: python, low-code_
-_Applies to connector with any support level_
+_Applies to connector with certified, community, archived support level_
 _Applies to connector with 300 internal support level_
 _Applies to connector with any Airbyte usage level_
 
@@ -194,7 +194,7 @@ Check verifies that For Airbyte Open Source: header section content follows stan
 
 _Applies to the following connector types: source_
 _Applies to the following connector languages: python, low-code_
-_Applies to connector with any support level_
+_Applies to connector with certified, community, archived support level_
 _Applies to connector with 300 internal support level_
 _Applies to connector with any Airbyte usage level_
 
@@ -213,7 +213,7 @@ The CONNECTOR_NAME_FROM_METADATA source connector supports the following [sync m
 
 _Applies to the following connector types: source_
 _Applies to the following connector languages: python, low-code_
-_Applies to connector with any support level_
+_Applies to connector with certified, community, archived support level_
 _Applies to connector with 300 internal support level_
 _Applies to connector with any Airbyte usage level_
 
@@ -232,7 +232,7 @@ Now that you have set up the CONNECTOR_NAME_FROM_METADATA source connector, chec
 
 _Applies to the following connector types: source_
 _Applies to the following connector languages: python, low-code_
-_Applies to connector with any support level_
+_Applies to connector with certified, community, archived support level_
 _Applies to connector with 300 internal support level_
 _Applies to connector with any Airbyte usage level_
 
@@ -250,7 +250,7 @@ Check verifies that Changelog header section content follows standard template:
 
 _Applies to the following connector types: source, destination_
 _Applies to the following connector languages: java, low-code, python, manifest-only_
-_Applies to connector with any support level_
+_Applies to connector with certified, community, archived support level_
 _Applies to connector with any internal support level_
 _Applies to connector with any Airbyte usage level_
 


### PR DESCRIPTION
## What
We need a support level for connectors which are under active development and which shouldn't be easily available to our users. For the time being, it's like `archived`; but it can't be `archived` because:
1. gradle deliberately does not support building archived java connectors;
2. airbyte-ci ignores archived connectors when deciding which connectors CI tests to run, we don't want for incubating connectors obviously;
3. we want metadata validation to behave differently for incubating connectors: their major version number should be 0, release notes are not required, etc.

## How
Adds an `incubating` support level value in connector_ops. Changes the metadata_service to treat this value in the same way as `archived`: the metadata for those connectors is ignored and so they (I believe) won't end up listed in the registry.

## Review guide
Commit by commit

## User Impact
None.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [x] NO ❌
