### PR TITLE
✨ Source GetLago:  feat customer usage

### DIFF
--- a/airbyte-integrations/connectors/source-getlago/manifest.yaml
+++ b/airbyte-integrations/connectors/source-getlago/manifest.yaml
@@ -349,6 +349,17 @@ definitions:
                 partition_field: external_subscription_id
                 stream:
                   $ref: "#/definitions/streams/subscriptions"
+      transformations:
+        - type: AddFields
+          fields:
+            - path:
+                - customer_id
+              value: "{{stream_slice.customer_external_id}}"
+        - type: AddFields
+          fields:
+            - path:
+                - subscription_id
+              value: "{{stream_slice.external_subscription_id}}"
       schema_loader:
         type: InlineSchemaLoader
         schema:
@@ -1379,6 +1390,44 @@ schemas:
               type:
                 - "null"
                 - integer
+            filters:
+              type:
+                - array
+                - "null"
+              items:
+                type:
+                  - object
+                  - "null"
+                properties:
+                  amount_cents:
+                    type:
+                      - number
+                      - "null"
+                  events_count:
+                    type:
+                      - number
+                      - "null"
+                  units:
+                    type:
+                      - string
+                      - "null"
+                  values:
+                    type:
+                      - object
+                      - "null"
+                    properties:
+                      card_type:
+                        type:
+                          - array
+                          - "null"
+                        items:
+                          type:
+                            - string
+                            - "null"
+            grouped_usage:
+              type:
+                - array
+                - "null"
             groups:
               type:
                 - "null"
@@ -1420,6 +1469,10 @@ schemas:
         type:
           - "null"
           - string
+      customer_id:
+        type:
+          - string
+          - "null"
       from_datetime:
         type:
           - "null"
@@ -1432,6 +1485,10 @@ schemas:
         type:
           - "null"
           - string
+      subscription_id:
+        type:
+          - string
+          - "null"
       taxes_amount_cents:
         type:
           - "null"

--- a/airbyte-integrations/connectors/source-getlago/manifest.yaml
+++ b/airbyte-integrations/connectors/source-getlago/manifest.yaml
@@ -400,6 +400,80 @@ definitions:
         type: InlineSchemaLoader
         schema:
           $ref: "#/schemas/fees"
+    customer_usage_past:
+      type: DeclarativeStream
+      name: customer_usage_past
+      primary_key:
+        - lago_invoice_id
+      retriever:
+        type: SimpleRetriever
+        requester:
+          $ref: "#/definitions/base_requester"
+          path: >-
+            /customers/{{stream_slice.customer_external_id}}/past_usage?external_subscription_id={{stream_slice.external_subscription_id}}
+          http_method: GET
+          error_handler:
+            type: CompositeErrorHandler
+            error_handlers:
+              - type: DefaultErrorHandler
+                response_filters:
+                  - type: HttpResponseFilter
+                    action: IGNORE
+                    predicate: >-
+                      {{response.status == 405 and response.code ==
+                      'no_active_subscription' }}
+                    http_codes: []
+        record_selector:
+          type: RecordSelector
+          extractor:
+            type: DpathExtractor
+            field_path:
+              - usage_periods
+        paginator:
+          type: DefaultPaginator
+          page_token_option:
+            type: RequestOption
+            inject_into: request_parameter
+            field_name: page
+          page_size_option:
+            type: RequestOption
+            inject_into: request_parameter
+            field_name: per_page
+          pagination_strategy:
+            type: CursorPagination
+            page_size: 100
+            cursor_value: "{{ response.meta.next_page }}"
+            stop_condition: "{{ response.meta.next_page is none}}"
+        partition_router:
+          - type: SubstreamPartitionRouter
+            parent_stream_configs:
+              - type: ParentStreamConfig
+                parent_key: external_customer_id
+                partition_field: customer_external_id
+                stream:
+                  $ref: "#/definitions/streams/subscriptions"
+          - type: SubstreamPartitionRouter
+            parent_stream_configs:
+              - type: ParentStreamConfig
+                parent_key: external_id
+                partition_field: external_subscription_id
+                stream:
+                  $ref: "#/definitions/streams/subscriptions"
+      transformations:
+        - type: AddFields
+          fields:
+            - path:
+                - customer_id
+              value: "{{stream_slice.customer_external_id}}"
+        - type: AddFields
+          fields:
+            - path:
+                - subscription_id
+              value: "{{stream_slice.external_subscription_id}}"
+      schema_loader:
+        type: InlineSchemaLoader
+        schema:
+          $ref: "#/schemas/customer_usage_past"
   base_requester:
     type: HttpRequester
     url_base: "{{ config.get('api_url', 'https://api.getlago.com/api/v1') }}"
