### PR TITLE
chore: skip closed streams in flush tick. Log when flushing due to time wind…

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/MessageQueue.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/MessageQueue.kt
@@ -5,6 +5,7 @@
 package io.airbyte.cdk.load.message
 
 import io.airbyte.cdk.load.util.CloseableCoroutine
+import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.receiveAsFlow
@@ -16,6 +17,7 @@ interface QueueReader<T> {
 
 interface QueueWriter<T> : CloseableCoroutine {
     suspend fun publish(message: T)
+    fun isClosedForPublish(): Boolean
 }
 
 interface MessageQueue<T> : QueueReader<T>, QueueWriter<T>
@@ -29,6 +31,8 @@ abstract class ChannelMessageQueue<T> : MessageQueue<T> {
     override suspend fun close() {
         channel.close()
     }
+    @OptIn(DelicateCoroutinesApi::class)
+    override fun isClosedForPublish(): Boolean = channel.isClosedForSend
 }
 
 interface MessageQueueSupplier<K, T> {

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/state/TimeWindowTrigger.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/state/TimeWindowTrigger.kt
@@ -15,7 +15,8 @@ data class TimeWindowTrigger(
     private val clock: Clock,
     private val windowWidthMs: Long,
 ) {
-    private var openedAtMs: Long? = null
+    var openedAtMs: Long? = null
+        private set
 
     /*
      * Sets window open timestamp for computing completeness. Idempotent. Mutative.

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/SpillToDiskTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/SpillToDiskTask.kt
@@ -102,6 +102,11 @@ class DefaultSpillToDiskTask(
                                 }
                                 is StreamFlushEvent -> {
                                     val forceFlush = timeWindow.isComplete()
+                                    if (forceFlush) {
+                                        log.info {
+                                            "Time window complete for $streamDescriptor@${timeWindow.openedAtMs} closing $tmpFile of (${sizeBytes}b)"
+                                        }
+                                    }
                                     ReadResult(range, sizeBytes, forceFlush = forceFlush)
                                 }
                             }

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/DestinationTaskLauncherTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/DestinationTaskLauncherTest.kt
@@ -117,7 +117,7 @@ class DestinationTaskLauncherTest<T> where T : LeveledTask, T : ScopedTask {
     @Requires(env = ["DestinationTaskLauncherTest"])
     class MockQueueWriter : QueueWriter<Reserved<CheckpointMessageWrapped>> {
         override suspend fun publish(message: Reserved<CheckpointMessageWrapped>) {}
-
+        override fun isClosedForPublish(): Boolean = false
         override suspend fun close() {}
     }
 


### PR DESCRIPTION
## What
Checks if queue (channel) is closed before sending tick tasks
Adds log for visibility on time window trigger

## How
* Adds a check in the loop for closed channels
* Handles exceptions due to any race
* Creates `MessageQueue#isClosedForPublish` for checking underlying channel
* Log line
