### PR TITLE
Add most_recent_cursor_value as part of the state

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/concurrent/cursor.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/concurrent/cursor.py
@@ -221,7 +221,7 @@ class ConcurrentCursor(Cursor):
                     self._connector_state_converter.END_KEY: self._extract_from_slice(
                         partition, self._slice_boundary_fields[self._END_BOUNDARY]
                     ),
-                    "most_recent_cursor_value": most_recent_cursor_value,
+                    self._connector_state_converter.MOST_RECENT_RECORD_KEY: most_recent_cursor_value,
                 }
             )
         elif most_recent_cursor_value:
@@ -245,7 +245,7 @@ class ConcurrentCursor(Cursor):
                 {
                     self._connector_state_converter.START_KEY: self.start,
                     self._connector_state_converter.END_KEY: most_recent_cursor_value,
-                    "most_recent_cursor_value": most_recent_cursor_value,
+                    self._connector_state_converter.MOST_RECENT_RECORD_KEY: most_recent_cursor_value,
                 }
             )
 

--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/concurrent/state_converters/abstract_stream_state_converter.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/concurrent/state_converters/abstract_stream_state_converter.py
@@ -17,6 +17,7 @@ class ConcurrencyCompatibleStateType(Enum):
 class AbstractStreamStateConverter(ABC):
     START_KEY = "start"
     END_KEY = "end"
+    MOST_RECENT_RECORD_KEY = "most_recent_cursor_value"
 
     @abstractmethod
     def _from_state_message(self, value: Any) -> Any:
@@ -71,12 +72,13 @@ class AbstractStreamStateConverter(ABC):
         """
         serialized_slices = []
         for stream_slice in state.get("slices", []):
-            serialized_slices.append(
-                {
-                    self.START_KEY: self._to_state_message(stream_slice[self.START_KEY]),
-                    self.END_KEY: self._to_state_message(stream_slice[self.END_KEY]),
-                }
-            )
+            serialized_slice = {
+                self.START_KEY: self._to_state_message(stream_slice[self.START_KEY]),
+                self.END_KEY: self._to_state_message(stream_slice[self.END_KEY]),
+            }
+            if stream_slice.get(self.MOST_RECENT_RECORD_KEY, None):
+                serialized_slice[self.MOST_RECENT_RECORD_KEY] = self._to_state_message(stream_slice[self.MOST_RECENT_RECORD_KEY])
+            serialized_slices.append(serialized_slice)
         return {"slices": serialized_slices, "state_type": state_type.value}
 
     @staticmethod

--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/concurrent/state_converters/abstract_stream_state_converter.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/concurrent/state_converters/abstract_stream_state_converter.py
@@ -76,7 +76,7 @@ class AbstractStreamStateConverter(ABC):
                 self.START_KEY: self._to_state_message(stream_slice[self.START_KEY]),
                 self.END_KEY: self._to_state_message(stream_slice[self.END_KEY]),
             }
-            if stream_slice.get(self.MOST_RECENT_RECORD_KEY, None):
+            if stream_slice.get(self.MOST_RECENT_RECORD_KEY):
                 serialized_slice[self.MOST_RECENT_RECORD_KEY] = self._to_state_message(stream_slice[self.MOST_RECENT_RECORD_KEY])
             serialized_slices.append(serialized_slice)
         return {"slices": serialized_slices, "state_type": state_type.value}

--- a/airbyte-cdk/python/unit_tests/sources/declarative/test_concurrent_declarative_source.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/test_concurrent_declarative_source.py
@@ -674,6 +674,7 @@ def test_read_with_concurrent_and_synchronous_streams():
         ]
     }
 
+
 @freezegun.freeze_time(_NOW)
 def test_read_with_concurrent_and_synchronous_streams_with_concurrent_state():
     """
