### PR TITLE
✨Docs(source-sftp-bulk): Update docs for file-transfer

### DIFF
--- a/docs/integrations/sources/sftp-bulk.md
+++ b/docs/integrations/sources/sftp-bulk.md
@@ -113,6 +113,14 @@ For example, assuming your folder path is not set in the connector configuration
 
 If your files are in a folder, include the folder in your glob pattern, like `my_folder/my_prefix_*.csv`.
 
+#### Copy Raw Files Configuration
+
+Copy raw files without parsing their contents. Bits are copied into the destination exactly as they appeared in the source. Recommended for use with unstructured text data, non-text and compressed files.
+
+Format options will not be taken into account, files storage in supported file-based destination without parsing underlying data.
+
+
+
 ## Supported sync modes
 
 The SFTP Bulk source connector supports the following [sync modes](https://docs.airbyte.com/cloud/core-concepts/#connection-sync-modes):


### PR DESCRIPTION
## What
Add documentation for the file-transfer feature in sftp-bulk connector

## How
Update current sftp-bulk guide.

## Review guide

1. `docs/integrations/sources/sftp-bulk.md`: new section "Copy Raw Files Configuration"


## User Impact
User understands better what file-transfer does.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
