### PR TITLE
Python-CDK: Add first pass pseudocode anyOf logic when rendering json schema

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/file_based/config/abstract_file_based_spec.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/file_based/config/abstract_file_based_spec.py
@@ -25,7 +25,7 @@ class DeliverRecords(BaseModel):
 class DeliverRawFiles(BaseModel):
     class Config(OneOfOptionConfig):
         title = "Copy Raw Files"
-        description = "Copy raw files without parsing their contents. Bits are copied into the destination exactly as they appeared in the source. Recommended for use with unstructured text data, non-text and compressed files."
+        description = "Copy raw files without parsing their contents. Bits are copied into the destination exactly as they appeared in the source. Recommended for use with unstructured text data, non-text and compressed files.\n\nRequires a supported file destination (see docs for detailed limitations)."
         discriminator = "delivery_type"
 
     delivery_type: Literal["use_file_transfer"] = Field("use_file_transfer", const=True)

--- a/airbyte-cdk/python/unit_tests/sources/file_based/scenarios/csv_scenarios.py
+++ b/airbyte-cdk/python/unit_tests/sources/file_based/scenarios/csv_scenarios.py
@@ -453,16 +453,12 @@ single_csv_scenario: TestScenario[InMemoryFilesSource] = (
                                         "title": "Delivery Type",
                                         "default": "use_records_transfer",
                                         "const": "use_records_transfer",
-                                        "enum": [
-                                            "use_records_transfer"
-                                        ],
-                                        "type": "string"
+                                        "enum": ["use_records_transfer"],
+                                        "type": "string",
                                     }
                                 },
                                 "description": "Recommended - Extract and load structured records into your destination of choice. This is the classic method of moving data in Airbyte. It allows for blocking and hashing individual fields or files from a structured schema. Data can be flattened, typed and deduped depending on the destination.",
-                                "required": [
-                                    "delivery_type"
-                                ]
+                                "required": ["delivery_type"],
                             },
                             {
                                 "title": "Copy Raw Files",
@@ -472,19 +468,15 @@ single_csv_scenario: TestScenario[InMemoryFilesSource] = (
                                         "title": "Delivery Type",
                                         "default": "use_file_transfer",
                                         "const": "use_file_transfer",
-                                        "enum": [
-                                            "use_file_transfer"
-                                        ],
-                                        "type": "string"
+                                        "enum": ["use_file_transfer"],
+                                        "type": "string",
                                     }
                                 },
-                                "description": "Copy raw files without parsing their contents. Bits are copied into the destination exactly as they appeared in the source. Recommended for use with unstructured text data, non-text and compressed files.",
-                                "required": [
-                                    "delivery_type"
-                                    ]
-                                }
-                            ]
-                        },
+                                "description": "Copy raw files without parsing their contents. Bits are copied into the destination exactly as they appeared in the source. Recommended for use with unstructured text data, non-text and compressed files.\n\nRequires a supported file destination (see docs for detailed limitations).",
+                                "required": ["delivery_type"],
+                            },
+                        ],
+                    },
                 },
                 "required": ["streams"],
             },


### PR DESCRIPTION
This is a first draft of using the delivery type (files or records) to influence how the `streams` config is rendered.

This relies on:

1. Existing anyOf behavior and descriminator behaviors in JSON Schema.
2. Existing front-end logic that leverages that JSON schema.

What this doesn't change:

- It doesn't actually change what config is expected or how Pydantic will validate and deserialize it.

Unknown:
- Whether the UI frontend can correctly handle these conditions (as it does for similar ones) or if there are aspects of this specific implementation that are unsupported in our UI engine.

## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->

## How
<!--
* Describe how code changes achieve the solution.
-->

## Review guide
<!--
1. `x.py`
4. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
