### PR TITLE
fix(source-amazon-ads): fix date parse in reports

### DIFF
--- a/airbyte-integrations/connectors/source-amazon-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-amazon-ads/metadata.yaml
@@ -13,7 +13,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: c6b0a29e-1da9-4512-9002-7bfd0cba2246
-  dockerImageTag: 6.1.0
+  dockerImageTag: 6.1.1
   dockerRepository: airbyte/source-amazon-ads
   documentationUrl: https://docs.airbyte.com/integrations/sources/amazon-ads
   githubIssueLabel: source-amazon-ads

--- a/airbyte-integrations/connectors/source-amazon-ads/pyproject.toml
+++ b/airbyte-integrations/connectors/source-amazon-ads/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "6.1.0"
+version = "6.1.1"
 name = "source-amazon-ads"
 description = "Source implementation for Amazon Ads."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-amazon-ads/source_amazon_ads/streams/report_streams/report_streams.py
+++ b/airbyte-integrations/connectors/source-amazon-ads/source_amazon_ads/streams/report_streams/report_streams.py
@@ -264,7 +264,7 @@ class ReportStream(BasicAmazonAdsStream, ABC):
         today = pendulum.today(tz=profile["timezone"]).date()
         start_date = stream_state.get(str(profile["profileId"]), {}).get(self.cursor_field)
         if start_date:
-            start_date = pendulum.from_format(start_date, self.REPORT_DATE_FORMAT).date()
+            start_date = pendulum.parse(start_date).date()
             # Taking date from state if it's not older than 60 days
             return max(start_date, today.subtract(days=self.REPORTING_PERIOD))
         if self._start_date:

--- a/docs/integrations/sources/amazon-ads.md
+++ b/docs/integrations/sources/amazon-ads.md
@@ -153,7 +153,8 @@ Information about expected report generation waiting time can be found [here](ht
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                         |
 |:--------|:-----------|:---------------------------------------------------------|:----------------------------------------------------------------------------------------------------------------|
-| 6.1.0   | 2024-10-31 | [47940](https://github.com/airbytehq/airbyte/pull/47940) | Bump CDK to ^5                                                                                                  |
+| 6.1.1   | 2024-11-04 | [48128](https://github.com/airbytehq/airbyte/pull/48128) | Fix date parse in report streams                                                                                |
+| 6.1.0   | 2024-11-01 | [47940](https://github.com/airbytehq/airbyte/pull/47940) | Bump CDK to ^5                                                                                                  |
 | 6.0.0   | 2024-10-28 | [47366](https://github.com/airbytehq/airbyte/pull/47366) | Migrate stream `SponsoredDisplayReportStream` to Amazon Ads Reports v3                                          |
 | 5.0.20  | 2024-10-29 | [47032](https://github.com/airbytehq/airbyte/pull/47032) | Update dependencies                                                                                             |
 | 5.0.19  | 2024-10-12 | [46860](https://github.com/airbytehq/airbyte/pull/46860) | Update dependencies                                                                                             |


### PR DESCRIPTION
## What

fix date parse in reports v3 after update to v6.0.0

## How

- use universal `pendulum.parse` function to parse both old and new formats: `YYYYMMDD` & `YYYY-MM-DD`

## Review guide

1. `airbyte-integrations/connectors/source-amazon-ads/source_amazon_ads/streams/report_streams/report_streams.py`

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
