### PR TITLE
feat(airbyte-cdk): Add extra fields to StreamSlice

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -2082,7 +2082,9 @@ definitions:
         default: false
       extra_fields:
         title: Extra Fields
-        description: Array of field paths to include as additional fields.
+        description: Array of field paths to include as additional fields in the stream slice. Each path is an array of strings representing keys to access fields in the respective parent record. Accessible via `stream_slice.extra_fields`. Missing fields are set to `None`.
+        interpolation_context:
+          - config
         type: array
         items:
           type: array

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -2080,6 +2080,18 @@ definitions:
         description: Indicates whether the parent stream should be read incrementally based on updates in the child stream.
         type: boolean
         default: false
+      extra_fields:
+        title: Extra Fields
+        description: Array of field paths to include as additional fields.
+        type: array
+        items:
+          type: array
+          items:
+            type: string
+          description: Defines a field path as an array of strings.
+          examples:
+            - [ "field1" ]
+            - [ "nested", "field2" ]
       $parameters:
         type: object
         additionalProperties: true

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -2090,8 +2090,8 @@ definitions:
             type: string
           description: Defines a field path as an array of strings.
           examples:
-            - [ "field1" ]
-            - [ "nested", "field2" ]
+            - ["field1"]
+            - ["nested", "field2"]
       $parameters:
         type: object
         additionalProperties: true

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/extractors/record_filter.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/extractors/record_filter.py
@@ -37,7 +37,7 @@ class RecordFilter:
             "stream_state": stream_state,
             "stream_slice": stream_slice,
             "next_page_token": next_page_token,
-            "stream_slice.extra_fields": stream_slice.extra_fields,
+            "stream_slice.extra_fields": stream_slice.extra_fields if stream_slice else {},
         }
         for record in records:
             if self._filter_interpolator.eval(self.config, record=record, **kwargs):

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/extractors/record_filter.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/extractors/record_filter.py
@@ -33,7 +33,12 @@ class RecordFilter:
         stream_slice: Optional[StreamSlice] = None,
         next_page_token: Optional[Mapping[str, Any]] = None,
     ) -> Iterable[Mapping[str, Any]]:
-        kwargs = {"stream_state": stream_state, "stream_slice": stream_slice, "next_page_token": next_page_token}
+        kwargs = {
+            "stream_state": stream_state,
+            "stream_slice": stream_slice,
+            "next_page_token": next_page_token,
+            "stream_slice.extra_fields": stream_slice.extra_fields,
+        }
         for record in records:
             if self._filter_interpolator.eval(self.config, record=record, **kwargs):
                 yield record

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/incremental/per_partition_cursor.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/incremental/per_partition_cursor.py
@@ -69,7 +69,7 @@ class PerPartitionCursor(DeclarativeCursor):
                 self._cursor_per_partition[self._to_partition_key(partition.partition)] = cursor
 
             for cursor_slice in cursor.stream_slices():
