### PR TITLE
Bulk Load CDK: Reservation Manager Conflated; CSV matches old cdk

### DIFF
--- a/airbyte-cdk/bulk/toolkits/load-csv/build.gradle
+++ b/airbyte-cdk/bulk/toolkits/load-csv/build.gradle
@@ -2,7 +2,7 @@ dependencies {
     implementation project(':airbyte-cdk:bulk:core:bulk-cdk-core-base')
     implementation project(':airbyte-cdk:bulk:core:bulk-cdk-core-load')
 
-    api("org.apache.commons:commons-csv:1.10.0")
+    api("org.apache.commons:commons-csv:1.11.0")
 
     testFixturesImplementation testFixtures(project(":airbyte-cdk:bulk:core:bulk-cdk-core-load"))
 }

--- a/airbyte-cdk/bulk/toolkits/load-csv/src/main/kotlin/io/airbyte/cdk/load/data/csv/AirbyteValueToCsvRow.kt
+++ b/airbyte-cdk/bulk/toolkits/load-csv/src/main/kotlin/io/airbyte/cdk/load/data/csv/AirbyteValueToCsvRow.kt
@@ -4,7 +4,6 @@
 
 package io.airbyte.cdk.load.data.csv
 
-import io.airbyte.cdk.load.data.AirbyteValue
 import io.airbyte.cdk.load.data.ArrayValue
 import io.airbyte.cdk.load.data.BooleanValue
 import io.airbyte.cdk.load.data.DateValue
@@ -21,31 +20,24 @@ import io.airbyte.cdk.load.data.UnknownValue
 import io.airbyte.cdk.load.data.json.toJson
 import io.airbyte.cdk.load.util.serializeToString
 
-class AirbyteValueToCsvRow {
-    fun convert(value: ObjectValue, schema: ObjectType): Array<String> {
-        return schema.properties
-            .map { (key, _) -> value.values[key]?.let { convertInner(it) } ?: "" }
-            .toTypedArray()
-    }
-
-    private fun convertInner(value: AirbyteValue): String {
-        return when (value) {
-            is ObjectValue -> value.toJson().serializeToString()
-            is ArrayValue -> value.toJson().serializeToString()
-            is StringValue -> value.value
-            is IntegerValue -> value.value.toString()
-            is NumberValue -> value.value.toString()
-            is NullValue -> ""
-            is TimestampValue -> value.value
-            is BooleanValue -> value.value.toString()
-            is DateValue -> value.value
-            is IntValue -> value.value.toString()
-            is TimeValue -> value.value
-            is UnknownValue -> ""
+fun ObjectValue.toCsvRecord(schema: ObjectType): List<Any> {
+    return schema.properties.map { (key, _) ->
+        values[key]?.let {
+            when (it) {
+                is ObjectValue -> it.toJson().serializeToString()
+                is ArrayValue -> it.toJson().serializeToString()
+                is StringValue -> it.value
+                is IntegerValue -> it.value
+                is NumberValue -> it.value
+                is NullValue -> ""
+                is TimestampValue -> it.value
+                is BooleanValue -> it.value
+                is DateValue -> it.value
+                is IntValue -> it.value
+                is TimeValue -> it.value
+                is UnknownValue -> ""
+            }
         }
+            ?: ""
     }
-}
-
-fun ObjectValue.toCsvRecord(schema: ObjectType): Array<String> {
-    return AirbyteValueToCsvRow().convert(this, schema)
 }

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/file/object_storage/ObjectStorageFormattingWriter.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/file/object_storage/ObjectStorageFormattingWriter.kt
@@ -92,7 +92,7 @@ class CSVFormattingWriter(
     private val printer = finalSchema.toCsvPrinterWithHeader(outputStream)
     override fun accept(record: DestinationRecord) {
         printer.printRecord(
-            *record.dataWithAirbyteMeta(stream, rootLevelFlattening).toCsvRecord(finalSchema)
+            record.dataWithAirbyteMeta(stream, rootLevelFlattening).toCsvRecord(finalSchema)
         )
     }
 


### PR DESCRIPTION
# What
@tryangul it didn't work as advertised 😄 (it broke the multi-threading test). The `value` updates aren't atomic, so I switched back to the `AtomicLong`. I'm still passing the value through the flow though so that something gets updated each time.

The CSV changes are to match the way the old code does it (`List<Any>` instead of `Array<String>`). I don't know if that's better. I also removed the extra object allocation, though that's pretty trivial. I have no idea if this helps at all.