### PR TITLE
source-datadog contribution from topefolorunso

### DIFF
--- a/airbyte-integrations/connectors/source-datadog/manifest.yaml
+++ b/airbyte-integrations/connectors/source-datadog/manifest.yaml
@@ -1,6 +1,8 @@
-version: 5.7.5
+version: 6.7.2
 
 type: DeclarativeSource
+
+description: removed `is_read_only` attribute from dashboards stream schema
 
 check:
   type: CheckStream
@@ -354,8 +356,8 @@ definitions:
             field_name: page[number]
           page_size_option:
             type: RequestOption
-            inject_into: request_parameter
             field_name: page[size]
+            inject_into: request_parameter
           pagination_strategy:
             type: PageIncrement
             page_size: 100
@@ -368,7 +370,7 @@ definitions:
     url_base: https://api.{{ config['site'] }}/api/
     authenticator:
       type: ApiKeyAuthenticator
-      api_token: '{{ config["api_key"] }}'
+      api_token: "{{ config[\"api_key\"] }}"
       inject_into:
         type: RequestOption
         field_name: DD-API-KEY
@@ -423,10 +425,10 @@ spec:
           syncs.
         order: 3
         title: Start date
+        default: "2023-12-01T00:00:00Z"
         pattern: ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$
         examples:
           - "2022-10-01T00:00:00Z"
-        default: "2023-12-01T00:00:00Z"
       site:
         type: string
         description: The site where Datadog data resides in.
@@ -448,10 +450,10 @@ spec:
           syncs.
         order: 5
         title: End date
+        default: "2024-01-01T00:00:00Z"
         pattern: ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$
         examples:
           - "2022-10-01T00:00:00Z"
-        default: "2024-01-01T00:00:00Z"
       max_records_per_request:
         type: integer
         description: Maximum number of records to collect per request.
@@ -510,82 +512,82 @@ metadata:
     users: false
   testedStreams:
     audit_logs:
+      hasRecords: true
       streamHash: 4938d5b333c624c8f301eac284c5a174d944f466
       hasResponse: true
-      responsesAreSuccessful: true
-      hasRecords: true
-      primaryKeysArePresent: true
       primaryKeysAreUnique: true
+      primaryKeysArePresent: true
+      responsesAreSuccessful: true
     dashboards:
-      streamHash: 277a1ea39fde86d246bc648ae60ff3b8ebd8ec41
-      hasResponse: true
-      responsesAreSuccessful: true
       hasRecords: true
-      primaryKeysArePresent: true
+      streamHash: c52a2f14823902c119c8052cf856e6f3371ea64e
+      hasResponse: true
       primaryKeysAreUnique: true
+      primaryKeysArePresent: true
+      responsesAreSuccessful: true
     downtimes:
+      hasRecords: true
       streamHash: d2cc478d2160b90412e4e9f6745cd3161820d6fb
       hasResponse: true
-      responsesAreSuccessful: true
-      hasRecords: true
-      primaryKeysArePresent: true
       primaryKeysAreUnique: true
+      primaryKeysArePresent: true
+      responsesAreSuccessful: true
     incident_teams:
+      hasRecords: true
       streamHash: 0d8bc56787c599e1011cfab5b7c0e84b2c851557
       hasResponse: true
-      responsesAreSuccessful: true
-      hasRecords: true
-      primaryKeysArePresent: true
       primaryKeysAreUnique: true
+      primaryKeysArePresent: true
+      responsesAreSuccessful: true
     incidents:
+      hasRecords: true
       streamHash: 47cc0e8fd035e7db2846b26520ab729458984f44
       hasResponse: true
-      responsesAreSuccessful: true
-      hasRecords: true
-      primaryKeysArePresent: true
       primaryKeysAreUnique: true
+      primaryKeysArePresent: true
+      responsesAreSuccessful: true
     logs:
-      streamHash: da4ac7b454e4b259796ed3314bad785bd9336e16
-      hasResponse: true
-      responsesAreSuccessful: true
       hasRecords: true
-      primaryKeysArePresent: true
+      streamHash: 7881ffe932a79ee2d6b6a4d9ff6d63d8f25ef4ad
+      hasResponse: true
       primaryKeysAreUnique: true
+      primaryKeysArePresent: true
+      responsesAreSuccessful: true
     metrics:
