### PR TITLE
Fix the default flow of cdc cursor

### DIFF
--- a/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/discover/Field.kt
+++ b/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/discover/Field.kt
@@ -66,7 +66,6 @@ enum class CommonMetaField(
     CDC_LSN(CdcStringMetaFieldType),
     CDC_UPDATED_AT(CdcOffsetDateTimeMetaFieldType),
     CDC_DELETED_AT(CdcOffsetDateTimeMetaFieldType),
-    CDC_CURSOR(CdcIntegerMetaFieldType),
     ;
 
     override val id: String

--- a/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/discover/Field.kt
+++ b/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/discover/Field.kt
@@ -66,6 +66,7 @@ enum class CommonMetaField(
     CDC_LSN(CdcStringMetaFieldType),
     CDC_UPDATED_AT(CdcOffsetDateTimeMetaFieldType),
     CDC_DELETED_AT(CdcOffsetDateTimeMetaFieldType),
+    CDC_CURSOR(CdcIntegerMetaFieldType),
     ;
 
     override val id: String

--- a/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/discover/MetadataQuerier.kt
+++ b/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/discover/MetadataQuerier.kt
@@ -27,4 +27,6 @@ interface MetadataQuerier : AutoCloseable {
         /** An implementation might open a connection to build a [MetadataQuerier] instance. */
         fun session(config: T): MetadataQuerier
     }
+
+    fun commonCursorOrNull(cursorColumnID: String): FieldOrMetaField?
 }

--- a/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/read/StateManagerFactory.kt
+++ b/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/read/StateManagerFactory.kt
@@ -198,19 +198,15 @@ class StateManagerFactory(
             if (cursorColumnIDComponents.isEmpty()) {
                 return null
             }
+
             val cursorColumnID: String = cursorColumnIDComponents.joinToString(separator = ".")
-            if (cursorColumnID == CommonMetaField.CDC_LSN.id) {
-                return CommonMetaField.CDC_LSN
-            }
-            if (cursorColumnID == CommonMetaField.CDC_CURSOR.id) {
-                return CommonMetaField.CDC_CURSOR
-            }
-            return dataColumnOrNull(cursorColumnID)
+            val maybeField: FieldOrMetaField? = metadataQuerier.commonCursorOrNull(cursorColumnID)
+            return maybeField ?: dataColumnOrNull(cursorColumnID)
         }
         val configuredPrimaryKey: List<Field>? =
             configuredStream.primaryKey?.asSequence()?.let { pkOrNull(it.toList()) }
         val configuredCursor: FieldOrMetaField? =
-            configuredStream.cursorField?.asSequence()?.let { cursorOrNull(it.toList()) }
+            configuredStream.cursorField?.asSequence()?.let {cursorOrNull(it.toList())}
         val configuredSyncMode: ConfiguredSyncMode =
             when (configuredStream.syncMode) {
                 SyncMode.INCREMENTAL ->

--- a/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/read/StateManagerFactory.kt
+++ b/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/read/StateManagerFactory.kt
@@ -200,9 +200,10 @@ class StateManagerFactory(
             }
 
             val cursorColumnID: String = cursorColumnIDComponents.joinToString(separator = ".")
-            val maybeField: FieldOrMetaField? = metadataQuerier.commonCursorOrNull(cursorColumnID)
-            return maybeField ?: dataColumnOrNull(cursorColumnID)
+            val maybeCursorField: FieldOrMetaField? = metadataQuerier.commonCursorOrNull(cursorColumnID)
+            return maybeCursorField ?: dataColumnOrNull(cursorColumnID)
         }
+
         val configuredPrimaryKey: List<Field>? =
             configuredStream.primaryKey?.asSequence()?.let { pkOrNull(it.toList()) }
         val configuredCursor: FieldOrMetaField? =

--- a/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/read/StateManagerFactory.kt
+++ b/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/read/StateManagerFactory.kt
@@ -202,6 +202,9 @@ class StateManagerFactory(
             if (cursorColumnID == CommonMetaField.CDC_LSN.id) {
                 return CommonMetaField.CDC_LSN
             }
+            if (cursorColumnID == CommonMetaField.CDC_CURSOR.id) {
+                return CommonMetaField.CDC_CURSOR
+            }
             return dataColumnOrNull(cursorColumnID)
         }
         val configuredPrimaryKey: List<Field>? =

--- a/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/read/StateManagerFactory.kt
+++ b/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/read/StateManagerFactory.kt
@@ -13,7 +13,6 @@ import io.airbyte.cdk.command.StreamInputState
 import io.airbyte.cdk.data.AirbyteSchemaType
 import io.airbyte.cdk.data.ArrayAirbyteSchemaType
 import io.airbyte.cdk.data.LeafAirbyteSchemaType
-import io.airbyte.cdk.discover.CommonMetaField
 import io.airbyte.cdk.discover.Field
 import io.airbyte.cdk.discover.FieldOrMetaField
 import io.airbyte.cdk.discover.MetaField
@@ -200,14 +199,15 @@ class StateManagerFactory(
             }
 
             val cursorColumnID: String = cursorColumnIDComponents.joinToString(separator = ".")
-            val maybeCursorField: FieldOrMetaField? = metadataQuerier.commonCursorOrNull(cursorColumnID)
+            val maybeCursorField: FieldOrMetaField? =
+                metadataQuerier.commonCursorOrNull(cursorColumnID)
             return maybeCursorField ?: dataColumnOrNull(cursorColumnID)
         }
 
         val configuredPrimaryKey: List<Field>? =
             configuredStream.primaryKey?.asSequence()?.let { pkOrNull(it.toList()) }
         val configuredCursor: FieldOrMetaField? =
