### PR TITLE
airbyte-ci: fix bump version

### DIFF
--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -851,7 +851,8 @@ airbyte-ci connectors --language=low-code migrate-to-manifest-only
 
 | Version | PR                                                         | Description                                                                                                                  |
 | ------- | ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| 4.41.1   | [#46914](https://github.com/airbytehq/airbyte/pull/46914)  | Upgrade to Dagger 0.13.3                                                                                                     |
+| 4.41.2  | [#47185](https://github.com/airbytehq/airbyte/pull/47185)  | Fix the bump version command which did not update the changelog.                                                             |
+| 4.41.1  | [#46914](https://github.com/airbytehq/airbyte/pull/46914)  | Upgrade to Dagger 0.13.3                                                                                                     |
 | 4.41.0  | [#46914](https://github.com/airbytehq/airbyte/pull/46914)  | Rework the connector rollback pipeline for progressive rollout                                                               |
 | 4.40.0  | [#46380](https://github.com/airbytehq/airbyte/pull/46380)  | The `bump-version` command now allows the `rc` bump type.                                                                    |
 | 4.39.0  | [#46696](https://github.com/airbytehq/airbyte/pull/46696)  | Bump PyAirbyte dependency and replace `airbyte-lib-validate-source` CLI command with new `validate` command                  |

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/bump_version/pipeline.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/bump_version/pipeline.py
@@ -89,7 +89,9 @@ async def run_connector_version_bump_pipeline(
             for modified_file in bump_version.modified_files:
                 await updated_connector_directory.file(modified_file).export(str(context.connector.code_directory / modified_file))
                 context.logger.info(f"Exported {modified_file} following the version bump.")
-            documentation_directory = await context.get_repo_dir(include=[str(context.connector.local_connector_documentation_directory)])
+            documentation_directory = await context.get_repo_dir(
+                include=[str(context.connector.local_connector_documentation_directory)]
+            ).directory(str(context.connector.local_connector_documentation_directory))
             add_changelog_entry = AddChangelogEntry(
                 context, documentation_directory, bump_version.new_version, changelog_entry, pull_request_number=pull_request_number
             )
@@ -100,11 +102,7 @@ async def run_connector_version_bump_pipeline(
                 context.report = report
                 return report
 
-            # Files modified by AddChangelogEntry are relative to airbyte repo root
-            for modified_file in add_changelog_entry.modified_files:
-                await add_changelog_entry_result.output.file(str(modified_file)).export(str(modified_file))
-                context.logger.info(f"Exported {modified_file} following the changelog entry addition.")
-
+            await add_changelog_entry.export_modified_files(context.connector.local_connector_documentation_directory)
             report = ConnectorReport(context, steps_results, name=report_name)
             context.report = report
     return report

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "4.41.1"
+version = "4.41.2"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 


### PR DESCRIPTION
## What
The bump version command did not update the Changelog.
It's a regression from my recent refacto/ introduction of the  StepModifyingFiles.

## How
* Fix the path used as the documentation directory in the bump version pipeline
* Use the `export_modified_files` method instead of native dagger calls in the pipeline.

