### PR TITLE
Add IAM Role Support to S3 V2 Destination.

### DIFF
--- a/airbyte-cdk/bulk/toolkits/load-aws/src/main/kotlin/io/airbyte/cdk/load/command/aws/AWSAccessKeySpecification.kt
+++ b/airbyte-cdk/bulk/toolkits/load-aws/src/main/kotlin/io/airbyte/cdk/load/command/aws/AWSAccessKeySpecification.kt
@@ -37,7 +37,7 @@ interface AWSAccessKeySpecification {
     }
 }
 
-data class AWSAccessKeyConfiguration(val accessKeyId: String, val secretAccessKey: String)
+data class AWSAccessKeyConfiguration(val accessKeyId: String?, val secretAccessKey: String?)
 
 interface AWSAccessKeyConfigurationProvider {
     val awsAccessKeyConfiguration: AWSAccessKeyConfiguration

--- a/airbyte-cdk/bulk/toolkits/load-aws/src/main/kotlin/io/airbyte/cdk/load/command/aws/AWSAccessKeySpecification.kt
+++ b/airbyte-cdk/bulk/toolkits/load-aws/src/main/kotlin/io/airbyte/cdk/load/command/aws/AWSAccessKeySpecification.kt
@@ -22,7 +22,7 @@ interface AWSAccessKeySpecification {
     )
     @get:JsonProperty("access_key_id")
     @get:JsonSchemaInject(json = """{"examples":["A012345678910EXAMPLE"]}""")
-    val accessKeyId: String
+    val accessKeyId: String?
 
     @get:JsonSchemaTitle("S3 Access Key")
     @get:JsonPropertyDescription(
@@ -30,7 +30,7 @@ interface AWSAccessKeySpecification {
     )
     @get:JsonProperty("secret_access_key")
     @get:JsonSchemaInject(json = """{"examples":["a012345678910ABCDEFGH/AbCdEfGhEXAMPLEKEY"]}""")
-    val secretAccessKey: String
+    val secretAccessKey: String?
 
     fun toAWSAccessKeyConfiguration(): AWSAccessKeyConfiguration {
         return AWSAccessKeyConfiguration(accessKeyId, secretAccessKey)

--- a/airbyte-cdk/bulk/toolkits/load-aws/src/main/kotlin/io/airbyte/cdk/load/command/aws/AWSArnRoleSpecification.kt
+++ b/airbyte-cdk/bulk/toolkits/load-aws/src/main/kotlin/io/airbyte/cdk/load/command/aws/AWSArnRoleSpecification.kt
@@ -9,15 +9,15 @@ interface AWSArnRoleSpecification {
     @get:JsonSchemaTitle("Role ARN")
     @get:JsonPropertyDescription("The Role ARN.")
     @get:JsonProperty("role_arn")
-    @get:JsonSchemaInject(json = """{"examples":[""arn:aws:iam::123456789:role/ExternalIdIsYourWorkspaceId""]}""")
-    val roleArn: String
+    @get:JsonSchemaInject(json = """{"examples":["arn:aws:iam::123456789:role/ExternalIdIsYourWorkspaceId"]}""")
+    val roleArn: String?
 
-    fun toAWSArnRole(): AWSArnRoleConfiguration {
+    fun toAWSArnRoleConfiguration(): AWSArnRoleConfiguration {
         return AWSArnRoleConfiguration(roleArn)
     }
 }
 
-data class AWSArnRoleConfiguration(val roleArn: String)
+data class AWSArnRoleConfiguration(val roleArn: String?)
 
 interface AWSArnRoleConfigurationProvider {
     val awsArnRoleConfiguration: AWSArnRoleConfiguration

--- a/airbyte-cdk/bulk/toolkits/load-aws/src/main/kotlin/io/airbyte/cdk/load/command/aws/AWSArnRoleSpecification.kt
+++ b/airbyte-cdk/bulk/toolkits/load-aws/src/main/kotlin/io/airbyte/cdk/load/command/aws/AWSArnRoleSpecification.kt
@@ -1,0 +1,24 @@
+package io.airbyte.cdk.load.command.aws
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.annotation.JsonPropertyDescription
+import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaInject
+import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaTitle
+
+interface AWSArnRoleSpecification {
+    @get:JsonSchemaTitle("Role ARN")
+    @get:JsonPropertyDescription("The Role ARN.")
+    @get:JsonProperty("role_arn")
+    @get:JsonSchemaInject(json = """{"examples":[""arn:aws:iam::123456789:role/ExternalIdIsYourWorkspaceId""]}""")
+    val roleArn: String
+
+    fun toAWSArnRole(): AWSArnRoleConfiguration {
+        return AWSArnRoleConfiguration(roleArn)
+    }
+}
+
+data class AWSArnRoleConfiguration(val roleArn: String)
+
+interface AWSArnRoleConfigurationProvider {
+    val awsArnRoleConfiguration: AWSArnRoleConfiguration
+}

--- a/airbyte-cdk/bulk/toolkits/load-aws/src/main/kotlin/io/airbyte/cdk/load/command/aws/AWSArnRoleSpecification.kt
+++ b/airbyte-cdk/bulk/toolkits/load-aws/src/main/kotlin/io/airbyte/cdk/load/command/aws/AWSArnRoleSpecification.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
 package io.airbyte.cdk.load.command.aws
 
 import com.fasterxml.jackson.annotation.JsonProperty
@@ -9,7 +13,9 @@ interface AWSArnRoleSpecification {
     @get:JsonSchemaTitle("Role ARN")
     @get:JsonPropertyDescription("The Role ARN.")
     @get:JsonProperty("role_arn")
-    @get:JsonSchemaInject(json = """{"examples":["arn:aws:iam::123456789:role/ExternalIdIsYourWorkspaceId"]}""")
+    @get:JsonSchemaInject(
+        json = """{"examples":["arn:aws:iam::123456789:role/ExternalIdIsYourWorkspaceId"]}"""
+    )
     val roleArn: String?
 
     fun toAWSArnRoleConfiguration(): AWSArnRoleConfiguration {

--- a/airbyte-cdk/bulk/toolkits/load-s3/src/main/kotlin/io/airbyte/cdk/load/file/s3/S3Client.kt
+++ b/airbyte-cdk/bulk/toolkits/load-s3/src/main/kotlin/io/airbyte/cdk/load/file/s3/S3Client.kt
@@ -193,6 +193,9 @@ class S3ClientFactory(
     }
 
     private val AIRBYTE_STS_SESSION_NAME = "airbyte-sts-session"
+    private val EXTERNAL_ID = "AWS_ASSUME_ROLE_EXTERNAL_ID"
+    private val AWS_ACCESS_KEY_ID = "AWS_ACCESS_KEY_ID"
+    private val AWS_SECRET_ACCESS_KEY = "AWS_SECRET_ACCESS_KEY"
 
     @Singleton
     @Secondary
@@ -207,9 +210,7 @@ class S3ClientFactory(
             } else if (arnRole.awsArnRoleConfiguration.roleArn != null) {
                 // The Platform is expected to inject via credentials if ROLE_ARN is present.
                 val externalId =
-                    System.getenv(
-                        "AWS_ASSUME_ROLE_EXTERNAL_ID"
-                    ) // Consider injecting this dependency
+                    System.getenv(EXTERNAL_ID) // Consider injecting this dependency
                 val assumeRoleParams =
                     AssumeRoleParameters(
                         roleArn = arnRole.awsArnRoleConfiguration.roleArn!!,
@@ -217,12 +218,8 @@ class S3ClientFactory(
                         externalId = externalId
                     )
                 val creds = StaticCredentialsProvider {
-                    accessKeyId = System.getenv(
-                        "AWS_ACCESS_KEY_ID"
-                    )
-                    secretAccessKey = System.getenv(
-                        "AWS_SECRET_ACCESS_KEY"
-                    )
+                    accessKeyId = System.getenv(AWS_ACCESS_KEY_ID)
+                    secretAccessKey = System.getenv(AWS_SECRET_ACCESS_KEY)
                 }
                 StsAssumeRoleCredentialsProvider(
                     bootstrapCredentialsProvider = creds,
@@ -246,11 +243,4 @@ class S3ClientFactory(
         )
     }
 
-}
-
-object MyApp {
-    @JvmStatic
-    fun main(args: Array<String>) {
-
-    }
 }

--- a/airbyte-cdk/bulk/toolkits/load-s3/src/main/kotlin/io/airbyte/cdk/load/file/s3/S3Client.kt
+++ b/airbyte-cdk/bulk/toolkits/load-s3/src/main/kotlin/io/airbyte/cdk/load/file/s3/S3Client.kt
@@ -201,7 +201,7 @@ class S3ClientFactory(
     @Secondary
     fun make(): S3Client {
 
-        val credsProvider : CredentialsProvider =
+        val credsProvider: CredentialsProvider =
             if (keyConfig.awsAccessKeyConfiguration.accessKeyId != null) {
                 StaticCredentialsProvider {
                     accessKeyId = keyConfig.awsAccessKeyConfiguration.accessKeyId
@@ -209,8 +209,7 @@ class S3ClientFactory(
                 }
             } else if (arnRole.awsArnRoleConfiguration.roleArn != null) {
                 // The Platform is expected to inject via credentials if ROLE_ARN is present.
-                val externalId =
-                    System.getenv(EXTERNAL_ID) // Consider injecting this dependency
+                val externalId = System.getenv(EXTERNAL_ID) // Consider injecting this dependency
                 val assumeRoleParams =
                     AssumeRoleParameters(
                         roleArn = arnRole.awsArnRoleConfiguration.roleArn!!,
@@ -242,5 +241,4 @@ class S3ClientFactory(
             uploadConfig?.objectStorageUploadConfiguration
         )
     }
-
 }

--- a/airbyte-cdk/bulk/toolkits/load-s3/src/main/kotlin/io/airbyte/cdk/load/file/s3/S3Client.kt
+++ b/airbyte-cdk/bulk/toolkits/load-s3/src/main/kotlin/io/airbyte/cdk/load/file/s3/S3Client.kt
@@ -16,6 +16,8 @@ import aws.smithy.kotlin.runtime.content.ByteStream
 import aws.smithy.kotlin.runtime.content.toInputStream
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 import io.airbyte.cdk.load.command.aws.AWSAccessKeyConfigurationProvider
+import io.airbyte.cdk.load.command.aws.AWSArnRoleConfigurationProvider
+import io.airbyte.cdk.load.command.aws.AWSArnRoleSpecification
 import io.airbyte.cdk.load.command.object_storage.ObjectStorageUploadConfiguration
 import io.airbyte.cdk.load.command.object_storage.ObjectStorageUploadConfigurationProvider
 import io.airbyte.cdk.load.command.s3.S3BucketConfiguration
@@ -174,6 +176,7 @@ class S3Client(
 
 @Factory
 class S3ClientFactory(
+    private val arnRole: AWSArnRoleConfigurationProvider,
     private val keyConfig: AWSAccessKeyConfigurationProvider,
     private val bucketConfig: S3BucketConfigurationProvider,
     private val uploadConifg: ObjectStorageUploadConfigurationProvider? = null,
@@ -182,8 +185,9 @@ class S3ClientFactory(
         fun <T> make(config: T) where
         T : S3BucketConfigurationProvider,
         T : AWSAccessKeyConfigurationProvider,
+        T : AWSArnRoleConfigurationProvider,
         T : ObjectStorageUploadConfigurationProvider =
-            S3ClientFactory(config, config, config).make()
+            S3ClientFactory(config, config, config, config).make()
     }
 
     @Singleton

--- a/airbyte-cdk/bulk/toolkits/load-s3/src/main/kotlin/io/airbyte/cdk/load/file/s3/S3Client.kt
+++ b/airbyte-cdk/bulk/toolkits/load-s3/src/main/kotlin/io/airbyte/cdk/load/file/s3/S3Client.kt
@@ -226,7 +226,7 @@ class S3ClientFactory(
                     assumeRoleParameters = assumeRoleParams
                 )
             } else {
-                // We should fill this in with a stubbed out credentials provider.
+                // Todo: fill in with a stubbed out credentials provider.
                 throw IllegalStateException("No valid AWS credentials configuration found.")
             }
 

--- a/airbyte-cdk/bulk/toolkits/load-s3/src/main/kotlin/io/airbyte/cdk/load/file/s3/S3Client.kt
+++ b/airbyte-cdk/bulk/toolkits/load-s3/src/main/kotlin/io/airbyte/cdk/load/file/s3/S3Client.kt
@@ -5,6 +5,7 @@
 package io.airbyte.cdk.load.file.s3
 
 import aws.sdk.kotlin.runtime.auth.credentials.AssumeRoleParameters
+import aws.sdk.kotlin.runtime.auth.credentials.DefaultChainCredentialsProvider
 import aws.sdk.kotlin.runtime.auth.credentials.StaticCredentialsProvider
 import aws.sdk.kotlin.runtime.auth.credentials.StsAssumeRoleCredentialsProvider
 import aws.sdk.kotlin.services.s3.model.CopyObjectRequest
@@ -226,7 +227,7 @@ class S3ClientFactory(
                 )
             } else {
                 // Todo: fill in with a stubbed out credentials provider.
-                throw IllegalStateException("No valid AWS credentials configuration found.")
+                DefaultChainCredentialsProvider()
             }
 
         val s3SdkClient =

--- a/airbyte-cdk/bulk/toolkits/load-s3/src/main/kotlin/io/airbyte/cdk/load/file/s3/S3Client.kt
+++ b/airbyte-cdk/bulk/toolkits/load-s3/src/main/kotlin/io/airbyte/cdk/load/file/s3/S3Client.kt
@@ -202,28 +202,43 @@ class S3ClientFactory(
             secretAccessKey = keyConfig.awsAccessKeyConfiguration.secretAccessKey
         }
 
-        val credsProvider = arnRole.awsArnRoleConfiguration.roleArn?.let { roleArn ->
-            val externalId = System.getenv("AWS_ASSUME_ROLE_EXTERNAL_ID") // Consider injecting this dependency
-            val assumeRoleParams = AssumeRoleParameters(
-                roleArn = roleArn,
-                roleSessionName = AIRBYTE_STS_SESSION_NAME,
-                externalId = externalId
-            )
-            StsAssumeRoleCredentialsProvider(
-                bootstrapCredentialsProvider = staticCredentialsProvider,
-                assumeRoleParameters = assumeRoleParams
-            )
-        } ?: staticCredentialsProvider
+        val credsProvider =
+            arnRole.awsArnRoleConfiguration.roleArn?.let { roleArn ->
+                val externalId =
+                    System.getenv(
+                        "AWS_ASSUME_ROLE_EXTERNAL_ID"
+                    ) // Consider injecting this dependency
+                val assumeRoleParams =
+                    AssumeRoleParameters(
+                        roleArn = roleArn,
+                        roleSessionName = AIRBYTE_STS_SESSION_NAME,
+                        externalId = externalId
+                    )
+                StsAssumeRoleCredentialsProvider(
+                    bootstrapCredentialsProvider = staticCredentialsProvider,
+                    assumeRoleParameters = assumeRoleParams
+                )
+            }
+                ?: staticCredentialsProvider
 
-        val s3SdkClient = aws.sdk.kotlin.services.s3.S3Client {
-            region = bucketConfig.s3BucketConfiguration.s3BucketRegion.name
-            credentialsProvider = credsProvider
-        }
+        val s3SdkClient =
+            aws.sdk.kotlin.services.s3.S3Client {
+                region = bucketConfig.s3BucketConfiguration.s3BucketRegion.name
+                credentialsProvider = credsProvider
+            }
 
         return S3Client(
             s3SdkClient,
             bucketConfig.s3BucketConfiguration,
             uploadConfig?.objectStorageUploadConfiguration
         )
+    }
+
+}
+
+object MyApp {
+    @JvmStatic
+    fun main(args: Array<String>) {
+
     }
 }

--- a/airbyte-cdk/bulk/toolkits/load-s3/src/main/kotlin/io/airbyte/cdk/load/file/s3/S3Client.kt
+++ b/airbyte-cdk/bulk/toolkits/load-s3/src/main/kotlin/io/airbyte/cdk/load/file/s3/S3Client.kt
@@ -14,6 +14,7 @@ import aws.sdk.kotlin.services.s3.model.GetObjectRequest
 import aws.sdk.kotlin.services.s3.model.HeadObjectRequest
 import aws.sdk.kotlin.services.s3.model.ListObjectsRequest
 import aws.sdk.kotlin.services.s3.model.PutObjectRequest
+import aws.smithy.kotlin.runtime.auth.awscredentials.CredentialsProvider
 import aws.smithy.kotlin.runtime.content.ByteStream
 import aws.smithy.kotlin.runtime.content.toInputStream
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
@@ -196,30 +197,41 @@ class S3ClientFactory(
     @Singleton
     @Secondary
     fun make(): S3Client {
-        // For now always assume credentials exists. Not true.
-        val staticCredentialsProvider = StaticCredentialsProvider {
-            accessKeyId = keyConfig.awsAccessKeyConfiguration.accessKeyId
-            secretAccessKey = keyConfig.awsAccessKeyConfiguration.secretAccessKey
-        }
 
-        val credsProvider =
-            arnRole.awsArnRoleConfiguration.roleArn?.let { roleArn ->
+        val credsProvider : CredentialsProvider =
+            if (keyConfig.awsAccessKeyConfiguration.accessKeyId != null) {
+                StaticCredentialsProvider {
+                    accessKeyId = keyConfig.awsAccessKeyConfiguration.accessKeyId
+                    secretAccessKey = keyConfig.awsAccessKeyConfiguration.secretAccessKey
+                }
+            } else if (arnRole.awsArnRoleConfiguration.roleArn != null) {
+                // The Platform is expected to inject via credentials if ROLE_ARN is present.
                 val externalId =
                     System.getenv(
                         "AWS_ASSUME_ROLE_EXTERNAL_ID"
                     ) // Consider injecting this dependency
                 val assumeRoleParams =
                     AssumeRoleParameters(
-                        roleArn = roleArn,
+                        roleArn = arnRole.awsArnRoleConfiguration.roleArn!!,
                         roleSessionName = AIRBYTE_STS_SESSION_NAME,
                         externalId = externalId
                     )
+                val creds = StaticCredentialsProvider {
+                    accessKeyId = System.getenv(
+                        "AWS_ACCESS_KEY_ID"
+                    )
+                    secretAccessKey = System.getenv(
+                        "AWS_SECRET_ACCESS_KEY"
+                    )
+                }
                 StsAssumeRoleCredentialsProvider(
-                    bootstrapCredentialsProvider = staticCredentialsProvider,
+                    bootstrapCredentialsProvider = creds,
                     assumeRoleParameters = assumeRoleParams
                 )
+            } else {
+                // We should fill this in with a stubbed out credentials provider.
+                throw IllegalStateException("No valid AWS credentials configuration found.")
             }
-                ?: staticCredentialsProvider
 
         val s3SdkClient =
             aws.sdk.kotlin.services.s3.S3Client {

--- a/airbyte-cdk/java/airbyte-cdk/typing-deduping/src/testFixtures/kotlin/io/airbyte/integrations/base/destination/typing_deduping/BaseTypingDedupingTest.kt
+++ b/airbyte-cdk/java/airbyte-cdk/typing-deduping/src/testFixtures/kotlin/io/airbyte/integrations/base/destination/typing_deduping/BaseTypingDedupingTest.kt
@@ -1537,16 +1537,17 @@ abstract class BaseTypingDedupingTest {
                 .withDestinationConnectionConfiguration(transformedConfig)
         val destination: AirbyteDestination =
             DefaultAirbyteDestination(
-                integrationLauncher = AirbyteIntegrationLauncher(
-                    "0",
-                    0,
-                    imageName,
-                    processFactory,
-                    null,
-                    null,
-                    false,
-                    EnvVariableFeatureFlags()
-                )
+                integrationLauncher =
+                    AirbyteIntegrationLauncher(
+                        "0",
+                        0,
+                        imageName,
+                        processFactory,
+                        null,
+                        null,
+                        false,
+                        EnvVariableFeatureFlags()
+                    )
             )
 
         destination.start(destinationConfig, jobRoot, emptyMap())

--- a/airbyte-cdk/java/airbyte-cdk/typing-deduping/src/testFixtures/kotlin/io/airbyte/integrations/base/destination/typing_deduping/BaseTypingDedupingTest.kt
+++ b/airbyte-cdk/java/airbyte-cdk/typing-deduping/src/testFixtures/kotlin/io/airbyte/integrations/base/destination/typing_deduping/BaseTypingDedupingTest.kt
@@ -1525,7 +1525,7 @@ abstract class BaseTypingDedupingTest {
                 workspaceRoot,
                 workspaceRoot.toString(),
                 localRoot.toString(),
-                null,
+                fileTransferMountSource = null,
                 "host",
                 emptyMap()
             )
@@ -1535,18 +1535,19 @@ abstract class BaseTypingDedupingTest {
                 .withConnectionId(UUID.randomUUID())
                 .withCatalog(convertProtocolObject(catalog, ConfiguredAirbyteCatalog::class.java))
                 .withDestinationConnectionConfiguration(transformedConfig)
-        val integrationLauncher = AirbyteIntegrationLauncher(
-            "0",
-            0,
-            imageName,
-            processFactory,
-            null,
-            null,
-            false,
-            EnvVariableFeatureFlags()
-        )
         val destination: AirbyteDestination =
-            DefaultAirbyteDestination(integrationLauncher)
+            DefaultAirbyteDestination(
+                integrationLauncher = AirbyteIntegrationLauncher(
+                    "0",
+                    0,
+                    imageName,
+                    processFactory,
+                    null,
+                    null,
+                    false,
+                    EnvVariableFeatureFlags()
+                )
+            )
 
         destination.start(destinationConfig, jobRoot, emptyMap())
 

--- a/airbyte-cdk/java/airbyte-cdk/typing-deduping/src/testFixtures/kotlin/io/airbyte/integrations/base/destination/typing_deduping/BaseTypingDedupingTest.kt
+++ b/airbyte-cdk/java/airbyte-cdk/typing-deduping/src/testFixtures/kotlin/io/airbyte/integrations/base/destination/typing_deduping/BaseTypingDedupingTest.kt
@@ -1525,7 +1525,7 @@ abstract class BaseTypingDedupingTest {
                 workspaceRoot,
                 workspaceRoot.toString(),
                 localRoot.toString(),
-                fileTransferMountSource = null,
+                null,
                 "host",
                 emptyMap()
             )
@@ -1535,21 +1535,18 @@ abstract class BaseTypingDedupingTest {
                 .withConnectionId(UUID.randomUUID())
                 .withCatalog(convertProtocolObject(catalog, ConfiguredAirbyteCatalog::class.java))
                 .withDestinationConnectionConfiguration(transformedConfig)
-
+        val integrationLauncher = AirbyteIntegrationLauncher(
+            "0",
+            0,
+            imageName,
+            processFactory,
+            null,
+            null,
+            false,
+            EnvVariableFeatureFlags()
+        )
         val destination: AirbyteDestination =
-            DefaultAirbyteDestination(
-                integrationLauncher =
-                    AirbyteIntegrationLauncher(
-                        "0",
-                        0,
-                        imageName,
-                        processFactory,
-                        null,
-                        null,
-                        false,
-                        EnvVariableFeatureFlags()
-                    )
-            )
+            DefaultAirbyteDestination(integrationLauncher)
 
         destination.start(destinationConfig, jobRoot, emptyMap())
 

--- a/airbyte-integrations/connectors/destination-s3-v2/build.gradle
+++ b/airbyte-integrations/connectors/destination-s3-v2/build.gradle
@@ -26,6 +26,6 @@ application {
 dependencies {
     // temporary dependencies so that we can continue running the legacy test suite.
     // eventually we should remove those tests + rely solely on the bulk CDK tests.
-    // integrationTestLegacyImplementation testFixtures(project(":airbyte-cdk:java:airbyte-cdk:airbyte-cdk-db-destinations"))
+     integrationTestLegacyImplementation testFixtures(project(":airbyte-cdk:java:airbyte-cdk:airbyte-cdk-db-destinations"))
     // integrationTestLegacyImplementation testFixtures("io.airbyte.cdk:airbyte-cdk-db-destinations:0.47.0")
 }

--- a/airbyte-integrations/connectors/destination-s3-v2/build.gradle
+++ b/airbyte-integrations/connectors/destination-s3-v2/build.gradle
@@ -26,6 +26,6 @@ application {
 dependencies {
     // temporary dependencies so that we can continue running the legacy test suite.
     // eventually we should remove those tests + rely solely on the bulk CDK tests.
-     integrationTestLegacyImplementation testFixtures(project(":airbyte-cdk:java:airbyte-cdk:airbyte-cdk-db-destinations"))
+    integrationTestLegacyImplementation testFixtures(project(":airbyte-cdk:java:airbyte-cdk:airbyte-cdk-s3-destinations"))
     // integrationTestLegacyImplementation testFixtures("io.airbyte.cdk:airbyte-cdk-db-destinations:0.47.0")
 }

--- a/airbyte-integrations/connectors/destination-s3-v2/gradle.properties
+++ b/airbyte-integrations/connectors/destination-s3-v2/gradle.properties
@@ -1,0 +1,1 @@
+testExecutionConcurrency=-1

--- a/airbyte-integrations/connectors/destination-s3-v2/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-s3-v2/metadata.yaml
@@ -81,4 +81,29 @@ data:
           secretStore:
             type: GSM
             alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION-S3-ASSUME-ROLE-CONFIG
+          fileName: s3_dest_assume_role_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION-S3_CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION-S3_MIN_REQUIRED_PERMISSIONS_CREDS
+          fileName: s3_dest_min_required_permissions_creds.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION-S3_POLICY_MANAGER_CREDENTIALS
+          fileName: s3_dest_policy_manager_credentials.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION-S3_DEST_IAM_ROLE_CREDENTIALS_FOR_ASSUME_ROLE_AUTH
+          fileName: s3_dest_iam_role_credentials_for_assume_role_auth.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-s3-v2/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-s3-v2/metadata.yaml
@@ -86,21 +86,6 @@ data:
           secretStore:
             type: GSM
             alias: airbyte-connector-testing-secret-store
-        - name: SECRET_DESTINATION-S3_CREDS
-          fileName: config.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-        - name: SECRET_DESTINATION-S3_MIN_REQUIRED_PERMISSIONS_CREDS
-          fileName: s3_dest_min_required_permissions_creds.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-        - name: SECRET_DESTINATION-S3_POLICY_MANAGER_CREDENTIALS
-          fileName: s3_dest_policy_manager_credentials.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
         - name: SECRET_DESTINATION-S3_DEST_IAM_ROLE_CREDENTIALS_FOR_ASSUME_ROLE_AUTH
           fileName: s3_dest_iam_role_credentials_for_assume_role_auth.json
           secretStore:

--- a/airbyte-integrations/connectors/destination-s3-v2/src/main/kotlin/S3V2Configuration.kt
+++ b/airbyte-integrations/connectors/destination-s3-v2/src/main/kotlin/S3V2Configuration.kt
@@ -8,6 +8,8 @@ import io.airbyte.cdk.load.command.DestinationConfiguration
 import io.airbyte.cdk.load.command.DestinationConfigurationFactory
 import io.airbyte.cdk.load.command.aws.AWSAccessKeyConfiguration
 import io.airbyte.cdk.load.command.aws.AWSAccessKeyConfigurationProvider
+import io.airbyte.cdk.load.command.aws.AWSArnRoleConfiguration
+import io.airbyte.cdk.load.command.aws.AWSArnRoleConfigurationProvider
 import io.airbyte.cdk.load.command.object_storage.ObjectStorageCompressionConfiguration
 import io.airbyte.cdk.load.command.object_storage.ObjectStorageCompressionConfigurationProvider
 import io.airbyte.cdk.load.command.object_storage.ObjectStorageFormatConfiguration
@@ -25,6 +27,7 @@ import java.io.OutputStream
 data class S3V2Configuration<T : OutputStream>(
     // Client-facing configuration
     override val awsAccessKeyConfiguration: AWSAccessKeyConfiguration,
+    override val awsArnRoleConfiguration: AWSArnRoleConfiguration,
     override val s3BucketConfiguration: S3BucketConfiguration,
     override val objectStoragePathConfiguration: ObjectStoragePathConfiguration,
     override val objectStorageFormatConfiguration: ObjectStorageFormatConfiguration,
@@ -36,6 +39,7 @@ data class S3V2Configuration<T : OutputStream>(
 ) :
     DestinationConfiguration(),
     AWSAccessKeyConfigurationProvider,
+    AWSArnRoleConfigurationProvider,
     S3BucketConfigurationProvider,
     ObjectStoragePathConfigurationProvider,
     ObjectStorageFormatConfigurationProvider,
@@ -48,6 +52,7 @@ class S3V2ConfigurationFactory :
     override fun makeWithoutExceptionHandling(pojo: S3V2Specification): S3V2Configuration<*> {
         return S3V2Configuration(
             awsAccessKeyConfiguration = pojo.toAWSAccessKeyConfiguration(),
+            awsArnRoleConfiguration = pojo.toAWSArnRoleConfiguration(),
             s3BucketConfiguration = pojo.toS3BucketConfiguration(),
             objectStoragePathConfiguration = pojo.toObjectStoragePathConfiguration(),
             objectStorageFormatConfiguration = pojo.toObjectStorageFormatConfiguration(),

--- a/airbyte-integrations/connectors/destination-s3-v2/src/main/kotlin/S3V2Specification.kt
+++ b/airbyte-integrations/connectors/destination-s3-v2/src/main/kotlin/S3V2Specification.kt
@@ -8,6 +8,8 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaTitle
 import io.airbyte.cdk.command.ConfigurationSpecification
 import io.airbyte.cdk.load.command.aws.AWSAccessKeySpecification
+import io.airbyte.cdk.load.command.aws.AWSArnRoleConfiguration
+import io.airbyte.cdk.load.command.aws.AWSArnRoleSpecification
 import io.airbyte.cdk.load.command.object_storage.JsonFormatSpecification
 import io.airbyte.cdk.load.command.object_storage.ObjectStorageFormatSpecification
 import io.airbyte.cdk.load.command.object_storage.ObjectStorageFormatSpecificationProvider
@@ -24,11 +26,13 @@ import jakarta.inject.Singleton
 class S3V2Specification :
     ConfigurationSpecification(),
     AWSAccessKeySpecification,
+    AWSArnRoleSpecification,
     S3BucketSpecification,
     S3PathSpecification,
     ObjectStorageFormatSpecificationProvider {
     override val accessKeyId: String = ""
     override val secretAccessKey: String = ""
+    override val roleArn: String? = null
     override val s3BucketName: String = ""
     override val s3BucketPath: String = ""
     override val s3BucketRegion: S3BucketRegion = S3BucketRegion.`us-west-1`

--- a/airbyte-integrations/connectors/destination-s3-v2/src/main/kotlin/S3V2Specification.kt
+++ b/airbyte-integrations/connectors/destination-s3-v2/src/main/kotlin/S3V2Specification.kt
@@ -29,8 +29,8 @@ class S3V2Specification :
     S3BucketSpecification,
     S3PathSpecification,
     ObjectStorageFormatSpecificationProvider {
-    override val accessKeyId: String = ""
-    override val secretAccessKey: String = ""
+    override val accessKeyId: String? = null
+    override val secretAccessKey: String? = null
     override val roleArn: String? = null
     override val s3BucketName: String = ""
     override val s3BucketPath: String = ""

--- a/airbyte-integrations/connectors/destination-s3-v2/src/main/kotlin/S3V2Specification.kt
+++ b/airbyte-integrations/connectors/destination-s3-v2/src/main/kotlin/S3V2Specification.kt
@@ -55,7 +55,6 @@ class S3V2SpecificationExtension : DestinationSpecificationExtension {
         listOf(
             DestinationSyncMode.OVERWRITE,
             DestinationSyncMode.APPEND,
-            DestinationSyncMode.APPEND_DEDUP,
         )
     override val supportsIncremental = true
 }

--- a/airbyte-integrations/connectors/destination-s3-v2/src/main/kotlin/S3V2Specification.kt
+++ b/airbyte-integrations/connectors/destination-s3-v2/src/main/kotlin/S3V2Specification.kt
@@ -8,7 +8,6 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaTitle
 import io.airbyte.cdk.command.ConfigurationSpecification
 import io.airbyte.cdk.load.command.aws.AWSAccessKeySpecification
-import io.airbyte.cdk.load.command.aws.AWSArnRoleConfiguration
 import io.airbyte.cdk.load.command.aws.AWSArnRoleSpecification
 import io.airbyte.cdk.load.command.object_storage.JsonFormatSpecification
 import io.airbyte.cdk.load.command.object_storage.ObjectStorageFormatSpecification

--- a/airbyte-integrations/connectors/destination-s3-v2/src/test-integration-legacy/kotlin/io/airbyte/integrations/destination/s3/S3V2CsvAssumeRoleDestinationAcceptanceTest.kt
+++ b/airbyte-integrations/connectors/destination-s3-v2/src/test-integration-legacy/kotlin/io/airbyte/integrations/destination/s3/S3V2CsvAssumeRoleDestinationAcceptanceTest.kt
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+ */
+package io.airbyte.integrations.destination.s3
+
+import com.fasterxml.jackson.databind.JsonNode
+import io.airbyte.cdk.integrations.destination.s3.S3BaseCsvDestinationAcceptanceTest
+
+class S3V2CsvAssumeRoleDestinationAcceptanceTest : S3BaseCsvDestinationAcceptanceTest() {
+    override val imageName: String = "airbyte/destination-s3-v2:dev"
+    override val baseConfigJson: JsonNode
+        get() = S3V2DestinationTestUtils.assumeRoleConfig
+
+    override fun getConnectorEnv(): Map<String, String> {
+        return S3V2DestinationTestUtils.assumeRoleInternalCredentials
+    }
+}

--- a/airbyte-integrations/connectors/destination-s3-v2/src/test-integration-legacy/kotlin/io/airbyte/integrations/destination/s3/S3V2CsvDestinationAcceptanceTest.kt
+++ b/airbyte-integrations/connectors/destination-s3-v2/src/test-integration-legacy/kotlin/io/airbyte/integrations/destination/s3/S3V2CsvDestinationAcceptanceTest.kt
@@ -1,4 +1,0 @@
-package io.airbyte.integrations.destination.s3
-
-class S3V2CsvDestinationAcceptanceTest {
-}

--- a/airbyte-integrations/connectors/destination-s3-v2/src/test-integration-legacy/kotlin/io/airbyte/integrations/destination/s3/S3V2CsvDestinationAcceptanceTest.kt
+++ b/airbyte-integrations/connectors/destination-s3-v2/src/test-integration-legacy/kotlin/io/airbyte/integrations/destination/s3/S3V2CsvDestinationAcceptanceTest.kt
@@ -1,0 +1,4 @@
+package io.airbyte.integrations.destination.s3
+
+class S3V2CsvDestinationAcceptanceTest {
+}

--- a/airbyte-integrations/connectors/destination-s3-v2/src/test-integration-legacy/kotlin/io/airbyte/integrations/destination/s3/S3V2DestinationTestUtils.kt
+++ b/airbyte-integrations/connectors/destination-s3-v2/src/test-integration-legacy/kotlin/io/airbyte/integrations/destination/s3/S3V2DestinationTestUtils.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
 package io.airbyte.integrations.destination.s3
 
 import com.fasterxml.jackson.databind.JsonNode

--- a/airbyte-integrations/connectors/destination-s3-v2/src/test-integration-legacy/kotlin/io/airbyte/integrations/destination/s3/S3V2DestinationTestUtils.kt
+++ b/airbyte-integrations/connectors/destination-s3-v2/src/test-integration-legacy/kotlin/io/airbyte/integrations/destination/s3/S3V2DestinationTestUtils.kt
@@ -1,0 +1,37 @@
+package io.airbyte.integrations.destination.s3
+
+import com.fasterxml.jackson.databind.JsonNode
+import io.airbyte.commons.io.IOs.readFile
+import io.airbyte.commons.json.Jsons.deserialize
+import java.nio.file.Path
+
+object S3V2DestinationTestUtils {
+    private const val ACCESS_KEY_CONFIG_SECRET_PATH =
+        "secrets/s3_dest_min_required_permissions_creds.json"
+    private const val ASSUME_ROLE_CONFIG_SECRET_PATH = "secrets/s3_dest_assume_role_config.json"
+    private const val ASSUME_ROLE_INTERNAL_CREDENTIALS_SECRET_PATH =
+        "secrets/s3_dest_iam_role_credentials_for_assume_role_auth.json"
+
+    private const val POLICY_MANAGER_CREDENTIALS_SECRET_PATH =
+        "secrets/s3_dest_policy_manager_credentials.json"
+
+    val baseConfigJsonFilePath: JsonNode
+        get() = deserialize(readFile(Path.of(ACCESS_KEY_CONFIG_SECRET_PATH)))
+
+    val assumeRoleConfig: JsonNode
+        get() = deserialize(readFile(Path.of(ASSUME_ROLE_CONFIG_SECRET_PATH)))
+
+    private fun getCredentials(secretPath: String): Map<String, String> {
+        val retVal = HashMap<String, String>()
+        for ((key, value) in deserialize(readFile(Path.of(secretPath))).properties()) {
+            retVal[key] = value.textValue()
+        }
+        return retVal
+    }
+
+    val assumeRoleInternalCredentials: Map<String, String>
+        get() = getCredentials(ASSUME_ROLE_INTERNAL_CREDENTIALS_SECRET_PATH)
+
+    val policyManagerCredentials: Map<String, String>
+        get() = getCredentials(POLICY_MANAGER_CREDENTIALS_SECRET_PATH)
+}

--- a/airbyte-integrations/connectors/destination-s3-v2/src/test-integration-legacy/kotlin/io/airbyte/integrations/destination/s3/S3V2DestinationTestUtils.kt
+++ b/airbyte-integrations/connectors/destination-s3-v2/src/test-integration-legacy/kotlin/io/airbyte/integrations/destination/s3/S3V2DestinationTestUtils.kt
@@ -6,17 +6,9 @@ import io.airbyte.commons.json.Jsons.deserialize
 import java.nio.file.Path
 
 object S3V2DestinationTestUtils {
-    private const val ACCESS_KEY_CONFIG_SECRET_PATH =
-        "secrets/s3_dest_min_required_permissions_creds.json"
     private const val ASSUME_ROLE_CONFIG_SECRET_PATH = "secrets/s3_dest_assume_role_config.json"
     private const val ASSUME_ROLE_INTERNAL_CREDENTIALS_SECRET_PATH =
         "secrets/s3_dest_iam_role_credentials_for_assume_role_auth.json"
-
-    private const val POLICY_MANAGER_CREDENTIALS_SECRET_PATH =
-        "secrets/s3_dest_policy_manager_credentials.json"
-
-    val baseConfigJsonFilePath: JsonNode
-        get() = deserialize(readFile(Path.of(ACCESS_KEY_CONFIG_SECRET_PATH)))
 
     val assumeRoleConfig: JsonNode
         get() = deserialize(readFile(Path.of(ASSUME_ROLE_CONFIG_SECRET_PATH)))
@@ -31,7 +23,4 @@ object S3V2DestinationTestUtils {
 
     val assumeRoleInternalCredentials: Map<String, String>
         get() = getCredentials(ASSUME_ROLE_INTERNAL_CREDENTIALS_SECRET_PATH)
-
-    val policyManagerCredentials: Map<String, String>
-        get() = getCredentials(POLICY_MANAGER_CREDENTIALS_SECRET_PATH)
 }

--- a/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/resources/expected-spec-cloud.json
+++ b/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/resources/expected-spec-cloud.json
@@ -330,7 +330,7 @@
         "type" : "integer"
       }
     },
-    "required" : [ "access_key_id", "secret_access_key", "s3_bucket_name", "s3_bucket_path", "s3_bucket_region", "format" ]
+    "required" : [ "s3_bucket_name", "s3_bucket_path", "s3_bucket_region", "format" ]
   },
   "supportsIncremental" : true,
   "supportsNormalization" : false,

--- a/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/resources/expected-spec-cloud.json
+++ b/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/resources/expected-spec-cloud.json
@@ -335,5 +335,5 @@
   "supportsIncremental" : true,
   "supportsNormalization" : false,
   "supportsDBT" : false,
-  "supported_destination_sync_modes" : [ "overwrite", "append", "append_dedup" ]
+  "supported_destination_sync_modes" : [ "overwrite", "append" ]
 }

--- a/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/resources/expected-spec-cloud.json
+++ b/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/resources/expected-spec-cloud.json
@@ -18,6 +18,12 @@
         "title" : "S3 Access Key",
         "examples" : [ "a012345678910ABCDEFGH/AbCdEfGhEXAMPLEKEY" ]
       },
+      "role_arn" : {
+        "type" : "string",
+        "description" : "The Role ARN.",
+        "title" : "Role ARN",
+        "examples" : [ "arn:aws:iam::123456789:role/ExternalIdIsYourWorkspaceId" ]
+      },
       "s3_bucket_name" : {
         "type" : "string",
         "description" : "The name of the S3 bucket. Read more <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/create-bucket-overview.html\">here</a>.",

--- a/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/resources/expected-spec-oss.json
+++ b/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/resources/expected-spec-oss.json
@@ -330,7 +330,7 @@
         "type" : "integer"
       }
     },
-    "required" : [ "access_key_id", "secret_access_key", "s3_bucket_name", "s3_bucket_path", "s3_bucket_region", "format" ]
+    "required" : [ "s3_bucket_name", "s3_bucket_path", "s3_bucket_region", "format" ]
   },
   "supportsIncremental" : true,
   "supportsNormalization" : false,

--- a/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/resources/expected-spec-oss.json
+++ b/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/resources/expected-spec-oss.json
@@ -335,5 +335,5 @@
   "supportsIncremental" : true,
   "supportsNormalization" : false,
   "supportsDBT" : false,
-  "supported_destination_sync_modes" : [ "overwrite", "append", "append_dedup" ]
+  "supported_destination_sync_modes" : [ "overwrite", "append" ]
 }

--- a/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/resources/expected-spec-oss.json
+++ b/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/resources/expected-spec-oss.json
@@ -18,6 +18,12 @@
         "title" : "S3 Access Key",
         "examples" : [ "a012345678910ABCDEFGH/AbCdEfGhEXAMPLEKEY" ]
       },
+      "role_arn" : {
+        "type" : "string",
+        "description" : "The Role ARN.",
+        "title" : "Role ARN",
+        "examples" : [ "arn:aws:iam::123456789:role/ExternalIdIsYourWorkspaceId" ]
+      },
       "s3_bucket_name" : {
         "type" : "string",
         "description" : "The name of the S3 bucket. Read more <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/create-bucket-overview.html\">here</a>.",


### PR DESCRIPTION
## What
Completes part of https://github.com/airbytehq/airbyte-internal-issues/issues/10731.

## How
- Add the IAM role logic.
- Make auth more closely match the existing auth logic. Though a stubbed version for when there are no auth credentials is still required.
- Add the existing IAM Role docker tests to the Dest S3 V2 connection. My thought is to add the non-docker version in a follow up PR, and not block this PR on the non-docker tests.

## Review guide


## User Impact
None. This is not yet released.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
