### PR TITLE
chore: rbroughan/disk back pressure no deadlock prevention

### DIFF
--- a/airbyte-cdk/bulk/core/base/src/main/resources/application.yaml
+++ b/airbyte-cdk/bulk/core/base/src/main/resources/application.yaml
@@ -4,4 +4,4 @@ airbyte:
     staging-path: ${AIRBYTE_STAGING_DIRECTORY:/staging/files}
   resources:
     disk:
-      bytes: ${CONNECTOR_STORAGE_LIMIT_BYTES:107374182400} // 100GB
+      bytes: ${CONNECTOR_STORAGE_LIMIT_BYTES:5368709120} // 5GB

--- a/airbyte-cdk/bulk/core/base/src/main/resources/application.yaml
+++ b/airbyte-cdk/bulk/core/base/src/main/resources/application.yaml
@@ -2,3 +2,6 @@ airbyte:
   file-transfer:
     enabled: ${USE_FILE_TRANSFER:false}
     staging-path: ${AIRBYTE_STAGING_DIRECTORY:/staging/files}
+  resources:
+    disk:
+      bytes: ${CONNECTOR_STORAGE_LIMIT_BYTES:107374182400} // 100GB

--- a/airbyte-cdk/bulk/core/base/src/main/resources/application.yaml
+++ b/airbyte-cdk/bulk/core/base/src/main/resources/application.yaml
@@ -4,4 +4,4 @@ airbyte:
     staging-path: ${AIRBYTE_STAGING_DIRECTORY:/staging/files}
   resources:
     disk:
-      bytes: ${CONNECTOR_STORAGE_LIMIT_BYTES:5368709120} // 5GB
+      bytes: ${CONNECTOR_STORAGE_LIMIT_BYTES:5368709120} # 5GB

--- a/airbyte-cdk/bulk/core/load/build.gradle
+++ b/airbyte-cdk/bulk/core/load/build.gradle
@@ -21,6 +21,7 @@ dependencies {
     testFixturesApi testFixtures(project(':airbyte-cdk:bulk:core:bulk-cdk-core-base'))
 
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.8.1")
+    testImplementation("io.mockk:mockk:1.13.12")
     implementation "org.jetbrains.kotlin:kotlin-reflect:2.0.20"
     testFixturesImplementation "uk.org.webcompere:system-stubs-jupiter:2.1.7"
 }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/config/SyncBeanFactory.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/config/SyncBeanFactory.kt
@@ -5,19 +5,30 @@
 package io.airbyte.cdk.load.config
 
 import io.airbyte.cdk.load.command.DestinationConfiguration
-import io.airbyte.cdk.load.state.MemoryManager
+import io.airbyte.cdk.load.state.ReservationManager
 import io.micronaut.context.annotation.Factory
+import io.micronaut.context.annotation.Value
+import jakarta.inject.Named
 import jakarta.inject.Singleton
 
 /** Factory for instantiating beans necessary for the sync process. */
 @Factory
 class SyncBeanFactory {
     @Singleton
+    @Named("memoryManager")
     fun memoryManager(
         config: DestinationConfiguration,
-    ): MemoryManager {
+    ): ReservationManager {
         val memory = config.maxMessageQueueMemoryUsageRatio * Runtime.getRuntime().maxMemory()
 
-        return MemoryManager(memory.toLong())
+        return ReservationManager(memory.toLong())
+    }
+
+    @Singleton
+    @Named("diskManager")
+    fun diskManager(
+        @Value("\${airbyte.resources.disk.bytes}") availableBytes: Long,
+    ): ReservationManager {
+        return ReservationManager(availableBytes)
     }
 }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/DestinationMessageQueues.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/DestinationMessageQueues.kt
@@ -6,7 +6,7 @@ package io.airbyte.cdk.load.message
 
 import io.airbyte.cdk.load.command.DestinationCatalog
 import io.airbyte.cdk.load.command.DestinationStream
