### PR TITLE
chore(auto-merge): increase frequency to every 2 hours

### DIFF
--- a/.github/workflows/auto_merge.yml
+++ b/.github/workflows/auto_merge.yml
@@ -2,8 +2,8 @@ name: Auto merge connector PRs Cron
 
 on:
   schedule:
-    # 0AM UTC is 2AM CEST, 3AM EEST, 5PM PDT.
-    - cron: "0 0 * * *"
+    # Every 2 hours on the hour.
+    - cron: "0 */2 * * *"
   workflow_dispatch:
 jobs:
   run_auto_merge:


### PR DESCRIPTION
## What
Now that progressive rollouts are relying on the automerge pipeline, we should run it more frequently.

This updates it to once every 2 hours.

## Can this PR be safely reverted and rolled back?
- [X] YES 💚
- [ ] NO ❌
