### PR TITLE
✨ Source Facebook Marketing: Increase default "start date"

### DIFF
--- a/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/source.py
+++ b/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/source.py
@@ -137,8 +137,8 @@ class SourceFacebookMarketing(AbstractSource):
         else:
             api = API(access_token=config.access_token, page_size=config.page_size)
 
-        # if start_date not specified then set default start_date for report streams to 2 years ago
-        report_start_date = config.start_date or pendulum.now().add(years=-2)
+        # if start_date not specified then set default start_date for report streams to 3 years ago
+        report_start_date = config.start_date or pendulum.now().add(years=-3)
 
         insights_args = dict(
             api=api,
@@ -311,7 +311,7 @@ class SourceFacebookMarketing(AbstractSource):
                 action_breakdowns_allow_empty=config.action_breakdowns_allow_empty,
                 action_report_time=insight.action_report_time,
                 time_increment=insight.time_increment,
-                start_date=insight.start_date or config.start_date or pendulum.now().add(years=-2),
+                start_date=insight.start_date or config.start_date or pendulum.now().add(years=-3),
                 end_date=insight.end_date or config.end_date,
                 insights_lookback_window=insight.insights_lookback_window or config.insights_lookback_window,
                 insights_job_timeout=insight.insights_job_timeout or config.insights_job_timeout,

--- a/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/source.py
+++ b/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/source.py
@@ -137,8 +137,8 @@ class SourceFacebookMarketing(AbstractSource):
         else:
             api = API(access_token=config.access_token, page_size=config.page_size)
 
-        # if start_date not specified then set default start_date for report streams to 3 years ago
-        report_start_date = config.start_date or pendulum.now().add(years=-3)
+        # if start_date not specified then set default start_date for report streams to 37 months ago
+        report_start_date = config.start_date or pendulum.now().add(months=-37)
 
         insights_args = dict(
             api=api,

--- a/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/source.py
+++ b/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/source.py
@@ -311,7 +311,7 @@ class SourceFacebookMarketing(AbstractSource):
                 action_breakdowns_allow_empty=config.action_breakdowns_allow_empty,
                 action_report_time=insight.action_report_time,
                 time_increment=insight.time_increment,
-                start_date=insight.start_date or config.start_date or pendulum.now().add(years=-3),
+                start_date=insight.start_date or config.start_date or pendulum.now().add(months=-37),
                 end_date=insight.end_date or config.end_date,
                 insights_lookback_window=insight.insights_lookback_window or config.insights_lookback_window,
                 insights_job_timeout=insight.insights_job_timeout or config.insights_job_timeout,

--- a/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/spec.py
+++ b/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/spec.py
@@ -210,7 +210,7 @@ class ConnectorConfig(BaseConfig):
         order=2,
         description=(
             "The date from which you'd like to replicate data for all incremental streams, "
-            "in the format YYYY-MM-DDT00:00:00Z. If not set then all data will be replicated for usual streams and only last 2 years for insight streams."
+            "in the format YYYY-MM-DDT00:00:00Z. If not set then all data will be replicated for usual streams and only last 3 years for insight streams."
         ),
         pattern=DATE_TIME_PATTERN,
         examples=["2017-01-25T00:00:00Z"],

--- a/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/spec.py
+++ b/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/spec.py
@@ -210,7 +210,8 @@ class ConnectorConfig(BaseConfig):
         order=2,
         description=(
             "The date from which you'd like to replicate data for all incremental streams, "
-            "in the format YYYY-MM-DDT00:00:00Z. If not set then all data will be replicated for usual streams and only last 3 years for insight streams."
+            "in the format YYYY-MM-DDT00:00:00Z. If not set then all data will be replicated for usual streams and only last 3 years"
+            "and 1 month for insight streams."
         ),
         pattern=DATE_TIME_PATTERN,
         examples=["2017-01-25T00:00:00Z"],


### PR DESCRIPTION
## What
Fix misleading "start date" tooltip and increase default "start date" to 37 months. #45459

The facebook marketing API allows 37 months of historical data to be pulled ([code pointer](https://github.com/airbytehq/airbyte/blob/8d04d840ba4d62634c98b37fbe3ed053e3ab7fab/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/streams/base_insight_streams.py#L56-L59)). Currently the connector defaults to pulling 2 years when a start date is not specific by the user. Also the tooltip defined in the spec file misleads the users into believing that only 2 years of history can be pulled when we actually have the ability to pull 37 months worth of history. Since we have the ability to pull more data then we should do this be default.

## How
- Update the default start_date to be 37 months ago
- Update tooltip in spec file to correctly reflect the maximum history that can be pulled by this API

## Review guide
- Follow the sources README.md file and run unit tests.

## User Impact
Users will be correctly informed on the maximum history that can be pulled via this source and by default they will get more data. This will not effect existing incremental append connections, but overwrite connections will start pulling in more data and as a result take longer to complete.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌
