### PR TITLE
Bulk load CDK: crash on no terminal status

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/command/DestinationStream.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/command/DestinationStream.kt
@@ -36,6 +36,8 @@ data class DestinationStream(
                     it.namespace = namespace
                 }
             }
+
+        fun toPrettyString() = "$namespace.$name"
     }
 
     /**

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/state/SyncManager.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/state/SyncManager.kt
@@ -116,6 +116,16 @@ class DefaultSyncManager(
     }
 
     override suspend fun markInputConsumed() {
+        val incompleteStreams =
+            streamManagers
+                .filter { (_, manager) -> !manager.endOfStreamRead() }
+                .map { (stream, _) -> stream }
+        if (incompleteStreams.isNotEmpty()) {
+            val prettyStreams = incompleteStreams.map { it.toPrettyString() }
+            throw IllegalStateException(
+                "Input was fully read, but some streams did not receive a terminal stream status message. This likely indicates an error in the source or platform. Streams without a status message: $prettyStreams"
+            )
+        }
         inputConsumed.complete(true)
     }
 


### PR DESCRIPTION
(copying from slack)

we should crash if we reach end-of-input, but some streams don't have a terminal status. This might happen if e.g. platform crashes before sending us the terminal status message.

(johnny basically wrote this code, I just wanted to have an excuse to get my hands dirty with this part of the codebase)