### PR TITLE
🐙 source-faker: release 6.2.17

### DIFF
--- a/airbyte-integrations/connectors/source-faker/metadata.yaml
+++ b/airbyte-integrations/connectors/source-faker/metadata.yaml
@@ -23,7 +23,7 @@ data:
       enabled: true
   releaseStage: beta
   releases:
-    isReleaseCandidate: true
+    isReleaseCandidate: false
     breakingChanges:
       4.0.0:
         message: This is a breaking change message

--- a/docs/integrations/sources/faker.md
+++ b/docs/integrations/sources/faker.md
@@ -104,6 +104,7 @@ None!
 
 | Version | Date       | Pull Request                                                                                                          | Subject                                                                                                         |
 | :------ | :--------- | :-------------------------------------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------------------------------------- |
+| 6.2.17 | 2024-10-09 | [46672](https://github.com/airbytehq/airbyte/pull/46672) | Promoting release candidate 6.2.17-rc.0 to a main version. |
 | 6.2.17 | 2024-10-05 | [46398](https://github.com/airbytehq/airbyte/pull/46398) | Update dependencies |
 | 6.2.16 | 2024-09-28 | [46207](https://github.com/airbytehq/airbyte/pull/46207) | Update dependencies |
 | 6.2.15 | 2024-09-21 | [45740](https://github.com/airbytehq/airbyte/pull/45740) | Update dependencies |


### PR DESCRIPTION
The release candidate version 6.2.17-rc.0 has been deemed stable and is now ready to be promoted to an official release (6.2.17).