### PR TITLE
Bulk CDK: remove redundant source set?

### DIFF
--- a/buildSrc/src/main/groovy/airbyte-bulk-connector.gradle
+++ b/buildSrc/src/main/groovy/airbyte-bulk-connector.gradle
@@ -140,16 +140,6 @@ class AirbyteBulkConnectorPlugin implements Plugin<Project> {
                 }
             }
         }
-
-        project.kotlin {
-            sourceSets {
-                testIntegration {
-                    kotlin.srcDir 'src/test-integration/kotlin'
-                    resources.srcDir 'src/test-integration/resources'
-                }
-            }
-        }
-
         project.tasks.named('spotbugsTest').configure {
             enabled = false
         }


### PR DESCRIPTION
this seems unnecessary, and destination-dev-null's integration tests run fine locally without it. Hopefully CI succeeds 🤞 

(for reviewers: we already declare an `integrationTestJava` source set containing these directories, which is what we actually pass into the integrationTestJava task)