### PR TITLE
Bulk Load CDK: Tolerate empty streams and update on empty batches

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/state/StreamManager.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/state/StreamManager.kt
@@ -182,6 +182,11 @@ class DefaultStreamManager(
             return false
         }
 
+        /* A closed empty stream is always complete. */
+        if (recordCount.get() == 0L) {
+            return true
+        }
+
         return isProcessingCompleteForState(recordCount.get(), Batch.State.COMPLETE)
     }
 

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/state/StreamManagerTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/state/StreamManagerTest.kt
@@ -322,4 +322,11 @@ class StreamManagerTest {
         // Can close now
         Assertions.assertDoesNotThrow(manager::markSucceeded)
     }
+
+    @Test
+    fun testEmptyCompletedStreamYieldsBatchProcessingComplete() {
+        val manager = DefaultStreamManager(stream1)
+        manager.markEndOfStream()
+        Assertions.assertTrue(manager.isBatchProcessingComplete())
+    }
 }

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/DestinationTaskLauncherTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/DestinationTaskLauncherTest.kt
@@ -444,6 +444,21 @@ class DestinationTaskLauncherTest<T> where T : LeveledTask, T : ScopedTask {
     }
 
     @Test
+    fun testHandleEmptySpilledFile() = runTest {
+        taskLauncher.handleNewSpilledFile(
+            MockDestinationCatalogFactory.stream1.descriptor,
+            SpilledRawMessagesLocalFile(Path("not/a/real/file"), 0L, Range.singleton(0))
+        )
+
+        mockSpillToDiskTaskFactory.streamHasRun[MockDestinationCatalogFactory.stream1.descriptor]
+            ?.receive()
+            ?: Assertions.fail("SpillToDiskTask not run")
+
+        delay(500)
+        Assertions.assertTrue(processRecordsTaskFactory.hasRun.tryReceive().isFailure)
+    }
+
+    @Test
     fun testHandleNewBatch() = runTest {
         val range = TreeRangeSet.create(listOf(Range.closed(0L, 100L)))
         val streamManager =
@@ -492,6 +507,18 @@ class DestinationTaskLauncherTest<T> where T : LeveledTask, T : ScopedTask {
         )
         closeStreamTaskFactory.hasRun.receive()
         Assertions.assertTrue(true)
+    }
+
+    @Test
+    fun handleEmptyBatch() = runTest {
+        val range = TreeRangeSet.create(listOf(Range.closed(0L, 0L)))
+        val streamManager =
+            syncManager.getStreamManager(MockDestinationCatalogFactory.stream1.descriptor)
+        streamManager.markEndOfStream()
+
+        val emptyBatch = BatchEnvelope(MockBatch(Batch.State.COMPLETE), range)
+        taskLauncher.handleNewBatch(MockDestinationCatalogFactory.stream1.descriptor, emptyBatch)
+        closeStreamTaskFactory.hasRun.receive()
     }
 
     @Test


### PR DESCRIPTION
## What
I found this fixing legacy DATs but am pulling it out because it's breaking some of @frifriSF59 's attempted test fixes.

* skips processing empty spill files to avoid cryptic XML AWS errors
* pushes a dummy batch update to force state update anyway (@benmoriceau  this is similar to your issue; we should break out a new event so this is less hacky)
* treats a fully processed empty stream as ipso facto complete
* tests
