### PR TITLE
Bulk load CDK: Even more tests

### DIFF
--- a/airbyte-cdk/bulk/core/load/build.gradle
+++ b/airbyte-cdk/bulk/core/load/build.gradle
@@ -31,6 +31,11 @@ task integrationTest(type: Test) {
     testClassesDirs = sourceSets.integrationTest.output.classesDirs
     classpath = sourceSets.integrationTest.runtimeClasspath
     useJUnitPlatform()
+
+    jvmArgs = project.test.jvmArgs
+    systemProperties = project.test.systemProperties
+    maxParallelForks = project.test.maxParallelForks
+    maxHeapSize = project.test.maxHeapSize
 }
 configurations {
     integrationTestImplementation.extendsFrom testImplementation

--- a/airbyte-cdk/bulk/core/load/src/integrationTest/kotlin/io/airbyte/cdk/load/mock_integration_test/MockBasicFunctionalityIntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/integrationTest/kotlin/io/airbyte/cdk/load/mock_integration_test/MockBasicFunctionalityIntegrationTest.kt
@@ -17,7 +17,8 @@ class MockBasicFunctionalityIntegrationTest :
         MockDestinationDataDumper,
         NoopDestinationCleaner,
         NoopExpectedRecordMapper,
-        NoopNameMapper
+        NoopNameMapper,
+        isStreamSchemaRetroactive = false,
     ) {
     @Test
     override fun testBasicWrite() {
@@ -42,5 +43,15 @@ class MockBasicFunctionalityIntegrationTest :
     @Test
     override fun testTruncateRefresh() {
         super.testTruncateRefresh()
+    }
+
+    @Test
+    override fun testAppend() {
+        super.testAppend()
+    }
+
+    @Test
+    override fun testAppendSchemaEvolution() {
+        super.testAppendSchemaEvolution()
     }
 }

--- a/airbyte-integrations/connectors/destination-dev-null/src/test-integration/kotlin/io/airbyte/integrations/destination/dev_null/DevNullBasicFunctionalityIntegrationTest.kt
+++ b/airbyte-integrations/connectors/destination-dev-null/src/test-integration/kotlin/io/airbyte/integrations/destination/dev_null/DevNullBasicFunctionalityIntegrationTest.kt
@@ -17,6 +17,7 @@ class DevNullBasicFunctionalityIntegrationTest :
         NoopDestinationCleaner,
         NoopExpectedRecordMapper,
         verifyDataWriting = false,
+        isStreamSchemaRetroactive = false,
     ) {
     @Test
     override fun testBasicWrite() {

--- a/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2WriteTest.kt
+++ b/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2WriteTest.kt
@@ -17,6 +17,7 @@ abstract class S3V2WriteTest(path: String) :
         S3V2DataDumper,
         NoopDestinationCleaner,
         NoopExpectedRecordMapper,
+        isStreamSchemaRetroactive = false,
     ) {
     @Test
     override fun testBasicWrite() {
@@ -27,6 +28,18 @@ abstract class S3V2WriteTest(path: String) :
     @Test
     override fun testMidSyncCheckpointingStreamState() {
         super.testMidSyncCheckpointingStreamState()
+    }
+
+    @Disabled("append mode doesn't yet work")
+    @Test
+    override fun testAppend() {
+        super.testAppend()
+    }
+
+    @Disabled("append mode doesn't yet work")
+    @Test
+    override fun testAppendSchemaEvolution() {
+        super.testAppendSchemaEvolution()
     }
 }
 


### PR DESCRIPTION
* even more gradle fiddling (this also is to enable concurrent execution in the mock test runner. Not _super_ necessary, but might as well run the mock tests identically to how real tests run)
* testAppend = DAT.testIncremental
* testAppendSchemaEvolution = DAT.testIncrementalSyncWithNormalizationDropOneColumn / testSyncNotFailsWithNewFields
    * testIncrementalSyncWithNormalizationDropOneColumn did what it sounded like
    * testSyncNotFailsWithNewFields was... actually testing undeclared fields? but I did add an actual new column here
        * I also added an undeclared field to the basic write test, because that seems reasonable
    * add a new param to the basic functionality test `isStreamSchemaRetroactive`. DB/DW destinations will set true; file destinations will set false.
    * iceberg could go either way, depending on (a) whether we're strongly typing the raw data, and (b) whether we're reading the files directly off s3, or going through some iceberg reader