### PR TITLE
chore(source-workramp): make available on Cloud

### DIFF
--- a/airbyte-integrations/connectors/source-workramp/metadata.yaml
+++ b/airbyte-integrations/connectors/source-workramp/metadata.yaml
@@ -3,7 +3,7 @@ data:
     oss:
       enabled: true
     cloud:
-      enabled: false
+      enabled: true
   remoteRegistries:
     pypi:
       enabled: false


### PR DESCRIPTION
Makes the connector available on Cloud, no version bump.