### PR TITLE
Concurrent cursor support multiple formats

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -172,7 +172,7 @@ from airbyte_cdk.sources.declarative.transformations.keys_to_lower_transformatio
 from airbyte_cdk.sources.message import InMemoryMessageRepository, LogAppenderMessageRepositoryDecorator, MessageRepository
 from airbyte_cdk.sources.streams.concurrent.cursor import ConcurrentCursor, CursorField
 from airbyte_cdk.sources.streams.concurrent.state_converters.datetime_stream_state_converter import (
-    CustomOutputFormatConcurrentStreamStateConverter,
+    CustomFormatConcurrentStreamStateConverter,
     DateTimeStreamStateConverter,
     EpochValueConcurrentStreamStateConverter,
 )
@@ -532,8 +532,9 @@ class ModelToComponentFactory:
         if datetime_format == self.EPOCH_DATETIME_FORMAT:
             connector_state_converter = EpochValueConcurrentStreamStateConverter(is_sequential_state=True)
         else:
-            connector_state_converter = CustomOutputFormatConcurrentStreamStateConverter(
+            connector_state_converter = CustomFormatConcurrentStreamStateConverter(
                 datetime_format=datetime_format,
+                input_datetime_formats=datetime_based_cursor_model.cursor_datetime_formats,
                 is_sequential_state=True,
                 cursor_granularity=cursor_granularity,
                 # type: ignore  # Having issues w/ inspection for GapType and CursorValueType as shown in existing tests. Confirmed functionality is working in practice

--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/concurrent/state_converters/datetime_stream_state_converter.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/concurrent/state_converters/datetime_stream_state_converter.py
@@ -179,13 +179,14 @@ class CustomFormatConcurrentStreamStateConverter(IsoMillisConcurrentStreamStateC
         super().__init__(is_sequential_state=is_sequential_state, cursor_granularity=cursor_granularity)
         self._datetime_format = datetime_format
         self._input_datetime_formats = input_datetime_formats if input_datetime_formats else []
+        self._input_datetime_formats += [self._datetime_format]
         self._parser = DatetimeParser()
 
     def output_format(self, timestamp: datetime) -> str:
         return timestamp.strftime(self._datetime_format)
 
     def parse_timestamp(self, timestamp: str) -> datetime:
-        for datetime_format in self._input_datetime_formats + [self._datetime_format]:
+        for datetime_format in self._input_datetime_formats:
             try:
                 return self._parser.parse(timestamp, datetime_format)
             except ValueError:

--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/concurrent/state_converters/datetime_stream_state_converter.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/concurrent/state_converters/datetime_stream_state_converter.py
@@ -169,7 +169,7 @@ class CustomFormatConcurrentStreamStateConverter(IsoMillisConcurrentStreamStateC
     incoming state in any valid datetime format via Pendulum.
     """
 
-    def __init__(self, datetime_format: str, input_datetime_formats: Optional[List[str]], is_sequential_state: bool = True, cursor_granularity: Optional[timedelta] = None):
+    def __init__(self, datetime_format: str, input_datetime_formats: Optional[List[str]] = None, is_sequential_state: bool = True, cursor_granularity: Optional[timedelta] = None):
         super().__init__(is_sequential_state=is_sequential_state, cursor_granularity=cursor_granularity)
         self._datetime_format = datetime_format
         self._input_datetime_formats = input_datetime_formats if input_datetime_formats else []

--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/concurrent/state_converters/datetime_stream_state_converter.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/concurrent/state_converters/datetime_stream_state_converter.py
@@ -169,7 +169,13 @@ class CustomFormatConcurrentStreamStateConverter(IsoMillisConcurrentStreamStateC
     incoming state in any valid datetime format via Pendulum.
     """
 
-    def __init__(self, datetime_format: str, input_datetime_formats: Optional[List[str]] = None, is_sequential_state: bool = True, cursor_granularity: Optional[timedelta] = None):
+    def __init__(
+        self,
+        datetime_format: str,
+        input_datetime_formats: Optional[List[str]] = None,
+        is_sequential_state: bool = True,
+        cursor_granularity: Optional[timedelta] = None,
+    ):
         super().__init__(is_sequential_state=is_sequential_state, cursor_granularity=cursor_granularity)
         self._datetime_format = datetime_format
         self._input_datetime_formats = input_datetime_formats if input_datetime_formats else []

--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/concurrent/state_converters/datetime_stream_state_converter.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/concurrent/state_converters/datetime_stream_state_converter.py
@@ -4,9 +4,13 @@
 
 from abc import abstractmethod
 from datetime import datetime, timedelta, timezone
-from typing import Any, Callable, MutableMapping, Optional, Tuple
+from typing import Any, Callable, List, MutableMapping, Optional, Tuple
 
 import pendulum
+
+# FIXME We would eventually like the Concurrent package do be agnostic of the declarative package. However, this is a breaking change and
+#  the goal in the short term is only to fix the issue we are seeing for source-declarative-manifest.
+from airbyte_cdk.sources.declarative.datetime.datetime_parser import DatetimeParser
 from airbyte_cdk.sources.streams.concurrent.cursor import CursorField
 from airbyte_cdk.sources.streams.concurrent.state_converters.abstract_stream_state_converter import (
     AbstractStreamStateConverter,
@@ -159,15 +163,25 @@ class IsoMillisConcurrentStreamStateConverter(DateTimeStreamStateConverter):
         return dt_object  # type: ignore  # we are manually type checking because pendulum.parse may return different types
 
 
-class CustomOutputFormatConcurrentStreamStateConverter(IsoMillisConcurrentStreamStateConverter):
+class CustomFormatConcurrentStreamStateConverter(IsoMillisConcurrentStreamStateConverter):
     """
     Datetime State converter that emits state according to the supplied datetime format. The converter supports reading
     incoming state in any valid datetime format via Pendulum.
     """
 
-    def __init__(self, datetime_format: str, is_sequential_state: bool = True, cursor_granularity: Optional[timedelta] = None):
+    def __init__(self, datetime_format: str, input_datetime_formats: Optional[List[str]], is_sequential_state: bool = True, cursor_granularity: Optional[timedelta] = None):
         super().__init__(is_sequential_state=is_sequential_state, cursor_granularity=cursor_granularity)
         self._datetime_format = datetime_format
+        self._input_datetime_formats = input_datetime_formats if input_datetime_formats else []
+        self._parser = DatetimeParser()
 
     def output_format(self, timestamp: datetime) -> str:
         return timestamp.strftime(self._datetime_format)
+
+    def parse_timestamp(self, timestamp: str) -> datetime:
+        for datetime_format in self._input_datetime_formats + [self._datetime_format]:
+            try:
+                return self._parser.parse(timestamp, datetime_format)
+            except ValueError:
+                pass
+        raise ValueError(f"No format in {self._input_datetime_formats} matching {timestamp}")

--- a/airbyte-cdk/python/unit_tests/sources/declarative/parsers/test_model_to_component_factory.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/parsers/test_model_to_component_factory.py
@@ -96,7 +96,7 @@ from airbyte_cdk.sources.declarative.transformations.add_fields import AddedFiel
 from airbyte_cdk.sources.declarative.yaml_declarative_source import YamlDeclarativeSource
 from airbyte_cdk.sources.streams.concurrent.cursor import ConcurrentCursor
 from airbyte_cdk.sources.streams.concurrent.state_converters.datetime_stream_state_converter import (
-    CustomOutputFormatConcurrentStreamStateConverter,
+    CustomFormatConcurrentStreamStateConverter,
 )
 from airbyte_cdk.sources.streams.http.error_handlers.response_models import ResponseAction
 from airbyte_cdk.sources.streams.http.requests_native_auth.oauth import SingleUseRefreshTokenOauth2Authenticator
@@ -2648,7 +2648,7 @@ def test_create_concurrent_cursor_from_datetime_based_cursor_all_fields(stream_s
     assert concurrent_cursor._end_provider() == expected_end
     assert concurrent_cursor._concurrent_state == expected_concurrent_state
 
-    assert isinstance(stream_state_converter, CustomOutputFormatConcurrentStreamStateConverter)
+    assert isinstance(stream_state_converter, CustomFormatConcurrentStreamStateConverter)
     assert stream_state_converter._datetime_format == expected_datetime_format
     assert stream_state_converter._is_sequential_state
     assert stream_state_converter._cursor_granularity == expected_cursor_granularity

--- a/airbyte-cdk/python/unit_tests/sources/declarative/test_concurrent_declarative_source.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/test_concurrent_declarative_source.py
@@ -462,7 +462,7 @@ def test_create_concurrent_cursor():
 
     incoming_locations_state = {
         "slices": [
-            {"start": "2024-07-01T00:00:00.000Z", "end": "2024-07-31T00:00:00.000Z"},
+            {"start": "2024-07-01T00:00:00", "end": "2024-07-31T00:00:00"},
         ],
         "state_type": "date-range"
     }

--- a/airbyte-cdk/python/unit_tests/sources/streams/concurrent/test_adapters.py
+++ b/airbyte-cdk/python/unit_tests/sources/streams/concurrent/test_adapters.py
@@ -22,7 +22,7 @@ from airbyte_cdk.sources.streams.concurrent.cursor import Cursor
 from airbyte_cdk.sources.streams.concurrent.exceptions import ExceptionWithDisplayMessage
 from airbyte_cdk.sources.streams.concurrent.partitions.record import Record
 from airbyte_cdk.sources.streams.concurrent.state_converters.datetime_stream_state_converter import (
-    CustomOutputFormatConcurrentStreamStateConverter,
+    CustomFormatConcurrentStreamStateConverter,
 )
 from airbyte_cdk.sources.streams.core import Stream
 from airbyte_cdk.sources.types import StreamSlice
@@ -377,7 +377,7 @@ def test_cursor_partition_generator():
     stream = Mock()
     cursor = Mock()
     message_repository = Mock()
-    connector_state_converter = CustomOutputFormatConcurrentStreamStateConverter(datetime_format="%Y-%m-%dT%H:%M:%S")
+    connector_state_converter = CustomFormatConcurrentStreamStateConverter(datetime_format="%Y-%m-%dT%H:%M:%S")
     cursor_field = Mock()
     slice_boundary_fields = ("start", "end")
 

--- a/airbyte-cdk/python/unit_tests/sources/streams/concurrent/test_datetime_state_converter.py
+++ b/airbyte-cdk/python/unit_tests/sources/streams/concurrent/test_datetime_state_converter.py
@@ -379,6 +379,7 @@ def test_given_multiple_input_datetime_format_when_parse_timestamp_then_iterate_
 
     assert parsed_datetime == datetime(2024, 1, 1, tzinfo=timezone.utc)
 
+
 def test_given_when_parse_timestamp_then_eventually_fallback_on_output_format():
     output_format = "%Y-%m-%dT%H:%M:%S"
     input_formats = ["%Y-%m-%dT%H:%M:%S.%f", "%Y-%m-%d"]

--- a/airbyte-cdk/python/unit_tests/sources/streams/concurrent/test_datetime_state_converter.py
+++ b/airbyte-cdk/python/unit_tests/sources/streams/concurrent/test_datetime_state_converter.py
@@ -8,6 +8,7 @@ import pytest
 from airbyte_cdk.sources.streams.concurrent.cursor import CursorField
 from airbyte_cdk.sources.streams.concurrent.state_converters.abstract_stream_state_converter import ConcurrencyCompatibleStateType
 from airbyte_cdk.sources.streams.concurrent.state_converters.datetime_stream_state_converter import (
+    CustomFormatConcurrentStreamStateConverter,
     EpochValueConcurrentStreamStateConverter,
     IsoMillisConcurrentStreamStateConverter,
 )
@@ -367,3 +368,22 @@ def test_convert_to_sequential_state(converter, concurrent_state, expected_outpu
 def test_convert_to_sequential_state_no_slices_returns_legacy_state(converter, concurrent_state, expected_output_state):
     with pytest.raises(RuntimeError):
         converter.convert_to_state_message(CursorField("created"), concurrent_state)
+
+
+def test_given_multiple_input_datetime_format_when_parse_timestamp_then_iterate_until_successful_parsing():
+    output_format = "%Y-%m-%dT%H:%M:%S"
+    input_formats = ["%Y-%m-%dT%H:%M:%S.%f", "%Y-%m-%d"]
+    converter = CustomFormatConcurrentStreamStateConverter(output_format, input_formats)
+
+    parsed_datetime = converter.parse_timestamp("2024-01-01")
+
+    assert parsed_datetime == datetime(2024, 1, 1, tzinfo=timezone.utc)
+
+def test_given_when_parse_timestamp_then_eventually_fallback_on_output_format():
+    output_format = "%Y-%m-%dT%H:%M:%S"
+    input_formats = ["%Y-%m-%dT%H:%M:%S.%f", "%Y-%m-%d"]
+    converter = CustomFormatConcurrentStreamStateConverter(output_format, input_formats)
+
+    parsed_datetime = converter.parse_timestamp("2024-01-01T02:00:00")
+
+    assert parsed_datetime == datetime(2024, 1, 1, 2, 0, 0, tzinfo=timezone.utc)


### PR DESCRIPTION
## What
Following [the PR to fix SDM](https://github.com/airbytehq/airbyte/pull/48344), we have seen that there was a CDK error popping up related to pendulum not being able to parse a datetime. 

## How
Support the same datetime parsing than `DatetimeBasedCursor` as part of the `CustomFormatConcurrentStreamStateConverter`

## User Impact
We should be able to unblock the release of datascope

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [X] YES 💚
- [ ] NO ❌
