### PR TITLE
bulk-cdk: decouple from protocol model somewhat

### DIFF
--- a/airbyte-cdk/bulk/core/base/src/main/kotlin/io/airbyte/cdk/StreamNamePair.kt
+++ b/airbyte-cdk/bulk/core/base/src/main/kotlin/io/airbyte/cdk/StreamNamePair.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk
+
+import io.airbyte.protocol.models.v0.AirbyteStreamNameNamespacePair
+import io.airbyte.protocol.models.v0.StreamDescriptor
+
+/**
+ * [StreamNamePair] is equivalent to [AirbyteStreamNameNamespacePair].
+ *
+ * This exists to avoid coupling the Bulk CDK code too closely to the Airbyte Protocol objects.
+ */
+data class StreamNamePair(val name: String, val namespace: String?) {
+    override fun toString(): String {
+        return if (namespace == null) name else "${namespace}_${name}"
+    }
+}
+
+fun StreamNamePair.asProtocolNameNamespacePair(): AirbyteStreamNameNamespacePair =
+    AirbyteStreamNameNamespacePair(name, namespace)
+
+fun StreamNamePair.asProtocolStreamDescriptor(): StreamDescriptor =
+    StreamDescriptor().withName(name).withNamespace(namespace)
+
+fun AirbyteStreamNameNamespacePair.asStreamName(): StreamNamePair = StreamNamePair(name, namespace)
+
+fun StreamDescriptor.asStreamName(): StreamNamePair = StreamNamePair(name, namespace)

--- a/airbyte-cdk/bulk/core/base/src/main/kotlin/io/airbyte/cdk/StreamNamePair.kt
+++ b/airbyte-cdk/bulk/core/base/src/main/kotlin/io/airbyte/cdk/StreamNamePair.kt
@@ -18,12 +18,7 @@ data class StreamNamePair(val name: String, val namespace: String?) {
     }
 }
 
-fun StreamNamePair.asProtocolNameNamespacePair(): AirbyteStreamNameNamespacePair =
-    AirbyteStreamNameNamespacePair(name, namespace)
-
 fun StreamNamePair.asProtocolStreamDescriptor(): StreamDescriptor =
     StreamDescriptor().withName(name).withNamespace(namespace)
 
-fun AirbyteStreamNameNamespacePair.asStreamName(): StreamNamePair = StreamNamePair(name, namespace)
-
-fun StreamDescriptor.asStreamName(): StreamNamePair = StreamNamePair(name, namespace)
+fun StreamDescriptor.asStreamNamePair(): StreamNamePair = StreamNamePair(name, namespace)

--- a/airbyte-cdk/bulk/core/base/src/main/kotlin/io/airbyte/cdk/command/InputState.kt
+++ b/airbyte-cdk/bulk/core/base/src/main/kotlin/io/airbyte/cdk/command/InputState.kt
@@ -2,7 +2,7 @@
 package io.airbyte.cdk.command
 
 import com.fasterxml.jackson.databind.JsonNode
-import io.airbyte.protocol.models.v0.AirbyteStreamNameNamespacePair
+import io.airbyte.cdk.StreamNamePair
 
 /** Union type of the state passed as input to a READ for a source connector. */
 sealed interface InputState
@@ -11,13 +11,13 @@ data object EmptyInputState : InputState
 
 data class GlobalInputState(
     val global: OpaqueStateValue,
-    val globalStreams: Map<AirbyteStreamNameNamespacePair, OpaqueStateValue>,
+    val globalStreams: Map<StreamNamePair, OpaqueStateValue>,
     /** Conceivably, some streams may undergo a full refresh alongside independently of the rest. */
-    val nonGlobalStreams: Map<AirbyteStreamNameNamespacePair, OpaqueStateValue>,
+    val nonGlobalStreams: Map<StreamNamePair, OpaqueStateValue>,
 ) : InputState
 
 data class StreamInputState(
-    val streams: Map<AirbyteStreamNameNamespacePair, OpaqueStateValue>,
+    val streams: Map<StreamNamePair, OpaqueStateValue>,
 ) : InputState
 
 /** State values are opaque for the CDK, the schema is owned by the connector. */

