### PR TITLE
connectors-qa: do not enforce PyPi publication

### DIFF
--- a/airbyte-ci/connectors/connectors_qa/README.md
+++ b/airbyte-ci/connectors/connectors_qa/README.md
@@ -108,6 +108,11 @@ poe lint
 
 ## Changelog
 
+### 1.10.0
+Do not enforce that PyPi publication is enabled for Python connectors.
+Enforce that it's declared in the metadata file.
+It can be set to true or false. 
+
 ### 1.9.1
 
 Fail assets icon check if the icon is the default Airbyte icon.
@@ -176,7 +181,7 @@ Fix access to connector types: it should be accessed from the `Connector.connect
 
 - Add `applies_to_connector_types` attribute to `Check` class to specify the connector types that
   the check applies to.
-- Make `CheckPublishToPyPiIsEnabled` run on source connectors only.
+- Make `CheckPublishToPyPiIsDeclared` run on source connectors only.
 
 ### 1.0.0
 

--- a/airbyte-ci/connectors/connectors_qa/pyproject.toml
+++ b/airbyte-ci/connectors/connectors_qa/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "connectors-qa"
-version = "1.9.1"
+version = "1.10.0"
 description = "A package to run QA checks on Airbyte connectors, generate reports and documentation."
 authors = ["Airbyte <contact@airbyte.io>"]
 readme = "README.md"

--- a/airbyte-ci/connectors/connectors_qa/src/connectors_qa/checks/packaging.py
+++ b/airbyte-ci/connectors/connectors_qa/src/connectors_qa/checks/packaging.py
@@ -42,8 +42,8 @@ class CheckConnectorUsesPoetry(PackagingCheck):
         )
 
 
-class CheckPublishToPyPiIsEnabled(PackagingCheck):
-    name = "Python connectors must have PyPi publishing enabled"
+class CheckPublishToPyPiIsDeclared(PackagingCheck):
+    name = "Python connectors must have PyPi publishing declared."
     description = f"Python connectors must have [PyPi](https://pypi.org/) publishing enabled in their `{consts.METADATA_FILE_NAME}` file. This is declared by setting `remoteRegistries.pypi.enabled` to `true` in {consts.METADATA_FILE_NAME}. This is to ensure that all connectors can be published to PyPi and can be used in `PyAirbyte`."
     applies_to_connector_languages = [
         ConnectorLanguage.PYTHON,
@@ -52,14 +52,14 @@ class CheckPublishToPyPiIsEnabled(PackagingCheck):
     applies_to_connector_types = ["source"]
 
     def _run(self, connector: Connector) -> CheckResult:
-        publish_to_pypi_is_enabled = get(connector.metadata, "remoteRegistries.pypi.enabled", False)
-        if not publish_to_pypi_is_enabled:
+        publish_to_pypi_is_enabled = get(connector.metadata, "remoteRegistries.pypi.enabled")
+        if publish_to_pypi_is_enabled is None:
             return self.create_check_result(
                 connector=connector,
                 passed=False,
-                message=f"PyPi publishing is not enabled. Please enable it in the {consts.METADATA_FILE_NAME} file",
+                message=f"PyPi publishing is not declared. Please set it in the {consts.METADATA_FILE_NAME} file",
             )
-        return self.create_check_result(connector=connector, passed=True, message="PyPi publishing is enabled")
+        return self.create_check_result(connector=connector, passed=True, message="PyPi publishing is declared")
 
 
 class CheckManifestOnlyConnectorBaseImage(PackagingCheck):
@@ -234,6 +234,6 @@ ENABLED_CHECKS = [
     CheckConnectorLicenseMatchInPyproject(),
     CheckVersionFollowsSemver(),
     CheckConnectorVersionMatchInPyproject(),
-    CheckPublishToPyPiIsEnabled(),
+    CheckPublishToPyPiIsDeclared(),
     CheckManifestOnlyConnectorBaseImage(),
 ]

--- a/airbyte-ci/connectors/connectors_qa/tests/unit_tests/test_checks/test_packaging.py
+++ b/airbyte-ci/connectors/connectors_qa/tests/unit_tests/test_checks/test_packaging.py
@@ -99,29 +99,39 @@ class TestCheckManifestOnlyConnectorBaseImage:
         assert "A manifest-only connector must use `source-declarative-manifest` base image" in result.message
 
 
-class TestCheckPublishToPyPiIsEnabled:
-    def test_fail_if_publish_to_pypi_is_not_enabled(self, mocker):
+class TestCheckPublishToPyPiIsDeclared:
+    def test_fail_if_publish_to_pypi_is_not_declared(self, mocker):
         # Arrange
-        connector = mocker.MagicMock(metadata={"remoteRegistries": {"pypi": {"enabled": False}}})
+        connector = mocker.MagicMock(metadata={"remoteRegistries": {}})
 
         # Act
-        result = packaging.CheckPublishToPyPiIsEnabled()._run(connector)
+        result = packaging.CheckPublishToPyPiIsDeclared()._run(connector)
 
         # Assert
         assert result.status == CheckStatus.FAILED
-        assert "PyPi publishing is not enabled" in result.message
+        assert "PyPi publishing is not declared" in result.message
 
     def test_pass_if_publish_to_pypi_is_enabled(self, mocker):
         # Arrange
         connector = mocker.MagicMock(metadata={"remoteRegistries": {"pypi": {"enabled": True}}})
 
         # Act
-        result = packaging.CheckPublishToPyPiIsEnabled()._run(connector)
+        result = packaging.CheckPublishToPyPiIsDeclared()._run(connector)
 
         # Assert
         assert result.status == CheckStatus.PASSED
-        assert "PyPi publishing is enabled" in result.message
+        assert "PyPi publishing is declared" in result.message
 
+    def test_pass_if_publish_to_pypi_is_disabled(self, mocker):
+        # Arrange
+        connector = mocker.MagicMock(metadata={"remoteRegistries": {"pypi": {"enabled": False}}})
+
+        # Act
+        result = packaging.CheckPublishToPyPiIsDeclared()._run(connector)
+
+        # Assert
+        assert result.status == CheckStatus.PASSED
+        assert "PyPi publishing is declared" in result.message
 
 class TestCheckConnectorLicense:
     def test_fail_when_license_is_missing(self, mocker):

--- a/docs/contributing-to-airbyte/resources/qa-checks.md
+++ b/docs/contributing-to-airbyte/resources/qa-checks.md
@@ -360,7 +360,7 @@ _Applies to connector with any Airbyte usage level_
 
 Connector version in metadata.yaml and pyproject.toml file must match. This is to ensure that connector release is consistent.
 
-### Python connectors must have PyPi publishing enabled
+### Python connectors must have PyPi publishing declared.
 
 _Applies to the following connector types: source_
 _Applies to the following connector languages: python, low-code_


### PR DESCRIPTION
## What
We do not want to enforce anymore that a connector is published to PyPi. 
We only want to enforce that enabling or disabling it is explicitely declared in the metadata.
