### PR TITLE
Bulk load CDK: Task launcher blocks and joins implementor scope

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/DestinationTaskLauncher.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/DestinationTaskLauncher.kt
@@ -25,6 +25,7 @@ import io.airbyte.cdk.load.task.internal.UpdateCheckpointsTask
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.micronaut.context.annotation.Secondary
 import jakarta.inject.Singleton
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
@@ -105,12 +106,15 @@ class DefaultDestinationTaskLauncher(
     private val log = KotlinLogging.logger {}
 
     private val batchUpdateLock = Mutex()
+    private val succeeded = Channel<Boolean>(Channel.UNLIMITED)
 
     private suspend fun enqueue(task: LeveledTask) {
         taskScopeProvider.launch(exceptionHandler.withExceptionHandling(task))
     }
 
-    override suspend fun start() {
+    override suspend fun run() {
+        exceptionHandler.setCallback { succeeded.send(false) }
+
         // Start the input consumer ASAP
         log.info { "Starting input consumer task" }
         enqueue(inputConsumerTask)
@@ -127,11 +131,19 @@ class DefaultDestinationTaskLauncher(
             enqueue(spillTask)
         }
 
+        // Start the checkpoint management tasks
         log.info { "Starting timed flush task" }
         enqueue(timedFlushTask)
 
         log.info { "Starting checkpoint update task" }
         enqueue(updateCheckpointsTask)
+
+        // Await completion
+        if (succeeded.receive()) {
+            taskScopeProvider.close()
+        } else {
+            taskScopeProvider.kill()
+        }
     }
 
     /** Called when the initial destination setup completes. */
@@ -207,6 +219,6 @@ class DefaultDestinationTaskLauncher(
 
     /** Called exactly once when all streams are closed. */
     override suspend fun handleTeardownComplete() {
-        taskScopeProvider.close()
+        succeeded.send(true)
     }
 }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/DestinationTaskScopeProvider.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/DestinationTaskScopeProvider.kt
@@ -9,12 +9,14 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import io.micronaut.context.annotation.Secondary
 import jakarta.inject.Singleton
 import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicLong
 import kotlin.system.measureTimeMillis
+import kotlinx.coroutines.CompletableJob
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.InternalCoroutinesApi
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
@@ -33,20 +35,12 @@ import kotlinx.coroutines.withTimeoutOrNull
  *       - should not block internal tasks (esp reading from stdin)
  *       - should complete if possible even when failing the sync
  * ```
- * - [ShutdownScope]: special case of [ImplementorScope]
- * ```
- *       - tasks that should run during shutdown
- *       - handles canceling/joining other tasks
- *       - (and so should not cancel themselves)
- * ```
  */
 sealed interface ScopedTask : Task
 
 interface InternalScope : ScopedTask
 
 interface ImplementorScope : ScopedTask
-
-interface ShutdownScope : ScopedTask
 
 @Singleton
 @Secondary
@@ -57,42 +51,60 @@ class DestinationTaskScopeProvider(config: DestinationConfiguration) :
     private val timeoutMs = config.gracefulCancellationTimeoutMs
 
     data class ControlScope(
-        val job: Job,
-        val dispatcher: CoroutineDispatcher,
+        val name: String,
+        val job: CompletableJob,
+        val dispatcher: CoroutineDispatcher
+    ) {
         val scope: CoroutineScope = CoroutineScope(dispatcher + job)
-    )
+        val runningJobs: AtomicLong = AtomicLong(0)
+    }
 
-    private val internalScope = ControlScope(Job(), Dispatchers.IO)
+    private val internalScope = ControlScope("internal", Job(), Dispatchers.IO)
 
     private val implementorScope =
         ControlScope(
-            SupervisorJob(),
+            "implementor",
+            Job(),
             Executors.newFixedThreadPool(config.maxNumImplementorTaskThreads)
                 .asCoroutineDispatcher()
         )
 
     override suspend fun launch(task: WrappedTask<ScopedTask>) {
-        when (task.innerTask) {
-            is InternalScope -> internalScope.scope.launch { execute(task, "internal") }
-            is ImplementorScope -> implementorScope.scope.launch { execute(task, "implementor") }
-            is ShutdownScope -> implementorScope.scope.launch { execute(task, "shutdown") }
+        val scope =
+            when (task.innerTask) {
+                is InternalScope -> internalScope
+                is ImplementorScope -> implementorScope
+            }
+        scope.scope.launch {
+            var nJobs = scope.runningJobs.incrementAndGet()
+            log.info { "Launching task $task in scope ${scope.name} ($nJobs now running)" }
+            val elapsed = measureTimeMillis { task.execute() }
+            nJobs = scope.runningJobs.decrementAndGet()
+            log.info { "Task $task completed in $elapsed ms ($nJobs now running)" }
         }
     }
 
-    private suspend fun execute(task: WrappedTask<ScopedTask>, scope: String) {
-        log.info { "Launching task $task in scope $scope" }
-        val elapsed = measureTimeMillis { task.execute() }
-        log.info { "Task $task completed in $elapsed ms" }
-    }
-
+    @OptIn(InternalCoroutinesApi::class)
     override suspend fun close() {
-        log.info { "Closing task scopes" }
         // Under normal operation, all tasks should be complete
         // (except things like force flush, which loop). So
         // - it's safe to force cancel the internal tasks
         // - implementor scope should join immediately
+        log.info { "Closing task scopes (${implementorScope.runningJobs.get()} remaining)" }
+        if (!implementorScope.job.isActive) {
+            val cause =
+                implementorScope.job.children
+                    .find { it.isCancelled }
+                    ?.getCancellationException()
+                    ?.cause
+            throw IllegalStateException("Implementor job killed by uncaught exception", cause)
+        }
+        implementorScope.job.complete()
         implementorScope.job.join()
-        log.info { "Implementor tasks completed, cancelling internal tasks." }
+
+        log.info {
+            "Implementor tasks completed, cancelling internal tasks (${internalScope.runningJobs.get()} remaining)."
+        }
         internalScope.job.cancel()
     }
 
@@ -104,6 +116,7 @@ class DestinationTaskScopeProvider(config: DestinationConfiguration) :
             log.info {
                 "Cancelled internal tasks, waiting ${timeoutMs}ms for implementor tasks to complete"
             }
+            implementorScope.job.complete()
             implementorScope.job.join()
             log.info { "Implementor tasks completed" }
         }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/Task.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/Task.kt
@@ -15,15 +15,23 @@ interface Task {
  * transitions between tasks.
  */
 interface TaskLauncher {
-    suspend fun start()
+    /**
+     * Execute the task workflow. Should dispatch tasks asynchronously and suspend until the
+     * workflow is complete.
+     */
+    suspend fun run()
 }
 
 /**
- * Wraps tasks with exception handling. It should provide an exception handling workflow and take
- * responsibility for closing scopes, etc.
+ * Wraps tasks with exception handling. It should perform all necessary exception handling, then
+ * execute the provided callback.
  */
 interface TaskExceptionHandler<T : Task, U : Task> {
-    fun withExceptionHandling(task: T): U
+    // Wrap a task with exception handling.
+    suspend fun withExceptionHandling(task: T): U
+
+    // Set a callback that will be invoked when any exception handling is done.
+    suspend fun setCallback(callback: suspend () -> Unit)
 }
 
 /** Provides the scope(s) in which tasks run. */
@@ -31,6 +39,6 @@ interface TaskScopeProvider<T : Task> : CloseableCoroutine {
     /** Launch a task in the correct scope. */
     suspend fun launch(task: T)
 
-    /** Unliked close, may attempt to fail gracefully, but should guarantee return. */
+    /** Unliked [close], may attempt to fail gracefully, but should guarantee return. */
     suspend fun kill()
 }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/implementor/FailStreamTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/implementor/FailStreamTask.kt
@@ -8,12 +8,12 @@ import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.state.StreamIncompleteResult
 import io.airbyte.cdk.load.state.SyncManager
 import io.airbyte.cdk.load.task.DestinationTaskExceptionHandler
-import io.airbyte.cdk.load.task.ShutdownScope
+import io.airbyte.cdk.load.task.ImplementorScope
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.micronaut.context.annotation.Secondary
 import jakarta.inject.Singleton
 
-interface FailStreamTask : ShutdownScope
+interface FailStreamTask : ImplementorScope
 
 /**
  * FailStreamTask is a task that is executed when a stream fails. It is responsible for cleaning up

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/implementor/FailSyncTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/implementor/FailSyncTask.kt
@@ -7,7 +7,7 @@ package io.airbyte.cdk.load.task.implementor
 import io.airbyte.cdk.load.state.CheckpointManager
 import io.airbyte.cdk.load.state.SyncManager
 import io.airbyte.cdk.load.task.DestinationTaskExceptionHandler
-import io.airbyte.cdk.load.task.ShutdownScope
+import io.airbyte.cdk.load.task.ImplementorScope
 import io.airbyte.cdk.load.util.setOnce
 import io.airbyte.cdk.load.write.DestinationWriter
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -15,7 +15,7 @@ import io.micronaut.context.annotation.Secondary
 import jakarta.inject.Singleton
 import java.util.concurrent.atomic.AtomicBoolean
 
-interface FailSyncTask : ShutdownScope
+interface FailSyncTask : ImplementorScope
 
 /**
  * FailSyncTask is a task that is executed when a sync fails. It is responsible for cleaning up

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/implementor/TeardownTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/implementor/TeardownTask.kt
@@ -7,7 +7,7 @@ package io.airbyte.cdk.load.task.implementor
 import io.airbyte.cdk.load.state.CheckpointManager
 import io.airbyte.cdk.load.state.SyncManager
 import io.airbyte.cdk.load.task.DestinationTaskLauncher
-import io.airbyte.cdk.load.task.ShutdownScope
+import io.airbyte.cdk.load.task.ImplementorScope
 import io.airbyte.cdk.load.task.SyncLevel
 import io.airbyte.cdk.load.util.setOnce
 import io.airbyte.cdk.load.write.DestinationWriter
@@ -16,7 +16,7 @@ import io.micronaut.context.annotation.Secondary
 import jakarta.inject.Singleton
 import java.util.concurrent.atomic.AtomicBoolean
 
-interface TeardownTask : SyncLevel, ShutdownScope
+interface TeardownTask : SyncLevel, ImplementorScope
 
 /**
  * Wraps @[DestinationWriter.teardown] and stops the task launcher.

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/write/WriteOperation.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/write/WriteOperation.kt
@@ -30,7 +30,7 @@ class WriteOperation(
     val log = KotlinLogging.logger {}
 
     override fun execute() = runBlocking {
-        taskLauncher.start()
+        taskLauncher.run()
 
         when (val result = syncManager.awaitSyncResult()) {
             is SyncSuccess -> {

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/DestinationTaskExceptionHandlerTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/DestinationTaskExceptionHandlerTest.kt
@@ -232,8 +232,10 @@ class DestinationTaskExceptionHandlerTest<T> where T : LeveledTask, T : ScopedTa
     }
 
     @Test
-    fun testHandleSyncFailed(scopeProvider: MockScopeProvider) = runTest {
+    fun testHandleSyncFailed() = runTest {
+        val wasHandled = Channel<Boolean>(Channel.UNLIMITED)
+        exceptionHandler.setCallback { wasHandled.send(true) }
         exceptionHandler.handleSyncFailed()
-        Assertions.assertTrue(scopeProvider.didKill)
+        Assertions.assertTrue(wasHandled.receive())
     }
 }

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/DestinationTaskLauncherTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/DestinationTaskLauncherTest.kt
@@ -276,6 +276,7 @@ class DestinationTaskLauncherTest<T> where T : LeveledTask, T : ScopedTask {
     T : LeveledTask,
     T : ScopedTask {
         val wrappedTasks = Channel<LeveledTask>(Channel.UNLIMITED)
+        val callbacks = Channel<suspend () -> Unit>(Channel.UNLIMITED)
 
         inner class IdentityWrapper(override val innerTask: ScopedTask) : WrappedTask<ScopedTask> {
             override suspend fun execute() {
@@ -283,7 +284,7 @@ class DestinationTaskLauncherTest<T> where T : LeveledTask, T : ScopedTask {
             }
         }
 
-        override fun withExceptionHandling(task: T): WrappedTask<ScopedTask> {
+        override suspend fun withExceptionHandling(task: T): WrappedTask<ScopedTask> {
             runBlocking { wrappedTasks.send(task) }
             val innerTask =
                 object : InternalScope {
@@ -293,11 +294,15 @@ class DestinationTaskLauncherTest<T> where T : LeveledTask, T : ScopedTask {
                 }
             return IdentityWrapper(innerTask)
         }
+
+        override suspend fun setCallback(callback: suspend () -> Unit) {
+            callbacks.send(callback)
+        }
     }
 
     @Test
-    fun testStart() = runTest {
-        taskLauncher.start()
+    fun testRun() = runTest {
+        val job = launch { taskLauncher.run() }
 
         Assertions.assertTrue(
             mockInputConsumerTask.hasRun.receive(),
@@ -327,6 +332,7 @@ class DestinationTaskLauncherTest<T> where T : LeveledTask, T : ScopedTask {
             mockSpillToDiskTaskFactory.streamHasRun.size,
             taskList.filterIsInstance<SpillToDiskTask>().size
         )
+        job.cancel()
     }
 
     @Test
@@ -431,7 +437,19 @@ class DestinationTaskLauncherTest<T> where T : LeveledTask, T : ScopedTask {
     @Test
     fun testHandleTeardownComplete() = runTest {
         // This should close the scope provider.
+        launch {
+            taskLauncher.run()
+            Assertions.assertTrue(mockScopeProvider.didClose)
+        }
         taskLauncher.handleTeardownComplete()
-        Assertions.assertTrue(mockScopeProvider.didClose)
+    }
+
+    @Test
+    fun testHandleCallbackWithFailure() = runTest {
+        launch {
+            taskLauncher.run()
+            Assertions.assertTrue(mockScopeProvider.didKill)
+        }
+        mockExceptionHandler.callbacks.receive().invoke()
     }
 }

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/MockTaskLauncher.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/MockTaskLauncher.kt
@@ -46,7 +46,7 @@ class MockTaskLauncher : DestinationTaskLauncher {
         throw NotImplementedError()
     }
 
-    override suspend fun start() {
+    override suspend fun run() {
         throw NotImplementedError()
     }
 }


### PR DESCRIPTION
## What
* removes shutdown scope
* TaskLauncher::start -> TaskLauncher::run, which blocks until the workflow is complete
* added a callback to the exception handler to facilitate that: callback returns flow to launcher for cleanup
* Launcher uses channel<bool> to track success/failure and conditionally calls close/kill

Also:
* Fixed a bug in the scope provider: parent `Job()`s are cancellable but won't actually `join` unless explicitly `complete`d. (Completion requires both 1) all children complete; 2) someone calls `Job::complete`, so it's safe to do it without waiting for all the jobs to be done.

Also:
* I added lots of extra logging to help me debug that issue

Also:
* Test changes!