### PR TITLE
Bulk Load CDK: File format Spec & Streaming Upload, S3V2 Usage

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/integrationTest/kotlin/io/airbyte/cdk/load/mock_integration_test/MockDestinationBackend.kt
+++ b/airbyte-cdk/bulk/core/load/src/integrationTest/kotlin/io/airbyte/cdk/load/mock_integration_test/MockDestinationBackend.kt
@@ -4,6 +4,8 @@
 
 package io.airbyte.cdk.load.mock_integration_test
 
+import io.airbyte.cdk.command.ConfigurationSpecification
+import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.test.util.DestinationDataDumper
 import io.airbyte.cdk.load.test.util.OutputRecord
 import java.util.concurrent.ConcurrentHashMap
@@ -25,9 +27,12 @@ object MockDestinationBackend {
 }
 
 object MockDestinationDataDumper : DestinationDataDumper {
-    override fun dumpRecords(streamName: String, streamNamespace: String?): List<OutputRecord> {
+    override fun dumpRecords(
+        spec: ConfigurationSpecification,
+        stream: DestinationStream
+    ): List<OutputRecord> {
         return MockDestinationBackend.readFile(
-            MockStreamLoader.getFilename(streamNamespace, streamName)
+            MockStreamLoader.getFilename(stream.descriptor.namespace, stream.descriptor.name)
         )
     }
 }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/command/DestinationStream.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/command/DestinationStream.kt
@@ -6,7 +6,13 @@ package io.airbyte.cdk.load.command
 
 import io.airbyte.cdk.load.data.AirbyteType
 import io.airbyte.cdk.load.data.AirbyteTypeToJsonSchema
+import io.airbyte.cdk.load.data.ArrayType
+import io.airbyte.cdk.load.data.FieldType
+import io.airbyte.cdk.load.data.IntegerType
 import io.airbyte.cdk.load.data.JsonSchemaToAirbyteType
+import io.airbyte.cdk.load.data.ObjectType
+import io.airbyte.cdk.load.data.StringType
+import io.airbyte.cdk.load.message.DestinationRecord
 import io.airbyte.protocol.models.v0.AirbyteStream
 import io.airbyte.protocol.models.v0.ConfiguredAirbyteStream
 import io.airbyte.protocol.models.v0.DestinationSyncMode
@@ -39,6 +45,65 @@ data class DestinationStream(
 
         fun toPrettyString() = "$namespace.$name"
     }
+
+    /**
+     * This is the schema of what we currently write to destinations, but this might not reflect
+     * what actually exists, as many destinations have legacy data from before this schema was
+     * adopted.
+     */
+    val schemaWithMeta: AirbyteType
+        get() =
+            ObjectType(
+                linkedMapOf(
+                    DestinationRecord.Meta.COLUMN_NAME_AB_RAW_ID to
+                        FieldType(StringType, nullable = false),
+                    DestinationRecord.Meta.COLUMN_NAME_AB_EXTRACTED_AT to
+                        FieldType(IntegerType, nullable = false),
+                    DestinationRecord.Meta.COLUMN_NAME_AB_META to
+                        FieldType(
+                            nullable = false,
+                            type =
+                                ObjectType(
+                                    linkedMapOf(
+                                        "sync_id" to FieldType(IntegerType, nullable = false),
+                                        "changes" to
+                                            FieldType(
+                                                nullable = false,
+                                                type =
+                                                    ArrayType(
+                                                        FieldType(
+                                                            nullable = false,
+                                                            type =
+                                                                ObjectType(
+                                                                    linkedMapOf(
+                                                                        "field" to
+                                                                            FieldType(
+                                                                                StringType,
+                                                                                nullable = false
+                                                                            ),
+                                                                        "change" to
+                                                                            FieldType(
+                                                                                StringType,
+                                                                                nullable = false
+                                                                            ),
+                                                                        "reason" to
+                                                                            FieldType(
+                                                                                StringType,
+                                                                                nullable = false
+                                                                            ),
+                                                                    )
+                                                                )
+                                                        )
+                                                    )
+                                            )
+                                    )
+                                )
+                        ),
+                    DestinationRecord.Meta.COLUMN_NAME_AB_GENERATION_ID to
+                        FieldType(IntegerType, nullable = false),
+                    DestinationRecord.Meta.COLUMN_NAME_DATA to FieldType(schema, nullable = false),
+                )
+            )
 
     /**
      * This is not fully round-trippable. Destinations don't care about most of the stuff in an

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/AirbyteValueToJson.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/AirbyteValueToJson.kt
@@ -29,3 +29,7 @@ class AirbyteValueToJson {
         }
     }
 }
+
+fun AirbyteValue.toJson(): JsonNode {
+    return AirbyteValueToJson().convert(this)
+}

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/DestinationRecordToAirbyteValueWithMeta.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/DestinationRecordToAirbyteValueWithMeta.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.load.data
+
+import io.airbyte.cdk.load.command.DestinationCatalog
+import io.airbyte.cdk.load.message.DestinationRecord
+import io.airbyte.cdk.load.message.DestinationRecord.Meta
+import jakarta.inject.Singleton
+import java.util.*
+
+@Singleton
+class DestinationRecordToAirbyteValueWithMeta(private val catalog: DestinationCatalog) {
+    fun decorate(record: DestinationRecord): ObjectValue {
+        val streamActual = catalog.getStream(record.stream.name, record.stream.namespace)
+        return ObjectValue(
+            linkedMapOf(
+                Meta.COLUMN_NAME_AB_RAW_ID to StringValue(UUID.randomUUID().toString()),
+                Meta.COLUMN_NAME_AB_EXTRACTED_AT to IntegerValue(record.emittedAtMs),
+                Meta.COLUMN_NAME_AB_META to
+                    ObjectValue(
+                        linkedMapOf(
+                            "sync_id" to IntegerValue(streamActual.syncId),
+                            "changes" to
+                                ArrayValue(
+                                    record.meta?.changes?.map {
+                                        ObjectValue(
+                                            linkedMapOf(
+                                                "field" to StringValue(it.field),
+                                                "change" to StringValue(it.change.name),
+                                                "reason" to StringValue(it.reason.name)
+                                            )
+                                        )
+                                    }
+                                        ?: emptyList()
+                                )
+                        )
+                    ),
+                Meta.COLUMN_NAME_AB_GENERATION_ID to IntegerValue(streamActual.generationId),
+                Meta.COLUMN_NAME_DATA to record.data
+            )
+        )
+    }
+}

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/JsonToAirbyteValue.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/JsonToAirbyteValue.kt
@@ -187,3 +187,7 @@ class JsonToAirbyteValue {
         }
     }
 }
+
+fun JsonNode.toAirbyteValue(schema: AirbyteType): AirbyteValue {
+    return JsonToAirbyteValue().convert(this, schema)
+}

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/Batch.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/Batch.kt
@@ -73,12 +73,6 @@ abstract class StagedLocalFile() : Batch {
     override val state: Batch.State = Batch.State.LOCAL
 }
 
-/** Represents a remote object containing persisted records. */
-abstract class RemoteObject() : Batch {
-    override val state: Batch.State = Batch.State.PERSISTED
-    abstract val key: String
-}
-
 /**
  * Represents a file of raw records staged to disk for pre-processing. Used internally by the
  * framework

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/DestinationMessage.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/DestinationMessage.kt
@@ -63,6 +63,14 @@ data class DestinationRecord(
     )
 
     data class Meta(val changes: List<Change>?) {
+        companion object {
+            const val COLUMN_NAME_AB_RAW_ID: String = "_airbyte_raw_id"
+            const val COLUMN_NAME_AB_EXTRACTED_AT: String = "_airbyte_extracted_at"
+            const val COLUMN_NAME_AB_META: String = "_airbyte_meta"
+            const val COLUMN_NAME_AB_GENERATION_ID: String = "_airbyte_generation_id"
+            const val COLUMN_NAME_DATA: String = "_airbyte_data"
+        }
+
         fun asProtocolObject(): AirbyteRecordMessageMeta =
             AirbyteRecordMessageMeta().also {
                 if (changes != null) {

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/util/JsonUtils.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/util/JsonUtils.kt
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.load.util
+
+import com.fasterxml.jackson.databind.JsonNode
+import io.airbyte.cdk.util.Jsons
+
+fun JsonNode.serializeToString(): String {
+    return Jsons.writeValueAsString(this)
+}
+
+fun String.deserializeToNode(): JsonNode {
+    return Jsons.readTree(this)
+}

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/DestinationTaskExceptionHandlerTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/DestinationTaskExceptionHandlerTest.kt
@@ -125,7 +125,6 @@ class DestinationTaskExceptionHandlerTest<T> where T : LeveledTask, T : ScopedTa
                 (stream, exception, kill) ->
                 stream to Pair(exception, kill)
             }
-        println(streamResults)
         catalog.streams.forEach { stream ->
             Assertions.assertTrue(streamResults[stream]!!.first is RuntimeException)
             Assertions.assertTrue(streamResults[stream]!!.second)

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/AirbyteValueWithMetaToOutputRecord.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/AirbyteValueWithMetaToOutputRecord.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.load.test.util
+
+import io.airbyte.cdk.load.data.AirbyteValue
+import io.airbyte.cdk.load.data.ArrayValue
+import io.airbyte.cdk.load.data.IntegerValue
+import io.airbyte.cdk.load.data.ObjectValue
+import io.airbyte.cdk.load.data.StringValue
+import io.airbyte.cdk.load.message.DestinationRecord
+import io.airbyte.protocol.models.v0.AirbyteRecordMessageMetaChange
+import java.time.Instant
+import java.util.*
+
+class AirbyteValueWithMetaToOutputRecord {
+    fun convert(value: ObjectValue): OutputRecord {
+        val meta = value.values[DestinationRecord.Meta.COLUMN_NAME_AB_META] as ObjectValue
+        return OutputRecord(
+            rawId =
+                UUID.fromString(
+                    (value.values[DestinationRecord.Meta.COLUMN_NAME_AB_RAW_ID] as StringValue)
+                        .value
+                ),
+            extractedAt =
+                Instant.ofEpochMilli(
+                    (value.values[DestinationRecord.Meta.COLUMN_NAME_AB_EXTRACTED_AT]
+                            as IntegerValue)
+                        .value
+                ),
+            loadedAt = null,
+            data = value.values[DestinationRecord.Meta.COLUMN_NAME_DATA] as ObjectValue,
+            generationId =
+                (value.values[DestinationRecord.Meta.COLUMN_NAME_AB_GENERATION_ID] as IntegerValue)
+                    .value,
+            airbyteMeta =
+                OutputRecord.Meta(
+                    syncId = (meta.values["sync_id"] as IntegerValue).value,
+                    changes =
+                        (meta.values["changes"] as ArrayValue).values.map {
+                            DestinationRecord.Change(
+                                field = ((it as ObjectValue).values["field"] as StringValue).value,
+                                change =
+                                    AirbyteRecordMessageMetaChange.Change.fromValue(
+                                        (it.values["change"] as StringValue).value
+                                    ),
+                                reason =
+                                    AirbyteRecordMessageMetaChange.Reason.fromValue(
+                                        (it.values["reason"] as StringValue).value
+                                    )
+                            )
+                        }
+                )
+        )
+    }
+}
+
+fun AirbyteValue.toOutputRecord(): OutputRecord {
+    return AirbyteValueWithMetaToOutputRecord().convert(this as ObjectValue)
+}

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/DestinationDataDumper.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/DestinationDataDumper.kt
@@ -4,11 +4,11 @@
 
 package io.airbyte.cdk.load.test.util
 
+import io.airbyte.cdk.command.ConfigurationSpecification
+import io.airbyte.cdk.load.command.DestinationStream
+
 fun interface DestinationDataDumper {
-    fun dumpRecords(
-        streamName: String,
-        streamNamespace: String?,
-    ): List<OutputRecord>
+    fun dumpRecords(spec: ConfigurationSpecification, stream: DestinationStream): List<OutputRecord>
 }
 
 /**
@@ -16,7 +16,10 @@ fun interface DestinationDataDumper {
  * implementation to satisfy the compiler.
  */
 object FakeDataDumper : DestinationDataDumper {
-    override fun dumpRecords(streamName: String, streamNamespace: String?): List<OutputRecord> {
+    override fun dumpRecords(
+        spec: ConfigurationSpecification,
+        stream: DestinationStream
+    ): List<OutputRecord> {
         throw NotImplementedError()
     }
 }

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/IntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/IntegrationTest.kt
@@ -104,13 +104,13 @@ abstract class IntegrationTest(
     }
 
     fun dumpAndDiffRecords(
+        config: ConfigurationSpecification,
         canonicalExpectedRecords: List<OutputRecord>,
-        streamName: String,
-        streamNamespace: String?,
+        stream: DestinationStream,
         primaryKey: List<List<String>>,
         cursor: List<String>?,
     ) {
-        val actualRecords: List<OutputRecord> = dataDumper.dumpRecords(streamName, streamNamespace)
+        val actualRecords: List<OutputRecord> = dataDumper.dumpRecords(config, stream)
         val expectedRecords: List<OutputRecord> =
             canonicalExpectedRecords.map { recordMangler.mapRecord(it) }
 

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/write/BasicFunctionalityIntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/write/BasicFunctionalityIntegrationTest.kt
@@ -38,17 +38,19 @@ abstract class BasicFunctionalityIntegrationTest(
 ) : IntegrationTest(dataDumper, destinationCleaner, recordMangler, nameMapper) {
     @Test
     open fun testBasicWrite() {
+        val stream =
+            DestinationStream(
+                DestinationStream.Descriptor(randomizedNamespace, "test_stream"),
+                Append,
+                ObjectTypeWithoutSchema,
+                generationId = 0,
+                minimumGenerationId = 0,
+                syncId = 42,
+            )
         val messages =
             runSync(
                 config,
-                DestinationStream(
-                    DestinationStream.Descriptor(randomizedNamespace, "test_stream"),
-                    Append,
-                    ObjectTypeWithoutSchema,
-                    generationId = 0,
-                    minimumGenerationId = 0,
-                    syncId = 42,
-                ),
+                stream,
                 listOf(
                     DestinationRecord(
                         namespace = randomizedNamespace,
@@ -98,6 +100,7 @@ abstract class BasicFunctionalityIntegrationTest(
             {
                 if (verifyDataWriting) {
                     dumpAndDiffRecords(
+                        config,
                         listOf(
                             OutputRecord(
                                 extractedAt = 1234,
@@ -121,8 +124,7 @@ abstract class BasicFunctionalityIntegrationTest(
                                     )
                             )
                         ),
-                        "test_stream",
-                        randomizedNamespace,
+                        stream,
                         primaryKey = listOf(listOf("id")),
                         cursor = null,
                     )

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/command/object_storage/ObjectStorageFormatSpecification.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/command/object_storage/ObjectStorageFormatSpecification.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.load.command.object_storage
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.annotation.JsonPropertyDescription
+import com.fasterxml.jackson.annotation.JsonSubTypes
+import com.fasterxml.jackson.annotation.JsonTypeInfo
+import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaTitle
+
+interface ObjectStorageFormatSpecificationProvider {
+    @get:JsonSchemaTitle("Output Format")
+    @get:JsonPropertyDescription(
+        "Format of the data output. See <a href=\"https://docs.airbyte.com/integrations/destinations/s3/#supported-output-schema\">here</a> for more details",
+    )
+    val format: ObjectStorageFormatSpecification
+
+    fun toObjectStorageFormatConfiguration(): ObjectStorageFormatConfiguration {
+        return when (format) {
+            is JsonFormatSpecification -> JsonFormatConfiguration()
+            is CSVFormatSpecification -> CSVFormatConfiguration()
+            is AvroFormatSpecification -> AvroFormatConfiguration()
+            is ParquetFormatSpecification -> ParquetFormatConfiguration()
+        }
+    }
+}
+
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NAME,
+    include = JsonTypeInfo.As.EXISTING_PROPERTY,
+    property = "format_type"
+)
+@JsonSubTypes(
+    JsonSubTypes.Type(value = JsonFormatSpecification::class, name = "JSONL"),
+    JsonSubTypes.Type(value = CSVFormatSpecification::class, name = "CSV"),
+    JsonSubTypes.Type(value = AvroFormatSpecification::class, name = "AVRO"),
+    JsonSubTypes.Type(value = ParquetFormatSpecification::class, name = "PARQUET")
+)
+sealed class ObjectStorageFormatSpecification {
+    @JsonSchemaTitle("Format Type") @JsonProperty("format_type") val formatType: String = "JSONL"
+}
+
+@JsonSchemaTitle("JSON Lines: Newline-delimited JSON")
+class JsonFormatSpecification : ObjectStorageFormatSpecification()
+
+@JsonSchemaTitle("CSV: Comma-Separated Values")
+class CSVFormatSpecification : ObjectStorageFormatSpecification()
+
+@JsonSchemaTitle("Avro: Apache Avro")
+class AvroFormatSpecification : ObjectStorageFormatSpecification()
+
+@JsonSchemaTitle("Parquet: Columnar Storage")
+class ParquetFormatSpecification : ObjectStorageFormatSpecification()
+
+interface OutputFormatConfigurationProvider {
+    val outputFormat: ObjectStorageFormatConfiguration
+}
+
+sealed interface ObjectStorageFormatConfiguration {
+    val extension: String
+}
+
+data class JsonFormatConfiguration(override val extension: String = "jsonl") :
+    ObjectStorageFormatConfiguration
+
+data class CSVFormatConfiguration(override val extension: String = "csv") :
+    ObjectStorageFormatConfiguration
+
+data class AvroFormatConfiguration(override val extension: String = "avro") :
+    ObjectStorageFormatConfiguration
+
+data class ParquetFormatConfiguration(override val extension: String = "parquet") :
+    ObjectStorageFormatConfiguration
+
+interface ObjectStorageFormatConfigurationProvider {
+    val objectStorageFormatConfiguration: ObjectStorageFormatConfiguration
+}

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/command/object_storage/ObjectStorageUploadConfiguration.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/command/object_storage/ObjectStorageUploadConfiguration.kt
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.load.command.object_storage
+
+data class ObjectStorageUploadConfiguration(val streamingUploadPartSize: Long)
+
+interface ObjectStorageUploadConfigurationProvider {
+    val objectStorageUploadConfiguration: ObjectStorageUploadConfiguration
+}

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/file/object_storage/ObjectStorageClient.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/file/object_storage/ObjectStorageClient.kt
@@ -4,11 +4,19 @@
 
 package io.airbyte.cdk.load.file.object_storage
 
-import io.airbyte.cdk.load.message.RemoteObject
+import java.io.InputStream
 import kotlinx.coroutines.flow.Flow
 
-interface ObjectStorageClient<T : RemoteObject> {
+interface ObjectStorageClient<T : RemoteObject<*>, U : ObjectStorageStreamingUploadWriter> {
     suspend fun list(prefix: String): Flow<T>
-    suspend fun put(key: String, bytes: ByteArray)
-    suspend fun delete(key: String)
+    suspend fun move(remoteObject: T, toKey: String): T
+    suspend fun <U> get(key: String, block: (InputStream) -> U): U
+    suspend fun put(key: String, bytes: ByteArray): T
+    suspend fun delete(remoteObject: T)
+    suspend fun streamingUpload(key: String, collector: suspend U.() -> Unit): T
+}
+
+interface ObjectStorageStreamingUploadWriter {
+    suspend fun write(bytes: ByteArray)
+    suspend fun write(string: String) = write(string.toByteArray(Charsets.UTF_8))
 }

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/file/object_storage/ObjectStoragePathFactory.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/file/object_storage/ObjectStoragePathFactory.kt
@@ -5,6 +5,7 @@
 package io.airbyte.cdk.load.file.object_storage
 
 import io.airbyte.cdk.load.command.DestinationStream
+import io.airbyte.cdk.load.command.object_storage.ObjectStorageFormatConfigurationProvider
 import io.airbyte.cdk.load.command.object_storage.ObjectStoragePathConfigurationProvider
 import io.airbyte.cdk.load.file.TimeProvider
 import io.micronaut.context.annotation.Secondary
@@ -14,51 +15,137 @@ import java.nio.file.Paths
 import java.time.Instant
 import java.time.ZoneId
 import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
 import java.util.*
 
 @Singleton
 @Secondary
 class ObjectStoragePathFactory(
     pathConfigProvider: ObjectStoragePathConfigurationProvider,
-    timeProvider: TimeProvider
+    formatConfigProvider: ObjectStorageFormatConfigurationProvider? = null,
+    timeProvider: TimeProvider? = null,
 ) {
-    private val loadedAt = Instant.ofEpochMilli(timeProvider.currentTimeMillis())
+    private val loadedAt = timeProvider?.let { Instant.ofEpochMilli(it.currentTimeMillis()) }
     private val pathConfig = pathConfigProvider.objectStoragePathConfiguration
+    private val defaultExtension = formatConfigProvider?.objectStorageFormatConfiguration?.extension
 
     inner class VariableContext(
         val stream: DestinationStream,
-        val time: Instant = loadedAt,
+        val time: Instant? = loadedAt,
+        val extension: String? = null,
+        val partNumber: Long? = null
     )
 
-    data class PathVariable(val variable: String, val provider: (VariableContext) -> String) {
-        fun toMacro(): String = "\${$variable}"
+    interface Variable {
+        val provider: (VariableContext) -> String
+        fun toMacro(): String
+        fun maybeApply(source: String, context: VariableContext): String {
+            val macro = toMacro()
+            if (source.contains(macro)) {
+                return source.replace(macro, provider(context))
+            }
+            return source
+        }
+    }
+
+    data class PathVariable(
+        val variable: String,
+        override val provider: (VariableContext) -> String
+    ) : Variable {
+        override fun toMacro(): String = "\${$variable}"
+    }
+
+    data class FileVariable(
+        val variable: String,
+        override val provider: (VariableContext) -> String
+    ) : Variable {
+        override fun toMacro(): String = "{$variable}"
     }
 
     companion object {
+        private val DATE_FORMATTER: DateTimeFormatter =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd").withZone(ZoneId.systemDefault())
+        private val TIMESTAMP_FORMATTER: DateTimeFormatter =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSX").withZone(ZoneId.of("UTC"))
+
         const val DEFAULT_STAGING_PREFIX_SUFFIX = "__airbyte_tmp"
         const val DEFAULT_PATH_FORMAT =
             "\${NAMESPACE}/\${STREAM_NAME}/\${YEAR}_\${MONTH}_\${DAY}_\${EPOCH}_"
+        const val DEFAULT_FILE_FORMAT = "{part_number}{format_extension}"
         val PATH_VARIABLES =
         // TODO: Vet that these match the past format exactly (eg day = 5 versus 05, etc)
         listOf(
                 PathVariable("NAMESPACE") { it.stream.descriptor.namespace ?: "" },
                 PathVariable("STREAM_NAME") { it.stream.descriptor.name },
                 PathVariable("YEAR") {
-                    ZonedDateTime.ofInstant(it.time, ZoneId.of("UTC")).year.toString()
+                    it.time?.let { t ->
+                        ZonedDateTime.ofInstant(t, ZoneId.of("UTC")).year.toString()
+                    }
+                        ?: throw IllegalArgumentException("time is required when {YEAR} is present")
                 },
                 PathVariable("MONTH") {
-                    ZonedDateTime.ofInstant(it.time, ZoneId.of("UTC")).monthValue.toString()
+                    it.time?.let { t ->
+                        ZonedDateTime.ofInstant(t, ZoneId.of("UTC")).monthValue.toString()
+                    }
+                        ?: throw IllegalArgumentException(
+                            "time is required when {MONTH} is present"
+                        )
                 },
                 PathVariable("DAY") {
-                    ZonedDateTime.ofInstant(it.time, ZoneId.of("UTC")).dayOfMonth.toString()
+                    it.time?.let { t ->
+                        ZonedDateTime.ofInstant(t, ZoneId.of("UTC")).dayOfMonth.toString()
+                    }
+                        ?: throw IllegalArgumentException("time is required when {DAY} is present")
                 },
-                PathVariable("HOUR") { (it.time.toEpochMilli() / 1000 / 60 / 60).toString() },
-                PathVariable("MINUTE") { (it.time.toEpochMilli() / 1000 / 60).toString() },
-                PathVariable("SECOND") { (it.time.toEpochMilli() / 1000).toString() },
-                PathVariable("MILLISECOND") { it.time.toEpochMilli().toString() },
-                PathVariable("EPOCH") { it.time.toEpochMilli().toString() },
+                PathVariable("HOUR") {
+                    it.time?.toEpochMilli()?.let { t -> t / 1000 / 60 / 60 }?.toString()
+                        ?: throw IllegalArgumentException("time is required when {HOUR} is present")
+                },
+                PathVariable("MINUTE") {
+                    (it.time?.toEpochMilli()?.let { t -> t / 1000 / 60 }?.toString()
+                        ?: throw IllegalArgumentException(
+                            "time is required when {MINUTE} is present"
+                        ))
+                },
+                PathVariable("SECOND") {
+                    (it.time?.toEpochMilli()?.div(1000)?.toString()
+                        ?: throw IllegalArgumentException(
+                            "time is required when {SECOND} is present"
+                        ))
+                },
+                PathVariable("MILLISECOND") {
+                    it.time?.toEpochMilli()?.toString()
+                        ?: throw IllegalArgumentException(
+                            "time is required when {MILLISECOND} is present"
+                        )
+                },
+                PathVariable("EPOCH") {
+                    it.time?.toEpochMilli()?.toString()
+                        ?: throw IllegalArgumentException(
+                            "time is required when {EPOCH} is present"
+                        )
+                },
                 PathVariable("UUID") { UUID.randomUUID().toString() }
             )
+        val FILENAME_VARIABLES =
+            listOf(
+                FileVariable("date") { DATE_FORMATTER.format(it.time) },
+                FileVariable("timestamp") { TIMESTAMP_FORMATTER.format(it.time) },
+                FileVariable("part_number") {
+                    it.partNumber?.toString()
+                        ?: throw IllegalArgumentException(
+                            "part_number is required when {part_number} is present"
+                        )
+                },
+                FileVariable("sync_id") { it.stream.syncId.toString() },
+                FileVariable("format_extension") { it.extension?.let { ext -> ".$ext" } ?: "" }
+            )
+
+        fun <T> from(config: T, timeProvider: TimeProvider? = null): ObjectStoragePathFactory where
+        T : ObjectStoragePathConfigurationProvider,
+        T : ObjectStorageFormatConfigurationProvider {
+            return ObjectStoragePathFactory(config, config, timeProvider)
+        }
     }
 
     fun getStagingDirectory(stream: DestinationStream): Path {
@@ -74,10 +161,33 @@ class ObjectStoragePathFactory(
         return Paths.get(pathConfig.prefix, path)
     }
 
+    fun getPathToFile(
+        stream: DestinationStream,
+        partNumber: Long?,
+        isStaging: Boolean = false,
+        extension: String? = defaultExtension
+    ): Path {
+        val path =
+            if (isStaging) {
+                getStagingDirectory(stream)
+            } else {
+                getFinalDirectory(stream)
+            }
+        val context = VariableContext(stream, extension = extension, partNumber = partNumber)
+        val fileName = getFormattedFileName(context)
+        return path.resolve(fileName)
+    }
+
     private fun getFormattedPath(stream: DestinationStream): String {
         val pattern = pathConfig.pathSuffixPattern ?: DEFAULT_PATH_FORMAT
-        return PATH_VARIABLES.fold(pattern) { acc, variable ->
-            acc.replace(variable.toMacro(), variable.provider(VariableContext(stream)))
+        val context = VariableContext(stream)
+        return PATH_VARIABLES.fold(pattern) { acc, variable -> variable.maybeApply(acc, context) }
+    }
+
+    private fun getFormattedFileName(context: VariableContext): String {
+        val pattern = pathConfig.fileNamePattern ?: DEFAULT_FILE_FORMAT
+        return FILENAME_VARIABLES.fold(pattern) { acc, variable ->
+            variable.maybeApply(acc, context)
         }
     }
 }

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/file/object_storage/RemoteObject.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/file/object_storage/RemoteObject.kt
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.load.file.object_storage
+
+interface RemoteObject<C> {
+    val key: String
+    val storageConfig: C
+}

--- a/airbyte-cdk/bulk/toolkits/load-s3/src/main/kotlin/io/airbyte/cdk/load/file/s3/S3Client.kt
+++ b/airbyte-cdk/bulk/toolkits/load-s3/src/main/kotlin/io/airbyte/cdk/load/file/s3/S3Client.kt
@@ -5,29 +5,50 @@
 package io.airbyte.cdk.load.file.s3
 
 import aws.sdk.kotlin.runtime.auth.credentials.StaticCredentialsProvider
+import aws.sdk.kotlin.services.s3.model.CompleteMultipartUploadRequest
+import aws.sdk.kotlin.services.s3.model.CompletedMultipartUpload
+import aws.sdk.kotlin.services.s3.model.CompletedPart
+import aws.sdk.kotlin.services.s3.model.CopyObjectRequest
+import aws.sdk.kotlin.services.s3.model.CreateMultipartUploadRequest
+import aws.sdk.kotlin.services.s3.model.CreateMultipartUploadResponse
+import aws.sdk.kotlin.services.s3.model.DeleteObjectRequest
+import aws.sdk.kotlin.services.s3.model.GetObjectRequest
 import aws.sdk.kotlin.services.s3.model.ListObjectsRequest
 import aws.sdk.kotlin.services.s3.model.PutObjectRequest
+import aws.sdk.kotlin.services.s3.model.UploadPartRequest
 import aws.smithy.kotlin.runtime.content.ByteStream
+import aws.smithy.kotlin.runtime.content.toInputStream
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 import io.airbyte.cdk.load.command.aws.AWSAccessKeyConfigurationProvider
+import io.airbyte.cdk.load.command.object_storage.ObjectStorageUploadConfiguration
+import io.airbyte.cdk.load.command.object_storage.ObjectStorageUploadConfigurationProvider
 import io.airbyte.cdk.load.command.s3.S3BucketConfiguration
 import io.airbyte.cdk.load.command.s3.S3BucketConfigurationProvider
 import io.airbyte.cdk.load.file.object_storage.ObjectStorageClient
-import io.airbyte.cdk.load.message.RemoteObject
+import io.airbyte.cdk.load.file.object_storage.ObjectStorageStreamingUploadWriter
+import io.airbyte.cdk.load.file.object_storage.RemoteObject
+import io.github.oshai.kotlinlogging.KotlinLogging
 import io.micronaut.context.annotation.Factory
 import io.micronaut.context.annotation.Secondary
 import jakarta.inject.Singleton
+import java.io.ByteArrayOutputStream
+import java.io.InputStream
 import kotlinx.coroutines.flow.flow
 
-data class S3Object(
-    override val key: String,
-) : RemoteObject()
+data class S3Object(override val key: String, override val storageConfig: S3BucketConfiguration) :
+    RemoteObject<S3BucketConfiguration> {
+    val keyWithBucketName
+        get() = "${storageConfig.s3BucketName}/$key"
+}
 
 @SuppressFBWarnings("NP_NONNULL_PARAM_VIOLATION", justification = "Kotlin async continuation")
 class S3Client(
     private val client: aws.sdk.kotlin.services.s3.S3Client,
-    private val bucketConfig: S3BucketConfiguration
-) : ObjectStorageClient<S3Object> {
+    val bucketConfig: S3BucketConfiguration,
+    private val uploadConfig: ObjectStorageUploadConfiguration?,
+) : ObjectStorageClient<S3Object, S3Client.S3MultipartUpload.Writer> {
+    private val log = KotlinLogging.logger {}
+
     override suspend fun list(prefix: String) = flow {
         var request = ListObjectsRequest {
             bucket = bucketConfig.s3BucketName
@@ -38,7 +59,7 @@ class S3Client(
             val response = client.listObjects(request)
             response.contents?.forEach { obj ->
                 lastKey = obj.key
-                emit(S3Object(obj.key!!))
+                emit(S3Object(obj.key!!, bucketConfig))
             } // null contents => empty list, not error
             if (client.listObjects(request).isTruncated == false) {
                 break
@@ -47,30 +68,137 @@ class S3Client(
         }
     }
 
-    override suspend fun put(key: String, bytes: ByteArray) {
+    override suspend fun move(remoteObject: S3Object, toKey: String): S3Object {
+        val request = CopyObjectRequest {
+            bucket = bucketConfig.s3BucketName
+            this.key = toKey
+            copySource = remoteObject.keyWithBucketName
+        }
+        client.copyObject(request)
+        delete(remoteObject)
+        return S3Object(toKey, bucketConfig)
+    }
+
+    override suspend fun <R> get(key: String, block: (InputStream) -> R): R {
+        val request = GetObjectRequest {
+            bucket = bucketConfig.s3BucketName
+            this.key = key
+        }
+        return client.getObject(request) {
+            val inputStream =
+                it.body?.toInputStream()
+                    ?: throw IllegalStateException(
+                        "S3 object body is null (this indicates a failure, not an empty object)"
+                    )
+            block(inputStream)
+        }
+    }
+
+    override suspend fun put(key: String, bytes: ByteArray): S3Object {
         val request = PutObjectRequest {
             bucket = bucketConfig.s3BucketName
             this.key = key
             body = ByteStream.fromBytes(bytes)
         }
         client.putObject(request)
+        return S3Object(key, bucketConfig)
     }
 
-    override suspend fun delete(key: String) {
-        val request =
-            aws.sdk.kotlin.services.s3.model.DeleteObjectRequest {
-                bucket = bucketConfig.s3BucketName
-                this.key = key
-            }
+    override suspend fun delete(remoteObject: S3Object) {
+        val request = DeleteObjectRequest {
+            bucket = remoteObject.storageConfig.s3BucketName
+            this.key = remoteObject.key
+        }
         client.deleteObject(request)
+    }
+
+    override suspend fun streamingUpload(
+        key: String,
+        collector: suspend S3MultipartUpload.Writer.() -> Unit
+    ): S3Object {
+        val request = CreateMultipartUploadRequest {
+            this.bucket = bucketConfig.s3BucketName
+            this.key = key
+        }
+        val response = client.createMultipartUpload(request)
+        S3MultipartUpload(response).upload(collector)
+        return S3Object(key, bucketConfig)
+    }
+
+    inner class S3MultipartUpload(private val response: CreateMultipartUploadResponse) {
+        private val uploadedParts = mutableListOf<CompletedPart>()
+        private var inputBuffer = ByteArrayOutputStream()
+        private val partSize =
+            uploadConfig?.streamingUploadPartSize
+                ?: throw IllegalStateException("Streaming upload part size is not configured")
+
+        suspend fun upload(collector: suspend S3MultipartUpload.Writer.() -> Unit) {
+            log.info {
+                "Starting multipart upload to ${response.bucket}/${response.key} (${response.uploadId}"
+            }
+            collector.invoke(Writer())
+            complete()
+        }
+
+        inner class Writer : ObjectStorageStreamingUploadWriter {
+            override suspend fun write(bytes: ByteArray) {
+                inputBuffer.write(bytes)
+                if (inputBuffer.size() >= partSize) {
+                    uploadPart()
+                }
+            }
+        }
+
+        private suspend fun uploadPart() {
+            val partNumber = uploadedParts.size + 1
+            val request = UploadPartRequest {
+                uploadId = response.uploadId
+                bucket = response.bucket
+                key = response.key
+                body = ByteStream.fromBytes(inputBuffer.toByteArray())
+                this.partNumber = partNumber
+            }
+            val uploadResponse = client.uploadPart(request)
+            uploadedParts.add(
+                CompletedPart {
+                    this.partNumber = partNumber
+                    this.eTag = uploadResponse.eTag
+                }
+            )
+            inputBuffer.reset()
+        }
+
+        private suspend fun complete() {
+            if (inputBuffer.size() > 0) {
+                uploadPart()
+            }
+            log.info {
+                "Completing multipart upload to ${response.bucket}/${response.key} (${response.uploadId}"
+            }
+            val request = CompleteMultipartUploadRequest {
+                uploadId = response.uploadId
+                bucket = response.bucket
+                key = response.key
+                this.multipartUpload = CompletedMultipartUpload { parts = uploadedParts }
+            }
+            client.completeMultipartUpload(request)
+        }
     }
 }
 
 @Factory
 class S3ClientFactory(
     private val keyConfig: AWSAccessKeyConfigurationProvider,
-    private val bucketConfig: S3BucketConfigurationProvider
+    private val bucketConfig: S3BucketConfigurationProvider,
+    private val uploadConifg: ObjectStorageUploadConfigurationProvider? = null,
 ) {
+    companion object {
+        fun <T> make(config: T) where
+        T : S3BucketConfigurationProvider,
+        T : AWSAccessKeyConfigurationProvider,
+        T : ObjectStorageUploadConfigurationProvider =
+            S3ClientFactory(config, config, config).make()
+    }
 
     @Singleton
     @Secondary
@@ -86,6 +214,10 @@ class S3ClientFactory(
                 credentialsProvider = credentials
             }
 
-        return S3Client(client, bucketConfig.s3BucketConfiguration)
+        return S3Client(
+            client,
+            bucketConfig.s3BucketConfiguration,
+            uploadConifg?.objectStorageUploadConfiguration
+        )
     }
 }

--- a/airbyte-integrations/connectors/destination-dev-null/src/test-integration/kotlin/io/airbyte/integrations/destination/dev_null/DevNullDestinationDataDumper.kt
+++ b/airbyte-integrations/connectors/destination-dev-null/src/test-integration/kotlin/io/airbyte/integrations/destination/dev_null/DevNullDestinationDataDumper.kt
@@ -4,11 +4,16 @@
 
 package io.airbyte.integrations.destination.dev_null
 
+import io.airbyte.cdk.command.ConfigurationSpecification
+import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.test.util.DestinationDataDumper
 import io.airbyte.cdk.load.test.util.OutputRecord
 
 object DevNullDestinationDataDumper : DestinationDataDumper {
-    override fun dumpRecords(streamName: String, streamNamespace: String?): List<OutputRecord> {
+    override fun dumpRecords(
+        spec: ConfigurationSpecification,
+        stream: DestinationStream
+    ): List<OutputRecord> {
         // E2e destination doesn't actually write records, so we shouldn't even
         // have tests that try to read back the records
         throw NotImplementedError()

--- a/airbyte-integrations/connectors/destination-s3-v2/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-s3-v2/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: file
   connectorType: destination
   definitionId: d6116991-e809-4c7c-ae09-c64712df5b66
-  dockerImageTag: 0.1.3
+  dockerImageTag: 0.1.4
   dockerRepository: airbyte/destination-s3-v2
   githubIssueLabel: destination-s3-v2
   icon: s3.svg

--- a/airbyte-integrations/connectors/destination-s3-v2/src/main/kotlin/S3V2Checker.kt
+++ b/airbyte-integrations/connectors/destination-s3-v2/src/main/kotlin/S3V2Checker.kt
@@ -5,35 +5,43 @@
 package io.airbyte.integrations.destination.s3_v2
 
 import io.airbyte.cdk.load.check.DestinationChecker
+import io.airbyte.cdk.load.command.object_storage.JsonFormatConfiguration
+import io.airbyte.cdk.load.file.TimeProvider
 import io.airbyte.cdk.load.file.object_storage.ObjectStoragePathFactory
-import io.airbyte.cdk.load.file.s3.S3Client
+import io.airbyte.cdk.load.file.s3.S3ClientFactory
+import io.airbyte.cdk.load.file.s3.S3Object
 import io.github.oshai.kotlinlogging.KotlinLogging
+import io.micronaut.context.exceptions.ConfigurationException
 import jakarta.inject.Singleton
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
 
 @Singleton
-class S3V2Checker(
-    private val s3Client: S3Client,
-    private val pathFactory: ObjectStoragePathFactory
-) : DestinationChecker<S3V2Configuration> {
+class S3V2Checker(private val timeProvider: TimeProvider) : DestinationChecker<S3V2Configuration> {
     private val log = KotlinLogging.logger {}
 
     override fun check(config: S3V2Configuration) {
         runBlocking {
+            if (config.objectStorageFormatConfiguration !is JsonFormatConfiguration) {
+                throw ConfigurationException("Currently only JSON format is supported")
+            }
+            val s3Client = S3ClientFactory.make(config)
+            val pathFactory = ObjectStoragePathFactory.from(config, timeProvider)
             val path = pathFactory.getStagingDirectory(mockStream())
             val key = path.resolve("_EMPTY").toString()
             log.info { "Checking if destination can write to $path" }
+            var s3Object: S3Object? = null
             try {
-                s3Client.put(key, byteArrayOf())
+                s3Object = s3Client.put(key, byteArrayOf())
                 val results = s3Client.list(path.toString()).toList()
                 if (results.isEmpty() || results.find { it.key == key } == null) {
                     throw IllegalStateException("Failed to write to S3 bucket")
                 }
-                log.info { "Successfully wrote: $results" }
+                log.info { "Successfully wrote test file: $results" }
             } finally {
-                s3Client.delete(key)
-                s3Client.list(path.toString()).toList()
+                s3Object?.also { s3Client.delete(it) }
+                val results = s3Client.list(path.toString()).toList()
+                log.info { "Successfully removed test tile: $results" }
             }
         }
     }

--- a/airbyte-integrations/connectors/destination-s3-v2/src/main/kotlin/S3V2Configuration.kt
+++ b/airbyte-integrations/connectors/destination-s3-v2/src/main/kotlin/S3V2Configuration.kt
@@ -8,22 +8,35 @@ import io.airbyte.cdk.load.command.DestinationConfiguration
 import io.airbyte.cdk.load.command.DestinationConfigurationFactory
 import io.airbyte.cdk.load.command.aws.AWSAccessKeyConfiguration
 import io.airbyte.cdk.load.command.aws.AWSAccessKeyConfigurationProvider
+import io.airbyte.cdk.load.command.object_storage.ObjectStorageFormatConfiguration
+import io.airbyte.cdk.load.command.object_storage.ObjectStorageFormatConfigurationProvider
 import io.airbyte.cdk.load.command.object_storage.ObjectStoragePathConfiguration
 import io.airbyte.cdk.load.command.object_storage.ObjectStoragePathConfigurationProvider
+import io.airbyte.cdk.load.command.object_storage.ObjectStorageUploadConfiguration
+import io.airbyte.cdk.load.command.object_storage.ObjectStorageUploadConfigurationProvider
 import io.airbyte.cdk.load.command.s3.S3BucketConfiguration
 import io.airbyte.cdk.load.command.s3.S3BucketConfigurationProvider
 import io.micronaut.context.annotation.Factory
 import jakarta.inject.Singleton
 
 data class S3V2Configuration(
+    // Client-facing configuration
     override val awsAccessKeyConfiguration: AWSAccessKeyConfiguration,
     override val s3BucketConfiguration: S3BucketConfiguration,
-    override val objectStoragePathConfiguration: ObjectStoragePathConfiguration
+    override val objectStoragePathConfiguration: ObjectStoragePathConfiguration,
+    override val objectStorageFormatConfiguration: ObjectStorageFormatConfiguration,
+
+    // Internal configuration
+    override val objectStorageUploadConfiguration: ObjectStorageUploadConfiguration =
+        ObjectStorageUploadConfiguration(5L * 1024 * 1024),
+    override val recordBatchSizeBytes: Long = 200L * 1024 * 1024
 ) :
     DestinationConfiguration(),
     AWSAccessKeyConfigurationProvider,
     S3BucketConfigurationProvider,
-    ObjectStoragePathConfigurationProvider
+    ObjectStoragePathConfigurationProvider,
+    ObjectStorageFormatConfigurationProvider,
+    ObjectStorageUploadConfigurationProvider
 
 @Singleton
 class S3V2ConfigurationFactory :
@@ -32,7 +45,8 @@ class S3V2ConfigurationFactory :
         return S3V2Configuration(
             awsAccessKeyConfiguration = pojo.toAWSAccessKeyConfiguration(),
             s3BucketConfiguration = pojo.toS3BucketConfiguration(),
-            objectStoragePathConfiguration = pojo.toObjectStoragePathConfiguration()
+            objectStoragePathConfiguration = pojo.toObjectStoragePathConfiguration(),
+            objectStorageFormatConfiguration = pojo.toObjectStorageFormatConfiguration()
         )
     }
 }

--- a/airbyte-integrations/connectors/destination-s3-v2/src/main/kotlin/S3V2Specification.kt
+++ b/airbyte-integrations/connectors/destination-s3-v2/src/main/kotlin/S3V2Specification.kt
@@ -7,6 +7,9 @@ package io.airbyte.integrations.destination.s3_v2
 import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaTitle
 import io.airbyte.cdk.command.ConfigurationSpecification
 import io.airbyte.cdk.load.command.aws.AWSAccessKeySpecification
+import io.airbyte.cdk.load.command.object_storage.JsonFormatSpecification
+import io.airbyte.cdk.load.command.object_storage.ObjectStorageFormatSpecification
+import io.airbyte.cdk.load.command.object_storage.ObjectStorageFormatSpecificationProvider
 import io.airbyte.cdk.load.command.s3.S3BucketRegion
 import io.airbyte.cdk.load.command.s3.S3BucketSpecification
 import io.airbyte.cdk.load.command.s3.S3PathSpecification
@@ -20,12 +23,14 @@ class S3V2Specification :
     ConfigurationSpecification(),
     AWSAccessKeySpecification,
     S3BucketSpecification,
-    S3PathSpecification {
+    S3PathSpecification,
+    ObjectStorageFormatSpecificationProvider {
     override val accessKeyId: String = ""
     override val secretAccessKey: String = ""
     override val s3BucketName: String = ""
     override val s3BucketPath: String = ""
     override val s3BucketRegion: S3BucketRegion = S3BucketRegion.`us-west-1`
+    override val format: ObjectStorageFormatSpecification = JsonFormatSpecification()
     override val s3Endpoint: String? = null
     override val s3PathFormat: String? = null
     override val fileNamePattern: String? = null

--- a/airbyte-integrations/connectors/destination-s3-v2/src/main/kotlin/S3V2Writer.kt
+++ b/airbyte-integrations/connectors/destination-s3-v2/src/main/kotlin/S3V2Writer.kt
@@ -4,24 +4,72 @@
 
 package io.airbyte.integrations.destination.s3_v2
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 import io.airbyte.cdk.load.command.DestinationStream
+import io.airbyte.cdk.load.data.DestinationRecordToAirbyteValueWithMeta
+import io.airbyte.cdk.load.data.toJson
+import io.airbyte.cdk.load.file.object_storage.ObjectStoragePathFactory
+import io.airbyte.cdk.load.file.s3.S3Client
+import io.airbyte.cdk.load.file.s3.S3Object
 import io.airbyte.cdk.load.message.Batch
 import io.airbyte.cdk.load.message.DestinationRecord
-import io.airbyte.cdk.load.message.SimpleBatch
+import io.airbyte.cdk.load.util.serializeToString
 import io.airbyte.cdk.load.write.DestinationWriter
 import io.airbyte.cdk.load.write.StreamLoader
 import jakarta.inject.Singleton
+import java.util.concurrent.atomic.AtomicLong
 
 @Singleton
-class S3V2Writer : DestinationWriter {
+class S3V2Writer(
+    private val s3Client: S3Client,
+    private val pathFactory: ObjectStoragePathFactory,
+    private val recordDecorator: DestinationRecordToAirbyteValueWithMeta
+) : DestinationWriter {
+    sealed interface S3V2Batch : Batch
+    data class StagedObject(
+        override val state: Batch.State = Batch.State.PERSISTED,
+        val s3Object: S3Object,
+        val partNumber: Long
+    ) : S3V2Batch
+    data class FinalizedObject(
+        override val state: Batch.State = Batch.State.COMPLETE,
+        val s3Object: S3Object,
+    ) : S3V2Batch
+
     override fun createStreamLoader(stream: DestinationStream): StreamLoader {
         return S3V2StreamLoader(stream)
     }
 
+    @SuppressFBWarnings("NP_NONNULL_PARAM_VIOLATION", justification = "Kotlin async continuation")
     inner class S3V2StreamLoader(override val stream: DestinationStream) : StreamLoader {
+        private val partNumber = AtomicLong(0L) // TODO: Get from destination state
+
         override suspend fun processRecords(
             records: Iterator<DestinationRecord>,
             totalSizeBytes: Long
-        ): Batch = SimpleBatch(state = Batch.State.COMPLETE)
+        ): Batch {
+            val partNumber = partNumber.getAndIncrement()
+            val key = pathFactory.getPathToFile(stream, partNumber, isStaging = true).toString()
+            val s3Object =
+                s3Client.streamingUpload(key) {
+                    records.forEach {
+                        val serialized = recordDecorator.decorate(it).toJson().serializeToString()
+                        write(serialized)
+                        write("\n")
+                    }
+                }
+            return StagedObject(s3Object = s3Object, partNumber = partNumber)
+        }
+
+        override suspend fun processBatch(batch: Batch): Batch {
+            val stagedObject = batch as StagedObject
+            val finalKey =
+                pathFactory
+                    .getPathToFile(stream, stagedObject.partNumber, isStaging = false)
+                    .toString()
+            val newObject = s3Client.move(stagedObject.s3Object, finalKey)
+            val finalizedObject = FinalizedObject(s3Object = newObject)
+            return finalizedObject
+        }
     }
 }

--- a/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2CheckTest.kt
+++ b/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2CheckTest.kt
@@ -13,12 +13,7 @@ class S3V2CheckTest :
     CheckIntegrationTest<S3V2Specification>(
         S3V2Specification::class.java,
         successConfigFilenames =
-            listOf(
-                CheckTestConfig(
-                    "secrets/s3_dest_v2_minimal_required_config.json",
-                    TestDeploymentMode.CLOUD
-                )
-            ),
+            listOf(CheckTestConfig(S3V2TestUtils.MINIMAL_CONFIG_PATH, TestDeploymentMode.CLOUD)),
         failConfigFilenamesAndFailureReasons = emptyMap()
     ) {
     @Test

--- a/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2TestUtils.kt
+++ b/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2TestUtils.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination.s3_v2
+
+import io.airbyte.cdk.command.ValidatedJsonUtils
+import java.nio.file.Files
+import java.nio.file.Path
+
+object S3V2TestUtils {
+    const val MINIMAL_CONFIG_PATH = "secrets/s3_dest_v2_minimal_required_config.json"
+    val minimalConfig: S3V2Specification =
+        ValidatedJsonUtils.parseOne(
+            S3V2Specification::class.java,
+            Files.readString(Path.of(MINIMAL_CONFIG_PATH)),
+        )
+}

--- a/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2WriteTest.kt
+++ b/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2WriteTest.kt
@@ -4,20 +4,33 @@
 
 package io.airbyte.integrations.destination.s3_v2
 
+import io.airbyte.cdk.command.ConfigurationSpecification
+import io.airbyte.cdk.load.command.DestinationStream
+import io.airbyte.cdk.load.data.toAirbyteValue
+import io.airbyte.cdk.load.file.object_storage.ObjectStoragePathFactory
+import io.airbyte.cdk.load.file.s3.S3ClientFactory
+import io.airbyte.cdk.load.file.s3.S3Object
 import io.airbyte.cdk.load.test.util.DestinationDataDumper
 import io.airbyte.cdk.load.test.util.NoopDestinationCleaner
 import io.airbyte.cdk.load.test.util.NoopExpectedRecordMapper
 import io.airbyte.cdk.load.test.util.OutputRecord
+import io.airbyte.cdk.load.test.util.toOutputRecord
+import io.airbyte.cdk.load.util.deserializeToNode
 import io.airbyte.cdk.load.write.BasicFunctionalityIntegrationTest
+import java.io.InputStream
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
 import org.junit.jupiter.api.Test
 
 class S3V2WriteTest :
     BasicFunctionalityIntegrationTest(
-        S3V2Specification(),
+        S3V2TestUtils.minimalConfig,
         S3V2DataDumper,
         NoopDestinationCleaner,
         NoopExpectedRecordMapper,
-        verifyDataWriting = false
     ) {
     @Test
     override fun testBasicWrite() {
@@ -26,9 +39,39 @@ class S3V2WriteTest :
 }
 
 object S3V2DataDumper : DestinationDataDumper {
-    override fun dumpRecords(streamName: String, streamNamespace: String?): List<OutputRecord> {
-        // E2e destination doesn't actually write records, so we shouldn't even
-        // have tests that try to read back the records
-        throw NotImplementedError()
+    override fun dumpRecords(
+        spec: ConfigurationSpecification,
+        stream: DestinationStream
+    ): List<OutputRecord> {
+        val config =
+            S3V2ConfigurationFactory().makeWithoutExceptionHandling(spec as S3V2Specification)
+        val s3Client = S3ClientFactory.make(config)
+        // Note: because we cannot mock wall time in docker, this
+        // path code cannot contain time-based macros.
+        // TODO: add pattern matching to the path factory.
+        val pathFactory = ObjectStoragePathFactory.from(config)
+        val prefix = pathFactory.getFinalDirectory(stream).toString()
+        return runBlocking {
+            withContext(Dispatchers.IO) {
+                s3Client
+                    .list(prefix)
+                    .map { listedObject: S3Object ->
+                        s3Client.get(listedObject.key) { objectData: InputStream ->
+                            objectData
+                                .bufferedReader()
+                                .lineSequence()
+                                .map { line ->
+                                    line
+                                        .deserializeToNode()
+                                        .toAirbyteValue(stream.schemaWithMeta)
+                                        .toOutputRecord()
+                                }
+                                .toList()
+                        }
+                    }
+                    .toList()
+                    .flatten()
+            }
+        }
     }
 }

--- a/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/resources/expected-spec-cloud.json
+++ b/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/resources/expected-spec-cloud.json
@@ -6,6 +6,60 @@
     "type" : "object",
     "additionalProperties" : true,
     "properties" : {
+      "format" : {
+        "oneOf" : [ {
+          "title" : "JSON Lines: Newline-delimited JSON",
+          "type" : "object",
+          "additionalProperties" : true,
+          "properties" : {
+            "format_type" : {
+              "type" : "string",
+              "enum" : [ "JSONL" ],
+              "default" : "JSONL"
+            }
+          },
+          "required" : [ "format_type" ]
+        }, {
+          "title" : "CSV: Comma-Separated Values",
+          "type" : "object",
+          "additionalProperties" : true,
+          "properties" : {
+            "format_type" : {
+              "type" : "string",
+              "enum" : [ "CSV" ],
+              "default" : "CSV"
+            }
+          },
+          "required" : [ "format_type" ]
+        }, {
+          "title" : "Avro: Apache Avro",
+          "type" : "object",
+          "additionalProperties" : true,
+          "properties" : {
+            "format_type" : {
+              "type" : "string",
+              "enum" : [ "AVRO" ],
+              "default" : "AVRO"
+            }
+          },
+          "required" : [ "format_type" ]
+        }, {
+          "title" : "Parquet: Columnar Storage",
+          "type" : "object",
+          "additionalProperties" : true,
+          "properties" : {
+            "format_type" : {
+              "type" : "string",
+              "enum" : [ "PARQUET" ],
+              "default" : "PARQUET"
+            }
+          },
+          "required" : [ "format_type" ]
+        } ],
+        "description" : "Format of the data output. See <a href=\"https://docs.airbyte.com/integrations/destinations/s3/#supported-output-schema\">here</a> for more details",
+        "title" : "Output Format",
+        "type" : "object"
+      },
       "access_key_id" : {
         "type" : "string",
         "description" : "The access key ID to access the S3 bucket. Airbyte requires Read and Write permissions to the given bucket. Read more <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys\">here</a>.",
@@ -63,7 +117,7 @@
         "examples" : [ "__staging/data_sync/test" ]
       }
     },
-    "required" : [ "access_key_id", "secret_access_key", "s3_bucket_name", "s3_bucket_path", "s3_bucket_region" ]
+    "required" : [ "format", "access_key_id", "secret_access_key", "s3_bucket_name", "s3_bucket_path", "s3_bucket_region" ]
   },
   "supportsIncremental" : true,
   "supportsNormalization" : false,

--- a/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/resources/expected-spec-oss.json
+++ b/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/resources/expected-spec-oss.json
@@ -6,6 +6,60 @@
     "type" : "object",
     "additionalProperties" : true,
     "properties" : {
+      "format" : {
+        "oneOf" : [ {
+          "title" : "JSON Lines: Newline-delimited JSON",
+          "type" : "object",
+          "additionalProperties" : true,
+          "properties" : {
+            "format_type" : {
+              "type" : "string",
+              "enum" : [ "JSONL" ],
+              "default" : "JSONL"
+            }
+          },
+          "required" : [ "format_type" ]
+        }, {
+          "title" : "CSV: Comma-Separated Values",
+          "type" : "object",
+          "additionalProperties" : true,
+          "properties" : {
+            "format_type" : {
+              "type" : "string",
+              "enum" : [ "CSV" ],
+              "default" : "CSV"
+            }
+          },
+          "required" : [ "format_type" ]
+        }, {
+          "title" : "Avro: Apache Avro",
+          "type" : "object",
+          "additionalProperties" : true,
+          "properties" : {
+            "format_type" : {
+              "type" : "string",
+              "enum" : [ "AVRO" ],
+              "default" : "AVRO"
+            }
+          },
+          "required" : [ "format_type" ]
+        }, {
+          "title" : "Parquet: Columnar Storage",
+          "type" : "object",
+          "additionalProperties" : true,
+          "properties" : {
+            "format_type" : {
+              "type" : "string",
+              "enum" : [ "PARQUET" ],
+              "default" : "PARQUET"
+            }
+          },
+          "required" : [ "format_type" ]
+        } ],
+        "description" : "Format of the data output. See <a href=\"https://docs.airbyte.com/integrations/destinations/s3/#supported-output-schema\">here</a> for more details",
+        "title" : "Output Format",
+        "type" : "object"
+      },
       "access_key_id" : {
         "type" : "string",
         "description" : "The access key ID to access the S3 bucket. Airbyte requires Read and Write permissions to the given bucket. Read more <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys\">here</a>.",
@@ -63,7 +117,7 @@
         "examples" : [ "__staging/data_sync/test" ]
       }
     },
-    "required" : [ "access_key_id", "secret_access_key", "s3_bucket_name", "s3_bucket_path", "s3_bucket_region" ]
+    "required" : [ "format", "access_key_id", "secret_access_key", "s3_bucket_name", "s3_bucket_path", "s3_bucket_region" ]
   },
   "supportsIncremental" : true,
   "supportsNormalization" : false,


### PR DESCRIPTION
## What
This grew a bit because of things I had to add to make tests work.

Core feature
* adds `ObjectStorageFormat` spec/config/provider (no flattening/compression/etc yet, just empty data objects)
* file paths added to the path factory
* add `streamingUpload` to the `S3Client` (uses a receiver interface with a `write` call: see `S3V2Writer` for how it works)
* also added `move` for the "move out of staging step"
* made `RemoteObject` not a batch; I think it makes more sense for the batches to just be whatever the client wants (I'm going to do a cleanup pass and do the same thing for the local files)
* `S3V2Writer` uses both to implement json only
* Support class for converting a destination record + meta to an AirbyteValue
* `S3V2Checker` throws (for now) if anything other than Json is set
* (Also: In the checker, I moved client/path factory initialization into the `execute` body to reduce the chance of throwing an exception during initialization)

For tests
* Added some static companion functions for constructing the s3 client / path factories from configs (checker also uses these)
* Support class for mapping from an airbyte ObjectValue containing meta back to an OutputRecord
* S3Client `get` yielding an input stream for the data dumper
* framework changes to thread the config and stream through to the dumper (path needs them)

Bonus
* Extension functions to make all the conversions more readable!

Punted
* mocking time well enough to use time in the path/filename