### PR TITLE
chore(source-convertkit): make available on Cloud

### DIFF
--- a/airbyte-integrations/connectors/source-convertkit/metadata.yaml
+++ b/airbyte-integrations/connectors/source-convertkit/metadata.yaml
@@ -14,7 +14,7 @@ data:
       packageName: airbyte-source-convertkit
   registryOverrides:
     cloud:
-      enabled: false
+      enabled: true
     oss:
       enabled: true
   releaseStage: alpha


### PR DESCRIPTION
Makes the connector available on Cloud, no version bump.