### PR TITLE
fix(source-file): fix poorly formatted excel columns to not break dataframe columns

### DIFF
--- a/airbyte-integrations/connectors/source-file/source_file/client.py
+++ b/airbyte-integrations/connectors/source-file/source_file/client.py
@@ -481,8 +481,9 @@ class Client:
             for col in df.columns:
                 # if data type of the same column differs in dataframes, we choose the broadest one
                 prev_frame_column_type = fields.get(col)
-                df_type = df[col].dtype
-                fields[col] = self.dtype_to_json_type(prev_frame_column_type, df_type)
+                if col is not None:
+                    df_type = df[col].dtype
+                    fields[col] = self.dtype_to_json_type(prev_frame_column_type, df_type)
         return {
             field: (
                 {"type": ["string", "null"], "format": "date-time"} if fields[field] == "date-time" else {"type": [fields[field], "null"]}


### PR DESCRIPTION
added None check before assuming object has dtype method.

## What
In a poorly formatted excel file, a column may be identified but will exist as a None type. Trying to call dataframe methods on the None type results in errors.

## How
Added a check for None before calling object methods.

## Review guide


## User Impact
Poorly formatted excel files will not trigger a failure in the Check and Discover steps. Only downside is that poorly formed columns in the file may be skipped over.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
