### PR TITLE
fix(source-mssql): connect to named instance

### DIFF
--- a/airbyte-integrations/connectors/source-mssql/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mssql/metadata.yaml
@@ -9,7 +9,7 @@ data:
   connectorSubtype: database
   connectorType: source
   definitionId: b5ea17b1-f170-46dc-bc31-cc744ca984c1
-  dockerImageTag: 4.1.14
+  dockerImageTag: 4.1.15
   dockerRepository: airbyte/source-mssql
   documentationUrl: https://docs.airbyte.com/integrations/sources/mssql
   githubIssueLabel: source-mssql

--- a/airbyte-integrations/connectors/source-mssql/src/main/java/io/airbyte/integrations/source/mssql/MssqlSource.java
+++ b/airbyte-integrations/connectors/source-mssql/src/main/java/io/airbyte/integrations/source/mssql/MssqlSource.java
@@ -154,11 +154,22 @@ public class MssqlSource extends AbstractJdbcSource<JDBCType> implements Source 
   public JsonNode toDatabaseConfig(final JsonNode mssqlConfig) {
     final List<String> additionalParameters = new ArrayList<>();
 
-    final StringBuilder jdbcUrl = new StringBuilder(
+    StringBuilder jdbcUrl = null;
+    if(mssqlConfig.has(JdbcUtils.PORT_KEY)){
+
+       jdbcUrl = new StringBuilder(
         String.format("jdbc:sqlserver://%s:%s;databaseName=%s;",
             mssqlConfig.get(JdbcUtils.HOST_KEY).asText(),
             mssqlConfig.get(JdbcUtils.PORT_KEY).asText(),
             mssqlConfig.get(JdbcUtils.DATABASE_KEY).asText()));
+    }
+    else{
+      jdbcUrl = new StringBuilder(
+        String.format("jdbc:sqlserver://%s;databaseName=%s;",
+            mssqlConfig.get(JdbcUtils.HOST_KEY).asText(),
+            mssqlConfig.get(JdbcUtils.DATABASE_KEY).asText()));
+
+    }
 
     if (mssqlConfig.has("schemas") && mssqlConfig.get("schemas").isArray()) {
       schemas = new ArrayList<>();

--- a/airbyte-integrations/connectors/source-mssql/src/main/java/io/airbyte/integrations/source/mssql/MssqlSource.java
+++ b/airbyte-integrations/connectors/source-mssql/src/main/java/io/airbyte/integrations/source/mssql/MssqlSource.java
@@ -155,19 +155,18 @@ public class MssqlSource extends AbstractJdbcSource<JDBCType> implements Source 
     final List<String> additionalParameters = new ArrayList<>();
 
     StringBuilder jdbcUrl = null;
-    if(mssqlConfig.has(JdbcUtils.PORT_KEY)){
+    if (mssqlConfig.has(JdbcUtils.PORT_KEY)) {
 
-       jdbcUrl = new StringBuilder(
-        String.format("jdbc:sqlserver://%s:%s;databaseName=%s;",
-            mssqlConfig.get(JdbcUtils.HOST_KEY).asText(),
-            mssqlConfig.get(JdbcUtils.PORT_KEY).asText(),
-            mssqlConfig.get(JdbcUtils.DATABASE_KEY).asText()));
-    }
-    else{
       jdbcUrl = new StringBuilder(
-        String.format("jdbc:sqlserver://%s;databaseName=%s;",
-            mssqlConfig.get(JdbcUtils.HOST_KEY).asText(),
-            mssqlConfig.get(JdbcUtils.DATABASE_KEY).asText()));
+          String.format("jdbc:sqlserver://%s:%s;databaseName=%s;",
+              mssqlConfig.get(JdbcUtils.HOST_KEY).asText(),
+              mssqlConfig.get(JdbcUtils.PORT_KEY).asText(),
+              mssqlConfig.get(JdbcUtils.DATABASE_KEY).asText()));
+    } else {
+      jdbcUrl = new StringBuilder(
+          String.format("jdbc:sqlserver://%s;databaseName=%s;",
+              mssqlConfig.get(JdbcUtils.HOST_KEY).asText(),
+              mssqlConfig.get(JdbcUtils.DATABASE_KEY).asText()));
 
     }
 

--- a/airbyte-integrations/connectors/source-mssql/src/main/resources/spec.json
+++ b/airbyte-integrations/connectors/source-mssql/src/main/resources/spec.json
@@ -4,7 +4,7 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "MSSQL Source Spec",
     "type": "object",
-    "required": ["host", "port", "database", "username", "password"],
+    "required": ["host", "database", "username", "password"],
     "properties": {
       "host": {
         "description": "The hostname of the database.",


### PR DESCRIPTION
"For optimal connection performance, you should set the portNumber when you connect to a named instance. This will avoid a round trip to the server to determine the port number. If both a portNumber and instanceName are used, the portNumber will take precedence and the instanceName will be ignored."

https://learn.microsoft.com/en-us/sql/connect/jdbc/building-the-connection-url?view=sql-server-ver16

## What
I changed the default setting of the port, and don't apply it to the connection string

## How
new connection string 

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
No default port needed for mssql server 

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ x ] YES 💚
- [ ] NO ❌
