### PR TITLE
Addition of Transactions List Endpoint to existing Airbyte Connector

### DIFF
--- a/airbyte-integrations/connectors/source-amazon-seller-partner/source_amazon_seller_partner/schemas/ListTransactions.json
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/source_amazon_seller_partner/schemas/ListTransactions.json
@@ -1,0 +1,273 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "ListTransactions",
+    "description": "List of Transactions",
+    "type": "object",
+    "properties": {
+      "transactions": {
+        "description": "A list of transactions within the specified time period.",
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/Transaction"
+        }
+      }
+    },
+    "definitions": {
+      "Transaction": {
+        "type": "object",
+        "properties": {
+          "sellingPartnerMetadata": {
+            "$ref": "#/definitions/SellingPartnerMetadata"
+          },
+          "relatedIdentifiers": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/RelatedIdentifier"
+            }
+          },
+          "transactionType": {
+            "type": "string",
+            "description": "The type of transaction.",
+            "enum": ["Shipment"]
+          },
+          "transactionId": {
+            "type": "string",
+            "description": "The unique identifier of the transaction."
+          },
+          "transactionStatus": {
+            "type": "string",
+            "description": "The status of the transaction.",
+            "enum": ["Deferred", "Released"]
+          },
+          "description": {
+            "type": "string",
+            "description": "Describes the reasons for the transaction."
+          },
+          "postedDate": {
+            "type": "string",
+            "format": "date-time",
+            "description": "The date and time when the transaction was posted."
+          },
+          "totalAmount": {
+            "$ref": "#/definitions/Currency"
+          },
+          "marketplaceDetails": {
+            "$ref": "#/definitions/MarketplaceDetails"
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Item"
+            }
+          },
+          "contexts": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Context"
+            }
+          },
+          "breakdowns": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Breakdown"
+            }
+          }
+        }
+      },
+      "SellingPartnerMetadata": {
+        "type": "object",
+        "properties": {
+          "sellingPartnerId": {
+            "type": "string",
+            "description": "A unique seller identifier."
+          },
+          "accountType": {
+            "type": "string",
+            "description": "The type of account in the transaction."
+          },
+          "marketplaceId": {
+            "type": "string",
+            "description": "The identifier of the marketplace where the transaction occurred."
+          }
+        }
+      },
+      "RelatedIdentifier": {
+        "type": "object",
+        "properties": {
+          "relatedIdentifierName": {
+            "type": "string",
+            "enum": ["ORDER_ID", "SHIPMENT_ID", "EVENT_GROUP_ID", "REFUND_ID", "INVOICE_ID", "DISBURSEMENT_ID", "TRANSFER_ID", "DEFERRED_TRANSACTION_ID"],
+            "description": "An enumerated set of related business identifier names."
+          },
+          "relatedIdentifierValue": {
+            "type": "string",
+            "description": "Corresponding value of RelatedIdentifierName."
+          }
+        }
+      },
+      "Currency": {
+        "type": "object",
+        "properties": {
+          "currencyCode": {
+            "type": "string",
+            "description": "The three-digit currency code in ISO 4217 format."
+          },
+          "currencyAmount": {
+            "type": "number",
+            "description": "The monetary value."
+          }
+        }
+      },
+      "MarketplaceDetails": {
+        "type": "object",
+        "properties": {
+          "marketplaceId": {
+            "type": "string",
+            "description": "The identifier of the marketplace where the transaction occurred."
+          },
+          "marketplaceName": {
+            "type": "string",
+            "description": "The name of the marketplace where the transaction occurred. For example: Amazon.com, Amazon.in"
+          }
+        }
+      },
+      "Item": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string",
+            "description": "A description of the items in a transaction."
+          },
+          "relatedIdentifiers": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/ItemRelatedIdentifier"
+            }
+          },
+          "totalAmount": {
+            "$ref": "#/definitions/Currency"
+          },
+          "breakdowns": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Breakdown"
+            }
+          },
+          "contexts": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Context"
+            }
+          }
+        }
+      },
+      "ItemRelatedIdentifier": {
+        "type": "object",
+        "properties": {
+          "itemRelatedIdentifierName": {
+            "type": "string",
+            "enum": ["ORDER_ADJUSTMENT_ITEM_ID", "COUPON_ID", "REMOVAL_SHIPMENT_ITEM_ID", "TRANSACTION_ID"],
+            "description": "Enumerated set of related item identifier names for the item."
+          },
+          "itemRelatedIdentifierValue": {
+            "type": "string",
+            "description": "Corresponding value to ItemRelatedIdentifierName."
+          }
+        }
+      },
+      "Breakdown": {
+        "type": "object",
+        "properties": {
+          "breakdownType": {
+            "type": "string",
+            "description": "The type of charge."
+          },
+          "breakdownAmount": {
+            "$ref": "#/definitions/Currency"
+          },
+          "breakdowns": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Breakdown"
+            }
+          }
+        }
+      },
+      "Context": {
+        "type": "object",
+        "properties": {
+          "contextType": {
+            "type": "string"
+          },
+          "storeName": {
+            "type": "string",
+            "description": "The name of the store that is related to the transaction."
+          },
+          "orderType": {
+            "type": "string",
+            "description": "The transaction's order type."
+          },
+          "channel": {
+            "type": "string",
+            "description": "Channel details of related transaction."
+          },
+          "asin": {
+            "type": "string",
+            "description": "The Amazon Standard Identification Number (ASIN) of the item."
+          },
+          "sku": {
+            "type": "string",
+            "description": "The Stock Keeping Unit (SKU) of the item."
+          },
+          "quantityShipped": {
+            "type": "integer",
+            "description": "The quantity of the item shipped."
+          },
+          "fulfillmentNetwork": {
+            "type": "string",
+            "description": "The fulfillment network of the item."
+          },
+          "paymentType": {
+            "type": "string",
+            "description": "The type of payment."
+          },
+          "paymentMethod": {
+            "type": "string",
+            "description": "The method of payment."
+          },
+          "paymentReference": {
+            "type": "string",
+            "description": "The reference number of the payment."
+          },
+          "paymentDate": {
+            "type": "string",
+            "format": "date-time",
+            "description": "The date of the payment."
+          },
+          "deferralReason": {
+            "type": "string",
+            "description": "Deferral policy applied on the transaction."
+          },
+          "maturityDate": {
+            "type": "string",
+            "format": "date-time",
+            "description": "The release date of the transaction."
+          },
+          "deferralStatus": {
+            "type": "string",
+            "description": "The status of the transaction. For example, HOLD, RELEASE."
+          },
+          "startTime": {
+            "type": "string",
+            "format": "date-time",
+            "description": "The start time of the transaction."
+          },
+          "endTime": {
+            "type": "string",
+            "format": "date-time",
+            "description": "The end time of the transaction."
+          }
+        }
+      }
+    }
+  }

