### PR TITLE
Add warning on AsyncRetriever

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_component_schema.yaml
@@ -2440,7 +2440,7 @@ definitions:
         items:
           type: string
   AsyncRetriever:
-    description: Retrieves records by Asynchronously sending requests to fetch records. The retriever acts as an orchestrator between the requester, the record selector, the paginator, and the partition router.
+    description: "[Experimental - We expect the interface to change shortly and we reserve the right to not consider this a breaking change] Retrieves records by Asynchronously sending requests to fetch records. The retriever acts as an orchestrator between the requester, the record selector, the paginator, and the partition router."
     type: object
     required:
       - type

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/retrievers/async_retriever.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/retrievers/async_retriever.py
@@ -2,7 +2,6 @@
 
 
 from dataclasses import InitVar, dataclass, field
-from deprecated.classic import deprecated
 from typing import Any, Callable, Iterable, Mapping, Optional
 
 from airbyte_cdk.models import FailureType
@@ -15,6 +14,7 @@ from airbyte_cdk.sources.source import ExperimentalClassWarning
 from airbyte_cdk.sources.streams.core import StreamData
 from airbyte_cdk.sources.types import Config, StreamSlice, StreamState
 from airbyte_cdk.utils.traced_exception import AirbyteTracedException
+from deprecated.classic import deprecated
 
 
 @deprecated("This class is experimental. Use at your own risk.", category=ExperimentalClassWarning)

--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/retrievers/async_retriever.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/retrievers/async_retriever.py
@@ -2,6 +2,7 @@
 
 
 from dataclasses import InitVar, dataclass, field
+from deprecated.classic import deprecated
 from typing import Any, Callable, Iterable, Mapping, Optional
 
 from airbyte_cdk.models import FailureType
@@ -10,11 +11,13 @@ from airbyte_cdk.sources.declarative.extractors.record_selector import RecordSel
 from airbyte_cdk.sources.declarative.partition_routers import SinglePartitionRouter
 from airbyte_cdk.sources.declarative.retrievers import Retriever
 from airbyte_cdk.sources.declarative.stream_slicers import StreamSlicer
+from airbyte_cdk.sources.source import ExperimentalClassWarning
 from airbyte_cdk.sources.streams.core import StreamData
 from airbyte_cdk.sources.types import Config, StreamSlice, StreamState
 from airbyte_cdk.utils.traced_exception import AirbyteTracedException
 
 
+@deprecated("This class is experimental. Use at your own risk.", category=ExperimentalClassWarning)
 @dataclass
 class AsyncRetriever(Retriever):
     config: Config


### PR DESCRIPTION
## What
We have users that have inquired about the async retriever [here](https://airbytehq-team.slack.com/archives/C027KKE4BCZ/p1728456483518839). We know the interface is flaky and will change in the future. In order to make it clear for our users the consequences of using that, we want to have a way to communicate this information.

## How
Add more information on the declarative component and a deprecated warning on the Python class

## User Impact
Developers should have a better understand on if they really want to use this component.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
