### PR TITLE
Destination S3V2: DO NOT MERGE: Test fix for backpressure issue

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/command/DestinationConfiguration.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/command/DestinationConfiguration.kt
@@ -84,6 +84,8 @@ abstract class DestinationConfiguration : Configuration {
      */
     open val gracefulCancellationTimeoutMs: Long = 60 * 1000L // 1 minutes
 
+    open val numProcessRecordsWorkers: Int = 2
+
     /**
      * Micronaut factory which glues [ConfigurationSpecificationSupplier] and
      * [DestinationConfigurationFactory] together to produce a [DestinationConfiguration] singleton.

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/config/SyncBeanFactory.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/config/SyncBeanFactory.kt
@@ -4,12 +4,16 @@
 
 package io.airbyte.cdk.load.config
 
+import io.airbyte.cdk.load.command.DestinationCatalog
 import io.airbyte.cdk.load.command.DestinationConfiguration
+import io.airbyte.cdk.load.message.LimitedMessageQueue
 import io.airbyte.cdk.load.state.ReservationManager
+import io.airbyte.cdk.load.task.implementor.FileQueueMessage
 import io.micronaut.context.annotation.Factory
 import io.micronaut.context.annotation.Value
 import jakarta.inject.Named
 import jakarta.inject.Singleton
+import kotlin.math.min
 
 /** Factory for instantiating beans necessary for the sync process. */
 @Factory
@@ -30,5 +34,17 @@ class SyncBeanFactory {
         @Value("\${airbyte.resources.disk.bytes}") availableBytes: Long,
     ): ReservationManager {
         return ReservationManager(availableBytes)
+    }
+
+    @Singleton
+    @Named("spillFileQueue")
+    fun spillFileQueue(
+        @Value("\${airbyte.resources.disk.bytes}") availableBytes: Long,
+        catalog: DestinationCatalog,
+        config: DestinationConfiguration,
+    ): LimitedMessageQueue<FileQueueMessage> {
+        val maxNumberChunksInFlight = ((availableBytes / config.recordBatchSizeBytes) * 0.8).toInt()
+        val minusOnePerStream = maxNumberChunksInFlight - catalog.streams.size
+        return LimitedMessageQueue(min(minusOnePerStream, 1))
     }
 }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/SpillToDiskTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/SpillToDiskTask.kt
@@ -5,11 +5,17 @@
 package io.airbyte.cdk.load.task.internal
 
 import com.google.common.collect.Range
+import com.google.common.collect.TreeRangeSet
 import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.file.SpillFileProvider
+import io.airbyte.cdk.load.message.Batch
+import io.airbyte.cdk.load.message.BatchEnvelope
 import io.airbyte.cdk.load.message.DestinationStreamEvent
+import io.airbyte.cdk.load.message.LimitedMessageQueue
+import io.airbyte.cdk.load.message.MessageQueue
 import io.airbyte.cdk.load.message.MessageQueueSupplier
 import io.airbyte.cdk.load.message.QueueReader
+import io.airbyte.cdk.load.message.SimpleBatch
 import io.airbyte.cdk.load.message.StreamCompleteEvent
 import io.airbyte.cdk.load.message.StreamFlushEvent
 import io.airbyte.cdk.load.message.StreamRecordEvent
@@ -20,7 +26,7 @@ import io.airbyte.cdk.load.state.TimeWindowTrigger
 import io.airbyte.cdk.load.task.DestinationTaskLauncher
 import io.airbyte.cdk.load.task.InternalScope
 import io.airbyte.cdk.load.task.StreamLevel
-import io.airbyte.cdk.load.util.takeUntilInclusive
+import io.airbyte.cdk.load.task.implementor.FileQueueMessage
 import io.airbyte.cdk.load.util.use
 import io.airbyte.cdk.load.util.withNextAdjacentValue
 import io.airbyte.cdk.load.util.write
@@ -28,11 +34,11 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import io.micronaut.context.annotation.Value
 import jakarta.inject.Named
 import jakarta.inject.Singleton
+import java.io.OutputStream
 import java.nio.file.Path
 import java.time.Clock
 import kotlin.io.path.outputStream
-import kotlinx.coroutines.flow.last
-import kotlinx.coroutines.flow.runningFold
+import kotlinx.coroutines.flow.fold
 
 interface SpillToDiskTask : StreamLevel, InternalScope
 
