### PR TITLE
Bulk Load CDK: Obj Storage Destination State + S3V2 Usage

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/state/DestinationStateManager.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/state/DestinationStateManager.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.load.state
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
+import io.airbyte.cdk.load.command.DestinationStream
+import io.micronaut.context.annotation.Secondary
+import jakarta.inject.Singleton
+import java.util.concurrent.ConcurrentHashMap
+
+interface DestinationState
+
+interface DestinationStateManager<T : DestinationState> {
+    suspend fun getState(stream: DestinationStream): T
+    suspend fun persistState(stream: DestinationStream)
+}
+
+@SuppressFBWarnings(
+    "NP_NONNULL_PARAM_VIOLATION",
+    justification = "state is guaranteed to be non-null by Kotlin's type system"
+)
+@Singleton
+@Secondary
+class DefaultDestinationStateManager<T : DestinationState>(
+    private val persister: DestinationStatePersister<T>,
+) : DestinationStateManager<T> {
+    private val states: ConcurrentHashMap<DestinationStream.Descriptor, T> = ConcurrentHashMap()
+
+    override suspend fun getState(stream: DestinationStream): T {
+        return states.getOrPut(stream.descriptor) { persister.load(stream) }
+    }
+
+    override suspend fun persistState(stream: DestinationStream) {
+        val state =
+            states[stream.descriptor]
+                ?: throw IllegalStateException("State not found for stream $stream")
+        persister.persist(stream, state)
+    }
+}
+
+interface DestinationStatePersister<T : DestinationState> {
+    suspend fun load(stream: DestinationStream): T
+    suspend fun persist(stream: DestinationStream, state: T)
+}

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/util/JsonUtils.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/util/JsonUtils.kt
@@ -14,3 +14,7 @@ fun JsonNode.serializeToString(): String {
 fun String.deserializeToNode(): JsonNode {
     return Jsons.readTree(this)
 }
+
+fun Any.serializeToJsonBytes(): ByteArray {
+    return Jsons.writeValueAsBytes(this)
+}

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/build.gradle
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/build.gradle
@@ -9,6 +9,8 @@ dependencies {
     api project(':airbyte-cdk:bulk:toolkits:bulk-cdk-toolkit-load-csv')
     api project(':airbyte-cdk:bulk:toolkits:bulk-cdk-toolkit-load-parquet')
 
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.8.1")
+
     testFixturesImplementation testFixtures(project(":airbyte-cdk:bulk:core:bulk-cdk-core-load"))
     testFixturesImplementation testFixtures(project(":airbyte-cdk:bulk:toolkits:bulk-cdk-toolkit-load-avro"))
     testFixturesImplementation testFixtures(project(":airbyte-cdk:bulk:toolkits:bulk-cdk-toolkit-load-csv"))

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/file/object_storage/ObjectStorageClient.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/file/object_storage/ObjectStorageClient.kt
@@ -13,9 +13,12 @@ import kotlinx.coroutines.flow.Flow
 interface ObjectStorageClient<T : RemoteObject<*>> {
     suspend fun list(prefix: String): Flow<T>
     suspend fun move(remoteObject: T, toKey: String): T
+    suspend fun move(key: String, toKey: String): T
     suspend fun <U> get(key: String, block: (InputStream) -> U): U
+    suspend fun getMetadata(key: String): Map<String, String>
     suspend fun put(key: String, bytes: ByteArray): T
     suspend fun delete(remoteObject: T)
+    suspend fun delete(key: String)
 
     /**
      * Streaming upload should provide an [OutputStream] managed within the lifecycle of [block].

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/file/object_storage/ObjectStorageFormattingWriter.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/file/object_storage/ObjectStorageFormattingWriter.kt
@@ -69,6 +69,7 @@ class JsonFormattingWriter(
 ) : ObjectStorageFormattingWriter {
     override fun accept(record: DestinationRecord) {
         outputStream.write(recordDecorator.decorate(record).toJson().serializeToString())
+        outputStream.write("\n")
     }
 
     override fun close() {

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/state/object_storage/ObjectStorageDestinationStateManager.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/state/object_storage/ObjectStorageDestinationStateManager.kt
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.load.state.object_storage
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.fasterxml.jackson.annotation.JsonProperty
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
+import io.airbyte.cdk.load.command.DestinationStream
+import io.airbyte.cdk.load.file.object_storage.ObjectStorageClient
+import io.airbyte.cdk.load.file.object_storage.PathFactory
+import io.airbyte.cdk.load.state.DestinationState
+import io.airbyte.cdk.load.state.DestinationStatePersister
+import io.airbyte.cdk.load.util.serializeToJsonBytes
+import io.airbyte.cdk.util.Jsons
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.micronaut.context.annotation.Factory
+import io.micronaut.context.annotation.Secondary
+import jakarta.inject.Singleton
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+@SuppressFBWarnings("NP_NONNULL_PARAM_VIOLATION", justification = "Kotlin async continuation")
+class ObjectStorageDestinationState(
+    @JsonProperty("generations_by_state")
+    var generationMap: MutableMap<State, MutableMap<Long, MutableMap<String, Long>>> =
+        mutableMapOf(),
+) : DestinationState {
+    enum class State {
+        STAGED,
+        FINALIZED
+    }
+
+    @JsonIgnore private val accessLock = Mutex()
+
+    suspend fun addObject(
+        generationId: Long,
+        key: String,
+        partNumber: Long,
+        isStaging: Boolean = false
+    ) {
+        val state = if (isStaging) State.STAGED else State.FINALIZED
+        accessLock.withLock {
+            generationMap
+                .getOrPut(state) { mutableMapOf() }
+                .getOrPut(generationId) { mutableMapOf() }[key] = partNumber
+        }
+    }
+
+    suspend fun removeObject(generationId: Long, key: String, isStaging: Boolean = false) {
+        val state = if (isStaging) State.STAGED else State.FINALIZED
+        accessLock.withLock { generationMap[state]?.get(generationId)?.remove(key) }
+    }
+
+    suspend fun dropGenerationsBefore(minimumGenerationId: Long) {
+        accessLock.withLock {
+            State.entries.forEach { state ->
+                (0 until minimumGenerationId).forEach { generationMap[state]?.remove(it) }
+            }
+        }
+    }
+
+    data class Generation(
+        val isStaging: Boolean,
+        val generationId: Long,
+        val objects: List<ObjectAndPart>
+    )
+
+    data class ObjectAndPart(
+        val key: String,
+        val partNumber: Long,
+    )
+
+    @get:JsonIgnore
+    val generations: Sequence<Generation>
+        get() =
+            generationMap.entries
+                .asSequence()
+                .map { (state, gens) ->
+                    val isStaging = state == State.STAGED
+                    gens.map { (generationId, objects) ->
+                        Generation(
+                            isStaging,
+                            generationId,
+                            objects.map { (key, partNumber) -> ObjectAndPart(key, partNumber) }
+                        )
+                    }
+                }
+                .flatten()
+}
+
+@SuppressFBWarnings("NP_NONNULL_PARAM_VIOLATION", justification = "Kotlin async continuation")
+class ObjectStorageStagingPersister(
+    private val client: ObjectStorageClient<*>,
+    private val pathFactory: PathFactory
+) : DestinationStatePersister<ObjectStorageDestinationState> {
+    private val log = KotlinLogging.logger {}
+
+    companion object {
+        const val STATE_FILENAME = "__airbyte_state.json"
+    }
+
+    private fun keyFor(stream: DestinationStream): String =
+        pathFactory.getStagingDirectory(stream).resolve(STATE_FILENAME).toString()
+
+    override suspend fun load(stream: DestinationStream): ObjectStorageDestinationState {
+        val key = keyFor(stream)
+        try {
+            log.info { "Loading destination state from $key" }
+            return client.get(key) { inputStream ->
+                Jsons.readTree(inputStream).let {
+                    Jsons.treeToValue(it, ObjectStorageDestinationState::class.java)
+                }
+            }
+        } catch (e: Exception) {
+            log.info { "No destination state found at $key: $e" }
+            return ObjectStorageDestinationState()
+        }
+    }
+
+    override suspend fun persist(stream: DestinationStream, state: ObjectStorageDestinationState) {
+        client.put(keyFor(stream), state.serializeToJsonBytes())
+    }
+}
+
+@Factory
+class ObjectStorageDestinationStatePersisterFactory(
+    private val client: ObjectStorageClient<*>,
+    private val pathFactory: PathFactory
+) {
+    @Singleton
+    @Secondary
+    fun create(): DestinationStatePersister<ObjectStorageDestinationState> =
+        ObjectStorageStagingPersister(client, pathFactory)
+}

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/test/kotlin/io/airbyte/cdk/load/state/object_storage/ObjectStorageDestinationStateTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/test/kotlin/io/airbyte/cdk/load/state/object_storage/ObjectStorageDestinationStateTest.kt
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.load.state.object_storage
+
+import io.airbyte.cdk.load.MockObjectStorageClient
+import io.airbyte.cdk.load.MockPathFactory
+import io.airbyte.cdk.load.command.MockDestinationCatalogFactory
+import io.airbyte.cdk.load.state.DestinationStateManager
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import jakarta.inject.Inject
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+@MicronautTest(
+    rebuildContext = true,
+    environments =
+        [
+            "ObjectStorageDestinationStateTest",
+            "MockDestinationCatalog",
+            "MockObjectStorageClient",
+            "MockPathFactory"
+        ]
+)
+class ObjectStorageDestinationStateTest {
+    @Inject lateinit var stateManager: DestinationStateManager<ObjectStorageDestinationState>
+    @Inject lateinit var mockClient: MockObjectStorageClient
+    @Inject lateinit var pathFactory: MockPathFactory
+
+    companion object {
+        val stream1 = MockDestinationCatalogFactory.stream1
+        const val PERSISTED =
+            """{"generations_by_state":{"FINALIZED":{"0":{"key1":0,"key2":1},"1":{"key3":0,"key4":1}}}}"""
+    }
+
+    @Test
+    fun testBasicLifecycle() = runTest {
+        // TODO: Test fallback to generation id
+        val state = stateManager.getState(stream1)
+        Assertions.assertEquals(
+            emptyList<ObjectStorageDestinationState.Generation>(),
+            state.generations.toList(),
+            "state should initially be empty"
+        )
+        state.addObject(0, "key1", 0)
+        state.addObject(0, "key2", 1)
+        state.addObject(1, "key3", 0)
+        state.addObject(1, "key4", 1)
+        Assertions.assertEquals(
+            4,
+            state.generations.flatMap { it.objects }.toList().size,
+            "state should contain 4 objects"
+        )
+
+        stateManager.persistState(stream1)
+        val obj = mockClient.list("").toList().first()
+        val data = mockClient.get(obj.key) { it.readBytes() }
+        Assertions.assertEquals(
+            PERSISTED,
+            data.toString(Charsets.UTF_8),
+            "state should be persisted"
+        )
+
+        state.removeObject(0, "key1")
+        state.removeObject(0, "key2")
+        state.removeObject(1, "key3")
+        state.removeObject(1, "key4")
+        Assertions.assertEquals(
+            emptyList<ObjectStorageDestinationState.ObjectAndPart>(),
+            state.generations.flatMap { it.objects }.toList(),
+            "objects should be removed"
+        )
+
+        val fetchedState = stateManager.getState(stream1)
+        Assertions.assertEquals(
+            0,
+            fetchedState.generations.flatMap { it.objects }.toList().size,
+            "state should still contain 0 objects (managed state is in cache)"
+        )
+    }
+
+    @Test
+    fun testLoadingExistingState() = runTest {
+        val key =
+            pathFactory
+                .getStagingDirectory(stream1)
+                .resolve(ObjectStorageStagingPersister.STATE_FILENAME)
+                .toString()
+        mockClient.put(key, PERSISTED.toByteArray())
+        val state = stateManager.getState(stream1)
+        Assertions.assertEquals(
+            listOf(
+                ObjectStorageDestinationState.Generation(
+                    false,
+                    0,
+                    listOf(
+                        ObjectStorageDestinationState.ObjectAndPart("key1", 0),
+                        ObjectStorageDestinationState.ObjectAndPart("key2", 1)
+                    )
+                ),
+                ObjectStorageDestinationState.Generation(
+                    false,
+                    1,
+                    listOf(
+                        ObjectStorageDestinationState.ObjectAndPart("key3", 0),
+                        ObjectStorageDestinationState.ObjectAndPart("key4", 1)
+                    )
+                )
+            ),
+            state.generations.toList(),
+            "state should be loaded from storage"
+        )
+    }
+}

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/testFixtures/kotlin/io/airbyte/cdk/load/MockObjectStorageClient.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/testFixtures/kotlin/io/airbyte/cdk/load/MockObjectStorageClient.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.load
+
+import io.airbyte.cdk.load.file.StreamProcessor
+import io.airbyte.cdk.load.file.object_storage.ObjectStorageClient
+import io.airbyte.cdk.load.file.object_storage.RemoteObject
+import io.micronaut.context.annotation.Requires
+import jakarta.inject.Singleton
+import java.io.InputStream
+import java.io.OutputStream
+import java.util.concurrent.ConcurrentHashMap
+import kotlinx.coroutines.flow.flow
+
+class MockRemoteObject(
+    override val key: String,
+    override val storageConfig: Int,
+    val data: ByteArray,
+    val metadata: Map<String, String> = emptyMap()
+) : RemoteObject<Int>
+
+@Singleton
+@Requires(env = ["MockObjectStorageClient"])
+class MockObjectStorageClient : ObjectStorageClient<MockRemoteObject> {
+    private val objects = ConcurrentHashMap<String, MockRemoteObject>()
+
+    override suspend fun list(prefix: String) = flow {
+        objects.values.filter { it.key.startsWith(prefix) }.forEach { emit(it) }
+    }
+
+    override suspend fun move(remoteObject: MockRemoteObject, toKey: String): MockRemoteObject {
+        val oldObject =
+            objects.remove(remoteObject.key) ?: throw IllegalArgumentException("Object not found")
+        val newObject = MockRemoteObject(toKey, oldObject.storageConfig, oldObject.data)
+        objects[toKey] = newObject
+        return newObject
+    }
+
+    override suspend fun move(key: String, toKey: String): MockRemoteObject {
+        val remoteObject = objects[key] ?: throw IllegalArgumentException("Object not found")
+        return move(remoteObject, toKey)
+    }
+
+    override suspend fun <R> get(key: String, block: (InputStream) -> R): R {
+        val remoteObject = objects[key] ?: throw IllegalArgumentException("Object not found")
+        return block(remoteObject.data.inputStream())
+    }
+
+    override suspend fun getMetadata(key: String): Map<String, String> {
+        return objects[key]?.metadata ?: emptyMap()
+    }
+
+    override suspend fun put(key: String, bytes: ByteArray): MockRemoteObject {
+        val remoteObject = MockRemoteObject(key, 0, bytes)
+        objects[key] = remoteObject
+        return remoteObject
+    }
+
+    override suspend fun delete(key: String) {
+        objects.remove(key)
+    }
+
+    override suspend fun <V : OutputStream> streamingUpload(
+        key: String,
+        streamProcessor: StreamProcessor<V>,
+        block: suspend (OutputStream) -> Unit
+    ): MockRemoteObject {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun delete(remoteObject: MockRemoteObject) {
+        objects.remove(remoteObject.key)
+    }
+}

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/testFixtures/kotlin/io/airbyte/cdk/load/MockPathFactory.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/testFixtures/kotlin/io/airbyte/cdk/load/MockPathFactory.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.load
+
+import io.airbyte.cdk.load.command.DestinationStream
+import io.airbyte.cdk.load.file.object_storage.PathFactory
+import io.micronaut.context.annotation.Requires
+import jakarta.inject.Singleton
+import java.nio.file.Path
+
+@Singleton
+@Requires(env = ["MockPathFactory"])
+class MockPathFactory : PathFactory {
+    private fun fromStream(stream: DestinationStream): String {
+        return "/${stream.descriptor.namespace}/${stream.descriptor.name}"
+    }
+
+    override fun getStagingDirectory(stream: DestinationStream): Path {
+        return Path.of("/staging/${fromStream(stream)}")
+    }
+
+    override fun getFinalDirectory(stream: DestinationStream): Path {
+        return Path.of("/final/${fromStream(stream)}")
+    }
+
+    override fun getPathToFile(
+        stream: DestinationStream,
+        partNumber: Long?,
+        isStaging: Boolean,
+        extension: String?
+    ): Path {
+        val prefix = if (isStaging) getStagingDirectory(stream) else getFinalDirectory(stream)
+        return prefix.resolve("file")
+    }
+}

--- a/airbyte-cdk/bulk/toolkits/load-s3/src/main/kotlin/io/airbyte/cdk/load/file/s3/S3Client.kt
+++ b/airbyte-cdk/bulk/toolkits/load-s3/src/main/kotlin/io/airbyte/cdk/load/file/s3/S3Client.kt
@@ -79,6 +79,10 @@ class S3Client(
         return S3Object(toKey, bucketConfig)
     }
 
+    override suspend fun move(key: String, toKey: String): S3Object {
+        return move(S3Object(key, bucketConfig), toKey)
+    }
+
     override suspend fun <R> get(key: String, block: (InputStream) -> R): R {
         val request = GetObjectRequest {
             bucket = bucketConfig.s3BucketName
@@ -92,6 +96,14 @@ class S3Client(
                     )
             block(inputStream)
         }
+    }
+
+    override suspend fun getMetadata(key: String): Map<String, String> {
+        val request = GetObjectRequest {
+            bucket = bucketConfig.s3BucketName
+            this.key = key
+        }
+        return client.getObject(request) { it.metadata ?: emptyMap() }
     }
 
     override suspend fun put(key: String, bytes: ByteArray): S3Object {
@@ -108,6 +120,14 @@ class S3Client(
         val request = DeleteObjectRequest {
             bucket = remoteObject.storageConfig.s3BucketName
             this.key = remoteObject.key
+        }
+        client.deleteObject(request)
+    }
+
+    override suspend fun delete(key: String) {
+        val request = DeleteObjectRequest {
+            bucket = bucketConfig.s3BucketName
+            this.key = key
         }
         client.deleteObject(request)
     }

--- a/airbyte-integrations/connectors/destination-s3-v2/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-s3-v2/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: file
   connectorType: destination
   definitionId: d6116991-e809-4c7c-ae09-c64712df5b66
-  dockerImageTag: 0.1.13
+  dockerImageTag: 0.1.14
   dockerRepository: airbyte/destination-s3-v2
   githubIssueLabel: destination-s3-v2
   icon: s3.svg

--- a/airbyte-integrations/connectors/destination-s3-v2/src/main/kotlin/S3V2Writer.kt
+++ b/airbyte-integrations/connectors/destination-s3-v2/src/main/kotlin/S3V2Writer.kt
@@ -12,8 +12,12 @@ import io.airbyte.cdk.load.file.s3.S3Client
 import io.airbyte.cdk.load.file.s3.S3Object
 import io.airbyte.cdk.load.message.Batch
 import io.airbyte.cdk.load.message.DestinationRecord
+import io.airbyte.cdk.load.state.DestinationStateManager
+import io.airbyte.cdk.load.state.StreamIncompleteResult
+import io.airbyte.cdk.load.state.object_storage.ObjectStorageDestinationState
 import io.airbyte.cdk.load.write.DestinationWriter
 import io.airbyte.cdk.load.write.StreamLoader
+import io.github.oshai.kotlinlogging.KotlinLogging
 import jakarta.inject.Singleton
 import java.util.concurrent.atomic.AtomicLong
 
@@ -22,7 +26,10 @@ class S3V2Writer(
     private val s3Client: S3Client,
     private val pathFactory: ObjectStoragePathFactory,
     private val writerFactory: ObjectStorageFormattingWriterFactory,
+    private val destinationStateManager: DestinationStateManager<ObjectStorageDestinationState>,
 ) : DestinationWriter {
+    private val log = KotlinLogging.logger {}
+
     sealed interface S3V2Batch : Batch
     data class StagedObject(
         override val state: Batch.State = Batch.State.PERSISTED,
@@ -40,7 +47,18 @@ class S3V2Writer(
 
     @SuppressFBWarnings("NP_NONNULL_PARAM_VIOLATION", justification = "Kotlin async continuation")
     inner class S3V2StreamLoader(override val stream: DestinationStream) : StreamLoader {
-        private val partNumber = AtomicLong(0L) // TODO: Get from destination state
+        private val partNumber = AtomicLong(0L)
+
+        override suspend fun start() {
+            val state = destinationStateManager.getState(stream)
+            val maxPartNumber =
+                state.generations
+                    .filter { it.generationId >= stream.minimumGenerationId }
+                    .mapNotNull { it.objects.maxOfOrNull { obj -> obj.partNumber } }
+                    .maxOrNull()
+            log.info { "Got max part number from destination state: $maxPartNumber" }
+            maxPartNumber?.let { partNumber.set(it + 1L) }
+        }
 
         override suspend fun processRecords(
             records: Iterator<DestinationRecord>,
@@ -48,12 +66,18 @@ class S3V2Writer(
         ): Batch {
             val partNumber = partNumber.getAndIncrement()
             val key = pathFactory.getPathToFile(stream, partNumber, isStaging = true).toString()
+
+            log.info { "Writing records to $key" }
+            val state = destinationStateManager.getState(stream)
+            state.addObject(stream.generationId, key, partNumber)
+
             val s3Object =
                 s3Client.streamingUpload(key) { outputStream ->
                     writerFactory.create(stream, outputStream).use { writer ->
                         records.forEach { writer.accept(it) }
                     }
                 }
+            log.info { "Finished writing records to $key" }
             return StagedObject(s3Object = s3Object, partNumber = partNumber)
         }
 
@@ -63,9 +87,56 @@ class S3V2Writer(
                 pathFactory
                     .getPathToFile(stream, stagedObject.partNumber, isStaging = false)
                     .toString()
+            log.info { "Moving staged object from ${stagedObject.s3Object.key} to $finalKey" }
             val newObject = s3Client.move(stagedObject.s3Object, finalKey)
+
+            val state = destinationStateManager.getState(stream)
+            state.removeObject(stream.generationId, stagedObject.s3Object.key)
+            state.addObject(stream.generationId, newObject.key, stagedObject.partNumber)
+
             val finalizedObject = FinalizedObject(s3Object = newObject)
             return finalizedObject
+        }
+
+        override suspend fun close(streamFailure: StreamIncompleteResult?) {
+            if (streamFailure != null) {
+                log.info { "Sync failed, persisting destination state for next run" }
+                destinationStateManager.persistState(stream)
+            } else {
+                log.info { "Sync succeeded, Moving any stragglers out of staging" }
+                val state = destinationStateManager.getState(stream)
+                val stagingToKeep =
+                    state.generations.filter {
+                        it.isStaging && it.generationId >= stream.minimumGenerationId
+                    }
+                stagingToKeep.toList().forEach {
+                    it.objects.forEach { obj ->
+                        val newKey =
+                            pathFactory
+                                .getPathToFile(stream, obj.partNumber, isStaging = false)
+                                .toString()
+                        log.info { "Moving staged object from ${obj.key} to $newKey" }
+                        val newObject = s3Client.move(obj.key, newKey)
+                        state.removeObject(it.generationId, obj.key, isStaging = true)
+                        state.addObject(it.generationId, newObject.key, obj.partNumber)
+                    }
+                }
+
+                log.info { "Removing old files" }
+                val (toKeep, toDrop) =
+                    state.generations.partition { it.generationId >= stream.minimumGenerationId }
+                val keepKeys = toKeep.flatMap { it.objects.map { obj -> obj.key } }.toSet()
+                toDrop
+                    .flatMap { it.objects.filter { obj -> obj.key !in keepKeys } }
+                    .forEach {
+                        log.info { "Deleting object ${it.key}" }
+                        s3Client.delete(it.key)
+                    }
+
+                log.info { "Updating and persisting state" }
+                state.dropGenerationsBefore(stream.minimumGenerationId)
+                destinationStateManager.persistState(stream)
+            }
         }
     }
 }

--- a/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2WriteTest.kt
+++ b/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2WriteTest.kt
@@ -36,7 +36,6 @@ abstract class S3V2WriteTest(path: String) :
         super.testMidSyncCheckpointingStreamState()
     }
 
-    @Disabled("append mode doesn't yet work")
     @Test
     override fun testAppend() {
         super.testAppend()
@@ -46,6 +45,11 @@ abstract class S3V2WriteTest(path: String) :
     @Test
     override fun testAppendSchemaEvolution() {
         super.testAppendSchemaEvolution()
+    }
+
+    @Test
+    override fun testTruncateRefresh() {
+        super.testTruncateRefresh()
     }
 }
 


### PR DESCRIPTION
## What
Object storage destination state done "right", with tests.

As I mentioned in standup, I'm going to put this behind configuration (next PR), but I wanted to establish the pattern before hacking it.

Next PR:
* break out "staging" as an opt-in config interface that can be added to the path config
* if absent, staging behavior in general is not used
* if absent, an alternate dst state manager will be used that creates the same data by inspecting generation id

So
* future object storage integrations can do it the right way
* opting in s3 in the future is easy
* migrating the manager to use platform-provided state is easy