### PR TITLE
feat(ci workflows): introducing bump-version workflow!

### DIFF
--- a/.github/workflows/bump-verison-command.yml
+++ b/.github/workflows/bump-verison-command.yml
@@ -1,0 +1,148 @@
+name: Bump versions for connectors in a PR
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: "Pull request number. This PR will be referenced in the changelog line."
+        type: number
+        required: false
+      comment-id:
+        description: "Optional. The comment-id of the slash command. Used to update the comment with the status."
+        required: false
+
+      type:
+        description: "The type of bump to perform. One of 'major', 'minor', or 'patch'."
+        required: false
+        default: "patch"
+
+      changelog:
+        description: "The comment to add to the changelog."
+        required: false
+        # TODO: We could infer the changelog string from the PR description!
+        default: "Bumped automatically in the pull request, please see PR description"
+
+      # These must be declared, but they are unused and ignored.
+      # TODO: Infer 'repo' and 'gitref' from PR number on other workflows, so we can remove these.
+      repo:
+        description: "Repo (Ignored)"
+        required: false
+        default: "airbytehq/airbyte"
+      gitref:
+        description: "Ref (Ignored)"
+        required: false
+
+run-name: "Bump connector versions in PR: #${{ github.event.inputs.pr }}"
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.inputs.pr }}
+  # Cancel any previous runs on the same branch if they are still in progress
+  cancel-in-progress: true
+
+jobs:
+  bump-version:
+    name: "Bump version of connectors in this PR"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get job variables
+        id: job-vars
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          PR_JSON=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.inputs.pr }})
+          echo "repo=$(echo "$PR_JSON" | jq -r .head.repo.full_name)" >> $GITHUB_OUTPUT
+          echo "branch=$(echo "$PR_JSON" | jq -r .head.ref)" >> $GITHUB_OUTPUT
+          echo "run-url=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" >> $GITHUB_OUTPUT
+
+      - name: Checkout Airbyte
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ steps.job-vars.outputs.repo }}
+          ref: ${{ steps.job-vars.outputs.branch }}
+          fetch-depth: 1
+          # Important that token is a PAT so that CI checks are triggered again.
+          # Without this we would be forever waiting on required checks to pass.
+          token: ${{ secrets.GH_PAT_APPROVINGTON_OCTAVIA }}
+
+      - name: Append comment with job run link
+        # If comment-id is not provided, this will create a new
+        # comment with the job run link.
+        id: first-comment-action
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          comment-id: ${{ github.event.inputs.comment-id }}
+          issue-number: ${{ github.event.inputs.pr }}
+          body: |
+
+            > Bump Version job started... [Check job output.][1]
+
+            [1]: ${{ steps.job-vars.outputs.run-url }}
+
+      - name: Run airbyte-ci connectors --modified bump-version
+        uses: ./.github/actions/run-airbyte-ci
+        continue-on-error: true
+        with:
+          context: "manual"
+          gcs_credentials: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
+          sentry_dsn: ${{ secrets.SENTRY_AIRBYTE_CI_DSN }}
+          github_token: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}
+          subcommand: |
+            connectors --modified bump-version \
+              ${{ github.event.inputs.type }} \
+              ${{ github.event.inputs.changelog }} \
+              --pr-number ${{ github.event.inputs.pr }}
+
+      # This is helpful in the case that we change a previously committed generated file to be ignored by git.
+      - name: Remove any files that have been gitignored
+        run: git ls-files -i -c --exclude-from=.gitignore | xargs -r git rm --cached
+
+      # Check for changes in git
+      - name: Check for changes
+        id: git-diff
+        run: |
+          git diff --quiet && echo "No changes to commit" || echo "::set-output name=changes::true"
+        shell: bash
+
+      # Commit changes (if any)
+      - name: Commit changes
+        id: commit-step
+        if: steps.git-diff.outputs.changes == 'true'
+        run: |
+          git config --global user.name "Octavia Squidington III"
+          git config --global user.email "octavia-squidington-iii@users.noreply.github.com"
+          git add .
+          git commit -m "chore: bump-version ${{ github.event.inputs.bump-type }}"
+          echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Push changes to '(${{ steps.job-vars.outputs.repo }})'
+        if: steps.git-diff.outputs.changes == 'true'
+        run: |
+          git remote add contributor https://github.com/${{ steps.job-vars.outputs.repo }}.git
+          git push contributor HEAD:${{ steps.job-vars.outputs.branch }}
+
+      - name: Append success comment
+        uses: peter-evans/create-or-update-comment@v4
+        if: steps.git-diff.outputs.changes == 'true'
+        with:
+          comment-id: ${{ steps.first-comment-action.outputs.comment-id }}
+          reactions: hooray
+          body: |
+            > ✅ Changes applied successfully. (${{ steps.commit-step.outputs.sha }})
+
+      - name: Append success comment (no-op)
+        uses: peter-evans/create-or-update-comment@v4
+        if: steps.git-diff.outputs.changes != 'true'
+        with:
+          comment-id: ${{ steps.first-comment-action.outputs.comment-id }}
+          reactions: "-1"
+          body: |
+            > 🔴 Job completed successfully (no changes, this is sus).
+
+      - name: Append failure comment
+        uses: peter-evans/create-or-update-comment@v4
+        if: failure()
+        with:
+          comment-id: ${{ steps.first-comment-action.outputs.comment-id }}
+          reactions: confused
+          body: |
+            > 🔴 Job failed.

--- a/.github/workflows/slash-commands.yml
+++ b/.github/workflows/slash-commands.yml
@@ -22,6 +22,7 @@ jobs:
           token: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}
           permission: write
           commands: |
+            bump-version
             format-fix
             test
             test-performance


### PR DESCRIPTION
## What

This PR wraps `airbyte-ci connectors --modified bump-version TYPE CHANGELOG --pr-number NUMBER` in a Github slash command! 

```
/bump-version %TYPE% %CHANGELOG% %PR_NUMBER%
```

This is going to make @marcosmarxm and @erohmensing 10% happier, I hope %)

## How

- Originally, copied over from `/format-fix` command, thanks @aaronsteers! 
- Inputs are optional, defaults values are designed to be "not dangerous" and clear.

## User Impact

None.

## Caveats

For this to work on manifest-only connectors, we need to migrate their docs template to include `Pull Request` column. I think it's okay to leave some PR numbers empty (such as for the initial contribution) but without the column, bump-version airbyte-ci command chokes.

## Testing

I've tested the underlying airbyte-ci command on source-basecamp locally (and discovered the need to migrate docs), but have not yet tested the slash command. Hoping to merge and give it a spin. Any better ways to test slash commands? ;) 