### PR TITLE
Bulk load CDK: Always wait for flush, even on failure

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/DestinationTaskExceptionHandler.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/DestinationTaskExceptionHandler.kt
@@ -82,8 +82,6 @@ T : ScopedTask {
                         "Task $innerTask run after sync has succeeded. This should not happen."
                     )
                 }
-                log.info { "Sync task $innerTask skipped because sync has already failed." }
-                return
             }
 
             try {
@@ -118,8 +116,6 @@ T : ScopedTask {
                         "Task $innerTask run after its stream ${stream.descriptor} has succeeded. This should not happen."
                     )
                 }
-                log.info { "Stream task $innerTask skipped because stream has already failed." }
-                return
             }
 
             try {

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/DestinationTaskExceptionHandler.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/DestinationTaskExceptionHandler.kt
@@ -82,6 +82,7 @@ T : ScopedTask {
                         "Task $innerTask run after sync has succeeded. This should not happen."
                     )
                 }
+                log.info { "Sync task $innerTask running after has already failed (this is not an error)." }
             }
 
             try {
@@ -116,6 +117,7 @@ T : ScopedTask {
                         "Task $innerTask run after its stream ${stream.descriptor} has succeeded. This should not happen."
                     )
                 }
+                log.info { "Stream task $innerTask running after stream has already failed (this is not an error)." }
             }
 
             try {

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/DestinationTaskExceptionHandler.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/DestinationTaskExceptionHandler.kt
@@ -82,7 +82,9 @@ T : ScopedTask {
                         "Task $innerTask run after sync has succeeded. This should not happen."
                     )
                 }
-                log.info { "Sync task $innerTask running after has already failed (this is not an error)." }
+                log.info {
+                    "Sync task $innerTask running after has already failed (this is not an error)."
+                }
             }
 
             try {
@@ -117,7 +119,9 @@ T : ScopedTask {
                         "Task $innerTask run after its stream ${stream.descriptor} has succeeded. This should not happen."
                     )
                 }
