### PR TITLE
Bulk load cdk: add checkpointing test

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/integrationTest/kotlin/io/airbyte/cdk/load/mock_integration_test/MockBasicFunctionalityIntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/integrationTest/kotlin/io/airbyte/cdk/load/mock_integration_test/MockBasicFunctionalityIntegrationTest.kt
@@ -22,4 +22,9 @@ class MockBasicFunctionalityIntegrationTest :
     override fun testBasicWrite() {
         super.testBasicWrite()
     }
+
+    @Test
+    override fun testMidSyncCheckpointingStreamState() {
+        super.testMidSyncCheckpointingStreamState()
+    }
 }

--- a/airbyte-cdk/bulk/core/load/src/integrationTest/kotlin/io/airbyte/cdk/load/mock_integration_test/MockDestinationConfiguration.kt
+++ b/airbyte-cdk/bulk/core/load/src/integrationTest/kotlin/io/airbyte/cdk/load/mock_integration_test/MockDestinationConfiguration.kt
@@ -10,7 +10,10 @@ import io.airbyte.cdk.load.command.DestinationConfigurationFactory
 import io.micronaut.context.annotation.Factory
 import jakarta.inject.Singleton
 
-class MockDestinationConfiguration : DestinationConfiguration()
+class MockDestinationConfiguration : DestinationConfiguration() {
+    // override to 10KB instead of 200MB
+    override val recordBatchSizeBytes = 10 * 1024L
+}
 
 @Singleton class MockDestinationSpecification : ConfigurationSpecification()
 

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/IntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/IntegrationTest.kt
@@ -21,7 +21,7 @@ import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.test.fail
-import kotlinx.coroutines.async
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import org.apache.commons.lang3.RandomStringUtils
 import org.junit.jupiter.api.AfterEach
