### PR TITLE
airbyte-ci: fix metadata existence check on master for IncrementalAcceptanceTest

### DIFF
--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -850,6 +850,7 @@ airbyte-ci connectors --language=low-code migrate-to-manifest-only
 
 | Version | PR                                                         | Description                                                                                                                  |
 | ------- | ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| 4.42.1  | [#47316](https://github.com/airbytehq/airbyte/pull/47316)      | Connector testing: skip incremental acceptance test when the connector is not released.                                      |
 | 4.42.0  | [#47386](https://github.com/airbytehq/airbyte/pull/47386)  | Version increment check: make sure consecutive RC remain on the same version.                                                |
 | 4.41.9  | [#47483](https://github.com/airbytehq/airbyte/pull/47483)  | Fix build logic used in `up-to-date` to support any connector language.                                                             |
 | 4.41.8  | [#47447](https://github.com/airbytehq/airbyte/pull/47447)  | Use `cache_ttl` for base image registry listing in `up-to-date`.                                                             |

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/common.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/common.py
@@ -423,11 +423,10 @@ class IncrementalAcceptanceTests(Step):
         return failed_nodes
 
     def _get_master_metadata(self) -> Dict[str, Any]:
-        raw_master_metadata = requests.get(f"{GITHUB_URL_PREFIX_FOR_CONNECTORS}/{self.context.connector.technical_name}/metadata.yaml")
-        master_metadata = yaml.safe_load(raw_master_metadata.text)
-        if not master_metadata:
+        metadata_response = requests.get(f"{GITHUB_URL_PREFIX_FOR_CONNECTORS}/{self.context.connector.technical_name}/metadata.yaml")
+        if not metadata_response.ok:
             raise FileNotFoundError(f"Could not fetch metadata file for {self.context.connector.technical_name} on master.")
-        return master_metadata
+        return yaml.safe_load(metadata_response.text)
 
     async def get_result_log_on_master(self, master_metadata: dict) -> Artifact:
         """Runs acceptance test on the released image of the connector and returns the report log.

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "4.42.0"
+version = "4.42.1"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 


### PR DESCRIPTION
## What
New connector do not have a `metadata.yaml` on `master`.
We should handle their absence correctly.

This pull request includes several updates to the `airbyte-ci` connectors, focusing on improving metadata handling, updating documentation, and versioning.

### Documentation Updates:
* [`airbyte-ci/connectors/pipelines/README.md`](diffhunk://#diff-62eccd92928fbcd3d285983bfdaa2b0d4ca49016cb9c2f63d6d9fc968c59c541R854): Added entry for version 4.41.7 to document that incremental acceptance tests are skipped when the connector is not released.

### Code Improvements:
* [`airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/common.py`](diffhunk://#diff-327f2bac70c2620621e8099dca8aefea4a6b95eecc123fc4389d1d73d8b834dbL392-R395): Improved error handling in the `_get_master_metadata` method by checking the response status before attempting to load metadata.

### Versioning:
* [`airbyte-ci/connectors/pipelines/pyproject.toml`](diffhunk://#diff-087e2c37602bbd6824f875004abddcb4e1a374da12bf84201671ed0900882ce0L7-R7): Updated the version from 4.41.6 to 4.41.7.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Comprehensive updates to the `airbyte-ci` CLI documentation, improving clarity and usability.
	- Added sections for setting up connector secrets, updating the tool, and verifying installations.

- **Bug Fixes**
	- Enhanced error handling and response validation in the metadata fetching logic for acceptance tests.

- **Chores**
	- Updated version number in the project configuration file from 4.42.0 to 4.42.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->