--- a/airbyte-integrations/connectors/source-amazon-seller-partner/source_amazon_seller_partner/source.py
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/source_amazon_seller_partner/source.py
@@ -70,6 +70,7 @@ from source_amazon_seller_partner.streams import (
     VendorSalesReports,
     VendorTrafficReport,
     XmlAllOrdersDataByOrderDataGeneral,
+    ListTransactions
 )
 from source_amazon_seller_partner.utils import AmazonConfigException
 
@@ -199,6 +200,7 @@ class SourceAmazonSellerPartner(AbstractSource):
             VendorOrders,
             VendorForecastingFreshReport,
             VendorForecastingRetailReport,
+            ListTransactions
         ]
 
         # TODO: Remove after Brand Analytics will be enabled in CLOUD: https://github.com/airbytehq/airbyte/issues/32353

--- a/airbyte-integrations/connectors/source-amazon-seller-partner/source_amazon_seller_partner/streams.py
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/source_amazon_seller_partner/streams.py
@@ -34,6 +34,7 @@ ORDERS_API_VERSION = "v0"
 VENDORS_API_VERSION = "v1"
 FINANCES_API_VERSION = "v0"
 VENDOR_ORDERS_API_VERSION = "v1"
+FINACES_TRANSACTION_API_VERSION = "2024-06-19"
 
 DATE_TIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 DATE_FORMAT = "%Y-%m-%d"
