### PR TITLE
🐛 Source Amazon Ads: Fix heartbeat issues on report processing

### DIFF
--- a/airbyte-integrations/connectors/source-amazon-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-amazon-ads/metadata.yaml
@@ -19,7 +19,8 @@ data:
   githubIssueLabel: source-amazon-ads
   icon: amazonads.svg
   license: MIT
-  maxSecondsBetweenMessages: 5400
+  # Based on https://advertising.amazon.com/API/docs/en-us/guides/reporting/v3/get-started#checking-report-status, report generation can take up to 3 hours
+  maxSecondsBetweenMessages: 10810
   name: Amazon Ads
   remoteRegistries:
     pypi:

--- a/airbyte-integrations/connectors/source-amazon-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-amazon-ads/metadata.yaml
@@ -20,7 +20,8 @@ data:
   icon: amazonads.svg
   license: MIT
   # Based on https://advertising.amazon.com/API/docs/en-us/guides/reporting/v3/get-started#checking-report-status, report generation can take up to 3 hours
-  maxSecondsBetweenMessages: 10810
+  # We've added one minute on top of the three hours because of the waiting time before we poll the report status
+  maxSecondsBetweenMessages: 10860
   name: Amazon Ads
   remoteRegistries:
     pypi:


### PR DESCRIPTION
## What
We've seen one case where the platform would consider the sync as dead because of heartbeat failure. Following report migration to API v3, the duration of those reports can be up to 3 hours (see https://advertising.amazon.com/API/docs/en-us/guides/reporting/v3/get-started#checking-report-status).

## How
Increase the `maxSecondsBetweenMessages`

## User Impact
Should fix the heartbeat issue we were seeing in prod

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
