### PR TITLE
Async Job/abort

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/async_job/job_orchestrator.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/async_job/job_orchestrator.py
@@ -305,3 +305,4 @@ class AsyncJobOrchestrator:
         """
         for job in partition.jobs:
             yield from self._job_repository.fetch_records(job)
+            self._job_repository.delete(job)

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/async_job/repository.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/async_job/repository.py
@@ -22,4 +22,8 @@ class AsyncJobRepository:
 
     @abstractmethod
     def abort(self, job: AsyncJob) -> None:
-        pass
+        """
+        Called when we need to stop on the API side. This method can raise NotImplementedError as not all the APIs will support aborting
+        jobs.
+        """
+        raise NotImplementedError("Either the API or the AsyncJobRepository implementation do not support aborting jobs")

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/async_job/repository.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/async_job/repository.py
@@ -27,3 +27,7 @@ class AsyncJobRepository:
         jobs.
         """
         raise NotImplementedError("Either the API or the AsyncJobRepository implementation do not support aborting jobs")
+
+    @abstractmethod
+    def delete(self, job: AsyncJob) -> None:
+        pass

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -2440,6 +2440,11 @@ definitions:
         anyOf:
           - "$ref": "#/definitions/CustomRequester"
           - "$ref": "#/definitions/HttpRequester"
+      delete_requester:
+        description: Requester component that describes how to prepare HTTP requests to send to the source API to delete a job once the records are extracted.
+        anyOf:
+          - "$ref": "#/definitions/CustomRequester"
+          - "$ref": "#/definitions/HttpRequester"
       partition_router:
         title: Partition Router
         description: PartitionRouter component that describes how to partition the stream, enabling incremental syncs and checkpointing.

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
@@ -1657,6 +1657,10 @@ class AsyncRetriever(BaseModel):
         None,
         description="Requester component that describes how to prepare HTTP requests to send to the source API to abort a job once it is timed out from the source's perspective.",
     )
