### PR TITLE
feat(airbyte-ci): connectors up-to-date manifest-only support

### DIFF
--- a/airbyte-ci/connectors/base_images/README.md
+++ b/airbyte-ci/connectors/base_images/README.md
@@ -94,6 +94,10 @@ poetry run mypy base_images --check-untyped-defs
 ```
 ## CHANGELOG
 
+### 1.0.2
+
+- Improved support for images with non-semantic-versioned tags.
+
 ### 1.0.1
 
 - Bumped dependencies ([#42581](https://github.com/airbytehq/airbyte/pull/42581))

--- a/airbyte-ci/connectors/base_images/base_images/bases.py
+++ b/airbyte-ci/connectors/base_images/base_images/bases.py
@@ -3,6 +3,7 @@
 #
 
 """This module declares common (abstract) classes and methods used by all base images."""
+
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
@@ -41,10 +42,8 @@ class AirbyteConnectorBaseImage(ABC):
         """
         return f"{self.repository}:{self.version}"
 
-    # MANDATORY SUBCLASSES ATTRIBUTES / PROPERTIES:
-
+    # Child classes should define their root image if the image is indeed managed by base_images.
     @property
-    @abstractmethod
     def root_image(self) -> PublishedImage:
         """Returns the base image used to build the Airbyte base image.
 
@@ -55,6 +54,8 @@ class AirbyteConnectorBaseImage(ABC):
             PublishedImage: The base image used to build the Airbyte base image.
         """
         raise NotImplementedError("Subclasses must define a 'root_image' attribute.")
+
+    # MANDATORY SUBCLASSES ATTRIBUTES / PROPERTIES:
 
     @property
     @abstractmethod

--- a/airbyte-ci/connectors/base_images/base_images/python/bases.py
+++ b/airbyte-ci/connectors/base_images/base_images/python/bases.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 from typing import Callable, Final
 
 import dagger
-
 from base_images import bases, published_image
 from base_images import sanity_checks as base_sanity_checks
 from base_images.python import sanity_checks as python_sanity_checks

--- a/airbyte-ci/connectors/base_images/base_images/python/bases.py
+++ b/airbyte-ci/connectors/base_images/base_images/python/bases.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from typing import Callable, Final
 
 import dagger
+
 from base_images import bases, published_image
 from base_images import sanity_checks as base_sanity_checks
 from base_images.python import sanity_checks as python_sanity_checks
@@ -15,7 +16,6 @@ from base_images.root_images import PYTHON_3_10_14
 class AirbyteManifestOnlyConnectorBaseImage(bases.AirbyteConnectorBaseImage):
     """ManifestOnly base image class, only used to fetch the registry."""
 
-    root_image: Final[published_image.PublishedImage] = PYTHON_3_10_14
     repository: Final[str] = "airbyte/source-declarative-manifest"
 
 

--- a/airbyte-ci/connectors/base_images/base_images/python/bases.py
+++ b/airbyte-ci/connectors/base_images/base_images/python/bases.py
@@ -1,20 +1,26 @@
 #
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 #
-
 from __future__ import annotations
 
 from typing import Callable, Final
 
 import dagger
+
 from base_images import bases, published_image
 from base_images import sanity_checks as base_sanity_checks
 from base_images.python import sanity_checks as python_sanity_checks
 from base_images.root_images import PYTHON_3_10_14
 
 
-class AirbytePythonConnectorBaseImage(bases.AirbyteConnectorBaseImage):
+class AirbyteManifestOnlyConnectorBaseImage(bases.AirbyteConnectorBaseImage):
+    """ManifestOnly base image class, only used to fetch the registry."""
 
+    root_image: Final[published_image.PublishedImage] = PYTHON_3_10_14
+    repository: Final[str] = "airbyte/source-declarative-manifest"
+
+
+class AirbytePythonConnectorBaseImage(bases.AirbyteConnectorBaseImage):
     root_image: Final[published_image.PublishedImage] = PYTHON_3_10_14
     repository: Final[str] = "airbyte/python-connector-base"
     pip_cache_name: Final[str] = "pip_cache"

--- a/airbyte-ci/connectors/base_images/base_images/version_registry.py
+++ b/airbyte-ci/connectors/base_images/base_images/version_registry.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple, Type, Mapping
+from typing import Dict, List, Mapping, Optional, Tuple, Type
 
 import dagger
 import semver

--- a/airbyte-ci/connectors/base_images/base_images/version_registry.py
+++ b/airbyte-ci/connectors/base_images/base_images/version_registry.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple, Type
+from typing import Dict, List, Optional, Tuple, Type, Mapping
 
 import dagger
 import semver
@@ -16,7 +16,6 @@ from base_images.bases import AirbyteConnectorBaseImage
 from base_images.python.bases import AirbyteManifestOnlyConnectorBaseImage, AirbytePythonConnectorBaseImage
 from base_images.utils import docker
 from connector_ops.utils import ConnectorLanguage  # type: ignore
-from deepdiff.model import Mapping
 
 MANAGED_BASE_IMAGES = [AirbytePythonConnectorBaseImage]
 

--- a/airbyte-ci/connectors/base_images/base_images/version_registry.py
+++ b/airbyte-ci/connectors/base_images/base_images/version_registry.py
@@ -11,14 +11,12 @@ from typing import Dict, List, Optional, Tuple, Type
 
 import dagger
 import semver
-from deepdiff.model import Mapping
-
 from base_images import consts, published_image
 from base_images.bases import AirbyteConnectorBaseImage
 from base_images.python.bases import AirbyteManifestOnlyConnectorBaseImage, AirbytePythonConnectorBaseImage
 from base_images.utils import docker
 from connector_ops.utils import ConnectorLanguage  # type: ignore
-
+from deepdiff.model import Mapping
 
 MANAGED_BASE_IMAGES = [AirbytePythonConnectorBaseImage]
 

--- a/airbyte-ci/connectors/base_images/pyproject.toml
+++ b/airbyte-ci/connectors/base_images/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "airbyte-connectors-base-images"
-version = "1.0.2"
+version = "1.0.3"
 description = "This package is used to generate and publish the base images for Airbyte Connectors."
 authors = ["Augustin Lafanechere <augustin@airbyte.io>"]
 readme = "README.md"

--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -851,6 +851,7 @@ airbyte-ci connectors --language=low-code migrate-to-manifest-only
 
 | Version | PR                                                         | Description                                                                                                                  |
 | ------- | ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| 4.38.0  | [#46380](https://github.com/airbytehq/airbyte/pull/46380)  | `connectors up-to-date` now supports manifest-only connectors!                                                               |
 | 4.37.0  | [#46380](https://github.com/airbytehq/airbyte/pull/46380)  | Include custom components file handling in manifest-only migrations                                                          |
 | 4.36.2  | [#46278](https://github.com/airbytehq/airbyte/pull/46278)  | Fixed a bug in RC rollout and promote not taking `semaphore`                                                                 |
 | 4.36.1  | [#46274](https://github.com/airbytehq/airbyte/pull/46274)  | `airbyte-ci format js` respects `.prettierc` and `.prettierignore`                                                           |

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/up_to_date/commands.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/up_to_date/commands.py
@@ -5,7 +5,6 @@
 from typing import List
 
 import asyncclick as click
-
 from pipelines.airbyte_ci.connectors.up_to_date.pipeline import run_connector_up_to_date_pipeline
 from pipelines.cli.dagger_pipeline_command import DaggerPipelineCommand
 from pipelines.helpers.connectors.command import run_connector_pipeline

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/up_to_date/commands.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/up_to_date/commands.py
@@ -5,6 +5,7 @@
 from typing import List
 
 import asyncclick as click
+
 from pipelines.airbyte_ci.connectors.up_to_date.pipeline import run_connector_up_to_date_pipeline
 from pipelines.cli.dagger_pipeline_command import DaggerPipelineCommand
 from pipelines.helpers.connectors.command import run_connector_pipeline
@@ -12,7 +13,7 @@ from pipelines.helpers.connectors.command import run_connector_pipeline
 
 @click.command(
     cls=DaggerPipelineCommand,
-    short_help="Get the selected Python connectors up to date.",
+    short_help="Get the selected connectors up to date.",
 )
 @click.option(
     "--dep",
@@ -65,7 +66,6 @@ async def up_to_date(
     open_reports: bool,
     ignore_connector: List[str],
 ) -> bool:
-
     if create_prs and not ctx.obj["ci_github_access_token"]:
         raise click.ClickException(
             "GitHub access token is required to create or simulate a pull request. Set the CI_GITHUB_ACCESS_TOKEN environment variable."

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/up_to_date/pipeline.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/up_to_date/pipeline.py
@@ -9,7 +9,6 @@ from typing import TYPE_CHECKING
 
 import dagger
 from jinja2 import Environment, PackageLoader, select_autoescape
-
 from pipelines.airbyte_ci.connectors.build_image.steps.python_connectors import BuildConnectorImages
 from pipelines.airbyte_ci.connectors.context import ConnectorContext
 from pipelines.airbyte_ci.connectors.reports import ConnectorReport
@@ -26,7 +25,6 @@ if TYPE_CHECKING:
 
     from anyio import Semaphore
     from github import PullRequest
-
     from pipelines.models.steps import StepResult
 
 UP_TO_DATE_PR_LABEL = "up-to-date"

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/up_to_date/steps.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/up_to_date/steps.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING
 import dagger
 from connector_ops.utils import POETRY_LOCK_FILE_NAME, PYPROJECT_FILE_NAME  # type: ignore
 from deepdiff import DeepDiff  # type: ignore
+
 from pipelines.airbyte_ci.connectors.context import ConnectorContext, PipelineContext
 from pipelines.consts import LOCAL_BUILD_PLATFORM
 from pipelines.models.steps import Step, StepResult, StepStatus
@@ -106,7 +107,6 @@ class DependencyUpdate:
 
 
 class GetDependencyUpdates(Step):
-
     SYFT_DOCKER_IMAGE = "anchore/syft:v1.6.0"
     context: ConnectorContext
     title: str = "Get dependency updates"

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/up_to_date/steps.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/up_to_date/steps.py
@@ -14,7 +14,6 @@ from typing import TYPE_CHECKING
 import dagger
 from connector_ops.utils import POETRY_LOCK_FILE_NAME, PYPROJECT_FILE_NAME  # type: ignore
 from deepdiff import DeepDiff  # type: ignore
-
 from pipelines.airbyte_ci.connectors.context import ConnectorContext, PipelineContext
 from pipelines.consts import LOCAL_BUILD_PLATFORM
 from pipelines.models.steps import Step, StepResult, StepStatus

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/steps/base_image.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/steps/base_image.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING
 import yaml
 from base_images import version_registry  # type: ignore
 from connector_ops.utils import METADATA_FILE_NAME  # type: ignore
-
 from pipelines.airbyte_ci.connectors.context import ConnectorContext
 from pipelines.helpers.connectors.dagger_fs import dagger_read_file, dagger_write_file
 from pipelines.models.steps import Step, StepResult, StepStatus

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/steps/base_image.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/steps/base_image.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 import yaml
 from base_images import version_registry  # type: ignore
 from connector_ops.utils import METADATA_FILE_NAME  # type: ignore
+
 from pipelines.airbyte_ci.connectors.context import ConnectorContext
 from pipelines.helpers.connectors.dagger_fs import dagger_read_file, dagger_write_file
 from pipelines.models.steps import Step, StepResult, StepStatus

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "4.37.0"
+version = "4.38.0"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 


### PR DESCRIPTION
## What

This PR adds manifest-only connector support in `airbyte-ci connectors up-to-date`.

Once this is merged, we would still need to tweak the cron invocation of `up-to-date` to take in the language tag, and then we should get automatic PRs for all manifest-only connectors.

## How

The only thing that needed a tweak was adding the manifest-only version registry. 


## User Impact

None. Internal tool.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌
