### PR TITLE
bulk-cdk: remove redundant Jsons methods, remove guava dependency

### DIFF
--- a/airbyte-cdk/bulk/core/base/src/main/kotlin/io/airbyte/cdk/util/Jsons.kt
+++ b/airbyte-cdk/bulk/core/base/src/main/kotlin/io/airbyte/cdk/util/Jsons.kt
@@ -3,9 +3,7 @@ package io.airbyte.cdk.util
 
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.core.JsonGenerator
-import com.fasterxml.jackson.core.JsonProcessingException
 import com.fasterxml.jackson.databind.DeserializationFeature
-import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.node.ArrayNode
 import com.fasterxml.jackson.databind.node.BinaryNode
@@ -16,7 +14,6 @@ import com.fasterxml.jackson.databind.node.TextNode
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.afterburner.AfterburnerModule
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
-import java.io.IOException
 import java.math.BigDecimal
 import java.math.BigInteger
 import java.nio.ByteBuffer
@@ -58,32 +55,4 @@ object Jsons : ObjectMapper() {
     }
 
     fun booleanNode(boolean: Boolean): BooleanNode = nodeFactory.booleanNode(boolean)
-
-    fun <T> `object`(jsonNode: JsonNode?, klass: Class<T>?): T? {
-        return convertValue(jsonNode, klass)
-    }
-
-    fun <T> serialize(`object`: T): String {
-        try {
-            return writeValueAsString(`object`)
-        } catch (e: JsonProcessingException) {
-            throw RuntimeException(e)
-        }
-    }
-
-    fun <T> deserialize(jsonString: String?, klass: Class<T>?): T {
-        try {
-            return readValue(jsonString, klass)
-        } catch (e: IOException) {
-            throw RuntimeException(e)
-        }
-    }
-
-    fun deserialize(jsonString: String?): JsonNode {
-        try {
-            return readTree(jsonString)
-        } catch (e: IOException) {
-            throw RuntimeException(e)
-        }
-    }
 }

--- a/airbyte-cdk/bulk/toolkits/extract-cdc/build.gradle
+++ b/airbyte-cdk/bulk/toolkits/extract-cdc/build.gradle
@@ -4,6 +4,5 @@ dependencies {
     implementation 'io.debezium:debezium-api:2.7.1.Final'
     implementation 'io.debezium:debezium-embedded:2.7.1.Final'
 
-    api 'com.google.guava:guava:33.0.0-jre'
-    implementation 'commons-io:commons-io:2.11.0'
+    implementation 'commons-io:commons-io:2.17.0'
 }

--- a/airbyte-cdk/bulk/toolkits/extract-cdc/src/main/kotlin/io.airbyte.cdk/read/AirbyteFileOffsetBackingStore.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-cdc/src/main/kotlin/io.airbyte.cdk/read/AirbyteFileOffsetBackingStore.kt
@@ -4,7 +4,6 @@
 package io.airbyte.cdk.integrations.debezium.internals
 
 import com.fasterxml.jackson.databind.JsonNode
-import com.google.common.base.Preconditions
 import io.airbyte.protocol.models.Jsons
 import io.github.oshai.kotlinlogging.KotlinLogging
 import java.io.EOFException
@@ -207,12 +206,10 @@ class AirbyteFileOffsetBackingStore(
         }
 
         private fun byteBufferToString(byteBuffer: ByteBuffer?): String {
-            Preconditions.checkNotNull(byteBuffer)
             return String(byteBuffer!!.array(), StandardCharsets.UTF_8)
         }
 
         private fun stringToByteBuffer(s: String?): ByteBuffer {
-            Preconditions.checkNotNull(s)
             return ByteBuffer.wrap(s!!.toByteArray(StandardCharsets.UTF_8))
         }
 

--- a/airbyte-cdk/bulk/toolkits/extract-cdc/src/main/kotlin/io.airbyte.cdk/read/CdcPartitionReader.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-cdc/src/main/kotlin/io.airbyte.cdk/read/CdcPartitionReader.kt
@@ -5,7 +5,6 @@
 package io.airbyte.cdk.cdc
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.google.common.annotations.VisibleForTesting
 import io.airbyte.cdk.command.OpaqueStateValue
 import io.airbyte.cdk.read.CdcContext
 import io.airbyte.cdk.read.ConcurrencyResource
@@ -97,7 +96,7 @@ class CdcPartitionReader(
                 if (event.value() == null) {
                     return@notifying
                 }
-                val record = DebeziumRecord(Jsons.deserialize(event.value()))
+                val record = DebeziumRecord(Jsons.readTree(event.value()))
                 // TODO : Migrate over all of the timeout/heartbeat timeout logic
                 if (!record.isHeartbeat) {
                     numRecords++
@@ -158,7 +157,6 @@ class CdcPartitionReader(
      * [DebeziumRecordIterator.heartbeatEventSourceField] acts as a cache so that we avoid using
      * reflection to setAccessible for each event
      */
-    @VisibleForTesting
     internal fun getSourceRecord(heartbeatEvent: ChangeEvent<String?, String?>): SourceRecord {
         try {
             val eventClass: Class<out ChangeEvent<*, *>?> = heartbeatEvent.javaClass


### PR DESCRIPTION
## What
This PR removes redundant methods added to `Jsons` from the legacy `Jsons`. These methods are not necessary because there exist Jackson equivalents which are just as easy to use and are better known.

This PR also removes a dependency on Guava in the CDC package.

This PR is required by upcoming changes.

## How
n/a

## Review guide
This PR does not change any functionality whatsoever.

## User Impact
None

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
