### PR TITLE
destination-s3: fix doc formatting

### DIFF
--- a/docs/integrations/destinations/s3.md
+++ b/docs/integrations/destinations/s3.md
@@ -214,36 +214,44 @@ Use an existing or create new
    destination**.
 3. On the destination setup page, select **S3** from the Destination type dropdown and enter a name
    for this connector.
-4. Configure fields: _ **Access Key Id** _ See
-   [this](https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys)
-   on how to generate an access key. _ See
-   [this](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles.html)
-   on how to create a instanceprofile. _ We recommend creating an Airbyte-specific user. This user
-   will require
-   [read and write permissions](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_examples_s3_rw-bucket.html)
-   to objects in the staging bucket. \_ If the Access Key and Secret Access Key are not provided, the
-   authentication will rely either on the Role ARN using STS Assume Role or on the instanceprofile.
-5. _ **Secret Access Key** _ Corresponding key to
-   the above key id. _ Make sure your S3 bucket is accessible from the machine running Airbyte. _
-   This depends on your networking setup. _ You can check AWS S3 documentation with a tutorial on
-   how to properly configure your S3's access
-   [here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-control-overview.html). _ If
-   you use instance profile authentication, make sure the role has permission to read/write on the
-   bucket. _ The easiest way to verify if Airbyte is able to connect to your S3 bucket is via the
-   check connection tool in the UI. _ **S3 Bucket Name** _ See
-   [this](https://docs.aws.amazon.com/AmazonS3/latest/userguide/create-bucket-overview.html) to
-   create an S3 bucket. _ **S3 Bucket Path** _ Subdirectory under the above bucket to sync the data
-   into. _ **S3 Bucket Region** _ See
-   [here](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-available-regions)
-   for all region codes. _ **S3 Path Format** _ Additional string format on how to store data under
-   S3 Bucket Path. Default value is `${NAMESPACE}/${STREAM_NAME}/${YEAR}_${MONTH}_${DAY}_${EPOCH}_`.
-   _ **S3 Endpoint** _ Leave empty if using AWS S3, fill in S3 URL if using Minio S3.
-
-   - **S3 Filename pattern** \* The pattern allows you to set the file-name format for the S3
-   staging file(s), next placeholders combinations are currently supported: `{date}`,
-   `{date:yyyy_MM}`, `{timestamp}`, `{timestamp:millis}`, `{timestamp:micros}`, `{part_number}`,
-   `{sync_id}`, `{format_extension}`. Please, don't use empty space and not supportable
-   placeholders, as they won't recognized.
+4. Configure fields:
+   - **Access Key Id** 
+     - See [this](https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys) on how to generate an access key. 
+     - See [this](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles.html) on how to create a instanceprofile. 
+     - We recommend creating an Airbyte-specific user. This user will require [read and write permissions](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_examples_s3_rw-bucket.html)
+        to objects in the staging bucket. 
+     - If the Access Key and Secret Access Key are not provided, the
+        authentication will rely either on the Role ARN using STS Assume Role or on the instanceprofile.
+   - **Secret Access Key** 
+     - Corresponding key to the above key id. 
+     - Make sure your S3 bucket is accessible from the machine running Airbyte. 
+     - This depends on your networking setup. 
+     - You can check AWS S3 documentation with a tutorial on how to properly configure your S3's access [here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-control-overview.html).
+     - If you use instance profile authentication, make sure the role has permission to read/write on the
+     bucket. 
+     - The easiest way to verify if Airbyte is able to connect to your S3 bucket is via the
+     check connection tool in the UI. 
+   - **S3 Bucket Name** 
+     - See [this](https://docs.aws.amazon.com/AmazonS3/latest/userguide/create-bucket-overview.html) to create an S3 bucket. 
+   - **S3 Bucket Path** 
+     - Subdirectory under the above bucket to sync the data
+     into. 
+   - **S3 Bucket Region** 
+     - See
+     [here](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-available-regions)
+     for all region codes. 
+   - **S3 Path Format** 
+     - Additional string format on how to store data under
+     S3 Bucket Path. Default value is `${NAMESPACE}/${STREAM_NAME}/${YEAR}_${MONTH}_${DAY}_${EPOCH}_`. 
+   - **S3 Endpoint** 
+     - Leave empty if using AWS S3, fill in S3 URL if using Minio S3.
+   - **S3 Filename pattern** 
+     - The pattern allows you to set the file-name format for the S3
+     staging file(s), next placeholders combinations are currently supported: `{date}`,
+     `{date:yyyy_MM}`, `{timestamp}`, `{timestamp:millis}`, `{timestamp:micros}`, `{part_number}`,
+     `{sync_id}`, `{format_extension}`. 
+     - Please, don't use empty space and not supportable
+     placeholders, as they won't recognized.
    <!-- /env:oss -->
 
 6. Click `Set up destination`.


### PR DESCRIPTION

before: ![before.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/3SDGNU3HUDO4hq9WbAZY/c2187977-bebd-4c10-b398-89a33bfa81ca.png)
after:

![Screenshot 2024-10-09 at 3.30.52 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/3SDGNU3HUDO4hq9WbAZY/bea8c828-9f35-4a4d-a1c9-8c1097244b8b.png)

## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->

## How
<!--
* Describe how code changes achieve the solution.
-->

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
