### PR TITLE
airbyte-ci: add `rc` bump type to bump version

### DIFF
--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -851,6 +851,7 @@ airbyte-ci connectors --language=low-code migrate-to-manifest-only
 
 | Version | PR                                                         | Description                                                                                                                  |
 | ------- | ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| 4.40.0  | [#46380](https://github.com/airbytehq/airbyte/pull/46380)  | The `bump-version` command now allows the `rc` bump type.                                                               |
 | 4.39.0  | [#46696](https://github.com/airbytehq/airbyte/pull/46696)  | Bump PyAirbyte dependency and replace `airbyte-lib-validate-source` CLI command with new `validate` command                                                               |
 | 4.38.0  | [#46380](https://github.com/airbytehq/airbyte/pull/46380)  | `connectors up-to-date` now supports manifest-only connectors!                                                               |
 | 4.37.0  | [#46380](https://github.com/airbytehq/airbyte/pull/46380)  | Include custom components file handling in manifest-only migrations                                                          |

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/bump_version/commands.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/bump_version/commands.py
@@ -16,7 +16,7 @@ class BumpType(click.ParamType):
     name = "bump-type"
 
     def __init__(self) -> None:
-        self.choices = ["patch", "minor", "major"]
+        self.choices = ["patch", "minor", "major", "rc"]
 
     def convert(self, value: str, param: Optional[click.Parameter], ctx: Optional[click.Context]) -> str:
         if value in self.choices:

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/steps/bump_version.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/steps/bump_version.py
@@ -139,6 +139,8 @@ class BumpConnectorVersion(SetConnectorVersion):
             new_version = current_version.bump_minor()
         elif bump_type == "major":
             new_version = current_version.bump_major()
+        elif bump_type == "rc":
+            new_version = current_version.bump_prerelease()
         elif bump_type.startswith("version:"):
             version_str = bump_type.split("version:", 1)[1]
             if semver.VersionInfo.is_valid(version_str):

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "4.39.0"
+version = "4.40.0"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 


### PR DESCRIPTION
## What
We want the bump version command to now allow RC bump type.
If you want to release a release candidate version you would:
* Do an initial bump of the projected bump type (major/minor/patch)
* Then perform an RC bump type to add the `-rc.1` suffix
* Following RC bump on an RC version will increment the `rc` number `-rc.1` > `-rc.2`   
