### PR TITLE
Add depedendency needed for ssh and ssl openssh format (ed25519) keys

### DIFF
--- a/airbyte-cdk/bulk/core/base/build.gradle
+++ b/airbyte-cdk/bulk/core/base/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     implementation 'org.apache.logging.log4j:log4j-slf4j2-impl'
     implementation 'org.apache.logging.log4j:log4j-layout-template-json:2.24.0'
     implementation 'org.bouncycastle:bcprov-jdk18on:1.78.1'
+    implementation 'net.i2p.crypto:eddsa:0.3.0'
     implementation 'org.openapi4j:openapi-schema-validator:1.0.7'
 
     // this is only needed because of exclusions in airbyte-protocol

--- a/airbyte-integrations/connectors/source-mysql/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mysql/metadata.yaml
@@ -9,7 +9,7 @@ data:
   connectorSubtype: database
   connectorType: source
   definitionId: 435bb9a5-7887-4809-aa58-28c27df0d7ad
-  dockerImageTag: 3.9.0-rc.17
+  dockerImageTag: 3.9.0-rc.18
   dockerRepository: airbyte/source-mysql
   documentationUrl: https://docs.airbyte.com/integrations/sources/mysql
   githubIssueLabel: source-mysql


### PR DESCRIPTION
This dependency is needed in order to load ed25519 keys configured in ssh tunnel and ssl client key.

resolves https://github.com/airbytehq/airbyte-internal-issues/issues/10904