### PR TITLE
Bulk L oad CDK: Add Avro/Parquet Mapper Pipelines to Writers

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/integrationTest/kotlin/io/airbyte/cdk/load/mock_integration_test/MockDestinationWriter.kt
+++ b/airbyte-cdk/bulk/core/load/src/integrationTest/kotlin/io/airbyte/cdk/load/mock_integration_test/MockDestinationWriter.kt
@@ -80,7 +80,7 @@ class MockStreamLoader(override val stream: DestinationStream) : StreamLoader {
                             stream.generationId,
                             it.data as ObjectValue,
                             OutputRecord.Meta(
-                                changes = it.meta?.changes ?: mutableListOf(),
+                                changes = it.meta?.changes ?: listOf(),
                                 syncId = stream.syncId
                             ),
                         )

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/AirbyteSchemaIdentityMapper.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/AirbyteSchemaIdentityMapper.kt
@@ -8,6 +8,10 @@ interface AirbyteSchemaMapper {
     fun map(schema: AirbyteType): AirbyteType
 }
 
+class AirbyteSchemaNoopMapper : AirbyteSchemaMapper {
+    override fun map(schema: AirbyteType): AirbyteType = schema
+}
+
 interface AirbyteSchemaIdentityMapper : AirbyteSchemaMapper {
     override fun map(schema: AirbyteType): AirbyteType =
         when (schema) {

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/DestinationRecordToAirbyteValueWithMeta.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/DestinationRecordToAirbyteValueWithMeta.kt
@@ -10,7 +10,7 @@ import io.airbyte.cdk.load.message.DestinationRecord.Meta
 import java.util.*
 
 class DestinationRecordToAirbyteValueWithMeta(val stream: DestinationStream) {
-    fun convert(data: AirbyteValue, emittedAtMs: Long, meta: DestinationRecord.Meta?): ObjectValue {
+    fun convert(data: AirbyteValue, emittedAtMs: Long, meta: Meta?): ObjectValue {
         return ObjectValue(
             linkedMapOf(
                 Meta.COLUMN_NAME_AB_RAW_ID to StringValue(UUID.randomUUID().toString()),
@@ -40,6 +40,11 @@ class DestinationRecordToAirbyteValueWithMeta(val stream: DestinationStream) {
         )
     }
 }
+
+fun Pair<AirbyteValue, List<DestinationRecord.Change>>.withAirbyteMeta(
+    stream: DestinationStream,
+    emittedAtMs: Long
+) = DestinationRecordToAirbyteValueWithMeta(stream).convert(first, emittedAtMs, Meta(second))
 
 fun DestinationRecord.dataWithAirbyteMeta(stream: DestinationStream) =
     DestinationRecordToAirbyteValueWithMeta(stream).convert(data, emittedAtMs, meta)

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/MapperPipeline.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/MapperPipeline.kt
@@ -23,13 +23,16 @@ class MapperPipeline(
         finalSchema = schemas.last()
     }
 
-    fun map(data: AirbyteValue): Pair<AirbyteValue, List<Change>> {
+    fun map(data: AirbyteValue, changes: List<Change>? = null): Pair<AirbyteValue, List<Change>> {
         val results =
             schemasWithMappers.runningFold(data) { value, (schema, mapper) ->
                 mapper.map(value, schema)
             }
         val changesFlattened =
-            schemasWithMappers.flatMap { it.second.collectedChanges }.toSet().toList()
+            schemasWithMappers
+                .flatMap { it.second.collectedChanges + (changes ?: emptyList()) }
+                .toSet()
+                .toList()
         return results.last() to changesFlattened
     }
 }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/MergeUnions.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/MergeUnions.kt
@@ -44,11 +44,10 @@ class MergeUnions : AirbyteSchemaIdentityMapper {
                         continue
                     }
 
-                    if (existingField != field) {
-                        throw IllegalArgumentException(
-                            "Cannot merge unions of objects with different types for the same field"
-                        )
-                    }
+                    // Combine the fields, recursively merging unions, object fields, etc
+                    val mergedFields = mapUnion(UnionType(listOf(existingField.type, field.type)))
+                    newProperties[name] =
+                        FieldType(mergedFields, existingField.nullable || field.nullable)
 
                     // If the fields are identical, we can just keep the existing field
                 }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/SchemalessTypesToJson.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/SchemalessTypesToJson.kt
@@ -12,6 +12,7 @@ class SchemalessTypesToJson : AirbyteSchemaIdentityMapper {
     override fun mapObjectWithEmptySchema(schema: ObjectTypeWithEmptySchema): AirbyteType =
         StringType
     override fun mapArrayWithoutSchema(schema: ArrayTypeWithoutSchema): AirbyteType = StringType
+    override fun mapUnknown(schema: UnknownType): AirbyteType = StringType
 }
 
 class SchemalessValuesToJson : AirbyteValueIdentityMapper() {
@@ -30,4 +31,6 @@ class SchemalessValuesToJson : AirbyteValueIdentityMapper() {
         schema: ArrayTypeWithoutSchema,
         path: List<String>
     ): AirbyteValue = value.toJson().serializeToString().let(::StringValue)
+    override fun mapUnknown(value: UnknownValue, path: List<String>): AirbyteValue =
+        StringValue(value.what)
 }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/TimeStringToInteger.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/TimeStringToInteger.kt
@@ -13,18 +13,6 @@ import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
 
-class TimeStringTypeToIntegerType : AirbyteSchemaIdentityMapper {
-    override fun mapDate(schema: DateType): AirbyteType = IntegerType
-    override fun mapTimeTypeWithTimezone(schema: TimeTypeWithTimezone): AirbyteType = IntegerType
-    override fun mapTimeTypeWithoutTimezone(schema: TimeTypeWithoutTimezone): AirbyteType =
-        IntegerType
-    override fun mapTimestampTypeWithTimezone(schema: TimestampTypeWithTimezone): AirbyteType =
-        IntegerType
-    override fun mapTimestampTypeWithoutTimezone(
-        schema: TimestampTypeWithoutTimezone
-    ): AirbyteType = IntegerType
-}
-
 /**
  * NOTE: To keep parity with the old avro/parquet code, we will always first try to parse the value
  * as with timezone, then fall back to without. But in theory we should be more strict.

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/DestinationMessage.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/DestinationMessage.kt
@@ -62,7 +62,7 @@ data class DestinationRecord(
         serialized = "",
     )
 
-    data class Meta(val changes: MutableList<Change> = mutableListOf()) {
+    data class Meta(val changes: List<Change> = mutableListOf()) {
         companion object {
             const val COLUMN_NAME_AB_RAW_ID: String = "_airbyte_raw_id"
             const val COLUMN_NAME_AB_EXTRACTED_AT: String = "_airbyte_extracted_at"

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/data/AirbyteValueIdentityMapperTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/data/AirbyteValueIdentityMapperTest.kt
@@ -52,7 +52,8 @@ class AirbyteValueIdentityMapperTest {
                 .with(
                     TimestampValue("2021-01-01T12:00:00Z"),
                     TimeTypeWithTimezone,
-                    nameOverride = "bad"
+                    nameOverride = "bad",
+                    nullable = true
                 )
                 .build()
         val mapper = AirbyteValueIdentityMapper()

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/data/MapperPipelineTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/data/MapperPipelineTest.kt
@@ -114,4 +114,16 @@ class MapperPipelineTest {
 
         Assertions.assertEquals(2, changes.size, "two failures were captured")
     }
+
+    @Test
+    fun testFailedMappingThrowsOnNonNullable() {
+        val (inputValue, inputSchema, _) =
+            ValueTestBuilder<Root>()
+                .with(IntegerValue(2), IntegerType, NullValue, nullable = false) // fail: reject 2
+                .build()
+
+        val pipeline = makePipeline(inputSchema)
+
+        Assertions.assertThrows(IllegalStateException::class.java) { pipeline.map(inputValue) }
+    }
 }

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/data/MergeUnionsTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/data/MergeUnionsTest.kt
@@ -8,7 +8,6 @@ import io.airbyte.cdk.load.test.util.Root
 import io.airbyte.cdk.load.test.util.SchemaRecordBuilder
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 
 class MergeUnionsTest {
     @Test
@@ -41,10 +40,25 @@ class MergeUnionsTest {
     }
 
     @Test
-    fun testNameClashFails() {
-        val (inputSchema, _) =
+    fun testNameClash() {
+        val (inputSchema, expectedOutput) =
             SchemaRecordBuilder<Root>()
-                .withUnion()
+                .withUnion(
+                    expectedInstead =
+                        FieldType(
+                            ObjectType(
+                                properties =
+                                    linkedMapOf(
+                                        "foo" to
+                                            FieldType(
+                                                UnionType(listOf(StringType, IntegerType)),
+                                                false
+                                            )
+                                    )
+                            ),
+                            false
+                        )
+                )
                 .withRecord()
                 .with(StringType, nameOverride = "foo")
                 .endRecord()
@@ -53,7 +67,8 @@ class MergeUnionsTest {
                 .endRecord()
                 .endUnion()
                 .build()
-        assertThrows<IllegalArgumentException> { MergeUnions().map(inputSchema) }
+        val output = MergeUnions().map(inputSchema)
+        Assertions.assertEquals(expectedOutput, output)
     }
 
     @Test

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/data/TimeStringToIntegerTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/data/TimeStringToIntegerTest.kt
@@ -4,8 +4,6 @@
 
 package io.airbyte.cdk.load.data
 
-import io.airbyte.cdk.load.test.util.Root
-import io.airbyte.cdk.load.test.util.SchemaRecordBuilder
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 
@@ -119,32 +117,5 @@ class TimeStringToIntegerTest {
                 "Failed for ${it.first} to ${it.second}"
             )
         }
-    }
-
-    @Test
-    fun testBasicSchemaBehavior() {
-        val (inputSchema, expectedOutput) =
-            SchemaRecordBuilder<Root>()
-                .with(DateType, IntegerType)
-                .withRecord()
-                .with(TimestampTypeWithTimezone, IntegerType)
-                .endRecord()
-                .with(TimestampTypeWithoutTimezone, IntegerType)
-                .withRecord()
-                .with(TimeTypeWithTimezone, IntegerType)
-                .withRecord()
-                .with(TimeTypeWithoutTimezone, IntegerType)
-                .endRecord()
-                .endRecord()
-                .withUnion(
-                    expectedInstead =
-                        FieldType(UnionType(listOf(IntegerType, IntegerType)), nullable = false)
-                )
-                .with(DateType)
-                .with(TimeTypeWithTimezone)
-                .endUnion()
-                .build()
-        val output = TimeStringTypeToIntegerType().map(inputSchema)
-        Assertions.assertEquals(expectedOutput, output)
     }
 }

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/OutputRecord.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/OutputRecord.kt
@@ -29,7 +29,7 @@ data class OutputRecord(
      * that we write to the destination.
      */
     data class Meta(
-        val changes: MutableList<Change> = mutableListOf(),
+        val changes: List<Change> = listOf(),
         val syncId: Long? = null,
     )
 

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/write/BasicFunctionalityIntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/write/BasicFunctionalityIntegrationTest.kt
@@ -1488,25 +1488,26 @@ abstract class BasicFunctionalityIntegrationTest(
                         "struct" to
                             FieldType(
                                 ObjectType(linkedMapOf("foo" to numberType)),
-                                nullable = false
+                                nullable = true
                             ),
                         "struct_schemaless" to
-                            FieldType(ObjectTypeWithEmptySchema, nullable = false),
-                        "struct_empty" to FieldType(ObjectTypeWithEmptySchema, nullable = false),
-                        "array" to FieldType(ArrayType(numberType), nullable = false),
-                        "array_schemaless" to FieldType(ArrayTypeWithoutSchema, nullable = false),
-                        "string" to FieldType(StringType, nullable = false),
-                        "number" to FieldType(NumberType, nullable = false),
-                        "boolean" to FieldType(BooleanType, nullable = false),
+                            FieldType(ObjectTypeWithEmptySchema, nullable = true),
+                        "struct_empty" to FieldType(ObjectTypeWithEmptySchema, nullable = true),
+                        "array" to FieldType(ArrayType(numberType), nullable = true),
+                        "array_schemaless" to FieldType(ArrayTypeWithoutSchema, nullable = true),
+                        "string" to FieldType(StringType, nullable = true),
+                        "number" to FieldType(NumberType, nullable = true),
+                        "integer" to FieldType(IntegerType, nullable = true),
+                        "boolean" to FieldType(BooleanType, nullable = true),
                         "timestamp_with_timezone" to
-                            FieldType(TimestampTypeWithTimezone, nullable = false),
+                            FieldType(TimestampTypeWithTimezone, nullable = true),
                         "timestamp_without_timezone" to
-                            FieldType(TimestampTypeWithoutTimezone, nullable = false),
-                        "time_with_timezone" to FieldType(TimeTypeWithTimezone, nullable = false),
+                            FieldType(TimestampTypeWithoutTimezone, nullable = true),
+                        "time_with_timezone" to FieldType(TimeTypeWithTimezone, nullable = true),
                         "time_without_timezone" to
-                            FieldType(TimeTypeWithoutTimezone, nullable = false),
-                        "date" to FieldType(DateType, nullable = false),
-                        "unknown" to FieldType(UnknownType("test"), nullable = false),
+                            FieldType(TimeTypeWithoutTimezone, nullable = true),
+                        "date" to FieldType(DateType, nullable = true),
+                        "unknown" to FieldType(UnknownType("test"), nullable = true),
                     )
                 ),
                 generationId = 42,
@@ -1879,7 +1880,8 @@ abstract class BasicFunctionalityIntegrationTest(
                         mapOf(
                             "id" to 1,
                             "schematized_object" to mapOf("id" to 1, "name" to "Joe"),
-                            "empty_object" to emptyMap<String, Any?>(),
+                            "empty_object" to
+                                if (stringifySchemalessObjects) "{}" else emptyMap<Any, Any>(),
                             "schemaless_object" to
                                 if (stringifySchemalessObjects) {
                                     """{"uuid":"38F52396-736D-4B23-B5B4-F504D8894B97","probability":1.5}"""
@@ -1891,7 +1893,7 @@ abstract class BasicFunctionalityIntegrationTest(
                                 },
                             "schemaless_array" to
                                 if (stringifySchemalessObjects) {
-                                    """[10,"foo",null,{"bar:"qua"}]"""
+                                    """[10,"foo",null,{"bar":"qua"}]"""
                                 } else {
                                     listOf(10, "foo", null, mapOf("bar" to "qua"))
                                 },
@@ -2137,24 +2139,18 @@ abstract class BasicFunctionalityIntegrationTest(
                             "id" to 1,
                             "combined_type" to maybePromote("string", "string1"),
                             "union_of_objects_with_properties_identical" to
-                                maybePromote("object", mapOf("id" to 10, "name" to "Joe")),
+                                mapOf("id" to 10, "name" to "Joe"),
                             "union_of_objects_with_properties_overlapping" to
-                                maybePromote(
-                                    "object",
-                                    mapOf("id" to 20, "name" to "Jane", "flagged" to true)
-                                ),
+                                mapOf("id" to 20, "name" to "Jane", "flagged" to true),
                             "union_of_objects_with_properties_contradicting" to
-                                maybePromote("object", mapOf("id" to 1, "name" to "Jenny")),
+                                mapOf("id" to maybePromote("integer", 1), "name" to "Jenny"),
                             "union_of_objects_with_properties_nonoverlapping" to
-                                maybePromote(
-                                    "object",
-                                    mapOf(
-                                        "id" to 30,
-                                        "name" to "Phil",
-                                        "flagged" to false,
-                                        "description" to "Very Phil",
-                                    )
-                                ),
+                                mapOf(
+                                    "id" to 30,
+                                    "name" to "Phil",
+                                    "flagged" to false,
+                                    "description" to "Very Phil",
+                                )
                         ),
                     airbyteMeta = OutputRecord.Meta(syncId = 42),
                 ),
@@ -2166,16 +2162,16 @@ abstract class BasicFunctionalityIntegrationTest(
                             "id" to 2,
                             "combined_type" to maybePromote("integer", 20),
                             "union_of_objects_with_properties_identical" to
-                                maybePromote("object", emptyMap<String, Any?>()),
+                                emptyMap<String, Any?>(),
                             "union_of_objects_with_properties_nonoverlapping" to
-                                maybePromote("object", emptyMap<String, Any?>()),
+                                emptyMap<String, Any?>(),
                             "union_of_objects_with_properties_overlapping" to
-                                maybePromote("object", emptyMap<String, Any?>()),
+                                emptyMap<String, Any?>(),
                             "union_of_objects_with_properties_contradicting" to
-                                maybePromote(
-                                    "object",
-                                    mapOf("id" to "seal-one-hippity", "name" to "James")
-                                ),
+                                mapOf(
+                                    "id" to maybePromote("string", "seal-one-hippity"),
+                                    "name" to "James"
+                                )
                         ),
                     airbyteMeta = OutputRecord.Meta(syncId = 42),
                 ),
@@ -2189,7 +2185,7 @@ abstract class BasicFunctionalityIntegrationTest(
                             "union_of_objects_with_properties_identical" to null,
                             "union_of_objects_with_properties_overlapping" to null,
                             "union_of_objects_with_properties_nonoverlapping" to null,
-                            "union_of_objects_with_properties_contradicting" to null,
+                            "union_of_objects_with_properties_contradicting" to null
                         ),
                     airbyteMeta = OutputRecord.Meta(syncId = 42),
                 ),

--- a/airbyte-cdk/bulk/toolkits/load-avro/src/main/kotlin/io/airbyte/cdk/load/data/avro/AirbyteTypeToAvroSchema.kt
+++ b/airbyte-cdk/bulk/toolkits/load-avro/src/main/kotlin/io/airbyte/cdk/load/data/avro/AirbyteTypeToAvroSchema.kt
@@ -35,10 +35,29 @@ class AirbyteTypeToAvroSchema {
                 val builder = SchemaBuilder.record(name).namespace(namespace).fields()
                 airbyteSchema.properties.entries
                     .fold(builder) { acc, (name, field) ->
-                        // NOTE: We will not support nullable at this stage.
-                        // All nullables should have been converted to union[this, null] upstream
-                        // TODO: Enforce this
-                        acc.name(name).type(convert(field.type, path + name)).noDefault()
+                        val converted = convert(field.type, path + name)
+                        acc.name(name).let {
+                            if (field.nullable && converted.type != Schema.Type.UNION) {
+                                it.type(
+                                        SchemaBuilder.unionOf()
+                                            .nullType()
+                                            .and()
+                                            .type(converted)
+                                            .endUnion()
+                                    )
+                                    .withDefault(null)
+                            } else if (field.nullable && converted.type == Schema.Type.UNION) {
+                                converted.types
+                                    .fold(SchemaBuilder.unionOf().nullType()) { acc, type ->
+                                        acc.and().type(type)
+                                    }
+                                    .endUnion()
+                                    .let { union -> it.type(union) }
+                                    .withDefault(null)
+                            } else {
+                                it.type(converted).noDefault()
+                            }
+                        }
                     }
                     .endRecord()
             }
@@ -70,7 +89,7 @@ class AirbyteTypeToAvroSchema {
                 LogicalTypes.timestampMicros().addToSchema(schema)
             }
             is UnionType -> Schema.createUnion(airbyteSchema.options.map { convert(it, path) })
-            is UnknownType -> throw IllegalArgumentException("Unknown type: ${airbyteSchema.what}")
+            is UnknownType -> SchemaBuilder.builder().nullType()
         }
     }
 }

