### PR TITLE
[source-mongodb-v2] Force state update once a while

### DIFF
--- a/airbyte-cdk/java/airbyte-cdk/db-sources/src/main/kotlin/io/airbyte/cdk/integrations/debezium/internals/DebeziumMessageProducer.kt
+++ b/airbyte-cdk/java/airbyte-cdk/db-sources/src/main/kotlin/io/airbyte/cdk/integrations/debezium/internals/DebeziumMessageProducer.kt
@@ -43,9 +43,7 @@ class DebeziumMessageProducer<T>(
     private val offsetManager: AirbyteFileOffsetBackingStore?
     private val targetPosition: CdcTargetPosition<T>
     private val schemaHistoryManager: Optional<AirbyteSchemaHistoryStorage>
-
-    private var shouldEmitStateMessage = false
-
+    
     private val eventConverter: DebeziumEventConverter
 
     init {
@@ -68,7 +66,6 @@ class DebeziumMessageProducer<T>(
         previousCheckpointOffset.clear()
         previousCheckpointOffset.putAll(checkpointOffsetToSend)
         checkpointOffsetToSend.clear()
-        shouldEmitStateMessage = false
         return stateMessage
     }
 
@@ -94,12 +91,6 @@ class DebeziumMessageProducer<T>(
             }
         }
 
-        if (checkpointOffsetToSend.size == 1 && !message.isSnapshotEvent) {
-            if (targetPosition.isEventAheadOffset(checkpointOffsetToSend, message)) {
-                shouldEmitStateMessage = true
-            }
-        }
-
         return eventConverter.toAirbyteMessage(message)
     }
 
@@ -119,7 +110,7 @@ class DebeziumMessageProducer<T>(
     }
 
     override fun shouldEmitStateMessage(stream: ConfiguredAirbyteStream?): Boolean {
-        return shouldEmitStateMessage
+        return true
     }
 
     /**

--- a/airbyte-integrations/connectors/source-mongodb-v2/build.gradle
+++ b/airbyte-integrations/connectors/source-mongodb-v2/build.gradle
@@ -5,7 +5,7 @@ plugins {
 airbyteJavaConnector {
     cdkVersionRequired = '0.45.1'
     features = ['db-sources', 'datastore-mongo']
-    useLocalCdk = false
+    useLocalCdk = true
 }
 
 application {

--- a/airbyte-integrations/connectors/source-postgres/build.gradle
+++ b/airbyte-integrations/connectors/source-postgres/build.gradle
@@ -14,7 +14,7 @@ java {
 airbyteJavaConnector {
     cdkVersionRequired = '0.48.2'
     features = ['db-sources', 'datastore-postgres']
-    useLocalCdk = false
+    useLocalCdk = true
 }
 
 application {


### PR DESCRIPTION
## What

https://github.com/airbytehq/airbyte/issues/48496

https://github.com/airbytehq/airbyte/issues/48435

I think we are not updating state message correctly. In case of a long hold (DBZ busy filtering out oplogs not related to target db), we are actually NOT updating our state message, because it will only update whenever it processes a record message. 

## How
<!--
* Describe how code changes achieve the solution.
-->

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
