### PR TITLE
Bulk Load CDK: Avro Compression Codec, S3V2Usage

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/SpillToDiskTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/SpillToDiskTask.kt
@@ -37,7 +37,7 @@ interface SpillToDiskTask : StreamLevel, InternalScope
  * TODO: Allow for the record batch size to be supplied per-stream. (Needed?)
  */
 class DefaultSpillToDiskTask(
-    private val tmpFileProvider: SpillFileProvider,
+    private val spillFileProvider: SpillFileProvider,
     private val queue: QueueReader<Reserved<DestinationRecordWrapped>>,
     private val flushStrategy: FlushStrategy,
     override val stream: DestinationStream,
@@ -53,7 +53,7 @@ class DefaultSpillToDiskTask(
     )
 
     override suspend fun execute() {
-        val tmpFile = tmpFileProvider.createTempFile()
+        val tmpFile = spillFileProvider.createTempFile()
         val result =
             tmpFile.outputStream().use { outputStream ->
                 queue
@@ -103,7 +103,7 @@ interface SpillToDiskTaskFactory {
 
 @Singleton
 class DefaultSpillToDiskTaskFactory(
-    private val tmpFileProvider: SpillFileProvider,
+    private val spillFileProvider: SpillFileProvider,
     private val queueSupplier:
         MessageQueueSupplier<DestinationStream.Descriptor, Reserved<DestinationRecordWrapped>>,
     private val flushStrategy: FlushStrategy,
@@ -113,7 +113,7 @@ class DefaultSpillToDiskTaskFactory(
         stream: DestinationStream
     ): SpillToDiskTask {
         return DefaultSpillToDiskTask(
-            tmpFileProvider,
+            spillFileProvider,
             queueSupplier.get(stream.descriptor),
             flushStrategy,
             stream,

--- a/airbyte-cdk/bulk/toolkits/load-avro/build.gradle
+++ b/airbyte-cdk/bulk/toolkits/load-avro/build.gradle
@@ -2,6 +2,7 @@ dependencies {
     implementation project(':airbyte-cdk:bulk:core:bulk-cdk-core-base')
     implementation project(':airbyte-cdk:bulk:core:bulk-cdk-core-load')
 
+    implementation("org.tukaani:xz:1.9")
     api("org.apache.avro:avro:1.11.0")
 
     testFixturesImplementation testFixtures(project(":airbyte-cdk:bulk:core:bulk-cdk-core-load"))

--- a/airbyte-cdk/bulk/toolkits/load-avro/src/main/kotlin/io/airbyte/cdk/load/command/avro/AvroFormatCompressionCodec.kt
+++ b/airbyte-cdk/bulk/toolkits/load-avro/src/main/kotlin/io/airbyte/cdk/load/command/avro/AvroFormatCompressionCodec.kt
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.load.command.avro
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.annotation.JsonSubTypes
+import com.fasterxml.jackson.annotation.JsonTypeInfo
+import com.fasterxml.jackson.annotation.JsonValue
+import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaTitle
+import org.apache.avro.file.CodecFactory
+
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NAME,
+    include = JsonTypeInfo.As.EXISTING_PROPERTY,
+    property = "codec"
+)
+@JsonSubTypes(
+    JsonSubTypes.Type(value = AvroFormatNoCompressionCodec::class, name = "no compression"),
+    JsonSubTypes.Type(value = AvroFormatDeflateCodec::class, name = "Deflate"),
+    JsonSubTypes.Type(value = AvroFormatBzip2Codec::class, name = "bzip2"),
+    JsonSubTypes.Type(value = AvroFormatXzCodec::class, name = "xz"),
+    JsonSubTypes.Type(value = AvroFormatZstandardCodec::class, name = "zstandard"),
+    JsonSubTypes.Type(value = AvroFormatSnappyCodec::class, name = "snappy")
+)
+sealed class AvroFormatCompressionCodec(
+    @JsonSchemaTitle("Compression Codec") @JsonProperty("codec") open val type: Type
+) {
+    enum class Type(@get:JsonValue val typeName: String) {
+        NO_COMPRESSION("no compression"),
+        DEFLATE("Deflate"),
+        BZIP2("bzip2"),
+        XZ("xz"),
+        ZSTANDARD("zstandard"),
+        SNAPPY("snappy")
+    }
+
+    fun toCompressionConfiguration() =
+        AvroCompressionConfiguration(
+            compressionCodec =
+                when (this) {
+                    is AvroFormatNoCompressionCodec -> CodecFactory.nullCodec()
+                    is AvroFormatDeflateCodec -> CodecFactory.deflateCodec(compressionLevel)
+                    is AvroFormatBzip2Codec -> CodecFactory.bzip2Codec()
+                    is AvroFormatXzCodec -> CodecFactory.xzCodec(compressionLevel)
+                    is AvroFormatZstandardCodec ->
+                        CodecFactory.zstandardCodec(compressionLevel, includeChecksum)
+                    is AvroFormatSnappyCodec -> CodecFactory.snappyCodec()
+                }
+        )
+}
+
+data class AvroFormatNoCompressionCodec(
+    @JsonSchemaTitle("Compression Codec")
+    @JsonProperty("codec")
+    override val type: Type = Type.NO_COMPRESSION,
+) : AvroFormatCompressionCodec(type)
+
+data class AvroFormatDeflateCodec(
+    @JsonSchemaTitle("Compression Codec")
+    @JsonProperty("codec")
+    override val type: Type = Type.DEFLATE,
+    @JsonSchemaTitle("Deflate Level")
+    @JsonProperty("compression_level")
+    val compressionLevel: Int = 0
+) : AvroFormatCompressionCodec(type)
+
+data class AvroFormatBzip2Codec(
+    @JsonSchemaTitle("Compression Codec")
+    @JsonProperty("codec")
+    override val type: Type = Type.BZIP2,
+) : AvroFormatCompressionCodec(type)
+
+data class AvroFormatXzCodec(
+    @JsonSchemaTitle("Compression Codec") @JsonProperty("codec") override val type: Type = Type.XZ,
+    @JsonSchemaTitle("Compression Level")
+    @JsonProperty("compression_level")
+    val compressionLevel: Int = 6
+) : AvroFormatCompressionCodec(type)
+
+data class AvroFormatZstandardCodec(
+    @JsonSchemaTitle("Compression Codec")
+    @JsonProperty("codec")
+    override val type: Type = Type.ZSTANDARD,
+    @JsonSchemaTitle("Compression Level")
+    @JsonProperty("compression_level")
+    val compressionLevel: Int = 3,
+    @JsonSchemaTitle("Include Checksum")
+    @JsonProperty("include_checksum")
+    val includeChecksum: Boolean = false
+) : AvroFormatCompressionCodec(type)
+
+data class AvroFormatSnappyCodec(
+    @JsonSchemaTitle("Compression Codec")
+    @JsonProperty("codec")
+    override val type: Type = Type.SNAPPY,
+) : AvroFormatCompressionCodec(type)
+
+data class AvroCompressionConfiguration(val compressionCodec: CodecFactory)
+
+interface AvroCompressionConfigurationProvider {
+    val avroCompressionConfiguration: AvroCompressionConfiguration
+}

--- a/airbyte-cdk/bulk/toolkits/load-avro/src/main/kotlin/io/airbyte/cdk/load/file/avro/AvroWriter.kt
+++ b/airbyte-cdk/bulk/toolkits/load-avro/src/main/kotlin/io/airbyte/cdk/load/file/avro/AvroWriter.kt
@@ -4,6 +4,7 @@
 
 package io.airbyte.cdk.load.file.avro
 
+import io.airbyte.cdk.load.command.avro.AvroCompressionConfiguration
 import java.io.Closeable
 import java.io.OutputStream
 import org.apache.avro.Schema
@@ -27,9 +28,13 @@ class AvroWriter(
     }
 }
 
-fun OutputStream.toAvroWriter(avroSchema: Schema): AvroWriter {
+fun OutputStream.toAvroWriter(
+    avroSchema: Schema,
+    config: AvroCompressionConfiguration
+): AvroWriter {
     val datumWriter = GenericDatumWriter<GenericRecord>(avroSchema)
     val dataFileWriter = DataFileWriter(datumWriter)
+    dataFileWriter.setCodec(config.compressionCodec)
     dataFileWriter.create(avroSchema, this)
     return AvroWriter(dataFileWriter)
 }

--- a/airbyte-integrations/connectors/destination-s3-v2/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-s3-v2/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: file
   connectorType: destination
   definitionId: d6116991-e809-4c7c-ae09-c64712df5b66
-  dockerImageTag: 0.1.8
+  dockerImageTag: 0.1.9
   dockerRepository: airbyte/destination-s3-v2
   githubIssueLabel: destination-s3-v2
   icon: s3.svg
@@ -48,6 +48,11 @@ data:
             alias: airbyte-connector-testing-secret-store
         - name: SECRET_DESTINATION-S3-V2-AVRO
           fileName: s3_dest_v2_avro_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION-S3-V2-AVRO-BZIP2
+          fileName: s3_dest_v2_avro_bzip2_config.json
           secretStore:
             type: GSM
             alias: airbyte-connector-testing-secret-store

--- a/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2TestUtils.kt
+++ b/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2TestUtils.kt
@@ -14,6 +14,7 @@ object S3V2TestUtils {
     const val CSV_UNCOMPRESSED_CONFIG_PATH = "secrets/s3_dest_v2_csv_config.json"
     const val CSV_GZIP_CONFIG_PATH = "secrets/s3_dest_v2_csv_gzip_config.json"
     const val AVRO_UNCOMPRESSED_CONFIG_PATH = "secrets/s3_dest_v2_avro_config.json"
+    const val AVRO_BZIP2_CONFIG_PATH = "secrets/s3_dest_v2_avro_bzip2_config.json"
     const val PARQUET_UNCOMPRESSED_CONFIG_PATH = "secrets/s3_dest_v2_parquet_config.json"
     fun getConfig(configPath: String): S3V2Specification =
         ValidatedJsonUtils.parseOne(

--- a/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2WriteTest.kt
+++ b/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2WriteTest.kt
@@ -38,6 +38,8 @@ class S3V2WriteTestCsvUncompressed : S3V2WriteTest(S3V2TestUtils.CSV_UNCOMPRESSE
 
 class S3V2WriteTestCsvGzip : S3V2WriteTest(S3V2TestUtils.CSV_GZIP_CONFIG_PATH)
 
-class S3V2WriteTestAvro : S3V2WriteTest(S3V2TestUtils.AVRO_UNCOMPRESSED_CONFIG_PATH)
+class S3V2WriteTestAvroUncompressed : S3V2WriteTest(S3V2TestUtils.AVRO_UNCOMPRESSED_CONFIG_PATH)
+
+class S3V2WriteTestAvroBzip2 : S3V2WriteTest(S3V2TestUtils.AVRO_BZIP2_CONFIG_PATH)
 
 class S3V2WriteTestParquet : S3V2WriteTest(S3V2TestUtils.PARQUET_UNCOMPRESSED_CONFIG_PATH)

--- a/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/resources/expected-spec-cloud.json
+++ b/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/resources/expected-spec-cloud.json
@@ -131,9 +131,103 @@
               "type" : "string",
               "enum" : [ "Avro" ],
               "default" : "Avro"
+            },
+            "compression_codec" : {
+              "oneOf" : [ {
+                "type" : "object",
+                "additionalProperties" : true,
+                "properties" : {
+                  "codec" : {
+                    "type" : "string",
+                    "enum" : [ "no compression" ],
+                    "default" : "no compression"
+                  }
+                },
+                "title" : "no compression",
+                "required" : [ "codec" ]
+              }, {
+                "type" : "object",
+                "additionalProperties" : true,
+                "properties" : {
+                  "codec" : {
+                    "type" : "string",
+                    "enum" : [ "Deflate" ],
+                    "default" : "Deflate"
+                  },
+                  "compression_level" : {
+                    "type" : "integer",
+                    "title" : "Deflate Level"
+                  }
+                },
+                "title" : "Deflate",
+                "required" : [ "codec", "compression_level" ]
+              }, {
+                "type" : "object",
+                "additionalProperties" : true,
+                "properties" : {
+                  "codec" : {
+                    "type" : "string",
+                    "enum" : [ "bzip2" ],
+                    "default" : "bzip2"
+                  }
+                },
+                "title" : "bzip2",
+                "required" : [ "codec" ]
+              }, {
+                "type" : "object",
+                "additionalProperties" : true,
+                "properties" : {
+                  "codec" : {
+                    "type" : "string",
+                    "enum" : [ "xz" ],
+                    "default" : "xz"
+                  },
+                  "compression_level" : {
+                    "type" : "integer",
+                    "title" : "Compression Level"
+                  }
+                },
+                "title" : "xz",
+                "required" : [ "codec", "compression_level" ]
+              }, {
+                "type" : "object",
+                "additionalProperties" : true,
+                "properties" : {
+                  "codec" : {
+                    "type" : "string",
+                    "enum" : [ "zstandard" ],
+                    "default" : "zstandard"
+                  },
+                  "compression_level" : {
+                    "type" : "integer",
+                    "title" : "Compression Level"
+                  },
+                  "include_checksum" : {
+                    "type" : "boolean",
+                    "title" : "Include Checksum"
+                  }
+                },
+                "title" : "zstandard",
+                "required" : [ "codec", "compression_level", "include_checksum" ]
+              }, {
+                "type" : "object",
+                "additionalProperties" : true,
+                "properties" : {
+                  "codec" : {
+                    "type" : "string",
+                    "enum" : [ "snappy" ],
+                    "default" : "snappy"
+                  }
+                },
+                "title" : "snappy",
+                "required" : [ "codec" ]
+              } ],
+              "description" : "The compression algorithm used to compress data. Default to no compression.",
+              "title" : "Compression Codec",
+              "type" : "object"
             }
           },
-          "required" : [ "format_type" ]
+          "required" : [ "format_type", "compression_codec" ]
         }, {
           "title" : "Parquet: Columnar Storage",
           "type" : "object",

--- a/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/resources/expected-spec-oss.json
+++ b/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/resources/expected-spec-oss.json
@@ -131,9 +131,103 @@
               "type" : "string",
               "enum" : [ "Avro" ],
               "default" : "Avro"
+            },
+            "compression_codec" : {
+              "oneOf" : [ {
+                "type" : "object",
+                "additionalProperties" : true,
+                "properties" : {
+                  "codec" : {
+                    "type" : "string",
+                    "enum" : [ "no compression" ],
+                    "default" : "no compression"
+                  }
+                },
+                "title" : "no compression",
+                "required" : [ "codec" ]
+              }, {
+                "type" : "object",
+                "additionalProperties" : true,
+                "properties" : {
+                  "codec" : {
+                    "type" : "string",
+                    "enum" : [ "Deflate" ],
+                    "default" : "Deflate"
+                  },
+                  "compression_level" : {
+                    "type" : "integer",
+                    "title" : "Deflate Level"
+                  }
+                },
+                "title" : "Deflate",
+                "required" : [ "codec", "compression_level" ]
+              }, {
+                "type" : "object",
+                "additionalProperties" : true,
+                "properties" : {
+                  "codec" : {
+                    "type" : "string",
+                    "enum" : [ "bzip2" ],
+                    "default" : "bzip2"
+                  }
+                },
+                "title" : "bzip2",
+                "required" : [ "codec" ]
+              }, {
+                "type" : "object",
+                "additionalProperties" : true,
+                "properties" : {
+                  "codec" : {
+                    "type" : "string",
+                    "enum" : [ "xz" ],
+                    "default" : "xz"
+                  },
+                  "compression_level" : {
+                    "type" : "integer",
+                    "title" : "Compression Level"
+                  }
+                },
+                "title" : "xz",
+                "required" : [ "codec", "compression_level" ]
+              }, {
+                "type" : "object",
+                "additionalProperties" : true,
+                "properties" : {
+                  "codec" : {
+                    "type" : "string",
+                    "enum" : [ "zstandard" ],
+                    "default" : "zstandard"
+                  },
+                  "compression_level" : {
+                    "type" : "integer",
+                    "title" : "Compression Level"
+                  },
+                  "include_checksum" : {
+                    "type" : "boolean",
+                    "title" : "Include Checksum"
+                  }
+                },
+                "title" : "zstandard",
+                "required" : [ "codec", "compression_level", "include_checksum" ]
+              }, {
+                "type" : "object",
+                "additionalProperties" : true,
+                "properties" : {
+                  "codec" : {
+                    "type" : "string",
+                    "enum" : [ "snappy" ],
+                    "default" : "snappy"
+                  }
+                },
+                "title" : "snappy",
+                "required" : [ "codec" ]
+              } ],
+              "description" : "The compression algorithm used to compress data. Default to no compression.",
+              "title" : "Compression Codec",
+              "type" : "object"
             }
           },
-          "required" : [ "format_type" ]
+          "required" : [ "format_type", "compression_codec" ]
         }, {
           "title" : "Parquet: Columnar Storage",
           "type" : "object",


### PR DESCRIPTION
## What
Add compression codecs to Avro.

Specs are still a little wonky until I can figure out how to make the format options pluggable (and until there's a need). But the top-level avro format has to be defined in `load-object-storage`, whereas the codec details are defined in `load-avro`.

