### PR TITLE
chore(source-gutendex): make available on Cloud

### DIFF
--- a/airbyte-integrations/connectors/source-gutendex/metadata.yaml
+++ b/airbyte-integrations/connectors/source-gutendex/metadata.yaml
@@ -13,7 +13,7 @@ data:
       packageName: airbyte-source-gutendex
   registryOverrides:
     cloud:
-      enabled: false
+      enabled: true
     oss:
       enabled: true
   releaseStage: alpha


### PR DESCRIPTION
Makes the connector available on Cloud, no version bump.