### PR TITLE
📚 docs: fix background color on Card component

### DIFF
--- a/docusaurus/src/components/Card/Card.module.css
+++ b/docusaurus/src/components/Card/Card.module.css
@@ -6,7 +6,7 @@
   gap: 10px;
   border-radius: 24px;
   border: 1px solid var(--color-grey-100);
-  background: #fff;
+  background: var(--color-white);
   height: 100%;
 }
 
@@ -35,11 +35,11 @@
 
 .cardCtaPrimary {
   background-color: var(--color-dark-blue-700);
-  color: #fff;
+  color: var(--color-white);
 }
 .cardCtaPrimary a {
   text-decoration: none;
-  color: #fff;
+  color: var(--color-white);
 }
 
 .cardCtaSecondary {

--- a/docusaurus/src/css/custom.css
+++ b/docusaurus/src/css/custom.css
@@ -26,6 +26,7 @@
   --color-active-nav-item-background: #f4f4ff;
   --color-active-nav-item-text: var(--ifm-color-primary-darker);
 
+  --color-white: hsl(0, 0%, 100%);
   --color-grey-40: hsl(240, 25%, 98%);
   --color-grey-100: hsl(240, 12%, 92%);
   --color-grey-400: hsl(240, 10%, 59%);
@@ -50,9 +51,13 @@ html[data-theme="dark"] {
   --color-active-nav-item-text: var(--ifm-color-primary-lighter);
 
   --color-grey-40: hsl(240, 14%, 14%);
+   --color-grey-100: hsl(240, 15%, 15%);
   --color-grey-400: hsl(240, 13%, 72%);
+  --color-grey-500: hsl(240, 10%, 70%);
   --color-green-50: hsl(184, 100%, 12%);
   --color-blue-30: hsl(252, 25%, 18%);
+  --color-dark-blue-700: hsl(240, 100%, 98%);
+  --color-white: hsl(0, 0%, 16%);
 }
 
 .docusaurus-highlight-code-line {


### PR DESCRIPTION
## What
Using a hardcoded value for <Card /> background was causing contrast issues in dark theme. This PR fix that  by using a css variable and adding missing new colours for dark theme.

<img width="873" alt="Screenshot 2024-09-23 at 21 36 44" src="https://github.com/user-attachments/assets/d0dc8edf-19f3-4591-aeef-ba7d12830f41">

## How
- using css variables instead of hardcoded values
- defining missing variables in dark mode



## User Impact
- Correct colours and contrast in dark theme.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
