### PR TITLE
docs: add warning about applications being deleted when migrating to SSO on Cloud

### DIFF
--- a/docs/access-management/sso-providers/azure-entra-id.md
+++ b/docs/access-management/sso-providers/azure-entra-id.md
@@ -61,6 +61,10 @@ You'll need to pass your Airbyte contact the following information of the create
 
 Once we've received this information from you, We'll setup SSO for you and let you know once it's ready to be used.
 
+:::warning
+For security purposes, existing applications to access the Airbyte API created by users before enabling SSO will be disabled once the user that owns the application signs in via SSO for the first time. Ensure to replace application secrets that may have been in use after SSO is enabled.
+:::
+
 </TabItem>
 <TabItem value="Self-Managed" label="Self-Managed">
 

--- a/docs/access-management/sso-providers/azure-entra-id.md
+++ b/docs/access-management/sso-providers/azure-entra-id.md
@@ -62,7 +62,7 @@ You'll need to pass your Airbyte contact the following information of the create
 Once we've received this information from you, We'll setup SSO for you and let you know once it's ready to be used.
 
 :::warning
-For security purposes, existing applications to access the Airbyte API created by users before enabling SSO will be disabled once the user that owns the application signs in via SSO for the first time. After enabling SSO, please make sure to replace any application secrets that were previously in use.
+For security purposes, existing [Applications](https://reference.airbyte.com/reference/authentication) used to access the Airbyte API that were created before enabling SSO **will be disabled** once the user that owns the Application signs in via SSO for the first time. After enabling SSO, please make sure to replace any Application secrets that were previously in use.
 :::
 
 </TabItem>

--- a/docs/access-management/sso-providers/azure-entra-id.md
+++ b/docs/access-management/sso-providers/azure-entra-id.md
@@ -62,7 +62,7 @@ You'll need to pass your Airbyte contact the following information of the create
 Once we've received this information from you, We'll setup SSO for you and let you know once it's ready to be used.
 
 :::warning
-For security purposes, existing applications to access the Airbyte API created by users before enabling SSO will be disabled once the user that owns the application signs in via SSO for the first time. Ensure to replace application secrets that may have been in use after SSO is enabled.
+For security purposes, existing applications to access the Airbyte API created by users before enabling SSO will be disabled once the user that owns the application signs in via SSO for the first time. After enabling SSO, please make sure to replace any application secrets that were previously in use.
 :::
 
 </TabItem>

--- a/docs/access-management/sso-providers/okta.md
+++ b/docs/access-management/sso-providers/okta.md
@@ -65,6 +65,10 @@ On the following screen you'll need to configure all parameters for your Okta ap
     * **Client Secret**
     * **Email Domain** (users signing in from this domain will be required to sign in via SSO)
 
+    :::warning
+    For security purposes, existing applications to access the Airbyte API created by users before enabling SSO will be disabled once the user that owns the application signs in via SSO for the first time. Ensure to replace application secrets that may have been in use after SSO is enabled.
+    :::
+
   </TabItem>
   <TabItem value="self-managed" label="Self Hosted">
     Create the application with the following parameters:

--- a/docs/access-management/sso-providers/okta.md
+++ b/docs/access-management/sso-providers/okta.md
@@ -65,9 +65,9 @@ On the following screen you'll need to configure all parameters for your Okta ap
     * **Client Secret**
     * **Email Domain** (users signing in from this domain will be required to sign in via SSO)
 
-    :::warning
-    For security purposes, existing [Applications](https://reference.airbyte.com/reference/authentication) used to access the Airbyte API that were created before enabling SSO **will be disabled** once the user that owns the Application signs in via SSO for the first time. After enabling SSO, please make sure to replace any Application secrets that were previously in use.
-    :::
+  :::warning
+  For security purposes, existing [Applications](https://reference.airbyte.com/reference/authentication) used to access the Airbyte API that were created before enabling SSO **will be disabled** once the user that owns the Application signs in via SSO for the first time. After enabling SSO, please make sure to replace any Application secrets that were previously in use.
+  :::
 
   </TabItem>
   <TabItem value="self-managed" label="Self Hosted">

--- a/docs/access-management/sso-providers/okta.md
+++ b/docs/access-management/sso-providers/okta.md
@@ -66,7 +66,7 @@ On the following screen you'll need to configure all parameters for your Okta ap
     * **Email Domain** (users signing in from this domain will be required to sign in via SSO)
 
     :::warning
-    For security purposes, existing applications to access the Airbyte API created by users before enabling SSO will be disabled once the user that owns the application signs in via SSO for the first time. After enabling SSO, please make sure to replace any application secrets that were previously in use.
+    For security purposes, existing [Applications](https://reference.airbyte.com/reference/authentication) used to access the Airbyte API that were created before enabling SSO **will be disabled** once the user that owns the Application signs in via SSO for the first time. After enabling SSO, please make sure to replace any Application secrets that were previously in use.
     :::
 
   </TabItem>

--- a/docs/access-management/sso-providers/okta.md
+++ b/docs/access-management/sso-providers/okta.md
@@ -66,7 +66,7 @@ On the following screen you'll need to configure all parameters for your Okta ap
     * **Email Domain** (users signing in from this domain will be required to sign in via SSO)
 
     :::warning
-    For security purposes, existing applications to access the Airbyte API created by users before enabling SSO will be disabled once the user that owns the application signs in via SSO for the first time. Ensure to replace application secrets that may have been in use after SSO is enabled.
+    For security purposes, existing applications to access the Airbyte API created by users before enabling SSO will be disabled once the user that owns the application signs in via SSO for the first time. After enabling SSO, please make sure to replace any application secrets that were previously in use.
     :::
 
   </TabItem>


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->

close https://github.com/airbytehq/airbyte-internal-issues/issues/10449

## How
<!--
* Describe how code changes achieve the solution.
-->

Add docs on entra ID / okta pages informing users that existing applications will be disabled when its owner signs in via SSO for the first time.

<img width="871" alt="Screenshot 2024-11-05 at 8 06 59 PM" src="https://github.com/user-attachments/assets/a241d766-16e7-4bc8-b94e-6798daa6890b">



## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
