### PR TITLE
cdk-java: improve java compatibility for s3-glue

### DIFF
--- a/airbyte-cdk/java/airbyte-cdk/README.md
+++ b/airbyte-cdk/java/airbyte-cdk/README.md
@@ -174,6 +174,7 @@ corresponds to that version.
 
 | Version    | Date       | Pull Request                                                | Subject                                                                                                                                                        |
 |:-----------|:-----------|:------------------------------------------------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 0.47.2     | 2024-10-21 | [\#47216](https://github.com/airbytehq/airbyte/pull/47216)  | improve java compatibiilty|
 | 0.47.1     | 2024-09-27 | [\#45397](https://github.com/airbytehq/airbyte/pull/45397)  | Allow logical replication from Postgres 16 read-replicas|
 | 0.47.0     | 2024-09-26 | [\#42030](https://github.com/airbytehq/airbyte/pull/42030)  | minor refactor                                                                                                                                                 |
 | 0.46.1     | 2024-09-20 | [\#45700](https://github.com/airbytehq/airbyte/pull/45700)  | Destinations: Fix bug in parsing jsonschema |

--- a/airbyte-cdk/java/airbyte-cdk/core/src/main/resources/version.properties
+++ b/airbyte-cdk/java/airbyte-cdk/core/src/main/resources/version.properties
@@ -1,1 +1,1 @@
-version=0.47.1
+version=0.47.2

--- a/airbyte-cdk/java/airbyte-cdk/s3-destinations/src/main/kotlin/io/airbyte/cdk/integrations/destination/s3/BaseS3Destination.kt
+++ b/airbyte-cdk/java/airbyte-cdk/s3-destinations/src/main/kotlin/io/airbyte/cdk/integrations/destination/s3/BaseS3Destination.kt
@@ -19,6 +19,7 @@ import java.util.function.Consumer
 private val LOGGER = KotlinLogging.logger {}
 
 abstract class BaseS3Destination
+@JvmOverloads
 protected constructor(
     protected val configFactory: S3DestinationConfigFactory = S3DestinationConfigFactory(),
     protected val environment: Map<String, String> = System.getenv(),

--- a/airbyte-cdk/java/airbyte-cdk/s3-destinations/src/main/kotlin/io/airbyte/cdk/integrations/destination/s3/WriteConfig.kt
+++ b/airbyte-cdk/java/airbyte-cdk/s3-destinations/src/main/kotlin/io/airbyte/cdk/integrations/destination/s3/WriteConfig.kt
@@ -6,7 +6,7 @@ package io.airbyte.cdk.integrations.destination.s3
 
 import io.airbyte.protocol.models.v0.DestinationSyncMode
 
-class WriteConfig
+open class WriteConfig
 @JvmOverloads
 constructor(
     val namespace: String?,


### PR DESCRIPTION
a customer is trying to modify destination-s3-glue, which is written in java. It calls a constructor to BaseS3Destination that doesn't have all optional parameters, and defines a class that extends WriteConfig. I just added an @JvmOverload and a open to the respective lines 