### PR TITLE
airbyte-ci: relax docs qa checks when sl == 0

### DIFF
--- a/airbyte-ci/connectors/connectors_qa/README.md
+++ b/airbyte-ci/connectors/connectors_qa/README.md
@@ -108,6 +108,10 @@ poe lint
 
 ## Changelog
 
+### 1.8.0
+
+Added minimum sl threshold value to documentation checks to skip them for connectors for which sl is 0.
+
 ### 1.7.0
 
 Added  `CheckDocumentationLinks`, `CheckDocumentationHeadersOrder`, `CheckPrerequisitesSectionDescribesRequiredFieldsFromSpec`, 

--- a/airbyte-ci/connectors/connectors_qa/pyproject.toml
+++ b/airbyte-ci/connectors/connectors_qa/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "connectors-qa"
-version = "1.7.0"
+version = "1.8.0"
 description = "A package to run QA checks on Airbyte connectors, generate reports and documentation."
 authors = ["Airbyte <contact@airbyte.io>"]
 readme = "README.md"

--- a/airbyte-ci/connectors/connectors_qa/src/connectors_qa/checks/documentation/documentation.py
+++ b/airbyte-ci/connectors/connectors_qa/src/connectors_qa/checks/documentation/documentation.py
@@ -24,6 +24,7 @@ from .models import DocumentationContent, TemplateContent
 
 class DocumentationCheck(Check):
     category = CheckCategory.DOCUMENTATION
+    applies_to_connector_ab_internal_sl = 100
 
 
 class CheckMigrationGuide(DocumentationCheck):

--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/generated/AirbyteInternal.py
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/generated/AirbyteInternal.py
@@ -13,5 +13,5 @@ class AirbyteInternal(BaseModel):
     class Config:
         extra = Extra.allow
 
-    sl: Optional[Literal[100, 200, 300]] = None
-    ql: Optional[Literal[100, 200, 300, 400, 500, 600]] = None
+    sl: Optional[Literal[0, 100, 200, 300]] = None
+    ql: Optional[Literal[0, 100, 200, 300, 400, 500, 600]] = None

--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/generated/ConnectorMetadataDefinitionV0.py
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/generated/ConnectorMetadataDefinitionV0.py
@@ -123,8 +123,8 @@ class AirbyteInternal(BaseModel):
     class Config:
         extra = Extra.allow
 
-    sl: Optional[Literal[100, 200, 300]] = None
-    ql: Optional[Literal[100, 200, 300, 400, 500, 600]] = None
+    sl: Optional[Literal[0, 100, 200, 300]] = None
+    ql: Optional[Literal[0, 100, 200, 300, 400, 500, 600]] = None
 
 
 class PyPi(BaseModel):

--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/generated/ConnectorRegistryDestinationDefinition.py
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/generated/ConnectorRegistryDestinationDefinition.py
@@ -100,8 +100,8 @@ class AirbyteInternal(BaseModel):
     class Config:
         extra = Extra.allow
 
-    sl: Optional[Literal[100, 200, 300]] = None
-    ql: Optional[Literal[100, 200, 300, 400, 500, 600]] = None
+    sl: Optional[Literal[0, 100, 200, 300]] = None
+    ql: Optional[Literal[0, 100, 200, 300, 400, 500, 600]] = None
 
 
 class GitInfo(BaseModel):

--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/generated/ConnectorRegistryReleases.py
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/generated/ConnectorRegistryReleases.py
@@ -86,8 +86,8 @@ class AirbyteInternal(BaseModel):
     class Config:
         extra = Extra.allow
 
-    sl: Optional[Literal[100, 200, 300]] = None
-    ql: Optional[Literal[100, 200, 300, 400, 500, 600]] = None
+    sl: Optional[Literal[0, 100, 200, 300]] = None
+    ql: Optional[Literal[0, 100, 200, 300, 400, 500, 600]] = None
 
 
 class GitInfo(BaseModel):

--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/generated/ConnectorRegistrySourceDefinition.py
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/generated/ConnectorRegistrySourceDefinition.py
@@ -100,8 +100,8 @@ class AirbyteInternal(BaseModel):
     class Config:
         extra = Extra.allow
 
-    sl: Optional[Literal[100, 200, 300]] = None
-    ql: Optional[Literal[100, 200, 300, 400, 500, 600]] = None
+    sl: Optional[Literal[0, 100, 200, 300]] = None
+    ql: Optional[Literal[0, 100, 200, 300, 400, 500, 600]] = None
 
 
 class GitInfo(BaseModel):

--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/generated/ConnectorRegistryV0.py
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/generated/ConnectorRegistryV0.py
@@ -100,8 +100,8 @@ class AirbyteInternal(BaseModel):
     class Config:
         extra = Extra.allow
 
-    sl: Optional[Literal[100, 200, 300]] = None
-    ql: Optional[Literal[100, 200, 300, 400, 500, 600]] = None
+    sl: Optional[Literal[0, 100, 200, 300]] = None
+    ql: Optional[Literal[0, 100, 200, 300, 400, 500, 600]] = None
 
 
 class GitInfo(BaseModel):

