### PR TITLE
airbyte-ci: handle custom components file in manifest-only migration

### DIFF
--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -851,6 +851,7 @@ airbyte-ci connectors --language=low-code migrate-to-manifest-only
 
 | Version | PR                                                         | Description                                                                                                                  |
 | ------- | ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| 4.37.0  | []() | Include custom components file handling in manifest-only migrations |
 | 4.36.2  | [#46278](https://github.com/airbytehq/airbyte/pull/46278)  | Fixed a bug in RC rollout and promote not taking `semaphore`                                                                 |
 | 4.36.1  | [#46274](https://github.com/airbytehq/airbyte/pull/46274)  | `airbyte-ci format js` respects `.prettierc` and `.prettierignore`                                                           |
 | 4.36.0  | [#44877](https://github.com/airbytehq/airbyte/pull/44877)  | Implement `--promote/rollback-release-candidate` in `connectors publish`.                                                    |

--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -851,7 +851,7 @@ airbyte-ci connectors --language=low-code migrate-to-manifest-only
 
 | Version | PR                                                         | Description                                                                                                                  |
 | ------- | ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| 4.37.0  | []() | Include custom components file handling in manifest-only migrations |
+| 4.37.0  | [#46380](https://github.com/airbytehq/airbyte/pull/46380)  | Include custom components file handling in manifest-only migrations                                                          |
 | 4.36.2  | [#46278](https://github.com/airbytehq/airbyte/pull/46278)  | Fixed a bug in RC rollout and promote not taking `semaphore`                                                                 |
 | 4.36.1  | [#46274](https://github.com/airbytehq/airbyte/pull/46274)  | `airbyte-ci format js` respects `.prettierc` and `.prettierignore`                                                           |
 | 4.36.0  | [#44877](https://github.com/airbytehq/airbyte/pull/44877)  | Implement `--promote/rollback-release-candidate` in `connectors publish`.                                                    |

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/migrate_to_manifest_only/manifest_component_transformer.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/migrate_to_manifest_only/manifest_component_transformer.py
@@ -219,4 +219,4 @@ class ManifestComponentTransformer:
         if isinstance(component_type, list):
             # Handle nullable types, ie ["null", "object"]
             return "object" in component_type
-        return propagated_component.get("type") == "object"
+        return component_type == "object"

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/migrate_to_manifest_only/manifest_component_transformer.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/migrate_to_manifest_only/manifest_component_transformer.py
@@ -133,7 +133,7 @@ logger = logging.getLogger(__name__)
 def get_model_fields(model_class: Optional[Type[BaseModel]]) -> Set[str]:
     """Fetches field names from a Pydantic model class if available."""
     if model_class is not None:
-        return set(model_class.model_fields.keys())
+        return set(model_class.__fields__.keys())
     return set()
 
 

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/migrate_to_manifest_only/manifest_component_transformer.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/migrate_to_manifest_only/manifest_component_transformer.py
@@ -5,7 +5,7 @@
 import copy
 import logging
 import typing
-from typing import Any, Mapping, Set, Type
+from typing import Any, Mapping, Optional, Set, Type
 
 from pydantic import BaseModel
 
@@ -133,7 +133,7 @@ logger = logging.getLogger(__name__)
 def get_model_fields(model_class: Optional[Type[BaseModel]]) -> Set[str]:
     """Fetches field names from a Pydantic model class if available."""
     if model_class is not None:
-        return set(model_class.__fields__.keys())
+        return set(model_class.model_fields.keys())
     return set()
 
 
@@ -216,4 +216,8 @@ class ManifestComponentTransformer:
 
     @staticmethod
     def _is_json_schema_object(propagated_component: Mapping[str, Any]) -> bool:
+        component_type = propagated_component.get("type")
+        if isinstance(component_type, list):
+            # Handle nullable types, ie ["null", "object"]
+            return "object" in component_type
         return propagated_component.get("type") == "object"

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/migrate_to_manifest_only/manifest_component_transformer.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/migrate_to_manifest_only/manifest_component_transformer.py
@@ -189,7 +189,6 @@ class ManifestComponentTransformer:
         # both exist
         for parameter_key, parameter_value in current_parameters.items():
             if parameter_key in valid_fields:
-                logger.info(f"Adding parameter {parameter_key} to {component_type}")
                 propagated_component[parameter_key] = propagated_component.get(parameter_key) or parameter_value
 
         for field_name, field_value in propagated_component.items():

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/migrate_to_manifest_only/pipeline.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/migrate_to_manifest_only/pipeline.py
@@ -174,10 +174,11 @@ class StripConnector(Step):
         connector.manifest_path.rename(root_manifest_path)
 
         ## 1b. Move components.py to the root level of the directory if it exists
-        if connector.manifest_only_components_path.exists():
+        components_path = connector.python_source_dir_path / "components.py"
+        if components_path.exists():
             self.logger.info("Custom components file found. Moving to the root level of the directory")
-            root_components_path = connector.code_directory / "components.py"
-            connector.manifest_only_components_path.rename(root_components_path)
+            root_components_path = connector.manifest_only_components_path
+            components_path.rename(root_components_path)
 
         ## 2. Update the version in manifest.yaml
         try:

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/migrate_to_manifest_only/pipeline.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/migrate_to_manifest_only/pipeline.py
@@ -28,8 +28,25 @@ from pipelines.models.steps import Step, StepResult, StepStatus
 ## GLOBAL VARIABLES ##
 
 # spec.yaml and spec.json will be removed as part of the conversion. But if they are present, it's fine to convert still.
-MANIFEST_ONLY_COMPATIBLE_FILES = ["manifest.yaml", "run.py", "__init__.py", "source.py", "spec.json", "spec.yaml"]
-MANIFEST_ONLY_KEEP_FILES = ["manifest.yaml", "metadata.yaml", "icon.svg", "integration_tests", "acceptance-test-config.yml", "secrets"]
+MANIFEST_ONLY_COMPATIBLE_FILES = [
+    "manifest.yaml",
+    "components.py",
+    "run.py",
+    "__init__.py",
+    "source.py",
+    "spec.json",
+    "spec.yaml",
+    "__pycache__",
+]
+MANIFEST_ONLY_FILES_TO_KEEP = [
+    "manifest.yaml",
+    "components.py",
+    "metadata.yaml",
+    "icon.svg",
+    "integration_tests",
+    "acceptance-test-config.yml",
+    "secrets",
+]
 
 
 ## STEPS ##
@@ -151,10 +168,16 @@ class StripConnector(Step):
     async def _run(self) -> StepResult:
         connector = self.context.connector
 
-        ## 1. Move manifest.yaml to the root level of the directory
+        ## 1a. Move manifest.yaml to the root level of the directory
         self.logger.info("Moving manifest to the root level of the directory")
         root_manifest_path = connector.code_directory / "manifest.yaml"
         connector.manifest_path.rename(root_manifest_path)
+
+        ## 1b. Move components.py to the root level of the directory if it exists
+        if connector.manifest_only_components_path.exists():
+            self.logger.info("Custom components file found. Moving to the root level of the directory")
+            root_components_path = connector.code_directory / "components.py"
+            connector.manifest_only_components_path.rename(root_components_path)
 
         ## 2. Update the version in manifest.yaml
         try:
@@ -195,7 +218,7 @@ class StripConnector(Step):
         ## 4. Delete all non-essential files
         try:
             for item in connector.code_directory.iterdir():
-                if item.name in MANIFEST_ONLY_KEEP_FILES:
+                if item.name in MANIFEST_ONLY_FILES_TO_KEEP:
                     continue  # Preserve the allowed files
                 else:
                     self._delete_directory_item(item)

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "4.36.2"
+version = "4.37.0"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 


### PR DESCRIPTION
## What

Adds handling of custom components file when migrating a connector to manifest-only format via `airbyte-ci` command. Also fixes a small bug with handling nullable types when resolving parameters.

Resolves [#9939](https://github.com/airbytehq/airbyte-internal-issues/issues/9939) and [#9940](https://github.com/airbytehq/airbyte-internal-issues/issues/9940)

## How
- Adds a check for an existing "components.py" file in the connector's python directory
- If the file is found, it is relocated to the root-level of the connector directory, alongside the manifest
- Adds a conditional check when resolving parameters to gracefully handle nullable types (such as [null, object])
- Removes logging when resolving parameters (it gets really verbose)

## Review guide
- pipeline.py
- manifest_component_transformer.py

## User Impact
None, internal tool only

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
