### PR TITLE
fix: typo in XmlDecoder description

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -1742,7 +1742,7 @@ definitions:
         enum: [IterableDecoder]
   XmlDecoder:
     title: XML Decoder
-    description: Use this is the response is XML.
+    description: Use this if the response is XML.
     type: object
     required:
       - type


### PR DESCRIPTION
## What

`is` -> `if`

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌
