### PR TITLE
chore(airbyte-ci): replace/remove final "airbyte_lib" refs

### DIFF
--- a/airbyte-ci/connectors/pipelines/CONTRIBUTING.md
+++ b/airbyte-ci/connectors/pipelines/CONTRIBUTING.md
@@ -301,7 +301,7 @@ def get_test_steps(context: ConnectorContext) -> STEP_TREE:
                 depends_on=[CONNECTOR_TEST_STEP_ID.BUILD],
             ),
             StepToRun(
-                id=CONNECTOR_TEST_STEP_ID.AIRBYTE_LIB_VALIDATION,
+                id=CONNECTOR_TEST_STEP_ID.PYTHON_CLI_VALIDATION,
                 step=PyAirbyteValidation(context),
                 args=lambda results: {"connector_under_test": results[CONNECTOR_TEST_STEP_ID.BUILD].output[LOCAL_BUILD_PLATFORM]},
                 depends_on=[CONNECTOR_TEST_STEP_ID.BUILD],

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/consts.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/consts.py
@@ -14,7 +14,7 @@ class CONNECTOR_TEST_STEP_ID(str, Enum):
     BUILD_TAR = "build_tar"
     BUILD = "build"
     INTEGRATION = "integration"
-    AIRBYTE_LIB_VALIDATION = "airbyte_lib_validation"
+    PYTHON_CLI_VALIDATION = "python_cli_validation"
     QA_CHECKS = "qa_checks"
     UNIT = "unit"
     VERSION_INC_CHECK = "version_inc_check"

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/python_connectors.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/python_connectors.py
@@ -277,7 +277,7 @@ def get_test_steps(context: ConnectorTestContext) -> STEP_TREE:
                 depends_on=[CONNECTOR_TEST_STEP_ID.BUILD],
             ),
             StepToRun(
-                id=CONNECTOR_TEST_STEP_ID.AIRBYTE_LIB_VALIDATION,
+                id=CONNECTOR_TEST_STEP_ID.PYTHON_CLI_VALIDATION,
                 step=PyAirbyteValidation(context),
                 args=lambda results: {"connector_under_test": results[CONNECTOR_TEST_STEP_ID.BUILD].output[LOCAL_BUILD_PLATFORM]},
                 depends_on=[CONNECTOR_TEST_STEP_ID.BUILD],


### PR DESCRIPTION
## What

Follow-on from:

- https://github.com/airbytehq/airbyte/pull/46696

This replaces a few more references that used underscore (airbyte_lib instead of airbyte-lib or AirbyteLib).

## How
<!--
* Describe how code changes achieve the solution.
-->

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
