### PR TITLE
bulk-cdk: gradle and github workflow improvements

### DIFF
--- a/.github/workflows/publish-bulk-cdk.yml
+++ b/.github/workflows/publish-bulk-cdk.yml
@@ -76,17 +76,6 @@ jobs:
           gradle-distribution-sha-256-sum-warning: false
           arguments: --scan :airbyte-cdk:bulk:bulkCdkBuild
 
-      - name: Integration test Bulk CDK
-        uses: burrunan/gradle-cache-action@v1
-        env:
-          CI: true
-        with:
-          read-only: true
-          job-id: bulk-cdk-publish
-          concurrent: true
-          gradle-distribution-sha-256-sum-warning: false
-          arguments: --scan :airbyte-cdk:bulk:bulkCdkIntegrationTest
-
       - name: Publish Poms and Jars to CloudRepo
         uses: burrunan/gradle-cache-action@v1
         env:

--- a/airbyte-cdk/bulk/build.gradle
+++ b/airbyte-cdk/bulk/build.gradle
@@ -61,10 +61,6 @@ allprojects {
     }
 }
 
-tasks.register('bulkCdkIntegrationTest').configure {
-    dependsOn allprojects.collect {it.tasks.matching { it.name == 'integrationTest' }}
-}
-
 if (buildNumberFile.exists()) {
     tasks.register('bulkCdkBuild').configure {
         dependsOn allprojects.collect {it.tasks.named('build')}

--- a/airbyte-cdk/bulk/core/load/build.gradle
+++ b/airbyte-cdk/bulk/core/load/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     testFixturesImplementation "uk.org.webcompere:system-stubs-jupiter:2.1.7"
 }
 
-task integrationTest(type: Test) {
+def integrationTestTask = tasks.register('integrationTest', Test) {
     description = 'Runs the integration tests.'
     group = 'verification'
     testClassesDirs = sourceSets.integrationTest.output.classesDirs
@@ -37,9 +37,12 @@ task integrationTest(type: Test) {
     maxParallelForks = project.test.maxParallelForks
     maxHeapSize = project.test.maxHeapSize
 }
+// These tests are lightweight enough to run on every PR.
+tasks.named('check').configure {
+    dependsOn integrationTest
+}
+
 configurations {
     integrationTestImplementation.extendsFrom testImplementation
     integrationTestRuntimeOnly.extendsFrom testRuntimeOnly
 }
-// These tests are lightweight enough to run on every PR.
-rootProject.check.dependsOn(integrationTest)


### PR DESCRIPTION
## What
I noticed some inefficiencies in the latest bulk CDK publish action run. This PR fixes them by doing some gradle bullshit.

## How
The `integrationTest` task in the `core/load` project should run as part of that project's `check` task. This PR fixes this and gets rid of everything made unnecessary.

## Review guide
n/a

## User Impact
None whatsoever, this does the same thing but better.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
