### PR TITLE
source-pokeapi contribution from bechurch-test

### DIFF
--- a/airbyte-integrations/connectors/source-pokeapi/manifest.yaml
+++ b/airbyte-integrations/connectors/source-pokeapi/manifest.yaml
@@ -1,6 +1,8 @@
-version: 4.5.4
+version: 5.8.1
 
 type: DeclarativeSource
+
+description: Test change from builder by ben
 
 check:
   type: CheckStream
@@ -18,7 +20,7 @@ definitions:
         type: SimpleRetriever
         requester:
           $ref: "#/definitions/base_requester"
-          path: /{{config['pokemon_name']}}
+          path: /pokemon/{{config['pokemon_name']}}
           http_method: GET
         record_selector:
           type: RecordSelector
@@ -29,12 +31,31 @@ definitions:
         type: InlineSchemaLoader
         schema:
           $ref: "#/schemas/pokemon"
+    abilities:
+      type: DeclarativeStream
+      name: abilities
+      retriever:
+        type: SimpleRetriever
+        requester:
+          $ref: "#/definitions/base_requester"
+          path: /ability
+          http_method: GET
+        record_selector:
+          type: RecordSelector
+          extractor:
+            type: DpathExtractor
+            field_path: []
+      schema_loader:
+        type: InlineSchemaLoader
+        schema:
+          $ref: "#/schemas/abilities"
   base_requester:
     type: HttpRequester
-    url_base: https://pokeapi.co/api/v2/pokemon
+    url_base: https://pokeapi.co/api/v2
 
 streams:
   - $ref: "#/definitions/streams/pokemon"
+  - $ref: "#/definitions/streams/abilities"
 
 spec:
   type: Spec
@@ -47,8 +68,6 @@ spec:
       pokemon_name:
         type: string
         description: Pokemon requested from the API.
-        title: Pokemon Name
-        pattern: ^[a-z0-9_\-]+$
         enum:
           - bulbasaur
           - ivysaur
@@ -948,16 +967,35 @@ spec:
           - glastrier
           - spectrier
           - calyrex
+        order: 0
+        title: Pokemon Name
+        pattern: ^[a-z0-9_\-]+$
         examples:
           - ditto
           - luxray
           - snorlax
-        order: 0
     additionalProperties: true
 
 metadata:
   autoImportSchema:
     pokemon: false
+    abilities: true
+  testedStreams:
+    pokemon:
+      streamHash: ce2852240d709bd351d441d66dd8fe64bd005771
+      hasResponse: true
+      responsesAreSuccessful: true
+      hasRecords: true
+      primaryKeysArePresent: true
+      primaryKeysAreUnique: true
+    abilities:
+      streamHash: 52853794595b76a825cd5f97933748a04e8b06ff
+      hasResponse: true
+      responsesAreSuccessful: true
+      hasRecords: true
+      primaryKeysArePresent: true
+      primaryKeysAreUnique: true
+  assist: {}
 
 schemas:
   pokemon:
@@ -1356,3 +1394,33 @@ schemas:
         type:
           - "null"
           - integer
+  abilities:
+    type: object
+    $schema: http://json-schema.org/schema#
+    additionalProperties: true
+    properties:
+      count:
+        type:
+          - number
+          - "null"
+      next:
+        type:
+          - string
+          - "null"
+      results:
+        type:
+          - array
+          - "null"
+        items:
+          type:
+            - object
+            - "null"
+          properties:
+            name:
+              type:
+                - string
+                - "null"
+            url:
+              type:
+                - string
+                - "null"

--- a/airbyte-integrations/connectors/source-pokeapi/metadata.yaml
+++ b/airbyte-integrations/connectors/source-pokeapi/metadata.yaml
@@ -1,7 +1,8 @@
+metadataSpecVersion: "1.0"
 data:
   allowedHosts:
     hosts:
-      - "*"
+      - "pokeapi.co"
   registryOverrides:
     oss:
       enabled: true
@@ -12,36 +13,23 @@ data:
       enabled: false
       packageName: airbyte-source-pokeapi
   connectorBuildOptions:
-    # Please update to the latest version of the connector base image.
-    # https://hub.docker.com/r/airbyte/python-connector-base
-    # Please use the full address with sha256 hash to guarantee build reproducibility.
-    baseImage: docker.io/airbyte/source-declarative-manifest:4.5.4@sha256:b07a521add11f987c63c0db68c1b57e90bec0c985f1cb6f3c5a1940cde628a70
+    baseImage: docker.io/airbyte/source-declarative-manifest:5.10.2@sha256:81db4f78a92d199f33c38c17f5b63fc87c56739f14dc10276ddec86c7b707b7a
   connectorSubtype: api
   connectorType: source
   definitionId: 6371b14b-bc68-4236-bfbd-468e8df8e968
-  dockerImageTag: 0.3.0
+  dockerImageTag: 0.0.1
   dockerRepository: airbyte/source-pokeapi
   githubIssueLabel: source-pokeapi
-  icon: pokeapi.svg
+  icon: icon.svg
   license: MIT
   name: PokeAPI
-  releaseDate: "2020-05-14"
+  releaseDate: 2024-10-03
   releaseStage: alpha
   supportLevel: community
   documentationUrl: https://docs.airbyte.com/integrations/sources/pokeapi
   tags:
-    - cdk:low-code
     - language:manifest-only
-  connectorTestSuitesOptions:
-    - suite: liveTests
-      testConnections:
-        - name: pokeapi_config_dev_null
-          id: 5a290dcf-b2cf-4768-ac2d-a1aaca90c186
-    - suite: acceptanceTests
-      testSecrets:
-        - name: SECRET_SOURCE-POKEAPI__CREDS
-          fileName: config.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-metadataSpecVersion: "1.0"
+    - cdk:low-code
+  ab_internal:
+    ql: 100
+    sl: 100


### PR DESCRIPTION
## What

This PR updates source PokeAPI (source-pokeapi).

The contributor provided the following description of the change:

Test change from builder by ben
## Reviewer checklist
- [ ] Resolve any merge conflicts and validate file diffs (make sure the PR only includes changes intended by the contributor)
- [ ] After reviewing the changes, run the [`bump-version` Airbyte-CI command](https://github.com/airbytehq/airbyte/blob/master/airbyte-ci/connectors/pipelines/README.md#connectors-bump-version-command) locally to update the version of the connector according to the [versioning guidelines](https://docs.airbyte.io/contributor-guide/versioning-guidelines). Add `breakingChanges` to metadata if necessary.
- [ ] Ensure connector docs are up to date with any changes
- [ ] Run `/format-fix` to resolve any formatting errors
- [ ] Click into the CI workflows that wait for a maintainer to run them, which should trigger CI runs

<!-- DO NOT REMOVE: connector-builder-edit-connector-contribution -->