-                yield StreamSlice(partition=partition, cursor_slice=cursor_slice)
+                yield StreamSlice(partition=partition, cursor_slice=cursor_slice, extra_fields=partition.extra_fields)
 
     def _ensure_partition_limit(self) -> None:
         """

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
@@ -1580,6 +1580,11 @@ class ParentStreamConfig(BaseModel):
         description='Indicates whether the parent stream should be read incrementally based on updates in the child stream.',
         title='Incremental Dependency',
     )
+    extra_fields: Optional[List[List[str]]] = Field(
+        None,
+        description='Array of field paths to include as additional fields.',
+        title='Extra Fields',
+    )
     parameters: Optional[Dict[str, Any]] = Field(None, alias='$parameters')
 
 

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/models/declarative_component_schema.py
@@ -1582,7 +1582,7 @@ class ParentStreamConfig(BaseModel):
     )
     extra_fields: Optional[List[List[str]]] = Field(
         None,
-        description='Array of field paths to include as additional fields.',
+        description='Array of field paths to include as additional fields in the stream slice. Each path is an array of strings representing keys to access fields in the respective parent record. Accessible via `stream_slice.extra_fields`. Missing fields are set to `None`.',
         title='Extra Fields',
     )
     parameters: Optional[Dict[str, Any]] = Field(None, alias='$parameters')

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -1081,6 +1081,7 @@ class ModelToComponentFactory:
             config=config,
             incremental_dependency=model.incremental_dependency or False,
             parameters=model.parameters or {},
+            extra_fields=model.extra_fields or [],
         )
 
     @staticmethod

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -1081,7 +1081,7 @@ class ModelToComponentFactory:
             config=config,
             incremental_dependency=model.incremental_dependency or False,
             parameters=model.parameters or {},
-            extra_fields=model.extra_fields or [],
+            extra_fields=model.extra_fields,
         )
 
     @staticmethod

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/partition_routers/substream_partition_router.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/partition_routers/substream_partition_router.py
@@ -36,7 +36,7 @@ class ParentStreamConfig:
     partition_field: Union[InterpolatedString, str]
     config: Config
     parameters: InitVar[Mapping[str, Any]]
-    extra_fields: Optional[List[List[Union[InterpolatedString, str]]]] = None  # List of field paths (arrays of strings)
+    extra_fields: Optional[Union[List[List[str]], List[List[InterpolatedString]]]] = None  # List of field paths (arrays of strings)
     request_option: Optional[RequestOption] = None
     incremental_dependency: bool = False
 
@@ -215,7 +215,9 @@ class SubstreamPartitionRouter(PartitionRouter):
 
                 yield from stream_slices_for_parent
 
-    def _extract_extra_fields(self, parent_record: Mapping[str, Any], extra_fields: Optional[List[List[str]]] = None) -> Mapping[str, Any]:
+    def _extract_extra_fields(
+        self, parent_record: Mapping[str, Any] | AirbyteMessage, extra_fields: Optional[List[List[str]]] = None
+    ) -> Mapping[str, Any]:
         """
         Extracts additional fields specified by their paths from the parent record.
 

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/partition_routers/substream_partition_router.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/partition_routers/substream_partition_router.py
@@ -26,6 +26,7 @@ class ParentStreamConfig:
     stream: The stream to read records from
     parent_key: The key of the parent stream's records that will be the stream slice key
     partition_field: The partition key
