### PR TITLE
[source-mysql] do not check binlog if we have gtid validated

### DIFF
--- a/airbyte-integrations/connectors/source-mysql/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mysql/metadata.yaml
@@ -9,7 +9,7 @@ data:
   connectorSubtype: database
   connectorType: source
   definitionId: 435bb9a5-7887-4809-aa58-28c27df0d7ad
-  dockerImageTag: 3.9.0-rc.20
+  dockerImageTag: 3.9.0-rc.21
   dockerRepository: airbyte/source-mysql
   documentationUrl: https://docs.airbyte.com/integrations/sources/mysql
   githubIssueLabel: source-mysql


### PR DESCRIPTION
## What
https://github.com/airbytehq/airbyte-internal-issues/issues/10907

If we have GTID checked, we can skip binlog validation because they are just independent system to guard integrity of the system.



To align with the old v1 logic (search for `airbyte-integrations/connectors/source-mysql/src/main/java/io/airbyte/integrations/source/mysql/cdc/MySqlCdcSavedInfoFetcher.java` in the following PR)

https://github.com/airbytehq/airbyte/pull/48369/files

Also added some logs.

This might reveal a problem where in v2 we might be too strict on CDC check - user can still disable GTID and use CDC (by using binlogs)

## How
<!--
* Describe how code changes achieve the solution.
-->

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
