### PR TITLE
Update codeowners.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -21,27 +21,27 @@
 /docs/understanding-airbyte/airbyte-protocol.md @airbytehq/protocol-reviewers
 
 # Bulk CDK
-/airbyte-cdk/bulk @airbytehq/dbsources @airbytehq/destinations
+/airbyte-cdk/bulk @airbytehq/dbsources @airbytehq/move-destinations
 /airbyte-cdk/bulk/core/extract/ @airbytehq/dbsources
-/airbyte-cdk/bulk/core/load/ @airbytehq/destinations
+/airbyte-cdk/bulk/core/load/ @airbytehq/move-destinations
 /airbyte-cdk/bulk/toolkits/extract-*/ @airbytehq/dbsources
-/airbyte-cdk/bulk/toolkits/load-*/ @airbytehq/destinations
+/airbyte-cdk/bulk/toolkits/load-*/ @airbytehq/move-destinations
 
 # Java CDK
-/airbyte-cdk/java/airbyte-cdk @airbytehq/dbsources @airbytehq/destinations
+/airbyte-cdk/java/airbyte-cdk @airbytehq/dbsources @airbytehq/move-destinations
 /airbyte-cdk/java/airbyte-cdk/*-sources/ @airbytehq/dbsources
-/airbyte-cdk/java/airbyte-cdk/*-destinations/ @airbytehq/destinations
-/airbyte-cdk/java/airbyte-cdk/typing-deduping/ @airbytehq/destinations
+/airbyte-cdk/java/airbyte-cdk/*-destinations/ @airbytehq/move-destinations
+/airbyte-cdk/java/airbyte-cdk/typing-deduping/ @airbytehq/move-destinations
 
 # Java connectors catch-all
-/buildSrc/ @airbytehq/dbsources @airbytehq/destinations
+/buildSrc/ @airbytehq/dbsources @airbytehq/move-destinations
 /airbyte-integrations/connectors/source-*/**/*.java @airbytehq/dbsources
 /airbyte-integrations/connectors/source-*/**/*.kt @airbytehq/dbsources
 /airbyte-integrations/connectors/source-*/**/*.gradle @airbytehq/dbsources
 /airbyte-integrations/connectors-performance/source-harness/ @airbytehq/dbsources
-/airbyte-integrations/connectors/destination-*/**/*.java @airbytehq/destinations
-/airbyte-integrations/connectors/destination-*/**/*.kt @airbytehq/destinations
-/airbyte-integrations/connectors/destination-*/**/*.gradle @airbytehq/destinations
+/airbyte-integrations/connectors/destination-*/**/*.java @airbytehq/move-destinations
+/airbyte-integrations/connectors/destination-*/**/*.kt @airbytehq/move-destinations
+/airbyte-integrations/connectors/destination-*/**/*.gradle @airbytehq/move-destinations
 /airbyte-integrations/connectors-performance/destination-harness/ @airbytehq/dbsources
 
 # Java-based certified or incubating source connectors
@@ -51,12 +51,12 @@
 /airbyte-integrations/connectors/source-postgres/ @airbytehq/dbsources
 
 # Java-based certified or incubating destination connectors
-/airbyte-integrations/connectors/destination-bigquery/ @airbytehq/destinations
-/airbyte-integrations/connectors/destination-postgres/ @airbytehq/destinations
-/airbyte-integrations/connectors/destination-postgres-strict-encrypt/ @airbytehq/destinations
-/airbyte-integrations/connectors/destination-s3/ @airbytehq/destinations
-/airbyte-integrations/connectors/destination-snowflake/ @airbytehq/destinations
-/airbyte-integrations/connectors/destination-redshift/ @airbytehq/destinations
+/airbyte-integrations/connectors/destination-bigquery/ @airbytehq/move-destinations
+/airbyte-integrations/connectors/destination-postgres/ @airbytehq/move-destinations
+/airbyte-integrations/connectors/destination-postgres-strict-encrypt/ @airbytehq/move-destinations
+/airbyte-integrations/connectors/destination-s3/ @airbytehq/move-destinations
+/airbyte-integrations/connectors/destination-snowflake/ @airbytehq/move-destinations
+/airbyte-integrations/connectors/destination-redshift/ @airbytehq/move-destinations
 
 # Python critical connectors
 /airbyte-integrations/connectors/source-facebook-marketing/ @airbytehq/python-team


### PR DESCRIPTION
## What
Update codeowners to highlight the Destination domain falls under Move now.

This reflect the github team change of `destinations` -> `move-destinations`.

## How
Update codeowners.

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
