### PR TITLE
Bulk Load CDK: GZip Compression and S3V2 Usage

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/DestinationRecordToAirbyteValueWithMeta.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/DestinationRecordToAirbyteValueWithMeta.kt
@@ -7,10 +7,12 @@ package io.airbyte.cdk.load.data
 import io.airbyte.cdk.load.command.DestinationCatalog
 import io.airbyte.cdk.load.message.DestinationRecord
 import io.airbyte.cdk.load.message.DestinationRecord.Meta
+import io.micronaut.context.annotation.Secondary
 import jakarta.inject.Singleton
 import java.util.*
 
 @Singleton
+@Secondary
 class DestinationRecordToAirbyteValueWithMeta(private val catalog: DestinationCatalog) {
     fun decorate(record: DestinationRecord): ObjectValue {
         val streamActual = catalog.getStream(record.stream.name, record.stream.namespace)

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/file/StreamProcessor.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/file/StreamProcessor.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.load.file
+
+import java.io.ByteArrayOutputStream
+import java.util.zip.GZIPOutputStream
+
+interface StreamProcessor<T> {
+    val wrapper: (ByteArrayOutputStream) -> T
+    val partFinisher: T.() -> Unit
+    val extension: String?
+}
+
+data object NoopProcessor : StreamProcessor<ByteArrayOutputStream> {
+    override val wrapper: (ByteArrayOutputStream) -> ByteArrayOutputStream = { it }
+    override val partFinisher: ByteArrayOutputStream.() -> Unit = {}
+    override val extension: String? = null
+}
+
+data object GZIPProcessor : StreamProcessor<GZIPOutputStream> {
+    override val wrapper: (ByteArrayOutputStream) -> GZIPOutputStream = { GZIPOutputStream(it) }
+    override val partFinisher: GZIPOutputStream.() -> Unit = { finish() }
+    override val extension: String = "gz"
+}

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/build.gradle
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/build.gradle
@@ -1,4 +1,6 @@
 dependencies {
     implementation project(':airbyte-cdk:bulk:core:bulk-cdk-core-base')
     implementation project(':airbyte-cdk:bulk:core:bulk-cdk-core-load')
+
+    testFixturesImplementation testFixtures(project(":airbyte-cdk:bulk:core:bulk-cdk-core-load"))
 }

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/command/object_storage/ObjectStorageCompressionSpecification.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/command/object_storage/ObjectStorageCompressionSpecification.kt
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.load.command.object_storage
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.annotation.JsonPropertyDescription
+import com.fasterxml.jackson.annotation.JsonSubTypes
+import com.fasterxml.jackson.annotation.JsonTypeInfo
+import com.fasterxml.jackson.annotation.JsonValue
+import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaTitle
+import io.airbyte.cdk.load.file.GZIPProcessor
+import io.airbyte.cdk.load.file.NoopProcessor
+import io.airbyte.cdk.load.file.StreamProcessor
+import java.io.ByteArrayOutputStream
+import java.io.OutputStream
+
+/**
+ * Mix-in to provide file format configuration.
+ *
+ * The specification is intended to be applied to file formats that are compatible with file-level
+ * compression (csv, jsonl) and does not need to be added to the destination spec directly. The
+ * [ObjectStorageCompressionConfigurationProvider] can be added to the top-level
+ * [io.airbyte.cdk.load.command.DestinationConfiguration] and initialized directly with
+ * [ObjectStorageFormatSpecificationProvider.toObjectStorageFormatConfiguration]. (See the comments
+ * on [io.airbyte.cdk.load.command.DestinationConfiguration] for more details.)
+ */
+interface ObjectStorageCompressionSpecificationProvider {
+    @get:JsonSchemaTitle("Compression")
+    @get:JsonPropertyDescription(
+        "Whether the output files should be compressed. If compression is selected, the output filename will have an extra extension (GZIP: \".jsonl.gz\").",
+    )
+    @get:JsonProperty("compression")
+    val compression: ObjectStorageCompressionSpecification
+
+    fun toCompressionConfiguration(): ObjectStorageCompressionConfiguration<*> {
+        return when (compression) {
+            is NoCompressionSpecification -> ObjectStorageCompressionConfiguration(NoopProcessor)
+            is GZIPCompressionSpecification -> ObjectStorageCompressionConfiguration(GZIPProcessor)
+        }
+    }
+
+    companion object {
+        fun getNoCompressionConfiguration():
+            ObjectStorageCompressionConfiguration<ByteArrayOutputStream> {
+            return ObjectStorageCompressionConfiguration(NoopProcessor)
+        }
+    }
+}
+
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NAME,
+    include = JsonTypeInfo.As.EXISTING_PROPERTY,
+    property = "compression_type",
+)
+@JsonSubTypes(
+    JsonSubTypes.Type(value = NoCompressionSpecification::class, name = "No Compression"),
+    JsonSubTypes.Type(value = GZIPCompressionSpecification::class, name = "GZIP"),
+)
+sealed class ObjectStorageCompressionSpecification(
+    @JsonProperty("compression_type") open val compressionType: Type
+) {
+    enum class Type(@get:JsonValue val typeName: String) {
+        NoCompression("No Compression"),
+        GZIP("GZIP"),
+    }
+}
+
+@JsonSchemaTitle("No Compression")
+class NoCompressionSpecification(
+    @JsonProperty("compression_type") override val compressionType: Type = Type.NoCompression
+) : ObjectStorageCompressionSpecification(compressionType)
+
+@JsonSchemaTitle("GZIP")
+class GZIPCompressionSpecification(
+    @JsonProperty("compression_type") override val compressionType: Type = Type.GZIP
+) : ObjectStorageCompressionSpecification(compressionType)
+
+data class ObjectStorageCompressionConfiguration<T : OutputStream>(
+    val compressor: StreamProcessor<T>
+)
+
+interface ObjectStorageCompressionConfigurationProvider<T : OutputStream> {
+    val objectStorageCompressionConfiguration: ObjectStorageCompressionConfiguration<T>
+}

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/command/object_storage/ObjectStorageFormatSpecification.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/command/object_storage/ObjectStorageFormatSpecification.kt
@@ -8,13 +8,24 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonPropertyDescription
 import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
+import com.fasterxml.jackson.annotation.JsonValue
 import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaTitle
 
+/**
+ * Mix-in to provide file format configuration.
+ *
+ * NOTE: This assumes a fixed set of file formats. If you need to support a different set, clone the
+ * [ObjectStorageFormatSpecification] class with a new set of enums.
+ *
+ * See [io.airbyte.cdk.load.command.DestinationConfiguration] for more details on how to use this
+ * interface.
+ */
 interface ObjectStorageFormatSpecificationProvider {
     @get:JsonSchemaTitle("Output Format")
     @get:JsonPropertyDescription(
         "Format of the data output. See <a href=\"https://docs.airbyte.com/integrations/destinations/s3/#supported-output-schema\">here</a> for more details",
     )
+    @get:JsonProperty("format")
     val format: ObjectStorageFormatSpecification
 
     fun toObjectStorageFormatConfiguration(): ObjectStorageFormatConfiguration {
@@ -23,6 +34,15 @@ interface ObjectStorageFormatSpecificationProvider {
             is CSVFormatSpecification -> CSVFormatConfiguration()
             is AvroFormatSpecification -> AvroFormatConfiguration()
             is ParquetFormatSpecification -> ParquetFormatConfiguration()
+        }
+    }
+
+    fun toCompressionConfiguration(): ObjectStorageCompressionConfiguration<*> {
+        return when (format) {
+            is ObjectStorageCompressionSpecificationProvider ->
+                (format as ObjectStorageCompressionSpecificationProvider)
+                    .toCompressionConfiguration()
+            else -> ObjectStorageCompressionSpecificationProvider.getNoCompressionConfiguration()
         }
     }
 }
@@ -38,21 +58,40 @@ interface ObjectStorageFormatSpecificationProvider {
     JsonSubTypes.Type(value = AvroFormatSpecification::class, name = "AVRO"),
     JsonSubTypes.Type(value = ParquetFormatSpecification::class, name = "PARQUET")
 )
-sealed class ObjectStorageFormatSpecification {
-    @JsonSchemaTitle("Format Type") @JsonProperty("format_type") val formatType: String = "JSONL"
+sealed class ObjectStorageFormatSpecification(
+    @JsonSchemaTitle("Format Type") @JsonProperty("format_type") open val formatType: Type
+) {
+    enum class Type(@get:JsonValue val typeName: String) {
+        JSONL("JSONL"),
+        CSV("CSV"),
+        AVRO("AVRO"),
+        PARQUET("PARQUET")
+    }
 }
 
 @JsonSchemaTitle("JSON Lines: Newline-delimited JSON")
-class JsonFormatSpecification : ObjectStorageFormatSpecification()
+class JsonFormatSpecification(
+    @JsonProperty("format_type") override val formatType: Type = Type.JSONL
+) : ObjectStorageFormatSpecification(formatType), ObjectStorageCompressionSpecificationProvider {
+    override val compression: ObjectStorageCompressionSpecification = NoCompressionSpecification()
+}
 
 @JsonSchemaTitle("CSV: Comma-Separated Values")
-class CSVFormatSpecification : ObjectStorageFormatSpecification()
+class CSVFormatSpecification(
+    @JsonProperty("format_type") override val formatType: Type = Type.CSV
+) : ObjectStorageFormatSpecification(formatType), ObjectStorageCompressionSpecificationProvider {
+    override val compression: ObjectStorageCompressionSpecification = NoCompressionSpecification()
+}
 
 @JsonSchemaTitle("Avro: Apache Avro")
-class AvroFormatSpecification : ObjectStorageFormatSpecification()
+class AvroFormatSpecification(
+    @JsonProperty("format_type") override val formatType: Type = Type.AVRO
+) : ObjectStorageFormatSpecification(formatType)
 
 @JsonSchemaTitle("Parquet: Columnar Storage")
-class ParquetFormatSpecification : ObjectStorageFormatSpecification()
+class ParquetFormatSpecification(
+    @JsonProperty("format_type") override val formatType: Type = Type.PARQUET
+) : ObjectStorageFormatSpecification(formatType)
 
 interface OutputFormatConfigurationProvider {
     val outputFormat: ObjectStorageFormatConfiguration

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/testFixtures/kotlin/io/airbyte/cdk/load/ObjectStorageDataDumper.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/testFixtures/kotlin/io/airbyte/cdk/load/ObjectStorageDataDumper.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.load
+
+import io.airbyte.cdk.load.command.DestinationStream
+import io.airbyte.cdk.load.command.object_storage.ObjectStorageCompressionConfiguration
+import io.airbyte.cdk.load.data.toAirbyteValue
+import io.airbyte.cdk.load.file.GZIPProcessor
+import io.airbyte.cdk.load.file.NoopProcessor
+import io.airbyte.cdk.load.file.object_storage.ObjectStorageClient
+import io.airbyte.cdk.load.file.object_storage.ObjectStoragePathFactory
+import io.airbyte.cdk.load.file.object_storage.RemoteObject
+import io.airbyte.cdk.load.test.util.OutputRecord
+import io.airbyte.cdk.load.test.util.toOutputRecord
+import io.airbyte.cdk.load.util.deserializeToNode
+import java.io.InputStream
+import java.util.zip.GZIPInputStream
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+
+class ObjectStorageDataDumper(
+    private val stream: DestinationStream,
+    private val client: ObjectStorageClient<*, *>,
+    private val pathFactory: ObjectStoragePathFactory,
+    private val compressionConfig: ObjectStorageCompressionConfiguration<*>? = null
+) {
+    fun dump(): List<OutputRecord> {
+        val prefix = pathFactory.getFinalDirectory(stream).toString()
+        return runBlocking {
+            withContext(Dispatchers.IO) {
+                client
+                    .list(prefix)
+                    .map { listedObject: RemoteObject<*> ->
+                        client.get(listedObject.key) { objectData: InputStream ->
+                            when (compressionConfig?.compressor) {
+                                    is GZIPProcessor -> GZIPInputStream(objectData)
+                                    is NoopProcessor,
+                                    null -> objectData
+                                    else -> error("Unsupported compressor")
+                                }
+                                .bufferedReader()
+                                .lineSequence()
+                                .map { line ->
+                                    line
+                                        .deserializeToNode()
+                                        .toAirbyteValue(stream.schemaWithMeta)
+                                        .toOutputRecord()
+                                }
+                                .toList()
+                        }
+                    }
+                    .toList()
+                    .flatten()
+            }
+        }
+    }
+}

--- a/airbyte-cdk/bulk/toolkits/load-s3/build.gradle
+++ b/airbyte-cdk/bulk/toolkits/load-s3/build.gradle
@@ -4,5 +4,6 @@ dependencies {
     api project(':airbyte-cdk:bulk:toolkits:bulk-cdk-toolkit-load-aws')
     api project(':airbyte-cdk:bulk:toolkits:bulk-cdk-toolkit-load-object-storage')
 
+    testFixturesApi(testFixtures(project(":airbyte-cdk:bulk:toolkits:bulk-cdk-toolkit-load-object-storage")))
     implementation("aws.sdk.kotlin:s3:1.0.0")
 }

--- a/airbyte-cdk/bulk/toolkits/load-s3/src/main/kotlin/io/airbyte/cdk/load/command/s3/S3PathSpecification.kt
+++ b/airbyte-cdk/bulk/toolkits/load-s3/src/main/kotlin/io/airbyte/cdk/load/command/s3/S3PathSpecification.kt
@@ -10,6 +10,15 @@ import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaInject
 import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaTitle
 import io.airbyte.cdk.load.command.object_storage.ObjectStoragePathConfiguration
 
+/**
+ * Mix-in to provide S3 path configuration fields as properties.
+ *
+ * NOTE: For legacy reasons, this is unnecessarily s3-specific. Future cloud storage solutions
+ * should create a single generic version of this in the `object-storage` toolkit and use that.
+ *
+ * See [io.airbyte.cdk.load.command.DestinationConfiguration] for more details on how to use this
+ * interface.
+ */
 interface S3PathSpecification {
     @get:JsonSchemaTitle("S3 Path Format")
     @get:JsonPropertyDescription(

--- a/airbyte-cdk/bulk/toolkits/load-s3/src/main/kotlin/io/airbyte/cdk/load/file/s3/S3Client.kt
+++ b/airbyte-cdk/bulk/toolkits/load-s3/src/main/kotlin/io/airbyte/cdk/load/file/s3/S3Client.kt
@@ -5,27 +5,25 @@
 package io.airbyte.cdk.load.file.s3
 
 import aws.sdk.kotlin.runtime.auth.credentials.StaticCredentialsProvider
-import aws.sdk.kotlin.services.s3.model.CompleteMultipartUploadRequest
-import aws.sdk.kotlin.services.s3.model.CompletedMultipartUpload
-import aws.sdk.kotlin.services.s3.model.CompletedPart
 import aws.sdk.kotlin.services.s3.model.CopyObjectRequest
 import aws.sdk.kotlin.services.s3.model.CreateMultipartUploadRequest
-import aws.sdk.kotlin.services.s3.model.CreateMultipartUploadResponse
 import aws.sdk.kotlin.services.s3.model.DeleteObjectRequest
 import aws.sdk.kotlin.services.s3.model.GetObjectRequest
 import aws.sdk.kotlin.services.s3.model.ListObjectsRequest
 import aws.sdk.kotlin.services.s3.model.PutObjectRequest
-import aws.sdk.kotlin.services.s3.model.UploadPartRequest
 import aws.smithy.kotlin.runtime.content.ByteStream
 import aws.smithy.kotlin.runtime.content.toInputStream
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 import io.airbyte.cdk.load.command.aws.AWSAccessKeyConfigurationProvider
+import io.airbyte.cdk.load.command.object_storage.ObjectStorageCompressionConfiguration
+import io.airbyte.cdk.load.command.object_storage.ObjectStorageCompressionConfigurationProvider
 import io.airbyte.cdk.load.command.object_storage.ObjectStorageUploadConfiguration
 import io.airbyte.cdk.load.command.object_storage.ObjectStorageUploadConfigurationProvider
 import io.airbyte.cdk.load.command.s3.S3BucketConfiguration
 import io.airbyte.cdk.load.command.s3.S3BucketConfigurationProvider
+import io.airbyte.cdk.load.file.NoopProcessor
+import io.airbyte.cdk.load.file.StreamProcessor
 import io.airbyte.cdk.load.file.object_storage.ObjectStorageClient
-import io.airbyte.cdk.load.file.object_storage.ObjectStorageStreamingUploadWriter
 import io.airbyte.cdk.load.file.object_storage.RemoteObject
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.micronaut.context.annotation.Factory
@@ -33,6 +31,7 @@ import io.micronaut.context.annotation.Secondary
 import jakarta.inject.Singleton
 import java.io.ByteArrayOutputStream
 import java.io.InputStream
+import java.io.OutputStream
 import kotlinx.coroutines.flow.flow
 
 data class S3Object(override val key: String, override val storageConfig: S3BucketConfiguration) :
@@ -46,7 +45,8 @@ class S3Client(
     private val client: aws.sdk.kotlin.services.s3.S3Client,
     val bucketConfig: S3BucketConfiguration,
     private val uploadConfig: ObjectStorageUploadConfiguration?,
-) : ObjectStorageClient<S3Object, S3Client.S3MultipartUpload.Writer> {
+    private val compressionConfig: ObjectStorageCompressionConfiguration<*>? = null,
+) : ObjectStorageClient<S3Object, S3MultipartUpload<*>.Writer> {
     private val log = KotlinLogging.logger {}
 
     override suspend fun list(prefix: String) = flow {
@@ -114,75 +114,35 @@ class S3Client(
 
     override suspend fun streamingUpload(
         key: String,
-        collector: suspend S3MultipartUpload.Writer.() -> Unit
+        block: suspend (S3MultipartUpload<*>.Writer) -> Unit
+    ): S3Object {
+        return streamingUpload(key, compressionConfig?.compressor ?: NoopProcessor, block)
+    }
+
+    override suspend fun <U : OutputStream> streamingUpload(
+        key: String,
+        streamProcessor: StreamProcessor<U>,
+        block: suspend (S3MultipartUpload<*>.Writer) -> Unit
     ): S3Object {
         val request = CreateMultipartUploadRequest {
             this.bucket = bucketConfig.s3BucketName
             this.key = key
         }
         val response = client.createMultipartUpload(request)
-        S3MultipartUpload(response).upload(collector)
-        return S3Object(key, bucketConfig)
-    }
-
-    inner class S3MultipartUpload(private val response: CreateMultipartUploadResponse) {
-        private val uploadedParts = mutableListOf<CompletedPart>()
-        private var inputBuffer = ByteArrayOutputStream()
-        private val partSize =
-            uploadConfig?.streamingUploadPartSize
-                ?: throw IllegalStateException("Streaming upload part size is not configured")
-
-        suspend fun upload(collector: suspend S3MultipartUpload.Writer.() -> Unit) {
-            log.info {
-                "Starting multipart upload to ${response.bucket}/${response.key} (${response.uploadId}"
-            }
-            collector.invoke(Writer())
-            complete()
-        }
-
-        inner class Writer : ObjectStorageStreamingUploadWriter {
-            override suspend fun write(bytes: ByteArray) {
-                inputBuffer.write(bytes)
-                if (inputBuffer.size() >= partSize) {
-                    uploadPart()
-                }
-            }
-        }
-
-        private suspend fun uploadPart() {
-            val partNumber = uploadedParts.size + 1
-            val request = UploadPartRequest {
-                uploadId = response.uploadId
-                bucket = response.bucket
-                key = response.key
-                body = ByteStream.fromBytes(inputBuffer.toByteArray())
-                this.partNumber = partNumber
-            }
-            val uploadResponse = client.uploadPart(request)
-            uploadedParts.add(
-                CompletedPart {
-                    this.partNumber = partNumber
-                    this.eTag = uploadResponse.eTag
-                }
+        val upload =
+            S3MultipartUpload(
+                client,
+                response,
+                ByteArrayOutputStream(),
+                streamProcessor,
+                uploadConfig
             )
-            inputBuffer.reset()
+        log.info {
+            "Starting multipart upload to ${response.bucket}/${response.key} (${response.uploadId}"
         }
-
-        private suspend fun complete() {
-            if (inputBuffer.size() > 0) {
-                uploadPart()
-            }
-            log.info {
-                "Completing multipart upload to ${response.bucket}/${response.key} (${response.uploadId}"
-            }
-            val request = CompleteMultipartUploadRequest {
-                uploadId = response.uploadId
-                bucket = response.bucket
-                key = response.key
-                this.multipartUpload = CompletedMultipartUpload { parts = uploadedParts }
-            }
-            client.completeMultipartUpload(request)
-        }
+        block(upload.Writer())
+        upload.complete()
+        return S3Object(key, bucketConfig)
     }
 }
 
@@ -191,6 +151,7 @@ class S3ClientFactory(
     private val keyConfig: AWSAccessKeyConfigurationProvider,
     private val bucketConfig: S3BucketConfigurationProvider,
     private val uploadConifg: ObjectStorageUploadConfigurationProvider? = null,
+    private val compressionConfig: ObjectStorageCompressionConfigurationProvider<*>? = null,
 ) {
     companion object {
         fun <T> make(config: T) where
@@ -217,7 +178,8 @@ class S3ClientFactory(
         return S3Client(
             client,
             bucketConfig.s3BucketConfiguration,
-            uploadConifg?.objectStorageUploadConfiguration
+            uploadConifg?.objectStorageUploadConfiguration,
+            compressionConfig?.objectStorageCompressionConfiguration,
         )
     }
 }

--- a/airbyte-cdk/bulk/toolkits/load-s3/src/main/kotlin/io/airbyte/cdk/load/file/s3/S3MultipartUpload.kt
+++ b/airbyte-cdk/bulk/toolkits/load-s3/src/main/kotlin/io/airbyte/cdk/load/file/s3/S3MultipartUpload.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.load.file.s3
+
+import aws.sdk.kotlin.services.s3.model.CompleteMultipartUploadRequest
+import aws.sdk.kotlin.services.s3.model.CompletedMultipartUpload
+import aws.sdk.kotlin.services.s3.model.CompletedPart
+import aws.sdk.kotlin.services.s3.model.CreateMultipartUploadResponse
+import aws.sdk.kotlin.services.s3.model.UploadPartRequest
+import aws.smithy.kotlin.runtime.content.ByteStream
+import io.airbyte.cdk.load.command.object_storage.ObjectStorageUploadConfiguration
+import io.airbyte.cdk.load.file.StreamProcessor
+import io.airbyte.cdk.load.file.object_storage.ObjectStorageStreamingUploadWriter
+import io.github.oshai.kotlinlogging.KotlinLogging
+import java.io.ByteArrayOutputStream
+import java.io.OutputStream
+
+class S3MultipartUpload<T : OutputStream>(
+    private val client: aws.sdk.kotlin.services.s3.S3Client,
+    private val response: CreateMultipartUploadResponse,
+    private val underlyingBuffer: ByteArrayOutputStream,
+    private val streamProcessor: StreamProcessor<T>,
+    uploadConfig: ObjectStorageUploadConfiguration?,
+) {
+    private val log = KotlinLogging.logger {}
+
+    private val uploadedParts = mutableListOf<CompletedPart>()
+    private val partSize =
+        uploadConfig?.streamingUploadPartSize
+            ?: throw IllegalStateException("Streaming upload part size is not configured")
+    private val wrappingBuffer = streamProcessor.wrapper(underlyingBuffer)
+
+    inner class Writer : ObjectStorageStreamingUploadWriter {
+        override suspend fun write(bytes: ByteArray) {
+            wrappingBuffer.write(bytes)
+            if (underlyingBuffer.size() >= partSize) {
+                uploadPart()
+            }
+        }
+
+        override suspend fun write(string: String) {
+            write(string.toByteArray(Charsets.UTF_8))
+        }
+    }
+
+    private suspend fun uploadPart() {
+        streamProcessor.partFinisher.invoke(wrappingBuffer)
+        val partNumber = uploadedParts.size + 1
+        val request = UploadPartRequest {
+            uploadId = response.uploadId
+            bucket = response.bucket
+            key = response.key
+            body = ByteStream.fromBytes(underlyingBuffer.toByteArray())
+            this.partNumber = partNumber
+        }
+        val uploadResponse = client.uploadPart(request)
+        uploadedParts.add(
+            CompletedPart {
+                this.partNumber = partNumber
+                this.eTag = uploadResponse.eTag
+            }
+        )
+        underlyingBuffer.reset()
+    }
+
+    suspend fun complete() {
+        if (underlyingBuffer.size() > 0) {
+            uploadPart()
+        }
+        log.info {
+            "Completing multipart upload to ${response.bucket}/${response.key} (${response.uploadId}"
+        }
+        val request = CompleteMultipartUploadRequest {
+            uploadId = response.uploadId
+            bucket = response.bucket
+            key = response.key
+            this.multipartUpload = CompletedMultipartUpload { parts = uploadedParts }
+        }
+        client.completeMultipartUpload(request)
+    }
+}

--- a/airbyte-integrations/connectors/destination-s3-v2/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-s3-v2/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: file
   connectorType: destination
   definitionId: d6116991-e809-4c7c-ae09-c64712df5b66
-  dockerImageTag: 0.1.4
+  dockerImageTag: 0.1.5
   dockerRepository: airbyte/destination-s3-v2
   githubIssueLabel: destination-s3-v2
   icon: s3.svg
@@ -28,6 +28,11 @@ data:
       testSecrets:
         - name: SECRET_DESTINATION-S3-V2-MINIMAL-REQUIRED-CONFIG
           fileName: s3_dest_v2_minimal_required_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION-S3-V2-JSONL-GZIP
+          fileName: s3_dest_v2_jsonl_gzip_config.json
           secretStore:
             type: GSM
             alias: airbyte-connector-testing-secret-store

--- a/airbyte-integrations/connectors/destination-s3-v2/src/main/kotlin/S3V2Checker.kt
+++ b/airbyte-integrations/connectors/destination-s3-v2/src/main/kotlin/S3V2Checker.kt
@@ -13,14 +13,16 @@ import io.airbyte.cdk.load.file.s3.S3Object
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.micronaut.context.exceptions.ConfigurationException
 import jakarta.inject.Singleton
+import java.io.OutputStream
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
 
 @Singleton
-class S3V2Checker(private val timeProvider: TimeProvider) : DestinationChecker<S3V2Configuration> {
+class S3V2Checker<T : OutputStream>(private val timeProvider: TimeProvider) :
+    DestinationChecker<S3V2Configuration<T>> {
     private val log = KotlinLogging.logger {}
 
-    override fun check(config: S3V2Configuration) {
+    override fun check(config: S3V2Configuration<T>) {
         runBlocking {
             if (config.objectStorageFormatConfiguration !is JsonFormatConfiguration) {
                 throw ConfigurationException("Currently only JSON format is supported")
@@ -28,11 +30,12 @@ class S3V2Checker(private val timeProvider: TimeProvider) : DestinationChecker<S
             val s3Client = S3ClientFactory.make(config)
             val pathFactory = ObjectStoragePathFactory.from(config, timeProvider)
             val path = pathFactory.getStagingDirectory(mockStream())
-            val key = path.resolve("_EMPTY").toString()
+            val key = path.resolve("_EXAMPLE").toString()
             log.info { "Checking if destination can write to $path" }
             var s3Object: S3Object? = null
+            val compressor = config.objectStorageCompressionConfiguration.compressor
             try {
-                s3Object = s3Client.put(key, byteArrayOf())
+                s3Object = s3Client.streamingUpload(key, compressor) { it.write("""{"data": 1}""") }
                 val results = s3Client.list(path.toString()).toList()
                 if (results.isEmpty() || results.find { it.key == key } == null) {
                     throw IllegalStateException("Failed to write to S3 bucket")

--- a/airbyte-integrations/connectors/destination-s3-v2/src/main/kotlin/S3V2Configuration.kt
+++ b/airbyte-integrations/connectors/destination-s3-v2/src/main/kotlin/S3V2Configuration.kt
@@ -8,6 +8,8 @@ import io.airbyte.cdk.load.command.DestinationConfiguration
 import io.airbyte.cdk.load.command.DestinationConfigurationFactory
 import io.airbyte.cdk.load.command.aws.AWSAccessKeyConfiguration
 import io.airbyte.cdk.load.command.aws.AWSAccessKeyConfigurationProvider
+import io.airbyte.cdk.load.command.object_storage.ObjectStorageCompressionConfiguration
+import io.airbyte.cdk.load.command.object_storage.ObjectStorageCompressionConfigurationProvider
 import io.airbyte.cdk.load.command.object_storage.ObjectStorageFormatConfiguration
 import io.airbyte.cdk.load.command.object_storage.ObjectStorageFormatConfigurationProvider
 import io.airbyte.cdk.load.command.object_storage.ObjectStoragePathConfiguration
@@ -18,43 +20,48 @@ import io.airbyte.cdk.load.command.s3.S3BucketConfiguration
 import io.airbyte.cdk.load.command.s3.S3BucketConfigurationProvider
 import io.micronaut.context.annotation.Factory
 import jakarta.inject.Singleton
+import java.io.OutputStream
 
-data class S3V2Configuration(
+data class S3V2Configuration<T : OutputStream>(
     // Client-facing configuration
     override val awsAccessKeyConfiguration: AWSAccessKeyConfiguration,
     override val s3BucketConfiguration: S3BucketConfiguration,
     override val objectStoragePathConfiguration: ObjectStoragePathConfiguration,
     override val objectStorageFormatConfiguration: ObjectStorageFormatConfiguration,
+    override val objectStorageCompressionConfiguration: ObjectStorageCompressionConfiguration<T>,
 
     // Internal configuration
     override val objectStorageUploadConfiguration: ObjectStorageUploadConfiguration =
         ObjectStorageUploadConfiguration(5L * 1024 * 1024),
-    override val recordBatchSizeBytes: Long = 200L * 1024 * 1024
+    override val recordBatchSizeBytes: Long = 200L * 1024 * 1024,
 ) :
     DestinationConfiguration(),
     AWSAccessKeyConfigurationProvider,
     S3BucketConfigurationProvider,
     ObjectStoragePathConfigurationProvider,
     ObjectStorageFormatConfigurationProvider,
-    ObjectStorageUploadConfigurationProvider
+    ObjectStorageUploadConfigurationProvider,
+    ObjectStorageCompressionConfigurationProvider<T>
 
 @Singleton
 class S3V2ConfigurationFactory :
-    DestinationConfigurationFactory<S3V2Specification, S3V2Configuration> {
-    override fun makeWithoutExceptionHandling(pojo: S3V2Specification): S3V2Configuration {
+    DestinationConfigurationFactory<S3V2Specification, S3V2Configuration<*>> {
+    override fun makeWithoutExceptionHandling(pojo: S3V2Specification): S3V2Configuration<*> {
         return S3V2Configuration(
             awsAccessKeyConfiguration = pojo.toAWSAccessKeyConfiguration(),
             s3BucketConfiguration = pojo.toS3BucketConfiguration(),
             objectStoragePathConfiguration = pojo.toObjectStoragePathConfiguration(),
-            objectStorageFormatConfiguration = pojo.toObjectStorageFormatConfiguration()
+            objectStorageFormatConfiguration = pojo.toObjectStorageFormatConfiguration(),
+            objectStorageCompressionConfiguration = pojo.toCompressionConfiguration()
         )
     }
 }
 
+@Suppress("UNCHECKED_CAST")
 @Factory
-class S3V2ConfigurationProvider(private val config: DestinationConfiguration) {
+class S3V2ConfigurationProvider<T : OutputStream>(private val config: DestinationConfiguration) {
     @Singleton
-    fun get(): S3V2Configuration {
-        return config as S3V2Configuration
+    fun get(): S3V2Configuration<T> {
+        return config as S3V2Configuration<T>
     }
 }

--- a/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2CheckTest.kt
+++ b/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2CheckTest.kt
@@ -15,8 +15,12 @@ class S3V2CheckTest :
         successConfigFilenames =
             listOf(
                 CheckTestConfig(
-                    S3V2TestUtils.MINIMAL_CONFIG_PATH,
+                    S3V2TestUtils.JSON_UNCOMPRESSED_CONFIG_PATH,
                     setOf(FeatureFlag.AIRBYTE_CLOUD_DEPLOYMENT)
+                ),
+                CheckTestConfig(
+                    S3V2TestUtils.JSON_GZIP_CONFIG_PATH,
+                    setOf(FeatureFlag.AIRBYTE_CLOUD_DEPLOYMENT),
                 )
             ),
         failConfigFilenamesAndFailureReasons = emptyMap()

--- a/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2DataDumper.kt
+++ b/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2DataDumper.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination.s3_v2
+
+import io.airbyte.cdk.command.ConfigurationSpecification
+import io.airbyte.cdk.load.ObjectStorageDataDumper
+import io.airbyte.cdk.load.command.DestinationStream
+import io.airbyte.cdk.load.file.object_storage.ObjectStoragePathFactory
+import io.airbyte.cdk.load.file.s3.S3ClientFactory
+import io.airbyte.cdk.load.test.util.DestinationDataDumper
+import io.airbyte.cdk.load.test.util.OutputRecord
+
+object S3V2DataDumper : DestinationDataDumper {
+    override fun dumpRecords(
+        spec: ConfigurationSpecification,
+        stream: DestinationStream
+    ): List<OutputRecord> {
+        val config =
+            S3V2ConfigurationFactory().makeWithoutExceptionHandling(spec as S3V2Specification)
+        val s3Client = S3ClientFactory.make(config)
+        val pathFactory = ObjectStoragePathFactory.from(config)
+        return ObjectStorageDataDumper(
+                stream,
+                s3Client,
+                pathFactory,
+                config.objectStorageCompressionConfiguration
+            )
+            .dump()
+    }
+}

--- a/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2TestUtils.kt
+++ b/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2TestUtils.kt
@@ -9,10 +9,11 @@ import java.nio.file.Files
 import java.nio.file.Path
 
 object S3V2TestUtils {
-    const val MINIMAL_CONFIG_PATH = "secrets/s3_dest_v2_minimal_required_config.json"
-    val minimalConfig: S3V2Specification =
+    const val JSON_UNCOMPRESSED_CONFIG_PATH = "secrets/s3_dest_v2_minimal_required_config.json"
+    const val JSON_GZIP_CONFIG_PATH = "secrets/s3_dest_v2_jsonl_gzip_config.json"
+    fun getConfig(configPath: String): S3V2Specification =
         ValidatedJsonUtils.parseOne(
             S3V2Specification::class.java,
-            Files.readString(Path.of(MINIMAL_CONFIG_PATH)),
+            Files.readString(Path.of(configPath)),
         )
 }

--- a/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2WriteTest.kt
+++ b/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2WriteTest.kt
@@ -4,30 +4,14 @@
 
 package io.airbyte.integrations.destination.s3_v2
 
-import io.airbyte.cdk.command.ConfigurationSpecification
-import io.airbyte.cdk.load.command.DestinationStream
-import io.airbyte.cdk.load.data.toAirbyteValue
-import io.airbyte.cdk.load.file.object_storage.ObjectStoragePathFactory
-import io.airbyte.cdk.load.file.s3.S3ClientFactory
-import io.airbyte.cdk.load.file.s3.S3Object
-import io.airbyte.cdk.load.test.util.DestinationDataDumper
 import io.airbyte.cdk.load.test.util.NoopDestinationCleaner
 import io.airbyte.cdk.load.test.util.NoopExpectedRecordMapper
-import io.airbyte.cdk.load.test.util.OutputRecord
-import io.airbyte.cdk.load.test.util.toOutputRecord
-import io.airbyte.cdk.load.util.deserializeToNode
 import io.airbyte.cdk.load.write.BasicFunctionalityIntegrationTest
-import java.io.InputStream
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.toList
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.withContext
 import org.junit.jupiter.api.Test
 
-class S3V2WriteTest :
+class S3V2WriteTestJsonUncompressed :
     BasicFunctionalityIntegrationTest(
-        S3V2TestUtils.minimalConfig,
+        S3V2TestUtils.getConfig(S3V2TestUtils.JSON_UNCOMPRESSED_CONFIG_PATH),
         S3V2DataDumper,
         NoopDestinationCleaner,
         NoopExpectedRecordMapper,
@@ -38,40 +22,15 @@ class S3V2WriteTest :
     }
 }
 
-object S3V2DataDumper : DestinationDataDumper {
-    override fun dumpRecords(
-        spec: ConfigurationSpecification,
-        stream: DestinationStream
-    ): List<OutputRecord> {
-        val config =
-            S3V2ConfigurationFactory().makeWithoutExceptionHandling(spec as S3V2Specification)
-        val s3Client = S3ClientFactory.make(config)
-        // Note: because we cannot mock wall time in docker, this
-        // path code cannot contain time-based macros.
-        // TODO: add pattern matching to the path factory.
-        val pathFactory = ObjectStoragePathFactory.from(config)
-        val prefix = pathFactory.getFinalDirectory(stream).toString()
-        return runBlocking {
-            withContext(Dispatchers.IO) {
-                s3Client
-                    .list(prefix)
-                    .map { listedObject: S3Object ->
-                        s3Client.get(listedObject.key) { objectData: InputStream ->
-                            objectData
-                                .bufferedReader()
-                                .lineSequence()
-                                .map { line ->
-                                    line
-                                        .deserializeToNode()
-                                        .toAirbyteValue(stream.schemaWithMeta)
-                                        .toOutputRecord()
-                                }
-                                .toList()
-                        }
-                    }
-                    .toList()
-                    .flatten()
-            }
-        }
+class S3V2WriteTestJsonGzip :
+    BasicFunctionalityIntegrationTest(
+        S3V2TestUtils.getConfig(S3V2TestUtils.JSON_GZIP_CONFIG_PATH),
+        S3V2DataDumper,
+        NoopDestinationCleaner,
+        NoopExpectedRecordMapper,
+    ) {
+    @Test
+    override fun testBasicWrite() {
+        super.testBasicWrite()
     }
 }

--- a/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/resources/expected-spec-cloud.json
+++ b/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/resources/expected-spec-cloud.json
@@ -6,60 +6,6 @@
     "type" : "object",
     "additionalProperties" : true,
     "properties" : {
-      "format" : {
-        "oneOf" : [ {
-          "title" : "JSON Lines: Newline-delimited JSON",
-          "type" : "object",
-          "additionalProperties" : true,
-          "properties" : {
-            "format_type" : {
-              "type" : "string",
-              "enum" : [ "JSONL" ],
-              "default" : "JSONL"
-            }
-          },
-          "required" : [ "format_type" ]
-        }, {
-          "title" : "CSV: Comma-Separated Values",
-          "type" : "object",
-          "additionalProperties" : true,
-          "properties" : {
-            "format_type" : {
-              "type" : "string",
-              "enum" : [ "CSV" ],
-              "default" : "CSV"
-            }
-          },
-          "required" : [ "format_type" ]
-        }, {
-          "title" : "Avro: Apache Avro",
-          "type" : "object",
-          "additionalProperties" : true,
-          "properties" : {
-            "format_type" : {
-              "type" : "string",
-              "enum" : [ "AVRO" ],
-              "default" : "AVRO"
-            }
-          },
-          "required" : [ "format_type" ]
-        }, {
-          "title" : "Parquet: Columnar Storage",
-          "type" : "object",
-          "additionalProperties" : true,
-          "properties" : {
-            "format_type" : {
-              "type" : "string",
-              "enum" : [ "PARQUET" ],
-              "default" : "PARQUET"
-            }
-          },
-          "required" : [ "format_type" ]
-        } ],
-        "description" : "Format of the data output. See <a href=\"https://docs.airbyte.com/integrations/destinations/s3/#supported-output-schema\">here</a> for more details",
-        "title" : "Output Format",
-        "type" : "object"
-      },
       "access_key_id" : {
         "type" : "string",
         "description" : "The access key ID to access the S3 bucket. Airbyte requires Read and Write permissions to the given bucket. Read more <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys\">here</a>.",
@@ -91,6 +37,120 @@
         "title" : "S3 Bucket Region",
         "examples" : [ "us-east-1" ]
       },
+      "format" : {
+        "oneOf" : [ {
+          "title" : "JSON Lines: Newline-delimited JSON",
+          "type" : "object",
+          "additionalProperties" : true,
+          "properties" : {
+            "format_type" : {
+              "type" : "string",
+              "enum" : [ "JSONL" ],
+              "default" : "JSONL"
+            },
+            "compression" : {
+              "oneOf" : [ {
+                "title" : "No Compression",
+                "type" : "object",
+                "additionalProperties" : true,
+                "properties" : {
+                  "compression_type" : {
+                    "type" : "string",
+                    "enum" : [ "No Compression" ],
+                    "default" : "No Compression"
+                  }
+                },
+                "required" : [ "compression_type" ]
+              }, {
+                "title" : "GZIP",
+                "type" : "object",
+                "additionalProperties" : true,
+                "properties" : {
+                  "compression_type" : {
+                    "type" : "string",
+                    "enum" : [ "GZIP" ],
+                    "default" : "GZIP"
+                  }
+                },
+                "required" : [ "compression_type" ]
+              } ],
+              "description" : "Whether the output files should be compressed. If compression is selected, the output filename will have an extra extension (GZIP: \".jsonl.gz\").",
+              "title" : "Compression",
+              "type" : "object"
+            }
+          },
+          "required" : [ "format_type", "compression" ]
+        }, {
+          "title" : "CSV: Comma-Separated Values",
+          "type" : "object",
+          "additionalProperties" : true,
+          "properties" : {
+            "format_type" : {
+              "type" : "string",
+              "enum" : [ "CSV" ],
+              "default" : "CSV"
+            },
+            "compression" : {
+              "oneOf" : [ {
+                "title" : "No Compression",
+                "type" : "object",
+                "additionalProperties" : true,
+                "properties" : {
+                  "compression_type" : {
+                    "type" : "string",
+                    "enum" : [ "No Compression" ],
+                    "default" : "No Compression"
+                  }
+                },
+                "required" : [ "compression_type" ]
+              }, {
+                "title" : "GZIP",
+                "type" : "object",
+                "additionalProperties" : true,
+                "properties" : {
+                  "compression_type" : {
+                    "type" : "string",
+                    "enum" : [ "GZIP" ],
+                    "default" : "GZIP"
+                  }
+                },
+                "required" : [ "compression_type" ]
+              } ],
+              "description" : "Whether the output files should be compressed. If compression is selected, the output filename will have an extra extension (GZIP: \".jsonl.gz\").",
+              "title" : "Compression",
+              "type" : "object"
+            }
+          },
+          "required" : [ "format_type", "compression" ]
+        }, {
+          "title" : "Avro: Apache Avro",
+          "type" : "object",
+          "additionalProperties" : true,
+          "properties" : {
+            "format_type" : {
+              "type" : "string",
+              "enum" : [ "AVRO" ],
+              "default" : "AVRO"
+            }
+          },
+          "required" : [ "format_type" ]
+        }, {
+          "title" : "Parquet: Columnar Storage",
+          "type" : "object",
+          "additionalProperties" : true,
+          "properties" : {
+            "format_type" : {
+              "type" : "string",
+              "enum" : [ "PARQUET" ],
+              "default" : "PARQUET"
+            }
+          },
+          "required" : [ "format_type" ]
+        } ],
+        "description" : "Format of the data output. See <a href=\"https://docs.airbyte.com/integrations/destinations/s3/#supported-output-schema\">here</a> for more details",
+        "title" : "Output Format",
+        "type" : "object"
+      },
       "s3_endpoint" : {
         "type" : "string",
         "description" : "Your S3 endpoint url. Read more <a href=\"https://docs.aws.amazon.com/general/latest/gr/s3.html#:~:text=Service%20endpoints-,Amazon%20S3%20endpoints,-When%20you%20use\">here</a>",
@@ -117,7 +177,7 @@
         "examples" : [ "__staging/data_sync/test" ]
       }
     },
-    "required" : [ "format", "access_key_id", "secret_access_key", "s3_bucket_name", "s3_bucket_path", "s3_bucket_region" ]
+    "required" : [ "access_key_id", "secret_access_key", "s3_bucket_name", "s3_bucket_path", "s3_bucket_region", "format" ]
   },
   "supportsIncremental" : true,
   "supportsNormalization" : false,

--- a/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/resources/expected-spec-oss.json
+++ b/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/resources/expected-spec-oss.json
@@ -6,60 +6,6 @@
     "type" : "object",
     "additionalProperties" : true,
     "properties" : {
-      "format" : {
-        "oneOf" : [ {
-          "title" : "JSON Lines: Newline-delimited JSON",
-          "type" : "object",
-          "additionalProperties" : true,
-          "properties" : {
-            "format_type" : {
-              "type" : "string",
-              "enum" : [ "JSONL" ],
-              "default" : "JSONL"
-            }
-          },
-          "required" : [ "format_type" ]
-        }, {
-          "title" : "CSV: Comma-Separated Values",
-          "type" : "object",
-          "additionalProperties" : true,
-          "properties" : {
-            "format_type" : {
-              "type" : "string",
-              "enum" : [ "CSV" ],
-              "default" : "CSV"
-            }
-          },
-          "required" : [ "format_type" ]
-        }, {
-          "title" : "Avro: Apache Avro",
-          "type" : "object",
-          "additionalProperties" : true,
-          "properties" : {
-            "format_type" : {
-              "type" : "string",
-              "enum" : [ "AVRO" ],
-              "default" : "AVRO"
-            }
-          },
-          "required" : [ "format_type" ]
-        }, {
-          "title" : "Parquet: Columnar Storage",
-          "type" : "object",
-          "additionalProperties" : true,
-          "properties" : {
-            "format_type" : {
-              "type" : "string",
-              "enum" : [ "PARQUET" ],
-              "default" : "PARQUET"
-            }
-          },
-          "required" : [ "format_type" ]
-        } ],
-        "description" : "Format of the data output. See <a href=\"https://docs.airbyte.com/integrations/destinations/s3/#supported-output-schema\">here</a> for more details",
-        "title" : "Output Format",
-        "type" : "object"
-      },
       "access_key_id" : {
         "type" : "string",
         "description" : "The access key ID to access the S3 bucket. Airbyte requires Read and Write permissions to the given bucket. Read more <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys\">here</a>.",
@@ -91,6 +37,120 @@
         "title" : "S3 Bucket Region",
         "examples" : [ "us-east-1" ]
       },
+      "format" : {
+        "oneOf" : [ {
+          "title" : "JSON Lines: Newline-delimited JSON",
+          "type" : "object",
+          "additionalProperties" : true,
+          "properties" : {
+            "format_type" : {
+              "type" : "string",
+              "enum" : [ "JSONL" ],
+              "default" : "JSONL"
+            },
+            "compression" : {
+              "oneOf" : [ {
+                "title" : "No Compression",
+                "type" : "object",
+                "additionalProperties" : true,
+                "properties" : {
+                  "compression_type" : {
+                    "type" : "string",
+                    "enum" : [ "No Compression" ],
+                    "default" : "No Compression"
+                  }
+                },
+                "required" : [ "compression_type" ]
+              }, {
+                "title" : "GZIP",
+                "type" : "object",
+                "additionalProperties" : true,
+                "properties" : {
+                  "compression_type" : {
+                    "type" : "string",
+                    "enum" : [ "GZIP" ],
+                    "default" : "GZIP"
+                  }
+                },
+                "required" : [ "compression_type" ]
+              } ],
+              "description" : "Whether the output files should be compressed. If compression is selected, the output filename will have an extra extension (GZIP: \".jsonl.gz\").",
+              "title" : "Compression",
+              "type" : "object"
+            }
+          },
+          "required" : [ "format_type", "compression" ]
+        }, {
+          "title" : "CSV: Comma-Separated Values",
+          "type" : "object",
+          "additionalProperties" : true,
+          "properties" : {
+            "format_type" : {
+              "type" : "string",
+              "enum" : [ "CSV" ],
+              "default" : "CSV"
+            },
+            "compression" : {
+              "oneOf" : [ {
+                "title" : "No Compression",
+                "type" : "object",
+                "additionalProperties" : true,
+                "properties" : {
+                  "compression_type" : {
+                    "type" : "string",
+                    "enum" : [ "No Compression" ],
+                    "default" : "No Compression"
+                  }
+                },
+                "required" : [ "compression_type" ]
+              }, {
+                "title" : "GZIP",
+                "type" : "object",
+                "additionalProperties" : true,
+                "properties" : {
+                  "compression_type" : {
+                    "type" : "string",
+                    "enum" : [ "GZIP" ],
+                    "default" : "GZIP"
+                  }
+                },
+                "required" : [ "compression_type" ]
+              } ],
+              "description" : "Whether the output files should be compressed. If compression is selected, the output filename will have an extra extension (GZIP: \".jsonl.gz\").",
+              "title" : "Compression",
+              "type" : "object"
+            }
+          },
+          "required" : [ "format_type", "compression" ]
+        }, {
+          "title" : "Avro: Apache Avro",
+          "type" : "object",
+          "additionalProperties" : true,
+          "properties" : {
+            "format_type" : {
+              "type" : "string",
+              "enum" : [ "AVRO" ],
+              "default" : "AVRO"
+            }
+          },
+          "required" : [ "format_type" ]
+        }, {
+          "title" : "Parquet: Columnar Storage",
+          "type" : "object",
+          "additionalProperties" : true,
+          "properties" : {
+            "format_type" : {
+              "type" : "string",
+              "enum" : [ "PARQUET" ],
+              "default" : "PARQUET"
+            }
+          },
+          "required" : [ "format_type" ]
+        } ],
+        "description" : "Format of the data output. See <a href=\"https://docs.airbyte.com/integrations/destinations/s3/#supported-output-schema\">here</a> for more details",
+        "title" : "Output Format",
+        "type" : "object"
+      },
       "s3_endpoint" : {
         "type" : "string",
         "description" : "Your S3 endpoint url. Read more <a href=\"https://docs.aws.amazon.com/general/latest/gr/s3.html#:~:text=Service%20endpoints-,Amazon%20S3%20endpoints,-When%20you%20use\">here</a>",
@@ -117,7 +177,7 @@
         "examples" : [ "__staging/data_sync/test" ]
       }
     },
-    "required" : [ "format", "access_key_id", "secret_access_key", "s3_bucket_name", "s3_bucket_path", "s3_bucket_region" ]
+    "required" : [ "access_key_id", "secret_access_key", "s3_bucket_name", "s3_bucket_path", "s3_bucket_region", "format" ]
   },
   "supportsIncremental" : true,
   "supportsNormalization" : false,


### PR DESCRIPTION
## What
* Adds compression to the specs for json and csv, with options "No Compression" and "GZIP"
* Adds a "stream processor" option to the streaming upload, which defaults to passing in the configured compression if/a
* Abstracts out the object-storage-general parts of data dumping, and adds it to the test fixtures of the object storage toolkit
* Moves S3MultipartUpload to its own file (it was getting big)
* Applies @edgao 's requested refactors to the `streamingUpload` interface (no receiver, cleaner execution of block wrapper)
* Checker tests compression
* Tweaks to the format spec to make it serializable