### PR TITLE
Bulk load CDK: handle various null things

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/data/JsonToAirbyteValueTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/data/JsonToAirbyteValueTest.kt
@@ -5,6 +5,7 @@
 package io.airbyte.cdk.load.data
 
 import com.fasterxml.jackson.databind.node.JsonNodeFactory
+import io.airbyte.cdk.util.Jsons
 import java.math.BigDecimal
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
@@ -159,5 +160,25 @@ class JsonToAirbyteValueTest {
                 .convert(JsonNodeFactory.instance.textNode("00:00:00"), TimeTypeWithTimezone)
         Assertions.assertTrue(value is TimeValue)
         Assertions.assertEquals("00:00:00", (value as TimeValue).value)
+    }
+
+    @Test
+    fun testMissingObjectField() {
+        val value =
+            JsonToAirbyteValue()
+                .convert(
+                    Jsons.readTree("""{"foo": 1}"""),
+                    ObjectType(
+                        properties =
+                            linkedMapOf(
+                                "foo" to FieldType(IntegerType, nullable = true),
+                                "bar" to FieldType(IntegerType, nullable = true),
+                            )
+                    )
+                )
+        Assertions.assertEquals(
+            ObjectValue(linkedMapOf("foo" to IntegerValue(1))),
+            value,
+        )
     }
 }


### PR DESCRIPTION
previously JsonToAirbyteValue returned an UnknownValue (because `json.get(name)` returned null, so we threw an NPE). Now it just skips missing fields.

it also converts explicit NullNode to NullValue. This is important to avoid having e.g. `TimestampValue("null")`.