### PR TITLE
Bulk CDK (Destinations): Use Descriptor instead of full Stream as map key

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/message/DestinationMessageQueue.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/message/DestinationMessageQueue.kt
@@ -54,7 +54,7 @@ class DestinationMessageQueue(
     config: DestinationConfiguration,
     private val memoryManager: MemoryManager,
     private val queueChannelFactory: QueueChannelFactory<DestinationRecordWrapped>
-) : MessageQueue<DestinationStream, DestinationRecordWrapped> {
+) : MessageQueue<DestinationStream.Descriptor, DestinationRecordWrapped> {
     private val channels:
         ConcurrentHashMap<DestinationStream.Descriptor, QueueChannel<DestinationRecordWrapped>> =
         ConcurrentHashMap()
@@ -89,12 +89,10 @@ class DestinationMessageQueue(
     }
 
     override suspend fun getChannel(
-        key: DestinationStream,
+        key: DestinationStream.Descriptor,
     ): QueueChannel<DestinationRecordWrapped> {
-        return channels[key.descriptor]
-            ?: throw IllegalArgumentException(
-                "Reading from non-existent QueueChannel: ${key.descriptor}"
-            )
+        return channels[key]
+            ?: throw IllegalArgumentException("Reading from non-existent QueueChannel: ${key}")
     }
 
     private val log = KotlinLogging.logger {}

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/message/MessageConverter.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/message/MessageConverter.kt
@@ -76,8 +76,8 @@ class DefaultMessageConverter : MessageConverter<CheckpointMessage, AirbyteMessa
         return AirbyteStreamState()
             .withStreamDescriptor(
                 StreamDescriptor()
-                    .withNamespace(checkpoint.stream.descriptor.namespace)
-                    .withName(checkpoint.stream.descriptor.name)
+                    .withNamespace(checkpoint.stream.namespace)
+                    .withName(checkpoint.stream.name)
             )
             .withStreamState(checkpoint.state)
     }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/message/MessageQueueReader.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/message/MessageQueueReader.kt
