### PR TITLE
live-tests: update `connection-retriever` to 0.7.4

### DIFF
--- a/airbyte-ci/connectors/live-tests/README.md
+++ b/airbyte-ci/connectors/live-tests/README.md
@@ -179,6 +179,9 @@ The traffic recorded on the control connector is passed to the target connector 
 
 ## Changelog
 
+### 0.19.4
+Update `connection_retriever` to 0.7.4
+
 ### 0.19.3
 Update `get_container_from_id` with the correct new Dagger API.
 

--- a/airbyte-ci/connectors/live-tests/poetry.lock
+++ b/airbyte-ci/connectors/live-tests/poetry.lock
@@ -804,7 +804,7 @@ files = [
 
 [[package]]
 name = "connection-retriever"
-version = "0.7.2"
+version = "0.7.4"
 description = "A tool to retrieve connection information from our Airbyte Cloud config api database"
 optional = false
 python-versions = "^3.10"
@@ -830,7 +830,7 @@ tqdm = "^4.66.2"
 type = "git"
 url = "git@github.com:airbytehq/airbyte-platform-internal"
 reference = "HEAD"
-resolved_reference = "9025e1a46e6c2b366826f30dbcaa3b7d360fd702"
+resolved_reference = "0f898a84169625700a77c39e9ead1382c5b070e3"
 subdirectory = "tools/connection-retriever"
 
 [[package]]

--- a/airbyte-ci/connectors/live-tests/pyproject.toml
+++ b/airbyte-ci/connectors/live-tests/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "live-tests"
-version = "0.19.3"
+version = "0.19.4"
 description = "Contains utilities for testing connectors against live data."
 authors = ["Airbyte <contact@airbyte.io>"]
 license = "MIT"


### PR DESCRIPTION
## What
Update `connection_retriever` to `0.7.4` following a fix
