### PR TITLE
chore(source-drift): make available on Cloud

### DIFF
--- a/airbyte-integrations/connectors/source-drift/metadata.yaml
+++ b/airbyte-integrations/connectors/source-drift/metadata.yaml
@@ -19,7 +19,7 @@ data:
   name: Drift
   registryOverrides:
     cloud:
-      enabled: false
+      enabled: true
     oss:
       enabled: true
   releaseDate: 2023-08-10


### PR DESCRIPTION
Makes the connector available on Cloud, no version bump.