### PR TITLE
Bulk Load CDK: Factor out DestinationTaskLauncherFactory

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/task/DestinationTaskLauncher.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/task/DestinationTaskLauncher.kt
@@ -15,9 +15,6 @@ import io.airbyte.cdk.state.CheckpointManager
 import io.airbyte.cdk.state.StreamsManager
 import io.airbyte.cdk.write.StreamLoader
 import io.github.oshai.kotlinlogging.KotlinLogging
-import io.micronaut.context.annotation.DefaultImplementation
-import io.micronaut.context.annotation.Factory
-import jakarta.inject.Provider
 import jakarta.inject.Singleton
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicBoolean
@@ -67,6 +64,7 @@ interface DestinationTaskLauncher : TaskLauncher {
  *
  * // TODO: Capture failures, retry, and call into close(failure=true) if can't recover.
  */
+@Singleton
 @SuppressFBWarnings(
     "NP_NONNULL_PARAM_VIOLATION",
     justification = "arguments are guaranteed to be non-null by Kotlin's type system"
@@ -182,39 +180,5 @@ class DefaultDestinationTaskLauncher(
     /** Called exactly once when all streams are closed. */
     override suspend fun handleTeardownComplete() {
         stop()
-    }
-}
-
-@Factory
-@DefaultImplementation(DefaultDestinationTaskLauncher::class)
-class DestinationTaskLauncherFactory(
-    private val catalog: DestinationCatalog,
-    private val streamsManager: StreamsManager,
-    private val taskRunner: TaskRunner,
-    private val checkpointManager:
-        CheckpointManager<DestinationStream.Descriptor, CheckpointMessage>,
-    private val setupTaskFactory: SetupTaskFactory,
-    private val openStreamTaskFactory: OpenStreamTaskFactory,
-    private val spillToDiskTaskFactory: SpillToDiskTaskFactory,
-    private val processRecordsTaskFactory: ProcessRecordsTaskFactory,
-    private val processBatchTaskFactory: ProcessBatchTaskFactory,
-    private val closeStreamTaskFactory: CloseStreamTaskFactory,
-    private val teardownTaskFactory: TeardownTaskFactory
-) : Provider<DestinationTaskLauncher> {
-    @Singleton
-    override fun get(): DestinationTaskLauncher {
-        return DefaultDestinationTaskLauncher(
-            catalog,
-            streamsManager,
-            taskRunner,
-            checkpointManager,
-            setupTaskFactory,
-            openStreamTaskFactory,
-            spillToDiskTaskFactory,
-            processRecordsTaskFactory,
-            processBatchTaskFactory,
-            closeStreamTaskFactory,
-            teardownTaskFactory,
-        )
     }
 }

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/task/DestinationTaskLauncherTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/task/DestinationTaskLauncherTest.kt
@@ -38,10 +38,16 @@ import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 
-@MicronautTest(rebuildContext = true, environments = ["DestinationTaskLauncherTest"])
+@MicronautTest(
+    rebuildContext = true,
+    environments =
+        [
+            "DestinationTaskLauncherTest",
+        ]
+)
 class DestinationTaskLauncherTest {
     @Inject lateinit var taskRunner: TaskRunner
-    @Inject lateinit var taskLauncherFactory: DestinationTaskLauncherFactory
+    @Inject lateinit var taskLauncher: DestinationTaskLauncher
     @Inject lateinit var streamsManager: StreamsManager
     @Inject lateinit var checkpointManager: MockCheckpointManager
 
@@ -239,31 +245,28 @@ class DestinationTaskLauncherTest {
 
     @Test
     fun testStart() = runTest {
-        val launcher = taskLauncherFactory.get()
         launch { taskRunner.run() }
-        launcher.start()
+        taskLauncher.start()
         mockSetupTaskFactory.hasRun.receive()
         mockSpillToDiskTaskFactory.streamHasRun.values.forEach { it.receive() }
-        launcher.stop()
+        taskLauncher.stop()
     }
 
     @Test
     fun testHandleSetupComplete() = runTest {
-        val launcher = taskLauncherFactory.get()
         launch { taskRunner.run() }
-        launcher.handleSetupComplete()
+        taskLauncher.handleSetupComplete()
         mockOpenStreamTaskFactory.streamHasRun.values.forEach { it.receive() }
-        launcher.stop()
+        taskLauncher.stop()
     }
 
     @Test
     fun testHandleJoinStreamOpenSpilledFileComplete() = runTest {
-        val launcher = taskLauncherFactory.get()
         launch { taskRunner.run() }
 
         // This will block until the stream is done opening.
         launch {
-            launcher.handleNewSpilledFile(
+            taskLauncher.handleNewSpilledFile(
                 stream1.descriptor,
                 BatchEnvelope(
                     SpilledRawMessagesLocalFile(DefaultLocalFile(Path("not/a/real/file")), 100L)
@@ -279,27 +282,26 @@ class DestinationTaskLauncherTest {
 
         // This should unblock the processRecords task.
         val destination = MockDestinationWrite()
-        launcher.handleStreamOpen(destination.getStreamLoader(stream1))
+        taskLauncher.handleStreamOpen(destination.getStreamLoader(stream1))
         processRecordsTaskFactory.hasRun.receive()
         Assertions.assertTrue(true)
 
-        launcher.stop()
+        taskLauncher.stop()
     }
 
     @Test
     fun testHandleNewBatch() = runTest {
-        val launcher = taskLauncherFactory.get()
         launch { taskRunner.run() }
 
         val range = TreeRangeSet.create(listOf(Range.closed(0L, 100L)))
 
         val destination = MockDestinationWrite()
         val streamLoader = destination.getStreamLoader(stream1)
-        launcher.handleStreamOpen(streamLoader)
+        taskLauncher.handleStreamOpen(streamLoader)
 
         // Verify incomplete batch triggers process batch
         val incompleteBatch = BatchEnvelope(MockBatch(Batch.State.PERSISTED), range)
-        launcher.handleNewBatch(streamLoader, incompleteBatch)
+        taskLauncher.handleNewBatch(streamLoader, incompleteBatch)
         Assertions.assertTrue(
             streamsManager.getManager(stream1.descriptor).areRecordsPersistedUntil(100L)
         )
@@ -308,27 +310,26 @@ class DestinationTaskLauncherTest {
 
         // Verify complete batch w/o batch processing complete does nothing
         val completeBatch = BatchEnvelope(MockBatch(Batch.State.COMPLETE))
-        launcher.handleNewBatch(streamLoader, completeBatch)
+        taskLauncher.handleNewBatch(streamLoader, completeBatch)
         delay(1000)
         Assertions.assertTrue(closeStreamTaskFactory.hasRun.tryReceive().isFailure)
         (streamsManager.getManager(stream1.descriptor) as MockStreamManager)
             .mockBatchProcessingComplete(true)
 
         // Verify complete batch w/ batch processing complete triggers close stream
-        launcher.handleNewBatch(streamLoader, completeBatch)
+        taskLauncher.handleNewBatch(streamLoader, completeBatch)
         closeStreamTaskFactory.hasRun.receive()
         Assertions.assertTrue(true)
 
-        launcher.stop()
+        taskLauncher.stop()
     }
 
     @Test
     fun testHandleStreamClosed() = runTest {
-        val launcher = taskLauncherFactory.get()
         launch { taskRunner.run() }
 
         // This should not run teardown until all streams are closed.
-        launch { launcher.handleStreamClosed(stream1) }
+        launch { taskLauncher.handleStreamClosed(stream1) }
         delay(1000)
         val hasRun = teardownTaskFactory.hasRun.tryReceive()
         Assertions.assertTrue(hasRun.isFailure)
@@ -342,12 +343,12 @@ class DestinationTaskLauncherTest {
         Assertions.assertTrue(true)
 
         // This should do nothing, since the teardown task has already run.
-        launch { launcher.handleStreamClosed(stream2) }
+        launch { taskLauncher.handleStreamClosed(stream2) }
         delay(1000)
         val hasRun3 = teardownTaskFactory.hasRun.tryReceive()
         Assertions.assertTrue(hasRun3.isFailure)
         checkpointManager.hasBeenFlushed.receive() // Stream2 close triggered flush
 
-        launcher.stop()
+        taskLauncher.stop()
     }
 }

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/task/MockTaskLauncher.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/task/MockTaskLauncher.kt
@@ -8,7 +8,13 @@ import io.airbyte.cdk.command.DestinationStream
 import io.airbyte.cdk.message.BatchEnvelope
 import io.airbyte.cdk.message.SpilledRawMessagesLocalFile
 import io.airbyte.cdk.write.StreamLoader
+import io.micronaut.context.annotation.Primary
+import io.micronaut.context.annotation.Requires
+import jakarta.inject.Singleton
 
+@Singleton
+@Primary
+@Requires(env = ["MockTaskLauncher"])
 class MockTaskLauncher(override val taskRunner: TaskRunner) : DestinationTaskLauncher {
     val spilledFiles = mutableListOf<BatchEnvelope<SpilledRawMessagesLocalFile>>()
     val batchEnvelopes = mutableListOf<BatchEnvelope<*>>()

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/task/ProcessRecordsTaskTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/task/ProcessRecordsTaskTest.kt
@@ -26,10 +26,16 @@ import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 
-@MicronautTest(environments = ["ProcessRecordsTaskTest"])
+@MicronautTest(
+    environments =
+        [
+            "ProcessRecordsTaskTest",
+            "MockTaskLauncher",
+        ]
+)
 class ProcessRecordsTaskTest {
-    @Inject lateinit var taskRunner: TaskRunner
     @Inject lateinit var processRecordsTaskFactory: DefaultProcessRecordsTaskFactory
+    @Inject lateinit var launcher: MockTaskLauncher
 
     class MockBatch(
         override val state: Batch.State,
@@ -82,7 +88,6 @@ class ProcessRecordsTaskTest {
         val byteSize = 999L
         val recordCount = 1024L
 
-        val launcher = MockTaskLauncher(taskRunner)
         val mockFile =
             MockTempFileProvider()
                 .createTempFile(directory = Path.of("tmp/"), prefix = "test", suffix = ".json")

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/task/SpillToDiskTaskTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/task/SpillToDiskTaskTest.kt
@@ -14,7 +14,6 @@ import io.airbyte.cdk.message.DestinationRecordWrapped
 import io.airbyte.cdk.message.MessageQueueReader
 import io.airbyte.cdk.message.StreamCompleteWrapped
 import io.airbyte.cdk.message.StreamRecordWrapped
-import io.micronaut.context.annotation.Factory
 import io.micronaut.context.annotation.Primary
 import io.micronaut.context.annotation.Requires
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest
@@ -28,20 +27,18 @@ import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 
-@MicronautTest(environments = ["SpillToDiskTaskTest", "MockTempFileProvider"])
+@MicronautTest(
+    environments =
+        [
+            "SpillToDiskTaskTest",
+            "MockTempFileProvider",
+            "MockTaskLauncher",
+        ]
+)
 class SpillToDiskTaskTest {
     @Inject lateinit var taskRunner: TaskRunner
     @Inject lateinit var spillToDiskTaskFactory: DefaultSpillToDiskTaskFactory
     @Inject lateinit var mockTempFileProvider: MockTempFileProvider
-
-    @Factory
-    @Requires(env = ["SpillToDiskTaskTest"])
-    class MockDestinationTaskLauncherFactory {
-        @Singleton
-        fun mockDestinationTaskLauncher(taskRunner: TaskRunner): DestinationTaskLauncher {
-            return MockTaskLauncher(taskRunner)
-        }
-    }
 
     @Singleton
     @Primary


### PR DESCRIPTION
## What
I killed [this monstrosity](https://github.com/airbytehq/airbyte/pull/45945), because I came up with a better solution.

This is just some preliminary housekeeping to clean up the `DestinationTaskLauncher` before adding more complexity.

It removes the `DestinationTaskLauncherFactory` hop, which is no longer necessary. There is no functional change.