+      hasRecords: true
       streamHash: f4ec990f551bab54c17838ed70867b1ec35f43e5
       hasResponse: true
-      responsesAreSuccessful: true
-      hasRecords: true
-      primaryKeysArePresent: true
       primaryKeysAreUnique: true
+      primaryKeysArePresent: true
+      responsesAreSuccessful: true
     monitors:
+      hasRecords: true
       streamHash: a062c312b114a0c93de6cf544cb3866a4d740cd0
       hasResponse: true
-      responsesAreSuccessful: true
-      hasRecords: true
-      primaryKeysArePresent: true
       primaryKeysAreUnique: true
+      primaryKeysArePresent: true
+      responsesAreSuccessful: true
     service_level_objectives:
+      hasRecords: true
       streamHash: 7fd5b7991c51fb67325aa0a7ff96577be2a7987d
       hasResponse: true
-      responsesAreSuccessful: true
-      hasRecords: true
-      primaryKeysArePresent: true
       primaryKeysAreUnique: true
+      primaryKeysArePresent: true
+      responsesAreSuccessful: true
     synthetic_tests:
+      hasRecords: true
       streamHash: c81afc074ea369f5ac1d5ee5c73431c3094912d2
       hasResponse: true
-      responsesAreSuccessful: true
-      hasRecords: true
-      primaryKeysArePresent: true
       primaryKeysAreUnique: true
+      primaryKeysArePresent: true
+      responsesAreSuccessful: true
     users:
+      hasRecords: true
       streamHash: b5f9f6ef4f26ab4ba4a9485496e18506c4fb3184
       hasResponse: true
-      responsesAreSuccessful: true
-      hasRecords: true
-      primaryKeysArePresent: true
       primaryKeysAreUnique: true
+      primaryKeysArePresent: true
+      responsesAreSuccessful: true
   assist: {}
 
 schemas:
@@ -681,14 +683,6 @@ schemas:
           - string
           - "null"
         description: Dashboard identifier.
-        readOnly: true
-      is_read_only:
-        type:
-          - boolean
-          - "null"
-        description: >-
-          Whether this dashboard is read-only. If True, only the author and
-          admins can make changes to it.
         readOnly: true
       layout_type:
         type:

--- a/airbyte-integrations/connectors/source-datadog/manifest.yaml
+++ b/airbyte-integrations/connectors/source-datadog/manifest.yaml
@@ -356,8 +356,8 @@ definitions:
             field_name: page[number]
           page_size_option:
             type: RequestOption
-            field_name: page[size]
             inject_into: request_parameter
+            field_name: page[size]
           pagination_strategy:
             type: PageIncrement
             page_size: 100
@@ -370,7 +370,7 @@ definitions:
     url_base: https://api.{{ config['site'] }}/api/
     authenticator:
       type: ApiKeyAuthenticator
-      api_token: "{{ config[\"api_key\"] }}"
+      api_token: '{{ config["api_key"] }}'
       inject_into:
         type: RequestOption
         field_name: DD-API-KEY
@@ -425,10 +425,10 @@ spec:
           syncs.
         order: 3
         title: Start date
-        default: "2023-12-01T00:00:00Z"
         pattern: ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$
         examples:
           - "2022-10-01T00:00:00Z"
+        default: "2023-12-01T00:00:00Z"
       site:
         type: string
         description: The site where Datadog data resides in.
@@ -450,10 +450,10 @@ spec:
           syncs.
         order: 5
         title: End date
-        default: "2024-01-01T00:00:00Z"
         pattern: ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$
         examples:
           - "2022-10-01T00:00:00Z"
+        default: "2024-01-01T00:00:00Z"
       max_records_per_request:
         type: integer
         description: Maximum number of records to collect per request.
@@ -512,82 +512,82 @@ metadata:
     users: false
   testedStreams:
     audit_logs:
-      hasRecords: true
       streamHash: 4938d5b333c624c8f301eac284c5a174d944f466
       hasResponse: true
-      primaryKeysAreUnique: true
-      primaryKeysArePresent: true
       responsesAreSuccessful: true
+      hasRecords: true
+      primaryKeysArePresent: true
+      primaryKeysAreUnique: true
     dashboards:
