### PR TITLE
[source-greenhouse] - adds `job_post_id` to applications stream schema

### DIFF
--- a/airbyte-integrations/connectors/source-greenhouse/metadata.yaml
+++ b/airbyte-integrations/connectors/source-greenhouse/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 59f1e50a-331f-4f09-b3e8-2e8d4d355f44
-  dockerImageTag: 0.5.23
+  dockerImageTag: 0.5.24
   dockerRepository: airbyte/source-greenhouse
   documentationUrl: https://docs.airbyte.com/integrations/sources/greenhouse
   githubIssueLabel: source-greenhouse

--- a/airbyte-integrations/connectors/source-greenhouse/pyproject.toml
+++ b/airbyte-integrations/connectors/source-greenhouse/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "0.5.23"
+version = "0.5.24"
 name = "source-greenhouse"
 description = "Source implementation for Greenhouse."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-greenhouse/source_greenhouse/manifest.yaml
+++ b/airbyte-integrations/connectors/source-greenhouse/source_greenhouse/manifest.yaml
@@ -205,7 +205,9 @@ definitions:
             type: integer
           job_post_id:
             decscription: The ID of the job post through which the candidate applied. This value is null if the application was created through other means, e.g. manually adding candidates or importing candidates through sourcing integrations
-            type: integer
+            type:
+              - integer
+              - "null"
           current_stage:
             description: Current stage of the application process.
             type:

--- a/airbyte-integrations/connectors/source-greenhouse/source_greenhouse/manifest.yaml
+++ b/airbyte-integrations/connectors/source-greenhouse/source_greenhouse/manifest.yaml
@@ -203,6 +203,9 @@ definitions:
           id:
             description: Unique identifier for the application.
             type: integer
+          job_post_id:
+            decscription: The ID of the job post through which the candidate applied. This value is null if the application was created through other means, e.g. manually adding candidates or importing candidates through sourcing integrations
+            type: integer
           current_stage:
             description: Current stage of the application process.
             type:

--- a/docs/integrations/sources/greenhouse.md
+++ b/docs/integrations/sources/greenhouse.md
@@ -74,6 +74,7 @@ The Greenhouse connector should not run into Greenhouse API limitations under no
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                                                              |
 | :------ | :--------- | :------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 0.5.24 | 2024-10-23 | [*PR_NUMBER_PLACEHOLDER*](https://github.com/airbytehq/airbyte/pull/*PR_NUMBER_PLACEHOLDER*) | Add 'job_post_id' to applications stream scehma |
 | 0.5.23 | 2024-10-12 | [46828](https://github.com/airbytehq/airbyte/pull/46828) | Update dependencies |
 | 0.5.22 | 2024-10-05 | [46506](https://github.com/airbytehq/airbyte/pull/46506) | Update dependencies |
 | 0.5.21 | 2024-09-28 | [46159](https://github.com/airbytehq/airbyte/pull/46159) | Update dependencies |

--- a/docs/integrations/sources/greenhouse.md
+++ b/docs/integrations/sources/greenhouse.md
@@ -74,7 +74,7 @@ The Greenhouse connector should not run into Greenhouse API limitations under no
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                                                              |
 | :------ | :--------- | :------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 0.5.24 | 2024-10-23 | [*PR_NUMBER_PLACEHOLDER*](https://github.com/airbytehq/airbyte/pull/*PR_NUMBER_PLACEHOLDER*) | Add 'job_post_id' to applications stream scehma |
+| 0.5.24 | 2024-10-23 | [47306](https://github.com/airbytehq/airbyte/pull/47306) | Add 'job_post_id' to applications stream scehma |
 | 0.5.23 | 2024-10-12 | [46828](https://github.com/airbytehq/airbyte/pull/46828) | Update dependencies |
 | 0.5.22 | 2024-10-05 | [46506](https://github.com/airbytehq/airbyte/pull/46506) | Update dependencies |
 | 0.5.21 | 2024-09-28 | [46159](https://github.com/airbytehq/airbyte/pull/46159) | Update dependencies |


### PR DESCRIPTION
## What
- OC Issue: https://github.com/airbytehq/oncall/issues/6755

## How
- Adds `job_post_id` to `applications` stream schema ([API Documentation](https://developers.greenhouse.io/harvest.html#applications))

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
