### PR TITLE
feat: `source-monday` move to the `DeclarativeOAuthFlow`

### DIFF
--- a/airbyte-integrations/connectors/source-monday/metadata.yaml
+++ b/airbyte-integrations/connectors/source-monday/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 80a54ea2-9959-4040-aac1-eee42423ec9b
-  dockerImageTag: 2.1.4
+  dockerImageTag: 2.1.5
   releases:
     breakingChanges:
       2.0.0:

--- a/airbyte-integrations/connectors/source-monday/pyproject.toml
+++ b/airbyte-integrations/connectors/source-monday/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "2.1.4"
+version = "2.1.5"
 name = "source-monday"
 description = "Source implementation for Monday."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-monday/source_monday/spec.json
+++ b/airbyte-integrations/connectors/source-monday/source_monday/spec.json
@@ -116,6 +116,16 @@
           }
         }
       },
+      "oauth_connector_input_specification": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "consent_url": "https://auth.monday.com/oauth2/authorize?{client_id_key}={{client_id_key}}&{redirect_uri_key}={urlEncoder:{{redirect_uri_key}}}&{scope_key}={urlEncoder:{{scope_key}}}&{state_key}={{state_key}}&subdomain={subdomain}",
+          "scope": "me:read boards:read workspaces:read users:read account:read updates:read assets:read tags:read teams:read",
+          "access_token_url": "https://auth.monday.com/oauth2/token?{client_id_key}={{client_id_key}}&{client_secret_key}={{client_secret_key}}&{auth_code_key}={{auth_code_key}}&{redirect_uri_key}={urlEncoder:{{redirect_uri_key}}}",
+          "extract_output": ["access_token"]
+        }
+      },
       "oauth_user_input_from_connector_config_specification": {
         "type": "object",
         "additionalProperties": false,

--- a/docs/integrations/sources/monday.md
+++ b/docs/integrations/sources/monday.md
@@ -77,6 +77,7 @@ The Monday connector should not run into Monday API limitations under normal usa
 
 | Version | Date       | Pull Request                                              | Subject                                                                                           |
 | :------ | :--------- | :-------------------------------------------------------- | :------------------------------------------------------------------------------------------------ |
+| 2.1.5 | 2024-10-31 | [48054](https://github.com/airbytehq/airbyte/pull/48054) | Moved to `DeclarativeOAuthFlow` specification |
 | 2.1.4 | 2024-08-17 | [44201](https://github.com/airbytehq/airbyte/pull/44201) | Add boards name to the `items` stream |
 | 2.1.3 | 2024-06-04 | [38958](https://github.com/airbytehq/airbyte/pull/38958) | [autopull] Upgrade base image to v1.2.1 |
 | 2.1.2 | 2024-04-30 | [37722](https://github.com/airbytehq/airbyte/pull/37722) | Fetch `display_value` field for column values of `Mirror`, `Dependency` and `Connect Board` types |


### PR DESCRIPTION
## What
Following up these changes:
- https://github.com/airbytehq/airbyte-protocol/pull/96
- https://github.com/airbytehq/airbyte-platform-internal/pull/14455

We need to update the `spec` with the `oauth_connector_input_specification` to switch to the `DeclarativeOAuthFlow` supported by the platform.

## How
- updated the `spec` with `oauth_connector_input_specification` and declared how the `OAuthFlow` should be constructed

## User Impact
No impact is expected. This is not a breaking change.

## Can this PR be safely reverted and rolled back?
- [X] YES 💚
- [ ] NO ❌
