### PR TITLE
chore: enable 5 more sources on cloud (plaid, flexport. apple search ads, n8n, etc)

### DIFF
--- a/airbyte-integrations/connectors/source-apple-search-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-apple-search-ads/metadata.yaml
@@ -14,7 +14,7 @@ data:
       packageName: airbyte-source-apple-search-ads
   registryOverrides:
     cloud:
-      enabled: false
+      enabled: true
     oss:
       enabled: true
   releaseStage: alpha

--- a/airbyte-integrations/connectors/source-flexport/metadata.yaml
+++ b/airbyte-integrations/connectors/source-flexport/metadata.yaml
@@ -11,7 +11,7 @@ data:
     oss:
       enabled: true
     cloud:
-      enabled: false
+      enabled: true
   connectorSubtype: api
   connectorType: source
   definitionId: f95337f1-2ad1-4baf-922f-2ca9152de630

--- a/airbyte-integrations/connectors/source-n8n/metadata.yaml
+++ b/airbyte-integrations/connectors/source-n8n/metadata.yaml
@@ -14,7 +14,7 @@ data:
       packageName: airbyte-source-n8n
   registryOverrides:
     cloud:
-      enabled: false
+      enabled: true
     oss:
       enabled: true
   releaseStage: alpha

--- a/airbyte-integrations/connectors/source-plaid/metadata.yaml
+++ b/airbyte-integrations/connectors/source-plaid/metadata.yaml
@@ -14,7 +14,7 @@ data:
       packageName: airbyte-source-plaid
   registryOverrides:
     cloud:
-      enabled: false
+      enabled: true
     oss:
       enabled: true
   releaseStage: alpha

--- a/airbyte-integrations/connectors/source-unleash/metadata.yaml
+++ b/airbyte-integrations/connectors/source-unleash/metadata.yaml
@@ -14,7 +14,7 @@ data:
       packageName: airbyte-source-unleash
   registryOverrides:
     cloud:
-      enabled: false
+      enabled: true
     oss:
       enabled: true
   releaseStage: alpha


### PR DESCRIPTION
## What
Enables 5 sources on Cloud, because we can! 

## How
Just the metadata change.

## Caveats
After merging, make sure to run Connector Insights on CI with overwrite=true.