+    extra_fields: Additional field paths to include in the stream slice
     request_option: How to inject the slice value on an outgoing HTTP request
     incremental_dependency (bool): Indicates if the parent stream should be read incrementally.
     """
@@ -35,12 +36,19 @@ class ParentStreamConfig:
     partition_field: Union[InterpolatedString, str]
     config: Config
     parameters: InitVar[Mapping[str, Any]]
+    extra_fields: Optional[List[List[Union[InterpolatedString, str]]]] = None  # List of field paths (arrays of strings)
     request_option: Optional[RequestOption] = None
     incremental_dependency: bool = False
 
     def __post_init__(self, parameters: Mapping[str, Any]) -> None:
         self.parent_key = InterpolatedString.create(self.parent_key, parameters=parameters)
         self.partition_field = InterpolatedString.create(self.partition_field, parameters=parameters)
+        if self.extra_fields:
+            # Create InterpolatedString for each field path in extra_keys
+            self.extra_fields = [
+                [InterpolatedString.create(path, parameters=parameters) for path in key_path]
+                for key_path in self.extra_fields
+            ]
 
 
 @dataclass
@@ -132,6 +140,9 @@ class SubstreamPartitionRouter(PartitionRouter):
                 parent_stream = parent_stream_config.stream
                 parent_field = parent_stream_config.parent_key.eval(self.config)  # type: ignore # parent_key is always casted to an interpolated string
                 partition_field = parent_stream_config.partition_field.eval(self.config)  # type: ignore # partition_field is always casted to an interpolated string
+                if parent_stream_config.extra_fields:
+                    extra_fields = [[field_path_part.eval(self.config) for field_path_part in field_path] for field_path in parent_stream_config.extra_fields]
+
                 incremental_dependency = parent_stream_config.incremental_dependency
 
                 stream_slices_for_parent = []
@@ -186,9 +197,14 @@ class SubstreamPartitionRouter(PartitionRouter):
                                 # Reset stream_slices_for_parent after we've flushed parent records for the previous parent slice
                                 stream_slices_for_parent = []
                                 previous_associated_slice = parent_associated_slice
+
+                        # Add extra fields
+                        extracted_extra_fields = self._extract_extra_fields(parent_record, extra_fields)
+
                         stream_slices_for_parent.append(
                             StreamSlice(
-                                partition={partition_field: partition_value, "parent_slice": parent_partition or {}}, cursor_slice={}
+                                partition={partition_field: partition_value, "parent_slice": parent_partition or {}}, cursor_slice={},
+                                extra_fields=extracted_extra_fields
                             )
                         )
 
@@ -197,6 +213,29 @@ class SubstreamPartitionRouter(PartitionRouter):
                     self._parent_state[parent_stream.name] = parent_stream.state
 
                 yield from stream_slices_for_parent
+
+    def _extract_extra_fields(self, parent_record: Mapping[str, Any], extra_fields: Optional[List[List[str]]] = None) -> Mapping[str, Any]:
+        """
+        Extracts additional fields specified by their paths from the parent record.
+
+        Args:
+            parent_record (Mapping[str, Any]): The record from the parent stream to extract fields from.
+            extra_fields (Optional[List[List[str]]]): A list of field paths (as lists of strings) to extract from the parent record.
+
+        Returns:
+            Mapping[str, Any]: A dictionary containing the extracted fields.
+                               The keys are the joined field paths, and the values are the corresponding extracted values.
+        """
+        extracted_extra_fields = {}
+        if extra_fields:
+            for extra_field_path in extra_fields:
+                try:
+                    extra_field_value = dpath.util.get(parent_record, extra_field_path)
+                except KeyError:
+                    self.logger.warning(f"Failed to extract extra_field_path: {extra_field_path}")
+                    extra_field_value = None
+                extracted_extra_fields[".".join(extra_field_path)] = extra_field_value
+        return extracted_extra_field
 
     def set_initial_state(self, stream_state: StreamState) -> None:
         """

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/partition_routers/substream_partition_router.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/partition_routers/substream_partition_router.py
@@ -234,8 +234,9 @@ class SubstreamPartitionRouter(PartitionRouter):
             for extra_field_path in extra_fields:
                 try:
                     extra_field_value = dpath.get(parent_record, extra_field_path)
+                    self.logger.debug(f"Extracted extra_field_path: {extra_field_path} with value: {extra_field_value}")
                 except KeyError:
-                    self.logger.warning(f"Failed to extract extra_field_path: {extra_field_path}")
+                    self.logger.debug(f"Failed to extract extra_field_path: {extra_field_path}")
                     extra_field_value = None
                 extracted_extra_fields[".".join(extra_field_path)] = extra_field_value
         return extracted_extra_fields

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/partition_routers/substream_partition_router.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/partition_routers/substream_partition_router.py
@@ -159,7 +159,7 @@ class SubstreamPartitionRouter(PartitionRouter):
                             f"Parent stream {parent_stream.name} returns records of type AirbyteMessage. This SubstreamPartitionRouter is not able to checkpoint incremental parent state."
                         )
                         if parent_record.type == MessageType.RECORD:
-                            parent_record = parent_record.record.data
+                            parent_record = parent_record.record.data  # type: ignore[union-attr]  # record is always a Record
                         else:
                             continue
                     elif isinstance(parent_record, Record):

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/partition_routers/substream_partition_router.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/partition_routers/substream_partition_router.py
@@ -46,8 +46,7 @@ class ParentStreamConfig:
         if self.extra_fields:
             # Create InterpolatedString for each field path in extra_keys
             self.extra_fields = [
-                [InterpolatedString.create(path, parameters=parameters) for path in key_path]
-                for key_path in self.extra_fields
+                [InterpolatedString.create(path, parameters=parameters) for path in key_path] for key_path in self.extra_fields
             ]
 
 
