### PR TITLE
bulk-cdk-toolkit-extract-cdc: tweak DebeziumOperations interface

### DIFF
--- a/airbyte-cdk/bulk/toolkits/extract-cdc/src/main/kotlin/io/airbyte/cdk/read/cdc/CdcPartitionReader.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-cdc/src/main/kotlin/io/airbyte/cdk/read/cdc/CdcPartitionReader.kt
@@ -88,7 +88,14 @@ class CdcPartitionReader<T : Comparable<T>>(
         val thread = Thread(engine, "debezium-engine")
         thread.setUncaughtExceptionHandler { _, e: Throwable -> engineException.set(e) }
         thread.start()
-        withContext(Dispatchers.IO) { thread.join() }
+        try {
+            withContext(Dispatchers.IO) { thread.join() }
+        } catch (e: Throwable) {
+            // This catches any exceptions thrown by join()
+            // but also by the kotlin coroutine dispatcher, like TimeoutCancellationException.
+            engineException.compareAndSet(null, e)
+        }
+        // Print a nice log message and re-throw any exception.
         val exception: Throwable? = engineException.get()
         val summary: Map<String, Any?> =
             mapOf(
@@ -138,54 +145,64 @@ class CdcPartitionReader<T : Comparable<T>>(
             val debeziumRecordValue: DebeziumRecordValue? =
                 event.value()?.let { DebeziumRecordValue(Jsons.readTree(it)) }
             // Process records, ignoring heartbeats which are only used for completion checks.
-            val isRecord: Boolean = run {
-                if (debeziumRecordValue == null) {
-                    numTombstones.incrementAndGet()
-                    return@run false
-                }
-                if (debeziumRecordValue.isHeartbeat) {
-                    numHeartbeats.incrementAndGet()
-                    return@run false
-                }
+            val eventType: EventType = run {
+                if (debeziumRecordValue == null) return@run EventType.TOMBSTONE
+                if (debeziumRecordValue.isHeartbeat) return@run EventType.HEARTBEAT
                 val debeziumRecordKey = DebeziumRecordKey(Jsons.readTree(event.key()))
-                val deserializedRecord: DeserializedRecord? =
+                val deserializedRecord: DeserializedRecord =
                     readerOps.deserialize(debeziumRecordKey, debeziumRecordValue)
-                if (deserializedRecord == null) {
-                    numDiscardedRecords.incrementAndGet()
-                    return@run true
-                }
-                val streamRecordConsumer: StreamRecordConsumer? =
+                        ?: return@run EventType.RECORD_DISCARDED_BY_DESERIALIZE
+                val streamRecordConsumer: StreamRecordConsumer =
                     streamRecordConsumers[deserializedRecord.streamID]
-                if (streamRecordConsumer == null) {
-                    numDiscardedRecords.incrementAndGet()
-                    return@run true
-                }
+                        ?: return@run EventType.RECORD_DISCARDED_BY_STREAM_ID
                 streamRecordConsumer.accept(deserializedRecord.data, deserializedRecord.changes)
-                numEmittedRecords.incrementAndGet()
-                return@run true
+                return@run EventType.RECORD_EMITTED
             }
+            // Update counters.
+            when (eventType) {
+                EventType.TOMBSTONE -> numTombstones
+                EventType.HEARTBEAT -> numHeartbeats
+                EventType.RECORD_DISCARDED_BY_DESERIALIZE,
+                EventType.RECORD_DISCARDED_BY_STREAM_ID -> numDiscardedRecords
+                EventType.RECORD_EMITTED -> numEmittedRecords
+            }.incrementAndGet()
             // Look for reasons to close down the engine.
-            val closeReason: CloseReason? = run {
+            val closeReason: CloseReason = run {
+                if (input.isSynthetic && eventType != EventType.HEARTBEAT) {
+                    // Special case where the engine started with a synthetic offset:
+                    // don't even consider closing the engine unless handling a heartbeat event.
+                    // For some databases, such as Oracle, Debezium actually needs to snapshot the
+                    // schema in order to collect the database schema history and there's no point
+                    // in interrupting it until the snapshot is done.
+                    return
+                }
                 if (!coroutineContext.isActive) {
                     return@run CloseReason.TIMEOUT
                 }
                 val currentPosition: T? = position(sourceRecord) ?: position(debeziumRecordValue)
                 if (currentPosition == null || currentPosition < upperBound) {
-                    return@run null
+                    return
                 }
                 // Close because the current event is past the sync upper bound.
-                if (isRecord) {
-                    CloseReason.RECORD_REACHED_TARGET_POSITION
-                } else {
-                    CloseReason.HEARTBEAT_OR_TOMBSTONE_REACHED_TARGET_POSITION
+                when (eventType) {
+                    EventType.TOMBSTONE,
+                    EventType.HEARTBEAT ->
+                        CloseReason.HEARTBEAT_OR_TOMBSTONE_REACHED_TARGET_POSITION
+                    EventType.RECORD_EMITTED,
+                    EventType.RECORD_DISCARDED_BY_DESERIALIZE,
+                    EventType.RECORD_DISCARDED_BY_STREAM_ID ->
+                        CloseReason.RECORD_REACHED_TARGET_POSITION
                 }
             }
-            // Idempotent engine shutdown.
-            if (closeReason != null && closeReasonReference.compareAndSet(null, closeReason)) {
-                log.info { "Shutting down Debezium engine: ${closeReason.message}." }
-                // TODO : send close analytics message
-                Thread({ engine.close() }, "debezium-close").start()
+            // At this point, if we haven't returned already, we want to close down the engine.
+            if (!closeReasonReference.compareAndSet(null, closeReason)) {
+                // An earlier event has already triggered closing down the engine, do nothing.
+                return
             }
+            // At this point, if we haven't returned already, we need to close down the engine.
+            log.info { "Shutting down Debezium engine: ${closeReason.message}." }
+            // TODO : send close analytics message
+            Thread({ engine.close() }, "debezium-close").start()
         }
 
         private fun position(sourceRecord: SourceRecord?): T? {
@@ -207,6 +224,14 @@ class CdcPartitionReader<T : Comparable<T>>(
             }
             return debeziumRecordValuePosition
         }
+    }
+
+    private enum class EventType {
+        TOMBSTONE,
+        HEARTBEAT,
+        RECORD_DISCARDED_BY_DESERIALIZE,
+        RECORD_DISCARDED_BY_STREAM_ID,
+        RECORD_EMITTED,
     }
 
     inner class CompletionCallback : DebeziumEngine.CompletionCallback {

--- a/airbyte-cdk/bulk/toolkits/extract-cdc/src/main/kotlin/io/airbyte/cdk/read/cdc/CdcPartitionsCreatorFactory.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-cdc/src/main/kotlin/io/airbyte/cdk/read/cdc/CdcPartitionsCreatorFactory.kt
@@ -22,6 +22,14 @@ class CdcPartitionsCreatorFactory<T : Comparable<T>>(
     val debeziumOps: DebeziumOperations<T>,
 ) : PartitionsCreatorFactory {
 
+
+    /**
+     * [AtomicReference] to a WAL position lower bound value shared by all [CdcPartitionsCreator]s.
+     * This value is updated by the [CdcPartitionsCreator] based on the incumbent state and is
+     * used to detect stalls.
+     */
+    private val lowerBoundReference = AtomicReference<T>()
+
     /**
      * [AtomicReference] to a WAL position upper bound value shared by all [CdcPartitionsCreator]s.
      * This value is set exactly once by the first [CdcPartitionsCreator].
@@ -39,6 +47,7 @@ class CdcPartitionsCreatorFactory<T : Comparable<T>>(
             feedBootstrap,
             debeziumOps,
             debeziumOps,
+            lowerBoundReference,
             upperBoundReference,
         )
     }

--- a/airbyte-cdk/bulk/toolkits/extract-cdc/src/main/kotlin/io/airbyte/cdk/read/cdc/CdcPartitionsCreatorFactory.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-cdc/src/main/kotlin/io/airbyte/cdk/read/cdc/CdcPartitionsCreatorFactory.kt
@@ -22,11 +22,10 @@ class CdcPartitionsCreatorFactory<T : Comparable<T>>(
     val debeziumOps: DebeziumOperations<T>,
 ) : PartitionsCreatorFactory {
 
-
     /**
      * [AtomicReference] to a WAL position lower bound value shared by all [CdcPartitionsCreator]s.
-     * This value is updated by the [CdcPartitionsCreator] based on the incumbent state and is
-     * used to detect stalls.
+     * This value is updated by the [CdcPartitionsCreator] based on the incumbent state and is used
+     * to detect stalls.
      */
     private val lowerBoundReference = AtomicReference<T>()
 

--- a/airbyte-cdk/bulk/toolkits/extract-cdc/src/main/kotlin/io/airbyte/cdk/read/cdc/Debezium.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-cdc/src/main/kotlin/io/airbyte/cdk/read/cdc/Debezium.kt
@@ -26,9 +26,9 @@ value class DebeziumRecordKey(val wrapped: JsonNode) {
 value class DebeziumRecordValue(val wrapped: JsonNode) {
 
     /**
-     * True if this is a Debezium heartbeat event, or the equivalent thereof.
-     * In any case, such events are only used for their position value and for triggering timeouts.
-     **/
+     * True if this is a Debezium heartbeat event, or the equivalent thereof. In any case, such
+     * events are only used for their position value and for triggering timeouts.
+     */
     val isHeartbeat: Boolean
         get() = source.isNull
 

--- a/airbyte-cdk/bulk/toolkits/extract-cdc/src/main/kotlin/io/airbyte/cdk/read/cdc/Debezium.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-cdc/src/main/kotlin/io/airbyte/cdk/read/cdc/Debezium.kt
@@ -25,7 +25,10 @@ value class DebeziumRecordKey(val wrapped: JsonNode) {
 @JvmInline
 value class DebeziumRecordValue(val wrapped: JsonNode) {
 
-    /** True if this is a Debezium heartbeat event. These aren't passed to [DebeziumConsumer]. */
+    /**
+     * True if this is a Debezium heartbeat event, or the equivalent thereof.
+     * In any case, such events are only used for their position value and for triggering timeouts.
+     **/
     val isHeartbeat: Boolean
         get() = source.isNull
 

--- a/airbyte-cdk/bulk/toolkits/extract-cdc/src/main/kotlin/io/airbyte/cdk/read/cdc/DebeziumOperations.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-cdc/src/main/kotlin/io/airbyte/cdk/read/cdc/DebeziumOperations.kt
@@ -30,8 +30,12 @@ interface CdcPartitionsCreatorDebeziumOperations<T : Comparable<T>> {
 
 interface CdcPartitionReaderDebeziumOperations<T : Comparable<T>> {
 
-    /** Transforms a [DebeziumRecordValue] into a [DeserializedRecord]. */
-    fun deserialize(key: DebeziumRecordKey, value: DebeziumRecordValue): DeserializedRecord
+    /**
+     * Transforms a [DebeziumRecordKey] and a [DebeziumRecordValue] into a [DeserializedRecord].
+     *
+     * Returning null means that the event should be treated like a heartbeat.
+     */
+    fun deserialize(key: DebeziumRecordKey, value: DebeziumRecordValue): DeserializedRecord?
 
     /** Maps a [DebeziumState] to an [OpaqueStateValue]. */
     fun serialize(debeziumState: DebeziumState): OpaqueStateValue

--- a/airbyte-cdk/bulk/toolkits/extract-cdc/src/test/kotlin/io/airbyte/cdk/read/cdc/CdcPartitionsCreatorTest.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-cdc/src/test/kotlin/io/airbyte/cdk/read/cdc/CdcPartitionsCreatorTest.kt
@@ -58,6 +58,7 @@ class CdcPartitionsCreatorTest {
 
     val global = Global(listOf(stream))
 
+    val lowerBoundReference = AtomicReference<CreatorPosition>(null)
     val upperBoundReference = AtomicReference<CreatorPosition>(null)
 
     val creator: CdcPartitionsCreator<CreatorPosition>
@@ -68,6 +69,7 @@ class CdcPartitionsCreatorTest {
                 globalFeedBootstrap,
                 creatorOps,
                 readerOps,
+                lowerBoundReference,
                 upperBoundReference,
             )
 


### PR DESCRIPTION
## What
Working on adding CDC to source-firetruck I noticed that some records would have `before` and `after` set to `null` and contain DDL statements corresponding to schema changes. The `DebeziumOperations.deserialize` method therefore needs to be able to filter out records which don't map to Airbyte RECORD messages.

## How
This PR does this by allowing `null` values to be returned, and handling them accordingly at the call site. For clarity, the call site has been rewritten as a `run { ... }` block.

## Review guide
n/a

## User Impact
None

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
