### PR TITLE
source-sftp-bulk: add suuports file transfer flag to metadata

### DIFF
--- a/airbyte-integrations/connectors/source-sftp-bulk/metadata.yaml
+++ b/airbyte-integrations/connectors/source-sftp-bulk/metadata.yaml
@@ -30,6 +30,7 @@ data:
         message: "This upgrade migrates the SFTP Bulk source to the Airbyte file-based CDK. This is the first necessary step of transitioning a file connector from community to Airbyte maintained."
         upgradeDeadline: "2024-04-30"
   supportLevel: community
+  supportsFileTransfer: true
   tags:
     - language:python
     - cdk:python-file-based


### PR DESCRIPTION
## What
Add supports file transfer to metadata 

Expecting the changes in [this PR](https://github.com/airbytehq/airbyte/pull/47007) that @stephane-airbyte worked to be enough.

## How
Add supportsFileTransfer to metadata.yaml

## Review guide

1. `airbyte-integrations/connectors/source-sftp-bulk/metadata.yaml`



## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
