### PR TITLE
Bulk Load CDK: Ambiguous UnionType

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/AirbyteSchemaIdentityMapper.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/AirbyteSchemaIdentityMapper.kt
@@ -49,7 +49,7 @@ interface AirbyteSchemaIdentityMapper : AirbyteSchemaMapper {
     fun mapObjectWithoutSchema(schema: ObjectTypeWithoutSchema): AirbyteType = schema
     fun mapObjectWithEmptySchema(schema: ObjectTypeWithEmptySchema): AirbyteType = schema
     fun mapUnion(schema: UnionType): AirbyteType {
-        return UnionType(schema.options.map { map(it) })
+        return UnionType.of(schema.options.map { map(it) })
     }
     fun mapDate(schema: DateType): AirbyteType = schema
     fun mapTimeTypeWithTimezone(schema: TimeTypeWithTimezone): AirbyteType = schema

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/AirbyteType.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/AirbyteType.kt
@@ -4,6 +4,8 @@
 
 package io.airbyte.cdk.load.data
 
+import com.fasterxml.jackson.databind.JsonNode
+
 sealed interface AirbyteType
 
 data object StringType : AirbyteType
@@ -34,8 +36,21 @@ data object ObjectTypeWithEmptySchema : AirbyteType
 
 data object ObjectTypeWithoutSchema : AirbyteType
 
-data class UnionType(val options: List<AirbyteType>) : AirbyteType
+data class UnionType(val options: Set<AirbyteType>) : AirbyteType {
+    companion object {
+        fun of(options: Set<AirbyteType>): AirbyteType {
+            if (options.size == 1) {
+                return options.first()
+            }
+            return UnionType(options)
+        }
 
-data class UnknownType(val what: String) : AirbyteType
+        fun of(options: List<AirbyteType>): AirbyteType = of(options.toSet())
+
+        fun of(vararg options: AirbyteType): AirbyteType = of(options.toSet())
+    }
+}
+
+data class UnknownType(val schema: JsonNode) : AirbyteType
 
 data class FieldType(val type: AirbyteType, val nullable: Boolean)

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/AirbyteValue.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/AirbyteValue.kt
@@ -4,6 +4,7 @@
 
 package io.airbyte.cdk.load.data
 
+import com.fasterxml.jackson.databind.JsonNode
 import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -161,4 +162,4 @@ value class ObjectValue(val values: LinkedHashMap<String, AirbyteValue>) : Airby
     }
 }
 
-@JvmInline value class UnknownValue(val what: String) : AirbyteValue
+@JvmInline value class UnknownValue(val value: JsonNode) : AirbyteValue

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/MergeUnions.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/MergeUnions.kt
@@ -9,19 +9,16 @@ class MergeUnions : AirbyteSchemaIdentityMapper {
         // Map the options first so they're in their final form
         val mappedOptions = schema.options.map { map(it) }
         val mergedOptions = mergeOptions(mappedOptions)
-        if (mergedOptions.size == 1) {
-            return mergedOptions.first()
-        }
-        return UnionType(mergedOptions.toList())
+        return UnionType.of(mergedOptions)
     }
 
