### PR TITLE
Bulk Load CDK: Restore CheckpointManager Test

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/message/DestinationMessageQueueWriterTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/message/DestinationMessageQueueWriterTest.kt
@@ -186,6 +186,7 @@ class DestinationMessageQueueWriterTest {
 
         Assertions.assertEquals(manager2.endOfStreamRead(), false)
         Assertions.assertEquals(manager1.endOfStreamRead(), true)
+
         Assertions.assertEquals(11, channel1.messages.size)
         Assertions.assertEquals(channel1.messages[10], StreamCompleteWrapped(10))
     }

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/state/CheckpointManagerTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/state/CheckpointManagerTest.kt
@@ -14,7 +14,6 @@ import io.airbyte.cdk.message.Batch
 import io.airbyte.cdk.message.BatchEnvelope
 import io.airbyte.cdk.message.MessageConverter
 import io.airbyte.cdk.message.SimpleBatch
-import io.micronaut.context.annotation.Prototype
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest
 import jakarta.inject.Inject
 import jakarta.inject.Singleton
@@ -29,6 +28,7 @@ import org.junit.jupiter.params.provider.ArgumentsProvider
 import org.junit.jupiter.params.provider.ArgumentsSource
 
 @MicronautTest(
+    rebuildContext = true,
     environments =
         [
             "CheckpointManagerTest",
@@ -37,6 +37,7 @@ import org.junit.jupiter.params.provider.ArgumentsSource
 )
 class CheckpointManagerTest {
     @Inject lateinit var checkpointManager: TestCheckpointManager
+    @Inject lateinit var syncManager: SyncManager
     /**
      * Test state messages.
      *
@@ -64,20 +65,23 @@ class CheckpointManagerTest {
         }
     }
 
-    @Prototype
+    @Singleton
     class MockOutputConsumer : Consumer<MockCheckpointOut> {
-        val collectedStreamOutput = mutableMapOf<DestinationStream, MutableList<String>>()
+        val collectedStreamOutput =
+            mutableMapOf<DestinationStream.Descriptor, MutableList<String>>()
         val collectedGlobalOutput = mutableListOf<String>()
         override fun accept(t: MockCheckpointOut) {
             when (t) {
                 is MockStreamCheckpointOut ->
-                    collectedStreamOutput.getOrPut(t.stream) { mutableListOf() }.add(t.payload)
+                    collectedStreamOutput
+                        .getOrPut(t.stream.descriptor) { mutableListOf() }
+                        .add(t.payload)
                 is MockGlobalCheckpointOut -> collectedGlobalOutput.add(t.payload)
             }
         }
     }
 
-    @Prototype
+    @Singleton
     class TestCheckpointManager(
         override val catalog: DestinationCatalog,
         override val syncManager: SyncManager,
@@ -104,7 +108,7 @@ class CheckpointManagerTest {
         val name: String,
         val events: List<TestEvent>,
         // Order matters, but only per stream
-        val expectedStreamOutput: Map<DestinationStream, List<String>> = mapOf(),
+        val expectedStreamOutput: Map<DestinationStream.Descriptor, List<String>> = mapOf(),
         val expectedGlobalOutput: List<String> = listOf(),
         val expectedException: Class<out Throwable>? = null
     )
@@ -124,7 +128,7 @@ class CheckpointManagerTest {
                                         mapOf(stream1 to listOf(Range.closed(0L, 20L)))
                                 )
                             ),
-                        expectedStreamOutput = mapOf(stream1 to listOf("1", "2"))
+                        expectedStreamOutput = mapOf(stream1.descriptor to listOf("1", "2"))
                     ),
                     TestCase(
                         name = "One stream, two messages, flush only the first",
@@ -137,7 +141,7 @@ class CheckpointManagerTest {
                                         mapOf(stream1 to listOf(Range.closed(0L, 10L)))
                                 )
                             ),
-                        expectedStreamOutput = mapOf(stream1 to listOf("1"))
+                        expectedStreamOutput = mapOf(stream1.descriptor to listOf("1"))
                     ),
                     TestCase(
                         name = "Two streams, two messages each, flush all",
@@ -156,7 +160,10 @@ class CheckpointManagerTest {
                                 )
                             ),
                         expectedStreamOutput =
-                            mapOf(stream1 to listOf("11", "12"), stream2 to listOf("22", "21"))
+                            mapOf(
+                                stream1.descriptor to listOf("11", "12"),
+                                stream2.descriptor to listOf("22", "21")
+                            )
                     ),
                     TestCase(
                         name = "One stream, only later range persisted",
@@ -335,7 +342,7 @@ class CheckpointManagerTest {
                                 TestStreamMessage(stream1, 30L, 3),
                                 FlushPoint(mapOf(stream1 to listOf(Range.closed(10L, 30L))))
                             ),
-                        expectedStreamOutput = mapOf(stream1 to listOf("1", "2", "3"))
+                        expectedStreamOutput = mapOf(stream1.descriptor to listOf("1", "2", "3"))
                     ),
                     TestCase(
                         name = "Global checkpoint, multiple flush points, no output",
@@ -402,7 +409,7 @@ class CheckpointManagerTest {
 
     @ParameterizedTest
     @ArgumentsSource(CheckpointManagerTestArgumentsProvider::class)
-    suspend fun testAddingAndFlushingCheckpoints(testCase: TestCase) = runTest {
+    fun testAddingAndFlushingCheckpoints(testCase: TestCase) = runTest {
         if (testCase.expectedException != null) {
             try {
                 runTestCase(testCase)
@@ -429,6 +436,15 @@ class CheckpointManagerTest {
         testCase.events.forEach {
             when (it) {
                 is TestStreamMessage -> {
+                    /**
+                     * Mock the correct state of the stream manager by advancing the record count to
+                     * the index of the message.
+                     */
+                    val streamManager = syncManager.getStreamManager(it.stream.descriptor)
+                    val recordCount = streamManager.recordCount()
+                    (recordCount until it.index).forEach { _ ->
+                        syncManager.getStreamManager(it.stream.descriptor).countRecordIn()
+                    }
                     checkpointManager.addStreamCheckpoint(
                         it.stream.descriptor,
                         it.index,
@@ -444,7 +460,7 @@ class CheckpointManagerTest {
                         val mockBatch = SimpleBatch(state = Batch.State.PERSISTED)
                         val rangeSet = TreeRangeSet.create(ranges)
                         val mockBatchEnvelope = BatchEnvelope(batch = mockBatch, ranges = rangeSet)
-                        checkpointManager.syncManager
+                        syncManager
                             .getStreamManager(stream.descriptor)
                             .updateBatchState(mockBatchEnvelope)
                     }

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/state/StreamManagerTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/state/StreamManagerTest.kt
@@ -68,6 +68,7 @@ class StreamManagerTest {
         Assertions.assertTrue(channel.tryReceive().isFailure)
         Assertions.assertThrows(IllegalStateException::class.java) { manager.markSucceeded() }
         manager.markEndOfStream()
+
         manager.markSucceeded()
         Assertions.assertTrue(channel.receive())
 


### PR DESCRIPTION
## What
Restores the broken CheckpointManagerTest (by removing `suspend`, which was confounding `ParameterizedTest`).

Additionally, this required test changes to keep it working: basically, because I removed the mocks for Sync/Stream manager, I had to manipulate the state from the outside a little (like, if the test case said index 10, I had to advance the record count 10 times, etc). This makes the test more realistic.

Also I switched it to `rebuildContext = true` so that the managers would get rest.

Also I removed some stray println statements and (accidentally) picked up a test improvement I left out of the previous PR :)