### PR TITLE
.github: fix airbyte-ci-release.yml

### DIFF
--- a/.github/workflows/airbyte-ci-release.yml
+++ b/.github/workflows/airbyte-ci-release.yml
@@ -54,7 +54,7 @@ jobs:
         working-directory: airbyte-ci/connectors/pipelines/
         run: poetry run poe build-release-binary ${{ env.BINARY_FILE_NAME }}
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: airbyte-ci-${{ matrix.os }}-${{ steps.get_short_sha.outputs.sha }}
           path: airbyte-ci/connectors/pipelines/dist/${{ env.BINARY_FILE_NAME }}


### PR DESCRIPTION
## What
The upload-artifact action v2 is no longer supported. 

## How
Bumped to v3; as v4 does not allow overwrites.

Tested on https://github.com/airbytehq/airbyte/pull/45360
Success!
https://github.com/airbytehq/airbyte/actions/runs/10794833086/job/29940025087?pr=45360

## Review guide
None

## User Impact
None

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [x] NO ❌
