### PR TITLE
up-to-date: fix quote escape in workflow

### DIFF
--- a/.github/workflows/connectors_up_to_date.yml
+++ b/.github/workflows/connectors_up_to_date.yml
@@ -11,7 +11,7 @@ on:
     inputs:
       connectors-options:
         description: "Options to pass to the 'airbyte-ci connectors' command group."
-        default: '--concurrency=10 --language=python --language=low-code --language=manifest-only --metadata-query="''-rc.'' not in data.dockerImageTag"'
+        default: '--concurrency=10 --language=python --language=low-code --language=manifest-only --metadata-query="''-rc.'' not in data.dockerImageTag" --metadata-query="''source-declarative-manifest'' not in data.dockerRepository"'
       auto-merge:
         description: "Whether to auto-merge the PRs created by the action."
         default: "false"
@@ -25,8 +25,9 @@ jobs:
     steps:
       - name: Checkout Airbyte
         uses: actions/checkout@v4
-      - name: Run airbyte-ci connectors up-to-date
-        id: airbyte-ci-connectors-up-to-date
+      - name: Run airbyte-ci connectors up-to-date [WORKFLOW]
+        if: github.event_name == 'workflow_dispatch'
+        id: airbyte-ci-connectors-up-to-date-workflow-dispatch
         uses: ./.github/actions/run-airbyte-ci
         with:
           context: "master"
@@ -39,4 +40,20 @@ jobs:
           sentry_dsn: ${{ secrets.SENTRY_AIRBYTE_CI_DSN }}
           s3_build_cache_access_key_id: ${{ secrets.SELF_RUNNER_AWS_ACCESS_KEY_ID }}
           s3_build_cache_secret_key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
