### PR TITLE
[bulk-extract-cdk] skip errors caused by unparseable DDLs

### DIFF
--- a/airbyte-cdk/bulk/toolkits/extract-cdc/src/main/kotlin/io/airbyte/cdk/read/cdc/DebeziumPropertiesBuilder.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-cdc/src/main/kotlin/io/airbyte/cdk/read/cdc/DebeziumPropertiesBuilder.kt
@@ -57,6 +57,8 @@ class DebeziumPropertiesBuilder(private val props: Properties = Properties()) {
         with("value.converter.replace.null.with.default", "false")
         // Timeout for DebeziumEngine's close() method.
         with("debezium.embedded.shutdown.pause.before.interrupt.ms", "10000")
+        // Unblock CDC syncs by skipping errors caused by unparseable DDLs
+        with("schema.history.internal.skip.unparseable.ddl", "true")
     }
 
     fun withOffset(): DebeziumPropertiesBuilder = apply {


### PR DESCRIPTION
## What
This change is to fix debezium bug mentioned in #48497

## How
It fixes the problem by setting schema.history.internal.skip.unparseable.ddl in DebeziumProperties to True to skip errors caused by unparseable DDLs

## Review guide
Reproduced the problem locally
Before the fix:
<img width="1576" alt="Screenshot 2024-11-22 at 10 25 15 AM" src="https://github.com/user-attachments/assets/7d73a12a-5b88-496e-a05e-0cb35b2f0def">
After fix:
<img width="806" alt="Screenshot 2024-11-22 at 10 23 57 AM" src="https://github.com/user-attachments/assets/46c3940a-3704-452b-997e-8d22e0f08d7e">


## User Impact
None

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌
