### PR TITLE
fix(source-circleci): set manifest CDK version to 5.7.5

### DIFF
--- a/airbyte-integrations/connectors/source-circleci/manifest.yaml
+++ b/airbyte-integrations/connectors/source-circleci/manifest.yaml
@@ -1,4 +1,4 @@
-version: 5.11.1
+version: 5.7.5
 
 type: DeclarativeSource
 


### PR DESCRIPTION
## What

Build doesn't go brrr because metadata has 5.7.5 source-decl-manifest base image. Quick fix.