### PR TITLE
Async job/pagination on download

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -2435,6 +2435,11 @@ definitions:
         anyOf:
           - "$ref": "#/definitions/CustomRequester"
           - "$ref": "#/definitions/HttpRequester"
+      download_paginator:
+        description: Paginator component that describes how to navigate through the API's pages during download.
+        anyOf:
+          - "$ref": "#/definitions/DefaultPaginator"
+          - "$ref": "#/definitions/NoPagination"
       abort_requester:
         description: Requester component that describes how to prepare HTTP requests to send to the source API to abort a job once it is timed out from the source's perspective.
         anyOf:

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/decoders/__init__.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/decoders/__init__.py
@@ -4,5 +4,7 @@
 
 from airbyte_cdk.sources.declarative.decoders.decoder import Decoder
 from airbyte_cdk.sources.declarative.decoders.json_decoder import JsonDecoder, JsonlDecoder, IterableDecoder
+from airbyte_cdk.sources.declarative.decoders.noop_decoder import NoopDecoder
 
-__all__ = ["Decoder", "JsonDecoder", "JsonlDecoder", "IterableDecoder"]
+
+__all__ = ["Decoder", "JsonDecoder", "JsonlDecoder", "IterableDecoder", "NoopDecoder"]

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
@@ -1653,6 +1653,10 @@ class AsyncRetriever(BaseModel):
         ...,
         description='Requester component that describes how to prepare HTTP requests to send to the source API to download the data provided by the completed async job.',
     )
