### PR TITLE
chore(source-primetric): make available on Cloud

### DIFF
--- a/airbyte-integrations/connectors/source-primetric/metadata.yaml
+++ b/airbyte-integrations/connectors/source-primetric/metadata.yaml
@@ -6,7 +6,7 @@ data:
     oss:
       enabled: true
     cloud:
-      enabled: false
+      enabled: true
   remoteRegistries:
     pypi:
       enabled: false


### PR DESCRIPTION
Makes the connector available on Cloud, no version bump.