### PR TITLE
Bulk Load CDK: ObjectStorageStreamLoader

### DIFF
--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/command/object_storage/ObjectStoragePathConfiguration.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/command/object_storage/ObjectStoragePathConfiguration.kt
@@ -8,7 +8,8 @@ data class ObjectStoragePathConfiguration(
     val prefix: String,
     val stagingPrefix: String?,
     val pathSuffixPattern: String?,
-    val fileNamePattern: String?
+    val fileNamePattern: String?,
+    val usesStagingDirectory: Boolean
 )
 
 interface ObjectStoragePathConfigurationProvider {

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/file/object_storage/ObjectStorageClient.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/file/object_storage/ObjectStorageClient.kt
@@ -4,7 +4,6 @@
 
 package io.airbyte.cdk.load.file.object_storage
 
-import io.airbyte.cdk.load.file.NoopProcessor
 import io.airbyte.cdk.load.file.StreamProcessor
 import java.io.InputStream
 import java.io.OutputStream
@@ -27,11 +26,9 @@ interface ObjectStorageClient<T : RemoteObject<*>> {
      * files). Specifically, the method should guarantee that no operations will be performed on the
      * stream after [block] completes.
      */
-    suspend fun streamingUpload(key: String, block: suspend (OutputStream) -> Unit): T =
-        streamingUpload(key, NoopProcessor, block)
     suspend fun <V : OutputStream> streamingUpload(
         key: String,
-        streamProcessor: StreamProcessor<V>,
+        streamProcessor: StreamProcessor<V>? = null,
         block: suspend (OutputStream) -> Unit
     ): T
 }

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/write/object_storage/ObjectStorageStreamLoaderFactory.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/write/object_storage/ObjectStorageStreamLoaderFactory.kt
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.load.write.object_storage
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
+import io.airbyte.cdk.load.command.DestinationStream
+import io.airbyte.cdk.load.command.object_storage.ObjectStorageCompressionConfigurationProvider
+import io.airbyte.cdk.load.file.NoopProcessor
+import io.airbyte.cdk.load.file.StreamProcessor
+import io.airbyte.cdk.load.file.object_storage.ObjectStorageClient
+import io.airbyte.cdk.load.file.object_storage.ObjectStorageFormattingWriterFactory
+import io.airbyte.cdk.load.file.object_storage.ObjectStoragePathFactory
+import io.airbyte.cdk.load.file.object_storage.RemoteObject
+import io.airbyte.cdk.load.message.Batch
+import io.airbyte.cdk.load.message.DestinationRecord
+import io.airbyte.cdk.load.state.DestinationStateManager
+import io.airbyte.cdk.load.state.StreamIncompleteResult
+import io.airbyte.cdk.load.state.object_storage.ObjectStorageDestinationState
+import io.airbyte.cdk.load.write.StreamLoader
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.micronaut.context.annotation.Secondary
+import jakarta.inject.Singleton
+import java.io.OutputStream
+import java.util.concurrent.atomic.AtomicLong
+
+@Singleton
+@Secondary
+class ObjectStorageStreamLoaderFactory<T : RemoteObject<*>>(
+    private val client: ObjectStorageClient<T>,
+    private val compressionConfig: ObjectStorageCompressionConfigurationProvider<*>? = null,
+    private val pathFactory: ObjectStoragePathFactory,
+    private val writerFactory: ObjectStorageFormattingWriterFactory,
+    private val destinationStateManager: DestinationStateManager<ObjectStorageDestinationState>,
+) {
+    fun create(stream: DestinationStream): StreamLoader {
+        return ObjectStorageStreamLoader(
+            stream,
+            client,
+            compressionConfig?.objectStorageCompressionConfiguration?.compressor ?: NoopProcessor,
+            pathFactory,
+            writerFactory,
+            destinationStateManager
+        )
+    }
+}
+
+@SuppressFBWarnings("NP_NONNULL_PARAM_VIOLATION", justification = "Kotlin async continuation")
+class ObjectStorageStreamLoader<T : RemoteObject<*>, U : OutputStream>(
+    override val stream: DestinationStream,
+    private val client: ObjectStorageClient<T>,
+    private val compressor: StreamProcessor<U>,
+    private val pathFactory: ObjectStoragePathFactory,
+    private val writerFactory: ObjectStorageFormattingWriterFactory,
+    private val destinationStateManager: DestinationStateManager<ObjectStorageDestinationState>,
+) : StreamLoader {
+    private val log = KotlinLogging.logger {}
+
+    sealed interface ObjectStorageBatch : Batch
+    data class StagedObject<T>(
+        override val state: Batch.State = Batch.State.PERSISTED,
+        val remoteObject: T,
+        val partNumber: Long
+    ) : ObjectStorageBatch
+    data class FinalizedObject<T>(
+        override val state: Batch.State = Batch.State.COMPLETE,
+        val remoteObject: T,
+    ) : ObjectStorageBatch
+
+    private val partNumber = AtomicLong(0L)
+
+    override suspend fun start() {
+        val state = destinationStateManager.getState(stream)
+        val maxPartNumber =
+            state.generations
+                .map {
+                    println(it)
+                    it
+                }
+                .filter { it.generationId >= stream.minimumGenerationId }
+                .mapNotNull { it.objects.maxOfOrNull { obj -> obj.partNumber } }
+                .maxOrNull()
+        log.info { "Got max part number from destination state: $maxPartNumber" }
+        maxPartNumber?.let { partNumber.set(it + 1L) }
+    }
+
+    override suspend fun processRecords(
+        records: Iterator<DestinationRecord>,
+        totalSizeBytes: Long
+    ): Batch {
+        val partNumber = partNumber.getAndIncrement()
+        val key = pathFactory.getPathToFile(stream, partNumber, isStaging = true).toString()
+
+        log.info { "Writing records to $key" }
+        val state = destinationStateManager.getState(stream)
+        state.addObject(stream.generationId, key, partNumber)
+
+        val obj =
+            client.streamingUpload(key, streamProcessor = compressor) { outputStream ->
+                writerFactory.create(stream, outputStream).use { writer ->
+                    records.forEach { writer.accept(it) }
+                }
+            }
+        log.info { "Finished writing records to $key" }
+        return StagedObject(remoteObject = obj, partNumber = partNumber)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    override suspend fun processBatch(batch: Batch): Batch {
+        val stagedObject = batch as StagedObject<T>
+        val finalKey =
+            pathFactory.getPathToFile(stream, stagedObject.partNumber, isStaging = false).toString()
+        log.info { "Moving staged object from ${stagedObject.remoteObject.key} to $finalKey" }
+        val newObject = client.move(stagedObject.remoteObject, finalKey)
+
+        val state = destinationStateManager.getState(stream)
+        state.removeObject(stream.generationId, stagedObject.remoteObject.key)
+        state.addObject(stream.generationId, newObject.key, stagedObject.partNumber)
+
+        val finalizedObject = FinalizedObject(remoteObject = newObject)
+        return finalizedObject
+    }
+
+    override suspend fun close(streamFailure: StreamIncompleteResult?) {
+        if (streamFailure != null) {
+            log.info { "Sync failed, persisting destination state for next run" }
+            destinationStateManager.persistState(stream)
+        } else {
+            log.info { "Sync succeeded, Moving any stragglers out of staging" }
+            val state = destinationStateManager.getState(stream)
+            val stagingToKeep =
+                state.generations.filter {
+                    it.isStaging && it.generationId >= stream.minimumGenerationId
+                }
+            stagingToKeep.toList().forEach {
+                it.objects.forEach { obj ->
+                    val newKey =
+                        pathFactory
+                            .getPathToFile(stream, obj.partNumber, isStaging = false)
+                            .toString()
+                    log.info { "Moving staged object from ${obj.key} to $newKey" }
+                    val newObject = client.move(obj.key, newKey)
+                    state.removeObject(it.generationId, obj.key, isStaging = true)
+                    state.addObject(it.generationId, newObject.key, obj.partNumber)
+                }
+            }
+
+            log.info { "Removing old files" }
+            val (toKeep, toDrop) =
+                state.generations.partition { it.generationId >= stream.minimumGenerationId }
+            val keepKeys = toKeep.flatMap { it.objects.map { obj -> obj.key } }.toSet()
+            toDrop
+                .flatMap { it.objects.filter { obj -> obj.key !in keepKeys } }
+                .forEach {
+                    log.info { "Deleting object ${it.key}" }
+                    client.delete(it.key)
+                }
+
+            log.info { "Updating and persisting state" }
+            state.dropGenerationsBefore(stream.minimumGenerationId)
+            destinationStateManager.persistState(stream)
+        }
+    }
+}

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/test/kotlin/io/airbyte/cdk/load/file/object_storage/ObjectStoragePathFactoryTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/test/kotlin/io/airbyte/cdk/load/file/object_storage/ObjectStoragePathFactoryTest.kt
@@ -63,7 +63,8 @@ class ObjectStoragePathFactoryTest {
                 stagingPrefix = "staging/prefix",
                 pathSuffixPattern =
                     "\${NAMESPACE}/\${STREAM_NAME}/\${YEAR}/\${MONTH}/\${DAY}/\${HOUR}/\${MINUTE}/\${SECOND}/\${MILLISECOND}/\${EPOCH}/",
-                fileNamePattern = "{date}-{timestamp}-{part_number}-{sync_id}{format_extension}"
+                fileNamePattern = "{date}-{timestamp}-{part_number}-{sync_id}{format_extension}",
+                usesStagingDirectory = true
             )
     }
 

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/testFixtures/kotlin/io/airbyte/cdk/load/MockObjectStorageClient.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/testFixtures/kotlin/io/airbyte/cdk/load/MockObjectStorageClient.kt
@@ -64,7 +64,7 @@ class MockObjectStorageClient : ObjectStorageClient<MockRemoteObject> {
 
     override suspend fun <V : OutputStream> streamingUpload(
         key: String,
-        streamProcessor: StreamProcessor<V>,
+        streamProcessor: StreamProcessor<V>?,
         block: suspend (OutputStream) -> Unit
     ): MockRemoteObject {
         TODO("Not yet implemented")

--- a/airbyte-cdk/bulk/toolkits/load-s3/src/main/kotlin/io/airbyte/cdk/load/command/s3/S3PathSpecification.kt
+++ b/airbyte-cdk/bulk/toolkits/load-s3/src/main/kotlin/io/airbyte/cdk/load/command/s3/S3PathSpecification.kt
@@ -50,9 +50,17 @@ interface S3PathSpecification {
     @get:JsonSchemaInject(json = """{"examples":["data_sync/test"]}""")
     val s3BucketPath: String
 
+    //    @get:JsonSchemaTitle("Use a Staging Directory")
+    //    @get:JsonPropertyDescription(
+    //        "Whether to use a staging directory in the bucket based on the s3_staging_prefix. If
+    // this is not set, airbyte will maintain sync integrity by adding metadata to each object."
+    //    )
+    //    @get:JsonProperty("use_staging_directory", defaultValue = "false")
+    //    val useStagingDirectory: Boolean
+
     @get:JsonSchemaTitle("S3 Staging Prefix")
     @get:JsonPropertyDescription(
-        "Path to use when staging data in the bucket directory. Documentation TBD."
+        "Path to use when staging data in the bucket directory. Airbyte will stage data here during sync and/or write small manifest/recovery files."
     )
     @get:JsonProperty("s3_staging_prefix", defaultValue = "{s3_bucket_path}/__airbyte_tmp")
     @get:JsonSchemaInject(json = """{"examples":["__staging/data_sync/test"]}""")
@@ -63,6 +71,7 @@ interface S3PathSpecification {
             prefix = s3BucketPath,
             stagingPrefix = s3StagingPrefix,
             pathSuffixPattern = s3PathFormat,
-            fileNamePattern = fileNamePattern
+            fileNamePattern = fileNamePattern,
+            usesStagingDirectory = true
         )
 }

--- a/airbyte-integrations/connectors/destination-s3-v2/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-s3-v2/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: file
   connectorType: destination
   definitionId: d6116991-e809-4c7c-ae09-c64712df5b66
-  dockerImageTag: 0.1.14
+  dockerImageTag: 0.1.15
   dockerRepository: airbyte/destination-s3-v2
   githubIssueLabel: destination-s3-v2
   icon: s3.svg

--- a/airbyte-integrations/connectors/destination-s3-v2/src/main/kotlin/S3V2Specification.kt
+++ b/airbyte-integrations/connectors/destination-s3-v2/src/main/kotlin/S3V2Specification.kt
@@ -34,6 +34,7 @@ class S3V2Specification :
     override val s3Endpoint: String? = null
     override val s3PathFormat: String? = null
     override val fileNamePattern: String? = null
+    // override val useStagingDirectory: Boolean = false
     override val s3StagingPrefix: String? = null
 }
 

--- a/airbyte-integrations/connectors/destination-s3-v2/src/main/kotlin/S3V2Writer.kt
+++ b/airbyte-integrations/connectors/destination-s3-v2/src/main/kotlin/S3V2Writer.kt
@@ -4,139 +4,18 @@
 
 package io.airbyte.integrations.destination.s3_v2
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 import io.airbyte.cdk.load.command.DestinationStream
-import io.airbyte.cdk.load.file.object_storage.ObjectStorageFormattingWriterFactory
-import io.airbyte.cdk.load.file.object_storage.ObjectStoragePathFactory
-import io.airbyte.cdk.load.file.s3.S3Client
 import io.airbyte.cdk.load.file.s3.S3Object
-import io.airbyte.cdk.load.message.Batch
-import io.airbyte.cdk.load.message.DestinationRecord
-import io.airbyte.cdk.load.state.DestinationStateManager
-import io.airbyte.cdk.load.state.StreamIncompleteResult
-import io.airbyte.cdk.load.state.object_storage.ObjectStorageDestinationState
 import io.airbyte.cdk.load.write.DestinationWriter
 import io.airbyte.cdk.load.write.StreamLoader
-import io.github.oshai.kotlinlogging.KotlinLogging
+import io.airbyte.cdk.load.write.object_storage.ObjectStorageStreamLoaderFactory
 import jakarta.inject.Singleton
-import java.util.concurrent.atomic.AtomicLong
 
 @Singleton
 class S3V2Writer(
-    private val s3Client: S3Client,
-    private val pathFactory: ObjectStoragePathFactory,
-    private val writerFactory: ObjectStorageFormattingWriterFactory,
-    private val destinationStateManager: DestinationStateManager<ObjectStorageDestinationState>,
+    private val streamLoaderFactory: ObjectStorageStreamLoaderFactory<S3Object>,
 ) : DestinationWriter {
-    private val log = KotlinLogging.logger {}
-
-    sealed interface S3V2Batch : Batch
-    data class StagedObject(
-        override val state: Batch.State = Batch.State.PERSISTED,
-        val s3Object: S3Object,
-        val partNumber: Long
-    ) : S3V2Batch
-    data class FinalizedObject(
-        override val state: Batch.State = Batch.State.COMPLETE,
-        val s3Object: S3Object,
-    ) : S3V2Batch
-
     override fun createStreamLoader(stream: DestinationStream): StreamLoader {
-        return S3V2StreamLoader(stream)
-    }
-
-    @SuppressFBWarnings("NP_NONNULL_PARAM_VIOLATION", justification = "Kotlin async continuation")
-    inner class S3V2StreamLoader(override val stream: DestinationStream) : StreamLoader {
-        private val partNumber = AtomicLong(0L)
-
-        override suspend fun start() {
-            val state = destinationStateManager.getState(stream)
-            val maxPartNumber =
-                state.generations
-                    .filter { it.generationId >= stream.minimumGenerationId }
-                    .mapNotNull { it.objects.maxOfOrNull { obj -> obj.partNumber } }
-                    .maxOrNull()
-            log.info { "Got max part number from destination state: $maxPartNumber" }
-            maxPartNumber?.let { partNumber.set(it + 1L) }
-        }
-
-        override suspend fun processRecords(
-            records: Iterator<DestinationRecord>,
-            totalSizeBytes: Long
-        ): Batch {
-            val partNumber = partNumber.getAndIncrement()
-            val key = pathFactory.getPathToFile(stream, partNumber, isStaging = true).toString()
-
-            log.info { "Writing records to $key" }
-            val state = destinationStateManager.getState(stream)
-            state.addObject(stream.generationId, key, partNumber)
-
-            val s3Object =
-                s3Client.streamingUpload(key) { outputStream ->
-                    writerFactory.create(stream, outputStream).use { writer ->
-                        records.forEach { writer.accept(it) }
-                    }
-                }
-            log.info { "Finished writing records to $key" }
-            return StagedObject(s3Object = s3Object, partNumber = partNumber)
-        }
-
-        override suspend fun processBatch(batch: Batch): Batch {
-            val stagedObject = batch as StagedObject
-            val finalKey =
-                pathFactory
-                    .getPathToFile(stream, stagedObject.partNumber, isStaging = false)
-                    .toString()
-            log.info { "Moving staged object from ${stagedObject.s3Object.key} to $finalKey" }
-            val newObject = s3Client.move(stagedObject.s3Object, finalKey)
-
-            val state = destinationStateManager.getState(stream)
-            state.removeObject(stream.generationId, stagedObject.s3Object.key)
-            state.addObject(stream.generationId, newObject.key, stagedObject.partNumber)
-
-            val finalizedObject = FinalizedObject(s3Object = newObject)
-            return finalizedObject
-        }
-
-        override suspend fun close(streamFailure: StreamIncompleteResult?) {
-            if (streamFailure != null) {
-                log.info { "Sync failed, persisting destination state for next run" }
-                destinationStateManager.persistState(stream)
-            } else {
-                log.info { "Sync succeeded, Moving any stragglers out of staging" }
-                val state = destinationStateManager.getState(stream)
-                val stagingToKeep =
-                    state.generations.filter {
-                        it.isStaging && it.generationId >= stream.minimumGenerationId
-                    }
-                stagingToKeep.toList().forEach {
-                    it.objects.forEach { obj ->
-                        val newKey =
-                            pathFactory
-                                .getPathToFile(stream, obj.partNumber, isStaging = false)
-                                .toString()
-                        log.info { "Moving staged object from ${obj.key} to $newKey" }
-                        val newObject = s3Client.move(obj.key, newKey)
-                        state.removeObject(it.generationId, obj.key, isStaging = true)
-                        state.addObject(it.generationId, newObject.key, obj.partNumber)
-                    }
-                }
-
-                log.info { "Removing old files" }
-                val (toKeep, toDrop) =
-                    state.generations.partition { it.generationId >= stream.minimumGenerationId }
-                val keepKeys = toKeep.flatMap { it.objects.map { obj -> obj.key } }.toSet()
-                toDrop
-                    .flatMap { it.objects.filter { obj -> obj.key !in keepKeys } }
-                    .forEach {
-                        log.info { "Deleting object ${it.key}" }
-                        s3Client.delete(it.key)
-                    }
-
-                log.info { "Updating and persisting state" }
-                state.dropGenerationsBefore(stream.minimumGenerationId)
-                destinationStateManager.persistState(stream)
-            }
-        }
+        return streamLoaderFactory.create(stream)
     }
 }

--- a/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/resources/expected-spec-cloud.json
+++ b/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/resources/expected-spec-cloud.json
@@ -297,7 +297,7 @@
       "s3_staging_prefix" : {
         "type" : "string",
         "default" : "{s3_bucket_path}/__airbyte_tmp",
-        "description" : "Path to use when staging data in the bucket directory. Documentation TBD.",
+        "description" : "Path to use when staging data in the bucket directory. Airbyte will stage data here during sync and/or write small manifest/recovery files.",
         "title" : "S3 Staging Prefix",
         "examples" : [ "__staging/data_sync/test" ]
       }

--- a/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/resources/expected-spec-oss.json
+++ b/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/resources/expected-spec-oss.json
@@ -297,7 +297,7 @@
       "s3_staging_prefix" : {
         "type" : "string",
         "default" : "{s3_bucket_path}/__airbyte_tmp",
-        "description" : "Path to use when staging data in the bucket directory. Documentation TBD.",
+        "description" : "Path to use when staging data in the bucket directory. Airbyte will stage data here during sync and/or write small manifest/recovery files.",
         "title" : "S3 Staging Prefix",
         "examples" : [ "__staging/data_sync/test" ]
       }


### PR DESCRIPTION
## What
Preparatory refactor:
* move the s3v2 code into a generic `ObjectStorageStreamLoader`

Path factory staging is optional:
* add `useStaging` flag to the path config
* drop staging prefix from s3 spec but keep `useStaging = true` (will use default staging until next pr)
* change the path factory to fail on staging operations when `useStaging` is false (tests)