### PR TITLE
Python CDK: concurrent - fix composite primary keys

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/streams/concurrent/default_stream.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/streams/concurrent/default_stream.py
@@ -73,7 +73,7 @@ class DefaultStream(AbstractStream):
 
         keys = self._primary_key
         if keys and len(keys) > 0:
-            stream.source_defined_primary_key = [keys]
+            stream.source_defined_primary_key = [[key] for key in keys]
 
         return stream
 

--- a/airbyte-cdk/python/unit_tests/sources/declarative/parsers/test_model_to_component_factory.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/parsers/test_model_to_component_factory.py
@@ -2667,7 +2667,7 @@ def test_create_concurrent_cursor_from_datetime_based_cursor_all_fields(stream_s
             "end_time": None,
             "cursor_granularity": None,
             "step": None,
-        }, "_slice_range", datetime.timedelta(days=61), None, id="test_uses_a_single_time_interval_when_no_specified_step_and_granularity"),
+        }, "_slice_range", datetime.timedelta.max, None, id="test_uses_a_single_time_interval_when_no_specified_step_and_granularity"),
     ]
 )
 @freezegun.freeze_time("2024-10-01T00:00:00")

--- a/airbyte-cdk/python/unit_tests/sources/streams/concurrent/test_default_stream.py
+++ b/airbyte-cdk/python/unit_tests/sources/streams/concurrent/test_default_stream.py
@@ -132,7 +132,7 @@ class ThreadBasedConcurrentStreamTest(unittest.TestCase):
             supported_sync_modes=[SyncMode.full_refresh],
             source_defined_cursor=None,
             default_cursor_field=None,
-            source_defined_primary_key=[["id_a", "id_b"]],
+            source_defined_primary_key=[["id_a"], ["id_b"]],
             namespace=None,
         )
 

--- a/airbyte-cdk/python/unit_tests/sources/streams/concurrent/test_default_stream.py
+++ b/airbyte-cdk/python/unit_tests/sources/streams/concurrent/test_default_stream.py
@@ -88,7 +88,7 @@ class ThreadBasedConcurrentStreamTest(unittest.TestCase):
             self._name,
             json_schema,
             self._availability_strategy,
-            ["id"],
+            ["composite_key_1", "composite_key_2"],
             self._cursor_field,
             self._logger,
             FinalStateCursor(stream_name=self._name, stream_namespace=None, message_repository=self._message_repository),
@@ -100,7 +100,7 @@ class ThreadBasedConcurrentStreamTest(unittest.TestCase):
             supported_sync_modes=[SyncMode.full_refresh],
             source_defined_cursor=None,
             default_cursor_field=None,
-            source_defined_primary_key=[["id"]],
+            source_defined_primary_key=[["composite_key_1"], ["composite_key_2"]],
             namespace=None,
         )
 


### PR DESCRIPTION
## What
Primary keys for the new DefaultStream for Concurrent CDK is built around the idea that nested primary keys are not possible anymore. Hence, it uses `get_primary_key_from_stream` to take the previous primary_key type (i.e. `Optional[Union[str, List[str], List[List[str]]]]`) and migrate this to a simple `List[str]` as we have dropped support for nested primary keys.

However, when calling `as_airbyte_stream`, we need to set `source_defined_primary_key` using the previous `Optional[Union[str, List[str], List[List[str]]]]` type. The `DefaultStream` sets the `source_defined_primary_key` to this `List[str]` but a `List[str]` in `AirbyteStream.source_defined_primary_key` means doesn't mean a composite key but a nested.

## How
Return `[[key] for key in self._primary_key]` as `source_defined_primary_key`

Note that this should not impact the current cases we have on concurrency as:
* source-salesforce does not support primary keys: https://github.com/airbytehq/airbyte/blob/c25f3fc140ef4fdfb180ddd4800ba9407814efe7/airbyte-integrations/connectors/source-salesforce/source_salesforce/streams.py#L74
* source-stripe does not support primary keys: https://github.com/airbytehq/airbyte/blob/c25f3fc140ef4fdfb180ddd4800ba9407814efe7/airbyte-integrations/connectors/source-stripe/source_stripe/streams.py#L153
* file based CDK re-implements its own primary_key method: https://github.com/airbytehq/airbyte/blob/c25f3fc140ef4fdfb180ddd4800ba9407814efe7/airbyte-cdk/python/airbyte_cdk/sources/file_based/stream/concurrent/adapters.py#L139-L141

## User Impact
This should fix the issue brought by a user [here](https://airbytehq-team.slack.com/archives/C02TL38U5L7/p1730921323064899) and unblock CDK migration to 6.X

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [X] YES 💚
- [ ] NO ❌