-import io.airbyte.cdk.load.state.MemoryManager
+import io.airbyte.cdk.load.state.ReservationManager
 import io.airbyte.cdk.load.state.Reserved
 import io.micronaut.context.annotation.Secondary
 import jakarta.inject.Singleton
@@ -55,7 +55,7 @@ data class StreamFileCompleteWrapped(
 class DestinationRecordQueue : ChannelMessageQueue<Reserved<DestinationRecordWrapped>>()
 
 /**
- * A supplier of message queues to which ([MemoryManager.reserve]'d) @ [DestinationRecordWrapped]
+ * A supplier of message queues to which ([ReservationManager.reserve]'d) @ [DestinationRecordWrapped]
  * messages can be published on a @ [DestinationStream] key. The queues themselves do not manage
  * memory.
  */

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/DestinationMessageQueues.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/DestinationMessageQueues.kt
@@ -55,9 +55,9 @@ data class StreamFileCompleteWrapped(
 class DestinationRecordQueue : ChannelMessageQueue<Reserved<DestinationRecordWrapped>>()
 
 /**
- * A supplier of message queues to which ([ReservationManager.reserve]'d) @ [DestinationRecordWrapped]
- * messages can be published on a @ [DestinationStream] key. The queues themselves do not manage
- * memory.
+ * A supplier of message queues to which ([ReservationManager.reserve]'d) @
+ * [DestinationRecordWrapped] messages can be published on a @ [DestinationStream] key. The queues
+ * themselves do not manage memory.
  */
 @Singleton
 @Secondary

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/state/ReservationManager.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/state/ReservationManager.kt
@@ -56,8 +56,8 @@ class ReservationManager(val totalCapacityBytes: Long) {
         return Reserved(this, bytes, reservedFor)
     }
 
-   /* Attempt to reserve memory. If enough memory is not available, waits until it is, then reserves. */
-   suspend fun reserve(bytes: Long) {
+    /* Attempt to reserve memory. If enough memory is not available, waits until it is, then reserves. */
+    suspend fun reserve(bytes: Long) {
         if (bytes > totalCapacityBytes) {
             throw IllegalArgumentException(
                 "Requested ${bytes}b exceeds ${totalCapacityBytes}b total"

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/InputConsumerTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/InputConsumerTask.kt
@@ -32,7 +32,7 @@ import io.airbyte.cdk.load.message.StreamFileWrapped
 import io.airbyte.cdk.load.message.StreamRecordCompleteWrapped
 import io.airbyte.cdk.load.message.StreamRecordWrapped
 import io.airbyte.cdk.load.message.Undefined
-import io.airbyte.cdk.load.state.MemoryManager
+import io.airbyte.cdk.load.state.ReservationManager
 import io.airbyte.cdk.load.state.Reserved
 import io.airbyte.cdk.load.state.SyncManager
 import io.airbyte.cdk.load.task.KillableScope
@@ -200,11 +200,11 @@ abstract class ReservingDeserializingInputFlow<T : Any> : SizedInputFlow<Reserve
 
     abstract val config: DestinationConfiguration
     abstract val deserializer: Deserializer<T>
-    abstract val memoryManager: MemoryManager
+    abstract val memoryManager: ReservationManager
     abstract val inputStream: InputStream
 
     override suspend fun collect(collector: FlowCollector<Pair<Long, Reserved<T>>>) {
-        log.info { "Reserved ${memoryManager.totalMemoryBytes/1024}mb memory for input processing" }
+        log.info { "Reserved ${memoryManager.totalCapacityBytes/1024}mb memory for input processing" }
 
         inputStream.bufferedReader().lineSequence().forEachIndexed { index, line ->
             if (line.isEmpty()) {
@@ -230,6 +230,6 @@ abstract class ReservingDeserializingInputFlow<T : Any> : SizedInputFlow<Reserve
 class DefaultInputFlow(
     override val config: DestinationConfiguration,
     override val deserializer: Deserializer<DestinationMessage>,
-    override val memoryManager: MemoryManager,
+    override val memoryManager: ReservationManager,
     override val inputStream: InputStream
 ) : ReservingDeserializingInputFlow<DestinationMessage>()

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/InputConsumerTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/InputConsumerTask.kt
@@ -40,6 +40,7 @@ import io.airbyte.cdk.load.task.SyncLevel
 import io.airbyte.cdk.load.util.use
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.micronaut.context.annotation.Secondary
+import jakarta.inject.Named
 import jakarta.inject.Singleton
 import java.io.InputStream
 import kotlinx.coroutines.flow.Flow
@@ -232,6 +233,6 @@ abstract class ReservingDeserializingInputFlow<T : Any> : SizedInputFlow<Reserve
 class DefaultInputFlow(
     override val config: DestinationConfiguration,
     override val deserializer: Deserializer<DestinationMessage>,
-    override val memoryManager: ReservationManager,
+    @Named("memoryManager") override val memoryManager: ReservationManager,
     override val inputStream: InputStream
 ) : ReservingDeserializingInputFlow<DestinationMessage>()

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/InputConsumerTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/InputConsumerTask.kt
@@ -204,7 +204,9 @@ abstract class ReservingDeserializingInputFlow<T : Any> : SizedInputFlow<Reserve
     abstract val inputStream: InputStream
 
     override suspend fun collect(collector: FlowCollector<Pair<Long, Reserved<T>>>) {
-        log.info { "Reserved ${memoryManager.totalCapacityBytes/1024}mb memory for input processing" }
+        log.info {
+            "Reserved ${memoryManager.totalCapacityBytes/1024}mb memory for input processing"
+        }
 
         inputStream.bufferedReader().lineSequence().forEachIndexed { index, line ->
             if (line.isEmpty()) {

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/SizedInputFlow.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/SizedInputFlow.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.load.task.internal
+
+import io.airbyte.cdk.load.command.DestinationConfiguration
+import io.airbyte.cdk.load.message.Deserializer
+import io.airbyte.cdk.load.message.DestinationMessage
+import io.airbyte.cdk.load.state.ReservationManager
+import io.airbyte.cdk.load.state.Reserved
+import io.github.oshai.kotlinlogging.KotlinLogging
+import jakarta.inject.Named
+import jakarta.inject.Singleton
+import java.io.InputStream
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.FlowCollector
+
+interface SizedInputFlow<T> : Flow<Pair<Long, T>>
+
+abstract class ReservingDeserializingInputFlow<T : Any> : SizedInputFlow<Reserved<T>> {
+    val log = KotlinLogging.logger {}
+
+    abstract val config: DestinationConfiguration
+    abstract val deserializer: Deserializer<T>
+    abstract val memoryManager: ReservationManager
+    abstract val inputStream: InputStream
+
+    override suspend fun collect(collector: FlowCollector<Pair<Long, Reserved<T>>>) {
+        log.info {
+            "Reserved ${memoryManager.totalCapacityBytes/1024}mb memory for input processing"
+        }
+
+        inputStream.bufferedReader().lineSequence().forEachIndexed { index, line ->
+            if (line.isEmpty()) {
+                return@forEachIndexed
+            }
+
+            val lineSize = line.length.toLong()
+            val estimatedSize = lineSize * config.estimatedRecordMemoryOverheadRatio
+            val reserved = memoryManager.reserve(estimatedSize.toLong(), line)
+            val message = deserializer.deserialize(line)
+            collector.emit(Pair(lineSize, reserved.replace(message)))
+
+            if (index % 10_000 == 0) {
+                log.info { "Processed $index lines" }
+            }
+        }
+
+        log.info { "Finished processing input" }
+    }
+}
+
+@Singleton
+class DefaultInputFlow(
+    override val config: DestinationConfiguration,
+    override val deserializer: Deserializer<DestinationMessage>,
+    @Named("memoryManager") override val memoryManager: ReservationManager,
+    override val inputStream: InputStream
+) : ReservingDeserializingInputFlow<DestinationMessage>()

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/SpillToDiskTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/SpillToDiskTask.kt
@@ -4,6 +4,7 @@
 
 package io.airbyte.cdk.load.task.internal
 
+import com.fasterxml.jackson.core.StreamReadConstraints
 import com.google.common.collect.Range
 import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.file.SpillFileProvider
@@ -13,6 +14,7 @@ import io.airbyte.cdk.load.message.QueueReader
 import io.airbyte.cdk.load.message.StreamRecordCompleteWrapped
 import io.airbyte.cdk.load.message.StreamRecordWrapped
 import io.airbyte.cdk.load.state.FlushStrategy
+import io.airbyte.cdk.load.state.ReservationManager
 import io.airbyte.cdk.load.state.Reserved
 import io.airbyte.cdk.load.task.DestinationTaskLauncher
 import io.airbyte.cdk.load.task.InternalScope
@@ -22,6 +24,7 @@ import io.airbyte.cdk.load.util.use
 import io.airbyte.cdk.load.util.withNextAdjacentValue
 import io.airbyte.cdk.load.util.write
 import io.github.oshai.kotlinlogging.KotlinLogging
+import jakarta.inject.Named
 import jakarta.inject.Singleton
 import java.nio.file.Path
 import kotlin.io.path.outputStream
@@ -42,6 +45,7 @@ class DefaultSpillToDiskTask(
     private val flushStrategy: FlushStrategy,
     override val stream: DestinationStream,
     private val launcher: DestinationTaskLauncher,
+    private val diskManager: ReservationManager,
 ) : SpillToDiskTask {
     private val log = KotlinLogging.logger {}
 
@@ -62,13 +66,21 @@ class DefaultSpillToDiskTask(
                         reserved.use {
                             when (val wrapped = it.value) {
                                 is StreamRecordWrapped -> {
+                                    // reserve enough room for the record
+                                    diskManager.reserve(wrapped.sizeBytes)
+
+                                    // calculate whether we should flush
+                                    val saturated = diskManager.remainingCapacityBytes <
+                                        StreamReadConstraints.DEFAULT_MAX_STRING_LEN
+                                    val rangeProcessed = range.withNextAdjacentValue(wrapped.index)
+                                    val bytesProcessed = sizeBytes + wrapped.sizeBytes
+                                    val forceFlush = saturated ||
+                                        flushStrategy.shouldFlush(stream, rangeProcessed, bytesProcessed)
+
+                                    // write and return output
                                     outputStream.write(wrapped.record.serialized)
                                     outputStream.write("\n")
-                                    val nextRange = range.withNextAdjacentValue(wrapped.index)
-                                    val nextSize = sizeBytes + wrapped.sizeBytes
-                                    val forceFlush =
-                                        flushStrategy.shouldFlush(stream, nextRange, nextSize)
-                                    ReadResult(nextRange, nextSize, forceFlush = forceFlush)
+                                    ReadResult(rangeProcessed, bytesProcessed, forceFlush = forceFlush)
                                 }
                                 is StreamRecordCompleteWrapped -> {
                                     val nextRange = range.withNextAdjacentValue(wrapped.index)
@@ -107,6 +119,7 @@ class DefaultSpillToDiskTaskFactory(
     private val queueSupplier:
         MessageQueueSupplier<DestinationStream.Descriptor, Reserved<DestinationRecordWrapped>>,
     private val flushStrategy: FlushStrategy,
+    @Named("diskManager") private val diskManager: ReservationManager,
 ) : SpillToDiskTaskFactory {
     override fun make(
         taskLauncher: DestinationTaskLauncher,
@@ -118,6 +131,7 @@ class DefaultSpillToDiskTaskFactory(
             flushStrategy,
             stream,
             taskLauncher,
+            diskManager,
         )
     }
 }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/SpillToDiskTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/SpillToDiskTask.kt
@@ -4,7 +4,6 @@
 
 package io.airbyte.cdk.load.task.internal
 
-import com.fasterxml.jackson.core.StreamReadConstraints
 import com.google.common.collect.Range
 import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.file.SpillFileProvider

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/SpillToDiskTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/SpillToDiskTask.kt
@@ -71,12 +71,21 @@ class DefaultSpillToDiskTask(
                                     // calculate whether we should flush
                                     val rangeProcessed = range.withNextAdjacentValue(wrapped.index)
                                     val bytesProcessed = sizeBytes + wrapped.sizeBytes
-                                    val forceFlush = flushStrategy.shouldFlush(stream, rangeProcessed, bytesProcessed)
+                                    val forceFlush =
+                                        flushStrategy.shouldFlush(
+                                            stream,
+                                            rangeProcessed,
+                                            bytesProcessed
+                                        )
 
                                     // write and return output
                                     outputStream.write(wrapped.record.serialized)
                                     outputStream.write("\n")
-                                    ReadResult(rangeProcessed, bytesProcessed, forceFlush = forceFlush)
+                                    ReadResult(
+                                        rangeProcessed,
+                                        bytesProcessed,
+                                        forceFlush = forceFlush
+                                    )
                                 }
                                 is StreamRecordCompleteWrapped -> {
                                     val nextRange = range.withNextAdjacentValue(wrapped.index)

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/SpillToDiskTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/SpillToDiskTask.kt
@@ -70,12 +70,9 @@ class DefaultSpillToDiskTask(
                                     diskManager.reserve(wrapped.sizeBytes)
 
                                     // calculate whether we should flush
-                                    val saturated = diskManager.remainingCapacityBytes <
-                                        StreamReadConstraints.DEFAULT_MAX_STRING_LEN
                                     val rangeProcessed = range.withNextAdjacentValue(wrapped.index)
                                     val bytesProcessed = sizeBytes + wrapped.sizeBytes
-                                    val forceFlush = saturated ||
-                                        flushStrategy.shouldFlush(stream, rangeProcessed, bytesProcessed)
+                                    val forceFlush = flushStrategy.shouldFlush(stream, rangeProcessed, bytesProcessed)
 
                                     // write and return output
                                     outputStream.write(wrapped.record.serialized)

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/implementor/ProcessRecordsTaskTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/implementor/ProcessRecordsTaskTest.kt
@@ -12,34 +12,46 @@ import io.airbyte.cdk.load.message.Batch
 import io.airbyte.cdk.load.message.Deserializer
 import io.airbyte.cdk.load.message.DestinationMessage
 import io.airbyte.cdk.load.message.DestinationRecord
+import io.airbyte.cdk.load.state.ReservationManager
 import io.airbyte.cdk.load.state.SyncManager
 import io.airbyte.cdk.load.task.MockTaskLauncher
 import io.airbyte.cdk.load.task.internal.SpilledRawMessagesLocalFile
 import io.airbyte.cdk.load.util.write
 import io.airbyte.cdk.load.write.StreamLoader
-import io.micronaut.context.annotation.Primary
-import io.micronaut.context.annotation.Requires
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import io.mockk.coVerify
+import io.mockk.mockk
 import jakarta.inject.Inject
-import jakarta.inject.Singleton
 import java.nio.file.Files
 import kotlin.io.path.outputStream
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 @MicronautTest(
     environments =
         [
-            "ProcessRecordsTaskTest",
             "MockDestinationCatalog",
-            "MockTaskLauncher",
         ]
 )
 class ProcessRecordsTaskTest {
-    @Inject lateinit var processRecordsTaskFactory: DefaultProcessRecordsTaskFactory
-    @Inject lateinit var launcher: MockTaskLauncher
+    private lateinit var diskManager: ReservationManager
+    private lateinit var processRecordsTaskFactory: DefaultProcessRecordsTaskFactory
+    private lateinit var launcher: MockTaskLauncher
     @Inject lateinit var syncManager: SyncManager
+
+    @BeforeEach
+    fun setup() {
+        diskManager = mockk(relaxed = true)
+        launcher = MockTaskLauncher()
+        processRecordsTaskFactory =
+            DefaultProcessRecordsTaskFactory(
+                MockDeserializer(),
+                syncManager,
+                diskManager,
+            )
+    }
 
     class MockBatch(
         override val state: Batch.State,
@@ -72,9 +84,6 @@ class ProcessRecordsTaskTest {
         }
     }
 
-    @Singleton
-    @Primary
-    @Requires(env = ["ProcessRecordsTaskTest"])
     class MockDeserializer : Deserializer<DestinationMessage> {
         override fun deserialize(serialized: String): DestinationMessage {
             return DestinationRecord(
@@ -119,5 +128,6 @@ class ProcessRecordsTaskTest {
         Assertions.assertEquals(recordCount, batch.recordCount)
         Assertions.assertEquals((0 until recordCount).sum(), batch.pmChecksum)
         Assertions.assertFalse(Files.exists(mockFile), "ensure task deleted file")
+        coVerify { diskManager.release(byteSize) }
     }
 }

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/internal/InputConsumerTaskTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/internal/InputConsumerTaskTest.kt
@@ -39,6 +39,7 @@ import io.micronaut.context.annotation.Primary
 import io.micronaut.context.annotation.Requires
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest
 import jakarta.inject.Inject
+import jakarta.inject.Named
 import jakarta.inject.Singleton
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.FlowCollector
@@ -74,7 +75,7 @@ class InputConsumerTaskTest {
     @Singleton
     @Primary
     @Requires(env = ["InputConsumerTaskTest"])
-    class MockInputFlow(val memoryManager: ReservationManager) :
+    class MockInputFlow(@Named("memoryManager") val memoryManager: ReservationManager) :
         SizedInputFlow<Reserved<DestinationMessage>> {
         private val messages = Channel<Pair<Long, Reserved<DestinationMessage>>>(Channel.UNLIMITED)
         val initialMemory = memoryManager.remainingCapacityBytes

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/internal/InputConsumerTaskTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/internal/InputConsumerTaskTest.kt
@@ -30,7 +30,7 @@ import io.airbyte.cdk.load.message.StreamFileCompleteWrapped
 import io.airbyte.cdk.load.message.StreamFileWrapped
 import io.airbyte.cdk.load.message.StreamRecordCompleteWrapped
 import io.airbyte.cdk.load.message.StreamRecordWrapped
-import io.airbyte.cdk.load.state.MemoryManager
+import io.airbyte.cdk.load.state.ReservationManager
 import io.airbyte.cdk.load.state.Reserved
 import io.airbyte.cdk.load.state.SyncManager
 import io.airbyte.cdk.load.test.util.CoroutineTestUtils
@@ -74,10 +74,10 @@ class InputConsumerTaskTest {
     @Singleton
     @Primary
     @Requires(env = ["InputConsumerTaskTest"])
-    class MockInputFlow(val memoryManager: MemoryManager) :
+    class MockInputFlow(val memoryManager: ReservationManager) :
         SizedInputFlow<Reserved<DestinationMessage>> {
         private val messages = Channel<Pair<Long, Reserved<DestinationMessage>>>(Channel.UNLIMITED)
-        val initialMemory = memoryManager.remainingMemoryBytes
+        val initialMemory = memoryManager.remainingCapacityBytes
 
         override suspend fun collect(
             collector: FlowCollector<Pair<Long, Reserved<DestinationMessage>>>
@@ -309,7 +309,7 @@ class InputConsumerTaskTest {
         Assertions.assertEquals(messages1[10].value, StreamRecordCompleteWrapped(10))
         Assertions.assertEquals(
             mockInputFlow.initialMemory - 11,
-            mockInputFlow.memoryManager.remainingMemoryBytes,
+            mockInputFlow.memoryManager.remainingCapacityBytes,
             "1 byte per message should have been reserved, but the end-of-stream should have been released"
         )
     }

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/internal/ReservingDeserializingInputFlowTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/internal/ReservingDeserializingInputFlowTest.kt
@@ -6,7 +6,7 @@ package io.airbyte.cdk.load.task.internal
 
 import io.airbyte.cdk.load.command.DestinationConfiguration
 import io.airbyte.cdk.load.message.Deserializer
-import io.airbyte.cdk.load.state.MemoryManager
+import io.airbyte.cdk.load.state.ReservationManager
 import io.micronaut.context.annotation.Primary
 import io.micronaut.context.annotation.Requires
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest
@@ -44,7 +44,7 @@ class ReservingDeserializingInputFlowTest {
         override val config: DestinationConfiguration,
         override val inputStream: InputStream,
         override val deserializer: Deserializer<String>,
-        override val memoryManager: MemoryManager,
+        override val memoryManager: ReservationManager,
     ) : ReservingDeserializingInputFlow<String>()
 
     @Singleton

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/internal/ReservingDeserializingInputFlowTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/internal/ReservingDeserializingInputFlowTest.kt
@@ -11,6 +11,7 @@ import io.micronaut.context.annotation.Primary
 import io.micronaut.context.annotation.Requires
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest
 import jakarta.inject.Inject
+import jakarta.inject.Named
 import jakarta.inject.Singleton
 import java.io.InputStream
 import java.util.stream.Stream
@@ -44,7 +45,7 @@ class ReservingDeserializingInputFlowTest {
         override val config: DestinationConfiguration,
         override val inputStream: InputStream,
         override val deserializer: Deserializer<String>,
-        override val memoryManager: ReservationManager,
+        @Named("memoryManager") override val memoryManager: ReservationManager,
     ) : ReservingDeserializingInputFlow<String>()
 
     @Singleton

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/internal/SpillToDiskTaskTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/internal/SpillToDiskTaskTest.kt
@@ -14,7 +14,7 @@ import io.airbyte.cdk.load.message.MessageQueueSupplier
 import io.airbyte.cdk.load.message.StreamRecordCompleteWrapped
 import io.airbyte.cdk.load.message.StreamRecordWrapped
 import io.airbyte.cdk.load.state.FlushStrategy
-import io.airbyte.cdk.load.state.MemoryManager
+import io.airbyte.cdk.load.state.ReservationManager
 import io.airbyte.cdk.load.state.Reserved
 import io.airbyte.cdk.load.task.MockTaskLauncher
 import io.airbyte.cdk.load.util.lineSequence
@@ -39,7 +39,7 @@ import org.junit.jupiter.api.Test
         ]
 )
 class SpillToDiskTaskTest {
-    @Inject lateinit var memoryManager: MemoryManager
+    @Inject lateinit var memoryManager: ReservationManager
     @Inject lateinit var spillToDiskTaskFactory: DefaultSpillToDiskTaskFactory
     @Inject
     lateinit var queueSupplier:
@@ -90,9 +90,9 @@ class SpillToDiskTaskTest {
 
     @Test
     fun testSpillToDiskTask() = runTest {
-        val availableMemory = memoryManager.remainingMemoryBytes
+        val availableMemory = memoryManager.remainingCapacityBytes
         val bytesReserved = primeMessageQueue()
-        Assertions.assertEquals(availableMemory - bytesReserved, memoryManager.remainingMemoryBytes)
+        Assertions.assertEquals(availableMemory - bytesReserved, memoryManager.remainingCapacityBytes)
 
         val mockTaskLauncher = MockTaskLauncher()
         spillToDiskTaskFactory
@@ -121,7 +121,7 @@ class SpillToDiskTaskTest {
         Assertions.assertEquals(expectedLinesFirst, file1.inputStream().lineSequence().toList())
         Assertions.assertEquals(expectedLinesSecond, file2.inputStream().lineSequence().toList())
 
-        Assertions.assertEquals(availableMemory, memoryManager.remainingMemoryBytes)
+        Assertions.assertEquals(availableMemory, memoryManager.remainingCapacityBytes)
 
         file1.toFile().delete()
         file2.toFile().delete()


### PR DESCRIPTION
## What
Caps amount of disk usage for aggregate buffering. No deadlock prevention.

## How
* Renames `MemoryManager` -> `ReservationManager`
* Adds `diskManager` instance of `ReservationManager`
* Reserves before file append
* Releases disk reservation after file deletion 

## Other
Brings in `mockk` so I don't have to hand roll a mock 
Winds back some micronaut injection in the tests
