### PR TITLE
Bulk load CDK: add complex type tests

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/integrationTest/kotlin/io/airbyte/cdk/load/mock_integration_test/MockBasicFunctionalityIntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/integrationTest/kotlin/io/airbyte/cdk/load/mock_integration_test/MockBasicFunctionalityIntegrationTest.kt
@@ -21,6 +21,9 @@ class MockBasicFunctionalityIntegrationTest :
         NoopNameMapper,
         isStreamSchemaRetroactive = false,
         supportsDedup = true,
+        stringifySchemalessObjects = false,
+        promoteUnionToObject = false,
+        preserveUndeclaredFields = true,
     ) {
     @Test
     override fun testBasicWrite() {
@@ -61,5 +64,15 @@ class MockBasicFunctionalityIntegrationTest :
     @Test
     override fun testDedup() {
         super.testDedup()
+    }
+
+    @Test
+    override fun testContainerTypes() {
+        super.testContainerTypes()
+    }
+
+    @Test
+    override fun testUnions() {
+        super.testUnions()
     }
 }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/AirbyteValue.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/AirbyteValue.kt
@@ -148,7 +148,7 @@ value class TimeValue(val value: String) : AirbyteValue, Comparable<TimeValue> {
 @JvmInline
 value class ArrayValue(val values: List<AirbyteValue>) : AirbyteValue {
     companion object {
-        fun from(list: List<Any?>): ArrayValue = ArrayValue(list.map { it as AirbyteValue })
+        fun from(list: List<Any?>): ArrayValue = ArrayValue(list.map { AirbyteValue.from(it) })
     }
 }
 

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/RecordDiffer.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/RecordDiffer.kt
@@ -297,8 +297,9 @@ class RecordDiffer(
                     }
                     // otherwise, just be a terrible person.
                     // we know these are the same type, so this is safe to do.
-                    else ->
+                    is Comparable<*> ->
                         @Suppress("UNCHECKED_CAST") (v1 as Comparable<AirbyteValue>).compareTo(v2)
+                    else -> if (v1 == v2) 0 else 1
                 }
             }
         }

