### PR TITLE
chore(source-zapier-supported-storage): make available on Cloud

### DIFF
--- a/airbyte-integrations/connectors/source-zapier-supported-storage/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zapier-supported-storage/metadata.yaml
@@ -16,7 +16,7 @@ data:
   name: Zapier Supported Storage
   registryOverrides:
     cloud:
-      enabled: false
+      enabled: true
     oss:
       enabled: true
   releaseStage: alpha


### PR DESCRIPTION
Makes the connector available on Cloud, no version bump.