### PR TITLE
Bulk load CDK: nondocker runner throws exception if destination fails

### DIFF
--- a/airbyte-cdk/bulk/core/base/src/main/kotlin/io/airbyte/cdk/AirbyteConnectorRunner.kt
+++ b/airbyte-cdk/bulk/core/base/src/main/kotlin/io/airbyte/cdk/AirbyteConnectorRunner.kt
@@ -105,6 +105,9 @@ sealed class AirbyteConnectorRunner(
         if (!isTest) {
             // Required by the platform, otherwise syncs may hang.
             exitProcess(exitCode)
+        } else if (exitCode != 0) {
+            // Otherwise, propagate failure to test callers.
+            throw ConnectorUncleanExitException(exitCode)
         }
     }
 }

--- a/airbyte-cdk/bulk/core/base/src/main/kotlin/io/airbyte/cdk/ConnectorUncleanExitException.kt
+++ b/airbyte-cdk/bulk/core/base/src/main/kotlin/io/airbyte/cdk/ConnectorUncleanExitException.kt
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk
+
+class ConnectorUncleanExitException(val exitCode: Int) :
+    Exception("Destination process exited uncleanly: $exitCode")

--- a/airbyte-cdk/bulk/core/base/src/testFixtures/kotlin/io/airbyte/cdk/command/CliRunner.kt
+++ b/airbyte-cdk/bulk/core/base/src/testFixtures/kotlin/io/airbyte/cdk/command/CliRunner.kt
@@ -65,7 +65,7 @@ data object CliRunner {
                     args,
                     testProperties,
                     inputBeanDefinition,
-                    out.beanDefinition
+                    out.beanDefinition,
                 )
             }
         return CliRunnable(runnable, out.results)

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/destination_process/DestinationUncleanExitException.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/destination_process/DestinationUncleanExitException.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.load.test.util.destination_process
+
+import io.airbyte.protocol.models.v0.AirbyteErrorTraceMessage
+import io.airbyte.protocol.models.v0.AirbyteTraceMessage
+
+class DestinationUncleanExitException(
+    exitCode: Int,
+    traceMessages: List<AirbyteErrorTraceMessage>
+) :
+    Exception(
+        """
+        Destination process exited uncleanly: $exitCode
+        Trace messages:
+        """.trimIndent()
+        // explicit concat because otherwise trimIndent behaves badly
+        + traceMessages
+    ) {
+    companion object {
+        // generic type erasure strikes again >.>
+        // this can't just be a second constructor, because both constructors
+        // would have signature `traceMessages: List`.
+        // so we have to pull this into a companion object function.
+        fun of(exitCode: Int, traceMessages: List<AirbyteTraceMessage>) =
+            DestinationUncleanExitException(
+                exitCode,
+                traceMessages.filter { it.type == AirbyteTraceMessage.Type.ERROR }.map { it.error }
+            )
+    }
+}

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/destination_process/NonDockerizedDestination.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/destination_process/NonDockerizedDestination.kt
@@ -4,6 +4,7 @@
 
 package io.airbyte.cdk.load.test.util.destination_process
 
+import io.airbyte.cdk.ConnectorUncleanExitException
 import io.airbyte.cdk.command.CliRunnable
 import io.airbyte.cdk.command.CliRunner
 import io.airbyte.cdk.command.ConfigurationSpecification
@@ -53,7 +54,11 @@ class NonDockerizedDestination(
     }
 
     override suspend fun run() {
-        destination.run()
+        try {
+            destination.run()
+        } catch (e: ConnectorUncleanExitException) {
+            throw DestinationUncleanExitException.of(e.exitCode, destination.results.traces())
+        }
     }
 
     override fun sendMessage(message: AirbyteMessage) {


### PR DESCRIPTION
AirbyteConnectorRunner now throws an exception if the connector exited uncleanly. Unfortunately, it doesn't actually have access to the trace messages from the connector, so it's not an incredibly useful exception >.>

NonDockerizedDestination _does_ have the trace messages though (via the BufferedOutputConsumer), so we can append those in the load CDK :shrug:

(also, a minor refactor to move the `filter(ERROR).map(it.error)` into DestinationUncleanExitException)