@@ -204,8 +203,9 @@ class SubstreamPartitionRouter(PartitionRouter):
 
                         stream_slices_for_parent.append(
                             StreamSlice(
-                                partition={partition_field: partition_value, "parent_slice": parent_partition or {}}, cursor_slice={},
-                                extra_fields=extracted_extra_fields
+                                partition={partition_field: partition_value, "parent_slice": parent_partition or {}},
+                                cursor_slice={},
+                                extra_fields=extracted_extra_fields,
                             )
                         )
 

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/partition_routers/substream_partition_router.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/partition_routers/substream_partition_router.py
@@ -140,8 +140,9 @@ class SubstreamPartitionRouter(PartitionRouter):
                 parent_stream = parent_stream_config.stream
                 parent_field = parent_stream_config.parent_key.eval(self.config)  # type: ignore # parent_key is always casted to an interpolated string
                 partition_field = parent_stream_config.partition_field.eval(self.config)  # type: ignore # partition_field is always casted to an interpolated string
+                extra_fields = None
                 if parent_stream_config.extra_fields:
-                    extra_fields = [[field_path_part.eval(self.config) for field_path_part in field_path] for field_path in parent_stream_config.extra_fields]
+                    extra_fields = [[field_path_part.eval(self.config) for field_path_part in field_path] for field_path in parent_stream_config.extra_fields]  # type: ignore # extra_fields is always casted to an interpolated string
 
                 incremental_dependency = parent_stream_config.incremental_dependency
 
@@ -230,12 +231,12 @@ class SubstreamPartitionRouter(PartitionRouter):
         if extra_fields:
             for extra_field_path in extra_fields:
                 try:
-                    extra_field_value = dpath.util.get(parent_record, extra_field_path)
+                    extra_field_value = dpath.get(parent_record, extra_field_path)
                 except KeyError:
                     self.logger.warning(f"Failed to extract extra_field_path: {extra_field_path}")
                     extra_field_value = None
                 extracted_extra_fields[".".join(extra_field_path)] = extra_field_value
