### PR TITLE
docs: Fix misspelling `successful`

### DIFF
--- a/docs/cloud/managing-airbyte-cloud/manage-airbyte-cloud-notifications.md
+++ b/docs/cloud/managing-airbyte-cloud/manage-airbyte-cloud-notifications.md
@@ -98,7 +98,7 @@ Airbyte passes both the `data` payload along with text blocks that are intended 
 
 </details>
 <details>
-  <summary>Succesful Sync</summary>
+  <summary>Successful Sync</summary>
 
 ```
 {


### PR DESCRIPTION
## What
Edit wording to fix misspelling
