### PR TITLE
📚docs: missing dark mode color

### DIFF
--- a/docusaurus/src/css/custom.css
+++ b/docusaurus/src/css/custom.css
@@ -51,9 +51,10 @@ html[data-theme="dark"] {
   --color-active-nav-item-text: var(--ifm-color-primary-lighter);
 
   --color-grey-40: hsl(240, 14%, 14%);
-   --color-grey-100: hsl(240, 15%, 15%);
+  --color-grey-100: hsl(240, 15%, 15%);
   --color-grey-400: hsl(240, 13%, 72%);
   --color-grey-500: hsl(240, 10%, 70%);
+  --color-grey-900: hsl(240, 10%, 90%);
   --color-green-50: hsl(184, 100%, 12%);
   --color-blue-30: hsl(252, 25%, 18%);
   --color-dark-blue-700: hsl(240, 100%, 98%);


### PR DESCRIPTION
Closes https://github.com/airbytehq/airbyte-internal-issues/issues/9980
## What

There were still a missing colour value in dark mode. It was causing issues on the <Chip /> component.
<img width="701" alt="Screenshot 2024-09-25 at 09 16 41" src="https://github.com/user-attachments/assets/f033e90b-0040-4bc7-8097-10a83401faa3">

## How
- Adding `--color-grey-100` value for dark theme



## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
