### PR TITLE
chore(source-freshservice): make available on Cloud

### DIFF
--- a/airbyte-integrations/connectors/source-freshservice/metadata.yaml
+++ b/airbyte-integrations/connectors/source-freshservice/metadata.yaml
@@ -16,7 +16,7 @@ data:
   name: Freshservice
   registryOverrides:
     cloud:
-      enabled: false
+      enabled: true
     oss:
       enabled: true
   releaseDate: "2021-10-29"


### PR DESCRIPTION
Makes the connector available on Cloud, no version bump.