### PR TITLE
bulk-cdk: CDC-related fixes and tweaks

### DIFF
--- a/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/read/FeedBootstrap.kt
+++ b/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/read/FeedBootstrap.kt
@@ -57,7 +57,8 @@ sealed class FeedBootstrap<T : Feed>(
      * to the next. Not doing this generates a lot of garbage and the increased GC activity has a
      * measurable impact on performance.
      */
-    private inner class EfficientStreamRecordConsumer(val stream: Stream) : StreamRecordConsumer {
+    private inner class EfficientStreamRecordConsumer(override val stream: Stream) :
+        StreamRecordConsumer {
 
         override fun accept(recordData: ObjectNode, changes: Map<Field, FieldValueChange>?) {
             if (changes.isNullOrEmpty()) {
@@ -214,7 +215,10 @@ sealed class FeedBootstrap<T : Feed>(
  *    b) field value changes and the motivating reason for these in the record metadata.
  * ```
  */
-fun interface StreamRecordConsumer {
+interface StreamRecordConsumer {
+
+    val stream: Stream
+
     fun accept(recordData: ObjectNode, changes: Map<Field, FieldValueChange>?)
 }
 

--- a/airbyte-cdk/bulk/toolkits/extract-cdc/src/main/kotlin/io/airbyte/cdk/read/cdc/Debezium.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-cdc/src/main/kotlin/io/airbyte/cdk/read/cdc/Debezium.kt
@@ -6,7 +6,43 @@ package io.airbyte.cdk.read.cdc
 
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.node.NullNode
+import io.airbyte.cdk.util.Jsons
+import io.debezium.embedded.EmbeddedEngineChangeEvent
+import io.debezium.engine.ChangeEvent
 import io.debezium.relational.history.HistoryRecord
+import org.apache.kafka.connect.source.SourceRecord
+
+/** Convenience wrapper around [ChangeEvent]. */
+class DebeziumEvent(event: ChangeEvent<String?, String?>) {
+
+    /** This [SourceRecord] object is the preferred way to obtain the current position. */
+    val sourceRecord: SourceRecord? = (event as? EmbeddedEngineChangeEvent<*, *, *>)?.sourceRecord()
+
+    val key: DebeziumRecordKey? =
+        event
+            .key()
+            ?.let { runCatching { Jsons.readTree(it) }.getOrNull() }
+            ?.let(::DebeziumRecordKey)
+
+    val value: DebeziumRecordValue? =
+        event
+            .value()
+            ?.let { runCatching { Jsons.readTree(it) }.getOrNull() }
+            ?.let(::DebeziumRecordValue)
+
+    /**
+     * Debezium can output a tombstone event that has a value of null. This is an artifact of how it
+     * interacts with kafka. We want to ignore it. More on the tombstone:
+     * https://debezium.io/documentation/reference/stable/transformations/event-flattening.html
+     */
+    val isTombstone: Boolean = event.value() == null
+
+    /**
+     * True if this is a Debezium heartbeat event, or the equivalent thereof. In any case, such
+     * events are only used for their position value and for triggering timeouts.
+     */
+    val isHeartbeat: Boolean = value?.source?.isNull == true
+}
 
 /** [DebeziumRecordKey] wraps a Debezium change data event key. */
 @JvmInline
@@ -24,13 +60,6 @@ value class DebeziumRecordKey(val wrapped: JsonNode) {
 /** [DebeziumRecordValue] wraps a Debezium change data event value. */
 @JvmInline
 value class DebeziumRecordValue(val wrapped: JsonNode) {
-
-    /**
-     * True if this is a Debezium heartbeat event, or the equivalent thereof. In any case, such
-     * events are only used for their position value and for triggering timeouts.
-     */
-    val isHeartbeat: Boolean
-        get() = source.isNull
 
     /** The datum prior to this event; null for insertions. */
     val before: JsonNode

--- a/airbyte-cdk/bulk/toolkits/extract-cdc/src/main/kotlin/io/airbyte/cdk/read/cdc/DebeziumOperations.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-cdc/src/main/kotlin/io/airbyte/cdk/read/cdc/DebeziumOperations.kt
@@ -5,7 +5,6 @@
 package io.airbyte.cdk.read.cdc
 
 import com.fasterxml.jackson.databind.node.ObjectNode
-import io.airbyte.cdk.StreamIdentifier
 import io.airbyte.cdk.command.OpaqueStateValue
 import io.airbyte.cdk.discover.Field
 import io.airbyte.cdk.read.FieldValueChange
@@ -35,7 +34,23 @@ interface CdcPartitionReaderDebeziumOperations<T : Comparable<T>> {
      *
      * Returning null means that the event should be treated like a heartbeat.
      */
-    fun deserialize(key: DebeziumRecordKey, value: DebeziumRecordValue): DeserializedRecord?
+    fun deserialize(
+        key: DebeziumRecordKey,
+        value: DebeziumRecordValue,
+        stream: Stream,
+    ): DeserializedRecord?
+
+    /** Identifies the namespace of the stream that this event belongs to, if applicable. */
+    fun findStreamNamespace(
+        key: DebeziumRecordKey,
+        value: DebeziumRecordValue,
+    ): String?
+
+    /** Identifies the null of the stream that this event belongs to, if applicable. */
+    fun findStreamName(
+        key: DebeziumRecordKey,
+        value: DebeziumRecordValue,
+    ): String?
 
     /** Maps a [DebeziumState] to an [OpaqueStateValue]. */
     fun serialize(debeziumState: DebeziumState): OpaqueStateValue
@@ -49,7 +64,6 @@ interface CdcPartitionReaderDebeziumOperations<T : Comparable<T>> {
 
 /** [DeserializedRecord]s are used to generate Airbyte RECORD messages. */
 data class DeserializedRecord(
-    val streamID: StreamIdentifier,
     val data: ObjectNode,
     val changes: Map<Field, FieldValueChange>,
 )

--- a/airbyte-integrations/connectors/source-mysql/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mysql/metadata.yaml
@@ -9,7 +9,7 @@ data:
   connectorSubtype: database
   connectorType: source
   definitionId: 435bb9a5-7887-4809-aa58-28c27df0d7ad
-  dockerImageTag: 3.9.0-rc.18
+  dockerImageTag: 3.9.0-rc.19
   dockerRepository: airbyte/source-mysql
   documentationUrl: https://docs.airbyte.com/integrations/sources/mysql
   githubIssueLabel: source-mysql


### PR DESCRIPTION
## What
While working on oracle I ran into some bugs and limitations which this PR addresses. By far the biggest limitation I ran into is that the `deserialize` record deserializer method in `CdcPartitionReaderDebeziumOperations` has no awareness of the schema of the records. This PR fixes this by breaking down `deserialize` into smaller pieces:
1. First the new methods `findStreamNamespace` and `findStreamName` identify the stream to which a Debezium event belongs to
2. Next `deserialized` is called with the corresponding `Stream` object which contains the schema.

This is very convenient for dealing with numbers which may be presented as strings by Debezium to preserve precision. This allows the `deserialize` implementation to check for numerical fields which have a `TextNode` instead of a `NumberNode` value and transform the value accordingly.
 
## How 

Doing the above lead to some changes in how `CdcPartitionReader` is implemented. In particular, the `EventConsumer`'s `accept` method implementation was starting to get a bit unwieldy so I moved some code into a new `DebeziumEvent` class definition.

Since source-mysql imports the bulk-cdk from source, I had to reflect the changes there as well. It's pretty much a no-op, from the perspective of functionality.

## Review guide
Commit by commit.

## User Impact
None of these changes should change any existing functionality.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
