### PR TITLE
[source-recurly] Corrects pattern to match with the exported format being used

### DIFF
--- a/airbyte-integrations/connectors/source-recurly/metadata.yaml
+++ b/airbyte-integrations/connectors/source-recurly/metadata.yaml
@@ -7,7 +7,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: cd42861b-01fc-4658-a8ab-5d11d0510f01
-  dockerImageTag: 1.1.12
+  dockerImageTag: 1.1.13
   dockerRepository: airbyte/source-recurly
   documentationUrl: https://docs.airbyte.com/integrations/sources/recurly
   githubIssueLabel: source-recurly

--- a/airbyte-integrations/connectors/source-recurly/pyproject.toml
+++ b/airbyte-integrations/connectors/source-recurly/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "1.1.12"
+version = "1.1.13"
 name = "source-recurly"
 description = "Source implementation for Recurly."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-recurly/source_recurly/manifest.yaml
+++ b/airbyte-integrations/connectors/source-recurly/source_recurly/manifest.yaml
@@ -781,8 +781,8 @@ spec:
           ISO8601 timestamp from which the replication from Recurly API will
           start from.
         examples:
-          - "2021-12-01T00:00:00"
-        pattern: ^$|^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}$
+          - "2021-12-01T00:00:00Z"
+        pattern: ^$|^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$
         order: 1
       end_time:
         type: string
@@ -790,8 +790,8 @@ spec:
           ISO8601 timestamp to which the replication from Recurly API will stop.
           Records after that date won't be imported.
         examples:
-          - "2021-12-01T00:00:00"
-        pattern: ^$|^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}$
+          - "2021-12-01T00:00:00Z"
+        pattern: ^$|^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$
         order: 2
 
 schemas:

--- a/docs/integrations/sources/recurly.md
+++ b/docs/integrations/sources/recurly.md
@@ -66,6 +66,7 @@ We recommend creating a restricted, read-only key specifically for Airbyte acces
 
 | Version | Date       | Pull Request                                             | Subject                                                                              |
 | :------ | :--------- | :------------------------------------------------------- | :----------------------------------------------------------------------------------- |
+| 1.1.13 | 2024-10-29 | [46722](https://github.com/airbytehq/airbyte/pull/46722) | Fixes timestamp pattern for UI to match what connector expects |
 | 1.1.12 | 2024-10-28 | [47067](https://github.com/airbytehq/airbyte/pull/47067) | Update dependencies |
 | 1.1.11 | 2024-10-12 | [46829](https://github.com/airbytehq/airbyte/pull/46829) | Update dependencies |
 | 1.1.10 | 2024-10-05 | [46456](https://github.com/airbytehq/airbyte/pull/46456) | Update dependencies |


### PR DESCRIPTION
## What
Fixes https://github.com/airbytehq/airbyte/issues/46888.  The connector definition is expecting `%Y-%m-%dT%H:%M:%SZ` for `begin_time`/`end_time`, but the spec and validation that the UI uses requires `%Y-%m-%dT%H:%M:%S`, which causes the inability to set a `begin_time` or `end_time` for the connector.

## How
This PR updates the spec which is used by the UI for validation to match with what the connector actually expects.  Allowing users to correctly set these datetimes.

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
There shouldn't be any user impact, since this is only updating the validation logic used on the frontend to match with what the connector already expected.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
