### PR TITLE
Bulk cdk: unit test experimentation

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/message/DestinationMessageQueue.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/message/DestinationMessageQueue.kt
@@ -9,6 +9,7 @@ import io.airbyte.cdk.command.DestinationStream
 import io.airbyte.cdk.command.WriteConfiguration
 import io.airbyte.cdk.state.MemoryManager
 import io.github.oshai.kotlinlogging.KotlinLogging
+import io.micronaut.context.annotation.Secondary
 import jakarta.inject.Singleton
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicLong
@@ -48,6 +49,7 @@ data class StreamCompleteWrapped(
  * This maximum is expected to be low, as the assumption is that data will be spooled to disk as
  * quickly as possible.
  */
+@Secondary
 @Singleton
 class DestinationMessageQueue(
     catalog: DestinationCatalog,

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/state/CheckpointManager.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/state/CheckpointManager.kt
@@ -10,6 +10,7 @@ import io.airbyte.cdk.message.CheckpointMessage
 import io.airbyte.cdk.message.MessageConverter
 import io.airbyte.protocol.models.v0.AirbyteMessage
 import io.github.oshai.kotlinlogging.KotlinLogging
+import io.micronaut.context.annotation.Secondary
 import io.micronaut.core.util.clhm.ConcurrentLinkedHashMap
 import jakarta.inject.Singleton
 import java.util.concurrent.ConcurrentHashMap
@@ -167,6 +168,7 @@ abstract class StreamsCheckpointManager<T, U>() : CheckpointManager<DestinationS
     }
 }
 
+@Secondary
 @Singleton
 class DefaultCheckpointManager(
     override val catalog: DestinationCatalog,

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/state/StreamsManager.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/state/StreamsManager.kt
@@ -13,6 +13,7 @@ import io.airbyte.cdk.message.Batch
 import io.airbyte.cdk.message.BatchEnvelope
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.micronaut.context.annotation.Factory
+import io.micronaut.context.annotation.Secondary
 import jakarta.inject.Singleton
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicBoolean
@@ -28,6 +29,7 @@ interface StreamsManager {
     suspend fun awaitAllStreamsClosed()
 }
 
+@Secondary
 class DefaultStreamsManager(
     private val streamManagers: ConcurrentHashMap<DestinationStream, StreamManager>
 ) : StreamsManager {

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/message/MockStreamsManagerFactory.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/message/MockStreamsManagerFactory.kt
@@ -11,9 +11,10 @@ import io.airbyte.cdk.command.DestinationCatalog
 import io.airbyte.cdk.command.DestinationStream
 import io.airbyte.cdk.state.StreamManager
 import io.airbyte.cdk.state.StreamsManager
-import io.micronaut.context.annotation.Prototype
+import io.micronaut.context.annotation.Replaces
 import io.micronaut.context.annotation.Requires
 import jakarta.inject.Named
+import javax.inject.Singleton
 
 class MockStreamManager : StreamManager {
     var persistedRanges: RangeSet<Long> = TreeRangeSet.create()
@@ -67,8 +68,9 @@ class MockStreamManager : StreamManager {
     }
 }
 
-@Prototype
+@Singleton
 @Requires(env = ["MockStreamsManager"])
+@Replaces(StreamsManager::class)
 class MockStreamsManager(@Named("mockCatalog") catalog: DestinationCatalog) : StreamsManager {
     private val mockManagers = catalog.streams.associateWith { MockStreamManager() }
 


### PR DESCRIPTION
b/c I got curious about https://github.com/airbytehq/airbyte/pull/45107/

this is mostly noodling / checking my understanding, no real intent to merge.

roughly:
* replace all the prototypes with `Singleton` +  `rebuildContext = true`
* remove the TestDestinationMessageQueueWriterFactory and just inject the writer directly to the test class
    * not sure about this one, it required some micronaut tweaks in other areas. In particular the `@Replaces` thing.
* tag runtime CDK stuff as Secondary
* add the `Requires(env)` stuff - I think this is an example of the guidelines you described, just want to check my understanding (modulo using class name instead of hardcoded string)