### PR TITLE
chore(source-oura): make available on Cloud

### DIFF
--- a/airbyte-integrations/connectors/source-oura/metadata.yaml
+++ b/airbyte-integrations/connectors/source-oura/metadata.yaml
@@ -3,7 +3,7 @@ data:
     oss:
       enabled: true
     cloud:
-      enabled: false
+      enabled: true
   remoteRegistries:
     pypi:
       enabled: false


### PR DESCRIPTION
Makes the connector available on Cloud, no version bump.