### PR TITLE
Bulk Load CDK: Fix transient failure due to multiple channel closures

### DIFF
--- a/airbyte-cdk/bulk/toolkits/load-s3/src/main/kotlin/io/airbyte/cdk/load/file/s3/S3MultipartUpload.kt
+++ b/airbyte-cdk/bulk/toolkits/load-s3/src/main/kotlin/io/airbyte/cdk/load/file/s3/S3MultipartUpload.kt
@@ -81,10 +81,8 @@ class S3MultipartUpload<T : OutputStream>(
 
     inner class UploadStream : OutputStream() {
         override fun close() = runBlocking {
-            workQueue.send {
-                if (closeOnce.setOnce()) {
-                    workQueue.close()
-                }
+            if (closeOnce.setOnce()) {
+                workQueue.send { workQueue.close() }
             }
         }
 


### PR DESCRIPTION
## What
This is causing transient channel closed exceptions in s3v2.