### PR TITLE
Bulk Load CDK Stream Incomplete Prep Refactor: Memory manager provide…

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/state/MemoryManager.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/state/MemoryManager.kt
@@ -4,8 +4,10 @@
 
 package io.airbyte.cdk.state
 
+import io.airbyte.cdk.util.CloseableCoroutine
 import io.micronaut.context.annotation.Secondary
 import jakarta.inject.Singleton
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicLong
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.sync.Mutex
@@ -19,17 +21,47 @@ import kotlinx.coroutines.sync.withLock
  * TODO: Some degree of logging/monitoring around how accurate we're actually being?
  */
 @Singleton
-class MemoryManager(private val availableMemoryProvider: AvailableMemoryProvider) {
-    private val totalMemoryBytes: Long = availableMemoryProvider.availableMemoryBytes
+class MemoryManager(availableMemoryProvider: AvailableMemoryProvider) {
+    // This is slightly awkward, but Micronaut only injects the primary constructor
+    constructor(
+        availableMemory: Long
+    ) : this(
+        object : AvailableMemoryProvider {
+            override val availableMemoryBytes: Long = availableMemory
+        }
+    )
+
+    private val totalMemoryBytes = availableMemoryProvider.availableMemoryBytes
     private var usedMemoryBytes = AtomicLong(0L)
     private val mutex = Mutex()
     private val syncChannel = Channel<Unit>(Channel.UNLIMITED)
+
+    /**
+     * Releasable reservation of memory. For large blocks (ie, from [reserveRatio], provides a
+     * submanager that can be used to manage allocating the reservation).
+     */
+    inner class Reservation(val bytes: Long) : CloseableCoroutine {
+        private var released = AtomicBoolean(false)
+
+        suspend fun release() {
+            if (!released.compareAndSet(false, true)) {
+                return
+            }
+            release(bytes)
+        }
+
+        fun getReservationManager(): MemoryManager = MemoryManager(bytes)
+
+        override suspend fun close() {
+            release()
+        }
+    }
 
     val remainingMemoryBytes: Long
         get() = totalMemoryBytes - usedMemoryBytes.get()
 
     /* Attempt to reserve memory. If enough memory is not available, waits until it is, then reserves. */
-    suspend fun reserveBlocking(memoryBytes: Long) {
+    suspend fun reserveBlocking(memoryBytes: Long): Reservation {
         if (memoryBytes > totalMemoryBytes) {
             throw IllegalArgumentException(
                 "Requested ${memoryBytes}b memory exceeds ${totalMemoryBytes}b total"
@@ -41,13 +73,15 @@ class MemoryManager(private val availableMemoryProvider: AvailableMemoryProvider
                 syncChannel.receive()
             }
             usedMemoryBytes.addAndGet(memoryBytes)
+
+            return Reservation(memoryBytes)
         }
     }
 
-    suspend fun reserveRatio(ratio: Double): Long {
+    suspend fun reserveRatio(ratio: Double): Reservation {
         val estimatedSize = (totalMemoryBytes.toDouble() * ratio).toLong()
         reserveBlocking(estimatedSize)
-        return estimatedSize
+        return Reservation(estimatedSize)
     }
 
     suspend fun release(memoryBytes: Long) {

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/util/CoroutineUtils.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/util/CoroutineUtils.kt
@@ -11,3 +11,15 @@ fun <T> Flow<T>.takeUntilInclusive(predicate: (T) -> Boolean): Flow<T> = transfo
     emit(value)
     !predicate(value)
 }
+
+interface CloseableCoroutine {
+    suspend fun close()
+}
+
+suspend fun <T : CloseableCoroutine> T.use(block: suspend (T) -> Unit) {
+    try {
+        block(this)
+    } finally {
+        close()
+    }
+}

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/state/MemoryManagerTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/state/MemoryManagerTest.kt
@@ -17,11 +17,11 @@ import kotlinx.coroutines.withTimeout
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 
-@MicronautTest
+@MicronautTest(environments = ["MemoryManagerTest"])
 class MemoryManagerTest {
     @Singleton
     @Replaces(MemoryManager::class)
-    @Requires(env = ["test"])
+    @Requires(env = ["MemoryManagerTest"])
     class MockAvailableMemoryProvider : AvailableMemoryProvider {
         override val availableMemoryBytes: Long = 1000
     }

--- a/spotbugs-exclude-filter-file.xml
+++ b/spotbugs-exclude-filter-file.xml
@@ -19,4 +19,7 @@
     <Class name="io.airbyte.cdk.integrations.debezium.internals.AirbyteFileOffsetBackingStore" />
     <Bug code="SECOBDES" />
   </Match>
+  <Match>
+    <Package name="io.airbyte.cdk.util.*" />
+  </Match>
 </FindBugsFilter>


### PR DESCRIPTION
## What
A light preparatory refactor

* change the memory manager so that reserving memory provides a releasable `Reservation` (so memory can be passed along to the point it's "freed")
* for large blocks (like the queue reserves at the beginning), let the `Reservation` return a sub manager for managing allocations within that block. This prevents us from having to test around extra features like scopes, etc.

This is preliminary to refactoring the `MessageQueue` to be much simpler, and ultimately adding new asynchronous Sync-level tasks for message publishing and state message updates. (Right now it's a bit of a traffic jam of locking, etc. Plus there's no safe place to throw the failure exception for `StreamIncomplete`.)