### PR TITLE
🐙 source-faker: Stop progressive rollout for 6.2.18-rc.1

### DIFF
--- a/airbyte-integrations/connectors/source-faker/metadata.yaml
+++ b/airbyte-integrations/connectors/source-faker/metadata.yaml
@@ -24,7 +24,7 @@ data:
   releaseStage: beta
   releases:
     rolloutConfiguration:
-      enableProgressiveRollout: true
+      enableProgressiveRollout: false
     breakingChanges:
       4.0.0:
         message: This is a breaking change message


### PR DESCRIPTION
The release candidate version 6.2.18-rc.1 has been deemed unstable. This PR stops its progressive rollout.