### PR TITLE
bulk-cdk: fix test-logs location

### DIFF
--- a/airbyte-cdk/bulk/core/base/src/testFixtures/resources/log4j2-test.xml
+++ b/airbyte-cdk/bulk/core/base/src/testFixtures/resources/log4j2-test.xml
@@ -7,7 +7,7 @@
         <Property name="container-log-pattern">%d{yyyy-MM-dd'T'HH:mm:ss,SSS}{GMT+0}`%replace{%X{log_source}}{^ -}{} > %replace{%m}{$${env:LOG_SCRUB_PATTERN:-\*\*\*\*\*}}{*****}%n</Property>
         <!-- Always log INFO by default. -->
         <Property name="log-level">${sys:LOG_LEVEL:-${env:LOG_LEVEL:-INFO}}</Property>
-        <Property name="logDir">target/test-logs/${date:yyyy-MM-dd'T'HH:mm:ss}</Property>
+        <Property name="logDir">build/test-logs/${date:yyyy-MM-dd'T'HH:mm:ss}</Property>
     </Properties>
 
     <Appenders>


### PR DESCRIPTION
## What
The test logs for Bulk CDK tests currently end up in `target/test-logs/`. This is a relic from my incubator repo which used maven. This repo uses gradle so the test logs should be in `build/test-logs/` instead, that way `./gradlew clean` will delete them.

## How
Correct the test log4j configuration file.

## Review guide
n/t

## User Impact
None

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
