### PR TITLE
Remove pandas from extras in file-based

### DIFF
--- a/airbyte-cdk/python/pyproject.toml
+++ b/airbyte-cdk/python/pyproject.toml
@@ -84,7 +84,7 @@ requests-mock = "*"
 codeflash = "*"
 
 [tool.poetry.extras]
-file-based = ["avro", "fastavro", "pyarrow", "unstructured", "pdf2image", "pdfminer.six", "unstructured.pytesseract", "pytesseract", "markdown", "python-calamine", "pandas"]
+file-based = ["avro", "fastavro", "pyarrow", "unstructured", "pdf2image", "pdfminer.six", "unstructured.pytesseract", "pytesseract", "markdown", "python-calamine"]
 sphinx-docs = ["Sphinx", "sphinx-rtd-theme"]
 vector-db-based = ["langchain", "openai", "cohere", "tiktoken"]
 


### PR DESCRIPTION
## What
Sources are getting the following errors after the release for async:
```
  File "/usr/local/lib/python3.10/site-packages/airbyte_cdk/sources/declarative/retrievers/simple_retriever.py", line 12, in <module>
    from airbyte_cdk.sources.declarative.extractors.http_selector import HttpSelector
  File "/usr/local/lib/python3.10/site-packages/airbyte_cdk/sources/declarative/extractors/__init__.py", line 9, in <module>
    from airbyte_cdk.sources.declarative.extractors.response_to_file_extractor import ResponseToFileExtractor
  File "/usr/local/lib/python3.10/site-packages/airbyte_cdk/sources/declarative/extractors/response_to_file_extractor.py", line 11, in <module>
    import pandas as pd
ModuleNotFoundError: No module named 'pandas'.
```

It seems to be because even though the dependency has been added in the list, it is flagged as extra for file-based

## How
Remove it from extras in file-based

### Tests
Tested locally by setting `airbyte-cdk = {path = "../../../airbyte-cdk/python/", develop = true}` in source-declarative-manifest and running `poetry lock --no-update`. We can see the dependency added in the lock file

## User Impact
The sources should not install pandas and therefore not fail with the module not found

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [X] YES 💚
- [ ] NO ❌