-        return extracted_extra_field
+        return extracted_extra_fields
 
     def set_initial_state(self, stream_state: StreamState) -> None:
         """

--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/checkpoint/checkpoint_reader.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/checkpoint/checkpoint_reader.py
@@ -165,7 +165,11 @@ class CursorBasedCheckpointReader(CheckpointReader):
                         next_candidate_slice = self.read_and_convert_slice()
                         state_for_slice = self._cursor.select_state(next_candidate_slice)
                         has_more = state_for_slice == FULL_REFRESH_COMPLETE_STATE
-                    return StreamSlice(cursor_slice=state_for_slice or {}, partition=next_candidate_slice.partition)
+                    return StreamSlice(
+                        cursor_slice=state_for_slice or {},
+                        partition=next_candidate_slice.partition,
+                        extra_fields=next_candidate_slice.extra_fields,
+                    )
                 # The reader continues to process the current partition if it's state is still in progress
                 return StreamSlice(
                     cursor_slice=state_for_slice or {}, partition=self.current_slice.partition, extra_fields=self.current_slice.extra_fields

--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/checkpoint/checkpoint_reader.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/checkpoint/checkpoint_reader.py
@@ -167,7 +167,9 @@ class CursorBasedCheckpointReader(CheckpointReader):
                         has_more = state_for_slice == FULL_REFRESH_COMPLETE_STATE
                     return StreamSlice(cursor_slice=state_for_slice or {}, partition=next_candidate_slice.partition)
                 # The reader continues to process the current partition if it's state is still in progress
-                return StreamSlice(cursor_slice=state_for_slice or {}, partition=self.current_slice.partition, extra_fields=self.current_slice.extra_fields)
+                return StreamSlice(
+                    cursor_slice=state_for_slice or {}, partition=self.current_slice.partition, extra_fields=self.current_slice.extra_fields
+                )
         else:
             # Unlike RFR cursors that iterate dynamically according to how stream state is updated, most cursors operate
             # on a fixed set of slices determined before reading records. They just iterate to the next slice

--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/checkpoint/checkpoint_reader.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/checkpoint/checkpoint_reader.py
@@ -152,7 +152,7 @@ class CursorBasedCheckpointReader(CheckpointReader):
                         next_slice = self.read_and_convert_slice()
                         state_for_slice = self._cursor.select_state(next_slice)
                         has_more = state_for_slice == FULL_REFRESH_COMPLETE_STATE
-                return StreamSlice(cursor_slice=state_for_slice or {}, partition=next_slice.partition)
+                return StreamSlice(cursor_slice=state_for_slice or {}, partition=next_slice.partition, extra_fields=next_slice.extra_fields)
             else:
                 state_for_slice = self._cursor.select_state(self.current_slice)
                 if state_for_slice == FULL_REFRESH_COMPLETE_STATE:
@@ -167,7 +167,7 @@ class CursorBasedCheckpointReader(CheckpointReader):
                         has_more = state_for_slice == FULL_REFRESH_COMPLETE_STATE
                     return StreamSlice(cursor_slice=state_for_slice or {}, partition=next_candidate_slice.partition)
                 # The reader continues to process the current partition if it's state is still in progress
-                return StreamSlice(cursor_slice=state_for_slice or {}, partition=self.current_slice.partition)
+                return StreamSlice(cursor_slice=state_for_slice or {}, partition=self.current_slice.partition, extra_fields=self.current_slice.extra_fields)
         else:
             # Unlike RFR cursors that iterate dynamically according to how stream state is updated, most cursors operate
             # on a fixed set of slices determined before reading records. They just iterate to the next slice

--- a/airbyte-cdk/python/airbyte_cdk/sources/types.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/types.py
@@ -53,8 +53,9 @@ class Record(Mapping[str, Any]):
 
 
 class StreamSlice(Mapping[str, Any]):
-    def __init__(self, *, partition: Mapping[str, Any], cursor_slice: Mapping[str, Any],
-                 extra_fields: Optional[Mapping[str, Any]] = None) -> None:
+    def __init__(
+        self, *, partition: Mapping[str, Any], cursor_slice: Mapping[str, Any], extra_fields: Optional[Mapping[str, Any]] = None
+    ) -> None:
         """
         :param partition: The partition keys representing a unique partition in the stream.
         :param cursor_slice: The incremental cursor slice keys, such as dates or pagination tokens.

--- a/airbyte-cdk/python/airbyte_cdk/sources/types.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/types.py
@@ -53,15 +53,26 @@ class Record(Mapping[str, Any]):
 
 
 class StreamSlice(Mapping[str, Any]):
-    def __init__(self, *, partition: Mapping[str, Any], cursor_slice: Mapping[str, Any]) -> None:
+    def __init__(self, *, partition: Mapping[str, Any], cursor_slice: Mapping[str, Any],
+                 extra_fields: Optional[Mapping[str, Any]] = None) -> None:
+        """
+        :param partition: The partition keys representing a unique partition in the stream.
+        :param cursor_slice: The incremental cursor slice keys, such as dates or pagination tokens.
+        :param extra_fields: Additional fields that should not be part of the partition but passed along, such as metadata from the parent stream.
+        """
         self._partition = partition
         self._cursor_slice = cursor_slice
+        self._extra_fields = extra_fields or {}
+
+        # Ensure that partition keys do not overlap with cursor slice keys
         if partition.keys() & cursor_slice.keys():
             raise ValueError("Keys for partition and incremental sync cursor should not overlap")
+
         self._stream_slice = dict(partition) | dict(cursor_slice)
 
     @property
     def partition(self) -> Mapping[str, Any]:
+        """Returns the partition portion of the stream slice."""
         p = self._partition
         while isinstance(p, StreamSlice):
             p = p.partition
@@ -69,10 +80,16 @@ class StreamSlice(Mapping[str, Any]):
 
     @property
     def cursor_slice(self) -> Mapping[str, Any]:
+        """Returns the cursor slice portion of the stream slice."""
         c = self._cursor_slice
         while isinstance(c, StreamSlice):
             c = c.cursor_slice
         return c
+
+    @property
+    def extra_fields(self) -> Mapping[str, Any]:
+        """Returns the extra fields that are not part of the partition."""
+        return self._extra_fields
 
     def __repr__(self) -> str:
         return repr(self._stream_slice)

