### PR TITLE
chore(source-workable): make available on Cloud

### DIFF
--- a/airbyte-integrations/connectors/source-workable/metadata.yaml
+++ b/airbyte-integrations/connectors/source-workable/metadata.yaml
@@ -18,7 +18,7 @@ data:
       packageName: airbyte-source-workable
   registryOverrides:
     cloud:
-      enabled: false
+      enabled: true
     oss:
       enabled: true
   releaseStage: alpha


### PR DESCRIPTION
Makes the connector available on Cloud, no version bump.