### PR TITLE
CAT Fix: include optional fields when parsing inline spec for manifest-only connectors

### DIFF
--- a/airbyte-integrations/bases/connector-acceptance-test/CHANGELOG.md
+++ b/airbyte-integrations/bases/connector-acceptance-test/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 3.9.5
+
+Fix parsing of inlined manifest specs in `test_match_expected`
+
+## 3.9.4
+
+Upgrade to Dagger 0.13
+
 ## 3.9.3
 
 Undo failure trace message test case changes from 3.9.1

--- a/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/utils/manifest_helper.py
+++ b/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/utils/manifest_helper.py
@@ -17,9 +17,8 @@ def is_manifest_file(file_name: Path) -> bool:
 def parse_manifest_spec(manifest_obj: dict) -> ConnectorSpecification:
     valid_spec_obj = {
         "connectionSpecification": manifest_obj["spec"]["connection_specification"],
-        "documentationUrl": manifest_obj.get("documentationUrl", None),
-        "changelogUrl": manifest_obj.get("changelogUrl", None),
-        "advanced_auth": manifest_obj.get("spec", {}).get("advanced_auth", None)
+        "documentationUrl": manifest_obj["spec"].get("documentationUrl", None),
+        "advanced_auth": manifest_obj["spec"].get("advanced_auth", None)
     }
 
     return ConnectorSpecification.parse_obj(valid_spec_obj)

--- a/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/utils/manifest_helper.py
+++ b/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/utils/manifest_helper.py
@@ -14,8 +14,12 @@ def is_manifest_file(file_name: Path) -> bool:
     return file_name.name in MANIFEST_FILE_NAMES
 
 
-def parse_manifest_spec(manifest_obj: dict) -> dict:
+def parse_manifest_spec(manifest_obj: dict) -> ConnectorSpecification:
     valid_spec_obj = {
         "connectionSpecification": manifest_obj["spec"]["connection_specification"],
+        "documentationUrl": manifest_obj.get("documentationUrl", None),
+        "changelogUrl": manifest_obj.get("changelogUrl", None),
+        "advanced_auth": manifest_obj.get("spec", {}).get("advanced_auth", None)
     }
+
     return ConnectorSpecification.parse_obj(valid_spec_obj)

--- a/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/utils/manifest_helper.py
+++ b/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/utils/manifest_helper.py
@@ -18,7 +18,7 @@ def parse_manifest_spec(manifest_obj: dict) -> ConnectorSpecification:
     valid_spec_obj = {
         "connectionSpecification": manifest_obj["spec"]["connection_specification"],
         "documentationUrl": manifest_obj["spec"].get("documentationUrl", None),
-        "advanced_auth": manifest_obj["spec"].get("advanced_auth", None)
+        "advanced_auth": manifest_obj["spec"].get("advanced_auth", None),
     }
 
     return ConnectorSpecification.parse_obj(valid_spec_obj)

--- a/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/utils/manifest_helper.py
+++ b/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/utils/manifest_helper.py
@@ -17,7 +17,7 @@ def is_manifest_file(file_name: Path) -> bool:
 def parse_manifest_spec(manifest_obj: dict) -> ConnectorSpecification:
     valid_spec_obj = {
         "connectionSpecification": manifest_obj["spec"]["connection_specification"],
-        "documentationUrl": manifest_obj["spec"].get("documentationUrl", None),
+        "documentationUrl": manifest_obj["spec"].get("documentation_url", None),
         "advanced_auth": manifest_obj["spec"].get("advanced_auth", None),
     }
 

--- a/airbyte-integrations/bases/connector-acceptance-test/pyproject.toml
+++ b/airbyte-integrations/bases/connector-acceptance-test/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "connector-acceptance-test"
-version = "3.9.4"
+version = "3.9.5"
 description = "Contains acceptance tests for connectors."
 authors = ["Airbyte <contact@airbyte.io>"]
 license = "MIT"


### PR DESCRIPTION
## What

The `test_match_expected` CAT test case is designed to compare the spec from a connector's code in our repo to the results of an actual spec call made against the connector. However, in the case of inlined manifest specs, we do not currently include any optional fields in the parsed spec object read from the manifest.

This causes failures on connectors that utilize our `advanced_auth` flow and/or have documentation urls listed in their specs.

![Screenshot 2024-11-01 at 10 48 10 AM](https://github.com/user-attachments/assets/94303321-0fa6-49b6-8a09-611da18b11ce)

This PR updates the test to include the optional `documentationUrl` and `advanced_auth` fields in the parsed spec object if they are found in the manifest.

## User Impact

Unblocks contributions to certified manifest-only connectors by resolving failing test case.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌
