### PR TITLE
refactor: use import type to select Iceberg writer

### DIFF
--- a/airbyte-integrations/connectors/destination-iceberg-v2/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-iceberg-v2/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: file
   connectorType: destination
   definitionId: 37a928c1-2d5c-431a-a97d-ae236bd1ea0c
-  dockerImageTag: 0.1.4
+  dockerImageTag: 0.1.5
   dockerRepository: airbyte/destination-iceberg-v2
   githubIssueLabel: destination-iceberg-v2
   icon: s3.svg

--- a/airbyte-integrations/connectors/destination-iceberg-v2/src/main/kotlin/io/airbyte/integrations/destination/iceberg/v2/IcebergStreamLoader.kt
+++ b/airbyte-integrations/connectors/destination-iceberg-v2/src/main/kotlin/io/airbyte/integrations/destination/iceberg/v2/IcebergStreamLoader.kt
@@ -36,7 +36,11 @@ class IcebergStreamLoader(
         totalSizeBytes: Long
     ): Batch {
         icebergTableWriterFactory
-            .create(table = table, generationId = icebergUtil.constructGenerationIdSuffix(stream))
+            .create(
+                table = table,
+                generationId = icebergUtil.constructGenerationIdSuffix(stream),
+                importType = stream.importType
+            )
             .use { writer ->
                 log.info { "Writing records to branch $stagingBranchName" }
                 records.forEach { record ->

--- a/airbyte-integrations/connectors/destination-iceberg-v2/src/test/kotlin/io/airbyte/integrations/destination/iceberg/v2/io/IcebergTableWriterFactoryTest.kt
+++ b/airbyte-integrations/connectors/destination-iceberg-v2/src/test/kotlin/io/airbyte/integrations/destination/iceberg/v2/io/IcebergTableWriterFactoryTest.kt
@@ -4,6 +4,8 @@
 
 package io.airbyte.integrations.destination.iceberg.v2.io
 
+import io.airbyte.cdk.load.command.Append
+import io.airbyte.cdk.load.command.Dedupe
 import io.mockk.every
 import io.mockk.mockk
 import java.nio.ByteBuffer
@@ -70,7 +72,16 @@ internal class IcebergTableWriterFactoryTest {
         }
 
         val factory = IcebergTableWriterFactory(icebergUtil = icebergUtil)
-        val writer = factory.create(table = table, generationId = generationIdSuffix)
+        val writer =
+            factory.create(
+                table = table,
+                generationId = generationIdSuffix,
+                importType =
+                    Dedupe(
+                        primaryKey = listOf(primaryKeyIds.map { it.toString() }),
+                        cursor = primaryKeyIds.map { it.toString() }
+                    )
+            )
         assertNotNull(writer)
         assertEquals(PartitionedDeltaWriter::class.java, writer.javaClass)
     }
@@ -120,7 +131,15 @@ internal class IcebergTableWriterFactoryTest {
 
         val factory = IcebergTableWriterFactory(icebergUtil = icebergUtil)
         val writer =
-            factory.create(table = table, generationId = "ab-generation-id-${Random.nextLong(100)}")
+            factory.create(
+                table = table,
+                generationId = "ab-generation-id-${Random.nextLong(100)}",
+                importType =
+                    Dedupe(
+                        primaryKey = listOf(primaryKeyIds.map { it.toString() }),
+                        cursor = primaryKeyIds.map { it.toString() }
+                    )
+            )
         assertNotNull(writer)
         assertEquals(UnpartitionedDeltaWriter::class.java, writer.javaClass)
     }
@@ -169,7 +188,11 @@ internal class IcebergTableWriterFactoryTest {
 
         val factory = IcebergTableWriterFactory(icebergUtil = icebergUtil)
         val writer =
-            factory.create(table = table, generationId = "ab-generation-id-${Random.nextLong(100)}")
+            factory.create(
+                table = table,
+                generationId = "ab-generation-id-${Random.nextLong(100)}",
+                importType = Append
+            )
         assertNotNull(writer)
         assertEquals(PartitionedAppendWriter::class.java, writer.javaClass)
     }
@@ -218,7 +241,11 @@ internal class IcebergTableWriterFactoryTest {
 
         val factory = IcebergTableWriterFactory(icebergUtil = icebergUtil)
         val writer =
-            factory.create(table = table, generationId = "ab-generation-id-${Random.nextLong(100)}")
+            factory.create(
+                table = table,
+                generationId = "ab-generation-id-${Random.nextLong(100)}",
+                importType = Append
+            )
         assertNotNull(writer)
         assertEquals(UnpartitionedAppendWriter::class.java, writer.javaClass)
     }


### PR DESCRIPTION
## What
* Improve code comprehension around Iceberg writer selection

## How
* Use the `ImportType` to determine the Iceberg writer

## Review guide
*`IcebergTableWriterFactory.kt`

## Can this PR be safely reverted and rolled back?
- [X] YES 💚
- [ ] NO ❌
