### PR TITLE
📚 docs: add custom styles for <table>

### DIFF
--- a/docusaurus/src/css/custom.css
+++ b/docusaurus/src/css/custom.css
@@ -25,6 +25,11 @@
   --ifm-hover-overlay: rgb(0 0 0 / 2%);
   --color-active-nav-item-background: #f4f4ff;
   --color-active-nav-item-text: var(--ifm-color-primary-darker);
+  --ifm-table-background: transparent;
+  --ifm-table-stripe-background: transparent;
+  --ifm-table-head-background: var(--ifm-color-primary);
+  --ifm-table-head-color: var(--color-white);
+  --ifm-table-border-color: var(--ifm-color-primary-lightest);
 
   --color-white: hsl(0, 0%, 100%);
   --color-grey-40: hsl(240, 25%, 98%);
@@ -53,6 +58,12 @@ html[data-theme="dark"] {
   --ifm-color-primary-lightest: #c8c7ff;
   --color-active-nav-item-background: #272729;
   --color-active-nav-item-text: var(--ifm-color-primary-lighter);
+
+  --ifm-table-background: transparent;
+  --ifm-table-stripe-background: transparent;
+  --ifm-table-head-background: var(--color-blue-30);
+  --ifm-table-head-color: hsl(240, 100%, 98%);
+  --ifm-table-border-color:hsl(240, 100%, 98%);
 
   --color-grey-40: hsl(240, 14%, 14%);
   --color-grey-100: hsl(240, 15%, 15%);
@@ -233,4 +244,46 @@ The variables for them have been added to :root at the top of this file */
 .menu__list-item-collapsible--active:hover {
   background: var(--color-active-nav-item-background);
   color: var(--color-active-nav-item-text);
+}
+
+
+table {
+  border-spacing: 0;
+  border-collapse: separate;
+  overflow-x: auto;
+}
+
+/* Add these new styles */
+table th:first-child {
+  border-top-left-radius: 10px;
+}
+
+table th:last-child {
+  border-top-right-radius: 10px;
+}
+
+table tr:last-child td:first-child {
+  border-bottom-left-radius: 10px;
+}
+
+table tr:last-child td:last-child {
+  border-bottom-right-radius: 10px;
+}
+
+
+
+table td code {
+  background-color: var(--color-blue-30);
+  padding: 2px 8px;
+  border: none;
+  font-family: monospace;
+  border-radius: 4px;
+}
+
+table tr:hover {
+  background-color: var(--color-grey-40);
+  transition: background-color 0.2s ease;
+}
+table thead tr:hover {
+  background-color: transparent;
 }


### PR DESCRIPTION
Closes https://github.com/airbytehq/airbyte-internal-issues/issues/8397
## What
- Align table styling with Airbyte brand.

![Screenshot 2024-11-26 at 16 46 39](https://github.com/user-attachments/assets/5c339c25-627b-497f-94cd-d49fc31f54cd)

<details>
<summary>
Dark mode
</summary>

![Screenshot 2024-11-26 at 16 46 30](https://github.com/user-attachments/assets/37d12f21-e86d-4508-9b98-21c616a8c3c9)
</details>

## How
- Since we want all tables to have this new style by default, I've updated `custom.css` instead of creating a new custom component as discussed [here](https://airbytehq-team.slack.com/archives/C061M060RDE/p1731938409544889?thread_ts=1730486344.398589&cid=C061M060RDE)


## User Impact
- Beautiful tables

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
