### PR TITLE
bugfix: Ensure that streams with partition router are not executed concurrently

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/concurrent_declarative_source.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/concurrent_declarative_source.py
@@ -11,6 +11,7 @@ from airbyte_cdk.sources.connector_state_manager import ConnectorStateManager
 from airbyte_cdk.sources.declarative.concurrency_level import ConcurrencyLevel
 from airbyte_cdk.sources.declarative.declarative_stream import DeclarativeStream
 from airbyte_cdk.sources.declarative.extractors import RecordSelector
+from airbyte_cdk.sources.declarative.incremental.datetime_based_cursor import DatetimeBasedCursor
 from airbyte_cdk.sources.declarative.interpolation import InterpolatedString
 from airbyte_cdk.sources.declarative.manifest_declarative_source import ManifestDeclarativeSource
 from airbyte_cdk.sources.declarative.models.declarative_component_schema import ConcurrencyLevel as ConcurrencyLevelModel
@@ -156,6 +157,8 @@ class ConcurrentDeclarativeSource(ManifestDeclarativeSource, Generic[TState]):
                     datetime_based_cursor_component_definition
                     and datetime_based_cursor_component_definition.get("type", "") == DatetimeBasedCursorModel.__name__
                     and self._stream_supports_concurrent_partition_processing(declarative_stream=declarative_stream)
+                    and hasattr(declarative_stream.retriever, "stream_slicer")
+                    and isinstance(declarative_stream.retriever.stream_slicer, DatetimeBasedCursor)
                 ):
                     stream_state = state_manager.get_stream_state(
                         stream_name=declarative_stream.name, namespace=declarative_stream.namespace


### PR DESCRIPTION
## What
We are currently trying to run streams with PerPartition cursors concurrently. However, the cursor does not support that very well leading to errors like:

```
2024-11-07 07:51:07 source > Exception while syncing stream <stream name>
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/airbyte_cdk/sources/streams/concurrent/partition_reader.py", line 37, in process_partition
    for record in partition.read():
  File "/usr/local/lib/python3.10/site-packages/airbyte_cdk/sources/streams/concurrent/adapters.py", line 276, in read
    raise e
  File "/usr/local/lib/python3.10/site-packages/airbyte_cdk/sources/streams/concurrent/adapters.py", line 259, in read
    for record_data in self._stream.read_records(
  File "/usr/local/lib/python3.10/site-packages/airbyte_cdk/sources/declarative/declarative_stream.py", line 137, in read_records
    yield from self.retriever.read_records(self.get_json_schema(), stream_slice)  # type: ignore # records are of the correct type
  File "/usr/local/lib/python3.10/site-packages/airbyte_cdk/sources/declarative/retrievers/simple_retriever.py", line 378, in read_records
    for stream_data in self._read_pages(record_generator, self.state, _slice):
  File "/usr/local/lib/python3.10/site-packages/airbyte_cdk/sources/declarative/retrievers/simple_retriever.py", line 301, in _read_pages
    response = self._fetch_next_page(stream_state, stream_slice, next_page_token)
  File "/usr/local/lib/python3.10/site-packages/airbyte_cdk/sources/declarative/retrievers/simple_retriever.py", line 281, in _fetch_next_page
    request_headers=self._request_headers(stream_state=stream_state, stream_slice=stream_slice, next_page_token=next_page_token),
  File "/usr/local/lib/python3.10/site-packages/airbyte_cdk/sources/declarative/retrievers/simple_retriever.py", line 137, in _request_headers
    headers = self._get_request_options(
  File "/usr/local/lib/python3.10/site-packages/airbyte_cdk/sources/declarative/retrievers/simple_retriever.py", line 124, in _get_request_options
    mappings.append(stream_slicer_method(stream_state=stream_state, stream_slice=stream_slice, next_page_token=next_page_token))
  File "/usr/local/lib/python3.10/site-packages/airbyte_cdk/sources/declarative/incremental/per_partition_with_global.py", line 152, in get_request_headers
    return self._get_active_cursor().get_request_headers(
  File "/usr/local/lib/python3.10/site-packages/airbyte_cdk/sources/declarative/incremental/per_partition_cursor.py", line 237, in get_request_headers
    ) | self._cursor_per_partition[self._to_partition_key(stream_slice.partition)].get_request_headers(
KeyError: '{}'
```

## How
By detecting if the stream slicer for a stream is also the DatetimeBasedCursor when deciding if we should instantiate a concurrent stream.

## User Impact
This should fix failing syncs that are using per partition

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
