### PR TITLE
Bulk Load CDK: Fix: Sync w/ Global State Hangs on Empty Stream

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/DestinationMessageDeserializer.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/DestinationMessageDeserializer.kt
@@ -25,7 +25,7 @@ class DefaultDestinationMessageDeserializer(private val messageFactory: Destinat
             val airbyteMessage = serialized.deserializeToClass(AirbyteMessage::class.java)
             return messageFactory.fromAirbyteMessage(airbyteMessage, serialized)
         } catch (t: Throwable) {
-            throw RuntimeException("Failed to deserialize AirbyteMessage")
+            throw RuntimeException("Failed to deserialize AirbyteMessage.")
         }
     }
 }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/state/CheckpointManager.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/state/CheckpointManager.kt
@@ -158,6 +158,9 @@ abstract class StreamsCheckpointManager<T> : CheckpointManager<DestinationStream
                 validateAndSendMessage(head.checkpointMessage, head.streamIndexes)
                 globalCheckpoints.poll() // don't remove until after we've successfully sent
             } else {
+                log.info {
+                    "Not flushing global checkpoint with stream indexes: ${head.streamIndexes}"
+                }
                 break
             }
         }
@@ -176,6 +179,7 @@ abstract class StreamsCheckpointManager<T> : CheckpointManager<DestinationStream
                     validateAndSendMessage(nextMessage, listOf(stream.descriptor to nextIndex))
                     streamCheckpoints.poll() // don't remove until after we've successfully sent
                 } else {
+                    log.info { "Not flushing next checkpoint for index $nextIndex" }
                     break
                 }
             }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/state/StreamManager.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/state/StreamManager.kt
@@ -173,6 +173,10 @@ class DefaultStreamManager(
     private fun isProcessingCompleteForState(index: Long, state: Batch.State): Boolean {
         val completeRanges = rangesState[state]!!
 
+        if (index == 0L && recordCount.get() == 0L) {
+            return true
+        }
+
         return completeRanges.encloses(Range.closedOpen(0L, index))
     }
 


### PR DESCRIPTION
## What
Fix plucked out of the staged legacy dats test, since it's blocking at least one person.

Syncs with global state were hanging forever when one stream was empty.