### PR TITLE
return better structured error logs to connector builder

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/connector_builder/message_grouper.py
+++ b/airbyte-cdk/python/airbyte_cdk/connector_builder/message_grouper.py
@@ -313,7 +313,10 @@ class MessageGrouper:
             # If it matches, don't yield this as we don't need to show this in the Builder.
             # This is somewhat brittle as it relies on the message string, but if they drift then the worst case
             # is that this message will be shown in the Builder.
-            if traced_exception.message is not None and "During the sync, the following streams did not sync successfully" in traced_exception.message:
+            if (
+                traced_exception.message is not None
+                and "During the sync, the following streams did not sync successfully" in traced_exception.message
+            ):
                 return
             yield traced_exception.as_airbyte_message()
         except Exception as e:

--- a/airbyte-cdk/python/airbyte_cdk/connector_builder/message_grouper.py
+++ b/airbyte-cdk/python/airbyte_cdk/connector_builder/message_grouper.py
@@ -107,8 +107,7 @@ class MessageGrouper:
                 log_messages.append(LogMessage(**{"message": message_group.message, "level": message_group.level.value}))
             elif isinstance(message_group, AirbyteTraceMessage):
                 if message_group.type == TraceType.ERROR:
-                    error_message = f"{message_group.error.message} - {message_group.error.stack_trace}"
-                    log_messages.append(LogMessage(**{"message": error_message, "level": "ERROR"}))
+                    log_messages.append(LogMessage(**{"message": message_group.error.message, "level": "ERROR", "internal_message": message_group.error.internal_message, "stacktrace": message_group.error.stack_trace}))
             elif isinstance(message_group, AirbyteControlMessage):
                 if not latest_config_update or latest_config_update.emitted_at <= message_group.emitted_at:
                     latest_config_update = message_group
@@ -300,6 +299,14 @@ class MessageGrouper:
         # iterate over the generated messages. if next raise an exception, catch it and yield it as an AirbyteLogMessage
         try:
             yield from AirbyteEntrypoint(source).read(source.spec(self.logger), config, configured_catalog, state)
+        except AirbyteTracedException as traced_exception:
+            # Look for this message which indicates that it is the "final exception" raised by AbstractSource.
+            # If it matches, don't yield this as we don't need to show this in the Builder.
+            # This is somewhat brittle as it relies on the message string, but if they drift then the worst case
+            # is that this message will be shown in the Builder.
+            if "During the sync, the following streams did not sync successfully" in traced_exception.message:
+                return
+            yield traced_exception.as_airbyte_message()
         except Exception as e:
             error_message = f"{e.args[0] if len(e.args) > 0 else str(e)}"
             yield AirbyteTracedException.from_exception(e, message=error_message).as_airbyte_message()

--- a/airbyte-cdk/python/airbyte_cdk/connector_builder/message_grouper.py
+++ b/airbyte-cdk/python/airbyte_cdk/connector_builder/message_grouper.py
@@ -107,7 +107,16 @@ class MessageGrouper:
                 log_messages.append(LogMessage(**{"message": message_group.message, "level": message_group.level.value}))
             elif isinstance(message_group, AirbyteTraceMessage):
                 if message_group.type == TraceType.ERROR:
-                    log_messages.append(LogMessage(**{"message": message_group.error.message, "level": "ERROR", "internal_message": message_group.error.internal_message, "stacktrace": message_group.error.stack_trace}))
+                    log_messages.append(
+                        LogMessage(
+                            **{
+                                "message": message_group.error.message,
+                                "level": "ERROR",
+                                "internal_message": message_group.error.internal_message,
+                                "stacktrace": message_group.error.stack_trace,
+                            }
+                        )
+                    )
             elif isinstance(message_group, AirbyteControlMessage):
                 if not latest_config_update or latest_config_update.emitted_at <= message_group.emitted_at:
                     latest_config_update = message_group

--- a/airbyte-cdk/python/airbyte_cdk/connector_builder/message_grouper.py
+++ b/airbyte-cdk/python/airbyte_cdk/connector_builder/message_grouper.py
@@ -313,7 +313,7 @@ class MessageGrouper:
             # If it matches, don't yield this as we don't need to show this in the Builder.
             # This is somewhat brittle as it relies on the message string, but if they drift then the worst case
             # is that this message will be shown in the Builder.
-            if "During the sync, the following streams did not sync successfully" in traced_exception.message:
+            if traced_exception.message is not None and "During the sync, the following streams did not sync successfully" in traced_exception.message:
                 return
             yield traced_exception.as_airbyte_message()
         except Exception as e:

