### PR TITLE
Bulk load CDK: Set WORKER_JOB_ID env var in non-dockerized integration test

### DIFF
--- a/airbyte-cdk/bulk/core/load/build.gradle
+++ b/airbyte-cdk/bulk/core/load/build.gradle
@@ -22,6 +22,7 @@ dependencies {
 
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.8.1")
     implementation "org.jetbrains.kotlin:kotlin-reflect:2.0.20"
+    testFixturesImplementation "uk.org.webcompere:system-stubs-jupiter:2.1.7"
 }
 
 task integrationTest(type: Test) {

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/IntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/IntegrationTest.kt
@@ -28,7 +28,6 @@ import kotlinx.coroutines.runBlocking
 import org.apache.commons.lang3.RandomStringUtils
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.TestInfo
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.parallel.Execution
 import org.junit.jupiter.api.parallel.ExecutionMode

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/IntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/IntegrationTest.kt
@@ -27,8 +27,14 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.runBlocking
 import org.apache.commons.lang3.RandomStringUtils
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.TestInfo
+import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.parallel.Execution
 import org.junit.jupiter.api.parallel.ExecutionMode
+import uk.org.webcompere.systemstubs.environment.EnvironmentVariables
+import uk.org.webcompere.systemstubs.jupiter.SystemStub
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension
 
 @MicronautTest
 @Execution(ExecutionMode.CONCURRENT)
@@ -36,12 +42,25 @@ import org.junit.jupiter.api.parallel.ExecutionMode
 // so we have to suppress the entire class.
 // Thanks, spotbugs.
 @SuppressFBWarnings("NP_NONNULL_RETURN_VIOLATION", justification = "Micronaut DI")
+@ExtendWith(SystemStubsExtension::class)
 abstract class IntegrationTest(
     val dataDumper: DestinationDataDumper,
     val destinationCleaner: DestinationCleaner,
     val recordMangler: ExpectedRecordMapper = NoopExpectedRecordMapper,
     val nameMapper: NameMapper = NoopNameMapper,
 ) {
+    // Connectors are calling System.getenv rather than using micronaut-y properties,
+    // so we have to mock it out, instead of just setting more properties
+    // inside NonDockerizedDestination.
+    // This field has no effect on DockerizedDestination, which explicitly
+    // sets env vars when invoking `docker run`.
+    @SystemStub private lateinit var nonDockerMockEnvVars: EnvironmentVariables
+
+    @BeforeEach
+    fun setEnvVars() {
+        nonDockerMockEnvVars.set("WORKER_JOB_ID", "0")
+    }
+
     // Intentionally don't inject the actual destination process - we need a full factory
     // because some tests want to run multiple syncs, so we need to run the destination
     // multiple times.


### PR DESCRIPTION
like the comment says - we can't just set more properties in the micronaut ApplicationContext, because some connectors ([s3 >.>](https://github.com/airbytehq/airbyte/blob/1c28040f0158ac2f691a19dd079cb8607fc34fad/airbyte-cdk/java/airbyte-cdk/s3-destinations/src/main/kotlin/io/airbyte/cdk/integrations/destination/s3/template/S3FilenameTemplateManager.kt#L68)) make raw System.getenv calls.

So instead, we'll use the system-stubs library to mock these out. Pretty sucky.