### PR TITLE
Bulk Load CDK: Async part upload dispatch per part, not per write

### DIFF
--- a/airbyte-integrations/connectors/destination-s3/build.gradle
+++ b/airbyte-integrations/connectors/destination-s3/build.gradle
@@ -17,6 +17,21 @@ application {
 
     // uncomment and replace to run locally
     //applicationDefaultJvmArgs = ['-XX:+ExitOnOutOfMemoryError', '-XX:MaxRAMPercentage=75.0', '--add-opens', 'java.base/java.lang=ALL-UNNAMED']
+    applicationDefaultJvmArgs = [
+            '-XX:+ExitOnOutOfMemoryError', '-XX:MaxRAMPercentage=75.0'
+//            Uncomment to enable remote profiling:
+//            '-XX:NativeMemoryTracking=detail',
+//            '-Djava.rmi.server.hostname=localhost',
+//            '-Dcom.sun.management.jmxremote=true',
+//            '-Dcom.sun.management.jmxremote.port=6000',
+//            '-Dcom.sun.management.jmxremote.rmi.port=6000',
+//            '-Dcom.sun.management.jmxremote.local.only=false',
+//            '-Dcom.sun.management.jmxremote.authenticate=false',
+//            '-Dcom.sun.management.jmxremote.ssl=false',
+    ]
+
+    // Uncomment and replace to run locally
+    //applicationDefaultJvmArgs = ['-XX:+ExitOnOutOfMemoryError', '-XX:MaxRAMPercentage=75.0', '--add-opens', 'java.base/sun.nio.ch=ALL-UNNAMED', '--add-opens', 'java.base/sun.security.action=ALL-UNNAMED', '--add-opens', 'java.base/java.lang=ALL-UNNAMED']
 }
 
 // uncomment to run locally


### PR DESCRIPTION
### What
S3MultipartUpload dispatches work per-part instead of per-write.

The underlying issue comes from how we're presenting the S3 multipart upload process as an output stream. Workflow:
* start a multipart upload
* present an output stream to client in a closure
* client writes to the output stream
* data is accumulated in a buffer
* when we reach the configured part size, we kick off `uploadPart`
* when the closure completes, we complete the upload (data becomes visible in s3)

The problem is that the AWS Kotlin SDK uses coroutines, but `OutputStream` does not. So whenever a suspend function is triggered by a write, we have to bridge.

Naively, you'd just wrap everything in `runBlocking`, but if you do this with long-running tasks it can block other coroutines on the thread and lead to unpredictable behavior.

The original solution was to dispatch all work on channel and process it asynchronously. This is not ideal, because it imposed a cost per-write. However, it did not initially seem to impact performance (much?) because most writes were a byte array per row or formatted block.

CSV however calls `write` per-byte, so the cost was enough to trigger a 10x slowdown.

### How

The solution is
* remove all unnecessary suspend functions from the interface (the only thing that absolutely must be suspend is the API calls)
* do the buffer accumulation synchronously, and only enqueue the finished byte arrays
* process the byte arrays asynchronously as upload parts api calls

### Results
See this [sheet](https://docs.google.com/spreadsheets/d/11WkVCiPh0AiIJvARgrFTv4oyQRB7_qvpKYogdgfkpPE/edit?gid=0#gid=0) for details. TLDR:
* json: slight perf hit -> parity with the old CDK
* csv: 10x perf hit -> parity with the old CDK
* parquet: slight perf hit -> 2x *improvement* over the old CDK
* avro: unclear; perf on the new cdk relative to pre-bug 2x'ed; but the old CDK tests failed to finish in a timely fashion (probably due to transient conditions?) so I need to re-run them to get a good comparison