### PR TITLE
chore: upgrade to iceberg 1.7.0

### DIFF
--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/build.gradle
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/build.gradle
@@ -1,12 +1,16 @@
+ext {
+    apacheIcebergVersion = '1.7.0'
+}
+
 dependencies {
     api project(':airbyte-cdk:bulk:toolkits:bulk-cdk-toolkit-load-s3')
 
     implementation project(':airbyte-cdk:bulk:core:bulk-cdk-core-base')
     implementation project(':airbyte-cdk:bulk:core:bulk-cdk-core-load')
-    api 'org.apache.iceberg:iceberg-core:1.6.1'
-    api 'org.apache.iceberg:iceberg-api:1.6.1'
-    api 'org.apache.iceberg:iceberg-parquet:1.6.1'
-    api 'org.apache.iceberg:iceberg-nessie:1.6.1'
+    api "org.apache.iceberg:iceberg-core:${project.ext.apacheIcebergVersion}"
+    api "org.apache.iceberg:iceberg-api:${project.ext.apacheIcebergVersion}"
+    api "org.apache.iceberg:iceberg-parquet:${project.ext.apacheIcebergVersion}"
+    api "org.apache.iceberg:iceberg-nessie:${project.ext.apacheIcebergVersion}"
 
     testFixturesImplementation testFixtures(project(":airbyte-cdk:bulk:core:bulk-cdk-core-load"))
 }

--- a/airbyte-integrations/connectors/destination-iceberg-v2/build.gradle
+++ b/airbyte-integrations/connectors/destination-iceberg-v2/build.gradle
@@ -19,9 +19,9 @@ application {
 }
 
 ext {
-    apacheIcebergVersion = "1.6.1"
-    awsSdkVersion = "2.29.9"
-    junitVersion = "5.11.3"
+    apacheIcebergVersion = '1.7.0'
+    awsSdkVersion = '2.29.9'
+    junitVersion = '5.11.3'
 }
 
 // Uncomment to run locally

--- a/airbyte-integrations/connectors/destination-iceberg-v2/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-iceberg-v2/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: file
   connectorType: destination
   definitionId: 37a928c1-2d5c-431a-a97d-ae236bd1ea0c
-  dockerImageTag: 0.1.9
+  dockerImageTag: 0.1.10
   dockerRepository: airbyte/destination-iceberg-v2
   githubIssueLabel: destination-iceberg-v2
   icon: s3.svg

