### PR TITLE
🐛bug(source-linkedin-ads): Fix unit tests running local

### DIFF
--- a/airbyte-integrations/connectors/source-linkedin-ads/source_linkedin_ads/source.py
+++ b/airbyte-integrations/connectors/source-linkedin-ads/source_linkedin_ads/source.py
@@ -40,6 +40,7 @@ class SourceLinkedinAds(YamlDeclarativeSource):
         :param logger: Logger object to log the information.
         :param config: Configuration mapping containing necessary parameters.
         :return: A tuple containing a boolean indicating success or failure and an optional message or object.
+        dummy change
         """
         self._validate_ad_analytics_reports(config)
         return super().check_connection(logger, config)

--- a/airbyte-integrations/connectors/source-linkedin-ads/source_linkedin_ads/source.py
+++ b/airbyte-integrations/connectors/source-linkedin-ads/source_linkedin_ads/source.py
@@ -40,7 +40,6 @@ class SourceLinkedinAds(YamlDeclarativeSource):
         :param logger: Logger object to log the information.
         :param config: Configuration mapping containing necessary parameters.
         :return: A tuple containing a boolean indicating success or failure and an optional message or object.
-        dummy change
         """
         self._validate_ad_analytics_reports(config)
         return super().check_connection(logger, config)

--- a/airbyte-integrations/connectors/source-linkedin-ads/unit_tests/test_source.py
+++ b/airbyte-integrations/connectors/source-linkedin-ads/unit_tests/test_source.py
@@ -90,7 +90,6 @@ class TestAllStreams:
 
     @pytest.mark.parametrize("error_code", [429, 500, 503])
     def test_should_retry_on_error(self, error_code, requests_mock, mocker):
-        # Define a helper function
         mocker.patch.object(ManifestDeclarativeSource, "_initialize_cache_for_parent_streams", side_effect=self._mock_initialize_cache_for_parent_streams)
         mocker.patch("time.sleep", lambda x: None)
         stream = find_stream("accounts", TEST_CONFIG)
@@ -98,7 +97,6 @@ class TestAllStreams:
             "GET", "https://api.linkedin.com/rest/adAccounts", [{"status_code": error_code, "json": {"elements": []}}]
         )
         stream.exit_on_rate_limit = True
-
         with pytest.raises(DefaultBackoffException):
             list(stream.read_records(sync_mode=SyncMode.full_refresh))
 
@@ -156,6 +154,8 @@ class TestAllStreams:
         ),
     )
     def test_check_connection(self, requests_mock, status_code, is_connection_successful, error_msg, mocker):
+        mocker.patch.object(ManifestDeclarativeSource, "_initialize_cache_for_parent_streams",
+                            side_effect=self._mock_initialize_cache_for_parent_streams)
         mocker.patch("time.sleep", lambda x: None)
         json = {"elements": [{"data": []}] * 500} if 200 >= status_code < 300 else {}
         requests_mock.register_uri(

--- a/airbyte-integrations/connectors/source-linkedin-ads/unit_tests/test_source.py
+++ b/airbyte-integrations/connectors/source-linkedin-ads/unit_tests/test_source.py
@@ -1,12 +1,13 @@
 #
 # Copyright (c) 2024 Airbyte, Inc., all rights reserved.
 #
-
+from typing import List, Dict, Any
 import logging
 
 import pytest
 import requests
 from airbyte_cdk.models import SyncMode
+from airbyte_cdk.sources.declarative.manifest_declarative_source import ManifestDeclarativeSource
 from airbyte_cdk.sources.streams import Stream
 from airbyte_cdk.sources.streams.http.exceptions import DefaultBackoffException
 from airbyte_cdk.sources.streams.http.requests_native_auth import Oauth2Authenticator, TokenAuthenticator
@@ -57,14 +58,47 @@ TEST_CONFIG_DUPLICATE_CUSTOM_AD_ANALYTICS_REPORTS: dict = {
 class TestAllStreams:
     _instance: SourceLinkedinAds = SourceLinkedinAds()
 
+    @staticmethod
+    def _mock_initialize_cache_for_parent_streams(stream_configs: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        parent_streams = set()
+
+        def update_with_cache_parent_configs(parent_configs: list[dict[str, Any]]) -> None:
+            for parent_config in parent_configs:
+                parent_streams.add(parent_config["stream"]["name"])
+                parent_config["stream"]["retriever"]["requester"]["use_cache"] = False
+
+        for stream_config in stream_configs:
+            if stream_config.get("incremental_sync", {}).get("parent_stream"):
+                parent_streams.add(stream_config["incremental_sync"]["parent_stream"]["name"])
+                stream_config["incremental_sync"]["parent_stream"]["retriever"]["requester"]["use_cache"] = False
+
+            elif stream_config.get("retriever", {}).get("partition_router", {}):
+                partition_router = stream_config["retriever"]["partition_router"]
+
+                if isinstance(partition_router, dict) and partition_router.get("parent_stream_configs"):
+                    update_with_cache_parent_configs(partition_router["parent_stream_configs"])
+                elif isinstance(partition_router, list):
+                    for router in partition_router:
+                        if router.get("parent_stream_configs"):
+                            update_with_cache_parent_configs(router["parent_stream_configs"])
+
+        for stream_config in stream_configs:
+            if stream_config["name"] in parent_streams:
+                stream_config["retriever"]["requester"]["use_cache"] = False
+
+        return stream_configs
+
     @pytest.mark.parametrize("error_code", [429, 500, 503])
     def test_should_retry_on_error(self, error_code, requests_mock, mocker):
+        # Define a helper function
+        mocker.patch.object(ManifestDeclarativeSource, "_initialize_cache_for_parent_streams", side_effect=self._mock_initialize_cache_for_parent_streams)
         mocker.patch("time.sleep", lambda x: None)
         stream = find_stream("accounts", TEST_CONFIG)
         requests_mock.register_uri(
             "GET", "https://api.linkedin.com/rest/adAccounts", [{"status_code": error_code, "json": {"elements": []}}]
         )
         stream.exit_on_rate_limit = True
+
         with pytest.raises(DefaultBackoffException):
             list(stream.read_records(sync_mode=SyncMode.full_refresh))
 

--- a/airbyte-integrations/connectors/source-linkedin-ads/unit_tests/test_source.py
+++ b/airbyte-integrations/connectors/source-linkedin-ads/unit_tests/test_source.py
@@ -1,8 +1,8 @@
 #
 # Copyright (c) 2024 Airbyte, Inc., all rights reserved.
 #
-from typing import List, Dict, Any
 import logging
+from typing import Any, Dict, List
 
 import pytest
 import requests


### PR DESCRIPTION
## What
@agarctfi noticed inconsistency through the unit tests when running locally, and after a few tries, I did it as well, which was odd. The problem is that we could get cached responses between tests as ManifestDeclarativeSource uses cache for parent streams. 

I guess this is not a problem for CI as pods are ephemeral but can cause confusion for local work.

![image](https://github.com/user-attachments/assets/44a9b6c6-0137-423f-a4d0-c7e214fd8ebe)

![image](https://github.com/user-attachments/assets/c7ba100d-5496-433f-8411-698c38e28d5c)

## How
Mock _initialize_cache_for_parent_streams method of ManifestDeclarativeSource

## Review guide

1. `airbyte-integrations/connectors/source-linkedin-ads/unit_tests/test_source.py`


## User Impact
Running unit tests locally will not make you confused about the results.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
