### PR TITLE
chore(source-chargify): make available on Cloud

### DIFF
--- a/airbyte-integrations/connectors/source-chargify/metadata.yaml
+++ b/airbyte-integrations/connectors/source-chargify/metadata.yaml
@@ -10,7 +10,7 @@ data:
     oss:
       enabled: true
     cloud:
-      enabled: false
+      enabled: true
   connectorSubtype: api
   connectorType: source
   definitionId: 9b2d3607-7222-4709-9fa2-c2abdebbdd88


### PR DESCRIPTION
Makes the connector available on Cloud, no version bump.