### PR TITLE
up-to-date: fix typo in GHA

### DIFF
--- a/.github/workflows/connectors_up_to_date.yml
+++ b/.github/workflows/connectors_up_to_date.yml
@@ -46,7 +46,7 @@ jobs:
           sentry_dsn: ${{ secrets.SENTRY_AIRBYTE_CI_DSN }}
           s3_build_cache_access_key_id: ${{ secrets.SELF_RUNNER_AWS_ACCESS_KEY_ID }}
           s3_build_cache_secret_key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
-          subcommand: 'connectors --concurrency=10 --languague=${{ matrix.connector_language}} --support-level=${{ matrix.support_level}} --metadata-query="\"source-declarative-manifest\" not in data.dockerRepository"  --metadata-query="\"-rc.\" not in data.dockerImageTag" up-to-date  --create-prs --auto-merge'
+          subcommand: 'connectors --concurrency=10 --language=${{ matrix.connector_language}} --support-level=${{ matrix.support_level}} --metadata-query="\"source-declarative-manifest\" not in data.dockerRepository"  --metadata-query="\"-rc.\" not in data.dockerImageTag" up-to-date  --create-prs --auto-merge'
 
   workflow_dispatch_connectors_up_to_date:
     name: Connectors up-to-date [MANUAL TRIGGER]


### PR DESCRIPTION
This pull request includes a small but important change to the `.github/workflows/connectors_up_to_date.yml` file. The change corrects a typo in the `subcommand` parameter by fixing the misspelling of the word "language."

* Corrected typo in the `subcommand` parameter from `languague` to `language` in the `jobs:` section of the `.github/workflows/connectors_up_to_date.yml` file.