### PR TITLE
Bulk load cdk: support batch groups

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/integrationTest/kotlin/io/airbyte/cdk/load/mock_integration_test/MockDestinationWriter.kt
+++ b/airbyte-cdk/bulk/core/load/src/integrationTest/kotlin/io/airbyte/cdk/load/mock_integration_test/MockDestinationWriter.kt
@@ -28,13 +28,17 @@ class MockDestinationWriter : DestinationWriter {
 }
 
 class MockStreamLoader(override val stream: DestinationStream) : StreamLoader {
-    data class LocalBatch(val records: List<DestinationRecord>) : Batch {
+    abstract class MockBatch : Batch {
+        override val groupId: String? = null
+    }
+
+    data class LocalBatch(val records: List<DestinationRecord>) : MockBatch() {
         override val state = Batch.State.LOCAL
     }
-    data class LocalFileBatch(val file: DestinationFile) : Batch {
+    data class LocalFileBatch(val file: DestinationFile) : MockBatch() {
         override val state = Batch.State.LOCAL
     }
-    data class PersistedBatch(val records: List<DestinationRecord>) : Batch {
+    data class PersistedBatch(val records: List<DestinationRecord>) : MockBatch() {
         override val state = Batch.State.PERSISTED
     }
 

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/DestinationTaskLauncher.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/DestinationTaskLauncher.kt
@@ -246,7 +246,7 @@ class DefaultDestinationTaskLauncher(
                 enqueue(task)
             } else if (streamManager.isBatchProcessingComplete()) {
                 log.info {
-                    "Batch $wrapped complete and batch processing complete: Starting close stream task for ${stream}"
+                    "Batch $wrapped complete and batch processing complete: Starting close stream task for $stream"
                 }
 
                 val task = closeStreamTaskFactory.make(this, stream)

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/state/StreamManagerTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/state/StreamManagerTest.kt
@@ -329,4 +329,91 @@ class StreamManagerTest {
         manager.markEndOfStream()
         Assertions.assertTrue(manager.isBatchProcessingComplete())
     }
+
+    @Test
+    fun `ranges with the same id conflate to latest state`() {
+        val manager = DefaultStreamManager(stream1)
+        val range1 = Range.closed(0L, 9L)
+        val batch1 = BatchEnvelope(SimpleBatch(Batch.State.LOCAL, groupId = "foo"), range1)
+
+        val range2 = Range.closed(10, 19L)
+        val batch2 = BatchEnvelope(SimpleBatch(Batch.State.PERSISTED, groupId = "foo"), range2)
+
+        manager.updateBatchState(batch1)
+        Assertions.assertFalse(manager.areRecordsPersistedUntil(10L), "local < persisted")
+        manager.updateBatchState(batch2)
+        Assertions.assertTrue(manager.areRecordsPersistedUntil(10L), "later state propagates back")
+    }
+
+    @Test
+    fun `ranges with a different id conflate to latest state`() {
+        val manager = DefaultStreamManager(stream1)
+        val range1 = Range.closed(0L, 9L)
+        val batch1 = BatchEnvelope(SimpleBatch(Batch.State.LOCAL, groupId = "foo"), range1)
+
+        val range2 = Range.closed(10, 19L)
+        val batch2 = BatchEnvelope(SimpleBatch(Batch.State.PERSISTED, groupId = "bar"), range2)
+
+        manager.updateBatchState(batch1)
+        Assertions.assertFalse(manager.areRecordsPersistedUntil(10L), "local < persisted")
+        manager.updateBatchState(batch2)
+        Assertions.assertFalse(
+            manager.areRecordsPersistedUntil(10L),
+            "state does not propagate to other ids"
+        )
+    }
+
+    @Test
+    fun `state does not conflate between id and no id`() {
+        val manager = DefaultStreamManager(stream1)
+        val range1 = Range.closed(0L, 9L)
+        val batch1 = BatchEnvelope(SimpleBatch(Batch.State.LOCAL, groupId = null), range1)
+
+        val range2 = Range.closed(10, 19L)
+        val batch2 = BatchEnvelope(SimpleBatch(Batch.State.PERSISTED, groupId = "bar"), range2)
+
+        manager.updateBatchState(batch1)
+        Assertions.assertFalse(manager.areRecordsPersistedUntil(10L), "local < persisted")
+        manager.updateBatchState(batch2)
+        Assertions.assertFalse(
+            manager.areRecordsPersistedUntil(10L),
+            "state does not propagate to null ids"
+        )
+    }
+
+    @Test
+    fun `max of newer and older state is always used`() {
+        val manager = DefaultStreamManager(stream1)
+        val range1 = Range.closed(0L, 9L)
+        val batch1 = BatchEnvelope(SimpleBatch(Batch.State.PERSISTED, groupId = "foo"), range1)
+
+        val range2 = Range.closed(10, 19L)
+        val batch2 = BatchEnvelope(SimpleBatch(Batch.State.LOCAL, groupId = "foo"), range2)
+
+        manager.updateBatchState(batch1)
+        Assertions.assertFalse(manager.areRecordsPersistedUntil(20L), "local < persisted")
+        manager.updateBatchState(batch2)
+        Assertions.assertTrue(
+            manager.areRecordsPersistedUntil(20L),
+            "max of newer and older state is used"
+        )
+    }
+
+    @Test
+    fun `max of older and newer state is always used`() {
+        val manager = DefaultStreamManager(stream1)
+        val range1 = Range.closed(0L, 9L)
+        val batch1 = BatchEnvelope(SimpleBatch(Batch.State.COMPLETE, groupId = "foo"), range1)
+
+        val range2 = Range.closed(10, 19L)
+        val batch2 = BatchEnvelope(SimpleBatch(Batch.State.PERSISTED, groupId = "foo"), range2)
+        manager.markEndOfStream()
+
+        manager.updateBatchState(batch2)
+        manager.updateBatchState(batch1)
+        Assertions.assertTrue(
+            manager.isBatchProcessingComplete(),
+            "max of older and newer state is used"
+        )
+    }
 }

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/DestinationTaskLauncherTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/DestinationTaskLauncherTest.kt
@@ -329,7 +329,7 @@ class DestinationTaskLauncherTest<T> where T : LeveledTask, T : ScopedTask {
         }
     }
 
-    class MockBatch(override val state: Batch.State) : Batch
+    class MockBatch(override val state: Batch.State, override val groupId: String? = null) : Batch
 
     @Singleton
     @Requires(env = ["DestinationTaskLauncherTest"])

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/implementor/ProcessRecordsTaskTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/implementor/ProcessRecordsTaskTest.kt
@@ -59,6 +59,7 @@ class ProcessRecordsTaskTest {
         val reportedByteSize: Long,
         val recordCount: Long,
         val pmChecksum: Long,
+        override val groupId: String? = null
     ) : Batch
 
     class MockStreamLoader : StreamLoader {

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/write/object_storage/ObjectStorageStreamLoaderFactory.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/write/object_storage/ObjectStorageStreamLoaderFactory.kt
@@ -73,7 +73,8 @@ class ObjectStorageStreamLoader<T : RemoteObject<*>, U : OutputStream>(
     data class RemoteObject<T>(
         override val state: Batch.State = Batch.State.COMPLETE,
         val remoteObject: T,
-        val partNumber: Long
+        val partNumber: Long,
+        override val groupId: String? = null
     ) : ObjectStorageBatch
 
     private val partNumber = AtomicLong(0L)

--- a/airbyte-integrations/connectors/destination-s3-v2/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-s3-v2/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: file
   connectorType: destination
   definitionId: d6116991-e809-4c7c-ae09-c64712df5b66
-  dockerImageTag: 0.2.12
+  dockerImageTag: 0.2.13
   dockerRepository: airbyte/destination-s3-v2
   githubIssueLabel: destination-s3-v2
   icon: s3.svg


### PR DESCRIPTION
## What
Batches can have `groupId`s now.

If they have `groupId`, then any time you return a batch with state X and `groupId` Y, it and all previously generated batches with `groupId` Y are set to the most advanced state. (ie, `max of {X, ... [all states w/ groupId Y] }`).

We use the most advanced instead of latest to avoid race conditions. For example, if you were doing a multipart upload, the last upload processed would be the one marked `COMPLETE`. However, there's no guarantee that this will be the last *batch* processed.