### PR TITLE
🐛 Source Chargebee: add missing `incremental dependency` to `full-refresh` sub-streams with `Incremental` parent streams

### DIFF
--- a/airbyte-integrations/connectors/source-chargebee/metadata.yaml
+++ b/airbyte-integrations/connectors/source-chargebee/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 686473f1-76d9-4994-9cc7-9b13da46147c
-  dockerImageTag: 0.6.13
+  dockerImageTag: 0.6.14
   dockerRepository: airbyte/source-chargebee
   documentationUrl: https://docs.airbyte.com/integrations/sources/chargebee
   githubIssueLabel: source-chargebee

--- a/airbyte-integrations/connectors/source-chargebee/pyproject.toml
+++ b/airbyte-integrations/connectors/source-chargebee/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "0.6.13"
+version = "0.6.14"
 name = "source-chargebee"
 description = "Source implementation for Chargebee."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-chargebee/source_chargebee/manifest.yaml
+++ b/airbyte-integrations/connectors/source-chargebee/source_chargebee/manifest.yaml
@@ -111,6 +111,7 @@ definitions:
             stream: "#/definitions/item_stream"
             parent_key: "id"
             partition_field: "item_id"
+            incremental_dependency: true
     $parameters:
       name: "attached_item"
       primary_key: "id"
@@ -133,6 +134,7 @@ definitions:
             stream: "#/definitions/customer_stream"
             parent_key: id
             partition_field: id
+            incremental_dependency: true
       requester:
         $ref: "#/definitions/requester"
         error_handler:
@@ -360,6 +362,7 @@ definitions:
             stream: "#/definitions/quote_stream"
             parent_key: id
             partition_field: id
+            incremental_dependency: true
       requester:
         $ref: "#/definitions/requester"
         error_handler:

--- a/docs/integrations/sources/chargebee.md
+++ b/docs/integrations/sources/chargebee.md
@@ -104,7 +104,8 @@ The Chargebee connector should not run into [Chargebee API](https://apidocs.char
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                                        |
 |:--------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------|
-| 0.6.13 | 2024-10-01 | [46294](https://github.com/airbytehq/airbyte/pull/46294) | Update CDK version to `^5`, increased the `maxSecondsBetweenMessages` to 6 hours. |
+| 0.6.14 | 2024-10-03 | [46343](https://github.com/airbytehq/airbyte/pull/46343) | Added `incremental dependency` for substreams with `Incremental` parent streams |
+| 0.6.13 | 2024-10-01 | [46294](https://github.com/airbytehq/airbyte/pull/46294) | Update CDK version to `^5`, increased the `maxSecondsBetweenMessages` to 6 hours |
 | 0.6.12 | 2024-09-28 | [46169](https://github.com/airbytehq/airbyte/pull/46169) | Update dependencies |
 | 0.6.11 | 2024-09-21 | [45805](https://github.com/airbytehq/airbyte/pull/45805) | Update dependencies |
 | 0.6.10 | 2024-09-14 | [45254](https://github.com/airbytehq/airbyte/pull/45254) | Update dependencies |


### PR DESCRIPTION
## What
Resolving:
- https://github.com/airbytehq/oncall/issues/6426

## Story:
- The missing `incremental dependency` for CDK `5.8.0`, for cases when substream is `full-refresh` and the parent stream is `incremental` causing the source to read all of the parent records first and then yield them to substream, which itself causes the `heartbeat issues` for the Platform.

## How
- Added `incremental_dependency: true` to the next streams:
    - `contact`
    - `attached_item_stream `
    - `quote_line_group_stream `

## User Impact
No impact is expected, for the existing Customers. 

## Can this PR be safely reverted and rolled back?
- [X] YES 💚
- [ ] NO ❌
