### PR TITLE
source-mysql-v2: set supportLevel to community

### DIFF
--- a/airbyte-integrations/connectors/source-mysql-v2/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mysql-v2/metadata.yaml
@@ -1,7 +1,7 @@
 data:
   ab_internal:
     ql: 200
-    sl: 100
+    sl: 0
   allowedHosts:
     hosts:
       - ${host}
@@ -9,7 +9,7 @@ data:
   connectorSubtype: database
   connectorType: source
   definitionId: 561393ed-7e3a-4d0d-8b8b-90ded371754c
-  dockerImageTag: 0.0.1
+  dockerImageTag: 0.0.2
   dockerRepository: airbyte/source-mysql-v2
   documentationUrl: https://docs.airbyte.com/integrations/sources/mysql
   githubIssueLabel: source-mysql-v2
@@ -22,7 +22,7 @@ data:
     oss:
       enabled: false
   releaseStage: alpha
-  supportLevel: archived
+  supportLevel: community
   tags:
     - language:java
 metadataSpecVersion: "1.0"


### PR DESCRIPTION
## What

Changes `supportLevel` from `archived` to `community`, sets `sl` to 0 to pass docs checks.

Depends on https://github.com/airbytehq/airbyte/pull/45360

This PR exists mainly to test the changes in the parent PR.

## How
n/a

## Review guide
n/a

## User Impact
None

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [x] NO ❌
