### PR TITLE
feat(source-fillout): add field `formId` to `submissions` stream

### DIFF
--- a/airbyte-integrations/connectors/source-fillout/manifest.yaml
+++ b/airbyte-integrations/connectors/source-fillout/manifest.yaml
@@ -3,9 +3,6 @@ version: 6.1.0
 type: DeclarativeSource
 
 description: >-
-  ✅ Added the `formId` value to `submissions` stream.
-
-
   The Airbyte connector for Fillout.com enables seamless data synchronization
   between Fillout forms and various target destinations. This connector allows
   you to extract form submissions and related data from Fillout and transfer it
@@ -181,7 +178,7 @@ metadata:
   autoImportSchema:
     forms: true
     form_metadata: true
-    submissions: false
+    submissions: true
   testedStreams:
     forms:
       hasRecords: true

--- a/airbyte-integrations/connectors/source-fillout/manifest.yaml
+++ b/airbyte-integrations/connectors/source-fillout/manifest.yaml
@@ -1,8 +1,11 @@
-version: 5.14.0
+version: 6.1.0
 
 type: DeclarativeSource
 
 description: >-
+  ✅ Added the `formId` value to `submissions` stream.
+
+
   The Airbyte connector for Fillout.com enables seamless data synchronization
   between Fillout forms and various target destinations. This connector allows
   you to extract form submissions and related data from Fillout and transfer it
@@ -126,6 +129,12 @@ definitions:
           type: MinMaxDatetime
           datetime: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%SZ') }}"
           datetime_format: "%Y-%m-%dT%H:%M:%SZ"
+      transformations:
+        - type: AddFields
+          fields:
+            - path:
+                - formId
+              value: "{{ stream_partition.form_id }}"
       schema_loader:
         type: InlineSchemaLoader
         schema:
@@ -172,24 +181,24 @@ metadata:
   autoImportSchema:
     forms: true
     form_metadata: true
-    submissions: true
+    submissions: false
   testedStreams:
     forms:
+      hasRecords: true
       streamHash: ed5a5bcc98a75c0ee799db522a659dc89c16344e
       hasResponse: true
-      responsesAreSuccessful: true
-      hasRecords: true
-      primaryKeysArePresent: true
       primaryKeysAreUnique: true
+      primaryKeysArePresent: true
+      responsesAreSuccessful: true
     form_metadata:
+      hasRecords: true
       streamHash: 9701fd2020429ea05b4611e4185d634aa669712a
       hasResponse: true
-      responsesAreSuccessful: true
-      hasRecords: true
-      primaryKeysArePresent: true
       primaryKeysAreUnique: true
+      primaryKeysArePresent: true
+      responsesAreSuccessful: true
     submissions:
-      streamHash: 615b40e78b07d3f97d5db304dc1ae28dfd782c5e
+      streamHash: 618af7b9b7be9ff9b37106ce75863fe568048443
       hasResponse: true
       responsesAreSuccessful: true
       hasRecords: true
@@ -361,6 +370,8 @@ schemas:
           - "null"
       submissionId:
         type: string
+      formId:
+        type: string
       submissionTime:
         type: string
       urlParameters:
@@ -368,5 +379,6 @@ schemas:
           - array
           - "null"
     required:
+      - formId
       - submissionId
       - submissionTime

--- a/airbyte-integrations/connectors/source-fillout/metadata.yaml
+++ b/airbyte-integrations/connectors/source-fillout/metadata.yaml
@@ -22,7 +22,7 @@ data:
   githubIssueLabel: source-fillout
   icon: icon.svg
   license: MIT
-  name: Fillout - Modified
+  name: Fillout
   releaseDate: 2024-11-14
   releaseStage: alpha
   supportLevel: community

--- a/airbyte-integrations/connectors/source-fillout/metadata.yaml
+++ b/airbyte-integrations/connectors/source-fillout/metadata.yaml
@@ -13,7 +13,7 @@ data:
       enabled: false
       packageName: airbyte-source-fillout
   connectorBuildOptions:
-    baseImage: docker.io/airbyte/source-declarative-manifest:5.16.0@sha256:6800f806944ee4fccf24ae01f6b8fbefb12d952c3b3da338f51f732b55de51f2
+    baseImage: docker.io/airbyte/source-declarative-manifest:6.5.2@sha256:3c89340fc033aab28e7ba7402a4a7c98cd9ca8eefa1503d23d3ea336c9a6e92b
   connectorSubtype: api
   connectorType: source
   definitionId: fae4092b-fcb4-4dba-8ad4-f8bf9a32d25e
@@ -22,8 +22,8 @@ data:
   githubIssueLabel: source-fillout
   icon: icon.svg
   license: MIT
