### PR TITLE
connectors-insights: fix permission issue when installing tools in connectors

### DIFF
--- a/airbyte-ci/connectors/connectors_insights/README.md
+++ b/airbyte-ci/connectors/connectors_insights/README.md
@@ -56,6 +56,9 @@ This CLI is currently running nightly in GitHub Actions. The workflow can be fou
 
 ## Changelog
 
+### 0.3.5
+Fix permissions issue when installing `pylint` in connector container.
+
 ### 0.3.4
 Update `dagger` to `0.13.3`.
 

--- a/airbyte-ci/connectors/connectors_insights/pyproject.toml
+++ b/airbyte-ci/connectors/connectors_insights/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "connectors-insights"
-version = "0.3.4"
+version = "0.3.5"
 description = ""
 authors = ["Airbyte <contact@airbyte.io>"]
 readme = "README.md"

--- a/airbyte-ci/connectors/connectors_insights/src/connectors_insights/pylint.py
+++ b/airbyte-ci/connectors/connectors_insights/src/connectors_insights/pylint.py
@@ -45,6 +45,7 @@ async def get_pylint_output(dagger_client: dagger.Client, connector: Connector) 
     return await (
         dagger_client.container()
         .from_(connector.image_address)
+        .with_user("root")
         .with_mounted_cache("/root/.cache/pip", pip_cache_volume)
         .with_new_file("__init__.py", contents="")
         .with_exec(["pip", "install", "pylint"])


### PR DESCRIPTION
This pull request includes updates to fix a permissions issue when installing `pylint` in the connector container and increments the version number. The most important changes include:

Bug Fix:

* [`airbyte-ci/connectors/connectors_insights/src/connectors_insights/pylint.py`](diffhunk://#diff-85decaf09428c6e98c48331bdb11c4a013cfddb09351048233ef117081d0db70R48): Added `.with_user("root")` to the `get_pylint_output` function to fix permissions issue when installing `pylint` in the connector container.

Documentation:

* [`airbyte-ci/connectors/connectors_insights/README.md`](diffhunk://#diff-9c44c5802e9c69685947ced2ecc8e054a7ef180d5be660cb6fb41f756e505629R59-R61): Updated the changelog to include version `0.3.5` with a note about the permissions fix.

Versioning:

* [`airbyte-ci/connectors/connectors_insights/pyproject.toml`](diffhunk://#diff-56cf5b94d1be4683d97597ebe57508ae8164ef75e4c55dd0bc8b728051413ecaL3-R3): Incremented the version number from `0.3.4` to `0.3.5`.