-          subcommand: 'connectors  ${{ github.event.inputs.connectors-options || ''--concurrency=10 --language=python --language=low-code --support-level=community --support-level=certified --metadata-query="''-rc.'' not in data.dockerImageTag"'' }} up-to-date --ignore-connector=source-declarative-manifest --create-prs ${{ github.event.inputs.auto-merge == ''false'' && '''' || ''--auto-merge'' }}'
+          subcommand: "connectors ${{ github.event.inputs.connectors-options }} up-to-date  --create-prs ${{ github.event.inputs.auto-merge == 'false' && '' || '--auto-merge' }}"
+      - name: Run airbyte-ci connectors up-to-date [SCHEDULE]
+        if: github.event_name == 'schedule'
+        id: airbyte-ci-connectors-up-to-date-schedule
+        uses: ./.github/actions/run-airbyte-ci
+        with:
+          context: "master"
+          dagger_cloud_token: ${{ secrets.DAGGER_CLOUD_TOKEN_CACHE_3 }}
+          docker_hub_password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+          docker_hub_username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          gcp_gsm_credentials: ${{ secrets.GCP_GSM_CREDENTIALS }}
+          gcs_credentials: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
+          github_token: ${{ secrets.GH_PAT_MAINTENANCE_OSS }}
+          sentry_dsn: ${{ secrets.SENTRY_AIRBYTE_CI_DSN }}
+          s3_build_cache_access_key_id: ${{ secrets.SELF_RUNNER_AWS_ACCESS_KEY_ID }}
+          s3_build_cache_secret_key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
+          subcommand: 'connectors --concurrency=10 --language=python --language=low-code --support-level=community --support-level=certified --metadata-query="\"source-declarative-manifest\" not in data.dockerRepository"  --metadata-query="\"-rc.\" not in data.dockerImageTag" up-to-date --ignore-connector=source-declarative-manifest --create-prs --auto-merge'

--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -525,7 +525,6 @@ Options:
   --open-reports    Auto open reports in the browser.
   --create-prs      Create pull requests for each updated connector.
   --auto-merge    Set the auto-merge label on created PRs.
-  --ignore-connector TEXT  Ignore a connector by its technical name (can be used multiple times).
   --help      Show this message and exit.
 ```
 
@@ -851,7 +850,8 @@ airbyte-ci connectors --language=low-code migrate-to-manifest-only
 
 | Version | PR                                                         | Description                                                                                                                  |
 | ------- | ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| 4.41.6  | [#47308](https://github.com/airbytehq/airbyte/pull/47308)      | Connector testing: skip incremental acceptance test when the connector is not released.                                      |
+| 4.41.7  | [#47444](https://github.com/airbytehq/airbyte/pull/47444)  | Remove redundant `--ignore-connector` error from up-to-date. `--metadata-query` can be used instead.                         |
+| 4.41.6  | [#47308](https://github.com/airbytehq/airbyte/pull/47308)  | Connector testing: skip incremental acceptance test when the connector is not released.                                      |
 | 4.41.5  | [#47255](https://github.com/airbytehq/airbyte/pull/47255)  | Fix `DisableProgressiveRollout`  following Dagger API change.                                                                |
 | 4.41.4  | [#47203](https://github.com/airbytehq/airbyte/pull/47203)  | Fix some `with_exec` and entrypoint usage following Dagger upgrade                                                           |
 | 4.41.3  | [#47189](https://github.com/airbytehq/airbyte/pull/47189)  | Fix up-to-date which did not export doc to the right path                                                                    |

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/up_to_date/commands.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/up_to_date/commands.py
@@ -49,12 +49,6 @@ from pipelines.helpers.connectors.command import run_connector_pipeline
     default=False,
     help="Auto open reports in browser",
 )
-@click.option(
-    "--ignore-connector",
-    type=str,
-    multiple=True,
-    help="Connector technical name to ignore in the pipeline",
-)
 @click.pass_context
 async def up_to_date(
     ctx: click.Context,
@@ -63,16 +57,12 @@ async def up_to_date(
     auto_merge: bool,
     no_bump: bool,
     open_reports: bool,
-    ignore_connector: List[str],
 ) -> bool:
     if create_prs and not ctx.obj["ci_github_access_token"]:
         raise click.ClickException(
             "GitHub access token is required to create or simulate a pull request. Set the CI_GITHUB_ACCESS_TOKEN environment variable."
         )
 
-    ctx.obj["selected_connectors_with_modified_files"] = [
-        connector for connector in ctx.obj["selected_connectors_with_modified_files"] if connector.technical_name not in ignore_connector
-    ]
     return await run_connector_pipeline(
         ctx,
         "Get Python connector up to date",

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "4.41.6"
+version = "4.41.7"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 


### PR DESCRIPTION
## Motivation
The single quote escaping syntax  used in GHA workflow to run `airbyte-ci` was wrong.
Separating `schedule` triggers from `workflow_dispatch` triggers makes it easier to get the syntax right.

### Workflow and Command Updates:

* [`.github/workflows/connectors_up_to_date.yml`](diffhunk://#diff-2d17c6d9c0d58a040bfab9725e36051d4330b78f1a76e2f9fb024f673b7a74d4L14-R14): Added a new metadata query to exclude `source-declarative-manifest` from the `connectors-options` input. Updated the workflow to handle both `workflow_dispatch` and `schedule` events separately. [[1]](diffhunk://#diff-2d17c6d9c0d58a040bfab9725e36051d4330b78f1a76e2f9fb024f673b7a74d4L14-R14) [[2]](diffhunk://#diff-2d17c6d9c0d58a040bfab9725e36051d4330b78f1a76e2f9fb024f673b7a74d4L28-R30) [[3]](diffhunk://#diff-2d17c6d9c0d58a040bfab9725e36051d4330b78f1a76e2f9fb024f673b7a74d4L42-R59)

### Documentation Changes:

* [`airbyte-ci/connectors/pipelines/README.md`](diffhunk://#diff-62eccd92928fbcd3d285983bfdaa2b0d4ca49016cb9c2f63d6d9fc968c59c541L528): Removed the `--ignore-connector` option from the documentation and added an entry to the changelog explaining the removal. [[1]](diffhunk://#diff-62eccd92928fbcd3d285983bfdaa2b0d4ca49016cb9c2f63d6d9fc968c59c541L528) [[2]](diffhunk://#diff-62eccd92928fbcd3d285983bfdaa2b0d4ca49016cb9c2f63d6d9fc968c59c541R853)

### Codebase Simplification:

* [`airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/up_to_date/commands.py`](diffhunk://#diff-e6ca381b7841536a83b88d6b45f24bbcdbe304f88248787054817373d8f73544L52-L57): Removed the `--ignore-connector` option and its related logic from the `up_to_date` command. [[1]](diffhunk://#diff-e6ca381b7841536a83b88d6b45f24bbcdbe304f88248787054817373d8f73544L52-L57) [[2]](diffhunk://#diff-e6ca381b7841536a83b88d6b45f24bbcdbe304f88248787054817373d8f73544L66-L75)

### Version Bump:

* [`airbyte-ci/connectors/pipelines/pyproject.toml`](diffhunk://#diff-087e2c37602bbd6824f875004abddcb4e1a374da12bf84201671ed0900882ce0L7-R7): Updated the version from `4.41.6` to `4.41.7`.