@@ -1518,6 +1519,47 @@ class ListFinancialEvents(FinanceStream):
         events[self.replication_end_date_field] = params.get(self.replication_end_date_field)
         yield from [events]
 
+
+class ListTransactions(FinanceStream):
+    """
+    API docs: https://developer-docs.amazon.com/sp-api/docs/finances-api-v2024-06-19-reference
+    """
+
+    name = "ListTransactions"
+    primary_key = "transactionId"
+    replication_start_date_field = "postedAfter"
+    replication_end_date_field = "postedBefore"
+    cursor_field = "postedDate"
+
+    def path(self, **kwargs) -> str:
+        return f"finances/{FINACES_TRANSACTION_API_VERSION}/transactions"
+
+    def request_params(
+        self, stream_state: Mapping[str, Any], next_page_token: Mapping[str, Any] = None, **kwargs
+    ) -> MutableMapping[str, Any]:
+        params = super().request_params(stream_state, next_page_token, **kwargs)
+        
+        # Add marketplaceId if it's set in the config
+        if self.marketplace_id:
+            params["marketplaceId"] = self.marketplace_id
+
+        return params
+
+    def parse_response(
+        self,
+        response: requests.Response,
+        stream_state: Mapping[str, Any] = None,
+        stream_slice: Mapping[str, Any] = None,
+        **kwargs: Any,
+    ) -> Iterable[Mapping]:
+        json_response = response.json()
+        yield from json_response.get("transactions", [])
+
+    def next_page_token(self, response: requests.Response) -> Optional[Mapping[str, Any]]:
+        json_response = response.json()
+        next_token = json_response.get("nextToken")
+        if next_token:
+            return {"nextToken": next_token}
 
 class FbaCustomerReturnsReports(IncrementalReportsAmazonSPStream):
     report_name = "GET_FBA_FULFILLMENT_CUSTOMER_RETURNS_DATA"

--- a/docs/integrations/sources/amazon-seller-partner.md
+++ b/docs/integrations/sources/amazon-seller-partner.md
@@ -114,6 +114,7 @@ The Amazon Seller Partner source connector supports the following [sync modes](h
 - [FBA Storage Fees Report](https://developer-docs.amazon.com/sp-api/docs/report-type-values-fba#fba-inventory-reports) \(incremental\)
 - [FBA Stranded Inventory Report](https://developer-docs.amazon.com/sp-api/docs/report-type-values-fba#fba-inventory-reports) \(incremental\)
 - [Financial Events](https://developer-docs.amazon.com/sp-api/docs/finances-api-reference#get-financesv0financialevents) \(incremental\)
+- [Transaction List](https://developer-docs.amazon.com/sp-api/docs/finances-api-v2024-06-19-reference)
 - [Financial Event Groups](https://developer-docs.amazon.com/sp-api/docs/finances-api-reference#get-financesv0financialeventgroups) \(incremental\)
 - [Flat File Archived Orders Report](https://developer-docs.amazon.com/sp-api/docs/report-type-values-order#order-tracking-reports) \(incremental\)
 - [Flat File Feedback Report](https://developer-docs.amazon.com/sp-api/docs/report-type-values-performance) \(incremental\)


### PR DESCRIPTION
# Adding Transaction List Endpoint

## What
<!-- Describe what the change is solving. Link all GitHub issues related to this change. -->
This PR introduces a new endpoint to retrieve a list of transactions from the amazon seller api. It addresses the need for users to view their transaction history efficiently and provides proper documentation and configuration for the new feature.

Related issue: # - Implement transaction list feature

## How
<!-- Describe how code changes achieve the solution. -->
- Created a new `TransactionListSchema` in `ListTransaction.json` to handle GET requests for transaction lists
- Implemented the stream logic in `streams.py`
- Added appropriate configuration of the stream in `source.py`
