### PR TITLE
🐛 Source Klaviyo: Retry on invalid url issues

### DIFF
--- a/airbyte-integrations/connectors/source-klaviyo/metadata.yaml
+++ b/airbyte-integrations/connectors/source-klaviyo/metadata.yaml
@@ -8,7 +8,7 @@ data:
   definitionId: 95e8cffd-b8c4-4039-968e-d32fb4a69bde
   connectorBuildOptions:
     baseImage: docker.io/airbyte/python-connector-base:2.0.0@sha256:c44839ba84406116e8ba68722a0f30e8f6e7056c726f447681bb9e9ece8bd916
-  dockerImageTag: 2.11.0
+  dockerImageTag: 2.11.1
   dockerRepository: airbyte/source-klaviyo
   githubIssueLabel: source-klaviyo
   icon: klaviyo.svg

--- a/airbyte-integrations/connectors/source-klaviyo/pyproject.toml
+++ b/airbyte-integrations/connectors/source-klaviyo/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "2.11.0"
+version = "2.11.1"
 name = "source-klaviyo"
 description = "Source implementation for Klaviyo."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-klaviyo/source_klaviyo/components/klaviyo_error_handler.py
+++ b/airbyte-integrations/connectors/source-klaviyo/source_klaviyo/components/klaviyo_error_handler.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+
+from typing import Optional, Union
+
+import requests
+from airbyte_cdk.models import FailureType
+from airbyte_cdk.sources.declarative.requesters.error_handlers import DefaultErrorHandler
+from airbyte_cdk.sources.streams.http.error_handlers import ErrorResolution, ResponseAction
+from requests.exceptions import InvalidURL
+
+
+class KlaviyoErrorHandler(DefaultErrorHandler):
+    def interpret_response(self, response_or_exception: Optional[Union[requests.Response, Exception]]) -> ErrorResolution:
+        """
+        We have seen `[Errno -3] Temporary failure in name resolution` a couple of times on two different connections
+        (1fed2ede-2d33-4543-85e3-7d6e5736075d and 1b276f7d-358a-4fe3-a437-6747fd780eed). Retrying the requests on later syncs is working
+        which makes it sound like a transient issue.
+        """
+        if isinstance(response_or_exception, InvalidURL):
+            return ErrorResolution(
+                response_action=ResponseAction.RETRY,
+                failure_type=FailureType.transient_error,
+                error_message="source-klaviyo has faced a temporary DNS resolution issue. Retrying...",
+            )
+        return super().interpret_response(response_or_exception)

--- a/airbyte-integrations/connectors/source-klaviyo/source_klaviyo/manifest.yaml
+++ b/airbyte-integrations/connectors/source-klaviyo/source_klaviyo/manifest.yaml
@@ -18,7 +18,8 @@ definitions:
     authenticator: "#/definitions/authenticator"
     http_method: GET
     error_handler:
-      type: DefaultErrorHandler
+      type: CustomErrorHandler
+      class_name: source_klaviyo.components.klaviyo_error_handler.KlaviyoErrorHandler
       backoff_strategies:
         - type: WaitTimeFromHeader
           header: "Retry-After"

--- a/docs/integrations/sources/klaviyo.md
+++ b/docs/integrations/sources/klaviyo.md
@@ -95,6 +95,7 @@ contain the `predictive_analytics` field and workflows depending on this field w
 
 | Version | Date       | Pull Request                                               | Subject                                                                                                                       |
 |:--------|:-----------|:-----------------------------------------------------------|:------------------------------------------------------------------------------------------------------------------------------|
+| 2.11.1  | 2024-11-26 | [48710](https://github.com/airbytehq/airbyte/pull/48710) | Retry on "Temporary failure in name resolution"                                                                               |
 | 2.11.0  | 2024-11-18 | [48452](https://github.com/airbytehq/airbyte/pull/48452) | Enable concurrency for syncs that don't have client-side filtering                                                            |
 | 2.10.14 | 2024-11-07 | [48391](https://github.com/airbytehq/airbyte/pull/48391) | Remove custom datetime cursor dependency                                                                                      |
 | 2.10.13 | 2024-11-05 | [48331](https://github.com/airbytehq/airbyte/pull/48331) | Update dependencies                                                                                                           |


### PR DESCRIPTION
## What
We have seen `InvalidURL: [Errno -3] Temporary failure in name resolution` a couple of times on two different connections (1fed2ede-2d33-4543-85e3-7d6e5736075d and 1b276f7d-358a-4fe3-a437-6747fd780eed). This happened after adding concurrency to the connector but we can't link the two meaning that maybe the error is just more visible now because we perform more requests. Retrying the requests on later syncs is working which makes it sound like a transient issue.

## How
Add an error handler that handles this exception or else delegate to the default error handler.

I didn't want to add a mock server test because it is not possible to set an exception on the first request and a response on the second (or at least I don't know how) which would lead to retrying indefinitely. I did test visually using this though:

```
def test_toto():
    with requests_mock.Mocker() as m:
        m.get("https://a.klaviyo.com/api/profiles", exc=InvalidURL)
        _read(_config(), SyncMode.full_refresh)
```

Outcome
```
{"type":"LOG","log":{"level":"INFO","message":"Syncing stream: profiles "}}
{"type":"LOG","log":{"level":"INFO","message":"Backing off _send(...) for 1.0s (airbyte_cdk.sources.streams.http.exceptions.DefaultBackoffException: source-klaviyo has faced a temporary DNS resolution issue. Retrying...)"}}
{"type":"LOG","log":{"level":"INFO","message":"Caught retryable error 'source-klaviyo has faced a temporary DNS resolution issue. Retrying...' after 1 tries. Waiting 1 seconds then retrying..."}}
{"type":"LOG","log":{"level":"INFO","message":"Backing off _send(...) for 2.0s (airbyte_cdk.sources.streams.http.exceptions.DefaultBackoffException: source-klaviyo has faced a temporary DNS resolution issue. Retrying...)"}}
{"type":"LOG","log":{"level":"INFO","message":"Caught retryable error 'source-klaviyo has faced a temporary DNS resolution issue. Retrying...' after 2 tries. Waiting 2 seconds then retrying..."}}
{"type":"LOG","log":{"level":"INFO","message":"Backing off _send(...) for 4.0s (airbyte_cdk.sources.streams.http.exceptions.DefaultBackoffException: source-klaviyo has faced a temporary DNS resolution issue. Retrying...)"}}
{"type":"LOG","log":{"level":"INFO","message":"Caught retryable error 'source-klaviyo has faced a temporary DNS resolution issue. Retrying...' after 3 tries. Waiting 4 seconds then retrying..."}}
<...>
```

## User Impact
Syncs with `InvalidURL: [Errno -3] Temporary failure in name resolution` will retry and hopefully it'll not need to do another sync.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [X] YES 💚
- [ ] NO ❌
