### PR TITLE
Docs OSS Quickstart guide revision

### DIFF
--- a/docs/deploying-airbyte/abctl-ec2.md
+++ b/docs/deploying-airbyte/abctl-ec2.md
@@ -1,0 +1,64 @@
+---
+products: oss-community
+---
+
+# Using an EC2 Instance with abctl
+
+<!-- This topic has been preserved from the original Quickstart guide, unchanged. It may be used later in rewritten deployment docs. -->
+
+This guide will assume that you are using the Amazon Linux distribution. However. any distribution that supports a docker engine should work with `abctl`. The launching and connecting to your EC2 Instance is outside the scope of this guide. You can find more information on how to launch and connect to EC2 Instances in the [Get started with Amazon EC2](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EC2_GetStarted.html) documentation from Amazon.
+
+1. Install the docker engine:
+
+```shell
+sudo yum install -y docker
+```
+
+2. Add the ec2-user (or whatever your distros default user) to the docker group:
+
+```shell
+sudo usermod -a -G docker ec2-user
+```
+
+3. Start and optionally enable (start on boot) the docker engine:
+
+```shell
+sudo systemctl start docker
+sudo systemctl enable docker
+```
+
+4. Exit the shell and reconnect to the ec2 instance, an example would look like:
+
+```shell
+exit
+ssh -i ec2-user-key.pem ec2-user@1.2.3.4
+```
+
+5. Download the latest version of abctl and install it in your path:
+
+```shell
+curl -LsfS https://get.airbyte.com | bash -
+```
+
+6. Run the `abctl` command and install Airbyte:
+   :::tip
+   By default, `abctl` only configures an ingress rule for the host `localhost`. In order to ensure that Airbyte can be accessed outside of the EC2 instance, you will need to specify the `--host` flag to the `local install` command, providing the FQDN of the host which is hosting Airbyte. For example, `abctl local install --host airbyte.company.example`.
+   :::
+
+By default, `abctl` will listen on port 8000. If port 8000 is already in used or you require a different port, you can specify this by passing the `--port` flag to the `local install` command. For example, `abctl local install --port 6598`
+
+Ensure the security group configured for the EC2 Instance allows traffic in on the port (8000 by default, or whatever port was passed to `--port`) that you deploy Airbyte on. See the [Control traffic to your AWS resources using security groups](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-security-groups.html) documentation for more information.
+
+```shell
+abctl local install --host [HOSTNAME]
+```
+
+## Running over HTTP
+
+Airbyte suggest that you secure your instance of Airbyte using TLS. Running over plain HTTP allows attackers to see your
+password over clear text. If you understand the risk and would still like to run Airbyte over HTTP, you must set
+Secure Cookies to false. You can do this with `abctl` by passing the `--insecure-cookies` flag to `abctl`:
+
+```shell
+abctl local install --host [HOSTNAME] --insecure-cookies
+```

