### PR TITLE
fix(airbyte-ci): fix progressive rollout finalize steps bugs

### DIFF
--- a/.github/workflows/finalize_rollout.yml
+++ b/.github/workflows/finalize_rollout.yml
@@ -43,6 +43,7 @@ jobs:
           metadata_service_gcs_credentials: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
           sentry_dsn: ${{ secrets.SENTRY_AIRBYTE_CI_DSN }}
           slack_webhook_url: ${{ secrets.PUBLISH_ON_MERGE_SLACK_WEBHOOK }}
+          spec_cache_gcs_credentials: ${{ secrets.SPEC_CACHE_SERVICE_ACCOUNT_KEY_PUBLISH }}
           subcommand: "connectors --name=${{ github.event.inputs.connector_name }} publish --promote-release-candidate"
       - name: Rollback {{ github.event.inputs.connector_name }} release candidate
         id: rollback-release-candidate

--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -851,7 +851,7 @@ airbyte-ci connectors --language=low-code migrate-to-manifest-only
 
 | Version | PR                                                         | Description                                                                                                                  |
 | ------- | ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| 4.36.2  | [#46274](https://github.com/airbytehq/airbyte/pull/46274)  | Fixed a bug in RC rollout and promote not taking `semaphore`                                                                 |
+| 4.36.2  | [#46278](https://github.com/airbytehq/airbyte/pull/46278)  | Fixed a bug in RC rollout and promote not taking `semaphore`                                                                 |
 | 4.36.1  | [#46274](https://github.com/airbytehq/airbyte/pull/46274)  | `airbyte-ci format js` respects `.prettierc` and `.prettierignore`                                                           |
 | 4.36.0  | [#44877](https://github.com/airbytehq/airbyte/pull/44877)  | Implement `--promote/rollback-release-candidate` in `connectors publish`.                                                    |
 | 4.35.6  | [#45632](https://github.com/airbytehq/airbyte/pull/45632)  | Add entry to format file ignore list (`destination-*/expected-spec.json`)                                                    |

--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -851,7 +851,8 @@ airbyte-ci connectors --language=low-code migrate-to-manifest-only
 
 | Version | PR                                                         | Description                                                                                                                  |
 | ------- | ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| 4.36.1  |  | `airbyte-ci format js` respects `.prettierc` and `.prettierignore`                                                           |
+| 4.36.2  | [#46274](https://github.com/airbytehq/airbyte/pull/46274)  | Fixed a bug in RC rollout and promote not taking `semaphore`                                                                 |
+| 4.36.1  | [#46274](https://github.com/airbytehq/airbyte/pull/46274)  | `airbyte-ci format js` respects `.prettierc` and `.prettierignore`                                                           |
 | 4.36.0  | [#44877](https://github.com/airbytehq/airbyte/pull/44877)  | Implement `--promote/rollback-release-candidate` in `connectors publish`.                                                    |
 | 4.35.6  | [#45632](https://github.com/airbytehq/airbyte/pull/45632)  | Add entry to format file ignore list (`destination-*/expected-spec.json`)                                                    |
 | 4.35.5  | [#45672](https://github.com/airbytehq/airbyte/pull/45672)  | Fix docs mount during publish                                                                                                |

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/publish/pipeline.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/publish/pipeline.py
@@ -12,6 +12,8 @@ import anyio
 from airbyte_protocol.models.airbyte_protocol import ConnectorSpecification  # type: ignore
 from connector_ops.utils import ConnectorLanguage  # type: ignore
 from dagger import Container, ExecError, File, ImageLayerCompression, Platform, QueryError
+from pydantic import BaseModel, ValidationError
+
 from pipelines import consts
 from pipelines.airbyte_ci.connectors.build_image import steps
 from pipelines.airbyte_ci.connectors.publish.context import PublishConnectorContext, RolloutMode
@@ -28,7 +30,6 @@ from pipelines.dagger.actions.remote_storage import upload_to_gcs
 from pipelines.dagger.actions.system import docker
 from pipelines.helpers.pip import is_package_published
 from pipelines.models.steps import Step, StepResult, StepStatus
-from pydantic import BaseModel, ValidationError
 
 
 class InvalidSpecOutputError(Exception):
@@ -543,7 +544,7 @@ async def _run_python_registry_publish_pipeline(context: PublishConnectorContext
     return results, False
 
 
-async def run_connector_rollback_pipeline(context: PublishConnectorContext) -> ConnectorReport:
+async def run_connector_rollback_pipeline(context: PublishConnectorContext, semaphore: anyio.Semaphore) -> ConnectorReport:
     """Run a rollback pipeline for a single connector.
 
     1. Check if the current metadata is a release candidate
@@ -554,19 +555,20 @@ async def run_connector_rollback_pipeline(context: PublishConnectorContext) -> C
     """
 
     results = []
-    async with context:
-        assert context.rollout_mode == RolloutMode.ROLLBACK, "This pipeline can only run in rollback mode."
-        assert context.connector.metadata.get("releases", {}).get(
-            "isReleaseCandidate", True
-        ), "This pipeline can only run for release candidates."
-        results.append(
-            await MetadataRollbackReleaseCandidate(context, context.metadata_bucket_name, context.metadata_service_gcs_credentials).run()
-        )
-
+    async with semaphore:
+        async with context:
+            assert context.rollout_mode == RolloutMode.ROLLBACK, "This pipeline can only run in rollback mode."
+            assert context.connector.metadata.get("releases", {}).get(
+                "isReleaseCandidate", True
+            ), "This pipeline can only run for release candidates."
+            results.append(
+                await MetadataRollbackReleaseCandidate(context, context.metadata_bucket_name, context.metadata_service_gcs_credentials).run()
+            )
+    
     return ConnectorReport(context, results, name="ROLLBACK RESULTS")
 
 
-async def run_connector_promote_pipeline(context: PublishConnectorContext) -> ConnectorReport:
+async def run_connector_promote_pipeline(context: PublishConnectorContext, semaphore: anyio.Semaphore) -> ConnectorReport:
     """Run a promote pipeline for a single connector.
 
     1. Publish the release candidate version docker image with the latest tag.
@@ -576,19 +578,20 @@ async def run_connector_promote_pipeline(context: PublishConnectorContext) -> Co
         ConnectorReport: The reports holding promote results.
     """
     results = []
-    async with context:
-        assert context.rollout_mode == RolloutMode.PROMOTE, "This pipeline can only run in promote mode."
-        assert context.connector.metadata.get("releases", {}).get(
-            "isReleaseCandidate", True
-        ), "This pipeline can only run for release candidates."
-        metadata_promote_result = await MetadataPromoteReleaseCandidate(
-            context, context.metadata_bucket_name, context.metadata_service_gcs_credentials
-        ).run()
-        results.append(metadata_promote_result)
-        if metadata_promote_result.status is StepStatus.FAILURE:
-            return ConnectorReport(context, results, name="PROMOTE RESULTS")
-        publish_latest_tag_results = await PushVersionImageAsLatest(context).run()
-        results.append(publish_latest_tag_results)
+    async with semaphore:
+        async with context:
+            assert context.rollout_mode == RolloutMode.PROMOTE, "This pipeline can only run in promote mode."
+            assert context.connector.metadata.get("releases", {}).get(
+                "isReleaseCandidate", True
+            ), "This pipeline can only run for release candidates."
+            metadata_promote_result = await MetadataPromoteReleaseCandidate(
+                context, context.metadata_bucket_name, context.metadata_service_gcs_credentials
+            ).run()
+            results.append(metadata_promote_result)
+            if metadata_promote_result.status is StepStatus.FAILURE:
+                return ConnectorReport(context, results, name="PROMOTE RESULTS")
+            publish_latest_tag_results = await PushVersionImageAsLatest(context).run()
+            results.append(publish_latest_tag_results)
     return ConnectorReport(context, results, name="PROMOTE RESULTS")
 
 

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/publish/pipeline.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/publish/pipeline.py
@@ -12,8 +12,6 @@ import anyio
 from airbyte_protocol.models.airbyte_protocol import ConnectorSpecification  # type: ignore
 from connector_ops.utils import ConnectorLanguage  # type: ignore
 from dagger import Container, ExecError, File, ImageLayerCompression, Platform, QueryError
-from pydantic import BaseModel, ValidationError
-
 from pipelines import consts
 from pipelines.airbyte_ci.connectors.build_image import steps
 from pipelines.airbyte_ci.connectors.publish.context import PublishConnectorContext, RolloutMode
@@ -30,6 +28,7 @@ from pipelines.dagger.actions.remote_storage import upload_to_gcs
 from pipelines.dagger.actions.system import docker
 from pipelines.helpers.pip import is_package_published
 from pipelines.models.steps import Step, StepResult, StepStatus
+from pydantic import BaseModel, ValidationError
 
 
 class InvalidSpecOutputError(Exception):
@@ -562,9 +561,11 @@ async def run_connector_rollback_pipeline(context: PublishConnectorContext, sema
                 "isReleaseCandidate", True
             ), "This pipeline can only run for release candidates."
             results.append(
-                await MetadataRollbackReleaseCandidate(context, context.metadata_bucket_name, context.metadata_service_gcs_credentials).run()
+                await MetadataRollbackReleaseCandidate(
+                    context, context.metadata_bucket_name, context.metadata_service_gcs_credentials
+                ).run()
             )
-    
+
     return ConnectorReport(context, results, name="ROLLBACK RESULTS")
 
 

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "4.36.1"
+version = "4.36.2"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 


### PR DESCRIPTION
## What

This PR fixes two bugs in progressive rollouts finalization:
1. `run_connector_rollback_pipeline` and it's promote buddy didn't take `semaphore` as the second arg, thus were not compatible with the API that the airbyte-ci command expected.
2. The finalize workflow did not pass `spec_cache_gcs_credentials` flag to airbyte-ci for promotions.
