### PR TITLE
chore(source-klaus-api): make available on Cloud

### DIFF
--- a/airbyte-integrations/connectors/source-klaus-api/metadata.yaml
+++ b/airbyte-integrations/connectors/source-klaus-api/metadata.yaml
@@ -10,7 +10,7 @@ data:
     oss:
       enabled: true
     cloud:
-      enabled: false
+      enabled: true
   connectorSubtype: api
   connectorType: source
   definitionId: aad35903-2c0d-4e25-8010-d62ed909e0b7
@@ -28,18 +28,18 @@ data:
     sl: 100
   tags:
     - cdk:low-code
-    # Disable acceptance tests for now
-    # They are not passing
-    # No Airbyte Cloud usage
-    #
-    # connectorTestSuitesOptions:
-    #   - suite: acceptanceTests
-    #     testSecrets:
-    #       - name: SECRET_SOURCE-KLAUS-API__CREDS
-    #         fileName: config.json
-    #         secretStore:
-    #           type: GSM
-    #           alias: airbyte-connector-testing-secret-store
+      # Disable acceptance tests for now
+      # They are not passing
+      # No Airbyte Cloud usage
+      #
+      # connectorTestSuitesOptions:
+      #   - suite: acceptanceTests
+      #     testSecrets:
+      #       - name: SECRET_SOURCE-KLAUS-API__CREDS
+      #         fileName: config.json
+      #         secretStore:
+      #           type: GSM
+      #           alias: airbyte-connector-testing-secret-store
     - language:manifest-only
   connectorBuildOptions:
     baseImage: docker.io/airbyte/source-declarative-manifest:4.5.4@sha256:b07a521add11f987c63c0db68c1b57e90bec0c985f1cb6f3c5a1940cde628a70


### PR DESCRIPTION
Makes the connector available on Cloud, no version bump.