### PR TITLE
chore(source-activecampaign): make available on Cloud

### DIFF
--- a/airbyte-integrations/connectors/source-activecampaign/metadata.yaml
+++ b/airbyte-integrations/connectors/source-activecampaign/metadata.yaml
@@ -6,7 +6,7 @@ data:
     oss:
       enabled: true
     cloud:
-      enabled: false
+      enabled: true
   remoteRegistries:
     pypi:
       enabled: false


### PR DESCRIPTION
Makes the connector available on Cloud, no version bump.