-    private fun mergeOptions(options: List<AirbyteType>): Set<AirbyteType> {
+    private fun mergeOptions(options: Iterable<AirbyteType>): Set<AirbyteType> {
         val mergedOptions = mutableSetOf<AirbyteType>()
         mergeOptions(mergedOptions, options)
         return mergedOptions
     }
 
-    private fun mergeOptions(into: MutableSet<AirbyteType>, from: List<AirbyteType>) {
+    private fun mergeOptions(into: MutableSet<AirbyteType>, from: Iterable<AirbyteType>) {
         for (option in from) {
             if (option is UnionType) {
                 // If this is a union of a union, recursively merge the other union's options in
@@ -45,7 +42,7 @@ class MergeUnions : AirbyteSchemaIdentityMapper {
                     }
 
                     // Combine the fields, recursively merging unions, object fields, etc
-                    val mergedFields = mapUnion(UnionType(listOf(existingField.type, field.type)))
+                    val mergedFields = map(UnionType.of(existingField.type, field.type))
                     newProperties[name] =
                         FieldType(mergedFields, existingField.nullable || field.nullable)
 

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/SchemalessTypesToJson.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/SchemalessTypesToJson.kt
@@ -32,5 +32,5 @@ class SchemalessValuesToJson : AirbyteValueIdentityMapper() {
         path: List<String>
     ): AirbyteValue = value.toJson().serializeToString().let(::StringValue)
     override fun mapUnknown(value: UnknownValue, path: List<String>): AirbyteValue =
-        StringValue(value.what)
+        value.value.serializeToString().let(::StringValue)
 }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/json/AirbyteValueToJson.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/json/AirbyteValueToJson.kt
@@ -27,7 +27,7 @@ class AirbyteValueToJson {
             is StringValue -> JsonNodeFactory.instance.textNode(value.value)
             is TimeValue -> JsonNodeFactory.instance.textNode(value.value)
             is TimestampValue -> JsonNodeFactory.instance.textNode(value.value)
-            is UnknownValue -> throw IllegalArgumentException("Unknown value: $value")
+            is UnknownValue -> value.value
         }
     }
 }

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/data/AirbyteSchemaIdentityMapperTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/data/AirbyteSchemaIdentityMapperTest.kt
@@ -20,7 +20,7 @@ class AirbyteSchemaIdentityMapperTest {
                 .with(BooleanType)
                 .with(NumberType)
                 .with(ArrayType(FieldType(StringType, true)))
-                .with(UnionType(listOf(StringType, IntegerType)))
+                .with(UnionType.of(StringType, IntegerType))
                 .withRecord()
                 .with(TimeTypeWithTimezone)
                 .with(TimeTypeWithoutTimezone)

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/data/MergeUnionsTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/data/MergeUnionsTest.kt
@@ -50,10 +50,7 @@ class MergeUnionsTest {
                                 properties =
                                     linkedMapOf(
                                         "foo" to
-                                            FieldType(
-                                                UnionType(listOf(StringType, IntegerType)),
-                                                false
-                                            )
+                                            FieldType(UnionType.of(StringType, IntegerType), false)
                                     )
                             ),
                             false
@@ -77,7 +74,7 @@ class MergeUnionsTest {
             SchemaRecordBuilder<Root>()
                 .withUnion(
                     expectedInstead =
-                        FieldType(UnionType(listOf(StringType, IntegerType)), nullable = false)
+                        FieldType(UnionType.of(StringType, IntegerType), nullable = false)
                 )
                 .with(StringType)
                 .with(IntegerType)
@@ -94,10 +91,10 @@ class MergeUnionsTest {
             SchemaRecordBuilder<Root>()
                 .withUnion(
                     expectedInstead =
-                        FieldType(UnionType(listOf(StringType, IntegerType)), nullable = false)
+                        FieldType(UnionType.of(StringType, IntegerType), nullable = false)
                 )
                 .with(StringType)
-                .with(UnionType(listOf(StringType, UnionType(listOf(IntegerType, StringType)))))
+                .with(UnionType.of(StringType, UnionType.of(IntegerType, StringType)))
                 .with(IntegerType)
                 .endUnion()
                 .build()

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/data/UnionTypeToDisjointRecordTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/data/UnionTypeToDisjointRecordTest.kt
@@ -22,8 +22,8 @@ class UnionTypeToDisjointRecordTest {
             )
         val (inputSchema, expectedOutput) =
             SchemaRecordBuilder<Root>()
-                .with(UnionType(listOf(StringType))) // union of 1 => ignore
-                .with(UnionType(listOf(StringType, IntegerType)), expected = disjointRecord)
+                .with(UnionType.of(StringType)) // union of 1 => ignore
+                .with(UnionType.of(StringType, IntegerType), expected = disjointRecord)
                 .build()
         val output = UnionTypeToDisjointRecord().map(inputSchema)
         Assertions.assertEquals(expectedOutput, output)
@@ -33,7 +33,7 @@ class UnionTypeToDisjointRecordTest {
     fun testUnionOfTypesWithSameNameThrows() {
         val (inputSchema, _) =
             SchemaRecordBuilder<Root>()
-                .with(UnionType(listOf(ObjectType(linkedMapOf()), ObjectTypeWithoutSchema)))
+                .with(UnionType.of(ObjectType(linkedMapOf()), ObjectTypeWithoutSchema))
                 .build()
         Assertions.assertThrows(IllegalArgumentException::class.java) {
             UnionTypeToDisjointRecord().map(inputSchema)

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/data/json/AirbyteSchemaTypeToJsonSchemaTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/data/json/AirbyteSchemaTypeToJsonSchemaTest.kt
@@ -35,7 +35,7 @@ class AirbyteSchemaTypeToJsonSchemaTest {
                     "friends" to ArrayType(FieldType(StringType, true)),
                     "mixed_array" to
                         ArrayType(
-                            FieldType(UnionType(listOf(StringType, IntegerType)), nullable = true)
+                            FieldType(UnionType.of(StringType, IntegerType), nullable = true)
                         ),
                     "address" to
                         ObjectType(
@@ -44,11 +44,10 @@ class AirbyteSchemaTypeToJsonSchemaTest {
                                 "city" to FieldType(StringType, true)
                             )
                         ),
-                    "nonnullable_union" to UnionType(listOf(StringType)),
                     "combined_denormalized" to
                         ObjectType(linkedMapOf("name" to FieldType(StringType, true))),
                     "union_array" to
-                        ArrayType(FieldType(UnionType(listOf(StringType, IntegerType)), true)),
+                        ArrayType(FieldType(UnionType.of(StringType, IntegerType), true)),
                     "date" to DateType,
                     "time" to TimeTypeWithTimezone,
                     "time_without_timezone" to TimeTypeWithoutTimezone,
@@ -109,13 +108,6 @@ class AirbyteSchemaTypeToJsonSchemaTest {
                   "type": "string"
                 }
               }
-            },
-            "nonnullable_union": {
-              "oneOf": [
-                {
-                  "type": "string"
-                }
-              ]
             },
             "combined_denormalized": {
               "type": "object",

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/data/json/AirbyteValueToJsonTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/data/json/AirbyteValueToJsonTest.kt
@@ -76,7 +76,7 @@ class AirbyteValueToJsonTest {
                             ),
                             false
                         ),
-                    "union" to FieldType(UnionType(listOf(StringType, IntegerType)), true),
+                    "union" to FieldType(UnionType.of(StringType, IntegerType), true),
                     "combined_denormalized" to
                         FieldType(
                             ObjectType(linkedMapOf("name" to FieldType(StringType, true))),
@@ -84,7 +84,7 @@ class AirbyteValueToJsonTest {
                         ),
                     "union_array" to
                         FieldType(
-                            ArrayType(FieldType(UnionType(listOf(StringType, IntegerType)), true)),
+                            ArrayType(FieldType(UnionType.of(StringType, IntegerType), true)),
                             true
                         ),
                     "date" to FieldType(DateType, false),

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/data/json/JsonSchemaToAirbyteSchemaTypeTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/data/json/JsonSchemaToAirbyteSchemaTypeTest.kt
@@ -241,6 +241,6 @@ class JsonSchemaToAirbyteSchemaTypeTest {
                 """.trimIndent()
             ) as ObjectNode
         val airbyteType = JsonSchemaToAirbyteType().convert(inputSchema)
-        Assertions.assertEquals(UnionType(listOf(StringType, IntegerType)), airbyteType)
+        Assertions.assertEquals(UnionType.of(StringType, IntegerType), airbyteType)
     }
 }

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/data/json/JsonToAirbyteValueTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/data/json/JsonToAirbyteValueTest.kt
@@ -136,7 +136,7 @@ class JsonToAirbyteValueTest {
             JsonToAirbyteValue()
                 .convert(
                     JsonNodeFactory.instance.textNode("hello"),
-                    UnionType(listOf(StringType, IntegerType))
+                    UnionType.of(StringType, IntegerType)
                 )
         Assertions.assertTrue(stringValue is StringValue)
         Assertions.assertEquals("hello", (stringValue as StringValue).value)
@@ -145,7 +145,7 @@ class JsonToAirbyteValueTest {
             JsonToAirbyteValue()
                 .convert(
                     JsonNodeFactory.instance.numberNode(42),
-                    UnionType(listOf(StringType, IntegerType))
+                    UnionType.of(StringType, IntegerType)
                 )
         Assertions.assertTrue(intValue is IntegerValue)
         Assertions.assertEquals(42, (intValue as IntegerValue).value)

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/test/util/SchemaRecordBuilder.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/test/util/SchemaRecordBuilder.kt
@@ -62,10 +62,10 @@ class SchemaRecordBuilder<T : SchemaRecordBuilderType>(
         expectedInstead: FieldType? = null
     ): SchemaTestUnionBuilder<T> {
         val name = nameOverride ?: UUID.randomUUID().toString()
-        val inputOptions = mutableListOf<AirbyteType>()
+        val inputOptions = mutableSetOf<AirbyteType>()
         val expectedOptions =
             if (expectedInstead == null) {
-                mutableListOf<AirbyteType>()
+                mutableSetOf<AirbyteType>()
             } else {
                 null
             }
@@ -92,8 +92,8 @@ class SchemaRecordBuilder<T : SchemaRecordBuilderType>(
 
 class SchemaTestUnionBuilder<T : SchemaRecordBuilderType>(
     private val parent: SchemaRecordBuilder<T>,
-    private val options: MutableList<AirbyteType>,
-    private val expectedOptions: MutableList<AirbyteType>?
+    private val options: MutableSet<AirbyteType>,
+    private val expectedOptions: MutableSet<AirbyteType>?
 ) : SchemaRecordBuilderType {
     fun with(option: AirbyteType, expected: AirbyteType? = null): SchemaTestUnionBuilder<T> {
         options.add(option)

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/write/BasicFunctionalityIntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/write/BasicFunctionalityIntegrationTest.kt
@@ -4,6 +4,7 @@
 
 package io.airbyte.cdk.load.write
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import io.airbyte.cdk.command.ConfigurationSpecification
 import io.airbyte.cdk.command.ValidatedJsonUtils
 import io.airbyte.cdk.load.command.Append
@@ -1507,7 +1508,11 @@ abstract class BasicFunctionalityIntegrationTest(
                         "time_without_timezone" to
                             FieldType(TimeTypeWithoutTimezone, nullable = true),
                         "date" to FieldType(DateType, nullable = true),
-                        "unknown" to FieldType(UnknownType("test"), nullable = true),
+                        "unknown" to
+                            FieldType(
+                                UnknownType(JsonNodeFactory.instance.textNode("test")),
+                                nullable = true
+                            ),
                     )
                 ),
                 generationId = 42,
@@ -1981,22 +1986,20 @@ abstract class BasicFunctionalityIntegrationTest(
                         // {oneOf: [{type: string}, {type: int}]}
                         // Our AirbyteType treats them identically, so we don't need two test cases.
                         "combined_type" to
-                            FieldType(UnionType(listOf(StringType, IntegerType)), nullable = true),
+                            FieldType(UnionType.of(StringType, IntegerType), nullable = true),
                         "union_of_objects_with_properties_identical" to
                             FieldType(
-                                UnionType(
-                                    listOf(
-                                        ObjectType(
-                                            linkedMapOf(
-                                                "id" to FieldType(IntegerType, nullable = true),
-                                                "name" to FieldType(StringType, nullable = true),
-                                            )
-                                        ),
-                                        ObjectType(
-                                            linkedMapOf(
-                                                "id" to FieldType(IntegerType, nullable = true),
-                                                "name" to FieldType(StringType, nullable = true),
-                                            )
+                                UnionType.of(
+                                    ObjectType(
+                                        linkedMapOf(
+                                            "id" to FieldType(IntegerType, nullable = true),
+                                            "name" to FieldType(StringType, nullable = true),
+                                        )
+                                    ),
+                                    ObjectType(
+                                        linkedMapOf(
+                                            "id" to FieldType(IntegerType, nullable = true),
+                                            "name" to FieldType(StringType, nullable = true),
                                         )
                                     )
                                 ),
@@ -2004,20 +2007,17 @@ abstract class BasicFunctionalityIntegrationTest(
                             ),
                         "union_of_objects_with_properties_overlapping" to
                             FieldType(
-                                UnionType(
-                                    listOf(
-                                        ObjectType(
-                                            linkedMapOf(
-                                                "id" to FieldType(IntegerType, nullable = true),
-                                                "name" to FieldType(StringType, nullable = true),
-                                            )
-                                        ),
-                                        ObjectType(
-                                            linkedMapOf(
-                                                "name" to FieldType(StringType, nullable = true),
-                                                "flagged" to
-                                                    FieldType(BooleanType, nullable = true),
-                                            )
+                                UnionType.of(
+                                    ObjectType(
+                                        linkedMapOf(
+                                            "id" to FieldType(IntegerType, nullable = true),
+                                            "name" to FieldType(StringType, nullable = true),
+                                        )
+                                    ),
+                                    ObjectType(
+                                        linkedMapOf(
+                                            "name" to FieldType(StringType, nullable = true),
+                                            "flagged" to FieldType(BooleanType, nullable = true),
                                         )
                                     )
                                 ),
@@ -2025,21 +2025,17 @@ abstract class BasicFunctionalityIntegrationTest(
                             ),
                         "union_of_objects_with_properties_nonoverlapping" to
                             FieldType(
-                                UnionType(
-                                    listOf(
-                                        ObjectType(
-                                            linkedMapOf(
-                                                "id" to FieldType(IntegerType, nullable = true),
-                                                "name" to FieldType(StringType, nullable = true),
-                                            )
-                                        ),
-                                        ObjectType(
-                                            linkedMapOf(
-                                                "flagged" to
-                                                    FieldType(BooleanType, nullable = true),
-                                                "description" to
-                                                    FieldType(StringType, nullable = true),
-                                            )
+                                UnionType.of(
+                                    ObjectType(
+                                        linkedMapOf(
+                                            "id" to FieldType(IntegerType, nullable = true),
+                                            "name" to FieldType(StringType, nullable = true),
+                                        )
+                                    ),
+                                    ObjectType(
+                                        linkedMapOf(
+                                            "flagged" to FieldType(BooleanType, nullable = true),
+                                            "description" to FieldType(StringType, nullable = true),
                                         )
                                     )
                                 ),
@@ -2047,19 +2043,17 @@ abstract class BasicFunctionalityIntegrationTest(
                             ),
                         "union_of_objects_with_properties_contradicting" to
                             FieldType(
-                                UnionType(
-                                    listOf(
-                                        ObjectType(
-                                            linkedMapOf(
-                                                "id" to FieldType(IntegerType, nullable = true),
-                                                "name" to FieldType(StringType, nullable = true),
-                                            )
-                                        ),
-                                        ObjectType(
-                                            linkedMapOf(
-                                                "id" to FieldType(StringType, nullable = true),
-                                                "name" to FieldType(StringType, nullable = true),
-                                            )
+                                UnionType.of(
+                                    ObjectType(
+                                        linkedMapOf(
+                                            "id" to FieldType(IntegerType, nullable = true),
+                                            "name" to FieldType(StringType, nullable = true),
+                                        )
+                                    ),
+                                    ObjectType(
+                                        linkedMapOf(
+                                            "id" to FieldType(StringType, nullable = true),
+                                            "name" to FieldType(StringType, nullable = true),
                                         )
                                     )
                                 ),

--- a/airbyte-cdk/bulk/toolkits/load-avro/src/main/kotlin/io/airbyte/cdk/load/data/avro/AvroMapperPipelineFactory.kt
+++ b/airbyte-cdk/bulk/toolkits/load-avro/src/main/kotlin/io/airbyte/cdk/load/data/avro/AvroMapperPipelineFactory.kt
@@ -13,11 +13,7 @@ import io.airbyte.cdk.load.data.MergeUnions
 import io.airbyte.cdk.load.data.SchemalessTypesToJson
 import io.airbyte.cdk.load.data.SchemalessValuesToJson
 import io.airbyte.cdk.load.data.TimeStringToInteger
-import io.micronaut.context.annotation.Secondary
-import jakarta.inject.Singleton
 
-@Singleton
-@Secondary
 class AvroMapperPipelineFactory : MapperPipelineFactory {
     override fun create(stream: DestinationStream): MapperPipeline =
         MapperPipeline(

--- a/airbyte-cdk/bulk/toolkits/load-csv/src/testFixtures/kotlin/io/airbyte/cdk/load/data/csv/CsvRowToAirbyteValue.kt
+++ b/airbyte-cdk/bulk/toolkits/load-csv/src/testFixtures/kotlin/io/airbyte/cdk/load/data/csv/CsvRowToAirbyteValue.kt
@@ -81,7 +81,9 @@ class CsvRowToAirbyteValue {
                     .fields()
                     .asSequence()
                     .map { entry ->
-                        val type = field.properties[entry.key]?.type ?: UnknownType("unknown")
+                        val type =
+                            field.properties[entry.key]?.type
+                                ?: UnknownType(value.deserializeToNode())
                         entry.key to entry.value.toAirbyteValue(type)
                     }
                     .toMap(properties)
@@ -110,7 +112,7 @@ class CsvRowToAirbyteValue {
             TimeTypeWithoutTimezone -> TimeValue(value)
             TimestampTypeWithTimezone,
             TimestampTypeWithoutTimezone -> TimestampValue(value)
-            is UnknownType -> UnknownValue(value)
+            is UnknownType -> UnknownValue(value.deserializeToNode())
         }
     }
 }

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/file/object_storage/ObjectStorageFormattingWriter.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/file/object_storage/ObjectStorageFormattingWriter.kt
@@ -95,6 +95,7 @@ class CSVFormattingWriter(
             *record.dataWithAirbyteMeta(stream, rootLevelFlattening).toCsvRecord(finalSchema)
         )
     }
+
     override fun close() {
         printer.close()
     }
@@ -112,7 +113,6 @@ class AvroFormattingWriter(
     private val writer =
         outputStream.toAvroWriter(avroSchema, formatConfig.avroCompressionConfiguration)
     override fun accept(record: DestinationRecord) {
-
         val dataMapped =
             pipeline
                 .map(record.data, record.meta?.changes)

--- a/airbyte-cdk/bulk/toolkits/load-parquet/src/main/kotlin/io/airbyte/cdk/load/data/parquet/ParquetMapperPipelineFactory.kt
+++ b/airbyte-cdk/bulk/toolkits/load-parquet/src/main/kotlin/io/airbyte/cdk/load/data/parquet/ParquetMapperPipelineFactory.kt
@@ -15,11 +15,7 @@ import io.airbyte.cdk.load.data.SchemalessValuesToJson
 import io.airbyte.cdk.load.data.TimeStringToInteger
 import io.airbyte.cdk.load.data.UnionTypeToDisjointRecord
 import io.airbyte.cdk.load.data.UnionValueToDisjointRecord
-import io.micronaut.context.annotation.Secondary
-import jakarta.inject.Singleton
 
-@Singleton
-@Secondary
 class ParquetMapperPipelineFactory : MapperPipelineFactory {
     override fun create(stream: DestinationStream): MapperPipeline =
         MapperPipeline(


### PR DESCRIPTION
cleanup/light refactor
* removed some unnecessary annotations
* unions are now unambiguous (as long as you use `.of`; I considered demoting it to a vanilla class w/ a private constructor, but it opened up a giant rabbit hole that wasn't worth it; but at least this way a lot of the complexity disappears into the constructor)
* unknown type/value now passes jsonnode through (not sure if this is 100% being used right, but let's just go forward and see what breaks)

I'll make the mappers stateless in the next one