@@ -47,26 +53,29 @@ class DefaultSpillToDiskTask(
     private val queue: QueueReader<Reserved<DestinationStreamEvent>>,
     private val flushStrategy: FlushStrategy,
     override val streamDescriptor: DestinationStream.Descriptor,
-    private val launcher: DestinationTaskLauncher,
     private val diskManager: ReservationManager,
     private val timeWindow: TimeWindowTrigger,
+    private val spillFileQueue: LimitedMessageQueue<FileQueueMessage>,
+    private val taskLauncher: DestinationTaskLauncher
 ) : SpillToDiskTask {
     private val log = KotlinLogging.logger {}
 
     data class ReadResult(
+        val spillFile: Path,
+        val spillFileOutputStream: OutputStream,
         val range: Range<Long>? = null,
         val sizeBytes: Long = 0,
-        val hasReadEndOfStream: Boolean = false,
-        val forceFlush: Boolean = false,
     )
 
     override suspend fun execute() {
-        val tmpFile = spillFileProvider.createTempFile()
-        val result =
-            tmpFile.outputStream().use { outputStream ->
-                queue
-                    .consume()
-                    .runningFold(ReadResult()) { (range, sizeBytes, _), reserved ->
+        val initialResult =  spillFileProvider.createTempFile().let {
+            ReadResult(it, it.outputStream())
+        }
+        spillFileQueue.take().use {
+            queue.consume().fold(initialResult) {
+                (spillFile, outputStream, range, sizeBytes),
+                reserved ->
+                    try {
                         reserved.use {
                             when (val wrapped = it.value) {
                                 is StreamRecordEvent -> {
@@ -87,48 +96,89 @@ class DefaultSpillToDiskTask(
                                             bytesProcessed
                                         )
 
-                                    // write and return output
                                     outputStream.write(wrapped.record.serialized)
                                     outputStream.write("\n")
-                                    ReadResult(
-                                        rangeProcessed,
-                                        bytesProcessed,
-                                        forceFlush = forceFlush
-                                    )
+
+                                    if (forceFlush) {
+                                        val file =
+                                            SpilledRawMessagesLocalFile(
+                                                spillFile,
+                                                bytesProcessed,
+                                                rangeProcessed
+                                            )
+                                        publishFile(file)
+                                        val nextTmpFile = spillFileProvider.createTempFile()
+                                        outputStream.close()
+                                        ReadResult(nextTmpFile, nextTmpFile.outputStream())
+                                    } else {
+                                        ReadResult(
+                                            spillFile,
+                                            outputStream,
+                                            rangeProcessed,
+                                            bytesProcessed
+                                        )
+                                    }
                                 }
+
                                 is StreamCompleteEvent -> {
                                     val nextRange = range.withNextAdjacentValue(wrapped.index)
-                                    ReadResult(nextRange, sizeBytes, hasReadEndOfStream = true)
+                                    val file =
+                                        SpilledRawMessagesLocalFile(
+                                            spillFile,
+                                            sizeBytes,
+                                            nextRange,
+                                            endOfStream = true
+                                        )
+                                    publishFile(file)
+                                    ReadResult(
+                                        spillFile,
+                                        outputStream,
+                                        range,
+                                        sizeBytes
+                                    ) // this will be the last message
                                 }
+
                                 is StreamFlushEvent -> {
                                     val forceFlush = timeWindow.isComplete()
                                     if (forceFlush) {
                                         log.info {
-                                            "Time window complete for $streamDescriptor@${timeWindow.openedAtMs} closing $tmpFile of (${sizeBytes}b)"
+                                            "Time window complete for $streamDescriptor@${timeWindow.openedAtMs} closing $spillFile of (${sizeBytes}b)"
                                         }
                                     }
-                                    ReadResult(range, sizeBytes, forceFlush = forceFlush)
+
+                                    if (range != null && sizeBytes > 0L) {
+                                        val file =
+                                            SpilledRawMessagesLocalFile(
+                                                spillFile,
+                                                sizeBytes,
+                                                range,
+                                                endOfStream = false
+                                            )
+                                        publishFile(file)
+                                        val nextTmpFile = spillFileProvider.createTempFile()
+                                        outputStream.close()
+                                        ReadResult(nextTmpFile, nextTmpFile.outputStream())
+                                    }
+                                    ReadResult(spillFile, outputStream, range, sizeBytes)
                                 }
                             }
                         }
+                    } finally {
+                        outputStream.close()
                     }
-                    .takeUntilInclusive { it.hasReadEndOfStream || it.forceFlush }
-                    .last()
+                }
             }
+    }
 
-        /** Handle the result */
-        val (range, sizeBytes, endOfStream) = result
-
-        log.info { "Finished writing $range records (${sizeBytes}b) to $tmpFile" }
-
-        // This could happen if the chunk only contained end-of-stream
-        if (range == null) {
-            // We read 0 records, do nothing
+    private suspend fun publishFile(file: SpilledRawMessagesLocalFile) {
+        if (file.totalSizeBytes == 0L) {
+            log.info { "Skipping empty file $file" }
+            val dummy = BatchEnvelope(SimpleBatch(Batch.State.COMPLETE), TreeRangeSet.create())
+            taskLauncher.handleNewBatch(streamDescriptor, dummy)
             return
         }
-
-        val file = SpilledRawMessagesLocalFile(tmpFile, sizeBytes, range, endOfStream)
-        launcher.handleNewSpilledFile(streamDescriptor, file)
+        log.info { "Publishing file $file" }
+        spillFileQueue.publish(FileQueueMessage(streamDescriptor, file))
     }
 }
 
@@ -148,6 +198,7 @@ class DefaultSpillToDiskTaskFactory(
     @Named("diskManager") private val diskManager: ReservationManager,
     private val clock: Clock,
     @Value("\${airbyte.flush.window-ms}") private val windowWidthMs: Long,
+    @Named("spillFileQueue") private val spillFileQueue: LimitedMessageQueue<FileQueueMessage>,
 ) : SpillToDiskTaskFactory {
     override fun make(
         taskLauncher: DestinationTaskLauncher,
@@ -160,9 +211,10 @@ class DefaultSpillToDiskTaskFactory(
             queueSupplier.get(stream),
             flushStrategy,
             stream,
-            taskLauncher,
             diskManager,
             timeWindow,
+            spillFileQueue,
+            taskLauncher
         )
     }
 }

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/DestinationTaskLauncherUTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/DestinationTaskLauncherUTest.kt
@@ -5,6 +5,7 @@
 package io.airbyte.cdk.load.task
 
 import io.airbyte.cdk.load.command.DestinationCatalog
+import io.airbyte.cdk.load.command.DestinationConfiguration
 import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.message.CheckpointMessageWrapped
 import io.airbyte.cdk.load.message.DestinationMessage
@@ -62,6 +63,7 @@ class DestinationTaskLauncherUTest {
     private val flushCheckpointsTaskFactory: FlushCheckpointsTaskFactory = mockk(relaxed = true)
     private val timedFlushTask: TimedForcedCheckpointFlushTask = mockk(relaxed = true)
     private val updateCheckpointsTask: UpdateCheckpointsTask = mockk(relaxed = true)
+    private val config: DestinationConfiguration = mockk(relaxed = true)
 
     // Exception handling
     private val exceptionHandler: TaskExceptionHandler<LeveledTask, WrappedTask<ScopedTask>> =
@@ -80,6 +82,7 @@ class DestinationTaskLauncherUTest {
         return DefaultDestinationTaskLauncher(
             taskScopeProvider,
             catalog,
+            config,
             syncManager,
             inputConsumerTaskFactory,
             spillToDiskTaskFactory,

--- a/airbyte-integrations/connectors/destination-s3-v2/build.gradle
+++ b/airbyte-integrations/connectors/destination-s3-v2/build.gradle
@@ -17,14 +17,14 @@ application {
 //            Uncomment to run locally:
 //          '--add-opens', 'java.base/java.lang=ALL-UNNAMED'
 //            Uncomment to enable remote profiling:
-            '-XX:NativeMemoryTracking=detail',
-            '-Djava.rmi.server.hostname=localhost',
-            '-Dcom.sun.management.jmxremote=true',
-            '-Dcom.sun.management.jmxremote.port=6000',
-            '-Dcom.sun.management.jmxremote.rmi.port=6000',
-            '-Dcom.sun.management.jmxremote.local.only=false',
-            '-Dcom.sun.management.jmxremote.authenticate=false',
-            '-Dcom.sun.management.jmxremote.ssl=false'
+//            '-XX:NativeMemoryTracking=detail',
+//            '-Djava.rmi.server.hostname=localhost',
+//            '-Dcom.sun.management.jmxremote=true',
+//            '-Dcom.sun.management.jmxremote.port=6000',
+//            '-Dcom.sun.management.jmxremote.rmi.port=6000',
+//            '-Dcom.sun.management.jmxremote.local.only=false',
+//            '-Dcom.sun.management.jmxremote.authenticate=false',
+//            '-Dcom.sun.management.jmxremote.ssl=false'
     ]
 }
 
@@ -39,7 +39,7 @@ dependencies {
     integrationTestLegacyImplementation testFixtures(project(":airbyte-cdk:java:airbyte-cdk:airbyte-cdk-s3-destinations"))
 }
 
-// Exclude conflicting log4j-over-slf4j dependency
-configurations.all {
-        exclude group: "org.slf4j", module: "slf4j-reload4j"
-}
+//// Exclude conflicting log4j-over-slf4j dependency
+//configurations.all {
+//        exclude group: "org.slf4j", module: "slf4j-reload4j"
+//}

--- a/airbyte-integrations/connectors/destination-s3-v2/src/main/kotlin/S3V2Configuration.kt
+++ b/airbyte-integrations/connectors/destination-s3-v2/src/main/kotlin/S3V2Configuration.kt
@@ -41,6 +41,8 @@ data class S3V2Configuration<T : OutputStream>(
     override val recordBatchSizeBytes: Long,
     override val maxMessageQueueMemoryUsageRatio: Double = 0.2,
     override val estimatedRecordMemoryOverheadRatio: Double = 1.1,
+
+    override val numProcessRecordsWorkers: Int
 ) :
     DestinationConfiguration(),
     AWSAccessKeyConfigurationProvider,
@@ -66,8 +68,11 @@ class S3V2ConfigurationFactory(
             objectStoragePathConfiguration = pojo.toObjectStoragePathConfiguration(),
             objectStorageFormatConfiguration = pojo.toObjectStorageFormatConfiguration(),
             objectStorageCompressionConfiguration = pojo.toCompressionConfiguration(),
-            recordBatchSizeBytes = recordBatchSizeBytes
-        )
+            recordBatchSizeBytes = recordBatchSizeBytes,
+            objectStorageUploadConfiguration = ObjectStorageUploadConfiguration(streamingUploadPartSize = pojo.partSizeBytes
+                ?: (10 * 1024 * 1024)),
+            numProcessRecordsWorkers = pojo.numConcurrentUploads ?: 2
+            )
     }
 }
 

--- a/airbyte-integrations/connectors/destination-s3-v2/src/main/kotlin/S3V2Specification.kt
+++ b/airbyte-integrations/connectors/destination-s3-v2/src/main/kotlin/S3V2Specification.kt
@@ -4,6 +4,7 @@
 
 package io.airbyte.integrations.destination.s3_v2
 
+import com.fasterxml.jackson.annotation.JsonProperty
 import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaInject
 import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaTitle
 import io.airbyte.cdk.command.ConfigurationSpecification
@@ -81,6 +82,12 @@ class S3V2Specification :
     //
     //    @get:JsonSchemaInject(json = """{"examples":["__staging/data_sync/test"],"order":11}""")
     //    override val s3StagingPrefix: String? = null
+
+    @get:JsonProperty("part_size_b")
+    val partSizeBytes: Long? = null
+
+    @get: JsonProperty("num_concurrent_uploads")
+    val numConcurrentUploads: Int? = null
 }
 
 @Singleton

--- a/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2WriteTest.kt
+++ b/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2WriteTest.kt
@@ -60,6 +60,11 @@ class S3V2WriteTestJsonUncompressed :
     override fun testInterruptedTruncateWithPriorData() {
         super.testInterruptedTruncateWithPriorData()
     }
+
+    @Test
+    override fun testNamespaces() {
+        super.testNamespaces()
+    }
 }
 
 class S3V2WriteTestJsonRootLevelFlattening :


### PR DESCRIPTION
## What
* creates a queue between spill-to-disk and process records
  * queue limited to a number of units equivalent to what would fill 80% of the disk
* launches two process records tasks that pull down work for arbitrary streams
* each spill-to-disk loops until end-of-stream, publishing to the queue, then closes
* each process records loops, running files through the stream loader, until the queues are closed

no unit test changes, but ITs pass