### PR TITLE
Update ingress.md

### DIFF
--- a/docs/deploying-airbyte/integrations/ingress.md
+++ b/docs/deploying-airbyte/integrations/ingress.md
@@ -14,7 +14,9 @@ If you are using `abctl` to manage your deployment, a nginx ingress is automatic
 To access the Airbyte UI, you will need to manually attach an ingress configuration to your deployment. These guides assume that you have already deployed an Ingress Controller.
 The following is a simplified definition of an ingress resource you could use for your Airbyte instance:
 
-Note: Set appropriate backend timeout values for the Airbyte webapp ingress. Timeout values that are too short can lead to 504 errors in the webapp when creating new sources or destinations.
+:::tip
+Set appropriate backend timeout values for the Airbyte webapp ingress. Timeout values that are too short can lead to 504 errors in the webapp when creating new sources or destinations.
+:::
 
 <Tabs>
 <TabItem value="NGINX" label="NGINX">

--- a/docs/deploying-airbyte/integrations/ingress.md
+++ b/docs/deploying-airbyte/integrations/ingress.md
@@ -14,6 +14,8 @@ If you are using `abctl` to manage your deployment, a nginx ingress is automatic
 To access the Airbyte UI, you will need to manually attach an ingress configuration to your deployment. These guides assume that you have already deployed an Ingress Controller.
 The following is a simplified definition of an ingress resource you could use for your Airbyte instance:
 
+Note: Set appropriate backend timeout values for the Airbyte webapp ingress. Timeout values that are too short can lead to 504 errors in the webapp when creating new sources or destinations.
+
 <Tabs>
 <TabItem value="NGINX" label="NGINX">
 


### PR DESCRIPTION
Added a note on setting appropriate timeout values for webapp ingress to prevent 504 errors.

## What
Docs have no mention of backend timeout values. Default values in GKE caused 504 errors when creating sources or destinations in the webapp. 

## How
Added a note to set appropriately long backend gateway values to prevent 504 errors.

## Review guide
`docs/deploying-airbyte/integrations/ingress.md`

## User Impact
Makes deployment easier

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [X] YES 💚
- [ ] NO ❌