--- a/airbyte-cdk/bulk/toolkits/load-avro/src/main/kotlin/io/airbyte/cdk/load/data/avro/AirbyteValueToAvroRecord.kt
+++ b/airbyte-cdk/bulk/toolkits/load-avro/src/main/kotlin/io/airbyte/cdk/load/data/avro/AirbyteValueToAvroRecord.kt
@@ -27,7 +27,9 @@ class AirbyteValueToAvroRecord {
             is ObjectValue -> {
                 val record = GenericData.Record(schema)
                 airbyteValue.values.forEach { (name, value) ->
-                    record.put(name, convert(value, schema.getField(name).schema()))
+                    schema.getField(name)?.let { field ->
+                        record.put(name, convert(value, field.schema()))
+                    }
                 }
                 return record
             }

--- a/airbyte-cdk/bulk/toolkits/load-csv/src/testFixtures/kotlin/io/airbyte/cdk/load/data/csv/CsvRowToAirbyteValue.kt
+++ b/airbyte-cdk/bulk/toolkits/load-csv/src/testFixtures/kotlin/io/airbyte/cdk/load/data/csv/CsvRowToAirbyteValue.kt
@@ -19,6 +19,7 @@ import io.airbyte.cdk.load.data.ObjectTypeWithoutSchema
 import io.airbyte.cdk.load.data.ObjectValue
 import io.airbyte.cdk.load.data.StringType
 import io.airbyte.cdk.load.data.StringValue
+import io.airbyte.cdk.load.data.UnknownType
 import io.airbyte.cdk.load.data.json.toAirbyteValue
 import io.airbyte.cdk.load.util.deserializeToNode
 import org.apache.commons.csv.CSVRecord
@@ -63,7 +64,8 @@ class CsvRowToAirbyteValue {
                     .fields()
                     .asSequence()
                     .map { entry ->
-                        entry.key to entry.value.toAirbyteValue(field.properties[entry.key]!!.type)
+                        val type = field.properties[entry.key]?.type ?: UnknownType("unknown")
+                        entry.key to entry.value.toAirbyteValue(type)
                     }
                     .toMap(properties)
                 ObjectValue(properties)

--- a/airbyte-integrations/connectors/destination-dev-null/src/test-integration/kotlin/io/airbyte/integrations/destination/dev_null/DevNullBasicFunctionalityIntegrationTest.kt
+++ b/airbyte-integrations/connectors/destination-dev-null/src/test-integration/kotlin/io/airbyte/integrations/destination/dev_null/DevNullBasicFunctionalityIntegrationTest.kt
@@ -19,6 +19,9 @@ class DevNullBasicFunctionalityIntegrationTest :
         verifyDataWriting = false,
         isStreamSchemaRetroactive = false,
         supportsDedup = false,
+        stringifySchemalessObjects = false,
+        promoteUnionToObject = false,
+        preserveUndeclaredFields = false,
     ) {
     @Test
     override fun testBasicWrite() {

--- a/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2WriteTest.kt
+++ b/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2WriteTest.kt
@@ -10,7 +10,12 @@ import io.airbyte.cdk.load.write.BasicFunctionalityIntegrationTest
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 
-abstract class S3V2WriteTest(path: String) :
+abstract class S3V2WriteTest(
+    path: String,
+    stringifySchemalessObjects: Boolean,
+    promoteUnionToObject: Boolean,
+    preserveUndeclaredFields: Boolean,
+) :
     BasicFunctionalityIntegrationTest(
         S3V2TestUtils.getConfig(path),
         S3V2Specification::class.java,
@@ -19,6 +24,9 @@ abstract class S3V2WriteTest(path: String) :
         NoopExpectedRecordMapper,
         isStreamSchemaRetroactive = false,
         supportsDedup = false,
+        stringifySchemalessObjects = stringifySchemalessObjects,
+        promoteUnionToObject = promoteUnionToObject,
+        preserveUndeclaredFields = preserveUndeclaredFields,
     ) {
     @Test
     override fun testBasicWrite() {
@@ -51,21 +59,125 @@ abstract class S3V2WriteTest(path: String) :
     override fun testTruncateRefresh() {
         super.testTruncateRefresh()
     }
+
+    override fun testContainerTypes() {
+        super.testContainerTypes()
+    }
+
+    @Test
+    override fun testUnions() {
+        super.testUnions()
+    }
 }
 
-class S3V2WriteTestJsonUncompressed : S3V2WriteTest(S3V2TestUtils.JSON_UNCOMPRESSED_CONFIG_PATH)
+class S3V2WriteTestJsonUncompressed :
+    S3V2WriteTest(
+        S3V2TestUtils.JSON_UNCOMPRESSED_CONFIG_PATH,
+        stringifySchemalessObjects = false,
+        promoteUnionToObject = false,
+        preserveUndeclaredFields = true,
+    )
 
-class S3V2WriteTestJsonGzip : S3V2WriteTest(S3V2TestUtils.JSON_GZIP_CONFIG_PATH)
+class S3V2WriteTestJsonGzip :
+    S3V2WriteTest(
+        S3V2TestUtils.JSON_GZIP_CONFIG_PATH,
+        stringifySchemalessObjects = false,
+        promoteUnionToObject = false,
+        preserveUndeclaredFields = true,
+    )
 
-class S3V2WriteTestCsvUncompressed : S3V2WriteTest(S3V2TestUtils.CSV_UNCOMPRESSED_CONFIG_PATH)
+class S3V2WriteTestCsvUncompressed :
+    S3V2WriteTest(
+        S3V2TestUtils.CSV_UNCOMPRESSED_CONFIG_PATH,
+        stringifySchemalessObjects = false,
+        promoteUnionToObject = false,
+        preserveUndeclaredFields = true,
+    )
 
-class S3V2WriteTestCsvGzip : S3V2WriteTest(S3V2TestUtils.CSV_GZIP_CONFIG_PATH)
+class S3V2WriteTestCsvGzip :
+    S3V2WriteTest(
+        S3V2TestUtils.CSV_GZIP_CONFIG_PATH,
+        stringifySchemalessObjects = false,
+        promoteUnionToObject = false,
+        preserveUndeclaredFields = true,
+    )
 
-class S3V2WriteTestAvroUncompressed : S3V2WriteTest(S3V2TestUtils.AVRO_UNCOMPRESSED_CONFIG_PATH)
+class S3V2WriteTestAvroUncompressed :
+    S3V2WriteTest(
+        S3V2TestUtils.AVRO_UNCOMPRESSED_CONFIG_PATH,
+        stringifySchemalessObjects = true,
+        promoteUnionToObject = false,
+        preserveUndeclaredFields = false,
+    ) {
+    @Disabled("Not yet working")
+    @Test
+    override fun testContainerTypes() {
+        super.testContainerTypes()
+    }
 
-class S3V2WriteTestAvroBzip2 : S3V2WriteTest(S3V2TestUtils.AVRO_BZIP2_CONFIG_PATH)
+    @Disabled("Not yet working")
+    @Test
+    override fun testUnions() {
+        super.testUnions()
+    }
+}
+
+class S3V2WriteTestAvroBzip2 :
+    S3V2WriteTest(
+        S3V2TestUtils.AVRO_BZIP2_CONFIG_PATH,
+        stringifySchemalessObjects = true,
+        promoteUnionToObject = false,
+        preserveUndeclaredFields = false,
+    ) {
+    @Disabled("Not yet working")
+    @Test
+    override fun testContainerTypes() {
+        super.testContainerTypes()
+    }
+
+    @Disabled("Not yet working")
+    @Test
+    override fun testUnions() {
+        super.testUnions()
+    }
+}
 
 class S3V2WriteTestParquetUncompressed :
-    S3V2WriteTest(S3V2TestUtils.PARQUET_UNCOMPRESSED_CONFIG_PATH)
+    S3V2WriteTest(
+        S3V2TestUtils.PARQUET_UNCOMPRESSED_CONFIG_PATH,
+        stringifySchemalessObjects = true,
+        promoteUnionToObject = true,
+        preserveUndeclaredFields = false,
+    ) {
+    @Disabled("Not yet working")
+    @Test
+    override fun testContainerTypes() {
+        super.testContainerTypes()
+    }
 
-class S3V2WriteTestParquetSnappy : S3V2WriteTest(S3V2TestUtils.PARQUET_SNAPPY_CONFIG_PATH)
+    @Disabled("Not yet working")
+    @Test
+    override fun testUnions() {
+        super.testUnions()
+    }
+}
+
+class S3V2WriteTestParquetSnappy :
+    S3V2WriteTest(
+        S3V2TestUtils.PARQUET_SNAPPY_CONFIG_PATH,
+        stringifySchemalessObjects = true,
+        promoteUnionToObject = true,
+        preserveUndeclaredFields = false,
+    ) {
+    @Disabled("Not yet working")
+    @Test
+    override fun testContainerTypes() {
+        super.testContainerTypes()
+    }
+
+    @Disabled("Not yet working")
+    @Test
+    override fun testUnions() {
+        super.testUnions()
+    }
+}


### PR DESCRIPTION
port over DAT.testProblematicTypes to the new framework. I split this into two separate tests:
* testContainerTypes has object/arrays (with/without schema)
* testUnions does all the union stuff
* I discarded a few parts of the test that were redundant (mostly b/c we have stronger schema handling now, so some schemas would have been duplicates)

There were a few behavior changes / bugfixes in other parts of the code; see the comments for explanation.