### PR TITLE
Bulk CDK Core: Rename ConfigJsonObj to ConnectorSpecification

### DIFF
--- a/airbyte-cdk/bulk/core/base/src/main/kotlin/io/airbyte/cdk/command/Configuration.kt
+++ b/airbyte-cdk/bulk/core/base/src/main/kotlin/io/airbyte/cdk/command/Configuration.kt
@@ -5,6 +5,6 @@ package io.airbyte.cdk.command
  * Interface that defines a typed connector configuration.
  *
  * Prefer this or its implementations over the corresponding configuration POJOs; i.e.
- * [ConfigurationJsonObjectBase] subclasses.
+ * [ConfigurationSpecification] subclasses.
  */
 interface Configuration

--- a/airbyte-cdk/bulk/core/base/src/main/kotlin/io/airbyte/cdk/command/ConfigurationSpecificationSupplier.kt
+++ b/airbyte-cdk/bulk/core/base/src/main/kotlin/io/airbyte/cdk/command/ConfigurationSpecificationSupplier.kt
@@ -25,7 +25,7 @@ import java.util.function.Supplier
  * The object is also validated against its [jsonSchema] JSON schema, derived from [javaClass].
  */
 @Singleton
-class ConfigurationJsonObjectSupplier<T : ConfigurationJsonObjectBase>(
+class ConfigurationSpecificationSupplier<T : ConfigurationSpecification>(
     private val micronautPropertiesFallback: T,
     @Value("\${${CONNECTOR_CONFIG_PREFIX}.json}") private val jsonPropertyValue: String? = null,
 ) : Supplier<T> {
@@ -51,8 +51,9 @@ class ConfigurationJsonObjectSupplier<T : ConfigurationJsonObjectBase>(
  * Connector configuration POJO supertype.
  *
  * This dummy base class is required by Micronaut. Without it, thanks to Java's type erasure, it
- * thinks that the [ConfigurationJsonObjectSupplier] requires a constructor argument of type [Any].
+ * thinks that the [ConfigurationSpecificationSupplier] requires a constructor argument of type
+ * [Any].
  *
  * Strictly speaking, its subclasses are not really POJOs anymore, but who cares.
  */
-abstract class ConfigurationJsonObjectBase
+abstract class ConfigurationSpecification

--- a/airbyte-cdk/bulk/core/base/src/main/kotlin/io/airbyte/cdk/spec/SpecOperation.kt
+++ b/airbyte-cdk/bulk/core/base/src/main/kotlin/io/airbyte/cdk/spec/SpecOperation.kt
@@ -2,7 +2,7 @@
 package io.airbyte.cdk.spec
 
 import io.airbyte.cdk.Operation
-import io.airbyte.cdk.command.ConfigurationJsonObjectSupplier
+import io.airbyte.cdk.command.ConfigurationSpecificationSupplier
 import io.airbyte.cdk.output.OutputConsumer
 import io.airbyte.protocol.models.v0.ConnectorSpecification
 import io.micronaut.context.annotation.DefaultImplementation
@@ -15,7 +15,7 @@ import java.net.URI
 @Requires(property = Operation.PROPERTY, value = "spec")
 class SpecOperation(
     @Value("\${airbyte.connector.metadata.documentation-url}") val documentationUrl: String,
-    val configJsonObjectSupplier: ConfigurationJsonObjectSupplier<*>,
+    val configJsonObjectSupplier: ConfigurationSpecificationSupplier<*>,
     val extendSpecification: SpecificationExtender,
     val outputConsumer: OutputConsumer,
 ) : Operation {

--- a/airbyte-cdk/bulk/core/base/src/main/kotlin/io/airbyte/cdk/ssh/SshTunnelMethodConfiguration.kt
+++ b/airbyte-cdk/bulk/core/base/src/main/kotlin/io/airbyte/cdk/ssh/SshTunnelMethodConfiguration.kt
@@ -98,7 +98,7 @@ data class SshPasswordAuthTunnelMethod(
 ) : SshTunnelMethodConfiguration
 
 @ConfigurationProperties("$CONNECTOR_CONFIG_PREFIX.tunnel_method")
-class MicronautPropertiesFriendlySshTunnelMethodConfigurationJsonObject {
+class MicronautPropertiesFriendlySshTunnelMethodConfigurationSpecification {
     var tunnelMethod: String = "NO_TUNNEL"
     var tunnelHost: String? = null
     var tunnelPort: Int = 22

--- a/airbyte-cdk/bulk/core/base/src/testFixtures/kotlin/io/airbyte/cdk/command/CliRunner.kt
+++ b/airbyte-cdk/bulk/core/base/src/testFixtures/kotlin/io/airbyte/cdk/command/CliRunner.kt
@@ -33,7 +33,7 @@ data object CliRunner {
      */
     fun source(
         op: String,
-        config: ConfigurationJsonObjectBase? = null,
+        config: ConfigurationSpecification? = null,
         catalog: ConfiguredAirbyteCatalog? = null,
         state: List<AirbyteStateMessage>? = null,
     ): CliRunnable {
@@ -48,7 +48,7 @@ data object CliRunner {
     /** Same as [source] but for destinations. */
     fun destination(
         op: String,
-        config: ConfigurationJsonObjectBase? = null,
+        config: ConfigurationSpecification? = null,
         catalog: ConfiguredAirbyteCatalog? = null,
         state: List<AirbyteStateMessage>? = null,
         inputStream: InputStream,
@@ -68,7 +68,7 @@ data object CliRunner {
     /** Same as the other [destination] but with [AirbyteMessage] input. */
     fun destination(
         op: String,
-        config: ConfigurationJsonObjectBase? = null,
+        config: ConfigurationSpecification? = null,
         catalog: ConfiguredAirbyteCatalog? = null,
         state: List<AirbyteStateMessage>? = null,
         vararg input: AirbyteMessage,
@@ -87,7 +87,7 @@ data object CliRunner {
 
     private fun makeRunnable(
         op: String,
-        config: ConfigurationJsonObjectBase?,
+        config: ConfigurationSpecification?,
         catalog: ConfiguredAirbyteCatalog?,
         state: List<AirbyteStateMessage>?,
         connectorRunnerConstructor: (Array<String>) -> AirbyteConnectorRunner,

--- a/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/check/CheckOperation.kt
+++ b/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/check/CheckOperation.kt
@@ -3,8 +3,8 @@ package io.airbyte.cdk.check
 
 import io.airbyte.cdk.ConfigErrorException
 import io.airbyte.cdk.Operation
-import io.airbyte.cdk.command.ConfigurationJsonObjectBase
-import io.airbyte.cdk.command.ConfigurationJsonObjectSupplier
+import io.airbyte.cdk.command.ConfigurationSpecification
+import io.airbyte.cdk.command.ConfigurationSpecificationSupplier
 import io.airbyte.cdk.command.SourceConfiguration
 import io.airbyte.cdk.command.SourceConfigurationFactory
 import io.airbyte.cdk.discover.MetadataQuerier
@@ -18,8 +18,8 @@ import jakarta.inject.Singleton
 @Singleton
 @Requires(property = Operation.PROPERTY, value = "check")
 @Requires(env = ["source"])
-class CheckOperation<T : ConfigurationJsonObjectBase>(
-    val configJsonObjectSupplier: ConfigurationJsonObjectSupplier<T>,
+class CheckOperation<T : ConfigurationSpecification>(
+    val configJsonObjectSupplier: ConfigurationSpecificationSupplier<T>,
     val configFactory: SourceConfigurationFactory<T, out SourceConfiguration>,
     val metadataQuerierFactory: MetadataQuerier.Factory<SourceConfiguration>,
     val outputConsumer: OutputConsumer,

--- a/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/command/SourceConfiguration.kt
+++ b/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/command/SourceConfiguration.kt
@@ -18,14 +18,14 @@ interface SourceConfiguration : Configuration, SshTunnelConfiguration {
     val resourceAcquisitionHeartbeat: Duration
 
     /**
-     * Micronaut factory which glues [ConfigurationJsonObjectSupplier] and
+     * Micronaut factory which glues [ConfigurationSpecificationSupplier] and
      * [SourceConfigurationFactory] together to produce a [SourceConfiguration] singleton.
      */
     @Factory
     private class MicronautFactory {
         @Singleton
-        fun <I : ConfigurationJsonObjectBase> sourceConfig(
-            pojoSupplier: ConfigurationJsonObjectSupplier<I>,
+        fun <I : ConfigurationSpecification> sourceConfig(
+            pojoSupplier: ConfigurationSpecificationSupplier<I>,
             factory: SourceConfigurationFactory<I, out SourceConfiguration>,
         ): SourceConfiguration = factory.make(pojoSupplier.get())
     }

--- a/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/command/SourceConfigurationFactory.kt
+++ b/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/command/SourceConfigurationFactory.kt
@@ -8,13 +8,13 @@ import io.airbyte.cdk.ConfigErrorException
  * configuration JSON object to a typed [Configuration] implementation which is more directly useful
  * to the rest of the connector.
  */
-interface SourceConfigurationFactory<I : ConfigurationJsonObjectBase, O : SourceConfiguration> {
+interface SourceConfigurationFactory<I : ConfigurationSpecification, O : SourceConfiguration> {
     fun makeWithoutExceptionHandling(pojo: I): O
 
     /** Wraps [makeWithoutExceptionHandling] exceptions in [ConfigErrorException]. */
-    fun make(pojo: I): O =
+    fun make(spec: I): O =
         try {
-            makeWithoutExceptionHandling(pojo)
+            makeWithoutExceptionHandling(spec)
         } catch (e: Exception) {
             // Wrap NPEs (mostly) in ConfigErrorException.
             throw ConfigErrorException("Failed to build ConnectorConfiguration.", e)

--- a/airbyte-cdk/bulk/core/extract/src/test/kotlin/io/airbyte/cdk/check/CheckTest.kt
+++ b/airbyte-cdk/bulk/core/extract/src/test/kotlin/io/airbyte/cdk/check/CheckTest.kt
@@ -2,7 +2,7 @@
 package io.airbyte.cdk.check
 
 import io.airbyte.cdk.Operation
-import io.airbyte.cdk.fakesource.FakeSourceConfigurationJsonObject
+import io.airbyte.cdk.fakesource.FakeSourceConfigurationSpecification
 import io.airbyte.cdk.output.BufferingOutputConsumer
 import io.airbyte.protocol.models.v0.AirbyteConnectionStatus
 import io.micronaut.context.annotation.Property
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.Test
 @MicronautTest(environments = ["source"], rebuildContext = true)
 @Property(name = Operation.PROPERTY, value = "check")
 class CheckTest {
-    @Inject lateinit var checkOperation: CheckOperation<FakeSourceConfigurationJsonObject>
+    @Inject lateinit var checkOperation: CheckOperation<FakeSourceConfigurationSpecification>
 
     @Inject lateinit var outputConsumer: BufferingOutputConsumer
 

--- a/airbyte-cdk/bulk/core/extract/src/test/kotlin/io/airbyte/cdk/command/ConfigurationSpecificationSupplierTest.kt
+++ b/airbyte-cdk/bulk/core/extract/src/test/kotlin/io/airbyte/cdk/command/ConfigurationSpecificationSupplierTest.kt
@@ -2,7 +2,7 @@
 package io.airbyte.cdk.command
 
 import io.airbyte.cdk.ConfigErrorException
-import io.airbyte.cdk.fakesource.FakeSourceConfigurationJsonObject
+import io.airbyte.cdk.fakesource.FakeSourceConfigurationSpecification
 import io.airbyte.cdk.ssh.SshNoTunnelMethod
 import io.airbyte.cdk.ssh.SshPasswordAuthTunnelMethod
 import io.airbyte.cdk.util.Jsons
@@ -14,13 +14,16 @@ import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 
 @MicronautTest(rebuildContext = true)
-class ConfigurationJsonObjectSupplierTest {
+class ConfigurationSpecificationSupplierTest {
     @Inject
-    lateinit var supplier: ConfigurationJsonObjectSupplier<FakeSourceConfigurationJsonObject>
+    lateinit var supplier: ConfigurationSpecificationSupplier<FakeSourceConfigurationSpecification>
 
     @Test
     fun testSchema() {
-        Assertions.assertEquals(FakeSourceConfigurationJsonObject::class.java, supplier.javaClass)
+        Assertions.assertEquals(
+            FakeSourceConfigurationSpecification::class.java,
+            supplier.javaClass
+        )
         val expected: String = ResourceUtils.readResource("fakesource/expected-schema.json")
         Assertions.assertEquals(Jsons.readTree(expected), supplier.jsonSchema)
     }
@@ -29,7 +32,7 @@ class ConfigurationJsonObjectSupplierTest {
     @Property(name = "airbyte.connector.config.host", value = "hello")
     @Property(name = "airbyte.connector.config.database", value = "testdb")
     fun testPropertyInjection() {
-        val pojo: FakeSourceConfigurationJsonObject = supplier.get()
+        val pojo: FakeSourceConfigurationSpecification = supplier.get()
         Assertions.assertEquals("hello", pojo.host)
         Assertions.assertEquals("testdb", pojo.database)
         Assertions.assertEquals(SshNoTunnelMethod, pojo.getTunnelMethodValue())
@@ -46,7 +49,7 @@ class ConfigurationJsonObjectSupplierTest {
         value = """{"host":"hello","port":123,"database":"testdb"}""",
     )
     fun testGoodJson() {
-        val pojo: FakeSourceConfigurationJsonObject = supplier.get()
+        val pojo: FakeSourceConfigurationSpecification = supplier.get()
         Assertions.assertEquals("hello", pojo.host)
         Assertions.assertEquals(123, pojo.port)
         Assertions.assertEquals("testdb", pojo.database)
@@ -74,7 +77,7 @@ class ConfigurationJsonObjectSupplierTest {
         value = "secret",
     )
     fun testPropertySubTypeInjection() {
-        val pojo: FakeSourceConfigurationJsonObject = supplier.get()
+        val pojo: FakeSourceConfigurationSpecification = supplier.get()
         Assertions.assertEquals("hello", pojo.host)
         Assertions.assertEquals("testdb", pojo.database)
         val expected = SshPasswordAuthTunnelMethod("localhost", 22, "sshuser", "secret")

--- a/airbyte-cdk/bulk/core/extract/src/test/kotlin/io/airbyte/cdk/fakesource/FakeSourceConfiguration.kt
+++ b/airbyte-cdk/bulk/core/extract/src/test/kotlin/io/airbyte/cdk/fakesource/FakeSourceConfiguration.kt
@@ -33,9 +33,9 @@ data class FakeSourceConfiguration(
 @Requires(env = [Environment.TEST])
 @Secondary
 class FakeSourceConfigurationFactory :
-    SourceConfigurationFactory<FakeSourceConfigurationJsonObject, FakeSourceConfiguration> {
+    SourceConfigurationFactory<FakeSourceConfigurationSpecification, FakeSourceConfiguration> {
     override fun makeWithoutExceptionHandling(
-        pojo: FakeSourceConfigurationJsonObject,
+        pojo: FakeSourceConfigurationSpecification,
     ): FakeSourceConfiguration {
         val sshConnectionOptions: SshConnectionOptions =
             SshConnectionOptions.fromAdditionalProperties(pojo.getAdditionalProperties())

--- a/airbyte-cdk/bulk/core/extract/src/test/kotlin/io/airbyte/cdk/fakesource/FakeSourceConfigurationSpecification.kt
+++ b/airbyte-cdk/bulk/core/extract/src/test/kotlin/io/airbyte/cdk/fakesource/FakeSourceConfigurationSpecification.kt
@@ -18,15 +18,15 @@ import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaInject
 import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaTitle
 import io.airbyte.cdk.ConfigErrorException
 import io.airbyte.cdk.command.CONNECTOR_CONFIG_PREFIX
-import io.airbyte.cdk.command.ConfigurationJsonObjectBase
-import io.airbyte.cdk.ssh.MicronautPropertiesFriendlySshTunnelMethodConfigurationJsonObject
+import io.airbyte.cdk.command.ConfigurationSpecification
+import io.airbyte.cdk.ssh.MicronautPropertiesFriendlySshTunnelMethodConfigurationSpecification
 import io.airbyte.cdk.ssh.SshTunnelMethodConfiguration
 import io.micronaut.context.annotation.ConfigurationBuilder
 import io.micronaut.context.annotation.ConfigurationProperties
 import io.micronaut.context.annotation.Secondary
 import jakarta.inject.Singleton
 
-/** [ConfigurationJsonObjectBase] implementation for a fake source. */
+/** [ConfigurationSpecification] implementation for a fake source. */
 @JsonSchemaTitle("Test Source Spec")
 @JsonPropertyOrder(
     value =
@@ -42,7 +42,7 @@ import jakarta.inject.Singleton
 @Singleton
 @Secondary
 @ConfigurationProperties(CONNECTOR_CONFIG_PREFIX)
-class FakeSourceConfigurationJsonObject : ConfigurationJsonObjectBase() {
+class FakeSourceConfigurationSpecification : ConfigurationSpecification() {
     @JsonProperty("host")
     @JsonSchemaTitle("Host")
     @JsonSchemaInject(json = """{"order":1}""")
@@ -72,7 +72,7 @@ class FakeSourceConfigurationJsonObject : ConfigurationJsonObjectBase() {
 
     @JsonIgnore
     @ConfigurationBuilder(configurationPrefix = "tunnel_method")
-    val tunnelMethod = MicronautPropertiesFriendlySshTunnelMethodConfigurationJsonObject()
+    val tunnelMethod = MicronautPropertiesFriendlySshTunnelMethodConfigurationSpecification()
 
     @JsonIgnore var tunnelMethodJson: SshTunnelMethodConfiguration? = null
 

--- a/airbyte-cdk/bulk/core/extract/src/testFixtures/kotlin/io/airbyte/cdk/command/SyncsTestFixture.kt
+++ b/airbyte-cdk/bulk/core/extract/src/testFixtures/kotlin/io/airbyte/cdk/command/SyncsTestFixture.kt
@@ -49,7 +49,7 @@ data object SyncsTestFixture {
         )
 
     fun testCheck(
-        configPojo: ConfigurationJsonObjectBase,
+        configPojo: ConfigurationSpecification,
         expectedFailure: String? = null,
     ) {
         val checkOutput: BufferingOutputConsumer = CliRunner.source("check", configPojo).run()
@@ -70,7 +70,7 @@ data object SyncsTestFixture {
     }
 
     fun testDiscover(
-        configPojo: ConfigurationJsonObjectBase,
+        configPojo: ConfigurationSpecification,
         expectedCatalog: AirbyteCatalog,
     ) {
         val discoverOutput: BufferingOutputConsumer = CliRunner.source("discover", configPojo).run()
@@ -78,7 +78,7 @@ data object SyncsTestFixture {
     }
 
     fun testDiscover(
-        configPojo: ConfigurationJsonObjectBase,
+        configPojo: ConfigurationSpecification,
         expectedCatalogResource: String,
     ) {
         testDiscover(configPojo, catalogFromResource(expectedCatalogResource))
@@ -90,7 +90,7 @@ data object SyncsTestFixture {
             AirbyteCatalog::class.java,
         )
 
-    fun <T : ConfigurationJsonObjectBase> testReads(
+    fun <T : ConfigurationSpecification> testReads(
         configPojo: T,
         connectionSupplier: Supplier<Connection>,
         prelude: (Connection) -> Unit,
@@ -109,7 +109,7 @@ data object SyncsTestFixture {
         }
     }
 
-    fun <T : ConfigurationJsonObjectBase> testReads(
+    fun <T : ConfigurationSpecification> testReads(
         configPojo: T,
         connectionSupplier: Supplier<Connection>,
         prelude: (Connection) -> Unit,
@@ -127,7 +127,7 @@ data object SyncsTestFixture {
         )
     }
 
-    fun <T : ConfigurationJsonObjectBase> testSyncs(
+    fun <T : ConfigurationSpecification> testSyncs(
         configPojo: T,
         connectionSupplier: Supplier<Connection>,
         prelude: (Connection) -> Unit,
@@ -148,7 +148,7 @@ data object SyncsTestFixture {
         }
     }
 
-    fun <T : ConfigurationJsonObjectBase> testSyncs(
+    fun <T : ConfigurationSpecification> testSyncs(
         configPojo: T,
         connectionSupplier: Supplier<Connection>,
         prelude: (Connection) -> Unit,

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/check/CheckOperation.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/check/CheckOperation.kt
@@ -5,8 +5,8 @@
 package io.airbyte.cdk.check
 
 import io.airbyte.cdk.Operation
-import io.airbyte.cdk.command.ConfigurationJsonObjectBase
-import io.airbyte.cdk.command.ConfigurationJsonObjectSupplier
+import io.airbyte.cdk.command.ConfigurationSpecification
+import io.airbyte.cdk.command.ConfigurationSpecificationSupplier
 import io.airbyte.cdk.command.DestinationConfiguration
 import io.airbyte.cdk.command.DestinationConfigurationFactory
 import io.airbyte.cdk.output.ExceptionHandler
@@ -19,8 +19,8 @@ import jakarta.inject.Singleton
 @Singleton
 @Requires(property = Operation.PROPERTY, value = "check")
 @Requires(env = ["destination"])
-class CheckOperation<T : ConfigurationJsonObjectBase, C : DestinationConfiguration>(
-    val configJsonObjectSupplier: ConfigurationJsonObjectSupplier<T>,
+class CheckOperation<T : ConfigurationSpecification, C : DestinationConfiguration>(
+    val configJsonObjectSupplier: ConfigurationSpecificationSupplier<T>,
     val configFactory: DestinationConfigurationFactory<T, C>,
     private val destinationChecker: DestinationChecker<C>,
     private val exceptionHandler: ExceptionHandler,

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/command/DestinationConfiguration.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/command/DestinationConfiguration.kt
@@ -20,17 +20,15 @@ abstract class DestinationConfiguration : Configuration {
         0.1 // 0 => No overhead, 1.0 => 100% overhead
 
     /**
-     * Micronaut factory which glues [ConfigurationJsonObjectSupplier] and
+     * Micronaut factory which glues [ConfigurationSpecificationSupplier] and
      * [DestinationConfigurationFactory] together to produce a [DestinationConfiguration] singleton.
      */
     @Factory
     private class MicronautFactory {
         @Singleton
-        fun <I : ConfigurationJsonObjectBase> destinationConfig(
-            pojoSupplier: ConfigurationJsonObjectSupplier<I>,
+        fun <I : ConfigurationSpecification> destinationConfig(
+            specificationSupplier: ConfigurationSpecificationSupplier<I>,
             factory: DestinationConfigurationFactory<I, out DestinationConfiguration>,
-        ): DestinationConfiguration {
-            return factory.make(pojoSupplier.get())
-        }
+        ): DestinationConfiguration = factory.make(specificationSupplier.get())
     }
 }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/command/DestinationConfigurationFactory.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/command/DestinationConfigurationFactory.kt
@@ -7,13 +7,13 @@ package io.airbyte.cdk.command
 import io.airbyte.cdk.ConfigErrorException
 
 interface DestinationConfigurationFactory<
-    I : ConfigurationJsonObjectBase, O : DestinationConfiguration> {
+    I : ConfigurationSpecification, O : DestinationConfiguration> {
     fun makeWithoutExceptionHandling(pojo: I): O
 
     /** Wraps [makeWithoutExceptionHandling] exceptions in [ConfigErrorException]. */
-    fun make(pojo: I): O =
+    fun make(spec: I): O =
         try {
-            makeWithoutExceptionHandling(pojo)
+            makeWithoutExceptionHandling(spec)
         } catch (e: Exception) {
             // Wrap NPEs (mostly) in ConfigErrorException.
             throw ConfigErrorException("Failed to build ConnectorConfiguration.", e)

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/spec/DestinationSpecificationInternal.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/spec/DestinationSpecificationInternal.kt
@@ -13,7 +13,7 @@ import jakarta.inject.Singleton
 @Singleton
 @Replaces(IdentitySpecificationExtender::class)
 @Requires(env = ["destination"])
-class DestinationSpecificationExtender(private val spec: DestinationSpecificationInternal) :
+class DestinationSpecificationExtender(private val spec: DestinationSpecificationExtension) :
     SpecificationExtender {
     override fun invoke(specification: ConnectorSpecification): ConnectorSpecification {
         return specification
@@ -22,7 +22,7 @@ class DestinationSpecificationExtender(private val spec: DestinationSpecificatio
     }
 }
 
-interface DestinationSpecificationInternal {
+interface DestinationSpecificationExtension {
     val supportedSyncModes: List<DestinationSyncMode>
     val supportsIncremental: Boolean
 }

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/test/check/CheckIntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/test/check/CheckIntegrationTest.kt
@@ -4,7 +4,7 @@
 
 package io.airbyte.cdk.test.check
 
-import io.airbyte.cdk.command.ConfigurationJsonObjectBase
+import io.airbyte.cdk.command.ConfigurationSpecification
 import io.airbyte.cdk.command.ValidatedJsonUtils
 import io.airbyte.cdk.test.util.FakeDataDumper
 import io.airbyte.cdk.test.util.IntegrationTest
@@ -21,7 +21,7 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertAll
 
-open class CheckIntegrationTest<T : ConfigurationJsonObjectBase>(
+open class CheckIntegrationTest<T : ConfigurationSpecification>(
     val configurationClass: Class<T>,
     val successConfigFilenames: List<String>,
     val failConfigFilenamesAndFailureReasons: Map<String, Pattern>,

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/test/util/DestinationProcess.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/test/util/DestinationProcess.kt
@@ -7,7 +7,7 @@ package io.airbyte.cdk.test.util
 import com.fasterxml.jackson.databind.JsonNode
 import io.airbyte.cdk.command.CliRunnable
 import io.airbyte.cdk.command.CliRunner
-import io.airbyte.cdk.command.ConfigurationJsonObjectBase
+import io.airbyte.cdk.command.ConfigurationSpecification
 import io.airbyte.protocol.models.Jsons
 import io.airbyte.protocol.models.v0.AirbyteMessage
 import io.airbyte.protocol.models.v0.ConfiguredAirbyteCatalog
@@ -52,14 +52,14 @@ interface DestinationProcess {
 interface DestinationProcessFactory {
     fun createDestinationProcess(
         command: String,
-        config: ConfigurationJsonObjectBase? = null,
+        config: ConfigurationSpecification? = null,
         catalog: ConfiguredAirbyteCatalog? = null,
     ): DestinationProcess
 }
 
 class NonDockerizedDestination(
     command: String,
-    config: ConfigurationJsonObjectBase?,
+    config: ConfigurationSpecification?,
     catalog: ConfiguredAirbyteCatalog?,
 ) : DestinationProcess {
     private val destinationStdinPipe: PrintWriter
@@ -107,7 +107,7 @@ class NonDockerizedDestination(
 class NonDockerizedDestinationFactory : DestinationProcessFactory {
     override fun createDestinationProcess(
         command: String,
-        config: ConfigurationJsonObjectBase?,
+        config: ConfigurationSpecification?,
         catalog: ConfiguredAirbyteCatalog?
     ): DestinationProcess {
         return NonDockerizedDestination(command, config, catalog)

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/test/util/IntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/test/util/IntegrationTest.kt
@@ -5,7 +5,7 @@
 package io.airbyte.cdk.test.util
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
-import io.airbyte.cdk.command.ConfigurationJsonObjectBase
+import io.airbyte.cdk.command.ConfigurationSpecification
 import io.airbyte.cdk.command.DestinationCatalog
 import io.airbyte.cdk.command.DestinationStream
 import io.airbyte.cdk.message.DestinationMessage
@@ -81,7 +81,7 @@ abstract class IntegrationTest(
 
     /** Convenience wrapper for [runSync] using a single stream. */
     fun runSync(
-        config: ConfigurationJsonObjectBase,
+        config: ConfigurationSpecification,
         stream: DestinationStream,
         messages: List<DestinationMessage>,
         streamStatus: AirbyteStreamStatus? = AirbyteStreamStatus.COMPLETE,
@@ -95,7 +95,7 @@ abstract class IntegrationTest(
      * want to send multiple stream status messages).
      */
     fun runSync(
-        config: ConfigurationJsonObjectBase,
+        config: ConfigurationSpecification,
         catalog: DestinationCatalog,
         messages: List<DestinationMessage>,
         streamStatus: AirbyteStreamStatus? = AirbyteStreamStatus.COMPLETE,

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/test/write/BasicFunctionalityIntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/test/write/BasicFunctionalityIntegrationTest.kt
@@ -5,7 +5,7 @@
 package io.airbyte.cdk.test.write
 
 import io.airbyte.cdk.command.Append
-import io.airbyte.cdk.command.ConfigurationJsonObjectBase
+import io.airbyte.cdk.command.ConfigurationSpecification
 import io.airbyte.cdk.command.DestinationStream
 import io.airbyte.cdk.data.ObjectTypeWithoutSchema
 import io.airbyte.cdk.message.DestinationRecord
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertAll
 
 abstract class BasicFunctionalityIntegrationTest(
-    val config: ConfigurationJsonObjectBase,
+    val config: ConfigurationSpecification,
     dataDumper: DestinationDataDumper,
     destinationCleaner: DestinationCleaner,
     recordMangler: ExpectedRecordMapper = NoopExpectedRecordMapper,

--- a/airbyte-cdk/bulk/toolkits/extract-jdbc/src/main/kotlin/io/airbyte/cdk/command/JdbcSourceConfiguration.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-jdbc/src/main/kotlin/io/airbyte/cdk/command/JdbcSourceConfiguration.kt
@@ -23,14 +23,14 @@ interface JdbcSourceConfiguration : SourceConfiguration {
         get() = true
 
     /**
-     * Micronaut factory which glues [ConfigurationJsonObjectSupplier] and
+     * Micronaut factory which glues [ConfigurationSpecificationSupplier] and
      * [SourceConfigurationFactory] together to produce a [JdbcSourceConfiguration] singleton.
      */
     @Factory
     private class MicronautFactory {
         @Singleton
-        fun <I : ConfigurationJsonObjectBase> jdbcSourceConfig(
-            pojoSupplier: ConfigurationJsonObjectSupplier<I>,
+        fun <I : ConfigurationSpecification> jdbcSourceConfig(
+            pojoSupplier: ConfigurationSpecificationSupplier<I>,
             factory: SourceConfigurationFactory<I, out JdbcSourceConfiguration>,
         ): JdbcSourceConfiguration = factory.make(pojoSupplier.get())
     }

--- a/airbyte-cdk/bulk/toolkits/extract-jdbc/src/test/kotlin/io/airbyte/cdk/discover/JdbcMetadataQuerierTest.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-jdbc/src/test/kotlin/io/airbyte/cdk/discover/JdbcMetadataQuerierTest.kt
@@ -6,7 +6,7 @@ import io.airbyte.cdk.check.JdbcCheckQueries
 import io.airbyte.cdk.h2.H2TestFixture
 import io.airbyte.cdk.h2source.H2SourceConfiguration
 import io.airbyte.cdk.h2source.H2SourceConfigurationFactory
-import io.airbyte.cdk.h2source.H2SourceConfigurationJsonObject
+import io.airbyte.cdk.h2source.H2SourceConfigurationSpecification
 import io.airbyte.cdk.h2source.H2SourceOperations
 import io.airbyte.cdk.jdbc.DefaultJdbcConstants
 import io.airbyte.protocol.models.v0.StreamDescriptor
@@ -32,7 +32,7 @@ class JdbcMetadataQuerierTest {
     @Test
     fun test() {
         val configPojo =
-            H2SourceConfigurationJsonObject().apply {
+            H2SourceConfigurationSpecification().apply {
                 port = h2.port
                 database = h2.database
             }

--- a/airbyte-cdk/bulk/toolkits/extract-jdbc/src/test/kotlin/io/airbyte/cdk/h2source/H2SourceIntegrationTest.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-jdbc/src/test/kotlin/io/airbyte/cdk/h2source/H2SourceIntegrationTest.kt
@@ -20,7 +20,7 @@ class H2SourceIntegrationTest {
     fun testCheckFailBadConfig() {
         SyncsTestFixture.testCheck(
             configPojo =
-                H2SourceConfigurationJsonObject().apply {
+                H2SourceConfigurationSpecification().apply {
                     port = -1
                     database = ""
                 },
@@ -32,7 +32,7 @@ class H2SourceIntegrationTest {
     fun testCheckFailNoDatabase() {
         H2TestFixture().use { h2: H2TestFixture ->
             val configPojo =
-                H2SourceConfigurationJsonObject().apply {
+                H2SourceConfigurationSpecification().apply {
                     port = h2.port
                     database = h2.database + "_garbage"
                 }
@@ -44,7 +44,7 @@ class H2SourceIntegrationTest {
     fun testCheckFailNoTables() {
         H2TestFixture().use { h2: H2TestFixture ->
             val configPojo =
-                H2SourceConfigurationJsonObject().apply {
+                H2SourceConfigurationSpecification().apply {
                     port = h2.port
                     database = h2.database
                 }
@@ -57,7 +57,7 @@ class H2SourceIntegrationTest {
         H2TestFixture().use { h2: H2TestFixture ->
             h2.createConnection().use(Companion::prelude)
             val configPojo =
-                H2SourceConfigurationJsonObject().apply {
+                H2SourceConfigurationSpecification().apply {
                     port = h2.port
                     database = h2.database
                 }
@@ -72,7 +72,7 @@ class H2SourceIntegrationTest {
             Testcontainers.exposeHostPorts(h2.port)
             SshBastionContainer(tunnelingToHostPort = h2.port).use { ssh: SshBastionContainer ->
                 val configPojo =
-                    H2SourceConfigurationJsonObject().apply {
+                    H2SourceConfigurationSpecification().apply {
                         host =
                             DOCKER_HOST_FROM_WITHIN_CONTAINER // required only because of container
                         port = h2.port
@@ -91,7 +91,7 @@ class H2SourceIntegrationTest {
         H2TestFixture().use { h2: H2TestFixture ->
             h2.createConnection().use(Companion::prelude)
             val configPojo =
-                H2SourceConfigurationJsonObject().apply {
+                H2SourceConfigurationSpecification().apply {
                     port = h2.port
                     database = h2.database
                 }
@@ -103,7 +103,7 @@ class H2SourceIntegrationTest {
     fun testReadStreams() {
         H2TestFixture().use { h2: H2TestFixture ->
             val configPojo =
-                H2SourceConfigurationJsonObject().apply {
+                H2SourceConfigurationSpecification().apply {
                     port = h2.port
                     database = h2.database
                     resumablePreferred = true
@@ -128,7 +128,7 @@ class H2SourceIntegrationTest {
     fun testReadStreamStateTooFarAhead() {
         H2TestFixture().use { h2: H2TestFixture ->
             val configPojo =
-                H2SourceConfigurationJsonObject().apply {
+                H2SourceConfigurationSpecification().apply {
                     port = h2.port
                     database = h2.database
                     resumablePreferred = true
@@ -150,7 +150,7 @@ class H2SourceIntegrationTest {
     fun testReadBadCatalog() {
         H2TestFixture().use { h2: H2TestFixture ->
             val configPojo =
-                H2SourceConfigurationJsonObject().apply {
+                H2SourceConfigurationSpecification().apply {
                     port = h2.port
                     database = h2.database
                     resumablePreferred = true

--- a/airbyte-cdk/bulk/toolkits/extract-jdbc/src/test/kotlin/io/airbyte/cdk/jdbc/JdbcConnectionFactoryTest.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-jdbc/src/test/kotlin/io/airbyte/cdk/jdbc/JdbcConnectionFactoryTest.kt
@@ -3,7 +3,7 @@ package io.airbyte.cdk.jdbc
 
 import io.airbyte.cdk.h2.H2TestFixture
 import io.airbyte.cdk.h2source.H2SourceConfigurationFactory
-import io.airbyte.cdk.h2source.H2SourceConfigurationJsonObject
+import io.airbyte.cdk.h2source.H2SourceConfigurationSpecification
 import io.airbyte.cdk.ssh.SshBastionContainer
 import io.airbyte.cdk.testcontainers.DOCKER_HOST_FROM_WITHIN_CONTAINER
 import org.junit.jupiter.api.Assertions
@@ -22,7 +22,7 @@ class JdbcConnectionFactoryTest {
     @Test
     fun testVanilla() {
         val configPojo =
-            H2SourceConfigurationJsonObject().apply {
+            H2SourceConfigurationSpecification().apply {
                 port = h2.port
                 database = h2.database
             }
@@ -33,7 +33,7 @@ class JdbcConnectionFactoryTest {
     @Test
     fun testSshKeyAuth() {
         val configPojo =
-            H2SourceConfigurationJsonObject().apply {
+            H2SourceConfigurationSpecification().apply {
                 host = DOCKER_HOST_FROM_WITHIN_CONTAINER // required only because of container
                 port = h2.port
                 database = h2.database
@@ -46,7 +46,7 @@ class JdbcConnectionFactoryTest {
     @Test
     fun testSshPasswordAuth() {
         val configPojo =
-            H2SourceConfigurationJsonObject().apply {
+            H2SourceConfigurationSpecification().apply {
                 host = DOCKER_HOST_FROM_WITHIN_CONTAINER // required only because of container
                 port = h2.port
                 database = h2.database

--- a/airbyte-cdk/bulk/toolkits/extract-jdbc/src/test/kotlin/io/airbyte/cdk/read/JdbcSelectQuerierTest.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-jdbc/src/test/kotlin/io/airbyte/cdk/read/JdbcSelectQuerierTest.kt
@@ -7,7 +7,7 @@ import io.airbyte.cdk.discover.Field
 import io.airbyte.cdk.h2.H2TestFixture
 import io.airbyte.cdk.h2source.H2SourceConfiguration
 import io.airbyte.cdk.h2source.H2SourceConfigurationFactory
-import io.airbyte.cdk.h2source.H2SourceConfigurationJsonObject
+import io.airbyte.cdk.h2source.H2SourceConfigurationSpecification
 import io.airbyte.cdk.jdbc.IntFieldType
 import io.airbyte.cdk.jdbc.JdbcConnectionFactory
 import io.airbyte.cdk.jdbc.StringFieldType
@@ -80,8 +80,8 @@ class JdbcSelectQuerierTest {
         q: SelectQuery,
         vararg expectedJson: String,
     ) {
-        val configPojo: H2SourceConfigurationJsonObject =
-            H2SourceConfigurationJsonObject().apply {
+        val configPojo: H2SourceConfigurationSpecification =
+            H2SourceConfigurationSpecification().apply {
                 port = h2.port
                 database = h2.database
             }

--- a/airbyte-cdk/bulk/toolkits/extract-jdbc/src/testFixtures/kotlin/io/airbyte/cdk/h2source/H2SourceConfiguration.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-jdbc/src/testFixtures/kotlin/io/airbyte/cdk/h2source/H2SourceConfiguration.kt
@@ -38,9 +38,9 @@ data class H2SourceConfiguration(
 @Requires(env = [Environment.TEST])
 @Secondary
 class H2SourceConfigurationFactory :
-    SourceConfigurationFactory<H2SourceConfigurationJsonObject, H2SourceConfiguration> {
+    SourceConfigurationFactory<H2SourceConfigurationSpecification, H2SourceConfiguration> {
     override fun makeWithoutExceptionHandling(
-        pojo: H2SourceConfigurationJsonObject,
+        pojo: H2SourceConfigurationSpecification,
     ): H2SourceConfiguration {
         val sshConnectionOptions: SshConnectionOptions =
             SshConnectionOptions.fromAdditionalProperties(pojo.getAdditionalProperties())

--- a/airbyte-cdk/bulk/toolkits/extract-jdbc/src/testFixtures/kotlin/io/airbyte/cdk/h2source/H2SourceConfigurationSpecification.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-jdbc/src/testFixtures/kotlin/io/airbyte/cdk/h2source/H2SourceConfigurationSpecification.kt
@@ -19,15 +19,15 @@ import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaTitle
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 import io.airbyte.cdk.ConfigErrorException
 import io.airbyte.cdk.command.CONNECTOR_CONFIG_PREFIX
-import io.airbyte.cdk.command.ConfigurationJsonObjectBase
-import io.airbyte.cdk.ssh.MicronautPropertiesFriendlySshTunnelMethodConfigurationJsonObject
+import io.airbyte.cdk.command.ConfigurationSpecification
+import io.airbyte.cdk.ssh.MicronautPropertiesFriendlySshTunnelMethodConfigurationSpecification
 import io.airbyte.cdk.ssh.SshTunnelMethodConfiguration
 import io.micronaut.context.annotation.ConfigurationBuilder
 import io.micronaut.context.annotation.ConfigurationProperties
 import io.micronaut.context.annotation.Secondary
 import jakarta.inject.Singleton
 
-/** [ConfigurationJsonObjectBase] implementation for [H2Source]. */
+/** [ConfigurationSpecification] implementation for [H2Source]. */
 @JsonSchemaTitle("Test Source Spec")
 @JsonPropertyOrder(
     value =
@@ -44,7 +44,7 @@ import jakarta.inject.Singleton
 @Secondary
 @ConfigurationProperties(CONNECTOR_CONFIG_PREFIX)
 @SuppressFBWarnings(value = ["NP_NONNULL_RETURN_VIOLATION"], justification = "Micronaut DI")
-class H2SourceConfigurationJsonObject : ConfigurationJsonObjectBase() {
+class H2SourceConfigurationSpecification : ConfigurationSpecification() {
     @JsonProperty("host")
     @JsonSchemaTitle("Host")
     @JsonSchemaInject(json = """{"order":1}""")
@@ -74,7 +74,7 @@ class H2SourceConfigurationJsonObject : ConfigurationJsonObjectBase() {
 
     @JsonIgnore
     @ConfigurationBuilder(configurationPrefix = "tunnel_method")
-    val tunnelMethod = MicronautPropertiesFriendlySshTunnelMethodConfigurationJsonObject()
+    val tunnelMethod = MicronautPropertiesFriendlySshTunnelMethodConfigurationSpecification()
 
     @JsonIgnore var tunnelMethodJson: SshTunnelMethodConfiguration? = null
 

--- a/airbyte-integrations/connectors/source-mysql-v2/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mysql-v2/metadata.yaml
@@ -9,7 +9,7 @@ data:
   connectorSubtype: database
   connectorType: source
   definitionId: 561393ed-7e3a-4d0d-8b8b-90ded371754c
-  dockerImageTag: 0.0.11
+  dockerImageTag: 0.0.12
   dockerRepository: airbyte/source-mysql-v2
   documentationUrl: https://docs.airbyte.com/integrations/sources/mysql
   githubIssueLabel: source-mysql-v2

--- a/airbyte-integrations/connectors/source-mysql-v2/src/main/kotlin/io/airbyte/integrations/source/mysql/MysqlSourceConfigurationJsonObject.kt
+++ b/airbyte-integrations/connectors/source-mysql-v2/src/main/kotlin/io/airbyte/integrations/source/mysql/MysqlSourceConfigurationJsonObject.kt
@@ -19,8 +19,8 @@ import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaTitle
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 import io.airbyte.cdk.ConfigErrorException
 import io.airbyte.cdk.command.CONNECTOR_CONFIG_PREFIX
-import io.airbyte.cdk.command.ConfigurationJsonObjectBase
-import io.airbyte.cdk.ssh.MicronautPropertiesFriendlySshTunnelMethodConfigurationJsonObject
+import io.airbyte.cdk.command.ConfigurationSpecification
+import io.airbyte.cdk.ssh.MicronautPropertiesFriendlySshTunnelMethodConfigurationSpecification
 import io.airbyte.cdk.ssh.SshTunnelMethodConfiguration
 import io.micronaut.context.annotation.ConfigurationBuilder
 import io.micronaut.context.annotation.ConfigurationProperties
@@ -51,7 +51,7 @@ import jakarta.inject.Singleton
 @Singleton
 @ConfigurationProperties(CONNECTOR_CONFIG_PREFIX)
 @SuppressFBWarnings(value = ["NP_NONNULL_RETURN_VIOLATION"], justification = "Micronaut DI")
-class MysqlSourceConfigurationJsonObject : ConfigurationJsonObjectBase() {
+class MysqlSourceConfigurationJsonObject : ConfigurationSpecification() {
     @JsonProperty("host")
     @JsonSchemaTitle("Host")
     @JsonSchemaInject(json = """{"order":1}""")
@@ -116,7 +116,7 @@ class MysqlSourceConfigurationJsonObject : ConfigurationJsonObjectBase() {
 
     @JsonIgnore
     @ConfigurationBuilder(configurationPrefix = "tunnel_method")
-    val tunnelMethod = MicronautPropertiesFriendlySshTunnelMethodConfigurationJsonObject()
+    val tunnelMethod = MicronautPropertiesFriendlySshTunnelMethodConfigurationSpecification()
 
     @JsonIgnore var tunnelMethodJson: SshTunnelMethodConfiguration? = null
 

--- a/airbyte-integrations/connectors/source-mysql-v2/src/test/kotlin/io/airbyte/integrations/source/mysql/MysqlSourceConfigurationJsonObjectTest.kt
+++ b/airbyte-integrations/connectors/source-mysql-v2/src/test/kotlin/io/airbyte/integrations/source/mysql/MysqlSourceConfigurationJsonObjectTest.kt
@@ -2,7 +2,7 @@
 package io.airbyte.integrations.source.mysql
 
 import io.airbyte.cdk.ConfigErrorException
-import io.airbyte.cdk.command.ConfigurationJsonObjectSupplier
+import io.airbyte.cdk.command.ConfigurationSpecificationSupplier
 import io.airbyte.cdk.ssh.SshPasswordAuthTunnelMethod
 import io.airbyte.cdk.ssh.SshTunnelMethodConfiguration
 import io.micronaut.context.annotation.Property
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.Test
 @MicronautTest(environments = [Environment.TEST], rebuildContext = true)
 class MysqlSourceConfigurationJsonObjectTest {
     @Inject
-    lateinit var supplier: ConfigurationJsonObjectSupplier<MysqlSourceConfigurationJsonObject>
+    lateinit var supplier: ConfigurationSpecificationSupplier<MysqlSourceConfigurationJsonObject>
 
     @Test
     fun testSchemaViolation() {

--- a/airbyte-integrations/connectors/source-mysql-v2/src/test/kotlin/io/airbyte/integrations/source/mysql/MysqlSourceConfigurationTest.kt
+++ b/airbyte-integrations/connectors/source-mysql-v2/src/test/kotlin/io/airbyte/integrations/source/mysql/MysqlSourceConfigurationTest.kt
@@ -1,7 +1,7 @@
 /* Copyright (c) 2024 Airbyte, Inc., all rights reserved. */
 package io.airbyte.integrations.source.mysql
 
-import io.airbyte.cdk.command.ConfigurationJsonObjectSupplier
+import io.airbyte.cdk.command.ConfigurationSpecificationSupplier
 import io.airbyte.cdk.command.SourceConfigurationFactory
 import io.micronaut.context.annotation.Property
 import io.micronaut.context.env.Environment
@@ -13,7 +13,8 @@ import org.junit.jupiter.api.Test
 @MicronautTest(environments = [Environment.TEST], rebuildContext = true)
 class MysqlSourceConfigurationTest {
     @Inject
-    lateinit var pojoSupplier: ConfigurationJsonObjectSupplier<MysqlSourceConfigurationJsonObject>
+    lateinit var pojoSupplier:
+        ConfigurationSpecificationSupplier<MysqlSourceConfigurationJsonObject>
 
     @Inject
     lateinit var factory:


### PR DESCRIPTION
## What
A name change suggestion: replace CofigObjectJsonBase with ConnectorSpecification, so it's more clear what's going on. (Inject into spec, copy from spec to config.) We're doing this in load land in the new DevNull connector (DevNullSpecification -> DevNullConfiguration), and the naming makes things a bit more clean. Might not work for you all, I can see arguments against it. Let me know if you want to adopt!