### PR TITLE
Bulk load CDK: test runner not micronaut, fix  concurrent execution

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/IntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/IntegrationTest.kt
@@ -15,13 +15,11 @@ import io.airbyte.protocol.models.v0.AirbyteStreamStatusTraceMessage
 import io.airbyte.protocol.models.v0.AirbyteStreamStatusTraceMessage.AirbyteStreamStatus
 import io.airbyte.protocol.models.v0.AirbyteTraceMessage
 import io.airbyte.protocol.models.v0.StreamDescriptor
-import io.micronaut.test.extensions.junit5.annotation.MicronautTest
 import java.time.Instant
 import java.time.LocalDateTime
 import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 import java.util.concurrent.atomic.AtomicBoolean
-import javax.inject.Inject
 import kotlin.test.fail
 import kotlinx.coroutines.async
 import kotlinx.coroutines.runBlocking
@@ -36,13 +34,6 @@ import uk.org.webcompere.systemstubs.environment.EnvironmentVariables
 import uk.org.webcompere.systemstubs.jupiter.SystemStub
 import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension
 
-@MicronautTest(
-    // Manually add metadata.yaml as a property source so that we can use its
-    // values as injectable properties.
-    // This is _infinitely_ easier than trying to wire up
-    // MetadataYamlPropertySource to be available at test time.
-    propertySources = ["classpath:metadata.yaml"]
-)
 @Execution(ExecutionMode.CONCURRENT)
 // Spotbugs doesn't let you suppress the actual lateinit property,
 // so we have to suppress the entire class.
@@ -70,7 +61,7 @@ abstract class IntegrationTest(
     // Intentionally don't inject the actual destination process - we need a full factory
     // because some tests want to run multiple syncs, so we need to run the destination
     // multiple times.
-    @Inject lateinit var destinationProcessFactory: DestinationProcessFactory
+    val destinationProcessFactory = DestinationProcessFactory.get()
 
     @Suppress("DEPRECATION") private val randomSuffix = RandomStringUtils.randomAlphabetic(4)
     private val timestampString =

--- a/buildSrc/src/main/groovy/airbyte-bulk-connector.gradle
+++ b/buildSrc/src/main/groovy/airbyte-bulk-connector.gradle
@@ -152,10 +152,6 @@ class AirbyteBulkConnectorPlugin implements Plugin<Project> {
                     resources {
                         srcDir 'src/test-integration/resources'
                     }
-                    resources {
-                        srcDir '.'
-                        include 'metadata.yaml'
-                    }
                 }
                 // This source set should only be used for tests based on the old CDK's test classes,
                 // in particular DestinationAcceptanceTest / BaseTypingDedupingTest.
@@ -178,6 +174,11 @@ class AirbyteBulkConnectorPlugin implements Plugin<Project> {
                 testClassesDirs = project.sourceSets.integrationTest.output.classesDirs
                 classpath = project.sourceSets.integrationTest.runtimeClasspath
                 useJUnitPlatform()
+
+                jvmArgs = project.test.jvmArgs
+                systemProperties = project.test.systemProperties
+                maxParallelForks = project.test.maxParallelForks
+                maxHeapSize = project.test.maxHeapSize
             }
 
             // For historical reasons (i.e. airbyte-ci), this task is called integrationTestJava.
@@ -193,7 +194,12 @@ class AirbyteBulkConnectorPlugin implements Plugin<Project> {
                 useJUnitPlatform()
                 // We need a docker image to run this task, so depend on assemble
                 dependsOn project.tasks.assemble
-                environment "MICRONAUT_ENVIRONMENTS", "DOCKERIZED_INTEGRATION_TEST"
+                environment "AIRBYTE_CONNECTOR_INTEGRATION_TEST_RUNNER", "docker"
+
+                jvmArgs = project.test.jvmArgs
+                systemProperties = project.test.systemProperties
+                maxParallelForks = project.test.maxParallelForks
+                maxHeapSize = project.test.maxHeapSize
             }
 
             project.dependencies {


### PR DESCRIPTION
grab the same jvm args/etc as the standard `test` task (copied from https://github.com/airbytehq/airbyte/blob/26f00100ceed1c4c1d608c4a6e08193d67179148/buildSrc/src/main/groovy/airbyte-java-connector.gradle#L207-L210). This makes concurrent execution work.

MicronautTest + TestInfo + concurrent execution = 😢 . Specifically, junit sometimes executes the BeforeEach function before micronaut injects the DockerProcessFactory (I have no idea why this isn't a problem in non-concurrent execution)

so just rip out the micronaut stuff from base IntegrationTest. It wasn't doing a _huge_ amount for us anyway. (this also means we don't need to put the root metadata.yaml on the classpath anymore, since we can just read it as a normal file)