### PR TITLE
Bulk load CDK: make tests comply with protocol by waiting for state ack

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/integrationTest/kotlin/io/airbyte/cdk/load/mock_integration_test/MockBasicFunctionalityIntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/integrationTest/kotlin/io/airbyte/cdk/load/mock_integration_test/MockBasicFunctionalityIntegrationTest.kt
@@ -9,7 +9,6 @@ import io.airbyte.cdk.load.test.util.NoopExpectedRecordMapper
 import io.airbyte.cdk.load.test.util.NoopNameMapper
 import io.airbyte.cdk.load.write.BasicFunctionalityIntegrationTest
 import io.airbyte.cdk.load.write.Untyped
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 
 class MockBasicFunctionalityIntegrationTest :

--- a/airbyte-cdk/bulk/core/load/src/integrationTest/kotlin/io/airbyte/cdk/load/mock_integration_test/MockBasicFunctionalityIntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/integrationTest/kotlin/io/airbyte/cdk/load/mock_integration_test/MockBasicFunctionalityIntegrationTest.kt
@@ -34,7 +34,6 @@ class MockBasicFunctionalityIntegrationTest :
     }
 
     @Test
-    @Disabled
     override fun testMidSyncCheckpointingStreamState() {
         super.testMidSyncCheckpointingStreamState()
     }

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/test/util/RecordDifferTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/test/util/RecordDifferTest.kt
@@ -5,6 +5,7 @@
 package io.airbyte.cdk.load.test.util
 
 import java.time.OffsetDateTime