@@ -418,6 +492,7 @@ streams:
   - $ref: "#/definitions/streams/wallets"
   - $ref: "#/definitions/streams/customer_usage"
   - $ref: "#/definitions/streams/fees"
+  - $ref: "#/definitions/streams/customer_usage_past"
 
 spec:
   type: Spec
@@ -1862,3 +1937,178 @@ schemas:
         type:
           - "null"
           - string
+  customer_usage_past:
+    type: object
+    $schema: http://json-schema.org/schema#
+    additionalProperties: true
+    properties:
+      amount_cents:
+        type:
+          - number
+          - "null"
+      charges_usage:
+        type:
+          - array
+          - "null"
+        items:
+          type:
+            - object
+            - "null"
+          properties:
+            amount_cents:
+              type:
+                - number
+                - "null"
+            amount_currency:
+              type:
+                - string
+                - "null"
+            billable_metric:
+              type:
+                - object
+                - "null"
+              properties:
+                aggregation_type:
+                  type:
+                    - string
+                    - "null"
+                code:
+                  type:
+                    - string
+                    - "null"
+                lago_id:
+                  type:
+                    - string
+                    - "null"
+                name:
+                  type:
+                    - string
+                    - "null"
+            charge:
+              type:
+                - object
+                - "null"
+              properties:
+                charge_model:
+                  type:
+                    - string
+                    - "null"
+                lago_id:
+                  type:
+                    - string
+                    - "null"
+            events_count:
+              type:
+                - number
+                - "null"
+            filters:
+              type:
+                - array
+                - "null"
+              items:
+                type:
+                  - object
+                  - "null"
+                properties:
+                  amount_cents:
+                    type:
+                      - number
+                      - "null"
+                  events_count:
+                    type:
+                      - number
+                      - "null"
+                  units:
+                    type:
+                      - string
+                      - "null"
+                  values:
+                    type:
+                      - object
+                      - "null"
+                    properties:
+                      card_type:
+                        type:
+                          - array
+                          - "null"
+                        items:
+                          type:
+                            - string
+                            - "null"
+            grouped_usage:
+              type:
+                - array
+                - "null"
+            groups:
+              type:
+                - array
+                - "null"
+              items:
+                type:
+                  - object
+                  - "null"
+                properties:
+                  amount_cents:
+                    type:
+                      - number
+                      - "null"
+                  events_count:
+                    type:
+                      - number
+                      - "null"
+                  key:
+                    type:
+                      - string
+                      - "null"
+                  lago_id:
+                    type:
+                      - string
+                      - "null"
+                  units:
+                    type:
+                      - string
+                      - "null"
+                  value:
+                    type:
+                      - string
+                      - "null"
+            units:
+              type:
+                - string
+                - "null"
+      currency:
+        type:
+          - string
+          - "null"
+      customer_id:
+        type:
+          - string
+          - "null"
+      from_datetime:
+        type:
+          - string
+          - "null"
+      issuing_date:
+        type:
+          - string
+          - "null"
+      lago_invoice_id:
+        type: string
+      subscription_id:
+        type:
+          - string
+          - "null"
+      taxes_amount_cents:
+        type:
+          - number
+          - "null"
+      to_datetime:
+        type:
+          - string
+          - "null"
+      total_amount_cents:
+        type:
+          - number
+          - "null"
+    required:
+      - lago_invoice_id

