### PR TITLE
Temporary GHA workflow to identify secrets with JSON data

### DIFF
--- a/.github/workflows/secrets_identifier.yml
+++ b/.github/workflows/secrets_identifier.yml
@@ -1,0 +1,20 @@
+name: secret_checker
+on:
+  workflow_dispatch:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:    
+      - name: Check secrets for curly braces
+        env:
+          SECRETS: ${{ toJSON(secrets) }}
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const jsonData = JSON.parse(process.env.SECRETS);
+            for (const key in jsonData) {
+              const stringValue = String(jsonData[key]);
+              if (stringValue.includes('{')) {
+                console.log(`Key: ${key}`);
+              }
+            }

--- a/.github/workflows/secrets_identifier.yml
+++ b/.github/workflows/secrets_identifier.yml
@@ -4,7 +4,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    steps:    
+    steps:
       - name: Check secrets for curly braces
         env:
           SECRETS: ${{ toJSON(secrets) }}


### PR DESCRIPTION
We want to identify secrets with have a `{` in them.
It's because we want to pass (non secret) json data in outputs for some GHA matrix strategy.
But if we have a secret line with curly braces GHA considers it's a secret and blocks output passing.