### PR TITLE
[fix] live-test: fix get_container_from_id

### DIFF
--- a/airbyte-ci/connectors/live-tests/README.md
+++ b/airbyte-ci/connectors/live-tests/README.md
@@ -179,6 +179,11 @@ The traffic recorded on the control connector is passed to the target connector 
 
 ## Changelog
 
+### 0.19.3
+Update `get_container_from_id` with the correct new Dagger API.
+
+### 0.19.2
+Update Dagger to 0.13.3
 ### 0.19.1
 
 Fixed the `UserDict` type annotation not found bug.

--- a/airbyte-ci/connectors/live-tests/pyproject.toml
+++ b/airbyte-ci/connectors/live-tests/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "live-tests"
-version = "0.19.2"
+version = "0.19.3"
 description = "Contains utilities for testing connectors against live data."
 authors = ["Airbyte <contact@airbyte.io>"]
 license = "MIT"

--- a/airbyte-ci/connectors/live-tests/src/live_tests/commons/utils.py
+++ b/airbyte-ci/connectors/live-tests/src/live_tests/commons/utils.py
@@ -24,7 +24,7 @@ async def get_container_from_id(dagger_client: dagger.Client, container_id: str)
         dagger_client (dagger.Client): The dagger client to use to import the connector image
     """
     try:
-        return await dagger_client.container(id=dagger.ContainerID(container_id))
+        return await dagger_client.load_container_from_id(dagger.ContainerID(container_id))
     except dagger.DaggerError as e:
         pytest.exit(f"Failed to load connector container: {e}")
 


### PR DESCRIPTION
## What
Dagger API change in 0.13.3:
`dagger_client.container(id=dagger.ContainerID(container_id))` -> `dagger_client.load_container_from_id(dagger.ContainerID(container_id))`
