### PR TITLE
Python-CDK(!): Temporarily break CDK builds during migration effort

### DIFF
--- a/airbyte-cdk/python/pyproject.toml-bak
+++ b/airbyte-cdk/python/pyproject.toml-bak
@@ -1,0 +1,127 @@
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
+[tool.poetry]
+name = "airbyte-cdk"
+version = "6.5.2"
+description = "A framework for writing Airbyte Connectors."
+authors = ["Airbyte <contact@airbyte.io>"]
+license = "MIT"
+readme = "README.md"
+homepage = "https://github.com/airbytehq/airbyte"
+repository = "https://github.com/airbytehq/airbyte"
+documentation = "https://docs.airbyte.io/"
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Scientific/Engineering",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3.10",
+]
+keywords = ["airbyte", "connector-development-kit", "cdk"]
+
+
+[tool.poetry.dependencies]
+python = "^3.10"
+airbyte-protocol-models-dataclasses = "^0.13"
+backoff = "*"
+cachetools = "*"
+Deprecated = "~1.2"
+dpath = "^2.1.6"
+genson = "1.2.2"
+isodate = "~0.6.1"
+Jinja2 = "~3.1.2"
+jsonref = "~0.2"
+jsonschema = "~3.2.0"
+pandas = "2.2.2"
+pendulum = "<3.0.0"
+psutil = "6.1.0"
+pydantic = "^2.7"
+pyrate-limiter = "~3.1.0"
+python-dateutil = "*"
+PyYAML = "^6.0.1"
+requests = "*"
+requests_cache = "*"
+wcmatch = "8.4"
+# Extras depedencies
+avro = { version = "~1.11.2", optional = true }
+cohere = { version = "4.21", optional = true }
+fastavro = { version = "~1.8.0", optional = true }
+langchain = { version = "0.1.16", optional = true }
+langchain_core = { version = "0.1.42", optional = true }
+markdown = { version = "*", optional = true }
+openai = { version = "0.27.9", extras = ["embeddings"], optional = true }
+pdf2image = { version = "1.16.3", optional = true }
+"pdfminer.six" = { version = "20221105", optional = true }
+pyarrow = { version = "~15.0.0", optional = true }
+pytesseract = { version = "0.3.10", optional = true }
+python-calamine = { version = "0.2.3", optional = true }
+python-snappy = { version = "0.7.3", optional = true }
+Sphinx = { version = "~4.2", optional = true }
+sphinx-rtd-theme = { version = "~1.0", optional = true }
+tiktoken = { version = "0.4.0", optional = true }
+nltk = { version = "3.8.1", optional = true }
+# This will ensure that even when you run poetry install or pip install, the compatible version of numpy will always be chosen.
+# airbyte-ci will try to install latest version when --use-local-cdk is used, resulting in the conflict.
+numpy = "<2"
+unstructured = { version = "0.10.27", extras = ["docx", "pptx"], optional = true }
+"unstructured.pytesseract" = { version = ">=0.3.12", optional = true }
+pyjwt = "^2.8.0"
+cryptography = "^42.0.5"
+pytz = "2024.1"
+orjson = "^3.10.7"
+serpyco-rs = "^1.10.2"
+sqlalchemy = {version = "^2.0,!=2.0.36", optional = true }
+xmltodict = "^0.13.0"
+
+[tool.poetry.group.dev.dependencies]
+freezegun = "*"
+mypy = "*"
+asyncio = "3.4.3"
+poethepoet = "^0.24.2"
+pyproject-flake8 = "^6.1.0"
+pytest = "^7"
+pytest-memray = "^1.6.0"
+pytest-cov = "*"
+pytest-httpserver = "*"
+pytest-mock = "*"
+requests-mock = "*"
+
+[tool.poetry.extras]
+file-based = ["avro", "fastavro", "pyarrow", "unstructured", "pdf2image", "pdfminer.six", "unstructured.pytesseract", "pytesseract", "markdown", "python-calamine", "python-snappy"]
+sphinx-docs = ["Sphinx", "sphinx-rtd-theme"]
+vector-db-based = ["langchain", "openai", "cohere", "tiktoken"]
+sql = ["sqlalchemy"]
+
+[tool.ruff]
+# Setting python version to at least 3.10 avoids `from __future__ import annotations`.
+target-version = "py310"
+# This is consistent with airbytehq/airbyte root pyproject.toml Black rule defined.
+line-length = 140
+
+[tool.poe.tasks]
+# Build tasks
+assemble = {cmd = "bin/generate-component-manifest-dagger.sh", help = "Generate component manifest files."}
+build-package = {cmd = "poetry build", help = "Build the python package: source and wheels archives."}
+build = {sequence = ["assemble", "build-package"], help = "Run all tasks to build the package."}
+
+# Check tasks
+lint =  {cmd = "pflake8 --config ../../pyproject.toml ./", help = "Lint with flake8."}
+type-check = {cmd = "bin/run-mypy-on-modified-files.sh", help = "Type check modified files with mypy."}
+unit-test-with-cov = {cmd = "pytest -s unit_tests -c pytest.ini --cov=airbyte_cdk --cov-report=term --cov-config ../../pyproject.toml", help = "Run unit tests and create a coverage report."}
+# TODO: find a version of the modified mypy check that works both locally and in CI.
+check-lockfile = {cmd = "poetry check", help = "Check the poetry lock file."}
+check-local = {sequence = ["lint", "type-check", "check-lockfile", "unit-test-with-cov"], help = "Lint all code, type-check modified files, and run unit tests."}
+check-ci = {sequence = ["check-lockfile", "build", "lint", "unit-test-with-cov"], help = "Build the package, lint and run unit tests. Does not include type-checking."}
+
+# Build and check
+pre-push = {sequence = ["build", "check-local"], help = "Run all build and check tasks."}
+
+[tool.airbyte_ci]
+python_versions = ["3.10", "3.11"]
+optional_poetry_groups = ["dev"]
+poetry_extras = ["file-based", "sphinx-docs", "vector-db-based"]
+poe_tasks = ["check-ci"]
+mount_docker_socket = true


### PR DESCRIPTION

## What

Block Python CDK changes and builds from this repo while we move to the new repo:

- https://github.com/airbytehq/airbyte-internal-issues/issues/10571

## How

Rename `pyproject.toml` to `pyproject.toml-bak`.

This should prevent any builds from succeeding from this repo.

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
