### PR TITLE
Bulk Load CDK: Checkpoint flush every 15 minutes

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/command/DestinationConfiguration.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/command/DestinationConfiguration.kt
@@ -20,6 +20,12 @@ abstract class DestinationConfiguration : Configuration {
         0.1 // 0 => No overhead, 1.0 => 100% overhead
 
     /**
+     * If we have not flushed state checkpoints in this amount of time, make a best-effort attempt
+     * to force a flush.
+     */
+    open val maxCheckpointFlushTimeMs: Long = 15 * 60 * 1000L // 15 minutes
+
+    /**
      * Micronaut factory which glues [ConfigurationSpecificationSupplier] and
      * [DestinationConfigurationFactory] together to produce a [DestinationConfiguration] singleton.
      */

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/file/TimeProvider.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/file/TimeProvider.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.file
+
+import io.micronaut.context.annotation.Secondary
+import jakarta.inject.Singleton
+
+interface TimeProvider {
+    fun currentTimeMillis(): Long
+    suspend fun delay(ms: Long)
+}
+
+@Singleton
+@Secondary
+class DefaultTimeProvider : TimeProvider {
+    override fun currentTimeMillis(): Long {
+        return System.currentTimeMillis()
+    }
+
+    override suspend fun delay(ms: Long) {
+        kotlinx.coroutines.delay(ms)
+    }
+}

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/state/EventConsumer.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/state/EventConsumer.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.state
+
+/**
+ * A multi-reader consumer of events produced by a single-writer [EventProducer].
+ *
+ * To use:
+ * - set up an [EventProducer] with the same type parameter as described in the producer's
+ * documentation
+ * - declare a subclass of [EventConsumer] and mark it `@Prototype` (multi-reader)
+ * - inject the producer and consumers where needed
+ */
+abstract class EventConsumer<T>(producer: EventProducer<T>) {
+    val channel = producer.subscribe()
+
+    suspend fun consumeMaybe(): T? {
+        return channel.tryReceive().getOrNull()
+    }
+}

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/state/EventProducer.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/state/EventProducer.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.state
+
+import java.util.concurrent.ConcurrentLinkedQueue
+import kotlinx.coroutines.channels.Channel
+
+/**
+ * A single-writer event producer for a multi-reader consumer.
+ *
+ * To use
+ * - declare a subclass of [EventProducer] with the type parameter of the events to produce
+ * - mark it `@Singleton` (single-writer!)
+ * - configure [EventConsumer]s as described in the consumer's documentation
+ * - inject the producer and consumers where needed
+ *
+ * TODO: If we need to support different paradigms (multi-writer, etc.), abstract this into an
+ * interface and provide abstract implementations for each type.
+ */
+abstract class EventProducer<T> {
+    private val subscribers = ConcurrentLinkedQueue<Channel<T>>()
+
+    fun subscribe(): Channel<T> {
+        val channel = Channel<T>(Channel.UNLIMITED)
+        subscribers.add(channel)
+        return channel
+    }
+
+    suspend fun produce(event: T) {
+        subscribers.forEach { it.send(event) }
+    }
+}

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/state/FlushStrategy.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/state/FlushStrategy.kt
@@ -5,10 +5,13 @@
 package io.airbyte.cdk.state
 
 import com.google.common.collect.Range
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 import io.airbyte.cdk.command.DestinationConfiguration
 import io.airbyte.cdk.command.DestinationStream
+import io.airbyte.cdk.task.ForceFlushEvent
 import io.micronaut.context.annotation.Secondary
 import jakarta.inject.Singleton
+import java.util.concurrent.ConcurrentHashMap
 
 interface FlushStrategy {
     suspend fun shouldFlush(
@@ -18,17 +21,42 @@ interface FlushStrategy {
     ): Boolean
 }
 
+/**
+ * Flush whenever
+ * - bytes consumed >= the configured batch size
+ * - the current range of indexes being consumed encloses a force flush index
+ */
+@SuppressFBWarnings(
+    "NP_NONNULL_PARAM_VIOLATION",
+    justification = "message is guaranteed to be non-null by Kotlin's type system"
+)
 @Singleton
 @Secondary
 class DefaultFlushStrategy(
     private val config: DestinationConfiguration,
+    private val eventConsumer: EventConsumer<ForceFlushEvent>
 ) : FlushStrategy {
+    private val forceFlushIndexes = ConcurrentHashMap<DestinationStream.Descriptor, Long>()
 
     override suspend fun shouldFlush(
         stream: DestinationStream,
         rangeRead: Range<Long>,
         bytesProcessed: Long
     ): Boolean {
-        return bytesProcessed >= config.recordBatchSizeBytes
+        if (bytesProcessed >= config.recordBatchSizeBytes) {
+            return true
+        }
+
+        // Listen to the event stream for a new force flush index
+        val nextFlushIndex = eventConsumer.consumeMaybe()?.indexes?.get(stream.descriptor)
+
+        // Always update the index if the new one is not null
+        return when (
+            val testIndex =
+                forceFlushIndexes.compute(stream.descriptor) { _, v -> nextFlushIndex ?: v }
+        ) {
+            null -> false
+            else -> rangeRead.contains(testIndex)
+        }
     }
 }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/task/TimedForcedCheckpointFlushTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/task/TimedForcedCheckpointFlushTask.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.task
+
+import io.airbyte.cdk.command.DestinationConfiguration
+import io.airbyte.cdk.command.DestinationStream
+import io.airbyte.cdk.file.TimeProvider
+import io.airbyte.cdk.state.CheckpointManager
+import io.airbyte.cdk.state.EventConsumer
+import io.airbyte.cdk.state.EventProducer
+import io.micronaut.context.annotation.Prototype
+import io.micronaut.context.annotation.Secondary
+import jakarta.inject.Singleton
+import kotlinx.coroutines.delay
+
+interface TimedForcedCheckpointFlushTask : SyncTask
+
+class DefaultTimedForcedCheckpointFlushTask(
+    private val delayMs: Long,
+    private val cadenceMs: Long,
+    private val checkpointManager: CheckpointManager<DestinationStream.Descriptor, *>,
+    private val eventProducer: EventProducer<ForceFlushEvent>,
+    private val timeProvider: TimeProvider,
+    private val taskLauncher: DestinationTaskLauncher
+) : TimedForcedCheckpointFlushTask {
+
+    override suspend fun execute() {
+        // Wait for the configured time
+        timeProvider.delay(delayMs)
+
+        // Flush whatever is handy
+        checkpointManager.flushReadyCheckpointMessages()
+
+        // Compare the time since the last successful flush to the configured interval
+        val lastFlushTimeMs = checkpointManager.getLastSuccessfulFlushTimeMs()
+        val nowMs = timeProvider.currentTimeMillis()
+        val timeSinceLastFlushMs = nowMs - lastFlushTimeMs
+
+        if (timeSinceLastFlushMs >= cadenceMs) {
+            // If the max time has elapsed, emit a force flush event with provided next checkpoint
+            // indexes
+            val nextIndexes = checkpointManager.getNextCheckpointIndexes()
+            eventProducer.produce(ForceFlushEvent(nextIndexes))
+            taskLauncher.scheduleNextForceFlushAttempt(cadenceMs)
+        } else {
+            // Otherwise schedule the next attempt to run at {time of last flush + configured
+            // interval}
+            taskLauncher.scheduleNextForceFlushAttempt(cadenceMs - timeSinceLastFlushMs)
+        }
+    }
+}
+
+interface TimedForcedCheckpointFlushTaskFactory {
+    fun make(
+        taskLauncher: DestinationTaskLauncher,
+        delayMs: Long? = null
+    ): TimedForcedCheckpointFlushTask
+}
+
+@Singleton
+@Secondary
+class DefaultTimedForcedCheckpointFlushTaskFactory(
+    private val config: DestinationConfiguration,
+    private val checkpointManager: CheckpointManager<DestinationStream.Descriptor, *>,
+    private val eventProducer: EventProducer<ForceFlushEvent>,
+    private val timeProvider: TimeProvider
+) : TimedForcedCheckpointFlushTaskFactory {
+    override fun make(
+        taskLauncher: DestinationTaskLauncher,
+        delayMs: Long?
+    ): TimedForcedCheckpointFlushTask {
+        return DefaultTimedForcedCheckpointFlushTask(
+            delayMs ?: config.maxCheckpointFlushTimeMs,
+            config.maxCheckpointFlushTimeMs,
+            checkpointManager,
+            eventProducer,
+            timeProvider,
+            taskLauncher
+        )
+    }
+}
+
+data class ForceFlushEvent(val indexes: Map<DestinationStream.Descriptor, Long>)
+
+@Singleton @Secondary class DefaultForceFlushEventProducer : EventProducer<ForceFlushEvent>()
+
+@Prototype
+@Secondary
+class DefaultForceFlushEventConsumer(private val eventProducer: EventProducer<ForceFlushEvent>) :
+    EventConsumer<ForceFlushEvent>(eventProducer)

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/command/MockDestinationConfiguration.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/command/MockDestinationConfiguration.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.command
+
+import io.micronaut.context.annotation.Primary
+import io.micronaut.context.annotation.Requires
+import jakarta.inject.Singleton
+import java.nio.file.Path
+
+@Singleton
+@Primary
+@Requires(env = ["MockDestinationConfiguration"])
+class MockDestinationConfiguration : DestinationConfiguration() {
+    override val recordBatchSizeBytes: Long = 1024L
+    override val tmpFileDirectory: Path = Path.of("/tmp-test")
+    override val firstStageTmpFilePrefix: String = "spilled"
+    override val firstStageTmpFileSuffix: String = ".jsonl"
+
+    override val maxCheckpointFlushTimeMs: Long = 1000L
+}

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/file/MockTimeProvider.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/file/MockTimeProvider.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.file
+
+import io.micronaut.context.annotation.Primary
+import io.micronaut.context.annotation.Requires
+import jakarta.inject.Singleton
+
+@Singleton
+@Primary
+@Requires(env = ["MockTimeProvider"])
+class MockTimeProvider : TimeProvider {
+    private var currentTime: Long = 0
+
+    override fun currentTimeMillis(): Long {
+        return currentTime
+    }
+
+    fun setCurrentTime(currentTime: Long) {
+        this.currentTime = currentTime
+    }
+
+    override suspend fun delay(ms: Long) {
+        currentTime += ms
+    }
+}

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/message/DestinationMessageQueueWriterTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/message/DestinationMessageQueueWriterTest.kt
@@ -10,7 +10,7 @@ import io.airbyte.cdk.command.DestinationStream
 import io.airbyte.cdk.command.MockDestinationCatalogFactory.Companion.stream1
 import io.airbyte.cdk.command.MockDestinationCatalogFactory.Companion.stream2
 import io.airbyte.cdk.data.NullValue
-import io.airbyte.cdk.state.CheckpointManager
+import io.airbyte.cdk.state.MockCheckpointManager
 import io.airbyte.cdk.state.SyncManager
 import io.micronaut.context.annotation.Prototype
 import io.micronaut.context.annotation.Requires
@@ -23,7 +23,12 @@ import org.junit.jupiter.api.Test
 
 @MicronautTest(
     rebuildContext = true,
-    environments = ["DestinationMessageQueueWriterTest", "MockDestinationCatalog"]
+    environments =
+        [
+            "DestinationMessageQueueWriterTest",
+            "MockDestinationCatalog",
+            "MockCheckpointManager",
+        ]
 )
 class DestinationMessageQueueWriterTest {
     @Inject lateinit var queueWriterFactory: TestDestinationMessageQueueWriterFactory
@@ -85,35 +90,6 @@ class DestinationMessageQueueWriterTest {
 
         override suspend fun releaseQueueBytes(bytes: Long) {
             TODO("Not yet implemented")
-        }
-    }
-
-    @Prototype
-    @Requires(env = ["DestinationMessageQueueWriterTest"])
-    class MockCheckpointManager :
-        CheckpointManager<DestinationStream.Descriptor, CheckpointMessage> {
-        val streamStates =
-            mutableMapOf<DestinationStream.Descriptor, MutableList<Pair<Long, CheckpointMessage>>>()
-        val globalStates =
-            mutableListOf<Pair<List<Pair<DestinationStream.Descriptor, Long>>, CheckpointMessage>>()
-
-        override fun addStreamCheckpoint(
-            key: DestinationStream.Descriptor,
-            index: Long,
-            checkpointMessage: CheckpointMessage
-        ) {
-            streamStates.getOrPut(key) { mutableListOf() }.add(index to checkpointMessage)
-        }
-
-        override fun addGlobalCheckpoint(
-            keyIndexes: List<Pair<DestinationStream.Descriptor, Long>>,
-            checkpointMessage: CheckpointMessage
-        ) {
-            globalStates.add(keyIndexes to checkpointMessage)
-        }
-
-        override suspend fun flushReadyCheckpointMessages() {
-            throw NotImplementedError()
         }
     }
 

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/state/CheckpointManagerTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/state/CheckpointManagerTest.kt
@@ -10,10 +10,12 @@ import io.airbyte.cdk.command.DestinationCatalog
 import io.airbyte.cdk.command.DestinationStream
 import io.airbyte.cdk.command.MockDestinationCatalogFactory.Companion.stream1
 import io.airbyte.cdk.command.MockDestinationCatalogFactory.Companion.stream2
+import io.airbyte.cdk.file.TimeProvider
 import io.airbyte.cdk.message.Batch
 import io.airbyte.cdk.message.BatchEnvelope
 import io.airbyte.cdk.message.MessageConverter
 import io.airbyte.cdk.message.SimpleBatch
+import io.micronaut.context.annotation.Requires
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest
 import jakarta.inject.Inject
 import jakarta.inject.Singleton
@@ -21,6 +23,7 @@ import java.util.function.Consumer
 import java.util.stream.Stream
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtensionContext
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
@@ -55,6 +58,7 @@ class CheckpointManagerTest {
     data class MockGlobalCheckpointOut(val payload: String) : MockCheckpointOut()
 
     @Singleton
+    @Requires(env = ["CheckpointManagerTest"])
     class MockStateMessageFactory : MessageConverter<MockCheckpointIn, MockCheckpointOut> {
         override fun from(message: MockCheckpointIn): MockCheckpointOut {
             return when (message) {
@@ -66,6 +70,7 @@ class CheckpointManagerTest {
     }
 
     @Singleton
+    @Requires(env = ["CheckpointManagerTest"])
     class MockOutputConsumer : Consumer<MockCheckpointOut> {
         val collectedStreamOutput =
             mutableMapOf<DestinationStream.Descriptor, MutableList<String>>()
@@ -82,11 +87,13 @@ class CheckpointManagerTest {
     }
 
     @Singleton
+    @Requires(env = ["CheckpointManagerTest"])
     class TestCheckpointManager(
         override val catalog: DestinationCatalog,
         override val syncManager: SyncManager,
         override val outputFactory: MessageConverter<MockCheckpointIn, MockCheckpointOut>,
-        override val outputConsumer: MockOutputConsumer
+        override val outputConsumer: MockOutputConsumer,
+        override val timeProvider: TimeProvider
     ) : StreamsCheckpointManager<MockCheckpointIn, MockCheckpointOut>()
 
     sealed class TestEvent
@@ -468,5 +475,151 @@ class CheckpointManagerTest {
                 }
             }
         }
+    }
+
+    @Test
+    fun testGetLastFlushTimeMs() = runTest {
+        val startTime = System.currentTimeMillis()
+        checkpointManager.addStreamCheckpoint(
+            stream1.descriptor,
+            1L,
+            MockStreamCheckpointIn(stream1, 1)
+        )
+        syncManager.markPersisted(stream1, Range.closed(0L, 1L))
+        Assertions.assertTrue(startTime >= checkpointManager.getLastSuccessfulFlushTimeMs())
+        checkpointManager.flushReadyCheckpointMessages()
+        Assertions.assertTrue(startTime < checkpointManager.getLastSuccessfulFlushTimeMs())
+    }
+
+    @Test
+    fun testGetNextStreamCheckpoints() = runTest {
+        Assertions.assertEquals(
+            emptyMap<DestinationStream.Descriptor, Long>(),
+            checkpointManager.getNextCheckpointIndexes()
+        )
+
+        checkpointManager.addStreamCheckpoint(
+            stream1.descriptor,
+            1L,
+            MockStreamCheckpointIn(stream1, 1)
+        )
+        Assertions.assertEquals(
+            mapOf(stream1.descriptor to 1L),
+            checkpointManager.getNextCheckpointIndexes()
+        )
+
+        checkpointManager.addStreamCheckpoint(
+            stream2.descriptor,
+            10L,
+            MockStreamCheckpointIn(stream2, 10)
+        )
+        Assertions.assertEquals(
+            mapOf(stream1.descriptor to 1L, stream2.descriptor to 10L),
+            checkpointManager.getNextCheckpointIndexes()
+        )
+
+        checkpointManager.addStreamCheckpoint(
+            stream1.descriptor,
+            2L,
+            MockStreamCheckpointIn(stream1, 2)
+        )
+        Assertions.assertEquals(
+            mapOf(stream1.descriptor to 1L, stream2.descriptor to 10L),
+            checkpointManager.getNextCheckpointIndexes(),
+            "only the first checkpoint is returned"
+        )
+
+        syncManager.markPersisted(stream1, Range.singleton(0))
+        Assertions.assertEquals(
+            mapOf(stream1.descriptor to 1L, stream2.descriptor to 10L),
+            checkpointManager.getNextCheckpointIndexes(),
+            "marking persisted is not sufficient"
+        )
+
+        checkpointManager.flushReadyCheckpointMessages()
+        Assertions.assertEquals(
+            mapOf(stream1.descriptor to 2L, stream2.descriptor to 10L),
+            checkpointManager.getNextCheckpointIndexes(),
+            "flushing the first checkpoint reveals the second one"
+        )
+
+        checkpointManager.addStreamCheckpoint(
+            stream2.descriptor,
+            20L,
+            MockStreamCheckpointIn(stream2, 20)
+        )
+        checkpointManager.flushReadyCheckpointMessages()
+        Assertions.assertEquals(
+            mapOf(stream1.descriptor to 2L, stream2.descriptor to 10L),
+            checkpointManager.getNextCheckpointIndexes(),
+            "but only on the stream that was flushed"
+        )
+
+        syncManager.markPersisted(stream2, Range.closed(0L, 19L))
+        checkpointManager.flushReadyCheckpointMessages()
+        Assertions.assertEquals(
+            mapOf(stream1.descriptor to 2L),
+            checkpointManager.getNextCheckpointIndexes(),
+            "flushing all the checkpoints clears the stream from the map"
+        )
+
+        syncManager.markPersisted(stream1, Range.singleton(1))
+        checkpointManager.flushReadyCheckpointMessages()
+        Assertions.assertEquals(
+            emptyMap<DestinationStream.Descriptor, Long>(),
+            checkpointManager.getNextCheckpointIndexes(),
+            "flushing all the checkpoints clears the map"
+        )
+    }
+
+    @Test
+    fun testGetNextGlobalCheckpoints() = runTest {
+        Assertions.assertEquals(
+            emptyMap<DestinationStream.Descriptor, Long>(),
+            checkpointManager.getNextCheckpointIndexes()
+        )
+
+        checkpointManager.addGlobalCheckpoint(
+            listOf(stream1.descriptor to 1L, stream2.descriptor to 10L),
+            MockGlobalCheckpointIn(1)
+        )
+        Assertions.assertEquals(
+            mapOf(stream1.descriptor to 1L, stream2.descriptor to 10L),
+            checkpointManager.getNextCheckpointIndexes()
+        )
+
+        checkpointManager.addGlobalCheckpoint(
+            listOf(stream1.descriptor to 2L, stream2.descriptor to 20L),
+            MockGlobalCheckpointIn(2)
+        )
+        Assertions.assertEquals(
+            mapOf(stream1.descriptor to 1L, stream2.descriptor to 10L),
+            checkpointManager.getNextCheckpointIndexes(),
+            "only the first checkpoint is returned"
+        )
+
+        syncManager.markPersisted(stream1, Range.singleton(0))
+        checkpointManager.flushReadyCheckpointMessages()
+        Assertions.assertEquals(
+            mapOf(stream1.descriptor to 1L, stream2.descriptor to 10L),
+            checkpointManager.getNextCheckpointIndexes(),
+            "if only 1 stream is persisted, neither are returned"
+        )
+
+        syncManager.markPersisted(stream2, Range.closed(0L, 19L))
+        checkpointManager.flushReadyCheckpointMessages()
+        Assertions.assertEquals(
+            mapOf(stream1.descriptor to 2L, stream2.descriptor to 20L),
+            checkpointManager.getNextCheckpointIndexes(),
+            "persisting the second stream triggers both to flush, revealing the next pair"
+        )
+
+        syncManager.markPersisted(stream1, Range.singleton(1))
+        checkpointManager.flushReadyCheckpointMessages()
+        Assertions.assertEquals(
+            emptyMap<DestinationStream.Descriptor, Long>(),
+            checkpointManager.getNextCheckpointIndexes(),
+            "flushing all the checkpoints clears the map"
+        )
     }
 }

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/state/DefaultFlushStrategyTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/state/DefaultFlushStrategyTest.kt
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.state
+
+import com.google.common.collect.Range
+import io.airbyte.cdk.command.DestinationConfiguration
+import io.airbyte.cdk.command.MockDestinationCatalogFactory
+import io.airbyte.cdk.command.MockDestinationCatalogFactory.Companion.stream2
+import io.airbyte.cdk.task.ForceFlushEvent
+import io.micronaut.context.annotation.Primary
+import io.micronaut.context.annotation.Requires
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import jakarta.inject.Singleton
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+@MicronautTest(
+    environments =
+        [
+            "FlushStrategyTest",
+            "MockDestinationConfiguration",
+        ]
+)
+class DefaultFlushStrategyTest {
+    val stream1 = MockDestinationCatalogFactory.stream1
+
+    @Singleton
+    @Primary
+    @Requires(env = ["FlushStrategyTest"])
+    class MockForceFlushEventProducer : EventProducer<ForceFlushEvent>()
+
+    @Test
+    fun testFlushByByteSize(flushStrategy: DefaultFlushStrategy, config: DestinationConfiguration) =
+        runTest {
+            Assertions.assertFalse(
+                flushStrategy.shouldFlush(stream1, Range.all(), config.recordBatchSizeBytes - 1L)
+            )
+            Assertions.assertTrue(
+                flushStrategy.shouldFlush(stream1, Range.all(), config.recordBatchSizeBytes)
+            )
+            Assertions.assertTrue(
+                flushStrategy.shouldFlush(stream1, Range.all(), config.recordBatchSizeBytes * 1000L)
+            )
+        }
+
+    @Test
+    fun testFlushByIndex(
+        flushStrategy: DefaultFlushStrategy,
+        config: DestinationConfiguration,
+        forceFlushEventProducer: MockForceFlushEventProducer
+    ) = runTest {
+        // Ensure the size trigger is not a factor
+        val insufficientSize = config.recordBatchSizeBytes - 1L
+
+        Assertions.assertFalse(
+            flushStrategy.shouldFlush(stream1, Range.all(), insufficientSize),
+            "Should not flush even with whole range if no event"
+        )
+
+        forceFlushEventProducer.produce(ForceFlushEvent(mapOf(stream1.descriptor to 42L)))
+        Assertions.assertFalse(
+            flushStrategy.shouldFlush(stream1, Range.closed(0, 41), insufficientSize),
+            "Should not flush if index is not in range"
+        )
+        Assertions.assertTrue(
+            flushStrategy.shouldFlush(stream1, Range.closed(0, 42), insufficientSize),
+            "Should flush if index is in range"
+        )
+
+        Assertions.assertFalse(
+            flushStrategy.shouldFlush(stream2, Range.closed(0, 42), insufficientSize),
+            "Should not flush other streams"
+        )
+        forceFlushEventProducer.produce(ForceFlushEvent(mapOf(stream2.descriptor to 200L)))
+        Assertions.assertTrue(
+            flushStrategy.shouldFlush(stream2, Range.closed(0, 200), insufficientSize),
+            "(Unless they also have flush points)"
+        )
+
+        Assertions.assertTrue(
+            flushStrategy.shouldFlush(stream1, Range.closed(42, 100), insufficientSize),
+            "Should flush even if barely in range"
+        )
+        Assertions.assertFalse(
+            flushStrategy.shouldFlush(stream1, Range.closed(43, 100), insufficientSize),
+            "Should not flush if index has been passed"
+        )
+
+        forceFlushEventProducer.produce(ForceFlushEvent(mapOf(stream1.descriptor to 100L)))
+        Assertions.assertFalse(
+            flushStrategy.shouldFlush(stream1, Range.closed(0, 42), insufficientSize),
+            "New events indexes should invalidate old ones"
+        )
+        Assertions.assertTrue(
+            flushStrategy.shouldFlush(stream1, Range.closed(43, 100), insufficientSize),
+            "New event indexes should be honored"
+        )
+    }
+}

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/state/MockCheckpointManager.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/state/MockCheckpointManager.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.state
+
+import io.airbyte.cdk.command.DestinationStream
+import io.airbyte.cdk.file.TimeProvider
+import io.airbyte.cdk.message.CheckpointMessage
+import io.micronaut.context.annotation.Requires
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+
+@Singleton
+@Requires(env = ["MockCheckpointManager"])
+class MockCheckpointManager : CheckpointManager<DestinationStream.Descriptor, CheckpointMessage> {
+    @Inject lateinit var timeProvider: TimeProvider
+
+    val streamStates =
+        mutableMapOf<DestinationStream.Descriptor, MutableList<Pair<Long, CheckpointMessage>>>()
+    val globalStates =
+        mutableListOf<Pair<List<Pair<DestinationStream.Descriptor, Long>>, CheckpointMessage>>()
+
+    val flushedAtMs = mutableListOf<Long>()
+    var mockCheckpointIndexes = mutableMapOf<DestinationStream.Descriptor, Long>()
+    var mockLastFlushTimeMs = 0L
+
+    override suspend fun addStreamCheckpoint(
+        key: DestinationStream.Descriptor,
+        index: Long,
+        checkpointMessage: CheckpointMessage
+    ) {
+        streamStates.getOrPut(key) { mutableListOf() }.add(index to checkpointMessage)
+    }
+
+    override suspend fun addGlobalCheckpoint(
+        keyIndexes: List<Pair<DestinationStream.Descriptor, Long>>,
+        checkpointMessage: CheckpointMessage
+    ) {
+        globalStates.add(keyIndexes to checkpointMessage)
+    }
+
+    override suspend fun flushReadyCheckpointMessages() {
+        flushedAtMs.add(timeProvider.currentTimeMillis())
+    }
+
+    override suspend fun getLastSuccessfulFlushTimeMs(): Long {
+        return mockLastFlushTimeMs
+    }
+
+    override suspend fun getNextCheckpointIndexes(): Map<DestinationStream.Descriptor, Long> {
+        return mockCheckpointIndexes
+    }
+}

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/state/SyncManagerUtils.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/state/SyncManagerUtils.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.state
+
+import com.google.common.collect.Range
+import io.airbyte.cdk.command.DestinationStream
+import io.airbyte.cdk.message.Batch
+import io.airbyte.cdk.message.BatchEnvelope
+import io.airbyte.cdk.message.SimpleBatch
+
+/**
+ * Because [SyncManager] and [StreamManager] have thin interfaces with no side effects, mocking them
+ * is overkill (the mock implementation converges with the real one). Instead, we provide
+ * convenience extension functions to simplify mocking state for testing.
+ *
+ * TODO: add more of these and apply them throughout the tests to simplify the code.
+ */
+fun SyncManager.markPersisted(stream: DestinationStream, range: Range<Long>) {
+    this.getStreamManager(stream.descriptor)
+        .updateBatchState(BatchEnvelope(SimpleBatch(Batch.State.PERSISTED), range))
+}

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/task/MockTaskLauncher.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/task/MockTaskLauncher.kt
@@ -17,6 +17,7 @@ import jakarta.inject.Singleton
 class MockTaskLauncher(override val taskRunner: TaskRunner) : DestinationTaskLauncher {
     val spilledFiles = mutableListOf<BatchEnvelope<SpilledRawMessagesLocalFile>>()
     val batchEnvelopes = mutableListOf<BatchEnvelope<*>>()
+    val scheduledForcedFlushes = mutableListOf<Long>()
 
     override suspend fun handleSetupComplete() {
         throw NotImplementedError()
@@ -48,5 +49,9 @@ class MockTaskLauncher(override val taskRunner: TaskRunner) : DestinationTaskLau
 
     override suspend fun start() {
         throw NotImplementedError()
+    }
+
+    override suspend fun scheduleNextForceFlushAttempt(msFromNow: Long) {
+        scheduledForcedFlushes.add(msFromNow)
     }
 }

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/task/SpillToDiskTaskTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/task/SpillToDiskTaskTest.kt
@@ -5,7 +5,6 @@
 package io.airbyte.cdk.task
 
 import com.google.common.collect.Range
-import io.airbyte.cdk.command.DestinationConfiguration
 import io.airbyte.cdk.command.DestinationStream
 import io.airbyte.cdk.command.MockDestinationCatalogFactory.Companion.stream1
 import io.airbyte.cdk.data.NullValue
@@ -21,7 +20,6 @@ import io.micronaut.context.annotation.Requires
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest
 import jakarta.inject.Inject
 import jakarta.inject.Singleton
-import java.nio.file.Path
 import java.util.concurrent.atomic.AtomicLong
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
@@ -33,6 +31,7 @@ import org.junit.jupiter.api.Test
     environments =
         [
             "SpillToDiskTaskTest",
+            "MockDestinationConfiguration",
             "MockTempFileProvider",
             "MockTaskLauncher",
         ]
@@ -41,16 +40,6 @@ class SpillToDiskTaskTest {
     @Inject lateinit var taskRunner: TaskRunner
     @Inject lateinit var spillToDiskTaskFactory: DefaultSpillToDiskTaskFactory
     @Inject lateinit var mockTempFileProvider: MockTempFileProvider
-
-    @Singleton
-    @Primary
-    @Requires(env = ["SpillToDiskTaskTest"])
-    class MockWriteConfiguration : DestinationConfiguration() {
-        override val recordBatchSizeBytes: Long = 1024L
-        override val tmpFileDirectory: Path = Path.of("/tmp-test")
-        override val firstStageTmpFilePrefix: String = "spilled"
-        override val firstStageTmpFileSuffix: String = ".jsonl"
-    }
 
     @Singleton
     @Requires(env = ["SpillToDiskTaskTest"])
@@ -92,7 +81,6 @@ class SpillToDiskTaskTest {
             rangeRead: Range<Long>,
             bytesProcessed: Long
         ): Boolean {
-            println(bytesProcessed)
             return bytesProcessed >= 1024
         }
     }

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/task/TimedForcedCheckpointFlushTaskTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/task/TimedForcedCheckpointFlushTaskTest.kt
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.task
+
+import io.airbyte.cdk.command.DestinationConfiguration
+import io.airbyte.cdk.command.DestinationStream
+import io.airbyte.cdk.file.MockTimeProvider
+import io.airbyte.cdk.state.EventConsumer
+import io.airbyte.cdk.state.MockCheckpointManager
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import jakarta.inject.Inject
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+@MicronautTest(
+    rebuildContext = true,
+    environments =
+        [
+            "TimedForcedCheckpointFlushTaskTest",
+            "MockDestinationConfiguration",
+            "MockCheckpointManager",
+            "MockTaskLauncher",
+            "MockTimeProvider"
+        ]
+)
+class TimedForcedCheckpointFlushTaskTest {
+    @Inject lateinit var flushTaskFactory: DefaultTimedForcedCheckpointFlushTaskFactory
+    @Inject lateinit var taskLauncher: MockTaskLauncher
+    @Inject lateinit var timeProvider: MockTimeProvider
+    @Inject lateinit var checkpointManager: MockCheckpointManager
+    @Inject lateinit var config: DestinationConfiguration
+    @Inject lateinit var eventConsumer: EventConsumer<ForceFlushEvent>
+
+    @Test
+    fun testTaskWillNotFlushIfTimeNotElapsed() = runTest {
+        val delayMs = 100L
+        val task = flushTaskFactory.make(taskLauncher, delayMs)
+        timeProvider.setCurrentTime(0L)
+        val mockLastFlushTime = delayMs + config.maxCheckpointFlushTimeMs - 1L
+        checkpointManager.mockLastFlushTimeMs = mockLastFlushTime
+        task.execute()
+        Assertions.assertEquals(
+            delayMs,
+            timeProvider.currentTimeMillis(),
+            "task delayed the specified time"
+        )
+        Assertions.assertEquals(
+            mutableListOf(delayMs),
+            checkpointManager.flushedAtMs,
+            "task tried to flush"
+        )
+        Assertions.assertNull(
+            eventConsumer.consumeMaybe(),
+            "task did not produce a force flush event"
+        )
+        val mockTimeSinceLastFlush = timeProvider.currentTimeMillis() - mockLastFlushTime
+        val nextRun = config.maxCheckpointFlushTimeMs - mockTimeSinceLastFlush
+        Assertions.assertEquals(
+            listOf(nextRun),
+            taskLauncher.scheduledForcedFlushes,
+            "task scheduled next flush for remaining interval"
+        )
+    }
+
+    @Test
+    fun testTaskWillFlushIfTimeElapsed() = runTest {
+        val delayMs =
+            config.maxCheckpointFlushTimeMs // task uses flush interval as delay by default
+        val task = flushTaskFactory.make(taskLauncher)
+        timeProvider.setCurrentTime(0L)
+        checkpointManager.mockLastFlushTimeMs = 0L
+        val expectedMap =
+            mutableMapOf(DestinationStream.Descriptor(name = "test", namespace = "testing") to 999L)
+        checkpointManager.mockCheckpointIndexes = expectedMap
+        task.execute()
+        Assertions.assertEquals(
+            delayMs,
+            timeProvider.currentTimeMillis(),
+            "task delayed for the configured interval"
+        )
+        Assertions.assertEquals(
+            listOf(delayMs),
+            checkpointManager.flushedAtMs,
+            "task tried to flush"
+        )
+        val flushEvent = eventConsumer.consumeMaybe()
+        Assertions.assertEquals(
+            expectedMap,
+            flushEvent?.indexes,
+            "task produced a force flush event with indexes provided by the checkpoint manager"
+        )
+        Assertions.assertEquals(
+            listOf(config.maxCheckpointFlushTimeMs),
+            taskLauncher.scheduledForcedFlushes,
+            "task scheduled next flush for full interval"
+        )
+    }
+}


### PR DESCRIPTION
## What
Adds a task that attempts a force checkpoint flush every configured interval (15 minutes by default).
* task is launched by the task launcher with a 15 minute initial delay
* every run it A) tries to flush; B) checks the time elapsed since last success; C) either broadcasts a `ForceFlushEvent` or reschedules itself to run 15 minutes after the last successful flush
* `DefaultFlushStrategy` enforces the indexes produced by the event if the range being processed encloses them

## How
* new task `TimedForcedCheckpointFlushTask`
* TimeProvider bean to aid testing
* added methods to the `CheckpointManager` for getting time elapsed and getting the indexes
* added lock semantics to the `CheckpointManager` to protect the indexes while they're being inspected
* Simple Multi-reader/single-writer event consumer/producer interface for message passing
* Tests for eveything
* Two *light* test refactors: moved `MockDestinationConfiguration` and `MockCheckpointManager` to common files and added only the new implementations necessary for the new tests (no change to what was moved)

## Issues
There's a lot of async stuff happening per-row now. It would probably make sense to limit how often `SpillToDiskTask` queries the `FlushStrategy`.
