### PR TITLE
GHA: dedicated dagger token for publish

### DIFF
--- a/.github/workflows/community_ci.yml
+++ b/.github/workflows/community_ci.yml
@@ -172,7 +172,6 @@ jobs:
         uses: ./.github/actions/run-airbyte-ci
         with:
           context: "pull_request"
-          dagger_cloud_token: ${{ secrets.DAGGER_CLOUD_TOKEN_CACHE_4 }}
           docker_hub_password: ${{ secrets.DOCKER_HUB_PASSWORD }}
           docker_hub_username: ${{ secrets.DOCKER_HUB_USERNAME }}
           gcp_gsm_credentials: ${{ secrets.GCP_GSM_CREDENTIALS }}
@@ -237,7 +236,6 @@ jobs:
         uses: ./.github/actions/run-airbyte-ci
         with:
           context: "pull_request"
-          dagger_cloud_token: ${{ secrets.DAGGER_CLOUD_TOKEN_CACHE_4 }}
           docker_hub_password: ${{ secrets.DOCKER_HUB_PASSWORD }}
           docker_hub_username: ${{ secrets.DOCKER_HUB_USERNAME }}
           gcp_gsm_credentials: ${{ secrets.GCP_GSM_CREDENTIALS }}

--- a/.github/workflows/live_tests.yml
+++ b/.github/workflows/live_tests.yml
@@ -116,7 +116,7 @@ jobs:
         uses: ./.github/actions/run-airbyte-ci
         with:
           context: "manual"
-          dagger_cloud_token: ${{ secrets.DAGGER_CLOUD_TOKEN_CACHE_4 }}
+          dagger_cloud_token: ${{ secrets.DAGGER_CLOUD_TOKEN_CACHE_3 }}
           docker_hub_password: ${{ secrets.DOCKER_HUB_PASSWORD }}
           docker_hub_username: ${{ secrets.DOCKER_HUB_USERNAME }}
           gcp_gsm_credentials: ${{ secrets.GCP_GSM_CREDENTIALS }}

--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -30,7 +30,7 @@ jobs:
         uses: ./.github/actions/run-airbyte-ci
         with:
           context: "master"
-          dagger_cloud_token: ${{ secrets.DAGGER_CLOUD_TOKEN_CACHE_3 }}
+          dagger_cloud_token: ${{ secrets.DAGGER_CLOUD_TOKEN_CACHE_4 }}
           docker_hub_password: ${{ secrets.DOCKER_HUB_PASSWORD }}
           docker_hub_username: ${{ secrets.DOCKER_HUB_USERNAME }}
           gcp_gsm_credentials: ${{ secrets.GCP_GSM_CREDENTIALS }}
@@ -53,7 +53,7 @@ jobs:
         uses: ./.github/actions/run-airbyte-ci
         with:
           context: "manual"
-          dagger_cloud_token: ${{ secrets.DAGGER_CLOUD_TOKEN_CACHE_3 }}
+          dagger_cloud_token: ${{ secrets.DAGGER_CLOUD_TOKEN_CACHE_4 }}
           docker_hub_password: ${{ secrets.DOCKER_HUB_PASSWORD }}
           docker_hub_username: ${{ secrets.DOCKER_HUB_USERNAME }}
           gcp_gsm_credentials: ${{ secrets.GCP_GSM_CREDENTIALS }}

--- a/.github/workflows/regression_tests.yml
+++ b/.github/workflows/regression_tests.yml
@@ -116,7 +116,7 @@ jobs:
         uses: ./.github/actions/run-airbyte-ci
         with:
           context: "manual"
-          dagger_cloud_token: ${{ secrets.DAGGER_CLOUD_TOKEN_CACHE_4 }}
+          dagger_cloud_token: ${{ secrets.DAGGER_CLOUD_TOKEN_CACHE_3 }}
           docker_hub_password: ${{ secrets.DOCKER_HUB_PASSWORD }}
           docker_hub_username: ${{ secrets.DOCKER_HUB_USERNAME }}
           gcp_gsm_credentials: ${{ secrets.GCP_GSM_CREDENTIALS }}


### PR DESCRIPTION
## What
Mitigate transient Dagger issues that might be related to cache size by using a dedicated token for the publish workflow.

`cache4` has not been used yet by our workflows, it's why I'm swapping `3` and `4`.

I'm also disabling caching on community PR for security.

## Summary

This pull request includes several changes to the GitHub Actions workflows, specifically updating the `dagger_cloud_token` values across different workflows for consistency and proper token usage.

Changes to GitHub Actions workflows:

* [`.github/workflows/community_ci.yml`](diffhunk://#diff-6abaa453ec6560d6a20e21f05b81a385e5aa4cb77b1a62f433f75def6be328b5L175): Removed the `dagger_cloud_token` input from the `run-airbyte-ci` action. [[1]](diffhunk://#diff-6abaa453ec6560d6a20e21f05b81a385e5aa4cb77b1a62f433f75def6be328b5L175) [[2]](diffhunk://#diff-6abaa453ec6560d6a20e21f05b81a385e5aa4cb77b1a62f433f75def6be328b5L240)
* [`.github/workflows/live_tests.yml`](diffhunk://#diff-a6af432b7c5fc6a2e42199492905c8de46f53cdded34d9074bc54f37afbac70cL119-R119): Updated the `dagger_cloud_token` value from `DAGGER_CLOUD_TOKEN_CACHE_4` to `DAGGER_CLOUD_TOKEN_CACHE_3`.
* [`.github/workflows/publish_connectors.yml`](diffhunk://#diff-8732ab1c8ef9c54ef8175e74b503aa18256f2f190de3b252254f83e283c1ccc1L33-R33): Updated the `dagger_cloud_token` value from `DAGGER_CLOUD_TOKEN_CACHE_3` to `DAGGER_CLOUD_TOKEN_CACHE_4` for both `master` and `manual` contexts. [[1]](diffhunk://#diff-8732ab1c8ef9c54ef8175e74b503aa18256f2f190de3b252254f83e283c1ccc1L33-R33) [[2]](diffhunk://#diff-8732ab1c8ef9c54ef8175e74b503aa18256f2f190de3b252254f83e283c1ccc1L56-R56)
* [`.github/workflows/regression_tests.yml`](diffhunk://#diff-86d9eb15186713951fbdae4ec3df1ed81da0030275c90876106d1f2a3164e80bL119-R119): Updated the `dagger_cloud_token` value from `DAGGER_CLOUD_TOKEN_CACHE_4` to `DAGGER_CLOUD_TOKEN_CACHE_3`.