### PR TITLE
Bulk load CDK: Fix longs in additionalProperties

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/DestinationMessage.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/DestinationMessage.kt
@@ -279,9 +279,7 @@ sealed interface CheckpointMessage : DestinationMessage {
             message.destinationStats =
                 AirbyteStateStats().withRecordCount(destinationStats!!.recordCount.toDouble())
         }
-        additionalProperties.forEach { (key, value) ->
-            message.withAdditionalProperty(key, value)
-        }
+        additionalProperties.forEach { (key, value) -> message.withAdditionalProperty(key, value) }
     }
 }
 

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/message/DestinationMessageTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/message/DestinationMessageTest.kt
@@ -43,19 +43,35 @@ class DestinationMessageTest {
             isFileTransferEnabled
         )
 
+    private fun convert(
+        factory: DestinationMessageFactory,
+        message: AirbyteMessage
+    ): DestinationMessage {
+        val serialized = Jsons.serialize(message)
+        return factory.fromAirbyteMessage(
+            // We have to set some stuff in additionalProperties, so force the protocol model back
+            // to a serialized representation and back.
+            // This avoids issues with e.g. `additionalProperties.put("foo", 12L)`:
+            // working directly with that object, `additionalProperties["foo"]` returns `Long?`,
+            // whereas converting to JSON yields `{"foo": 12}`, which then deserializes back out
+            // as `Int?`.
+            // Fortunately, the protocol models are (by definition) round-trippable through JSON.
+            Jsons.deserialize(serialized, AirbyteMessage::class.java),
+            serialized,
+        )
+    }
+
     @ParameterizedTest
     @MethodSource("roundTrippableMessages")
     fun testRoundTripRecord(message: AirbyteMessage) {
-        val roundTripped =
-            factory(false).fromAirbyteMessage(message, Jsons.serialize(message)).asProtocolMessage()
+        val roundTripped = convert(factory(false), message).asProtocolMessage()
         Assertions.assertEquals(message, roundTripped)
     }
 
     @ParameterizedTest
     @MethodSource("roundTrippableFileMessages")
     fun testRoundTripFile(message: AirbyteMessage) {
-        val roundTripped =
-            factory(true).fromAirbyteMessage(message, Jsons.serialize(message)).asProtocolMessage()
+        val roundTripped = convert(factory(true), message).asProtocolMessage()
         Assertions.assertEquals(message, roundTripped)
     }
 
@@ -76,18 +92,23 @@ class DestinationMessageTest {
                         )
                         // Note: only source stats, no destination stats
                         .withSourceStats(AirbyteStateStats().withRecordCount(2.0))
-                        .withAdditionalProperty("id", 1234L)
+                        .withAdditionalProperty("id", 1234)
                 )
 
-        val parsedMessage =
-            factory(false).fromAirbyteMessage(inputMessage, Jsons.serialize(inputMessage))
-                as StreamCheckpoint
+        val parsedMessage = convert(factory(false), inputMessage) as StreamCheckpoint
 
         Assertions.assertEquals(
-            inputMessage.also {
-                it.state.destinationStats = AirbyteStateStats().withRecordCount(3.0)
-            },
-            parsedMessage.withDestinationStats(CheckpointMessage.Stats(3)).asProtocolMessage(),
+            // we represent the state message ID as a long, but jackson sees that 1234 can be Int,
+            // and Int(1234) != Long(1234). (and additionalProperties is just a Map<String, Any?>)
+            // So we just compare the serialized protocol messages.
+            Jsons.serialize(
+                inputMessage.also {
+                    it.state.destinationStats = AirbyteStateStats().withRecordCount(3.0)
+                }
+            ),
+            Jsons.serialize(
+                parsedMessage.withDestinationStats(CheckpointMessage.Stats(3)).asProtocolMessage()
+            ),
         )
     }
 
@@ -112,21 +133,20 @@ class DestinationMessageTest {
                         )
                         // Note: only source stats, no destination stats
                         .withSourceStats(AirbyteStateStats().withRecordCount(2.0))
-                        .withAdditionalProperty("id", 1234L)
+                        .withAdditionalProperty("id", 1234)
                 )
 
-        val parsedMessage =
-            factory(false)
-                .fromAirbyteMessage(
-                    inputMessage,
-                    Jsons.serialize(inputMessage),
-                ) as GlobalCheckpoint
+        val parsedMessage = convert(factory(false), inputMessage) as GlobalCheckpoint
 
         Assertions.assertEquals(
-            inputMessage.also {
-                it.state.destinationStats = AirbyteStateStats().withRecordCount(3.0)
-            },
-            parsedMessage.withDestinationStats(CheckpointMessage.Stats(3)).asProtocolMessage(),
+            Jsons.serialize(
+                inputMessage.also {
+                    it.state.destinationStats = AirbyteStateStats().withRecordCount(3.0)
+                }
+            ),
+            Jsons.serialize(
+                parsedMessage.withDestinationStats(CheckpointMessage.Stats(3)).asProtocolMessage()
+            ),
         )
     }
 

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/internal/InputConsumerTaskTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/internal/InputConsumerTaskTest.kt
@@ -150,7 +150,8 @@ class InputConsumerTaskTest {
         return GlobalCheckpoint(
             state = JsonNodeFactory.instance.objectNode(),
             sourceStats = CheckpointMessage.Stats(recordCount),
-            checkpoints = emptyList()
+            checkpoints = emptyList(),
+            additionalProperties = emptyMap(),
         )
     }
 

--- a/airbyte-integrations/connectors/destination-dev-null/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-dev-null/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: file
   connectorType: destination
   definitionId: a7bcc9d8-13b3-4e49-b80d-d020b90045e3
-  dockerImageTag: 0.7.9
+  dockerImageTag: 0.7.10
   dockerRepository: airbyte/destination-dev-null
   githubIssueLabel: destination-dev-null
   icon: airbyte.svg
@@ -10,10 +10,8 @@ data:
   name: End-to-End Testing (/dev/null)
   registryOverrides:
     cloud:
-      dockerImageTag: 0.7.7
       enabled: true
     oss:
-      dockerImageTag: 0.7.7
       enabled: true
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/destinations/dev-null

--- a/docs/integrations/destinations/dev-null.md
+++ b/docs/integrations/destinations/dev-null.md
@@ -49,6 +49,7 @@ The OSS and Cloud variants have the same version number starting from version `0
 
 | Version | Date       | Pull Request                                             | Subject                                                                                      |
 |:--------|:-----------|:---------------------------------------------------------|:---------------------------------------------------------------------------------------------|
+| 0.7.10  | 2024-11-08 | [48429](https://github.com/airbytehq/airbyte/pull/48429) | Bugfix: correctly handle state ID field                                                      |
 | 0.7.9   | 2024-11-07 | [48417](https://github.com/airbytehq/airbyte/pull/48417) | Only pass through the state ID field, not all additional properties                          |
 | 0.7.8   | 2024-11-07 | [48416](https://github.com/airbytehq/airbyte/pull/48416) | Bugfix: global state correclty sends additional properties                                   |
 | 0.7.7   | 2024-10-17 | [46692](https://github.com/airbytehq/airbyte/pull/46692) | Internal code changes                                                                        |


### PR DESCRIPTION
jackson defaults to parsing ints to Int, not Long. And the jvm doesn't know how to cast Int -> Long. This affects both the state message ID thing, and some file record fields.

I ran a basic test locally, and it didn't crash the same way we saw last night after this fix. (plus updated unit tests to detect this bug)