### PR TITLE
(fix) Add saas_mode=true to MotherDuck connection

### DIFF
--- a/airbyte-integrations/connectors/destination-motherduck/destination_motherduck/destination.py
+++ b/airbyte-integrations/connectors/destination-motherduck/destination_motherduck/destination.py
@@ -237,6 +237,12 @@ class DestinationMotherDuck(Destination):
                 logger.info(f"Using DuckDB file at {path}")
                 os.makedirs(os.path.dirname(path), exist_ok=True)
 
+            # Add SaaS mode to prevent loading extensions
+            if path.endswith("?"):
+                path += "&saas_mode=true"
+            else:
+                path += "?saas_mode=true"
+
             duckdb_config = {}
             if CONFIG_MOTHERDUCK_API_KEY in config:
                 duckdb_config["motherduck_token"] = str(config[CONFIG_MOTHERDUCK_API_KEY])

--- a/airbyte-integrations/connectors/destination-motherduck/destination_motherduck/destination.py
+++ b/airbyte-integrations/connectors/destination-motherduck/destination_motherduck/destination.py
@@ -238,7 +238,7 @@ class DestinationMotherDuck(Destination):
                 os.makedirs(os.path.dirname(path), exist_ok=True)
 
             # Add SaaS mode to prevent loading extensions
-            if path.endswith("?"):
+            if path.contains("?"):
                 path += "&saas_mode=true"
             else:
                 path += "?saas_mode=true"


### PR DESCRIPTION
Use SaaS mode to prevent extensions from being loaded
see docs here: https://motherduck.com/docs/key-tasks/authenticating-and-connecting-to-motherduck/authenticating-to-motherduck/#authentication-using-saas-mode