### PR TITLE
Fix typo where destination was written as dstination

### DIFF
--- a/docs/using-airbyte/core-concepts/readme.md
+++ b/docs/using-airbyte/core-concepts/readme.md
@@ -81,7 +81,7 @@ For more details, see our [Namespace documentation](namespaces.md).
 
 ## Sync Mode
 
-A sync mode governs how Airbyte reads from a source and writes to a destination. Airbyte provides several sync modes depending what you want to accomplish. The sync modes define how your data will sync and whether duplicates will exist in the dstination.
+A sync mode governs how Airbyte reads from a source and writes to a destination. Airbyte provides several sync modes depending what you want to accomplish. The sync modes define how your data will sync and whether duplicates will exist in the destination.
 
 Read more about each [sync mode](/using-airbyte/core-concepts/sync-modes/README.md) and how they differ.
 


### PR DESCRIPTION
## What

It fixes a typo where `destination` was written as `dstination`


## How

It changes `dstination` to `destination`


## Review guide

None, its a typo fix


## User Impact

User no longer sees typo in docs


## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌
