### PR TITLE
✨ Source Metabase: Add API Key Authentication

### DIFF
--- a/airbyte-integrations/connectors/source-metabase/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-metabase/acceptance-test-config.yml
@@ -7,6 +7,8 @@ acceptance_tests:
     tests:
       - config_path: "secrets/config.json"
         status: "succeed"
+      - config_path: "secrets/config_session.json"
+        status: "succeed"
       - config_path: "integration_tests/invalid_config.json"
         status: "failed"
       - config_path: "integration_tests/config_http_url.json"

--- a/airbyte-integrations/connectors/source-metabase/integration_tests/invalid_config.json
+++ b/airbyte-integrations/connectors/source-metabase/integration_tests/invalid_config.json
@@ -1,6 +1,7 @@
-{
-  "instance_api_url": "https://localhost:3000",
-  "username": "wrong-account-id",
-  "password": "2020-05-01T00:00:00Z",
-  "session_token": "invalid"
+{   
+    "instance_api_url": "https://localhost:3000",
+    "credentials": {
+        "auth_type": "api_token",
+        "api_key": "invalid"
+    }
 }

--- a/airbyte-integrations/connectors/source-metabase/manifest.yaml
+++ b/airbyte-integrations/connectors/source-metabase/manifest.yaml
@@ -1,9 +1,12 @@
-version: 4.3.0
+version: 4.6.2
+
 type: DeclarativeSource
+
 check:
   type: CheckStream
   stream_names:
     - dashboards
+
 definitions:
   streams:
     cards:
@@ -14,17 +17,7 @@ definitions:
       retriever:
         type: SimpleRetriever
         requester:
-          url_base: "{{ config['instance_api_url'] }}"
-          http_method: GET
-          authenticator:
-            type: "LegacySessionTokenAuthenticator"
-            username: "{{ config['username'] }}"
-            password: "{{ config['password'] }}"
-            header: "X-Metabase-Session"
-            session_token: "{{ config['session_token'] }}"
-            session_token_response_key: "id"
-            login_url: "session"
-            validate_session_url: "user/current"
+          $ref: "#/definitions/base_requester"
           path: card
         record_selector:
           type: RecordSelector
@@ -34,262 +27,7 @@ definitions:
       schema_loader:
         type: InlineSchemaLoader
         schema:
-          type: object
-          $schema: http://json-schema.org/draft-07/schema#
-          additionalProperties: true
-          properties:
-            archived:
-              type:
-                - "null"
-                - boolean
-            cache_ttl:
-              type:
-                - "null"
-                - integer
-            collection:
-              type:
-                - "null"
-                - object
-              properties:
-                archived:
-                  type:
-                    - "null"
-                    - boolean
-                authority_level:
-                  type:
-                    - "null"
-                    - string
-                color:
-                  type:
-                    - "null"
-                    - string
-                description:
-                  type:
-                    - "null"
-                    - string
-                id:
-                  type:
-                    - "null"
-                    - integer
-                location:
-                  type:
-                    - "null"
-                    - string
-                name:
-                  type:
-                    - "null"
-                    - string
-                namespace:
-                  type:
-                    - "null"
-                    - string
-                personal_owner_id:
-                  type:
-                    - "null"
-                    - integer
-                slug:
-                  type:
-                    - "null"
-                    - string
-            collection_id:
-              type:
-                - "null"
-                - integer
-            collection_position:
-              type:
-                - "null"
-                - integer
-            created_at:
-              type:
-                - "null"
-                - string
-            creator:
-              type:
-                - "null"
-                - object
-              properties:
-                common_name:
-                  type:
-                    - "null"
-                    - string
-                date_joined:
-                  type:
-                    - "null"
-                    - string
-                email:
-                  type:
-                    - "null"
-                    - string
-                first_name:
-                  type:
-                    - "null"
-                    - string
-                id:
-                  type:
-                    - "null"
-                    - integer
-                is_qbnewb:
-                  type:
-                    - "null"
-                    - boolean
-                is_superuser:
-                  type:
-                    - "null"
-                    - boolean
-                last_login:
-                  type:
-                    - "null"
-                    - string
-                last_name:
-                  type:
-                    - "null"
-                    - string
-            creator_id:
-              type:
-                - "null"
-                - integer
-            database_id:
-              type:
-                - "null"
-                - integer
-            dataset:
-              type:
-                - "null"
-                - boolean
-            dataset_query:
-              type:
-                - "null"
-                - object
-              properties:
-                type:
-                  type:
-                    - "null"
-                    - string
-                database:
-                  type:
-                    - "null"
-                    - integer
-                native:
-                  type:
-                    - "null"
-                    - object
-                  properties:
-                    query:
-                      type:
-                        - "null"
-                        - string
-                    template-tags:
-                      type:
-                        - "null"
-                        - object
-            description:
-              type:
-                - "null"
-                - string
-            display:
-              type:
-                - "null"
-                - string
-            embedding_params:
-              type:
-                - "null"
-                - string
-            enable_embedding:
-              type:
-                - "null"
-                - boolean
-            id:
-              type:
-                - "null"
-                - integer
-            last-edit-info:
-              type:
-                - "null"
-                - object
-              properties:
-                email:
-                  type:
-                    - "null"
-                    - string
-                first_name:
-                  type:
-                    - "null"
-                    - string
-                id:
-                  type:
-                    - "null"
-                    - integer
-                last_name:
-                  type:
-                    - "null"
-                    - string
-                timestamp:
-                  type:
-                    - "null"
-                    - string
-            made_public_by_id:
-              type:
-                - "null"
-                - integer
-            name:
-              type:
-                - "null"
-                - string
-            public_uuid:
-              type:
-                - "null"
-                - string
-            query_type:
-              type:
-                - "null"
-                - string
-            result_metadata:
-              type:
-                - "null"
-                - array
-              items:
-                properties:
-                  base_type:
-                    type:
-                      - "null"
-                      - string
-                  display_name:
-                    type:
-                      - "null"
-                      - string
-                  effective_type:
-                    type:
-                      - "null"
-                      - string
-                  field_ref:
-                    type:
-                      - "null"
-                      - string
-                      - array
-                  fingerprint:
-                    type:
-                      - "null"
-                      - object
-                  name:
-                    type:
-                      - "null"
-                      - string
-                  semantic_type:
-                    type:
-                      - "null"
-                      - string
-            table_id:
-              type:
-                - "null"
-                - integer
-            updated_at:
-              type:
-                - "null"
-                - string
-            visualization_settings:
-              type:
-                - "null"
-                - object
+          $ref: "#/schemas/cards"
     collections:
       type: DeclarativeStream
       name: collections
@@ -298,17 +36,7 @@ definitions:
       retriever:
         type: SimpleRetriever
         requester:
-          url_base: "{{ config['instance_api_url'] }}"
-          http_method: GET
-          authenticator:
-            type: "LegacySessionTokenAuthenticator"
-            username: "{{ config['username'] }}"
-            password: "{{ config['password'] }}"
-            header: "X-Metabase-Session"
-            session_token: "{{ config['session_token'] }}"
-            session_token_response_key: "id"
-            login_url: "session"
-            validate_session_url: "user/current"
+          $ref: "#/definitions/base_requester"
           path: collection
         record_selector:
           type: RecordSelector
@@ -318,55 +46,7 @@ definitions:
       schema_loader:
         type: InlineSchemaLoader
         schema:
-          type: object
-          $schema: http://json-schema.org/draft-07/schema#
-          additionalProperties: true
-          properties:
-            archived:
-              type:
-                - "null"
-                - boolean
-            authority_level:
-              type:
-                - "null"
-                - string
-            can_write:
-              type:
-                - "null"
-                - boolean
-            color:
-              type:
-                - "null"
-                - string
-            description:
-              type:
-                - "null"
-                - string
-            id:
-              type:
-                - "null"
-                - integer
-                - string
-            location:
-              type:
-                - "null"
-                - string
-            name:
-              type:
-                - "null"
-                - string
-            namespace:
-              type:
-                - "null"
-                - string
-            personal_owner_id:
-              type:
-                - "null"
-                - integer
-            slug:
-              type:
-                - "null"
-                - string
+          $ref: "#/schemas/collections"
     dashboards:
       type: DeclarativeStream
       name: dashboards
@@ -375,17 +55,7 @@ definitions:
       retriever:
         type: SimpleRetriever
         requester:
-          url_base: "{{ config['instance_api_url'] }}"
-          http_method: GET
-          authenticator:
-            type: "LegacySessionTokenAuthenticator"
-            username: "{{ config['username'] }}"
-            password: "{{ config['password'] }}"
-            header: "X-Metabase-Session"
-            session_token: "{{ config['session_token'] }}"
-            session_token_response_key: "id"
-            login_url: "session"
-            validate_session_url: "user/current"
+          $ref: "#/definitions/base_requester"
           path: /dashboard/{{stream_slice.id}}
         record_selector:
           type: RecordSelector
@@ -399,302 +69,11 @@ definitions:
                 parent_key: id
                 partition_field: id
                 stream:
-                  type: DeclarativeStream
-                  name: collections_items_dashboards
-                  retriever:
-                    type: SimpleRetriever
-                    requester:
-                      url_base: "{{ config['instance_api_url'] }}"
-                      http_method: GET
-                      authenticator:
-                        type: "LegacySessionTokenAuthenticator"
-                        username: "{{ config['username'] }}"
-                        password: "{{ config['password'] }}"
-                        header: "X-Metabase-Session"
-                        session_token: "{{ config['session_token'] }}"
-                        session_token_response_key: "id"
-                        login_url: "session"
-                        validate_session_url: "user/current"
-                      path: collection/{{stream_slice.id}}/items?models=dashboard
-                    record_selector:
-                      type: RecordSelector
-                      extractor:
-                        type: DpathExtractor
-                        field_path:
-                          - data
-                    partition_router:
-                      - type: SubstreamPartitionRouter
-                        parent_stream_configs:
-                          - type: ParentStreamConfig
-                            parent_key: id
-                            partition_field: id
-                            stream:
-                              type: DeclarativeStream
-                              name: collections
-                              primary_key:
-                                - id
-                              retriever:
-                                type: SimpleRetriever
-                                requester:
-                                  url_base: "{{ config['instance_api_url'] }}"
-                                  http_method: GET
-                                  authenticator:
-                                    type: "LegacySessionTokenAuthenticator"
-                                    username: "{{ config['username'] }}"
-                                    password: "{{ config['password'] }}"
-                                    header: "X-Metabase-Session"
-                                    session_token: "{{ config['session_token'] }}"
-                                    session_token_response_key: "id"
-                                    login_url: "session"
-                                    validate_session_url: "user/current"
-                                  path: collection
-                                record_selector:
-                                  type: RecordSelector
-                                  extractor:
-                                    type: DpathExtractor
-                                    field_path: []
-                              schema_loader:
-                                type: InlineSchemaLoader
-                                schema:
-                                  type: object
-                                  $schema: http://json-schema.org/draft-07/schema#
-                                  additionalProperties: true
-                                  properties:
-                                    archived:
-                                      type:
-                                        - "null"
-                                        - boolean
-                                    authority_level:
-                                      type:
-                                        - "null"
-                                        - string
-                                    can_write:
-                                      type:
-                                        - "null"
-                                        - boolean
-                                    color:
-                                      type:
-                                        - "null"
-                                        - string
-                                    description:
-                                      type:
-                                        - "null"
-                                        - string
-                                    id:
-                                      type:
-                                        - "null"
-                                        - integer
-                                        - string
-                                    location:
-                                      type:
-                                        - "null"
-                                        - string
-                                    name:
-                                      type:
-                                        - "null"
-                                        - string
-                                    namespace:
-                                      type:
-                                        - "null"
-                                        - string
-                                    personal_owner_id:
-                                      type:
-                                        - "null"
-                                        - integer
-                                    slug:
-                                      type:
-                                        - "null"
-                                        - string
-                  schema_loader:
-                    type: InlineSchemaLoader
-                    schema:
-                      type: object
-                      $schema: http://json-schema.org/draft-07/schema#
-                      additionalProperties: true
-                      properties: {}
+                  $ref: '#/definitions/streams/collections_items_dashboards'
       schema_loader:
         type: InlineSchemaLoader
         schema:
-          type: object
-          $schema: http://json-schema.org/draft-07/schema#
-          additionalProperties: true
-          properties:
-            archived:
-              type:
-                - "null"
-                - boolean
-            cache_ttl:
-              type:
-                - "null"
-                - integer
-            can_write:
-              type:
-                - "null"
-                - boolean
-            caveats:
-              type:
-                - "null"
-                - string
-            collection:
-              type:
-                - "null"
-                - object
-              properties: {}
-            collection_authority_level:
-              type:
-                - "null"
-                - string
-            collection_id:
-              type:
-                - "null"
-                - integer
-            collection_position:
-              type:
-                - "null"
-                - integer
-            created_at:
-              type:
-                - "null"
-                - string
-            creator_id:
-              type:
-                - "null"
-                - integer
-            dashcards:
-              type:
-                - "null"
-                - array
-              items:
-                type:
-                  - "null"
-                  - object
-                properties: {}
-            description:
-              type:
-                - "null"
-                - string
-            embedding_params:
-              type:
-                - "null"
-                - object
-            enable_embedding:
-              type:
-                - "null"
-                - boolean
-            id:
-              type:
-                - "null"
-                - integer
-            last-edit-info:
-              type:
-                - "null"
-                - object
-              properties:
-                email:
-                  type:
-                    - "null"
-                    - string
-                first_name:
-                  type:
-                    - "null"
-                    - string
-                id:
-                  type:
-                    - "null"
-                    - integer
-                last_name:
-                  type:
-                    - "null"
-                    - string
-                timestamp:
-                  type:
-                    - "null"
-                    - string
-            made_public_by_id:
-              type:
-                - "null"
-                - integer
-            name:
-              type:
-                - "null"
-                - string
-            param_fields:
-              type:
-                - "null"
-                - object
-              properties: {}
-            param_values:
-              type:
-                - "null"
-                - object
-              properties: {}
-            parameters:
-              type:
-                - "null"
-                - array
-              items:
-                properties:
-                  type:
-                    type:
-                      - "null"
-                      - string
-                  default:
-                    type:
-                      - "null"
-                      - array
-                      - string
-                    items:
-                      type:
-                        - "null"
-                        - array
-                        - boolean
-                        - integer
-                        - string
-                  id:
-                    type:
-                      - "null"
-                      - string
-                  name:
-                    type:
-                      - "null"
-                      - string
-                  sectionId:
-                    type:
-                      - "null"
-                      - string
-                  slug:
-                    type:
-                      - "null"
-                      - string
-            points_of_interest:
-              type:
-                - "null"
-                - string
-            position:
-              type:
-                - "null"
-                - string
-            public_uuid:
-              type:
-                - "null"
-                - string
-            show_in_getting_started:
-              type:
-                - "null"
-                - boolean
-            tabs:
-              type:
-                - "null"
-                - array
-              items:
-                type:
-                  - "null"
-                  - object
-                properties: {}
-            updated_at:
-              type:
-                - "null"
-                - string
+          $ref: "#/schemas/dashboards"
     users:
       type: DeclarativeStream
       name: users
@@ -703,17 +82,7 @@ definitions:
       retriever:
         type: SimpleRetriever
         requester:
-          url_base: "{{ config['instance_api_url'] }}"
-          http_method: GET
-          authenticator:
-            type: "LegacySessionTokenAuthenticator"
-            username: "{{ config['username'] }}"
-            password: "{{ config['password'] }}"
-            header: "X-Metabase-Session"
-            session_token: "{{ config['session_token'] }}"
-            session_token_response_key: "id"
-            login_url: "session"
-            validate_session_url: "user/current"
+          $ref: "#/definitions/base_requester"
           path: user
         record_selector:
           type: RecordSelector
@@ -724,30 +93,7 @@ definitions:
       schema_loader:
         type: InlineSchemaLoader
         schema:
-          type: object
-          $schema: http://json-schema.org/draft-07/schema#
-          additionalProperties: true
-          properties:
-            common_name:
-              type:
-                - "null"
-                - string
-            email:
-              type:
-                - "null"
-                - string
-            first_name:
-              type:
-                - "null"
-                - string
-            id:
-              type:
-                - "null"
-                - integer
-            last_name:
-              type:
-                - "null"
-                - string
+          $ref: "#/schemas/users"
     databases:
       type: DeclarativeStream
       name: databases
@@ -756,17 +102,7 @@ definitions:
       retriever:
         type: SimpleRetriever
         requester:
-          url_base: "{{ config['instance_api_url'] }}"
-          http_method: GET
-          authenticator:
-            type: "LegacySessionTokenAuthenticator"
-            username: "{{ config['username'] }}"
-            password: "{{ config['password'] }}"
-            header: "X-Metabase-Session"
-            session_token: "{{ config['session_token'] }}"
-            session_token_response_key: "id"
-            login_url: "session"
-            validate_session_url: "user/current"
+          $ref: "#/definitions/base_requester"
           path: database
         record_selector:
           type: RecordSelector
@@ -777,188 +113,7 @@ definitions:
       schema_loader:
         type: InlineSchemaLoader
         schema:
-          type: object
-          $schema: http://json-schema.org/draft-07/schema#
-          additionalProperties: true
-          properties:
-            auto_run_queries:
-              type:
-                - "null"
-                - boolean
-            cache_field_values_schedule:
-              type:
-                - "null"
-                - string
-            cache_ttl:
-              type:
-                - "null"
-                - integer
-            can_upload:
-              type:
-                - "null"
-                - boolean
-            caveats:
-              type:
-                - "null"
-                - string
-            created_at:
-              type:
-                - "null"
-                - string
-            creator_id:
-              type:
-                - "null"
-                - integer
-            dbms_version:
-              type:
-                - object
-                - "null"
-              properties:
-                version:
-                  type:
-                    - "null"
-                    - string
-                flavor:
-                  type:
-                    - "null"
-                    - string
-                semantic-version:
-                  type:
-                    - array
-                    - "null"
-                  items:
-                    type:
-                      - integer
-                      - "null"
-            description:
-              type:
-                - string
-                - "null"
-            details:
-              type:
-                - object
-                - "null"
-              properties:
-                advanced-options:
-                  type:
-                    - "null"
-                    - boolean
-                cloud-ip-address-info:
-                  type:
-                    - "null"
-                    - string
-                dataset-filters-patterns:
-                  type:
-                    - "null"
-                    - string
-                dataset-filters-type:
-                  type:
-                    - "null"
-                    - string
-                db:
-                  type:
-                    - "null"
-                    - string
-                include-user-id-and-hash:
-                  type:
-                    - "null"
-                    - boolean
-                let-user-control-scheduling:
-                  type:
-                    - "null"
-                    - boolean
-                project-id:
-                  type:
-                    - "null"
-                    - string
-                project-id-from-credentials:
-                  type:
-                    - "null"
-                    - string
-                service-account-json:
-                  type:
-                    - "null"
-                    - string
-                ssl:
-                  type:
-                    - "null"
-                    - boolean
-                use-jvm-timezone:
-                  type:
-                    - "null"
-                    - boolean
-            engine:
-              type:
-                - "null"
-                - string
-            features:
-              type:
-                - "null"
-                - array
-              items:
-                type:
-                  - "null"
-                  - string
-            id:
-              type:
-                - integer
-                - "null"
-            initial_sync_status:
-              type:
-                - "null"
-                - string
-            is_audit:
-              type:
-                - "null"
-                - boolean
-            is_full_sync:
-              type:
-                - "null"
-                - boolean
-            is_on_demand:
-              type:
-                - "null"
-                - boolean
-            is_sample:
-              type:
-                - "null"
-                - boolean
-            metadata_sync_schedule:
-              type:
-                - "null"
-                - string
-            name:
-              type:
-                - "null"
-                - string
-            native_permissions:
-              type:
-                - "null"
-                - string
-            options:
-              type:
-                - "null"
-                - string
-            points_of_interest:
-              type:
-                - "null"
-                - string
-            refingerprint:
-              type:
-                - "null"
-                - boolean
-            settings:
-              type:
-                - "null"
-                - string
-            timezone:
-              type:
-                - "null"
-                - string
-            updated_at:
-              type:
-                - "null"
-                - string
+          $ref: "#/schemas/databases"
     native_query_snippets:
       type: DeclarativeStream
       name: native_query_snippets
@@ -967,17 +122,7 @@ definitions:
       retriever:
         type: SimpleRetriever
         requester:
-          url_base: "{{ config['instance_api_url'] }}"
-          http_method: GET
-          authenticator:
-            type: "LegacySessionTokenAuthenticator"
-            username: "{{ config['username'] }}"
-            password: "{{ config['password'] }}"
-            header: "X-Metabase-Session"
-            session_token: "{{ config['session_token'] }}"
-            session_token_response_key: "id"
-            login_url: "session"
-            validate_session_url: "user/current"
+          $ref: "#/definitions/base_requester"
           path: native-query-snippet
         record_selector:
           type: RecordSelector
@@ -987,108 +132,14 @@ definitions:
       schema_loader:
         type: InlineSchemaLoader
         schema:
-          type: object
-          $schema: http://json-schema.org/draft-07/schema#
-          additionalProperties: true
-          properties:
-            archived:
-              type:
-                - "null"
-                - boolean
-            collection_id:
-              type:
-                - "null"
-                - integer
-            content:
-              type:
-                - "null"
-                - string
-            created_at:
-              type:
-                - "null"
-                - string
-            creator:
-              type:
-                - "null"
-                - object
-              properties:
-                common_name:
-                  type:
-                    - "null"
-                    - string
-                date_joined:
-                  type:
-                    - "null"
-                    - string
-                email:
-                  type:
-                    - "null"
-                    - string
-                first_name:
-                  type:
-                    - "null"
-                    - string
-                id:
-                  type:
-                    - integer
-                    - "null"
-                is_qbnewb:
-                  type:
-                    - "null"
-                    - boolean
-                is_superuser:
-                  type:
-                    - "null"
-                    - boolean
-                last_login:
-                  type:
-                    - "null"
-                    - string
-                last_name:
-                  type:
-                    - "null"
-                    - string
-            creator_id:
-              type:
-                - "null"
-                - integer
-            description:
-              type:
-                - "null"
-                - string
-            entity_id:
-              type:
-                - "null"
-                - string
-            id:
-              type:
-                - integer
-                - "null"
-            name:
-              type:
-                - "null"
-                - string
-            updated_at:
-              type:
-                - "null"
-                - string
+          $ref: "#/schemas/native_query_snippets"
     collections_items_dashboards:
       type: DeclarativeStream
       name: collections_items_dashboards
       retriever:
         type: SimpleRetriever
         requester:
-          url_base: "{{ config['instance_api_url'] }}"
-          http_method: GET
-          authenticator:
-            type: "LegacySessionTokenAuthenticator"
-            username: "{{ config['username'] }}"
-            password: "{{ config['password'] }}"
-            header: "X-Metabase-Session"
-            session_token: "{{ config['session_token'] }}"
-            session_token_response_key: "id"
-            login_url: "session"
-            validate_session_url: "user/current"
+          $ref: "#/definitions/base_requester"
           path: collection/{{stream_slice.id}}/items?models=dashboard
         record_selector:
           type: RecordSelector
@@ -1103,82 +154,7 @@ definitions:
                 parent_key: id
                 partition_field: id
                 stream:
-                  type: DeclarativeStream
-                  name: collections
-                  primary_key:
-                    - id
-                  retriever:
-                    type: SimpleRetriever
-                    requester:
-                      url_base: "{{ config['instance_api_url'] }}"
-                      http_method: GET
-                      authenticator:
-                        type: "LegacySessionTokenAuthenticator"
-                        username: "{{ config['username'] }}"
-                        password: "{{ config['password'] }}"
-                        header: "X-Metabase-Session"
-                        session_token: "{{ config['session_token'] }}"
-                        session_token_response_key: "id"
-                        login_url: "session"
-                        validate_session_url: "user/current"
-                      path: collection
-                    record_selector:
-                      type: RecordSelector
-                      extractor:
-                        type: DpathExtractor
-                        field_path: []
-                  schema_loader:
-                    type: InlineSchemaLoader
-                    schema:
-                      type: object
-                      $schema: http://json-schema.org/draft-07/schema#
-                      additionalProperties: true
-                      properties:
-                        archived:
-                          type:
-                            - "null"
-                            - boolean
-                        authority_level:
-                          type:
-                            - "null"
-                            - string
-                        can_write:
-                          type:
-                            - "null"
-                            - boolean
-                        color:
-                          type:
-                            - "null"
-                            - string
-                        description:
-                          type:
-                            - "null"
-                            - string
-                        id:
-                          type:
-                            - "null"
-                            - integer
-                            - string
-                        location:
-                          type:
-                            - "null"
-                            - string
-                        name:
-                          type:
-                            - "null"
-                            - string
-                        namespace:
-                          type:
-                            - "null"
-                            - string
-                        personal_owner_id:
-                          type:
-                            - "null"
-                            - integer
-                        slug:
-                          type:
-                            - "null"
-                            - string
+                  $ref: "#/definitions/streams/collections"
       schema_loader:
         type: InlineSchemaLoader
         schema:
@@ -1187,1201 +163,54 @@ definitions:
           additionalProperties: true
           properties: {}
   base_requester:
+    type: HttpRequester
     url_base: "{{ config['instance_api_url'] }}"
-    http_method: "GET"
+    http_method: GET
     authenticator:
-      type: "LegacySessionTokenAuthenticator"
-      username: "{{ config['username'] }}"
-      password: "{{ config['password'] }}"
-      header: "X-Metabase-Session"
-      session_token: "{{ config['session_token'] }}"
-      session_token_response_key: "id"
-      login_url: "session"
-      validate_session_url: "user/current"
+      type: SelectiveAuthenticator
+      additionalProperties: true
+      authenticator_selection_path:
+        - "instance_api_url"
+        - "auth_type"
+        - "credentials"
+      authenticators:
+        api_key: 
+          type: ApiKeyAuthenticator
+          header: "X-API-KEY"
+          api_key: "{{ config['credentials']['api_key'] }}"        
+        session_token:
+          type: SessionTokenAuthenticator
+          login_requester:
+            type: HttpRequester
+            url_base: "{{ config['instance_api_url'] }}"
+            http_method: POST
+            path: session
+            authenticator:
+              type: NoAuth
+            request_headers: {}
+            request_parameters: {}
+            request_body_json:
+              username: "{{ config['credentials']['username'] }}"
+              password: "{{ config['credentials']['password'] }}"
+          session_token_path:
+            - id
+          expiration_duration: "{{ config['credentials']['expiration_duration'] }}"
+          request_authentication:
+            type: ApiKey
+            inject_into:
+              type: RequestOption
+              field_name: "X-Metabase-Session"
+              inject_into: header
+
 streams:
-  - type: DeclarativeStream
-    name: cards
-    primary_key:
-      - id
-    retriever:
-      type: SimpleRetriever
-      requester:
-        url_base: "{{ config['instance_api_url'] }}"
-        http_method: GET
-        authenticator:
-          type: "LegacySessionTokenAuthenticator"
-          username: "{{ config['username'] }}"
-          password: "{{ config['password'] }}"
-          header: "X-Metabase-Session"
-          session_token: "{{ config['session_token'] }}"
-          session_token_response_key: "id"
-          login_url: "session"
-          validate_session_url: "user/current"
-        path: card
-        type: HttpRequester
-      record_selector:
-        type: RecordSelector
-        extractor:
-          type: DpathExtractor
-          field_path: []
-    schema_loader:
-      type: InlineSchemaLoader
-      schema:
-        type: object
-        $schema: http://json-schema.org/draft-07/schema#
-        additionalProperties: true
-        properties:
-          archived:
-            type:
-              - "null"
-              - boolean
-          cache_ttl:
-            type:
-              - "null"
-              - integer
-          collection:
-            type:
-              - "null"
-              - object
-            properties:
-              archived:
-                type:
-                  - "null"
-                  - boolean
-              authority_level:
-                type:
-                  - "null"
-                  - string
-              color:
-                type:
-                  - "null"
-                  - string
-              description:
-                type:
-                  - "null"
-                  - string
-              id:
-                type:
-                  - "null"
-                  - integer
-              location:
-                type:
-                  - "null"
-                  - string
-              name:
-                type:
-                  - "null"
-                  - string
-              namespace:
-                type:
-                  - "null"
-                  - string
-              personal_owner_id:
-                type:
-                  - "null"
-                  - integer
-              slug:
-                type:
-                  - "null"
-                  - string
-          collection_id:
-            type:
-              - "null"
-              - integer
-          collection_position:
-            type:
-              - "null"
-              - integer
-          created_at:
-            type:
-              - "null"
-              - string
-          creator:
-            type:
-              - "null"
-              - object
-            properties:
-              common_name:
-                type:
-                  - "null"
-                  - string
-              date_joined:
-                type:
-                  - "null"
-                  - string
-              email:
-                type:
-                  - "null"
-                  - string
-              first_name:
-                type:
-                  - "null"
-                  - string
-              id:
-                type:
-                  - "null"
-                  - integer
-              is_qbnewb:
-                type:
-                  - "null"
-                  - boolean
-              is_superuser:
-                type:
-                  - "null"
-                  - boolean
-              last_login:
-                type:
-                  - "null"
-                  - string
-              last_name:
-                type:
-                  - "null"
-                  - string
-          creator_id:
-            type:
-              - "null"
-              - integer
-          database_id:
-            type:
-              - "null"
-              - integer
-          dataset:
-            type:
-              - "null"
-              - boolean
-          dataset_query:
-            type:
-              - "null"
-              - object
-            properties:
-              type:
-                type:
-                  - "null"
-                  - string
-              database:
-                type:
-                  - "null"
-                  - integer
-              native:
-                type:
-                  - "null"
-                  - object
-                properties:
-                  query:
-                    type:
-                      - "null"
-                      - string
-                  template-tags:
-                    type:
-                      - "null"
-                      - object
-          description:
-            type:
-              - "null"
-              - string
-          display:
-            type:
-              - "null"
-              - string
-          embedding_params:
-            type:
-              - "null"
-              - string
-          enable_embedding:
-            type:
-              - "null"
-              - boolean
-          id:
-            type:
-              - "null"
-              - integer
-          last-edit-info:
-            type:
-              - "null"
-              - object
-            properties:
-              email:
-                type:
-                  - "null"
-                  - string
-              first_name:
-                type:
-                  - "null"
-                  - string
-              id:
-                type:
-                  - "null"
-                  - integer
-              last_name:
-                type:
-                  - "null"
-                  - string
-              timestamp:
-                type:
-                  - "null"
-                  - string
-          made_public_by_id:
-            type:
-              - "null"
-              - integer
-          name:
-            type:
-              - "null"
-              - string
-          public_uuid:
-            type:
-              - "null"
-              - string
-          query_type:
-            type:
-              - "null"
-              - string
-          result_metadata:
-            type:
-              - "null"
-              - array
-            items:
-              properties:
-                base_type:
-                  type:
-                    - "null"
-                    - string
-                display_name:
-                  type:
-                    - "null"
-                    - string
-                effective_type:
-                  type:
-                    - "null"
-                    - string
-                field_ref:
-                  type:
-                    - "null"
-                    - string
-                    - array
-                fingerprint:
-                  type:
-                    - "null"
-                    - object
-                name:
-                  type:
-                    - "null"
-                    - string
-                semantic_type:
-                  type:
-                    - "null"
-                    - string
-          table_id:
-            type:
-              - "null"
-              - integer
-          updated_at:
-            type:
-              - "null"
-              - string
-          visualization_settings:
-            type:
-              - "null"
-              - object
-  - type: DeclarativeStream
-    name: collections
-    primary_key:
-      - id
-    retriever:
-      type: SimpleRetriever
-      requester:
-        url_base: "{{ config['instance_api_url'] }}"
-        http_method: GET
-        authenticator:
-          type: "LegacySessionTokenAuthenticator"
-          username: "{{ config['username'] }}"
-          password: "{{ config['password'] }}"
-          header: "X-Metabase-Session"
-          session_token: "{{ config['session_token'] }}"
-          session_token_response_key: "id"
-          login_url: "session"
-          validate_session_url: "user/current"
-        path: collection
-        type: HttpRequester
-      record_selector:
-        type: RecordSelector
-        extractor:
-          type: DpathExtractor
-          field_path: []
-    schema_loader:
-      type: InlineSchemaLoader
-      schema:
-        type: object
-        $schema: http://json-schema.org/draft-07/schema#
-        additionalProperties: true
-        properties:
-          archived:
-            type:
-              - "null"
-              - boolean
-          authority_level:
-            type:
-              - "null"
-              - string
-          can_write:
-            type:
-              - "null"
-              - boolean
-          color:
-            type:
-              - "null"
-              - string
-          description:
-            type:
-              - "null"
-              - string
-          id:
-            type:
-              - "null"
-              - integer
-              - string
-          location:
-            type:
-              - "null"
-              - string
-          name:
-            type:
-              - "null"
-              - string
-          namespace:
-            type:
-              - "null"
-              - string
-          personal_owner_id:
-            type:
-              - "null"
-              - integer
-          slug:
-            type:
-              - "null"
-              - string
-  - type: DeclarativeStream
-    name: dashboards
-    primary_key:
-      - id
-    retriever:
-      type: SimpleRetriever
-      requester:
-        url_base: "{{ config['instance_api_url'] }}"
-        http_method: GET
-        authenticator:
-          type: "LegacySessionTokenAuthenticator"
-          username: "{{ config['username'] }}"
-          password: "{{ config['password'] }}"
-          header: "X-Metabase-Session"
-          session_token: "{{ config['session_token'] }}"
-          session_token_response_key: "id"
-          login_url: "session"
-          validate_session_url: "user/current"
-        path: /dashboard/{{stream_slice.id}}
-        type: HttpRequester
-      record_selector:
-        type: RecordSelector
-        extractor:
-          type: DpathExtractor
-          field_path: []
-      partition_router:
-        - type: SubstreamPartitionRouter
-          parent_stream_configs:
-            - type: ParentStreamConfig
-              parent_key: id
-              partition_field: id
-              stream:
-                type: DeclarativeStream
-                name: collections_items_dashboards
-                retriever:
-                  type: SimpleRetriever
-                  requester:
-                    url_base: "{{ config['instance_api_url'] }}"
-                    http_method: GET
-                    authenticator:
-                      type: "LegacySessionTokenAuthenticator"
-                      username: "{{ config['username'] }}"
-                      password: "{{ config['password'] }}"
-                      header: "X-Metabase-Session"
-                      session_token: "{{ config['session_token'] }}"
-                      session_token_response_key: "id"
-                      login_url: "session"
-                      validate_session_url: "user/current"
-                    path: collection/{{stream_slice.id}}/items?models=dashboard
-                    type: HttpRequester
-                  record_selector:
-                    type: RecordSelector
-                    extractor:
-                      type: DpathExtractor
-                      field_path:
-                        - data
-                  partition_router:
-                    - type: SubstreamPartitionRouter
-                      parent_stream_configs:
-                        - type: ParentStreamConfig
-                          parent_key: id
-                          partition_field: id
-                          stream:
-                            type: DeclarativeStream
-                            name: collections
-                            primary_key:
-                              - id
-                            retriever:
-                              type: SimpleRetriever
-                              requester:
-                                url_base: "{{ config['instance_api_url'] }}"
-                                http_method: GET
-                                authenticator:
-                                  type: "LegacySessionTokenAuthenticator"
-                                  username: "{{ config['username'] }}"
-                                  password: "{{ config['password'] }}"
-                                  header: "X-Metabase-Session"
-                                  session_token: "{{ config['session_token'] }}"
-                                  session_token_response_key: "id"
-                                  login_url: "session"
-                                  validate_session_url: "user/current"
-                                path: collection
-                                type: HttpRequester
-                              record_selector:
-                                type: RecordSelector
-                                extractor:
-                                  type: DpathExtractor
-                                  field_path: []
-                            schema_loader:
-                              type: InlineSchemaLoader
-                              schema:
-                                type: object
-                                $schema: http://json-schema.org/draft-07/schema#
-                                additionalProperties: true
-                                properties:
-                                  archived:
-                                    type:
-                                      - "null"
-                                      - boolean
-                                  authority_level:
-                                    type:
-                                      - "null"
-                                      - string
-                                  can_write:
-                                    type:
-                                      - "null"
-                                      - boolean
-                                  color:
-                                    type:
-                                      - "null"
-                                      - string
-                                  description:
-                                    type:
-                                      - "null"
-                                      - string
-                                  id:
-                                    type:
-                                      - "null"
-                                      - integer
-                                      - string
-                                  location:
-                                    type:
-                                      - "null"
-                                      - string
-                                  name:
-                                    type:
-                                      - "null"
-                                      - string
-                                  namespace:
-                                    type:
-                                      - "null"
-                                      - string
-                                  personal_owner_id:
-                                    type:
-                                      - "null"
-                                      - integer
-                                  slug:
-                                    type:
-                                      - "null"
-                                      - string
-                schema_loader:
-                  type: InlineSchemaLoader
-                  schema:
-                    type: object
-                    $schema: http://json-schema.org/draft-07/schema#
-                    additionalProperties: true
-                    properties: {}
-    schema_loader:
-      type: InlineSchemaLoader
-      schema:
-        type: object
-        $schema: http://json-schema.org/draft-07/schema#
-        additionalProperties: true
-        properties:
-          archived:
-            type:
-              - "null"
-              - boolean
-          cache_ttl:
-            type:
-              - "null"
-              - integer
-          can_write:
-            type:
-              - "null"
-              - boolean
-          caveats:
-            type:
-              - "null"
-              - string
-          collection:
-            type:
-              - "null"
-              - object
-            properties: {}
-          collection_authority_level:
-            type:
-              - "null"
-              - string
-          collection_id:
-            type:
-              - "null"
-              - integer
-          collection_position:
-            type:
-              - "null"
-              - integer
-          created_at:
-            type:
-              - "null"
-              - string
-          creator_id:
-            type:
-              - "null"
-              - integer
-          dashcards:
-            type:
-              - "null"
-              - array
-            items:
-              type:
-                - "null"
-                - object
-              properties: {}
-          description:
-            type:
-              - "null"
-              - string
-          embedding_params:
-            type:
-              - "null"
-              - object
-          enable_embedding:
-            type:
-              - "null"
-              - boolean
-          id:
-            type:
-              - "null"
-              - integer
-          last-edit-info:
-            type:
-              - "null"
-              - object
-            properties:
-              email:
-                type:
-                  - "null"
-                  - string
-              first_name:
-                type:
-                  - "null"
-                  - string
-              id:
-                type:
-                  - "null"
-                  - integer
-              last_name:
-                type:
-                  - "null"
-                  - string
-              timestamp:
-                type:
-                  - "null"
-                  - string
-          made_public_by_id:
-            type:
-              - "null"
-              - integer
-          name:
-            type:
-              - "null"
-              - string
-          param_fields:
-            type:
-              - "null"
-              - object
-            properties: {}
-          param_values:
-            type:
-              - "null"
-              - object
-            properties: {}
-          parameters:
-            type:
-              - "null"
-              - array
-            items:
-              properties:
-                type:
-                  type:
-                    - "null"
-                    - string
-                default:
-                  type:
-                    - "null"
-                    - array
-                    - string
-                  items:
-                    type:
-                      - "null"
-                      - array
-                      - boolean
-                      - integer
-                      - string
-                id:
-                  type:
-                    - "null"
-                    - string
-                name:
-                  type:
-                    - "null"
-                    - string
-                sectionId:
-                  type:
-                    - "null"
-                    - string
-                slug:
-                  type:
-                    - "null"
-                    - string
-          points_of_interest:
-            type:
-              - "null"
-              - string
-          position:
-            type:
-              - "null"
-              - string
-          public_uuid:
-            type:
-              - "null"
-              - string
-          show_in_getting_started:
-            type:
-              - "null"
-              - boolean
-          tabs:
-            type:
-              - "null"
-              - array
-            items:
-              type:
-                - "null"
-                - object
-              properties: {}
-          updated_at:
-            type:
-              - "null"
-              - string
-  - type: DeclarativeStream
-    name: users
-    primary_key:
-      - id
-    retriever:
-      type: SimpleRetriever
-      requester:
-        url_base: "{{ config['instance_api_url'] }}"
-        http_method: GET
-        authenticator:
-          type: "LegacySessionTokenAuthenticator"
-          username: "{{ config['username'] }}"
-          password: "{{ config['password'] }}"
-          header: "X-Metabase-Session"
-          session_token: "{{ config['session_token'] }}"
-          session_token_response_key: "id"
-          login_url: "session"
-          validate_session_url: "user/current"
-        path: user
-        type: HttpRequester
-      record_selector:
-        type: RecordSelector
-        extractor:
-          type: DpathExtractor
-          field_path:
-            - data
-    schema_loader:
-      type: InlineSchemaLoader
-      schema:
-        type: object
-        $schema: http://json-schema.org/draft-07/schema#
-        additionalProperties: true
-        properties:
-          common_name:
-            type:
-              - "null"
-              - string
-          email:
-            type:
-              - "null"
-              - string
-          first_name:
-            type:
-              - "null"
-              - string
-          id:
-            type:
-              - "null"
-              - integer
-          last_name:
-            type:
-              - "null"
-              - string
-  - type: DeclarativeStream
-    name: databases
-    primary_key:
-      - id
-    retriever:
-      type: SimpleRetriever
-      requester:
-        url_base: "{{ config['instance_api_url'] }}"
-        http_method: GET
-        authenticator:
-          type: "LegacySessionTokenAuthenticator"
-          username: "{{ config['username'] }}"
-          password: "{{ config['password'] }}"
-          header: "X-Metabase-Session"
-          session_token: "{{ config['session_token'] }}"
-          session_token_response_key: "id"
-          login_url: "session"
-          validate_session_url: "user/current"
-        path: database
-        type: HttpRequester
-      record_selector:
-        type: RecordSelector
-        extractor:
-          type: DpathExtractor
-          field_path:
-            - data
-    schema_loader:
-      type: InlineSchemaLoader
-      schema:
-        type: object
-        $schema: http://json-schema.org/draft-07/schema#
-        additionalProperties: true
-        properties:
-          auto_run_queries:
-            type:
-              - "null"
-              - boolean
-          cache_field_values_schedule:
-            type:
-              - "null"
-              - string
-          cache_ttl:
-            type:
-              - "null"
-              - integer
-          can_upload:
-            type:
-              - "null"
-              - boolean
-          caveats:
-            type:
-              - "null"
-              - string
-          created_at:
-            type:
-              - "null"
-              - string
-          creator_id:
-            type:
-              - "null"
-              - integer
-          dbms_version:
-            type:
-              - object
-              - "null"
-            properties:
-              version:
-                type:
-                  - "null"
-                  - string
-              flavor:
-                type:
-                  - "null"
-                  - string
-              semantic-version:
-                type:
-                  - array
-                  - "null"
-                items:
-                  type:
-                    - integer
-                    - "null"
-          description:
-            type:
-              - string
-              - "null"
-          details:
-            type:
-              - object
-              - "null"
-            properties:
-              advanced-options:
-                type:
-                  - "null"
-                  - boolean
-              cloud-ip-address-info:
-                type:
-                  - "null"
-                  - string
-              dataset-filters-patterns:
-                type:
-                  - "null"
-                  - string
-              dataset-filters-type:
-                type:
-                  - "null"
-                  - string
-              db:
-                type:
-                  - "null"
-                  - string
-              include-user-id-and-hash:
-                type:
-                  - "null"
-                  - boolean
-              let-user-control-scheduling:
-                type:
-                  - "null"
-                  - boolean
-              project-id:
-                type:
-                  - "null"
-                  - string
-              project-id-from-credentials:
-                type:
-                  - "null"
-                  - string
-              service-account-json:
-                type:
-                  - "null"
-                  - string
-              ssl:
-                type:
-                  - "null"
-                  - boolean
-              use-jvm-timezone:
-                type:
-                  - "null"
-                  - boolean
-          engine:
-            type:
-              - "null"
-              - string
-          features:
-            type:
-              - "null"
-              - array
-            items:
-              type:
-                - "null"
-                - string
-          id:
-            type:
-              - integer
-              - "null"
-          initial_sync_status:
-            type:
-              - "null"
-              - string
-          is_audit:
-            type:
-              - "null"
-              - boolean
-          is_full_sync:
-            type:
-              - "null"
-              - boolean
-          is_on_demand:
-            type:
-              - "null"
-              - boolean
-          is_sample:
-            type:
-              - "null"
-              - boolean
-          metadata_sync_schedule:
-            type:
-              - "null"
-              - string
-          name:
-            type:
-              - "null"
-              - string
-          native_permissions:
-            type:
-              - "null"
-              - string
-          options:
-            type:
-              - "null"
-              - string
-          points_of_interest:
-            type:
-              - "null"
-              - string
-          refingerprint:
-            type:
-              - "null"
-              - boolean
-          settings:
-            type:
-              - "null"
-              - string
-          timezone:
-            type:
-              - "null"
-              - string
-          updated_at:
-            type:
-              - "null"
-              - string
-  - type: DeclarativeStream
-    name: native_query_snippets
-    primary_key:
-      - id
-    retriever:
-      type: SimpleRetriever
-      requester:
-        url_base: "{{ config['instance_api_url'] }}"
-        http_method: GET
-        authenticator:
-          type: "LegacySessionTokenAuthenticator"
-          username: "{{ config['username'] }}"
-          password: "{{ config['password'] }}"
-          header: "X-Metabase-Session"
-          session_token: "{{ config['session_token'] }}"
-          session_token_response_key: "id"
-          login_url: "session"
-          validate_session_url: "user/current"
-        path: native-query-snippet
-        type: HttpRequester
-      record_selector:
-        type: RecordSelector
-        extractor:
-          type: DpathExtractor
-          field_path: []
-    schema_loader:
-      type: InlineSchemaLoader
-      schema:
-        type: object
-        $schema: http://json-schema.org/draft-07/schema#
-        additionalProperties: true
-        properties:
-          archived:
-            type:
-              - "null"
-              - boolean
-          collection_id:
-            type:
-              - "null"
-              - integer
-          content:
-            type:
-              - "null"
-              - string
-          created_at:
-            type:
-              - "null"
-              - string
-          creator:
-            type:
-              - "null"
-              - object
-            properties:
-              common_name:
-                type:
-                  - "null"
-                  - string
-              date_joined:
-                type:
-                  - "null"
-                  - string
-              email:
-                type:
-                  - "null"
-                  - string
-              first_name:
-                type:
-                  - "null"
-                  - string
-              id:
-                type:
-                  - integer
-                  - "null"
-              is_qbnewb:
-                type:
-                  - "null"
-                  - boolean
-              is_superuser:
-                type:
-                  - "null"
-                  - boolean
-              last_login:
-                type:
-                  - "null"
-                  - string
-              last_name:
-                type:
-                  - "null"
-                  - string
-          creator_id:
-            type:
-              - "null"
-              - integer
-          description:
-            type:
-              - "null"
-              - string
-          entity_id:
-            type:
-              - "null"
-              - string
-          id:
-            type:
-              - integer
-              - "null"
-          name:
-            type:
-              - "null"
-              - string
-          updated_at:
-            type:
-              - "null"
-              - string
-  - type: DeclarativeStream
-    name: collections_items_dashboards
-    retriever:
-      type: SimpleRetriever
-      requester:
-        url_base: "{{ config['instance_api_url'] }}"
-        http_method: GET
-        authenticator:
-          type: "LegacySessionTokenAuthenticator"
-          username: "{{ config['username'] }}"
-          password: "{{ config['password'] }}"
-          header: "X-Metabase-Session"
-          session_token: "{{ config['session_token'] }}"
-          session_token_response_key: "id"
-          login_url: "session"
-          validate_session_url: "user/current"
-        path: collection/{{stream_slice.id}}/items?models=dashboard
-        type: HttpRequester
-      record_selector:
-        type: RecordSelector
-        extractor:
-          type: DpathExtractor
-          field_path:
-            - data
-      partition_router:
-        - type: SubstreamPartitionRouter
-          parent_stream_configs:
-            - type: ParentStreamConfig
-              parent_key: id
-              partition_field: id
-              stream:
-                type: DeclarativeStream
-                name: collections
-                primary_key:
-                  - id
-                retriever:
-                  type: SimpleRetriever
-                  requester:
-                    url_base: "{{ config['instance_api_url'] }}"
-                    http_method: GET
-                    authenticator:
-                      type: "LegacySessionTokenAuthenticator"
-                      username: "{{ config['username'] }}"
-                      password: "{{ config['password'] }}"
-                      header: "X-Metabase-Session"
-                      session_token: "{{ config['session_token'] }}"
-                      session_token_response_key: "id"
-                      login_url: "session"
-                      validate_session_url: "user/current"
-                    path: collection
-                    type: HttpRequester
-                  record_selector:
-                    type: RecordSelector
-                    extractor:
-                      type: DpathExtractor
-                      field_path: []
-                schema_loader:
-                  type: InlineSchemaLoader
-                  schema:
-                    type: object
-                    $schema: http://json-schema.org/draft-07/schema#
-                    additionalProperties: true
-                    properties:
-                      archived:
-                        type:
-                          - "null"
-                          - boolean
-                      authority_level:
-                        type:
-                          - "null"
-                          - string
-                      can_write:
-                        type:
-                          - "null"
-                          - boolean
-                      color:
-                        type:
-                          - "null"
-                          - string
-                      description:
-                        type:
-                          - "null"
-                          - string
-                      id:
-                        type:
-                          - "null"
-                          - integer
-                          - string
-                      location:
-                        type:
-                          - "null"
-                          - string
-                      name:
-                        type:
-                          - "null"
-                          - string
-                      namespace:
-                        type:
-                          - "null"
-                          - string
-                      personal_owner_id:
-                        type:
-                          - "null"
-                          - integer
-                      slug:
-                        type:
-                          - "null"
-                          - string
-    schema_loader:
-      type: InlineSchemaLoader
-      schema:
-        type: object
-        $schema: http://json-schema.org/draft-07/schema#
-        additionalProperties: true
-        properties: {}
+  - $ref: "#/definitions/streams/cards"
+  - $ref: "#/definitions/streams/collections"
+  - $ref: "#/definitions/streams/dashboards"
+  - $ref: "#/definitions/streams/users"
+  - $ref: "#/definitions/streams/databases"
+  - $ref: "#/definitions/streams/native_query_snippets"
+  - $ref: "#/definitions/streams/collections_items_dashboards"
+
 spec:
   type: Spec
   connection_specification:
@@ -2389,7 +218,7 @@ spec:
     $schema: http://json-schema.org/draft-07/schema#
     required:
       - instance_api_url
-      - username
+    additionalProperties: true
     properties:
       instance_api_url:
         type: string
@@ -2397,34 +226,63 @@ spec:
         description: URL to your metabase instance API
         examples:
           - https://localhost:3000/api/
-        pattern: ^https://
+        pattern: ^https:\/\/.*\/api\/$
         order: 0
-      username:
-        type: string
-        title: Username
+      credentials:
         order: 1
-      password:
-        type: string
-        title: Password
-        always_show: true
-        airbyte_secret: true
-        order: 2
-      session_token:
-        type: string
-        description: >-
-          To generate your session token, you need to run the following command:
-          ``` curl -X POST \
-            -H "Content-Type: application/json" \
-            -d '{"username": "person@metabase.com", "password": "fakepassword"}' \
-            http://localhost:3000/api/session
-          ``` Then copy the value of the `id` field returned by a successful
-          call to that API.
+        title: Authentication Mechanism
+        description: Choose how to authenticate to Metabase API
+        type: object
+        oneOf:
+          - type: object
+            title: Authenticate via API Key
+            required:
+              - auth_type
+              - api_key
+            additionalProperties: true
+            properties:
+              auth_type:
+                type: string
+                const: api_key
+                order: 0
+              api_key:
+                title: API Key
+                type: string
+                description: The generated API Key for Metabase API
+                airbyte_secret: true
+          - type: object
+            title: Authenticate via User Session Token
+            required:
+              - auth_type
+              - username
+              - password
+            additionalProperties: true
+            properties:
+              auth_type:
+                type: string
+                const: session_token
+                order: 1
+              username:
+                type: string
+                title: Username
+                order: 2
+              password:
+                type: string
+                title: Password
+                airbyte_secret: true
+              expiration_duration:
+                type: string
+                description: >-
+                  The duration in ISO 8601 duration notation after which the
+                  session token expires, starting from the time it was obtained.
+                  Omitting it will result in the session token being refreshed
+                  for every request. By default Metabase tokens expire after
+                  14 days. If you are hosting your own Metabase instance, you
+                  can configure this session duration on your Metabase server
+                  by setting the environment variable MAX_SESSION_AGE (value 
+                  is in minutes).
+                default: P14D
 
-          Note that by default, sessions are good for 14 days and needs to be
-          regenerated.
-        airbyte_secret: true
-        order: 3
-    additionalProperties: true
 metadata:
   autoImportSchema:
     cards: false
@@ -2434,6 +292,7 @@ metadata:
     databases: false
     native_query_snippets: false
     collections_items_dashboards: false
+
 schemas:
   cards:
     type: object

--- a/airbyte-integrations/connectors/source-metabase/metadata.yaml
+++ b/airbyte-integrations/connectors/source-metabase/metadata.yaml
@@ -6,11 +6,11 @@ data:
     hosts:
       - "*"
   connectorBuildOptions:
-    baseImage: docker.io/airbyte/source-declarative-manifest:4.4.3@sha256:8937b693c7e01087f6e86e683826ac20f160f7952b8f0a13cbf4f9bfdd7af570
+    baseImage: docker.io/airbyte/source-declarative-manifest:4.6.2@sha256:f5fcd3d4703b7590b6166a7853c5ed1686731607cd30a159a8c24e2fe2c1ee98
   connectorSubtype: api
   connectorType: source
   definitionId: c7cb421b-942e-4468-99ee-e369bcabaec5
-  dockerImageTag: 2.1.1
+  dockerImageTag: 2.2.0
   dockerRepository: airbyte/source-metabase
   documentationUrl: https://docs.airbyte.com/integrations/sources/metabase
   githubIssueLabel: source-metabase

--- a/docs/integrations/sources/metabase.md
+++ b/docs/integrations/sources/metabase.md
@@ -1,16 +1,36 @@
 # Metabase
 
-This page contains the setup guide and reference information for the Metabase source connector.
-
 ## Prerequisites
 
-To set up Metabase you need:
+To set up the Metabase source connector you need:
 
-- `username` and `password` - Credential pairs to authenticate with Metabase instance. This may be used to generate a new `session_token` if necessary. An email from Metabase may be sent to the owner's account every time this is being used to open a new session.
-- `session_token` - Credential token to authenticate requests sent to Metabase API. Usually expires after 14 days.
 - `instance_api_url` - URL to interact with Metabase instance API, that uses https.
+- Either an [API Key](https://www.metabase.com/docs/latest/people-and-groups/api-keys) or a Metabase user with the proper authorization
+
 
 ## Setup guide
+
+The Metabse source connector supports two authentication methods:
+- API token (recommended)
+- User Session token
+
+
+### Generate an API Token
+1. Login to Metabase as an Administrator
+2. Click on the gear icon in the upper right.
+3. Select Admin settings.
+4. Go to the Settings tab.
+5. Click on the Authentication tab on the left menu.
+6. Scroll to API Keys and click Manage.
+7. Click the Create API Key button.
+8. Enter a Key name. You can have multiple API keys, so give it a name that will help you remember what you’re using the key for.
+9. Select a Group. The key will have the same permissions granted to that group.
+10. Click Create.
+11. Copy the generated API key and save it somewhere safe. Metabase won’t be able to show you the key again. If you lose the key, you’ll need to regenerate a new key.
+
+### Use an existing Metabase User
+- `username` and `password` - Credential pairs to authenticate with Metabase instance. This may be used to generate a new `session_token` if necessary. An email from Metabase may be sent to the owner's account every time this is being used to open a new session.
+- `session_token` - Credential token to authenticate requests sent to Metabase API. Usually expires after 14 days.
 
 You can find or create authentication tokens from [Metabase](https://www.metabase.com/learn/administration/metabase-api.html#authenticate-your-requests-with-a-session-token) by running the following command:`
 
@@ -77,6 +97,7 @@ The Metabase source connector supports the following [sync modes](https://docs.a
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                          |
 | :------ | :--------- | :------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------- |
+| 2.2.0   | 2024-08-27 | 
 | 2.1.1   | 2024-08-16 | [44196](https://github.com/airbytehq/airbyte/pull/44196) | Bump source-declarative-manifest version   |
 | 2.1.0 | 2024-08-15 | [44127](https://github.com/airbytehq/airbyte/pull/44127) | Refactor connector to manifest-only format |
 | 2.0.13 | 2024-08-12 | [43857](https://github.com/airbytehq/airbyte/pull/43857) | Update dependencies |


### PR DESCRIPTION
## What
Resolves https://github.com/airbytehq/airbyte/issues/45356

The preferred way of authenticating to the [Metabase API is via API key](https://www.metabase.com/docs/latest/people-and-groups/api-keys) over the current implemented way (user login/ session token).

## How
Adds `SelectiveAuthenticator` to allow users to select between session auth and API key auth.

Note: this PR also cleans up the `manifest.yaml`, I can split this out into a different PR if needed.

## Review guide
1. `manifest.yaml`

## User Impact
On source creation, users can now select between session auth and API key auth.

## Can this PR be safely reverted and rolled back?
- [ ] YES 💚
- [ ] NO ❌
