### PR TITLE
Destination Typesense: Fix default port number in spec.json

### DIFF
--- a/airbyte-integrations/connectors/destination-typesense/destination_typesense/spec.json
+++ b/airbyte-integrations/connectors/destination-typesense/destination_typesense/spec.json
@@ -24,7 +24,7 @@
       "port": {
         "title": "Port",
         "type": "string",
-        "description": "Port of the Typesense instance. Ex: 8108, 80, 443. Default is 443",
+        "description": "Port of the Typesense instance. Ex: 8108, 80, 443. Default is 8108",
         "order": 2
       },
       "protocol": {


### PR DESCRIPTION
## What
Fixes the default port number in the Typesense connector doc from 443 (incorrect) to 8108 (correct)

## How
Docs/spec change

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
Saves Typesense Cloud users 15 minutes of waiting for the timeout error message 😭 

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
