### PR TITLE
fix(source-coalesce): Update metadata.yaml

### DIFF
--- a/airbyte-integrations/connectors/source-coassemble/metadata.yaml
+++ b/airbyte-integrations/connectors/source-coassemble/metadata.yaml
@@ -13,7 +13,7 @@ data:
       enabled: false
       packageName: airbyte-source-coassemble
   connectorBuildOptions:
-    baseImage: docker.io/airbyte/source-declarative-manifest:5.7.3@sha256:efd4066158014a4e10fe39af5d2c196d6f69b56b4f3258db8696aae1baff17a5
+    baseImage: docker.io/airbyte/source-declarative-manifest:5.7.3@sha256:4c4a567211fbcdf42805f261020bf5be46454bfeba781a92d30fe414ef964212
   connectorSubtype: api
   connectorType: source
   definitionId: 85999b05-fae0-4312-a3ae-f4987f50d434


### PR DESCRIPTION
## What
Fixing source declarative manifest hash after voodoo-failing to fix it in #45939. 