--- a/airbyte-cdk/python/unit_tests/sources/declarative/extractors/test_record_filter.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/extractors/test_record_filter.py
@@ -65,6 +65,11 @@ RECORDS_TO_FILTER_DATE_TIME_WITHOUT_TZ_FORMAT = [
             [{"id": 1, "created_at": "06-06-21"}, {"id": 2, "created_at": "06-07-21"}, {"id": 3, "created_at": "06-08-21"}],
             [{"id": 3, "created_at": "06-08-21"}],
         ),
+        (
+            "{{ record['created_at'] > stream_slice.extra_fields['created_at'] }}",
+            [{"id": 1, "created_at": "06-06-21"}, {"id": 2, "created_at": "06-07-21"}, {"id": 3, "created_at": "06-08-21"}],
+            [{"id": 3, "created_at": "06-08-21"}],
+        ),
     ],
     ids=[
         "test_using_state_filter",
@@ -72,13 +77,14 @@ RECORDS_TO_FILTER_DATE_TIME_WITHOUT_TZ_FORMAT = [
         "test_with_next_page_token_filter",
         "test_missing_filter_fields_return_no_results",
         "test_using_parameters_filter",
+        "test_using_extra_fields_filter",
     ],
 )
 def test_record_filter(filter_template: str, records: List[Mapping], expected_records: List[Mapping]):
     config = {"response_override": "stop_if_you_see_me"}
     parameters = {"created_at": "06-07-21"}
     stream_state = {"created_at": "06-06-21"}
-    stream_slice = {"last_seen": "06-10-21"}
+    stream_slice = StreamSlice(partition={}, cursor_slice={"last_seen": "06-10-21"}, extra_fields={"created_at": "06-07-21"})
     next_page_token = {"last_seen_id": 14}
     record_filter = RecordFilter(config=config, condition=filter_template, parameters=parameters)
 

--- a/airbyte-cdk/python/unit_tests/sources/declarative/extractors/test_record_selector.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/extractors/test_record_selector.py
@@ -12,7 +12,7 @@ from airbyte_cdk.sources.declarative.extractors.dpath_extractor import DpathExtr
 from airbyte_cdk.sources.declarative.extractors.record_filter import RecordFilter
 from airbyte_cdk.sources.declarative.extractors.record_selector import RecordSelector
 from airbyte_cdk.sources.declarative.transformations import RecordTransformation
-from airbyte_cdk.sources.types import Record
+from airbyte_cdk.sources.types import Record, StreamSlice
 from airbyte_cdk.sources.utils.transform import TransformConfig, TypeTransformer
 
 
