### PR TITLE
source-mysql-v2: rename MysqlSourceConfigurationJsonObject to MysqlSourceConfigurationSpecification

### DIFF
--- a/airbyte-integrations/connectors/source-mysql-v2/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mysql-v2/metadata.yaml
@@ -9,7 +9,7 @@ data:
   connectorSubtype: database
   connectorType: source
   definitionId: 561393ed-7e3a-4d0d-8b8b-90ded371754c
-  dockerImageTag: 0.0.14
+  dockerImageTag: 0.0.15
   dockerRepository: airbyte/source-mysql-v2
   documentationUrl: https://docs.airbyte.com/integrations/sources/mysql
   githubIssueLabel: source-mysql-v2

--- a/airbyte-integrations/connectors/source-mysql-v2/src/main/kotlin/io/airbyte/integrations/source/mysql/MysqlSourceConfiguration.kt
+++ b/airbyte-integrations/connectors/source-mysql-v2/src/main/kotlin/io/airbyte/integrations/source/mysql/MysqlSourceConfiguration.kt
@@ -44,17 +44,17 @@ data class MysqlSourceConfiguration(
         fun mysqlSourceConfig(
             factory:
                 SourceConfigurationFactory<
-                    MysqlSourceConfigurationJsonObject, MysqlSourceConfiguration>,
-            supplier: ConfigurationSpecificationSupplier<MysqlSourceConfigurationJsonObject>,
+                    MysqlSourceConfigurationSpecification, MysqlSourceConfiguration>,
+            supplier: ConfigurationSpecificationSupplier<MysqlSourceConfigurationSpecification>,
         ): MysqlSourceConfiguration = factory.make(supplier.get())
     }
 }
 
 @Singleton
 class MysqlSourceConfigurationFactory :
