### PR TITLE
Bulk Load CDK: Fix: teardown awaits input processing

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/state/CheckpointManager.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/state/CheckpointManager.kt
@@ -13,7 +13,6 @@ import io.airbyte.cdk.load.util.use
 import io.airbyte.protocol.models.v0.AirbyteMessage
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.micronaut.context.annotation.Secondary
-import io.micronaut.core.util.clhm.ConcurrentLinkedHashMap
 import jakarta.inject.Singleton
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentLinkedQueue
@@ -65,10 +64,11 @@ abstract class StreamsCheckpointManager<T> : CheckpointManager<DestinationStream
 
     private val checkpointsAreGlobal: AtomicReference<Boolean?> = AtomicReference(null)
     private val streamCheckpoints:
-        ConcurrentHashMap<DestinationStream.Descriptor, ConcurrentLinkedHashMap<Long, T>> =
+        ConcurrentHashMap<DestinationStream.Descriptor, ConcurrentLinkedQueue<Pair<Long, T>>> =
         ConcurrentHashMap()
     private val globalCheckpoints: ConcurrentLinkedQueue<GlobalCheckpoint<T>> =
         ConcurrentLinkedQueue()
+    private val lastIndexEmitted = ConcurrentHashMap<DestinationStream.Descriptor, Long>()
 
     override suspend fun addStreamCheckpoint(
         key: DestinationStream.Descriptor,
@@ -82,29 +82,18 @@ abstract class StreamsCheckpointManager<T> : CheckpointManager<DestinationStream
                 )
             }
 
-            streamCheckpoints.compute(key) { _, indexToMessage ->
-                val map =
-                    if (indexToMessage == null) {
-                        // If the map doesn't exist yet, build it.
-                        ConcurrentLinkedHashMap.Builder<Long, T>()
-                            .maximumWeightedCapacity(1000)
-                            .build()
-                    } else {
-                        if (indexToMessage.isNotEmpty()) {
-                            // Make sure the messages are coming in order
-                            val oldestIndex = indexToMessage.ascendingKeySet().first()
-                            if (oldestIndex > index) {
-                                throw IllegalStateException(
-                                    "Checkpoint message received out of order ($oldestIndex before $index)"
-                                )
-                            }
-                        }
-                        indexToMessage
-                    }
-                // Actually add the message
-                map[index] = checkpointMessage
-                map
+            val indexedMessages: ConcurrentLinkedQueue<Pair<Long, T>> =
+                streamCheckpoints.getOrPut(key) { ConcurrentLinkedQueue() }
+            if (indexedMessages.isNotEmpty()) {
+                // Make sure the messages are coming in order
+                val (latestIndex, _) = indexedMessages.last()!!
+                if (latestIndex > index) {
+                    throw IllegalStateException(
+                        "Checkpoint message received out of order ($latestIndex before $index)"
+                    )
+                }
             }
+            indexedMessages.add(index to checkpointMessage)
 
             log.info { "Added checkpoint for stream: $key at index: $index" }
         }
@@ -163,8 +152,9 @@ abstract class StreamsCheckpointManager<T> : CheckpointManager<DestinationStream
                     syncManager.getStreamManager(stream).areRecordsPersistedUntil(index)
                 }
             if (allStreamsPersisted) {
+                log.info { "Flushing global checkpoint with stream indexes: ${head.streamIndexes}" }
                 globalCheckpoints.poll()
-                sendMessage(head.checkpointMessage)
+                validateAndSendMessage(head.checkpointMessage, head.streamIndexes)
             } else {
                 break
             }
