### PR TITLE
fix (airbyte-ci): include advanced_auth in spec migration

### DIFF
--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -850,10 +850,10 @@ airbyte-ci connectors --language=low-code migrate-to-manifest-only
 
 | Version | PR                                                         | Description                                                                                                                  |
 | ------- | ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| 4.42.2  | []() | Include `advanced_auth` in spec migration for manifest-only pipeline |
-| 4.42.1  | [#47316](https://github.com/airbytehq/airbyte/pull/47316)      | Connector testing: skip incremental acceptance test when the connector is not released.                                      |
+| 4.42.2  | [#48404](https://github.com/airbytehq/airbyte/pull/48404)  | Include `advanced_auth` in spec migration for manifest-only pipeline                                                         |
+| 4.42.1  | [#47316](https://github.com/airbytehq/airbyte/pull/47316)  | Connector testing: skip incremental acceptance test when the connector is not released.                                      |
 | 4.42.0  | [#47386](https://github.com/airbytehq/airbyte/pull/47386)  | Version increment check: make sure consecutive RC remain on the same version.                                                |
-| 4.41.9  | [#47483](https://github.com/airbytehq/airbyte/pull/47483)  | Fix build logic used in `up-to-date` to support any connector language.                                                             |
+| 4.41.9  | [#47483](https://github.com/airbytehq/airbyte/pull/47483)  | Fix build logic used in `up-to-date` to support any connector language.                                                      |
 | 4.41.8  | [#47447](https://github.com/airbytehq/airbyte/pull/47447)  | Use `cache_ttl` for base image registry listing in `up-to-date`.                                                             |
 | 4.41.7  | [#47444](https://github.com/airbytehq/airbyte/pull/47444)  | Remove redundant `--ignore-connector` error from up-to-date. `--metadata-query` can be used instead.                         |
 | 4.41.6  | [#47308](https://github.com/airbytehq/airbyte/pull/47308)  | Connector testing: skip incremental acceptance test when the connector is not released.                                      |

--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -850,6 +850,7 @@ airbyte-ci connectors --language=low-code migrate-to-manifest-only
 
 | Version | PR                                                         | Description                                                                                                                  |
 | ------- | ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| 4.42.2  | []() | Include `advanced_auth` in spec migration for manifest-only pipeline |
 | 4.42.1  | [#47316](https://github.com/airbytehq/airbyte/pull/47316)      | Connector testing: skip incremental acceptance test when the connector is not released.                                      |
 | 4.42.0  | [#47386](https://github.com/airbytehq/airbyte/pull/47386)  | Version increment check: make sure consecutive RC remain on the same version.                                                |
 | 4.41.9  | [#47483](https://github.com/airbytehq/airbyte/pull/47483)  | Fix build logic used in `up-to-date` to support any connector language.                                                             |

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/migrate_to_manifest_only/pipeline.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/migrate_to_manifest_only/pipeline.py
@@ -161,7 +161,11 @@ class StripConnector(Step):
             documentation_url = spec.get("documentationUrl") or spec.get("documentation_url")
             connection_specification = spec.get("connection_specification") or spec.get("connectionSpecification")
             advanced_auth = spec.get("advanced_auth")
-            return {"documentation_url": documentation_url, "connection_specification": connection_specification, "advanced_auth": advanced_auth}
+            return {
+                "documentation_url": documentation_url,
+                "connection_specification": connection_specification,
+                "advanced_auth": advanced_auth,
+            }
 
         except Exception as e:
             raise ValueError(f"Failed to read data in spec file: {e}")

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/migrate_to_manifest_only/pipeline.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/migrate_to_manifest_only/pipeline.py
@@ -160,7 +160,8 @@ class StripConnector(Step):
 
             documentation_url = spec.get("documentationUrl") or spec.get("documentation_url")
             connection_specification = spec.get("connection_specification") or spec.get("connectionSpecification")
-            return {"documentation_url": documentation_url, "connection_specification": connection_specification}
+            advanced_auth = spec.get("advanced_auth")
+            return {"documentation_url": documentation_url, "connection_specification": connection_specification, "advanced_auth": advanced_auth}
 
         except Exception as e:
             raise ValueError(f"Failed to read data in spec file: {e}")
@@ -211,6 +212,7 @@ class StripConnector(Step):
                     "type": "Spec",
                     "documentation_url": spec_data.get("documentation_url"),
                     "connection_specification": spec_data.get("connection_specification"),
+                    "advanced_auth": spec_data.get("advanced_auth"),
                 }
                 write_yaml(manifest, root_manifest_path)
             except Exception as e:

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/migrate_to_manifest_only/pipeline.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/migrate_to_manifest_only/pipeline.py
@@ -43,6 +43,7 @@ MANIFEST_ONLY_FILES_TO_KEEP = [
     "components.py",
     "metadata.yaml",
     "icon.svg",
+    "unit_tests",
     "integration_tests",
     "acceptance-test-config.yml",
     "secrets",
@@ -188,7 +189,7 @@ class StripConnector(Step):
         ## 2. Update the version in manifest.yaml
         try:
             manifest = read_yaml(root_manifest_path)
-            manifest["version"] = "4.3.2"
+            manifest["version"] = "5.15.0"
             manifest["type"] = "DeclarativeSource"
 
             # Resolve $parameters and types with CDK magic

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "4.42.1"
+version = "4.42.2"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 

--- a/airbyte-ci/connectors/pipelines/tests/test_poetry/test_poetry_publish.py
+++ b/airbyte-ci/connectors/pipelines/tests/test_poetry/test_poetry_publish.py
@@ -61,7 +61,9 @@ def context(dagger_client: Client):
         ),
     ],
 )
-async def test_run_poetry_publish(context: PythonRegistryPublishContext, package_path: str, package_name: str, version: str, expected_asset: str):
+async def test_run_poetry_publish(
+    context: PythonRegistryPublishContext, package_path: str, package_name: str, version: str, expected_asset: str
+):
     context.package_metadata = PythonPackageMetadata(package_name, version)
     context.package_path = package_path
     pypi_registry = (

--- a/airbyte-ci/connectors/pipelines/tests/test_poetry/test_poetry_publish.py
+++ b/airbyte-ci/connectors/pipelines/tests/test_poetry/test_poetry_publish.py
@@ -43,24 +43,26 @@ def context(dagger_client: Client):
 
 
 @pytest.mark.parametrize(
-    "package_path, package_name, expected_asset",
+    "package_path, package_name, version, expected_asset",
     [
         pytest.param(
-            "airbyte-integrations/connectors/source-apify-dataset",
-            "airbyte-source-apify-dataset",
-            "airbyte_source_apify_dataset-0.2.0-py3-none-any.whl",
+            "airbyte-integrations/connectors/source-fauna",
+            "airbyte-source-fauna",
+            "1.0.0",
+            "airbyte_source_fauna-1.0.0-py3-none-any.whl",
             id="setup.py project",
         ),
         pytest.param(
             "airbyte-integrations/connectors/destination-duckdb",
             "destination-duckdb",
+            "0.2.0",
             "destination_duckdb-0.2.0-py3-none-any.whl",
             id="poetry project",
         ),
     ],
 )
-async def test_run_poetry_publish(context: PythonRegistryPublishContext, package_path: str, package_name: str, expected_asset: str):
-    context.package_metadata = PythonPackageMetadata(package_name, "0.2.0")
+async def test_run_poetry_publish(context: PythonRegistryPublishContext, package_path: str, package_name: str, version: str, expected_asset: str):
+    context.package_metadata = PythonPackageMetadata(package_name, version)
     context.package_path = package_path
     pypi_registry = (
         # need to use linux/amd64 because the pypiserver image is only available for that platform


### PR DESCRIPTION
## What

Following up on [48375](https://github.com/airbytehq/airbyte/pull/48375), we caught that advanced_auth config was not being migrated to the inlined spec in manifest-only migrations. Whoops 😬

## How

- Includes the advanced_auth object when grabbing a non-inlined spec to copy into the manifest.
- Fixed a failing publish unit test
- Added unit_tests folder to the list of resources not to nuke