--- a/docs/deploying-airbyte/migrating-from-docker-compose.md
+++ b/docs/deploying-airbyte/migrating-from-docker-compose.md
@@ -1,0 +1,41 @@
+---
+products: oss-community
+---
+
+# Migrating from Docker Compose
+
+<!-- This topic has been preserved from the original Quickstart guide, unchanged. It may be used later in rewritten deployment docs. -->
+
+:::note
+
+If you're using an external database or secret manager you don't need to run `--migrate` flag.
+You must create the `secrets.yaml` and `values.yaml` and then run `abctl local install --values ./values.yaml --secret ./secrets.yaml`.
+Please check [instructions](integrations/database.md) to setup the external database as example.
+
+:::
+
+If you have data that you would like to migrate from an existing docker compose instance follow the steps below:
+
+1. Make sure that you have stopped the instance running in docker compose, this may require the following command:
+
+```
+docker compose stop
+```
+
+2. Make sure that you have the latest version of abctl by running the following command:
+
+```
+curl -LsfS https://get.airbyte.com | bash -
+```
+
+3. Run abctl with the migrate flag set with the following command:
+
+```
+abctl local install --migrate
+```
+
+:::note
+
+If you're using a version of Airbyte that you've installed with `abctl`, you can find instructions on upgrading your Airbyte installation [here](../operator-guides/upgrading-airbyte.md#upgrading-with-abctl).
+
+:::

--- a/docs/integrations/sources/stripe.md
+++ b/docs/integrations/sources/stripe.md
@@ -127,11 +127,7 @@ The Stripe source connector supports the following streams:
 - [Transactions](https://stripe.com/docs/api/transfers/list) \(Incremental\)
 - [Transfers](https://stripe.com/docs/api/transfers/list) \(Incremental\)
 - [Transfer Reversals](https://stripe.com/docs/api/transfer_reversals/list)
-<<<<<<< HEAD
-- [Usage Records](https://stripe.com/docs/api/usage_records/)
-=======
 - [Usage Records](https://stripe.com/docs/api/usage_records)
->>>>>>> master
 
 ### Entity-Relationship Diagram (ERD)
 <EntityRelationshipDiagram></EntityRelationshipDiagram>

--- a/docs/using-airbyte/getting-started/oss-quickstart.md
+++ b/docs/using-airbyte/getting-started/oss-quickstart.md
@@ -7,247 +7,260 @@ import TabItem from "@theme/TabItem";
 
 # Quickstart
 
-Airbyte Open Source is a reliable and extensible open source data pipeline.
+This quickstart guides you through deploying a local instance of Airbyte Self-Managed Community, Airbyte's open source product. Setup only takes a few minutes, and you can start moving data on our platform immediately.
 
-If you're getting started with Airbyte Cloud, you can skip ahead to moving data by [adding your first source](add-a-source.md).
+## Overview
 
-This quickstart guides you through creating a locally deployed instance of Airbyte in just minutes using `abctl` ([Airbyte Command Line Tool](https://github.com/airbytehq/abctl)). You'll be able to move data with minimal setup while you're exploring what Airbyte can do!
+This quickstart shows you how to:
 
-If you've already set up an Airbyte instance using Docker Compose and want to move to abctl, see the section on [migrating from Docker Compose](#migrating-from-docker-compose-optional).
+- [Install abctl](#install-abctl)
+- [Run Airbyte](#run-airbyte)
+- [Set up authentication](#authentication)
+- [Decide on your next steps](#next-steps)
 
-:::tip
-**When you're ready to put an Airbyte instance into production, you'll want to review our guides on deployment.**
+This is intended for most people who want to manage their own Airbyte instance, but it assumes you have basic knowledge of:
 
-For the best experience, we recommend [Deploying Airbyte on Kubernetes via Helm](../../deploying-airbyte/deploying-airbyte.md).
+- Docker
+- Command-line tools
 
-On a local deployment, Airbyte's default behavior is to store connector secrets in your configured database. These secrets are stored in plain text and are not encrypted. Refer to the [Secret Management documentation](../../deploying-airbyte/integrations/secrets.md) to set up an external secrets manager.
-:::
+If you do not want to self-manage Airbyte, skip this guide. Sign up for an [Airbyte Cloud](https://cloud.airbyte.com/signup) trial and [start syncing data](add-a-source.md) now.
 
-If setting up an Airbyte server does not fit your use case needs (i.e. you're using Jupyter Notebooks or iterating on an early prototype for your project) you may find the [PyAirbyte](../pyairbyte/getting-started.mdx) documentation useful.
+If you want to use Python to move data, our Python library, [PyAirbyte](../pyairbyte/getting-started.mdx), might be the best fit for you. It's a good choice if you're using Jupyter Notebook or iterating on an early prototype for a large data project and don't need to run a server.
 
-## Prerequisites
+## Before you start
 
-- To use `abctl`, you'll need to have **Docker Desktop** installed. See Docker's instructions for installation: [Mac](https://docs.docker.com/desktop/install/mac-install/), [Windows](https://docs.docker.com/desktop/install/windows-install/), [Linux](https://docs.docker.com/desktop/install/linux-install/)
+Before running this quickstart, complete the following prerequisites:
 
-## 1: Install `abctl`
+1. Install Docker Desktop on your machine: [Mac](https://docs.docker.com/desktop/install/mac-install/), [Windows](https://docs.docker.com/desktop/install/windows-install/), [Linux](https://docs.docker.com/desktop/install/linux-install/).
+2. Make sure you have enough computing power (see Suggested resources, below).
 
-The easiest method for installing `abctl` for Mac and Linux users is to use the following command:
+### Suggested resources {#suggested-resources}
 
-```shell
-curl -LsfS https://get.airbyte.com | bash -
-```
+For best performance, run Airbyte on a machine with 4 or more CPUs and at least 8GB of memory. We also support running Airbyte with 2 CPUs and 8GM of memory in low-resource mode. This guide explains how to do both. Follow this [Github discussion](https://github.com/airbytehq/airbyte/discussions/44391) to upvote and track progress toward supporting lower resource environments.
 
-If you would rather install `abctl` yourself, follow the instructions for your operating system:
+## Part 1: Install abctl
 
-<Tabs
-defaultValue="abctl-mac">
+abctl is Airbyte's command-line tool for deploying and managing Airbyte. 
+
+### Install abctl the fast way (Mac, Linux) <!-- I think Windows ships with cURL now - can we use it? -->
+
+1. Open a terminal and run the following command.
+
+    ```shell
+    curl -LsfS https://get.airbyte.com | bash -
+    ```
+
+2. If your terminal asks you to enter your password, do so.
+
+When installation completes, you'll see `abctl install succeeded.`
+
+### Install abctl manually (Mac, Linux, Windows)
+
+To install abctl yourself, follow the instructions for your operating system.
+
+<Tabs defaultValue="abctl-mac">
 <TabItem value="abctl-mac" label="Mac">
 
-We recommend that Mac users use Brew to install the `abctl` command.
+Use [Homebrew](https://brew.sh/) to install abctl.
 
-```bash
-brew tap airbytehq/tap
-brew install abctl
-```
+1. Install Homebrew, if you haven't already.
 
-With Brew, you can keep abctl up to date easily, by running:
+2. Run the following commands after Homebrew is installed.
 
-```bash
-brew upgrade abctl
-```
+    ```bash
+    brew tap airbytehq/tap
+    brew install abctl
+    ```
+
+3. Keep abctl up to date with Homebrew, too.
+
+    ```bash
+    brew upgrade abctl
+    ```
 
 </TabItem>
 <TabItem value="abctl-linux" label="Linux" default>
 
-**1: Download the latest release of `abctl`.**
+1. Verify your processor architecture.
 
-<a class="abctl-download button button--primary" data-architecture="linux-amd64" href="https://github.com/airbytehq/abctl/releases/latest" target="\_blank" style={{ marginRight: '10px' }} download>Latest linux-amd64 Release</a>
-<a class="abctl-download button button--primary" data-architecture="linux-arm64" href="https://github.com/airbytehq/abctl/releases/latest" target="_blank" download>Latest linux-arm64 Release</a>
-<br/>
-<br/>
+    ```bash
+    uname -m
+    ```
 
-:::info
+    If the output is `x86_64`, you'll download the **linux-amd64** release. If the output is `aarch64` or similar, you'll download the **linux-arm64** release.
 
-<details>
-<summary>Be sure to download the file that is compatible with your machine's processor architecture.</summary>
+2. Download the file that is compatible with your machine's processor architecture
 
-You'll see two options: `linux-amd64` and `linux-arm64`
-If you're unsure which one you need, running the following command will help:
+    <a class="abctl-download button button--primary" data-architecture="linux" href="https://github.com/airbytehq/abctl/releases/latest" target="_blank" download>Latest Linux Release</a>
 
-```bash
-uname -m
-```
+3. Extract the archive. This creates a directory named `abctl`, which contains the executable and other needed files.
 
-- If the output is `x86_64`, you have an x86-64 processor.
-- If the output is `aarch64` or something similar, you have an ARM-based processor.
-</details>
+    ```bash
+    tar -xvzf {name-of-file-downloaded.linux-*.tar.gz}
+    ```
 
-:::
+4. Make the extracted executable accessible. This allows you to run `abctl` as a command.
 
-**2: Extract the archive**
+    ```bash
+    chmod +x abctl/abctl
+    ```
 
-This will create a directory named abctl which contains the executable along with other needed files.
+5. Add `abctl` to your PATH. This allows you to run `abctl` from any directory in your terminal.
 
-```bash
-tar -xvzf {name-of-file-downloaded.linux-*.tar.gz}
-```
+    ```bash
+    sudo mv abctl /usr/local/bin
+    ```
 
-**3: Make the extracted executable accessible**
-
-This will allow you to run `abctl` as a command
-
-```bash
-chmod +x abctl/abctl
-```
-
-**4: Add `abctl` to your PATH**
-
-This will allow you to run `abctl` from any directory in your terminal.
-
-```bash
-sudo mv abctl /usr/local/bin
-```
-
-**5: Verify the installation**
+6. Verify the installation. If this command prints the installed version of abctl, you can now use it to manage a local Airbyte instance.
 
 ```bash
 abctl version
 ```
-
-If this command prints the installed version of the Airbyte Command Line Tool, it confirm that you are now ready to manage a local Airbyte instance using `abctl`.
 
 </TabItem>
 <TabItem value="abctl-windows" label="Windows" default>
 
-**1: Download the latest release of `abctl`.**
+1. Verify your processor architecture.
 
-<a class="abctl-download button button--primary" data-architecture="windows-amd64" href="https://github.com/airbytehq/abctl/releases/latest" target="_blank" download>Latest windows-amd64 Release</a>
-<br/>
-<br/>
+    1. Press <kbd><svg xmlns="http://www.w3.org/2000/svg" height="10" width="8.75" viewBox="0 0 448 512"><path d="M0 93.7l183.6-25.3v177.4H0V93.7zm0 324.6l183.6 25.3V268.4H0v149.9zm203.8 28L448 480V268.4H203.8v177.9zm0-380.6v180.1H448V32L203.8 65.7z"/></svg></kbd> + <kbd>I</kbd>.
 
-**2: Extract the archive**
+    2. Click **System** > **About**.
 
-- Right click the zip file you've downloaded and select `Extract All...`, then choose a destination folder.
+    3. Next to **Processor**, if it says `AMD`, you'll download the **windows-amd64** release. If the output is `ARM` or similar, you'll download the **windows-arm64** release.
 
-This creates a folder called abctl containing the abctl executable and other reqired files.
+2. Download the latest release of `abctl`.
 
-**3: Add the executable to your PATH**
+    <a class="abctl-download button button--primary" data-architecture="windows" href="https://github.com/airbytehq/abctl/releases/latest" target="_blank" download>Latest Windows Release</a>
 
-- In the "System Properties" window (you can find this by searching for "enviornment variables" in the Start menu), click the `Environment Variables` button
-- Under System variables, find the path and click to `Edit`
-- Click `New` and add the path to the folder you extracted the abctl files to in the previous step.
-- Click `OK` to save these changes.
+3. Extract the zip file to a destination of your choice. This creates a folder containing the abctl executable and other required files. Copy the filepath because you'll need this in a moment.
 
-**4: Open a new Command Prompt or PowerShell window**
+4. Add the executable to your `Path` environment variable.
 
-This is important because changes to your PATH will only take effect in a newly opened window.
+    1. Click <svg xmlns="http://www.w3.org/2000/svg" height="10" width="8.75" viewBox="0 0 448 512"><path d="M0 93.7l183.6-25.3v177.4H0V93.7zm0 324.6l183.6 25.3V268.4H0v149.9zm203.8 28L448 480V268.4H203.8v177.9zm0-380.6v180.1H448V32L203.8 65.7z"/></svg> **Start** and type `environment`.
 
-**5: Verify the installation**
+    2. Click **Edit the system environment variables**. The System Properties opens.
 
-```bash
-abctl version
-```
+    3. Click **Environment Variables**.
 
-If this command prints the installed version of the Airbyte Command Line Tool, it confirm that you are now ready to manage a local Airbyte instance using `abctl`.
+    4. Find the Path variable and click **Edit**.
+
+    5. Click **New**, then paste the filepath you saved in step 3.
+
+    6. Click **OK**, then click **OK**, then close the System Properties.
+
+5. Open a new Command Prompt or PowerShell window. Changes to your Path variable only take effect in a new Window.
+
+6. Verify abctl is installed correctly. If this command prints the installed version of abctl, you can now use it to manage a local Airbyte instance.
+
+    ```bash
+    abctl version
+    ```
 
 </TabItem>
-
 </Tabs>
 
-:::tip
-For troubleshooting assistance, visit our [deployment troubleshooting guide](../../deploying-airbyte/troubleshoot-deploy).
-:::
+## Part 2: Run Airbyte
 
-## 2: Run Airbyte
+1. Run Docker Desktop.
 
-Ensure that Docker Desktop is up and running. Then, with abctl installed, the following command gets Airbyte running:
+2. Install Airbyte.
 
-:::tip
-By default, `abctl` only configures an ingress rule for the host `localhost`. If you plan to access Airbyte outside of `localhost`, you will need to specify the `--host` flag to the `local install` command, providing the FQDN of the host which is hosting Airbyte. For example, `abctl local install --host airbyte.company.example`.
+    To run Airbyte with on a machine with the recommended resources (4 or more CPUs), use this command:
 
-By specifying the `--host` flag, Airbyte will be accessible to both `localhost` and the FDQN passed to the `--host` flag.
-:::
+    ```bash
+    abctl local install
+    ```
 
-```
-abctl local install
-```
+    <!-- [[[This is good to know but I don't think it's within the scope of this guide.]]]
+    To make Airbyte accessible outside `localhost`, specify the `--host` flag to the local install command, and provide a fully qualified domain name for Airbyte's host.
 
-Your browser may open automatically to the Airbyte Application. If not, access it by visiting [http://localhost:8000](http://localhost:8000).
+    ```bash
+    abctl local install --host airbyte.example.com
+    ``` 
+    -->
 
-You will be asked to enter your email address and an organization name. Your email address will be used to authenticate
-to your instance of Airbyte. You will also need a password, which is randomly generated as part of the install command.
-To get your password run:
+    To run Airbyte in a low-resource environment (fewer than 4 CPUs), specify the `--low-resource-mode` flag to the local install command.
 
-```shell
-abctl local credentials
-```
+    ```bash
+    abctl local install --low-resource-mode
+    ```
 
-Which should output something similar to:
+Installation may take up to 15 minutes depending on your internet connection. When it completes, your Airbyte instance opens in your web browser at [http://localhost:8000](http://localhost:8000).
 
-```shell
-Credentials:
-  Email: user@company.example
-  Password: random_password
-  Client-Id: 03ef466c-5558-4ca5-856b-4960ba7c161b
-  Client-Secret: m2UjnDO4iyBQ3IsRiy5GG3LaZWP6xs9I
-```
+As long as your Docker Desktop daemon is running in the background, use Airbyte by returning to [http://localhost:8000](http://localhost:8000). If you quit Docker Desktop and want to return to Airbyte, start Docker Desktop again. Once your containers are running again, you can access Airbyte normally.
 
-Use the value in the password field to authenticate to your new Airbyte instance.
+## Part 3: Set up authentication
 
-You can set your email and password with the `credentials` command using `abctl`. To set your email you can run:
+To access your Airbyte instance, you need a password.
 
-```shell
-abctl local credentials --email user@company.example
-```
+1. Get your default password.
 
-To set your password you can run:
+    ```bash
+    abctl local credentials
+    ```
 
-```shell
-abctl local credentials --password new_password
-```
+    This outputs something like this:
 
-If you wish to configure authentication when install abctl, follow the documentation on the [Authentication Integration](../../deploying-airbyte/integrations/authentication)
-page.
+    ```shell
+    Credentials:
+    Email: user@company.example
+    // highlight-next-line
+    Password: random_password
+    Client-Id: 03ef466c-5558-4ca5-856b-4960ba7c161b
+    Client-Secret: m2UjnDO4iyBQ3IsRiy5GG3LaZWP6xs9I
+    ```
 
-As long as your Docker Desktop daemon is running in the background, you can use Airbyte by returning to [http://localhost:8000](http://localhost:8000).
+    You can use that password to log into Airbyte, but you probably want to use your own email and password.
 
-If you quit Docker Desktop and want to return to your local Airbyte workspace, just start Docker Desktop again. Once Docker finishes restarting, you'll be able to access Airbyte's local installation as normal.
+3. Set an email.
 
-### Suggested Resources
+    ```bash
+    abctl local credentials --email your.name@example.com
+    ```
 
-For the best performance, we suggest you run on a machine with 4 or more CPU's and at least 8 GB of memory. Currently
-`abctl` does support running on 2 cpus and 8 gb of ram with the `--low-resource-mode` flag. You can pass the low
-resource mode flag when install Airbyte with `abctl`:
+4. Set a new password.
 
-```shell
-abctl local install --low-resource-mode
-```
+    ```bash
+    abctl local credentials --password YourStrongPasswordExample
+    ```
 
-Follow this [Github discussion](https://github.com/airbytehq/airbyte/discussions/44391) to upvote and track progress towards supporting lower resource environments.
+Use this email and password to log into Airbyte in the future.
 
-## 3: Move Data
+## What's next
 
-In the Building Connections section, you'll learn how to start moving data. Generally, there are three steps:
+Congratulations! You have a fully-functional instance of Airbyte running locally. Time to take Airbyte for a spin.
 
-1: [Set up a Source](./add-a-source)
+### Move data
 
-2: [Set up a Destination](./add-a-destination.md)
+In Airbyte, you move data from [sources](./add-a-source) to [destinations](./add-a-destination.md). The relationship between sources and destination is called a [connection](./set-up-a-connection.md). Try moving some data on your local instance!
 
-3: [Set up a Connection](./set-up-a-connection.md)
+### Deploy Airbyte
 
-## Customizing your Installation with a Values file
+If you want to scale data movement in your organization, you eventually need to move Airbyte off your local machine. You can use a cloud provider like AWS, Google Cloud, or Azure. You can also use a single node like an AWS EC2 virtual machine. See the [deployment guide](../../deploying-airbyte/) to learn more.
 
-Optionally, you can use a `values.yaml` file to customize your installation of Airbyte. Create the `values.yaml` on your local storage. Then, apply the values you've defined by running the following command and adjusting the path to the `values.yaml` file as needed:
+## Uninstall Airbyte
+
+To stop running all containers, but keep your data:
 
 ```shell
-abctl local install --values ./values.yaml
+abctl local uninstall
 ```
 
-Here's a list of common customizations.
+To stop running containers and delete all data:
 
-- [External Database](../../deploying-airbyte/integrations/database)
-- [State and Logging Storage](../../deploying-airbyte/integrations/storage)
-- [Secret Management](../../deploying-airbyte/integrations/secrets)
+1. Uninstall Airbyte with the `--persisted` flag.
+
+    ```shell
+    abctl local uninstall --persisted
+    ```
+
+2. Clear any remaining information abctl created.
+
+    ```shell
+    rm -rf ~/.airbyte/abctl
+    ```
+
+<!-- [[[this info is probably not required anymore. Preserving here just in case.]]]
 
 ## Migrating from Docker Compose (Optional)
 
@@ -284,6 +297,30 @@ abctl local install --migrate
 If you're using a version of Airbyte that you've installed with `abctl`, you can find instructions on upgrading your Airbyte installation [here](../../operator-guides/upgrading-airbyte.md#upgrading-with-abctl).
 
 :::
+
+-->
+
+
+
+
+
+
+<!-- [[[move to deployment section for now]]]
+
+## Customizing your Installation with a Values file
+
+Optionally, you can use a `values.yaml` file to customize your installation of Airbyte. Create the `values.yaml` on your local storage. Then, apply the values you've defined by running the following command and adjusting the path to the `values.yaml` file as needed:
+
+```shell
+abctl local install --values ./values.yaml
+```
+
+Here's a list of common customizations.
+
+- [External Database](../../deploying-airbyte/integrations/database)
+- [State and Logging Storage](../../deploying-airbyte/integrations/storage)
+- [Secret Management](../../deploying-airbyte/integrations/secrets)
+
 
 ## Using an EC2 Instance with abctl
 
@@ -344,24 +381,5 @@ Secure Cookies to false. You can do this with `abctl` by passing the `--insecure
 abctl local install --host [HOSTNAME] --insecure-cookies
 ```
 
-## Uninstalling
 
-If you want to remove Airbyte from your system, consider which of the following two options you would like to use.
-
-1: Run the following command to stop all running containers that `abctl` has created **while preserving any data you've created**:
-
-```shell
-abctl local uninstall
-```
-
-2: If you want to clear the persistent data in addition to stopping containers, run:
-
-```shell
-abctl local uninstall --persisted
-```
-
-As a last step, to clear out any additional information that `abctl` may have created, you can run:
-
-```shell
-rm -rf ~/.airbyte/abctl
-```
+-->

--- a/docs/using-airbyte/getting-started/oss-quickstart.md
+++ b/docs/using-airbyte/getting-started/oss-quickstart.md
@@ -7,16 +7,16 @@ import TabItem from "@theme/TabItem";
 
 # Quickstart
 
-This quickstart guides you through deploying a local instance of Airbyte Self-Managed Community, Airbyte's open source product. Setup only takes a few minutes, and you can start moving data on our platform immediately.
+This quickstart guides you through deploying a local instance of Airbyte Self-Managed Community, Airbyte's open source product. Setup only takes a few minutes, and you can start moving data immediately.
 
 ## Overview
 
 This quickstart shows you how to:
 
-- [Install abctl](#install-abctl)
-- [Run Airbyte](#run-airbyte)
-- [Set up authentication](#authentication)
-- [Decide on your next steps](#next-steps)
+- [Install abctl](#part-1-install-abctl)
+- [Run Airbyte](#part-2-run-airbyte)
+- [Set up authentication](#part-3-set-up-authentication)
+- [Decide on your next steps](#whats-next)
 
 This is intended for most people who want to manage their own Airbyte instance, but it assumes you have basic knowledge of:
 
@@ -42,7 +42,7 @@ For best performance, run Airbyte on a machine with 4 or more CPUs and at least 
 
 abctl is Airbyte's command-line tool for deploying and managing Airbyte. 
 
-### Install abctl the fast way (Mac, Linux) <!-- I think Windows ships with cURL now - can we use it? -->
+### Install abctl the fast way (Mac, Linux)
 
 1. Open a terminal and run the following command.
 
@@ -185,6 +185,10 @@ abctl version
     abctl local install --low-resource-mode
     ```
 
+    :::note
+    If you see the warning `Encountered an issue deploying Airbyte` with the message `Readiness probe failed: HTTP probe failed with statuscode: 503`, allow installation to continue. You may need to allocate more resources for Airbyte, but installation will complete anyway. See [Suggested resources](#suggested-resources).
+    :::
+
 Installation may take up to 15 minutes depending on your internet connection. When it completes, your Airbyte instance opens in your web browser at [http://localhost:8000](http://localhost:8000).
 
 As long as your Docker Desktop daemon is running in the background, use Airbyte by returning to [http://localhost:8000](http://localhost:8000). If you quit Docker Desktop and want to return to Airbyte, start Docker Desktop again. Once your containers are running again, you can access Airbyte normally.
@@ -228,15 +232,15 @@ Use this email and password to log into Airbyte in the future.
 
 ## What's next
 
-Congratulations! You have a fully-functional instance of Airbyte running locally. Time to take Airbyte for a spin.
+Congratulations! You have a fully functional instance of Airbyte running locally.
 
 ### Move data
 
-In Airbyte, you move data from [sources](./add-a-source) to [destinations](./add-a-destination.md). The relationship between sources and destination is called a [connection](./set-up-a-connection.md). Try moving some data on your local instance!
+In Airbyte, you move data from [sources](./add-a-source) to [destinations](./add-a-destination.md). The relationship between a source and a destination is called a [connection](./set-up-a-connection.md). Try moving some data on your local instance.
 
 ### Deploy Airbyte
 
-If you want to scale data movement in your organization, you eventually need to move Airbyte off your local machine. You can use a cloud provider like AWS, Google Cloud, or Azure. You can also use a single node like an AWS EC2 virtual machine. See the [deployment guide](../../deploying-airbyte/) to learn more.
+If you want to scale data movement in your organization, you probably need to move Airbyte off your local machine. You can deploy to a cloud provider like AWS, Google Cloud, or Azure. You can also use a single node like an AWS EC2 virtual machine. See the [deployment guide](../../deploying-airbyte/) to learn more.
 
 ## Uninstall Airbyte
 
@@ -260,52 +264,7 @@ To stop running containers and delete all data:
     rm -rf ~/.airbyte/abctl
     ```
 
-<!-- [[[this info is probably not required anymore. Preserving here just in case.]]]
-
-## Migrating from Docker Compose (Optional)
-
-:::note
-
-If you're using an external database or secret manager you don't need to run `--migrate` flag.
-You must create the `secrets.yaml` and `values.yaml` and then run `abctl local install --values ./values.yaml --secret ./secrets.yaml`.
-Please check [instructions](../../deploying-airbyte/integrations/database.md) to setup the external database as example.
-
-:::
-
-If you have data that you would like to migrate from an existing docker compose instance follow the steps below:
-
-1. Make sure that you have stopped the instance running in docker compose, this may require the following command:
-
-```
-docker compose stop
-```
-
-2. Make sure that you have the latest version of abctl by running the following command:
-
-```
-curl -LsfS https://get.airbyte.com | bash -
-```
-
-3. Run abctl with the migrate flag set with the following command:
-
-```
-abctl local install --migrate
-```
-
-:::note
-
-If you're using a version of Airbyte that you've installed with `abctl`, you can find instructions on upgrading your Airbyte installation [here](../../operator-guides/upgrading-airbyte.md#upgrading-with-abctl).
-
-:::
-
--->
-
-
-
-
-
-
-<!-- [[[move to deployment section for now]]]
+<!-- --Preserving for posterity but probably not relevant to include in the quick start. May move to deployment section later.--
 
 ## Customizing your Installation with a Values file
 
@@ -320,66 +279,4 @@ Here's a list of common customizations.
 - [External Database](../../deploying-airbyte/integrations/database)
 - [State and Logging Storage](../../deploying-airbyte/integrations/storage)
 - [Secret Management](../../deploying-airbyte/integrations/secrets)
-
-
-## Using an EC2 Instance with abctl
-
-This guide will assume that you are using the Amazon Linux distribution. However. any distribution that supports a docker engine should work with `abctl`. The launching and connecting to your EC2 Instance is outside the scope of this guide. You can find more information on how to launch and connect to EC2 Instances in the [Get started with Amazon EC2](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EC2_GetStarted.html) documentation from Amazon.
-
-1. Install the docker engine:
-
-```shell
-sudo yum install -y docker
-```
-
-2. Add the ec2-user (or whatever your distros default user) to the docker group:
-
-```shell
-sudo usermod -a -G docker ec2-user
-```
-
-3. Start and optionally enable (start on boot) the docker engine:
-
-```shell
-sudo systemctl start docker
-sudo systemctl enable docker
-```
-
-4. Exit the shell and reconnect to the ec2 instance, an example would look like:
-
-```shell
-exit
-ssh -i ec2-user-key.pem ec2-user@1.2.3.4
-```
-
-5. Download the latest version of abctl and install it in your path:
-
-```shell
-curl -LsfS https://get.airbyte.com | bash -
-```
-
-6. Run the `abctl` command and install Airbyte:
-   :::tip
-   By default, `abctl` only configures an ingress rule for the host `localhost`. In order to ensure that Airbyte can be accessed outside of the EC2 instance, you will need to specify the `--host` flag to the `local install` command, providing the FQDN of the host which is hosting Airbyte. For example, `abctl local install --host airbyte.company.example`.
-   :::
-
-By default, `abctl` will listen on port 8000. If port 8000 is already in used or you require a different port, you can specify this by passing the `--port` flag to the `local install` command. For example, `abctl local install --port 6598`
-
-Ensure the security group configured for the EC2 Instance allows traffic in on the port (8000 by default, or whatever port was passed to `--port`) that you deploy Airbyte on. See the [Control traffic to your AWS resources using security groups](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-security-groups.html) documentation for more information.
-
-```shell
-abctl local install --host [HOSTNAME]
-```
-
-### Running over HTTP
-
-Airbyte suggest that you secure your instance of Airbyte using TLS. Running over plain HTTP allows attackers to see your
-password over clear text. If you understand the risk and would still like to run Airbyte over HTTP, you must set
-Secure Cookies to false. You can do this with `abctl` by passing the `--insecure-cookies` flag to `abctl`:
-
-```shell
-abctl local install --host [HOSTNAME] --insecure-cookies
-```
-
-
 -->

--- a/docs/using-airbyte/getting-started/oss-quickstart.md
+++ b/docs/using-airbyte/getting-started/oss-quickstart.md
@@ -4,6 +4,8 @@ products: oss-community
 
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faWindows } from "@fortawesome/free-brands-svg-icons";
 
 # Quickstart
 
@@ -122,7 +124,7 @@ abctl version
 
 1. Verify your processor architecture.
 
-    1. Press <kbd><svg xmlns="http://www.w3.org/2000/svg" height="10" width="8.75" viewBox="0 0 448 512"><path d="M0 93.7l183.6-25.3v177.4H0V93.7zm0 324.6l183.6 25.3V268.4H0v149.9zm203.8 28L448 480V268.4H203.8v177.9zm0-380.6v180.1H448V32L203.8 65.7z"/></svg></kbd> + <kbd>I</kbd>.
+    1. Press <kbd><FontAwesomeIcon icon={faWindows} /> Windows</kbd> + <kbd>I</kbd>.
 
     2. Click **System** > **About**.
 
@@ -136,7 +138,7 @@ abctl version
 
 4. Add the executable to your `Path` environment variable.
 
-    1. Click <svg xmlns="http://www.w3.org/2000/svg" height="10" width="8.75" viewBox="0 0 448 512"><path d="M0 93.7l183.6-25.3v177.4H0V93.7zm0 324.6l183.6 25.3V268.4H0v149.9zm203.8 28L448 480V268.4H203.8v177.9zm0-380.6v180.1H448V32L203.8 65.7z"/></svg> **Start** and type `environment`.
+    1. Click <FontAwesomeIcon icon={faWindows} /> **Start** and type `environment`.
 
     2. Click **Edit the system environment variables**. The System Properties opens.
 

--- a/docs/using-airbyte/getting-started/oss-quickstart.md
+++ b/docs/using-airbyte/getting-started/oss-quickstart.md
@@ -191,9 +191,9 @@ abctl version
     If you see the warning `Encountered an issue deploying Airbyte` with the message `Readiness probe failed: HTTP probe failed with statuscode: 503`, allow installation to continue. You may need to allocate more resources for Airbyte, but installation will complete anyway. See [Suggested resources](#suggested-resources).
     :::
 
-Installation may take up to 15 minutes depending on your internet connection. When it completes, your Airbyte instance opens in your web browser at [http://localhost:8000](http://localhost:8000).
+    Installation may take up to 15 minutes depending on your internet connection. When it completes, your Airbyte instance opens in your web browser at [http://localhost:8000](http://localhost:8000). As long as your Docker Desktop daemon is running in the background, use Airbyte by returning to [http://localhost:8000](http://localhost:8000). If you quit Docker Desktop and want to return to Airbyte, start Docker Desktop again. Once your containers are running, you can access Airbyte normally.
 
-As long as your Docker Desktop daemon is running in the background, use Airbyte by returning to [http://localhost:8000](http://localhost:8000). If you quit Docker Desktop and want to return to Airbyte, start Docker Desktop again. Once your containers are running again, you can access Airbyte normally.
+3. Enter your **Email** and **Organization name**, then click **Get Started**. Airbyte asks you to log in with a password.
 
 ## Part 3: Set up authentication
 
@@ -209,28 +209,22 @@ To access your Airbyte instance, you need a password.
 
     ```shell
     Credentials:
-    Email: user@company.example
+    Email: user@example.com
     // highlight-next-line
     Password: random_password
     Client-Id: 03ef466c-5558-4ca5-856b-4960ba7c161b
     Client-Secret: m2UjnDO4iyBQ3IsRiy5GG3LaZWP6xs9I
     ```
 
-    You can use that password to log into Airbyte, but you probably want to use your own email and password.
+2. Return to your browser and use that password to log into Airbyte.
 
-3. Set an email.
-
-    ```bash
-    abctl local credentials --email your.name@example.com
-    ```
-
-4. Set a new password.
+3. Optional: Since you probably want to set your own password, you can change it any time.
 
     ```bash
     abctl local credentials --password YourStrongPasswordExample
     ```
 
-Use this email and password to log into Airbyte in the future.
+    Your Airbyte server restarts. Once it finishes, use your new password to log into Airbyte again.
 
 ## What's next
 

--- a/docusaurus/docusaurus.config.js
+++ b/docusaurus/docusaurus.config.js
@@ -189,6 +189,7 @@ const config = {
       prism: {
         theme: lightCodeTheme,
         darkTheme: darkCodeTheme,
+        additionalLanguages:['bash'],
       },
     }),
 };

--- a/docusaurus/package.json
+++ b/docusaurus/package.json
@@ -87,6 +87,7 @@
     "@docusaurus/theme-search-algolia": "^3.0.1",
     "@docusaurus/types": "^3.0.1",
     "@fortawesome/fontawesome-svg-core": "^6.5.1",
+    "@fortawesome/free-brands-svg-icons": "^6.7.1",
     "@fortawesome/free-regular-svg-icons": "^6.5.1",
     "@fortawesome/free-solid-svg-icons": "^6.5.1",
     "@fortawesome/react-fontawesome": "^0.2.0",

--- a/docusaurus/pnpm-lock.yaml
+++ b/docusaurus/pnpm-lock.yaml
@@ -230,6 +230,9 @@ importers:
       '@fortawesome/fontawesome-svg-core':
         specifier: ^6.5.1
         version: 6.5.1
+      '@fortawesome/free-brands-svg-icons':
+        specifier: ^6.7.1
+        version: 6.7.1
       '@fortawesome/free-regular-svg-icons':
         specifier: ^6.5.1
         version: 6.5.1
@@ -1458,8 +1461,16 @@ packages:
     resolution: {integrity: sha512-GkWzv+L6d2bI5f/Vk6ikJ9xtl7dfXtoRu3YGE6nq0p/FFqA1ebMOAWg3XgRyb0I6LYyYkiAo+3/KrwuBp8xG7A==}
     engines: {node: '>=6'}
 
+  '@fortawesome/fontawesome-common-types@6.7.1':
+    resolution: {integrity: sha512-gbDz3TwRrIPT3i0cDfujhshnXO9z03IT1UKRIVi/VEjpNHtSBIP2o5XSm+e816FzzCFEzAxPw09Z13n20PaQJQ==}
+    engines: {node: '>=6'}
+
   '@fortawesome/fontawesome-svg-core@6.5.1':
     resolution: {integrity: sha512-MfRCYlQPXoLlpem+egxjfkEuP9UQswTrlCOsknus/NcMoblTH2g0jPrapbcIb04KGA7E2GZxbAccGZfWoYgsrQ==}
+    engines: {node: '>=6'}
+
+  '@fortawesome/free-brands-svg-icons@6.7.1':
+    resolution: {integrity: sha512-nJR76eqPzCnMyhbiGf6X0aclDirZriTPRcFm1YFvuupyJOGwlNF022w3YBqu+yrHRhnKRpzFX+8wJKqiIjWZkA==}
     engines: {node: '>=6'}
 
   '@fortawesome/free-regular-svg-icons@6.5.1':
@@ -7760,9 +7771,15 @@ snapshots:
 
   '@fortawesome/fontawesome-common-types@6.5.1': {}
 
+  '@fortawesome/fontawesome-common-types@6.7.1': {}
+
   '@fortawesome/fontawesome-svg-core@6.5.1':
     dependencies:
       '@fortawesome/fontawesome-common-types': 6.5.1
+
+  '@fortawesome/free-brands-svg-icons@6.7.1':
+    dependencies:
+      '@fortawesome/fontawesome-common-types': 6.7.1
 
   '@fortawesome/free-regular-svg-icons@6.5.1':
     dependencies:

--- a/docusaurus/sidebars.js
+++ b/docusaurus/sidebars.js
@@ -456,6 +456,14 @@ const deployAirbyte = {
       type: "doc",
       id: "deploying-airbyte/troubleshoot-deploy",
     },
+    {
+      type: "doc",
+      id: "deploying-airbyte/migrating-from-docker-compose",
+    },
+    {
+      type: "doc",
+      id: "deploying-airbyte/abctl-ec2",
+    },
   ],
 };
 

--- a/docusaurus/src/css/custom.css
+++ b/docusaurus/src/css/custom.css
@@ -30,6 +30,7 @@
   --ifm-table-head-background: var(--ifm-color-primary);
   --ifm-table-head-color: var(--color-white);
   --ifm-table-border-color: var(--ifm-color-primary-lightest);
+  --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.2);
 
   --color-white: hsl(0, 0%, 100%);
   --color-grey-40: hsl(240, 25%, 98%);
@@ -58,6 +59,7 @@ html[data-theme="dark"] {
   --ifm-color-primary-lightest: #c8c7ff;
   --color-active-nav-item-background: #272729;
   --color-active-nav-item-text: var(--ifm-color-primary-lighter);
+  --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.8);
 
   --ifm-table-background: transparent;
   --ifm-table-stripe-background: transparent;
@@ -78,17 +80,6 @@ html[data-theme="dark"] {
 
   --modal-overlay-background: hsla(236, 11%, 42%, 70%);
   --icon-background: hsl(0, 0%, 100%);
-}
-
-.docusaurus-highlight-code-line {
-  background-color: rgba(0, 0, 0, 0.1);
-  display: block;
-  margin: 0 calc(-1 * var(--ifm-pre-padding));
-  padding: 0 var(--ifm-pre-padding);
-}
-
-html[data-theme="dark"] .docusaurus-highlight-code-line {
-  background-color: rgba(0, 0, 0, 0.3);
 }
 
 .admonition-icon,


### PR DESCRIPTION
## What

A new, Open Source Quickstart guide that is, well, quick.

## How

Rewrites the OSS Quickstart guide. This is a more focused, minimum-steps approach that omits any information that isn't strictly necessary to get Airbyte running. That extra additional information is being temporarily preserved in the deployment guide until that is redone later. It's not meant to exist in its current form indefinitely.

## Review guide

1. /using-airbyte/getting-started/oss-quickstart - this file has been heavily edited and should be reviewed end-to-end.
2. docusaurus/docusaurus.config.js - add syntax highlighting for terminal/bash commands
3. docusaurus/src/css/custom.css - style changes to improve the legibility of highlighted lines of code (highlighted lines were almost unreadable in light mode).

The other changes are not really important. They're just to avoid losing anything someone might need.

## User Impact

The tighter focus around just getting Airbyte running is intended to make the first-touch easier and get people using Airbyte. This should help reduce the many downvotes this topic has received in the past, but probably won't fully achieve this goal in isolation. Later planned changes to the full deployment guide are critical to improving how this content is received.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
