### PR TITLE
fix(amazon-seller-partner): ReportsAmazonSPStream, dataStartTime is after dataEndTime

### DIFF
--- a/airbyte-integrations/connectors/source-amazon-seller-partner/source_amazon_seller_partner/streams.py
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/source_amazon_seller_partner/streams.py
@@ -376,8 +376,9 @@ class ReportsAmazonSPStream(HttpStream, ABC):
         if stream_state:
             state = stream_state.get(self.cursor_field)
             start_date = state and pendulum.parse(state) or start_date
-
         start_date = min(start_date, end_date)
+        # Adjust end_date to match the timezone of start_date
+        end_date = end_date.in_timezone(start_date.timezone)
         while start_date < end_date:
             end_date_slice = start_date.add(days=self.period_in_days)
             yield {


### PR DESCRIPTION
…

## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->

We noticed that for records with timezones other than `utc` in some cases the `ReportsAmazonSPStream.stream_slices` method was returning `dataStartTime` > `dataEndTime` which was resulting in `400 Client Error` from amazon-seller-partner's API with message `dataStartTime is after dataEndTime`.

The reason is this code:

```python
while start_date < end_date:
    end_date_slice = start_date.add(days=self.period_in_days)
    yield {
        "dataStartTime": start_date.strftime(DATE_TIME_FORMAT),
        "dataEndTime": min(end_date_slice.subtract(seconds=1), end_date).strftime(DATE_TIME_FORMAT),
    }
    start_date = end_date_slice
```      

because the timezone of `start_date` and `end_date` can be different, `end_date` can be in `utc` but the date from the records could have other time zone, in our case this timezone was `+09:00`

when calling `strftime` it converts the datetime object to `"%Y-%m-%dT%H:%M:%SZ"` format no matter the timezone it is in. 

So even if the calculated dates where `start_date` was less than `min(end_date_slice.subtract(seconds=1), end_date)` 
example `2024-10-14T10:51:34+09:00` and `2024-09-14T10:00:00+00:00` but the datestring created from it which is 
`2024-10-14T10:51:34` & `2024-09-14T10:00:00` results in 400 errors with `dataStartTime is after dataEndTime`

## How
<!--
* Describe how code changes achieve the solution.
-->

By adding 

```python
end_date = end_date.in_timezone(start_date.timezone)
```

We sync up the end_date timezone with the start_date timezone, so the stringified version of the datetime object is also relatively correct

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