--- a/airbyte-cdk/bulk/toolkits/load-avro/src/main/kotlin/io/airbyte/cdk/load/data/avro/AvroMapperPipelineFactory.kt
+++ b/airbyte-cdk/bulk/toolkits/load-avro/src/main/kotlin/io/airbyte/cdk/load/data/avro/AvroMapperPipelineFactory.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.load.data.avro
+
+import io.airbyte.cdk.load.command.DestinationStream
+import io.airbyte.cdk.load.data.AirbyteSchemaNoopMapper
+import io.airbyte.cdk.load.data.AirbyteValueNoopMapper
+import io.airbyte.cdk.load.data.MapperPipeline
+import io.airbyte.cdk.load.data.MapperPipelineFactory
+import io.airbyte.cdk.load.data.MergeUnions
+import io.airbyte.cdk.load.data.SchemalessTypesToJson
+import io.airbyte.cdk.load.data.SchemalessValuesToJson
+import io.airbyte.cdk.load.data.TimeStringToInteger
+import io.micronaut.context.annotation.Secondary
+import jakarta.inject.Singleton
+
+@Singleton
+@Secondary
+class AvroMapperPipelineFactory : MapperPipelineFactory {
+    override fun create(stream: DestinationStream): MapperPipeline =
+        MapperPipeline(
+            stream.schema,
+            listOf(
+                SchemalessTypesToJson() to SchemalessValuesToJson(),
+                AirbyteSchemaNoopMapper() to TimeStringToInteger(),
+                MergeUnions() to AirbyteValueNoopMapper(),
+            ),
+        )
+}