--- a/airbyte-cdk/python/airbyte_cdk/connector_builder/models.py
+++ b/airbyte-cdk/python/airbyte_cdk/connector_builder/models.py
@@ -39,6 +39,8 @@ class StreamReadSlices:
 class LogMessage:
     message: str
     level: str
+    internal_message: Optional[str] = None
+    stacktrace: Optional[str] = None
 
 
 @dataclass

--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/http/error_handlers/json_error_message_parser.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/http/error_handlers/json_error_message_parser.py
@@ -45,4 +45,7 @@ class JsonErrorMessageParser(ErrorMessageParser):
             body = response.json()
             return self._try_get_error(body)
         except requests.exceptions.JSONDecodeError:
-            return None
+            try:
+                return response.content.decode("utf-8")
+            except Exception:
+                return None

--- a/airbyte-cdk/python/unit_tests/connector_builder/test_connector_builder_handler.py
+++ b/airbyte-cdk/python/unit_tests/connector_builder/test_connector_builder_handler.py
@@ -574,7 +574,7 @@ def test_read_returns_error_response(mock_from_exception):
     response = read_stream(source, TEST_READ_CONFIG, ConfiguredAirbyteCatalogSerializer.load(CONFIGURED_CATALOG), _A_STATE, limits)
 
     expected_stream_read = StreamRead(
-        logs=[LogMessage("error_message - a stack trace", "ERROR")],
+        logs=[LogMessage("error_message", "ERROR", "error_message", "a stack trace")],
         slices=[],
         test_read_limit_reached=False,
         auxiliary_requests=[],

--- a/airbyte-cdk/python/unit_tests/connector_builder/test_connector_builder_handler.py
+++ b/airbyte-cdk/python/unit_tests/connector_builder/test_connector_builder_handler.py
@@ -898,7 +898,7 @@ def test_handle_read_external_requests(deployment_mode, url_base, expected_error
             assert len(output_data["logs"]) > 0, "Expected at least one log message with the expected error"
             error_message = output_data["logs"][0]
             assert error_message["level"] == "ERROR"
-            assert expected_error in error_message["message"]
+            assert expected_error in error_message["stacktrace"]
         else:
             page_records = output_data["slices"][0]["pages"][0]
             assert len(page_records) == len(MOCK_RESPONSE["result"])
@@ -956,7 +956,7 @@ def test_handle_read_external_oauth_request(deployment_mode, token_url, expected
             assert len(output_data["logs"]) > 0, "Expected at least one log message with the expected error"
             error_message = output_data["logs"][0]
             assert error_message["level"] == "ERROR"
-            assert expected_error in error_message["message"]
+            assert expected_error in error_message["stacktrace"]
 
 
 def test_read_stream_exception_with_secrets():

--- a/airbyte-cdk/python/unit_tests/connector_builder/test_message_grouper.py
+++ b/airbyte-cdk/python/unit_tests/connector_builder/test_message_grouper.py
@@ -591,7 +591,7 @@ def test_read_stream_returns_error_if_stream_does_not_exist() -> None:
     )
 
     assert len(actual_response.logs) == 1
-    assert "Traceback" in actual_response.logs[0].message
+    assert "Traceback" in actual_response.logs[0].stacktrace
     assert "ERROR" in actual_response.logs[0].level
 
 

--- a/airbyte-cdk/python/unit_tests/sources/streams/http/error_handlers/test_json_error_message_parser.py
+++ b/airbyte-cdk/python/unit_tests/sources/streams/http/error_handlers/test_json_error_message_parser.py
@@ -35,4 +35,4 @@ def test_given_invalid_json_body_parse_response_error_message_returns_none():
     response = requests.Response()
     response._content = b"invalid json body"
     error_message = JsonErrorMessageParser().parse_response_error_message(response)
-    assert error_message is None
+    assert error_message == "invalid json body"


### PR DESCRIPTION
## What
Partially resolves https://github.com/airbytehq/airbyte-internal-issues/issues/6977

This is the first of 3 PRs to have better structured error messages in the Connector Builder.
See the other 2 PRs that build on top of this one:
- https://github.com/airbytehq/airbyte-platform-internal/pull/14378
- https://github.com/airbytehq/airbyte-platform-internal/pull/14400

## How
This PR changes how the connector_builder module of the CDK returns trace messages back to the connector builder server in a few key ways:
- Breaks apart the error `message` and `stacktrace` into separate fields
- Adds the `internal_message` of the trace message to another field in the returned Log
- Suppresses the final raised `AirbyteTracedException` which is only meant to cause a non-zero return value to result in a sync failure, but does not provide any useful information beyond the other traced exceptions that are already yielded

## Testing
Follow the Testing instructions in the description of this PR to test this end-to-end: 
- https://github.com/airbytehq/airbyte-platform-internal/pull/14400

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