-      hasRecords: true
-      streamHash: c52a2f14823902c119c8052cf856e6f3371ea64e
+      streamHash: 277a1ea39fde86d246bc648ae60ff3b8ebd8ec41
       hasResponse: true
-      primaryKeysAreUnique: true
-      primaryKeysArePresent: true
       responsesAreSuccessful: true
-    downtimes:
       hasRecords: true
+      primaryKeysArePresent: true
+      primaryKeysAreUnique: true
+    downtimes:
       streamHash: d2cc478d2160b90412e4e9f6745cd3161820d6fb
       hasResponse: true
-      primaryKeysAreUnique: true
-      primaryKeysArePresent: true
       responsesAreSuccessful: true
-    incident_teams:
       hasRecords: true
+      primaryKeysArePresent: true
+      primaryKeysAreUnique: true
+    incident_teams:
       streamHash: 0d8bc56787c599e1011cfab5b7c0e84b2c851557
       hasResponse: true
-      primaryKeysAreUnique: true
-      primaryKeysArePresent: true
       responsesAreSuccessful: true
-    incidents:
       hasRecords: true
+      primaryKeysArePresent: true
+      primaryKeysAreUnique: true
+    incidents:
       streamHash: 47cc0e8fd035e7db2846b26520ab729458984f44
       hasResponse: true
-      primaryKeysAreUnique: true
-      primaryKeysArePresent: true
       responsesAreSuccessful: true
+      hasRecords: true
+      primaryKeysArePresent: true
+      primaryKeysAreUnique: true
     logs:
-      hasRecords: true
-      streamHash: 7881ffe932a79ee2d6b6a4d9ff6d63d8f25ef4ad
+      streamHash: da4ac7b454e4b259796ed3314bad785bd9336e16
       hasResponse: true
-      primaryKeysAreUnique: true
-      primaryKeysArePresent: true
       responsesAreSuccessful: true
-    metrics:
       hasRecords: true
+      primaryKeysArePresent: true
+      primaryKeysAreUnique: true
+    metrics:
       streamHash: f4ec990f551bab54c17838ed70867b1ec35f43e5
       hasResponse: true
-      primaryKeysAreUnique: true
-      primaryKeysArePresent: true
       responsesAreSuccessful: true
-    monitors:
       hasRecords: true
+      primaryKeysArePresent: true
+      primaryKeysAreUnique: true
+    monitors:
       streamHash: a062c312b114a0c93de6cf544cb3866a4d740cd0
       hasResponse: true
-      primaryKeysAreUnique: true
-      primaryKeysArePresent: true
       responsesAreSuccessful: true
-    service_level_objectives:
       hasRecords: true
+      primaryKeysArePresent: true
+      primaryKeysAreUnique: true
+    service_level_objectives:
       streamHash: 7fd5b7991c51fb67325aa0a7ff96577be2a7987d
       hasResponse: true
-      primaryKeysAreUnique: true
-      primaryKeysArePresent: true
       responsesAreSuccessful: true
-    synthetic_tests:
       hasRecords: true
+      primaryKeysArePresent: true
+      primaryKeysAreUnique: true
+    synthetic_tests:
       streamHash: c81afc074ea369f5ac1d5ee5c73431c3094912d2
       hasResponse: true
-      primaryKeysAreUnique: true
-      primaryKeysArePresent: true
       responsesAreSuccessful: true
-    users:
       hasRecords: true
+      primaryKeysArePresent: true
+      primaryKeysAreUnique: true
+    users:
       streamHash: b5f9f6ef4f26ab4ba4a9485496e18506c4fb3184
       hasResponse: true
-      primaryKeysAreUnique: true
-      primaryKeysArePresent: true
       responsesAreSuccessful: true
+      hasRecords: true
+      primaryKeysArePresent: true
+      primaryKeysAreUnique: true
   assist: {}
 
 schemas:

--- a/airbyte-integrations/connectors/source-datadog/manifest.yaml
+++ b/airbyte-integrations/connectors/source-datadog/manifest.yaml
@@ -1,4 +1,4 @@
-version: 6.7.2
+version: 5.16.0
 
 type: DeclarativeSource
 

--- a/airbyte-integrations/connectors/source-datadog/metadata.yaml
+++ b/airbyte-integrations/connectors/source-datadog/metadata.yaml
@@ -1,35 +1,29 @@
+metadataSpecVersion: "1.0"
 data:
   allowedHosts:
     hosts:
