### PR TITLE
Bulk load CDK: move oneshot boolean to factory instance field

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/implementor/FailSyncTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/implementor/FailSyncTask.kt
@@ -26,13 +26,10 @@ class DefaultFailSyncTask(
     private val destinationWriter: DestinationWriter,
     private val exception: Exception,
     private val syncManager: SyncManager,
-    private val checkpointManager: CheckpointManager<*, *>
+    private val checkpointManager: CheckpointManager<*, *>,
+    private val syncFailedHasRun: AtomicBoolean,
 ) : FailSyncTask {
     private val log = KotlinLogging.logger {}
-
-    companion object {
-        private val syncFailedHasRun = AtomicBoolean(false)
-    }
 
     override suspend fun execute() {
         if (syncFailedHasRun.setOnce()) {
@@ -63,6 +60,7 @@ class DefaultFailSyncTaskFactory(
     private val checkpointManager: CheckpointManager<*, *>,
     private val destinationWriter: DestinationWriter
 ) : FailSyncTaskFactory {
+    private val syncFailedHasRun = AtomicBoolean(false)
 
     override fun make(
         exceptionHandler: DestinationTaskExceptionHandler<*, *>,
@@ -73,7 +71,8 @@ class DefaultFailSyncTaskFactory(
             destinationWriter,
             exception,
             syncManager,
-            checkpointManager
+            checkpointManager,
+            syncFailedHasRun,
         )
     }
 }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/implementor/TeardownTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/implementor/TeardownTask.kt
@@ -12,22 +12,11 @@ import io.airbyte.cdk.load.task.SyncLevel
 import io.airbyte.cdk.load.util.setOnce
 import io.airbyte.cdk.load.write.DestinationWriter
 import io.github.oshai.kotlinlogging.KotlinLogging
-import io.micronaut.context.annotation.Factory
 import io.micronaut.context.annotation.Secondary
 import jakarta.inject.Singleton
 import java.util.concurrent.atomic.AtomicBoolean
-import javax.inject.Named
 
 interface TeardownTask : SyncLevel, ShutdownScope
-
-@Factory
-class TeardownAtomicBooleanProvider {
-    @Singleton
-    @Named("teardown-oneshot-atomic-boolean")
-    fun get(): AtomicBoolean {
-        return AtomicBoolean(false)
-    }
-}
 
 /**
  * Wraps @[DestinationWriter.teardown] and stops the task launcher.
@@ -76,8 +65,8 @@ class DefaultTeardownTaskFactory(
     private val checkpointManager: CheckpointManager<*, *>,
     private val syncManager: SyncManager,
     private val destination: DestinationWriter,
-    @Named("teardown-oneshot-atomic-boolean") private val teardownHasRun: AtomicBoolean,
 ) : TeardownTaskFactory {
+    private val teardownHasRun = AtomicBoolean(false)
 
     override fun make(taskLauncher: DestinationTaskLauncher): TeardownTask {
         return DefaultTeardownTask(


### PR DESCRIPTION
having it in the `companion object` caused problems when I tried running multiple tests (because only the first test would complete correctly). Construct this once per factory instantiation and pass it to the task appropriately.