### PR TITLE
fix(live-tests): hot-fix UserDict annotation bug

### DIFF
--- a/airbyte-ci/connectors/live-tests/README.md
+++ b/airbyte-ci/connectors/live-tests/README.md
@@ -179,13 +179,17 @@ The traffic recorded on the control connector is passed to the target connector 
 
 ## Changelog
 
+### 0.19.1
+
+Fixed the `UserDict` type annotation not found bug.
+
 ### 0.19.0
 
 Delete the `debug`command.
 
 ### 0.18.8
 
-Improve error message when failing to retrieve connection. 
+Improve error message when failing to retrieve connection.
 Ask to double-check that a sync ran with the control version on the selected connection.
 
 ### 0.18.7

--- a/airbyte-ci/connectors/live-tests/pyproject.toml
+++ b/airbyte-ci/connectors/live-tests/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "live-tests"
-version = "0.19.0"
+version = "0.19.1"
 description = "Contains utilities for testing connectors against live data."
 authors = ["Airbyte <contact@airbyte.io>"]
 license = "MIT"

--- a/airbyte-ci/connectors/live-tests/src/live_tests/commons/models.py
+++ b/airbyte-ci/connectors/live-tests/src/live_tests/commons/models.py
@@ -1,4 +1,7 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+
+from __future__ import annotations
+
 import json
 import logging
 import tempfile


### PR DESCRIPTION
## What

In https://github.com/airbytehq/airbyte/pull/46731, I broke type annotations, and it started breaking regression tests. This should fix it. 