### PR TITLE
feat(airbyte-ci): format: pick up .prettierc and .prettierignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,12 @@
 airbyte-integrations/bases/base-normalization/integration_tests/normalization_test_output
 airbyte-ci/connectors/pipelines/tests/test_changelog/result_files
 airbyte-integrations/bases/connector-acceptance-test/unit_tests/data/docs
+
+# Ignore manifest files in manifest-only connectors
+# This is done due to prettier being overly opinionated on the formatting of quotes
+# Ref: https://github.com/prettier/prettier/issues/973
+# And it not allowing rule opt outs
+# Ref: https://github.com/prettier/prettier/discussions/13925
+# Instead we rely on the contribution service to format these files
+# See: https://github.com/airbytehq/airbyte/blob/master/CONTRIBUTING.md#adding-a-new-connector
+airbyte-integrations/connectors/*/manifest.yaml

--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -851,6 +851,7 @@ airbyte-ci connectors --language=low-code migrate-to-manifest-only
 
 | Version | PR                                                         | Description                                                                                                                  |
 | ------- | ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| 4.36.1  |  | `airbyte-ci format js` respects `.prettierc` and `.prettierignore`                                                           |
 | 4.36.0  | [#44877](https://github.com/airbytehq/airbyte/pull/44877)  | Implement `--promote/rollback-release-candidate` in `connectors publish`.                                                    |
 | 4.35.6  | [#45632](https://github.com/airbytehq/airbyte/pull/45632)  | Add entry to format file ignore list (`destination-*/expected-spec.json`)                                                    |
 | 4.35.5  | [#45672](https://github.com/airbytehq/airbyte/pull/45672)  | Fix docs mount during publish                                                                                                |

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/format/consts.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/format/consts.py
@@ -72,4 +72,5 @@ WARM_UP_INCLUSIONS = {
     ],
     Formatter.PYTHON: ["pyproject.toml", "poetry.lock"],
     Formatter.LICENSE: [LICENSE_FILE_NAME],
+    Formatter.JS: [".prettierrc", ".prettierignore"],
 }

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/format/containers.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/format/containers.py
@@ -5,7 +5,6 @@
 from typing import Any, Dict, List, Optional, Union
 
 import dagger
-
 from pipelines.airbyte_ci.format.consts import CACHE_MOUNT_PATH, DEFAULT_FORMAT_IGNORE_LIST, REPO_MOUNT_PATH, WARM_UP_INCLUSIONS, Formatter
 from pipelines.consts import AIRBYTE_SUBMODULE_DIR_NAME, GO_IMAGE, MAVEN_IMAGE, NODE_IMAGE, PYTHON_3_10_IMAGE
 from pipelines.helpers import cache_keys

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/format/containers.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/format/containers.py
@@ -5,6 +5,7 @@
 from typing import Any, Dict, List, Optional, Union
 
 import dagger
+
 from pipelines.airbyte_ci.format.consts import CACHE_MOUNT_PATH, DEFAULT_FORMAT_IGNORE_LIST, REPO_MOUNT_PATH, WARM_UP_INCLUSIONS, Formatter
 from pipelines.consts import AIRBYTE_SUBMODULE_DIR_NAME, GO_IMAGE, MAVEN_IMAGE, NODE_IMAGE, PYTHON_3_10_IMAGE
 from pipelines.helpers import cache_keys
@@ -109,6 +110,7 @@ def format_js_container(dagger_client: dagger.Client, js_code: dagger.Directory,
     return build_container(
         dagger_client,
         base_image=NODE_IMAGE,
+        warmup_dir=warmup_directory(dagger_client, Formatter.JS),
         dir_to_format=js_code,
         install_commands=[f"npm install -g npm@10.1.0 prettier@{prettier_version}"],
         cache_volume=dagger_client.cache_volume(cache_keys.get_prettier_cache_key(prettier_version)),

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "4.36.0"
+version = "4.36.1"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 


### PR DESCRIPTION
## What

This PR adds `.prettierrc` and `.prettierignore` into `airbyte-ci format` containers. It also ignores the escaped doublequotes in yaml files specifically. 

The goal of this PR is to make Builder Contributions valid, because they have escaped quotes.

Closes https://github.com/airbytehq/airbyte-internal-issues/issues/9558

## How

Using existing `warmup_dirs` mechanism! @alafanechere thank you for putting that in. 

@bnchrch @erohmensing @lmossman check this out <3 