### PR TITLE
up-to-date: ignore RC from the up to date pipeline

### DIFF
--- a/.github/workflows/connectors_up_to_date.yml
+++ b/.github/workflows/connectors_up_to_date.yml
@@ -11,7 +11,7 @@ on:
     inputs:
       connectors-options:
         description: "Options to pass to the 'airbyte-ci connectors' command group."
-        default: "--concurrency=10 --language=python --language=low-code --language=manifest-only"
+        default: '--concurrency=10 --language=python --language=low-code --language=manifest-only --metadata-query="''-rc.'' not in data.dockerImageTag"'
       auto-merge:
         description: "Whether to auto-merge the PRs created by the action."
         default: "false"
@@ -39,4 +39,4 @@ jobs:
           sentry_dsn: ${{ secrets.SENTRY_AIRBYTE_CI_DSN }}
           s3_build_cache_access_key_id: ${{ secrets.SELF_RUNNER_AWS_ACCESS_KEY_ID }}
           s3_build_cache_secret_key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
-          subcommand: "connectors  ${{ github.event.inputs.connectors-options || '--concurrency=10 --language=python --language=low-code --support-level=community --support-level=certified' }} up-to-date --ignore-connector=source-declarative-manifest --create-prs ${{ github.event.inputs.auto-merge == 'false' && '' || '--auto-merge' }}"
+          subcommand: 'connectors  ${{ github.event.inputs.connectors-options || ''--concurrency=10 --language=python --language=low-code --support-level=community --support-level=certified --metadata-query="''-rc.'' not in data.dockerImageTag"'' }} up-to-date --ignore-connector=source-declarative-manifest --create-prs ${{ github.event.inputs.auto-merge == ''false'' && '''' || ''--auto-merge'' }}'


### PR DESCRIPTION
## What
When we run the up-to-date pipeline we update connector dependencies and cut a new patch version.
It's something that can lead to awkward situation if the connector is a release candidate under progressive rollout.
This PR ignores RC connectors in the up-to-date pipeline.
