### PR TITLE
docs: removing reference to alpha in the operators documentation

### DIFF
--- a/docs/operator-guides/using-dagster-integration.md
+++ b/docs/operator-guides/using-dagster-integration.md
@@ -67,7 +67,7 @@ After running the file, `dagster job execute -f airbyte_dagster.py ` this will t
 
 Don't be fooled by our simple example of only one Dagster Flow. Airbyte is a powerful data integration platform supporting many sources and destinations. The Airbyte Dagster Integration means Airbyte can now be easily used with the Dagster ecosystem - give it a shot!
 
-We love to hear any questions or feedback on our [Slack](https://slack.airbyte.io/). We're still in alpha, so if you see any rough edges or want to request a connector, feel free to create an issue on our [Github](https://github.com/airbytehq/airbyte) or thumbs up an existing issue.
+We love to hear any questions or feedback on our [Slack](https://slack.airbyte.io/). If you see any rough edges or want to request a connector, feel free to create an issue on our [Github](https://github.com/airbytehq/airbyte) or thumbs up an existing issue.
 
 ## Related articles and guides
 

--- a/docs/operator-guides/using-prefect-task.md
+++ b/docs/operator-guides/using-prefect-task.md
@@ -80,7 +80,7 @@ After that you have the option to configure a more complex Schedule to your Flow
 
 Don't be fooled by our simple example of only one Prefect Flow. Airbyte is a powerful data integration platform supporting many sources and destinations. The Airbyte Prefect Task means Airbyte can now be easily used with the Prefect ecosystem - give it a shot!
 
-We love to hear any questions or feedback on our [Slack](https://slack.airbyte.io/). We're still in alpha, so if you see any rough edges or want to request a connector, feel free to create an issue on our [Github](https://github.com/airbytehq/airbyte) or thumbs up an existing issue.
+We love to hear any questions or feedback on our [Slack](https://slack.airbyte.io/). If you see any rough edges or want to request a connector, feel free to create an issue on our [Github](https://github.com/airbytehq/airbyte) or thumbs up an existing issue.
 
 ## Related articles and guides
 

--- a/docs/operator-guides/using-the-airflow-airbyte-operator.md
+++ b/docs/operator-guides/using-the-airflow-airbyte-operator.md
@@ -131,7 +131,7 @@ with DAG(dag_id='airbyte_trigger_job_example_async',
 
 Don't be fooled by our simple example of only one Airflow task. Airbyte is a powerful data integration platform supporting many sources and destinations. The Airbyte Airflow Operator means Airbyte can now be easily used with the Airflow ecosystem - give it a shot!
 
-We love to hear any questions or feedback on our [Slack](https://slack.airbyte.io/). We're still in alpha, so if you see any rough edges or want to request a connector, feel free to create an issue on our [Github](https://github.com/airbytehq/airbyte) or thumbs up an existing issue.
+We love to hear any questions or feedback on our [Slack](https://slack.airbyte.io/). If you see any rough edges or want to request a connector, feel free to create an issue on our [Github](https://github.com/airbytehq/airbyte) or thumbs up an existing issue.
 
 ## Related articles and guides
 


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->
The current documentation for the operators makes reference to the project still being in Alpha. It is no longer in Alpha so this tidies up those references

## How
<!--
* Describe how code changes achieve the solution.
-->
Documentation correction

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
