### PR TITLE
Bulk Load CDK: Object Storage Dst State from Metadata

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/file/StreamProcessor.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/file/StreamProcessor.kt
@@ -5,9 +5,10 @@
 package io.airbyte.cdk.load.file
 
 import java.io.ByteArrayOutputStream
+import java.io.OutputStream
 import java.util.zip.GZIPOutputStream
 
-interface StreamProcessor<T> {
+interface StreamProcessor<T : OutputStream> {
     val wrapper: (ByteArrayOutputStream) -> T
     val partFinisher: T.() -> Unit
     val extension: String?

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/file/object_storage/ObjectStorageClient.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/file/object_storage/ObjectStorageClient.kt
@@ -28,6 +28,7 @@ interface ObjectStorageClient<T : RemoteObject<*>> {
      */
     suspend fun <V : OutputStream> streamingUpload(
         key: String,
+        metadata: Map<String, String> = emptyMap(),
         streamProcessor: StreamProcessor<V>? = null,
         block: suspend (OutputStream) -> Unit
     ): T

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/file/object_storage/ObjectStoragePathFactory.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/file/object_storage/ObjectStoragePathFactory.kt
@@ -29,7 +29,23 @@ interface PathFactory {
         isStaging: Boolean = false,
         extension: String? = null
     ): Path
+    fun getPathMatcher(stream: DestinationStream): PathMatcher
+
+    val supportsStaging: Boolean
+    val prefix: String
 }
+
+data class PathMatcher(val regex: Regex, val variableToIndex: Map<String, Int>) {
+    fun match(path: String): PathMatcherResult? {
+        val match = regex.matchEntire(path) ?: return null
+        return PathMatcherResult(
+            path,
+            variableToIndex["part_number"]?.let { match.groupValues[it].toLong() }
+        )
+    }
+}
+
+data class PathMatcherResult(val path: String, val partNumber: Long?)
 
 @Singleton
 @Secondary
@@ -41,6 +57,11 @@ class ObjectStoragePathFactory(
 ) : PathFactory {
     private val loadedAt = timeProvider.let { Instant.ofEpochMilli(it.currentTimeMillis()) }
     private val pathConfig = pathConfigProvider.objectStoragePathConfiguration
+    private val stagingPrefixResolved =
+        pathConfig.stagingPrefix
+            ?: Paths.get(pathConfig.prefix, DEFAULT_STAGING_PREFIX_SUFFIX).toString()
+    private val pathPatternResolved = pathConfig.pathSuffixPattern ?: DEFAULT_PATH_FORMAT
+    private val filePatternResolved = pathConfig.fileNamePattern ?: DEFAULT_FILE_FORMAT
     private val fileFormatExtension =
         formatConfigProvider?.objectStorageFormatConfiguration?.extension
     private val compressionExtension =
@@ -52,6 +73,41 @@ class ObjectStoragePathFactory(
             fileFormatExtension ?: compressionExtension
         }
 
+    private val stagingPrefix: String
+        get() {
+            if (!pathConfig.usesStagingDirectory) {
+                throw UnsupportedOperationException(
+                    "Staging is not supported by this configuration"
+                )
+            }
+            return stagingPrefixResolved
+        }
+
+    override val supportsStaging: Boolean
+        get() = pathConfig.usesStagingDirectory
+    override val prefix: String
+        get() = pathConfig.prefix
+
+    /**
+     * Variable substitution is complex.
+     *
+     * 1. There are two types: path variables and file name variables.
+     * 2. Path variables use the ${NAME} syntax, while file name variables use the {name} syntax. (I
+     * have no idea why this is.)
+     * 3. A variable is defined by a [Variable.pattern] and a [Variable.provider]
+     * 4. [Variable.provider] is a function that takes a [VariableContext] and returns a string.
+     * It's used for substitution to get the actual path.
+     * 5. [Variable.pattern] is a regex pattern that can match any results of [Variable.provider].
+     * 6. If [Variable.pattern] is null, [Variable.provider] is used to get the value. (Ie, we won't
+     * match against a pattern, but always against the realized value. In practice this is for
+     * stream name and namespace, because matching always performed at the stream level.)
+     * 7. Matching should be considered deprecated. It is only required for configurations that do
+     * not enable staging, which populate destination state by collecting metadata from object
+     * headers. It is extremely brittle and can break against malformed paths or paths that do not
+     * include enough variables to avoid clashes. If you run into a client issue which requires a
+     * path change anyway (a breaking change for some workflows), consider advising them to enable
+     * staging.
+     */
     inner class VariableContext(
         val stream: DestinationStream,
         val time: Instant = loadedAt,
@@ -60,7 +116,9 @@ class ObjectStoragePathFactory(
     )
 
     interface Variable {
+        val pattern: String?
         val provider: (VariableContext) -> String
+
         fun toMacro(): String
         fun maybeApply(source: String, context: VariableContext): String {
             val macro = toMacro()
@@ -73,14 +131,16 @@ class ObjectStoragePathFactory(
 
     data class PathVariable(
         val variable: String,
-        override val provider: (VariableContext) -> String
+        override val pattern: String? = null,
+        override val provider: (VariableContext) -> String,
     ) : Variable {
         override fun toMacro(): String = "\${$variable}"
     }
 
     data class FileVariable(
         val variable: String,
-        override val provider: (VariableContext) -> String
+        override val pattern: String? = null,
+        override val provider: (VariableContext) -> String,
     ) : Variable {
         override fun toMacro(): String = "{$variable}"
     }
@@ -97,31 +157,31 @@ class ObjectStoragePathFactory(
             listOf(
                 PathVariable("NAMESPACE") { it.stream.descriptor.namespace ?: "" },
                 PathVariable("STREAM_NAME") { it.stream.descriptor.name },
-                PathVariable("YEAR") {
+                PathVariable("YEAR", """\d{4}""") {
                     ZonedDateTime.ofInstant(it.time, ZoneId.of("UTC")).year.toString()
                 },
-                PathVariable("MONTH") {
+                PathVariable("MONTH", """\d{2}""") {
                     String.format(
                         "%02d",
                         ZonedDateTime.ofInstant(it.time, ZoneId.of("UTC")).monthValue
                     )
                 },
-                PathVariable("DAY") {
+                PathVariable("DAY", """\d{2}""") {
                     String.format(
                         "%02d",
                         ZonedDateTime.ofInstant(it.time, ZoneId.of("UTC")).dayOfMonth
                     )
                 },
-                PathVariable("HOUR") {
+                PathVariable("HOUR", """\d{2}""") {
                     String.format("%02d", ZonedDateTime.ofInstant(it.time, ZoneId.of("UTC")).hour)
                 },
-                PathVariable("MINUTE") {
+                PathVariable("MINUTE", """\d{2}""") {
                     String.format("%02d", ZonedDateTime.ofInstant(it.time, ZoneId.of("UTC")).minute)
                 },
-                PathVariable("SECOND") {
+                PathVariable("SECOND", """\d{2}""") {
                     String.format("%02d", ZonedDateTime.ofInstant(it.time, ZoneId.of("UTC")).second)
                 },
-                PathVariable("MILLISECOND") {
+                PathVariable("MILLISECOND", """\d{4}""") {
                     // Unclear why this is %04d, but that's what it was in the old code
                     String.format(
                         "%04d",
@@ -130,20 +190,20 @@ class ObjectStoragePathFactory(
                             .toNanoOfDay() / 1_000_000 % 1_000
                     )
                 },
-                PathVariable("EPOCH") { it.time.toEpochMilli().toString() },
-                PathVariable("UUID") { UUID.randomUUID().toString() }
+                PathVariable("EPOCH", """\d+""") { it.time.toEpochMilli().toString() },
+                PathVariable("UUID", """[a-fA-F0-9\\-]{36}""") { UUID.randomUUID().toString() }
             )
         val FILENAME_VARIABLES =
             listOf(
-                FileVariable("date") { DATE_FORMATTER.format(it.time) },
-                FileVariable("timestamp") { it.time.toEpochMilli().toString() },
-                FileVariable("part_number") {
+                FileVariable("date", """\d{4}_\d{2}_\d{2}""") { DATE_FORMATTER.format(it.time) },
+                FileVariable("timestamp", """\d+""") { it.time.toEpochMilli().toString() },
+                FileVariable("part_number", """\d+""") {
                     it.partNumber?.toString()
                         ?: throw IllegalArgumentException(
                             "part_number is required when {part_number} is present"
                         )
                 },
-                FileVariable("sync_id") { it.stream.syncId.toString() },
+                FileVariable("sync_id", """\d+""") { it.stream.syncId.toString() },
                 FileVariable("format_extension") { it.extension?.let { ext -> ".$ext" } ?: "" }
             )
 
@@ -159,16 +219,13 @@ class ObjectStoragePathFactory(
     }
 
     override fun getStagingDirectory(stream: DestinationStream): Path {
-        val prefix =
-            pathConfig.stagingPrefix
-                ?: Paths.get(pathConfig.prefix, DEFAULT_STAGING_PREFIX_SUFFIX).toString()
         val path = getFormattedPath(stream)
-        return Paths.get(prefix, path)
+        return Paths.get(stagingPrefix, path)
     }
 
     override fun getFinalDirectory(stream: DestinationStream): Path {
         val path = getFormattedPath(stream)
-        return Paths.get(pathConfig.prefix, path)
+        return Paths.get(prefix, path)
     }
 
     override fun getPathToFile(
@@ -191,15 +248,67 @@ class ObjectStoragePathFactory(
     }
 
     private fun getFormattedPath(stream: DestinationStream): String {
-        val pattern = pathConfig.pathSuffixPattern ?: DEFAULT_PATH_FORMAT
+        val pattern = pathPatternResolved
         val context = VariableContext(stream)
         return PATH_VARIABLES.fold(pattern) { acc, variable -> variable.maybeApply(acc, context) }
     }
 
     private fun getFormattedFileName(context: VariableContext): String {
-        val pattern = pathConfig.fileNamePattern ?: DEFAULT_FILE_FORMAT
+        val pattern = filePatternResolved
         return FILENAME_VARIABLES.fold(pattern) { acc, variable ->
             variable.maybeApply(acc, context)
         }
+    }
+
+    private fun getPathVariableToPattern(stream: DestinationStream): Map<String, String> {
+        return PATH_VARIABLES.associate {
+            it.variable to (it.pattern ?: it.provider(VariableContext(stream)))
+        } +
+            FILENAME_VARIABLES.associate {
+                it.variable to
+                    (it.pattern
+                        ?: it.provider(VariableContext(stream, extension = defaultExtension)))
+            }
+    }
+
+    private fun buildPattern(
+        input: String,
+        macroPattern: String,
+        variableToPattern: Map<String, String>,
+        variableToIndex: MutableMap<String, Int>
+    ): String {
+        return Regex.escapeReplacement(input).replace(macroPattern.toRegex()) {
+            val variable = it.groupValues[1]
+            val pattern = variableToPattern[variable]
+            if (pattern != null) {
+                variableToIndex[variable] = variableToIndex.size + 1
+                "($pattern)"
+            } else {
+                variable
+            }
+        }
+    }
+
+    override fun getPathMatcher(stream: DestinationStream): PathMatcher {
+        val pathVariableToPattern = getPathVariableToPattern(stream)
+        val variableToIndex = mutableMapOf<String, Int>()
+
+        val replacedForPath =
+            buildPattern(
+                pathPatternResolved,
+                """\\\$\{(\w+)}""",
+                pathVariableToPattern,
+                variableToIndex
+            )
+        val replacedForFile =
+            buildPattern(
+                filePatternResolved,
+                """\{(\w+)}""",
+                pathVariableToPattern,
+                variableToIndex
+            )
+        val combined = Path.of(prefix).resolve(replacedForPath).resolve(replacedForFile).toString()
+
+        return PathMatcher(Regex(combined), variableToIndex)
     }
 }

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/test/kotlin/io/airbyte/cdk/load/file/object_storage/ObjectStoragePathFactoryTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/test/kotlin/io/airbyte/cdk/load/file/object_storage/ObjectStoragePathFactoryTest.kt
@@ -16,31 +16,23 @@ import io.airbyte.cdk.load.file.GZIPProcessor
 import io.airbyte.cdk.load.file.MockTimeProvider
 import io.airbyte.cdk.load.file.TimeProvider
 import io.micronaut.context.annotation.Primary
+import io.micronaut.context.annotation.Property
 import io.micronaut.context.annotation.Requires
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest
-import jakarta.inject.Inject
 import jakarta.inject.Singleton
 import java.time.LocalDateTime
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.util.zip.GZIPOutputStream
 import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
-@MicronautTest(
-    environments =
-        [
-            "ObjectStoragePathFactoryTest",
-            "MockDestinationCatalog",
-        ]
-)
 class ObjectStoragePathFactoryTest {
-    @Inject lateinit var timeProvider: TimeProvider
-
     @Singleton
     @Primary
     @Requires(env = ["ObjectStoragePathFactoryTest"])
-    class PathTimeProvider : MockTimeProvider() {
+    class PathTimeProvider : MockTimeProvider(), TimeProvider {
         init {
             val dateTime =
                 LocalDateTime.parse(
@@ -56,6 +48,7 @@ class ObjectStoragePathFactoryTest {
     @Singleton
     @Primary
     @Requires(env = ["ObjectStoragePathFactoryTest"])
+    @Requires(property = "object-storage-path-factory-test.use-staging", value = "true")
     class MockPathConfigProvider : ObjectStoragePathConfigurationProvider {
         override val objectStoragePathConfiguration: ObjectStoragePathConfiguration =
             ObjectStoragePathConfiguration(
@@ -66,6 +59,17 @@ class ObjectStoragePathFactoryTest {
                 fileNamePattern = "{date}-{timestamp}-{part_number}-{sync_id}{format_extension}",
                 usesStagingDirectory = true
             )
+    }
+
+    @Singleton
+    @Primary
+    @Requires(env = ["ObjectStoragePathFactoryTest"])
+    @Requires(property = "object-storage-path-factory-test.use-staging", value = "false")
+    class MockPathConfigProviderWithoutStaging : ObjectStoragePathConfigurationProvider {
+        override val objectStoragePathConfiguration: ObjectStoragePathConfiguration =
+            MockPathConfigProvider()
+                .objectStoragePathConfiguration
+                .copy(usesStagingDirectory = false)
     }
 
     @Singleton
@@ -86,28 +90,89 @@ class ObjectStoragePathFactoryTest {
             ObjectStorageCompressionConfiguration(compressor = GZIPProcessor)
     }
 
-    @Test
-    fun testBasicBehavior(pathFactory: ObjectStoragePathFactory) {
-        val epochMilli = timeProvider.currentTimeMillis()
-        val stream1 = MockDestinationCatalogFactory.stream1
-        val (namespace, name) = stream1.descriptor
-        val prefixOnly = "prefix/$namespace/$name/2020/01/02/03/04/05/0678/$epochMilli"
-        val fileName = "2020_01_02-1577934245678-173-42.jsonl.gz"
-        Assertions.assertEquals(
-            "staging/$prefixOnly",
-            pathFactory.getStagingDirectory(stream1).toString(),
-        )
-        Assertions.assertEquals(
-            prefixOnly,
-            pathFactory.getFinalDirectory(stream1).toString(),
-        )
-        Assertions.assertEquals(
-            "staging/$prefixOnly/$fileName",
-            pathFactory.getPathToFile(stream1, 173, true).toString(),
-        )
-        Assertions.assertEquals(
-            "$prefixOnly/$fileName",
-            pathFactory.getPathToFile(stream1, 173, false).toString(),
-        )
+    @Nested
+    @MicronautTest(
+        environments =
+            [
+                "ObjectStoragePathFactoryTest",
+                "MockDestinationCatalog",
+            ],
+    )
+    @Property(name = "object-storage-path-factory-test.use-staging", value = "true")
+    inner class ObjectStoragePathFactoryTestWithStaging {
+        @Test
+        fun testBasicBehavior(pathFactory: ObjectStoragePathFactory, timeProvider: TimeProvider) {
+            val epochMilli = timeProvider.currentTimeMillis()
+            val stream1 = MockDestinationCatalogFactory.stream1
+            val (namespace, name) = stream1.descriptor
+            val prefixOnly = "prefix/$namespace/$name/2020/01/02/03/04/05/0678/$epochMilli"
+            val fileName = "2020_01_02-1577934245678-173-42.jsonl.gz"
+            Assertions.assertEquals(
+                "staging/$prefixOnly",
+                pathFactory.getStagingDirectory(stream1).toString(),
+            )
+            Assertions.assertEquals(
+                prefixOnly,
+                pathFactory.getFinalDirectory(stream1).toString(),
+            )
+            Assertions.assertEquals(
+                "staging/$prefixOnly/$fileName",
+                pathFactory.getPathToFile(stream1, 173, true).toString(),
+            )
+            Assertions.assertEquals(
+                "$prefixOnly/$fileName",
+                pathFactory.getPathToFile(stream1, 173, false).toString(),
+            )
+        }
+
+        @Test
+        fun testPathMatchingPattern(
+            pathFactory: ObjectStoragePathFactory,
+            timeProvider: TimeProvider
+        ) {
+            val epochMilli = timeProvider.currentTimeMillis()
+            val stream1 = MockDestinationCatalogFactory.stream1
+            val (namespace, name) = stream1.descriptor
+            val expectedToMatch =
+                "prefix/$namespace/$name/2020/01/02/03/04/05/0678/$epochMilli/2020_01_02-1577934245678-173-42.jsonl.gz"
+            val match = pathFactory.getPathMatcher(stream1).match(expectedToMatch)
+            Assertions.assertTrue(match != null)
+            Assertions.assertTrue(match?.partNumber == 173L)
+        }
+    }
+
+    @Nested
+    @MicronautTest(
+        environments =
+            [
+                "ObjectStoragePathFactoryTest",
+                "MockDestinationCatalog",
+            ],
+    )
+    @Property(name = "object-storage-path-factory-test.use-staging", value = "false")
+    inner class ObjectStoragePathFactoryTestWithoutStaging {
+        @Test
+        fun testBasicBehavior(pathFactory: ObjectStoragePathFactory, timeProvider: TimeProvider) {
+            val epochMilli = timeProvider.currentTimeMillis()
+            val stream1 = MockDestinationCatalogFactory.stream1
+            val (namespace, name) = stream1.descriptor
+            val prefixOnly = "prefix/$namespace/$name/2020/01/02/03/04/05/0678/$epochMilli"
+            val fileName = "2020_01_02-1577934245678-173-42.jsonl.gz"
+            Assertions.assertEquals(
+                prefixOnly,
+                pathFactory.getFinalDirectory(stream1).toString(),
+            )
+            Assertions.assertEquals(
+                "$prefixOnly/$fileName",
+                pathFactory.getPathToFile(stream1, 173, false).toString(),
+            )
+
+            Assertions.assertThrows(UnsupportedOperationException::class.java) {
+                pathFactory.getStagingDirectory(stream1)
+            }
+            Assertions.assertThrows(UnsupportedOperationException::class.java) {
+                pathFactory.getPathToFile(stream1, 173, true)
+            }
+        }
     }
 }

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/test/kotlin/io/airbyte/cdk/load/state/object_storage/ObjectStorageDestinationStateTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/test/kotlin/io/airbyte/cdk/load/state/object_storage/ObjectStorageDestinationStateTest.kt
@@ -7,28 +7,27 @@ package io.airbyte.cdk.load.state.object_storage
 import io.airbyte.cdk.load.MockObjectStorageClient
 import io.airbyte.cdk.load.MockPathFactory
 import io.airbyte.cdk.load.command.MockDestinationCatalogFactory
+import io.airbyte.cdk.load.file.NoopProcessor
 import io.airbyte.cdk.load.state.DestinationStateManager
+import io.micronaut.context.annotation.Primary
+import io.micronaut.context.annotation.Property
+import io.micronaut.context.annotation.Requires
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest
-import jakarta.inject.Inject
+import jakarta.inject.Singleton
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
-@MicronautTest(
-    rebuildContext = true,
-    environments =
-        [
-            "ObjectStorageDestinationStateTest",
-            "MockDestinationCatalog",
-            "MockObjectStorageClient",
-            "MockPathFactory"
-        ]
-)
 class ObjectStorageDestinationStateTest {
-    @Inject lateinit var stateManager: DestinationStateManager<ObjectStorageDestinationState>
-    @Inject lateinit var mockClient: MockObjectStorageClient
-    @Inject lateinit var pathFactory: MockPathFactory
+    @Singleton
+    @Requires(env = ["ObjectStorageDestinationStateTest"])
+    data class Dependencies(
+        val stateManager: DestinationStateManager<ObjectStorageDestinationState>,
+        val mockClient: MockObjectStorageClient,
+        val pathFactory: MockPathFactory
+    )
 
     companion object {
         val stream1 = MockDestinationCatalogFactory.stream1
@@ -36,82 +35,163 @@ class ObjectStorageDestinationStateTest {
             """{"generations_by_state":{"FINALIZED":{"0":{"key1":0,"key2":1},"1":{"key3":0,"key4":1}}}}"""
     }
 
-    @Test
-    fun testBasicLifecycle() = runTest {
-        // TODO: Test fallback to generation id
-        val state = stateManager.getState(stream1)
-        Assertions.assertEquals(
-            emptyList<ObjectStorageDestinationState.Generation>(),
-            state.generations.toList(),
-            "state should initially be empty"
-        )
-        state.addObject(0, "key1", 0)
-        state.addObject(0, "key2", 1)
-        state.addObject(1, "key3", 0)
-        state.addObject(1, "key4", 1)
-        Assertions.assertEquals(
-            4,
-            state.generations.flatMap { it.objects }.toList().size,
-            "state should contain 4 objects"
-        )
-
-        stateManager.persistState(stream1)
-        val obj = mockClient.list("").toList().first()
-        val data = mockClient.get(obj.key) { it.readBytes() }
-        Assertions.assertEquals(
-            PERSISTED,
-            data.toString(Charsets.UTF_8),
-            "state should be persisted"
-        )
-
-        state.removeObject(0, "key1")
-        state.removeObject(0, "key2")
-        state.removeObject(1, "key3")
-        state.removeObject(1, "key4")
-        Assertions.assertEquals(
-            emptyList<ObjectStorageDestinationState.ObjectAndPart>(),
-            state.generations.flatMap { it.objects }.toList(),
-            "objects should be removed"
-        )
-
-        val fetchedState = stateManager.getState(stream1)
-        Assertions.assertEquals(
-            0,
-            fetchedState.generations.flatMap { it.objects }.toList().size,
-            "state should still contain 0 objects (managed state is in cache)"
-        )
+    @Singleton
+    @Primary
+    @Requires(property = "object-storage-destination-state-test.use-staging", value = "true")
+    class MockPathFactoryWithStaging : MockPathFactory() {
+        override var doSupportStaging = true
     }
 
-    @Test
-    fun testLoadingExistingState() = runTest {
-        val key =
-            pathFactory
-                .getStagingDirectory(stream1)
-                .resolve(ObjectStorageStagingPersister.STATE_FILENAME)
-                .toString()
-        mockClient.put(key, PERSISTED.toByteArray())
-        val state = stateManager.getState(stream1)
-        Assertions.assertEquals(
-            listOf(
-                ObjectStorageDestinationState.Generation(
-                    false,
-                    0,
-                    listOf(
-                        ObjectStorageDestinationState.ObjectAndPart("key1", 0),
-                        ObjectStorageDestinationState.ObjectAndPart("key2", 1)
+    @Singleton
+    @Primary
+    @Requires(property = "object-storage-destination-state-test.use-staging", value = "false")
+    class MockPathFactoryWithoutStaging : MockPathFactory() {
+        override var doSupportStaging = false
+    }
+
+    @Nested
+    @MicronautTest(
+        rebuildContext = true,
+        environments =
+            [
+                "ObjectStorageDestinationStateTest",
+                "MockObjectStorageClient",
+                "MockDestinationCatalog",
+            ],
+    )
+    @Property(name = "object-storage-destination-state-test.use-staging", value = "true")
+    inner class ObjectStorageDestinationStateTestStaging {
+        @Test
+        fun testBasicLifecycle(d: Dependencies) = runTest {
+            // TODO: Test fallback to generation id
+            val state = d.stateManager.getState(stream1)
+            Assertions.assertEquals(
+                emptyList<ObjectStorageDestinationState.Generation>(),
+                state.generations.toList(),
+                "state should initially be empty"
+            )
+            state.addObject(0, "key1", 0)
+            state.addObject(0, "key2", 1)
+            state.addObject(1, "key3", 0)
+            state.addObject(1, "key4", 1)
+            Assertions.assertEquals(
+                4,
+                state.generations.flatMap { it.objects }.toList().size,
+                "state should contain 4 objects"
+            )
+
+            d.stateManager.persistState(stream1)
+            val obj = d.mockClient.list("").toList().first()
+            val data = d.mockClient.get(obj.key) { it.readBytes() }
+            Assertions.assertEquals(
+                PERSISTED,
+                data.toString(Charsets.UTF_8),
+                "state should be persisted"
+            )
+
+            state.removeObject(0, "key1")
+            state.removeObject(0, "key2")
+            state.removeObject(1, "key3")
+            state.removeObject(1, "key4")
+            Assertions.assertEquals(
+                emptyList<ObjectStorageDestinationState.ObjectAndPart>(),
+                state.generations.flatMap { it.objects }.toList(),
+                "objects should be removed"
+            )
+
+            val fetchedState = d.stateManager.getState(stream1)
+            Assertions.assertEquals(
+                0,
+                fetchedState.generations.flatMap { it.objects }.toList().size,
+                "state should still contain 0 objects (managed state is in cache)"
+            )
+        }
+
+        @Test
+        fun testLoadingExistingState(d: Dependencies) = runTest {
+            val key =
+                d.pathFactory
+                    .getStagingDirectory(stream1)
+                    .resolve(ObjectStorageStagingPersister.STATE_FILENAME)
+                    .toString()
+            d.mockClient.put(key, PERSISTED.toByteArray())
+            val state = d.stateManager.getState(stream1)
+            Assertions.assertEquals(
+                listOf(
+                    ObjectStorageDestinationState.Generation(
+                        false,
+                        0,
+                        listOf(
+                            ObjectStorageDestinationState.ObjectAndPart("key1", 0),
+                            ObjectStorageDestinationState.ObjectAndPart("key2", 1)
+                        )
+                    ),
+                    ObjectStorageDestinationState.Generation(
+                        false,
+                        1,
+                        listOf(
+                            ObjectStorageDestinationState.ObjectAndPart("key3", 0),
+                            ObjectStorageDestinationState.ObjectAndPart("key4", 1)
+                        )
                     )
                 ),
-                ObjectStorageDestinationState.Generation(
-                    false,
-                    1,
-                    listOf(
-                        ObjectStorageDestinationState.ObjectAndPart("key3", 0),
-                        ObjectStorageDestinationState.ObjectAndPart("key4", 1)
-                    )
+                state.generations.toList(),
+                "state should be loaded from storage"
+            )
+        }
+    }
+
+    @Nested
+    @MicronautTest(
+        environments =
+            [
+                "ObjectStorageDestinationStateTest",
+                "MockObjectStorageClient",
+                "MockDestinationCatalog",
+            ],
+    )
+    @Property(name = "object-storage-destination-state-test.use-staging", value = "false")
+    inner class ObjectStorageDestinationStateTestWithoutStaging {
+        @Test
+        fun testRecoveringFromMetadata(d: Dependencies) = runTest {
+            val genIdKey = ObjectStorageDestinationState.METADATA_GENERATION_ID_KEY
+            val prefix = d.pathFactory.prefix
+            val generations =
+                listOf(
+                    Triple(0, "$prefix/key1-0", 0L),
+                    Triple(0, "$prefix/key2-1", 1L),
+                    Triple(1, "$prefix/key3-0", 0L),
+                    Triple(1, "$prefix/key4-1", 1L)
                 )
-            ),
-            state.generations.toList(),
-            "state should be loaded from storage"
-        )
+            generations.forEach { (genId, key, _) ->
+                d.mockClient.streamingUpload(
+                    key,
+                    mapOf(genIdKey to genId.toString()),
+                    NoopProcessor
+                ) { it.write(0) }
+            }
+            val state = d.stateManager.getState(stream1)
+            Assertions.assertEquals(
+                generations
+                    .groupBy { it.first }
+                    .map { (generationId, triples) ->
+                        ObjectStorageDestinationState.Generation(
+                            false,
+                            generationId.toLong(),
+                            triples
+                                .map { (_, key, partNumber) ->
+                                    ObjectStorageDestinationState.ObjectAndPart(key, partNumber)
+                                }
+                                .sortedByDescending {
+                                    // Brittle hack to get the order to line up
+                                    it.key.contains("key2") || it.key.contains("key3")
+                                }
+                                .toMutableList()
+                        )
+                    },
+                state.generations.toList(),
+                "state should be recovered from metadata"
+            )
+        }
     }
 }

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/testFixtures/kotlin/io/airbyte/cdk/load/MockPathFactory.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/testFixtures/kotlin/io/airbyte/cdk/load/MockPathFactory.kt
@@ -6,23 +6,31 @@ package io.airbyte.cdk.load
 
 import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.file.object_storage.PathFactory
+import io.airbyte.cdk.load.file.object_storage.PathMatcher
 import io.micronaut.context.annotation.Requires
 import jakarta.inject.Singleton
 import java.nio.file.Path
 
 @Singleton
 @Requires(env = ["MockPathFactory"])
-class MockPathFactory : PathFactory {
+open class MockPathFactory : PathFactory {
+    open var doSupportStaging = false
+
+    override val supportsStaging: Boolean
+        get() = doSupportStaging
+    override val prefix: String
+        get() = "prefix"
+
     private fun fromStream(stream: DestinationStream): String {
         return "/${stream.descriptor.namespace}/${stream.descriptor.name}"
     }
 
     override fun getStagingDirectory(stream: DestinationStream): Path {
-        return Path.of("/staging/${fromStream(stream)}")
+        return Path.of("$prefix/staging/${fromStream(stream)}")
     }
 
     override fun getFinalDirectory(stream: DestinationStream): Path {
-        return Path.of("/final/${fromStream(stream)}")
+        return Path.of("$prefix/${fromStream(stream)}")
     }
 
     override fun getPathToFile(
@@ -33,5 +41,12 @@ class MockPathFactory : PathFactory {
     ): Path {
         val prefix = if (isStaging) getStagingDirectory(stream) else getFinalDirectory(stream)
         return prefix.resolve("file")
+    }
+
+    override fun getPathMatcher(stream: DestinationStream): PathMatcher {
+        return PathMatcher(
+            regex = Regex("$prefix/(.*)-(.*)$"),
+            variableToIndex = mapOf("part_number" to 2)
+        )
     }
 }

--- a/airbyte-cdk/bulk/toolkits/load-s3/src/main/kotlin/io/airbyte/cdk/load/command/s3/S3PathSpecification.kt
+++ b/airbyte-cdk/bulk/toolkits/load-s3/src/main/kotlin/io/airbyte/cdk/load/command/s3/S3PathSpecification.kt
@@ -50,13 +50,12 @@ interface S3PathSpecification {
     @get:JsonSchemaInject(json = """{"examples":["data_sync/test"]}""")
     val s3BucketPath: String
 
-    //    @get:JsonSchemaTitle("Use a Staging Directory")
-    //    @get:JsonPropertyDescription(
-    //        "Whether to use a staging directory in the bucket based on the s3_staging_prefix. If
-    // this is not set, airbyte will maintain sync integrity by adding metadata to each object."
-    //    )
-    //    @get:JsonProperty("use_staging_directory", defaultValue = "false")
-    //    val useStagingDirectory: Boolean
+    @get:JsonSchemaTitle("Use a Staging Directory")
+    @get:JsonPropertyDescription(
+        "Whether to use a staging directory in the bucket based on the s3_staging_prefix. If this is not set, airbyte will maintain sync integrity by adding metadata to each object."
+    )
+    @get:JsonProperty("use_staging_directory", defaultValue = "false")
+    val useStagingDirectory: Boolean?
 
     @get:JsonSchemaTitle("S3 Staging Prefix")
     @get:JsonPropertyDescription(
@@ -72,6 +71,6 @@ interface S3PathSpecification {
             stagingPrefix = s3StagingPrefix,
             pathSuffixPattern = s3PathFormat,
             fileNamePattern = fileNamePattern,
-            usesStagingDirectory = true
+            usesStagingDirectory = useStagingDirectory ?: false
         )
 }

--- a/airbyte-integrations/connectors/destination-s3-v2/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-s3-v2/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: file
   connectorType: destination
   definitionId: d6116991-e809-4c7c-ae09-c64712df5b66
-  dockerImageTag: 0.1.15
+  dockerImageTag: 0.1.16
   dockerRepository: airbyte/destination-s3-v2
   githubIssueLabel: destination-s3-v2
   icon: s3.svg
@@ -33,6 +33,11 @@ data:
             alias: airbyte-connector-testing-secret-store
         - name: SECRET_DESTINATION-S3-V2-JSONL-GZIP
           fileName: s3_dest_v2_jsonl_gzip_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION-S3-V2-JSONL-STAGING
+          fileName: s3_dest_v2_jsonl_staging_config.json
           secretStore:
             type: GSM
             alias: airbyte-connector-testing-secret-store

--- a/airbyte-integrations/connectors/destination-s3-v2/src/main/kotlin/S3V2Checker.kt
+++ b/airbyte-integrations/connectors/destination-s3-v2/src/main/kotlin/S3V2Checker.kt
@@ -25,13 +25,21 @@ class S3V2Checker<T : OutputStream>(private val timeProvider: TimeProvider) :
         runBlocking {
             val s3Client = S3ClientFactory.make(config)
             val pathFactory = ObjectStoragePathFactory.from(config, timeProvider)
-            val path = pathFactory.getStagingDirectory(mockStream())
+            val path =
+                if (pathFactory.supportsStaging) {
+                    pathFactory.getStagingDirectory(mockStream())
+                } else {
+                    pathFactory.getFinalDirectory(mockStream())
+                }
             val key = path.resolve("_EXAMPLE").toString()
             log.info { "Checking if destination can write to $path" }
             var s3Object: S3Object? = null
             val compressor = config.objectStorageCompressionConfiguration.compressor
             try {
-                s3Object = s3Client.streamingUpload(key, compressor) { it.write("""{"data": 1}""") }
+                s3Object =
+                    s3Client.streamingUpload(key, streamProcessor = compressor) {
+                        it.write("""{"data": 1}""")
+                    }
                 val results = s3Client.list(path.toString()).toList()
                 if (results.isEmpty() || results.find { it.key == key } == null) {
                     throw IllegalStateException("Failed to write to S3 bucket")

--- a/airbyte-integrations/connectors/destination-s3-v2/src/main/kotlin/S3V2Specification.kt
+++ b/airbyte-integrations/connectors/destination-s3-v2/src/main/kotlin/S3V2Specification.kt
@@ -34,7 +34,7 @@ class S3V2Specification :
     override val s3Endpoint: String? = null
     override val s3PathFormat: String? = null
     override val fileNamePattern: String? = null
-    // override val useStagingDirectory: Boolean = false
+    override val useStagingDirectory: Boolean? = null
     override val s3StagingPrefix: String? = null
 }
 

--- a/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2CheckTest.kt
+++ b/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2CheckTest.kt
@@ -20,6 +20,10 @@ class S3V2CheckTest :
                     setOf(FeatureFlag.AIRBYTE_CLOUD_DEPLOYMENT)
                 ),
                 CheckTestConfig(
+                    Path.of(S3V2TestUtils.JSON_STAGING_CONFIG_PATH),
+                    setOf(FeatureFlag.AIRBYTE_CLOUD_DEPLOYMENT),
+                ),
+                CheckTestConfig(
                     Path.of(S3V2TestUtils.JSON_GZIP_CONFIG_PATH),
                     setOf(FeatureFlag.AIRBYTE_CLOUD_DEPLOYMENT),
                 ),

--- a/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2TestUtils.kt
+++ b/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2TestUtils.kt
@@ -10,6 +10,7 @@ import java.nio.file.Path
 object S3V2TestUtils {
     const val JSON_UNCOMPRESSED_CONFIG_PATH = "secrets/s3_dest_v2_minimal_required_config.json"
     const val JSON_GZIP_CONFIG_PATH = "secrets/s3_dest_v2_jsonl_gzip_config.json"
+    const val JSON_STAGING_CONFIG_PATH = "secrets/s3_dest_v2_jsonl_staging_config.json"
     const val CSV_UNCOMPRESSED_CONFIG_PATH = "secrets/s3_dest_v2_csv_config.json"
     const val CSV_GZIP_CONFIG_PATH = "secrets/s3_dest_v2_csv_gzip_config.json"
     const val AVRO_UNCOMPRESSED_CONFIG_PATH = "secrets/s3_dest_v2_avro_config.json"

--- a/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2WriteTest.kt
+++ b/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2WriteTest.kt
@@ -78,6 +78,14 @@ class S3V2WriteTestJsonUncompressed :
         preserveUndeclaredFields = true,
     )
 
+class S3V2WriteTestJsonStaging :
+    S3V2WriteTest(
+        S3V2TestUtils.JSON_STAGING_CONFIG_PATH,
+        stringifySchemalessObjects = false,
+        promoteUnionToObject = false,
+        preserveUndeclaredFields = true,
+    )
+
 class S3V2WriteTestJsonGzip :
     S3V2WriteTest(
         S3V2TestUtils.JSON_GZIP_CONFIG_PATH,

--- a/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/resources/expected-spec-cloud.json
+++ b/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/resources/expected-spec-cloud.json
@@ -294,6 +294,12 @@
         "title" : "File Name Pattern",
         "examples" : [ "{date}", "{date:yyyy_MM}", "{timestamp}", "{part_number}", "{sync_id}" ]
       },
+      "use_staging_directory" : {
+        "type" : "boolean",
+        "default" : false,
+        "description" : "Whether to use a staging directory in the bucket based on the s3_staging_prefix. If this is not set, airbyte will maintain sync integrity by adding metadata to each object.",
+        "title" : "Use a Staging Directory"
+      },
       "s3_staging_prefix" : {
         "type" : "string",
         "default" : "{s3_bucket_path}/__airbyte_tmp",

--- a/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/resources/expected-spec-oss.json
+++ b/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/resources/expected-spec-oss.json
@@ -294,6 +294,12 @@
         "title" : "File Name Pattern",
         "examples" : [ "{date}", "{date:yyyy_MM}", "{timestamp}", "{part_number}", "{sync_id}" ]
       },
+      "use_staging_directory" : {
+        "type" : "boolean",
+        "default" : false,
+        "description" : "Whether to use a staging directory in the bucket based on the s3_staging_prefix. If this is not set, airbyte will maintain sync integrity by adding metadata to each object.",
+        "title" : "Use a Staging Directory"
+      },
       "s3_staging_prefix" : {
         "type" : "string",
         "default" : "{s3_bucket_path}/__airbyte_tmp",


### PR DESCRIPTION
## What
* Adds a "fallback to metadata" version of the destination state persister for object storage.
* add pattern support to the path factory to support that
* s3 spec provides staging option (defaults to not)
* integration test config with staging