--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/src/AirbyteInternal.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/src/AirbyteInternal.yaml
@@ -9,12 +9,14 @@ properties:
   sl:
     type: integer
     enum:
+      - 0
       - 100
       - 200
       - 300
   ql:
     type: integer
     enum:
+      - 0
       - 100
       - 200
       - 300

--- a/airbyte-ci/connectors/metadata_service/lib/pyproject.toml
+++ b/airbyte-ci/connectors/metadata_service/lib/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metadata-service"
-version = "0.14.1"
+version = "0.15.0"
 description = ""
 authors = ["Ben Church <ben@airbyte.io>"]
 readme = "README.md"

--- a/airbyte-ci/connectors/metadata_service/lib/tests/test_validators/test_metadata_validators.py
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/test_validators/test_metadata_validators.py
@@ -71,10 +71,8 @@ def test_validation_fail_on_docker_image_tag_decrement(metadata_definition, decr
     metadata_definition.data.dockerImageTag = decremented_version
     success, error_message = metadata_validator.validate_docker_image_tag_is_not_decremented(metadata_definition, None)
     assert not success
-    assert (
-        error_message
-        == f"The dockerImageTag value ({decremented_version}) can't be decremented: it should be equal to or above {current_version}."
-    )
+    expected_prefix = f"The dockerImageTag value ({decremented_version}) can't be decremented: it should be equal to or above"
+    assert error_message.startswith(expected_prefix), error_message
 
 
 def test_validation_pass_on_docker_image_tag_increment(metadata_definition, incremented_version):

--- a/airbyte-ci/connectors/metadata_service/orchestrator/pyproject.toml
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "orchestrator"
-version = "0.5.4"
+version = "0.5.5"
 description = ""
 authors = ["Ben Church <ben@airbyte.io>"]
 readme = "README.md"

--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -843,6 +843,7 @@ airbyte-ci connectors --language=low-code migrate-to-manifest-only
 
 | Version | PR                                                         | Description                                                                                                                  |
 | ------- | ---------------------------------------------------------- |------------------------------------------------------------------------------------------------------------------------------|
+| 4.35.2  | [#45360](https://github.com/airbytehq/airbyte/pull/45360)  | Updated dependencies.                                                                                                        |
 | 4.35.1  | [#45160](https://github.com/airbytehq/airbyte/pull/45160)  | Remove deps.toml dependency for java connectors.                                                                             |
 | 4.35.0  | [#44879](https://github.com/airbytehq/airbyte/pull/44879)  | Mount `components.py` when building manifest-only connector image                                                            |
 | 4.34.2  | [#44786](https://github.com/airbytehq/airbyte/pull/44786)  | Pre-emptively skip archived connectors when searching for modified files                                                     |

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "4.35.1"
+version = "4.35.2"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 

--- a/docs/contributing-to-airbyte/resources/qa-checks.md
+++ b/docs/contributing-to-airbyte/resources/qa-checks.md
@@ -13,7 +13,7 @@ They are by no mean replacing the need for a manual review of the connector code
 _Applies to the following connector types: source, destination_
 _Applies to the following connector languages: java, low-code, python, manifest-only_
 _Applies to connector with any support level_
-_Applies to connector with any internal support level_
+_Applies to connector with 100 internal support level_
 _Applies to connector with any Airbyte usage level_
 
 When a breaking change is introduced, we check that a migration guide is available. It should be stored under `./docs/integrations/<connector-type>s/<connector-name>-migrations.md`.
@@ -24,7 +24,7 @@ This document should contain a section for each breaking change, in order of the
 _Applies to the following connector types: source, destination_
 _Applies to the following connector languages: java, low-code, python, manifest-only_
 _Applies to connector with any support level_
-_Applies to connector with any internal support level_
+_Applies to connector with 100 internal support level_
 _Applies to connector with any Airbyte usage level_
 
 The user facing connector documentation should be stored under `./docs/integrations/<connector-type>s/<connector-name>.md`.
@@ -251,7 +251,7 @@ Check verifies that Changelog header section content follows standard template:
 _Applies to the following connector types: source, destination_
 _Applies to the following connector languages: java, low-code, python, manifest-only_
 _Applies to connector with any support level_
-_Applies to connector with any internal support level_
+_Applies to connector with 100 internal support level_
 _Applies to connector with any Airbyte usage level_
 
 Each new version of a connector must have a changelog entry defined in the user facing documentation in `./docs/integrations/<connector-type>s/<connector-name>.md`.


### PR DESCRIPTION
## What
When developing new connectors, the QA checks related to documentation are annoying. For instance, there's no point in maintaining a changelog and being forced to adds needless friction.

## How

Allow 0 `sl` values in AirbyteInternal objects in metadata.yaml. For good measure, allow 0 `ql` values also. Make docs checks applicable only to `sl >= 100`. 100 is the default `sl` value anyway so this shouldn't break anything.

Depends on https://github.com/airbytehq/airbyte/pull/45361

## Review guide
Commit by commit

## User Impact
None

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [x] NO ❌
