### PR TITLE
🐙 source-faker: release 6.2.17

### DIFF
--- a/airbyte-integrations/connectors/source-faker/metadata.yaml
+++ b/airbyte-integrations/connectors/source-faker/metadata.yaml
@@ -23,7 +23,7 @@ data:
       enabled: true
   releaseStage: beta
   releases:
-    isReleaseCandidate: true
+    isReleaseCandidate: false
     breakingChanges:
       4.0.0:
         message: This is a breaking change message


### PR DESCRIPTION
The release candidate version has been deemed stable and is now promoted to an official release.