### PR TITLE
Bulk load CDK: move control flow from tasks into launcher

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/DestinationTaskExceptionHandler.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/DestinationTaskExceptionHandler.kt
@@ -12,9 +12,11 @@ import io.airbyte.cdk.load.state.SyncManager
 import io.airbyte.cdk.load.state.SyncSuccess
 import io.airbyte.cdk.load.task.implementor.FailStreamTaskFactory
 import io.airbyte.cdk.load.task.implementor.FailSyncTaskFactory
+import io.airbyte.cdk.load.util.setOnce
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.micronaut.context.annotation.Secondary
 import jakarta.inject.Singleton
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
 import kotlinx.coroutines.CancellationException
 
@@ -66,6 +68,7 @@ T : ScopedTask {
     val log = KotlinLogging.logger {}
 
     val onException = AtomicReference(suspend {})
+    private val failSyncTaskEnqueued = AtomicBoolean(false)
 
     inner class SyncTaskWrapper(
         private val syncManager: SyncManager,
@@ -163,8 +166,12 @@ T : ScopedTask {
             val task = failStreamTaskFactory.make(this, e, it, kill = true)
             taskScopeProvider.launch(NoHandlingWrapper(task))
         }
-        val failSyncTask = failSyncTaskFactory.make(this, e)
-        taskScopeProvider.launch(NoHandlingWrapper(failSyncTask))
+        if (failSyncTaskEnqueued.setOnce()) {
+            val failSyncTask = failSyncTaskFactory.make(this, e)
+            taskScopeProvider.launch(NoHandlingWrapper(failSyncTask))
+        } else {
+            log.info { "Sync fail task already launched, not triggering a second one" }
+        }
     }
 
     override suspend fun handleStreamFailure(stream: DestinationStream, e: Exception) {

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/DestinationTaskLauncher.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/DestinationTaskLauncher.kt
@@ -22,9 +22,11 @@ import io.airbyte.cdk.load.task.internal.InputConsumerTask
 import io.airbyte.cdk.load.task.internal.SpillToDiskTaskFactory
 import io.airbyte.cdk.load.task.internal.TimedForcedCheckpointFlushTask
 import io.airbyte.cdk.load.task.internal.UpdateCheckpointsTask
+import io.airbyte.cdk.load.util.setOnce
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.micronaut.context.annotation.Secondary
 import jakarta.inject.Singleton
+import java.util.concurrent.atomic.AtomicBoolean
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -107,6 +109,8 @@ class DefaultDestinationTaskLauncher(
 
     private val batchUpdateLock = Mutex()
     private val succeeded = Channel<Boolean>(Channel.UNLIMITED)
+
+    private val teardownIsEnqueued = AtomicBoolean(false)
 
     private suspend fun enqueue(task: LeveledTask) {
         taskScopeProvider.launch(exceptionHandler.withExceptionHandling(task))
@@ -214,7 +218,11 @@ class DefaultDestinationTaskLauncher(
 
     /** Called when a stream is closed. */
     override suspend fun handleStreamClosed(stream: DestinationStream) {
-        enqueue(teardownTaskFactory.make(this))
+        if (teardownIsEnqueued.setOnce()) {
+            enqueue(teardownTaskFactory.make(this))
+        } else {
+            log.info { "Teardown task already enqueued, not enqueuing another one" }
+        }
     }
 
     /** Called exactly once when all streams are closed. */

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/implementor/FailSyncTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/implementor/FailSyncTask.kt
@@ -8,12 +8,10 @@ import io.airbyte.cdk.load.state.CheckpointManager
 import io.airbyte.cdk.load.state.SyncManager
 import io.airbyte.cdk.load.task.DestinationTaskExceptionHandler
 import io.airbyte.cdk.load.task.ImplementorScope
-import io.airbyte.cdk.load.util.setOnce
 import io.airbyte.cdk.load.write.DestinationWriter
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.micronaut.context.annotation.Secondary
 import jakarta.inject.Singleton
-import java.util.concurrent.atomic.AtomicBoolean
 
 interface FailSyncTask : ImplementorScope
 
@@ -27,22 +25,17 @@ class DefaultFailSyncTask(
     private val exception: Exception,
     private val syncManager: SyncManager,
     private val checkpointManager: CheckpointManager<*, *>,
-    private val syncFailedHasRun: AtomicBoolean,
 ) : FailSyncTask {
     private val log = KotlinLogging.logger {}
 
     override suspend fun execute() {
-        if (syncFailedHasRun.setOnce()) {
-            // Ensure any remaining ready state gets captured: don't waste work!
-            checkpointManager.flushReadyCheckpointMessages()
-            val result = syncManager.markFailed(exception) // awaits stream completion
-            log.info { "Calling teardown with failure result $result" }
-            exceptionHandler.handleSyncFailed()
-            // Do this cleanup last, after all the tasks have had a decent chance to finish.
-            destinationWriter.teardown(result)
-        } else {
-            log.info { "Fail sync task already initiated, doing nothing." }
-        }
+        // Ensure any remaining ready state gets captured: don't waste work!
+        checkpointManager.flushReadyCheckpointMessages()
+        val result = syncManager.markFailed(exception) // awaits stream completion
+        log.info { "Calling teardown with failure result $result" }
+        exceptionHandler.handleSyncFailed()
+        // Do this cleanup last, after all the tasks have had a decent chance to finish.
+        destinationWriter.teardown(result)
     }
 }
 
@@ -60,8 +53,6 @@ class DefaultFailSyncTaskFactory(
     private val checkpointManager: CheckpointManager<*, *>,
     private val destinationWriter: DestinationWriter
 ) : FailSyncTaskFactory {
-    private val syncFailedHasRun = AtomicBoolean(false)
-
     override fun make(
         exceptionHandler: DestinationTaskExceptionHandler<*, *>,
         exception: Exception
@@ -72,7 +63,6 @@ class DefaultFailSyncTaskFactory(
             exception,
             syncManager,
             checkpointManager,
-            syncFailedHasRun,
         )
     }
 }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/implementor/TeardownTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/implementor/TeardownTask.kt
@@ -9,12 +9,10 @@ import io.airbyte.cdk.load.state.SyncManager
 import io.airbyte.cdk.load.task.DestinationTaskLauncher
 import io.airbyte.cdk.load.task.ImplementorScope
 import io.airbyte.cdk.load.task.SyncLevel
-import io.airbyte.cdk.load.util.setOnce
 import io.airbyte.cdk.load.write.DestinationWriter
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.micronaut.context.annotation.Secondary
 import jakarta.inject.Singleton
-import java.util.concurrent.atomic.AtomicBoolean
 
 interface TeardownTask : SyncLevel, ImplementorScope
 
@@ -28,30 +26,24 @@ class DefaultTeardownTask(
     private val syncManager: SyncManager,
     private val destination: DestinationWriter,
     private val taskLauncher: DestinationTaskLauncher,
-    private val teardownHasRun: AtomicBoolean,
 ) : TeardownTask {
     val log = KotlinLogging.logger {}
 
     override suspend fun execute() {
-        // Run the task exactly once, and only after all streams have closed.
-        if (teardownHasRun.setOnce()) {
-            syncManager.awaitInputProcessingComplete()
-            checkpointManager.awaitAllCheckpointsFlushed()
+        syncManager.awaitInputProcessingComplete()
+        checkpointManager.awaitAllCheckpointsFlushed()
 
-            log.info { "Teardown task awaiting stream completion" }
-            if (!syncManager.awaitAllStreamsCompletedSuccessfully()) {
-                log.info { "Streams failed to complete successfully, doing nothing." }
-                return
-            }
-
-            log.info { "Starting teardown task" }
-            destination.teardown()
-            log.info { "Teardown task complete, marking sync succeeded." }
-            syncManager.markSucceeded()
-            taskLauncher.handleTeardownComplete()
-        } else {
-            log.info { "Teardown already initiated, doing nothing." }
+        log.info { "Teardown task awaiting stream completion" }
+        if (!syncManager.awaitAllStreamsCompletedSuccessfully()) {
+            log.info { "Streams failed to complete successfully, doing nothing." }
+            return
         }
+
+        log.info { "Starting teardown task" }
+        destination.teardown()
+        log.info { "Teardown task complete, marking sync succeeded." }
+        syncManager.markSucceeded()
+        taskLauncher.handleTeardownComplete()
     }
 }
 
@@ -66,15 +58,7 @@ class DefaultTeardownTaskFactory(
     private val syncManager: SyncManager,
     private val destination: DestinationWriter,
 ) : TeardownTaskFactory {
-    private val teardownHasRun = AtomicBoolean(false)
-
     override fun make(taskLauncher: DestinationTaskLauncher): TeardownTask {
-        return DefaultTeardownTask(
-            checkpointManager,
-            syncManager,
-            destination,
-            taskLauncher,
-            teardownHasRun
-        )
+        return DefaultTeardownTask(checkpointManager, syncManager, destination, taskLauncher)
     }
 }


### PR DESCRIPTION
previously, it was possible for e.g. a TeardownTask to try and run after a different teardown task, and trigger this exception https://github.com/airbytehq/airbyte/blob/510c9f10e3326c207599790834311f4843188ddb/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/DestinationTaskExceptionHandler.kt#L75-L77

prevent the task from being enqueued if another one is already enqueued/running. (do the same for FailSyncTask)