-                log.info { "Stream task $innerTask running after stream has already failed (this is not an error)." }
+                log.info {
+                    "Stream task $innerTask running after stream has already failed (this is not an error)."
+                }
             }
 
             try {

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/DestinationTaskScopeProvider.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/DestinationTaskScopeProvider.kt
@@ -42,7 +42,7 @@ interface InternalScope : ScopedTask
 
 interface ImplementorScope : ScopedTask
 
-interface InputScope: ScopedTask
+interface InputScope : ScopedTask
 
 @Singleton
 @Secondary

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/InputConsumerTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/InputConsumerTask.kt
@@ -30,7 +30,6 @@ import io.airbyte.cdk.load.state.MemoryManager
 import io.airbyte.cdk.load.state.Reserved
 import io.airbyte.cdk.load.state.SyncManager
 import io.airbyte.cdk.load.task.InputScope
-import io.airbyte.cdk.load.task.InternalScope
 import io.airbyte.cdk.load.task.SyncLevel
 import io.airbyte.cdk.load.util.use
 import io.github.oshai.kotlinlogging.KotlinLogging

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/InputConsumerTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/InputConsumerTask.kt
@@ -29,6 +29,7 @@ import io.airbyte.cdk.load.message.Undefined
 import io.airbyte.cdk.load.state.MemoryManager
 import io.airbyte.cdk.load.state.Reserved
 import io.airbyte.cdk.load.state.SyncManager
+import io.airbyte.cdk.load.task.InputScope
 import io.airbyte.cdk.load.task.InternalScope
 import io.airbyte.cdk.load.task.SyncLevel
 import io.airbyte.cdk.load.util.use
@@ -39,7 +40,7 @@ import java.io.InputStream
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.FlowCollector
 
-interface InputConsumerTask : SyncLevel, InternalScope
+interface InputConsumerTask : SyncLevel, InputScope
 
 /**
  * Routes @[DestinationStreamAffinedMessage]s by stream to the appropriate channel and @

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/InputConsumerTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/InputConsumerTask.kt
@@ -29,7 +29,7 @@ import io.airbyte.cdk.load.message.Undefined
 import io.airbyte.cdk.load.state.MemoryManager
 import io.airbyte.cdk.load.state.Reserved
 import io.airbyte.cdk.load.state.SyncManager
-import io.airbyte.cdk.load.task.InputScope
+import io.airbyte.cdk.load.task.KillableScope
 import io.airbyte.cdk.load.task.SyncLevel
 import io.airbyte.cdk.load.util.use
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -39,7 +39,7 @@ import java.io.InputStream
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.FlowCollector
 
-interface InputConsumerTask : SyncLevel, InputScope
+interface InputConsumerTask : SyncLevel, KillableScope
 
 /**
  * Routes @[DestinationStreamAffinedMessage]s by stream to the appropriate channel and @

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/TimedForcedCheckpointFlushTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/TimedForcedCheckpointFlushTask.kt
@@ -10,14 +10,14 @@ import io.airbyte.cdk.load.file.TimeProvider
 import io.airbyte.cdk.load.message.ChannelMessageQueue
 import io.airbyte.cdk.load.message.QueueWriter
 import io.airbyte.cdk.load.state.CheckpointManager
-import io.airbyte.cdk.load.task.InternalScope
+import io.airbyte.cdk.load.task.KillableScope
 import io.airbyte.cdk.load.task.SyncLevel
 import io.airbyte.cdk.load.util.use
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.micronaut.context.annotation.Secondary
 import jakarta.inject.Singleton
 
-interface TimedForcedCheckpointFlushTask : SyncLevel, InternalScope
+interface TimedForcedCheckpointFlushTask : SyncLevel, KillableScope
 
 @Singleton
 @Secondary

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/write/BasicFunctionalityIntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/write/BasicFunctionalityIntegrationTest.kt
@@ -677,30 +677,21 @@ abstract class BasicFunctionalityIntegrationTest(
                 syncId = 42,
             )
         // Run a sync, but don't emit a stream status. This should not delete any existing data.
-        // There's a race condition between the end of stream killing the connector,
-        // and the connector starting to process the record.
-        // So we run this in a loop until the connector acks the state message.
-        while (true) {
-            val e =
-                assertThrows<DestinationUncleanExitException> {
-                    runSync(
-                        configContents,
-                        stream2,
-                        listOf(
-                            makeInputRecord(1, "2024-01-23T02:00Z", 200),
-                            StreamCheckpoint(
-                                randomizedNamespace,
-                                "test_stream",
-                                "{}",
-                                sourceRecordCount = 1,
-                            )
-                        ),
-                        streamStatus = null,
+        assertThrows<DestinationUncleanExitException> {
+            runSync(
+                configContents,
+                stream2,
+                listOf(
+                    makeInputRecord(1, "2024-01-23T02:00Z", 200),
+                    StreamCheckpoint(
+                        randomizedNamespace,
+                        "test_stream",
+                        "{}",
+                        sourceRecordCount = 1,
                     )
-                }
-            if (e.stateMessages.isNotEmpty()) {
-                break
-            }
+                ),
+                streamStatus = null,
+            )
         }
         dumpAndDiffRecords(
             parsedConfig,

--- a/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2WriteTest.kt
+++ b/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2WriteTest.kt
@@ -63,6 +63,7 @@ abstract class S3V2WriteTest(
         super.testTruncateRefresh()
     }
 
+    @Test
     override fun testContainerTypes() {
         super.testContainerTypes()
     }


### PR DESCRIPTION
previously: if we failed (e.g. INCOMPLETE stream status, EOS without status message), we would discard some unprocessed work

now: let all our outstanding work to terminate before we exit

this makes destinations a bit easier to reason about. (mostly for the sake of writing tests :P ) Remove the hacky test-loopy-thing.