+    download_paginator: Optional[Union[DefaultPaginator, NoPagination]] = Field(
+        None,
+        description="Paginator component that describes how to navigate through the API's pages during download.",
+    )
     abort_requester: Optional[Union[CustomRequester, HttpRequester]] = Field(
         None,
         description="Requester component that describes how to prepare HTTP requests to send to the source API to abort a job once it is timed out from the source's perspective.",

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -29,8 +29,8 @@ from airbyte_cdk.sources.declarative.auth.token_provider import InterpolatedStri
 from airbyte_cdk.sources.declarative.checks import CheckStream
 from airbyte_cdk.sources.declarative.datetime import MinMaxDatetime
 from airbyte_cdk.sources.declarative.declarative_stream import DeclarativeStream
-from airbyte_cdk.sources.declarative.decoders import Decoder, IterableDecoder, JsonDecoder, JsonlDecoder
-from airbyte_cdk.sources.declarative.extractors import DpathExtractor, RecordFilter, RecordSelector
+from airbyte_cdk.sources.declarative.decoders import Decoder, IterableDecoder, JsonDecoder, JsonlDecoder, NoopDecoder
+from airbyte_cdk.sources.declarative.extractors import DpathExtractor, RecordFilter, RecordSelector, ResponseToFileExtractor
 from airbyte_cdk.sources.declarative.extractors.record_filter import ClientSideIncrementalRecordFilterDecorator
 from airbyte_cdk.sources.declarative.extractors.record_selector import SCHEMA_TRANSFORMER_TYPE_MAPPING
 from airbyte_cdk.sources.declarative.incremental import (
@@ -153,7 +153,7 @@ from airbyte_cdk.sources.declarative.transformations.keys_to_lower_transformatio
 from airbyte_cdk.sources.message import InMemoryMessageRepository, LogAppenderMessageRepositoryDecorator, MessageRepository
 from airbyte_cdk.sources.streams.http.error_handlers.response_models import ResponseAction
 from airbyte_cdk.sources.types import Config
-from airbyte_cdk.sources.utils.transform import TypeTransformer
+from airbyte_cdk.sources.utils.transform import TypeTransformer, TransformConfig
 from isodate import parse_duration
 from pydantic.v1 import BaseModel
 
@@ -1245,8 +1245,27 @@ class ModelToComponentFactory:
         polling_requester = self._create_component_from_model(
             model=model.polling_requester, decoder=decoder, config=config, name=f"job polling - {name}"
         )
+        job_download_components_name = f"job download - {name}"
         download_requester = self._create_component_from_model(
-            model=model.download_requester, decoder=decoder, config=config, name=f"job download - {name}"
+            model=model.download_requester, decoder=decoder, config=config, name=job_download_components_name
+        )
+        download_retriever = SimpleRetriever(
+            requester=download_requester,
+            record_selector=RecordSelector(
+                extractor=ResponseToFileExtractor(),
+                record_filter=None,
+                transformations=[],
+                schema_normalization=TypeTransformer(TransformConfig.NoTransform),
+                config=config,
+                parameters={},
+            ),
+            primary_key=None,
+            name=job_download_components_name,
+            paginator=self._create_component_from_model(
+                model=model.download_paginator, decoder=decoder, config=config, url_base=""
+            ) if model.download_paginator else NoPagination(parameters={}),
+            config=config,
+            parameters={},
         )
         abort_requester = self._create_component_from_model(
             model=model.abort_requester, decoder=decoder, config=config, name=f"job abort - {name}"
@@ -1256,7 +1275,7 @@ class ModelToComponentFactory:
         job_repository: AsyncJobRepository = AsyncHttpJobRepository(
             creation_requester=creation_requester,
             polling_requester=polling_requester,
-            download_requester=download_requester,
+            download_retriever=download_retriever,
             abort_requester=abort_requester,
             status_extractor=status_extractor,
             status_mapping=self._create_async_job_status_mapping(model.status_mapping, config),

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -29,7 +29,7 @@ from airbyte_cdk.sources.declarative.auth.token_provider import InterpolatedStri
 from airbyte_cdk.sources.declarative.checks import CheckStream
 from airbyte_cdk.sources.declarative.datetime import MinMaxDatetime
 from airbyte_cdk.sources.declarative.declarative_stream import DeclarativeStream
-from airbyte_cdk.sources.declarative.decoders import Decoder, IterableDecoder, JsonDecoder, JsonlDecoder, NoopDecoder
+from airbyte_cdk.sources.declarative.decoders import Decoder, IterableDecoder, JsonDecoder, JsonlDecoder
 from airbyte_cdk.sources.declarative.extractors import DpathExtractor, RecordFilter, RecordSelector, ResponseToFileExtractor
 from airbyte_cdk.sources.declarative.extractors.record_filter import ClientSideIncrementalRecordFilterDecorator
 from airbyte_cdk.sources.declarative.extractors.record_selector import SCHEMA_TRANSFORMER_TYPE_MAPPING
@@ -153,7 +153,7 @@ from airbyte_cdk.sources.declarative.transformations.keys_to_lower_transformatio
 from airbyte_cdk.sources.message import InMemoryMessageRepository, LogAppenderMessageRepositoryDecorator, MessageRepository
 from airbyte_cdk.sources.streams.http.error_handlers.response_models import ResponseAction
 from airbyte_cdk.sources.types import Config
-from airbyte_cdk.sources.utils.transform import TypeTransformer, TransformConfig
+from airbyte_cdk.sources.utils.transform import TransformConfig, TypeTransformer
 from isodate import parse_duration
 from pydantic.v1 import BaseModel
 
@@ -1261,15 +1261,17 @@ class ModelToComponentFactory:
             ),
             primary_key=None,
             name=job_download_components_name,
-            paginator=self._create_component_from_model(
-                model=model.download_paginator, decoder=decoder, config=config, url_base=""
-            ) if model.download_paginator else NoPagination(parameters={}),
+            paginator=self._create_component_from_model(model=model.download_paginator, decoder=decoder, config=config, url_base="")
+            if model.download_paginator
+            else NoPagination(parameters={}),
             config=config,
             parameters={},
         )
-        abort_requester = self._create_component_from_model(
-            model=model.abort_requester, decoder=decoder, config=config, name=f"job abort - {name}"
-        ) if model.abort_requester else None
+        abort_requester = (
+            self._create_component_from_model(model=model.abort_requester, decoder=decoder, config=config, name=f"job abort - {name}")
+            if model.abort_requester
+            else None
+        )
         status_extractor = self._create_component_from_model(model=model.status_extractor, decoder=decoder, config=config, name=name)
         urls_extractor = self._create_component_from_model(model=model.urls_extractor, decoder=decoder, config=config, name=name)
         job_repository: AsyncJobRepository = AsyncHttpJobRepository(

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/requesters/http_job_repository.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/requesters/http_job_repository.py
@@ -5,7 +5,6 @@ from dataclasses import dataclass, field
 from typing import Any, Dict, Iterable, Mapping, Optional
 
 import requests
-
 from airbyte_cdk import AirbyteMessage
 from airbyte_cdk.logger import lazy_log
 from airbyte_cdk.models import FailureType, Type
@@ -16,7 +15,7 @@ from airbyte_cdk.sources.declarative.extractors.dpath_extractor import DpathExtr
 from airbyte_cdk.sources.declarative.extractors.response_to_file_extractor import ResponseToFileExtractor
 from airbyte_cdk.sources.declarative.requesters.requester import Requester
 from airbyte_cdk.sources.declarative.retrievers.simple_retriever import SimpleRetriever
-from airbyte_cdk.sources.types import StreamSlice, Record
+from airbyte_cdk.sources.types import Record, StreamSlice
 from airbyte_cdk.utils import AirbyteTracedException
 from requests import Response
 

--- a/airbyte-cdk/python/unit_tests/sources/declarative/requesters/test_http_job_repository.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/requesters/test_http_job_repository.py
@@ -6,7 +6,6 @@ from unittest import TestCase
 from unittest.mock import Mock
 
 import pytest
-
 from airbyte_cdk.sources.declarative.async_job.status import AsyncJobStatus
 from airbyte_cdk.sources.declarative.decoders import NoopDecoder
 from airbyte_cdk.sources.declarative.decoders.json_decoder import JsonDecoder
@@ -22,7 +21,6 @@ from airbyte_cdk.sources.declarative.retrievers.simple_retriever import SimpleRe
 from airbyte_cdk.sources.types import StreamSlice
 from airbyte_cdk.sources.utils.transform import TransformConfig, TypeTransformer
 from airbyte_cdk.test.mock_http import HttpMocker, HttpRequest, HttpResponse
-
 
 _ANY_CONFIG = {}
 _ANY_SLICE = StreamSlice(partition={}, cursor_slice={})
@@ -114,8 +112,8 @@ class HttpJobRepositoryTest(TestCase):
                 config=_ANY_CONFIG,
                 parameters={},
             ),
-            config = _ANY_CONFIG,
-            parameters = {},
+            config=_ANY_CONFIG,
+            parameters={},
         )
 
         self._repository = AsyncHttpJobRepository(

--- a/airbyte-integrations/connectors/source-salesforce/source_salesforce/rate_limiting.py
+++ b/airbyte-integrations/connectors/source-salesforce/source_salesforce/rate_limiting.py
@@ -9,9 +9,9 @@ from typing import Any, Mapping, Optional, Union
 
 import backoff
 import requests
+from airbyte_cdk.models import FailureType
 from airbyte_cdk.sources.streams.http.error_handlers import ErrorHandler, ErrorResolution, ResponseAction
 from airbyte_cdk.sources.streams.http.exceptions import DefaultBackoffException
-from airbyte_cdk.models import FailureType
 from requests import codes, exceptions  # type: ignore[import]
 
 RESPONSE_CONSUMPTION_EXCEPTIONS = (

--- a/airbyte-integrations/connectors/source-salesforce/source_salesforce/streams.py
+++ b/airbyte-integrations/connectors/source-salesforce/source_salesforce/streams.py
@@ -17,11 +17,12 @@ import pandas as pd
 import pendulum
 import requests  # type: ignore[import]
 from airbyte_cdk import DeclarativeStream, JsonDecoder, DpathExtractor, HttpMethod, BearerAuthenticator, HttpRequester, RecordSelector, \
-    SinglePartitionRouter, StreamSlice
+    SinglePartitionRouter, StreamSlice, SimpleRetriever, DefaultPaginator, RequestOption, RequestOptionType, CursorPaginationStrategy
 from airbyte_cdk.models import ConfiguredAirbyteCatalog, FailureType, SyncMode
 from airbyte_cdk.sources.declarative.async_job.job_orchestrator import AsyncJobOrchestrator
 from airbyte_cdk.sources.declarative.async_job.status import AsyncJobStatus
 from airbyte_cdk.sources.declarative.auth.token_provider import InterpolatedStringTokenProvider
+from airbyte_cdk.sources.declarative.decoders import NoopDecoder
 from airbyte_cdk.sources.declarative.extractors import ResponseToFileExtractor
 from airbyte_cdk.sources.declarative.requesters.http_job_repository import AsyncHttpJobRepository
 from airbyte_cdk.sources.declarative.requesters.request_options import InterpolatedRequestOptionsProvider
@@ -501,9 +502,9 @@ class BulkSalesforceStream(SalesforceStream):
         )
         # "GET", url, headers = {"Accept-Encoding": "gzip"}, request_kwargs = {"stream": True}
         download_id_interpolation = "{{stream_slice['url']}}"
-        ResponseToFileExtractor()
+        job_download_components_name = f"{self.name} - download requester"
         download_requester = HttpRequester(
-            name=f"{self.name} - download requester",
+            name=job_download_components_name,
             url_base=url_base,
             path=f"{job_query_path}/{download_id_interpolation}/results",
             authenticator=authenticator,
@@ -524,12 +525,45 @@ class BulkSalesforceStream(SalesforceStream):
             use_cache=False,
             stream_response=True,
         )
+        download_retriever = SimpleRetriever(
+            requester=download_requester,
+            record_selector=RecordSelector(
+                extractor=ResponseToFileExtractor(),
+                record_filter=None,
+                transformations=[],
+                schema_normalization=TypeTransformer(TransformConfig.NoTransform),
+                config=config,
+                parameters={},
+            ),
+            primary_key=None,
+            name=job_download_components_name,
+            paginator=DefaultPaginator(
+                decoder=NoopDecoder(),
+                page_size_option=None,
+                page_token_option=RequestOption(
+                    field_name="locator",
+                    inject_into=RequestOptionType.request_parameter,
+                    parameters={},
+                ),
+                pagination_strategy=CursorPaginationStrategy(
+                    cursor_value="{{ headers['Sforce-Locator'] }}",
+                    decoder=NoopDecoder(),
+                    config=config,
+                    parameters={},
+                ),
+                url_base=url_base,
+                config=config,
+                parameters={},
+            ),
+            config=config,
+            parameters={},
+        )
         status_extractor = DpathExtractor(decoder=JsonDecoder(parameters={}), field_path=["state"], config={}, parameters={})
         urls_extractor = DpathExtractor(decoder=JsonDecoder(parameters={}), field_path=["id"], config={}, parameters={})
         job_repository = AsyncHttpJobRepository(
             creation_requester=creation_requester,
             polling_requester=polling_requester,
-            download_requester=download_requester,
+            download_retriever=download_retriever,
             abort_requester=None,
             status_extractor=status_extractor,
             status_mapping={

--- a/airbyte-integrations/connectors/source-salesforce/source_salesforce/streams.py
+++ b/airbyte-integrations/connectors/source-salesforce/source_salesforce/streams.py
@@ -16,8 +16,22 @@ from typing import Any, Callable, Iterable, List, Mapping, MutableMapping, Optio
 import pandas as pd
 import pendulum
 import requests  # type: ignore[import]
-from airbyte_cdk import DeclarativeStream, JsonDecoder, DpathExtractor, HttpMethod, BearerAuthenticator, HttpRequester, RecordSelector, \
-    SinglePartitionRouter, StreamSlice, SimpleRetriever, DefaultPaginator, RequestOption, RequestOptionType, CursorPaginationStrategy
+from airbyte_cdk import (
+    BearerAuthenticator,
+    CursorPaginationStrategy,
+    DeclarativeStream,
+    DefaultPaginator,
+    DpathExtractor,
+    HttpMethod,
+    HttpRequester,
+    JsonDecoder,
+    RecordSelector,
+    RequestOption,
+    RequestOptionType,
+    SimpleRetriever,
+    SinglePartitionRouter,
+    StreamSlice,
+)
 from airbyte_cdk.models import ConfiguredAirbyteCatalog, FailureType, SyncMode
 from airbyte_cdk.sources.declarative.async_job.job_orchestrator import AsyncJobOrchestrator
 from airbyte_cdk.sources.declarative.async_job.status import AsyncJobStatus
@@ -31,7 +45,7 @@ from airbyte_cdk.sources.declarative.schema import InlineSchemaLoader
 from airbyte_cdk.sources.declarative.stream_slicers import StreamSlicer
 from airbyte_cdk.sources.message import NoopMessageRepository
 from airbyte_cdk.sources.streams.availability_strategy import AvailabilityStrategy
-from airbyte_cdk.sources.streams.concurrent.cursor import Cursor, ConcurrentCursor
+from airbyte_cdk.sources.streams.concurrent.cursor import ConcurrentCursor, Cursor
 from airbyte_cdk.sources.streams.concurrent.state_converters.datetime_stream_state_converter import IsoMillisConcurrentStreamStateConverter
 from airbyte_cdk.sources.streams.core import CheckpointMixin, Stream, StreamData
 from airbyte_cdk.sources.streams.http import HttpClient, HttpStream, HttpSubStream
@@ -374,20 +388,40 @@ class BulkDatetimeStreamSlicer(StreamSlicer):
     def __init__(self, cursor: Optional[ConcurrentCursor]) -> None:
         self._cursor = cursor
 
-    def get_request_params(self, *, stream_state: Optional[StreamState] = None, stream_slice: Optional[StreamSlice] = None,
-                           next_page_token: Optional[Mapping[str, Any]] = None) -> Mapping[str, Any]:
+    def get_request_params(
+        self,
+        *,
+        stream_state: Optional[StreamState] = None,
+        stream_slice: Optional[StreamSlice] = None,
+        next_page_token: Optional[Mapping[str, Any]] = None,
+    ) -> Mapping[str, Any]:
         return {}
 
-    def get_request_headers(self, *, stream_state: Optional[StreamState] = None, stream_slice: Optional[StreamSlice] = None,
-                            next_page_token: Optional[Mapping[str, Any]] = None) -> Mapping[str, Any]:
+    def get_request_headers(
+        self,
+        *,
+        stream_state: Optional[StreamState] = None,
+        stream_slice: Optional[StreamSlice] = None,
+        next_page_token: Optional[Mapping[str, Any]] = None,
+    ) -> Mapping[str, Any]:
         return {}
 
-    def get_request_body_data(self, *, stream_state: Optional[StreamState] = None, stream_slice: Optional[StreamSlice] = None,
-                              next_page_token: Optional[Mapping[str, Any]] = None) -> Union[Mapping[str, Any], str]:
+    def get_request_body_data(
+        self,
+        *,
+        stream_state: Optional[StreamState] = None,
+        stream_slice: Optional[StreamSlice] = None,
+        next_page_token: Optional[Mapping[str, Any]] = None,
+    ) -> Union[Mapping[str, Any], str]:
         return {}
 
-    def get_request_body_json(self, *, stream_state: Optional[StreamState] = None, stream_slice: Optional[StreamSlice] = None,
-                              next_page_token: Optional[Mapping[str, Any]] = None) -> Mapping[str, Any]:
+    def get_request_body_json(
+        self,
+        *,
+        stream_state: Optional[StreamState] = None,
+        stream_slice: Optional[StreamSlice] = None,
+        next_page_token: Optional[Mapping[str, Any]] = None,
+    ) -> Mapping[str, Any]:
         return {}
 
     def stream_slices(self) -> Iterable[StreamSlice]:
@@ -401,7 +435,7 @@ class BulkDatetimeStreamSlicer(StreamSlicer):
                 cursor_slice={
                     "start_date": slice_start.isoformat(timespec="milliseconds"),
                     "end_date": slice_end.isoformat(timespec="milliseconds"),
-                }
+                },
             )
 
 
@@ -443,9 +477,13 @@ class BulkSalesforceStream(SalesforceStream):
         query = f"SELECT {select_fields} FROM {self.name}"  # FIXME "def request_params" is also handling `next_token` (I don't know why, I think it's always None) and parent streams
         if self.cursor_field:
             where_in_query = '{{ " WHERE " if stream_slice["start_date"] or stream_slice["end_date"] else "" }}'
-            lower_boundary_interpolation = '{{ "'f'{self.cursor_field}'' >= " + stream_slice["start_date"] if stream_slice["start_date"] else "" }}'
+            lower_boundary_interpolation = (
+                '{{ "' f"{self.cursor_field}" ' >= " + stream_slice["start_date"] if stream_slice["start_date"] else "" }}'
+            )
             and_keyword_interpolation = '{{" AND " if stream_slice["start_date"] and stream_slice["end_date"] else "" }}'
-            upper_boundary_interpolation = '{{ "'f'{self.cursor_field}'' < " + stream_slice["end_date"] if stream_slice["end_date"] else "" }}'
+            upper_boundary_interpolation = (
+                '{{ "' f"{self.cursor_field}" ' < " + stream_slice["end_date"] if stream_slice["end_date"] else "" }}'
+            )
             query = query + where_in_query + lower_boundary_interpolation + and_keyword_interpolation + upper_boundary_interpolation
         creation_requester = HttpRequester(
             name=f"{self.name} - creation requester",
@@ -461,7 +499,7 @@ class BulkSalesforceStream(SalesforceStream):
                     "query": query,
                     "contentType": "CSV",
                     "columnDelimiter": "COMMA",
-                    "lineEnding": "LF"
+                    "lineEnding": "LF",
                 },
                 request_headers=None,
                 request_parameters=None,

--- a/airbyte-integrations/connectors/source-salesforce/unit_tests/integration/test_bulk_stream.py
+++ b/airbyte-integrations/connectors/source-salesforce/unit_tests/integration/test_bulk_stream.py
@@ -7,8 +7,8 @@ from typing import Any, Dict, List, Optional
 from unittest import TestCase
 
 import freezegun
-from airbyte_cdk.test.mock_http import HttpMocker, HttpRequest, HttpResponse
 from airbyte_cdk.models import AirbyteStreamStatus, SyncMode
+from airbyte_cdk.test.mock_http import HttpMocker, HttpRequest, HttpResponse
 from config_builder import ConfigBuilder
 from integration.test_rest_stream import create_http_request as create_standard_http_request
 from integration.test_rest_stream import create_http_response as create_standard_http_response


### PR DESCRIPTION
## What
Addresses https://github.com/airbytehq/airbyte-internal-issues/issues/9738

## How
The SimpleRetriever already handles the pagination over a requester. Hence, we will:
* Add a paginator in the low-code declarative language
* Pass the download requester that already exists and the newly added paginator to the SimpleRetriever
* Call the SimpleRetriever in the HttpJobRepository

## Review guide
1. `airbyte-cdk/python/airbyte_cdk/sources/declarative/requesters/http_job_repository.py`
2. `airbyte-integrations/connectors/source-salesforce/source_salesforce/streams.py` to see how it is used in source-salesforce
3. `airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py` to see how it is used in low-code

## User Impact
Results will be paginated in Salesforce. To prove that, the test `test_given_locator_when_read_then_extract_records_from_both_pages` is passing
![image](https://github.com/user-attachments/assets/4fd540f0-3b36-4716-aa14-38fb06e0dfd5)


## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [X] YES 💚
- [ ] NO ❌
