### PR TITLE
Bulk Load CDK: Cleanup: Files/Objects no longer Batches

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/Batch.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/Batch.kt
@@ -7,7 +7,6 @@ package io.airbyte.cdk.load.message
 import com.google.common.collect.Range
 import com.google.common.collect.RangeSet
 import com.google.common.collect.TreeRangeSet
-import io.airbyte.cdk.load.file.LocalFile
 
 /**
  * Represents an accumulated batch of records in some stage of processing.
@@ -47,7 +46,6 @@ import io.airbyte.cdk.load.file.LocalFile
  */
 interface Batch {
     enum class State {
-        SPILLED,
         LOCAL,
         PERSISTED,
         COMPLETE
@@ -65,23 +63,6 @@ interface Batch {
 
 /** Simple batch: use if you need no other metadata for processing. */
 data class SimpleBatch(override val state: Batch.State) : Batch
-
-/** Represents a file of records locally staged. */
-abstract class StagedLocalFile() : Batch {
-    abstract val localFile: LocalFile
-    abstract val totalSizeBytes: Long
-    override val state: Batch.State = Batch.State.LOCAL
-}
-
-/**
- * Represents a file of raw records staged to disk for pre-processing. Used internally by the
- * framework
- */
-data class SpilledRawMessagesLocalFile(
-    override val localFile: LocalFile,
-    override val totalSizeBytes: Long,
-    override val state: Batch.State = Batch.State.SPILLED
-) : StagedLocalFile()
 
 /**
  * Internally-used wrapper for tracking the association between a batch and the range of records it

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/SpillToDiskTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/SpillToDiskTask.kt
@@ -7,12 +7,11 @@ package io.airbyte.cdk.load.task.internal
 import com.google.common.collect.Range
 import io.airbyte.cdk.load.command.DestinationConfiguration
 import io.airbyte.cdk.load.command.DestinationStream
+import io.airbyte.cdk.load.file.LocalFile
 import io.airbyte.cdk.load.file.TempFileProvider
-import io.airbyte.cdk.load.message.BatchEnvelope
 import io.airbyte.cdk.load.message.DestinationRecordWrapped
 import io.airbyte.cdk.load.message.MessageQueueSupplier
 import io.airbyte.cdk.load.message.QueueReader
-import io.airbyte.cdk.load.message.SpilledRawMessagesLocalFile
 import io.airbyte.cdk.load.message.StreamCompleteWrapped
 import io.airbyte.cdk.load.message.StreamRecordWrapped
 import io.airbyte.cdk.load.state.FlushStrategy
@@ -98,9 +97,8 @@ class DefaultSpillToDiskTask(
             return
         }
 
-        val batch = SpilledRawMessagesLocalFile(tmpFile, sizeBytes)
-        val wrapped = BatchEnvelope(batch, range)
-        launcher.handleNewSpilledFile(stream, wrapped, endOfStream)
+        val file = SpilledRawMessagesLocalFile(tmpFile, sizeBytes, range, endOfStream)
+        launcher.handleNewSpilledFile(stream, file)
     }
 }
 
@@ -130,3 +128,10 @@ class DefaultSpillToDiskTaskFactory(
         )
     }
 }
+
+data class SpilledRawMessagesLocalFile(
+    val localFile: LocalFile,
+    val totalSizeBytes: Long,
+    val indexRange: Range<Long>,
+    val endOfStream: Boolean = false
+)

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/MockTaskLauncher.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/MockTaskLauncher.kt
@@ -6,7 +6,7 @@ package io.airbyte.cdk.load.task
 
 import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.message.BatchEnvelope
-import io.airbyte.cdk.load.message.SpilledRawMessagesLocalFile
+import io.airbyte.cdk.load.task.internal.SpilledRawMessagesLocalFile
 import io.micronaut.context.annotation.Primary
 import io.micronaut.context.annotation.Requires
 import jakarta.inject.Singleton
@@ -15,7 +15,7 @@ import jakarta.inject.Singleton
 @Primary
 @Requires(env = ["MockTaskLauncher"])
 class MockTaskLauncher : DestinationTaskLauncher {
-    val spilledFiles = mutableListOf<BatchEnvelope<SpilledRawMessagesLocalFile>>()
+    val spilledFiles = mutableListOf<SpilledRawMessagesLocalFile>()
     val batchEnvelopes = mutableListOf<BatchEnvelope<*>>()
 
     override suspend fun handleSetupComplete() {
@@ -28,10 +28,9 @@ class MockTaskLauncher : DestinationTaskLauncher {
 
     override suspend fun handleNewSpilledFile(
         stream: DestinationStream,
-        wrapped: BatchEnvelope<SpilledRawMessagesLocalFile>,
-        endOfStream: Boolean
+        file: SpilledRawMessagesLocalFile
     ) {
-        spilledFiles.add(wrapped)
+        spilledFiles.add(file)
     }
 
     override suspend fun handleNewBatch(stream: DestinationStream, wrapped: BatchEnvelope<*>) {

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/implementor/ProcessRecordsTaskTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/implementor/ProcessRecordsTaskTest.kt
@@ -10,13 +10,12 @@ import io.airbyte.cdk.load.command.MockDestinationCatalogFactory
 import io.airbyte.cdk.load.data.IntegerValue
 import io.airbyte.cdk.load.file.MockTempFileProvider
 import io.airbyte.cdk.load.message.Batch
-import io.airbyte.cdk.load.message.BatchEnvelope
 import io.airbyte.cdk.load.message.Deserializer
 import io.airbyte.cdk.load.message.DestinationMessage
 import io.airbyte.cdk.load.message.DestinationRecord
-import io.airbyte.cdk.load.message.SpilledRawMessagesLocalFile
 import io.airbyte.cdk.load.state.SyncManager
 import io.airbyte.cdk.load.task.MockTaskLauncher
+import io.airbyte.cdk.load.task.internal.SpilledRawMessagesLocalFile
 import io.airbyte.cdk.load.write.StreamLoader
 import io.micronaut.context.annotation.Primary
 import io.micronaut.context.annotation.Requires
@@ -100,12 +99,13 @@ class ProcessRecordsTaskTest {
             SpilledRawMessagesLocalFile(
                 localFile = mockFile,
                 totalSizeBytes = byteSize,
+                indexRange = Range.closed(0, recordCount)
             )
         val task =
             processRecordsTaskFactory.make(
                 taskLauncher = launcher,
                 stream = MockDestinationCatalogFactory.stream1,
-                fileEnvelope = BatchEnvelope(file, Range.closed(0, 1024))
+                file = file
             )
         mockFile.linesToRead = (0 until recordCount).map { "$it" }.toMutableList()
 

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/internal/SpillToDiskTaskTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/internal/SpillToDiskTaskTest.kt
@@ -104,16 +104,16 @@ class SpillToDiskTaskTest {
             .execute()
         Assertions.assertEquals(2, mockTaskLauncher.spilledFiles.size)
 
-        Assertions.assertEquals(1024, mockTaskLauncher.spilledFiles[0].batch.totalSizeBytes)
-        Assertions.assertEquals(512, mockTaskLauncher.spilledFiles[1].batch.totalSizeBytes)
+        Assertions.assertEquals(1024, mockTaskLauncher.spilledFiles[0].totalSizeBytes)
+        Assertions.assertEquals(512, mockTaskLauncher.spilledFiles[1].totalSizeBytes)
 
-        val env1 = mockTaskLauncher.spilledFiles[0]
-        val env2 = mockTaskLauncher.spilledFiles[1]
-        Assertions.assertEquals(1024, env1.batch.totalSizeBytes)
-        Assertions.assertEquals(512, env2.batch.totalSizeBytes)
+        val spilled1 = mockTaskLauncher.spilledFiles[0]
+        val spilled2 = mockTaskLauncher.spilledFiles[1]
+        Assertions.assertEquals(1024, spilled1.totalSizeBytes)
+        Assertions.assertEquals(512, spilled2.totalSizeBytes)
 
-        val file1 = env1.batch.localFile as MockTempFileProvider.MockLocalFile
-        val file2 = env2.batch.localFile as MockTempFileProvider.MockLocalFile
+        val file1 = spilled1.localFile as MockTempFileProvider.MockLocalFile
+        val file2 = spilled2.localFile as MockTempFileProvider.MockLocalFile
         Assertions.assertTrue(file1.writersCreated[0].isClosed)
         Assertions.assertTrue(file2.writersCreated[0].isClosed)
 


### PR DESCRIPTION
## What
Pretty simple
* removed StagedLocalFile batch (unused)
* demoted Spilled... to a data class provided by the task, got rid of its batch envelope
* got rid of SPILLED as a state

All changes nonfunctional.
