### PR TITLE
fix(bump-version): quotes around changelog line

### DIFF
--- a/.github/workflows/bump-version-command.yml
+++ b/.github/workflows/bump-version-command.yml
@@ -89,7 +89,7 @@ jobs:
           subcommand: |
             connectors --modified bump-version \
               ${{ github.event.inputs.type }} \
-              ${{ github.event.inputs.changelog }} \
+              "${{ github.event.inputs.changelog }}" \
               --pr-number ${{ github.event.inputs.pr }}
 
       # This is helpful in the case that we change a previously committed generated file to be ignored by git.


### PR DESCRIPTION
## What

Fixes a bug in `/bump-version` introduced in #46252 by wrapping changelog input in doublequotes.