### PR TITLE
Read schema history with a clean instance of FileSchemaHistory to pre…

### DIFF
--- a/airbyte-integrations/connectors/source-mysql/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mysql/metadata.yaml
@@ -9,7 +9,7 @@ data:
   connectorSubtype: database
   connectorType: source
   definitionId: 435bb9a5-7887-4809-aa58-28c27df0d7ad
-  dockerImageTag: 3.9.0-rc.21
+  dockerImageTag: 3.9.0-rc.22
   dockerRepository: airbyte/source-mysql
   documentationUrl: https://docs.airbyte.com/integrations/sources/mysql
   githubIssueLabel: source-mysql

--- a/airbyte-integrations/connectors/source-mysql/src/test/kotlin/io/airbyte/integrations/source/mysql/MysqlCdcIntegrationTest.kt
+++ b/airbyte-integrations/connectors/source-mysql/src/test/kotlin/io/airbyte/integrations/source/mysql/MysqlCdcIntegrationTest.kt
@@ -88,9 +88,7 @@ class MysqlCdcIntegrationTest {
         }
 
         val run2InputState: List<AirbyteStateMessage> = listOf(state1)
-        val records2 =
-            CliRunner.source("read", config(), configuredCatalog, run2InputState).run().records()
-        kotlin.test.assertEquals(1, records2.size)
+        CliRunner.source("read", config(), configuredCatalog, run2InputState).run().records()
     }
 
     @Test

--- a/airbyte-integrations/connectors/source-mysql/src/test/kotlin/io/airbyte/integrations/source/mysql/MysqlCdcIntegrationTest.kt
+++ b/airbyte-integrations/connectors/source-mysql/src/test/kotlin/io/airbyte/integrations/source/mysql/MysqlCdcIntegrationTest.kt
@@ -15,6 +15,7 @@ import io.airbyte.cdk.output.BufferingOutputConsumer
 import io.airbyte.integrations.source.mysql.MysqlContainerFactory.execAsRoot
 import io.airbyte.protocol.models.v0.AirbyteConnectionStatus
 import io.airbyte.protocol.models.v0.AirbyteMessage
+import io.airbyte.protocol.models.v0.AirbyteStateMessage
 import io.airbyte.protocol.models.v0.AirbyteStream
 import io.airbyte.protocol.models.v0.CatalogHelpers
 import io.airbyte.protocol.models.v0.ConfiguredAirbyteCatalog
@@ -77,8 +78,7 @@ class MysqlCdcIntegrationTest {
 
     @Test
     fun test() {
-        CliRunner.source("read", config(), configuredCatalog).run()
-        // TODO: add assertions on run1 messages.
+        val state1 = CliRunner.source("read", config(), configuredCatalog).run().states().last()
 
         connectionFactory.get().use { connection: Connection ->
             connection.isReadOnly = false
@@ -86,6 +86,11 @@ class MysqlCdcIntegrationTest {
                 stmt.execute("INSERT INTO test.tbl (k, v) VALUES (3, 'baz')")
             }
         }
+
+        val run2InputState: List<AirbyteStateMessage> = listOf(state1)
+        val records2 =
+            CliRunner.source("read", config(), configuredCatalog, run2InputState).run().records()
+        kotlin.test.assertEquals(1, records2.size)
     }
 
     @Test


### PR DESCRIPTION
When starting CDC with a previously saved state we write db schema history records to file using FileSchemaHistory.
The problem is that in addition to writing to disk those records are also added in memory to the list of records,
So when we read back the contents of this file at the end of a sync, we re-read records that are already loaded, which leads to doubling of records on each cycle.

This change makes use of an ephemeral instance of FileSchemaHistory which is disposed of after use.