-            configuredStream.cursorField?.asSequence()?.let {cursorOrNull(it.toList())}
+            configuredStream.cursorField?.asSequence()?.let { cursorOrNull(it.toList()) }
         val configuredSyncMode: ConfiguredSyncMode =
             when (configuredStream.syncMode) {
                 SyncMode.INCREMENTAL ->

--- a/airbyte-cdk/bulk/core/extract/src/testFixtures/kotlin/io/airbyte/cdk/discover/ResourceDrivenMetadataQuerierFactory.kt
+++ b/airbyte-cdk/bulk/core/extract/src/testFixtures/kotlin/io/airbyte/cdk/discover/ResourceDrivenMetadataQuerierFactory.kt
@@ -73,6 +73,9 @@ class ResourceDrivenMetadataQuerierFactory(
             }
 
             override fun extraChecks() {}
+            override fun commonCursorOrNull(cursorColumnID: String): FieldOrMetaField? {
+                TODO("Not yet implemented")
+            }
 
             override fun close() {
                 isClosed = true

--- a/airbyte-cdk/bulk/core/extract/src/testFixtures/kotlin/io/airbyte/cdk/discover/ResourceDrivenMetadataQuerierFactory.kt
+++ b/airbyte-cdk/bulk/core/extract/src/testFixtures/kotlin/io/airbyte/cdk/discover/ResourceDrivenMetadataQuerierFactory.kt
@@ -74,7 +74,10 @@ class ResourceDrivenMetadataQuerierFactory(
 
             override fun extraChecks() {}
             override fun commonCursorOrNull(cursorColumnID: String): FieldOrMetaField? {
-                TODO("Not yet implemented")
+                return when (cursorColumnID) {
+                    CommonMetaField.CDC_LSN.id -> CommonMetaField.CDC_LSN
+                    else -> null
+                }
             }
 
             override fun close() {

--- a/airbyte-cdk/bulk/toolkits/extract-jdbc/src/main/kotlin/io/airbyte/cdk/discover/JdbcMetadataQuerier.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-jdbc/src/main/kotlin/io/airbyte/cdk/discover/JdbcMetadataQuerier.kt
@@ -325,6 +325,13 @@ class JdbcMetadataQuerier(
         checkQueries.executeAll(conn)
     }
 
+    override fun commonCursorOrNull(cursorColumnID: String): FieldOrMetaField? {
+        if (cursorColumnID == CommonMetaField.CDC_LSN.id) {
+            return CommonMetaField.CDC_LSN
+        }
+        return null
+    }
+
     override fun close() {
         log.info { "Closing JDBC connection." }
         conn.close()

--- a/airbyte-cdk/bulk/toolkits/extract-jdbc/src/main/kotlin/io/airbyte/cdk/discover/JdbcMetadataQuerier.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-jdbc/src/main/kotlin/io/airbyte/cdk/discover/JdbcMetadataQuerier.kt
@@ -326,10 +326,10 @@ class JdbcMetadataQuerier(
     }
 
     override fun commonCursorOrNull(cursorColumnID: String): FieldOrMetaField? {
-        if (cursorColumnID == CommonMetaField.CDC_LSN.id) {
-            return CommonMetaField.CDC_LSN
+        return when (cursorColumnID) {
+            CommonMetaField.CDC_LSN.id -> CommonMetaField.CDC_LSN
+            else -> null
         }
-        return null
     }
 
     override fun close() {

--- a/airbyte-integrations/connectors/source-mysql-v2/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mysql-v2/metadata.yaml
@@ -9,7 +9,7 @@ data:
   connectorSubtype: database
   connectorType: source
   definitionId: 561393ed-7e3a-4d0d-8b8b-90ded371754c
-  dockerImageTag: 0.0.24
+  dockerImageTag: 0.0.25
   dockerRepository: airbyte/source-mysql-v2
   documentationUrl: https://docs.airbyte.com/integrations/sources/mysql
   githubIssueLabel: source-mysql-v2

--- a/airbyte-integrations/connectors/source-mysql-v2/src/main/kotlin/io/airbyte/integrations/source/mysql/MysqlSourceMetadataQuerier.kt
+++ b/airbyte-integrations/connectors/source-mysql-v2/src/main/kotlin/io/airbyte/integrations/source/mysql/MysqlSourceMetadataQuerier.kt
@@ -6,6 +6,7 @@ import io.airbyte.cdk.StreamIdentifier
 import io.airbyte.cdk.check.JdbcCheckQueries
 import io.airbyte.cdk.command.SourceConfiguration
 import io.airbyte.cdk.discover.Field
+import io.airbyte.cdk.discover.FieldOrMetaField
 import io.airbyte.cdk.discover.JdbcMetadataQuerier
 import io.airbyte.cdk.discover.MetadataQuerier
 import io.airbyte.cdk.discover.TableName
@@ -173,6 +174,13 @@ class MysqlSourceMetadataQuerier(
     ): List<List<String>> {
         val table: TableName = findTableName(streamID) ?: return listOf()
         return memoizedPrimaryKeys[table] ?: listOf()
+    }
+
+    override fun commonCursorOrNull(cursorColumnID: String): FieldOrMetaField? {
+        if (cursorColumnID == MysqlJdbcStreamFactory.MysqlCDCMetaFields.CDC_CURSOR.id) {
+            return MysqlJdbcStreamFactory.MysqlCDCMetaFields.CDC_CURSOR
+        }
+        return null
     }
 
     private data class AllPrimaryKeysRow(

--- a/airbyte-integrations/connectors/source-mysql-v2/src/main/kotlin/io/airbyte/integrations/source/mysql/MysqlSourceMetadataQuerier.kt
+++ b/airbyte-integrations/connectors/source-mysql-v2/src/main/kotlin/io/airbyte/integrations/source/mysql/MysqlSourceMetadataQuerier.kt
@@ -13,6 +13,7 @@ import io.airbyte.cdk.discover.TableName
 import io.airbyte.cdk.jdbc.DefaultJdbcConstants
 import io.airbyte.cdk.jdbc.JdbcConnectionFactory
 import io.airbyte.cdk.read.SelectQueryGenerator
+import io.airbyte.integrations.source.mysql.MysqlJdbcStreamFactory.MysqlCDCMetaFields
 import io.airbyte.protocol.models.v0.StreamDescriptor
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.micronaut.context.annotation.Primary
@@ -177,10 +178,10 @@ class MysqlSourceMetadataQuerier(
     }
 
     override fun commonCursorOrNull(cursorColumnID: String): FieldOrMetaField? {
-        if (cursorColumnID == MysqlJdbcStreamFactory.MysqlCDCMetaFields.CDC_CURSOR.id) {
-            return MysqlJdbcStreamFactory.MysqlCDCMetaFields.CDC_CURSOR
+        return when (cursorColumnID) {
+            MysqlCDCMetaFields.CDC_CURSOR.id -> MysqlCDCMetaFields.CDC_CURSOR
+            else -> null
         }
-        return null
     }
 
     private data class AllPrimaryKeysRow(


### PR DESCRIPTION
## What
The default flow of CDC tables chooses _ab_cdc_cursor as the cursor column,
But then state manager factory doesn't handle this column correctly and warns
```
source > WARN main i.a.c.o.LoggingCatalogValidationFailureHandler(accept):87 In stream 'newcdk_table' in namespace '1gb': incremental sync not possible
```

## How
The fix makes _ab_cdc_cursor an acceptable cursor.
I'm not sure if the previously handled column CDC_LSN is still needed.
