### PR TITLE
bug(source-openweather) - fixes longitude regex

### DIFF
--- a/airbyte-integrations/connectors/source-openweather/manifest.yaml
+++ b/airbyte-integrations/connectors/source-openweather/manifest.yaml
@@ -138,7 +138,7 @@ spec:
         description: >-
           Latitude, decimal (-90; 90). If you need the geocoder to automatic
           convert city names and zip-codes to geo coordinates and the other way
-          around, please use our Geocoding API
+          around, please use the OpenWeather Geocoding API
         pattern: ^[-]?\d{1,2}(\.\d+)?$
         examples:
           - "45.7603"
@@ -149,8 +149,8 @@ spec:
         description: >-
           Longitude, decimal (-180; 180). If you need the geocoder to automatic
           convert city names and zip-codes to geo coordinates and the other way
-          around, please use our Geocoding API
-        pattern: ^[-]?\d{1,2}(\.\d+)?$
+          around, please use the OpenWeather Geocoding API
+        pattern: ^[-]?\d{1,3}(\.\d+)?$
         examples:
           - "4.835659"
           - "-70.39482074115321"

--- a/airbyte-integrations/connectors/source-openweather/metadata.yaml
+++ b/airbyte-integrations/connectors/source-openweather/metadata.yaml
@@ -7,7 +7,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 561d7787-b45e-4f3b-af58-0163c3ba9d5a
-  dockerImageTag: 0.3.0
+  dockerImageTag: 0.3.1
   dockerRepository: airbyte/source-openweather
   documentationUrl: https://docs.airbyte.com/integrations/sources/openweather
   githubIssueLabel: source-openweather

--- a/docs/integrations/sources/openweather.md
+++ b/docs/integrations/sources/openweather.md
@@ -38,6 +38,7 @@ The free plan allows 60 calls per minute and 1,000,000 calls per month, you won'
 
 | Version | Date       | Pull Request                                             | Subject                                                                         |
 | :------ | :--------- | :------------------------------------------------------- | :------------------------------------------------------------------------------ |
+| 0.3.1 | 2024-10-08 | [*PR_NUMBER_PLACEHOLDER*](https://github.com/airbytehq/airbyte/pull/*PR_NUMBER_PLACEHOLDER*) | Fix longitude regex matching |
 | 0.3.0 | 2024-08-26 | [44772](https://github.com/airbytehq/airbyte/pull/44772) | Refactor connector to manifest-only format |
 | 0.2.17 | 2024-08-24 | [44725](https://github.com/airbytehq/airbyte/pull/44725) | Update dependencies |
 | 0.2.16 | 2024-08-17 | [44236](https://github.com/airbytehq/airbyte/pull/44236) | Update dependencies |

--- a/docs/integrations/sources/openweather.md
+++ b/docs/integrations/sources/openweather.md
@@ -38,7 +38,7 @@ The free plan allows 60 calls per minute and 1,000,000 calls per month, you won'
 
 | Version | Date       | Pull Request                                             | Subject                                                                         |
 | :------ | :--------- | :------------------------------------------------------- | :------------------------------------------------------------------------------ |
-| 0.3.1 | 2024-10-08 | [*PR_NUMBER_PLACEHOLDER*](https://github.com/airbytehq/airbyte/pull/*PR_NUMBER_PLACEHOLDER*) | Fix longitude regex matching |
+| 0.3.1 | 2024-10-08 | [46652](https://github.com/airbytehq/airbyte/pull/46652) | Fix longitude regex matching |
 | 0.3.0 | 2024-08-26 | [44772](https://github.com/airbytehq/airbyte/pull/44772) | Refactor connector to manifest-only format |
 | 0.2.17 | 2024-08-24 | [44725](https://github.com/airbytehq/airbyte/pull/44725) | Update dependencies |
 | 0.2.16 | 2024-08-17 | [44236](https://github.com/airbytehq/airbyte/pull/44236) | Update dependencies |


### PR DESCRIPTION
## What
- The regex matching for the longitude coordinate erroneously limited the range to two digits, while longitudinal values range from -180 to +180.
- Updates the regex accordingly to allow three-digit values for longitudes.
- Updates reference to Geolocation API in manifest
- Patch version bump

## Review guide
1. manifest.yaml

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [X] YES 💚
- [ ] NO ❌
