### PR TITLE
Load CDK TaskLauncher Refactor + Unit Tests

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/message/Batch.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/message/Batch.kt
@@ -21,7 +21,7 @@ import java.nio.file.Path
  * the associated ranges have been persisted remotely, and that platform checkpoint messages can be
  * emitted.
  *
- * [State.SPOOLED] is used internally to indicate that records have been spooled to disk for
+ * [State.SPILLED] is used internally to indicate that records have been spooled to disk for
  * processing and should not be used by implementors.
  *
  * When a stream has been read to End-of-stream, and all ranges between 0 and End-of-stream are
@@ -47,7 +47,7 @@ import java.nio.file.Path
  */
 interface Batch {
     enum class State {
-        SPOOLED,
+        SPILLED,
         LOCAL,
         PERSISTED,
         COMPLETE
@@ -61,9 +61,9 @@ data class SimpleBatch(override val state: Batch.State) : Batch
 
 /** Represents a file of records locally staged. */
 abstract class StagedLocalFile() : Batch {
-    override val state: Batch.State = Batch.State.LOCAL
     abstract val localPath: Path
     abstract val totalSizeBytes: Long
+    override val state: Batch.State = Batch.State.LOCAL
 }
 
 /** Represents a remote object containing persisted records. */
@@ -76,10 +76,10 @@ abstract class RemoteObject() : Batch {
  * Represents a file of raw records staged to disk for pre-processing. Used internally by the
  * framework
  */
-data class SpooledRawMessagesLocalFile(
+data class SpilledRawMessagesLocalFile(
     override val localPath: Path,
     override val totalSizeBytes: Long,
-    override val state: Batch.State = Batch.State.SPOOLED
+    override val state: Batch.State = Batch.State.SPILLED
 ) : StagedLocalFile()
 
 /**

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/state/CheckpointManager.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/state/CheckpointManager.kt
@@ -24,7 +24,7 @@ import java.util.function.Consumer
 interface CheckpointManager<K, T> {
     fun addStreamCheckpoint(key: K, index: Long, checkpointMessage: T)
     fun addGlobalCheckpoint(keyIndexes: List<Pair<K, Long>>, checkpointMessage: T)
-    fun flushReadyCheckpointMessages()
+    suspend fun flushReadyCheckpointMessages()
 }
 
 /**
@@ -116,7 +116,7 @@ abstract class StreamsCheckpointManager<T, U>() : CheckpointManager<DestinationS
         log.info { "Added global checkpoint with stream indexes: $keyIndexes" }
     }
 
-    override fun flushReadyCheckpointMessages() {
+    override suspend fun flushReadyCheckpointMessages() {
         /*
            Iterate over the checkpoints in order, evicting each that passes
            the persistence check. If a checkpoint is not persisted, then

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/state/StreamsManager.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/state/StreamsManager.kt
@@ -159,6 +159,7 @@ class DefaultStreamManager(
         return isProcessingCompleteForState(recordCount.get(), Batch.State.COMPLETE)
     }
 
+    /** TODO: Handle conflating PERSISTED w/ COMPLETE upstream, to allow for overlap? */
     override fun areRecordsPersistedUntil(index: Long): Boolean {
         return isProcessingCompleteForState(index, Batch.State.PERSISTED) ||
             isProcessingCompleteForState(index, Batch.State.COMPLETE) // complete => persisted

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/task/CloseStreamTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/task/CloseStreamTask.kt
@@ -4,51 +4,38 @@
 
 package io.airbyte.cdk.task
 
-import io.airbyte.cdk.command.DestinationStream
-import io.airbyte.cdk.state.StreamManager
-import io.airbyte.cdk.state.StreamsManager
 import io.airbyte.cdk.write.StreamLoader
 import io.micronaut.context.annotation.Secondary
 import jakarta.inject.Singleton
-import org.apache.mina.util.ConcurrentHashSet
+
+interface CloseStreamTask : Task
 
 /**
  * Wraps @[StreamLoader.close] and marks the stream as closed in the stream manager. Also starts the
  * teardown task.
  */
-class CloseStreamTask(
+class DefaultCloseStreamTask(
     private val streamLoader: StreamLoader,
-    private val streamManager: StreamManager,
     private val taskLauncher: DestinationTaskLauncher
-) : Task {
-    companion object {
-        val oncePerStream: ConcurrentHashSet<DestinationStream> = ConcurrentHashSet()
-    }
+) : CloseStreamTask {
 
     override suspend fun execute() {
-        /** Guard against running this more than once per stream */
-        if (oncePerStream.contains(streamLoader.stream) || streamManager.streamIsClosed()) {
-            return
-        }
-        oncePerStream.add(streamLoader.stream)
         streamLoader.close()
-        streamManager.markClosed()
-        /* TODO: just signal to the launcher that the stream is closed
-        and let it decide what to do next */
-        taskLauncher.startTeardownTask()
+        taskLauncher.handleStreamClosed(streamLoader.stream)
     }
+}
+
+interface CloseStreamTaskFactory {
+    fun make(taskLauncher: DestinationTaskLauncher, streamLoader: StreamLoader): CloseStreamTask
 }
 
 @Singleton
 @Secondary
-class CloseStreamTaskFactory(
-    private val streamsManager: StreamsManager,
-) {
-    fun make(taskLauncher: DestinationTaskLauncher, streamLoader: StreamLoader): CloseStreamTask {
-        return CloseStreamTask(
-            streamLoader,
-            streamsManager.getManager(streamLoader.stream),
-            taskLauncher
-        )
+class DefaultCloseStreamTaskFactory : CloseStreamTaskFactory {
+    override fun make(
+        taskLauncher: DestinationTaskLauncher,
+        streamLoader: StreamLoader
+    ): CloseStreamTask {
+        return DefaultCloseStreamTask(streamLoader, taskLauncher)
     }
 }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/task/DestinationTaskLauncher.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/task/DestinationTaskLauncher.kt
@@ -4,28 +4,64 @@
 
 package io.airbyte.cdk.task
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 import io.airbyte.cdk.command.DestinationCatalog
 import io.airbyte.cdk.command.DestinationStream
+import io.airbyte.cdk.message.Batch
 import io.airbyte.cdk.message.BatchEnvelope
 import io.airbyte.cdk.message.CheckpointMessage
-import io.airbyte.cdk.message.SpooledRawMessagesLocalFile
+import io.airbyte.cdk.message.SpilledRawMessagesLocalFile
 import io.airbyte.cdk.state.CheckpointManager
+import io.airbyte.cdk.state.StreamsManager
 import io.airbyte.cdk.write.StreamLoader
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.micronaut.context.annotation.Factory
 import io.micronaut.context.annotation.Secondary
 import jakarta.inject.Provider
 import jakarta.inject.Singleton
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 
 /**
  * Governs the task workflow for the entire destination life-cycle.
  *
  * The domain is "decide what to do next given the reported results of the individual task."
  *
- * TODO: Some of that logic still lives in the tasks. Migrate it here.
+ * The workflow is as follows:
+ *
+ * 1. Start the destination setup task.
+ * 2. Start the spill-to-disk task for each stream
+ * 3. When setup completes, start the open stream task for each stream
+ * 4. When each new spilled file is ready, start the process records task
+ * ```
+ *    (This task will wait if open stream is not yet complete for that stream.)
+ * ```
+ * 5. When each batch is ready
+ * ```
+ *    - update the batch state in the stream manager
+ *    - if the batch is not complete, start the process batch task
+ *    - if the batch is complete and all batches are complete, start the close stream task
+ * ```
+ * 6. When the stream is closed
+ * ```
+ *    - mark the stream as closed in the stream manager
+ *    - start the teardown task
+ *    (The teardown task will only run once, and only after all streams are closed.)
+ * ```
+ * 7. When the teardown task is complete, stop the task launcher
+ *
+ * // TODO: Capture failures, retry, and call into close(failure=true) if can't recover.
  */
+@SuppressFBWarnings(
+    "NP_NONNULL_PARAM_VIOLATION",
+    justification = "arguments are guaranteed to be non-null by Kotlin's type system"
+)
 class DestinationTaskLauncher(
     private val catalog: DestinationCatalog,
+    private val streamsManager: StreamsManager,
     override val taskRunner: TaskRunner,
     private val checkpointManager: CheckpointManager<DestinationStream, CheckpointMessage>,
     private val setupTaskFactory: SetupTaskFactory,
@@ -38,54 +74,108 @@ class DestinationTaskLauncher(
 ) : TaskLauncher {
     private val log = KotlinLogging.logger {}
 
-    override suspend fun start() {
-        log.info { "Starting startup task" }
-        taskRunner.enqueue(setupTaskFactory.make(this))
+    private val runTeardownOnce = AtomicBoolean(false)
+    private val batchUpdateLock = Mutex()
+
+    private val streamLoaders:
+        ConcurrentHashMap<DestinationStream, CompletableDeferred<StreamLoader>> =
+        ConcurrentHashMap()
+
+    init {
+        catalog.streams.forEach { streamLoaders[it] = CompletableDeferred() }
     }
 
-    suspend fun startOpenStreamTasks() {
-        catalog.streams.forEach {
-            log.info { "Starting open stream task for $it" }
-            taskRunner.enqueue(openStreamTaskFactory.make(this, it))
+    override suspend fun start() {
+        log.info { "Starting startup task" }
+        val setupTask = setupTaskFactory.make(this)
+        taskRunner.enqueue(setupTask)
+        catalog.streams.forEach { stream ->
+            log.info { "Starting spill-to-disk task for $stream" }
+            val spillTask = spillToDiskTaskFactory.make(this, stream)
+            taskRunner.enqueue(spillTask)
         }
     }
 
-    suspend fun startSpillToDiskTasks(streamLoader: StreamLoader) {
-        log.info { "Starting spill-to-disk task for ${streamLoader.stream}" }
-        val task = spillToDiskTaskFactory.make(this, streamLoader)
+    /** Called when the initial destination setup completes. */
+    suspend fun handleSetupComplete() {
+        catalog.streams.forEach {
+            log.info { "Starting open stream task for $it" }
+            val openStreamTask = openStreamTaskFactory.make(this, it)
+            taskRunner.enqueue(openStreamTask)
+        }
+    }
+
+    /** Called when a stream is ready for loading. */
+    suspend fun handleStreamOpen(streamLoader: StreamLoader) {
+        log.info { "Registering stream open and loader available for ${streamLoader.stream}" }
+        streamLoaders[streamLoader.stream]!!.complete(streamLoader)
+    }
+
+    /** Called for each new spilled file. */
+    suspend fun handleNewSpilledFile(
+        stream: DestinationStream,
+        wrapped: BatchEnvelope<SpilledRawMessagesLocalFile>
+    ) {
+        val streamLoader = streamLoaders[stream]!!.await()
+        log.info {
+            "Starting process records task for ${streamLoader.stream}, file ${wrapped.batch}"
+        }
+        val task = processRecordsTaskFactory.make(this, streamLoader, wrapped)
         taskRunner.enqueue(task)
     }
 
-    suspend fun startProcessRecordsTask(
-        streamLoader: StreamLoader,
-        fileEnvelope: BatchEnvelope<SpooledRawMessagesLocalFile>
-    ) {
-        log.info {
-            "Starting process records task for ${streamLoader.stream}, file ${fileEnvelope.batch}"
+    /**
+     * Called for each new batch. Enqueues processing for any incomplete batch, and enqueues closing
+     * the stream if all batches are complete.
+     */
+    suspend fun handleNewBatch(streamLoader: StreamLoader, wrapped: BatchEnvelope<*>) {
+        batchUpdateLock.withLock {
+            val streamManager = streamsManager.getManager(streamLoader.stream)
+            streamManager.updateBatchState(wrapped)
+
+            if (wrapped.batch.state != Batch.State.COMPLETE) {
+                log.info {
+                    "Batch not complete: Starting process batch task for ${streamLoader.stream}, batch $wrapped"
+                }
+
+                val task = processBatchTaskFactory.make(this, streamLoader, wrapped)
+                taskRunner.enqueue(task)
+            } else if (streamManager.isBatchProcessingComplete()) {
+                log.info {
+                    "Batch $wrapped complete and batch processing complete: Starting close stream task for ${streamLoader.stream}"
+                }
+
+                val task = closeStreamTaskFactory.make(this, streamLoader)
+                taskRunner.enqueue(task)
+            } else {
+                log.info {
+                    "Batch $wrapped complete, but batch processing not complete: nothing else to do."
+                }
+            }
         }
-        taskRunner.enqueue(processRecordsTaskFactory.make(this, streamLoader, fileEnvelope))
     }
 
-    suspend fun startProcessBatchTask(streamLoader: StreamLoader, batch: BatchEnvelope<*>) {
-        log.info { "Starting process batch task for ${streamLoader.stream}, batch ${batch.batch}" }
-        taskRunner.enqueue(processBatchTaskFactory.make(this, streamLoader, batch))
-    }
-
-    suspend fun startCloseStreamTasks(streamLoader: StreamLoader) {
-        log.info { "Starting close stream task for ${streamLoader.stream}" }
-        taskRunner.enqueue(closeStreamTaskFactory.make(this, streamLoader))
-    }
-
-    suspend fun startTeardownTask() {
-        log.info { "Starting teardown task" }
+    /** Called when a stream is closed. */
+    suspend fun handleStreamClosed(stream: DestinationStream) {
+        streamsManager.getManager(stream).markClosed()
         checkpointManager.flushReadyCheckpointMessages()
-        taskRunner.enqueue(teardownTaskFactory.make(this))
+        if (runTeardownOnce.compareAndSet(false, true)) {
+            streamsManager.awaitAllStreamsClosed()
+            log.info { "Starting teardown task" }
+            taskRunner.enqueue(teardownTaskFactory.make(this))
+        }
+    }
+
+    /** Called exactly once when all streams are closed. */
+    suspend fun handleTeardownComplete() {
+        stop()
     }
 }
 
 @Factory
 class DestinationTaskLauncherFactory(
     private val catalog: DestinationCatalog,
+    private val streamsManager: StreamsManager,
     private val taskRunner: TaskRunner,
     private val checkpointManager: CheckpointManager<DestinationStream, CheckpointMessage>,
     private val setupTaskFactory: SetupTaskFactory,
@@ -101,6 +191,7 @@ class DestinationTaskLauncherFactory(
     override fun get(): DestinationTaskLauncher {
         return DestinationTaskLauncher(
             catalog,
+            streamsManager,
             taskRunner,
             checkpointManager,
             setupTaskFactory,

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/task/ProcessBatchTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/task/ProcessBatchTask.kt
@@ -4,54 +4,45 @@
 
 package io.airbyte.cdk.task
 
-import io.airbyte.cdk.message.Batch
 import io.airbyte.cdk.message.BatchEnvelope
-import io.airbyte.cdk.state.StreamManager
 import io.airbyte.cdk.state.StreamsManager
 import io.airbyte.cdk.write.StreamLoader
 import io.micronaut.context.annotation.Secondary
 import jakarta.inject.Singleton
 
-/**
- * Wraps @[StreamLoader.processBatch] and handles the resulting batch, possibly calling back into
- * the task or initiating close stream if processing is complete.
- *
- * TODO: Move handling batch results into the task launcher.
- */
-class ProcessBatchTask(
+interface ProcessBatchTask : Task
+
+/** Wraps @[StreamLoader.processBatch] and handles the resulting batch. */
+class DefaultProcessBatchTask(
     private val batchEnvelope: BatchEnvelope<*>,
     private val streamLoader: StreamLoader,
-    private val streamManager: StreamManager,
     private val taskLauncher: DestinationTaskLauncher
-) : Task {
+) : ProcessBatchTask {
     override suspend fun execute() {
         val nextBatch = streamLoader.processBatch(batchEnvelope.batch)
         val nextWrapped = batchEnvelope.withBatch(nextBatch)
-        streamManager.updateBatchState(nextWrapped)
-
-        if (nextBatch.state != Batch.State.COMPLETE) {
-            taskLauncher.startProcessBatchTask(streamLoader, nextWrapped)
-        } else if (streamManager.isBatchProcessingComplete()) {
-            taskLauncher.startCloseStreamTasks(streamLoader)
-        }
+        taskLauncher.handleNewBatch(streamLoader, nextWrapped)
     }
 }
 
-@Singleton
-@Secondary
-class ProcessBatchTaskFactory(
-    private val streamsManager: StreamsManager,
-) {
+interface ProcessBatchTaskFactory {
     fun make(
         taskLauncher: DestinationTaskLauncher,
         streamLoader: StreamLoader,
         batchEnvelope: BatchEnvelope<*>
+    ): ProcessBatchTask
+}
+
+@Singleton
+@Secondary
+class DefaultProcessBatchTaskFactory(
+    private val streamsManager: StreamsManager,
+) : ProcessBatchTaskFactory {
+    override fun make(
+        taskLauncher: DestinationTaskLauncher,
+        streamLoader: StreamLoader,
+        batchEnvelope: BatchEnvelope<*>
     ): ProcessBatchTask {
-        return ProcessBatchTask(
-            batchEnvelope,
-            streamLoader,
-            streamsManager.getManager(streamLoader.stream),
-            taskLauncher
-        )
+        return DefaultProcessBatchTask(batchEnvelope, streamLoader, taskLauncher)
     }
 }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/task/SetupTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/task/SetupTask.kt
@@ -8,28 +8,34 @@ import io.airbyte.cdk.write.DestinationWriteOperation
 import io.micronaut.context.annotation.Secondary
 import jakarta.inject.Singleton
 
+interface SetupTask : Task
+
 /**
  * Wraps @[DestinationWriteOperation.setup] and starts the open stream tasks.
  *
  * TODO: This should call something like "TaskLauncher.setupComplete" and let it decide what to do
  * next.
  */
-class SetupTask(
+class DefaultSetupTask(
     private val destination: DestinationWriteOperation,
     private val taskLauncher: DestinationTaskLauncher
-) : Task {
+) : SetupTask {
     override suspend fun execute() {
         destination.setup()
-        taskLauncher.startOpenStreamTasks()
+        taskLauncher.handleSetupComplete()
     }
+}
+
+interface SetupTaskFactory {
+    fun make(taskLauncher: DestinationTaskLauncher): SetupTask
 }
 
 @Singleton
 @Secondary
-class SetupTaskFactory(
+class DefaultSetupTaskFactory(
     private val destination: DestinationWriteOperation,
-) {
-    fun make(taskLauncher: DestinationTaskLauncher): SetupTask {
-        return SetupTask(destination, taskLauncher)
+) : SetupTaskFactory {
+    override fun make(taskLauncher: DestinationTaskLauncher): SetupTask {
+        return DefaultSetupTask(destination, taskLauncher)
     }
 }

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/command/MockCatalogFactory.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/command/MockCatalogFactory.kt
@@ -9,6 +9,7 @@ import io.airbyte.cdk.data.IntegerType
 import io.airbyte.cdk.data.ObjectType
 import io.airbyte.cdk.data.StringType
 import io.micronaut.context.annotation.Factory
+import io.micronaut.context.annotation.Primary
 import io.micronaut.context.annotation.Replaces
 import io.micronaut.context.annotation.Requires
 import jakarta.inject.Named
@@ -55,6 +56,7 @@ class MockCatalogFactory : DestinationCatalogFactory {
 
     @Singleton
     @Named("mockCatalog")
+    @Primary
     override fun make(): DestinationCatalog {
         return DestinationCatalog(streams = listOf(stream1, stream2))
     }

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/message/DestinationMessageQueueWriterTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/message/DestinationMessageQueueWriterTest.kt
@@ -103,7 +103,7 @@ class DestinationMessageQueueWriterTest {
             globalStates.add(keyIndexes to checkpointMessage)
         }
 
-        override fun flushReadyCheckpointMessages() {
+        override suspend fun flushReadyCheckpointMessages() {
             TODO("Not yet implemented")
         }
     }

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/state/MockStreamsManager.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/state/MockStreamsManager.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.state
+
+import com.google.common.collect.Range
+import com.google.common.collect.RangeSet
+import com.google.common.collect.TreeRangeSet
+import io.airbyte.cdk.command.DestinationCatalog
+import io.airbyte.cdk.command.DestinationStream
+import io.airbyte.cdk.message.Batch
+import io.airbyte.cdk.message.BatchEnvelope
+import jakarta.inject.Named
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlinx.coroutines.CompletableDeferred
+
+class MockStreamsManager(@Named("mockCatalog") catalog: DestinationCatalog) : StreamsManager {
+    private val mockManagers = catalog.streams.associateWith { MockStreamManager() }
+
+    fun addPersistedRanges(stream: DestinationStream, ranges: List<Range<Long>>) {
+        mockManagers[stream]!!.persistedRanges.addAll(ranges)
+    }
+
+    override fun getManager(stream: DestinationStream): StreamManager {
+        return mockManagers[stream] ?: throw IllegalArgumentException("Stream not found: $stream")
+    }
+
+    override suspend fun awaitAllStreamsClosed() {
+        mockManagers.forEach { (_, manager) -> manager.awaitStreamClosed() }
+    }
+}
+
+/**
+ * The only thing we really need is `areRecordsPersistedUntil`. (Technically we're emulating the @
+ * [StreamManager] behavior here, since the state manager doesn't actually know what ranges are
+ * closed, but less than that would make the test unrealistic.)
+ */
+class MockStreamManager : StreamManager {
+    var persistedRanges: RangeSet<Long> = TreeRangeSet.create()
+    private var batchProcessingComplete: AtomicBoolean = AtomicBoolean(false)
+    val streamLatch = CompletableDeferred<Unit>()
+
+    fun mockBatchProcessingComplete(value: Boolean = true) {
+        return batchProcessingComplete.set(value)
+    }
+
+    override fun countRecordIn(): Long {
+        throw NotImplementedError()
+    }
+
+    override fun countEndOfStream(): Long {
+        throw NotImplementedError()
+    }
+
+    override fun markCheckpoint(): Pair<Long, Long> {
+        throw NotImplementedError()
+    }
+
+    override fun <B : Batch> updateBatchState(batch: BatchEnvelope<B>) {
+        batch.ranges.asRanges().forEach { persistedRanges.add(it) }
+    }
+
+    override fun isBatchProcessingComplete(): Boolean {
+        return batchProcessingComplete.get()
+    }
+
+    override fun areRecordsPersistedUntil(index: Long): Boolean {
+        return persistedRanges.encloses(Range.closedOpen(0, index))
+    }
+
+    override fun markClosed() {
+        streamLatch.complete(Unit)
+    }
+
+    override fun streamIsClosed(): Boolean {
+        throw NotImplementedError()
+    }
+
+    override suspend fun awaitStreamClosed() {
+        streamLatch.await()
+    }
+}

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/task/DestinationTaskLauncherTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/task/DestinationTaskLauncherTest.kt
@@ -1,0 +1,347 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.task
+
+import com.google.common.collect.Range
+import com.google.common.collect.TreeRangeSet
+import io.airbyte.cdk.command.DestinationCatalog
+import io.airbyte.cdk.command.DestinationStream
+import io.airbyte.cdk.command.MockCatalogFactory.Companion.stream1
+import io.airbyte.cdk.command.MockCatalogFactory.Companion.stream2
+import io.airbyte.cdk.message.Batch
+import io.airbyte.cdk.message.BatchEnvelope
+import io.airbyte.cdk.message.CheckpointMessage
+import io.airbyte.cdk.message.DestinationRecord
+import io.airbyte.cdk.message.SimpleBatch
+import io.airbyte.cdk.message.SpilledRawMessagesLocalFile
+import io.airbyte.cdk.state.CheckpointManager
+import io.airbyte.cdk.state.MockStreamManager
+import io.airbyte.cdk.state.MockStreamsManager
+import io.airbyte.cdk.state.StreamsManager
+import io.airbyte.cdk.write.DestinationWriteOperation
+import io.airbyte.cdk.write.StreamLoader
+import io.micronaut.context.annotation.Factory
+import io.micronaut.context.annotation.Primary
+import io.micronaut.context.annotation.Replaces
+import io.micronaut.context.annotation.Requires
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+import kotlin.io.path.Path
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+@MicronautTest(rebuildContext = true, environments = ["DestinationTaskLauncherTest"])
+class DestinationTaskLauncherTest {
+    @Inject lateinit var taskRunner: TaskRunner
+    @Inject lateinit var taskLauncherFactory: DestinationTaskLauncherFactory
+    @Inject lateinit var streamsManager: StreamsManager
+    @Inject lateinit var checkpointManager: MockCheckpointManager
+
+    @Inject lateinit var mockSetupTaskFactory: MockSetupTaskFactory
+    @Inject lateinit var mockSpillToDiskTaskFactory: MockSpillToDiskTaskFactory
+    @Inject lateinit var mockOpenStreamTaskFactory: MockOpenStreamTaskFactory
+    @Inject lateinit var processRecordsTaskFactory: MockProcessRecordsTaskFactory
+    @Inject lateinit var processBatchTaskFactory: MockProcessBatchTaskFactory
+    @Inject lateinit var closeStreamTaskFactory: MockCloseStreamTaskFactory
+    @Inject lateinit var teardownTaskFactory: MockTeardownTaskFactory
+
+    @Singleton
+    @Replaces(DefaultSetupTaskFactory::class)
+    @Requires(env = ["DestinationTaskLauncherTest"])
+    class MockSetupTaskFactory : SetupTaskFactory {
+        val hasRun: Channel<Unit> = Channel(Channel.UNLIMITED)
+
+        override fun make(taskLauncher: DestinationTaskLauncher): SetupTask {
+            return object : SetupTask {
+                override suspend fun execute() {
+                    hasRun.send(Unit)
+                }
+            }
+        }
+    }
+
+    @Singleton
+    @Replaces(DefaultSpillToDiskTaskFactory::class)
+    @Requires(env = ["DestinationTaskLauncherTest"])
+    class MockSpillToDiskTaskFactory(catalog: DestinationCatalog) : SpillToDiskTaskFactory {
+        val streamHasRun = mutableMapOf<DestinationStream, Channel<Unit>>()
+
+        init {
+            catalog.streams.forEach { streamHasRun[it] = Channel(Channel.UNLIMITED) }
+        }
+
+        override fun make(
+            taskLauncher: DestinationTaskLauncher,
+            stream: DestinationStream
+        ): SpillToDiskTask {
+            return object : SpillToDiskTask {
+                override suspend fun execute() {
+                    streamHasRun[stream]?.send(Unit)
+                }
+            }
+        }
+    }
+
+    @Singleton
+    @Replaces(DefaultOpenStreamTaskFactory::class)
+    @Requires(env = ["DestinationTaskLauncherTest"])
+    class MockOpenStreamTaskFactory(catalog: DestinationCatalog) : OpenStreamTaskFactory {
+        val streamHasRun = mutableMapOf<DestinationStream, Channel<Unit>>()
+
+        init {
+            catalog.streams.forEach { streamHasRun[it] = Channel(Channel.UNLIMITED) }
+        }
+
+        override fun make(
+            taskLauncher: DestinationTaskLauncher,
+            stream: DestinationStream
+        ): OpenStreamTask {
+            return object : OpenStreamTask {
+                override suspend fun execute() {
+                    streamHasRun[stream]?.send(Unit)
+                }
+            }
+        }
+    }
+
+    @Singleton
+    @Replaces(DefaultProcessRecordsTaskFactory::class)
+    @Requires(env = ["DestinationTaskLauncherTest"])
+    class MockProcessRecordsTaskFactory : ProcessRecordsTaskFactory {
+        val hasRun: Channel<Unit> = Channel(Channel.UNLIMITED)
+
+        override fun make(
+            taskLauncher: DestinationTaskLauncher,
+            streamLoader: StreamLoader,
+            fileEnvelope: BatchEnvelope<SpilledRawMessagesLocalFile>
+        ): ProcessRecordsTask {
+            return object : ProcessRecordsTask {
+                override suspend fun execute() {
+                    hasRun.send(Unit)
+                }
+            }
+        }
+    }
+
+    @Singleton
+    @Replaces(DefaultProcessBatchTaskFactory::class)
+    @Requires(env = ["DestinationTaskLauncherTest"])
+    class MockProcessBatchTaskFactory : ProcessBatchTaskFactory {
+        val hasRun: Channel<BatchEnvelope<*>> = Channel(Channel.UNLIMITED)
+
+        override fun make(
+            taskLauncher: DestinationTaskLauncher,
+            streamLoader: StreamLoader,
+            batchEnvelope: BatchEnvelope<*>
+        ): ProcessBatchTask {
+            return object : ProcessBatchTask {
+                override suspend fun execute() {
+                    hasRun.send(batchEnvelope)
+                }
+            }
+        }
+    }
+
+    @Singleton
+    @Replaces(DefaultCloseStreamTaskFactory::class)
+    @Requires(env = ["DestinationTaskLauncherTest"])
+    class MockCloseStreamTaskFactory : CloseStreamTaskFactory {
+        val hasRun: Channel<Unit> = Channel(Channel.UNLIMITED)
+
+        override fun make(
+            taskLauncher: DestinationTaskLauncher,
+            streamLoader: StreamLoader
+        ): CloseStreamTask {
+            return object : CloseStreamTask {
+                override suspend fun execute() {
+                    hasRun.send(Unit)
+                }
+            }
+        }
+    }
+
+    @Singleton
+    @Replaces(DefaultTeardownTaskFactory::class)
+    @Requires(env = ["DestinationTaskLauncherTest"])
+    class MockTeardownTaskFactory : TeardownTaskFactory {
+        val hasRun: Channel<Unit> = Channel(Channel.UNLIMITED)
+
+        override fun make(taskLauncher: DestinationTaskLauncher): TeardownTask {
+            return object : TeardownTask {
+                override suspend fun execute() {
+                    hasRun.send(Unit)
+                }
+            }
+        }
+    }
+
+    @Factory
+    class MockStreamsManagerFactory {
+        @Singleton
+        @Primary
+        @Requires(env = ["DestinationTaskLauncherTest"])
+        fun make(catalog: DestinationCatalog): MockStreamsManager {
+            return MockStreamsManager(catalog)
+        }
+    }
+
+    @Singleton
+    @Primary
+    @Requires(env = ["DestinationTaskLauncherTest"])
+    class MockCheckpointManager : CheckpointManager<DestinationStream, CheckpointMessage> {
+        val hasBeenFlushed = Channel<Unit>()
+
+        override fun addStreamCheckpoint(
+            key: DestinationStream,
+            index: Long,
+            checkpointMessage: CheckpointMessage
+        ) {
+            TODO("Not needed")
+        }
+
+        override fun addGlobalCheckpoint(
+            keyIndexes: List<Pair<DestinationStream, Long>>,
+            checkpointMessage: CheckpointMessage
+        ) {
+            TODO("Not needed")
+        }
+
+        override suspend fun flushReadyCheckpointMessages() {
+            hasBeenFlushed.send(Unit)
+        }
+    }
+
+    class MockDestinationWrite : DestinationWriteOperation {
+        override fun getStreamLoader(stream: DestinationStream): StreamLoader {
+            return object : StreamLoader {
+                override val stream: DestinationStream = stream
+
+                override suspend fun processRecords(
+                    records: Iterator<DestinationRecord>,
+                    totalSizeBytes: Long
+                ): Batch {
+                    return SimpleBatch(state = Batch.State.COMPLETE)
+                }
+            }
+        }
+    }
+
+    class MockBatch(override val state: Batch.State) : Batch
+
+    @Test
+    fun testStart() = runTest {
+        val launcher = taskLauncherFactory.get()
+        launch { taskRunner.run() }
+        launcher.start()
+        mockSetupTaskFactory.hasRun.receive()
+        mockSpillToDiskTaskFactory.streamHasRun.values.forEach { it.receive() }
+        launcher.stop()
+    }
+
+    @Test
+    fun testHandleSetupComplete() = runTest {
+        val launcher = taskLauncherFactory.get()
+        launch { taskRunner.run() }
+        launcher.handleSetupComplete()
+        mockOpenStreamTaskFactory.streamHasRun.values.forEach { it.receive() }
+        launcher.stop()
+    }
+
+    @Test
+    fun testHandleJoinStreamOpenSpilledFileComplete() = runTest {
+        val launcher = taskLauncherFactory.get()
+        launch { taskRunner.run() }
+
+        // This will block until the stream is done opening.
+        launch {
+            launcher.handleNewSpilledFile(
+                stream1,
+                BatchEnvelope(SpilledRawMessagesLocalFile(Path("not/a/real/file"), 100L))
+            )
+        }
+
+        // So, it should not have run yet.
+
+        delay(1000)
+        val processRecordsHasRun = processRecordsTaskFactory.hasRun.tryReceive()
+        Assertions.assertTrue(processRecordsHasRun.isFailure)
+
+        // This should unblock the processRecords task.
+        val destination = MockDestinationWrite()
+        launcher.handleStreamOpen(destination.getStreamLoader(stream1))
+        processRecordsTaskFactory.hasRun.receive()
+        Assertions.assertTrue(true)
+
+        launcher.stop()
+    }
+
+    @Test
+    fun testHandleNewBatch() = runTest {
+        val launcher = taskLauncherFactory.get()
+        launch { taskRunner.run() }
+
+        val range = TreeRangeSet.create(listOf(Range.closed(0L, 100L)))
+
+        val destination = MockDestinationWrite()
+        val streamLoader = destination.getStreamLoader(stream1)
+        launcher.handleStreamOpen(streamLoader)
+
+        // Verify incomplete batch triggers process batch
+        val incompleteBatch = BatchEnvelope(MockBatch(Batch.State.PERSISTED), range)
+        launcher.handleNewBatch(streamLoader, incompleteBatch)
+        Assertions.assertTrue(streamsManager.getManager(stream1).areRecordsPersistedUntil(100L))
+        val batchReceived = processBatchTaskFactory.hasRun.receive()
+        Assertions.assertEquals(incompleteBatch, batchReceived)
+
+        // Verify complete batch w/o batch processing complete does nothing
+        val completeBatch = BatchEnvelope(MockBatch(Batch.State.COMPLETE))
+        launcher.handleNewBatch(streamLoader, completeBatch)
+        delay(1000)
+        Assertions.assertTrue(closeStreamTaskFactory.hasRun.tryReceive().isFailure)
+        (streamsManager.getManager(stream1) as MockStreamManager).mockBatchProcessingComplete(true)
+
+        // Verify complete batch w/ batch processing complete triggers close stream
+        launcher.handleNewBatch(streamLoader, completeBatch)
+        closeStreamTaskFactory.hasRun.receive()
+        Assertions.assertTrue(true)
+
+        launcher.stop()
+    }
+
+    @Test
+    fun testHandleStreamClosed() = runTest {
+        val launcher = taskLauncherFactory.get()
+        launch { taskRunner.run() }
+
+        // This should not run teardown until all streams are closed.
+        launch { launcher.handleStreamClosed(stream1) }
+        delay(1000)
+        val hasRun = teardownTaskFactory.hasRun.tryReceive()
+        Assertions.assertTrue(hasRun.isFailure)
+        checkpointManager.hasBeenFlushed.receive() // Stream1 close triggered flush
+
+        streamsManager.getManager(stream1).markClosed()
+        delay(1000)
+        val hasRun2 = teardownTaskFactory.hasRun.tryReceive()
+        Assertions.assertTrue(hasRun2.isFailure)
+        streamsManager.getManager(stream2).markClosed()
+        teardownTaskFactory.hasRun.receive()
+        Assertions.assertTrue(true)
+
+        // This should do nothing, since the teardown task has already run.
+        launch { launcher.handleStreamClosed(stream2) }
+        delay(1000)
+        val hasRun3 = teardownTaskFactory.hasRun.tryReceive()
+        Assertions.assertTrue(hasRun3.isFailure)
+        checkpointManager.hasBeenFlushed.receive() // Stream2 close triggered flush
+
+        launcher.stop()
+    }
+}


### PR DESCRIPTION
## What
Refactor DestinationTaskLauncher
* all workflow logic now lives there (workflow in comment at top of class)
* spill-to-disk now starts right away
* unit tests for workflow
* all tasks/factories now inherit from interfaces (for testability)
* moves MockStreamsManager to common class