### PR TITLE
fix(source-coassemble): fix build failure in outdated SDM

### DIFF
--- a/airbyte-integrations/connectors/source-coassemble/metadata.yaml
+++ b/airbyte-integrations/connectors/source-coassemble/metadata.yaml
@@ -13,7 +13,7 @@ data:
       enabled: false
       packageName: airbyte-source-coassemble
   connectorBuildOptions:
-    baseImage: docker.io/airbyte/source-declarative-manifest:4.6.2@sha256:f5fcd3d4703b7590b6166a7853c5ed1686731607cd30a159a8c24e2fe2c1ee98
+    baseImage: docker.io/airbyte/source-declarative-manifest:5.7.3@sha256:efd4066158014a4e10fe39af5d2c196d6f69b56b4f3258db8696aae1baff17a5
   connectorSubtype: api
   connectorType: source
   definitionId: 85999b05-fae0-4312-a3ae-f4987f50d434


### PR DESCRIPTION
## What

So, @topefolorunso made a PR from Builder with source-coalesce, and then manually re-uploaded the manifest.yaml file. I merged the PR and didn't wait for CI — my bad. 

[Connector Publishing failed, because the SDM version mismatched](https://github.com/airbytehq/airbyte/actions/runs/11060142028/job/30730052727).

I _think_ this happened because the `metadata.yaml` was written at the time of the original PR contribution, and it had sdm 4.6.2, but the new manifest wanted 5.7.3. This should not be a problem for new Builder contribution, so fixing this one-off. 

Since the connector never got published, I'm OK just merging this in without version bump.