-      - datadoghq.com
-      - us3.datadoghq.com
-      - us5.datadoghq.com
-      - datadoghq.eu
-      - ddog-gov.com
-  remoteRegistries:
-    pypi:
-      enabled: false
-      packageName: airbyte-source-datadog
+      - "api."
   registryOverrides:
     oss:
       enabled: true
     cloud:
       enabled: true
-  releases:
-    breakingChanges:
-      1.0.0:
-        message: "Spec and schema are inline now, and default start and end date is setup for incremental sync."
-        upgradeDeadline: "2024-09-18"
+  remoteRegistries:
+    pypi:
+      enabled: false
+      packageName: airbyte-source-datadog
+  connectorBuildOptions:
+    baseImage: docker.io/airbyte/source-declarative-manifest:6.9.0@sha256:bd3e30997f750a68c365f0b5c235324f8a95bbd2a902d827cbf743f9c714b13f
   connectorSubtype: api
   connectorType: source
   definitionId: 1cfc30c7-82db-43f4-9fd7-ac1b42312cda
-  dockerImageTag: 1.1.1
+  dockerImageTag: 0.0.1
   dockerRepository: airbyte/source-datadog
   githubIssueLabel: source-datadog
-  icon: datadog.svg
+  icon: icon.svg
   license: MIT
   name: Datadog
-  releaseDate: 2023-08-27
+  releaseDate: 2024-12-06
   releaseStage: alpha
   supportLevel: community
   documentationUrl: https://docs.airbyte.com/integrations/sources/datadog
@@ -37,20 +31,5 @@ data:
     - language:manifest-only
     - cdk:low-code
   ab_internal:
-    sl: 100
     ql: 100
-  connectorTestSuitesOptions:
-    - suite: liveTests
-      testConnections:
-        - name: datadog_config_dev_null
-          id: 168fe6d6-d7fd-4d8e-8efb-db69857d7daf
-    - suite: acceptanceTests
-      testSecrets:
-        - name: SECRET_SOURCE-DATADOG__CREDS
-          fileName: config.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-  connectorBuildOptions:
-    baseImage: docker.io/airbyte/source-declarative-manifest:5.16.0@sha256:6800f806944ee4fccf24ae01f6b8fbefb12d952c3b3da338f51f732b55de51f2
-metadataSpecVersion: "1.0"
+    sl: 100

--- a/airbyte-integrations/connectors/source-datadog/metadata.yaml
+++ b/airbyte-integrations/connectors/source-datadog/metadata.yaml
@@ -1,29 +1,38 @@
-metadataSpecVersion: "1.0"
 data:
   allowedHosts:
     hosts:
-      - "api."
+      - datadoghq.com
+      - us3.datadoghq.com
+      - us5.datadoghq.com
+      - datadoghq.eu
+      - ddog-gov.com
+  remoteRegistries:
+    pypi:
+      enabled: false
+      packageName: airbyte-source-datadog
   registryOverrides:
     oss:
       enabled: true
     cloud:
       enabled: true
-  remoteRegistries:
-    pypi:
-      enabled: false
-      packageName: airbyte-source-datadog
-  connectorBuildOptions:
-    baseImage: docker.io/airbyte/source-declarative-manifest:6.9.0@sha256:bd3e30997f750a68c365f0b5c235324f8a95bbd2a902d827cbf743f9c714b13f
+  releases:
+    breakingChanges:
+      1.0.0:
+        message: "Spec and schema are inline now, and default start and end date is setup for incremental sync."
+        upgradeDeadline: "2024-09-18"
+      2.0.0:
+        message: "`is_read_only` has been removed from the `dashboards` stream schema. This attribute is deprecated as per API upgrade. See more [here](https://docs.datadoghq.com/dashboards/guide/is-read-only-deprecation/)"
+        upgradeDeadline: "2024-12-13"
   connectorSubtype: api
   connectorType: source
   definitionId: 1cfc30c7-82db-43f4-9fd7-ac1b42312cda
-  dockerImageTag: 0.0.1
+  dockerImageTag: 2.0.0
   dockerRepository: airbyte/source-datadog
   githubIssueLabel: source-datadog
-  icon: icon.svg
+  icon: datadog.svg
   license: MIT
   name: Datadog
