### PR TITLE
Bulk Load CDK: Exception Handling for DestinationTaskLauncher

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/task/CloseStreamTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/task/CloseStreamTask.kt
@@ -8,7 +8,7 @@ import io.airbyte.cdk.write.StreamLoader
 import io.micronaut.context.annotation.Secondary
 import jakarta.inject.Singleton
 
-interface CloseStreamTask : Task
+interface CloseStreamTask : StreamTask
 
 /**
  * Wraps @[StreamLoader.close] and marks the stream as closed in the stream manager. Also starts the

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/task/OpenStreamTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/task/OpenStreamTask.kt
@@ -10,7 +10,7 @@ import io.airbyte.cdk.write.StreamLoader
 import io.micronaut.context.annotation.Secondary
 import jakarta.inject.Singleton
 
-interface OpenStreamTask : Task
+interface OpenStreamTask : StreamTask
 
 /**
  * Wraps @[StreamLoader.start] and starts the spill-to-disk tasks.

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/task/ProcessBatchTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/task/ProcessBatchTask.kt
@@ -9,7 +9,7 @@ import io.airbyte.cdk.write.StreamLoader
 import io.micronaut.context.annotation.Secondary
 import jakarta.inject.Singleton
 
-interface ProcessBatchTask : Task
+interface ProcessBatchTask : StreamTask
 
 /** Wraps @[StreamLoader.processBatch] and handles the resulting batch. */
 class DefaultProcessBatchTask(

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/task/ProcessRecordsTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/task/ProcessRecordsTask.kt
@@ -19,7 +19,7 @@ import jakarta.inject.Singleton
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
-interface ProcessRecordsTask : Task
+interface ProcessRecordsTask : StreamTask
 
 /**
  * Wraps @[StreamLoader.processRecords] and feeds it a lazy iterator over the last batch of spooled

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/task/SetupTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/task/SetupTask.kt
@@ -8,7 +8,7 @@ import io.airbyte.cdk.write.DestinationWriter
 import io.micronaut.context.annotation.Secondary
 import jakarta.inject.Singleton
 
-interface SetupTask : Task
+interface SetupTask : SyncTask
 
 /**
  * Wraps @[DestinationWriter.setup] and starts the open stream tasks.

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/task/SpillToDiskTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/task/SpillToDiskTask.kt
@@ -23,7 +23,7 @@ import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.yield
 
-interface SpillToDiskTask : Task
+interface SpillToDiskTask : StreamTask
 
 /**
  * Reads records from the message queue and writes them to disk. This task is internal and is not

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/task/TaskLauncher.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/task/TaskLauncher.kt
@@ -20,3 +20,7 @@ interface TaskLauncher {
         taskRunner.close()
     }
 }
+
+interface TaskLauncherExceptionHandler<T : Task> {
+    fun withExceptionHandling(task: T): Task
+}

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/task/TeardownTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/task/TeardownTask.kt
@@ -9,7 +9,7 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import io.micronaut.context.annotation.Secondary
 import jakarta.inject.Singleton
 
-interface TeardownTask : Task
+interface TeardownTask : SyncTask
 
 /**
  * Wraps @[DestinationWriter.teardown] and stops the task launcher.


### PR DESCRIPTION
Builds on [this](https://github.com/airbytehq/airbyte/pull/46255), replacing [this](https://github.com/airbytehq/airbyte/pull/45945).

The mistake in the previous attempts was in trying to handle exceptions outside the `TaskLauncher` workflow -- especially allowing them to propagate all the way out of the queue. Exceptions are part of the workflow.

This:
* creates two task types `StreamTask` and `SyncTask` and creates the correct inheritance
* when the launcher enqueues a `SyncTask`, it wraps it in a try/catch (via `SyncTaskWrapper`) that calls into `handleSyncFailure`
* when it enqueues a `StreamTask`, it wraps it in `StreamTaskWrapper`, which calls `handleStreamFailure` AND then wraps that in `SyncTaskWrapper`

This way:

* failures in SyncTask's can call into teardown, etc
* failures in StreamTask's can call into their affined StreamLoader::close, etc; AND exceptions thrown in this process can also fail the sync

There's no actual exception handling in this PR yet, just the framework for it + tests. (I don't love mixing exception handler tests in with the existing ones, but it was the simplest way)

The next PR will factor all the interactions with the stream manager, etc out of the launcher, in order to pave the way to make exception handling simpler.

## How
<!--
* Describe how code changes achieve the solution.
-->

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
