### PR TITLE
Bulk CDK: ConnectorRunner accepts explicit isTest flag

### DIFF
--- a/airbyte-cdk/bulk/core/base/src/testFixtures/kotlin/io/airbyte/cdk/command/CliRunner.kt
+++ b/airbyte-cdk/bulk/core/base/src/testFixtures/kotlin/io/airbyte/cdk/command/CliRunner.kt
@@ -65,7 +65,7 @@ data object CliRunner {
                     args,
                     testProperties,
                     inputBeanDefinition,
-                    out.beanDefinition
+                    out.beanDefinition,
                 )
             }
         return CliRunnable(runnable, out.results)


### PR DESCRIPTION
see the javadoc comment for why this is necessary. AirbyteConnectorRunner defaults to `isTest = false` because it's used for runtime code; CliRunner defaults to `true` because it's intended for tests.

in particular https://docs.micronaut.io/4.1.8/api/io/micronaut/context/env/Environment.html
> When establishing the environment name from the class the started the application Micronaut will inspect the stacktrace. If JUnit or Spock are featured in the stacktrace the [TEST](https://docs.micronaut.io/4.1.8/api/io/micronaut/context/env/Environment.html#TEST) environment is included.