### PR TITLE
chore(source-vitally): make available on Cloud

### DIFF
--- a/airbyte-integrations/connectors/source-vitally/metadata.yaml
+++ b/airbyte-integrations/connectors/source-vitally/metadata.yaml
@@ -18,7 +18,7 @@ data:
       packageName: airbyte-source-vitally
   registryOverrides:
     cloud:
-      enabled: false
+      enabled: true
     oss:
       enabled: true
   releaseStage: alpha


### PR DESCRIPTION
Makes the connector available on Cloud, no version bump.