### PR TITLE
🐛 Fix exception in dedupe stage when source data has a field called `row_number`

### DIFF
--- a/airbyte-cdk/java/airbyte-cdk/db-destinations/src/main/kotlin/io/airbyte/cdk/integrations/destination/jdbc/typing_deduping/JdbcSqlGenerator.kt
+++ b/airbyte-cdk/java/airbyte-cdk/db-destinations/src/main/kotlin/io/airbyte/cdk/integrations/destination/jdbc/typing_deduping/JdbcSqlGenerator.kt
@@ -128,7 +128,7 @@ constructor(
 
     /**
      * Get the window step function row_number() over (partition by primary_key order by
-     * cursor_field) as row_number.
+     * cursor_field) as _airbyte_row_number.
      *
      * @param primaryKey list of primary keys
      * @param cursorField cursor field used for ordering
@@ -628,7 +628,7 @@ constructor(
     }
 
     companion object {
-        const val ROW_NUMBER_COLUMN_NAME: String = "row_number"
+        const val ROW_NUMBER_COLUMN_NAME: String = "_airbyte_row_number"
         private const val TYPING_CTE_ALIAS = "intermediate_data"
         private const val NUMBERED_ROWS_CTE_ALIAS = "numbered_rows"
     }

--- a/airbyte-integrations/connectors/destination-databricks/src/main/kotlin/io/airbyte/integrations/destination/databricks/jdbc/DatabricksSqlGenerator.kt
+++ b/airbyte-integrations/connectors/destination-databricks/src/main/kotlin/io/airbyte/integrations/destination/databricks/jdbc/DatabricksSqlGenerator.kt
@@ -423,7 +423,7 @@ class DatabricksSqlGenerator(
             |), numbered_rows AS (
             |   SELECT *, row_number() OVER (
             |       PARTITION BY $commaSeperatedPks ORDER BY $cursorOrderBy `$AB_EXTRACTED_AT` DESC
-            |   ) as row_number
+            |   ) as _airbyte_row_number
             |   FROM
             |       new_records
             |)
@@ -433,7 +433,7 @@ class DatabricksSqlGenerator(
             |FROM
             |   numbered_rows
             |WHERE
-            |   row_number=1
+            |   _airbyte_row_number=1
         """.trimMargin()
 
         return selectCTEDedupe

--- a/airbyte-integrations/connectors/destination-redshift/src/test/resources/typing_deduping_with_cdc.sql
+++ b/airbyte-integrations/connectors/destination-redshift/src/test/resources/typing_deduping_with_cdc.sql
@@ -173,7 +173,7 @@ with
             order by
                 "updated_at" desc NULLS LAST,
                 "_airbyte_extracted_at" desc
-            ) as "row_number"
+            ) as "_airbyte_row_number"
         from "intermediate_data"
     )
 select
@@ -198,7 +198,7 @@ select
     "_airbyte_generation_id",
     "_airbyte_meta"
 from "numbered_rows"
-where "row_number" = 1;
+where "_airbyte_row_number" = 1;
 delete from "test_schema"."users_finalunittest"
 where "_airbyte_raw_id" in (
     select "_airbyte_raw_id"
@@ -210,10 +210,10 @@ where "_airbyte_raw_id" in (
                 order by
                     "updated_at" desc NULLS LAST,
                     "_airbyte_extracted_at" desc
-                ) as "row_number"
+                ) as "_airbyte_row_number"
              from "test_schema"."users_finalunittest"
          ) as "airbyte_ids"
-    where "row_number" <> 1
+    where "_airbyte_row_number" <> 1
 );
 delete from "test_schema"."users_finalunittest"
 where "_ab_cdc_deleted_at" is not null;

--- a/airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/typing_deduping/SnowflakeSqlGenerator.kt
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/typing_deduping/SnowflakeSqlGenerator.kt
@@ -479,7 +479,7 @@ class SnowflakeSqlGenerator(
                 |${abMetaColumn.replaceIndent("    ")},
                 |    row_number() OVER (
                 |      PARTITION BY $pkList ORDER BY $cursorOrderClause "_AIRBYTE_EXTRACTED_AT" DESC
-                |    ) AS row_number
+                |    ) AS _airbyte_row_number
                 |  FROM intermediate_data
                 |)
                 |SELECT 
@@ -487,7 +487,7 @@ class SnowflakeSqlGenerator(
                 |  "_AIRBYTE_META"
                 |FROM 
                 |  new_records
-                |WHERE row_number = 1
+                |WHERE _airbyte_row_number = 1
             """.trimMargin()
         }
     }
@@ -514,11 +514,11 @@ class SnowflakeSqlGenerator(
         |      SELECT 
         |        "_AIRBYTE_RAW_ID", 
         |        row_number() OVER (PARTITION BY $pkList ORDER BY $cursorOrderClause ${airbyteExtractedAtUtcForced("_AIRBYTE_EXTRACTED_AT".quoted())} DESC) 
-        |        as row_number 
+        |        as _airbyte_row_number 
         |      FROM 
         |        $quotedFinalTable
         |    )
-        |    WHERE row_number != 1
+        |    WHERE _airbyte_row_number != 1
         |  );
         |""".trimMargin()
     }


### PR DESCRIPTION
Fix exception in dedupe stage when source data also has a field called `row_number`.

Fixes #45855

## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->

If the source stream has a field called `row_number` this clashes with the queries used in the dedupe phase, which use `row_number` as a column alias. As a result the dedupe phase fails with the PostgreSQL exception `column reference "row_number" is ambiguous`. I expect the same will be true of other destinations that use the same basic SQL statement.

This issue will occur if the source is a table that has a field named `row_number`. There are also other Airbyte connectors that produce streams with `row_number` as a hard-coded field name ([Smartsheets](https://docs.airbyte.com/integrations/sources/smartsheets/#supported-streams) for example). A connection from these sources to the PostgreSQL destination with a deduped sync mode will hit this issue.

## How
<!--
* Describe how code changes achieve the solution.
-->

The change renames the `row_number` alias to `_airbyte_row_number`.

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

This is basically a simple search-and-replace for `row_number` being used as an alias for the `row_number() over ...` window function. I've been running this code in our test environment for a few days with no issues. I'm only able to test with PostgreSQL though, while the patch covers other destinations that use the code from the CDK.

I'm new to Airbyte development, so could do with a bit of guidance as to the other pieces that need updating to land this (`metadata.yaml` files and the CDK `version.properties`, I think).

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

I don't anticipate any impact for the user other than reducing the likelihood of a sync failing.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