+import kotlin.test.assertEquals
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 
@@ -117,5 +118,121 @@ class RecordDifferTest {
             """.trimIndent(),
             diff
         )
+    }
+
+    /**
+     * Verify that the differ can sort records which are identical other than the PK
+     */
+    @Test
+    fun testSortPk() {
+        val diff = RecordDiffer(primaryKey = listOf(listOf("id")), cursor = null).diffRecords(
+            listOf(
+                OutputRecord(
+                    extractedAt = 0,
+                    generationId = 0,
+                    data = mapOf("id" to 1, "name" to "foo"),
+                    airbyteMeta = null,
+                ),
+                OutputRecord(
+                    extractedAt = 0,
+                    generationId = 0,
+                    data = mapOf("id" to 2, "name" to "bar"),
+                    airbyteMeta = null,
+                ),
+            ),
+            listOf(
+                OutputRecord(
+                    extractedAt = 0,
+                    generationId = 0,
+                    data = mapOf("id" to 2, "name" to "bar"),
+                    airbyteMeta = null,
+                ),
+                OutputRecord(
+                    extractedAt = 0,
+                    generationId = 0,
+                    data = mapOf("id" to 1, "name" to "foo"),
+                    airbyteMeta = null,
+                ),
+            )
+        )
+        assertEquals(null, diff)
+    }
+
+    /**
+     * Verify that the differ can sort records which are identical other than the cursor
+     */
+    @Test
+    fun testSortCursor() {
+        val diff =
+            RecordDiffer(primaryKey = listOf(listOf("id")), cursor = listOf("updated_at"))
+                .diffRecords(
+                    listOf(
+                        OutputRecord(
+                            extractedAt = 0,
+                            generationId = 0,
+                            data = mapOf("id" to 1, "name" to "foo", "updated_at" to 1),
+                            airbyteMeta = null,
+                        ),
+                        OutputRecord(
+                            extractedAt = 0,
+                            generationId = 0,
+                            data = mapOf("id" to 1, "name" to "bar", "updated_at" to 2),
+                            airbyteMeta = null,
+                        ),
+                    ),
+                    listOf(
+                        OutputRecord(
+                            extractedAt = 0,
+                            generationId = 0,
+                            data = mapOf("id" to 1, "name" to "bar", "updated_at" to 2),
+                            airbyteMeta = null,
+                        ),
+                        OutputRecord(
+                            extractedAt = 0,
+                            generationId = 0,
+                            data = mapOf("id" to 1, "name" to "foo", "updated_at" to 1),
+                            airbyteMeta = null,
+                        ),
+                    ),
+                )
+        assertEquals(null, diff)
+    }
+
+    /**
+     * Verify that the differ can sort records which are identical other than extractedAt
+     */
+    @Test
+    fun testSortExtractedAt() {
+        val diff = RecordDiffer(primaryKey = listOf(listOf("id")), cursor = null).diffRecords(
+            listOf(
+                OutputRecord(
+                    extractedAt = 0,
+                    generationId = 0,
+                    data = mapOf("id" to 1, "name" to "foo"),
+                    airbyteMeta = null,
+                ),
+                OutputRecord(
+                    extractedAt = 1,
+                    generationId = 0,
+                    data = mapOf("id" to 1, "name" to "bar"),
+                    airbyteMeta = null,
+                ),
+            ),
+            listOf(
+                OutputRecord(
+                    extractedAt = 1,
+                    generationId = 0,
+                    data = mapOf("id" to 1, "name" to "bar"),
+                    airbyteMeta = null,
+                ),
+                OutputRecord(
+                    extractedAt = 0,
+                    generationId = 0,
+                    data = mapOf("id" to 1, "name" to "foo"),
+                    airbyteMeta = null,
+                ),
+            )
+        )
+        assertEquals(null, diff)
     }
 }

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/test/util/RecordDifferTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/test/util/RecordDifferTest.kt
@@ -120,47 +120,45 @@ class RecordDifferTest {
         )
     }
 
-    /**
-     * Verify that the differ can sort records which are identical other than the PK
-     */
+    /** Verify that the differ can sort records which are identical other than the PK */
     @Test
     fun testSortPk() {
-        val diff = RecordDiffer(primaryKey = listOf(listOf("id")), cursor = null).diffRecords(
-            listOf(
-                OutputRecord(
-                    extractedAt = 0,
-                    generationId = 0,
-                    data = mapOf("id" to 1, "name" to "foo"),
-                    airbyteMeta = null,
-                ),
-                OutputRecord(
-                    extractedAt = 0,
-                    generationId = 0,
-                    data = mapOf("id" to 2, "name" to "bar"),
-                    airbyteMeta = null,
-                ),
-            ),
-            listOf(
-                OutputRecord(
-                    extractedAt = 0,
-                    generationId = 0,
-                    data = mapOf("id" to 2, "name" to "bar"),
-                    airbyteMeta = null,
-                ),
-                OutputRecord(
-                    extractedAt = 0,
-                    generationId = 0,
-                    data = mapOf("id" to 1, "name" to "foo"),
-                    airbyteMeta = null,
-                ),
-            )
-        )
+        val diff =
+            RecordDiffer(primaryKey = listOf(listOf("id")), cursor = null)
+                .diffRecords(
+                    listOf(
+                        OutputRecord(
+                            extractedAt = 0,
+                            generationId = 0,
+                            data = mapOf("id" to 1, "name" to "foo"),
+                            airbyteMeta = null,
+                        ),
+                        OutputRecord(
+                            extractedAt = 0,
+                            generationId = 0,
+                            data = mapOf("id" to 2, "name" to "bar"),
+                            airbyteMeta = null,
+                        ),
+                    ),
+                    listOf(
+                        OutputRecord(
+                            extractedAt = 0,
+                            generationId = 0,
+                            data = mapOf("id" to 2, "name" to "bar"),
+                            airbyteMeta = null,
+                        ),
+                        OutputRecord(
+                            extractedAt = 0,
+                            generationId = 0,
+                            data = mapOf("id" to 1, "name" to "foo"),
+                            airbyteMeta = null,
+                        ),
+                    )
+                )
         assertEquals(null, diff)
     }
 
-    /**
-     * Verify that the differ can sort records which are identical other than the cursor
-     */
+    /** Verify that the differ can sort records which are identical other than the cursor */
     @Test
     fun testSortCursor() {
         val diff =
@@ -198,41 +196,41 @@ class RecordDifferTest {
         assertEquals(null, diff)
     }
 
-    /**
-     * Verify that the differ can sort records which are identical other than extractedAt
-     */
+    /** Verify that the differ can sort records which are identical other than extractedAt */
     @Test
     fun testSortExtractedAt() {
-        val diff = RecordDiffer(primaryKey = listOf(listOf("id")), cursor = null).diffRecords(
-            listOf(
-                OutputRecord(
-                    extractedAt = 0,
-                    generationId = 0,
-                    data = mapOf("id" to 1, "name" to "foo"),
-                    airbyteMeta = null,
-                ),
-                OutputRecord(
-                    extractedAt = 1,
-                    generationId = 0,
-                    data = mapOf("id" to 1, "name" to "bar"),
-                    airbyteMeta = null,
-                ),
-            ),
-            listOf(
-                OutputRecord(
-                    extractedAt = 1,
-                    generationId = 0,
-                    data = mapOf("id" to 1, "name" to "bar"),
-                    airbyteMeta = null,
-                ),
-                OutputRecord(
-                    extractedAt = 0,
-                    generationId = 0,
-                    data = mapOf("id" to 1, "name" to "foo"),
-                    airbyteMeta = null,
-                ),
-            )
-        )
+        val diff =
+            RecordDiffer(primaryKey = listOf(listOf("id")), cursor = null)
+                .diffRecords(
+                    listOf(
+                        OutputRecord(
+                            extractedAt = 0,
+                            generationId = 0,
+                            data = mapOf("id" to 1, "name" to "foo"),
+                            airbyteMeta = null,
+                        ),
+                        OutputRecord(
+                            extractedAt = 1,
+                            generationId = 0,
+                            data = mapOf("id" to 1, "name" to "bar"),
+                            airbyteMeta = null,
+                        ),
+                    ),
+                    listOf(
+                        OutputRecord(
+                            extractedAt = 1,
+                            generationId = 0,
+                            data = mapOf("id" to 1, "name" to "bar"),
+                            airbyteMeta = null,
+                        ),
+                        OutputRecord(
+                            extractedAt = 0,
+                            generationId = 0,
+                            data = mapOf("id" to 1, "name" to "foo"),
+                            airbyteMeta = null,
+                        ),
+                    )
+                )
         assertEquals(null, diff)
     }
 }

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/RecordDiffer.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/RecordDiffer.kt
@@ -126,8 +126,8 @@ class RecordDiffer(
             expectedRecordIndex < expectedRecordsSorted.size &&
                 actualRecordIndex < actualRecordsSorted.size
         ) {
-            val expectedRecord = expectedRecords[expectedRecordIndex]
-            val actualRecord = actualRecords[actualRecordIndex]
+            val expectedRecord = expectedRecordsSorted[expectedRecordIndex]
+            val actualRecord = actualRecordsSorted[actualRecordIndex]
             val compare = everythingComparator.compare(expectedRecord, actualRecord)
             if (compare == 0) {
                 // These records are the same underlying record

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/RecordDiffer.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/RecordDiffer.kt
@@ -155,10 +155,7 @@ class RecordDiffer(
         if (!allowUnexpectedRecord) {
             while (actualRecordIndex < actualRecords.size) {
                 matches.add(
-                    MatchingRecords(
-                        expectedRecord = null,
-                        actualRecords[actualRecordIndex]
-                    )
+                    MatchingRecords(expectedRecord = null, actualRecords[actualRecordIndex])
                 )
                 actualRecordIndex++
             }

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/destination_process/DestinationProcess.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/destination_process/DestinationProcess.kt
@@ -29,6 +29,7 @@ interface DestinationProcess {
      */
     suspend fun run()
 
+    fun sendMessage(string: String)
     fun sendMessage(message: AirbyteMessage)
     fun sendMessages(vararg messages: AirbyteMessage) {
         messages.forEach { sendMessage(it) }

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/destination_process/DockerizedDestination.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/destination_process/DockerizedDestination.kt
@@ -211,6 +211,11 @@ class DockerizedDestination(
         destinationStdin.newLine()
     }
 
+    override fun sendMessage(string: String) {
+        destinationStdin.write(string)
+        destinationStdin.newLine()
+    }
+
     override fun readMessages(): List<AirbyteMessage> {
         return destinationOutput.newMessages()
     }

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/destination_process/NonDockerizedDestination.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/destination_process/NonDockerizedDestination.kt
@@ -77,6 +77,10 @@ class NonDockerizedDestination(
         destinationStdinPipe.println(message.serializeToString())
     }
 
+    override fun sendMessage(string: String) {
+        destinationStdinPipe.println(string)
+    }
+
     override fun readMessages(): List<AirbyteMessage> = destination.results.newMessages()
 
     override suspend fun shutdown() {

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/write/BasicFunctionalityIntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/write/BasicFunctionalityIntegrationTest.kt
@@ -241,31 +241,26 @@ abstract class BasicFunctionalityIntegrationTest(
                     minimumGenerationId = 0,
                     syncId = 42,
                 )
-            val stateMessage = runSyncUntilStateAck(
-                configContents,
-                stream,
-                listOf(
-                    DestinationRecord(
-                        namespace = randomizedNamespace,
-                        name = "test_stream",
-                        data = """{"id": 12}""",
-                        emittedAtMs = 1234,
-                    )
-                ),
-                StreamCheckpoint(
-                    streamNamespace = randomizedNamespace,
-                    streamName = "test_stream",
-                    blob = """{"foo": "bar1"}""",
-                    sourceRecordCount = 1
-                ),
-                fillerRecord = DestinationRecord(
-                    namespace = randomizedNamespace,
-                    name = "test_stream",
-                    data = """{"id": 56}""",
-                    emittedAtMs = 1234,
-                ),
-                allowGracefulShutdown = false,
-            )
+            val stateMessage =
+                runSyncUntilStateAck(
+                    configContents,
+                    stream,
+                    listOf(
+                        DestinationRecord(
+                            namespace = randomizedNamespace,
+                            name = "test_stream",
+                            data = """{"id": 12}""",
+                            emittedAtMs = 1234,
+                        )
+                    ),
+                    StreamCheckpoint(
+                        streamNamespace = randomizedNamespace,
+                        streamName = "test_stream",
+                        blob = """{"foo": "bar1"}""",
+                        sourceRecordCount = 1
+                    ),
+                    allowGracefulShutdown = false,
+                )
             runSync(configContents, stream, emptyList())
 
             val streamName = stateMessage.stream.streamDescriptor.name
@@ -635,8 +630,7 @@ abstract class BasicFunctionalityIntegrationTest(
                 """{}""",
                 sourceRecordCount = 1,
             ),
-            makeInputRecord(42, "2024-01-23T02:00:00Z", 200),
-            allowGracefulShutdown = true,
+            allowGracefulShutdown = false,
         )
         dumpAndDiffRecords(
             parsedConfig,
@@ -766,8 +760,7 @@ abstract class BasicFunctionalityIntegrationTest(
                 """{}""",
                 sourceRecordCount = 1,
             ),
-            makeInputRecord(42, "2024-01-23T02:00:00Z", 200),
-            allowGracefulShutdown = true,
+            allowGracefulShutdown = false,
         )
         dumpAndDiffRecords(
             parsedConfig,
@@ -916,7 +909,8 @@ abstract class BasicFunctionalityIntegrationTest(
                 minimumGenerationId = 42,
                 syncId = 42,
             )
-        // Run a sync, but emit a stream status incomplete. This should not delete any existing data.
+        // Run a sync, but emit a stream status incomplete. This should not delete any existing
+        // data.
         runSyncUntilStateAck(
             configContents,
             stream2,
@@ -927,8 +921,7 @@ abstract class BasicFunctionalityIntegrationTest(
                 """{}""",
                 sourceRecordCount = 1,
             ),
-            makeInputRecord(42, "2024-01-23T02:00:00Z", 200),
-            allowGracefulShutdown = true,
+            allowGracefulShutdown = false,
         )
         dumpAndDiffRecords(
             parsedConfig,

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/write/BasicFunctionalityIntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/write/BasicFunctionalityIntegrationTest.kt
@@ -46,11 +46,9 @@ import io.airbyte.cdk.load.test.util.NameMapper
 import io.airbyte.cdk.load.test.util.NoopExpectedRecordMapper
 import io.airbyte.cdk.load.test.util.NoopNameMapper
 import io.airbyte.cdk.load.test.util.OutputRecord
-import io.airbyte.cdk.load.test.util.destination_process.DestinationUncleanExitException
 import io.airbyte.cdk.load.util.deserializeToNode
 import io.airbyte.protocol.models.v0.AirbyteMessage
 import io.airbyte.protocol.models.v0.AirbyteRecordMessageMetaChange
-import io.airbyte.protocol.models.v0.AirbyteStateMessage
 import java.math.BigDecimal
 import java.math.BigInteger
 import java.time.LocalDate
@@ -59,8 +57,6 @@ import java.time.LocalTime
 import java.time.OffsetDateTime
 import java.time.OffsetTime
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assertions.assertDoesNotThrow
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -69,7 +65,6 @@ import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertAll
-import org.junit.jupiter.api.assertThrows
 
 sealed interface AllTypesBehavior
 
@@ -263,7 +258,7 @@ abstract class BasicFunctionalityIntegrationTest(
                     blob = """{"foo": "bar1"}""",
                     sourceRecordCount = 1
                 ),
-                fillerMessage = DestinationRecord(
+                fillerRecord = DestinationRecord(
                     namespace = randomizedNamespace,
                     name = "test_stream",
                     data = """{"id": 56}""",

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/write/BasicFunctionalityIntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/write/BasicFunctionalityIntegrationTest.kt
@@ -629,15 +629,20 @@ abstract class BasicFunctionalityIntegrationTest(
                 minimumGenerationId = 42,
                 syncId = 42,
             )
-        // Run a sync, but don't emit a stream status. This should not delete any existing data.
-        assertThrows<DestinationUncleanExitException> {
-            runSync(
-                configContents,
-                stream2,
-                listOf(makeInputRecord(1, "2024-01-23T02:00:00Z", 200)),
-                streamStatus = null,
-            )
-        }
+        // Run a sync, but emit a status incomplete. This should not delete any existing data.
+        runSyncUntilStateAck(
+            configContents,
+            stream2,
+            listOf(makeInputRecord(1, "2024-01-23T02:00:00Z", 200)),
+            StreamCheckpoint(
+                randomizedNamespace,
+                stream2.descriptor.name,
+                """{}""",
+                sourceRecordCount = 1,
+            ),
+            makeInputRecord(42, "2024-01-23T02:00:00Z", 200),
+            allowGracefulShutdown = true,
+        )
         dumpAndDiffRecords(
             parsedConfig,
             listOfNotNull(
@@ -702,6 +707,7 @@ abstract class BasicFunctionalityIntegrationTest(
             primaryKey = listOf(listOf("id")),
             cursor = null,
             "Records were incorrect after a successful sync following a failed sync. This may indicate that we are not retaining data from the failed sync.",
+            allowUnexpectedRecord = true,
         )
     }
 
@@ -754,15 +760,20 @@ abstract class BasicFunctionalityIntegrationTest(
                 minimumGenerationId = 42,
                 syncId = 42,
             )
-        // Run a sync, but don't emit a stream status.
-        assertThrows<DestinationUncleanExitException> {
-            runSync(
-                configContents,
-                stream,
-                listOf(makeInputRecord(1, "2024-01-23T02:00:00Z", 200)),
-                streamStatus = null,
-            )
-        }
+        // Run a sync, but emit a stream status incomplete.
+        runSyncUntilStateAck(
+            configContents,
+            stream,
+            listOf(makeInputRecord(1, "2024-01-23T02:00:00Z", 200)),
+            StreamCheckpoint(
+                randomizedNamespace,
+                stream.descriptor.name,
+                """{}""",
+                sourceRecordCount = 1,
+            ),
+            makeInputRecord(42, "2024-01-23T02:00:00Z", 200),
+            allowGracefulShutdown = true,
+        )
         dumpAndDiffRecords(
             parsedConfig,
             if (commitDataIncrementally) {
@@ -813,6 +824,7 @@ abstract class BasicFunctionalityIntegrationTest(
             primaryKey = listOf(listOf("id")),
             cursor = null,
             "Records were incorrect after a successful sync following a failed sync. This may indicate that we are not retaining data from the failed sync.",
+            allowUnexpectedRecord = true,
         )
     }
 
@@ -909,15 +921,20 @@ abstract class BasicFunctionalityIntegrationTest(
                 minimumGenerationId = 42,
                 syncId = 42,
             )
-        // Run a sync, but don't emit a stream status. This should not delete any existing data.
-        assertThrows<DestinationUncleanExitException> {
-            runSync(
-                configContents,
-                stream2,
-                listOf(makeInputRecord(1, "2024-01-23T02:00:00Z", 200)),
-                streamStatus = null,
-            )
-        }
+        // Run a sync, but emit a stream status incomplete. This should not delete any existing data.
+        runSyncUntilStateAck(
+            configContents,
+            stream2,
+            listOf(makeInputRecord(1, "2024-01-23T02:00:00Z", 200)),
+            StreamCheckpoint(
+                randomizedNamespace,
+                stream2.descriptor.name,
+                """{}""",
+                sourceRecordCount = 1,
+            ),
+            makeInputRecord(42, "2024-01-23T02:00:00Z", 200),
+            allowGracefulShutdown = true,
+        )
         dumpAndDiffRecords(
             parsedConfig,
             listOfNotNull(
@@ -1005,6 +1022,7 @@ abstract class BasicFunctionalityIntegrationTest(
             primaryKey = listOf(listOf("id")),
             cursor = null,
             "Records were incorrect after a successful sync following a failed sync. This may indicate that we are not retaining data from the failed sync.",
+            allowUnexpectedRecord = true,
         )
     }
 

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/resources/application.yaml
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/resources/application.yaml
@@ -9,4 +9,4 @@ airbyte:
     rate-ms: 900000 # 15 minutes
     window-ms: 900000 # 15 minutes
   destination:
-    record-batch-size: 209715200 # 200MB
+    record-batch-size: 1 # 1 byte for testing; 1 record => 1 upload

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/write/object_storage/ObjectStorageStreamLoaderFactory.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/write/object_storage/ObjectStorageStreamLoaderFactory.kt
@@ -100,7 +100,6 @@ class ObjectStorageStreamLoader<T : RemoteObject<*>, U : OutputStream>(
             client.streamingUpload(key, metadata, streamProcessor = compressor) { outputStream ->
                 writerFactory.create(stream, outputStream).use { writer ->
                     records.forEach {
-                        println("writing record $it to key $key")
                         writer.accept(it)
                     }
                 }

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/write/object_storage/ObjectStorageStreamLoaderFactory.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/write/object_storage/ObjectStorageStreamLoaderFactory.kt
@@ -99,12 +99,11 @@ class ObjectStorageStreamLoader<T : RemoteObject<*>, U : OutputStream>(
         val obj =
             client.streamingUpload(key, metadata, streamProcessor = compressor) { outputStream ->
                 writerFactory.create(stream, outputStream).use { writer ->
-                    records.forEach {
-                        writer.accept(it)
-                    }
+                    records.forEach { writer.accept(it) }
                 }
             }
-        log.info { "Finished writing records to $key" }
+        log.info { "Finished writing records to $key, persisting state" }
+        destinationStateManager.persistState(stream)
         return RemoteObject(remoteObject = obj, partNumber = partNumber)
     }
 

--- a/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2DataDumper.kt
+++ b/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2DataDumper.kt
@@ -18,7 +18,7 @@ object S3V2DataDumper : DestinationDataDumper {
         stream: DestinationStream
     ): List<OutputRecord> {
         val config =
-            S3V2ConfigurationFactory().makeWithoutExceptionHandling(spec as S3V2Specification)
+            S3V2ConfigurationFactory(0L).makeWithoutExceptionHandling(spec as S3V2Specification)
         val s3Client = S3ClientFactory.make(config)
         val pathFactory = ObjectStoragePathFactory.from(config)
         return ObjectStorageDataDumper(

--- a/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2WriteTest.kt
+++ b/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2WriteTest.kt
@@ -48,7 +48,6 @@ abstract class S3V2WriteTest(
         super.testFunkyCharacters()
     }
 
-    @Disabled("https://github.com/airbytehq/airbyte-internal-issues/issues/10413?")
     @Test
     override fun testMidSyncCheckpointingStreamState() {
         super.testMidSyncCheckpointingStreamState()
@@ -124,25 +123,16 @@ class S3V2WriteTestJsonStaging :
     ) {
 
     @Test
-    @Disabled(
-        "Test framework doesn't await ack before killing the sync, so the behavior is unpredictable"
-    )
     override fun testInterruptedTruncateWithPriorData() {
         super.testInterruptedTruncateWithPriorData()
     }
 
     @Test
-    @Disabled(
-        "Test framework doesn't await ack before killing the sync, so the behavior is unpredictable"
-    )
     override fun resumeAfterCancelledTruncate() {
         super.resumeAfterCancelledTruncate()
     }
 
     @Test
-    @Disabled(
-        "Test framework doesn't await ack before killing the sync, so the behavior is unpredictable"
-    )
     override fun testInterruptedTruncateWithoutPriorData() {
         super.testInterruptedTruncateWithoutPriorData()
     }


### PR DESCRIPTION
closes https://github.com/airbytehq/airbyte-internal-issues/issues/10413. This is heavily based on https://github.com/airbytehq/airbyte/pull/48583, with some refactors:
* extract the "run sync until state ack" into a method on IntegrationTest
* add an option to RecordDiffer to allow unexpected records (since we don't know how many records will actually get flushed as part of the state ack)
* switch the mid-sync checkpointing test, and the truncate tests, to use the new `allowUnexpectedRecords` option

this PR also fixes a bug in the RecordDiffer (it wasn't correctly sorting records, so tests could fail nondeterminstically).

legacy CDK connectors always flushed all pending data, even on a stream INCOMPLETE. The new CDK has stricter protocol compliance, in that it doesn't make any guarantees about pending work, it only guarantees that records prior to an acked state message are persisted.

So tests from the old CDK don't directly work on bulk CDK connectors. This PR updates these tests to force a state ack (by pushing a ton of records to force a flush). This makes the tests take longer to run, which we should improve at some point in the future (https://github.com/airbytehq/airbyte-internal-issues/issues/10911).