### PR TITLE
🐛 Source Pennylane: fix available sync strategies for stream `category_groups`

### DIFF
--- a/airbyte-integrations/connectors/source-pennylane/manifest.yaml
+++ b/airbyte-integrations/connectors/source-pennylane/manifest.yaml
@@ -824,10 +824,7 @@ streams:
         url_base: https://app.pennylane.com/api/external/v1/
         path: category_groups
         http_method: GET
-        request_parameters:
-          filter: >-
-            '[{"field": "updated_at", "operator": "gteq", "value":  "{{
-            stream_interval.start_time }}" }]'
+        request_parameters: {}
         request_headers: {}
         authenticator:
           type: BearerAuthenticator
@@ -853,20 +850,6 @@ streams:
           type: PageIncrement
           page_size: 1000
           start_from_page: 1
-    incremental_sync:
-      type: DatetimeBasedCursor
-      cursor_field: updated_at
-      cursor_datetime_formats:
-        - "%Y-%m-%dT%H:%M:%S.%fZ"
-      datetime_format: "%Y-%m-%dT%H:%M:%S.%fZ"
-      start_datetime:
-        type: MinMaxDatetime
-        datetime: "{{ config['start_time'] }}"
-        datetime_format: "%Y-%m-%dT%H:%M:%SZ"
-      end_datetime:
-        type: MinMaxDatetime
-        datetime: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%SZ') }}"
-        datetime_format: "%Y-%m-%dT%H:%M:%SZ"
   - type: DeclarativeStream
     name: categories
     primary_key:

--- a/docs/integrations/sources/pennylane.md
+++ b/docs/integrations/sources/pennylane.md
@@ -2,31 +2,31 @@
 
 ## Configuration
 
-| Input | Type | Description | Default Value |
-|-------|------|-------------|---------------|
-| `start_time` | `string` | Start time, used for incremental syncs. No records created before that date will be synced.  |  |
-| `api_key` | `string` | Pennylane API key.  |  |
+| Input        | Type     | Description                                                                                 | Default Value |
+| ------------ | -------- | ------------------------------------------------------------------------------------------- | ------------- |
+| `start_time` | `string` | Start time, used for incremental syncs. No records created before that date will be synced. |               |
+| `api_key`    | `string` | Pennylane API key.                                                                          |               |
 
 ## Streams
-| Stream Name | Primary Key | Pagination | Supports Full Sync | Supports Incremental |
-|-------------|-------------|------------|---------------------|----------------------|
-| `supplier_invoices` | `id` | DefaultPaginator | ✅ |  ✅  |
-| `suppliers` | `source_id` | DefaultPaginator | ✅ |  ✅  |
-| `plan_items` | `number` | DefaultPaginator | ✅ |  ❌  |
-| `customers` | `source_id` | DefaultPaginator | ✅ |  ✅  |
-| `customer_invoices` | `id` | DefaultPaginator | ✅ |  ✅  |
-| `products` | `source_id` | DefaultPaginator | ✅ |  ✅  |
-| `category_groups` | `id` | DefaultPaginator | ✅ |  ✅  |
-| `categories` | `source_id` | DefaultPaginator | ✅ |  ✅  |
 
+| Stream Name         | Primary Key | Pagination       | Supports Full Sync | Supports Incremental |
+| ------------------- | ----------- | ---------------- | ------------------ | -------------------- |
+| `supplier_invoices` | `id`        | DefaultPaginator | ✅                 | ✅                   |
+| `suppliers`         | `source_id` | DefaultPaginator | ✅                 | ✅                   |
+| `plan_items`        | `number`    | DefaultPaginator | ✅                 | ❌                   |
+| `customers`         | `source_id` | DefaultPaginator | ✅                 | ✅                   |
+| `customer_invoices` | `id`        | DefaultPaginator | ✅                 | ✅                   |
+| `products`          | `source_id` | DefaultPaginator | ✅                 | ✅                   |
+| `category_groups`   | `id`        | DefaultPaginator | ✅                 | ❌                   |
+| `categories`        | `source_id` | DefaultPaginator | ✅                 | ✅                   |
 
 ## Changelog
 
 <details>
   <summary>Expand to review</summary>
 
-| Version | Date | Pull Request | Subject |
-|---------|------|--------------|---------|
-| 0.0.1 | 2024-08-21 | | Initial release by natikgadzhi via Connector Builder |
+| Version | Date       | Pull Request | Subject                                              |
+| ------- | ---------- | ------------ | ---------------------------------------------------- |
+| 0.0.1   | 2024-08-21 |              | Initial release by natikgadzhi via Connector Builder |
 
 </details>


### PR DESCRIPTION
## What
The `category_groups` endpoint does actually return an `updated_at` field which means incremental sync is not supported. 

## How
- Remove the parts of the manifest that are related to the incremental sync configuration for the `category_groups` stream.

## Review guide
<!--
1. `manifest.yaml`
2. `README.md`
-->

## User Impact
The user will use the correct sync strategy to replicate the `category_groups` records.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌
