### PR TITLE
chore(source-mailerlite): make available on Cloud

### DIFF
--- a/airbyte-integrations/connectors/source-mailerlite/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mailerlite/metadata.yaml
@@ -34,7 +34,7 @@ data:
       packageName: airbyte-source-mailerlite
   registryOverrides:
     cloud:
-      enabled: false
+      enabled: true
     oss:
       enabled: true
   releaseDate: 2022-10-25


### PR DESCRIPTION
Makes the connector available on Cloud, no version bump.