### PR TITLE
Revert async component release release

### DIFF
--- a/airbyte-integrations/connectors/source-salesforce/metadata.yaml
+++ b/airbyte-integrations/connectors/source-salesforce/metadata.yaml
@@ -25,6 +25,7 @@ data:
   registryOverrides:
     cloud:
       enabled: true
+      dockerImageTag: 2.5.34
     oss:
       enabled: true
   releaseStage: generally_available


### PR DESCRIPTION
## What
Revert the release on cloud. We have seen an unusual number of collision in the record and want to take the proper time to investigate

## How
Pinning the version to [2.5.34](https://hub.docker.com/layers/airbyte/source-salesforce/2.5.34/images/sha256-34071491fbc75d971ae134cc764025f15305e69fbc11643cfc02944487f38010?context=explore) the most recent tag before 2.6.0

## User Impact
Users on cloud will be reverted to 2.5.34. The change was not breaking so everything should be fine to revert

## Can this PR be safely reverted and rolled back?
- [X] YES 💚
- [ ] NO ❌