@@ -67,7 +67,7 @@ def test_record_filter(test_name, field_path, filter_template, body, expected_da
     config = {"response_override": "stop_if_you_see_me"}
     parameters = {"parameters_field": "data", "created_at": "06-07-21"}
     stream_state = {"created_at": "06-06-21"}
-    stream_slice = {"last_seen": "06-10-21"}
+    stream_slice = StreamSlice(partition={}, cursor_slice={"last_seen": "06-10-21"})
     next_page_token = {"last_seen_id": 14}
     schema = create_schema()
     first_transformation = Mock(spec=RecordTransformation)

--- a/airbyte-cdk/python/unit_tests/sources/declarative/partition_routers/test_substream_partition_router.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/partition_routers/test_substream_partition_router.py
@@ -833,3 +833,50 @@ def test_substream_using_resumable_full_refresh_parent_stream_slices(use_increme
         assert final_state["states"] == expected_substream_state["states"], "State for substreams is not valid!"
     else:
         assert final_state == expected_substream_state, "State for substreams with incremental dependency is not valid!"
+
+
+@pytest.mark.parametrize(
+    "parent_stream_configs, expected_slices",
+    [
+        (
+            [
+                ParentStreamConfig(
+                    stream=MockStream([{}], [{"id": 1, "field_1": "value_1", "field_2": {"nested_field": "nested_value_1"}}, {"id": 2, "field_1": "value_2", "field_2": {"nested_field": "nested_value_2"}}], "first_stream"),
+                    parent_key="id",
+                    partition_field="first_stream_id",
+                    extra_fields=[["field_1"], ["field_2", "nested_field"]],
+                    parameters={},
+                    config={},
+                )
+            ],
+            [
+                {"first_stream_id": 1, "parent_slice": {}, "field_1": "value_1", "field_2.nested_field": "nested_value_1"},
+                {"first_stream_id": 2, "parent_slice": {}, "field_1": "value_2", "field_2.nested_field": "nested_value_2"}
+            ],
+        ),
+        (
+            [
+                ParentStreamConfig(
+                    stream=MockStream([{}], [{"id": 1, "field_1": "value_1"}, {"id": 2, "field_1": "value_2"}], "first_stream"),
+                    parent_key="id",
+                    partition_field="first_stream_id",
+                    extra_fields=[["field_1"]],
+                    parameters={},
+                    config={},
+                )
+            ],
+            [
+                {"first_stream_id": 1, "parent_slice": {}, "field_1": "value_1"},
+                {"first_stream_id": 2, "parent_slice": {}, "field_1": "value_2"}
+            ],
+        )
+    ],
+    ids=[
+        "test_with_nested_extra_keys",
+        "test_with_single_extra_key",
+    ]
+)
+def test_substream_partition_router_with_extra_keys(parent_stream_configs, expected_slices):
+    partition_router = SubstreamPartitionRouter(parent_stream_configs=parent_stream_configs, parameters={}, config={})
+    slices = [s for s in partition_router.stream_slices()]
+    assert slices == expected_slices

--- a/airbyte-cdk/python/unit_tests/sources/declarative/partition_routers/test_substream_partition_router.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/partition_routers/test_substream_partition_router.py
@@ -850,8 +850,8 @@ def test_substream_using_resumable_full_refresh_parent_stream_slices(use_increme
                 )
             ],
             [
-                {"first_stream_id": 1, "parent_slice": {}, "field_1": "value_1", "field_2.nested_field": "nested_value_1"},
-                {"first_stream_id": 2, "parent_slice": {}, "field_1": "value_2", "field_2.nested_field": "nested_value_2"}
+                {"field_1": "value_1", "field_2.nested_field": "nested_value_1"},
+                {"field_1": "value_2", "field_2.nested_field": "nested_value_2"}
             ],
         ),
         (
@@ -866,8 +866,8 @@ def test_substream_using_resumable_full_refresh_parent_stream_slices(use_increme
                 )
             ],
             [
-                {"first_stream_id": 1, "parent_slice": {}, "field_1": "value_1"},
-                {"first_stream_id": 2, "parent_slice": {}, "field_1": "value_2"}
+                {"field_1": "value_1"},
+                {"field_1": "value_2"}
             ],
         )
     ],
@@ -878,5 +878,5 @@ def test_substream_using_resumable_full_refresh_parent_stream_slices(use_increme
 )
 def test_substream_partition_router_with_extra_keys(parent_stream_configs, expected_slices):
     partition_router = SubstreamPartitionRouter(parent_stream_configs=parent_stream_configs, parameters={}, config={})
-    slices = [s for s in partition_router.stream_slices()]
+    slices = [s.extra_fields for s in partition_router.stream_slices()]
     assert slices == expected_slices


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->
This PR introduces the ability to include extra fields from parent records into the StreamSlice. This feature allows for additional data, beyond the partition key, to be extracted and utilized in downstream processes.
Resolves: https://github.com/airbytehq/airbyte-internal-issues/issues/9909 

## How
<!--
* Describe how code changes achieve the solution.
-->
- Added support for defining extra fields in the `ParentStreamConfig`.
- The extra fields are specified as paths and are extracted from the parent record during the `StreamSlice` generation.
- Enhanced the `SubstreamPartitionRouter` to include these extracted fields within each StreamSlice.

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->
- Users can now define additional field paths in their configuration that will be included in each StreamSlice.
- This offers more flexibility in how data is extracted and used for further processing within streams.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
