### PR TITLE
feat(airbyte-cdk): add clear method to HttpMocker

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/test/mock_http/mocker.py
+++ b/airbyte-cdk/python/airbyte_cdk/test/mock_http/mocker.py
@@ -133,3 +133,7 @@ class HttpMocker(contextlib.ContextDecorator):
                 return result
 
         return wrapper
+
+    def clear_all_matchers(self) -> None:
+        """Clears all stored matchers by resetting the _matchers list to an empty state."""
+        self._matchers = []


### PR DESCRIPTION
## What

It is not possible to redefine matchers inside httpmocker, thus we need to remove all of them and define again.
[Example case](https://github.com/airbytehq/airbyte/pull/48116/files): 
`airbyte-integrations/connectors/source-amazon-ads/unit_tests/integrations/test_report_streams.py`:::`test_given_known_error_when_read_brands_v3_report_then_skip_report`. `for` cycle is used to mimic parametrization (unittest library does not support pytest.parametrize)

## How

add new method `clear_all_matchers`

## Review guide


1. `airbyte-cdk/python/airbyte_cdk/test/mock_http/mocker.py`

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
