### PR TITLE
Provide correct grant_type in Apple Ads Oauth

### DIFF
--- a/airbyte-integrations/connectors/source-apple-search-ads/manifest.yaml
+++ b/airbyte-integrations/connectors/source-apple-search-ads/manifest.yaml
@@ -452,6 +452,7 @@ definitions:
       type: OAuthAuthenticator
       client_id: "{{ config.client_id }}"
       client_secret: "{{ config.client_secret }}"
+      grant_type: client_credentials
       token_refresh_endpoint: >-
         https://appleid.apple.com/auth/oauth2/token?grant_type=client_credentials&scope=searchadsorg
 

--- a/airbyte-integrations/connectors/source-apple-search-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-apple-search-ads/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: e59c8416-c2fa-4bd3-9e95-52677ea281c1
-  dockerImageTag: 0.2.0
+  dockerImageTag: 0.2.1
   dockerRepository: airbyte/source-apple-search-ads
   githubIssueLabel: source-apple-search-ads
   icon: apple.svg

--- a/docs/integrations/sources/apple-search-ads.md
+++ b/docs/integrations/sources/apple-search-ads.md
@@ -60,6 +60,7 @@ However, at this moment and as indicated in the stream names, the connector only
 
 | Version | Date       | Pull Request                                             | Subject                                                                              |
 | :------ | :--------- | :------------------------------------------------------- | :----------------------------------------------------------------------------------- |
+| 0.2.1  | 2024-11-01 | [46706](https://github.com/airbytehq/airbyte/pull/46706) | Provide correct grant_type in Apple Ads Oauth |
 | 0.2.0  | 2024-10-01 | [46288](https://github.com/airbytehq/airbyte/pull/46288) | Migrate to Manifest-only |
 | 0.1.20 | 2024-09-28 | [46153](https://github.com/airbytehq/airbyte/pull/46153) | Update dependencies |
 | 0.1.19 | 2024-09-21 | [45803](https://github.com/airbytehq/airbyte/pull/45803) | Update dependencies |


### PR DESCRIPTION
Based on our testing of this source, it seems like an explicit specification of grant_type: client_credentials is necessary in order not to crash the DeclarativeOauth2Authenticator.

When no grant type is specified, it expects grant type refresh token, but we have no refresh token and attempt to use client credentials

This fixes https://github.com/airbytehq/airbyte/issues/46879

## What
Avoid OAuth ValueError "OauthAuthenticator needs a refresh_token parameter when grant_type is set to `refresh_token` when initializing a new Apple Search Ads source.

## How
Explicitly specify that grant_type is client_credentials (this is already reflected in the url that we try to use)

## Review guide
1. Follow the installation steps for the Apple Search ads extension at main (import the yaml into your builder)
2. Test the source
  - This should crash with the above-mentioned error
3. Apply the fix from this PR (explicitly set grant_type to client_credentials in the auth-yaml) and retest
  - You should now receive data 🎉  

## User Impact
Now it should be possible to set up new Apple Search Ads sources again 🎉 

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌
