### PR TITLE
feat:  add user-agent header to be able to track Airbyte integration on Apify

### DIFF
--- a/airbyte-integrations/connectors/source-apify-dataset/pyproject.toml
+++ b/airbyte-integrations/connectors/source-apify-dataset/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "2.1.23"
+version = "2.1.24"
 name = "source-apify-dataset"
 description = "Source implementation for Apify Dataset."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-apify-dataset/source_apify_dataset/manifest.yaml
+++ b/airbyte-integrations/connectors/source-apify-dataset/source_apify_dataset/manifest.yaml
@@ -51,6 +51,9 @@ definitions:
       authenticator:
         type: BearerAuthenticator
         api_token: "{{ config['token'] }}"
+      request_options_provider:
+        request_headers:
+          User-Agent: "Airbyte"
     paginator:
       type: "DefaultPaginator"
       page_size_option:


### PR DESCRIPTION
## What
We are tracking external integration usage using the HTTP `User-Agent` request headers on the Apify platform.
In this PR, I'm adding the `User-Agent` header to Apify components, it helps us to debug bugs and track usage of this component on Apify.

## How
Adding the `User-Agent` header to the Apify component requester.

## Review guide
TBD

## User Impact
Users who were using Apify component did not notice this change.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
