### PR TITLE
Bulk Load CDK: prefix search nonambiguous; filename uses wall time

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/integrationTest/kotlin/io/airbyte/cdk/load/mock_integration_test/MockDestinationConfiguration.kt
+++ b/airbyte-cdk/bulk/core/load/src/integrationTest/kotlin/io/airbyte/cdk/load/mock_integration_test/MockDestinationConfiguration.kt
@@ -11,7 +11,7 @@ import io.micronaut.context.annotation.Factory
 import jakarta.inject.Singleton
 
 class MockDestinationConfiguration : DestinationConfiguration() {
-    // Microbatch for testing
+    // Micro-batch for testing.
     override val recordBatchSizeBytes = 1L
 }
 

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/state/object_storage/ObjectStorageDestinationStateManager.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/state/object_storage/ObjectStorageDestinationStateManager.kt
@@ -163,14 +163,8 @@ class ObjectStorageFallbackPersister(
 ) : DestinationStatePersister<ObjectStorageDestinationState> {
     override suspend fun load(stream: DestinationStream): ObjectStorageDestinationState {
         val matcher = pathFactory.getPathMatcher(stream)
-        val pathConstant = pathFactory.getFinalDirectory(stream, streamConstant = true).toString()
-        val firstVariableIndex = pathConstant.indexOfFirst { it == '$' }
         val longestUnambiguous =
-            if (firstVariableIndex > 0) {
-                pathConstant.substring(0, firstVariableIndex)
-            } else {
-                pathConstant
-            }
+            pathFactory.getLongestStreamConstantPrefix(stream, isStaging = false)
         client
             .list(longestUnambiguous)
             .mapNotNull { matcher.match(it.key) }

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/testFixtures/kotlin/io/airbyte/cdk/load/MockPathFactory.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/testFixtures/kotlin/io/airbyte/cdk/load/MockPathFactory.kt
@@ -43,6 +43,13 @@ open class MockPathFactory : PathFactory {
         return prefix.resolve("file")
     }
 
+    override fun getLongestStreamConstantPrefix(
+        stream: DestinationStream,
+        isStaging: Boolean
+    ): String {
+        TODO("Not yet implemented")
+    }
+
     override fun getPathMatcher(stream: DestinationStream): PathMatcher {
         return PathMatcher(
             regex = Regex("$prefix/(.*)-(.*)$"),

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/testFixtures/kotlin/io/airbyte/cdk/load/ObjectStorageDataDumper.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/testFixtures/kotlin/io/airbyte/cdk/load/ObjectStorageDataDumper.kt
@@ -32,6 +32,7 @@ import io.airbyte.cdk.load.util.deserializeToNode
 import java.io.InputStream
 import java.util.zip.GZIPInputStream
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
@@ -50,11 +51,16 @@ class ObjectStorageDataDumper(
     private val parquetMapperPipeline = ParquetMapperPipelineFactory().create(stream)
 
     fun dump(): List<OutputRecord> {
-        val prefix = pathFactory.getFinalDirectory(stream).toString()
+        // Note: this is implicitly a test of the `streamConstant` final directory
+        // and the path matcher, so a failure here might imply a bug in the metadata-based
+        // destination state loader, which lists by `prefix` and filters against the matcher.
+        val prefix = pathFactory.getLongestStreamConstantPrefix(stream, isStaging = false)
+        val matcher = pathFactory.getPathMatcher(stream)
         return runBlocking {
             withContext(Dispatchers.IO) {
                 client
                     .list(prefix)
+                    .filter { matcher.match(it.key) != null }
                     .map { listedObject: RemoteObject<*> ->
                         client.get(listedObject.key) { objectData: InputStream ->
                             val decompressed =


### PR DESCRIPTION
## What
* fix for truncate sync:
  * when we search metadata for old files, we
     * start with a prefix that is the longest possible constant path across streams (take the path, sub in stream name and namespace, then take everything up to the first unrealized variable)
     * match against a matcher that matches the path/file pattern exactly
  * bug: we were matching against everything except UUID (doesn't work; because even tho write time is constant across the sync, it isn't across sync(s)
  * fix: only match against the stream name & namespace

Also:

* change the filename epoch to use wall time instead of load time (the YEAR/MONTH/DAY/etc in the path use load time, but the filename in the old code uses wall time)
* change the integration test data dumper so it uses the same strategy as metadata; this way you can actually have full paths in the test configs; as soon as this is merged, I will update the secrets so the ITs are more robust