+    delete_requester: Optional[Union[CustomRequester, HttpRequester]] = Field(
+        None,
+        description='Requester component that describes how to prepare HTTP requests to send to the source API to delete a job once the records are extracted.',
+    )
     partition_router: Optional[
         Union[
             CustomPartitionRouter,

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -1254,6 +1254,11 @@ class ModelToComponentFactory:
             if model.abort_requester
             else None
         )
+        delete_requester = (
+            self._create_component_from_model(model=model.delete_requester, decoder=decoder, config=config, name=f"job delete - {name}")
+            if model.delete_requester
+            else None
+        )
         status_extractor = self._create_component_from_model(model=model.status_extractor, decoder=decoder, config=config, name=name)
         urls_extractor = self._create_component_from_model(model=model.urls_extractor, decoder=decoder, config=config, name=name)
         job_repository: AsyncJobRepository = AsyncHttpJobRepository(
@@ -1261,6 +1266,7 @@ class ModelToComponentFactory:
             polling_requester=polling_requester,
             download_requester=download_requester,
             abort_requester=abort_requester,
+            delete_requester=delete_requester,
             status_extractor=status_extractor,
             status_mapping=self._create_async_job_status_mapping(model.status_mapping, config),
             urls_extractor=urls_extractor,

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/requesters/http_job_repository.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/requesters/http_job_repository.py
@@ -2,6 +2,7 @@
 import logging
 import uuid
 from dataclasses import dataclass, field
+from datetime import timedelta
 from typing import Any, Dict, Iterable, Mapping, Optional
 
 import requests
@@ -30,6 +31,7 @@ class AsyncHttpJobRepository(AsyncJobRepository):
     status_mapping: Mapping[str, AsyncJobStatus]
     urls_extractor: DpathExtractor
 
+    job_timeout: Optional[timedelta] = None
     record_extractor: RecordExtractor = field(init=False, repr=False, default_factory=lambda: ResponseToFileExtractor())
 
     def __post_init__(self) -> None:
@@ -119,7 +121,7 @@ class AsyncHttpJobRepository(AsyncJobRepository):
         job_id: str = str(uuid.uuid4())
         self._create_job_response_by_id[job_id] = response
 
-        return AsyncJob(api_job_id=job_id, job_parameters=stream_slice)
+        return AsyncJob(api_job_id=job_id, job_parameters=stream_slice, timeout=self.job_timeout)
 
     def update_jobs_status(self, jobs: Iterable[AsyncJob]) -> None:
         """

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/requesters/requester.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/requesters/requester.py
@@ -18,6 +18,7 @@ class HttpMethod(Enum):
     """
 
     GET = "GET"
+    PATCH = "PATCH"
     POST = "POST"
 
 

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/requesters/requester.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/requesters/requester.py
@@ -17,6 +17,7 @@ class HttpMethod(Enum):
     Http Method to use when submitting an outgoing HTTP request
     """
 
+    DELETE = "DELETE"
     GET = "GET"
     PATCH = "PATCH"
     POST = "POST"

--- a/airbyte-cdk/python/airbyte_cdk/test/mock_http/mocker.py
+++ b/airbyte-cdk/python/airbyte_cdk/test/mock_http/mocker.py
@@ -12,6 +12,7 @@ from airbyte_cdk.test.mock_http import HttpRequest, HttpRequestMatcher, HttpResp
 
 class SupportedHttpMethods(str, Enum):
     GET = "get"
+    PATCH = "patch"
     POST = "post"
     DELETE = "delete"
 
@@ -68,6 +69,9 @@ class HttpMocker(contextlib.ContextDecorator):
 
     def get(self, request: HttpRequest, responses: Union[HttpResponse, List[HttpResponse]]) -> None:
         self._mock_request_method(SupportedHttpMethods.GET, request, responses)
+
+    def patch(self, request: HttpRequest, responses: Union[HttpResponse, List[HttpResponse]]) -> None:
+        self._mock_request_method(SupportedHttpMethods.PATCH, request, responses)
 
     def post(self, request: HttpRequest, responses: Union[HttpResponse, List[HttpResponse]]) -> None:
         self._mock_request_method(SupportedHttpMethods.POST, request, responses)

--- a/airbyte-cdk/python/unit_tests/sources/declarative/async_job/test_job_orchestrator.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/async_job/test_job_orchestrator.py
@@ -148,6 +148,7 @@ class AsyncJobOrchestratorTest(TestCase):
 
         assert len(records) == 2
         assert self._job_repository.fetch_records.mock_calls == [call(first_job), call(second_job)]
+        assert self._job_repository.delete.mock_calls == [call(first_job), call(second_job)]
 
     def _orchestrator(self, slices: List[StreamSlice], job_tracker: Optional[JobTracker] = None) -> AsyncJobOrchestrator:
         job_tracker = job_tracker if job_tracker else JobTracker(_NO_JOB_LIMIT)

--- a/airbyte-integrations/connectors/source-salesforce/source_salesforce/streams.py
+++ b/airbyte-integrations/connectors/source-salesforce/source_salesforce/streams.py
@@ -581,7 +581,22 @@ class BulkSalesforceStream(SalesforceStream):
             disable_retries=False,
             message_repository=message_repository,
             use_cache=False,
-            stream_response=True,
+            stream_response=False,
+        )
+        delete_requester = HttpRequester(
+            name=f"{self.name} - delete requester",
+            url_base=url_base,
+            path=f"{job_query_path}/{polling_id_interpolation}",
+            authenticator=authenticator,
+            error_handler=error_handler,
+            http_method=HttpMethod.DELETE,
+            request_options_provider=None,
+            config=config,
+            parameters=parameters,
+            disable_retries=False,
+            message_repository=message_repository,
+            use_cache=False,
+            stream_response=False,
         )
         status_extractor = DpathExtractor(decoder=JsonDecoder(parameters={}), field_path=["state"], config={}, parameters={})
         urls_extractor = DpathExtractor(decoder=JsonDecoder(parameters={}), field_path=["id"], config={}, parameters={})
@@ -590,6 +605,7 @@ class BulkSalesforceStream(SalesforceStream):
             polling_requester=polling_requester,
             download_requester=download_requester,
             abort_requester=abort_requester,
+            delete_requester=delete_requester,
             status_extractor=status_extractor,
             status_mapping={
                 "InProgress": AsyncJobStatus.RUNNING,

--- a/airbyte-integrations/connectors/source-salesforce/source_salesforce/streams.py
+++ b/airbyte-integrations/connectors/source-salesforce/source_salesforce/streams.py
@@ -11,6 +11,7 @@ import urllib.parse
 import uuid
 from abc import ABC
 from contextlib import closing
+from datetime import timedelta
 from typing import Any, Callable, Iterable, List, Mapping, MutableMapping, Optional, Tuple, Type, Union
 
 import pandas as pd
@@ -560,13 +561,35 @@ class BulkSalesforceStream(SalesforceStream):
             use_cache=False,
             stream_response=True,
         )
+        abort_requester = HttpRequester(
+            name=f"{self.name} - abort requester",
+            url_base=url_base,
+            path=f"{job_query_path}/{polling_id_interpolation}",
+            authenticator=authenticator,
+            error_handler=error_handler,
+            http_method=HttpMethod.PATCH,
+            request_options_provider=InterpolatedRequestOptionsProvider(
+                request_body_data=None,
+                request_body_json={"state": "Aborted"},
+                request_headers=None,
+                request_parameters=None,
+                config=config,
+                parameters=parameters,
+            ),
+            config=config,
+            parameters=parameters,
+            disable_retries=False,
+            message_repository=message_repository,
+            use_cache=False,
+            stream_response=True,
+        )
         status_extractor = DpathExtractor(decoder=JsonDecoder(parameters={}), field_path=["state"], config={}, parameters={})
         urls_extractor = DpathExtractor(decoder=JsonDecoder(parameters={}), field_path=["id"], config={}, parameters={})
         job_repository = AsyncHttpJobRepository(
             creation_requester=creation_requester,
             polling_requester=polling_requester,
             download_requester=download_requester,
-            abort_requester=None,
+            abort_requester=abort_requester,
             status_extractor=status_extractor,
             status_mapping={
                 "InProgress": AsyncJobStatus.RUNNING,
@@ -576,6 +599,7 @@ class BulkSalesforceStream(SalesforceStream):
                 "Failed": AsyncJobStatus.FAILED,
             },
             urls_extractor=urls_extractor,
+            job_timeout=self.DEFAULT_WAIT_TIMEOUT,
         )
         record_selector = RecordSelector(
             extractor=None,  # FIXME typing won't like that
@@ -607,7 +631,7 @@ class BulkSalesforceStream(SalesforceStream):
             stream_cursor_field="",
         )
 
-    DEFAULT_WAIT_TIMEOUT_SECONDS = 86400  # 24-hour bulk job running time
+    DEFAULT_WAIT_TIMEOUT = timedelta(hours=24)
     MAX_CHECK_INTERVAL_SECONDS = 2.0
     MAX_RETRY_NUMBER = 3
 

--- a/airbyte-integrations/connectors/source-salesforce/unit_tests/api_test.py
+++ b/airbyte-integrations/connectors/source-salesforce/unit_tests/api_test.py
@@ -204,7 +204,7 @@ def test_bulk_sync_successful_long_response(stream_config, stream_api):
 @pytest.mark.timeout(17)
 def test_bulk_sync_successful_retry(stream_config, stream_api):
     stream: BulkIncrementalSalesforceStream = generate_stream("Account", stream_config, stream_api)
-    stream.DEFAULT_WAIT_TIMEOUT_SECONDS = 6  # maximum wait timeout will be 6 seconds
+    stream.DEFAULT_WAIT_TIMEOUT = timedelta(seconds=6)
 
     with requests_mock.Mocker() as m:
         job_id = _prepare_mock(m, stream)
@@ -219,7 +219,7 @@ def test_bulk_sync_successful_retry(stream_config, stream_api):
 @pytest.mark.timeout(30)
 def test_bulk_sync_failed_retry(stream_config, stream_api):
     stream: BulkIncrementalSalesforceStream = generate_stream("Account", stream_config, stream_api)
-    stream.DEFAULT_WAIT_TIMEOUT_SECONDS = 6  # maximum wait timeout will be 6 seconds
+    stream.DEFAULT_WAIT_TIMEOUT = timedelta(seconds=6)
     with requests_mock.Mocker() as m:
         job_id = _prepare_mock(m, stream)
         m.register_uri("GET", stream.path() + f"/{job_id}", json={"state": "InProgress", "id": job_id})
@@ -366,7 +366,7 @@ def configure_request_params_mock(stream_1, stream_2):
 def test_pagination_rest(stream_config, stream_api):
     stream_name = "AcceptedEventRelation"
     stream: RestSalesforceStream = generate_stream(stream_name, stream_config, stream_api)
-    stream.DEFAULT_WAIT_TIMEOUT_SECONDS = 6  # maximum wait timeout will be 6 seconds
+    stream.DEFAULT_WAIT_TIMEOUT = timedelta(seconds=6)
     next_page_url = "/services/data/v57.0/query/012345"
     with requests_mock.Mocker() as m:
         resp_1 = {

--- a/airbyte-integrations/connectors/source-salesforce/unit_tests/integration/test_bulk_stream.py
+++ b/airbyte-integrations/connectors/source-salesforce/unit_tests/integration/test_bulk_stream.py
@@ -15,7 +15,7 @@ from integration.test_rest_stream import create_http_response as create_standard
 from integration.utils import create_base_url, given_authentication, given_stream, read
 from salesforce_describe_response_builder import SalesforceDescribeResponseBuilder
 from salesforce_job_response_builder import JobCreateResponseBuilder, JobInfoResponseBuilder
-from source_salesforce.streams import LOOKBACK_SECONDS
+from source_salesforce.streams import LOOKBACK_SECONDS, BulkSalesforceStream
 
 _A_FIELD_NAME = "a_field"
 _ACCESS_TOKEN = "an_access_token"
@@ -55,7 +55,34 @@ def _calculate_start_time(start_time: datetime) -> datetime:
     return start_time.replace(microsecond=0)
 
 
-@freezegun.freeze_time(_NOW.isoformat())
+def _build_job_creation_request(query: str) -> HttpRequest:
+    return HttpRequest(f"{_BASE_URL}/jobs/query", body=json.dumps({
+        "operation": "queryAll",
+        "query": query,
+        "contentType": "CSV",
+        "columnDelimiter": "COMMA",
+        "lineEnding": "LF"
+    }))
+
+
+def _make_sliced_job_request(lower_boundary: datetime, upper_boundary: datetime, fields: List[str]) -> HttpRequest:
+    return _build_job_creation_request(f"SELECT {', '.join(fields)} FROM a_stream_name WHERE SystemModstamp >= {lower_boundary.isoformat(timespec='milliseconds')} AND SystemModstamp < {upper_boundary.isoformat(timespec='milliseconds')}")
+
+
+def _make_full_job_request(fields: List[str]) -> HttpRequest:
+    return _build_job_creation_request(f"SELECT {', '.join(fields)} FROM a_stream_name")
+
+
+def _generate_csv(fields: List[str], count: int = 1) -> str:
+    """
+    This method does not handle field types for now which may cause some test failures on change if we start considering using some
+    fields for calculation. One example of that would be cursor field parsing to datetime.
+    """
+    record = ','.join([f"{field}_value" for field in fields])
+    records = '\n'.join([record for _ in range(count)])
+    return f"{','.join(fields)}\n{records}"
+
+
 class BulkStreamTest(TestCase):
 
     def setUp(self) -> None:
@@ -65,14 +92,17 @@ class BulkStreamTest(TestCase):
         self._http_mocker.__enter__()
 
         given_authentication(self._http_mocker, _CLIENT_ID, _CLIENT_SECRET, _REFRESH_TOKEN, _INSTANCE_URL, _ACCESS_TOKEN)
+        self._timeout = BulkSalesforceStream.DEFAULT_WAIT_TIMEOUT
 
     def tearDown(self) -> None:
         self._http_mocker.__exit__(None, None, None)
+        BulkSalesforceStream.DEFAULT_WAIT_TIMEOUT = self._timeout
 
+    @freezegun.freeze_time(_NOW.isoformat())
     def test_when_read_then_create_job_and_extract_records_from_result(self) -> None:
         given_stream(self._http_mocker, _BASE_URL, _STREAM_NAME, SalesforceDescribeResponseBuilder().field(_A_FIELD_NAME))
         self._http_mocker.post(
-            self._make_full_job_request([_A_FIELD_NAME]),
+            _make_full_job_request([_A_FIELD_NAME]),
             JobCreateResponseBuilder().with_id(_JOB_ID).build(),
         )
         self._http_mocker.get(
@@ -93,10 +123,11 @@ class BulkStreamTest(TestCase):
 
         assert len(output.records) == 1
 
+    @freezegun.freeze_time(_NOW.isoformat())
     def test_given_locator_when_read_then_extract_records_from_both_pages(self):
         given_stream(self._http_mocker, _BASE_URL, _STREAM_NAME, SalesforceDescribeResponseBuilder().field(_A_FIELD_NAME))
         self._http_mocker.post(
-            self._make_full_job_request([_A_FIELD_NAME]),
+            _make_full_job_request([_A_FIELD_NAME]),
             JobCreateResponseBuilder().with_id(_JOB_ID).build(),
         )
         self._http_mocker.get(
@@ -117,10 +148,11 @@ class BulkStreamTest(TestCase):
 
         assert len(output.records) == 2
 
+    @freezegun.freeze_time(_NOW.isoformat())
     def test_given_job_creation_have_transient_error_when_read_then_sync_properly(self):
         given_stream(self._http_mocker, _BASE_URL, _STREAM_NAME, SalesforceDescribeResponseBuilder().field(_A_FIELD_NAME))
         self._http_mocker.post(
-            self._make_full_job_request([_A_FIELD_NAME]),
+            _make_full_job_request([_A_FIELD_NAME]),
             [
                 _RETRYABLE_RESPONSE,
                 JobCreateResponseBuilder().with_id(_JOB_ID).build(),
@@ -141,10 +173,11 @@ class BulkStreamTest(TestCase):
         assert len(output.errors) == 0
         assert len(output.records) == 1
 
+    @freezegun.freeze_time(_NOW.isoformat())
     def test_given_bulk_restrictions_when_read_then_switch_to_standard(self):
         given_stream(self._http_mocker, _BASE_URL, _STREAM_NAME, SalesforceDescribeResponseBuilder().field(_A_FIELD_NAME))
         self._http_mocker.post(
-            self._make_full_job_request([_A_FIELD_NAME]),
+            _make_full_job_request([_A_FIELD_NAME]),
             [
                 HttpResponse("[{}]", 403),
                 JobCreateResponseBuilder().with_id(_JOB_ID).build(),
@@ -159,10 +192,11 @@ class BulkStreamTest(TestCase):
 
         assert len(output.records) == 1
 
+    @freezegun.freeze_time(_NOW.isoformat())
     def test_given_non_transient_error_on_job_creation_when_read_then_fail_sync(self):
         given_stream(self._http_mocker, _BASE_URL, _STREAM_NAME, SalesforceDescribeResponseBuilder().field(_A_FIELD_NAME))
         self._http_mocker.post(
-            self._make_full_job_request([_A_FIELD_NAME]),
+            _make_full_job_request([_A_FIELD_NAME]),
             HttpResponse(json.dumps([{"errorCode": "API_ERROR", "message": "Implementation restriction... <can't complete the error message as I can't reproduce this issue>"}]), 400),
         )
 
@@ -170,10 +204,32 @@ class BulkStreamTest(TestCase):
 
         assert output.get_stream_statuses(_STREAM_NAME)[-1] == AirbyteStreamStatus.INCOMPLETE
 
+    def test_given_job_times_out_when_read_then_abort_job(self):
+        BulkSalesforceStream.DEFAULT_WAIT_TIMEOUT = timedelta(microseconds=1)
+        given_stream(self._http_mocker, _BASE_URL, _STREAM_NAME, SalesforceDescribeResponseBuilder().field(_A_FIELD_NAME))
+        self._http_mocker.post(
+            _make_full_job_request([_A_FIELD_NAME]),
+            JobCreateResponseBuilder().with_id(_JOB_ID).build(),
+        )
+        abort_request = HttpRequest(f"{_BASE_URL}/jobs/query/{_JOB_ID}", body=json.dumps({"state": "Aborted"}))
+        self._http_mocker.patch(
+            abort_request,
+            JobInfoResponseBuilder().with_id(_JOB_ID).with_state("Aborted").build(),
+        )
+        self._http_mocker.get(
+            HttpRequest(f"{_BASE_URL}/jobs/query/{_JOB_ID}"),
+            JobInfoResponseBuilder().with_id(_JOB_ID).with_state("InProgress").build(),
+        )
+
+        read(_STREAM_NAME, SyncMode.full_refresh, self._config)
+
+        self._http_mocker.assert_number_of_calls(abort_request, 3)
+
+    @freezegun.freeze_time(_NOW.isoformat())
     def test_given_job_is_aborted_when_read_then_fail_sync(self):
         given_stream(self._http_mocker, _BASE_URL, _STREAM_NAME, SalesforceDescribeResponseBuilder().field(_A_FIELD_NAME))
         self._http_mocker.post(
-            self._make_full_job_request([_A_FIELD_NAME]),
+            _make_full_job_request([_A_FIELD_NAME]),
             JobCreateResponseBuilder().with_id(_JOB_ID).build(),
         )
         self._http_mocker.get(
@@ -186,10 +242,11 @@ class BulkStreamTest(TestCase):
 
         assert output.get_stream_statuses(_STREAM_NAME)[-1] == AirbyteStreamStatus.INCOMPLETE
 
+    @freezegun.freeze_time(_NOW.isoformat())
     def test_given_job_is_failed_when_read_then_switch_to_standard(self):
         given_stream(self._http_mocker, _BASE_URL, _STREAM_NAME, SalesforceDescribeResponseBuilder().field(_A_FIELD_NAME))
         self._http_mocker.post(
-            self._make_full_job_request([_A_FIELD_NAME]),
+            _make_full_job_request([_A_FIELD_NAME]),
             JobCreateResponseBuilder().with_id(_JOB_ID).build(),
         )
         self._http_mocker.get(
@@ -206,10 +263,11 @@ class BulkStreamTest(TestCase):
 
         assert len(output.records) == 1
 
+    @freezegun.freeze_time(_NOW.isoformat())
     def test_given_retryable_error_on_download_job_result_when_read_then_extract_records(self):
         given_stream(self._http_mocker, _BASE_URL, _STREAM_NAME, SalesforceDescribeResponseBuilder().field(_A_FIELD_NAME))
         self._http_mocker.post(
-            self._make_full_job_request([_A_FIELD_NAME]),
+            _make_full_job_request([_A_FIELD_NAME]),
             JobCreateResponseBuilder().with_id(_JOB_ID).build(),
         )
         self._http_mocker.get(
@@ -229,10 +287,11 @@ class BulkStreamTest(TestCase):
 
         assert len(output.records) == 1
 
+    @freezegun.freeze_time(_NOW.isoformat())
     def test_given_retryable_error_on_delete_job_result_when_read_then_do_not_break(self):
         given_stream(self._http_mocker, _BASE_URL, _STREAM_NAME, SalesforceDescribeResponseBuilder().field(_A_FIELD_NAME))
         self._http_mocker.post(
-            self._make_full_job_request([_A_FIELD_NAME]),
+            _make_full_job_request([_A_FIELD_NAME]),
             JobCreateResponseBuilder().with_id(_JOB_ID).build(),
         )
         self._http_mocker.get(
@@ -255,6 +314,7 @@ class BulkStreamTest(TestCase):
 
         assert output.get_stream_statuses(_STREAM_NAME)[-1] == AirbyteStreamStatus.COMPLETE
 
+    @freezegun.freeze_time(_NOW.isoformat())
     def test_given_non_retryable_error_on_delete_job_result_when_read_then_fail_to_sync(self):
         """
         This is interesting: right now, we retry with the same policies has the other requests but it seems fair to just be a best effort,
@@ -262,7 +322,7 @@ class BulkStreamTest(TestCase):
         """
         given_stream(self._http_mocker, _BASE_URL, _STREAM_NAME, SalesforceDescribeResponseBuilder().field(_A_FIELD_NAME))
         self._http_mocker.post(
-            self._make_full_job_request([_A_FIELD_NAME]),
+            _make_full_job_request([_A_FIELD_NAME]),
             JobCreateResponseBuilder().with_id(_JOB_ID).build(),
         )
         self._http_mocker.get(
@@ -282,6 +342,7 @@ class BulkStreamTest(TestCase):
 
         assert output.get_stream_statuses(_STREAM_NAME)[-1] == AirbyteStreamStatus.INCOMPLETE
 
+    @freezegun.freeze_time(_NOW.isoformat())
     def test_given_incremental_when_read_then_create_job_and_extract_records_from_result(self) -> None:
         start_date = (_NOW - timedelta(days=10)).replace(microsecond=0)
         first_upper_boundary = start_date + timedelta(days=7)
@@ -294,6 +355,7 @@ class BulkStreamTest(TestCase):
 
         assert len(output.records) == 3
 
+    @freezegun.freeze_time(_NOW.isoformat())
     def test_given_slice_fails_when_read_then_state_is_partitioned(self) -> None:
         # FIXME this test fails because the error happens in the thread that generates the slices as oppose to the thread the read the
         #  partition. In order to fix that, we probably need a flag to allow for the job orchestrator to continue creating the jobs even if
@@ -306,7 +368,7 @@ class BulkStreamTest(TestCase):
         given_stream(self._http_mocker, _BASE_URL, _STREAM_NAME, _INCREMENTAL_SCHEMA_BUILDER)
         self._create_sliced_job(start_date, first_upper_boundary, _INCREMENTAL_FIELDS, "first_slice_job_id", record_count=2)
         self._http_mocker.post(
-            self._make_sliced_job_request(first_upper_boundary, second_upper_boundary, _INCREMENTAL_FIELDS),
+            _make_sliced_job_request(first_upper_boundary, second_upper_boundary, _INCREMENTAL_FIELDS),
             HttpResponse("", status_code=400),
         )
         self._create_sliced_job(second_upper_boundary, _NOW, _INCREMENTAL_FIELDS, "third_slice_job_id", record_count=1)
@@ -318,7 +380,7 @@ class BulkStreamTest(TestCase):
 
     def _create_sliced_job(self, lower_boundary: datetime, upper_boundary: datetime, fields: List[str], job_id: str, record_count: int) -> None:
         self._http_mocker.post(
-            self._make_sliced_job_request(lower_boundary, upper_boundary, fields),
+            _make_sliced_job_request(lower_boundary, upper_boundary, fields),
             JobCreateResponseBuilder().with_id(job_id).build(),
         )
         self._http_mocker.get(
@@ -327,7 +389,7 @@ class BulkStreamTest(TestCase):
         )
         self._http_mocker.get(
             HttpRequest(f"{_BASE_URL}/jobs/query/{job_id}/results"),
-            HttpResponse(self._generate_csv(fields, count=record_count)),
+            HttpResponse(_generate_csv(fields, count=record_count)),
         )
         self._mock_delete_job(job_id)
 
@@ -336,27 +398,3 @@ class BulkStreamTest(TestCase):
             HttpRequest(f"{_BASE_URL}/jobs/query/{job_id}"),
             HttpResponse(""),
         )
-
-    def _make_sliced_job_request(self, lower_boundary: datetime, upper_boundary: datetime, fields: List[str]) -> HttpRequest:
-        return self._build_job_creation_request(f"SELECT {', '.join(fields)} FROM a_stream_name WHERE SystemModstamp >= {lower_boundary.isoformat(timespec='milliseconds')} AND SystemModstamp < {upper_boundary.isoformat(timespec='milliseconds')}")
-
-    def _make_full_job_request(self, fields: List[str]) -> HttpRequest:
-        return self._build_job_creation_request(f"SELECT {', '.join(fields)} FROM a_stream_name")
-
-    def _generate_csv(self, fields: List[str], count: int = 1) -> str:
-        """
-        This method does not handle field types for now which may cause some test failures on change if we start considering using some
-        fields for calculation. One example of that would be cursor field parsing to datetime.
-        """
-        record = ','.join([f"{field}_value" for field in fields])
-        records = '\n'.join([record for _ in range(count)])
-        return f"{','.join(fields)}\n{records}"
-
-    def _build_job_creation_request(self, query: str) -> HttpRequest:
-        return HttpRequest(f"{_BASE_URL}/jobs/query", body=json.dumps({
-            "operation": "queryAll",
-            "query": query,
-            "contentType": "CSV",
-            "columnDelimiter": "COMMA",
-            "lineEnding": "LF"
-        }))

--- a/airbyte-integrations/connectors/source-salesforce/unit_tests/integration/test_bulk_stream.py
+++ b/airbyte-integrations/connectors/source-salesforce/unit_tests/integration/test_bulk_stream.py
@@ -117,11 +117,12 @@ class BulkStreamTest(TestCase):
             HttpRequest(f"{_BASE_URL}/jobs/query/{_JOB_ID}/results"),
             HttpResponse(f"{_A_FIELD_NAME}\nfield_value"),
         )
-        self._mock_delete_job(_JOB_ID)
+        delete_request = self._mock_delete_job(_JOB_ID)
 
         output = read(_STREAM_NAME, SyncMode.full_refresh, self._config)
 
         assert len(output.records) == 1
+        self._http_mocker.assert_number_of_calls(delete_request, 1)
 
     @freezegun.freeze_time(_NOW.isoformat())
     def test_given_locator_when_read_then_extract_records_from_both_pages(self):
@@ -393,8 +394,10 @@ class BulkStreamTest(TestCase):
         )
         self._mock_delete_job(job_id)
 
-    def _mock_delete_job(self, job_id: str) -> None:
+    def _mock_delete_job(self, job_id: str) -> HttpRequest:
+        request = HttpRequest(f"{_BASE_URL}/jobs/query/{job_id}")
         self._http_mocker.delete(
-            HttpRequest(f"{_BASE_URL}/jobs/query/{job_id}"),
+            request,
             HttpResponse(""),
         )
+        return request


### PR DESCRIPTION
## What
Addresses https://github.com/airbytehq/airbyte-internal-issues/issues/9737

## How
Adding a requester for aborting and calling this through the JobOrchestrator so that we can free API job budget.

## Review guide
1. `airbyte-integrations/connectors/source-salesforce/unit_tests/integration/test_bulk_stream.py` Test `test_given_job_times_out_when_read_then_abort_job` was added from master to make sure we capture the current behavior and was ported to this branch
2. `airbyte-cdk/python/airbyte_cdk/sources/declarative/async_job/repository.py` adding to the interface
3. `airbyte-cdk/python/airbyte_cdk/sources/declarative/async_job/job_orchestrator.py` using the interface
4. `airbyte-cdk/python/airbyte_cdk/sources/declarative/requesters/http_job_repository.py` passing the timeout (I was considering setting this in the JobOrchestrator as it will probably be the same for all the implementation of JobRepository but it was a bit awkward so please share any clean idea to do that or we could wait for later when we implement another repository to have more information when we will take decisions


## User Impact
Probably none in practice as we didn't abort job in prod (see the result of the investigation documented in https://github.com/airbytehq/airbyte-internal-issues/issues/9737)

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [X] YES 💚
- [ ] NO ❌
