### PR TITLE
fix(source-amazon-ads): add error message for TooManyRequests exception

### DIFF
--- a/airbyte-integrations/connectors/source-amazon-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-amazon-ads/metadata.yaml
@@ -13,7 +13,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: c6b0a29e-1da9-4512-9002-7bfd0cba2246
-  dockerImageTag: 6.1.1
+  dockerImageTag: 6.1.2
   dockerRepository: airbyte/source-amazon-ads
   documentationUrl: https://docs.airbyte.com/integrations/sources/amazon-ads
   githubIssueLabel: source-amazon-ads

--- a/airbyte-integrations/connectors/source-amazon-ads/pyproject.toml
+++ b/airbyte-integrations/connectors/source-amazon-ads/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "6.1.1"
+version = "6.1.2"
 name = "source-amazon-ads"
 description = "Source implementation for Amazon Ads."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-amazon-ads/source_amazon_ads/streams/report_streams/report_streams.py
+++ b/airbyte-integrations/connectors/source-amazon-ads/source_amazon_ads/streams/report_streams/report_streams.py
@@ -15,7 +15,8 @@ from urllib.parse import urljoin
 import backoff
 import pendulum
 import requests
-from airbyte_cdk.models import SyncMode
+from airbyte_cdk import AirbyteTracedException
+from airbyte_cdk.models import FailureType, SyncMode
 from airbyte_cdk.sources.streams.availability_strategy import AvailabilityStrategy
 from airbyte_cdk.sources.streams.http.requests_native_auth import Oauth2Authenticator
 from pendulum import Date
@@ -122,7 +123,14 @@ class ReportStream(BasicAmazonAdsStream, ABC):
             return
         profile = stream_slice["profile"]
         report_date = stream_slice[self.cursor_field]
-        report_info_list = self._init_and_try_read_records(profile, report_date)
+        try:
+            report_info_list = self._init_and_try_read_records(profile, report_date)
+        except TooManyRequests as e:
+            raise AirbyteTracedException(
+                failure_type=FailureType.transient_error,
+                message=f"Too many requests on resource {e}. Please retry later",
+                internal_message=f"Errors received from the API were: {e}",
+            )
         self._update_state(profile, report_date)
 
         for report_info in report_info_list:

--- a/airbyte-integrations/connectors/source-amazon-ads/source_amazon_ads/streams/report_streams/report_streams.py
+++ b/airbyte-integrations/connectors/source-amazon-ads/source_amazon_ads/streams/report_streams/report_streams.py
@@ -250,7 +250,7 @@ class ReportStream(BasicAmazonAdsStream, ABC):
             session = self._report_download_session if is_download_report else self._session
             response = session.get(url, headers=headers)
         if response.status_code == HTTPStatus.TOO_MANY_REQUESTS:
-            raise TooManyRequests()
+            raise TooManyRequests("429: Too many requests during report creation. Please try again later...")
         return response
 
     def get_date_range(self, start_date: Date, timezone: str) -> Iterable[str]:

--- a/airbyte-integrations/connectors/source-amazon-ads/unit_tests/test_report_streams.py
+++ b/airbyte-integrations/connectors/source-amazon-ads/unit_tests/test_report_streams.py
@@ -13,7 +13,6 @@ import pendulum
 import pytest
 import requests_mock
 import responses
-
 from airbyte_cdk import AirbyteTracedException
 from airbyte_cdk.models import SyncMode
 from freezegun import freeze_time

--- a/airbyte-integrations/connectors/source-amazon-ads/unit_tests/test_report_streams.py
+++ b/airbyte-integrations/connectors/source-amazon-ads/unit_tests/test_report_streams.py
@@ -13,6 +13,8 @@ import pendulum
 import pytest
 import requests_mock
 import responses
+
+from airbyte_cdk import AirbyteTracedException
 from airbyte_cdk.models import SyncMode
 from freezegun import freeze_time
 from pendulum import Date
@@ -328,7 +330,7 @@ def test_display_report_stream_init_too_many_requests(mocker, config):
     stream_slice = {"profile": profiles[0], "reportDate": "2021-07-25"}
     responses.add(responses.POST, "https://advertising-api.amazon.com/reporting/reports", json={}, status=429)
 
-    with raises(TooManyRequests):
+    with raises(AirbyteTracedException):
         _ = [m for m in stream.read_records(SyncMode.incremental, stream_slice=stream_slice)]
     assert len(responses.calls) == 10
 

--- a/docs/integrations/sources/amazon-ads.md
+++ b/docs/integrations/sources/amazon-ads.md
@@ -153,6 +153,7 @@ Information about expected report generation waiting time can be found [here](ht
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                         |
 |:--------|:-----------|:---------------------------------------------------------|:----------------------------------------------------------------------------------------------------------------|
+| 6.1.2   | 2024-11-04 | [48138](https://github.com/airbytehq/airbyte/pull/48138) | Add error message for TooManyRequests exception                                                                 |
 | 6.1.1   | 2024-11-04 | [48128](https://github.com/airbytehq/airbyte/pull/48128) | Fix date parse in report streams                                                                                |
 | 6.1.0   | 2024-11-01 | [47940](https://github.com/airbytehq/airbyte/pull/47940) | Bump CDK to ^5                                                                                                  |
 | 6.0.0   | 2024-10-28 | [47366](https://github.com/airbytehq/airbyte/pull/47366) | Migrate stream `SponsoredDisplayReportStream` to Amazon Ads Reports v3                                          |


### PR DESCRIPTION
## What

add error message for TooManyRequests exception


## How
<!--
* Describe how code changes achieve the solution.
-->

## Review guide

1. `airbyte-integrations/connectors/source-amazon-ads/source_amazon_ads/streams/report_streams/report_streams.py`


## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
