### PR TITLE
⚡️ Speed up function `combine_mappings` by 132% in `airbyte-cdk/python/airbyte_cdk/utils/mapping_helpers.py`

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/utils/mapping_helpers.py
+++ b/airbyte-cdk/python/airbyte_cdk/utils/mapping_helpers.py
@@ -14,30 +14,29 @@ def combine_mappings(mappings: List[Optional[Union[Mapping[str, Any], str]]]) ->
     * If there are multiple string mappings
     * If there are multiple mappings containing keys and one of them is a string
     """
-    all_keys: List[Set[str]] = []
+    combined_mapping = {}
+    unique_keys = set()
+    string_mappings = 0
+    string_mapping_value = None
+
     for part in mappings:
         if part is None:
             continue
-        keys = set(part.keys()) if not isinstance(part, str) else set()
-        all_keys.append(keys)
+        if isinstance(part, str):
+            string_mappings += 1
+            string_mapping_value = part
+            if string_mappings > 1:
+                raise ValueError("Cannot combine multiple string options")
+        else:
+            for key in part:
+                if key in unique_keys:
+                    raise ValueError(f"Duplicate keys found: {key}")
+                combined_mapping[key] = part[key]
+                unique_keys.add(key)
 
-    string_options = sum(isinstance(mapping, str) for mapping in mappings)
-    # If more than one mapping is a string, raise a ValueError
-    if string_options > 1:
-        raise ValueError("Cannot combine multiple string options")
+    if string_mappings == 1:
+        if combined_mapping:
+            raise ValueError("Cannot combine multiple options if one is a string")
+        return string_mapping_value
 
-    if string_options == 1 and sum(len(keys) for keys in all_keys) > 0:
-        raise ValueError("Cannot combine multiple options if one is a string")
-
-    # If any mapping is a string, return it
-    for mapping in mappings:
-        if isinstance(mapping, str):
-            return mapping
-
-    # If there are duplicate keys across mappings, raise a ValueError
-    intersection = set().union(*all_keys)
-    if len(intersection) < sum(len(keys) for keys in all_keys):
-        raise ValueError(f"Duplicate keys found: {intersection}")
-
-    # Return the combined mappings
-    return {key: value for mapping in mappings if mapping for key, value in mapping.items()}  # type: ignore # mapping can't be string here
+    return combined_mapping


### PR DESCRIPTION
### 📄 `combine_mappings()` in `airbyte-cdk/python/airbyte_cdk/utils/mapping_helpers.py`

📈 Performance improved by **`132%`** (**`1.32x` faster**)

⏱️ Runtime went down from **`6.42 milliseconds`** to **`2.76 milliseconds`**
### Explanation and details

Let's optimize the given Python program for better performance. Here are some strategies we'll employ.

1. **Remove Redundant Computations**: Avoid summing and counting multiple times.
2. **Efficient Data Structures**: Use more efficient data structures where applicable, e.g., using a single dictionary for key tracking.
3. **Single Pass**: Combine multiple operations into a single loop where possible.

Here's the optimized version.



**Key Optimizations:**

1. **Single Loop**: Combines the string check and the key collision check into a single loop, reducing the complexity.
2. **Avoid Redundant Summation and Counting**: Reduces the overhead of unnecessary summation operations by maintaining counters.
3. **Immediate Error Tracking**: Checks for errors immediately within the loop, avoiding the need for subsequent error checks.

This should provide a more efficient execution for the function without altering its behavior.


### Correctness verification

The new optimized code was tested for correctness. The results are listed below.
#### ✅ 8 Passed − ⚙️ Existing Unit Tests
<details>
<summary>(click to show existing tests)</summary>

```python
- utils/test_mapping_helpers.py
```
</details>

#### ✅ 35 Passed − 🌀 Generated Regression Tests
<details>
<summary>(click to show generated tests)</summary>

```python
# imports
# function to test
from typing import Any, List, Mapping, Optional, Set, Union

import pytest  # used for our unit tests
from airbyte_cdk.utils.mapping_helpers import combine_mappings

# unit tests

# Basic functionality tests
def test_single_mapping():
    codeflash_output = combine_mappings([{'a': 1, 'b': 2}])
    # Outputs were verified to be equal to the original implementation

def test_multiple_mappings_unique_keys():
    codeflash_output = combine_mappings([{'a': 1}, {'b': 2}])
    # Outputs were verified to be equal to the original implementation

def test_single_string():
    codeflash_output = combine_mappings(['string_value'])
    # Outputs were verified to be equal to the original implementation

# Handling None values
def test_mappings_with_none_values():
    codeflash_output = combine_mappings([None, {'a': 1}])
    codeflash_output = combine_mappings([{'a': 1}, None])
    codeflash_output = combine_mappings([None, None])
    # Outputs were verified to be equal to the original implementation

# Error handling
def test_duplicate_keys_across_mappings():
    with pytest.raises(ValueError, match="Duplicate keys found"):
        combine_mappings([{'a': 1}, {'a': 2}])
    # Outputs were verified to be equal to the original implementation

def test_multiple_string_mappings():
    with pytest.raises(ValueError, match="Cannot combine multiple string options"):
        combine_mappings(['string1', 'string2'])
    # Outputs were verified to be equal to the original implementation

def test_string_and_non_empty_mappings():
    with pytest.raises(ValueError, match="Cannot combine multiple options if one is a string"):
        combine_mappings(['string_value', {'a': 1}])
    with pytest.raises(ValueError, match="Cannot combine multiple options if one is a string"):
        combine_mappings([{'a': 1}, 'string_value'])
    # Outputs were verified to be equal to the original implementation

# Mixed inputs
def test_mixed_none_strings_and_mappings():
    codeflash_output = combine_mappings([None, 'string_value'])
    codeflash_output = combine_mappings(['string_value', None])
    codeflash_output = combine_mappings([None, {'a': 1}, None])
    # Outputs were verified to be equal to the original implementation

# Edge cases
def test_empty_list():
    codeflash_output = combine_mappings([])
    # Outputs were verified to be equal to the original implementation

def test_empty_mappings():
    codeflash_output = combine_mappings([{}, {}])
    codeflash_output = combine_mappings([{}, {'a': 1}])
    # Outputs were verified to be equal to the original implementation

# Large scale test cases
def test_large_number_of_mappings():
    mappings = [{f'key{i}': i} for i in range(1000)]
    expected = {f'key{i}': i for i in range(1000)}
    codeflash_output = combine_mappings(mappings)
    # Outputs were verified to be equal to the original implementation

def test_large_single_mapping():
    large_mapping = {f'key{i}': i for i in range(1000)}
    codeflash_output = combine_mappings([large_mapping])
    # Outputs were verified to be equal to the original implementation

# Performance and scalability
def test_performance_with_large_data_samples():
    large_mappings = [{f'key{i}': i} for i in range(5000)]
    codeflash_output = combine_mappings(large_mappings)
    # Outputs were verified to be equal to the original implementation

# Rare or unexpected edge cases

def test_mappings_with_non_hashable_keys():
    with pytest.raises(TypeError):
        combine_mappings([{'a': 1, ['list']: 'value'}])
    with pytest.raises(TypeError):
        combine_mappings([{'a': 1}, {{'set'}: 'value'}])
    # Outputs were verified to be equal to the original implementation

def test_deeply_nested_mappings():
    codeflash_output = combine_mappings([{'a': {'b': {'c': 1}}}, {'d': 2}])
    # Outputs were verified to be equal to the original implementation

def test_mappings_with_mixed_types_of_values():
    codeflash_output = combine_mappings([{'a': 1, 'b': 'string', 'c': [1, 2, 3], 'd': {'nested': 'dict'}}])
    codeflash_output = combine_mappings([{'a': 1}, {'b': [2, 3]}, {'c': {'nested': 'value'}}])
    # Outputs were verified to be equal to the original implementation

def test_mappings_with_special_characters_in_keys():
    codeflash_output = combine_mappings([{'a!@#$%^&*()': 1}])
    codeflash_output = combine_mappings([{'key with spaces': 'value'}, {'another-key': 2}])
    # Outputs were verified to be equal to the original implementation

def test_mappings_with_empty_strings_as_keys():
    codeflash_output = combine_mappings([{'': 'empty_key'}])
    codeflash_output = combine_mappings([{'a': 1}, {'': 'empty_key'}])
    # Outputs were verified to be equal to the original implementation

def test_mappings_with_none_as_values():
    codeflash_output = combine_mappings([{'a': None}])
    codeflash_output = combine_mappings([{'a': 1}, {'b': None}])
    # Outputs were verified to be equal to the original implementation


def test_mappings_with_boolean_values():
    codeflash_output = combine_mappings([{'a': True}])
    codeflash_output = combine_mappings([{'a': 1}, {'b': False}])
    # Outputs were verified to be equal to the original implementation

def test_mappings_with_special_floating_point_values():
    codeflash_output = combine_mappings([{'a': float('inf')}])
    codeflash_output = combine_mappings([{'a': 1}, {'b': float('nan')}])
    # Outputs were verified to be equal to the original implementation

def test_mappings_with_large_numerical_values():
    codeflash_output = combine_mappings([{'a': 10**100}])
    codeflash_output = combine_mappings([{'a': 1}, {'b': 10**100}])
    # Outputs were verified to be equal to the original implementation
```
</details>

#### 🔘 (none found) − ⏪ Replay Tests
