### PR TITLE
cat/live-test: give ownership of copied objects to the image user

### DIFF
--- a/airbyte-ci/connectors/live-tests/README.md
+++ b/airbyte-ci/connectors/live-tests/README.md
@@ -179,6 +179,10 @@ The traffic recorded on the control connector is passed to the target connector 
 
 ## Changelog
 
+### 0.19.8
+
+Give ownership of copied connection object files to the image user to make sure it has permission to write them (config migration).
+
 ### 0.19.7
 
 Mount connection objects to readable paths in the container for rootless images.

--- a/airbyte-ci/connectors/live-tests/pyproject.toml
+++ b/airbyte-ci/connectors/live-tests/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "live-tests"
-version = "0.19.7"
+version = "0.19.8"
 description = "Contains utilities for testing connectors against live data."
 authors = ["Airbyte <contact@airbyte.io>"]
 license = "MIT"

--- a/airbyte-integrations/bases/connector-acceptance-test/CHANGELOG.md
+++ b/airbyte-integrations/bases/connector-acceptance-test/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.9.8
+
+Give ownership of copied connection object files to the image user to make sure it has permission to write them (config migration).
+
 ## 3.9.7
 
 Mount connection objects to readable paths in the container for rootless images.

--- a/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/utils/connector_runner.py
+++ b/airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/utils/connector_runner.py
@@ -249,15 +249,17 @@ class ConnectorRunner:
             List[AirbyteMessage]: The list of AirbyteMessages emitted by the connector.
         """
         container = self._connector_under_test_container
+        current_user = (await container.with_exec(["whoami"]).stdout()).strip()
+        container = container.with_user(current_user)
         container = container.with_exec(["mkdir", "-p", self.DATA_DIR])
         if not enable_caching:
             container = container.with_env_variable("CAT_CACHEBUSTER", str(uuid.uuid4()))
         if config:
-            container = container.with_new_file(self.IN_CONTAINER_CONFIG_PATH, contents=json.dumps(dict(config)))
+            container = container.with_new_file(self.IN_CONTAINER_CONFIG_PATH, contents=json.dumps(dict(config)), owner=current_user)
         if state:
-            container = container.with_new_file(self.IN_CONTAINER_STATE_PATH, contents=json.dumps(state))
+            container = container.with_new_file(self.IN_CONTAINER_STATE_PATH, contents=json.dumps(state), owner=current_user)
         if catalog:
-            container = container.with_new_file(self.IN_CONTAINER_CATALOG_PATH, contents=catalog.json())
+            container = container.with_new_file(self.IN_CONTAINER_CATALOG_PATH, contents=catalog.json(), owner=current_user)
         try:
             output = await self._read_output_from_file(airbyte_command, container)
         except dagger.QueryError as e:

--- a/airbyte-integrations/bases/connector-acceptance-test/pyproject.toml
+++ b/airbyte-integrations/bases/connector-acceptance-test/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "connector-acceptance-test"
-version = "3.9.7"
+version = "3.9.8"
 description = "Contains acceptance tests for connectors."
 authors = ["Airbyte <contact@airbyte.io>"]
 license = "MIT"


### PR DESCRIPTION
Live tests / CAT: give ownership of copied connection object files to the image user to ensure proper permissions. Additionally, version bumps for the `live-tests` and `connector-acceptance-test` packages are included.

Key changes:

### Permission Updates:
* [`airbyte-ci/connectors/live-tests/src/live_tests/commons/connector_runner.py`](diffhunk://#diff-260fceccf2b86abb88c4dfd1f490dd6c0c6c1c9713392bdc2683437f13b86e46R121-R122): Added code to set the container user to the current user and specified the owner for new files to ensure proper permissions. [[1]](diffhunk://#diff-260fceccf2b86abb88c4dfd1f490dd6c0c6c1c9713392bdc2683437f13b86e46R121-R122) [[2]](diffhunk://#diff-260fceccf2b86abb88c4dfd1f490dd6c0c6c1c9713392bdc2683437f13b86e46L135-R144)
* [`airbyte-integrations/bases/connector-acceptance-test/connector_acceptance_test/utils/connector_runner.py`](diffhunk://#diff-2d8b63e9ae10780a331facd6e00a438b01c442eb419811116b52179438ec0514R252-R262): Similar updates to set the container user and specify the owner for new files.

