### PR TITLE
chore(source-nasa): make available on Cloud

### DIFF
--- a/airbyte-integrations/connectors/source-nasa/metadata.yaml
+++ b/airbyte-integrations/connectors/source-nasa/metadata.yaml
@@ -10,7 +10,7 @@ data:
     oss:
       enabled: true
     cloud:
-      enabled: false
+      enabled: true
   connectorSubtype: api
   connectorType: source
   definitionId: 1a8667d7-7978-43cd-ba4d-d32cbd478971
@@ -26,16 +26,16 @@ data:
   documentationUrl: https://docs.airbyte.com/integrations/sources/nasa
   tags:
     - cdk:low-code
-    # Disable acceptance tests for now
-    # No/Low Airbyte cloud usage
-    # connectorTestSuitesOptions:
-    #   - suite: acceptanceTests
-    #     testSecrets:
-    #       - name: SECRET_SOURCE-NASA__CREDS
-    #         fileName: config.json
-    #         secretStore:
-    #           type: GSM
-    #           alias: airbyte-connector-testing-secret-store
+      # Disable acceptance tests for now
+      # No/Low Airbyte cloud usage
+      # connectorTestSuitesOptions:
+      #   - suite: acceptanceTests
+      #     testSecrets:
+      #       - name: SECRET_SOURCE-NASA__CREDS
+      #         fileName: config.json
+      #         secretStore:
+      #           type: GSM
+      #           alias: airbyte-connector-testing-secret-store
     - language:manifest-only
   connectorBuildOptions:
     baseImage: docker.io/airbyte/source-declarative-manifest:4.4.3@sha256:8937b693c7e01087f6e86e683826ac20f160f7952b8f0a13cbf4f9bfdd7af570


### PR DESCRIPTION
Makes the connector available on Cloud, no version bump.