### PR TITLE
bulk-cdk-toolkit-extract-cdc: use Debezium 3.0.0.Final

### DIFF
--- a/airbyte-cdk/bulk/toolkits/extract-cdc/build.gradle
+++ b/airbyte-cdk/bulk/toolkits/extract-cdc/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-    api platform('io.debezium:debezium-bom:2.7.3.Final')
+    api platform('io.debezium:debezium-bom:3.0.0.Final')
     api 'io.debezium:debezium-api'
     api 'io.debezium:debezium-embedded'
 


### PR DESCRIPTION
Debezium 3.0.0.Final came out today. We might as well use it. The breaking changes do not concern us. This release includes a lot of Oracle-specific changes, which we might find useful.
