### PR TITLE
chore(source-rd-station-marketing): make available on Cloud

### DIFF
--- a/airbyte-integrations/connectors/source-rd-station-marketing/metadata.yaml
+++ b/airbyte-integrations/connectors/source-rd-station-marketing/metadata.yaml
@@ -14,7 +14,7 @@ data:
       packageName: airbyte-source-rd-station-marketing
   registryOverrides:
     cloud:
-      enabled: false
+      enabled: true
     oss:
       enabled: true
   releaseStage: alpha


### PR DESCRIPTION
Makes the connector available on Cloud, no version bump.