### PR TITLE
Bulk load CDK: More refresh tests

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/integrationTest/kotlin/io/airbyte/cdk/load/mock_integration_test/MockBasicFunctionalityIntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/integrationTest/kotlin/io/airbyte/cdk/load/mock_integration_test/MockBasicFunctionalityIntegrationTest.kt
@@ -58,6 +58,11 @@ class MockBasicFunctionalityIntegrationTest :
     }
 
     @Test
+    override fun resumeAfterCancelledTruncate() {
+        super.resumeAfterCancelledTruncate()
+    }
+
+    @Test
     override fun testAppend() {
         super.testAppend()
     }

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/IntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/IntegrationTest.kt
@@ -24,6 +24,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import org.apache.commons.lang3.RandomStringUtils
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.TestInfo
 import org.junit.jupiter.api.extension.ExtendWith
@@ -45,18 +46,6 @@ abstract class IntegrationTest(
     val recordMangler: ExpectedRecordMapper = NoopExpectedRecordMapper,
     val nameMapper: NameMapper = NoopNameMapper,
 ) {
-    // Connectors are calling System.getenv rather than using micronaut-y properties,
-    // so we have to mock it out, instead of just setting more properties
-    // inside NonDockerizedDestination.
-    // This field has no effect on DockerizedDestination, which explicitly
-    // sets env vars when invoking `docker run`.
-    @SystemStub private lateinit var nonDockerMockEnvVars: EnvironmentVariables
-
-    @BeforeEach
-    fun setEnvVars() {
-        nonDockerMockEnvVars.set("WORKER_JOB_ID", "0")
-    }
-
     // Intentionally don't inject the actual destination process - we need a full factory
     // because some tests want to run multiple syncs, so we need to run the destination
     // multiple times.
@@ -185,5 +174,18 @@ abstract class IntegrationTest(
 
     companion object {
         private val hasRunCleaner = AtomicBoolean(false)
+
+        // Connectors are calling System.getenv rather than using micronaut-y properties,
+        // so we have to mock it out, instead of just setting more properties
+        // inside NonDockerizedDestination.
+        // This field has no effect on DockerizedDestination, which explicitly
+        // sets env vars when invoking `docker run`.
+        @SystemStub private lateinit var nonDockerMockEnvVars: EnvironmentVariables
+
+        @JvmStatic
+        @BeforeAll
+        fun setEnvVars() {
+            nonDockerMockEnvVars.set("WORKER_JOB_ID", "0")
+        }
     }
 }

--- a/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2WriteTest.kt
+++ b/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2WriteTest.kt
@@ -78,6 +78,18 @@ abstract class S3V2WriteTest(
     override fun testInterruptedTruncateWithPriorData() {
         super.testInterruptedTruncateWithPriorData()
     }
+
+    @Disabled("connector doesn't yet do refreshes correctly - failed sync deletes old data")
+    @Test
+    override fun resumeAfterCancelledTruncate() {
+        super.resumeAfterCancelledTruncate()
+    }
+
+    @Disabled("connector doesn't yet do refreshes correctly - failed sync deletes old data")
+    @Test
+    override fun testInterruptedTruncateWithoutPriorData() {
+        super.testInterruptedTruncateWithoutPriorData()
+    }
 }
 
 class S3V2WriteTestJsonUncompressed :


### PR DESCRIPTION
these are also taken from BaseTypingDedupingTest. Still disabled for s3v2, probably same reasons as https://github.com/airbytehq/airbyte/pull/48107#discussion_r1826258393