### PR TITLE
ci(source-s3): fix skipped unit tests in CI

### DIFF
--- a/airbyte-integrations/connectors/source-s3/metadata.yaml
+++ b/airbyte-integrations/connectors/source-s3/metadata.yaml
@@ -41,6 +41,7 @@ data:
     - language:python
     - cdk:python-file-based
   connectorTestSuitesOptions:
+    - suite: unitTests
     - suite: liveTests
       testConnections:
         - name: s3_v4_jsonl_config_dev_null


### PR DESCRIPTION
## What

Found this additional case where unit tests appear to have been inadvertently disabled in CI once they were required to be explicitly declared.

This declares the unit tests suite explicitly so they will not be skipped.

Sidebar: Should we do an audit of all connectors to see if any others are missing these tests?

UPDATE: Following up to find others with disabled-but-passable-unit-tests here:

- #46301 

## How
<!--
* Describe how code changes achieve the solution.
-->

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
