### PR TITLE
airbyte-ci: improve QA checks for airbyte-enterprise

### DIFF
--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -843,6 +843,7 @@ airbyte-ci connectors --language=low-code migrate-to-manifest-only
 
 | Version | PR                                                         | Description                                                                                                                  |
 | ------- | ---------------------------------------------------------- |------------------------------------------------------------------------------------------------------------------------------|
+| 4.35.3  | [#45393](https://github.com/airbytehq/airbyte/pull/45393)  | Improved support for airbyte-enterprise in QA checks.                                                                        |
 | 4.35.2  | [#45360](https://github.com/airbytehq/airbyte/pull/45360)  | Updated dependencies.                                                                                                        |
 | 4.35.1  | [#45160](https://github.com/airbytehq/airbyte/pull/45160)  | Remove deps.toml dependency for java connectors.                                                                             |
 | 4.35.0  | [#44879](https://github.com/airbytehq/airbyte/pull/44879)  | Mount `components.py` when building manifest-only connector image                                                            |

--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -843,7 +843,7 @@ airbyte-ci connectors --language=low-code migrate-to-manifest-only
 
 | Version | PR                                                         | Description                                                                                                                  |
 | ------- | ---------------------------------------------------------- |------------------------------------------------------------------------------------------------------------------------------|
-| 4.35.3  | [#45393](https://github.com/airbytehq/airbyte/pull/45393)  | Improved support for airbyte-enterprise in QA checks.                                                                        |
+| 4.35.3  | [#45393](https://github.com/airbytehq/airbyte/pull/45393)  | Resolve symlinks in `SimpleDockerStep`.                                                                        |
 | 4.35.2  | [#45360](https://github.com/airbytehq/airbyte/pull/45360)  | Updated dependencies.                                                                                                        |
 | 4.35.1  | [#45160](https://github.com/airbytehq/airbyte/pull/45160)  | Remove deps.toml dependency for java connectors.                                                                             |
 | 4.35.0  | [#44879](https://github.com/airbytehq/airbyte/pull/44879)  | Mount `components.py` when building manifest-only connector image                                                            |

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/steps/docker.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/steps/docker.py
@@ -1,7 +1,7 @@
 #
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 #
-
+from pathlib import Path
 from typing import Dict, List, Optional
 
 import dagger
@@ -55,13 +55,21 @@ class SimpleDockerStep(Step):
             if path_to_mount.optional and not path_to_mount.get_path().exists():
                 continue
 
-            path_string = str(path_to_mount)
-            destination_path = f"/{path_string}"
-            if path_to_mount.is_file:
-                file_to_load = self.context.get_repo_file(path_string)
-                container = container.with_mounted_file(destination_path, file_to_load)
-            else:
-                container = container.with_mounted_directory(destination_path, self.context.get_repo_dir(path_string))
+            if path_to_mount.get_path().is_symlink():
+                container = self._mount_path(container, path_to_mount.get_path().readlink())
+
+            container = self._mount_path(container, path_to_mount.get_path())
+        return container
+
+    def _mount_path(self, container: dagger.Container, path: Path) -> dagger.Container:
+        path_string = str(path)
+        destination_path = f"/{path_string}"
+        if path.is_file():
+            file_to_load = self.context.get_repo_file(path_string)
+            container = container.with_mounted_file(destination_path, file_to_load)
+        else:
+            dir_to_load = self.context.get_repo_dir(path_string)
+            container = container.with_mounted_directory(destination_path, dir_to_load)
         return container
 
     async def _install_internal_tools(self, container: dagger.Container) -> dagger.Container:

--- a/airbyte-ci/connectors/pipelines/pipelines/models/steps.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/models/steps.py
@@ -62,10 +62,6 @@ class MountPath:
     def __str__(self) -> str:
         return str(self.path)
 
-    @property
-    def is_file(self) -> bool:
-        return self.get_path().is_file()
-
 
 @dataclass(kw_only=True, frozen=True)
 class Result:

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "4.35.2"
+version = "4.35.3"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 


### PR DESCRIPTION
## What

This PR makes it possible for airbyte-ci to run in airbyte-enterprise with symlinks instead of actual docs.

This is a companion to https://github.com/airbytehq/airbyte-enterprise/pull/43 and is required by it for it to pass CI. See its description for context.

## How
Improves symlink support in airbyte-ci.

## Review guide
n/a

## User Impact
None

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