@@ -141,7 +141,7 @@ abstract class IntegrationTest(
                 catalog.asProtocolObject(),
             )
         return runBlocking {
-            val destinationCompletion = async { destination.run() }
+            launch { destination.run() }
             messages.forEach { destination.sendMessage(it.asProtocolMessage()) }
             if (streamStatus != null) {
                 catalog.streams.forEach {
@@ -166,7 +166,6 @@ abstract class IntegrationTest(
                 }
             }
             destination.shutdown()
-            destinationCompletion.await()
             destination.readMessages()
         }
     }

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/destination_process/DestinationProcess.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/destination_process/DestinationProcess.kt
@@ -33,13 +33,15 @@ interface DestinationProcess {
     suspend fun run()
 
     fun sendMessage(message: AirbyteMessage)
+    fun sendMessages(vararg messages: AirbyteMessage) {
+        messages.forEach { sendMessage(it) }
+    }
 
     /** Return all messages the destination emitted since the last call to [readMessages]. */
     fun readMessages(): List<AirbyteMessage>
 
     /**
-     * Wait for the destination to terminate, then return all messages it emitted since the last
-     * call to [readMessages].
+     * Signal the destination to exit (i.e. close its stdin stream), then wait for it to terminate.
      */
     suspend fun shutdown()
 }

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/destination_process/DockerizedDestination.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/destination_process/DockerizedDestination.kt
@@ -199,13 +199,13 @@ class DockerizedDestination(
     override suspend fun shutdown() {
         withContext(Dispatchers.IO) {
             destinationStdin.close()
-            // The old cdk had a 1-minute timeout here. That seems... weird?
-            // We can just rely on the junit timeout, presumably?
-            process.waitFor()
             // Wait for ourselves to drain stdout/stderr. Otherwise we won't capture
             // all the destination output (logs/trace messages).
             stdoutDrained.join()
             stderrDrained.join()
+            // The old cdk had a 1-minute timeout here. That seems... weird?
+            // We can just rely on the junit timeout, presumably?
+            process.waitFor()
             val exitCode = process.exitValue()
             if (exitCode != 0) {
                 throw DestinationUncleanExitException.of(exitCode, destinationOutput.traces())

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/write/BasicFunctionalityIntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/write/BasicFunctionalityIntegrationTest.kt
@@ -6,9 +6,13 @@ package io.airbyte.cdk.load.write
 
 import io.airbyte.cdk.command.ConfigurationSpecification
 import io.airbyte.cdk.load.command.Append
+import io.airbyte.cdk.load.command.DestinationCatalog
 import io.airbyte.cdk.load.command.DestinationStream
-import io.airbyte.cdk.load.data.ObjectTypeWithoutSchema
+import io.airbyte.cdk.load.data.FieldType
+import io.airbyte.cdk.load.data.IntegerType
+import io.airbyte.cdk.load.data.ObjectType
 import io.airbyte.cdk.load.message.DestinationRecord
+import io.airbyte.cdk.load.message.DestinationStreamComplete
 import io.airbyte.cdk.load.message.StreamCheckpoint
 import io.airbyte.cdk.load.test.util.DestinationCleaner
 import io.airbyte.cdk.load.test.util.DestinationDataDumper
@@ -18,9 +22,15 @@ import io.airbyte.cdk.load.test.util.NameMapper
 import io.airbyte.cdk.load.test.util.NoopExpectedRecordMapper
 import io.airbyte.cdk.load.test.util.NoopNameMapper
 import io.airbyte.cdk.load.test.util.OutputRecord
+import io.airbyte.cdk.util.Jsons
 import io.airbyte.protocol.models.v0.AirbyteMessage
 import io.airbyte.protocol.models.v0.AirbyteRecordMessageMetaChange
+import io.airbyte.protocol.models.v0.AirbyteStateMessage
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertAll
 
@@ -42,7 +52,7 @@ abstract class BasicFunctionalityIntegrationTest(
             DestinationStream(
                 DestinationStream.Descriptor(randomizedNamespace, "test_stream"),
                 Append,
-                ObjectTypeWithoutSchema,
+                ObjectType(linkedMapOf("id" to FieldType(IntegerType, nullable = true))),
                 generationId = 0,
                 minimumGenerationId = 0,
                 syncId = 42,
@@ -132,4 +142,167 @@ abstract class BasicFunctionalityIntegrationTest(
             },
         )
     }
+
+    @Test
+    open fun testMidSyncCheckpointingStreamState() =
+        runBlocking(Dispatchers.IO) {
+            fun makeStream(name: String) =
+                DestinationStream(
+                    DestinationStream.Descriptor(randomizedNamespace, name),
+                    Append,
+                    ObjectType(linkedMapOf("id" to FieldType(IntegerType, nullable = true))),
+                    generationId = 0,
+                    minimumGenerationId = 0,
+                    syncId = 42,
+                )
+            val destination =
+                destinationProcessFactory.createDestinationProcess(
+                    "write",
+                    config,
+                    DestinationCatalog(
+                            listOf(
+                                makeStream("test_stream1"),
+                                makeStream("test_stream2"),
+                            )
+                        )
+                        .asProtocolObject(),
+                )
+            launch { destination.run() }
+
+            // Send one record+state to each stream
+            destination.sendMessages(
+                DestinationRecord(
+                        namespace = randomizedNamespace,
+                        name = "test_stream1",
+                        data = """{"id": 12}""",
+                        emittedAtMs = 1234,
+                    )
+                    .asProtocolMessage(),
+                StreamCheckpoint(
+                        streamNamespace = randomizedNamespace,
+                        streamName = "test_stream1",
+                        blob = """{"foo": "bar1"}""",
+                        sourceRecordCount = 1
+                    )
+                    .asProtocolMessage(),
+                DestinationRecord(
+                        namespace = randomizedNamespace,
+                        name = "test_stream2",
+                        data = """{"id": 34}""",
+                        emittedAtMs = 1234,
+                    )
+                    .asProtocolMessage(),
+                StreamCheckpoint(
+                        streamNamespace = randomizedNamespace,
+                        streamName = "test_stream2",
+                        blob = """{"foo": "bar2"}""",
+                        sourceRecordCount = 1
+                    )
+                    .asProtocolMessage()
+            )
+            // Send records to stream1 until we get a state message back.
+            // Generally, we expect that that state message will belong to stream1.
+            val stateMessages: List<AirbyteStateMessage>
+            var i = 0
+            while (true) {
+                destination.sendMessage(
+                    DestinationRecord(
+                            namespace = randomizedNamespace,
+                            name = "test_stream1",
+                            data = """{"id": 56}""",
+                            emittedAtMs = 1234,
+                        )
+                        .asProtocolMessage()
+                )
+                val returnedMessages = destination.readMessages()
+                if (returnedMessages.any { it.type == AirbyteMessage.Type.STATE }) {
+                    stateMessages =
+                        returnedMessages
+                            .filter { it.type == AirbyteMessage.Type.STATE }
+                            .map { it.state }
+                    break
+                }
+                i++
+            }
+
+            // for each state message, verify that it's a valid state,
+            // and that we actually wrote the data
+            stateMessages.forEach { stateMessage ->
+                val streamName = stateMessage.stream.streamDescriptor.name
+                val streamNamespace = stateMessage.stream.streamDescriptor.namespace
+                // basic state message checks - this is mostly just exercising the CDK itself,
+                // but is cheap and easy to do.
+                assertAll(
+                    { assertEquals(randomizedNamespace, streamNamespace) },
+                    {
+                        assertTrue(
+                            streamName == "test_stream1" || streamName == "test_stream2",
+                            "Expected stream name to be test_stream1 or test_stream2, got $streamName"
+                        )
+                    },
+                    {
+                        assertEquals(
+                            1.0,
+                            stateMessage.destinationStats.recordCount,
+                            "Expected destination stats to show 1 record"
+                        )
+                    },
+                    {
+                        when (streamName) {
+                            "test_stream1" -> {
+                                assertEquals(
+                                    Jsons.readTree("""{"foo": "bar1"}"""),
+                                    stateMessage.stream.streamState,
+                                )
+                            }
+                            "test_stream2" -> {
+                                assertEquals(
+                                    Jsons.readTree("""{"foo": "bar2"}"""),
+                                    stateMessage.stream.streamState
+                                )
+                            }
+                            else ->
+                                throw IllegalStateException("Unexpected stream name: $streamName")
+                        }
+                    }
+                )
+                if (verifyDataWriting) {
+                    val records = dataDumper.dumpRecords(config, makeStream(streamName))
+                    val expectedId =
+                        when (streamName) {
+                            "test_stream1" -> 12
+                            "test_stream2" -> 34
+                            else ->
+                                throw IllegalStateException("Unexpected stream name: $streamName")
+                        }
+                    val expectedRecord =
+                        recordMangler.mapRecord(
+                            OutputRecord(
+                                extractedAt = 1234,
+                                generationId = 0,
+                                data = mapOf("id" to expectedId),
+                                airbyteMeta = OutputRecord.Meta(changes = listOf(), syncId = 42)
+                            )
+                        )
+
+                    assertTrue("Expected the first record to be present in the dumped records.") {
+                        records.any { actualRecord -> expectedRecord.data == actualRecord.data }
+                    }
+                }
+            }
+
+            destination.sendMessages(
+                DestinationStreamComplete(
+                        DestinationStream.Descriptor(randomizedNamespace, "test_stream1"),
+                        System.currentTimeMillis()
+                    )
+                    .asProtocolMessage(),
+                DestinationStreamComplete(
+                        DestinationStream.Descriptor(randomizedNamespace, "test_stream2"),
+                        System.currentTimeMillis()
+                    )
+                    .asProtocolMessage()
+            )
+            destination.shutdown()
+        }
 }

--- a/airbyte-integrations/connectors/destination-dev-null/src/test-integration/kotlin/io/airbyte/integrations/destination/dev_null/DevNullBasicFunctionalityIntegrationTest.kt
+++ b/airbyte-integrations/connectors/destination-dev-null/src/test-integration/kotlin/io/airbyte/integrations/destination/dev_null/DevNullBasicFunctionalityIntegrationTest.kt
@@ -21,4 +21,9 @@ class DevNullBasicFunctionalityIntegrationTest :
     override fun testBasicWrite() {
         super.testBasicWrite()
     }
+
+    @Test
+    override fun testMidSyncCheckpointingStreamState() {
+        super.testMidSyncCheckpointingStreamState()
+    }
 }


### PR DESCRIPTION
add a test which pushes records into the destination until it gets a state ack, and then verifies that the destination actually contains the acked record

(fun fact: this test runs about 3x faster in nondocker mode, at least on my laptop 😓 so I guess the overhead of running a real docker process + pushing high volumes into it over stdin is actually pretty high)