### PR TITLE
feat: add the ability to enable snowflake change tracking

### DIFF
--- a/airbyte-integrations/connectors/destination-snowflake/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-snowflake/metadata.yaml
@@ -5,7 +5,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: 424892c4-daac-4491-b35d-c6688ba547ba
-  dockerImageTag: 3.15.0
+  dockerImageTag: 3.16.0
   dockerRepository: airbyte/destination-snowflake
   documentationUrl: https://docs.airbyte.com/integrations/destinations/snowflake
   githubIssueLabel: destination-snowflake

--- a/airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/SnowflakeDestination.kt
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/SnowflakeDestination.kt
@@ -202,7 +202,10 @@ constructor(
             )
         val useMergeForUpsert =
             config.has(USE_MERGE_FOR_UPSERT) && config[USE_MERGE_FOR_UPSERT].asBoolean(false)
-        val sqlGenerator = SnowflakeSqlGenerator(retentionPeriodDays, useMergeForUpsert)
+        val enableChangeTracking =
+            config.has(ENABLE_CHANGE_TRACKING) && config[ENABLE_CHANGE_TRACKING].asBoolean(false)
+
+        val sqlGenerator = SnowflakeSqlGenerator(retentionPeriodDays, useMergeForUpsert, enableChangeTracking)
         val database = getDatabase(getDataSource(config))
         val databaseName = config[JdbcUtils.DATABASE_KEY].asText()
         val rawTableSchemaName: String =
@@ -362,6 +365,8 @@ constructor(
         const val RETENTION_PERIOD_DAYS: String = "retention_period_days"
         const val DISABLE_TYPE_DEDUPE: String = "disable_type_dedupe"
         const val USE_MERGE_FOR_UPSERT: String = "use_merge_for_upsert"
+        const val ENABLE_CHANGE_TRACKING: String = "enable_change_tracking"
+
         @JvmField
         val SCHEDULED_EXECUTOR_SERVICE: ScheduledExecutorService =
             Executors.newScheduledThreadPool(1)

--- a/airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/typing_deduping/SnowflakeSqlGenerator.kt
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/typing_deduping/SnowflakeSqlGenerator.kt
@@ -30,7 +30,8 @@ import java.util.*
 
 class SnowflakeSqlGenerator(
     private val retentionPeriodDays: Int,
-    private val useMergeForUpserts: Boolean = false
+    private val useMergeForUpserts: Boolean = false,
+    private val enableChangeTracking: Boolean = false
 ) : SqlGenerator {
     private val cdcDeletedAtColumn = buildColumnId("_ab_cdc_deleted_at")
 
@@ -107,7 +108,8 @@ class SnowflakeSqlGenerator(
             |  "_AIRBYTE_META" VARIANT NOT NULL,
             |  "_AIRBYTE_GENERATION_ID" INTEGER
             |  $columnDeclarations
-            |) data_retention_time_in_days = $retentionPeriodDays;
+            |) data_retention_time_in_days = $retentionPeriodDays
+            CHANGE_TRACKING = $enableChangeTracking;
         """.trimMargin()
 
         return of(createTableSql)

--- a/airbyte-integrations/connectors/destination-snowflake/src/main/resources/spec.json
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/resources/spec.json
@@ -188,6 +188,14 @@
         "description": "Use MERGE for de-duplication of final tables. This option no effect if Final tables are disabled or Sync mode is not DEDUPE",
         "title": "Use MERGE for De-duplication of final tables",
         "order": 14
+      },
+      "enable_change_tracking": {
+        "type": "boolean",
+        "default": false,
+        "description": "Whether to enable change tracking for the destination",
+        "title": "Enable Change Tracking",
+        "order": 15
+
       }
     }
   },

--- a/docs/integrations/destinations/snowflake.md
+++ b/docs/integrations/destinations/snowflake.md
@@ -269,7 +269,7 @@ desired namespace.
 
 | Version         | Date       | Pull Request                                               | Subject                                                                                                                                                                          |
 | :-------------- | :--------- | :--------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 3.16.0          | 2024-10-03 |                                                              | add ability to enable change tracking
+| 3.16.0          | 2024-10-03 | [\#46356](https://github.com/airbytehq/airbyte/pull/46356)   | add ability to enable change tracking
 | 3.15.0          | 2024-09-18 | [\#45437](https://github.com/airbytehq/airbyte/pull/45437)   | upgrade all dependencies                                                                                                                                          |
 | 3.14.0          | 2024-09-18 | [\#45431](https://github.com/airbytehq/airbyte/pull/45431) | truncate large records queries                                                                                                                                                        |
 | 3.13.0          | 2024-09-17 | [\#45422](https://github.com/airbytehq/airbyte/pull/45422) | speed up metadata queries                                                                                                                                                        |

--- a/docs/integrations/destinations/snowflake.md
+++ b/docs/integrations/destinations/snowflake.md
@@ -209,6 +209,7 @@ could be subject to change in future versions.
 dedicated transient database for Airbyte. For more information, refer
 to[ Working with Temporary and Transient Tables](https://docs.snowflake.com/en/user-guide/tables-temp-transient.html)
 
+**Note:** By default, change tracking is disabled on the final tables. By enabling `enable_change_tracking`, you can enable this functionality on the final tables that Airbyte creates
 ## Data type map
 
 | Airbyte type                        | Snowflake type |
@@ -268,6 +269,7 @@ desired namespace.
 
 | Version         | Date       | Pull Request                                               | Subject                                                                                                                                                                          |
 | :-------------- | :--------- | :--------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 3.16.0          | 2024-10-03 |                                                              | add ability to enable change tracking
 | 3.15.0          | 2024-09-18 | [\#45437](https://github.com/airbytehq/airbyte/pull/45437)   | upgrade all dependencies                                                                                                                                          |
 | 3.14.0          | 2024-09-18 | [\#45431](https://github.com/airbytehq/airbyte/pull/45431) | truncate large records queries                                                                                                                                                        |
 | 3.13.0          | 2024-09-17 | [\#45422](https://github.com/airbytehq/airbyte/pull/45422) | speed up metadata queries                                                                                                                                                        |


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->
- This change enables the user to enable change tracking on their Snowflake tables #34322

## How
<!--
* Describe how code changes achieve the solution.
-->
- I added a new config options called enable_change_tracking
- Added functionality to the SQL builder in the snowflake destination to leverage that change tracking flag and enable it.

## Review guide
<!--
1. `x.py`
2. `y.py`
-->
- 'airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/typing_deduping/SnowflakeSqlGenerator.kt'
- 'airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/SnowflakeDestination.kt'
- 'airbyte-integrations/connectors/destination-snowflake/metadata.yaml'
## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->
- The primary impact is that it is possible to enable change tracking, which is important to leverage new Snowflake feature sets.
- I do not see any negative impacts, as it defaults to the original functionality of being disabled.
## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ *] YES 💚
- [ ] NO ❌