--- a/airbyte-cdk/bulk/toolkits/load-parquet/src/main/kotlin/io/airbyte/cdk/load/data/parquet/ParquetMapperPipelineFactory.kt
+++ b/airbyte-cdk/bulk/toolkits/load-parquet/src/main/kotlin/io/airbyte/cdk/load/data/parquet/ParquetMapperPipelineFactory.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.load.data.parquet
+
+import io.airbyte.cdk.load.command.DestinationStream
+import io.airbyte.cdk.load.data.AirbyteSchemaNoopMapper
+import io.airbyte.cdk.load.data.AirbyteValueNoopMapper
+import io.airbyte.cdk.load.data.MapperPipeline
+import io.airbyte.cdk.load.data.MapperPipelineFactory
+import io.airbyte.cdk.load.data.MergeUnions
+import io.airbyte.cdk.load.data.SchemalessTypesToJson
+import io.airbyte.cdk.load.data.SchemalessValuesToJson
+import io.airbyte.cdk.load.data.TimeStringToInteger
+import io.airbyte.cdk.load.data.UnionTypeToDisjointRecord
+import io.airbyte.cdk.load.data.UnionValueToDisjointRecord
+import io.micronaut.context.annotation.Secondary
+import jakarta.inject.Singleton
+
+@Singleton
+@Secondary
+class ParquetMapperPipelineFactory : MapperPipelineFactory {
+    override fun create(stream: DestinationStream): MapperPipeline =
+        MapperPipeline(
+            stream.schema,
+            listOf(
+                SchemalessTypesToJson() to SchemalessValuesToJson(),
+                AirbyteSchemaNoopMapper() to TimeStringToInteger(),
+                MergeUnions() to AirbyteValueNoopMapper(),
+                UnionTypeToDisjointRecord() to UnionValueToDisjointRecord(),
+            ),
+        )
+}