@@ -33,13 +33,13 @@ class DestinationMessageQueueReader(
         var totalBytesRead = 0L
         var recordsRead = 0L
         while (totalBytesRead < maxBytes) {
-            when (val wrapped = messageQueue.getChannel(key).receive()) {
+            when (val wrapped = messageQueue.getChannel(key.descriptor).receive()) {
                 is StreamRecordWrapped -> {
                     totalBytesRead += wrapped.sizeBytes
                     emit(wrapped)
                 }
                 is StreamCompleteWrapped -> {
-                    messageQueue.getChannel(key).close()
+                    messageQueue.getChannel(key.descriptor).close()
                     emit(wrapped)
                     log.info { "Read end-of-stream for $key" }
                     return@flow

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/message/MessageQueueWriter.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/message/MessageQueueWriter.kt
@@ -29,9 +29,10 @@ interface MessageQueueWriter<T : Any> {
 )
 class DestinationMessageQueueWriter(
     private val catalog: DestinationCatalog,
-    private val messageQueue: MessageQueue<DestinationStream, DestinationRecordWrapped>,
+    private val messageQueue: MessageQueue<DestinationStream.Descriptor, DestinationRecordWrapped>,
     private val streamsManager: StreamsManager,
-    private val checkpointManager: CheckpointManager<DestinationStream, CheckpointMessage>
+    private val checkpointManager:
+        CheckpointManager<DestinationStream.Descriptor, CheckpointMessage>
 ) : MessageQueueWriter<DestinationMessage> {
     /**
      * Deserialize and route the message to the appropriate channel.
@@ -89,14 +90,15 @@ class DestinationMessageQueueWriter(
                     is GlobalCheckpoint -> {
                         val streamWithIndexAndCount =
                             catalog.streams.map { stream ->
-                                val manager = streamsManager.getManager(stream)
+                                val manager = streamsManager.getManager(stream.descriptor)
                                 val (currentIndex, countSinceLast) = manager.markCheckpoint()
                                 Triple(stream, currentIndex, countSinceLast)
                             }
                         val totalCount = streamWithIndexAndCount.sumOf { it.third }
                         val messageWithCount =
                             message.withDestinationStats(CheckpointMessage.Stats(totalCount))
-                        val streamIndexes = streamWithIndexAndCount.map { it.first to it.second }
+                        val streamIndexes =
+                            streamWithIndexAndCount.map { it.first.descriptor to it.second }
                         checkpointManager.addGlobalCheckpoint(streamIndexes, messageWithCount)
                     }
                 }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/state/StreamsManager.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/state/StreamsManager.kt
@@ -22,16 +22,16 @@ import kotlinx.coroutines.channels.Channel
 /** Manages the state of all streams in the destination. */
 interface StreamsManager {
     /** Get the manager for the given stream. Throws an exception if the stream is not found. */
-    fun getManager(stream: DestinationStream): StreamManager
+    fun getManager(stream: DestinationStream.Descriptor): StreamManager
 
     /** Suspend until all streams are closed. */
     suspend fun awaitAllStreamsClosed()
 }
 
 class DefaultStreamsManager(
-    private val streamManagers: ConcurrentHashMap<DestinationStream, StreamManager>
+    private val streamManagers: ConcurrentHashMap<DestinationStream.Descriptor, StreamManager>
 ) : StreamsManager {
-    override fun getManager(stream: DestinationStream): StreamManager {
+    override fun getManager(stream: DestinationStream.Descriptor): StreamManager {
         return streamManagers[stream] ?: throw IllegalArgumentException("Stream not found: $stream")
     }
 
@@ -191,8 +191,8 @@ class StreamsManagerFactory(
 ) {
     @Singleton
     fun make(): StreamsManager {
-        val hashMap = ConcurrentHashMap<DestinationStream, StreamManager>()
-        catalog.streams.forEach { hashMap[it] = DefaultStreamManager(it) }
+        val hashMap = ConcurrentHashMap<DestinationStream.Descriptor, StreamManager>()
+        catalog.streams.forEach { hashMap[it.descriptor] = DefaultStreamManager(it) }
         return DefaultStreamsManager(hashMap)
     }
 }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/task/CloseStreamTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/task/CloseStreamTask.kt
@@ -47,7 +47,7 @@ class CloseStreamTaskFactory(
     fun make(taskLauncher: DestinationTaskLauncher, streamLoader: StreamLoader): CloseStreamTask {
         return CloseStreamTask(
             streamLoader,
-            streamsManager.getManager(streamLoader.stream),
+            streamsManager.getManager(streamLoader.stream.descriptor),
             taskLauncher
         )
     }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/task/DestinationTaskLauncher.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/task/DestinationTaskLauncher.kt
@@ -27,7 +27,8 @@ import jakarta.inject.Singleton
 class DestinationTaskLauncher(
     private val catalog: DestinationCatalog,
     override val taskRunner: TaskRunner,
-    private val checkpointManager: CheckpointManager<DestinationStream, CheckpointMessage>,
+    private val checkpointManager:
+        CheckpointManager<DestinationStream.Descriptor, CheckpointMessage>,
     private val setupTaskFactory: SetupTaskFactory,
     private val openStreamTaskFactory: OpenStreamTaskFactory,
     private val spillToDiskTaskFactory: SpillToDiskTaskFactory,
@@ -87,7 +88,8 @@ class DestinationTaskLauncher(
 class DestinationTaskLauncherFactory(
     private val catalog: DestinationCatalog,
     private val taskRunner: TaskRunner,
-    private val checkpointManager: CheckpointManager<DestinationStream, CheckpointMessage>,
+    private val checkpointManager:
+        CheckpointManager<DestinationStream.Descriptor, CheckpointMessage>,
     private val setupTaskFactory: SetupTaskFactory,
     private val openStreamTaskFactory: OpenStreamTaskFactory,
     private val spillToDiskTaskFactory: SpillToDiskTaskFactory,

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/task/ProcessBatchTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/task/ProcessBatchTask.kt
@@ -50,7 +50,7 @@ class ProcessBatchTaskFactory(
         return ProcessBatchTask(
             batchEnvelope,
             streamLoader,
-            streamsManager.getManager(streamLoader.stream),
+            streamsManager.getManager(streamLoader.stream.descriptor),
             taskLauncher
         )
     }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/task/ProcessRecordsTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/task/ProcessRecordsTask.kt
@@ -86,7 +86,7 @@ class ProcessRecordsTaskFactory(
     ): ProcessRecordsTask {
         return ProcessRecordsTask(
             streamLoader,
-            streamsManager.getManager(streamLoader.stream),
+            streamsManager.getManager(streamLoader.stream.descriptor),
             taskLauncher,
             fileEnvelope,
             deserializer,

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/state/CheckpointManagerTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/state/CheckpointManagerTest.kt
@@ -121,13 +121,14 @@ class CheckpointManagerTest {
     @Prototype
     @Requires(env = ["StateManagerTest"])
     class MockStreamsManager(@Named("mockCatalog") catalog: DestinationCatalog) : StreamsManager {
-        private val mockManagers = catalog.streams.associateWith { MockStreamManager() }
+        private val mockManagers =
+            catalog.streams.map { it.descriptor }.associateWith { MockStreamManager() }
 
         fun addPersistedRanges(stream: DestinationStream, ranges: List<Range<Long>>) {
-            mockManagers[stream]!!.persistedRanges.addAll(ranges)
+            mockManagers[stream.descriptor]!!.persistedRanges.addAll(ranges)
         }
 
-        override fun getManager(stream: DestinationStream): StreamManager {
+        override fun getManager(stream: DestinationStream.Descriptor): StreamManager {
             return mockManagers[stream]
                 ?: throw IllegalArgumentException("Stream not found: $stream")
         }
@@ -151,7 +152,7 @@ class CheckpointManagerTest {
         fun toMockCheckpointIn() = MockStreamCheckpointIn(stream, message)
     }
     data class TestGlobalMessage(
-        val streamIndexes: List<Pair<DestinationStream, Long>>,
+        val streamIndexes: List<Pair<DestinationStream.Descriptor, Long>>,
         val message: Int
     ) : TestEvent() {
         fun toMockCheckpointIn() = MockGlobalCheckpointIn(message)
@@ -248,8 +249,14 @@ class CheckpointManagerTest {
                         name = "Global checkpoint, two messages, flush all",
                         events =
                             listOf(
-                                TestGlobalMessage(listOf(stream1 to 10L, stream2 to 20L), 1),
-                                TestGlobalMessage(listOf(stream1 to 20L, stream2 to 30L), 2),
+                                TestGlobalMessage(
+                                    listOf(stream1.descriptor to 10L, stream2.descriptor to 20L),
+                                    1
+                                ),
+                                TestGlobalMessage(
+                                    listOf(stream1.descriptor to 20L, stream2.descriptor to 30L),
+                                    2
+                                ),
                                 FlushPoint(
                                     persistedRanges =
                                         mapOf(
@@ -264,8 +271,14 @@ class CheckpointManagerTest {
                         name = "Global checkpoint, two messages, range only covers the first",
                         events =
                             listOf(
-                                TestGlobalMessage(listOf(stream1 to 10L, stream2 to 20L), 1),
-                                TestGlobalMessage(listOf(stream1 to 20L, stream2 to 30L), 2),
+                                TestGlobalMessage(
+                                    listOf(stream1.descriptor to 10L, stream2.descriptor to 20L),
+                                    1
+                                ),
+                                TestGlobalMessage(
+                                    listOf(stream1.descriptor to 20L, stream2.descriptor to 30L),
+                                    2
+                                ),
                                 FlushPoint(
                                     persistedRanges =
                                         mapOf(
@@ -281,8 +294,14 @@ class CheckpointManagerTest {
                             "Global checkpoint, two messages, where the range only covers *one stream*",
                         events =
                             listOf(
-                                TestGlobalMessage(listOf(stream1 to 10L, stream2 to 20L), 1),
-                                TestGlobalMessage(listOf(stream1 to 20L, stream2 to 30L), 2),
+                                TestGlobalMessage(
+                                    listOf(stream1.descriptor to 10L, stream2.descriptor to 20L),
+                                    1
+                                ),
+                                TestGlobalMessage(
+                                    listOf(stream1.descriptor to 20L, stream2.descriptor to 30L),
+                                    2
+                                ),
                                 FlushPoint(
                                     mapOf(
                                         stream1 to listOf(Range.closed(0L, 20L)),
@@ -296,8 +315,14 @@ class CheckpointManagerTest {
                         name = "Global checkpoint, out of order (should fail)",
                         events =
                             listOf(
-                                TestGlobalMessage(listOf(stream1 to 20L, stream2 to 30L), 2),
-                                TestGlobalMessage(listOf(stream1 to 10L, stream2 to 20L), 1),
+                                TestGlobalMessage(
+                                    listOf(stream1.descriptor to 20L, stream2.descriptor to 30L),
+                                    2
+                                ),
+                                TestGlobalMessage(
+                                    listOf(stream1.descriptor to 10L, stream2.descriptor to 20L),
+                                    1
+                                ),
                                 FlushPoint(
                                     mapOf(
                                         stream1 to listOf(Range.closed(0L, 20L)),
@@ -312,7 +337,10 @@ class CheckpointManagerTest {
                         events =
                             listOf(
                                 TestStreamMessage(stream1, 10L, 1),
-                                TestGlobalMessage(listOf(stream1 to 20L, stream2 to 30L), 2),
+                                TestGlobalMessage(
+                                    listOf(stream1.descriptor to 20L, stream2.descriptor to 30L),
+                                    2
+                                ),
                                 FlushPoint(
                                     mapOf(
                                         stream1 to listOf(Range.closed(0L, 20L)),
@@ -326,7 +354,10 @@ class CheckpointManagerTest {
                         name = "Mixed: first global, then stream checkpoint (should fail)",
                         events =
                             listOf(
-                                TestGlobalMessage(listOf(stream1 to 10L, stream2 to 20L), 1),
+                                TestGlobalMessage(
+                                    listOf(stream1.descriptor to 10L, stream2.descriptor to 20L),
+                                    1
+                                ),
                                 TestStreamMessage(stream1, 20L, 2),
                                 FlushPoint(
                                     persistedRanges =
@@ -371,15 +402,24 @@ class CheckpointManagerTest {
                         name = "Global checkpoint, multiple flush points, no output",
                         events =
                             listOf(
-                                TestGlobalMessage(listOf(stream1 to 10L, stream2 to 20L), 1),
+                                TestGlobalMessage(
+                                    listOf(stream1.descriptor to 10L, stream2.descriptor to 20L),
+                                    1
+                                ),
                                 FlushPoint(),
-                                TestGlobalMessage(listOf(stream1 to 20L, stream2 to 30L), 2),
+                                TestGlobalMessage(
+                                    listOf(stream1.descriptor to 20L, stream2.descriptor to 30L),
+                                    2
+                                ),
                                 FlushPoint(
                                     mapOf(
                                         stream1 to listOf(Range.closed(0L, 20L)),
                                     )
                                 ),
-                                TestGlobalMessage(listOf(stream1 to 30L, stream2 to 40L), 3),
+                                TestGlobalMessage(
+                                    listOf(stream1.descriptor to 30L, stream2.descriptor to 40L),
+                                    3
+                                ),
                                 FlushPoint(mapOf(stream2 to listOf(Range.closed(20L, 30L))))
                             ),
                         expectedGlobalOutput = listOf()
@@ -388,15 +428,24 @@ class CheckpointManagerTest {
                         name = "Global checkpoint, multiple flush points, no output until end",
                         events =
                             listOf(
-                                TestGlobalMessage(listOf(stream1 to 10L, stream2 to 20L), 1),
+                                TestGlobalMessage(
+                                    listOf(stream1.descriptor to 10L, stream2.descriptor to 20L),
+                                    1
+                                ),
                                 FlushPoint(),
-                                TestGlobalMessage(listOf(stream1 to 20L, stream2 to 30L), 2),
+                                TestGlobalMessage(
+                                    listOf(stream1.descriptor to 20L, stream2.descriptor to 30L),
+                                    2
+                                ),
                                 FlushPoint(
                                     mapOf(
                                         stream1 to listOf(Range.closed(0L, 20L)),
                                     )
                                 ),
-                                TestGlobalMessage(listOf(stream1 to 30L, stream2 to 40L), 3),
+                                TestGlobalMessage(
+                                    listOf(stream1.descriptor to 30L, stream2.descriptor to 40L),
+                                    3
+                                ),
                                 FlushPoint(
                                     mapOf(
                                         stream1 to listOf(Range.closed(20L, 30L)),
@@ -437,7 +486,7 @@ class CheckpointManagerTest {
             when (it) {
                 is TestStreamMessage -> {
                     checkpointManager.addStreamCheckpoint(
-                        it.stream,
+                        it.stream.descriptor,
                         it.index,
                         it.toMockCheckpointIn()
                     )

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/state/StreamsManagerTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/state/StreamsManagerTest.kt
@@ -5,12 +5,10 @@
 package io.airbyte.cdk.state
 
 import com.google.common.collect.Range
-import io.airbyte.cdk.command.Append
 import io.airbyte.cdk.command.DestinationCatalog
 import io.airbyte.cdk.command.DestinationStream
 import io.airbyte.cdk.command.MockCatalogFactory.Companion.stream1
 import io.airbyte.cdk.command.MockCatalogFactory.Companion.stream2
-import io.airbyte.cdk.data.NullType
 import io.airbyte.cdk.message.Batch
 import io.airbyte.cdk.message.BatchEnvelope
 import io.airbyte.cdk.message.SimpleBatch
@@ -37,8 +35,8 @@ class StreamsManagerTest {
     @Test
     fun testCountRecordsAndCheckpoint() {
         val streamsManager = StreamsManagerFactory(catalog).make()
-        val manager1 = streamsManager.getManager(stream1)
-        val manager2 = streamsManager.getManager(stream2)
+        val manager1 = streamsManager.getManager(stream1.descriptor)
+        val manager2 = streamsManager.getManager(stream2.descriptor)
 
         // Incrementing once yields (n, n)
         repeat(10) { manager1.countRecordIn() }
@@ -71,16 +69,7 @@ class StreamsManagerTest {
     fun testGettingNonexistentManagerFails() {
         val streamsManager = StreamsManagerFactory(catalog).make()
         Assertions.assertThrows(IllegalArgumentException::class.java) {
-            streamsManager.getManager(
-                DestinationStream(
-                    DestinationStream.Descriptor("test", "non-existent"),
-                    importType = Append,
-                    schema = NullType,
-                    generationId = 42,
-                    minimumGenerationId = 0,
-                    syncId = 42,
-                )
-            )
+            streamsManager.getManager(DestinationStream.Descriptor("test", "non-existent"))
         }
     }
 
@@ -181,7 +170,7 @@ class StreamsManagerTest {
     fun testUpdateBatchState(testCase: TestCase) {
         val streamsManager = StreamsManagerFactory(catalog).make()
         testCase.events.forEach { (stream, event) ->
-            val manager = streamsManager.getManager(stream)
+            val manager = streamsManager.getManager(stream.descriptor)
             when (event) {
                 is SetRecordCount -> repeat(event.count.toInt()) { manager.countRecordIn() }
                 is SetEndOfStream -> manager.countEndOfStream()
@@ -218,7 +207,7 @@ class StreamsManagerTest {
     @Test
     fun testCannotUpdateOrCloseReadClosedStream() {
         val streamsManager = StreamsManagerFactory(catalog).make()
-        val manager = streamsManager.getManager(stream1)
+        val manager = streamsManager.getManager(stream1.descriptor)
 
         // Can't close before end-of-stream
         Assertions.assertThrows(IllegalStateException::class.java) { manager.markClosed() }
@@ -237,7 +226,7 @@ class StreamsManagerTest {
     @Test
     fun testAwaitStreamClosed() = runTest {
         val streamsManager = StreamsManagerFactory(catalog).make()
-        val manager = streamsManager.getManager(stream1)
+        val manager = streamsManager.getManager(stream1.descriptor)
         val hasClosed = AtomicBoolean(false)
 
         val job = launch {
@@ -259,8 +248,8 @@ class StreamsManagerTest {
     @Test
     fun testAwaitAllStreamsClosed() = runTest {
         val streamsManager = StreamsManagerFactory(catalog).make()
-        val manager1 = streamsManager.getManager(stream1)
-        val manager2 = streamsManager.getManager(stream2)
+        val manager1 = streamsManager.getManager(stream1.descriptor)
+        val manager2 = streamsManager.getManager(stream2.descriptor)
         val allHaveClosed = AtomicBoolean(false)
 
         val awaitStream1 = launch { manager1.awaitStreamClosed() }


### PR DESCRIPTION
it took me way longer than it should have to figure out that micronaut's "no such bean" errors were complaining about all the things like `checkpointManager: CheckpointManager<DestinationStream, CheckpointMessage>` needing to be `checkpointManager: CheckpointManager<DestinationStream.Descriptor, CheckpointMessage>` >.>

but otherwise - pretty straightforward PR to have all the state tracking stuff use a plain Descriptor as the key instead of a full Stream object. This (a) clarifies their needs (state management never needs e.g. sync mode, schema, etc), and (b) makes my life easier when writing tests :P