### PR TITLE
[source-postgres] support cdc against a read-replica (continuation)

### DIFF
--- a/airbyte-integrations/connectors/source-postgres/metadata.yaml
+++ b/airbyte-integrations/connectors/source-postgres/metadata.yaml
@@ -9,7 +9,7 @@ data:
   connectorSubtype: database
   connectorType: source
   definitionId: decd338e-5647-4c0b-adf4-da0e75f5a750
-  dockerImageTag: 3.6.20
+  dockerImageTag: 3.6.21
   dockerRepository: airbyte/source-postgres
   documentationUrl: https://docs.airbyte.com/integrations/sources/postgres
   githubIssueLabel: source-postgres

--- a/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/cdc/PostgresDebeziumStateUtil.java
+++ b/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/cdc/PostgresDebeziumStateUtil.java
@@ -247,7 +247,9 @@ public class PostgresDebeziumStateUtil implements DebeziumStateUtil {
   }
 
   private Long currentTransactionId(final JdbcDatabase database) throws SQLException {
-    final List<Long> transactionId = database.bufferedResultSetQuery(conn -> conn.createStatement().executeQuery("select * from txid_current()"),
+    final List<Long> transactionId = database.bufferedResultSetQuery(
+        conn -> conn.createStatement().executeQuery(
+            "SELECT CASE WHEN pg_is_in_recovery() THEN txid_snapshot_xmax(txid_current_snapshot()) ELSE txid_current() END AS pg_current_txid;"),
         resultSet -> resultSet.getLong(1));
     Preconditions.checkState(transactionId.size() == 1);
     return transactionId.get(0);

--- a/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/cdc/PostgresDebeziumStateUtil.java
+++ b/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/cdc/PostgresDebeziumStateUtil.java
@@ -249,7 +249,7 @@ public class PostgresDebeziumStateUtil implements DebeziumStateUtil {
   private Long currentTransactionId(final JdbcDatabase database) throws SQLException {
     final List<Long> transactionId = database.bufferedResultSetQuery(
         conn -> conn.createStatement().executeQuery(
-            "SELECT CASE WHEN pg_is_in_recovery() THEN txid_snapshot_xmax(txid_current_snapshot()) ELSE txid_current() END AS pg_current_txid;"),
+            "SELECT CASE WHEN pg_is_in_recovery() THEN txid_snapshot_xmin(txid_current_snapshot()) ELSE txid_current() END AS pg_current_txid;"),
         resultSet -> resultSet.getLong(1));
     Preconditions.checkState(transactionId.size() == 1);
     return transactionId.get(0);

--- a/docs/integrations/sources/postgres.md
+++ b/docs/integrations/sources/postgres.md
@@ -329,6 +329,7 @@ According to Postgres [documentation](https://www.postgresql.org/docs/14/datatyp
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                                                                   |
 |---------|------------|----------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 3.6.21 | 2024-10-02 | [46322](https://github.com/airbytehq/airbyte/pull/46322) | Support CDC against a read-replica (continuation) |
 | 3.6.20 | 2024-10-01 | [46299](https://github.com/airbytehq/airbyte/pull/46299) | Make postgres source compile and use the latest CDK |
 | 3.6.19 | 2024-09-17 | [45639](https://github.com/airbytehq/airbyte/pull/45639) | Adopt latest CDK to use the latest apache sshd mina to handle tcpkeepalive requests. |
 | 3.6.18 | 2024-08-28 | [44878](https://github.com/airbytehq/airbyte/pull/44878) | Enable tcpKeepAlive for jdbc connection. |


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->

Fixes https://github.com/airbytehq/airbyte/issues/45396

In a previous [community PR](https://github.com/airbytehq/airbyte/pull/45397) , we added support to query LSN against a read replica. However, this is still not sufficient as we also need to retrieve current transaction id to create Debezium state together with the LSN. 

However, we currently retrieve transaction id using `select * from txid_current()` which can only be performed against a primary. We will approximate this in this patch if we read against a replica:

```
SELECT 
    CASE 
        WHEN pg_is_in_recovery() THEN txid_snapshot_xmin(txid_current_snapshot())
        ELSE txid_current()
    END AS current_txid;
```

Here, `txid_snapshot_xmin(txid_current_snapshot())` provides a lower bound to `txid_current()`, and can be executed on the replica.


## How
<!--
* Describe how code changes achieve the solution.
-->

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [X ] YES 💚
- [ ] NO ❌
