### PR TITLE
Update testMidSyncCheckpointingStreamState to be usable again

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/integrationTest/kotlin/io/airbyte/cdk/load/mock_integration_test/MockBasicFunctionalityIntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/integrationTest/kotlin/io/airbyte/cdk/load/mock_integration_test/MockBasicFunctionalityIntegrationTest.kt
@@ -9,7 +9,6 @@ import io.airbyte.cdk.load.test.util.NoopExpectedRecordMapper
 import io.airbyte.cdk.load.test.util.NoopNameMapper
 import io.airbyte.cdk.load.write.BasicFunctionalityIntegrationTest
 import io.airbyte.cdk.load.write.Untyped
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 
 class MockBasicFunctionalityIntegrationTest :

--- a/airbyte-cdk/bulk/core/load/src/integrationTest/kotlin/io/airbyte/cdk/load/mock_integration_test/MockBasicFunctionalityIntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/integrationTest/kotlin/io/airbyte/cdk/load/mock_integration_test/MockBasicFunctionalityIntegrationTest.kt
@@ -34,7 +34,6 @@ class MockBasicFunctionalityIntegrationTest :
     }
 
     @Test
-    @Disabled
     override fun testMidSyncCheckpointingStreamState() {
         super.testMidSyncCheckpointingStreamState()
     }

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/write/BasicFunctionalityIntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/write/BasicFunctionalityIntegrationTest.kt
@@ -236,16 +236,15 @@ abstract class BasicFunctionalityIntegrationTest(
     @Test
     open fun testMidSyncCheckpointingStreamState(): Unit =
         runBlocking(Dispatchers.IO) {
-            fun makeStream(name: String) =
+            val stream =
                 DestinationStream(
-                    DestinationStream.Descriptor(randomizedNamespace, name),
+                    DestinationStream.Descriptor(randomizedNamespace, "test_stream"),
                     Append,
                     ObjectType(linkedMapOf("id" to intType)),
                     generationId = 0,
                     minimumGenerationId = 0,
                     syncId = 42,
                 )
-            val stream = makeStream("test_stream")
             val destination =
                 destinationProcessFactory.createDestinationProcess(
                     "write",

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/write/BasicFunctionalityIntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/write/BasicFunctionalityIntegrationTest.kt
@@ -250,12 +250,7 @@ abstract class BasicFunctionalityIntegrationTest(
                 destinationProcessFactory.createDestinationProcess(
                     "write",
                     configContents,
-                    DestinationCatalog(
-                            listOf(
-                                stream
-                            )
-                        )
-                        .asProtocolObject(),
+                    DestinationCatalog(listOf(stream)).asProtocolObject(),
                 )
             launch {
                 try {
@@ -329,9 +324,7 @@ abstract class BasicFunctionalityIntegrationTest(
             // but is cheap and easy to do.
             assertAll(
                 { assertEquals(randomizedNamespace, streamNamespace) },
-                {
-                    assertEquals(streamName, "test_stream")
-                },
+                { assertEquals(streamName, "test_stream") },
                 {
                     assertEquals(
                         1.0,
@@ -339,7 +332,12 @@ abstract class BasicFunctionalityIntegrationTest(
                         "Expected destination stats to show 1 record"
                     )
                 },
-                {assertEquals("""{"foo": "bar1"}""".deserializeToNode(),stateMessage.stream.streamState)}
+                {
+                    assertEquals(
+                        """{"foo": "bar1"}""".deserializeToNode(),
+                        stateMessage.stream.streamState
+                    )
+                }
             )
             if (verifyDataWriting) {
                 val records = dataDumper.dumpRecords(parsedConfig, stream)
@@ -354,7 +352,7 @@ abstract class BasicFunctionalityIntegrationTest(
                     )
 
                 assertTrue(
-                    records.any { expectedRecord.data == it.data},
+                    records.any { expectedRecord.data == it.data },
                     "Expected the first record to be present in the dumped records.",
                 )
             }

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/write/BasicFunctionalityIntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/write/BasicFunctionalityIntegrationTest.kt
@@ -245,14 +245,14 @@ abstract class BasicFunctionalityIntegrationTest(
                     minimumGenerationId = 0,
                     syncId = 42,
                 )
-            val stream1 = makeStream("test_stream1")
+            val stream = makeStream("test_stream")
             val destination =
                 destinationProcessFactory.createDestinationProcess(
                     "write",
                     configContents,
                     DestinationCatalog(
                             listOf(
-                                stream1
+                                stream
                             )
                         )
                         .asProtocolObject(),
@@ -270,14 +270,14 @@ abstract class BasicFunctionalityIntegrationTest(
             destination.sendMessages(
                 DestinationRecord(
                         namespace = randomizedNamespace,
-                        name = "test_stream1",
+                        name = "test_stream",
                         data = """{"id": 12}""",
                         emittedAtMs = 1234,
                     )
                     .asProtocolMessage(),
                 StreamCheckpoint(
                         streamNamespace = randomizedNamespace,
-                        streamName = "test_stream1",
+                        streamName = "test_stream",
                         blob = """{"foo": "bar1"}""",
                         sourceRecordCount = 1
                     )
@@ -294,7 +294,7 @@ abstract class BasicFunctionalityIntegrationTest(
                     destination.sendMessage(
                         DestinationRecord(
                                 namespace = randomizedNamespace,
-                                name = "test_stream1",
+                                name = "test_stream",
                                 data = """{"id": 56}""",
                                 emittedAtMs = 1234,
                             )
@@ -318,8 +318,8 @@ abstract class BasicFunctionalityIntegrationTest(
 
             // Forcefully kill the destination
             destination.kill()
-            
-            runSync(configContents, DestinationCatalog(listOf(stream1)), listOf())
+
+            runSync(configContents, DestinationCatalog(listOf(stream)), listOf())
 
             // for each state message, verify that it's a valid state,
             // and that we actually wrote the data
@@ -330,7 +330,7 @@ abstract class BasicFunctionalityIntegrationTest(
             assertAll(
                 { assertEquals(randomizedNamespace, streamNamespace) },
                 {
-                    assertEquals(streamName, "test_stream1")
+                    assertEquals(streamName, "test_stream")
                 },
                 {
                     assertEquals(
@@ -342,7 +342,7 @@ abstract class BasicFunctionalityIntegrationTest(
                 {assertEquals("""{"foo": "bar1"}""".deserializeToNode(),stateMessage.stream.streamState)}
             )
             if (verifyDataWriting) {
-                val records = dataDumper.dumpRecords(parsedConfig, stream1)
+                val records = dataDumper.dumpRecords(parsedConfig, stream)
                 val expectedRecord =
                     recordMangler.mapRecord(
                         OutputRecord(

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/write/BasicFunctionalityIntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/write/BasicFunctionalityIntegrationTest.kt
@@ -316,7 +316,9 @@ abstract class BasicFunctionalityIntegrationTest(
                 }
             }
 
+            // Forcefully kill the destination
             destination.kill()
+            
             runSync(configContents, DestinationCatalog(listOf(stream1)), listOf())
 
             // for each state message, verify that it's a valid state,

--- a/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2WriteTest.kt
+++ b/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2WriteTest.kt
@@ -120,12 +120,12 @@ class S3V2WriteTestJsonStaging :
         preserveUndeclaredFields = true,
         allTypesBehavior = Untyped,
     ) {
-        @Test
-        @Disabled
-        override fun testMidSyncCheckpointingStreamState() {
-            super.testMidSyncCheckpointingStreamState()
-        }
+    @Test
+    @Disabled
+    override fun testMidSyncCheckpointingStreamState() {
+        super.testMidSyncCheckpointingStreamState()
     }
+}
 
 class S3V2WriteTestJsonGzip :
     S3V2WriteTest(

--- a/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2WriteTest.kt
+++ b/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2WriteTest.kt
@@ -119,7 +119,13 @@ class S3V2WriteTestJsonStaging :
         promoteUnionToObject = false,
         preserveUndeclaredFields = true,
         allTypesBehavior = Untyped,
-    )
+    ) {
+        @Test
+        @Disabled
+        override fun testMidSyncCheckpointingStreamState() {
+            super.testMidSyncCheckpointingStreamState()
+        }
+    }
 
 class S3V2WriteTestJsonGzip :
     S3V2WriteTest(

--- a/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2WriteTest.kt
+++ b/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2WriteTest.kt
@@ -48,7 +48,6 @@ abstract class S3V2WriteTest(
         super.testFunkyCharacters()
     }
 
-    @Disabled("https://github.com/airbytehq/airbyte-internal-issues/issues/10413?")
     @Test
     override fun testMidSyncCheckpointingStreamState() {
         super.testMidSyncCheckpointingStreamState()


### PR DESCRIPTION
## What

Update testMidSyncCheckpointingStreamState to have the following flow:
* Produce 1 record and 1 state message
* .kill the destination
* Run a normal sync
* Ensure that the record produce above was indeed commited

I also removed `Disabled` decorators to reenable that test 

Closes https://github.com/airbytehq/airbyte-internal-issues/issues/10413

## Can this PR be safely reverted and rolled back?

- [X] YES 💚
- [ ] NO ❌
