### PR TITLE
Bulk load CDK: misc DestinationProcess improvements

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/IntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/IntegrationTest.kt
@@ -21,7 +21,7 @@ import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.test.fail
-import kotlinx.coroutines.async
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import org.apache.commons.lang3.RandomStringUtils
 import org.junit.jupiter.api.AfterEach
@@ -141,7 +141,7 @@ abstract class IntegrationTest(
                 catalog.asProtocolObject(),
             )
         return runBlocking {
-            val destinationCompletion = async { destination.run() }
+            launch { destination.run() }
             messages.forEach { destination.sendMessage(it.asProtocolMessage()) }
             if (streamStatus != null) {
                 catalog.streams.forEach {
@@ -166,7 +166,6 @@ abstract class IntegrationTest(
                 }
             }
             destination.shutdown()
-            destinationCompletion.await()
             destination.readMessages()
         }
     }

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/destination_process/DestinationProcess.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/destination_process/DestinationProcess.kt
@@ -33,13 +33,15 @@ interface DestinationProcess {
     suspend fun run()
 
     fun sendMessage(message: AirbyteMessage)
+    fun sendMessages(vararg messages: AirbyteMessage) {
+        messages.forEach { sendMessage(it) }
+    }
 
     /** Return all messages the destination emitted since the last call to [readMessages]. */
     fun readMessages(): List<AirbyteMessage>
 
     /**
-     * Wait for the destination to terminate, then return all messages it emitted since the last
-     * call to [readMessages].
+     * Signal the destination to exit (i.e. close its stdin stream), then wait for it to terminate.
      */
     suspend fun shutdown()
 }

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/destination_process/DockerizedDestination.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/destination_process/DockerizedDestination.kt
@@ -199,13 +199,13 @@ class DockerizedDestination(
     override suspend fun shutdown() {
         withContext(Dispatchers.IO) {
             destinationStdin.close()
-            // The old cdk had a 1-minute timeout here. That seems... weird?
-            // We can just rely on the junit timeout, presumably?
-            process.waitFor()
             // Wait for ourselves to drain stdout/stderr. Otherwise we won't capture
             // all the destination output (logs/trace messages).
             stdoutDrained.join()
             stderrDrained.join()
+            // The old cdk had a 1-minute timeout here. That seems... weird?
+            // We can just rely on the junit timeout, presumably?
+            process.waitFor()
             val exitCode = process.exitValue()
             if (exitCode != 0) {
                 throw DestinationUncleanExitException.of(exitCode, destinationOutput.traces())


### PR DESCRIPTION
* add a utility sendMessages(list<message>) function to DestinationProcess
* DockerDestination now waits for stdout/stderr to drain _before_ waiting for the process to terminate (no real behavior change here, but is more obviously correct)
* NonDockerDestination.shutdown now waits for the destination to complete (DockerDestination already had `process.waitFor()`)
* IntegrationTest now sets rebuildContext=true (this is most important for the docker runner, where we want to set the test name on the factory instance)
* IntegrationTest.runSync now uses launch instead of async+await, and no longer explicitly awaits (because `shutdown` now does that implicitly for both docker and nondocker)