### PR TITLE
Bulk Load CDK: Simply Interface & Add Check

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/check/CheckOperation.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/check/CheckOperation.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.check
+
+import io.airbyte.cdk.Operation
+import io.airbyte.cdk.output.ExceptionHandler
+import io.micronaut.context.annotation.Requires
+import jakarta.inject.Singleton
+
+@Singleton
+@Requires(property = Operation.PROPERTY, value = "check")
+@Requires(env = ["destination"])
+class CheckOperation(
+    private val destination: DestinationCheck,
+    private val exceptionHandler: ExceptionHandler,
+) : Operation {
+    override fun execute() {
+        try {
+            destination.check()
+        } catch (e: Exception) {
+            exceptionHandler.handle(e)
+        } finally {
+            destination.cleanup()
+        }
+    }
+}

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/check/DestinationCheck.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/check/DestinationCheck.kt
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.check
+
+interface DestinationCheck {
+    fun check()
+    fun cleanup() {}
+}

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/state/MemoryManager.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/state/MemoryManager.kt
@@ -19,7 +19,7 @@ import kotlinx.coroutines.sync.withLock
  * TODO: Some degree of logging/monitoring around how accurate we're actually being?
  */
 @Singleton
-class MemoryManager(availableMemoryProvider: AvailableMemoryProvider) {
+class MemoryManager(private val availableMemoryProvider: AvailableMemoryProvider) {
     private val totalMemoryBytes: Long = availableMemoryProvider.availableMemoryBytes
     private var usedMemoryBytes = AtomicLong(0L)
     private val mutex = Mutex()

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/task/OpenStreamTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/task/OpenStreamTask.kt
@@ -5,13 +5,13 @@
 package io.airbyte.cdk.task
 
 import io.airbyte.cdk.command.DestinationStream
-import io.airbyte.cdk.write.Destination
+import io.airbyte.cdk.write.DestinationWrite
 import io.airbyte.cdk.write.StreamLoader
 import io.micronaut.context.annotation.Secondary
 import jakarta.inject.Singleton
 
 /**
- * Wraps @[StreamLoader.open] and starts the spill-to-disk tasks.
+ * Wraps @[StreamLoader.start] and starts the spill-to-disk tasks.
  *
  * TODO: There's no reason to wait on initialization to start spilling to disk.
  */
@@ -20,7 +20,7 @@ class OpenStreamTask(
     private val taskLauncher: DestinationTaskLauncher
 ) : Task {
     override suspend fun execute() {
-        streamLoader.open()
+        streamLoader.start()
         taskLauncher.startSpillToDiskTasks(streamLoader)
     }
 }
@@ -28,7 +28,7 @@ class OpenStreamTask(
 @Singleton
 @Secondary
 class OpenStreamTaskFactory(
-    private val destination: Destination,
+    private val destination: DestinationWrite,
 ) {
     fun make(taskLauncher: DestinationTaskLauncher, stream: DestinationStream): OpenStreamTask {
         return OpenStreamTask(destination.getStreamLoader(stream), taskLauncher)

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/task/SetupTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/task/SetupTask.kt
@@ -4,18 +4,18 @@
 
 package io.airbyte.cdk.task
 
-import io.airbyte.cdk.write.Destination
+import io.airbyte.cdk.write.DestinationWrite
 import io.micronaut.context.annotation.Secondary
 import jakarta.inject.Singleton
 
 /**
- * Wraps @[Destination.setup] and starts the open stream tasks.
+ * Wraps @[DestinationWrite.setup] and starts the open stream tasks.
  *
  * TODO: This should call something like "TaskLauncher.setupComplete" and let it decide what to do
  * next.
  */
 class SetupTask(
-    private val destination: Destination,
+    private val destination: DestinationWrite,
     private val taskLauncher: DestinationTaskLauncher
 ) : Task {
     override suspend fun execute() {
@@ -27,7 +27,7 @@ class SetupTask(
 @Singleton
 @Secondary
 class SetupTaskFactory(
-    private val destination: Destination,
+    private val destination: DestinationWrite,
 ) {
     fun make(taskLauncher: DestinationTaskLauncher): SetupTask {
         return SetupTask(destination, taskLauncher)

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/task/TeardownTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/task/TeardownTask.kt
@@ -5,19 +5,19 @@
 package io.airbyte.cdk.task
 
 import io.airbyte.cdk.state.StreamsManager
-import io.airbyte.cdk.write.Destination
+import io.airbyte.cdk.write.DestinationWrite
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.micronaut.context.annotation.Secondary
 import jakarta.inject.Singleton
 import java.util.concurrent.atomic.AtomicBoolean
 
 /**
- * Wraps @[Destination.teardown] and stops the task launcher.
+ * Wraps @[DestinationWrite.teardown] and stops the task launcher.
  *
  * TODO: Report teardown-complete and let the task launcher decide what to do next.
  */
 class TeardownTask(
-    private val destination: Destination,
+    private val destination: DestinationWrite,
     private val streamsManager: StreamsManager,
     private val taskLauncher: DestinationTaskLauncher
 ) : Task {
@@ -44,7 +44,7 @@ class TeardownTask(
 @Singleton
 @Secondary
 class TeardownTaskFactory(
-    private val destination: Destination,
+    private val destination: DestinationWrite,
     private val streamsManager: StreamsManager,
 ) {
     fun make(taskLauncher: DestinationTaskLauncher): TeardownTask {

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/write/DestinationWrite.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/write/DestinationWrite.kt
@@ -9,26 +9,30 @@ import io.micronaut.context.annotation.Secondary
 import jakarta.inject.Singleton
 
 /**
- * Implementor interface. Extended this only if you need to perform initialization and teardown
- * *across all streams*, or if your per-stream operations need shared global state.
- *
- * If initialization can be done on a per-stream basis, implement @[StreamLoaderFactory] instead.
+ * Implementor interface. Every Destination must extend this and at least provide an implementation
+ * of [getStreamLoader].
  */
-interface Destination {
+interface DestinationWrite {
     // Called once before anything else
     suspend fun setup() {}
 
     // Return a StreamLoader for the given stream
     fun getStreamLoader(stream: DestinationStream): StreamLoader
 
-    // Called once at the end of the job
+    // Called once at the end of the job, unconditionally.
     suspend fun teardown(succeeded: Boolean = true) {}
 }
 
 @Singleton
 @Secondary
-class DefaultDestination(private val streamLoaderFactory: StreamLoaderFactory) : Destination {
+class DefaultDestinationWrite : DestinationWrite {
+    init {
+        throw NotImplementedError(
+            "DestinationWrite not implemented. Please create a custom @Singleton implementation."
+        )
+    }
+
     override fun getStreamLoader(stream: DestinationStream): StreamLoader {
-        return streamLoaderFactory.make(stream)
+        throw NotImplementedError()
     }
 }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/write/InputConsumer.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/write/InputConsumer.kt
@@ -9,7 +9,6 @@ import io.airbyte.cdk.message.DestinationMessage
 import io.airbyte.cdk.message.MessageQueueWriter
 import io.github.oshai.kotlinlogging.KLogger
 import io.github.oshai.kotlinlogging.KotlinLogging
-import io.micronaut.context.annotation.Factory
 import jakarta.inject.Singleton
 import java.io.InputStream
 import java.nio.charset.StandardCharsets
@@ -62,13 +61,4 @@ class DefaultInputConsumer(
     override val messageQueue: MessageQueueWriter<DestinationMessage>
 ) : DeserializingInputStreamConsumer<DestinationMessage> {
     override val log = KotlinLogging.logger {}
-}
-
-/** Override to provide a custom input stream. */
-@Factory
-class InputStreamFactory {
-    @Singleton
-    fun make(): InputStream {
-        return System.`in`
-    }
 }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/write/WriteOperation.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/write/WriteOperation.kt
@@ -8,7 +8,10 @@ import io.airbyte.cdk.Operation
 import io.airbyte.cdk.message.DestinationMessage
 import io.airbyte.cdk.task.TaskLauncher
 import io.airbyte.cdk.task.TaskRunner
+import io.micronaut.context.annotation.Factory
 import io.micronaut.context.annotation.Requires
+import io.micronaut.context.annotation.Secondary
+import java.io.InputStream
 import javax.inject.Singleton
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
@@ -32,5 +35,16 @@ class WriteOperation(
 
             launch { taskRunner.run() }
         }
+    }
+}
+
+/** Override to provide a custom input stream. */
+@Factory
+class InputStreamFactory {
+    @Singleton
+    @Secondary
+    @Requires(property = Operation.PROPERTY, value = "write")
+    fun make(): InputStream {
+        return System.`in`
     }
 }


### PR DESCRIPTION
## What
* Simplify destination interface. Got rid of StreamLoaderFactory. Client must implement Destination (now called DestinationWrite).
* Added DesitnationCheck (no default implementation yet)