### PR TITLE
📚 docs: add zendesk site verification

### DIFF
--- a/docusaurus/docusaurus.config.js
+++ b/docusaurus/docusaurus.config.js
@@ -49,6 +49,15 @@ const config = {
       "data-api-key": "wk_BEtrdAz2_2qgdexg5KRa6YWLWVwDdieFC7CAHkDKz",
     },
   ],
+  headTags: [
+    {
+      tagName: "meta",
+      attributes: {
+        name: "zd-site-verification",
+        content: "plvcr4wcl9abmq0itvi63c",
+      },
+    },
+  ],
 
   plugins: [
     [


### PR DESCRIPTION
Closes https://github.com/airbytehq/airbyte-internal-issues/issues/10022 
## What
We want to add  our public docs inside Zendesk help center. This will allow users to find useful content directly from the app.
Zendesk allow having external search sources but we need to verify our domain.



## How
 - Add `<meta>` tag to `<head>` so we can verify our site within Zendesk. [How to add head tags in docusaurus](https://docusaurus.io/docs/seo)
<img width="1726" alt="Screenshot 2024-10-10 at 10 11 53" src="https://github.com/user-attachments/assets/56936a75-c56d-4d83-bb20-143751a3bf2c">

## User Impact
- There's no user impact


## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