-  releaseDate: 2024-12-06
+  releaseDate: 2023-08-27
   releaseStage: alpha
   supportLevel: community
   documentationUrl: https://docs.airbyte.com/integrations/sources/datadog
@@ -31,5 +40,20 @@ data:
     - language:manifest-only
     - cdk:low-code
   ab_internal:
-    ql: 100
     sl: 100
+    ql: 100
+  connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: datadog_config_dev_null
+          id: 168fe6d6-d7fd-4d8e-8efb-db69857d7daf
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-DATADOG__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+  connectorBuildOptions:
+    baseImage: docker.io/airbyte/source-declarative-manifest:5.16.0@sha256:6800f806944ee4fccf24ae01f6b8fbefb12d952c3b3da338f51f732b55de51f2
+metadataSpecVersion: "1.0"

--- a/docs/integrations/sources/datadog-migrations.md
+++ b/docs/integrations/sources/datadog-migrations.md
@@ -3,3 +3,7 @@
 ## Upgrading to 1.0.0
 
 Starting 1.0, Datadog source will apply start and end dates to sync data incrementally. When upgrading, take a minute to set start and end date config options.
+
+## Upgrading to 2.0.0
+
+On December 13, 2024, Datadog is removing support for the `is_read_only` attribute in the Dashboards API’s. Hence, the `is_read_only` attribute will no longer be available in the dashboards stream response. Upgrade and resync to reset the schema and update the records.

--- a/docs/integrations/sources/datadog-migrations.md
+++ b/docs/integrations/sources/datadog-migrations.md
@@ -1,9 +1,10 @@
 # Datadog Migration Guide
 
+## Upgrading to 2.0.0
+
+On December 13, 2024, Datadog is removing support for the `is_read_only` attribute in the Dashboards API’s. Hence, the `is_read_only` attribute will no longer be available in the dashboards stream response. Upgrade and resync to reset the schema and update the records.
+
 ## Upgrading to 1.0.0
 
 Starting 1.0, Datadog source will apply start and end dates to sync data incrementally. When upgrading, take a minute to set start and end date config options.
 
-## Upgrading to 2.0.0
-
-On December 13, 2024, Datadog is removing support for the `is_read_only` attribute in the Dashboards API’s. Hence, the `is_read_only` attribute will no longer be available in the dashboards stream response. Upgrade and resync to reset the schema and update the records.

--- a/docs/integrations/sources/datadog.md
+++ b/docs/integrations/sources/datadog.md
@@ -76,6 +76,7 @@ The Datadog source connector supports the following [sync modes](https://docs.ai
 
 | Version | Date       | Pull Request                                             | Subject                                                                      |
 |:--------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------|
+| 2.0.0 | 2024-12-06 | [48833](https://github.com/airbytehq/airbyte/pull/48833) | Remove `is_read_only` parameter from dashboards stream schema |
 | 1.1.1 | 2024-10-28 | [46502](https://github.com/airbytehq/airbyte/pull/46502) | Update dependencies |
 | 1.1.0 | 2023-10-04 | [46387](https://github.com/airbytehq/airbyte/pull/46387) | Migrate to manifest only |
 | 1.0.6 | 2024-09-28 | [46190](https://github.com/airbytehq/airbyte/pull/46190) | Update dependencies |


### PR DESCRIPTION
## What

This PR updates source Datadog (source-datadog).

The contributor provided the following description of the change:

removed `is_read_only` attribute from dashboards stream schema
## Reviewer checklist
- [ ] Resolve any merge conflicts and validate file diffs (make sure the PR only includes changes intended by the contributor)
- [ ] After reviewing the changes, run the [`bump-version` Airbyte-CI command](https://github.com/airbytehq/airbyte/blob/master/airbyte-ci/connectors/pipelines/README.md#connectors-bump-version-command) locally to update the version of the connector according to the [versioning guidelines](https://docs.airbyte.io/contributor-guide/versioning-guidelines). Add `breakingChanges` to metadata if necessary.
- [ ] Ensure connector docs are up to date with any changes
- [ ] Run `/format-fix` to resolve any formatting errors
- [ ] Click into the CI workflows that wait for a maintainer to run them, which should trigger CI runs

<!-- DO NOT REMOVE: connector-builder-edit-connector-contribution -->
