### PR TITLE
Bulk load CDK: Start porting tests

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/integrationTest/kotlin/io/airbyte/cdk/load/mock_integration_test/MockBasicFunctionalityIntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/integrationTest/kotlin/io/airbyte/cdk/load/mock_integration_test/MockBasicFunctionalityIntegrationTest.kt
@@ -28,4 +28,9 @@ class MockBasicFunctionalityIntegrationTest :
     override fun testMidSyncCheckpointingStreamState() {
         super.testMidSyncCheckpointingStreamState()
     }
+
+    @Test
+    override fun testNamespaces() {
+        super.testNamespaces()
+    }
 }

--- a/airbyte-cdk/bulk/core/load/src/integrationTest/kotlin/io/airbyte/cdk/load/mock_integration_test/MockBasicFunctionalityIntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/integrationTest/kotlin/io/airbyte/cdk/load/mock_integration_test/MockBasicFunctionalityIntegrationTest.kt
@@ -33,4 +33,9 @@ class MockBasicFunctionalityIntegrationTest :
     override fun testNamespaces() {
         super.testNamespaces()
     }
+
+    @Test
+    override fun testFunkyStreamAndColumnNames() {
+        super.testFunkyStreamAndColumnNames()
+    }
 }


### PR DESCRIPTION
the new testNamespaces is a very different test from DAT.testNamespaces, but DAT.testNamespaces was... kind of useless? It's unclear to me what it was intended to do. This test is a lot more effective at verifying that namespaces actually work.

the funky stream/column names test is also a combination of a few things in DATs (edge_case_catalog, etc)

(in fact, DAT.testSyncWriteSameTableNameDifferentNamespace is more like what this test does)