### PR TITLE
chore(source-plausible): make available on Cloud

### DIFF
--- a/airbyte-integrations/connectors/source-plausible/metadata.yaml
+++ b/airbyte-integrations/connectors/source-plausible/metadata.yaml
@@ -3,7 +3,7 @@ data:
     oss:
       enabled: true
     cloud:
-      enabled: false
+      enabled: true
   remoteRegistries:
     pypi:
       enabled: false


### PR DESCRIPTION
Makes the connector available on Cloud, no version bump.