### PR TITLE
Update security.md - add note about sensitive data potentially being exposed when server component loglevel set to 'DEBUG' on Airbyte OSS

### DIFF
--- a/docs/operating-airbyte/security.md
+++ b/docs/operating-airbyte/security.md
@@ -84,6 +84,11 @@ Note that this process is not reversible. Once you have converted to a secret st
 
 Most Airbyte Open Source connectors support encryption-in-transit (SSL or HTTPS). We recommend configuring your connectors to use the encryption option whenever available.
 
+### Sensitive Data
+
+To facilitate troubleshooting, the Server component may output initial user configurations to the log stream when server loglevel is set to `DEBUG`.
+To keep this information private, it is recommended to keep loglevel set to `INFO`  outside of troubleshooting.
+
 ## Securing Airbyte Cloud
 
 Airbyte Cloud leverages the security features of leading Cloud providers and sets least-privilege access policies to ensure data security.


### PR DESCRIPTION


## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->
This PR adds a note about the fact that potentially sensitive data (initial user config) may be exposed when server component loglevel is set to 'DEBUG' on Airbyte OSS. 

## How
<!--
* Describe how code changes achieve the solution.
-->

Example of log output in question:
```yaml
2024-09-10 17:45:26 [36mDEBUG[m i.m.c.DefaultBeanContext(postBeanCreated):2364 - Created bean 
[InitialUserConfig(email=example@email.com, firstName=Joe, lastName=Bloggs, password=mypassword!)] from 
definition [Definition: io.airbyte.commons.auth.config.InitialUserConfigFactory] with qualifier [null]
```

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
