### PR TITLE
Bulk CDK Plugin: use required integration test task name

### DIFF
--- a/buildSrc/src/main/groovy/airbyte-bulk-connector.gradle
+++ b/buildSrc/src/main/groovy/airbyte-bulk-connector.gradle
@@ -130,8 +130,9 @@ class AirbyteBulkConnectorPlugin implements Plugin<Project> {
             ]
         }
 
+        // The name integrationTestJava is required by airbyte-ci.
         project.sourceSets {
-            integrationTest {
+            integrationTestJava {
                 kotlin {
                     srcDir 'src/test-integration/kotlin'
                 }
@@ -158,25 +159,25 @@ class AirbyteBulkConnectorPlugin implements Plugin<Project> {
             dependsOn project.tasks.matching { it.name ==~ /(compile|spotbugs)[a-zA-Z]*Java/ }
         }
 
-        project.tasks.register('integrationTest', Test) {
+        project.tasks.register('integrationTestJava', Test) {
             description = 'Runs the integration tests.'
             group = 'verification'
-            testClassesDirs = project.sourceSets.integrationTest.output.classesDirs
-            classpath = project.sourceSets.integrationTest.runtimeClasspath
+            testClassesDirs = project.sourceSets.integrationTestJava.output.classesDirs
+            classpath = project.sourceSets.integrationTestJava.runtimeClasspath
             useJUnitPlatform()
             mustRunAfter project.tasks.check
         }
 
         project.tasks.named('build').configure {
-            dependsOn project.tasks.integrationTest
+            dependsOn project.tasks.integrationTestJava
         }
 
         project.configurations {
             testFixturesImplementation.extendsFrom implementation
             testFixturesRuntimeOnly.extendsFrom runtimeOnly
 
-            integrationTestImplementation.extendsFrom testImplementation
-            integrationTestRuntimeOnly.extendsFrom testRuntimeOnly
+            integrationTestJavaImplementation.extendsFrom testImplementation
+            integrationTesJavaRuntimeOnly.extendsFrom testRuntimeOnly
         }
 
         project.extensions.create('airbyteBulkConnector', AirbyteBulkConnectorExtension, project)


### PR DESCRIPTION
## What
* airbyte-ci definitely requires the name "integrationTestJava"
* in the absence of this name, any change to `src/test-integration` (including deleting all the old tests from a migrated connector and leaving it blank) seems to trigger an attempt to run the command
* if the command doesn't exist, airbyte-ci swallows the exception then fails later with an inscrutable `lstat build no such directory`
* changing the name is sufficient to fix this problem locally

NOTE: This isn't the ideal solution. @edgao will be working this demiquarter on the final form of the test protocol (specifically what should be run with and without a docker image, and at what level gradle/airbyte-ci/etc that distinction will be handled), after which we will make the changes necessary to correct this name. In the meantime, this should not disrupt sources workflow unless you migrate a connector in-place w/ old style integration tests.