@@ -709,15 +710,13 @@ def test_read_with_concurrent_and_synchronous_streams_with_concurrent_state():
 
     party_members_slices_and_responses = _NO_STATE_PARTY_MEMBERS_SLICES_AND_RESPONSES + [
         (
-            {"start": "2024-09-04", "end": "2024-09-10"},
-             HttpResponse(
-                 json.dumps(
-                     [
-                         {"id": "yoshizawa", "first_name": "sumire", "last_name": "yoshizawa", "updated_at": "2024-09-10"}
-                     ]
+            {
+                "start": "2024-09-04", "end": "2024-09-10"},  # considering lookback window
+                HttpResponse(
+                    json.dumps([{"id": "yoshizawa", "first_name": "sumire", "last_name": "yoshizawa", "updated_at": "2024-09-10"}]
                  )
              ),
-         )  # considering lookback window
+         )
     ]
     location_slices = [
         {"start": "2024-07-26", "end": "2024-08-25"},

--- a/airbyte-cdk/python/unit_tests/sources/declarative/test_concurrent_declarative_source.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/test_concurrent_declarative_source.py
@@ -710,12 +710,10 @@ def test_read_with_concurrent_and_synchronous_streams_with_concurrent_state():
 
     party_members_slices_and_responses = _NO_STATE_PARTY_MEMBERS_SLICES_AND_RESPONSES + [
         (
-            {
-                "start": "2024-09-04", "end": "2024-09-10"},  # considering lookback window
-                HttpResponse(
-                    json.dumps([{"id": "yoshizawa", "first_name": "sumire", "last_name": "yoshizawa", "updated_at": "2024-09-10"}]
-                 )
-             ),
+            {"start": "2024-09-04", "end": "2024-09-10"},  # considering lookback window
+            HttpResponse(
+                json.dumps([{"id": "yoshizawa", "first_name": "sumire", "last_name": "yoshizawa", "updated_at": "2024-09-10"}])
+            ),
          )
     ]
     location_slices = [

--- a/airbyte-cdk/python/unit_tests/sources/streams/concurrent/test_cursor.py
+++ b/airbyte-cdk/python/unit_tests/sources/streams/concurrent/test_cursor.py
@@ -10,7 +10,6 @@ from unittest.mock import Mock
 
 import freezegun
 import pytest
-
 from airbyte_cdk.sources.connector_state_manager import ConnectorStateManager
 from airbyte_cdk.sources.declarative.datetime.min_max_datetime import MinMaxDatetime
 from airbyte_cdk.sources.declarative.incremental.datetime_based_cursor import DatetimeBasedCursor

--- a/airbyte-cdk/python/unit_tests/sources/streams/concurrent/test_cursor.py
+++ b/airbyte-cdk/python/unit_tests/sources/streams/concurrent/test_cursor.py
@@ -591,7 +591,7 @@ class ConcurrentCursorStateTest(TestCase):
                 (datetime(2024, 1, 21, 0, 0, tzinfo=timezone.utc), datetime(2024, 1, 30, 23, 59, 59, tzinfo=timezone.utc)),
                 (datetime(2024, 1, 31, 0, 0, tzinfo=timezone.utc), datetime(2024, 2, 9, 23, 59, 59, tzinfo=timezone.utc)),
                 (datetime(2024, 2, 10, 0, 0, tzinfo=timezone.utc), datetime(2024, 2, 19, 23, 59, 59, tzinfo=timezone.utc)),
-                (datetime(2024, 2, 20, 0, 0, tzinfo=timezone.utc), datetime(2024, 2, 29, 23, 59, 59, tzinfo=timezone.utc))
+                (datetime(2024, 2, 20, 0, 0, tzinfo=timezone.utc), datetime(2024, 3, 1, 0, 0, 0, tzinfo=timezone.utc))
             ],
             id="test_datetime_based_cursor_all_fields",
         ),
@@ -613,7 +613,7 @@ class ConcurrentCursorStateTest(TestCase):
             [
                 (datetime(2024, 2, 5, 0, 0, 0, tzinfo=timezone.utc), datetime(2024, 2, 14, 23, 59, 59, tzinfo=timezone.utc)),
                 (datetime(2024, 2, 15, 0, 0, 0, tzinfo=timezone.utc), datetime(2024, 2, 24, 23, 59, 59, tzinfo=timezone.utc)),
-                (datetime(2024, 2, 25, 0, 0, 0, tzinfo=timezone.utc), datetime(2024, 2, 29, 23, 59, 59, tzinfo=timezone.utc))
+                (datetime(2024, 2, 25, 0, 0, 0, tzinfo=timezone.utc), datetime(2024, 3, 1, 0, 0, 0, tzinfo=timezone.utc))
             ],
             id="test_datetime_based_cursor_with_state",
         ),
@@ -636,7 +636,7 @@ class ConcurrentCursorStateTest(TestCase):
                 (datetime(2024, 1, 20, 0, 0, tzinfo=timezone.utc), datetime(2024, 2, 8, 23, 59, 59, tzinfo=timezone.utc)),
                 (datetime(2024, 2, 9, 0, 0, tzinfo=timezone.utc), datetime(2024, 2, 28, 23, 59, 59, tzinfo=timezone.utc)),
                 (datetime(2024, 2, 29, 0, 0, tzinfo=timezone.utc), datetime(2024, 3, 19, 23, 59, 59, tzinfo=timezone.utc)),