-  name: Fillout
-  releaseDate: 2024-10-28
+  name: Fillout - Modified
+  releaseDate: 2024-11-14
   releaseStage: alpha
   supportLevel: community
   documentationUrl: https://docs.airbyte.com/integrations/sources/fillout

--- a/airbyte-integrations/connectors/source-fillout/metadata.yaml
+++ b/airbyte-integrations/connectors/source-fillout/metadata.yaml
@@ -17,7 +17,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: fae4092b-fcb4-4dba-8ad4-f8bf9a32d25e
-  dockerImageTag: 0.0.1
+  dockerImageTag: 0.2.0
   dockerRepository: airbyte/source-fillout
   githubIssueLabel: source-fillout
   icon: icon.svg

--- a/docs/integrations/sources/fillout.md
+++ b/docs/integrations/sources/fillout.md
@@ -1,27 +1,30 @@
 # Fillout
+
 The Airbyte connector for Fillout.com enables seamless data synchronization between Fillout forms and various target destinations. This connector allows you to extract form submissions and related data from Fillout and transfer it to your chosen data warehouse, analytics platform, or other destinations. With this integration, you can automate workflows, perform data analysis, and centralize data management for improved insights and reporting.
 
 ## Configuration
 
-| Input | Type | Description | Default Value |
-|-------|------|-------------|---------------|
-| `api_key` | `string` | API Key. API key to use. Find it in the Developer settings tab of your Fillout account. |  |
-| `start_date` | `string` | Start date.  |  |
+| Input        | Type     | Description                                                                             | Default Value |
+| ------------ | -------- | --------------------------------------------------------------------------------------- | ------------- |
+| `api_key`    | `string` | API Key. API key to use. Find it in the Developer settings tab of your Fillout account. |               |
+| `start_date` | `string` | Start date.                                                                             |               |
 
 ## Streams
-| Stream Name | Primary Key | Pagination | Supports Full Sync | Supports Incremental |
-|-------------|-------------|------------|---------------------|----------------------|
-| forms | formId | DefaultPaginator | ✅ |  ❌  |
-| form_metadata | id | DefaultPaginator | ✅ |  ❌  |
-| submissions | submissionId | DefaultPaginator | ✅ |  ✅  |
+
+| Stream Name   | Primary Key  | Pagination       | Supports Full Sync | Supports Incremental |
+| ------------- | ------------ | ---------------- | ------------------ | -------------------- |
+| forms         | formId       | DefaultPaginator | ✅                 | ❌                   |
+| form_metadata | id           | DefaultPaginator | ✅                 | ❌                   |
+| submissions   | submissionId | DefaultPaginator | ✅                 | ✅                   |
 
 ## Changelog
 
 <details>
   <summary>Expand to review</summary>
 
-| Version          | Date              | Pull Request | Subject        |
-|------------------|-------------------|--------------|----------------|
-| 0.0.1 | 2024-10-28 | | Initial release by [@parthiv11](https://github.com/parthiv11) via Connector Builder |
+| Version | Date       | Pull Request | Subject                                                                             |
+| ------- | ---------- | ------------ | ----------------------------------------------------------------------------------- |
+| 0.2.0   | 2024-11-14 |              | Add `formId` to `submissions` stream                                                |
+| 0.0.1   | 2024-10-28 |              | Initial release by [@parthiv11](https://github.com/parthiv11) via Connector Builder |
 
 </details>


### PR DESCRIPTION
## What

This PR updates source Fillout - Modified (source-fillout).

The contributor provided the following description of the change:

✅ Added the `formId` value to `submissions` stream.

The Airbyte connector for Fillout.com enables seamless data synchronization between Fillout forms and various target destinations. This connector allows you to extract form submissions and related data from Fillout and transfer it to your chosen data warehouse, analytics platform, or other destinations. With this integration, you can automate workflows, perform data analysis, and centralize data management for improved insights and reporting.
## Reviewer checklist
- [ ] Resolve any merge conflicts and validate file diffs (make sure the PR only includes changes intended by the contributor)
- [ ] After reviewing the changes, run the [`bump-version` Airbyte-CI command](https://github.com/airbytehq/airbyte/blob/master/airbyte-ci/connectors/pipelines/README.md#connectors-bump-version-command) locally to update the version of the connector according to the [versioning guidelines](https://docs.airbyte.io/contributor-guide/versioning-guidelines). Add `breakingChanges` to metadata if necessary.
- [ ] Ensure connector docs are up to date with any changes
- [ ] Run `/format-fix` to resolve any formatting errors
- [ ] Click into the CI workflows that wait for a maintainer to run them, which should trigger CI runs

<!-- DO NOT REMOVE: connector-builder-edit-connector-contribution -->
