### PR TITLE
[source-mongodb] lazy init current iterator to prevent cursor timeout issue

### DIFF
--- a/airbyte-integrations/connectors/source-mongodb-v2/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mongodb-v2/metadata.yaml
@@ -8,7 +8,7 @@ data:
   connectorSubtype: database
   connectorType: source
   definitionId: b2e713cd-cc36-4c0a-b5bd-b47cb8a0561e
-  dockerImageTag: 1.5.10
+  dockerImageTag: 1.5.11
   dockerRepository: airbyte/source-mongodb-v2
   documentationUrl: https://docs.airbyte.com/integrations/sources/mongodb-v2
   githubIssueLabel: source-mongodb-v2

--- a/airbyte-integrations/connectors/source-mongodb-v2/src/main/java/io/airbyte/integrations/source/mongodb/MongoDbInitialLoadRecordIterator.java
+++ b/airbyte-integrations/connectors/source-mongodb-v2/src/main/java/io/airbyte/integrations/source/mongodb/MongoDbInitialLoadRecordIterator.java
@@ -68,7 +68,8 @@ public class MongoDbInitialLoadRecordIterator extends AbstractIterator<Document>
     this.currentState = existingState;
     this.isEnforceSchema = isEnforceSchema;
     this.chunkSize = chunkSize;
-    this.currentIterator = buildNewQueryIterator();
+    // lazy init mongo cursor, otherwise it will risk time out (10 minutes).
+    this.currentIterator = null;
     this.startInstant = startInstant;
     this.cdcInitialLoadTimeout = cdcInitialLoadTimeout;
   }
@@ -170,6 +171,9 @@ public class MongoDbInitialLoadRecordIterator extends AbstractIterator<Document>
 
   private boolean shouldBuildNextQuery() {
     // The next sub-query should be built if the previous subquery has finished.
+    if (currentIterator == null) {
+      currentIterator = buildNewQueryIterator();
+    }
     return !currentIterator.hasNext();
   }
 

--- a/docs/integrations/sources/mongodb-v2.md
+++ b/docs/integrations/sources/mongodb-v2.md
@@ -199,6 +199,7 @@ For more information regarding configuration parameters, please see [MongoDb Doc
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                   |
 |:--------|:-----------|:---------------------------------------------------------|:----------------------------------------------------------------------------------------------------------|
+| 1.5.11  | 2024-09-24 | [45883](https://github.com/airbytehq/airbyte/pull/45883) | Lazy init mongocursor to prevent timeout.                                                                 |
 | 1.5.10  | 2024-09-17 | [45639](https://github.com/airbytehq/airbyte/pull/45639) | Adopt latest CDK to use the latest apache sshd mina to handle tcpkeepalive requests.                      |
 | 1.5.9   | 2024-08-28 | [42927](https://github.com/airbytehq/airbyte/pull/42927) | Support binary subtype.                                                                                   |
 | 1.5.8   | 2024-08-27 | [44841](https://github.com/airbytehq/airbyte/pull/44841) | Adopt latest CDK.                                                                                         |


### PR DESCRIPTION
## What
attempt to fix https://github.com/airbytehq/oncall/issues/6486

We are seeing MongoCursorNotFoundException error, which is likely due to the cursor has been expired. We established cursor in the constructor, but we didn't use it until we finished all WASS logic. The cursor timeout is set to be 10 minutes by mongodb.

## How
<!--
* Describe how code changes achieve the solution.
-->

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
