### PR TITLE
Bulk Load CDK: Various small exception handling/shutdown workflow fixes/improvements

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/DestinationTaskExceptionHandler.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/DestinationTaskExceptionHandler.kt
@@ -33,7 +33,7 @@ interface StreamLevel : LeveledTask {
 interface DestinationTaskExceptionHandler<T : Task, U : Task> : TaskExceptionHandler<T, U> {
     suspend fun handleSyncFailure(e: Exception)
     suspend fun handleStreamFailure(stream: DestinationStream, e: Exception)
-    suspend fun handleTeardownComplete()
+    suspend fun handleSyncFailed()
 }
 
 interface WrappedTask<T : Task> : Task {
@@ -76,6 +76,7 @@ T : ScopedTask {
                         "Task $innerTask run after sync has succeeded. This should not happen."
                     )
                 }
+                log.info { "Sync task $innerTask skipped because sync has already failed." }
                 return
             }
 
@@ -110,6 +111,7 @@ T : ScopedTask {
                         "Task $innerTask run after its stream ${stream.descriptor} has succeeded. This should not happen."
                     )
                 }
+                log.info { "Stream task $innerTask skipped because stream has already failed." }
                 return
             }
 
@@ -164,7 +166,7 @@ T : ScopedTask {
         taskScopeProvider.launch(NoHandlingWrapper(failStreamTask))
     }
 
-    override suspend fun handleTeardownComplete() {
+    override suspend fun handleSyncFailed() {
         taskScopeProvider.kill()
     }
 }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/DestinationTaskExceptionHandler.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/DestinationTaskExceptionHandler.kt
@@ -15,6 +15,7 @@ import io.airbyte.cdk.load.task.implementor.FailSyncTaskFactory
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.micronaut.context.annotation.Secondary
 import jakarta.inject.Singleton
+import kotlinx.coroutines.CancellationException
 
 /**
  * The level at which a task operates:
@@ -76,6 +77,8 @@ class DefaultDestinationTaskExceptionHandler(
 
             try {
                 innerTask.execute()
+            } catch (e: CancellationException) {
+                log.warn { "Sync task $innerTask was cancelled." }
             } catch (e: Exception) {
                 handleSyncFailure(e)
             }
@@ -109,6 +112,8 @@ class DefaultDestinationTaskExceptionHandler(
 
             try {
                 innerTask.execute()
+            } catch(e: CancellationException) {
+                log.warn { "Stream task $innerTask was cancelled." }
             } catch (e: Exception) {
                 handleStreamFailure(innerTask.stream, e)
             }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/DestinationTaskExceptionHandler.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/DestinationTaskExceptionHandler.kt
@@ -136,7 +136,7 @@ T : ScopedTask {
         }
 
         override fun toString(): String {
-            return "IdWrapper(innerTask=$innerTask)"
+            return "NoHandlingWrapper(innerTask=$innerTask)"
         }
     }
 

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/DestinationTaskLauncher.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/DestinationTaskLauncher.kt
@@ -78,7 +78,7 @@ interface DestinationTaskLauncher : TaskLauncher {
     justification = "arguments are guaranteed to be non-null by Kotlin's type system"
 )
 class DefaultDestinationTaskLauncher(
-    private val taskScopeProvider: TaskScopeProvider<ScopedTask>,
+    private val taskScopeProvider: TaskScopeProvider<WrappedTask<ScopedTask>>,
     private val catalog: DestinationCatalog,
     private val syncManager: SyncManager,
 
@@ -100,7 +100,7 @@ class DefaultDestinationTaskLauncher(
     private val updateCheckpointsTask: UpdateCheckpointsTask,
 
     // Exception handling
-    private val exceptionHandler: TaskExceptionHandler<LeveledTask, ScopedTask>
+    private val exceptionHandler: TaskExceptionHandler<LeveledTask, WrappedTask<ScopedTask>>
 ) : DestinationTaskLauncher {
     private val log = KotlinLogging.logger {}
 

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/DestinationTaskScopeProvider.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/DestinationTaskScopeProvider.kt
@@ -17,34 +17,41 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.supervisorScope
 import kotlinx.coroutines.withTimeoutOrNull
 
 /**
  * The scope in which a task should run
- * - InternalTask:
+ * - [InternalScope]:
  * ```
  *       - internal to the task launcher
  *       - should not be blockable by implementor errors
  *       - killable w/o side effects
  * ```
- * - ImplementorTask: implemented by the destination
+ * - [ImplementorScope]: implemented by the destination
  * ```
  *       - calls implementor interface
  *       - should not block internal tasks (esp reading from stdin)
  *       - should complete if possible even when failing the sync
  * ```
+ * - [ShutdownScope]: special case of [ImplementorScope]
+ * ```
+ *       - tasks that should run during shutdown
+ *       - handles canceling/joining other tasks
+ *       - (and so should not cancel themselves)
+ * ```
  */
 sealed interface ScopedTask : Task
 