--- a/airbyte-integrations/connectors/destination-s3-v2/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-s3-v2/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: file
   connectorType: destination
   definitionId: d6116991-e809-4c7c-ae09-c64712df5b66
-  dockerImageTag: 0.1.16
+  dockerImageTag: 0.2.0
   dockerRepository: airbyte/destination-s3-v2
   githubIssueLabel: destination-s3-v2
   icon: s3.svg

--- a/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2WriteTest.kt
+++ b/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2WriteTest.kt
@@ -150,19 +150,7 @@ class S3V2WriteTestAvroUncompressed :
         preserveUndeclaredFields = false,
         allTypesBehavior = StronglyTyped(),
     ) {
-    @Disabled("Not yet working")
-    @Test
-    override fun testContainerTypes() {
-        super.testContainerTypes()
-    }
-
-    @Disabled("Not yet working")
-    @Test
-    override fun testUnions() {
-        super.testUnions()
-    }
-
-    @Disabled("Not yet working")
+    @Disabled("Test does not support `stringifyShemalessObjects == true`")
     @Test
     override fun testAllTypes() {
         super.testAllTypes()
@@ -177,19 +165,7 @@ class S3V2WriteTestAvroBzip2 :
         preserveUndeclaredFields = false,
         allTypesBehavior = StronglyTyped(),
     ) {
-    @Disabled("Not yet working")
-    @Test
-    override fun testContainerTypes() {
-        super.testContainerTypes()
-    }
-
-    @Disabled("Not yet working")
-    @Test
-    override fun testUnions() {
-        super.testUnions()
-    }
-
-    @Disabled("Not yet working")
+    @Disabled("Test does not support `stringifyShemalessObjects == true`")
     @Test
     override fun testAllTypes() {
         super.testAllTypes()
@@ -204,19 +180,7 @@ class S3V2WriteTestParquetUncompressed :
         preserveUndeclaredFields = false,
         allTypesBehavior = StronglyTyped(),
     ) {
-    @Disabled("Not yet working")
-    @Test
-    override fun testContainerTypes() {
-        super.testContainerTypes()
-    }
-
-    @Disabled("Not yet working")
-    @Test
-    override fun testUnions() {
-        super.testUnions()
-    }
-
-    @Disabled("Not yet working")
+    @Disabled("Test does not support `stringifyShemalessObjects == true`")
     @Test
     override fun testAllTypes() {
         super.testAllTypes()
@@ -231,19 +195,7 @@ class S3V2WriteTestParquetSnappy :
         preserveUndeclaredFields = false,
         allTypesBehavior = StronglyTyped(),
     ) {
-    @Disabled("Not yet working")
-    @Test
-    override fun testContainerTypes() {
-        super.testContainerTypes()
-    }
-
-    @Disabled("Not yet working")
-    @Test
-    override fun testUnions() {
-        super.testUnions()
-    }
-
-    @Disabled("Not yet working")
+    @Disabled("Test does not support `stringifyShemalessObjects == true`")
     @Test
     override fun testAllTypes() {
         super.testAllTypes()


### PR DESCRIPTION
Final PR in this series

### What

Creates specific Avro and Parquet composed transformation pipelines and adds them to the formatting writers used by object storage. Also undisables the relevant integration tests.

Some improvements/fixes along the way
* `MergeUnions` was incorrectly rejecting fields with the same name of different types instead of turning them into unions of the two types
* `AirbyteValueIdentityMapper` was failing casts on `NullValue`s and repeatedly re-nulling the fields. I tightened up the behavior so that null is handled explicitly, and so that any attempt to null out a non-nullable rethrows the exception
* While I was in there I added an outstanding improvement to pass `UnknownValue` through (treat it as a wildcard instead of an error; this is more correct but technically a non-functional change)
* The Avro Schema/Record mappers needed better handling of nullable fields, now that `NullType` is gone. (Avro schemas represent nullables as unions of null with other types)
* tweaks to the ObjectStorageDataDumper so that it uses the final mangled schemas when loading data for diffs