### PR TITLE
cat/live-test: mount connection objects to readable path

### DIFF
--- a/airbyte-ci/connectors/live-tests/README.md
+++ b/airbyte-ci/connectors/live-tests/README.md
@@ -179,6 +179,10 @@ The traffic recorded on the control connector is passed to the target connector 
 
 ## Changelog
 
+### 0.19.7
+
+Mount connection objects to readable paths in the container for rootless images.
+
 ### 0.19.6
 
 Write connector output to a different in container path to avoid permission issues now that connector images are rootless.

--- a/airbyte-ci/connectors/live-tests/pyproject.toml
+++ b/airbyte-ci/connectors/live-tests/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "live-tests"
-version = "0.19.6"
+version = "0.19.7"
 description = "Contains utilities for testing connectors against live data."
 authors = ["Airbyte <contact@airbyte.io>"]
 license = "MIT"

--- a/airbyte-integrations/bases/connector-acceptance-test/CHANGELOG.md
+++ b/airbyte-integrations/bases/connector-acceptance-test/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 3.9.7
+
+Mount connection objects to readable paths in the container for rootless images.
+ 
+## 3.9.6
+
+Write connector output to a writtable directory to avoid permission issues on rootless images.
+
 ## 3.9.5
 
 Fix parsing of inlined manifest specs in `test_match_expected`

--- a/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/utils/connector_runner.py
+++ b/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/utils/connector_runner.py
@@ -128,10 +128,11 @@ async def get_connector_container(dagger_client: dagger.Client, image_name_with_
 
 
 class ConnectorRunner:
-    IN_CONTAINER_CONFIG_PATH = "/data/config.json"
-    IN_CONTAINER_CATALOG_PATH = "/data/catalog.json"
-    IN_CONTAINER_STATE_PATH = "/data/state.json"
-    IN_CONTAINER_OUTPUT_PATH = "/output.txt"
+    DATA_DIR = "/airbyte/data"
+    IN_CONTAINER_CONFIG_PATH = f"{DATA_DIR}/config.json"
+    IN_CONTAINER_CATALOG_PATH = f"{DATA_DIR}/catalog.json"
+    IN_CONTAINER_STATE_PATH = f"{DATA_DIR}/state.json"
+    IN_CONTAINER_OUTPUT_PATH = f"{DATA_DIR}/output.txt"
 
     def __init__(
         self,
@@ -248,6 +249,7 @@ class ConnectorRunner:
             List[AirbyteMessage]: The list of AirbyteMessages emitted by the connector.
         """
         container = self._connector_under_test_container
+        container = container.with_exec(["mkdir", "-p", self.DATA_DIR])
         if not enable_caching:
             container = container.with_env_variable("CAT_CACHEBUSTER", str(uuid.uuid4()))
         if config:
@@ -278,6 +280,7 @@ class ConnectorRunner:
         local_output_file_path = f"/tmp/{str(uuid.uuid4())}"
         entrypoint = await container.entrypoint()
         airbyte_command = entrypoint + airbyte_command
+
         container = container.with_exec(
             ["sh", "-c", " ".join(airbyte_command) + f" > {self.IN_CONTAINER_OUTPUT_PATH} 2>&1 | tee -a {self.IN_CONTAINER_OUTPUT_PATH}"]
         )

--- a/airbyte-integrations/bases/connector-acceptance-test/pyproject.toml
+++ b/airbyte-integrations/bases/connector-acceptance-test/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "connector-acceptance-test"
-version = "3.9.5"
+version = "3.9.7"
 description = "Contains acceptance tests for connectors."
 authors = ["Airbyte <contact@airbyte.io>"]
 license = "MIT"


### PR DESCRIPTION
This pull request includes several changes to improve the handling of container paths for rootless images and updates version numbers accordingly. The most important changes involve modifying paths in the `ConnectorRunner` class and updating the changelogs and version numbers.

Changes to container paths:

* [`airbyte-ci/connectors/live-tests/src/live_tests/commons/connector_runner.py`](diffhunk://#diff-260fceccf2b86abb88c4dfd1f490dd6c0c6c1c9713392bdc2683437f13b86e46L24-R28): Refactored paths to use a common `DATA_DIR` and ensured the directory is created before use. [[1]](diffhunk://#diff-260fceccf2b86abb88c4dfd1f490dd6c0c6c1c9713392bdc2683437f13b86e46L24-R28) [[2]](diffhunk://#diff-260fceccf2b86abb88c4dfd1f490dd6c0c6c1c9713392bdc2683437f13b86e46R121) [[3]](diffhunk://#diff-260fceccf2b86abb88c4dfd1f490dd6c0c6c1c9713392bdc2683437f13b86e46L151-L154)
* [`airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/utils/connector_runner.py`](diffhunk://#diff-2d8b63e9ae10780a331facd6e00a438b01c442eb419811116b52179438ec0514L131-R135): Updated paths to use `DATA_DIR` and ensured the directory is created before use. [[1]](diffhunk://#diff-2d8b63e9ae10780a331facd6e00a438b01c442eb419811116b52179438ec0514L131-R135) [[2]](diffhunk://#diff-2d8b63e9ae10780a331facd6e00a438b01c442eb419811116b52179438ec0514R252) [[3]](diffhunk://#diff-2d8b63e9ae10780a331facd6e00a438b01c442eb419811116b52179438ec0514R283)

Changelog updates:

* [`airbyte-ci/connectors/live-tests/README.md`](diffhunk://#diff-2c30a4a05182df3125d72b8df4f6b3dcb75ed97138496d269b630d131d047104R182-R185): Added version 0.19.7 with details on mounting connection objects to readable paths.
* [`airbyte-integrations/bases/connector-acceptance-test/CHANGELOG.md`](diffhunk://#diff-cd1f490dd1a54000e6e7e2c4e70d7426d65545b4e27d5f841f93947377e956bdR3-R10): Added version 3.9.7 with details on mounting connection objects to readable paths.

Version number updates:

* [`airbyte-ci/connectors/live-tests/pyproject.toml`](diffhunk://#diff-29b6e69f449fc33f25f15bb63936caf80cf72762c9e3c534ce29379f07d7919aL7-R7): Bumped version from 0.19.6 to 0.19.7.
* [`airbyte-integrations/bases/connector-acceptance-test/pyproject.toml`](diffhunk://#diff-c0ebc58a9fa29e2d3127e27a090e37f15fa20fdab04d844e1eb4d5b5a4b8177bL7-R7): Bumped version from 3.9.5 to 3.9.7.