### PR TITLE
Bulk Load CDK: Missing test coverage for Path Factory

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/command/MockDestinationCatalogFactory.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/command/MockDestinationCatalogFactory.kt
@@ -14,21 +14,6 @@ import io.micronaut.context.annotation.Requires
 import jakarta.inject.Singleton
 
 /**
- * In order to make sure test implementors are aware of the catalog they're using, force a failure
- * if nothing is either injected or opted-in.
- */
-@Factory
-class DefaultMockDestinationCatalogFactory {
-    @Singleton
-    @Requires(env = ["test"])
-    fun make(): DestinationCatalog {
-        throw RuntimeException(
-            "Test implementors should inject a destination catalog or include a mock (ie, @MicronautTest(environments = [ ..., \"MockDestinationCatalog\"]))"
-        )
-    }
-}
-
-/**
  * Basic two-stream catalog, good for most testing purposes. Inject with
  * `@MicronautTest(environments = [ ..., MockDestinationCatalog])`.
  */

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/file/MockTimeProvider.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/file/MockTimeProvider.kt
@@ -12,7 +12,7 @@ import java.util.concurrent.atomic.AtomicLong
 @Singleton
 @Primary
 @Requires(env = ["MockTimeProvider"])
-class MockTimeProvider : TimeProvider {
+open class MockTimeProvider : TimeProvider {
     private var currentTime = AtomicLong(0)
 
     override fun currentTimeMillis(): Long {

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/test/kotlin/io/airbyte/cdk/load/file/object_storage/ObjectStoragePathFactoryTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/test/kotlin/io/airbyte/cdk/load/file/object_storage/ObjectStoragePathFactoryTest.kt
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.load.file.object_storage
+
+import io.airbyte.cdk.load.command.MockDestinationCatalogFactory
+import io.airbyte.cdk.load.command.object_storage.JsonFormatConfiguration
+import io.airbyte.cdk.load.command.object_storage.ObjectStorageCompressionConfiguration
+import io.airbyte.cdk.load.command.object_storage.ObjectStorageCompressionConfigurationProvider
+import io.airbyte.cdk.load.command.object_storage.ObjectStorageFormatConfiguration
+import io.airbyte.cdk.load.command.object_storage.ObjectStorageFormatConfigurationProvider
+import io.airbyte.cdk.load.command.object_storage.ObjectStoragePathConfiguration
+import io.airbyte.cdk.load.command.object_storage.ObjectStoragePathConfigurationProvider
+import io.airbyte.cdk.load.file.GZIPProcessor
+import io.airbyte.cdk.load.file.MockTimeProvider
+import io.airbyte.cdk.load.file.TimeProvider
+import io.micronaut.context.annotation.Primary
+import io.micronaut.context.annotation.Requires
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.util.zip.GZIPOutputStream
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+@MicronautTest(
+    environments =
+        [
+            "ObjectStoragePathFactoryTest",
+            "MockDestinationCatalog",
+        ]
+)
+class ObjectStoragePathFactoryTest {
+    @Inject lateinit var timeProvider: TimeProvider
+
+    @Singleton
+    @Primary
+    @Requires(env = ["ObjectStoragePathFactoryTest"])
+    class PathTimeProvider : MockTimeProvider() {
+        init {
+            val dateTime =
+                LocalDateTime.parse(
+                    "2020-01-02T03:04:05.6789",
+                    DateTimeFormatter.ISO_LOCAL_DATE_TIME
+                )
+            val epochMilli =
+                dateTime.toInstant(ZoneId.of("UTC").rules.getOffset(dateTime)).toEpochMilli()
+            setCurrentTime(epochMilli)
+        }
+    }
+
+    @Singleton
+    @Primary
+    @Requires(env = ["ObjectStoragePathFactoryTest"])
+    class MockPathConfigProvider : ObjectStoragePathConfigurationProvider {
+        override val objectStoragePathConfiguration: ObjectStoragePathConfiguration =
+            ObjectStoragePathConfiguration(
+                prefix = "prefix",
+                stagingPrefix = "staging/prefix",
+                pathSuffixPattern =
+                    "\${NAMESPACE}/\${STREAM_NAME}/\${YEAR}/\${MONTH}/\${DAY}/\${HOUR}/\${MINUTE}/\${SECOND}/\${MILLISECOND}/\${EPOCH}/",
+                fileNamePattern = "{date}-{timestamp}-{part_number}-{sync_id}{format_extension}"
+            )
+    }
+
+    @Singleton
+    @Primary
+    @Requires(env = ["ObjectStoragePathFactoryTest"])
+    class MockFormatConfigProvider : ObjectStorageFormatConfigurationProvider {
+        override val objectStorageFormatConfiguration: ObjectStorageFormatConfiguration =
+            JsonFormatConfiguration()
+    }
+
+    @Singleton
+    @Primary
+    @Requires(env = ["ObjectStoragePathFactoryTest"])
+    class MockCompressionConfigProvider :
+        ObjectStorageCompressionConfigurationProvider<GZIPOutputStream> {
+        override val objectStorageCompressionConfiguration:
+            ObjectStorageCompressionConfiguration<GZIPOutputStream> =
+            ObjectStorageCompressionConfiguration(compressor = GZIPProcessor)
+    }
+
+    @Test
+    fun testBasicBehavior(pathFactory: ObjectStoragePathFactory) {
+        val epochMilli = timeProvider.currentTimeMillis()
+        val stream1 = MockDestinationCatalogFactory.stream1
+        val (namespace, name) = stream1.descriptor
+        val prefixOnly = "prefix/$namespace/$name/2020/01/02/03/04/05/0678/$epochMilli"
+        val fileName = "2020_01_02-1577934245678-173-42.jsonl.gz"
+        Assertions.assertEquals(
+            "staging/$prefixOnly",
+            pathFactory.getStagingDirectory(stream1).toString(),
+        )
+        Assertions.assertEquals(
+            prefixOnly,
+            pathFactory.getFinalDirectory(stream1).toString(),
+        )
+        Assertions.assertEquals(
+            "staging/$prefixOnly/$fileName",
+            pathFactory.getPathToFile(stream1, 173, true).toString(),
+        )
+        Assertions.assertEquals(
+            "$prefixOnly/$fileName",
+            pathFactory.getPathToFile(stream1, 173, false).toString(),
+        )
+    }
+}


### PR DESCRIPTION
## What
Adds test coverage for the path factory, cleans up the interface a bit, and also changes a few things that were not matching the old code exactly. I verified this against s3-v1, and it makes the same path (as long as the env variable is set for sync id).
