### PR TITLE
Bulk load CDK: First test for refreshes behavior

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/integrationTest/kotlin/io/airbyte/cdk/load/mock_integration_test/MockBasicFunctionalityIntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/integrationTest/kotlin/io/airbyte/cdk/load/mock_integration_test/MockBasicFunctionalityIntegrationTest.kt
@@ -24,6 +24,7 @@ class MockBasicFunctionalityIntegrationTest :
         stringifySchemalessObjects = false,
         promoteUnionToObject = false,
         preserveUndeclaredFields = true,
+        commitDataIncrementally = false,
     ) {
     @Test
     override fun testBasicWrite() {
@@ -49,6 +50,11 @@ class MockBasicFunctionalityIntegrationTest :
     @Test
     override fun testTruncateRefresh() {
         super.testTruncateRefresh()
+    }
+
+    @Test
+    override fun testInterruptedTruncateWithPriorData() {
+        super.testInterruptedTruncateWithPriorData()
     }
 
     @Test

--- a/airbyte-cdk/bulk/core/load/src/integrationTest/kotlin/io/airbyte/cdk/load/mock_integration_test/MockDestinationBackend.kt
+++ b/airbyte-cdk/bulk/core/load/src/integrationTest/kotlin/io/airbyte/cdk/load/mock_integration_test/MockDestinationBackend.kt
@@ -78,6 +78,23 @@ object MockDestinationBackend {
         }
     }
 
+    fun commitFrom(srcFilename: String, dstFilename: String) {
+        val src = getFile(srcFilename)
+        insert(dstFilename, *src.toTypedArray())
+        src.clear()
+    }
+
+    fun commitAndDedupeFrom(
+        srcFilename: String,
+        dstFilename: String,
+        primaryKey: List<List<String>>,
+        cursor: List<String>,
+    ) {
+        val src = getFile(srcFilename)
+        upsert(dstFilename, primaryKey, cursor, *src.toTypedArray())
+        src.clear()
+    }
+
     fun readFile(filename: String): List<OutputRecord> {
         return getFile(filename)
     }

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/IntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/IntegrationTest.kt
@@ -139,6 +139,26 @@ abstract class IntegrationTest(
         configContents: String,
         catalog: DestinationCatalog,
         messages: List<DestinationMessage>,
+        /**
+         * If you set this to anything other than `COMPLETE`, you may run into a race condition.
+         * It's recommended that you send an explicit state message in [messages], and run the sync
+         * in a loop until it acks the state message, e.g.
+         * ```
+         * while (true) {
+         *   val e = assertThrows<DestinationUncleanExitException> {
+         *     runSync(
+         *       ...,
+         *       listOf(
+         *         ...,
+         *         StreamCheckpoint(...),
+         *       ),
+         *       ...
+         *     )
+         *   }
+         *   if (e.stateMessages.isNotEmpty()) { break }
+         * }
+         * ```
+         */
         streamStatus: AirbyteStreamStatus? = AirbyteStreamStatus.COMPLETE,
     ): List<AirbyteMessage> {
         val destination =

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/IntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/IntegrationTest.kt
@@ -99,6 +99,7 @@ abstract class IntegrationTest(
         stream: DestinationStream,
         primaryKey: List<List<String>>,
         cursor: List<String>?,
+        reason: String? = null,
     ) {
         val actualRecords: List<OutputRecord> = dataDumper.dumpRecords(config, stream)
         val expectedRecords: List<OutputRecord> =
@@ -110,9 +111,12 @@ abstract class IntegrationTest(
             )
             .diffRecords(expectedRecords, actualRecords)
             ?.let {
-                fail(
+                var message =
                     "Incorrect records for ${stream.descriptor.namespace}.${stream.descriptor.name}:\n$it"
-                )
+                if (reason != null) {
+                    message = reason + "\n" + message
+                }
+                fail(message)
             }
     }
 

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/destination_process/DestinationUncleanExitException.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/destination_process/DestinationUncleanExitException.kt
@@ -5,11 +5,17 @@
 package io.airbyte.cdk.load.test.util.destination_process
 
 import io.airbyte.protocol.models.v0.AirbyteErrorTraceMessage
+import io.airbyte.protocol.models.v0.AirbyteStateMessage
 import io.airbyte.protocol.models.v0.AirbyteTraceMessage
 
 class DestinationUncleanExitException(
     exitCode: Int,
-    traceMessages: List<AirbyteErrorTraceMessage>
+    traceMessages: List<AirbyteErrorTraceMessage>,
+    /**
+     * If the destination emitted any state messages before crashing, they will be stored into this
+     * list.
+     */
+    val stateMessages: List<AirbyteStateMessage>,
 ) :
     Exception(
         """
@@ -24,10 +30,15 @@ class DestinationUncleanExitException(
         // this can't just be a second constructor, because both constructors
         // would have signature `traceMessages: List`.
         // so we have to pull this into a companion object function.
-        fun of(exitCode: Int, traceMessages: List<AirbyteTraceMessage>) =
+        fun of(
+            exitCode: Int,
+            traceMessages: List<AirbyteTraceMessage>,
+            stateMessages: List<AirbyteStateMessage>,
+        ) =
             DestinationUncleanExitException(
                 exitCode,
-                traceMessages.filter { it.type == AirbyteTraceMessage.Type.ERROR }.map { it.error }
+                traceMessages.filter { it.type == AirbyteTraceMessage.Type.ERROR }.map { it.error },
+                stateMessages,
             )
     }
 }

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/destination_process/DockerizedDestination.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/destination_process/DockerizedDestination.kt
@@ -225,7 +225,11 @@ class DockerizedDestination(
             process.waitFor()
             val exitCode = process.exitValue()
             if (exitCode != 0) {
-                throw DestinationUncleanExitException.of(exitCode, destinationOutput.traces())
+                throw DestinationUncleanExitException.of(
+                    exitCode,
+                    destinationOutput.traces(),
+                    destinationOutput.states(),
+                )
             }
         }
     }

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/destination_process/NonDockerizedDestination.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/destination_process/NonDockerizedDestination.kt
@@ -63,7 +63,8 @@ class NonDockerizedDestination(
                     } catch (e: ConnectorUncleanExitException) {
                         throw DestinationUncleanExitException.of(
                             e.exitCode,
-                            destination.results.traces()
+                            destination.results.traces(),
+                            destination.results.states(),
                         )
                     }
                     destinationComplete.complete(Unit)

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/write/BasicFunctionalityIntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/write/BasicFunctionalityIntegrationTest.kt
@@ -50,6 +50,7 @@ import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertAll
+import org.junit.jupiter.api.assertThrows
 
 abstract class BasicFunctionalityIntegrationTest(
     /** The config to pass into the connector, as a serialized JSON blob */
@@ -77,6 +78,16 @@ abstract class BasicFunctionalityIntegrationTest(
     val stringifySchemalessObjects: Boolean,
     val promoteUnionToObject: Boolean,
     val preserveUndeclaredFields: Boolean,
+    /**
+     * Whether the destination commits new data when it receives a non-`COMPLETE` stream status. For
+     * example:
+     * * A destination which writes new data to a temporary directory, and moves those files to the
+     * "real" directory at the end of the sync if and only if it received a COMPLETE status, would
+     * set this parameter to `false`.
+     * * A destination which writes new data directly into the real directory throughout the sync,
+     * would set this parameter to `true`.
+     */
+    val commitDataIncrementally: Boolean,
 ) : IntegrationTest(dataDumper, destinationCleaner, recordMangler, nameMapper) {
     val parsedConfig = ValidatedJsonUtils.parseOne(configSpecClass, configContents)
 
@@ -570,6 +581,174 @@ abstract class BasicFunctionalityIntegrationTest(
             finalStream,
             primaryKey = listOf(listOf("id")),
             cursor = null,
+        )
+    }
+
+    /**
+     * Test behavior in a failed truncate refresh. Sync 1 just populates two records with ID 1 and
+     * 2. The test then runs two more syncs:
+     * 1. Sync 2 emits ID 1, and then fails the sync (i.e. no COMPLETE stream status). We expect the
+     * first sync's records to still exist in the destination. The new record may be visible to the
+     * data dumper, depending on the [commitDataIncrementally] parameter.
+     * 2. Sync 3 emits ID 2, and then ends the sync normally (i.e. COMPLETE stream status). After
+     * this sync, the data from the first sync should be deleted, and the data from both the second
+     * and third syncs should be visible to the data dumper.
+     */
+    @Test
+    open fun testInterruptedTruncateWithPriorData() {
+        assumeTrue(verifyDataWriting)
+        fun makeInputRecord(id: Int, updatedAt: String, extractedAt: Long) =
+            DestinationRecord(
+                randomizedNamespace,
+                "test_stream",
+                """{"id": $id, "updated_at": "$updatedAt", "name": "foo_${id}_$extractedAt"}""",
+                emittedAtMs = extractedAt,
+            )
+        fun makeOutputRecord(
+            id: Int,
+            updatedAt: String,
+            extractedAt: Long,
+            generationId: Long,
+            syncId: Long,
+        ) =
+            OutputRecord(
+                extractedAt = extractedAt,
+                generationId = generationId,
+                data =
+                    mapOf(
+                        "id" to id,
+                        "updated_at" to OffsetDateTime.parse(updatedAt),
+                        "name" to "foo_${id}_$extractedAt",
+                    ),
+                airbyteMeta = OutputRecord.Meta(syncId = syncId),
+            )
+        // Run a normal sync with nonempty data
+        val stream1 =
+            DestinationStream(
+                DestinationStream.Descriptor(randomizedNamespace, "test_stream"),
+                Append,
+                ObjectType(
+                    linkedMapOf(
+                        "id" to intType,
+                        "updated_at" to timestamptzType,
+                        "name" to stringType,
+                    )
+                ),
+                generationId = 41,
+                minimumGenerationId = 0,
+                syncId = 41,
+            )
+        runSync(
+            configContents,
+            stream1,
+            listOf(
+                makeInputRecord(1, "2024-01-23T01:00Z", 100),
+                makeInputRecord(2, "2024-01-23T01:00Z", 100),
+            ),
+        )
+        dumpAndDiffRecords(
+            parsedConfig,
+            listOf(
+                makeOutputRecord(
+                    id = 1,
+                    updatedAt = "2024-01-23T01:00Z",
+                    extractedAt = 100,
+                    generationId = 41,
+                    syncId = 41,
+                ),
+                makeOutputRecord(
+                    id = 2,
+                    updatedAt = "2024-01-23T01:00Z",
+                    extractedAt = 100,
+                    generationId = 41,
+                    syncId = 41,
+                ),
+            ),
+            stream1,
+            primaryKey = listOf(listOf("id")),
+            cursor = null,
+            "Records were incorrect after initial sync - this indicates a bug in basic connector behavior",
+        )
+
+        val stream2 =
+            stream1.copy(
+                generationId = 42,
+                minimumGenerationId = 42,
+                syncId = 42,
+            )
+        // Run a sync, but don't emit a stream status. This should not delete any existing data.
+        assertThrows<DestinationUncleanExitException> {
+            runSync(
+                configContents,
+                stream2,
+                listOf(makeInputRecord(1, "2024-01-23T02:00Z", 200)),
+                streamStatus = null,
+            )
+        }
+        dumpAndDiffRecords(
+            parsedConfig,
+            listOfNotNull(
+                makeOutputRecord(
+                    id = 1,
+                    updatedAt = "2024-01-23T01:00Z",
+                    extractedAt = 100,
+                    generationId = 41,
+                    syncId = 41,
+                ),
+                makeOutputRecord(
+                    id = 2,
+                    updatedAt = "2024-01-23T01:00Z",
+                    extractedAt = 100,
+                    generationId = 41,
+                    syncId = 41,
+                ),
+                if (commitDataIncrementally) {
+                    makeOutputRecord(
+                        id = 1,
+                        updatedAt = "2024-01-23T02:00Z",
+                        extractedAt = 200,
+                        generationId = 42,
+                        syncId = 42,
+                    )
+                } else {
+                    null
+                }
+            ),
+            stream2,
+            primaryKey = listOf(listOf("id")),
+            cursor = null,
+            "Records were incorrect after a failed sync.",
+        )
+
+        // Run a third sync, this time with a successful status.
+        // This should delete the first sync's data, and retain the second+third syncs' data.
+        runSync(
+            configContents,
+            stream2,
+            listOf(makeInputRecord(2, "2024-01-23T03:00Z", 300)),
+        )
+        dumpAndDiffRecords(
+            parsedConfig,
+            listOf(
+                makeOutputRecord(
+                    id = 1,
+                    updatedAt = "2024-01-23T02:00Z",
+                    extractedAt = 200,
+                    generationId = 42,
+                    syncId = 42,
+                ),
+                makeOutputRecord(
+                    id = 2,
+                    updatedAt = "2024-01-23T03:00Z",
+                    extractedAt = 300,
+                    generationId = 42,
+                    syncId = 42,
+                ),
+            ),
+            stream2,
+            primaryKey = listOf(listOf("id")),
+            cursor = null,
+            "Records were incorrect after a successful sync following a failed sync. This may indicate that we are not retaining data from the failed sync.",
         )
     }
 

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/write/BasicFunctionalityIntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/write/BasicFunctionalityIntegrationTest.kt
@@ -677,13 +677,30 @@ abstract class BasicFunctionalityIntegrationTest(
                 syncId = 42,
             )
         // Run a sync, but don't emit a stream status. This should not delete any existing data.
-        assertThrows<DestinationUncleanExitException> {
-            runSync(
-                configContents,
-                stream2,
-                listOf(makeInputRecord(1, "2024-01-23T02:00Z", 200)),
-                streamStatus = null,
-            )
+        // There's a race condition between the end of stream killing the connector,
+        // and the connector starting to process the record.
+        // So we run this in a loop until the connector acks the state message.
+        while (true) {
+            val e =
+                assertThrows<DestinationUncleanExitException> {
+                    runSync(
+                        configContents,
+                        stream2,
+                        listOf(
+                            makeInputRecord(1, "2024-01-23T02:00Z", 200),
+                            StreamCheckpoint(
+                                randomizedNamespace,
+                                "test_stream",
+                                "{}",
+                                sourceRecordCount = 1,
+                            )
+                        ),
+                        streamStatus = null,
+                    )
+                }
+            if (e.stateMessages.isNotEmpty()) {
+                break
+            }
         }
         dumpAndDiffRecords(
             parsedConfig,

--- a/airbyte-integrations/connectors/destination-dev-null/src/test-integration/kotlin/io/airbyte/integrations/destination/dev_null/DevNullBasicFunctionalityIntegrationTest.kt
+++ b/airbyte-integrations/connectors/destination-dev-null/src/test-integration/kotlin/io/airbyte/integrations/destination/dev_null/DevNullBasicFunctionalityIntegrationTest.kt
@@ -22,6 +22,7 @@ class DevNullBasicFunctionalityIntegrationTest :
         stringifySchemalessObjects = false,
         promoteUnionToObject = false,
         preserveUndeclaredFields = false,
+        commitDataIncrementally = false,
     ) {
     @Test
     override fun testBasicWrite() {

--- a/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2WriteTest.kt
+++ b/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2WriteTest.kt
@@ -15,6 +15,8 @@ abstract class S3V2WriteTest(
     stringifySchemalessObjects: Boolean,
     promoteUnionToObject: Boolean,
     preserveUndeclaredFields: Boolean,
+    /** This is false for staging mode, and true for non-staging mode. */
+    commitDataIncrementally: Boolean = false,
 ) :
     BasicFunctionalityIntegrationTest(
         S3V2TestUtils.getConfig(path),
@@ -27,6 +29,7 @@ abstract class S3V2WriteTest(
         stringifySchemalessObjects = stringifySchemalessObjects,
         promoteUnionToObject = promoteUnionToObject,
         preserveUndeclaredFields = preserveUndeclaredFields,
+        commitDataIncrementally = commitDataIncrementally,
     ) {
     @Test
     override fun testBasicWrite() {
@@ -67,6 +70,12 @@ abstract class S3V2WriteTest(
     @Test
     override fun testUnions() {
         super.testUnions()
+    }
+
+    @Disabled("connector doesn't yet do refreshes correctly - data from failed sync is lost")
+    @Test
+    override fun testInterruptedTruncateWithPriorData() {
+        super.testInterruptedTruncateWithPriorData()
     }
 }
 


### PR DESCRIPTION
trying to get these tests scaffolded up. I'd appreciate a relatively thorough review on this first test case (other refresh-related tests should be pretty similar, I just want to check that this is correct + legible)

also:
* add a `reason` param to dumpAndDiff for convenience
* fix the mock destination to do refreshes correctly
* disables the new test for s3 for now b/c I didn't want to track down the buggy behavior