### PR TITLE
chore(source-zenefits): make available on Cloud

### DIFF
--- a/airbyte-integrations/connectors/source-zenefits/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zenefits/metadata.yaml
@@ -19,7 +19,7 @@ data:
   name: Zenefits
   registryOverrides:
     cloud:
-      enabled: false
+      enabled: true
     oss:
       enabled: true
   releaseDate: 2022-08-24


### PR DESCRIPTION
Makes the connector available on Cloud, no version bump.