### PR TITLE
(moved to #48804) Adding reader options for Excel: header & skiprows

### DIFF
--- a/airbyte-integrations/connectors/source-file/metadata.yaml
+++ b/airbyte-integrations/connectors/source-file/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: file
   connectorType: source
   definitionId: 778daa7c-feaf-4db6-96f3-70fd645acc77
-  dockerImageTag: 0.5.15
+  dockerImageTag: 0.5.16
   dockerRepository: airbyte/source-file
   documentationUrl: https://docs.airbyte.com/integrations/sources/file
   githubIssueLabel: source-file

--- a/airbyte-integrations/connectors/source-file/pyproject.toml
+++ b/airbyte-integrations/connectors/source-file/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "0.5.15"
+version = "0.5.16"
 name = "source-file"
 description = "Source implementation for File"
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-file/source_file/client.py
+++ b/airbyte-integrations/connectors/source-file/source_file/client.py
@@ -542,7 +542,7 @@ class Client:
                         failure_type=FailureType.config_error,
                     )
                 column_names = data[header]  # Extract the header row
-                data = data[header + 1 :]   # Remove the header row and rows above it
+                data = data[header + 1 :]  # Remove the header row and rows above it
             else:
                 raise AirbyteTracedException(
                     message="Unable to determine column names. Please provide valid reader options.",
@@ -556,7 +556,6 @@ class Client:
                     internal_message="Column names are empty or invalid.",
                     failure_type=FailureType.config_error,
                 )
-
 
             if len(data) == 0:
                 raise AirbyteTracedException(
@@ -574,6 +573,7 @@ class Client:
 
             if chunk:
                 yield pd.DataFrame(chunk)
+
 
 class URLFileSecure(URLFile):
     """Updating of default logic:

--- a/airbyte-integrations/connectors/source-file/unit_tests/test_client.py
+++ b/airbyte-integrations/connectors/source-file/unit_tests/test_client.py
@@ -3,17 +3,17 @@
 #
 
 
+from tempfile import NamedTemporaryFile
 from unittest.mock import patch, sentinel
 
-import pytest
 import pandas as pd
+import pytest
 from airbyte_cdk.utils import AirbyteTracedException
 from pandas import read_csv, read_excel, testing
 from paramiko import SSHException
 from source_file.client import Client, URLFile
 from source_file.utils import backoff_handler
 from urllib3.exceptions import ProtocolError
-from tempfile import NamedTemporaryFile
 
 
 @pytest.fixture

--- a/docs/integrations/sources/file.md
+++ b/docs/integrations/sources/file.md
@@ -298,6 +298,7 @@ In order to read large files from a remote location, this connector uses the [sm
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                 |
 | :------ | :--------- | :------------------------------------------------------- | :------------------------------------------------------------------------------------------------------ |
+| 0.5.16 | 2024-12-04 | [48800](https://github.com/airbytehq/airbyte/pull/48800) | Added reader options: skiprows & header for Excel files |
 | 0.5.15 | 2024-11-05 | [48317](https://github.com/airbytehq/airbyte/pull/48317) | Update dependencies |
 | 0.5.14 | 2024-10-29 | [47115](https://github.com/airbytehq/airbyte/pull/47115) | Update dependencies |
 | 0.5.13 | 2024-10-12 | [45795](https://github.com/airbytehq/airbyte/pull/45795) | Update dependencies |


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->
This PR resolves issues with the `openpyxl_chunk_reader` method in the `source-file` connector to ensure the `reader_options` (`names`, `header`, and `skiprows`) work as expected. We use `openpyxl_chunk_reader`  for excel files to use its lazy loading feature to solve for OOM issues related to large Excel files(https://github.com/airbytehq/airbyte/pull/25575). Due to this, pandas reader options need to be manually implemented. 

Fixes #<Insert-GitHub-Issue-Link> (if applicable).

---

## How
<!--
* Describe how code changes achieve the solution.
-->
- Updated the `openpyxl_chunk_reader` to:
  - Properly handle the `names` option by overriding column names.
  - Correctly use the `header` option to extract and apply the specified row as headers.
  -  Handle the `skiprows` option to skip rows on the Excel file specified by the user.
  - Refactored logic to align with expected behavior while maintaining existing chunking functionality.

---

## Review guide
<!--
1. `x.py`
2. `y.py`
-->
1. **`client.py`**
   - See changes to the `openpyxl_chunk_reader` method.
   - Focus on the handling of `reader_options` and edge case logic.
2. **`unit_tests/test_client.py`**
   - Review the tests for `names`, `header`, and `skiprows`.
   - Check edge case tests.

---

## User Impact
<!--
* What is the end result perceived by the user?
Users should be able to use these reader options for Excel file connectors. 
* If there are negative side effects, please list them. 
-->
### End Result:
- Users can now reliably use `names`, `header`, and `skiprows` options when processing Excel files.
- Meaningful error messages are returned for invalid configurations or insufficient data.

### Negative Side Effects:
- None identified. Changes maintain existing functionality while addressing bugs and improving edge case handling.

---

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [X] YES 💚
- [] NO ❌

