### PR TITLE
chore(source-ashby): make available on Cloud

### DIFF
--- a/airbyte-integrations/connectors/source-ashby/metadata.yaml
+++ b/airbyte-integrations/connectors/source-ashby/metadata.yaml
@@ -14,7 +14,7 @@ data:
       packageName: airbyte-source-ashby
   registryOverrides:
     cloud:
-      enabled: false
+      enabled: true
     oss:
       enabled: true
   releaseStage: alpha


### PR DESCRIPTION
Makes the connector available on Cloud, no version bump.