### PR TITLE
Set fetch size on a jdbc resultset rather than on a statement

### DIFF
--- a/airbyte-cdk/bulk/toolkits/extract-jdbc/src/main/kotlin/io/airbyte/cdk/read/SelectQuerier.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-jdbc/src/main/kotlin/io/airbyte/cdk/read/SelectQuerier.kt
@@ -62,10 +62,7 @@ class JdbcSelectQuerier(
             try {
                 conn = jdbcConnectionFactory.get()
                 stmt = conn!!.prepareStatement(q.sql)
-                parameters.fetchSize?.let { fetchSize: Int ->
-                    log.info { "Setting fetchSize to $fetchSize." }
-                    stmt!!.fetchSize = fetchSize
-                }
+                stmt!!.fetchSize = Int.MIN_VALUE
                 var paramIdx = 1
                 for (binding in q.bindings) {
                     log.info { "Setting parameter #$paramIdx to $binding." }
@@ -73,6 +70,10 @@ class JdbcSelectQuerier(
                     paramIdx++
                 }
                 rs = stmt!!.executeQuery()
+                parameters.fetchSize?.let { fetchSize: Int ->
+                    log.info { "Setting fetchSize to $fetchSize." }
+                    rs!!.fetchSize = fetchSize
+                }
             } catch (e: Throwable) {
                 close()
                 throw e

--- a/airbyte-cdk/bulk/toolkits/extract-jdbc/src/main/kotlin/io/airbyte/cdk/read/SelectQuerier.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-jdbc/src/main/kotlin/io/airbyte/cdk/read/SelectQuerier.kt
@@ -72,7 +72,7 @@ open class JdbcSelectQuerier(
         var hasNext = false
         var hasLoggedResultsReceived = false
 
-        /** Initialize a connection and readies the resultset. */
+        /** Initializes a connection and readies the resultset. */
         open fun initQueryExecution() {
             conn = jdbcConnectionFactory.get()
             stmt = conn!!.prepareStatement(q.sql)

--- a/airbyte-integrations/connectors/source-mysql/build.gradle
+++ b/airbyte-integrations/connectors/source-mysql/build.gradle
@@ -13,7 +13,7 @@ airbyteBulkConnector {
 }
 
 dependencies {
-    implementation 'mysql:mysql-connector-java:8.0.30'
+    implementation 'com.mysql:mysql-connector-j:9.1.0'
     implementation 'org.codehaus.plexus:plexus-utils:4.0.0'
     implementation 'io.debezium:debezium-connector-mysql'
 

--- a/airbyte-integrations/connectors/source-mysql/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mysql/metadata.yaml
@@ -9,7 +9,7 @@ data:
   connectorSubtype: database
   connectorType: source
   definitionId: 435bb9a5-7887-4809-aa58-28c27df0d7ad
-  dockerImageTag: 3.9.0-rc.25
+  dockerImageTag: 3.9.0-rc.26
   dockerRepository: airbyte/source-mysql
   documentationUrl: https://docs.airbyte.com/integrations/sources/mysql
   githubIssueLabel: source-mysql

--- a/airbyte-integrations/connectors/source-mysql/src/main/kotlin/io/airbyte/integrations/source/mysql/MysqlJdbcPartitionFactory.kt
+++ b/airbyte-integrations/connectors/source-mysql/src/main/kotlin/io/airbyte/integrations/source/mysql/MysqlJdbcPartitionFactory.kt
@@ -26,13 +26,13 @@ import io.airbyte.cdk.read.Stream
 import io.airbyte.cdk.read.StreamFeedBootstrap
 import io.airbyte.cdk.util.Jsons
 import io.micronaut.context.annotation.Primary
+import jakarta.inject.Singleton
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import java.time.format.DateTimeFormatterBuilder
 import java.time.temporal.ChronoField
 import java.util.*
 import java.util.concurrent.ConcurrentHashMap
-import javax.inject.Singleton
 
 @Primary
 @Singleton

--- a/airbyte-integrations/connectors/source-mysql/src/main/kotlin/io/airbyte/integrations/source/mysql/MysqlSelectQuerier.kt
+++ b/airbyte-integrations/connectors/source-mysql/src/main/kotlin/io/airbyte/integrations/source/mysql/MysqlSelectQuerier.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.source.mysql
+
+import io.airbyte.cdk.jdbc.JdbcConnectionFactory
+import io.airbyte.cdk.read.JdbcSelectQuerier
+import io.airbyte.cdk.read.SelectQuerier
+import io.airbyte.cdk.read.SelectQuery
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.micronaut.context.annotation.Primary
+import jakarta.inject.Singleton
+
+private val log = KotlinLogging.logger {}
+
+/** Mysql implementation of [JdbcSelectQuerier], which sets fetch size differently */
+@Singleton
+@Primary
+class MysqlSelectQuerier(
+    jdbcConnectionFactory: JdbcConnectionFactory,
+) : JdbcSelectQuerier(jdbcConnectionFactory) {
+    override fun executeQuery(
+        q: SelectQuery,
+        parameters: SelectQuerier.Parameters,
+    ): Result = MysqlResult(jdbcConnectionFactory, q, parameters)
+
+    inner class MysqlResult(
+        jdbcConnectionFactory: JdbcConnectionFactory,
+        q: SelectQuery,
+        parameters: SelectQuerier.Parameters,
+    ) : JdbcSelectQuerier.Result(jdbcConnectionFactory, q, parameters) {
+        /**
+         * Mysql does things differently with fetch size. Setting fetch size on a result set is
+         * safer than on a statement.
+         */
+        override fun initQueryExecution() {
+            conn = jdbcConnectionFactory.get()
+            stmt = conn!!.prepareStatement(q.sql)
+            stmt!!.fetchSize = Int.MIN_VALUE
+            var paramIdx = 1
+            for (binding in q.bindings) {
+                log.info { "Setting parameter #$paramIdx to $binding." }
+                binding.type.set(stmt!!, paramIdx, binding.value)
+                paramIdx++
+            }
+            rs = stmt!!.executeQuery()
+            parameters.fetchSize?.let { fetchSize: Int ->
+                log.info { "Setting fetchSize to $fetchSize." }
+                rs!!.fetchSize = fetchSize
+            }
+        }
+    }
+}


### PR DESCRIPTION
Setting this fetch on a statement caused a query to hang.
The way we set a fetch size in this change is more in line with previous implementation in AdaptiveStreamingQueryConfig