### PR TITLE
🐛 🎉  Source Amplitude: Add possibility to toggle the grouping by `Country` for Active Users stream

### DIFF
--- a/airbyte-integrations/connectors/source-amplitude/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-amplitude/acceptance-test-config.yml
@@ -7,7 +7,8 @@ acceptance_tests:
     tests:
       - spec_path: "source_amplitude/spec.yaml"
         backward_compatibility_tests_config:
-          disable_for_version: 0.3.2 # `start_date` format changed to format: date-time
+          # added new `active_users_group_by_country` prop to toggle grouping by country
+          disable_for_version: 0.6.10
   connection:
     tests:
       - config_path: "secrets/config.json"

--- a/airbyte-integrations/connectors/source-amplitude/metadata.yaml
+++ b/airbyte-integrations/connectors/source-amplitude/metadata.yaml
@@ -11,7 +11,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: fa9f58c6-2d03-4237-aaa4-07d75e0c1396
-  dockerImageTag: 0.6.10
+  dockerImageTag: 0.6.11
   dockerRepository: airbyte/source-amplitude
   documentationUrl: https://docs.airbyte.com/integrations/sources/amplitude
   githubIssueLabel: source-amplitude

--- a/airbyte-integrations/connectors/source-amplitude/pyproject.toml
+++ b/airbyte-integrations/connectors/source-amplitude/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "0.6.10"
+version = "0.6.11"
 name = "source-amplitude"
 description = "Source implementation for Amplitude."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-amplitude/source_amplitude/manifest.yaml
+++ b/airbyte-integrations/connectors/source-amplitude/source_amplitude/manifest.yaml
@@ -308,7 +308,7 @@ definitions:
           end: "{{format_datetime(stream_slice.end_time, '%Y%m%d') }}"
           m: "active"
           i: "1"
-          g: "country"
+          g: "{{ 'country' if config['active_users_group_by_country'] else '' }}"
       record_selector:
         type: RecordSelector
         extractor:

--- a/airbyte-integrations/connectors/source-amplitude/source_amplitude/spec.yaml
+++ b/airbyte-integrations/connectors/source-amplitude/source_amplitude/spec.yaml
@@ -50,3 +50,10 @@ connectionSpecification:
       default: 24
       minimum: 1
       maximum: 8760
+    active_users_group_by_country:
+      type: boolean
+      title: Active Users Group by Country
+      description:
+        According to <a href="https://amplitude.com/docs/apis/analytics/dashboard-rest#query-parameters">Considerations</a> the grouping by `Country` is optional,
+        if you're facing issues fetching the stream, or checking the connection please set this to `False` instead.
+      default: true

--- a/docs/integrations/sources/amplitude.md
+++ b/docs/integrations/sources/amplitude.md
@@ -58,6 +58,8 @@ The Amplitude connector ideally should gracefully handle Amplitude API limitatio
 
 | Version | Date       | Pull Request                                             | Subject                                                                                      |
 | :------ | :--------- | :------------------------------------------------------- | :------------------------------------------------------------------------------------------- |
+| 0.6.11 | 2024-10-11 | [46736](https://github.com/airbytehq/airbyte/pull/46736) | Added possibility to toggle groupping by `Country` for `Active Users` stream |
+| 0.6.10 | 2024-10-05 | [46489](https://github.com/airbytehq/airbyte/pull/46489) | Update dependencies |
 | 0.6.10 | 2024-10-05 | [46489](https://github.com/airbytehq/airbyte/pull/46489) | Update dependencies |
 | 0.6.9 | 2024-09-28 | [46121](https://github.com/airbytehq/airbyte/pull/46121) | Update dependencies |
 | 0.6.8 | 2024-09-21 | [45732](https://github.com/airbytehq/airbyte/pull/45732) | Update dependencies |


### PR DESCRIPTION
## What
Resolving:
- https://github.com/airbytehq/airbyte/issues/46712

## How
- The customer reported the issue with `check connection`. For this operation, we rely on the `Active Users` stream. This stream has an additional query parameter `g=country` that sets the grouping by `Country` for the `active users` aggregation results. For some customers, this property isn't useful or even enabled which causing `check connection` issues and possibly could cause the incorrect interpretation of the `HTTP-400` code error, handled [here](https://github.com/airbytehq/airbyte/blob/214a007e22a97b05b4ad9922dc882edc82cfa449/airbyte-integrations/connectors/source-amplitude/source_amplitude/manifest.yaml#L22-L28). This handling is generalized to look at the fact we receive `HTTP-400`, however, we can have something like this reported:
```
{"error": {"http_code": 400, "type": "invalid", "message": "Invalid chart definition", "metadata": {"details": "Invalid user property country"}}}%
```
Which should be treated in a different way.

For now, the quick patch is to unblock Customers setting up the source and fetching the data without grouping.

## User Impact
No impact is expected since the default value for the new property is set to `True` as it was.

## Can this PR be safely reverted and rolled back?
- [X] YES 💚
- [ ] NO ❌
