### PR TITLE
Make decoder arg optional in ModelToComponentFactory.create_http_requester

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -884,7 +884,9 @@ class ModelToComponentFactory:
     def create_exponential_backoff_strategy(model: ExponentialBackoffStrategyModel, config: Config) -> ExponentialBackoffStrategy:
         return ExponentialBackoffStrategy(factor=model.factor or 5, parameters=model.parameters or {}, config=config)
 
-    def create_http_requester(self, model: HttpRequesterModel, decoder: Decoder, config: Config, *, name: str) -> HttpRequester:
+    def create_http_requester(
+        self, model: HttpRequesterModel, config: Config, *, name: str, decoder: Optional[Decoder] = None
+    ) -> HttpRequester:
         authenticator = (
             self._create_component_from_model(model=model.authenticator, config=config, url_base=model.url_base, name=name, decoder=decoder)
             if model.authenticator


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->
Fix for the bug I encountered when using Slack connector with PyAirbyte.

To reproduce:
```python
import airbyte as ab

source = ab.get_source(
    "source-slack",
    config={
        "api_token": "<Slack token here>",
        "start_date": "2024-10-14T00:00:00Z",
        "lookback_window": 1,
        "join_channels": False,
    },
    install_if_missing=True,
)
source.check()
source.select_streams(
    [
        "channels",
        "channel_members",
        "channel_messages",
    ]
)


result = source.read()

for name, records in result.streams.items():
    print(f"Stream {name}: {len(list(records))} records")
    for record in records:
        print(record)
```

Log:

```
2024-10-20 11:38:42 - INFO - Error creating component 'HttpRequester' with parent custom component source_slack.components.join_channels.ChannelsRetriever: ModelToComponentFactory.create_http_requester() missing 1 required positional argument: 'decoder'
Traceback (most recent call last):
  File "/Users/whimo/misc/test_slack/venv/lib/python3.11/site-packages/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py", line 543, in _create_nested_component
    return self._create_component_from_model(model=parsed_model, config=config, **matching_parameters)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/whimo/misc/test_slack/venv/lib/python3.11/site-packages/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py", line 266, in _create_component_from_model
    return component_constructor(model=model, config=config, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: ModelToComponentFactory.create_http_requester() missing 1 required positional argument: 'decoder'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/whimo/misc/test_slack/venv/bin/source-slack", line 8, in <module>
    sys.exit(run())
             ^^^^^
  File "/Users/whimo/misc/test_slack/venv/lib/python3.11/site-packages/source_slack/run.py", line 16, in run
    launch(source, sys.argv[1:])
  File "/Users/whimo/misc/test_slack/venv/lib/python3.11/site-packages/airbyte_cdk/entrypoint.py", line 235, in launch
    for message in source_entrypoint.run(parsed_args):
  File "/Users/whimo/misc/test_slack/venv/lib/python3.11/site-packages/airbyte_cdk/entrypoint.py", line 115, in run
    yield from map(AirbyteEntrypoint.airbyte_message_to_string, self.check(source_spec, config))
  File "/Users/whimo/misc/test_slack/venv/lib/python3.11/site-packages/airbyte_cdk/entrypoint.py", line 139, in check
    check_result = self.source.check(self.logger, config)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/whimo/misc/test_slack/venv/lib/python3.11/site-packages/airbyte_cdk/sources/declarative/manifest_declarative_source.py", line 155, in check
    return super().check(logger, config)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/whimo/misc/test_slack/venv/lib/python3.11/site-packages/airbyte_cdk/sources/abstract_source.py", line 81, in check
    check_succeeded, error = self.check_connection(logger, config)
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/whimo/misc/test_slack/venv/lib/python3.11/site-packages/airbyte_cdk/sources/declarative/declarative_source.py", line 34, in check_connection
    return self.connection_checker.check_connection(self, logger, config)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/whimo/misc/test_slack/venv/lib/python3.11/site-packages/airbyte_cdk/sources/declarative/checks/check_stream.py", line 31, in check_connection
    streams = source.streams(config)  # type: ignore # source is always a DeclarativeSource, but this parameter type adheres to the outer interface
              ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/whimo/misc/test_slack/venv/lib/python3.11/site-packages/source_slack/source.py", line 53, in streams
    declarative_streams = super().streams(config)
                          ^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/whimo/misc/test_slack/venv/lib/python3.11/site-packages/airbyte_cdk/sources/declarative/manifest_declarative_source.py", line 95, in streams
    source_streams = [
                     ^
  File "/Users/whimo/misc/test_slack/venv/lib/python3.11/site-packages/airbyte_cdk/sources/declarative/manifest_declarative_source.py", line 96, in <listcomp>
    self._constructor.create_component(
  File "/Users/whimo/misc/test_slack/venv/lib/python3.11/site-packages/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py", line 258, in create_component
    return self._create_component_from_model(model=declarative_component_model, config=config, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/whimo/misc/test_slack/venv/lib/python3.11/site-packages/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py", line 266, in _create_component_from_model
    return component_constructor(model=model, config=config, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/whimo/misc/test_slack/venv/lib/python3.11/site-packages/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py", line 640, in create_declarative_stream
    retriever = self._create_component_from_model(
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/whimo/misc/test_slack/venv/lib/python3.11/site-packages/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py", line 266, in _create_component_from_model
    return component_constructor(model=model, config=config, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/whimo/misc/test_slack/venv/lib/python3.11/site-packages/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py", line 465, in create_custom_component
    model_args[model_field] = self._create_nested_component(model, model_field, model_value, config)
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/whimo/misc/test_slack/venv/lib/python3.11/site-packages/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py", line 551, in _create_nested_component
    raise TypeError(f"Error creating component '{type_name}' with parent custom component {model.class_name}: {error}")
TypeError: Error creating component 'HttpRequester' with parent custom component source_slack.components.join_channels.ChannelsRetriever: ModelToComponentFactory.create_http_requester() missing 1 required positional argument: 'decoder'
```

## How
<!--
* Describe how code changes achieve the solution.
-->
From the code of [create_component](https://github.com/airbytehq/airbyte/blob/7b70a70eb098e16924ecafbf0896910a821f1ad2/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py#L268) method and other constructors of ModelToComponentFactory, it seems like the `decoder` argument should not be mandatory. The proposed fix solves the problem with the code snippet above.

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
