### PR TITLE
chore(source-mailjet-mail): make available on Cloud

### DIFF
--- a/airbyte-integrations/connectors/source-mailjet-mail/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mailjet-mail/metadata.yaml
@@ -14,7 +14,7 @@ data:
       packageName: airbyte-source-mailjet-mail
   registryOverrides:
     cloud:
-      enabled: false
+      enabled: true
     oss:
       enabled: true
   releaseStage: alpha


### PR DESCRIPTION
Makes the connector available on Cloud, no version bump.