-    SourceConfigurationFactory<MysqlSourceConfigurationJsonObject, MysqlSourceConfiguration> {
+    SourceConfigurationFactory<MysqlSourceConfigurationSpecification, MysqlSourceConfiguration> {
     override fun makeWithoutExceptionHandling(
-        pojo: MysqlSourceConfigurationJsonObject,
+        pojo: MysqlSourceConfigurationSpecification,
     ): MysqlSourceConfiguration {
         val realHost: String = pojo.host
         val realPort: Int = pojo.port

--- a/airbyte-integrations/connectors/source-mysql-v2/src/main/kotlin/io/airbyte/integrations/source/mysql/MysqlSourceConfigurationSpecification.kt
+++ b/airbyte-integrations/connectors/source-mysql-v2/src/main/kotlin/io/airbyte/integrations/source/mysql/MysqlSourceConfigurationSpecification.kt
@@ -51,7 +51,7 @@ import jakarta.inject.Singleton
 @Singleton
 @ConfigurationProperties(CONNECTOR_CONFIG_PREFIX)
 @SuppressFBWarnings(value = ["NP_NONNULL_RETURN_VIOLATION"], justification = "Micronaut DI")
-class MysqlSourceConfigurationJsonObject : ConfigurationSpecification() {
+class MysqlSourceConfigurationSpecification : ConfigurationSpecification() {
     @JsonProperty("host")
     @JsonSchemaTitle("Host")
     @JsonSchemaInject(json = """{"order":1}""")

--- a/airbyte-integrations/connectors/source-mysql-v2/src/test/kotlin/io/airbyte/integrations/source/mysql/MysqlCdcIntegrationTest.kt
+++ b/airbyte-integrations/connectors/source-mysql-v2/src/test/kotlin/io/airbyte/integrations/source/mysql/MysqlCdcIntegrationTest.kt
@@ -52,7 +52,7 @@ class MysqlCdcIntegrationTest {
             )
             .use { nonCdcDbContainer ->
                 {
-                    val invalidConfig: MysqlSourceConfigurationJsonObject =
+                    val invalidConfig: MysqlSourceConfigurationSpecification =
                         MysqlContainerFactory.config(nonCdcDbContainer).apply {
                             setCursorMethodValue(CdcCursor())
                         }
@@ -112,7 +112,7 @@ class MysqlCdcIntegrationTest {
         val log = KotlinLogging.logger {}
         lateinit var dbContainer: MySQLContainer<*>
 
-        fun config(): MysqlSourceConfigurationJsonObject =
+        fun config(): MysqlSourceConfigurationSpecification =
             MysqlContainerFactory.config(dbContainer).apply { setCursorMethodValue(CdcCursor()) }
 
         val connectionFactory: JdbcConnectionFactory by lazy {

--- a/airbyte-integrations/connectors/source-mysql-v2/src/test/kotlin/io/airbyte/integrations/source/mysql/MysqlContainerFactory.kt
+++ b/airbyte-integrations/connectors/source-mysql-v2/src/test/kotlin/io/airbyte/integrations/source/mysql/MysqlContainerFactory.kt
@@ -50,8 +50,8 @@ object MysqlContainerFactory {
     }
 
     @JvmStatic
-    fun config(mySQLContainer: MySQLContainer<*>): MysqlSourceConfigurationJsonObject =
-        MysqlSourceConfigurationJsonObject().apply {
+    fun config(mySQLContainer: MySQLContainer<*>): MysqlSourceConfigurationSpecification =
+        MysqlSourceConfigurationSpecification().apply {
             host = mySQLContainer.host
             port = mySQLContainer.getMappedPort(MySQLContainer.MYSQL_PORT)
             username = mySQLContainer.username

--- a/airbyte-integrations/connectors/source-mysql-v2/src/test/kotlin/io/airbyte/integrations/source/mysql/MysqlSourceConfigurationSpecificationTest.kt
+++ b/airbyte-integrations/connectors/source-mysql-v2/src/test/kotlin/io/airbyte/integrations/source/mysql/MysqlSourceConfigurationSpecificationTest.kt
@@ -13,9 +13,9 @@ import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 
 @MicronautTest(environments = [Environment.TEST], rebuildContext = true)
-class MysqlSourceConfigurationJsonObjectTest {
+class MysqlSourceConfigurationSpecificationTest {
     @Inject
-    lateinit var supplier: ConfigurationSpecificationSupplier<MysqlSourceConfigurationJsonObject>
+    lateinit var supplier: ConfigurationSpecificationSupplier<MysqlSourceConfigurationSpecification>
 
     @Test
     fun testSchemaViolation() {
@@ -25,7 +25,7 @@ class MysqlSourceConfigurationJsonObjectTest {
     @Test
     @Property(name = "airbyte.connector.config.json", value = CONFIG_JSON)
     fun testJson() {
-        val pojo: MysqlSourceConfigurationJsonObject = supplier.get()
+        val pojo: MysqlSourceConfigurationSpecification = supplier.get()
         Assertions.assertEquals("localhost", pojo.host)
         Assertions.assertEquals(12345, pojo.port)
         Assertions.assertEquals("FOO", pojo.username)

--- a/airbyte-integrations/connectors/source-mysql-v2/src/test/kotlin/io/airbyte/integrations/source/mysql/MysqlSourceConfigurationTest.kt
+++ b/airbyte-integrations/connectors/source-mysql-v2/src/test/kotlin/io/airbyte/integrations/source/mysql/MysqlSourceConfigurationTest.kt
@@ -14,16 +14,16 @@ import org.junit.jupiter.api.Test
 class MysqlSourceConfigurationTest {
     @Inject
     lateinit var pojoSupplier:
-        ConfigurationSpecificationSupplier<MysqlSourceConfigurationJsonObject>
+        ConfigurationSpecificationSupplier<MysqlSourceConfigurationSpecification>
 
     @Inject
     lateinit var factory:
-        SourceConfigurationFactory<MysqlSourceConfigurationJsonObject, MysqlSourceConfiguration>
+        SourceConfigurationFactory<MysqlSourceConfigurationSpecification, MysqlSourceConfiguration>
 
     @Test
     @Property(name = "airbyte.connector.config.json", value = CONFIG)
     fun testParseJdbcParameters() {
-        val pojo: MysqlSourceConfigurationJsonObject = pojoSupplier.get()
+        val pojo: MysqlSourceConfigurationSpecification = pojoSupplier.get()
 
         val config = factory.makeWithoutExceptionHandling(pojo)
 

--- a/airbyte-integrations/connectors/source-mysql-v2/src/test/kotlin/io/airbyte/integrations/source/mysql/MysqlSourceDatatypeIntegrationTest.kt
+++ b/airbyte-integrations/connectors/source-mysql-v2/src/test/kotlin/io/airbyte/integrations/source/mysql/MysqlSourceDatatypeIntegrationTest.kt
@@ -155,7 +155,8 @@ class MysqlSourceDatatypeIntegrationTest {
     companion object {
         lateinit var dbContainer: MySQLContainer<*>
 
-        fun config(): MysqlSourceConfigurationJsonObject = MysqlContainerFactory.config(dbContainer)
+        fun config(): MysqlSourceConfigurationSpecification =
+            MysqlContainerFactory.config(dbContainer)
 
         val connectionFactory: JdbcConnectionFactory by lazy {
             JdbcConnectionFactory(MysqlSourceConfigurationFactory().make(config()))

--- a/airbyte-integrations/connectors/source-mysql-v2/src/test/kotlin/io/airbyte/integrations/source/mysql/MysqlSourceTestConfigurationFactory.kt
+++ b/airbyte-integrations/connectors/source-mysql-v2/src/test/kotlin/io/airbyte/integrations/source/mysql/MysqlSourceTestConfigurationFactory.kt
@@ -12,9 +12,9 @@ import java.time.Duration
 @Requires(env = [Environment.TEST])
 @Primary
 class MysqlSourceTestConfigurationFactory :
-    SourceConfigurationFactory<MysqlSourceConfigurationJsonObject, MysqlSourceConfiguration> {
+    SourceConfigurationFactory<MysqlSourceConfigurationSpecification, MysqlSourceConfiguration> {
     override fun makeWithoutExceptionHandling(
-        pojo: MysqlSourceConfigurationJsonObject,
+        pojo: MysqlSourceConfigurationSpecification,
     ): MysqlSourceConfiguration =
         MysqlSourceConfigurationFactory()
             .makeWithoutExceptionHandling(pojo)


### PR DESCRIPTION
Strictly a rename of this class, to keep its name in line with the current Bulk CDK nomenclature.