-interface InternalTask : ScopedTask
+interface InternalScope : ScopedTask
 
-interface ImplementorTask : ScopedTask
+interface ImplementorScope : ScopedTask
+
+interface ShutdownScope : ScopedTask
 
 @Singleton
 @Secondary
 class DestinationTaskScopeProvider(config: DestinationConfiguration) :
-    TaskScopeProvider<ScopedTask> {
+    TaskScopeProvider<WrappedTask<ScopedTask>> {
     private val log = KotlinLogging.logger {}
 
     private val timeoutMs = config.gracefulCancellationTimeoutMs
@@ -64,31 +71,42 @@ class DestinationTaskScopeProvider(config: DestinationConfiguration) :
                 .asCoroutineDispatcher()
         )
 
-    override suspend fun launch(task: ScopedTask) {
-        when (task) {
-            is InternalTask -> internalScope.scope.launch { execute(task) }
-            is ImplementorTask -> implementorScope.scope.launch { execute(task) }
+    override suspend fun launch(task: WrappedTask<ScopedTask>) {
+        when (task.innerTask) {
+            is InternalScope -> internalScope.scope.launch { execute(task, "internal") }
+            is ImplementorScope -> implementorScope.scope.launch { execute(task, "implementor") }
+            is ShutdownScope -> implementorScope.scope.launch { execute(task, "shutdown") }
         }
     }
 
-    private suspend fun execute(task: ScopedTask) {
-        log.info { "Launching task $task" }
+    private suspend fun execute(task: WrappedTask<ScopedTask>, scope: String) {
+        log.info { "Launching task $task in scope $scope" }
         val elapsed = measureTimeMillis { task.execute() }
         log.info { "Task $task completed in $elapsed ms" }
     }
 
-    override suspend fun close() = supervisorScope {
+    override suspend fun close() {
         log.info { "Closing task scopes" }
-        internalScope.job.cancel()
         // Under normal operation, all tasks should be complete
         // (except things like force flush, which loop). So
         // - it's safe to force cancel the internal tasks
-        // - implementor scope should join immediately unless we're
-        //   failing, in which case we want to give them a chance to
-        //   fail gracefully
+        // - implementor scope should join immediately
+        internalScope.job.cancel()
+        log.info { "Cancelled internal tasks, waiting for implementor tasks to complete" }
+        implementorScope.job.join()
+        log.info { "Implementor tasks completed" }
+    }
+
+    override suspend fun kill() {
+        log.info { "Killing task scopes" }
+        internalScope.job.cancel()
+        // Give the implementor tasks a chance to fail gracefully
         withTimeoutOrNull(timeoutMs) {
-            log.info { "Waiting ${timeoutMs}ms for implementor tasks to complete" }
+            log.info {
+                "Cancelled internal tasks, waiting ${timeoutMs}ms for implementor tasks to complete"
+            }
             implementorScope.job.join()
+            log.info { "Implementor tasks completed" }
         }
             ?: run {
                 log.error { "Implementor tasks did not complete within ${timeoutMs}ms, cancelling" }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/Task.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/Task.kt
@@ -30,4 +30,7 @@ interface TaskExceptionHandler<T : Task, U : Task> {
 interface TaskScopeProvider<T : Task> : CloseableCoroutine {
     /** Launch a task in the correct scope. */
     suspend fun launch(task: T)
+
+    /** Unliked close, may attempt to fail gracefully, but should guarantee return. */
+    suspend fun kill()
 }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/implementor/CloseStreamTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/implementor/CloseStreamTask.kt
@@ -7,13 +7,13 @@ package io.airbyte.cdk.load.task.implementor
 import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.state.SyncManager
 import io.airbyte.cdk.load.task.DestinationTaskLauncher
-import io.airbyte.cdk.load.task.ImplementorTask
-import io.airbyte.cdk.load.task.StreamTask
+import io.airbyte.cdk.load.task.ImplementorScope
+import io.airbyte.cdk.load.task.StreamLevel
 import io.airbyte.cdk.load.write.StreamLoader
 import io.micronaut.context.annotation.Secondary
 import jakarta.inject.Singleton
 
-interface CloseStreamTask : StreamTask, ImplementorTask
+interface CloseStreamTask : StreamLevel, ImplementorScope
 
 /**
  * Wraps @[StreamLoader.close] and marks the stream as closed in the stream manager. Also starts the

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/implementor/FailStreamTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/implementor/FailStreamTask.kt
@@ -8,19 +8,19 @@ import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.state.StreamIncompleteResult
 import io.airbyte.cdk.load.state.SyncManager
 import io.airbyte.cdk.load.task.DestinationTaskExceptionHandler
-import io.airbyte.cdk.load.task.ImplementorTask
+import io.airbyte.cdk.load.task.ShutdownScope
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.micronaut.context.annotation.Secondary
 import jakarta.inject.Singleton
 
-interface FailStreamTask : ImplementorTask
+interface FailStreamTask : ShutdownScope
 
 /**
  * FailStreamTask is a task that is executed when a stream fails. It is responsible for cleaning up
  * resources and reporting the failure.
  */
 class DefaultFailStreamTask(
-    private val exceptionHandler: DestinationTaskExceptionHandler<*>,
+    private val exceptionHandler: DestinationTaskExceptionHandler<*, *>,
     private val exception: Exception,
     private val syncManager: SyncManager,
     private val stream: DestinationStream,
@@ -64,7 +64,7 @@ class DefaultFailStreamTask(
 
 interface FailStreamTaskFactory {
     fun make(
-        exceptionHandler: DestinationTaskExceptionHandler<*>,
+        exceptionHandler: DestinationTaskExceptionHandler<*, *>,
         exception: Exception,
         stream: DestinationStream,
         kill: Boolean,
@@ -75,7 +75,7 @@ interface FailStreamTaskFactory {
 @Secondary
 class DefaultFailStreamTaskFactory(private val syncManager: SyncManager) : FailStreamTaskFactory {
     override fun make(
-        exceptionHandler: DestinationTaskExceptionHandler<*>,
+        exceptionHandler: DestinationTaskExceptionHandler<*, *>,
         exception: Exception,
         stream: DestinationStream,
         kill: Boolean,

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/implementor/FailSyncTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/implementor/FailSyncTask.kt
@@ -6,7 +6,7 @@ package io.airbyte.cdk.load.task.implementor
 
 import io.airbyte.cdk.load.state.SyncManager
 import io.airbyte.cdk.load.task.DestinationTaskExceptionHandler
-import io.airbyte.cdk.load.task.ImplementorTask
+import io.airbyte.cdk.load.task.ShutdownScope
 import io.airbyte.cdk.load.util.setOnce
 import io.airbyte.cdk.load.write.DestinationWriter
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -14,36 +14,39 @@ import io.micronaut.context.annotation.Secondary
 import jakarta.inject.Singleton
 import java.util.concurrent.atomic.AtomicBoolean
 
-interface FailSyncTask : ImplementorTask
+interface FailSyncTask : ShutdownScope
 
 /**
  * FailSyncTask is a task that is executed when a sync fails. It is responsible for cleaning up
  * resources and reporting the failure.
  */
 class DefaultFailSyncTask(
-    private val exceptionHandler: DestinationTaskExceptionHandler<*>,
+    private val exceptionHandler: DestinationTaskExceptionHandler<*, *>,
     private val destinationWriter: DestinationWriter,
     private val exception: Exception,
     private val syncManager: SyncManager,
 ) : FailSyncTask {
     private val log = KotlinLogging.logger {}
-    private val teardownRan = AtomicBoolean(false)
+
+    companion object {
+        private val teardownHasRun = AtomicBoolean(false)
+    }
 
     override suspend fun execute() {
-        if (teardownRan.setOnce()) {
+        if (teardownHasRun.setOnce()) {
             val result = syncManager.markFailed(exception) // awaits stream completion
             log.info { "Calling teardown with failure result $result" }
             destinationWriter.teardown(result)
             exceptionHandler.handleTeardownComplete()
         } else {
-            log.info { "Teardown already ran, doing nothing." }
+            log.info { "Fail sync task already initiated, doing nothing." }
         }
     }
 }
 
 interface FailSyncTaskFactory {
     fun make(
-        exceptionHandler: DestinationTaskExceptionHandler<*>,
+        exceptionHandler: DestinationTaskExceptionHandler<*, *>,
         exception: Exception
     ): FailSyncTask
 }
@@ -54,10 +57,16 @@ class DefaultFailSyncTaskFactory(
     private val syncManager: SyncManager,
     private val destinationWriter: DestinationWriter
 ) : FailSyncTaskFactory {
+
     override fun make(
-        exceptionHandler: DestinationTaskExceptionHandler<*>,
+        exceptionHandler: DestinationTaskExceptionHandler<*, *>,
         exception: Exception
     ): FailSyncTask {
-        return DefaultFailSyncTask(exceptionHandler, destinationWriter, exception, syncManager)
+        return DefaultFailSyncTask(
+            exceptionHandler,
+            destinationWriter,
+            exception,
+            syncManager,
+        )
     }
 }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/implementor/OpenStreamTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/implementor/OpenStreamTask.kt
@@ -7,14 +7,14 @@ package io.airbyte.cdk.load.task.implementor
 import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.state.SyncManager
 import io.airbyte.cdk.load.task.DestinationTaskLauncher
-import io.airbyte.cdk.load.task.ImplementorTask
-import io.airbyte.cdk.load.task.StreamTask
+import io.airbyte.cdk.load.task.ImplementorScope
+import io.airbyte.cdk.load.task.StreamLevel
 import io.airbyte.cdk.load.write.DestinationWriter
 import io.airbyte.cdk.load.write.StreamLoader
 import io.micronaut.context.annotation.Secondary
 import jakarta.inject.Singleton
 
-interface OpenStreamTask : StreamTask, ImplementorTask
+interface OpenStreamTask : StreamLevel, ImplementorScope
 
 /**
  * Wraps @[StreamLoader.start] and starts the spill-to-disk tasks.

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/implementor/ProcessBatchTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/implementor/ProcessBatchTask.kt
@@ -8,13 +8,13 @@ import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.message.BatchEnvelope
 import io.airbyte.cdk.load.state.SyncManager
 import io.airbyte.cdk.load.task.DestinationTaskLauncher
-import io.airbyte.cdk.load.task.ImplementorTask
-import io.airbyte.cdk.load.task.StreamTask
+import io.airbyte.cdk.load.task.ImplementorScope
+import io.airbyte.cdk.load.task.StreamLevel
 import io.airbyte.cdk.load.write.StreamLoader
 import io.micronaut.context.annotation.Secondary
 import jakarta.inject.Singleton
 
-interface ProcessBatchTask : StreamTask, ImplementorTask
+interface ProcessBatchTask : StreamLevel, ImplementorScope
 
 /** Wraps @[StreamLoader.processBatch] and handles the resulting batch. */
 class DefaultProcessBatchTask(

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/implementor/ProcessRecordsTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/implementor/ProcessRecordsTask.kt
@@ -15,14 +15,14 @@ import io.airbyte.cdk.load.message.DestinationStreamIncomplete
 import io.airbyte.cdk.load.message.SpilledRawMessagesLocalFile
 import io.airbyte.cdk.load.state.SyncManager
 import io.airbyte.cdk.load.task.DestinationTaskLauncher
-import io.airbyte.cdk.load.task.ImplementorTask
-import io.airbyte.cdk.load.task.StreamTask
+import io.airbyte.cdk.load.task.ImplementorScope
+import io.airbyte.cdk.load.task.StreamLevel
 import io.airbyte.cdk.load.write.StreamLoader
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.micronaut.context.annotation.Secondary
 import jakarta.inject.Singleton
 
-interface ProcessRecordsTask : StreamTask, ImplementorTask
+interface ProcessRecordsTask : StreamLevel, ImplementorScope
 
 /**
  * Wraps @[StreamLoader.processRecords] and feeds it a lazy iterator over the last batch of spooled

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/implementor/SetupTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/implementor/SetupTask.kt
@@ -5,13 +5,13 @@
 package io.airbyte.cdk.load.task.implementor
 
 import io.airbyte.cdk.load.task.DestinationTaskLauncher
-import io.airbyte.cdk.load.task.ImplementorTask
-import io.airbyte.cdk.load.task.SyncTask
+import io.airbyte.cdk.load.task.ImplementorScope
+import io.airbyte.cdk.load.task.SyncLevel
 import io.airbyte.cdk.load.write.DestinationWriter
 import io.micronaut.context.annotation.Secondary
 import jakarta.inject.Singleton
 
-interface SetupTask : SyncTask, ImplementorTask
+interface SetupTask : SyncLevel, ImplementorScope
 
 /**
  * Wraps @[DestinationWriter.setup] and starts the open stream tasks.

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/FlushCheckpointsTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/FlushCheckpointsTask.kt
@@ -5,12 +5,12 @@
 package io.airbyte.cdk.load.task.internal
 
 import io.airbyte.cdk.load.state.CheckpointManager
-import io.airbyte.cdk.load.task.InternalTask
-import io.airbyte.cdk.load.task.SyncTask
+import io.airbyte.cdk.load.task.InternalScope
+import io.airbyte.cdk.load.task.SyncLevel
 import io.micronaut.context.annotation.Secondary
 import jakarta.inject.Singleton
 
-interface FlushCheckpointsTask : SyncTask, InternalTask
+interface FlushCheckpointsTask : SyncLevel, InternalScope
 
 class DefaultFlushCheckpointsTask(
     private val checkpointManager: CheckpointManager<*, *>,

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/InputConsumerTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/InputConsumerTask.kt
@@ -29,8 +29,8 @@ import io.airbyte.cdk.load.message.Undefined
 import io.airbyte.cdk.load.state.MemoryManager
 import io.airbyte.cdk.load.state.Reserved
 import io.airbyte.cdk.load.state.SyncManager
-import io.airbyte.cdk.load.task.InternalTask
-import io.airbyte.cdk.load.task.SyncTask
+import io.airbyte.cdk.load.task.InternalScope
+import io.airbyte.cdk.load.task.SyncLevel
 import io.airbyte.cdk.load.util.use
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.micronaut.context.annotation.Secondary
@@ -39,7 +39,7 @@ import java.io.InputStream
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.FlowCollector
 
-interface InputConsumerTask : SyncTask, InternalTask
+interface InputConsumerTask : SyncLevel, InternalScope
 
 /**
  * Routes @[DestinationStreamAffinedMessage]s by stream to the appropriate channel and @

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/SpillToDiskTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/SpillToDiskTask.kt
@@ -18,8 +18,8 @@ import io.airbyte.cdk.load.message.StreamRecordWrapped
 import io.airbyte.cdk.load.state.FlushStrategy
 import io.airbyte.cdk.load.state.Reserved
 import io.airbyte.cdk.load.task.DestinationTaskLauncher
-import io.airbyte.cdk.load.task.InternalTask
-import io.airbyte.cdk.load.task.StreamTask
+import io.airbyte.cdk.load.task.InternalScope
+import io.airbyte.cdk.load.task.StreamLevel
 import io.airbyte.cdk.load.util.takeUntilInclusive
 import io.airbyte.cdk.load.util.use
 import io.airbyte.cdk.load.util.withNextAdjacentValue
@@ -28,7 +28,7 @@ import jakarta.inject.Singleton
 import kotlinx.coroutines.flow.last
 import kotlinx.coroutines.flow.runningFold
 
-interface SpillToDiskTask : StreamTask, InternalTask
+interface SpillToDiskTask : StreamLevel, InternalScope
 
 /**
  * Reads records from the message queue and writes them to disk. This task is internal and is not

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/TimedForcedCheckpointFlushTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/TimedForcedCheckpointFlushTask.kt
@@ -10,13 +10,14 @@ import io.airbyte.cdk.load.file.TimeProvider
 import io.airbyte.cdk.load.message.ChannelMessageQueue
 import io.airbyte.cdk.load.message.QueueWriter
 import io.airbyte.cdk.load.state.CheckpointManager
-import io.airbyte.cdk.load.task.SyncTask
+import io.airbyte.cdk.load.task.InternalScope
+import io.airbyte.cdk.load.task.SyncLevel
 import io.airbyte.cdk.load.util.use
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.micronaut.context.annotation.Secondary
 import jakarta.inject.Singleton
 
-interface TimedForcedCheckpointFlushTask : SyncTask
+interface TimedForcedCheckpointFlushTask : SyncLevel, InternalScope
 
 @Singleton
 @Secondary

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/UpdateCheckpointsTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/UpdateCheckpointsTask.kt
@@ -13,12 +13,13 @@ import io.airbyte.cdk.load.message.StreamCheckpointWrapped
 import io.airbyte.cdk.load.state.CheckpointManager
 import io.airbyte.cdk.load.state.Reserved
 import io.airbyte.cdk.load.state.SyncManager
-import io.airbyte.cdk.load.task.SyncTask
+import io.airbyte.cdk.load.task.InternalScope
+import io.airbyte.cdk.load.task.SyncLevel
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.micronaut.context.annotation.Secondary
 import jakarta.inject.Singleton
 
-interface UpdateCheckpointsTask : SyncTask
+interface UpdateCheckpointsTask : SyncLevel, InternalScope
 
 @Singleton
 @Secondary

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/state/MockCheckpointManager.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/state/MockCheckpointManager.kt
@@ -55,4 +55,8 @@ class MockCheckpointManager : CheckpointManager<DestinationStream.Descriptor, Ch
     override suspend fun getNextCheckpointIndexes(): Map<DestinationStream.Descriptor, Long> {
         return mockCheckpointIndexes
     }
+
+    override suspend fun awaitAllCheckpointsFlushed() {
+        TODO("Not yet implemented")
+    }
 }

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/state/MockCheckpointManager.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/state/MockCheckpointManager.kt
@@ -57,6 +57,6 @@ class MockCheckpointManager : CheckpointManager<DestinationStream.Descriptor, Ch
     }
 
     override suspend fun awaitAllCheckpointsFlushed() {
-        TODO("Not yet implemented")
+        throw NotImplementedError()
     }
 }

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/DestinationTaskExceptionHandlerTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/DestinationTaskExceptionHandlerTest.kt
@@ -227,14 +227,13 @@ class DestinationTaskExceptionHandlerTest<T> where T : LeveledTask, T : ScopedTa
         manager.markEndOfStream()
         manager.markSucceeded()
 
-        // This won't throw, because the sync wrapper will catch it and call it a sync error
         CoroutineTestUtils.assertThrows(IllegalStateException::class) { wrappedTask.execute() }
         mockFailStreamTaskFactory.didRunFor.close()
     }
 
     @Test
-    fun testHandleTeardownComplete(scopeProvider: MockScopeProvider) = runTest {
-        exceptionHandler.handleTeardownComplete()
+    fun testHandleSyncFailed(scopeProvider: MockScopeProvider) = runTest {
+        exceptionHandler.handleSyncFailed()
         Assertions.assertTrue(scopeProvider.didKill)
     }
 }

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/DestinationTaskExceptionHandlerTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/DestinationTaskExceptionHandlerTest.kt
@@ -32,12 +32,14 @@ import org.junit.jupiter.api.Test
     environments =
         [
             "DestinationTaskLauncherExceptionHandlerTest",
+            "MockDestinationConfiguration",
             "MockDestinationCatalog",
             "MockScopeProvider"
         ]
 )
-class DestinationTaskExceptionHandlerTest {
-    @Inject lateinit var exceptionHandler: DestinationTaskExceptionHandler<*>
+class DestinationTaskExceptionHandlerTest<T> where T : LeveledTask, T : ScopedTask {
+    @Inject
+    lateinit var exceptionHandler: DestinationTaskExceptionHandler<T, WrappedTask<ScopedTask>>
 
     @Singleton
     @Primary
@@ -46,7 +48,7 @@ class DestinationTaskExceptionHandlerTest {
         val didRunFor = Channel<Triple<DestinationStream, Exception, Boolean>>(Channel.UNLIMITED)
 
         override fun make(
-            exceptionHandler: DestinationTaskExceptionHandler<*>,
+            exceptionHandler: DestinationTaskExceptionHandler<*, *>,
             exception: Exception,
             stream: DestinationStream,
             kill: Boolean
@@ -66,7 +68,7 @@ class DestinationTaskExceptionHandlerTest {
         val didRunWith = Channel<Exception>(Channel.UNLIMITED)
 
         override fun make(
-            exceptionHandler: DestinationTaskExceptionHandler<*>,
+            exceptionHandler: DestinationTaskExceptionHandler<*, *>,
             exception: Exception
         ): FailSyncTask {
             return object : FailSyncTask {
@@ -82,38 +84,40 @@ class DestinationTaskExceptionHandlerTest {
      * - StreamTask(s) to handleStreamFailure (and to an injected Mock FailStreamTask)
      * - SyncTask(s) to handleSyncFailure (and to an injected Mock FailSyncTask)
      */
+    @Suppress("UNCHECKED_CAST")
     @Test
-    fun testHandleStreamTaskException(mockFailStreamTaskFactory: MockFailStreamTaskFactory) =
-        runTest {
-            val mockTask =
-                object : StreamTask {
-                    override val stream: DestinationStream = MockDestinationCatalogFactory.stream1
-
-                    override suspend fun execute() {
-                        throw RuntimeException("StreamTask failure")
-                    }
+    fun testHandleStreamTaskException(
+        mockFailStreamTaskFactory: MockFailStreamTaskFactory,
+    ) = runTest {
+        val mockTask =
+            object : StreamLevel, ImplementorScope {
+                override val stream = MockDestinationCatalogFactory.stream1
+                override suspend fun execute() {
+                    throw RuntimeException("StreamTask failure")
                 }
+            }
 
-            val wrappedTask = exceptionHandler.withExceptionHandling(mockTask)
-            wrappedTask.execute()
-            val (stream, exception) = mockFailStreamTaskFactory.didRunFor.receive()
-            Assertions.assertEquals(MockDestinationCatalogFactory.stream1, stream)
-            Assertions.assertTrue(exception is RuntimeException)
-        }
+        val wrappedTask = exceptionHandler.withExceptionHandling(mockTask as T)
+        wrappedTask.execute()
+        val (stream, exception) = mockFailStreamTaskFactory.didRunFor.receive()
+        Assertions.assertEquals(MockDestinationCatalogFactory.stream1, stream)
+        Assertions.assertTrue(exception is RuntimeException)
+    }
 
+    @Suppress("UNCHECKED_CAST")
     @Test
     fun testHandleSyncTaskException(
         mockFailStreamTaskFactory: MockFailStreamTaskFactory,
         catalog: DestinationCatalog
     ) = runTest {
         val mockTask =
-            object : SyncTask {
+            object : SyncLevel, ImplementorScope {
                 override suspend fun execute() {
                     throw RuntimeException("SyncTask failure")
                 }
             }
 
-        val wrappedTask = exceptionHandler.withExceptionHandling(mockTask)
+        val wrappedTask = exceptionHandler.withExceptionHandling(mockTask as T)
         wrappedTask.execute()
         mockFailStreamTaskFactory.didRunFor.close()
         val streamResults =
@@ -128,6 +132,7 @@ class DestinationTaskExceptionHandlerTest {
         }
     }
 
+    @Suppress("UNCHECKED_CAST")
     @Test
     fun testSyncFailureBlocksSyncTasks(
         mockFailSyncTaskFactory: MockFailSyncTaskFactory,
@@ -136,13 +141,13 @@ class DestinationTaskExceptionHandlerTest {
     ) = runTest {
         val innerTaskRan = Channel<Boolean>(Channel.UNLIMITED)
         val mockTask =
-            object : SyncTask {
+            object : SyncLevel, ImplementorScope {
                 override suspend fun execute() {
                     innerTaskRan.send(true)
                 }
             }
 
-        val wrappedTask = exceptionHandler.withExceptionHandling(mockTask)
+        val wrappedTask = exceptionHandler.withExceptionHandling(mockTask as T)
         catalog.streams.forEach {
             syncManager.getStreamManager(it.descriptor).markFailed(RuntimeException("dummy"))
         }
@@ -153,17 +158,18 @@ class DestinationTaskExceptionHandlerTest {
         Assertions.assertTrue(innerTaskRan.tryReceive().isFailure)
     }
 
+    @Suppress("UNCHECKED_CAST")
     @Test
     fun testSyncFailureAfterSuccessThrows(syncManager: SyncManager, catalog: DestinationCatalog) =
         runTest {
             val mockTask =
-                object : SyncTask {
+                object : SyncLevel, ImplementorScope {
                     override suspend fun execute() {
                         // do nothing
                     }
                 }
 
-            val wrappedTask = exceptionHandler.withExceptionHandling(mockTask)
+            val wrappedTask = exceptionHandler.withExceptionHandling(mockTask as T)
 
             for (stream in catalog.streams) {
                 val manager = syncManager.getStreamManager(stream.descriptor)
@@ -174,6 +180,7 @@ class DestinationTaskExceptionHandlerTest {
             CoroutineTestUtils.assertThrows(IllegalStateException::class) { wrappedTask.execute() }
         }
 
+    @Suppress("UNCHECKED_CAST")
     @Test
     fun testStreamFailureBlocksStreamTasks(
         mockFailStreamTaskFactory: MockFailStreamTaskFactory,
@@ -181,7 +188,7 @@ class DestinationTaskExceptionHandlerTest {
     ) = runTest {
         val innerTaskRan = Channel<Boolean>(Channel.UNLIMITED)
         val mockTask =
-            object : StreamTask {
+            object : StreamLevel, ImplementorScope {
                 override val stream: DestinationStream = MockDestinationCatalogFactory.stream1
 
                 override suspend fun execute() {
@@ -189,7 +196,7 @@ class DestinationTaskExceptionHandlerTest {
                 }
             }
 
-        val wrappedTask = exceptionHandler.withExceptionHandling(mockTask)
+        val wrappedTask = exceptionHandler.withExceptionHandling(mockTask as T)
         val manager = syncManager.getStreamManager(MockDestinationCatalogFactory.stream1.descriptor)
         manager.markEndOfStream()
         manager.markFailed(RuntimeException("dummy failure"))
@@ -199,14 +206,14 @@ class DestinationTaskExceptionHandlerTest {
         Assertions.assertTrue(innerTaskRan.tryReceive().isFailure)
     }
 
+    @Suppress("UNCHECKED_CAST")
     @Test
     fun testStreamFailureAfterSuccessThrows(
         mockFailStreamTaskFactory: MockFailStreamTaskFactory,
         syncManager: SyncManager,
-        catalog: DestinationCatalog
     ) = runTest {
         val mockTask =
-            object : StreamTask {
+            object : StreamLevel, ImplementorScope {
                 override val stream: DestinationStream = MockDestinationCatalogFactory.stream1
 
                 override suspend fun execute() {
@@ -214,22 +221,20 @@ class DestinationTaskExceptionHandlerTest {
                 }
             }
 
-        val wrappedTask = exceptionHandler.withExceptionHandling(mockTask)
+        val wrappedTask = exceptionHandler.withExceptionHandling(mockTask as T)
 
         val manager = syncManager.getStreamManager(MockDestinationCatalogFactory.stream1.descriptor)
         manager.markEndOfStream()
         manager.markSucceeded()
 
         // This won't throw, because the sync wrapper will catch it and call it a sync error
-        CoroutineTestUtils.assertDoesNotThrow { wrappedTask.execute() }
+        CoroutineTestUtils.assertThrows(IllegalStateException::class) { wrappedTask.execute() }
         mockFailStreamTaskFactory.didRunFor.close()
-        val results = mockFailStreamTaskFactory.didRunFor.consumeAsFlow().toList()
-        Assertions.assertEquals(catalog.streams.size, results.size)
     }
 
     @Test
     fun testHandleTeardownComplete(scopeProvider: MockScopeProvider) = runTest {
         exceptionHandler.handleTeardownComplete()
-        Assertions.assertTrue(scopeProvider.didClose)
+        Assertions.assertTrue(scopeProvider.didKill)
     }
 }

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/MockScopeProvider.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/MockScopeProvider.kt
@@ -12,17 +12,24 @@ import java.util.concurrent.atomic.AtomicBoolean
 @Singleton
 @Primary
 @Requires(env = ["MockScopeProvider"])
-class MockScopeProvider : TaskScopeProvider<ScopedTask> {
+class MockScopeProvider : TaskScopeProvider<WrappedTask<ScopedTask>> {
     private val didCloseAB = AtomicBoolean(false)
+    private val didKillAB = AtomicBoolean(false)
 
     val didClose
         get() = didCloseAB.get()
+    val didKill
+        get() = didKillAB.get()
 
-    override suspend fun launch(task: ScopedTask) {
+    override suspend fun launch(task: WrappedTask<ScopedTask>) {
         task.execute()
     }
 
     override suspend fun close() {
         didCloseAB.set(true)
+    }
+
+    override suspend fun kill() {
+        didKillAB.set(true)
     }
 }


### PR DESCRIPTION
## What

**A lot of small changes that accomplish the same thing: make sure shutdown happens in the right order, that everything that needs to finish finishes, plus add a bunch of logging etc to make it easier to trace.**

* various defensive guards against state not getting completely flushed:
  * do not evict checkpoints until after they've definitely been sent
  * teardown awaits all checkpoints having been evicted
* scope launching bug 1:
  * launcher was launching tasks in the *wrapper* scope
  * was causing tasks to get canceled that shouldn't be
  * fix: make `WrappedTask` a first-class thing providing `innerTask` & scope launcher uses scope of inner tasks
* scope launching bug 2:
  * `TaskScopeProvider::close()` was getting called from within the `Internal/ImplementorScope`, so it was canceling/joining itself, causing early shutdown
  * fix: make `ShutdownScope` a first-class thing, put all the Teardown/Failure tasks in it
* scope launching improvement
  * now there's close and kill, where close will absolutely let the implementor tasks finish
  * got rid of the supervisor scope, which was doing nothing
* exception handling/shutdown improvements
  * exception wrappers now correctly rethrow `CancellationException` (this is the expected behavior for coroutines, it needs to propagate to kill scopes properly)
  * reordered the call to `handleSetupComplete` so that the scope shutdown can block the sync completing
 * shutdown bug: teardown task was running more than once b/c its guard was local to the task