### PR TITLE
Bulk Load CDK: Preparatory Refactor for adding Force Flush

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/state/FlushStrategy.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/state/FlushStrategy.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.state
+
+import com.google.common.collect.Range
+import io.airbyte.cdk.command.DestinationConfiguration
+import io.airbyte.cdk.command.DestinationStream
+import io.micronaut.context.annotation.Secondary
+import jakarta.inject.Singleton
+
+interface FlushStrategy {
+    suspend fun shouldFlush(
+        stream: DestinationStream,
+        rangeRead: Range<Long>,
+        bytesProcessed: Long
+    ): Boolean
+}
+
+@Singleton
+@Secondary
+class DefaultFlushStrategy(
+    private val config: DestinationConfiguration,
+) : FlushStrategy {
+
+    override suspend fun shouldFlush(
+        stream: DestinationStream,
+        rangeRead: Range<Long>,
+        bytesProcessed: Long
+    ): Boolean {
+        return bytesProcessed >= config.recordBatchSizeBytes
+    }
+}

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/util/CoroutineUtils.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/util/CoroutineUtils.kt
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.util
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.transformWhile
+
+fun <T> Flow<T>.takeUntilInclusive(predicate: (T) -> Boolean): Flow<T> = transformWhile { value ->
+    emit(value)
+    !predicate(value)
+}

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/util/RangeUtils.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/util/RangeUtils.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.util
+
+import com.google.common.collect.Range
+
+// Necessary because Guava's Range/sets have no "empty" range
+fun Range<Long>?.withNextAdjacentValue(index: Long): Range<Long> {
+    return if (this == null) {
+        Range.singleton(index)
+    } else if (index != this.upperEndpoint() + 1L) {
+        throw IllegalStateException("Expected index ${this.upperEndpoint() + 1}, got $index")
+    } else {
+        this.span(Range.singleton(index))
+    }
+}


### PR DESCRIPTION
## What
Preliminary refactor before pushing the force flush so the PR isn't overwhelming. :)

* MessageQueueReader::read no longer chunks. It just provides a flow. (I will refactor this away completely later: this has gotten so simple the queue itself should be able to provide it.)
* Added a FlushStrategy that currently just takes over the chunking behavior. (This will be the target for force flushing as well.)
* injected the FlushStrategy into the `SpillToDiskTask`; now it short-circuits whenever flush says so
* doing this revealed an issue: `return@runningFold` does not short-circuit. we were being saved here by the fact that the channel that feeds the flow was getting closed after end-of-stream. so I had to refactor a bit and add `takeUntilInclusive`, which did not exist (I added an extension to support it in CoroutineUtils; this was a bit of a nightmare to figure out, because it was fiendishly difficult to get the behavior we needed without `transformWhile`)
* moved that `withIndex` function to a dedicated kotlin extension (apparently you can to this even for nullables? which is cool)
* modified the `SpillToDiskTaskTest` to use an injected mock flush strategy that did the same thing `readChunk` used to do