### PR TITLE
fix(databend): add ssl param for databend destination

### DIFF
--- a/airbyte-integrations/connectors/destination-databend/destination_databend/client.py
+++ b/airbyte-integrations/connectors/destination-databend/destination_databend/client.py
@@ -6,15 +6,17 @@ from databend_sqlalchemy import connector
 
 
 class DatabendClient:
-    def __init__(self, host: str, port: int, database: str, table: str, username: str, password: str = None):
+    def __init__(self, host: str, port: int, database: str, table: str, username: str, ssl: bool, password: str = None):
         self.host = host
         self.port = port
         self.database = database
         self.table = table
         self.username = username
         self.password = password
+        self.ssl = ssl
 
     def open(self):
-        handle = connector.connect(f"https://{self.username}:{self.password}@{self.host}:{self.port}/{self.database}").cursor()
+        handle = connector.connect(
+            f"https://{self.username}:{self.password}@{self.host}:{self.port}/{self.database}?secure={self.ssl}").cursor()
 
         return handle

--- a/airbyte-integrations/connectors/destination-databend/destination_databend/spec.json
+++ b/airbyte-integrations/connectors/destination-databend/destination_databend/spec.json
@@ -51,6 +51,13 @@
         "type": "string",
         "airbyte_secret": true,
         "order": 6
+      },
+      "ssl": {
+        "title": "SSL Connection",
+        "description": "Encrypt data using SSL.",
+        "type": "boolean",
+        "default": true,
+        "order": 7
       }
     }
   }

--- a/airbyte-integrations/connectors/destination-databend/setup.py
+++ b/airbyte-integrations/connectors/destination-databend/setup.py
@@ -5,7 +5,7 @@
 
 from setuptools import find_packages, setup
 
-MAIN_REQUIREMENTS = ["airbyte-cdk", "requests", "databend-sqlalchemy==0.1.6"]
+MAIN_REQUIREMENTS = ["airbyte-cdk", "requests", "databend-sqlalchemy==0.3.2"]
 
 TEST_REQUIREMENTS = ["pytest~=6.1"]
 setup(


### PR DESCRIPTION
## What
Closes https://github.com/airbytehq/airbyte/issues/34473
*Describe what the change is solving*
- Add ssl config for databend DSN
- Upgrade `databend-sqlalchemy` to 0.3.2

## Recommended reading order
1. `client.py`
2. `spec.json`

## How
Add `ssl` param for databend spec.json

## Review guide
1. `client.py`
2. `spec.json`

## User Impact
User will connect to databend via https.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
