### PR TITLE
[ONCALL #6327] have headers match during HTTP cache hit

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/http/http_client.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/http/http_client.py
@@ -134,7 +134,7 @@ class HttpClient:
                 sqlite_path = str(Path(cache_dir) / self.cache_filename)
             else:
                 sqlite_path = "file::memory:?cache=shared"
-            return CachedLimiterSession(sqlite_path, backend="sqlite", api_budget=self._api_budget)  # type: ignore # there are no typeshed stubs for requests_cache
+            return CachedLimiterSession(sqlite_path, backend="sqlite", api_budget=self._api_budget, match_headers=True)  # type: ignore # there are no typeshed stubs for requests_cache
         else:
             return LimiterSession(api_budget=self._api_budget)
 

--- a/airbyte-cdk/python/unit_tests/sources/streams/http/test_http_client.py
+++ b/airbyte-cdk/python/unit_tests/sources/streams/http/test_http_client.py
@@ -556,6 +556,7 @@ def test_backoff_strategy_endless(exit_on_rate_limit, expected_call_count, expec
             )
         assert mocked_send.call_count == expected_call_count
 
+
 def test_given_different_headers_then_response_is_not_cached(requests_mock):
     http_client = HttpClient(name="test", logger=MagicMock(), use_cache=True)
     first_request_headers = {"header_key": "first"}

--- a/airbyte-cdk/python/unit_tests/sources/streams/http/test_http_client.py
+++ b/airbyte-cdk/python/unit_tests/sources/streams/http/test_http_client.py
@@ -555,3 +555,15 @@ def test_backoff_strategy_endless(exit_on_rate_limit, expected_call_count, expec
                 http_method="get", url="https://test_base_url.com/v1/endpoint", request_kwargs={}, exit_on_rate_limit=exit_on_rate_limit
             )
         assert mocked_send.call_count == expected_call_count
+
+def test_given_different_headers_then_response_is_not_cached(requests_mock):
+    http_client = HttpClient(name="test", logger=MagicMock(), use_cache=True)
+    first_request_headers = {"header_key": "first"}
+    second_request_headers = {"header_key": "second"}
+    requests_mock.register_uri("GET", "https://google.com/", request_headers=first_request_headers, json={"test": "first response"})
+    requests_mock.register_uri("GET", "https://google.com/", request_headers=second_request_headers, json={"test": "second response"})
+
+    http_client.send_request("GET", "https://google.com/", headers=first_request_headers, request_kwargs={})
+    _, second_response = http_client.send_request("GET", "https://google.com/", headers=second_request_headers, request_kwargs={})
+
+    assert second_response.json()["test"] == "second response"


### PR DESCRIPTION
## What
Addresses https://github.com/airbytehq/oncall/issues/6327

## How
By having the cache match on headers too

## User Impact
If a query should yield a different result when a different header is passed, then the response will differ.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [X] YES 💚
- [ ] NO ❌
