### PR TITLE
bulk-cdk-core-extract: fix TRACE STATUS message emission

### DIFF
--- a/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/read/Feed.kt
+++ b/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/read/Feed.kt
@@ -44,3 +44,11 @@ data class Stream(
     override val label: String
         get() = id.toString()
 }
+
+/** List of [Stream]s this [Feed] emits records for. */
+val Feed.streams
+    get() =
+        when (this) {
+            is Global -> streams
+            is Stream -> listOf(this)
+        }

--- a/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/read/RootReader.kt
+++ b/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/read/RootReader.kt
@@ -10,7 +10,6 @@ import kotlin.coroutines.CoroutineContext
 import kotlin.time.toKotlinDuration
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.update
@@ -51,6 +50,8 @@ class RootReader(
         }
     }
 
+    val streamStatusManager = StreamStatusManager(stateManager.feeds, outputConsumer::accept)
+
     /** Reads records from all [Feed]s. */
     suspend fun read(listener: suspend (Map<Feed, Job>) -> Unit = {}) {
         supervisorScope {
@@ -60,7 +61,7 @@ class RootReader(
             val feedJobs: Map<Feed, Job> =
                 feeds.associateWith { feed: Feed ->
                     val coroutineName = ThreadRenamingCoroutineName(feed.label)
-                    val handler = FeedExceptionHandler(feed, exceptions)
+                    val handler = FeedExceptionHandler(feed, streamStatusManager, exceptions)
                     launch(coroutineName + handler) { FeedReader(this@RootReader, feed).read() }
                 }
             // Call listener hook.
@@ -71,21 +72,6 @@ class RootReader(
                     feedJobs[it]?.join()
                     exceptions[it]
                 }
-            // Cancel any incomplete global feed job whose stream feed jobs have not all succeeded.
-            for ((global, globalJob) in feedJobs) {
-                if (global !is Global) continue
-                if (globalJob.isCompleted) continue
-                val globalStreamExceptions: List<Throwable> =
-                    global.streams.mapNotNull { streamExceptions[it] }
-                if (globalStreamExceptions.isNotEmpty()) {
-                    val cause: Throwable =
-                        globalStreamExceptions.reduce { acc: Throwable, exception: Throwable ->
-                            acc.addSuppressed(exception)
-                            acc
-                        }
-                    globalJob.cancel("at least one stream did non complete", cause)
-                }
-            }
             // Join on all global feeds and collect caught exceptions.
             val globalExceptions: Map<Global, Throwable?> =
                 feeds.filterIsInstance<Global>().associateWith {
@@ -109,6 +95,7 @@ class RootReader(
 
     class FeedExceptionHandler(
         val feed: Feed,
+        val streamStatusManager: StreamStatusManager,
         private val exceptions: ConcurrentHashMap<Feed, Throwable>,
     ) : CoroutineExceptionHandler {
         private val log = KotlinLogging.logger {}
@@ -121,6 +108,7 @@ class RootReader(
             exception: Throwable,
         ) {
             log.warn(exception) { "canceled feed '${feed.label}' due to thrown exception" }
+            streamStatusManager.notifyFailure(feed)
             exceptions[feed] = exception
         }
 

--- a/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/read/StreamStatusManager.kt
+++ b/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/read/StreamStatusManager.kt
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.read
+
+import io.airbyte.cdk.StreamIdentifier
+import io.airbyte.cdk.asProtocolStreamDescriptor
+import io.airbyte.protocol.models.v0.AirbyteStreamStatusTraceMessage
+import io.airbyte.protocol.models.v0.AirbyteStreamStatusTraceMessage.AirbyteStreamStatus
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
+import org.apache.mina.util.ConcurrentHashSet
+
+/**
+ * [StreamStatusManager] emits [AirbyteStreamStatusTraceMessage]s in response to [Feed] activity
+ * events, via [notifyStarting], [notifyComplete] and [notifyFailure].
+ */
+class StreamStatusManager(
+    feeds: List<Feed>,
+    private val emit: (AirbyteStreamStatusTraceMessage) -> Unit,
+) {
+    private val streamStates: Map<StreamIdentifier, StreamState> =
+        feeds
+            .flatMap { feed: Feed -> feed.streams.map { it.id to feed } }
+            .groupBy({ it.first }, { it.second })
+            .mapValues { (id: StreamIdentifier, feeds: List<Feed>) ->
+                StreamState(id, feeds.toSet())
+            }
+
+    /**
+     * Notify that the [feed] is about to start running.
+     *
+     * Emits Airbyte TRACE messages of type STATUS accordingly. Safe to call even if
+     * [notifyStarting], [notifyComplete] or [notifyFailure] have been called before.
+     */
+    fun notifyStarting(feed: Feed) {
+        handle(feed) { it.onStarting() }
+    }
+
+    /**
+     * Notify that the [feed] has completed running.
+     *
+     * Emits Airbyte TRACE messages of type STATUS accordingly. Idempotent. Safe to call even if
+     * [notifyStarting] hasn't been called previously.
+     */
+    fun notifyComplete(feed: Feed) {
+        handle(feed) { it.onComplete(feed) }
+    }
+
+    /**
+     * Notify that the [feed] has stopped running due to a failure.
+     *
+     * Emits Airbyte TRACE messages of type STATUS accordingly. Idempotent. Safe to call even if
+     * [notifyStarting] hasn't been called previously.
+     */
+    fun notifyFailure(feed: Feed) {
+        handle(feed) { it.onFailure(feed) }
+    }
+
+    private fun handle(feed: Feed, notification: (StreamState) -> List<AirbyteStreamStatus>) {
+        for (stream in feed.streams) {
+            val streamState: StreamState = streamStates[stream.id] ?: continue
+            for (statusToEmit: AirbyteStreamStatus in notification(streamState)) {
+                emit(
+                    AirbyteStreamStatusTraceMessage()
+                        .withStreamDescriptor(stream.id.asProtocolStreamDescriptor())
+                        .withStatus(statusToEmit)
+                )
+            }
+        }
+    }
+
+    data class StreamState(
+        val id: StreamIdentifier,
+        val feeds: Set<Feed>,
+        val state: AtomicReference<State> = AtomicReference(State.PENDING),
+        val stoppedFeeds: ConcurrentHashSet<Feed> = ConcurrentHashSet(),
+        val numStoppedFeeds: AtomicInteger = AtomicInteger()
+    ) {
+        fun onStarting(): List<AirbyteStreamStatus> =
+            if (state.compareAndSet(State.PENDING, State.SUCCESS)) {
+                listOf(AirbyteStreamStatus.STARTED)
+            } else {
+                emptyList()
+            }
+
+        fun onComplete(feed: Feed): List<AirbyteStreamStatus> =
+            onStarting() + // ensure the state is not PENDING
+            run {
+                    if (!finalStop(feed)) {
+                        return@run emptyList()
+                    }
+                    // At this point, we just stopped the last feed for this stream.
+                    // Transition to DONE.
+                    if (state.compareAndSet(State.SUCCESS, State.DONE)) {
+                        listOf(AirbyteStreamStatus.COMPLETE)
+                    } else if (state.compareAndSet(State.FAILURE, State.DONE)) {
+                        listOf(AirbyteStreamStatus.INCOMPLETE)
+                    } else {
+                        emptyList() // this should never happen
+                    }
+                }
+
+        fun onFailure(feed: Feed): List<AirbyteStreamStatus> =
+            onStarting() + // ensure the state is not PENDING
+            run {
+                    state.compareAndSet(State.SUCCESS, State.FAILURE)
+                    if (!finalStop(feed)) {
+                        return@run emptyList()
+                    }
+                    // At this point, we just stopped the last feed for this stream.
+                    // Transition from FAILURE to DONE.
+                    if (state.compareAndSet(State.FAILURE, State.DONE)) {
+                        listOf(AirbyteStreamStatus.INCOMPLETE)
+                    } else {
+                        emptyList() // this should never happen
+                    }
+                }
+
+        private fun finalStop(feed: Feed): Boolean {
+            if (!stoppedFeeds.add(feed)) {
+                // This feed was stopped before.
+                return false
+            }
+            // True if and only if this feed was stopped and all others were already stopped.
+            return numStoppedFeeds.incrementAndGet() == feeds.size
+        }
+    }
+
+    enum class State {
+        PENDING,
+        SUCCESS,
+        FAILURE,
+        DONE,
+    }
+}

--- a/airbyte-cdk/bulk/core/extract/src/test/kotlin/io/airbyte/cdk/read/StreamStatusManagerTest.kt
+++ b/airbyte-cdk/bulk/core/extract/src/test/kotlin/io/airbyte/cdk/read/StreamStatusManagerTest.kt
@@ -1,0 +1,228 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.read
+
+import io.airbyte.cdk.StreamIdentifier
+import io.airbyte.cdk.discover.Field
+import io.airbyte.cdk.discover.IntFieldType
+import io.airbyte.protocol.models.v0.AirbyteStreamStatusTraceMessage
+import io.airbyte.protocol.models.v0.StreamDescriptor
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+class StreamStatusManagerTest {
+
+    val streamIncremental =
+        Stream(
+            id = StreamIdentifier.from(StreamDescriptor().withName("streamIncremental")),
+            fields = listOf(Field("v", IntFieldType)),
+            configuredSyncMode = ConfiguredSyncMode.INCREMENTAL,
+            configuredPrimaryKey = null,
+            configuredCursor = null,
+        )
+    val streamFullRefresh =
+        Stream(
+            id = StreamIdentifier.from(StreamDescriptor().withName("streamFullRefresh")),
+            fields = listOf(Field("v", IntFieldType)),
+            configuredSyncMode = ConfiguredSyncMode.FULL_REFRESH,
+            configuredPrimaryKey = null,
+            configuredCursor = null,
+        )
+
+    val allStreams: Set<Stream> = setOf(streamFullRefresh, streamIncremental)
+
+    val global: Global
+        get() = Global(listOf(streamIncremental))
+
+    val allFeeds: List<Feed> = listOf(global) + allStreams
+
+    @Test
+    fun testNothing() {
+        TestCase(allFeeds).runTest {}
+    }
+
+    @Test
+    fun testRunningStream() {
+        val testCase = TestCase(listOf(streamFullRefresh), started = setOf(streamFullRefresh))
+        testCase.runTest { it.notifyStarting(streamFullRefresh) }
+        // Check that the outcome is the same if we call notifyStarting multiple times.
+        testCase.runTest {
+            it.notifyStarting(streamFullRefresh)
+            it.notifyStarting(streamFullRefresh)
+            it.notifyStarting(streamFullRefresh)
+        }
+    }
+
+    @Test
+    fun testRunningAndCompleteStream() {
+        val testCase =
+            TestCase(
+                feeds = listOf(streamFullRefresh),
+                started = setOf(streamFullRefresh),
+                success = setOf(streamFullRefresh),
+            )
+        testCase.runTest {
+            it.notifyStarting(streamFullRefresh)
+            it.notifyComplete(streamFullRefresh)
+        }
+        // Check that the outcome is the same if we forget to call notifyStarting.
+        testCase.runTest { it.notifyComplete(streamFullRefresh) }
+        // Check that the outcome is the same if we call notifyComplete many times.
+        testCase.runTest {
+            it.notifyStarting(streamFullRefresh)
+            it.notifyComplete(streamFullRefresh)
+            it.notifyComplete(streamFullRefresh)
+            it.notifyComplete(streamFullRefresh)
+        }
+        // Check that the outcome is the same if we call notifyFailure afterwards.
+        testCase.runTest {
+            it.notifyStarting(streamFullRefresh)
+            it.notifyComplete(streamFullRefresh)
+            it.notifyFailure(streamFullRefresh)
+        }
+    }
+
+    @Test
+    fun testRunningAndIncompleteStream() {
+        val testCase =
+            TestCase(
+                feeds = listOf(streamFullRefresh),
+                started = setOf(streamFullRefresh),
+                failure = setOf(streamFullRefresh),
+            )
+        testCase.runTest {
+            it.notifyStarting(streamFullRefresh)
+            it.notifyFailure(streamFullRefresh)
+        }
+        // Check that the outcome is the same if we forget to call notifyStarting.
+        testCase.runTest { it.notifyFailure(streamFullRefresh) }
+        // Check that the outcome is the same if we call notifyFailure many times.
+        testCase.runTest {
+            it.notifyStarting(streamFullRefresh)
+            it.notifyFailure(streamFullRefresh)
+            it.notifyFailure(streamFullRefresh)
+            it.notifyFailure(streamFullRefresh)
+        }
+        // Check that the outcome is the same if we call notifyComplete afterwards.
+        testCase.runTest {
+            it.notifyStarting(streamFullRefresh)
+            it.notifyFailure(streamFullRefresh)
+            it.notifyComplete(streamFullRefresh)
+        }
+    }
+
+    @Test
+    fun testRunningStreamWithGlobal() {
+        val testCase = TestCase(allFeeds, started = setOf(streamIncremental))
+        testCase.runTest { it.notifyStarting(streamIncremental) }
+        // Check that the outcome is the same if we call notifyStarting with the global feed.
+        testCase.runTest { it.notifyStarting(global) }
+        testCase.runTest {
+            it.notifyStarting(global)
+            it.notifyStarting(streamIncremental)
+        }
+    }
+
+    @Test
+    fun testRunningAndCompleteWithGlobal() {
+        val testCase =
+            TestCase(
+                feeds = allFeeds,
+                started = setOf(streamIncremental),
+                success = setOf(streamIncremental),
+            )
+        testCase.runTest {
+            it.notifyStarting(global)
+            it.notifyComplete(global)
+            it.notifyStarting(streamIncremental)
+            it.notifyComplete(streamIncremental)
+        }
+        // Check that the outcome is the same if we mix things up a bit.
+        testCase.runTest {
+            it.notifyStarting(global)
+            it.notifyStarting(streamIncremental)
+            it.notifyComplete(global)
+            it.notifyComplete(streamIncremental)
+        }
+        testCase.runTest {
+            it.notifyStarting(streamIncremental)
+            it.notifyStarting(global)
+            it.notifyComplete(global)
+            it.notifyComplete(streamIncremental)
+        }
+    }
+
+    @Test
+    fun testRunningAndIncompleteAll() {
+        val testCase =
+            TestCase(
+                feeds = allFeeds,
+                started = allStreams,
+                success = setOf(streamFullRefresh),
+                failure = setOf(streamIncremental),
+            )
+        testCase.runTest {
+            it.notifyStarting(streamFullRefresh)
+            it.notifyComplete(streamFullRefresh)
+            it.notifyStarting(global)
+            it.notifyFailure(global)
+            it.notifyStarting(streamIncremental)
+            it.notifyComplete(streamIncremental)
+        }
+        // Check that the outcome is the same if we mix things up a bit.
+        testCase.runTest {
+            it.notifyStarting(streamFullRefresh)
+            it.notifyStarting(global)
+            it.notifyStarting(streamIncremental)
+            it.notifyComplete(streamIncremental)
+            it.notifyFailure(global)
+            it.notifyComplete(streamFullRefresh)
+            it.notifyComplete(global)
+        }
+    }
+
+    data class TestCase
+    private constructor(
+        val started: Set<StreamIdentifier>,
+        val success: Set<StreamIdentifier>,
+        val failure: Set<StreamIdentifier>,
+        val feeds: List<Feed>,
+    ) {
+        constructor(
+            feeds: List<Feed>,
+            started: Set<Stream> = emptySet(),
+            success: Set<Stream> = emptySet(),
+            failure: Set<Stream> = emptySet(),
+        ) : this(
+            started.map { it.id }.toSet(),
+            success.map { it.id }.toSet(),
+            failure.map { it.id }.toSet(),
+            feeds,
+        )
+
+        fun runTest(fn: (StreamStatusManager) -> Unit) {
+            val started = mutableSetOf<StreamIdentifier>()
+            val success = mutableSetOf<StreamIdentifier>()
+            val failure = mutableSetOf<StreamIdentifier>()
+            val streamStatusManager =
+                StreamStatusManager(feeds) {
+                    val streamID = StreamIdentifier.from(it.streamDescriptor)
+                    when (it.status) {
+                        AirbyteStreamStatusTraceMessage.AirbyteStreamStatus.STARTED ->
+                            Assertions.assertTrue(started.add(streamID))
+                        AirbyteStreamStatusTraceMessage.AirbyteStreamStatus.COMPLETE ->
+                            Assertions.assertTrue(success.add(streamID))
+                        AirbyteStreamStatusTraceMessage.AirbyteStreamStatus.INCOMPLETE ->
+                            Assertions.assertTrue(failure.add(streamID))
+                        else -> throw RuntimeException("unexpected status ${it.status}")
+                    }
+                }
+            fn(streamStatusManager)
+            Assertions.assertEquals(this.started, started)
+            Assertions.assertEquals(this.success, success)
+            Assertions.assertEquals(this.failure, failure)
+        }
+    }
+}


### PR DESCRIPTION
## What
In the Bulk CDK, the current logic which causes Airbyte TRACE messages of type STATUS to be emitted by a source is broken when `Global` feeds are in use. This PR fixes this.

## How
This PR introduces a `StreamStatusManager` class which is used by `RootReader` and `FeedReader` to emit these messages. The source connectors don't need to do anything.

## Review guide
n/a

## User Impact
None

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