@@ -175,13 +165,14 @@ abstract class StreamsCheckpointManager<T> : CheckpointManager<DestinationStream
         for (stream in catalog.streams) {
             val manager = syncManager.getStreamManager(stream.descriptor)
             val streamCheckpoints = streamCheckpoints[stream.descriptor] ?: return
-            for (index in streamCheckpoints.keys) {
-                if (manager.areRecordsPersistedUntil(index)) {
-                    val checkpointMessage =
-                        streamCheckpoints.remove(index)
-                            ?: throw IllegalStateException("Checkpoint not found for index: $index")
-                    log.info { "Flushing checkpoint for stream: $stream at index: $index" }
-                    sendMessage(checkpointMessage)
+            while (true) {
+                val (nextIndex, nextMessage) = streamCheckpoints.peek() ?: break
+                if (manager.areRecordsPersistedUntil(nextIndex)) {
+                    streamCheckpoints.poll()
+                    log.info {
+                        "Flushing checkpoint for stream: ${stream.descriptor} at index: $nextIndex"
+                    }
+                    validateAndSendMessage(nextMessage, listOf(stream.descriptor to nextIndex))
                 } else {
                     break
                 }
@@ -189,7 +180,20 @@ abstract class StreamsCheckpointManager<T> : CheckpointManager<DestinationStream
         }
     }
 
-    private suspend fun sendMessage(checkpointMessage: T) {
+    private suspend fun validateAndSendMessage(
+        checkpointMessage: T,
+        streamIndexes: List<Pair<DestinationStream.Descriptor, Long>>
+    ) {
+        streamIndexes.forEach { (stream, index) ->
+            val lastIndex = lastIndexEmitted[stream]
+            if (lastIndex != null && index <= lastIndex) {
+                throw IllegalStateException(
+                    "Checkpoint message for $stream emitted out of order (emitting $index after $lastIndex)"
+                )
+            }
+            lastIndexEmitted[stream] = index
+        }
+
         lastFlushTimeMs.set(timeProvider.currentTimeMillis())
         outputConsumer.invoke(checkpointMessage)
     }
@@ -210,7 +214,7 @@ abstract class StreamsCheckpointManager<T> : CheckpointManager<DestinationStream
                 }
                 false -> {
                     streamCheckpoints
-                        .mapValues { it.value.ascendingKeySet().firstOrNull() }
+                        .mapValues { it.value.firstOrNull()?.first }
                         .filterValues { it != null }
                         .mapValues { it.value!! }
                 }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/state/StreamManager.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/state/StreamManager.kt
@@ -153,7 +153,7 @@ class DefaultStreamManager(
             batch.ranges.asRanges().map { it.span(Range.singleton(it.upperEndpoint() + 1)) }
 
         stateRanges.addAll(expanded)
-        log.info { "Updated ranges for $stream[${batch.batch.state}]: $stateRanges" }
+        log.info { "Updated ranges for ${stream.descriptor}[${batch.batch.state}]: $stateRanges" }
     }
 
     /** True if all records in `[0, index)` have reached the given state. */

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/implementor/TeardownTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/implementor/TeardownTask.kt
@@ -33,6 +33,7 @@ class DefaultTeardownTask(
 
     override suspend fun execute() {
         // TODO: This should be its own task, dispatched on a timer or something.
+        syncManager.awaitInputProcessingComplete()
         checkpointManager.flushReadyCheckpointMessages()
 
         // Run the task exactly once, and only after all streams have closed.

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/InputConsumerTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/InputConsumerTask.kt
@@ -159,6 +159,7 @@ class DefaultInputConsumerTask(
                     }
                 }
             }
+            syncManager.markInputConsumed()
         } finally {
             log.info { "Closing record queues" }
             catalog.streams.forEach { recordQueueSupplier.get(it.descriptor).close() }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/UpdateCheckpointsTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/UpdateCheckpointsTask.kt
@@ -12,6 +12,7 @@ import io.airbyte.cdk.load.message.MessageQueue
 import io.airbyte.cdk.load.message.StreamCheckpointWrapped
 import io.airbyte.cdk.load.state.CheckpointManager
 import io.airbyte.cdk.load.state.Reserved
+import io.airbyte.cdk.load.state.SyncManager
 import io.airbyte.cdk.load.task.SyncTask
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.micronaut.context.annotation.Secondary
@@ -22,6 +23,7 @@ interface UpdateCheckpointsTask : SyncTask
 @Singleton
 @Secondary
 class DefaultUpdateCheckpointsTask(
+    private val syncManager: SyncManager,
     private val checkpointManager:
         CheckpointManager<DestinationStream.Descriptor, Reserved<CheckpointMessage>>,
     private val checkpointMessageQueue: MessageQueue<Reserved<CheckpointMessageWrapped>>
@@ -41,6 +43,7 @@ class DefaultUpdateCheckpointsTask(
                 }
             }
         }
+        syncManager.markCheckpointsProcessed()
         log.info { "All checkpoints (state) updated" }
     }
 }

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/state/CheckpointManagerTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/state/CheckpointManagerTest.kt
@@ -149,7 +149,7 @@ class CheckpointManagerTest {
                         expectedStreamOutput =
                             mapOf(
                                 stream1.descriptor to listOf("11", "12"),
-                                stream2.descriptor to listOf("22", "21")
+                                stream2.descriptor to listOf("21", "22")
                             )
                     ),
                     TestCase(


### PR DESCRIPTION
## What
Enforces that all input processing is complete before shutdown can commence

Also adds a guard against out-of-order state message emission per stream (I haven't seen this happen for sure yet)

Also cleans up a couple of the log statements that were logging the whole stream instead of the descriptor.

Also there was a failing test due to the out of order guard -- now that there are guards on both end, I simplified index handling to a linked queue instead of an ordered map, which addressed the issue.