### PR TITLE
Update source-declarative-manifest to CDK version 6.X

### DIFF
--- a/airbyte-integrations/connectors/source-declarative-manifest/metadata.yaml
+++ b/airbyte-integrations/connectors/source-declarative-manifest/metadata.yaml
@@ -8,7 +8,7 @@ data:
   connectorType: source
   definitionId: 64a2f99c-542f-4af8-9a6f-355f1217b436
   # This version should not be updated manually - it is updated by the CDK release workflow.
-  dockerImageTag: 6.1.1
+  dockerImageTag: 6.1.2
   dockerRepository: airbyte/source-declarative-manifest
   # This page is hidden from the docs for now, since the connector is not in any Airbyte registries.
   documentationUrl: https://docs.airbyte.com/integrations/sources/low-code

--- a/airbyte-integrations/connectors/source-declarative-manifest/pyproject.toml
+++ b/airbyte-integrations/connectors/source-declarative-manifest/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "6.1.1"
+version = "6.1.2"
 name = "source-declarative-manifest"
 description = "Base source implementation for low-code sources."
 authors = ["Airbyte <contact@airbyte.io>"]

--- a/airbyte-integrations/connectors/source-declarative-manifest/source_declarative_manifest/run.py
+++ b/airbyte-integrations/connectors/source-declarative-manifest/source_declarative_manifest/run.py
@@ -6,14 +6,26 @@ from __future__ import annotations
 import json
 import pkgutil
 import sys
+import traceback
+from datetime import datetime
 from pathlib import Path
-from typing import List
+from typing import Any, List, Mapping, Optional
 
+from airbyte_cdk import TState
 from airbyte_cdk.connector import BaseConnector
 from airbyte_cdk.entrypoint import AirbyteEntrypoint, launch
-from airbyte_cdk.models import AirbyteMessage, ConnectorSpecificationSerializer, Type
+from airbyte_cdk.models import (
+    AirbyteErrorTraceMessage,
+    AirbyteMessage,
+    AirbyteMessageSerializer,
+    AirbyteTraceMessage,
+    ConfiguredAirbyteCatalog,
+    TraceType,
+    Type,
+)
 from airbyte_cdk.sources.declarative.manifest_declarative_source import ManifestDeclarativeSource
 from airbyte_cdk.sources.declarative.yaml_declarative_source import YamlDeclarativeSource
+from orjson import orjson
 
 
 class SourceLocalYaml(YamlDeclarativeSource):
@@ -21,7 +33,7 @@ class SourceLocalYaml(YamlDeclarativeSource):
     Declarative source defined by a yaml file in the local filesystem
     """
 
-    def __init__(self):
+    def __init__(self, catalog: Optional[ConfiguredAirbyteCatalog], config: Optional[Mapping[str, Any]], state: TState, **kwargs):
         """
         HACK!
             Problem: YamlDeclarativeSource relies on the calling module name/path to find the yaml file.
