### PR TITLE
Destination iceberg v2: config scaffolding; check test

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/check/CheckIntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/check/CheckIntegrationTest.kt
@@ -25,7 +25,6 @@ import org.junit.jupiter.api.assertAll
 data class CheckTestConfig(val configPath: Path, val featureFlags: Set<FeatureFlag> = emptySet())
 
 open class CheckIntegrationTest<T : ConfigurationSpecification>(
-    val configurationClass: Class<T>,
     val successConfigFilenames: List<CheckTestConfig>,
     val failConfigFilenamesAndFailureReasons: Map<CheckTestConfig, Pattern>,
 ) :

--- a/airbyte-integrations/connectors/destination-dev-null/src/test-integration/kotlin/io/airbyte/integrations/destination/dev_null/DevNullCheckIntegrationTest.kt
+++ b/airbyte-integrations/connectors/destination-dev-null/src/test-integration/kotlin/io/airbyte/integrations/destination/dev_null/DevNullCheckIntegrationTest.kt
@@ -12,7 +12,6 @@ import org.junit.jupiter.api.Test
 
 class DevNullCheckIntegrationTest :
     CheckIntegrationTest<DevNullSpecificationOss>(
-        DevNullSpecificationOss::class.java,
         successConfigFilenames =
             listOf(
                 CheckTestConfig(DevNullTestUtils.loggingConfigPath),

--- a/airbyte-integrations/connectors/destination-iceberg-v2/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-iceberg-v2/metadata.yaml
@@ -22,15 +22,15 @@ data:
     ql: 100
   supportLevel: community
   supportsRefreshes: true
-#  connectorTestSuitesOptions:
-#    - suite: unitTests
-#    - suite: integrationTests
-#      testSecrets:
-#        - name: SECRET_DESTINATION-S3-V2-MINIMAL-REQUIRED-CONFIG
-#          fileName: s3_dest_v2_minimal_required_config.json
-#          secretStore:
-#            type: GSM
-#            alias: airbyte-connector-testing-secret-store
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_DESTINATION-S3-V2-MINIMAL-REQUIRED-CONFIG
+          fileName: s3_dest_v2_minimal_required_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 #        - name: SECRET_DESTINATION-S3-V2-JSONL-ROOT-LEVEL-FLATTENING
 #          fileName: s3_dest_v2_jsonl_root_level_flattening_config.json
 #          secretStore:

--- a/airbyte-integrations/connectors/destination-iceberg-v2/src/main/kotlin/io/airbyte/integrations/destination/iceberg_v2/IcebergV2Checker.kt
+++ b/airbyte-integrations/connectors/destination-iceberg-v2/src/main/kotlin/io/airbyte/integrations/destination/iceberg_v2/IcebergV2Checker.kt
@@ -1,0 +1,11 @@
+package io.airbyte.integrations.destination.iceberg_v2
+
+import io.airbyte.cdk.load.check.DestinationChecker
+import javax.inject.Singleton
+
+@Singleton
+class IcebergV2Checker: DestinationChecker<IcebergV2Configuration> {
+    override fun check(config: IcebergV2Configuration) {
+        // TODO validate the config
+    }
+}

--- a/airbyte-integrations/connectors/destination-iceberg-v2/src/main/kotlin/io/airbyte/integrations/destination/iceberg_v2/IcebergV2Checker.kt
+++ b/airbyte-integrations/connectors/destination-iceberg-v2/src/main/kotlin/io/airbyte/integrations/destination/iceberg_v2/IcebergV2Checker.kt
@@ -1,10 +1,14 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
 package io.airbyte.integrations.destination.iceberg_v2
 
 import io.airbyte.cdk.load.check.DestinationChecker
 import javax.inject.Singleton
 
 @Singleton
-class IcebergV2Checker: DestinationChecker<IcebergV2Configuration> {
+class IcebergV2Checker : DestinationChecker<IcebergV2Configuration> {
     override fun check(config: IcebergV2Configuration) {
         // TODO validate the config
     }

--- a/airbyte-integrations/connectors/destination-iceberg-v2/src/main/kotlin/io/airbyte/integrations/destination/iceberg_v2/IcebergV2Configuration.kt
+++ b/airbyte-integrations/connectors/destination-iceberg-v2/src/main/kotlin/io/airbyte/integrations/destination/iceberg_v2/IcebergV2Configuration.kt
@@ -1,0 +1,20 @@
+package io.airbyte.integrations.destination.iceberg_v2
+
+import io.airbyte.cdk.load.command.DestinationConfiguration
+import io.airbyte.cdk.load.command.DestinationConfigurationFactory
+import javax.inject.Singleton
+
+// TODO put real fields here
+data class IcebergV2Configuration(val something: String) : DestinationConfiguration()
+
+@Singleton
+class IcebergV2ConfigurationFactory :
+    DestinationConfigurationFactory<IcebergV2Specification, IcebergV2Configuration> {
+    override fun makeWithoutExceptionHandling(
+        pojo: IcebergV2Specification
+    ): IcebergV2Configuration {
+        // TODO convert from the jackson-friendly IcebergV2Specification
+        //   to the programmer-friendly IcebergV2Configuration
+        return IcebergV2Configuration("hello world")
+    }
+}

--- a/airbyte-integrations/connectors/destination-iceberg-v2/src/main/kotlin/io/airbyte/integrations/destination/iceberg_v2/IcebergV2Configuration.kt
+++ b/airbyte-integrations/connectors/destination-iceberg-v2/src/main/kotlin/io/airbyte/integrations/destination/iceberg_v2/IcebergV2Configuration.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
 package io.airbyte.integrations.destination.iceberg_v2
 
 import io.airbyte.cdk.load.command.DestinationConfiguration

--- a/airbyte-integrations/connectors/destination-iceberg-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/iceberg_v2/IcebergV2CheckTest.kt
+++ b/airbyte-integrations/connectors/destination-iceberg-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/iceberg_v2/IcebergV2CheckTest.kt
@@ -1,13 +1,17 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
 package io.airbyte.integrations.destination.iceberg_v2
 
 import io.airbyte.cdk.load.check.CheckIntegrationTest
 import io.airbyte.cdk.load.check.CheckTestConfig
 import java.nio.file.Path
 
-class IcebergV2CheckTest: CheckIntegrationTest<IcebergV2Specification>(
-    successConfigFilenames = listOf(
-        CheckTestConfig(Path.of(IcebergV2TestUtil.SOME_RANDOM_S3_CONFIG))
-    ),
-    // TODO we maybe should add some configs that are expected to fail `check`
-    failConfigFilenamesAndFailureReasons = mapOf(),
-)
+class IcebergV2CheckTest :
+    CheckIntegrationTest<IcebergV2Specification>(
+        successConfigFilenames =
+            listOf(CheckTestConfig(Path.of(IcebergV2TestUtil.SOME_RANDOM_S3_CONFIG))),
+        // TODO we maybe should add some configs that are expected to fail `check`
+        failConfigFilenamesAndFailureReasons = mapOf(),
+    )

--- a/airbyte-integrations/connectors/destination-iceberg-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/iceberg_v2/IcebergV2CheckTest.kt
+++ b/airbyte-integrations/connectors/destination-iceberg-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/iceberg_v2/IcebergV2CheckTest.kt
@@ -1,0 +1,13 @@
+package io.airbyte.integrations.destination.iceberg_v2
+
+import io.airbyte.cdk.load.check.CheckIntegrationTest
+import io.airbyte.cdk.load.check.CheckTestConfig
+import java.nio.file.Path
+
+class IcebergV2CheckTest: CheckIntegrationTest<IcebergV2Specification>(
+    successConfigFilenames = listOf(
+        CheckTestConfig(Path.of(IcebergV2TestUtil.SOME_RANDOM_S3_CONFIG))
+    ),
+    // TODO we maybe should add some configs that are expected to fail `check`
+    failConfigFilenamesAndFailureReasons = mapOf(),
+)

--- a/airbyte-integrations/connectors/destination-iceberg-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/iceberg_v2/IcebergV2TestUtil.kt
+++ b/airbyte-integrations/connectors/destination-iceberg-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/iceberg_v2/IcebergV2TestUtil.kt
@@ -1,0 +1,10 @@
+package io.airbyte.integrations.destination.iceberg_v2
+
+import java.nio.file.Files
+import java.nio.file.Path
+
+object IcebergV2TestUtil {
+    // TODO this is just here as an example, we should remove it + add real configs
+    const val SOME_RANDOM_S3_CONFIG = "secrets/s3_dest_v2_minimal_required_config.json"
+    fun getConfig(configPath: String): String = Files.readString(Path.of(configPath))
+}

--- a/airbyte-integrations/connectors/destination-iceberg-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/iceberg_v2/IcebergV2TestUtil.kt
+++ b/airbyte-integrations/connectors/destination-iceberg-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/iceberg_v2/IcebergV2TestUtil.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
 package io.airbyte.integrations.destination.iceberg_v2
 
 import java.nio.file.Files

--- a/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2CheckTest.kt
+++ b/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2CheckTest.kt
@@ -12,7 +12,6 @@ import org.junit.jupiter.api.Test
 
 class S3V2CheckTest :
     CheckIntegrationTest<S3V2Specification>(
-        S3V2Specification::class.java,
         successConfigFilenames =
             listOf(
                 CheckTestConfig(


### PR DESCRIPTION
* first commit is just cleanup
* second commit is the relevant code change - adds a blank iceberg Config data class + demo check test
* third commit is just autoformat

most of this is placeholder fluff, I'm just trying to speedrun all the boilerplate that the cdk requires

destination-s3-v2 CI failure is expected, so we'll need an approve-and-merge later