### PR TITLE
Load CDK Clean up Tmp File; SpillToDisk/ProcessRecords Unit Tests

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/command/WriteConfiguration.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/command/WriteConfiguration.kt
@@ -6,6 +6,7 @@ package io.airbyte.cdk.command
 
 import io.micronaut.context.annotation.Secondary
 import jakarta.inject.Singleton
+import java.nio.file.Path
 
 /**
  * General configuration for the write operation. The implementor can override this to tweak runtime
@@ -14,7 +15,9 @@ import jakarta.inject.Singleton
 interface WriteConfiguration {
     /** Batch accumulation settings. */
     val recordBatchSizeBytes: Long
+    val tmpFileDirectory: Path
     val firstStageTmpFilePrefix: String
+    val firstStageTmpFileSuffix: String
 
     /** Memory queue settings */
     val maxMessageQueueMemoryUsageRatio: Double // as fraction of available memory
@@ -25,7 +28,9 @@ interface WriteConfiguration {
 @Secondary
 open class DefaultWriteConfiguration : WriteConfiguration {
     override val recordBatchSizeBytes: Long = 200L * 1024L * 1024L
-    override val firstStageTmpFilePrefix = "airbyte-cdk-load-staged-raw-records"
+    override val tmpFileDirectory: Path = Path.of("/airbyte-cdk-load")
+    override val firstStageTmpFilePrefix = "staged-raw-records"
+    override val firstStageTmpFileSuffix = ".jsonl"
 
     override val maxMessageQueueMemoryUsageRatio: Double = 0.2
     override val estimatedRecordMemoryOverheadRatio: Double = 0.1

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/file/LocalFile.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/file/LocalFile.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.file
+
+import io.micronaut.context.annotation.DefaultImplementation
+import java.io.Closeable
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.streams.asSequence
+
+/**
+ * Simple wrappers around java's file interface. This is for testability, and to allow us to do
+ * resource management, etc in one place.
+ */
+interface FileWriter : Closeable {
+    fun write(str: String)
+    override fun close()
+}
+
+interface FileReader : Closeable {
+    fun lines(): Sequence<String>
+    override fun close()
+}
+
+@DefaultImplementation(DefaultLocalFile::class)
+interface LocalFile {
+    fun toFileWriter(): FileWriter
+    fun toFileReader(): FileReader
+    fun delete()
+}
+
+class DefaultLocalFile(val localFile: Path) : LocalFile {
+    override fun toFileWriter(): FileWriter {
+        return object : FileWriter {
+            private val writer = Files.newBufferedWriter(localFile)
+            override fun write(str: String) {
+                writer.write(str)
+            }
+
+            override fun close() {
+                writer.close()
+            }
+        }
+    }
+
+    override fun toFileReader(): FileReader {
+        return object : FileReader {
+            private val reader = Files.newBufferedReader(localFile)
+            override fun lines(): Sequence<String> {
+                return reader.lines().asSequence()
+            }
+
+            override fun close() {
+                reader.close()
+            }
+        }
+    }
+
+    override fun delete() {
+        Files.delete(localFile)
+    }
+}

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/file/TempFileProvider.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/file/TempFileProvider.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.file
+
+import io.micronaut.context.annotation.DefaultImplementation
+import java.nio.file.Files
+import java.nio.file.Path
+
+@DefaultImplementation(DefaultTempFileProvider::class)
+interface TempFileProvider {
+    fun createTempFile(directory: Path, prefix: String, suffix: String): LocalFile
+}
+
+class DefaultTempFileProvider : TempFileProvider {
+    override fun createTempFile(directory: Path, prefix: String, suffix: String): LocalFile {
+        return DefaultLocalFile(Files.createTempFile(directory, prefix, suffix))
+    }
+}

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/message/Batch.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/message/Batch.kt
@@ -7,7 +7,7 @@ package io.airbyte.cdk.message
 import com.google.common.collect.Range
 import com.google.common.collect.RangeSet
 import com.google.common.collect.TreeRangeSet
-import java.nio.file.Path
+import io.airbyte.cdk.file.LocalFile
 
 /**
  * Represents an accumulated batch of records in some stage of processing.
@@ -61,7 +61,7 @@ data class SimpleBatch(override val state: Batch.State) : Batch
 
 /** Represents a file of records locally staged. */
 abstract class StagedLocalFile() : Batch {
-    abstract val localPath: Path
+    abstract val localFile: LocalFile
     abstract val totalSizeBytes: Long
     override val state: Batch.State = Batch.State.LOCAL
 }
@@ -77,7 +77,7 @@ abstract class RemoteObject() : Batch {
  * framework
  */
 data class SpilledRawMessagesLocalFile(
-    override val localPath: Path,
+    override val localFile: LocalFile,
     override val totalSizeBytes: Long,
     override val state: Batch.State = Batch.State.SPILLED
 ) : StagedLocalFile()

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/message/MessageQueueReader.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/message/MessageQueueReader.kt
@@ -6,7 +6,7 @@ package io.airbyte.cdk.message
 
 import io.airbyte.cdk.command.DestinationStream
 import io.github.oshai.kotlinlogging.KotlinLogging
-import jakarta.inject.Singleton
+import io.micronaut.context.annotation.DefaultImplementation
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 
@@ -14,11 +14,11 @@ import kotlinx.coroutines.flow.flow
  * A reader should provide a byte-limited flow of messages of the underlying type. The flow should
  * terminate when maxBytes has been read, or when the stream is complete.
  */
+@DefaultImplementation(DestinationMessageQueueReader::class)
 interface MessageQueueReader<K, T> {
     suspend fun readChunk(key: K, maxBytes: Long): Flow<T>
 }
 
-@Singleton
 class DestinationMessageQueueReader(
     private val messageQueue: DestinationMessageQueue,
 ) : MessageQueueReader<DestinationStream, DestinationRecordWrapped> {

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/task/TeardownTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/task/TeardownTask.kt
@@ -36,8 +36,8 @@ interface TeardownTaskFactory {
 @Secondary
 class DefaultTeardownTaskFactory(
     private val destination: DestinationWriteOperation,
-) {
-    fun make(taskLauncher: DestinationTaskLauncher): TeardownTask {
+) : TeardownTaskFactory {
+    override fun make(taskLauncher: DestinationTaskLauncher): TeardownTask {
         return DefaultTeardownTask(destination, taskLauncher)
     }
 }

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/task/DestinationTaskLauncherTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/task/DestinationTaskLauncherTest.kt
@@ -10,6 +10,7 @@ import io.airbyte.cdk.command.DestinationCatalog
 import io.airbyte.cdk.command.DestinationStream
 import io.airbyte.cdk.command.MockCatalogFactory.Companion.stream1
 import io.airbyte.cdk.command.MockCatalogFactory.Companion.stream2
+import io.airbyte.cdk.file.DefaultLocalFile
 import io.airbyte.cdk.message.Batch
 import io.airbyte.cdk.message.BatchEnvelope
 import io.airbyte.cdk.message.CheckpointMessage
@@ -263,7 +264,9 @@ class DestinationTaskLauncherTest {
         launch {
             launcher.handleNewSpilledFile(
                 stream1,
-                BatchEnvelope(SpilledRawMessagesLocalFile(Path("not/a/real/file"), 100L))
+                BatchEnvelope(
+                    SpilledRawMessagesLocalFile(DefaultLocalFile(Path("not/a/real/file")), 100L)
+                )
             )
         }
 
@@ -326,7 +329,6 @@ class DestinationTaskLauncherTest {
         val hasRun = teardownTaskFactory.hasRun.tryReceive()
         Assertions.assertTrue(hasRun.isFailure)
         checkpointManager.hasBeenFlushed.receive() // Stream1 close triggered flush
-
         streamsManager.getManager(stream1).markClosed()
         delay(1000)
         val hasRun2 = teardownTaskFactory.hasRun.tryReceive()

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/task/SpillToDiskTaskTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/task/SpillToDiskTaskTest.kt
@@ -1,0 +1,201 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.task
+
+import io.airbyte.cdk.command.DefaultWriteConfiguration
+import io.airbyte.cdk.command.DestinationStream
+import io.airbyte.cdk.command.MockCatalogFactory.Companion.stream1
+import io.airbyte.cdk.command.WriteConfiguration
+import io.airbyte.cdk.data.NullValue
+import io.airbyte.cdk.file.FileReader
+import io.airbyte.cdk.file.FileWriter
+import io.airbyte.cdk.file.LocalFile
+import io.airbyte.cdk.file.TempFileProvider
+import io.airbyte.cdk.message.BatchEnvelope
+import io.airbyte.cdk.message.DestinationRecord
+import io.airbyte.cdk.message.DestinationRecordWrapped
+import io.airbyte.cdk.message.MessageQueueReader
+import io.airbyte.cdk.message.SpilledRawMessagesLocalFile
+import io.airbyte.cdk.message.StreamCompleteWrapped
+import io.airbyte.cdk.message.StreamRecordWrapped
+import io.airbyte.cdk.write.StreamLoader
+import io.micronaut.context.annotation.Factory
+import io.micronaut.context.annotation.Requires
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+import java.nio.file.Path
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicLong
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+@MicronautTest(environments = ["SpillToDiskTaskTest"])
+class SpillToDiskTaskTest {
+    @Inject lateinit var taskRunner: TaskRunner
+    @Inject lateinit var spillToDiskTaskFactory: DefaultSpillToDiskTaskFactory
+    @Inject lateinit var mockTempFileProvider: MockTempFileProvider
+
+    @Singleton
+    @Requires(env = ["SpillToDiskTaskTest"])
+    class MockTempFileProvider : TempFileProvider {
+        data class MockFile(
+            val path: Path,
+            val lines: MutableList<String> = mutableListOf(),
+            val isDeleted: Boolean = false,
+        )
+        private val tmpFileCounter = AtomicInteger(0)
+        val writerClosed = AtomicBoolean(false)
+        val mockFiles = mutableMapOf<String, MockFile>()
+        override fun createTempFile(directory: Path, prefix: String, suffix: String): LocalFile {
+            val path =
+                Path.of(
+                    directory.toString(),
+                    "/${prefix}-${tmpFileCounter.getAndIncrement()}${suffix}"
+                )
+            return object : LocalFile {
+                override fun toFileWriter(): FileWriter {
+                    val mockFile = MockFile(path)
+                    mockFiles[path.toString()] = mockFile
+
+                    return object : FileWriter {
+                        override fun write(str: String) {
+                            mockFile.lines.add(str)
+                        }
+
+                        override fun close() {
+                            writerClosed.set(true)
+                        }
+                    }
+                }
+
+                override fun toFileReader(): FileReader {
+                    throw NotImplementedError()
+                }
+
+                override fun delete() {
+                    throw NotImplementedError()
+                }
+            }
+        }
+    }
+
+    // TODO: Migrate this to a common mock.
+    class MockTaskLauncher(override val taskRunner: TaskRunner) : DestinationTaskLauncher {
+        val spilledFiles = mutableListOf<BatchEnvelope<SpilledRawMessagesLocalFile>>()
+
+        override suspend fun handleSetupComplete() {
+            throw NotImplementedError()
+        }
+
+        override suspend fun handleStreamOpen(streamLoader: StreamLoader) {
+            throw NotImplementedError()
+        }
+
+        override suspend fun handleNewSpilledFile(
+            stream: DestinationStream,
+            wrapped: BatchEnvelope<SpilledRawMessagesLocalFile>
+        ) {
+            spilledFiles.add(wrapped)
+        }
+
+        override suspend fun handleNewBatch(streamLoader: StreamLoader, wrapped: BatchEnvelope<*>) {
+            throw NotImplementedError()
+        }
+
+        override suspend fun handleStreamClosed(stream: DestinationStream) {
+            throw NotImplementedError()
+        }
+
+        override suspend fun handleTeardownComplete() {
+            throw NotImplementedError()
+        }
+
+        override suspend fun start() {
+            throw NotImplementedError()
+        }
+    }
+
+    @Factory
+    @Requires(env = ["SpillToDiskTaskTest"])
+    class MockDestinationTaskLauncherFactory {
+        @Singleton
+        fun mockDestinationTaskLauncher(taskRunner: TaskRunner): DestinationTaskLauncher {
+            return MockTaskLauncher(taskRunner)
+        }
+    }
+
+    @Singleton
+    @Requires(env = ["SpillToDiskTaskTest"])
+    class MockWriteConfiguration : DefaultWriteConfiguration(), WriteConfiguration {
+        override val recordBatchSizeBytes: Long = 1024L
+        override val tmpFileDirectory: Path = Path.of("/tmp-test")
+        override val firstStageTmpFilePrefix: String = "spilled"
+        override val firstStageTmpFileSuffix: String = ".jsonl"
+    }
+
+    @Singleton
+    @Requires(env = ["SpillToDiskTaskTest"])
+    class MockQueueReader : MessageQueueReader<DestinationStream, DestinationRecordWrapped> {
+        // Make enough records for a full batch + half a batch
+        private val maxRecords = ((1024 * 1.5) / 8).toLong()
+        private val recordsWritten = AtomicLong(0)
+        override suspend fun readChunk(
+            key: DestinationStream,
+            maxBytes: Long
+        ): Flow<DestinationRecordWrapped> = flow {
+            var totalBytes = 0
+            while (recordsWritten.get() < maxRecords) {
+                val index = recordsWritten.getAndIncrement()
+                emit(
+                    StreamRecordWrapped(
+                        index = index,
+                        sizeBytes = 8,
+                        record =
+                            DestinationRecord(
+                                stream = stream1,
+                                data = NullValue,
+                                emittedAtMs = 0,
+                                meta = null,
+                                serialized = "test${index}"
+                            )
+                    )
+                )
+                totalBytes += 8
+                if (totalBytes >= maxBytes) {
+                    return@flow
+                }
+            }
+            emit(StreamCompleteWrapped(index = maxRecords))
+        }
+    }
+
+    @Test
+    fun testSpillToDiskTask() = runTest {
+        val mockTaskLauncher = MockTaskLauncher(taskRunner)
+        spillToDiskTaskFactory.make(mockTaskLauncher, stream1).execute()
+        Assertions.assertEquals(2, mockTaskLauncher.spilledFiles.size)
+        Assertions.assertEquals(1024, mockTaskLauncher.spilledFiles[0].batch.totalSizeBytes)
+        Assertions.assertEquals(512, mockTaskLauncher.spilledFiles[1].batch.totalSizeBytes)
+        Assertions.assertTrue(mockTempFileProvider.writerClosed.get())
+        Assertions.assertEquals(2, mockTempFileProvider.mockFiles.size)
+
+        val expectedLinesFirst = (0 until 1024 / 8).flatMap { listOf("test$it", "\n") }
+        val expectedLinesSecond = (1024 / 8 until 1536 / 8).flatMap { listOf("test$it", "\n") }
+
+        Assertions.assertEquals(
+            expectedLinesFirst,
+            mockTempFileProvider.mockFiles.values.first().lines
+        )
+        Assertions.assertEquals(
+            expectedLinesSecond,
+            mockTempFileProvider.mockFiles.values.last().lines
+        )
+    }
+}


### PR DESCRIPTION
## What
* Unit tests for the spill-to-disk task.
* I audited the life-cycle of the temp spill file: it's guaranteed to last until explicitly deleted
* (Also I now explicitly delete the temp spill file)

Note: There are no tests around the delete, that will come from testing process records task (next pr)