@@ -33,7 +45,7 @@ class SourceLocalYaml(YamlDeclarativeSource):
                 When all manifest connectors are updated to use the new airbyte-cdk.
                 When all manifest connectors are updated to use the source-declarative-manifest as the base image.
         """
-        super().__init__(**{"path_to_yaml": "manifest.yaml"})
+        super().__init__(catalog=catalog, config=config, state=state, **{"path_to_yaml": "manifest.yaml"})
 
 
 def _is_local_manifest_command(args: List[str]) -> bool:
@@ -48,8 +60,39 @@ def handle_command(args: List[str]) -> None:
         handle_remote_manifest_command(args)
 
 
+def _get_local_yaml_source(args: List[str]):
+    catalog_path = AirbyteEntrypoint.extract_catalog(args)
+    config_path = AirbyteEntrypoint.extract_config(args)
+    state_path = AirbyteEntrypoint.extract_state(args)
+    try:
+        return SourceLocalYaml(
+            SourceLocalYaml.read_catalog(catalog_path) if catalog_path else None,
+            SourceLocalYaml.read_config(config_path) if config_path else None,
+            SourceLocalYaml.read_state(state_path) if state_path else None,
+        )
+    except Exception as error:
+        print(
+            orjson.dumps(
+                AirbyteMessageSerializer.dump(
+                    AirbyteMessage(
+                        type=Type.TRACE,
+                        trace=AirbyteTraceMessage(
+                            type=TraceType.ERROR,
+                            emitted_at=int(datetime.now().timestamp() * 1000),
+                            error=AirbyteErrorTraceMessage(
+                                message=f"Error starting the sync. This could be due to an invalid configuration or catalog. Please contact Support for assistance. Error: {error}",
+                                stack_trace=traceback.format_exc(),
+                            ),
+                        ),
+                    )
+                )
+            ).decode()
+        )
+        return None
+
+
 def handle_local_manifest_command(args: List[str]) -> None:
-    source = SourceLocalYaml()
+    source = _get_local_yaml_source(args)
     launch(source, args)
 
 

--- a/airbyte-integrations/connectors/source-declarative-manifest/source_declarative_manifest/run.py
+++ b/airbyte-integrations/connectors/source-declarative-manifest/source_declarative_manifest/run.py
@@ -20,6 +20,7 @@ from airbyte_cdk.models import (
     AirbyteMessageSerializer,
     AirbyteTraceMessage,
     ConfiguredAirbyteCatalog,
+    ConnectorSpecificationSerializer,
     TraceType,
     Type,
 )

--- a/airbyte-integrations/connectors/source-declarative-manifest/source_declarative_manifest/run.py
+++ b/airbyte-integrations/connectors/source-declarative-manifest/source_declarative_manifest/run.py
@@ -89,7 +89,7 @@ def _get_local_yaml_source(args: List[str]):
                 )
             ).decode()
         )
-        return None
+        raise error
 
 
 def handle_local_manifest_command(args: List[str]) -> None:

--- a/docs/integrations/sources/low-code.md
+++ b/docs/integrations/sources/low-code.md
@@ -9,6 +9,7 @@ The changelog below is automatically updated by the `bump_version` command as pa
 
 | Version | Date       | Pull Request                                             | Subject                                                              |
 | :------ | :--------- | :------------------------------------------------------- | :------------------------------------------------------------------- |
+| 6.1.2 | 2024-11-05 | [48344](https://github.com/airbytehq/airbyte/pull/48344) | Fix discover failing on new CDK |
 | 6.1.1 | 2024-11-04 | [36501](https://github.com/airbytehq/airbyte/pull/36501) | Bump CDK version to 6.1.1 |
 | 6.1.0 | 2024-10-31 | [36501](https://github.com/airbytehq/airbyte/pull/36501) | Bump CDK version to 6.1.0 |
 | 6.0.0 | 2024-10-30 | [36501](https://github.com/airbytehq/airbyte/pull/36501) | Bump CDK version to 6.0.0 |


### PR DESCRIPTION
## What
Update source-declarative-manifest to CDK version 6.X

## How
Following [the migration guide](https://github.com/airbytehq/airbyte/blob/master/airbyte-cdk/python/cdk-migrations.md#upgrading-to-6xx), we need to pass the catalog, config and state when initializing the source now.

## User Impact
Example using source-datascope

### Output on version 0.2.3
```
{"type":"CATALOG","catalog":{"streams":[{"name":"locations","json_schema":{"$schema":"http://json-schema.org/draft-04/schema#","type":"object","properties":{"id":{"type":"integer"},"name":{"type":"string"},"description":{"type":["string","null"]},"code":{"type":["string","null"]},"address":{"type":["string","null"]},"city":{"type":["string","null"]},"country":{"type":["string","null"]},"latitude":{"type":["number","null"]},"longitude":{"type":["number","null"]},"region":{"type":["string","null"]},"phone":{"type":["string","null"]},"company_code":{"type":["string","null"]},"company_name":{"type":["string","null"]}}},"supported_sync_modes":["full_refresh"],"source_defined_primary_key":[["id"]],"is_resumable":true},{"name":"answers","json_schema":{"$schema":"http://json-schema.org/draft-07/schema#","type":"object","properties":{"form_name":{"type":"string"},"form_state":{"type":["string","null"]},"user_name":{"type":"string"},"user_identifier":{"type":"string"},"code":{"type":"string"},"form_id":{"type":"integer"},"created_at":{"type":"string"},"form_answer_id":{"type":"integer"},"latitude":{"type":["number","null"]},"longitude":{"type":["number","null"]},"[question_name1]":{"type":"string"},"[question_name2]":{"type":"string"},"[question_name3]":{"type":"string"}}},"supported_sync_modes":["full_refresh","incremental"],"source_defined_cursor":true,"default_cursor_field":["created_at"],"source_defined_primary_key":[["form_answer_id"]],"is_resumable":true},{"name":"lists","json_schema":{"$schema":"http://json-schema.org/draft-07/schema#","type":"object","properties":{"id":{"type":"integer"},"name":{"type":"string"},"description":{"type":"string"},"attribute1":{"type":"string"},"attribute2":{"type":"string"},"list_id":{"type":"integer"},"account_id":{"type":"integer"},"code":{"type":"string"},"created_at":{"type":"string"},"updated_at":{"type":"string"}}},"supported_sync_modes":["full_refresh"],"source_defined_primary_key":[["id"]],"is_resumable":true},{"name":"notifications","json_schema":{"$schema":"http://json-schema.org/draft-04/schema#","type":"object","properties":{"id":{"type":"integer"},"type":{"type":"string"},"url":{"type":"string"},"form_name":{"type":"string"},"form_code":{"type":"string"},"user":{"type":"string"},"created_at":{"type":"string"}}},"supported_sync_modes":["full_refresh","incremental"],"source_defined_cursor":true,"default_cursor_field":["created_at"],"source_defined_primary_key":[["id"]],"is_resumable":true}]}}
```

### Output on version 0.2.4
```
{"type":"CATALOG","catalog":{"streams":[]}}
```

### Output on fixed version
* Copying source-datascope manifest in `airbyte-integrations/connectors/source-declarative-manifest/source_declarative_manifest/manifest.yaml`
* Updating [this line](https://github.com/airbytehq/airbyte/blob/eb18c21d43eeec789f2cba16e10bbc94f795ac52/airbyte-integrations/connectors/source-declarative-manifest/source_declarative_manifest/run.py#L41) to reference the copied manifest

The output is the following:
```
{"type":"CATALOG","catalog":{"streams":[{"name":"answers","json_schema":{"$schema":"http://json-schema.org/draft-07/schema#","type":"object","properties":{"form_name":{"type":"string"},"form_state":{"type":["string","null"]},"user_name":{"type":"string"},"user_identifier":{"type":"string"},"code":{"type":"string"},"form_id":{"type":"integer"},"created_at":{"type":"string"},"form_answer_id":{"type":"integer"},"latitude":{"type":["number","null"]},"longitude":{"type":["number","null"]},"[question_name1]":{"type":"string"},"[question_name2]":{"type":"string"},"[question_name3]":{"type":"string"}}},"supported_sync_modes":["full_refresh","incremental"],"source_defined_cursor":true,"default_cursor_field":["created_at"],"source_defined_primary_key":[["form_answer_id"]],"is_resumable":true},{"name":"notifications","json_schema":{"$schema":"http://json-schema.org/draft-04/schema#","type":"object","properties":{"id":{"type":"integer"},"type":{"type":"string"},"url":{"type":"string"},"form_name":{"type":"string"},"form_code":{"type":"string"},"user":{"type":"string"},"created_at":{"type":"string"}}},"supported_sync_modes":["full_refresh","incremental"],"source_defined_cursor":true,"default_cursor_field":["created_at"],"source_defined_primary_key":[["id"]],"is_resumable":true},{"name":"locations","json_schema":{"$schema":"http://json-schema.org/draft-04/schema#","type":"object","properties":{"id":{"type":"integer"},"name":{"type":"string"},"description":{"type":["string","null"]},"code":{"type":["string","null"]},"address":{"type":["string","null"]},"city":{"type":["string","null"]},"country":{"type":["string","null"]},"latitude":{"type":["number","null"]},"longitude":{"type":["number","null"]},"region":{"type":["string","null"]},"phone":{"type":["string","null"]},"company_code":{"type":["string","null"]},"company_name":{"type":["string","null"]}}},"supported_sync_modes":["full_refresh"],"source_defined_primary_key":[["id"]],"is_resumable":true},{"name":"lists","json_schema":{"$schema":"http://json-schema.org/draft-07/schema#","type":"object","properties":{"id":{"type":"integer"},"name":{"type":"string"},"description":{"type":"string"},"attribute1":{"type":"string"},"attribute2":{"type":"string"},"list_id":{"type":"integer"},"account_id":{"type":"integer"},"code":{"type":"string"},"created_at":{"type":"string"},"updated_at":{"type":"string"}}},"supported_sync_modes":["full_refresh"],"source_defined_primary_key":[["id"]],"is_resumable":true}]}}
```

As you can see, the order of the streams changes but this should not have any impact.

## Can this PR be safely reverted and rolled back?
- [X] YES 💚
- [ ] NO ❌
