### PR TITLE
metadata-service[lib]: add commands to promote or pull release candidates

### DIFF
--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/commands.py
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/commands.py
@@ -5,8 +5,6 @@
 import pathlib
 
 import click
-from pydantic import ValidationError
-
 from metadata_service.constants import METADATA_FILE_NAME
 from metadata_service.gcs_upload import (
     MetadataDeleteInfo,
@@ -16,6 +14,7 @@ from metadata_service.gcs_upload import (
     upload_metadata_to_gcs,
 )
 from metadata_service.validators.metadata_validator import PRE_UPLOAD_VALIDATORS, ValidatorOptions, validate_and_load
+from pydantic import ValidationError
 
 
 def log_metadata_upload_info(metadata_upload_info: MetadataUploadInfo):

--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/commands.py
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/commands.py
@@ -7,7 +7,7 @@ import pathlib
 import click
 from pydantic import ValidationError
 
-from metadata_service.constants import METADATA_FILE_NAME, RELEASE_CANDIDATE_GCS_FOLDER_NAME
+from metadata_service.constants import METADATA_FILE_NAME
 from metadata_service.gcs_upload import (
     MetadataDeleteInfo,
     MetadataUploadInfo,

--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/commands.py
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/commands.py
@@ -5,13 +5,21 @@
 import pathlib
 
 import click
-from metadata_service.constants import METADATA_FILE_NAME
-from metadata_service.gcs_upload import MetadataUploadInfo, upload_metadata_to_gcs
-from metadata_service.validators.metadata_validator import PRE_UPLOAD_VALIDATORS, ValidatorOptions, validate_and_load
 from pydantic import ValidationError
+
+from metadata_service.constants import METADATA_FILE_NAME, RELEASE_CANDIDATE_GCS_FOLDER_NAME
+from metadata_service.gcs_upload import (
+    MetadataDeleteInfo,
+    MetadataUploadInfo,
+    delete_release_candidate_from_gcs,
+    promote_release_candidate_in_gcs,
+    upload_metadata_to_gcs,
+)
+from metadata_service.validators.metadata_validator import PRE_UPLOAD_VALIDATORS, ValidatorOptions, validate_and_load
 
 
 def log_metadata_upload_info(metadata_upload_info: MetadataUploadInfo):
+    """Log the results of the metadata upload."""
     for file in metadata_upload_info.uploaded_files:
         if file.uploaded:
             click.secho(f"File:{file.id} for {metadata_upload_info.metadata_file_path} was uploaded to {file.blob_id}.", fg="green")
@@ -19,6 +27,18 @@ def log_metadata_upload_info(metadata_upload_info: MetadataUploadInfo):
             click.secho(
                 f"File:{file.id} for {metadata_upload_info.metadata_file_path} was not uploaded.",
                 fg="yellow",
+            )
+
+
+def log_metadata_deletion_info(metadata_deletion_info: MetadataDeleteInfo):
+    """Log the results of the metadata deletion."""
+    for remote_file in metadata_deletion_info.deleted_files:
+        if remote_file.deleted:
+            click.secho(f"The {remote_file.description} was deleted ({remote_file.blob_id}).", fg="green")
+        else:
+            click.secho(
+                f"The {remote_file.description} was not deleted ({remote_file.blob_id}).",
+                fg="red",
             )
 
 
@@ -64,3 +84,30 @@ def upload(metadata_file_path: pathlib.Path, docs_path: pathlib.Path, bucket_nam
         exit(0)
     else:
         exit(5)
+
+
+@metadata_service.command(help="Rollback a release candidate by deleting its metadata files from a GCS bucket.")
+@click.argument("connector-docker-repository", type=click.STRING)
+@click.argument("connector-version", type=click.STRING)
+@click.argument("bucket-name", type=click.STRING)
+def rollback_release_candidate(connector_docker_repository: str, connector_version: str, bucket_name: str):
+    try:
+        deletion_info = delete_release_candidate_from_gcs(bucket_name, connector_docker_repository, connector_version)
+        log_metadata_deletion_info(deletion_info)
+    except (FileNotFoundError, ValueError) as e:
+        click.secho(f"The release candidate could not be deleted: {str(e)}", fg="red")
+        exit(1)
+
+
+@metadata_service.command(help="Promote a release candidate by moving its metadata files to the main release folder in a GCS bucket.")
+@click.argument("connector-docker-repository", type=click.STRING)
+@click.argument("connector-version", type=click.STRING)
+@click.argument("bucket-name", type=click.STRING)
+def promote_release_candidate(connector_docker_repository: str, connector_version: str, bucket_name: str):
+    try:
+        upload_info, deletion_info = promote_release_candidate_in_gcs(bucket_name, connector_docker_repository, connector_version)
+        log_metadata_upload_info(upload_info)
+        log_metadata_deletion_info(deletion_info)
+    except (FileNotFoundError, ValueError) as e:
+        click.secho(f"The release candidate could not be promoted: {str(e)}", fg="red")
+        exit(1)

--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/gcs_upload.py
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/gcs_upload.py
@@ -16,9 +16,6 @@ import requests
 import yaml
 from google.cloud import storage
 from google.oauth2 import service_account
-from pydash import set_
-from pydash.objects import get
-
 from metadata_service.constants import (
     COMPONENTS_PY_FILE_NAME,
     COMPONENTS_ZIP_FILE_NAME,
@@ -37,6 +34,8 @@ from metadata_service.models.generated.ConnectorMetadataDefinitionV0 import Conn
 from metadata_service.models.generated.GitInfo import GitInfo
 from metadata_service.models.transform import to_json_sanitized_dict
 from metadata_service.validators.metadata_validator import POST_UPLOAD_VALIDATORS, ValidatorOptions, validate_and_load
+from pydash import set_
+from pydash.objects import get
 
 # 🧩 TYPES
 

--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/gcs_upload.py
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/gcs_upload.py
@@ -606,7 +606,7 @@ def delete_release_candidate_from_gcs(bucket_name: str, docker_repository: str, 
         raise FileNotFoundError(f"Release candidate metadata file {rc_path} does not exist in the bucket. ")
     if rc_blob.md5_hash != version_blob.md5_hash:
         raise ValueError(
-            f"Release candidate metadata file {rc_path} hash does not match the version metadata file {version_path} hash. Unsafe to delete."
+            f"Release candidate metadata file {rc_path} hash does not match the version metadata file {version_path} hash. Unsafe to delete. Please check the Remote Release Candidate to confirm its the version you would like to remove and rerun with --force"
         )
 
     deleted_files = []

--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/gcs_upload.py
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/gcs_upload.py
@@ -136,14 +136,6 @@ def _write_metadata_to_tmp_file(metadata_dict: dict) -> Path:
 # 🛠️ HELPERS
 
 
-def _delete_blob_from_gcs(blob_to_delete: storage.blob.Blob) -> bool:
-    """Deletes a blob from the bucket."""
-    print(f"Deleting {blob_to_delete.name}...")
-    blob_to_delete.delete()
-
-    return True
-
-
 def _get_storage_client() -> storage.Client:
     """Get the GCS storage client using credentials form GCS_CREDENTIALS env variable."""
     gcs_creds = os.environ.get("GCS_CREDENTIALS")

--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/gcs_upload.py
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/gcs_upload.py
@@ -76,8 +76,8 @@ class MaybeUpload(NamedTuple):
 
 @dataclass
 class ManifestOnlyFilePaths:
-    zip_file_path: Path
-    sha256_file_path: Path
+    zip_file_path: Path | None
+    sha256_file_path: Path | None
     sha256: str | None
     manifest_file_path: Path
 
@@ -85,7 +85,7 @@ class ManifestOnlyFilePaths:
 # 🛣️ FILES AND PATHS
 
 
-def get_doc_local_file_path(metadata: ConnectorMetadataDefinitionV0, docs_path: Path, inapp: bool) -> Path:
+def get_doc_local_file_path(metadata: ConnectorMetadataDefinitionV0, docs_path: Path, inapp: bool) -> Optional[Path]:
     pattern = re.compile(r"^https://docs\.airbyte\.com/(.+)$")
     match = pattern.search(metadata.data.documentationUrl)
     if match:
@@ -211,7 +211,7 @@ def _get_git_info_for_file(original_metadata_file_path: Path) -> Optional[GitInf
 # 🚀 UPLOAD
 
 
-def _save_blob_to_gcs(blob_to_save: storage.blob.Blob, file_path: str, disable_cache: bool = False) -> bool:
+def _save_blob_to_gcs(blob_to_save: storage.blob.Blob, file_path: Path, disable_cache: bool = False) -> bool:
     """Uploads a file to the bucket."""
     print(f"Uploading {file_path} to {blob_to_save.name}...")
 
@@ -402,7 +402,6 @@ def _apply_modifications_to_metadata_file(
     metadata = _apply_prerelease_overrides(metadata, validator_opts)
     metadata = _apply_author_info_to_metadata_file(metadata, original_metadata_file_path)
     metadata = _apply_python_components_sha_to_metadata_file(metadata, components_zip_sha256)
-
     metadata = _apply_sbom_url_to_metadata_file(metadata)
     return _write_metadata_to_tmp_file(metadata)
 

--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/gcs_upload.py
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/gcs_upload.py
@@ -9,7 +9,7 @@ import re
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
-from typing import List, Literal, NamedTuple, Optional, Tuple
+from typing import List, NamedTuple, Optional, Tuple
 
 import git
 import requests
@@ -32,7 +32,7 @@ from metadata_service.constants import (
     METADATA_FOLDER,
     RELEASE_CANDIDATE_GCS_FOLDER_NAME,
 )
-from metadata_service.helpers.files import compute_gcs_md5, compute_sha256, create_zip_and_get_sha256
+from metadata_service.helpers.files import compute_gcs_md5, create_zip_and_get_sha256
 from metadata_service.models.generated.ConnectorMetadataDefinitionV0 import ConnectorMetadataDefinitionV0
 from metadata_service.models.generated.GitInfo import GitInfo
 from metadata_service.models.transform import to_json_sanitized_dict

--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/helpers/files.py
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/helpers/files.py
@@ -7,16 +7,16 @@ from pathlib import Path
 from typing import List
 
 
-def compute_gcs_md5(file_name: str) -> str:
+def compute_gcs_md5(file_name: Path) -> str:
     hash_md5 = hashlib.md5()
-    with open(file_name, "rb") as f:
+    with Path.open(file_name, "rb") as f:
         for chunk in iter(lambda: f.read(4096), b""):
             hash_md5.update(chunk)
 
     return base64.b64encode(hash_md5.digest()).decode("utf8")
 
 
-def compute_sha256(file_name: str) -> str:
+def compute_sha256(file_name: Path) -> str:
     hash_sha256 = hashlib.sha256()
     with Path.open(file_name, "rb") as f:
         for chunk in iter(lambda: f.read(4096), b""):

--- a/airbyte-ci/connectors/metadata_service/lib/pyproject.toml
+++ b/airbyte-ci/connectors/metadata_service/lib/pyproject.toml
@@ -1,10 +1,10 @@
 [tool.poetry]
 name = "metadata-service"
-version = "0.16.0"
+version = "0.17.0"
 description = ""
 authors = ["Ben Church <ben@airbyte.io>"]
 readme = "README.md"
-packages = [{include = "metadata_service"}]
+packages = [{ include = "metadata_service" }]
 
 [tool.poetry.dependencies]
 python = "~3.10"
@@ -17,7 +17,6 @@ google-cloud-storage = "^2.8.0"
 pydash = "^6.0.2"
 semver = "^3.0.1"
 gitpython = "^3.1.40"
-
 
 
 [tool.poetry.group.dev.dependencies]
@@ -44,3 +43,7 @@ poe_tasks = ["test"]
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.ruff]
+target-version = "py310"
+line-length = 140

--- a/airbyte-ci/connectors/metadata_service/lib/tests/test_gcs_upload.py
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/test_gcs_upload.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 #
 
-import json
 from pathlib import Path
 from typing import Optional
 
@@ -17,7 +16,6 @@ from metadata_service.constants import (
     METADATA_FILE_NAME,
     RELEASE_CANDIDATE_GCS_FOLDER_NAME,
 )
-from metadata_service.helpers import files
 from metadata_service.models.generated.ConnectorMetadataDefinitionV0 import ConnectorMetadataDefinitionV0
 from metadata_service.models.transform import to_json_sanitized_dict
 from metadata_service.validators.metadata_validator import ValidatorOptions
@@ -191,7 +189,7 @@ def setup_upload_mocks(
             else:
                 return mock_sha_version_blob
 
-        if file_path_str.endswith(f".zip"):
+        if file_path_str.endswith(".zip"):
             if is_latest:
                 return mock_zip_latest_blob
             else:
@@ -352,7 +350,7 @@ def test_upload_metadata_to_gcs_valid_metadata(
     mocker.spy(gcs_upload, "_file_upload")
     mocker.spy(gcs_upload, "upload_file_if_changed")
     for valid_metadata_upload_file in valid_metadata_upload_files:
-        print(f"\nTesting upload of valid metadata file: " + valid_metadata_upload_file)
+        print("\nTesting upload of valid metadata file: " + valid_metadata_upload_file)
         metadata_file_path = Path(valid_metadata_upload_file)
         metadata = ConnectorMetadataDefinitionV0.parse_obj(yaml.safe_load(metadata_file_path.read_text()))
         mocks = setup_upload_mocks(
@@ -490,7 +488,7 @@ def test_upload_invalid_metadata_to_gcs(mocker, invalid_metadata_yaml_files):
 
     # Test that all invalid metadata files throw a ValueError
     for invalid_metadata_file in invalid_metadata_yaml_files:
-        print(f"\nTesting upload of invalid metadata file: " + invalid_metadata_file)
+        print("\nTesting upload of invalid metadata file: " + invalid_metadata_file)
         metadata_file_path = Path(invalid_metadata_file)
 
         error_match_if_validation_fails_as_expected = "Validation error"
@@ -510,7 +508,7 @@ def test_upload_metadata_to_gcs_invalid_docker_images(mocker, invalid_metadata_u
 
     # Test that valid metadata files that reference invalid docker images throw a ValueError
     for invalid_metadata_file in invalid_metadata_upload_files:
-        print(f"\nTesting upload of valid metadata file with invalid docker image: " + invalid_metadata_file)
+        print("\nTesting upload of valid metadata file with invalid docker image: " + invalid_metadata_file)
         metadata_file_path = Path(invalid_metadata_file)
 
         error_match_if_validation_fails_as_expected = "does not exist in DockerHub"
@@ -534,7 +532,7 @@ def test_upload_metadata_to_gcs_with_prerelease(mocker, valid_metadata_upload_fi
         if tmp_metadata_file_path.exists():
             tmp_metadata_file_path.unlink()
 
-        print(f"\nTesting prerelease upload of valid metadata file: " + valid_metadata_upload_file)
+        print("\nTesting prerelease upload of valid metadata file: " + valid_metadata_upload_file)
         metadata_file_path = Path(valid_metadata_upload_file)
         metadata = ConnectorMetadataDefinitionV0.parse_obj(yaml.safe_load(metadata_file_path.read_text()))
         expected_version_key = f"metadata/{metadata.data.dockerRepository}/{prerelease_image_tag}/{METADATA_FILE_NAME}"


### PR DESCRIPTION
## What

This pull request reworks https://github.com/airbytehq/airbyte/pull/44876 on top of fresh master, as that one got difficult to resolve conflicts on.

It's the part of Augustin's stack that was closest to Master, so hypothetically as long as the happy path upload looks solid, this is safe to merge.

## Review guide
Really not much — look into `gcs_upload.py`. I especially would love a review from @bnchrch, @aaronsteers, and @clnoll.

Once we ship this, we should get the next two pull requests and test this thoroughly. I am worried that I might be missing some things about what happens when we uploaded an RC with custom components, but then decided to promote / pull it. should the components file be moved to a versioned dir? In theory, no, because it's already there.

TODOs:
- Should we consider checking SHAs of custom components of RC folder and versioned folder? Are custom component files uploaded twice or no?

