### PR TITLE
fix: pinned dompurify version

### DIFF
--- a/docusaurus/package.json
+++ b/docusaurus/package.json
@@ -136,6 +136,9 @@
     "webpack-dev-server": "4.9.2",
     "yaml-loader": "^0.8.0"
   },
+  "resolutions": {
+    "dompurify": "3.1.6"
+  },
   "browserslist": {
     "production": [
       ">0.5%",

--- a/docusaurus/pnpm-lock.yaml
+++ b/docusaurus/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  dompurify: 3.1.6
+
 importers:
 
   .:
@@ -2880,8 +2883,8 @@ packages:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
-  dompurify@3.1.7:
-    resolution: {integrity: sha512-VaTstWtsneJY8xzy7DekmYWEOZcmzIe3Qb3zPd4STve1OBTa+e+WmS1ITQec1fZYXI3HCsOZZiSMpG6oxoWMWQ==}
+  dompurify@3.1.6:
+    resolution: {integrity: sha512-cTOAhc36AalkjtBpfG6O8JimdTMWNXjiePT2xQH/ppBGi/4uIpmj8eKyIkMJErXWARyINV/sB38yf8JCLF5pbQ==}
 
   domutils@2.8.0:
     resolution: {integrity: sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==}
@@ -9391,7 +9394,7 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
-  dompurify@3.1.7: {}
+  dompurify@3.1.6: {}
 
   domutils@2.8.0:
     dependencies:
@@ -10672,7 +10675,7 @@ snapshots:
       d3-sankey: 0.12.3
       dagre-d3-es: 7.0.10
       dayjs: 1.11.11
-      dompurify: 3.1.7
+      dompurify: 3.1.6
       elkjs: 0.8.2
       khroma: 2.1.0
       lodash-es: 4.17.21


### PR DESCRIPTION
Closes  https://github.com/airbytehq/oncall/issues/6726
## What
Text nodes were not being displayed in some mermaid diagrams because of a bug introduced by `dompurify@3.1.7` https://github.com/facebook/docusaurus/issues/10526 

## Before

![Screenshot 2024-10-18 at 08 32 37](https://github.com/user-attachments/assets/3ee9f77d-05a0-46e3-be3a-1b53adfc592d)


## After

![Screenshot 2024-10-18 at 08 36 50](https://github.com/user-attachments/assets/1e08da46-ec36-44b1-96a3-bb8fa9dc3e08)


## How
Pin `dompurify` to 3.1.6 to avoid the bug.

To test it works, you can visit any of these pages in the preview:
https://airbyte-docs-git-leti-fix-text-in-archite-7b7153-airbyte-growth.vercel.app/understanding-airbyte/high-level-view 
https://airbyte-docs-git-leti-fix-text-in-archite-7b7153-airbyte-growth.vercel.app/understanding-airbyte/jobs


## User Impact
Users will be able to see the diagrams text nodes again

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