--- a/airbyte-integrations/connectors/source-getlago/manifest.yaml
+++ b/airbyte-integrations/connectors/source-getlago/manifest.yaml
@@ -310,13 +310,12 @@ definitions:
     customer_usage:
       type: DeclarativeStream
       name: customer_usage
-      primary_key:
-        - lago_invoice_id
       retriever:
         type: SimpleRetriever
         requester:
           $ref: "#/definitions/base_requester"
-          path: /customers/{{stream_slice.customer_external_id}}/current_usage
+          path: >-
+            /customers/{{stream_slice.customer_external_id}}/current_usage?external_subscription_id={{stream_slice.external_subscription_id}}
           http_method: GET
           error_handler:
             type: CompositeErrorHandler
@@ -336,13 +335,20 @@ definitions:
             field_path:
               - customer_usage
         partition_router:
-          type: SubstreamPartitionRouter
-          parent_stream_configs:
-            - type: ParentStreamConfig
-              parent_key: external_id
-              partition_field: customer_external_id
-              stream:
-                $ref: "#/definitions/streams/customers"
+          - type: SubstreamPartitionRouter
+            parent_stream_configs:
+              - type: ParentStreamConfig
+                parent_key: external_customer_id
+                partition_field: customer_external_id
+                stream:
+                  $ref: "#/definitions/streams/subscriptions"
+          - type: SubstreamPartitionRouter
+            parent_stream_configs:
+              - type: ParentStreamConfig
+                parent_key: external_id
+                partition_field: external_subscription_id
+                stream:
+                  $ref: "#/definitions/streams/subscriptions"
       schema_loader:
         type: InlineSchemaLoader
         schema:

--- a/airbyte-integrations/connectors/source-getlago/metadata.yaml
+++ b/airbyte-integrations/connectors/source-getlago/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: e1a3866b-d3b2-43b6-b6d7-8c1ee4d7f53f
-  dockerImageTag: 0.6.0
+  dockerImageTag: 0.7.0
   dockerRepository: airbyte/source-getlago
   githubIssueLabel: source-getlago
   icon: getlago.svg

--- a/docs/integrations/sources/getlago.md
+++ b/docs/integrations/sources/getlago.md
@@ -32,6 +32,7 @@ This source can sync data from the [Lago API](https://doc.getlago.com/docs/guide
 
 | Version | Date       | Pull Request                                              | Subject                                   |
 | :------ | :--------- | :-------------------------------------------------------- | :---------------------------------------- |
+| 0.7.0 | 2024-09-12 | [45452](https://github.com/airbytehq/airbyte/pull/45452) | Endpoint customer usage: import current from subscription and add new stream customer_usage_past |
 | 0.6.0 | 2024-09-06 | [45193](https://github.com/airbytehq/airbyte/pull/45193) | Endpoint customer usage ignore 405 response |
 | 0.5.0 | 2024-08-23 | [44613](https://github.com/airbytehq/airbyte/pull/44613) | Refactor connector to manifest-only format |
 | 0.4.11 | 2024-08-17 | [44273](https://github.com/airbytehq/airbyte/pull/44273) | Update dependencies |

--- a/docs/integrations/sources/getlago.md
+++ b/docs/integrations/sources/getlago.md
@@ -13,6 +13,8 @@ This source can sync data from the [Lago API](https://doc.getlago.com/docs/guide
 - invoices
 - customers
 - subscriptions
+- customer_usage
+- customer_usage_past
 
 ### Features
 


### PR DESCRIPTION
## What
1. Fix import for stream customer_usage the [API](https://docs.getlago.com/api-reference/customer-usage/get-current) required the external_subscription_id
2. The customer_usage stream only get current usage we need another stream for past usage

## How
1. customer_usage stream import from subscription stream
2. Add a new stream for customer_usage_past [API](https://docs.getlago.com/api-reference/customer-usage/get-past)

## Review guide
Import customer_usage and customer_usage_past

## User Impact

Import new real customer usage and the user can import past usage.

## Can this PR be safely reverted and rolled back?

- [X ] YES 💚
- [ ] NO ❌