### PR TITLE
source-sftp-bulk: make the private key an airbyte secret

### DIFF
--- a/airbyte-integrations/connectors/source-sftp-bulk/integration_tests/spec.json
+++ b/airbyte-integrations/connectors/source-sftp-bulk/integration_tests/spec.json
@@ -524,6 +524,7 @@
               "private_key": {
                 "title": "Private key",
                 "description": "The Private key",
+                "airbyte_secret": true,
                 "multiline": true,
                 "order": 4,
                 "type": "string"

--- a/airbyte-integrations/connectors/source-sftp-bulk/metadata.yaml
+++ b/airbyte-integrations/connectors/source-sftp-bulk/metadata.yaml
@@ -7,7 +7,7 @@ data:
   connectorSubtype: file
   connectorType: source
   definitionId: 31e3242f-dee7-4cdc-a4b8-8e06c5458517
-  dockerImageTag: 1.3.0
+  dockerImageTag: 1.4.0
   dockerRepository: airbyte/source-sftp-bulk
   documentationUrl: https://docs.airbyte.com/integrations/sources/sftp-bulk
   githubIssueLabel: source-sftp-bulk

--- a/airbyte-integrations/connectors/source-sftp-bulk/pyproject.toml
+++ b/airbyte-integrations/connectors/source-sftp-bulk/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "1.3.0"
+version = "1.4.0"
 name = "source-sftp-bulk"
 description = "Source implementation for SFTP Bulk."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-sftp-bulk/source_sftp_bulk/spec.py
+++ b/airbyte-integrations/connectors/source-sftp-bulk/source_sftp_bulk/spec.py
@@ -23,7 +23,7 @@ class PrivateKeyCredentials(BaseModel):
         discriminator = "auth_type"
 
     auth_type: Literal["private_key"] = Field("private_key", const=True)
-    private_key: str = Field(title="Private key", description="The Private key", multiline=True, order=4)
+    private_key: str = Field(title="Private key", description="The Private key", multiline=True, order=4, airbyte_secret=True)
 
 
 class SourceSFTPBulkSpec(AbstractFileBasedSpec):

--- a/docs/integrations/sources/sftp-bulk.md
+++ b/docs/integrations/sources/sftp-bulk.md
@@ -156,6 +156,7 @@ This source provides a single stream per file with a dynamic schema. The current
 
 | Version | Date       | Pull Request                                             | Subject                                                     |
 |:--------|:-----------|:---------------------------------------------------------|:------------------------------------------------------------|
+| 1.4.0   | 2024-10-31 | [46739](https://github.com/airbytehq/airbyte/pull/46739) | make private key an airbyte secret.                         |
 | 1.3.0   | 2024-10-31 | [47703](https://github.com/airbytehq/airbyte/pull/47703) | Update dependency to CDK v6 with ability to transfer files. |
 | 1.2.0   | 2024-09-03 | [46323](https://github.com/airbytehq/airbyte/pull/46323) | Update dependency to CDK v5                                 |
 | 1.1.0   | 2024-08-14 | [44028](https://github.com/airbytehq/airbyte/pull/44028) | Update dependency to CDK v4                                 |


### PR DESCRIPTION
simply making the private key an airbyte secret.
I also tested this change in cloud on an existing connection where the field was not an airbyteSecret, and everything worked smoothly