### PR TITLE
base-images: prompt for bump type with optional pre-releases

### DIFF
--- a/airbyte-ci/connectors/base_images/README.md
+++ b/airbyte-ci/connectors/base_images/README.md
@@ -94,6 +94,9 @@ poetry run mypy base_images --check-untyped-defs
 ```
 ## CHANGELOG
 
+### 1.2.0
+- Improve new version prompt to pick bump type with optional pre-release version.
+
 ### 1.1.0
 - Add a cache ttl for base image listing to avoid DockerHub rate limiting.
 

--- a/airbyte-ci/connectors/base_images/base_images/commands.py
+++ b/airbyte-ci/connectors/base_images/base_images/commands.py
@@ -69,15 +69,20 @@ async def _generate_release(dagger_client: dagger.Client):
                 message=f"Which kind of new version would you like to cut? (latest version is {latest_version}))",
                 choices=[
                     ("prerelease", latest_version.bump_prerelease()),
+                    ("finalize", latest_version.finalize_version()),
                     ("patch", latest_version.bump_patch()),
+                    ("patch-prerelease", latest_version.bump_patch().bump_prerelease()),
                     ("minor", latest_version.bump_minor()),
+                    ("minor-prerelease", latest_version.bump_minor().bump_prerelease()),
                     ("major", latest_version.bump_major()),
+                    ("major-prerelease", latest_version.bump_major().bump_prerelease()),
                 ],
             ),
             inquirer.Text("changelog_entry", message="What should the changelog entry be?", validate=lambda _, entry: len(entry) > 0),
             inquirer.Confirm("publish_now", message="Would you like to publish it to our remote registry now?"),
         ]
     )
+
     new_version, changelog_entry, publish_now = (
         new_version_answers["new_version"],
         new_version_answers["changelog_entry"],

--- a/airbyte-ci/connectors/base_images/base_images/templates/README.md.j2
+++ b/airbyte-ci/connectors/base_images/base_images/templates/README.md.j2
@@ -77,3 +77,21 @@ poetry run pytest
 poetry run mypy base_images --check-untyped-defs
 ```
 
+## CHANGELOG
+
+### 1.2.0
+- Improve new version prompt to pick bump type with optional pre-release version.
+
+### 1.1.0
+- Add a cache ttl for base image listing to avoid DockerHub rate limiting.
+
+### 1.0.4
+- Upgrade Dagger to `0.13.3`
+
+### 1.0.2
+
+- Improved support for images with non-semantic-versioned tags.
+
+### 1.0.1
+
+- Bumped dependencies ([#42581](https://github.com/airbytehq/airbyte/pull/42581))

--- a/airbyte-ci/connectors/base_images/pyproject.toml
+++ b/airbyte-ci/connectors/base_images/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "airbyte-connectors-base-images"
-version = "1.1.0"
+version = "1.2.0"
 description = "This package is used to generate and publish the base images for Airbyte Connectors."
 authors = ["Augustin Lafanechere <augustin@airbyte.io>"]
 readme = "README.md"


### PR DESCRIPTION
This pull request includes changes to the `airbyte-ci/connectors/base_images` project to improve the version bumping process. The most important changes include the addition of new version bump types.

### Improvements to version bumping:

* [`airbyte-ci/connectors/base_images/base_images/commands.py`](diffhunk://#diff-93762b8060ab6ef8715aaa28b065ae6e6d8779f2ca3d7f693366389ee0b3fd7fR73-R84): Added new version bump types (`patch-prerelease`, `minor-prerelease`, `major-prerelease`, `finalize`) to the choices for generating a release.