--- a/airbyte-integrations/connectors/destination-iceberg-v2/src/main/kotlin/io/airbyte/integrations/destination/iceberg/v2/io/IcebergTableCleaner.kt
+++ b/airbyte-integrations/connectors/destination-iceberg-v2/src/main/kotlin/io/airbyte/integrations/destination/iceberg/v2/io/IcebergTableCleaner.kt
@@ -56,9 +56,7 @@ class IcebergTableCleaner(private val icebergUtil: IcebergUtil) {
 
         table.newScan().planFiles().use { tasks ->
             tasks
-                .filter { task ->
-                    genIdsToDelete.any { id -> task.file().location().contains(id) }
-                }
+                .filter { task -> genIdsToDelete.any { id -> task.file().location().contains(id) } }
                 .forEach { task ->
                     table
                         .newDelete()

--- a/airbyte-integrations/connectors/destination-iceberg-v2/src/main/kotlin/io/airbyte/integrations/destination/iceberg/v2/io/IcebergTableCleaner.kt
+++ b/airbyte-integrations/connectors/destination-iceberg-v2/src/main/kotlin/io/airbyte/integrations/destination/iceberg/v2/io/IcebergTableCleaner.kt
@@ -57,13 +57,13 @@ class IcebergTableCleaner(private val icebergUtil: IcebergUtil) {
         table.newScan().planFiles().use { tasks ->
             tasks
                 .filter { task ->
-                    genIdsToDelete.any { id -> task.file().path().toString().contains(id) }
+                    genIdsToDelete.any { id -> task.file().location().toString().contains(id) }
                 }
                 .forEach { task ->
                     table
                         .newDelete()
                         .toBranch(stagingBranchName)
-                        .deleteFile(task.file().path())
+                        .deleteFile(task.file().location())
                         .commit()
                 }
         }

--- a/airbyte-integrations/connectors/destination-iceberg-v2/src/main/kotlin/io/airbyte/integrations/destination/iceberg/v2/io/IcebergTableCleaner.kt
+++ b/airbyte-integrations/connectors/destination-iceberg-v2/src/main/kotlin/io/airbyte/integrations/destination/iceberg/v2/io/IcebergTableCleaner.kt
@@ -57,7 +57,7 @@ class IcebergTableCleaner(private val icebergUtil: IcebergUtil) {
         table.newScan().planFiles().use { tasks ->
             tasks
                 .filter { task ->
-                    genIdsToDelete.any { id -> task.file().location().toString().contains(id) }
+                    genIdsToDelete.any { id -> task.file().location().contains(id) }
                 }
                 .forEach { task ->
                     table

--- a/airbyte-integrations/connectors/destination-iceberg-v2/src/test/kotlin/io/airbyte/integrations/destination/iceberg/v2/io/IcebergTableCleanerTest.kt
+++ b/airbyte-integrations/connectors/destination-iceberg-v2/src/test/kotlin/io/airbyte/integrations/destination/iceberg/v2/io/IcebergTableCleanerTest.kt
@@ -102,11 +102,11 @@ internal class IcebergTableCleanerTest {
         every { tasks.close() } just Runs
         every { table.newScan().planFiles() } returns tasks
 
-        every { fileScanTask.file().location().toString() } returns filePathToDelete
+        every { fileScanTask.file().location() } returns filePathToDelete
 
         val delete = mockk<DeleteFiles>()
         every { table.newDelete().toBranch("staging") } returns delete
-        every { delete.deleteFile(fileScanTask.file().location()) } returns delete
+        every { delete.deleteFile(filePathToDelete) } returns delete
         every { delete.commit() } just Runs
 
         assertDoesNotThrow {
@@ -116,7 +116,7 @@ internal class IcebergTableCleanerTest {
         verify {
             icebergUtil.assertGenerationIdSuffixIsOfValidFormat(generationIdSuffix)
             table.newDelete().toBranch(eq("staging"))
-            delete.deleteFile(fileScanTask.file().location())
+            delete.deleteFile(filePathToDelete)
             delete.commit()
         }
     }

--- a/airbyte-integrations/connectors/destination-iceberg-v2/src/test/kotlin/io/airbyte/integrations/destination/iceberg/v2/io/IcebergTableCleanerTest.kt
+++ b/airbyte-integrations/connectors/destination-iceberg-v2/src/test/kotlin/io/airbyte/integrations/destination/iceberg/v2/io/IcebergTableCleanerTest.kt
@@ -102,11 +102,11 @@ internal class IcebergTableCleanerTest {
         every { tasks.close() } just Runs
         every { table.newScan().planFiles() } returns tasks
 
-        every { fileScanTask.file().path().toString() } returns filePathToDelete
+        every { fileScanTask.file().location().toString() } returns filePathToDelete
 
         val delete = mockk<DeleteFiles>()
         every { table.newDelete().toBranch("staging") } returns delete
-        every { delete.deleteFile(fileScanTask.file().path()) } returns delete
+        every { delete.deleteFile(fileScanTask.file().location()) } returns delete
         every { delete.commit() } just Runs
 
         assertDoesNotThrow {
@@ -116,7 +116,7 @@ internal class IcebergTableCleanerTest {
         verify {
             icebergUtil.assertGenerationIdSuffixIsOfValidFormat(generationIdSuffix)
             table.newDelete().toBranch(eq("staging"))
-            delete.deleteFile(fileScanTask.file().path())
+            delete.deleteFile(fileScanTask.file().location())
             delete.commit()
         }
     }
@@ -138,11 +138,11 @@ internal class IcebergTableCleanerTest {
         every { tasks.close() } just Runs
         every { table.newScan().planFiles() } returns tasks
 
-        every { fileScanTask.file().path().toString() } returns filePathToDelete
+        every { fileScanTask.file().location().toString() } returns filePathToDelete
 
         val delete = mockk<DeleteFiles>()
         every { table.newDelete().toBranch("staging") } returns delete
-        every { delete.deleteFile(fileScanTask.file().path()) } returns delete
+        every { delete.deleteFile(fileScanTask.file().location()) } returns delete
         every { delete.commit() } just Runs
 
         assertDoesNotThrow {


### PR DESCRIPTION
## What
* Update to [latest Iceberg release](https://github.com/apache/iceberg/releases/tag/apache-iceberg-1.7.0)

## How
* Bump CDK to Iceberg 1.7.0
* Bump destination iceberg v2 to Iceberg 1.7.0
* Fix API changes

## Review guide
1. `build.gradle`

This PR has been tested with the in-progress integration tests to prove that it still works against Nessie.

## Can this PR be safely reverted and rolled back?
- [X] YES 💚
- [ ] NO ❌
