### PR TITLE
fix: fix `error message pattern` to handle the `Product 1.0 catalog` related issues 

### DIFF
--- a/airbyte-integrations/connectors/source-chargebee/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-chargebee/acceptance-test-config.yml
@@ -45,7 +45,7 @@ acceptance_tests:
         expect_records:
           path: "integration_tests/expected_records.jsonl"
           exact_order: no
-        validate_state_messages: False
+        validate_state_messages: false
         fail_on_extra_columns: true
   incremental:
     tests:

--- a/airbyte-integrations/connectors/source-chargebee/metadata.yaml
+++ b/airbyte-integrations/connectors/source-chargebee/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 686473f1-76d9-4994-9cc7-9b13da46147c
-  dockerImageTag: 0.7.0
+  dockerImageTag: 0.7.1
   dockerRepository: airbyte/source-chargebee
   documentationUrl: https://docs.airbyte.com/integrations/sources/chargebee
   githubIssueLabel: source-chargebee

--- a/airbyte-integrations/connectors/source-chargebee/pyproject.toml
+++ b/airbyte-integrations/connectors/source-chargebee/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "0.7.0"
+version = "0.7.1"
 name = "source-chargebee"
 description = "Source implementation for Chargebee."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-chargebee/source_chargebee/manifest.yaml
+++ b/airbyte-integrations/connectors/source-chargebee/source_chargebee/manifest.yaml
@@ -21,7 +21,7 @@ definitions:
       error_handlers:
         - type: DefaultErrorHandler
           response_filters:
-            - error_message_contains: "The API endpoint is incompatible with the product catalog"
+            - predicate: "{{ 'api_error_code' in response and response['api_error_code'] == 'configuration_incompatible' }}"
               action: IGNORE
               error_message: "Stream is available only for Product Catalog 1.0"
         - type: DefaultErrorHandler

--- a/airbyte-integrations/connectors/source-chargebee/source_chargebee/manifest.yaml
+++ b/airbyte-integrations/connectors/source-chargebee/source_chargebee/manifest.yaml
@@ -21,7 +21,7 @@ definitions:
       error_handlers:
         - type: DefaultErrorHandler
           response_filters:
-            - error_message_contains: "This API operation is not enabled for this site"
+            - error_message_contains: "The API endpoint is incompatible with the product catalog"
               action: IGNORE
               error_message: "Stream is available only for Product Catalog 1.0"
         - type: DefaultErrorHandler

--- a/docs/integrations/sources/chargebee.md
+++ b/docs/integrations/sources/chargebee.md
@@ -104,6 +104,7 @@ The Chargebee connector should not run into [Chargebee API](https://apidocs.char
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                                        |
 |:--------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------|
+| 0.7.1   | 2024-11-04 | [48133](https://github.com/airbytehq/airbyte/pull/48133)     | Fix `error message pattern` to handle `Product 1.0` related errors |
 | 0.7.0   | 2024-10-30 | [47978](https://github.com/airbytehq/airbyte/pull/47978)     | Upgrade the CDK and startup files to sync incremental streams concurrently |
 | 0.6.18 | 2024-10-31 | [47099](https://github.com/airbytehq/airbyte/pull/47099) | Update dependencies |
 | 0.6.17  | 2024-10-28 | [46846](https://github.com/airbytehq/airbyte/pull/47387)      | Update CDK dependencies to yield parent records more frequently                                                                                |


### PR DESCRIPTION
## What
Resolving:
- https://github.com/airbytehq/oncall/issues/6816

This is to support the following responses from the API:
```
{"message":"The API endpoint is incompatible with the product catalog version. You are calling product catalog 2.0 API endpoint but you are using product catalog 1.0 ","api_error_code":"configuration_incompatible","error_code":"pc1_to_pc2_error","error_msg":"The API endpoint is incompatible with the product catalog version. You are calling product catalog 2.0 API endpoint but you are using product catalog 1.0 ","http_status_code":400}
```

## How
- changed the `DefaultErrorHandler > error_message_contains`:
    - from: `This API operation is not enabled for this site`
    - to: `The API endpoint is incompatible with the product catalog`

## User Impact
No impact is expected, we are getting back on track after the API has changed the error messaging.

## Can this PR be safely reverted and rolled back?
- [X] YES 💚
- [ ] NO ❌
