### PR TITLE
bugfix: Move to CustomFormatConcurrentStreamStateConverter on epoch as well a…

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py
@@ -174,7 +174,6 @@ from airbyte_cdk.sources.streams.concurrent.cursor import ConcurrentCursor, Curs
 from airbyte_cdk.sources.streams.concurrent.state_converters.datetime_stream_state_converter import (
     CustomFormatConcurrentStreamStateConverter,
     DateTimeStreamStateConverter,
-    EpochValueConcurrentStreamStateConverter,
 )
 from airbyte_cdk.sources.streams.http.error_handlers.response_models import ResponseAction
 from airbyte_cdk.sources.types import Config
@@ -529,16 +528,13 @@ class ModelToComponentFactory:
                 lookback_window = parse_duration(evaluated_lookback_window)
 
         connector_state_converter: DateTimeStreamStateConverter
-        if datetime_format == self.EPOCH_DATETIME_FORMAT:
-            connector_state_converter = EpochValueConcurrentStreamStateConverter(is_sequential_state=True)
-        else:
-            connector_state_converter = CustomFormatConcurrentStreamStateConverter(
-                datetime_format=datetime_format,
-                input_datetime_formats=datetime_based_cursor_model.cursor_datetime_formats,
-                is_sequential_state=True,
-                cursor_granularity=cursor_granularity,
-                # type: ignore  # Having issues w/ inspection for GapType and CursorValueType as shown in existing tests. Confirmed functionality is working in practice
-            )
+        connector_state_converter = CustomFormatConcurrentStreamStateConverter(
+            datetime_format=datetime_format,
+            input_datetime_formats=datetime_based_cursor_model.cursor_datetime_formats,
+            is_sequential_state=True,
+            cursor_granularity=cursor_granularity,
+            # type: ignore  # Having issues w/ inspection for GapType and CursorValueType as shown in existing tests. Confirmed functionality is working in practice
+        )
 
         start_date_runtime_value: Union[InterpolatedString, str, MinMaxDatetime]
         if isinstance(datetime_based_cursor_model.start_datetime, MinMaxDatetimeModel):
@@ -579,7 +575,7 @@ class ModelToComponentFactory:
             )
 
         # When step is not defined, default to a step size from the starting date to the present moment
-        step_length = datetime.datetime.now(tz=datetime.timezone.utc) - start_date
+        step_length = datetime.timedelta.max
         interpolated_step = (
             InterpolatedString.create(datetime_based_cursor_model.step, parameters=datetime_based_cursor_model.parameters or {})
             if datetime_based_cursor_model.step

--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/concurrent/default_stream.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/concurrent/default_stream.py
@@ -73,7 +73,7 @@ class DefaultStream(AbstractStream):
 
         keys = self._primary_key
         if keys and len(keys) > 0:
-            stream.source_defined_primary_key = [keys]
+            stream.source_defined_primary_key = [[key] for key in keys]
 
         return stream
 

--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/concurrent/state_converters/datetime_stream_state_converter.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/concurrent/state_converters/datetime_stream_state_converter.py
@@ -183,7 +183,7 @@ class CustomFormatConcurrentStreamStateConverter(IsoMillisConcurrentStreamStateC
         self._parser = DatetimeParser()
 
     def output_format(self, timestamp: datetime) -> str:
-        return timestamp.strftime(self._datetime_format)
+        return self._parser.format(timestamp, self._datetime_format)
 
     def parse_timestamp(self, timestamp: str) -> datetime:
         for datetime_format in self._input_datetime_formats:

--- a/airbyte-cdk/python/unit_tests/sources/declarative/parsers/test_model_to_component_factory.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/parsers/test_model_to_component_factory.py
@@ -2667,7 +2667,7 @@ def test_create_concurrent_cursor_from_datetime_based_cursor_all_fields(stream_s
             "end_time": None,
             "cursor_granularity": None,
             "step": None,
-        }, "_slice_range", datetime.timedelta(days=61), None, id="test_uses_a_single_time_interval_when_no_specified_step_and_granularity"),
+        }, "_slice_range", datetime.timedelta.max, None, id="test_uses_a_single_time_interval_when_no_specified_step_and_granularity"),
     ]
 )
 @freezegun.freeze_time("2024-10-01T00:00:00")

--- a/airbyte-cdk/python/unit_tests/sources/streams/concurrent/test_default_stream.py
+++ b/airbyte-cdk/python/unit_tests/sources/streams/concurrent/test_default_stream.py
@@ -88,7 +88,7 @@ class ThreadBasedConcurrentStreamTest(unittest.TestCase):
             self._name,
             json_schema,
             self._availability_strategy,
-            ["id"],
+            ["composite_key_1", "composite_key_2"],
             self._cursor_field,
             self._logger,
             FinalStateCursor(stream_name=self._name, stream_namespace=None, message_repository=self._message_repository),
@@ -100,7 +100,7 @@ class ThreadBasedConcurrentStreamTest(unittest.TestCase):
             supported_sync_modes=[SyncMode.full_refresh],
             source_defined_cursor=None,
             default_cursor_field=None,
-            source_defined_primary_key=[["id"]],
+            source_defined_primary_key=[["composite_key_1"], ["composite_key_2"]],
             namespace=None,
         )
 
@@ -132,7 +132,7 @@ class ThreadBasedConcurrentStreamTest(unittest.TestCase):
             supported_sync_modes=[SyncMode.full_refresh],
             source_defined_cursor=None,
             default_cursor_field=None,
-            source_defined_primary_key=[["id_a", "id_b"]],
+            source_defined_primary_key=[["id_a"], ["id_b"]],
             namespace=None,
         )
 


### PR DESCRIPTION
…nd support no slice_range

## What
We have seen some small parity gap migrating low-code CDK to Concurrent CDK. Namely:
* Datetime output formatting is not on par with all the formats we support in low-code
* Low-code support having a slice_range that causes overflows, Concurrent CDK does not
* Primary key fix where composite keys were considered nested

Those were added to support zendesk-support migration [here](https://github.com/airbytehq/airbyte/pull/48379)

## How
* Always instantiate `CustomFormatConcurrentStreamStateConverter` and use the same formatter as low-code.
* Fallback on `end_provider` on overflow

## Review guide
1. `airbyte-cdk/python/airbyte_cdk/sources/streams/concurrent/state_converters/datetime_stream_state_converter.py`
2. `airbyte-cdk/python/airbyte_cdk/sources/streams/concurrent/cursor.py`
3. The rest

## User Impact
It should fix a couple of issues we've seen with the migration to the Concurrent CDK

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌
