### PR TITLE
Bulk CDK Core: Escape Dollar Signs in Command Line File Property Sources

### DIFF
--- a/airbyte-cdk/bulk/core/base/src/main/kotlin/io/airbyte/cdk/command/ConnectorCommandLinePropertySource.kt
+++ b/airbyte-cdk/bulk/core/base/src/main/kotlin/io/airbyte/cdk/command/ConnectorCommandLinePropertySource.kt
@@ -53,7 +53,7 @@ private fun resolveValues(
             log.warn { "File '$jsonFile' not found for '$cliOptionKey'." }
             continue
         }
-        values["$prefix.json"] = jsonFile.readText()
+        values["$prefix.json"] = jsonFile.readText().replace("$", "\${:$}")
     }
     return values
 }


### PR DESCRIPTION
## What
Escape any `$` in a file referenced by a command line option with `\${:$}` so that micronaut will not try (and fail) do to variable substitution.

See the workaround described [here](https://github.com/micronaut-projects/micronaut-core/issues/6783).

## Why
S3 config allows for [customized storage paths](https://docs.airbyte.com/integrations/destinations/s3#step-1-set-up-s3) variable substitutions like `${NAMESPACE}/${STREAM_NAME}/${YEAR}_${MONTH}_${DAY}_${EPOCH}_`. Without this change, micronaut tries to substitute them and fails, failing config injection **silently**, causing the operation to proceed with a default config.