### PR TITLE
Make progressive rollout use explicit in metadata

### DIFF
--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/gcs_upload.py
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/gcs_upload.py
@@ -429,7 +429,7 @@ def upload_metadata_to_gcs(bucket_name: str, metadata_file_path: Path, validator
         raise ValueError(f"Metadata file {metadata_file_path} is invalid for uploading: {error}")
 
     is_pre_release = validator_opts.prerelease_tag is not None
-    is_release_candidate = getattr(metadata.data.releases, "isReleaseCandidate", False)
+    is_release_candidate = "-rc" in metadata.data.dockerImageTag
     should_upload_release_candidate = is_release_candidate and not is_pre_release
     should_upload_latest = not is_release_candidate and not is_pre_release
 

--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/generated/ConnectorMetadataDefinitionV0.py
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/generated/ConnectorMetadataDefinitionV0.py
@@ -100,6 +100,7 @@ class RolloutConfiguration(BaseModel):
     class Config:
         extra = Extra.forbid
 
+    enableProgressiveRollout: Optional[bool] = Field(False, description="Whether to enable progressive rollout for the connector.")
     initialPercentage: Optional[conint(ge=0, le=100)] = Field(
         0, description="The percentage of users that should receive the new version initially."
     )
@@ -286,7 +287,6 @@ class ConnectorReleases(BaseModel):
     class Config:
         extra = Extra.forbid
 
-    isReleaseCandidate: Optional[bool] = Field(False, description="Whether the release is eligible to be a release candidate.")
     rolloutConfiguration: Optional[RolloutConfiguration] = None
     breakingChanges: Optional[ConnectorBreakingChanges] = None
     migrationDocumentationUrl: Optional[AnyUrl] = Field(

--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/generated/ConnectorRegistryDestinationDefinition.py
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/generated/ConnectorRegistryDestinationDefinition.py
@@ -67,6 +67,7 @@ class RolloutConfiguration(BaseModel):
     class Config:
         extra = Extra.forbid
 
+    enableProgressiveRollout: Optional[bool] = Field(False, description="Whether to enable progressive rollout for the connector.")
     initialPercentage: Optional[conint(ge=0, le=100)] = Field(
         0, description="The percentage of users that should receive the new version initially."
     )
@@ -242,7 +243,6 @@ class ConnectorRegistryReleases(BaseModel):
     class Config:
         extra = Extra.forbid
 
-    isReleaseCandidate: Optional[bool] = Field(None, description="Whether the current version is a release candidate.")
     releaseCandidates: Optional[ConnectorReleaseCandidates] = None
     rolloutConfiguration: Optional[RolloutConfiguration] = None
     breakingChanges: Optional[ConnectorBreakingChanges] = None

--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/generated/ConnectorRegistryReleases.py
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/generated/ConnectorRegistryReleases.py
@@ -15,6 +15,7 @@ class RolloutConfiguration(BaseModel):
     class Config:
         extra = Extra.forbid
 
+    enableProgressiveRollout: Optional[bool] = Field(False, description="Whether to enable progressive rollout for the connector.")
     initialPercentage: Optional[conint(ge=0, le=100)] = Field(
         0, description="The percentage of users that should receive the new version initially."
     )
@@ -203,7 +204,6 @@ class ConnectorRegistryReleases(BaseModel):
     class Config:
         extra = Extra.forbid
 
-    isReleaseCandidate: Optional[bool] = Field(None, description="Whether the current version is a release candidate.")
     releaseCandidates: Optional[ConnectorReleaseCandidates] = None
     rolloutConfiguration: Optional[RolloutConfiguration] = None
     breakingChanges: Optional[ConnectorBreakingChanges] = None

--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/generated/ConnectorRegistrySourceDefinition.py
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/generated/ConnectorRegistrySourceDefinition.py
@@ -63,6 +63,7 @@ class RolloutConfiguration(BaseModel):
     class Config:
         extra = Extra.forbid
 
+    enableProgressiveRollout: Optional[bool] = Field(False, description="Whether to enable progressive rollout for the connector.")
     initialPercentage: Optional[conint(ge=0, le=100)] = Field(
         0, description="The percentage of users that should receive the new version initially."
     )
@@ -239,7 +240,6 @@ class ConnectorRegistryReleases(BaseModel):
     class Config:
         extra = Extra.forbid
 
-    isReleaseCandidate: Optional[bool] = Field(None, description="Whether the current version is a release candidate.")
     releaseCandidates: Optional[ConnectorReleaseCandidates] = None
     rolloutConfiguration: Optional[RolloutConfiguration] = None
     breakingChanges: Optional[ConnectorBreakingChanges] = None

--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/generated/ConnectorRegistryV0.py
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/generated/ConnectorRegistryV0.py
@@ -67,6 +67,7 @@ class RolloutConfiguration(BaseModel):
     class Config:
         extra = Extra.forbid
 
+    enableProgressiveRollout: Optional[bool] = Field(False, description="Whether to enable progressive rollout for the connector.")
     initialPercentage: Optional[conint(ge=0, le=100)] = Field(
         0, description="The percentage of users that should receive the new version initially."
     )
@@ -247,7 +248,6 @@ class ConnectorRegistryReleases(BaseModel):
     class Config:
         extra = Extra.forbid
 
-    isReleaseCandidate: Optional[bool] = Field(None, description="Whether the current version is a release candidate.")
     releaseCandidates: Optional[ConnectorReleaseCandidates] = None
     rolloutConfiguration: Optional[RolloutConfiguration] = None
     breakingChanges: Optional[ConnectorBreakingChanges] = None

--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/generated/ConnectorReleases.py
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/generated/ConnectorReleases.py
@@ -14,6 +14,7 @@ class RolloutConfiguration(BaseModel):
     class Config:
         extra = Extra.forbid
 
+    enableProgressiveRollout: Optional[bool] = Field(False, description="Whether to enable progressive rollout for the connector.")
     initialPercentage: Optional[conint(ge=0, le=100)] = Field(
         0, description="The percentage of users that should receive the new version initially."
     )
@@ -70,7 +71,6 @@ class ConnectorReleases(BaseModel):
     class Config:
         extra = Extra.forbid
 
-    isReleaseCandidate: Optional[bool] = Field(False, description="Whether the release is eligible to be a release candidate.")
     rolloutConfiguration: Optional[RolloutConfiguration] = None
     breakingChanges: Optional[ConnectorBreakingChanges] = None
     migrationDocumentationUrl: Optional[AnyUrl] = Field(

--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/generated/RolloutConfiguration.py
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/generated/RolloutConfiguration.py
@@ -12,6 +12,7 @@ class RolloutConfiguration(BaseModel):
     class Config:
         extra = Extra.forbid
 
+    enableProgressiveRollout: Optional[bool] = Field(False, description="Whether to enable progressive rollout for the connector.")
     initialPercentage: Optional[conint(ge=0, le=100)] = Field(
         0, description="The percentage of users that should receive the new version initially."
     )

--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/src/ConnectorRegistryReleases.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/src/ConnectorRegistryReleases.yaml
@@ -6,9 +6,6 @@ description: Contains information about different types of releases for a connec
 type: object
 additionalProperties: false
 properties:
-  isReleaseCandidate:
-    type: boolean
-    description: Whether the current version is a release candidate.
   releaseCandidates:
     $ref: "#/definitions/ConnectorReleaseCandidates"
   rolloutConfiguration:

--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/src/ConnectorReleases.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/src/ConnectorReleases.yaml
@@ -6,10 +6,6 @@ description: Contains information about different types of releases for a connec
 type: object
 additionalProperties: false
 properties:
-  isReleaseCandidate:
-    description: Whether the release is eligible to be a release candidate.
-    type: boolean
-    default: false
   rolloutConfiguration:
     $ref: RolloutConfiguration.yaml
   breakingChanges:

--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/src/RolloutConfiguration.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/src/RolloutConfiguration.yaml
@@ -6,6 +6,10 @@ description: configuration for the rollout of a connector
 type: object
 additionalProperties: false
 properties:
+  enableProgressiveRollout:
+    type: boolean
+    default: false
+    description: Whether to enable progressive rollout for the connector.
   initialPercentage:
     type: integer
     minimum: 0

--- a/airbyte-ci/connectors/metadata_service/lib/pyproject.toml
+++ b/airbyte-ci/connectors/metadata_service/lib/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metadata-service"
-version = "0.20.1"
+version = "0.21.0"
 description = ""
 authors = ["Ben Church <ben@airbyte.io>"]
 readme = "README.md"

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/invalid/metadata_progressive_rollout_no_rc_suffix.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/invalid/metadata_progressive_rollout_no_rc_suffix.yaml
@@ -11,7 +11,8 @@ data:
   releaseStage: generally_available
   license: MIT
   releases:
-    isReleaseCandidate: true
+    rolloutConfiguration:
+      enableProgressiveRollout: true
     breakingChanges:
       2.0.0:
         upgradeDeadline: 2023-08-22

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/invalid/metadata_release_candidate_no_progressive_rollout.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/invalid/metadata_release_candidate_no_progressive_rollout.yaml
@@ -5,20 +5,16 @@ data:
   connectorType: source
   dockerRepository: airbyte/image-exists-1
   githubIssueLabel: source-alloydb-strict-encrypt
-  dockerImageTag: 2.1.0-rc.1
+  dockerImageTag: 2.0.1-rc.1
   documentationUrl: https://docs.airbyte.com/integrations/sources/existingsource
   connectorSubtype: database
   releaseStage: generally_available
   license: MIT
   releases:
-    rolloutConfiguration:
-      enableProgressiveRollout: true
-      initialPercentage: 5
-      maxPercentage: 50
-      advanceDelayMinutes: 60
     breakingChanges:
       2.0.0:
         upgradeDeadline: 2023-08-22
         message: "This version changes the connector’s authentication method from `ApiKey` to `oAuth`, per the [API guide](https://amazon-sqs.com/api/someguide)."
+
   tags:
     - language:java

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/valid/with_optional_field/with_releases/metadata_release_candidate_disable_progressive_rollout.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/valid/with_optional_field/with_releases/metadata_release_candidate_disable_progressive_rollout.yaml
@@ -5,20 +5,18 @@ data:
   connectorType: source
   dockerRepository: airbyte/image-exists-1
   githubIssueLabel: source-alloydb-strict-encrypt
-  dockerImageTag: 2.1.0-rc.1
+  dockerImageTag: 2.0.1-rc.1
   documentationUrl: https://docs.airbyte.com/integrations/sources/existingsource
   connectorSubtype: database
   releaseStage: generally_available
   license: MIT
   releases:
     rolloutConfiguration:
-      enableProgressiveRollout: true
-      initialPercentage: 5
-      maxPercentage: 50
-      advanceDelayMinutes: 60
+      enableProgressiveRollout: false
     breakingChanges:
       2.0.0:
         upgradeDeadline: 2023-08-22
         message: "This version changes the connector’s authentication method from `ApiKey` to `oAuth`, per the [API guide](https://amazon-sqs.com/api/someguide)."
+
   tags:
     - language:java

--- a/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/valid/with_optional_field/with_releases/metadata_release_candidate_enable_progressive_rollout.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/metadata_validate/valid/with_optional_field/with_releases/metadata_release_candidate_enable_progressive_rollout.yaml
@@ -11,7 +11,8 @@ data:
   releaseStage: generally_available
   license: MIT
   releases:
-    isReleaseCandidate: true
+    rolloutConfiguration:
+      enableProgressiveRollout: true
     breakingChanges:
       2.0.0:
         upgradeDeadline: 2023-08-22

--- a/airbyte-ci/connectors/metadata_service/lib/tests/test_gcs_upload.py
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/test_gcs_upload.py
@@ -374,7 +374,7 @@ def test_upload_metadata_to_gcs_valid_metadata(
         expected_version_doc_key = f"metadata/{metadata.data.dockerRepository}/{metadata.data.dockerImageTag}/{DOC_FILE_NAME}"
         expected_latest_doc_key = f"metadata/{metadata.data.dockerRepository}/latest/{DOC_FILE_NAME}"
 
-        is_release_candidate = getattr(metadata.data.releases, "isReleaseCandidate", False)
+        is_release_candidate = "-rc" in metadata.data.dockerImageTag
 
         # Call function under tests
 
@@ -641,7 +641,7 @@ def test_upload_metadata_to_gcs_release_candidate(mocker, get_fixture_path, tmp_
         "NamedTemporaryFile",
         mocker.Mock(return_value=mocker.Mock(__enter__=mocker.Mock(return_value=tmp_metadata_file_path.open("w")), __exit__=mocker.Mock())),
     )
-    assert metadata.data.releases.isReleaseCandidate
+    assert metadata.data.releases.rolloutConfiguration.enableProgressiveRollout
 
     prerelease_tag = "1.5.6-dev.f80318f754" if prerelease else None
 

--- a/airbyte-ci/connectors/metadata_service/lib/tests/test_transform.py
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/test_transform.py
@@ -61,7 +61,10 @@ def test_transform_to_json_does_not_mutate_keys(valid_metadata_upload_files, val
 
     fields_with_defaults = [
         "data.supportsRefreshes",
-        "data.releases.isReleaseCandidate",
+        "data.releases.rolloutConfiguration.enableProgressiveRollout",
+        "data.releases.rolloutConfiguration.initialPercentage",
+        "data.releases.rolloutConfiguration.maxPercentage",
+        "data.releases.rolloutConfiguration.advanceDelayMinutes",
         "data.releases.breakingChanges.2.0.0.deadlineAction",
     ]
 

--- a/airbyte-ci/connectors/metadata_service/lib/tests/test_validators/test_metadata_validators.py
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/test_validators/test_metadata_validators.py
@@ -1,6 +1,5 @@
 # Copyright (c) 2024 Airbyte, Inc., all rights reserved.
 
-
 import pytest
 import requests
 import semver
@@ -11,14 +10,65 @@ from metadata_service.validators import metadata_validator
 
 @pytest.fixture
 def metadata_definition():
-    metadata_file_url = (
-        "https://raw.githubusercontent.com/airbytehq/airbyte/master/airbyte-integrations/connectors/source-faker/metadata.yaml"
+    return ConnectorMetadataDefinitionV0.parse_obj(
+        {
+            "data": {
+                "ab_internal": {"ql": 300, "sl": 100},
+                "allowedHosts": {"hosts": []},
+                "connectorBuildOptions": {
+                    "baseImage": "docker.io/airbyte/python-connector-base:2.0.0@sha256:c44839ba84406116e8ba68722a0f30e8f6e7056c726f447681bb9e9ece8bd916"
+                },
+                "connectorSubtype": "api",
+                "connectorType": "source",
+                "definitionId": "dfd88b22-b603-4c3d-aad7-3701784586b1",
+                "dockerImageTag": "6.2.18-rc.1",
+                "dockerRepository": "airbyte/source-faker",
+                "documentationUrl": "https://docs.airbyte.com/integrations/sources/faker",
+                "githubIssueLabel": "source-faker",
+                "icon": "faker.svg",
+                "license": "MIT",
+                "name": "Sample Data (Faker)",
+                "registryOverrides": {"cloud": {"enabled": True}, "oss": {"enabled": True}},
+                "releaseStage": "beta",
+                "releases": {
+                    "rolloutConfiguration": {"enableProgressiveRollout": True},
+                    "breakingChanges": {
+                        "4.0.0": {"message": "This is a breaking change message", "upgradeDeadline": "2023-07-19"},
+                        "5.0.0": {
+                            "message": "ID and products.year fields are changing to be integers instead of floats.",
+                            "upgradeDeadline": "2023-08-31",
+                        },
+                        "6.0.0": {"message": "Declare 'id' columns as primary keys.", "upgradeDeadline": "2024-04-01"},
+                    },
+                },
+                "remoteRegistries": {"pypi": {"enabled": True, "packageName": "airbyte-source-faker"}},
+                "resourceRequirements": {
+                    "jobSpecific": [{"jobType": "sync", "resourceRequirements": {"cpu_limit": "4.0", "cpu_request": "1.0"}}]
+                },
+                "suggestedStreams": {"streams": ["users", "products", "purchases"]},
+                "supportLevel": "community",
+                "tags": ["language:python", "cdk:python"],
+                "connectorTestSuitesOptions": [
+                    {
+                        "suite": "liveTests",
+                        "testConnections": [{"name": "faker_config_dev_null", "id": "73abc3a9-3fea-4e7c-b58d-2c8236464a95"}],
+                    },
+                    {"suite": "unitTests"},
+                    {
+                        "suite": "acceptanceTests",
+                        "testSecrets": [
+                            {
+                                "name": "SECRET_SOURCE-FAKER_CREDS",
+                                "fileName": "config.json",
+                                "secretStore": {"type": "GSM", "alias": "airbyte-connector-testing-secret-store"},
+                            }
+                        ],
+                    },
+                ],
+            },
+            "metadataSpecVersion": "1.0",
+        }
     )
-    response = requests.get(metadata_file_url)
-    response.raise_for_status()
-
-    metadata_yaml_dict = yaml.safe_load(response.text)
-    return ConnectorMetadataDefinitionV0.parse_obj(metadata_yaml_dict)
 
 
 @pytest.mark.parametrize(

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/github.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/github.py
@@ -123,7 +123,8 @@ def entry_should_be_on_gcs(metadata_entry: LatestMetadataEntry) -> bool:
     """
     if metadata_entry.metadata_definition.data.supportLevel == "archived":
         return False
-    if getattr(metadata_entry.metadata_definition.data.releases, "isReleaseCandidate", False):
+    # TODO: We should improve this logic to be able to detect missing metadata files for release candidates.
+    if "-rc" in metadata_entry.metadata_definition.data.dockerImageTag:
         return False
     if entry_is_younger_than_grace_period(metadata_entry):
         return False

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/registry.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/registry.py
@@ -89,18 +89,20 @@ def apply_release_candidates(
     latest_registry_entry: dict,
     release_candidate_registry_entry: PolymorphicRegistryEntry,
 ) -> dict:
+    if not release_candidate_registry_entry.releases.rolloutConfiguration.enableProgressiveRollout:
+        return latest_registry_entry
     # Ensure that the release candidate is newer than the latest registry entry
-    if semver.Version.parse(release_candidate_registry_entry.dockerImageTag) > semver.Version.parse(
+    if semver.Version.parse(release_candidate_registry_entry.dockerImageTag) < semver.Version.parse(
         latest_registry_entry["dockerImageTag"]
     ):
-        updated_registry_entry = copy.deepcopy(latest_registry_entry)
-        updated_registry_entry.setdefault("releases", {})
-        updated_registry_entry["releases"]["releaseCandidates"] = {
-            release_candidate_registry_entry.dockerImageTag: to_json_sanitized_dict(release_candidate_registry_entry)
-        }
-        return updated_registry_entry
-    else:
         return latest_registry_entry
+
+    updated_registry_entry = copy.deepcopy(latest_registry_entry)
+    updated_registry_entry.setdefault("releases", {})
+    updated_registry_entry["releases"]["releaseCandidates"] = {
+        release_candidate_registry_entry.dockerImageTag: to_json_sanitized_dict(release_candidate_registry_entry)
+    }
+    return updated_registry_entry
 
 
 def apply_release_candidate_entries(registry_entry_dict: dict, docker_repository_to_rc_registry_entry: dict) -> dict:

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/registry_entry.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/registry_entry.py
@@ -113,7 +113,6 @@ def apply_connector_releases(metadata: dict) -> Optional[pd.DataFrame]:
 
     if releases is not None and releases.get("rolloutConfiguration"):
         final_registry_releases["rolloutConfiguration"] = metadata["releases"]["rolloutConfiguration"]
-    final_registry_releases["isReleaseCandidate"] = False if releases is None else metadata["releases"].get("isReleaseCandidate", False)
     return final_registry_releases
 
 

--- a/airbyte-ci/connectors/metadata_service/orchestrator/poetry.lock
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/poetry.lock
@@ -1769,7 +1769,7 @@ files = [
 
 [[package]]
 name = "metadata-service"
-version = "0.20.1"
+version = "0.21.0"
 description = ""
 optional = false
 python-versions = "^3.10"

--- a/airbyte-ci/connectors/metadata_service/orchestrator/pyproject.toml
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "orchestrator"
-version = "0.5.9"
+version = "0.6.0"
 description = ""
 authors = ["Ben Church <ben@airbyte.io>"]
 readme = "README.md"

--- a/airbyte-ci/connectors/metadata_service/orchestrator/tests/test_registry.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/tests/test_registry.py
@@ -508,7 +508,7 @@ def test_apply_release_candidates_with_older_rc(mocker):
             "documentationUrl": "https://test_documentation_url.com",
             "spec": {},
             "dockerImageTag": "1.1.0-rc.1",
-            "releases": {"isReleaseCandidate": True},
+            "releases": {"rolloutConfiguration": {"enableProgressiveRollout": True}},
         }
     )
 
@@ -535,7 +535,7 @@ def test_apply_release_candidates_newer_version(mocker):
             "documentationUrl": "https://test_documentation_url.com",
             "spec": {},
             "dockerImageTag": "1.1.0-rc.1",
-            "releases": {"isReleaseCandidate": True},
+            "releases": {"rolloutConfiguration": {"enableProgressiveRollout": True}},
         }
     )
     result = registry.apply_release_candidates(latest_registry_entry, rc_registry_entry)

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/metadata/pipeline.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/metadata/pipeline.py
@@ -199,7 +199,7 @@ class DeployOrchestrator(Step):
         self.context.logger.info(f"Deploying to deployment: {target_deployment}")
 
         container_to_run = (
-            python_with_dependencies.with_mounted_directory("/src", parent_dir)
+            python_with_dependencies.with_directory("/src", parent_dir)
             .with_secret_variable("DAGSTER_CLOUD_API_TOKEN", dagster_cloud_api_token_secret)
             .with_env_variable("DAGSTER_CLOUD_DEPLOYMENT", target_deployment)
             .with_workdir("/src/orchestrator")

--- a/airbyte-ci/connectors/pipelines/tests/test_publish.py
+++ b/airbyte-ci/connectors/pipelines/tests/test_publish.py
@@ -421,19 +421,20 @@ async def test_run_connector_python_registry_publish_pipeline(
 
 class TestPushConnectorImageToRegistry:
     @pytest.mark.parametrize(
-        "is_pre_release, is_release_candidate, should_publish_latest",
+        "is_pre_release, version, should_publish_latest",
         [
-            (False, False, True),
-            (True, False, False),
-            (False, True, False),
-            (True, True, False),
+            (False, "1.0.0", True),
+            (True, "1.1.0-dev", False),
+            (False, "1.1.0-rc.1", False),
+            (True, "1.1.0-rc.1", False),
         ],
     )
-    async def test_publish_latest_tag(self, mocker, publish_context, is_pre_release, is_release_candidate, should_publish_latest):
+    async def test_publish_latest_tag(self, mocker, publish_context, is_pre_release, version, should_publish_latest):
         publish_context.docker_image = "airbyte/source-pokeapi:0.0.0"
         publish_context.docker_repository = "airbyte/source-pokeapi"
         publish_context.pre_release = is_pre_release
-        publish_context.connector.metadata = {"releases": {"isReleaseCandidate": is_release_candidate}}
+        publish_context.connector.version = version
+        publish_context.connector.metadata = {"dockerImageTag": version}
         step = publish_pipeline.PushConnectorImageToRegistry(publish_context)
         amd_built_container = mocker.Mock(publish=mocker.AsyncMock())
         arm_built_container = mocker.Mock(publish=mocker.AsyncMock())

--- a/airbyte-integrations/connectors/source-faker/metadata.yaml
+++ b/airbyte-integrations/connectors/source-faker/metadata.yaml
@@ -23,7 +23,8 @@ data:
       enabled: true
   releaseStage: beta
   releases:
-    isReleaseCandidate: true
+    rolloutConfiguration:
+      enableProgressiveRollout: true
     breakingChanges:
       4.0.0:
         message: This is a breaking change message

--- a/airbyte-integrations/connectors/source-harvest/metadata.yaml
+++ b/airbyte-integrations/connectors/source-harvest/metadata.yaml
@@ -28,7 +28,6 @@ data:
     oss:
       enabled: true
   releases:
-    isReleaseCandidate: false
     breakingChanges:
       1.0.0:
         message:

--- a/airbyte-integrations/connectors/source-quickbooks/metadata.yaml
+++ b/airbyte-integrations/connectors/source-quickbooks/metadata.yaml
@@ -26,7 +26,8 @@ data:
       enabled: true
   releaseStage: alpha
   releases:
-    isReleaseCandidate: true
+    rolloutConfiguration:
+      enableProgressiveRollout: true
     breakingChanges:
       3.0.0:
         message:

--- a/airbyte-integrations/connectors/source-s3/metadata.yaml
+++ b/airbyte-integrations/connectors/source-s3/metadata.yaml
@@ -29,7 +29,8 @@ data:
       enabled: true
   releaseStage: generally_available
   releases:
-    isReleaseCandidate: true
+    rolloutConfiguration:
+      enableProgressiveRollout: true
     breakingChanges:
       4.0.0:
         message: UX improvement, multi-stream support and deprecation of some parsing features

--- a/airbyte-integrations/connectors/source-snapchat-marketing/metadata.yaml
+++ b/airbyte-integrations/connectors/source-snapchat-marketing/metadata.yaml
@@ -26,7 +26,8 @@ data:
       enabled: true
   releaseStage: generally_available
   releases:
-    isReleaseCandidate: true
+    rolloutConfiguration:
+      enableProgressiveRollout: true
     breakingChanges:
       1.0.0:
         message: >-

--- a/airbyte-integrations/connectors/source-woocommerce/metadata.yaml
+++ b/airbyte-integrations/connectors/source-woocommerce/metadata.yaml
@@ -27,7 +27,8 @@ data:
       enabled: true
   releaseStage: generally_available
   releases:
-    isReleaseCandidate: true
+    rolloutConfiguration:
+      enableProgressiveRollout: true
   supportLevel: certified
   tags:
     - language:manifest-only


### PR DESCRIPTION
## What
Relates to https://github.com/airbytehq/airbyte-internal-issues/issues/10211

### Motivation
I want to break the  fact`-rc` suffix means the connector uses progressive rollout.
Why: Because a connector with `-rc` version suffix that has been rolled back should not use progressive rollout.
I suggest making it explicit in `metadata.yaml` that a connector is using progressive rollout by setting a `rolloutConfiguration.enableProgressiveRollout` flag in the metaddata.

**This will allow us to keep rolled back RC version on `master` while stopping their progressive rollout.** 

_Note: we considered using `registryOverrides` for that but it'll have a strange effect on the generated registries: the nested release candidates would be a copy of the main version, which can be confusing on consumption by the platform._

### Source of truth change:
* What makes a connector a release candidate is its use of an `-rc`suffix in its version
* What makes a connector use progressive rollout is the value of the `enableProgressiveRollout` in `rolloutConfiguration` in metadata
* A release candidate will never be considered as a *latest* version.

### Validation change:
* A connector with an `-rc` version must have set `enableProgressiveRollout` to `True` or `False`
* A connector with `enableProgressiveRollout: true` must have a `-rc` suffix in its version

### Publish workflow change:
* What makes a connector an RC from the publish workflow perspective is not the `isReleaseCandidate` field anymore but the presence of `-rc` in its version. A connector with an `-rc` suffix will never land in the `latest` GCS dir, nor be pushed as a `:latest` to DockerHub

### Registry generation change
The orchestrator will not nest `releaseCandidates` under a main version if the registry entry for the RC has `enableProgressiveRollout: false`. **This is how we'll ignore rolled back version and stop their progressive rollout.**

