### PR TITLE
delete job once read

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/async_job/job_orchestrator.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/async_job/job_orchestrator.py
@@ -305,3 +305,4 @@ class AsyncJobOrchestrator:
         """
         for job in partition.jobs:
             yield from self._job_repository.fetch_records(job)
+            self._job_repository.delete(job)

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/async_job/repository.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/async_job/repository.py
@@ -27,3 +27,7 @@ class AsyncJobRepository:
         jobs.
         """
         raise NotImplementedError("Either the API or the AsyncJobRepository implementation do not support aborting jobs")
+
+    @abstractmethod
+    def delete(self, job: AsyncJob) -> None:
+        pass

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -2440,6 +2440,11 @@ definitions:
         anyOf:
           - "$ref": "#/definitions/CustomRequester"
           - "$ref": "#/definitions/HttpRequester"
+      delete_requester:
+        description: Requester component that describes how to prepare HTTP requests to send to the source API to delete a job once the records are extracted.
+        anyOf:
+          - "$ref": "#/definitions/CustomRequester"
+          - "$ref": "#/definitions/HttpRequester"
       partition_router:
         title: Partition Router
         description: PartitionRouter component that describes how to partition the stream, enabling incremental syncs and checkpointing.

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
@@ -1657,6 +1657,10 @@ class AsyncRetriever(BaseModel):
         None,
         description="Requester component that describes how to prepare HTTP requests to send to the source API to abort a job once it is timed out from the source's perspective.",
     )
+    delete_requester: Optional[Union[CustomRequester, HttpRequester]] = Field(
+        None,
+        description='Requester component that describes how to prepare HTTP requests to send to the source API to delete a job once the records are extracted.',
+    )
     partition_router: Optional[
         Union[
             CustomPartitionRouter,

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -1254,6 +1254,11 @@ class ModelToComponentFactory:
             if model.abort_requester
             else None
         )
+        delete_requester = (
+            self._create_component_from_model(model=model.delete_requester, decoder=decoder, config=config, name=f"job delete - {name}")
+            if model.delete_requester
+            else None
+        )
         status_extractor = self._create_component_from_model(model=model.status_extractor, decoder=decoder, config=config, name=name)
         urls_extractor = self._create_component_from_model(model=model.urls_extractor, decoder=decoder, config=config, name=name)
         job_repository: AsyncJobRepository = AsyncHttpJobRepository(
@@ -1261,6 +1266,7 @@ class ModelToComponentFactory:
             polling_requester=polling_requester,
             download_requester=download_requester,
             abort_requester=abort_requester,
+            delete_requester=delete_requester,
             status_extractor=status_extractor,
             status_mapping=self._create_async_job_status_mapping(model.status_mapping, config),
             urls_extractor=urls_extractor,

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/requesters/requester.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/requesters/requester.py
@@ -17,6 +17,7 @@ class HttpMethod(Enum):
     Http Method to use when submitting an outgoing HTTP request
     """
 
+    DELETE = "DELETE"
     GET = "GET"
     PATCH = "PATCH"
     POST = "POST"

--- a/airbyte-cdk/python/unit_tests/sources/declarative/async_job/test_job_orchestrator.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/async_job/test_job_orchestrator.py
@@ -148,6 +148,7 @@ class AsyncJobOrchestratorTest(TestCase):
 
         assert len(records) == 2
         assert self._job_repository.fetch_records.mock_calls == [call(first_job), call(second_job)]
+        assert self._job_repository.delete.mock_calls == [call(first_job), call(second_job)]
 
     def _orchestrator(self, slices: List[StreamSlice], job_tracker: Optional[JobTracker] = None) -> AsyncJobOrchestrator:
         job_tracker = job_tracker if job_tracker else JobTracker(_NO_JOB_LIMIT)

--- a/airbyte-integrations/connectors/source-salesforce/source_salesforce/streams.py
+++ b/airbyte-integrations/connectors/source-salesforce/source_salesforce/streams.py
@@ -581,7 +581,22 @@ class BulkSalesforceStream(SalesforceStream):
             disable_retries=False,
             message_repository=message_repository,
             use_cache=False,
-            stream_response=True,
+            stream_response=False,
+        )
+        delete_requester = HttpRequester(
+            name=f"{self.name} - delete requester",
+            url_base=url_base,
+            path=f"{job_query_path}/{polling_id_interpolation}",
+            authenticator=authenticator,
+            error_handler=error_handler,
+            http_method=HttpMethod.DELETE,
+            request_options_provider=None,
+            config=config,
+            parameters=parameters,
+            disable_retries=False,
+            message_repository=message_repository,
+            use_cache=False,
+            stream_response=False,
         )
         status_extractor = DpathExtractor(decoder=JsonDecoder(parameters={}), field_path=["state"], config={}, parameters={})
         urls_extractor = DpathExtractor(decoder=JsonDecoder(parameters={}), field_path=["id"], config={}, parameters={})
@@ -590,6 +605,7 @@ class BulkSalesforceStream(SalesforceStream):
             polling_requester=polling_requester,
             download_requester=download_requester,
             abort_requester=abort_requester,
+            delete_requester=delete_requester,
             status_extractor=status_extractor,
             status_mapping={
                 "InProgress": AsyncJobStatus.RUNNING,

--- a/airbyte-integrations/connectors/source-salesforce/unit_tests/integration/test_bulk_stream.py
+++ b/airbyte-integrations/connectors/source-salesforce/unit_tests/integration/test_bulk_stream.py
@@ -117,11 +117,12 @@ class BulkStreamTest(TestCase):
             HttpRequest(f"{_BASE_URL}/jobs/query/{_JOB_ID}/results"),
             HttpResponse(f"{_A_FIELD_NAME}\nfield_value"),
         )
-        self._mock_delete_job(_JOB_ID)
+        delete_request = self._mock_delete_job(_JOB_ID)
 
         output = read(_STREAM_NAME, SyncMode.full_refresh, self._config)
 
         assert len(output.records) == 1
+        self._http_mocker.assert_number_of_calls(delete_request, 1)
 
     @freezegun.freeze_time(_NOW.isoformat())
     def test_given_locator_when_read_then_extract_records_from_both_pages(self):
@@ -393,8 +394,10 @@ class BulkStreamTest(TestCase):
         )
         self._mock_delete_job(job_id)
 
-    def _mock_delete_job(self, job_id: str) -> None:
+    def _mock_delete_job(self, job_id: str) -> HttpRequest:
+        request = HttpRequest(f"{_BASE_URL}/jobs/query/{job_id}")
         self._http_mocker.delete(
-            HttpRequest(f"{_BASE_URL}/jobs/query/{job_id}"),
+            request,
             HttpResponse(""),
         )
+        return request


### PR DESCRIPTION
## What
Addresses https://github.com/airbytehq/airbyte-internal-issues/issues/9739

## How
By creating a new method "delete" in the JobRepository that is called once the records are read from a job.

## Review guide

1. `airbyte-cdk/python/airbyte_cdk/sources/declarative/async_job/job_orchestrator.py`: Where we delete the jobs
2. `airbyte-cdk/python/airbyte_cdk/sources/declarative/requesters/http_job_repository.py`: The implementation of how we delete the job
3. The rest

`test_when_read_then_create_job_and_extract_records_from_result` has been updated to ensure that the delete is called
`test_given_non_retryable_error_on_delete_job_result_when_read_then_fail_to_sync` is now passing

## User Impact
The Salesforce users won't see the jobs that were successfully synced in the job UI. Only the failed one or the one that have not been consumed will be available.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [X] YES 💚
- [ ] NO ❌
