### PR TITLE
chore(source-gocardless): make available on Cloud

### DIFF
--- a/airbyte-integrations/connectors/source-gocardless/metadata.yaml
+++ b/airbyte-integrations/connectors/source-gocardless/metadata.yaml
@@ -14,7 +14,7 @@ data:
       packageName: airbyte-source-gocardless
   registryOverrides:
     cloud:
-      enabled: false
+      enabled: true
     oss:
       enabled: true
   releaseStage: alpha


### PR DESCRIPTION
Makes the connector available on Cloud, no version bump.