### PR TITLE
fix: add white background to icons in dark mode

### DIFF
--- a/docusaurus/src/components/ConnectorRegistry.jsx
+++ b/docusaurus/src/components/ConnectorRegistry.jsx
@@ -1,11 +1,10 @@
-import React from "react";
-import { useEffect, useState } from "react";
-import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
-import styles from "./ConnectorRegistry.module.css";
+import Tabs from "@theme/Tabs";
+import React, { useEffect, useState } from "react";
 import { REGISTRY_URL } from "../connector_registry";
+import styles from "./ConnectorRegistry.module.css";
 
-const iconStyle = { maxWidth: 25 };
+const iconStyle = { maxWidth: 25, maxHeight: 25 };
 
 async function fetchCatalog(url, setter) {
   const response = await fetch(url);
@@ -57,8 +56,11 @@ function ConnectorTable({ connectors, connectorSupportLevel }) {
                 <td>
                   <div className={styles.connectorName}>
                     {connector.iconUrl_oss && (
-                      <img src={connector.iconUrl_oss} style={iconStyle} />
+                      <div className={styles.connectorIconBackground}>
+                        <img src={connector.iconUrl_oss} style={iconStyle} />
+                      </div>
                     )}
+
                     <a href={docsLink}>{connector.name_oss}</a>
                   </div>
                 </td>

--- a/docusaurus/src/components/ConnectorRegistry.module.css
+++ b/docusaurus/src/components/ConnectorRegistry.module.css
@@ -4,3 +4,16 @@
   gap: 4px;
   font-weight: bold;
 }
+
+.connectorIconBackground {
+  background-color: var(--icon-background);
+  border-radius: 6px;
+  padding: 2px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  margin-right: 4px;
+}
+

--- a/docusaurus/src/css/custom.css
+++ b/docusaurus/src/css/custom.css
@@ -38,6 +38,7 @@
   --color-red-400: hsl(0, 73%, 50%);
 
   --modal-overlay-background: hsla(241, 51%, 20%, 50%);
+  --icon-background: transparent;
 }
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */
@@ -65,6 +66,7 @@ html[data-theme="dark"] {
   --color-red-400: hsl(0, 81%, 71%);
 
   --modal-overlay-background: hsla(236, 11%, 42%, 70%);
+  --icon-background: hsl(0, 0%, 100%);
 }
 
 .docusaurus-highlight-code-line {


### PR DESCRIPTION
Closes  https://github.com/airbytehq/airbyte-internal-issues/issues/10249
## What
Some icons with transparent background got lost in dark mode.

Follow up of : https://github.com/airbytehq/airbyte/pull/45889#pullrequestreview-2328255338 

## How
- Add a white background to icons in dark mode

<img width="680" alt="Screenshot 2024-10-10 at 09 45 31" src="https://github.com/user-attachments/assets/f4e215de-c7cc-4258-a124-200ac1d19dd4">


## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
