### PR TITLE
Bulk Load CDK: Tests verifying that we resend all additionalProperties

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/message/DestinationMessageTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/message/DestinationMessageTest.kt
@@ -76,6 +76,7 @@ class DestinationMessageTest {
                         )
                         // Note: only source stats, no destination stats
                         .withSourceStats(AirbyteStateStats().withRecordCount(2.0))
+                        .withAdditionalProperty("sneaky_undocumented_id", 1234L)
                 )
 
         val parsedMessage =
@@ -111,6 +112,7 @@ class DestinationMessageTest {
                         )
                         // Note: only source stats, no destination stats
                         .withSourceStats(AirbyteStateStats().withRecordCount(2.0))
+                        .withAdditionalProperty("sneaky_undocumented_id", 1234L)
                 )
 
         val parsedMessage =


### PR DESCRIPTION
I neglected to add this w/ the fix because I assumed tests would be more involved and I wanted to unblock sources.

I verified that this breaks before the fix was added