### PR TITLE
feat(airbyte-cdk): add jinja macros today_with_timezone

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/interpolation/macros.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/interpolation/macros.py
@@ -37,6 +37,16 @@ def today_utc() -> datetime.date:
     return datetime.datetime.now(datetime.timezone.utc).date()
 
 
+def today_with_timezone(timezone: str) -> datetime.date:
+    """
+    Current date in custom timezone
+
+    :param timezone: timezone expressed as IANA keys format. Example: "Pacific/Tarawa"
+    :return:
+    """
+    return datetime.datetime.now(tz=pytz.timezone(timezone)).date()
+
+
 def timestamp(dt: Union[float, str]) -> Union[int, float]:
     """
     Converts a number or a string to a timestamp
@@ -126,5 +136,5 @@ def format_datetime(dt: Union[str, datetime.datetime], format: str, input_format
     return dt_datetime.strftime(format)
 
 
-_macros_list = [now_utc, today_utc, timestamp, max, day_delta, duration, format_datetime]
+_macros_list = [now_utc, today_utc, timestamp, max, day_delta, duration, format_datetime, today_with_timezone]
 macros = {f.__name__: f for f in _macros_list}

--- a/airbyte-cdk/python/unit_tests/sources/declarative/interpolation/test_jinja.py
+++ b/airbyte-cdk/python/unit_tests/sources/declarative/interpolation/test_jinja.py
@@ -279,6 +279,18 @@ def test_macros_examples(template_string, expected_value):
     assert now_utc == expected_value
 
 
+@freeze_time("2021-09-01 12:00:00", tz_offset=5)
+@pytest.mark.parametrize(
+    "template_string, expected_value",
+    [
+        pytest.param("{{ today_with_timezone('Pacific/Kiritimati') }}", "2021-09-02", id="test_today_timezone_pacific"),
+    ],
+)
+def test_macros_timezone(template_string: str, expected_value: str):
+    interpolated_string = interpolation.eval(template_string, {})
+    assert interpolated_string == expected_value
+
+
 def test_interpolation_private_partition_attribute():
     inner_partition = StreamSlice(partition={}, cursor_slice={})
     expected_output = "value"


### PR DESCRIPTION
## What

Resolving [Amazon Ads migration to low-code](https://github.com/airbytehq/airbyte/pull/48116/)
 [lines](https://github.com/airbytehq/airbyte/pull/48116/files#diff-6f2420fea56c6bc473d6dbe283de54e8a81644276309718f561c9a50330f9ffcR886-R892)

## How

add jinja macros today_with_timezone

## Review guide

1. `airbyte-cdk/python/airbyte_cdk/sources/declarative/interpolation/macros.py`
2. `airbyte-cdk/python/unit_tests/sources/declarative/interpolation/test_jinja.py`


## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