-                (datetime(2024, 3, 20, 0, 0, tzinfo=timezone.utc), datetime(2024, 3, 31, 23, 59, 59, tzinfo=timezone.utc)),
+                (datetime(2024, 3, 20, 0, 0, tzinfo=timezone.utc), datetime(2024, 4, 1, 0, 0, 0, tzinfo=timezone.utc)),
             ],
             id="test_datetime_based_cursor_with_state_and_end_date",
         ),
@@ -649,7 +649,7 @@ class ConcurrentCursorStateTest(TestCase):
             {},
             [
                 (datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc), datetime(2024, 1, 31, 23, 59, 59, tzinfo=timezone.utc)),
-                (datetime(2024, 2, 1, 0, 0, 0, tzinfo=timezone.utc), datetime(2024, 2, 29, 23, 59, 59, tzinfo=timezone.utc)),
+                (datetime(2024, 2, 1, 0, 0, 0, tzinfo=timezone.utc), datetime(2024, 3, 1, 0, 0, 0, tzinfo=timezone.utc)),
             ],
             id="test_datetime_based_cursor_using_large_step_duration",
         ),
@@ -856,7 +856,7 @@ def test_close_partition_concurrent_cursor_from_datetime_based_cursor():
         "gods",
         _A_STREAM_NAMESPACE,
         {
-            "slices": [{"end": "2024-08-23T00:00:00.000Z", "start": "2024-08-01T00:00:00.000Z"}],
+            "slices": [{"end": "2024-08-23T00:00:00.000Z", "start": "2024-08-01T00:00:00.000Z", "most_recent_cursor_value": "2024-08-23T00:00:00.000Z"}],
             "state_type": "date-range"
         },
     )
@@ -934,9 +934,8 @@ def test_close_partition_with_slice_range_concurrent_cursor_from_datetime_based_
         _A_STREAM_NAMESPACE,
         {
             "slices": [
-                {"start": "2024-07-01T00:00:00.000Z", "end": "2024-07-16T00:00:00.000Z"},
-                {"start": "2024-08-15T00:00:00.000Z", "end": "2024-08-30T00:00:00.000Z"}
-
+                {"start": "2024-07-01T00:00:00.000Z", "end": "2024-07-16T00:00:00.000Z", "most_recent_cursor_value": "2024-07-05T00:00:00.000Z"},
+                {"start": "2024-08-15T00:00:00.000Z", "end": "2024-08-30T00:00:00.000Z", "most_recent_cursor_value": "2024-08-20T00:00:00.000Z"},
             ],
             "state_type": "date-range"
         },
@@ -1026,8 +1025,8 @@ def test_close_partition_with_slice_range_granularity_concurrent_cursor_from_dat
         _A_STREAM_NAMESPACE,
         {
             "slices": [
-                {"start": "2024-07-01T00:00:00.000Z", "end": "2024-07-31T00:00:00.000Z"},
-                {"start": "2024-08-15T00:00:00.000Z", "end": "2024-08-29T00:00:00.000Z"}
+                {"start": "2024-07-01T00:00:00.000Z", "end": "2024-07-31T00:00:00.000Z", "most_recent_cursor_value": "2024-07-25T00:00:00.000Z"},
+                {"start": "2024-08-15T00:00:00.000Z", "end": "2024-08-29T00:00:00.000Z", "most_recent_cursor_value": "2024-08-20T00:00:00.000Z"}
 
             ],
             "state_type": "date-range"


### PR DESCRIPTION
## What
We want syncs to start from the most recent cursor value, not the higher boundary of the most recent slice we fetched. The reason is that rare are the APIs that prevent us from fetching data if the data can't be populated within this range (for example assuming a cursor field of `created_time`, I can query from `NOW - 10 minutes` to `NOW + 10 minutes` without the API returning an error even though there won't be data in the future).

## How
There are three steps to end up to this state:
* Track the most_recent_cursor_value (but we are not saving it): This has been done [here](https://github.com/airbytehq/airbyte/pull/45180)
* Save this new information as part of the state: The current PR tackles this
* Use this new information to generate the slices: Can only be done once all the states in prod has been updated else the code will assume that there are no records synced in the previous jobs.

Also note that for now, the low-code connectors will emit sequential state. The migration to partitioned state can happen later. We want to decouple those two because the second part is a change we can't revert (ConcurrentCursor understand sequential state but DatetimeBasedCursor does not understand partitioned state).

## User Impact
None for now as this is a transition step to hydrate the most_recent_cursor_value in the database without using it. Eventually, we will start using this new information.

Currently, only source-salesforce is using partitioned state so we will need to release this connector.

## Can this PR be safely reverted and rolled back?
- [X] YES 💚
- [ ] NO ❌
