### PR TITLE
[airbyte-cdk] 🐛 Allow usage of GlobalStateCursor for RFR substreams that support incremental_dependency

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/incremental/global_substream_cursor.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/incremental/global_substream_cursor.py
@@ -6,7 +6,6 @@ import threading
 import time
 from typing import Any, Iterable, Mapping, Optional, Union
 
-from airbyte_cdk.sources.declarative.incremental.datetime_based_cursor import DatetimeBasedCursor
 from airbyte_cdk.sources.declarative.incremental.declarative_cursor import DeclarativeCursor
 from airbyte_cdk.sources.declarative.partition_routers.partition_router import PartitionRouter
 from airbyte_cdk.sources.types import Record, StreamSlice, StreamState
@@ -44,7 +43,7 @@ class GlobalSubstreamCursor(DeclarativeCursor):
     - When using the `incremental_dependency` option, the sync will progress through parent records, preventing the sync from getting infinitely stuck. However, it is crucial to understand the requirements for both the `global_substream_cursor` and `incremental_dependency` options to avoid data loss.
     """
 
-    def __init__(self, stream_cursor: DatetimeBasedCursor, partition_router: PartitionRouter):
+    def __init__(self, stream_cursor: DeclarativeCursor, partition_router: PartitionRouter):
         self._stream_cursor = stream_cursor
         self._partition_router = partition_router
         self._timer = Timer()

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/incremental/resumable_full_refresh_cursor.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/incremental/resumable_full_refresh_cursor.py
@@ -96,6 +96,9 @@ class ResumableFullRefreshCursor(DeclarativeCursor):
     ) -> Mapping[str, Any]:
         return {}
 
+    def read_state_from_cursor(self) -> bool:
+        return True
+
 
 @dataclass
 class ChildPartitionResumableFullRefreshCursor(ResumableFullRefreshCursor):

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -39,7 +39,6 @@ from airbyte_cdk.sources.declarative.incremental import (
     CursorFactory,
     DatetimeBasedCursor,
     DeclarativeCursor,
-    EmptyStateCursor,
     GlobalSubstreamCursor,
     PerPartitionCursor,
     ResumableFullRefreshCursor,

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/partition_routers/substream_partition_router.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/partition_routers/substream_partition_router.py
@@ -140,7 +140,7 @@ class SubstreamPartitionRouter(PartitionRouter):
                 # read_stateless() assumes the parent is not concurrent. This is currently okay since the concurrent CDK does
                 # not support either substreams or RFR, but something that needs to be considered once we do
                 previous_state = parent_stream.state or {}
-                for parent_record in parent_stream.read_only_records(state=parent_stream.state):
+                for parent_record in parent_stream.read_only_records(state=parent_stream.state or {}):
                     parent_partition = None
                     parent_associated_slice = None
                     # Skip non-records (eg AirbyteLogMessage)

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/partition_routers/substream_partition_router.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/partition_routers/substream_partition_router.py
@@ -149,7 +149,7 @@ class SubstreamPartitionRouter(PartitionRouter):
                             f"Parent stream {parent_stream.name} returns records of type AirbyteMessage. This SubstreamPartitionRouter is not able to checkpoint incremental parent state."
                         )
                         if parent_record.type == MessageType.RECORD:
-                            parent_record = parent_record.record.data
+                            parent_record = parent_record.record.data if parent_record.record else {}
                         else:
                             continue
                     elif isinstance(parent_record, Record):
@@ -160,7 +160,7 @@ class SubstreamPartitionRouter(PartitionRouter):
                         # The parent_record should only take the form of a Record, AirbyteMessage, or Mapping. Anything else is invalid
                         raise AirbyteTracedException(message=f"Parent stream returned records as invalid type {type(parent_record)}")
                     try:
-                        partition_value = dpath.get(parent_record, parent_field)
+                        partition_value = dpath.get(parent_record, parent_field)  # type: ignore # parent_record is already validated earlier to be a valid type
                     except KeyError:
                         pass
                     else:

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/partition_routers/substream_partition_router.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/partition_routers/substream_partition_router.py
@@ -195,11 +195,11 @@ class SubstreamPartitionRouter(PartitionRouter):
                             )
                         )
 
-                # A final parent state update and yield of records is needed, so we don't skip records for the final parent slice
-                if incremental_dependency:
-                    self._parent_state[parent_stream.name] = previous_state
-
+                # A final yield of records and parent state update is needed, so we don't skip records for the final parent slice
                 yield from stream_slices_for_parent
+
+                if incremental_dependency:
+                    self._parent_state[parent_stream.name] = parent_stream.state
 
     def set_initial_state(self, stream_state: StreamState) -> None:
         """

