### PR TITLE
fix(airbyte-cdk): fix connector builder output serialization

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/connector_builder/main.py
+++ b/airbyte-cdk/python/airbyte_cdk/connector_builder/main.py
@@ -70,11 +70,11 @@ def handle_connector_builder_request(
         raise ValueError(f"Unrecognized command {command}.")
 
 
-def handle_request(args: List[str]) -> AirbyteMessage:
+def handle_request(args: List[str]) -> str:
     command, config, catalog, state = get_config_and_catalog_from_args(args)
     limits = get_limits(config)
     source = create_source(config, limits)
-    return AirbyteMessageSerializer.dump(handle_connector_builder_request(source, command, config, catalog, state, limits))  # type: ignore[no-any-return] # Serializer.dump() always returns AirbyteMessage
+    return orjson.dumps(AirbyteMessageSerializer.dump(handle_connector_builder_request(source, command, config, catalog, state, limits))).decode()  # type: ignore[no-any-return] # Serializer.dump() always returns AirbyteMessage
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

Reason: handle request should return str: https://github.com/airbytehq/airbyte/pull/44444/files#diff-2274e38cbe6011392ab3ba8908fffa4e0cd0d948621f728f9c06eb86c8c6a564R77
fix connector builder output serialization

## How

use `orjson`

## Review guide

1. `airbyte-cdk/python/airbyte_cdk/connector_builder/main.py`


## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
