### PR TITLE
Bulk Load CDK: Fixes: CheckpointManager & OutputConsumer always flush…

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/message/DestinationMessage.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/message/DestinationMessage.kt
@@ -193,7 +193,7 @@ data class StreamCheckpoint(
                             AirbyteStateStats()
                                 .withRecordCount(destinationStats.recordCount.toDouble())
                     }
-                    it.additionalProperties.forEach { (key, value) ->
+                    additionalProperties.forEach { (key, value) ->
                         it.withAdditionalProperty(key, value)
                     }
                 }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/write/WriteOperation.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/write/WriteOperation.kt
@@ -42,7 +42,6 @@ class WriteOperation(
                     when (val result = syncManager.awaitSyncResult()) {
                         is SyncSuccess -> {
                             log.info { "Sync completed successfully" }
-                            exitProcess(0)
                         }
                         is SyncFailure -> {
                             log.error { "Caught exception during sync: ${result.syncFailure}" }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/write/WriteOperation.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/write/WriteOperation.kt
@@ -5,8 +5,6 @@
 package io.airbyte.cdk.write
 
 import io.airbyte.cdk.Operation
-import io.airbyte.cdk.output.ExceptionHandler
-import io.airbyte.cdk.output.OutputConsumer
 import io.airbyte.cdk.state.SyncFailure
 import io.airbyte.cdk.state.SyncManager
 import io.airbyte.cdk.state.SyncSuccess
@@ -17,7 +15,6 @@ import io.micronaut.context.annotation.Requires
 import io.micronaut.context.annotation.Secondary
 import java.io.InputStream
 import javax.inject.Singleton
-import kotlin.system.exitProcess
 import kotlinx.coroutines.runBlocking
 
 /**
@@ -29,35 +26,21 @@ import kotlinx.coroutines.runBlocking
 class WriteOperation(
     private val taskLauncher: TaskLauncher,
     private val syncManager: SyncManager,
-    private val exceptionHandler: ExceptionHandler,
-    private val outputConsumer: OutputConsumer
 ) : Operation {
     val log = KotlinLogging.logger {}
 
-    override fun execute() {
-        runCatching {
-                runBlocking {
-                    taskLauncher.start()
+    override fun execute() = runBlocking {
+        taskLauncher.start()
 
-                    when (val result = syncManager.awaitSyncResult()) {
-                        is SyncSuccess -> {
-                            log.info { "Sync completed successfully" }
-                        }
-                        is SyncFailure -> {
-                            log.error { "Caught exception during sync: ${result.syncFailure}" }
-                            val errorMessage = exceptionHandler.handle(result.syncFailure)
-                            outputConsumer.accept(errorMessage)
-                            exitProcess(1)
-                        }
-                    }
-                }
+        when (val result = syncManager.awaitSyncResult()) {
+            is SyncSuccess -> {
+                log.info { "Sync completed successfully" }
             }
-            .onFailure {
-                log.error { "Uncaught exception during sync: $it" }
-                val errorMessage = exceptionHandler.handle(it)
-                outputConsumer.accept(errorMessage)
-                exitProcess(1)
+            is SyncFailure -> {
+                log.info { "Sync failed with stream results ${result.streamResults}" }
+                throw result.syncFailure
             }
+        }
     }
 }
 


### PR DESCRIPTION
## What
* flushReadyCheckpointMessages is no longer skippable: every flush attempt must succeed for the method to return (this was causing state messages sometimes not to flush at the very end)
* WriteOperation does not exit on success (this was causing the output consumer not to flush)
* additional properties forwarded from the source message (instead of the output message, bone-headedly)
* bonus: stray println!