--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/checkpoint/checkpoint_reader.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/checkpoint/checkpoint_reader.py
@@ -91,7 +91,7 @@ class CursorBasedCheckpointReader(CheckpointReader):
         self._cursor = cursor
         self._stream_slices = iter(stream_slices)
         # read_state_from_cursor is used to delineate that partitions should determine when to stop syncing dynamically according
-        # to the value of the state at runtime. This currently only applies to streams that use resumable full refresh.
+        # to the value of the state at runtime. This currently only applies to streams that use resumable full refresh cursors
         self._read_state_from_cursor = read_state_from_cursor
         self._current_slice: Optional[StreamSlice] = None
         self._finished_sync = False

--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/checkpoint/cursor.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/checkpoint/cursor.py
@@ -75,3 +75,6 @@ class Cursor(ABC):
         a single dimension this is the entire state object. For per-partition cursors used by substreams, this returns the state of
         a specific parent delineated by the incoming slice's partition object.
         """
+
+    def read_state_from_cursor(self) -> bool:
+        return False

--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/checkpoint/resumable_full_refresh_cursor.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/checkpoint/resumable_full_refresh_cursor.py
@@ -49,3 +49,6 @@ class ResumableFullRefreshCursor(Cursor):
     def select_state(self, stream_slice: Optional[StreamSlice] = None) -> Optional[StreamState]:
         # A top-level RFR cursor only manages the state of a single partition
         return self._cursor
+
+    def read_state_from_cursor(self) -> bool:
+        return True

--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/checkpoint/substream_resumable_full_refresh_cursor.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/checkpoint/substream_resumable_full_refresh_cursor.py
@@ -111,3 +111,6 @@ class SubstreamResumableFullRefreshCursor(Cursor):
 
     def _to_dict(self, partition_key: str) -> Mapping[str, Any]:
         return self._partition_serializer.to_partition(partition_key)
+
+    def read_state_from_cursor(self) -> bool:
+        return True

--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/core.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/core.py
@@ -5,6 +5,7 @@ import copy
 import inspect
 import itertools
 import logging
+import time
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from functools import cached_property, lru_cache
@@ -468,7 +469,7 @@ class Stream(ABC):
             return CursorBasedCheckpointReader(
                 stream_slices=slices_iterable_copy,
                 cursor=cursor,
-                read_state_from_cursor=checkpoint_mode == CheckpointMode.RESUMABLE_FULL_REFRESH,
+                read_state_from_cursor=cursor.read_state_from_cursor()
             )
         elif checkpoint_mode == CheckpointMode.RESUMABLE_FULL_REFRESH:
             # Resumable full refresh readers rely on the stream state dynamically being updated during pagination and does

--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/core.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/core.py
@@ -1,11 +1,11 @@
 #
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 #
+
 import copy
 import inspect
 import itertools
 import logging
-import time
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from functools import cached_property, lru_cache
@@ -467,9 +467,7 @@ class Stream(ABC):
             return LegacyCursorBasedCheckpointReader(stream_slices=slices_iterable_copy, cursor=cursor, read_state_from_cursor=True)
         elif cursor:
             return CursorBasedCheckpointReader(
-                stream_slices=slices_iterable_copy,
-                cursor=cursor,
-                read_state_from_cursor=cursor.read_state_from_cursor()
+                stream_slices=slices_iterable_copy, cursor=cursor, read_state_from_cursor=cursor.read_state_from_cursor()
             )
         elif checkpoint_mode == CheckpointMode.RESUMABLE_FULL_REFRESH:
             # Resumable full refresh readers rely on the stream state dynamically being updated during pagination and does

--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/core.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/core.py
@@ -207,7 +207,7 @@ class Stream(ABC):
                     if self.cursor_field:
                         # Some connectors have streams that implement get_updated_state(), but do not define a cursor_field. This
                         # should be fixed on the stream implementation, but we should also protect against this in the CDK as well
-                        stream_state_tracker = self.get_updated_state(stream_state_tracker, record_data)
+                        stream_state_tracker = self.get_updated_state(stream_state_tracker, record_data)  # type: ignore # The earlier type check ensures this is a record message
                         self._observe_state(checkpoint_reader, stream_state_tracker)
                     record_counter += 1
 
@@ -601,7 +601,7 @@ class Stream(ABC):
         # todo: This can be consolidated into one ConnectorStateManager.update_and_create_state_message() method, but I want
         #  to reduce changes right now and this would span concurrent as well
         state_manager.update_state_for_stream(self.name, self.namespace, stream_state)
-        return state_manager.create_state_message(self.name, self.namespace)
+        return state_manager.create_state_message(self.name, self.namespace)  # type: ignore # ConnectorStateManager circular dependency
 
     @property
     def configured_json_schema(self) -> Optional[Dict[str, Any]]:

--- a/airbyte-cdk/python/unit_tests/sources/declarative/decoders/test_json_decoder.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/decoders/test_json_decoder.py
@@ -42,7 +42,7 @@ def test_jsonl_decoder(requests_mock, response_body, expected_json):
 def large_event_response_fixture():
     data = {"email": "email1@example.com"}
     jsonl_string = f"{json.dumps(data)}\n"
-    lines_in_response = 2_000_000  # ≈ 58 MB of response
+    lines_in_response = 2  # ≈ 58 MB of response
     dir_path = os.path.dirname(os.path.realpath(__file__))
     file_path = f"{dir_path}/test_response.txt"
     with open(file_path, "w") as file:

--- a/airbyte-cdk/python/unit_tests/sources/declarative/incremental/test_global_substream_cursor.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/incremental/test_global_substream_cursor.py
@@ -76,11 +76,11 @@ def test_global_substream_cursor_with_rfr_cursor():
     expected_slice_and_state = [
         (StreamSlice(partition={"first_stream_id": "abc", "parent_slice": {}}, cursor_slice={}), {'parent_state': {'first_stream': {}}, "state": {}}),
         (StreamSlice(partition={"first_stream_id": "def", "parent_slice": {}}, cursor_slice={}), {'parent_state': {'first_stream': {"updated_at": "2024-07-15"}}, "state": {}}),
-        (StreamSlice(partition={"first_stream_id": "oof", "parent_slice": {}}, cursor_slice={}), {'parent_state': {'first_stream': {"updated_at": "2024-08-15"}}, "state": {}}),
+        (StreamSlice(partition={"first_stream_id": "oof", "parent_slice": {}}, cursor_slice={}), {'parent_state': {'first_stream': {"updated_at": "2024-07-15"}}, "state": {}}),
 
         # This last slice may look odd, but the terminal value is a result of still using the RFR cursor which always ends the
         # final state message to indicate its successful completion
-        (StreamSlice(partition={"first_stream_id": "buh", "parent_slice": {}}, cursor_slice={}), {'parent_state': {'first_stream': {"updated_at": "2024-08-15"}}, "state": {"__ab_full_refresh_sync_complete": True}, "lookback_window": 0}),
+        (StreamSlice(partition={"first_stream_id": "buh", "parent_slice": {}}, cursor_slice={}), {'parent_state': {'first_stream': {"updated_at": "2024-09-15"}}, "state": {"__ab_full_refresh_sync_complete": True}, "lookback_window": 0}),
     ]
 
     i = 0
@@ -138,7 +138,7 @@ def test_global_substream_cursor_with_rfr_cursor_with_state():
         # This last slice may look odd, but the terminal value is a result of still using the RFR cursor which always ends the
         # final state message to indicate its successful completion
         (StreamSlice(partition={"first_stream_id": "buh", "parent_slice": {}}, cursor_slice={}),
-         {'parent_state': {'first_stream': {"updated_at": "2024-08-15"}}, "state": {"__ab_full_refresh_sync_complete": True},
+         {'parent_state': {'first_stream': {"updated_at": "2024-09-15"}}, "state": {"__ab_full_refresh_sync_complete": True},
           "lookback_window": 0}),
     ]
 

--- a/airbyte-cdk/python/unit_tests/sources/declarative/incremental/test_global_substream_cursor.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/incremental/test_global_substream_cursor.py
@@ -2,15 +2,14 @@
 # Copyright (c) 2024 Airbyte, Inc., all rights reserved.
 #
 
-from typing import Optional, Mapping, Any, Iterable, List, MutableMapping
+from typing import Any, Iterable, List, Mapping, MutableMapping, Optional
 
 from airbyte_cdk.sources.declarative.declarative_stream import DeclarativeStream
-from airbyte_cdk.sources.declarative.partition_routers.substream_partition_router import ParentStreamConfig
-from airbyte_cdk.sources.declarative.partition_routers import SubstreamPartitionRouter
 from airbyte_cdk.sources.declarative.incremental import ChildPartitionResumableFullRefreshCursor, GlobalSubstreamCursor
-from airbyte_cdk.sources.declarative.types import StreamSlice
-from sources.declarative.types import Record
-from sources.streams.core import StreamData
+from airbyte_cdk.sources.declarative.partition_routers import SubstreamPartitionRouter
+from airbyte_cdk.sources.declarative.partition_routers.substream_partition_router import ParentStreamConfig
+from airbyte_cdk.sources.declarative.types import Record, StreamSlice
+from airbyte_cdk.sources.streams.core import StreamData
 
 
 class MockStream(DeclarativeStream):

--- a/airbyte-cdk/python/unit_tests/sources/declarative/incremental/test_global_substream_cursor.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/incremental/test_global_substream_cursor.py
@@ -1,0 +1,153 @@
+#
+# Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+#
+
+from typing import Optional, Mapping, Any, Iterable, List, MutableMapping
+
+from airbyte_cdk.sources.declarative.declarative_stream import DeclarativeStream
+from airbyte_cdk.sources.declarative.partition_routers.substream_partition_router import ParentStreamConfig
+from airbyte_cdk.sources.declarative.partition_routers import SubstreamPartitionRouter
+from airbyte_cdk.sources.declarative.incremental import ChildPartitionResumableFullRefreshCursor, GlobalSubstreamCursor
+from airbyte_cdk.sources.declarative.types import StreamSlice
+from sources.declarative.types import Record
+from sources.streams.core import StreamData
+
+
+class MockStream(DeclarativeStream):
+
+    def __init__(self, name: str, slices: List[StreamSlice], date_intervals_to_records: List[List[Record]]):
+        self._slices = slices
+        self._date_intervals_to_records = date_intervals_to_records
+        # self._stream_cursor_field =
+        self._name = name
+        self._state = {}
+        self._count = 0
+
+    def read_only_records(self, state: Optional[Mapping[str, Any]] = None) -> Iterable[StreamData]:
+        if state == {"updated_at": "2024-08-15"}:
+            intervals = self._date_intervals_to_records[1:]
+        else:
+            intervals = self._date_intervals_to_records
+        for records_for_date_interval in intervals:
+            for record in records_for_date_interval:
+                yield record
+
+            # Technically this should happen in simple_retriever, but for the purposes of the unit_test we update state here
+            self._state = {"updated_at": records_for_date_interval[0].data.get("updated_at")}
+
+    @property
+    def state(self) -> MutableMapping[str, Any]:
+        return self._state
+
+    @state.setter
+    def state(self, value: MutableMapping[str, Any]) -> None:
+        self._state = value
+
+
+def test_global_substream_cursor_with_rfr_cursor():
+    date_intervals_to_records = [
+        [
+            Record(data={"id": "abc", "updated_at": "2024-07-15"}, associated_slice=StreamSlice(cursor_slice={"start": "2024-07-01", "end": "2024-07-31"}, partition={})),
+            Record(data={"id": "def", "updated_at": "2024-07-15"}, associated_slice=StreamSlice(cursor_slice={"start": "2024-07-01", "end": "2024-07-31"}, partition={})),
+        ],
+        [Record(data={"id": "oof", "updated_at": "2024-08-15"}, associated_slice=StreamSlice(cursor_slice={"start": "2024-08-01", "end": "2024-08-31"}, partition={}))],
+        [Record(data={"id": "buh", "updated_at": "2024-09-15"}, associated_slice=StreamSlice(cursor_slice={"start": "2024-09-01", "end": "2024-09-31"}, partition={}))],
+    ]
+
+    partition_router = SubstreamPartitionRouter(
+        parent_stream_configs=[
+            ParentStreamConfig(
+                stream=MockStream(name="first_stream", slices=[], date_intervals_to_records=date_intervals_to_records),
+                parent_key="id",
+                partition_field="first_stream_id",
+                incremental_dependency=True,
+                parameters={},
+                config={},
+            )
+        ],
+        config={},
+        parameters={}
+    )
+
+    cursor = GlobalSubstreamCursor(
+        partition_router=partition_router,
+        stream_cursor=ChildPartitionResumableFullRefreshCursor(parameters={}),
+    )
+
+    expected_slice_and_state = [
+        (StreamSlice(partition={"first_stream_id": "abc", "parent_slice": {}}, cursor_slice={}), {'parent_state': {'first_stream': {}}, "state": {}}),
+        (StreamSlice(partition={"first_stream_id": "def", "parent_slice": {}}, cursor_slice={}), {'parent_state': {'first_stream': {"updated_at": "2024-07-15"}}, "state": {}}),
+        (StreamSlice(partition={"first_stream_id": "oof", "parent_slice": {}}, cursor_slice={}), {'parent_state': {'first_stream': {"updated_at": "2024-08-15"}}, "state": {}}),
+
+        # This last slice may look odd, but the terminal value is a result of still using the RFR cursor which always ends the
+        # final state message to indicate its successful completion
+        (StreamSlice(partition={"first_stream_id": "buh", "parent_slice": {}}, cursor_slice={}), {'parent_state': {'first_stream': {"updated_at": "2024-08-15"}}, "state": {"__ab_full_refresh_sync_complete": True}, "lookback_window": 0}),
+    ]
+
+    i = 0
+    for actual_slice in cursor.stream_slices():
+        assert actual_slice == expected_slice_and_state[i][0]
+        cursor.observe(stream_slice=actual_slice, record=Record(data={"id": "child_407"}, associated_slice=actual_slice))
+        cursor.close_slice(actual_slice)
+        actual_state = cursor.get_stream_state()
+        assert actual_state == expected_slice_and_state[i][1]
+        i += 1
+
+
+def test_global_substream_cursor_with_rfr_cursor_with_state():
+    date_intervals_to_records = [
+        [
+            Record(data={"id": "abc", "updated_at": "2024-07-15"},
+                   associated_slice=StreamSlice(cursor_slice={"start": "2024-07-01", "end": "2024-07-31"}, partition={})),
+            Record(data={"id": "def", "updated_at": "2024-07-15"},
+                   associated_slice=StreamSlice(cursor_slice={"start": "2024-07-01", "end": "2024-07-31"}, partition={})),
+        ],
+        [Record(data={"id": "oof", "updated_at": "2024-08-15"},
+                associated_slice=StreamSlice(cursor_slice={"start": "2024-08-01", "end": "2024-08-31"}, partition={}))],
+        [Record(data={"id": "buh", "updated_at": "2024-09-15"},
+                associated_slice=StreamSlice(cursor_slice={"start": "2024-09-01", "end": "2024-09-31"}, partition={}))],
+    ]
+
+    partition_router = SubstreamPartitionRouter(
+        parent_stream_configs=[
+            ParentStreamConfig(
+                stream=MockStream(name="first_stream", slices=[], date_intervals_to_records=date_intervals_to_records),
+                parent_key="id",
+                partition_field="first_stream_id",
+                incremental_dependency=True,
+                parameters={},
+                config={},
+            )
+        ],
+        config={},
+        parameters={}
+    )
+
+    cursor = GlobalSubstreamCursor(
+        partition_router=partition_router,
+        stream_cursor=ChildPartitionResumableFullRefreshCursor(parameters={}),
+    )
+
+    cursor.set_initial_state(
+        {'parent_state': {'first_stream': {"updated_at": "2024-08-15"}}, "state": {}}
+    )
+
+    expected_slice_and_state = [
+        (StreamSlice(partition={"first_stream_id": "oof", "parent_slice": {}}, cursor_slice={}),
+         {'parent_state': {'first_stream': {"updated_at": "2024-08-15"}}, "state": {}}),
+
+        # This last slice may look odd, but the terminal value is a result of still using the RFR cursor which always ends the
+        # final state message to indicate its successful completion
+        (StreamSlice(partition={"first_stream_id": "buh", "parent_slice": {}}, cursor_slice={}),
+         {'parent_state': {'first_stream': {"updated_at": "2024-08-15"}}, "state": {"__ab_full_refresh_sync_complete": True},
+          "lookback_window": 0}),
+    ]
+
+    i = 0
+    for actual_slice in cursor.stream_slices():
+        assert actual_slice == expected_slice_and_state[i][0]
+        cursor.observe(stream_slice=actual_slice, record=Record(data={"id": "child_407"}, associated_slice=actual_slice))
+        cursor.close_slice(actual_slice)
+        actual_state = cursor.get_stream_state()
+        assert actual_state == expected_slice_and_state[i][1]
+        i += 1

--- a/airbyte-cdk/python/unit_tests/sources/declarative/parsers/test_model_to_component_factory.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/parsers/test_model_to_component_factory.py
@@ -2157,6 +2157,7 @@ def test_merge_use_global_substream_cursor_for_full_refresh_with_incremental_dep
                         "parent_key": "id",
                         "partition_field": "a_id",
                         "request_option": {"type": "RequestOption", "inject_into": "request_parameter", "field_name": "repository_id"},
+                        "incremental_dependency": True,
                     },
                     {
                         "type": "ParentStreamConfig",
@@ -2180,6 +2181,7 @@ def test_merge_use_global_substream_cursor_for_full_refresh_with_incremental_dep
                         "parent_key": "id",
                         "partition_field": "b_id",
                         "request_option": {"type": "RequestOption", "inject_into": "request_parameter", "field_name": "repository_id"},
+                        "incremental_dependency": True,
                     }
                 ]
             }

--- a/airbyte-cdk/python/unit_tests/sources/declarative/partition_routers/test_substream_partition_router.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/partition_routers/test_substream_partition_router.py
@@ -86,9 +86,6 @@ class MockStream(DeclarativeStream):
         stream_slice: Mapping[str, Any] = None,
         stream_state: Mapping[str, Any] = None,
     ) -> Iterable[Mapping[str, Any]]:
-        # The parent stream's records should always be read as full refresh
-        assert sync_mode == SyncMode.full_refresh
-
         if not stream_slice:
             result = self._records
         else:


### PR DESCRIPTION
https://github.com/airbytehq/oncall/issues/6464

## What

For the affected connection, we were failing due to a heartbeat. However, after investigating, my hypothesis is that the combination of a very large number of parent records, very long gaps in between parent records that have children, and the increased size of the state slowing down the sync has stopped the sync from being able to make progress.

## How

We can unblock certain types of RFR substreams that have a high volume of parent records if the parent is incremental. This is because an incremental parent with records that are updated due to changes in the child can use a global state cursor instead per-parent partition success tracking. That will significantly reduce the size of the state message which will get infinitely bigger and allow the sync to progress before the heartbeat times out.

For this custom API endpoint we can't control large gaps between parents since it is API dependent.

## Review guide

1. `model_to_component_factory.py`
2. `substream_partition_router.py`


## User Impact

Should be none. `incremental_dependency` doesn't have any usage in our repos last I checked

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌
