### PR TITLE
Bulk Load CDK: Parquet block config and codecs; S3V2 Usage

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/DestinationTaskExceptionHandler.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/DestinationTaskExceptionHandler.kt
@@ -92,6 +92,7 @@ T : ScopedTask {
                 log.warn { "Sync task $innerTask was cancelled." }
                 throw e
             } catch (e: Exception) {
+                log.error { "Caught exception in sync task $innerTask: $e" }
                 handleSyncFailure(e)
             }
         }
@@ -127,6 +128,7 @@ T : ScopedTask {
                 log.warn { "Stream task $innerTask was cancelled." }
                 throw e
             } catch (e: Exception) {
+                log.error { "Caught exception in sync task $innerTask: $e" }
                 handleStreamFailure(stream, e)
             }
         }

--- a/airbyte-cdk/bulk/toolkits/load-avro/src/main/kotlin/io/airbyte/cdk/load/command/avro/AvroFormatCompressionCodecSpecification.kt
+++ b/airbyte-cdk/bulk/toolkits/load-avro/src/main/kotlin/io/airbyte/cdk/load/command/avro/AvroFormatCompressionCodecSpecification.kt
@@ -17,14 +17,17 @@ import org.apache.avro.file.CodecFactory
     property = "codec"
 )
 @JsonSubTypes(
-    JsonSubTypes.Type(value = AvroFormatNoCompressionCodec::class, name = "no compression"),
-    JsonSubTypes.Type(value = AvroFormatDeflateCodec::class, name = "Deflate"),
-    JsonSubTypes.Type(value = AvroFormatBzip2Codec::class, name = "bzip2"),
-    JsonSubTypes.Type(value = AvroFormatXzCodec::class, name = "xz"),
-    JsonSubTypes.Type(value = AvroFormatZstandardCodec::class, name = "zstandard"),
-    JsonSubTypes.Type(value = AvroFormatSnappyCodec::class, name = "snappy")
+    JsonSubTypes.Type(
+        value = AvroFormatNoCompressionCodecSpecification::class,
+        name = "no compression"
+    ),
+    JsonSubTypes.Type(value = AvroFormatDeflateCodecSpecification::class, name = "Deflate"),
+    JsonSubTypes.Type(value = AvroFormatBzip2CodecSpecification::class, name = "bzip2"),
+    JsonSubTypes.Type(value = AvroFormatXzCodecSpecification::class, name = "xz"),
+    JsonSubTypes.Type(value = AvroFormatZstandardCodecSpecification::class, name = "zstandard"),
+    JsonSubTypes.Type(value = AvroFormatSnappyCodecSpecification::class, name = "snappy")
 )
-sealed class AvroFormatCompressionCodec(
+sealed class AvroFormatCompressionCodecSpecification(
     @JsonSchemaTitle("Compression Codec") @JsonProperty("codec") open val type: Type
 ) {
     enum class Type(@get:JsonValue val typeName: String) {
@@ -40,46 +43,47 @@ sealed class AvroFormatCompressionCodec(
         AvroCompressionConfiguration(
             compressionCodec =
                 when (this) {
-                    is AvroFormatNoCompressionCodec -> CodecFactory.nullCodec()
-                    is AvroFormatDeflateCodec -> CodecFactory.deflateCodec(compressionLevel)
-                    is AvroFormatBzip2Codec -> CodecFactory.bzip2Codec()
-                    is AvroFormatXzCodec -> CodecFactory.xzCodec(compressionLevel)
-                    is AvroFormatZstandardCodec ->
+                    is AvroFormatNoCompressionCodecSpecification -> CodecFactory.nullCodec()
+                    is AvroFormatDeflateCodecSpecification ->
+                        CodecFactory.deflateCodec(compressionLevel)
+                    is AvroFormatBzip2CodecSpecification -> CodecFactory.bzip2Codec()
+                    is AvroFormatXzCodecSpecification -> CodecFactory.xzCodec(compressionLevel)
+                    is AvroFormatZstandardCodecSpecification ->
                         CodecFactory.zstandardCodec(compressionLevel, includeChecksum)
-                    is AvroFormatSnappyCodec -> CodecFactory.snappyCodec()
+                    is AvroFormatSnappyCodecSpecification -> CodecFactory.snappyCodec()
                 }
         )
 }
 
-data class AvroFormatNoCompressionCodec(
+data class AvroFormatNoCompressionCodecSpecification(
     @JsonSchemaTitle("Compression Codec")
     @JsonProperty("codec")
     override val type: Type = Type.NO_COMPRESSION,
-) : AvroFormatCompressionCodec(type)
+) : AvroFormatCompressionCodecSpecification(type)
 
-data class AvroFormatDeflateCodec(
+data class AvroFormatDeflateCodecSpecification(
     @JsonSchemaTitle("Compression Codec")
     @JsonProperty("codec")
     override val type: Type = Type.DEFLATE,
     @JsonSchemaTitle("Deflate Level")
     @JsonProperty("compression_level")
     val compressionLevel: Int = 0
-) : AvroFormatCompressionCodec(type)
+) : AvroFormatCompressionCodecSpecification(type)
 
-data class AvroFormatBzip2Codec(
+data class AvroFormatBzip2CodecSpecification(
     @JsonSchemaTitle("Compression Codec")
     @JsonProperty("codec")
     override val type: Type = Type.BZIP2,
-) : AvroFormatCompressionCodec(type)
+) : AvroFormatCompressionCodecSpecification(type)
 
-data class AvroFormatXzCodec(
+data class AvroFormatXzCodecSpecification(
     @JsonSchemaTitle("Compression Codec") @JsonProperty("codec") override val type: Type = Type.XZ,
     @JsonSchemaTitle("Compression Level")
     @JsonProperty("compression_level")
     val compressionLevel: Int = 6
-) : AvroFormatCompressionCodec(type)
+) : AvroFormatCompressionCodecSpecification(type)
 
-data class AvroFormatZstandardCodec(
+data class AvroFormatZstandardCodecSpecification(
     @JsonSchemaTitle("Compression Codec")
     @JsonProperty("codec")
     override val type: Type = Type.ZSTANDARD,
@@ -89,13 +93,13 @@ data class AvroFormatZstandardCodec(
     @JsonSchemaTitle("Include Checksum")
     @JsonProperty("include_checksum")
     val includeChecksum: Boolean = false
-) : AvroFormatCompressionCodec(type)
+) : AvroFormatCompressionCodecSpecification(type)
 
-data class AvroFormatSnappyCodec(
+data class AvroFormatSnappyCodecSpecification(
     @JsonSchemaTitle("Compression Codec")
     @JsonProperty("codec")
     override val type: Type = Type.SNAPPY,
-) : AvroFormatCompressionCodec(type)
+) : AvroFormatCompressionCodecSpecification(type)
 
 data class AvroCompressionConfiguration(val compressionCodec: CodecFactory)
 

--- a/airbyte-cdk/bulk/toolkits/load-parquet/build.gradle
+++ b/airbyte-cdk/bulk/toolkits/load-parquet/build.gradle
@@ -3,6 +3,8 @@ dependencies {
     implementation project(':airbyte-cdk:bulk:core:bulk-cdk-core-load')
     api project(':airbyte-cdk:bulk:toolkits:bulk-cdk-toolkit-load-avro')
 
+    implementation("org.lz4:lz4-java:1.8.0")
+    runtimeOnly 'com.hadoop.gplcompression:hadoop-lzo:0.4.20'
     api ('org.apache.hadoop:hadoop-common:3.4.0') {
         exclude group: 'org.apache.zookeeper'
         exclude group: 'org.apache.hadoop', module: 'hadoop-yarn-common'

--- a/airbyte-integrations/connectors/destination-s3-v2/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-s3-v2/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: file
   connectorType: destination
   definitionId: d6116991-e809-4c7c-ae09-c64712df5b66
-  dockerImageTag: 0.1.9
+  dockerImageTag: 0.1.10
   dockerRepository: airbyte/destination-s3-v2
   githubIssueLabel: destination-s3-v2
   icon: s3.svg
@@ -58,6 +58,11 @@ data:
             alias: airbyte-connector-testing-secret-store
         - name: SECRET_DESTINATION-S3-V2-PARQUET
           fileName: s3_dest_v2_parquet_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION-S3-V2-PARQUET-SNAPPY
+          fileName: s3_dest_v2_parquet_snappy_config.json
           secretStore:
             type: GSM
             alias: airbyte-connector-testing-secret-store

--- a/airbyte-integrations/connectors/destination-s3-v2/src/main/kotlin/S3V2Writer.kt
+++ b/airbyte-integrations/connectors/destination-s3-v2/src/main/kotlin/S3V2Writer.kt
@@ -111,13 +111,18 @@ class S3V2Writer(
                                 }
                         }
                         is ParquetFormatConfiguration -> {
-                            outputStream.toParquetWriter(avroSchema!!).use { writer ->
-                                records.forEach {
-                                    writer.write(
-                                        recordDecorator.decorate(it).toAvroRecord(avroSchema)
-                                    )
+                            outputStream
+                                .toParquetWriter(
+                                    avroSchema!!,
+                                    formatConfig.parquetWriterConfiguration
+                                )
+                                .use { writer ->
+                                    records.forEach {
+                                        writer.write(
+                                            recordDecorator.decorate(it).toAvroRecord(avroSchema)
+                                        )
+                                    }
                                 }
-                            }
                         }
                         else -> throw IllegalStateException("Unsupported format")
                     }

--- a/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2TestUtils.kt
+++ b/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2TestUtils.kt
@@ -16,6 +16,7 @@ object S3V2TestUtils {
     const val AVRO_UNCOMPRESSED_CONFIG_PATH = "secrets/s3_dest_v2_avro_config.json"
     const val AVRO_BZIP2_CONFIG_PATH = "secrets/s3_dest_v2_avro_bzip2_config.json"
     const val PARQUET_UNCOMPRESSED_CONFIG_PATH = "secrets/s3_dest_v2_parquet_config.json"
+    const val PARQUET_SNAPPY_CONFIG_PATH = "secrets/s3_dest_v2_parquet_snappy_config.json"
     fun getConfig(configPath: String): S3V2Specification =
         ValidatedJsonUtils.parseOne(
             S3V2Specification::class.java,

--- a/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2WriteTest.kt
+++ b/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2WriteTest.kt
@@ -42,4 +42,7 @@ class S3V2WriteTestAvroUncompressed : S3V2WriteTest(S3V2TestUtils.AVRO_UNCOMPRES
 
 class S3V2WriteTestAvroBzip2 : S3V2WriteTest(S3V2TestUtils.AVRO_BZIP2_CONFIG_PATH)
 
-class S3V2WriteTestParquet : S3V2WriteTest(S3V2TestUtils.PARQUET_UNCOMPRESSED_CONFIG_PATH)
+class S3V2WriteTestParquetUncompressed :
+    S3V2WriteTest(S3V2TestUtils.PARQUET_UNCOMPRESSED_CONFIG_PATH)
+
+class S3V2WriteTestParquetSnappy : S3V2WriteTest(S3V2TestUtils.PARQUET_SNAPPY_CONFIG_PATH)

--- a/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/resources/expected-spec-cloud.json
+++ b/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/resources/expected-spec-cloud.json
@@ -237,6 +237,37 @@
               "type" : "string",
               "enum" : [ "Parquet" ],
               "default" : "Parquet"
+            },
+            "compression_codec" : {
+              "type" : "string",
+              "enum" : [ "UNCOMPRESSED", "SNAPPY", "GZIP", "LZO", "BROTLI", "LZ4", "ZSTD" ],
+              "description" : "The compression algorithm used to compress data pages.",
+              "title" : "Compression Codec"
+            },
+            "block_size_mb" : {
+              "type" : "integer",
+              "description" : "This is the size of a row group being buffered in memory. It limits the memory usage when writing. Larger values will improve the IO when reading, but consume more memory when writing. Default: 128 MB.",
+              "title" : "Block Size (Row Group Size) (MB)"
+            },
+            "max_padding_size_mb" : {
+              "type" : "integer",
+              "description" : "Maximum size allowed as padding to align row groups. This is also the minimum size of a row group. Default: 8 MB.",
+              "title" : "Max Padding Size (MB)"
+            },
+            "page_size_kb" : {
+              "type" : "integer",
+              "description" : "The page size is for compression. A block is composed of pages. A page is the smallest unit that must be read fully to access a single record. If this value is too small, the compression will deteriorate. Default: 1024 KB.",
+              "title" : "Page Size (KB)"
+            },
+            "dictionary_page_size_kb" : {
+              "type" : "integer",
+              "description" : "There is one dictionary page per column per row group when dictionary encoding is used. The dictionary page size works like the page size but for dictionary. Default: 1024 KB.",
+              "title" : "Dictionary Page Size (KB)"
+            },
+            "dictionary_encoding" : {
+              "type" : "boolean",
+              "description" : "Default: true.",
+              "title" : "Dictionary Encoding"
             }
           },
           "required" : [ "format_type" ]

--- a/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/resources/expected-spec-oss.json
+++ b/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/resources/expected-spec-oss.json
@@ -237,6 +237,37 @@
               "type" : "string",
               "enum" : [ "Parquet" ],
               "default" : "Parquet"
+            },
+            "compression_codec" : {
+              "type" : "string",
+              "enum" : [ "UNCOMPRESSED", "SNAPPY", "GZIP", "LZO", "BROTLI", "LZ4", "ZSTD" ],
+              "description" : "The compression algorithm used to compress data pages.",
+              "title" : "Compression Codec"
+            },
+            "block_size_mb" : {
+              "type" : "integer",
+              "description" : "This is the size of a row group being buffered in memory. It limits the memory usage when writing. Larger values will improve the IO when reading, but consume more memory when writing. Default: 128 MB.",
+              "title" : "Block Size (Row Group Size) (MB)"
+            },
+            "max_padding_size_mb" : {
+              "type" : "integer",
+              "description" : "Maximum size allowed as padding to align row groups. This is also the minimum size of a row group. Default: 8 MB.",
+              "title" : "Max Padding Size (MB)"
+            },
+            "page_size_kb" : {
+              "type" : "integer",
+              "description" : "The page size is for compression. A block is composed of pages. A page is the smallest unit that must be read fully to access a single record. If this value is too small, the compression will deteriorate. Default: 1024 KB.",
+              "title" : "Page Size (KB)"
+            },
+            "dictionary_page_size_kb" : {
+              "type" : "integer",
+              "description" : "There is one dictionary page per column per row group when dictionary encoding is used. The dictionary page size works like the page size but for dictionary. Default: 1024 KB.",
+              "title" : "Dictionary Page Size (KB)"
+            },
+            "dictionary_encoding" : {
+              "type" : "boolean",
+              "description" : "Default: true.",
+              "title" : "Dictionary Encoding"
             }
           },
           "required" : [ "format_type" ]


### PR DESCRIPTION
## What
Parquet dict/block config and compression codecs. Slight tweaks to the format to get it to match the existing spec better. (+ updated the secrets to match).

Same issues as before: lzo won't run locally, even in docker; no tests for it yet.

Also Brotli seems to be broken, but it breaks the same way in s3 v1. I'm going to check prod to see if anyone's using it and/or if it ever worked.

I also added some logging statements to the exception handler to help diagnose an unrelated bug.

