### PR TITLE
bulk-cdk-toolkit-extract-cdc,source-mysql-v2: speed up Debezium tests with mysql

### DIFF
--- a/airbyte-cdk/bulk/toolkits/extract-cdc/src/test/kotlin/io/airbyte/cdk/read/cdc/CdcPartitionReaderTest.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-cdc/src/test/kotlin/io/airbyte/cdk/read/cdc/CdcPartitionReaderTest.kt
@@ -387,6 +387,7 @@ class CdcPartitionReaderMySQLTest :
             .withDebeziumName(databaseName)
             .withHeartbeats(heartbeat)
             .with("include.schema.changes", "false")
+            .with("connect.keep.alive.interval.ms", "1000")
             .withDatabase("hostname", host)
             .withDatabase("port", firstMappedPort.toString())
             .withDatabase("user", username)

--- a/airbyte-integrations/connectors/source-mysql-v2/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mysql-v2/metadata.yaml
@@ -9,7 +9,7 @@ data:
   connectorSubtype: database
   connectorType: source
   definitionId: 561393ed-7e3a-4d0d-8b8b-90ded371754c
-  dockerImageTag: 0.0.13
+  dockerImageTag: 0.0.14
   dockerRepository: airbyte/source-mysql-v2
   documentationUrl: https://docs.airbyte.com/integrations/sources/mysql
   githubIssueLabel: source-mysql-v2

--- a/airbyte-integrations/connectors/source-mysql-v2/src/main/kotlin/io/airbyte/integrations/source/mysql/MysqlSourceConfiguration.kt
+++ b/airbyte-integrations/connectors/source-mysql-v2/src/main/kotlin/io/airbyte/integrations/source/mysql/MysqlSourceConfiguration.kt
@@ -3,12 +3,14 @@ package io.airbyte.integrations.source.mysql
 
 import io.airbyte.cdk.ConfigErrorException
 import io.airbyte.cdk.command.CdcSourceConfiguration
+import io.airbyte.cdk.command.ConfigurationSpecificationSupplier
 import io.airbyte.cdk.command.JdbcSourceConfiguration
 import io.airbyte.cdk.command.SourceConfiguration
 import io.airbyte.cdk.command.SourceConfigurationFactory
 import io.airbyte.cdk.ssh.SshConnectionOptions
 import io.airbyte.cdk.ssh.SshTunnelMethodConfiguration
 import io.github.oshai.kotlinlogging.KotlinLogging
+import io.micronaut.context.annotation.Factory
 import jakarta.inject.Singleton
 import java.net.URLDecoder
 import java.nio.charset.StandardCharsets
@@ -30,9 +32,22 @@ data class MysqlSourceConfiguration(
     override val resourceAcquisitionHeartbeat: Duration = Duration.ofMillis(100L),
     override val checkpointTargetInterval: Duration,
     override val checkPrivileges: Boolean,
-    override val debeziumHeartbeatInterval: Duration = Duration.ofSeconds(1),
+    override val debeziumHeartbeatInterval: Duration = Duration.ofSeconds(10),
+    val debeziumKeepAliveInterval: Duration = Duration.ofMinutes(1),
 ) : JdbcSourceConfiguration, CdcSourceConfiguration {
     override val global = cursorConfiguration is CdcCursor
+
+    /** Required to inject [MysqlSourceConfiguration] directly. */
+    @Factory
+    private class MicronautFactory {
+        @Singleton
+        fun mysqlSourceConfig(
+            factory:
+                SourceConfigurationFactory<
+                    MysqlSourceConfigurationJsonObject, MysqlSourceConfiguration>,
+            supplier: ConfigurationSpecificationSupplier<MysqlSourceConfigurationJsonObject>,
+        ): MysqlSourceConfiguration = factory.make(supplier.get())
+    }
 }
 
 @Singleton

--- a/airbyte-integrations/connectors/source-mysql-v2/src/test/kotlin/io/airbyte/integrations/source/mysql/MysqlSourceTestConfigurationFactory.kt
+++ b/airbyte-integrations/connectors/source-mysql-v2/src/test/kotlin/io/airbyte/integrations/source/mysql/MysqlSourceTestConfigurationFactory.kt
@@ -18,5 +18,10 @@ class MysqlSourceTestConfigurationFactory :
     ): MysqlSourceConfiguration =
         MysqlSourceConfigurationFactory()
             .makeWithoutExceptionHandling(pojo)
-            .copy(maxConcurrency = 1, checkpointTargetInterval = Duration.ofSeconds(3))
+            .copy(
+                maxConcurrency = 1,
+                checkpointTargetInterval = Duration.ofSeconds(3),
+                debeziumHeartbeatInterval = Duration.ofMillis(100),
+                debeziumKeepAliveInterval = Duration.ofSeconds(1),
+            )
 }


### PR DESCRIPTION
## What
I found an undocumented debezium property which when changed dramatically speeds up all debezium+mysql tests. This PR implements this change.

## How
In source-mysql-v2, I made this property value defined by the connector configuration.

## Review guide
Commit by commit.

## User Impact
None.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
