### PR TITLE
Source-snapchat-marketing(fix): re-implement advanced-auth in spec

### DIFF
--- a/airbyte-integrations/connectors/source-snapchat-marketing/manifest.yaml
+++ b/airbyte-integrations/connectors/source-snapchat-marketing/manifest.yaml
@@ -4951,6 +4951,37 @@ spec:
         title: View Attribution Window
         default: 1_DAY
     additionalProperties: true
+  advanced_auth:
+    auth_flow_type: "auth2.0"
+    predicate_key: null,
+    predicate_value: null,
+    oauth_config_specification:
+      oauth_user_input_from_connector_config_specification: null,
+      complete_oauth_output_specification:
+        type: object
+        properties:
+          refresh_token:
+            type: string
+            path_in_connector_config:
+              - refresh_token
+      complete_oauth_server_input_specification:
+        type: object
+        properties:
+          client_id:
+            type: string
+          client_secret:
+            type: string
+      complete_oauth_server_output_specification:
+        type: object
+        properties:
+          client_id:
+            type: string
+            path_in_connector_config:
+              - client_id
+          client_secret:
+            type: string
+            path_in_connector_config:
+              - client_secret
 
 metadata:
   autoImportSchema:

--- a/airbyte-integrations/connectors/source-snapchat-marketing/manifest.yaml
+++ b/airbyte-integrations/connectors/source-snapchat-marketing/manifest.yaml
@@ -4952,7 +4952,7 @@ spec:
         default: 1_DAY
     additionalProperties: true
   advanced_auth:
-    auth_flow_type: "auth2.0"
+    auth_flow_type: "oauth2.0"
     predicate_key: null,
     predicate_value: null,
     oauth_config_specification:

--- a/airbyte-integrations/connectors/source-snapchat-marketing/manifest.yaml
+++ b/airbyte-integrations/connectors/source-snapchat-marketing/manifest.yaml
@@ -4953,17 +4953,22 @@ spec:
     additionalProperties: true
   advanced_auth:
     auth_flow_type: "oauth2.0"
-    predicate_key: null,
-    predicate_value: null,
     oauth_config_specification:
-      oauth_user_input_from_connector_config_specification: null,
+      oauth_user_input_from_connector_config_specification:
+        type: object
+        properties:
+          client_id:
+            type: string
+            path_in_connector_config: ["client_id"]
+          client_secret:
+            type: string
+            path_in_connector_config: ["client_secret"]
       complete_oauth_output_specification:
         type: object
         properties:
           refresh_token:
             type: string
-            path_in_connector_config:
-              - refresh_token
+            path_in_connector_config: ["credentials", "refresh_token"]
       complete_oauth_server_input_specification:
         type: object
         properties:
@@ -4976,12 +4981,10 @@ spec:
         properties:
           client_id:
             type: string
-            path_in_connector_config:
-              - client_id
+            path_in_connector_config: ["credentials", "client_id"]
           client_secret:
             type: string
-            path_in_connector_config:
-              - client_secret
+            path_in_connector_config: ["credentials", "client_secret"]
 
 metadata:
   autoImportSchema:

--- a/airbyte-integrations/connectors/source-snapchat-marketing/manifest.yaml
+++ b/airbyte-integrations/connectors/source-snapchat-marketing/manifest.yaml
@@ -4968,7 +4968,7 @@ spec:
         properties:
           refresh_token:
             type: string
-            path_in_connector_config: ["credentials", "refresh_token"]
+            path_in_connector_config: ["refresh_token"]
       complete_oauth_server_input_specification:
         type: object
         properties:
@@ -4981,10 +4981,10 @@ spec:
         properties:
           client_id:
             type: string
-            path_in_connector_config: ["credentials", "client_id"]
+            path_in_connector_config: ["client_id"]
           client_secret:
             type: string
-            path_in_connector_config: ["credentials", "client_secret"]
+            path_in_connector_config: ["client_secret"]
 
 metadata:
   autoImportSchema:

--- a/airbyte-integrations/connectors/source-snapchat-marketing/metadata.yaml
+++ b/airbyte-integrations/connectors/source-snapchat-marketing/metadata.yaml
@@ -8,7 +8,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 200330b2-ea62-4d11-ac6d-cfe3e3f8ab2b
-  dockerImageTag: 1.3.1
+  dockerImageTag: 1.3.2
   dockerRepository: airbyte/source-snapchat-marketing
   githubIssueLabel: source-snapchat-marketing
   icon: snapchat.svg

--- a/docs/integrations/sources/snapchat-marketing.md
+++ b/docs/integrations/sources/snapchat-marketing.md
@@ -143,6 +143,7 @@ Syncing data with an hourly granularity often generates large data volumes and c
 
 | Version | Date       | Pull Request                                             | Subject                                                                        |
 |:--------|:-----------|:---------------------------------------------------------|:-------------------------------------------------------------------------------|
+| 1.3.2 | 2024-11-05 | [48375](https://github.com/airbytehq/airbyte/pull/48375) | Re-implement advanced_auth in connector spec |
 | 1.3.1 | 2024-10-29 | [47837](https://github.com/airbytehq/airbyte/pull/47837) | Update dependencies |
 | 1.3.0 | 2024-10-15 | [46927](https://github.com/airbytehq/airbyte/pull/46927) | Promoting release candidate 1.3.0-rc.1 to a main version. |
 | 1.3.0-rc.1  | 2024-10-08 | [46570](https://github.com/airbytehq/airbyte/pull/46570) | Migrate to Manifest-only |


### PR DESCRIPTION
## What

The advanced_auth configuration was accidentally removed from Snapchat Marketing in version 1.3.0, when we [migrated the connector to manifest-only format](https://github.com/airbytehq/airbyte/pull/46570). This has led to the removal of the automated auth flow in Cloud. This PR is a patch that reimplements the advanced_auth config in the spec.

## How

- Adds the previously extant advanced_auth configuration to the spec
- Tested by pinning my sandbox connection to a pre-release version and was able to navigate the auth flow successfully.

![Screenshot 2024-11-06 at 11 54 29 AM](https://github.com/user-attachments/assets/eef8d4b6-66ce-4005-81f5-d82057f84cfb)

- Also pinned connector to the last working version 1.2.12, created a connection, synced, and verified that the next sync worked after updating to the pre-release version:

<img width="1446" alt="Screenshot 2024-11-06 at 1 01 28 PM" src="https://github.com/user-attachments/assets/56fad2fa-bcb8-4f6b-b158-5c5a918a43e0">