### PR TITLE
Correct typo in SubstreamPartitionRouter example

### DIFF
--- a/docs/connector-development/config-based/understanding-the-yaml-file/partition-router.md
+++ b/docs/connector-development/config-based/understanding-the-yaml-file/partition-router.md
@@ -119,7 +119,7 @@ Example:
 ```yaml
 partition_router:
   type: SubstreamPartitionRouter
-  parent_streams_configs:
+  parent_stream_configs:
     - stream: "#/repositories_stream"
       parent_key: "id"
       partition_field: "repository"


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->

There's a typo on https://docs.airbyte.com/connector-development/config-based/understanding-the-yaml-file/partition-router#SubstreamPartitionRouter

As documented elsewhere and on this page it's `parent_stream_configs` not `parent_streams_configs`.

## How
<!--
* Describe how code changes achieve the solution.
-->

It's just a typo fix in the documentation.

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->
If you try to use the example code as is, you'll see this error in the builder:
```
Traceback (most recent call last):
  File "/home/airbyte/.pyenv/versions/3.9.19/lib/python3.9/site-packages/airbyte_cdk/sources/declarative/manifest_declarative_source.py", line 194, in _validate_source
    validate(self._source_config, declarative_component_schema)
  File "/home/airbyte/.pyenv/versions/3.9.19/lib/python3.9/site-packages/jsonschema/validators.py", line 934, in validate
    raise error
jsonschema.exceptions.ValidationError: 'SubstreamPartitionRouter' is not one of ['CustomPartitionRouter']

Failed validating 'enum' in schema[0]['properties']['type']:
    {'enum': ['CustomPartitionRouter'], 'type': 'string'}

On instance['type']:
    'SubstreamPartitionRouter'
```

After correcting the typo, the example code works as-is.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
