### PR TITLE
Invoice Line Items and Subscription Items - Adding Incremental Syncing support

### DIFF
--- a/airbyte-integrations/connectors/source-stripe/erd/discovered_catalog.json
+++ b/airbyte-integrations/connectors/source-stripe/erd/discovered_catalog.json
@@ -12503,12 +12503,22 @@
                 }
               }
             }
+          },
+          "created": {
+            "description": "Timestamp for when the parent invoice was created",
+            "type": ["null", "integer"]
+          },
+          "updated": {
+            "description": "Timestamp for when the parent invoice was last updated",
+            "type": ["null", "integer"]
           }
         }
       },
-      "supported_sync_modes": ["full_refresh"],
+      "supported_sync_modes": ["full_refresh", "incremental"],
       "source_defined_primary_key": [["id"]],
-      "is_resumable": false
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated"],
+      "is_resumable": true
     },
     {
       "name": "subscription_items",

--- a/airbyte-integrations/connectors/source-stripe/erd/discovered_catalog.json
+++ b/airbyte-integrations/connectors/source-stripe/erd/discovered_catalog.json
@@ -12806,12 +12806,18 @@
               "unit_amount": { "type": ["null", "integer"] },
               "unit_amount_decimal": { "type": ["null", "string"] }
             }
+          },
+          "updated": {
+            "description": "Timestamp for when the parent subscription was last updated",
+            "type": ["null", "integer"]
           }
         }
       },
-      "supported_sync_modes": ["full_refresh"],
+      "supported_sync_modes": ["full_refresh", "incremental"],
       "source_defined_primary_key": [["id"]],
-      "is_resumable": false
+      "source_defined_cursor": true,
+      "default_cursor_field": ["updated"],
+      "is_resumable": true
     },
     {
       "name": "transfer_reversals",

--- a/airbyte-integrations/connectors/source-stripe/erd/source.dbml
+++ b/airbyte-integrations/connectors/source-stripe/erd/source.dbml
@@ -1141,6 +1141,8 @@ Table "invoice_line_items" {
     "discounts" array
     "tax_rates" array
     "tax_amounts" array
+    "created" integer
+    "updated" integer
 }
 
 Table "subscription_items" {

--- a/airbyte-integrations/connectors/source-stripe/erd/source.dbml
+++ b/airbyte-integrations/connectors/source-stripe/erd/source.dbml
@@ -1169,6 +1169,7 @@ Table "subscription_items" {
     "billing_thresholds" object
     "tax_rates" array
     "price" object
+    "updated" integer
 }
 
 Table "transfer_reversals" {

--- a/airbyte-integrations/connectors/source-stripe/metadata.yaml
+++ b/airbyte-integrations/connectors/source-stripe/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: e094cb9a-26de-4645-8761-65c0c425d1de
-  dockerImageTag: 5.6.0
+  dockerImageTag: 5.6.1
   dockerRepository: airbyte/source-stripe
   documentationUrl: https://docs.airbyte.com/integrations/sources/stripe
   erdUrl: https://dbdocs.io/airbyteio/source-stripe?view=relationships

--- a/airbyte-integrations/connectors/source-stripe/pyproject.toml
+++ b/airbyte-integrations/connectors/source-stripe/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "5.6.0"
+version = "5.6.1"
 name = "source-stripe"
 description = "Source implementation for Stripe."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/invoice_line_items.json
+++ b/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/invoice_line_items.json
@@ -297,6 +297,14 @@
           }
         }
       }
+    },
+    "created": {
+      "description": "Timestamp for when the parent invoice was created",
+      "type": ["null", "integer"]
+    },
+    "updated": {
+      "description": "Timestamp for when the parent invoice was last updated",
+      "type": ["null", "integer"]
     }
   }
 }

--- a/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/subscription_items.json
+++ b/airbyte-integrations/connectors/source-stripe/source_stripe/schemas/subscription_items.json
@@ -217,6 +217,10 @@
     "price": {
       "description": "Price of the subscription item.",
       "$ref": "price.json"
+    },
+    "updated": {
+      "description": "The timestamp at which the subscription was last updated.",
+      "type": ["null", "integer"]
     }
   }
 }

--- a/airbyte-integrations/connectors/source-stripe/source_stripe/source.py
+++ b/airbyte-integrations/connectors/source-stripe/source_stripe/source.py
@@ -206,13 +206,21 @@ class SourceStripe(ConcurrentSourceAdapter):
             ],
             **args,
         )
-        subscription_items = StripeLazySubStream(
+        subscription_items = UpdatedCursorIncrementalStripeLazySubStream(
             name="subscription_items",
             path="subscription_items",
-            extra_request_params=lambda self, stream_slice, *args, **kwargs: {"subscription": stream_slice["parent"]["id"]},
             parent=subscriptions,
+            extra_request_params=lambda self, stream_slice, *args, **kwargs: {
+                "subscription": stream_slice["parent"]["id"],
+                "created": stream_slice["parent"]["created"],
+                "updated": stream_slice["parent"]["updated"]
+            },
             use_cache=USE_CACHE,
             sub_items_attr="items",
+            event_types=[
+                "customer.subscription.created",
+                "customer.subscription.updated"
+            ],
             **args,
         )
         transfers = IncrementalStripeStream(

--- a/airbyte-integrations/connectors/source-stripe/source_stripe/source.py
+++ b/airbyte-integrations/connectors/source-stripe/source_stripe/source.py
@@ -213,14 +213,11 @@ class SourceStripe(ConcurrentSourceAdapter):
             extra_request_params=lambda self, stream_slice, *args, **kwargs: {
                 "subscription": stream_slice["parent"]["id"],
                 "created": stream_slice["parent"]["created"],
-                "updated": stream_slice["parent"]["updated"]
+                "updated": stream_slice["parent"]["updated"],
             },
             use_cache=USE_CACHE,
             sub_items_attr="items",
-            event_types=[
-                "customer.subscription.created",
-                "customer.subscription.updated"
-            ],
+            event_types=["customer.subscription.created", "customer.subscription.updated"],
             **args,
         )
         transfers = IncrementalStripeStream(
@@ -538,7 +535,7 @@ class SourceStripe(ConcurrentSourceAdapter):
                     "invoice_id": stream_slice["parent"]["id"],
                     "created": stream_slice["parent"]["created"],
                     "updated": stream_slice["parent"]["updated"],
-                    **record
+                    **record,
                 },
                 **args,
             ),


### PR DESCRIPTION
## What
* This PR adds support for incremental streams for two SubStreams, invoice_line_items and subscription_items. Previous to this PR, these two streams needed full loaded on every sync, even though the parent streams (invoices and subscriptions) are loaded incrementally based on when that parent object is updated. 

## How
*  I followed a pattern already laid for a different SubStream (bank_accounts), that uses the parent streams updated value to provide the needed cursor field to make the SubStream incremental. I've used that pattern to implement it with these two substreams.


## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
* What is the end result perceived by the user? A user syncing either the invoice line items stream or the subscription items stream will now be able to choose if they do a full refresh, full append, or incremental append. 
* If there are negative side effects, please list them. None I can think of.

## Can this PR be safely reverted and rolled back?
- [ ] YES 💚
- [ ] NO ❌