--- a/airbyte-cdk/bulk/core/base/src/main/kotlin/io/airbyte/cdk/command/InputStateFactory.kt
+++ b/airbyte-cdk/bulk/core/base/src/main/kotlin/io/airbyte/cdk/command/InputStateFactory.kt
@@ -4,13 +4,12 @@ package io.airbyte.cdk.command
 import com.fasterxml.jackson.databind.JsonNode
 import io.airbyte.cdk.ConfigErrorException
 import io.airbyte.cdk.StreamNamePair
-import io.airbyte.cdk.asStreamName
+import io.airbyte.cdk.asStreamNamePair
 import io.airbyte.cdk.util.Jsons
 import io.airbyte.cdk.util.ResourceUtils
 import io.airbyte.protocol.models.v0.AirbyteGlobalState
 import io.airbyte.protocol.models.v0.AirbyteStateMessage
 import io.airbyte.protocol.models.v0.AirbyteStreamState
-import io.airbyte.protocol.models.v0.StreamDescriptor
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.micronaut.context.annotation.Factory
 import io.micronaut.context.annotation.Requires
@@ -50,8 +49,7 @@ class InputStateFactory {
                     if (msg.stream == null) {
                         msg.type.toString()
                     } else {
-                        val desc: StreamDescriptor = msg.stream.streamDescriptor
-                        desc.asStreamName().toString()
+                        msg.stream.streamDescriptor.asStreamNamePair().toString()
                     }
                 }
                 .mapNotNull { (groupKey, groupValues) ->
@@ -84,8 +82,7 @@ class InputStateFactory {
         streamStates: List<AirbyteStreamState>?,
     ): Map<StreamNamePair, OpaqueStateValue> =
         (streamStates ?: listOf()).associate { msg: AirbyteStreamState ->
-            val sd: StreamDescriptor = msg.streamDescriptor
-            val key: StreamNamePair = sd.asStreamName()
+            val key: StreamNamePair = msg.streamDescriptor.asStreamNamePair()
             val jsonValue: JsonNode = msg.streamState ?: Jsons.objectNode()
             key to ValidatedJsonUtils.parseUnvalidated(jsonValue, OpaqueStateValue::class.java)
         }

--- a/airbyte-cdk/bulk/core/base/src/test/kotlin/io/airbyte/cdk/command/InputStateTest.kt
+++ b/airbyte-cdk/bulk/core/base/src/test/kotlin/io/airbyte/cdk/command/InputStateTest.kt
@@ -1,8 +1,8 @@
 /* Copyright (c) 2024 Airbyte, Inc., all rights reserved. */
 package io.airbyte.cdk.command
 
+import io.airbyte.cdk.StreamNamePair
 import io.airbyte.cdk.util.Jsons
-import io.airbyte.protocol.models.v0.AirbyteStreamNameNamespacePair
 import io.micronaut.context.annotation.Property
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest
 import jakarta.inject.Inject
@@ -27,10 +27,9 @@ class InputStateTest {
         val expected =
             StreamInputState(
                 mapOf(
-                    AirbyteStreamNameNamespacePair("bar", "foo") to
+                    StreamNamePair("bar", "foo") to
                         Jsons.readTree("{\"primary_key\":{\"k1\":10,\"k2\":20}}"),
-                    AirbyteStreamNameNamespacePair("baz", "foo") to
-                        Jsons.readTree("{\"cursors\":{\"c\":30}}"),
+                    StreamNamePair("baz", "foo") to Jsons.readTree("{\"cursors\":{\"c\":30}}"),
                 ),
             )
         Assertions.assertEquals(
@@ -50,7 +49,7 @@ class InputStateTest {
                 global = Jsons.readTree("{\"cdc\":{}}"),
                 globalStreams =
                     mapOf(
-                        AirbyteStreamNameNamespacePair("bar", "foo") to
+                        StreamNamePair("bar", "foo") to
                             Jsons.readTree("{\"primary_key\":{\"k1\":10,\"k2\":20}}"),
                     ),
                 nonGlobalStreams = mapOf(),
@@ -72,12 +71,12 @@ class InputStateTest {
                 global = Jsons.readTree("{\"cdc\":{}}"),
                 globalStreams =
                     mapOf(
-                        AirbyteStreamNameNamespacePair("bar", "foo") to
+                        StreamNamePair("bar", "foo") to
                             Jsons.readTree("{\"primary_key\":{\"k1\":10,\"k2\":20}}"),
                     ),
                 nonGlobalStreams =
                     mapOf(
-                        AirbyteStreamNameNamespacePair("baz", "foo") to
+                        StreamNamePair("baz", "foo") to
                             Jsons.readTree("{\"primary_key\":{\"k\":1}}"),
                     ),
             )
@@ -95,12 +94,12 @@ class InputStateTest {
                 global = Jsons.readTree("{\"cdc\":{}}"),
                 globalStreams =
                     mapOf(
-                        AirbyteStreamNameNamespacePair("bar", "foo") to
+                        StreamNamePair("bar", "foo") to
                             Jsons.readTree("{\"primary_key\":{\"k1\":10,\"k2\":20}}"),
                     ),
                 nonGlobalStreams =
                     mapOf(
-                        AirbyteStreamNameNamespacePair("baz", "foo") to
+                        StreamNamePair("baz", "foo") to
                             Jsons.readTree("{\"primary_key\":{\"k\":10}}"),
                     ),
             )

--- a/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/read/ConfiguredSyncMode.kt
+++ b/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/read/ConfiguredSyncMode.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.read
+
+import io.airbyte.protocol.models.v0.SyncMode
+
+/**
+ * [ConfiguredSyncMode] is equivalent to [SyncMode].
+ *
+ * This exists to avoid coupling the Bulk CDK code too closely to the Airbyte Protocol objects.
+ */
+enum class ConfiguredSyncMode {
+    FULL_REFRESH,
+    INCREMENTAL,
+}
+
+fun ConfiguredSyncMode.asProtocolSyncMode(): SyncMode =
+    when (this) {
+        ConfiguredSyncMode.FULL_REFRESH -> SyncMode.FULL_REFRESH
+        ConfiguredSyncMode.INCREMENTAL -> SyncMode.INCREMENTAL
+    }
+
+fun SyncMode.asSyncMode(): ConfiguredSyncMode =
+    when (this) {
+        SyncMode.FULL_REFRESH -> ConfiguredSyncMode.FULL_REFRESH
+        SyncMode.INCREMENTAL -> ConfiguredSyncMode.INCREMENTAL
+    }

--- a/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/read/Feed.kt
+++ b/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/read/Feed.kt
@@ -1,11 +1,9 @@
 /* Copyright (c) 2024 Airbyte, Inc., all rights reserved. */
 package io.airbyte.cdk.read
 
+import io.airbyte.cdk.StreamNamePair
 import io.airbyte.cdk.discover.Field
 import io.airbyte.cdk.discover.FieldOrMetaField
-import io.airbyte.protocol.models.v0.AirbyteStreamNameNamespacePair
-import io.airbyte.protocol.models.v0.StreamDescriptor
-import io.airbyte.protocol.models.v0.SyncMode
 
 /**
  * [Feed] identifies part of the data consumed during a READ operation.
@@ -34,15 +32,12 @@ data class Stream(
     val name: String,
     val namespace: String?,
     val fields: List<Field>,
-    val configuredSyncMode: SyncMode,
+    val configuredSyncMode: ConfiguredSyncMode,
     val configuredPrimaryKey: List<Field>?,
     val configuredCursor: FieldOrMetaField?,
 ) : Feed {
-    val namePair: AirbyteStreamNameNamespacePair
-        get() = AirbyteStreamNameNamespacePair(name, namespace)
-
-    val streamDescriptor: StreamDescriptor
-        get() = StreamDescriptor().withName(name).withNamespace(namespace)
+    val namePair: StreamNamePair
+        get() = StreamNamePair(name, namespace)
 
     override val label: String
         get() = namePair.toString()

--- a/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/read/FeedReader.kt
+++ b/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/read/FeedReader.kt
@@ -1,6 +1,7 @@
 /* Copyright (c) 2024 Airbyte, Inc., all rights reserved. */
 package io.airbyte.cdk.read
 
+import io.airbyte.cdk.asProtocolStreamDescriptor
 import io.airbyte.cdk.command.OpaqueStateValue
 import io.airbyte.cdk.util.ThreadRenamingCoroutineName
 import io.airbyte.protocol.models.v0.AirbyteStateMessage
@@ -305,7 +306,7 @@ class FeedReader(
         if (feed is Stream) {
             root.outputConsumer.accept(
                 AirbyteStreamStatusTraceMessage()
-                    .withStreamDescriptor(feed.streamDescriptor)
+                    .withStreamDescriptor(feed.namePair.asProtocolStreamDescriptor())
                     .withStatus(status),
             )
         }

--- a/airbyte-cdk/bulk/core/extract/src/test/kotlin/io/airbyte/cdk/read/RootReaderIntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/extract/src/test/kotlin/io/airbyte/cdk/read/RootReaderIntegrationTest.kt
@@ -11,7 +11,6 @@ import io.airbyte.protocol.models.v0.AirbyteMessage
 import io.airbyte.protocol.models.v0.AirbyteStateMessage
 import io.airbyte.protocol.models.v0.AirbyteStreamStatusTraceMessage
 import io.airbyte.protocol.models.v0.AirbyteTraceMessage
-import io.airbyte.protocol.models.v0.SyncMode
 import io.github.oshai.kotlinlogging.KotlinLogging
 import java.lang.RuntimeException
 import java.time.Duration
@@ -210,7 +209,7 @@ data class TestCase(
             name = name,
             namespace = "test",
             fields = listOf(),
-            configuredSyncMode = SyncMode.FULL_REFRESH,
+            configuredSyncMode = ConfiguredSyncMode.FULL_REFRESH,
             configuredPrimaryKey = null,
             configuredCursor = null,
         )

--- a/airbyte-cdk/bulk/core/extract/src/test/kotlin/io/airbyte/cdk/read/StateManagerGlobalStatesTest.kt
+++ b/airbyte-cdk/bulk/core/extract/src/test/kotlin/io/airbyte/cdk/read/StateManagerGlobalStatesTest.kt
@@ -9,7 +9,6 @@ import io.airbyte.cdk.output.CatalogValidationFailure
 import io.airbyte.cdk.util.Jsons
 import io.airbyte.protocol.models.v0.AirbyteStateMessage
 import io.airbyte.protocol.models.v0.ConfiguredAirbyteCatalog
-import io.airbyte.protocol.models.v0.SyncMode
 import io.micronaut.context.annotation.Property
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest
 import jakarta.inject.Inject
@@ -205,12 +204,12 @@ class StateManagerGlobalStatesTest {
         Assertions.assertEquals("KV", kv.name)
         Assertions.assertEquals(listOf("V", "K"), kv.fields.map { it.id })
         Assertions.assertEquals(listOf("K"), kv.configuredPrimaryKey?.map { it.id })
-        Assertions.assertEquals(SyncMode.INCREMENTAL, kv.configuredSyncMode)
+        Assertions.assertEquals(ConfiguredSyncMode.INCREMENTAL, kv.configuredSyncMode)
         val events: Stream = streams.filter { it.namePair != kv.namePair }.first()
         Assertions.assertEquals("EVENTS", events.name)
         Assertions.assertEquals(listOf("MSG", "ID", "TS"), events.fields.map { it.id })
         Assertions.assertEquals(listOf("ID"), events.configuredPrimaryKey?.map { it.id })
-        Assertions.assertEquals(SyncMode.FULL_REFRESH, events.configuredSyncMode)
+        Assertions.assertEquals(ConfiguredSyncMode.FULL_REFRESH, events.configuredSyncMode)
         return Streams(global, kv, events)
     }
 

--- a/airbyte-cdk/bulk/core/extract/src/test/kotlin/io/airbyte/cdk/read/StateManagerStreamStatesTest.kt
+++ b/airbyte-cdk/bulk/core/extract/src/test/kotlin/io/airbyte/cdk/read/StateManagerStreamStatesTest.kt
@@ -11,7 +11,6 @@ import io.airbyte.cdk.output.StreamNotFound
 import io.airbyte.cdk.util.Jsons
 import io.airbyte.protocol.models.v0.AirbyteStateMessage
 import io.airbyte.protocol.models.v0.ConfiguredAirbyteCatalog
-import io.airbyte.protocol.models.v0.SyncMode
 import io.micronaut.context.annotation.Property
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest
 import jakarta.inject.Inject
@@ -101,7 +100,7 @@ class StateManagerStreamStatesTest {
     @Property(name = "airbyte.connector.state.json", value = "[]")
     fun testFullRefreshColdStart() {
         // test current state
-        val stream: Stream = prelude(SyncMode.FULL_REFRESH, listOf("ID"))
+        val stream: Stream = prelude(ConfiguredSyncMode.FULL_REFRESH, listOf("ID"))
         Assertions.assertNull(stateManager.scoped(stream).current())
         Assertions.assertEquals(listOf<CatalogValidationFailure>(), handler.get())
         // update state manager with fake work result
@@ -148,7 +147,7 @@ class StateManagerStreamStatesTest {
     )
     fun testFullRefreshWarmStart() {
         // test current state
-        val stream: Stream = prelude(SyncMode.FULL_REFRESH, listOf("ID"))
+        val stream: Stream = prelude(ConfiguredSyncMode.FULL_REFRESH, listOf("ID"))
         Assertions.assertEquals(
             Jsons.readTree("{\"cursor_incremental\": \"initial_sync_ongoing\"}"),
             stateManager.scoped(stream).current(),
@@ -176,7 +175,7 @@ class StateManagerStreamStatesTest {
     }
 
     private fun prelude(
-        expectedSyncMode: SyncMode,
+        expectedSyncMode: ConfiguredSyncMode,
         expectedPrimaryKey: List<String>? = null,
         expectedCursor: String? = null,
     ): Stream {

--- a/airbyte-cdk/bulk/toolkits/extract-jdbc/src/main/kotlin/io/airbyte/cdk/discover/JdbcMetadataQuerier.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-jdbc/src/main/kotlin/io/airbyte/cdk/discover/JdbcMetadataQuerier.kt
@@ -1,6 +1,7 @@
 /* Copyright (c) 2024 Airbyte, Inc., all rights reserved. */
 package io.airbyte.cdk.discover
 
+import io.airbyte.cdk.StreamNamePair
 import io.airbyte.cdk.check.JdbcCheckQueries
 import io.airbyte.cdk.command.JdbcSourceConfiguration
 import io.airbyte.cdk.jdbc.DefaultJdbcConstants
@@ -13,7 +14,6 @@ import io.airbyte.cdk.read.SelectColumns
 import io.airbyte.cdk.read.SelectQueryGenerator
 import io.airbyte.cdk.read.SelectQuerySpec
 import io.airbyte.cdk.read.optimize
-import io.airbyte.protocol.models.v0.AirbyteStreamNameNamespacePair
 import io.github.oshai.kotlinlogging.KotlinLogging
 import jakarta.inject.Singleton
 import java.sql.Connection
@@ -292,7 +292,7 @@ class JdbcMetadataQuerier(
         val memoized: List<List<String>>? = memoizedPrimaryKeys[table]
         if (memoized != null) return memoized
         val results = mutableListOf<PrimaryKeyRow>()
-        val streamPair = AirbyteStreamNameNamespacePair(streamName, streamNamespace)
+        val streamPair = StreamNamePair(streamName, streamNamespace)
         log.info { "Querying primary keys in '$streamPair' for catalog discovery." }
         try {
             val dbmd: DatabaseMetaData = conn.metaData

--- a/airbyte-cdk/bulk/toolkits/extract-jdbc/src/main/kotlin/io/airbyte/cdk/read/DefaultJdbcPartitionFactory.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-jdbc/src/main/kotlin/io/airbyte/cdk/read/DefaultJdbcPartitionFactory.kt
@@ -15,7 +15,6 @@ import io.airbyte.cdk.output.InvalidCursor
 import io.airbyte.cdk.output.InvalidPrimaryKey
 import io.airbyte.cdk.output.ResetStream
 import io.airbyte.cdk.util.Jsons
-import io.airbyte.protocol.models.v0.SyncMode
 import jakarta.inject.Singleton
 import java.util.concurrent.ConcurrentHashMap
 
@@ -67,7 +66,7 @@ class DefaultJdbcPartitionFactory(
             }
 
         val isCursorBasedIncremental: Boolean =
-            stream.configuredSyncMode == SyncMode.INCREMENTAL && !configuration.global
+            stream.configuredSyncMode == ConfiguredSyncMode.INCREMENTAL && !configuration.global
 
         return if (cursorPair == null) {
             if (isCursorBasedIncremental) {
@@ -162,7 +161,7 @@ class DefaultJdbcPartitionFactory(
     private fun coldStart(streamState: DefaultJdbcStreamState): DefaultJdbcPartition {
         val stream: Stream = streamState.stream
         val pkChosenFromCatalog: List<Field> = stream.configuredPrimaryKey ?: listOf()
-        if (stream.configuredSyncMode == SyncMode.FULL_REFRESH || configuration.global) {
+        if (stream.configuredSyncMode == ConfiguredSyncMode.FULL_REFRESH || configuration.global) {
             if (pkChosenFromCatalog.isEmpty()) {
                 return DefaultJdbcUnsplittableSnapshotPartition(
                     selectQueryGenerator,

--- a/airbyte-cdk/bulk/toolkits/extract-jdbc/src/test/kotlin/io/airbyte/cdk/read/TestFixtures.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-jdbc/src/test/kotlin/io/airbyte/cdk/read/TestFixtures.kt
@@ -20,7 +20,6 @@ import io.airbyte.cdk.output.CatalogValidationFailure
 import io.airbyte.cdk.ssh.SshConnectionOptions
 import io.airbyte.cdk.ssh.SshTunnelMethodConfiguration
 import io.airbyte.cdk.util.Jsons
-import io.airbyte.protocol.models.v0.SyncMode
 import java.time.Duration
 import java.time.LocalDate
 import org.junit.jupiter.api.Assertions
@@ -39,7 +38,8 @@ object TestFixtures {
             name = "events",
             namespace = "test",
             fields = listOf(id, ts, msg),
-            configuredSyncMode = if (withCursor) SyncMode.INCREMENTAL else SyncMode.FULL_REFRESH,
+            configuredSyncMode =
+                if (withCursor) ConfiguredSyncMode.INCREMENTAL else ConfiguredSyncMode.FULL_REFRESH,
             configuredPrimaryKey = listOf(id).takeIf { withPK },
             configuredCursor = ts.takeIf { withCursor },
         )


### PR DESCRIPTION
## What
The last CDK sync meeting brought up the desirability of not relying on the Airbyte Protocol's object definitions too much in the Bulk CDK. Ideally those should be used only at the seams. This PR implements that for the common base module and for the extract modules.

## How
Get rid of internal `AirbyteStreamNameNamespacePair`, `StreamDescriptor` and `SyncMode` usages.

## Review guide

The changes are mostly mechanical.

IMHO the usages of the `AirbyteMessage` types are OK, as is having the `ConfiguredAirbyteCatalog` injected directly, as opposed to wrapping it into something else like we did for `InputState`.

Let me know you think this PR should go further.

## User Impact

None

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [x] NO ❌
