### PR TITLE
docs: clarifying how the prefix works for vault secret storage

### DIFF
--- a/docs/operator-guides/configuring-airbyte.md
+++ b/docs/operator-guides/configuring-airbyte.md
@@ -52,7 +52,7 @@ The following variables are relevant to both Docker and Kubernetes.
 2. `SECRET_STORE_GCP_PROJECT_ID` - Defines the GCP Project to store secrets in. Alpha support.
 3. `SECRET_STORE_GCP_CREDENTIALS` - Defines the JSON credentials used to read/write Airbyte Configuration to Google Secret Manager. These credentials must have Secret Manager Read/Write access. Alpha support.
 4. `VAULT_ADDRESS` - Defines the vault address to read/write Airbyte Configuration to Hashicorp Vault. Alpha Support.
-5. `VAULT_PREFIX` - Defines the vault path prefix. Should follow the format `<engine>/<directory>`, for example `kv/airbyte/` or `secret/airbyte/`. Empty by default. Alpha Support.
+5. `VAULT_PREFIX` - Defines the vault path prefix. Should follow the format `<engine>/<directory>/`, for example `kv/airbyte/` or `secret/airbyte/`. Empty by default. Alpha Support.
 6. `VAULT_AUTH_TOKEN` - The token used for vault authentication. Alpha Support.
 7. `VAULT_AUTH_METHOD` - How vault will preform authentication. Currently, only supports Token auth. Defaults to token. Alpha Support.
 8. `AWS_ACCESS_KEY` - Defines the aws_access_key_id from the AWS credentials to use for AWS Secret Manager.

--- a/docs/operator-guides/configuring-airbyte.md
+++ b/docs/operator-guides/configuring-airbyte.md
@@ -52,7 +52,7 @@ The following variables are relevant to both Docker and Kubernetes.
 2. `SECRET_STORE_GCP_PROJECT_ID` - Defines the GCP Project to store secrets in. Alpha support.
 3. `SECRET_STORE_GCP_CREDENTIALS` - Defines the JSON credentials used to read/write Airbyte Configuration to Google Secret Manager. These credentials must have Secret Manager Read/Write access. Alpha support.
 4. `VAULT_ADDRESS` - Defines the vault address to read/write Airbyte Configuration to Hashicorp Vault. Alpha Support.
-5. `VAULT_PREFIX` - Defines the vault path prefix. Empty by default. Alpha Support.
+5. `VAULT_PREFIX` - Defines the vault path prefix. Should follow the format `<engine>/<directory>`, for example `kv/airbyte/` or `secret/airbyte/`. Empty by default. Alpha Support.
 6. `VAULT_AUTH_TOKEN` - The token used for vault authentication. Alpha Support.
 7. `VAULT_AUTH_METHOD` - How vault will preform authentication. Currently, only supports Token auth. Defaults to token. Alpha Support.
 8. `AWS_ACCESS_KEY` - Defines the aws_access_key_id from the AWS credentials to use for AWS Secret Manager.


### PR DESCRIPTION
## What
The documentation around using Vault as the secrets store is very poor. This is a step towards improving them by providing specific examples of the format that the prefix should take.

## How
<!--
* Describe how code changes achieve the solution.
-->

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
