### PR TITLE
chore(source-visma-economic): make available on Cloud

### DIFF
--- a/airbyte-integrations/connectors/source-visma-economic/metadata.yaml
+++ b/airbyte-integrations/connectors/source-visma-economic/metadata.yaml
@@ -16,7 +16,7 @@ data:
   name: Visma Economic
   registryOverrides:
     cloud:
-      enabled: false
+      enabled: true
     oss:
       enabled: true
   releaseDate: "2022-11-08"


### PR DESCRIPTION
Makes the connector available on Cloud, no version bump.