### PR TITLE
✨ Source Recharge: add new stream Bundle Selection

### DIFF
--- a/airbyte-integrations/connectors/source-recharge/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-recharge/acceptance-test-config.yml
@@ -11,6 +11,8 @@ acceptance_tests:
             bypass_reason: "The stream is tested with `Integration Tests`, since no data is available"
           - name: events
             bypass_reason: "The stream is tested with `Integration Tests`, since no data is available"
+          - name: bundle_selections
+            bypass_reason: "The stream is tested with `Integration Tests`, since no data is available"
           - name: shop
             bypass_reason: "The stream is not empty, but the primary key is the entire record, so it is constantly changing"
         expect_records:
@@ -24,6 +26,8 @@ acceptance_tests:
           - name: onetimes
             bypass_reason: "The stream is tested with `Integration Tests`, since no data is available"
           - name: events
+            bypass_reason: "The stream is tested with `Integration Tests`, since no data is available"
+          - name: bundle_selections
             bypass_reason: "The stream is tested with `Integration Tests`, since no data is available"
           - name: shop
             bypass_reason: "The stream is not empty, but the primary key is the entire record, so it is constantly changing"

--- a/airbyte-integrations/connectors/source-recharge/integration_tests/abnormal_state.json
+++ b/airbyte-integrations/connectors/source-recharge/integration_tests/abnormal_state.json
@@ -54,5 +54,12 @@
       "stream_state": { "created_at": "2050-05-18T00:00:00Z" },
       "stream_descriptor": { "name": "events" }
     }
+  },
+  {
+    "type": "STREAM",
+    "stream": {
+      "stream_state": { "updated_at": "2050-05-18T00:00:00Z" },
+      "stream_descriptor": { "name": "bundle_selections" }
+    }
   }
 ]

--- a/airbyte-integrations/connectors/source-recharge/integration_tests/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-recharge/integration_tests/configured_catalog.json
@@ -143,6 +143,19 @@
       },
       "sync_mode": "full_refresh",
       "destination_sync_mode": "overwrite"
+    },
+    {
+      "stream": {
+        "name": "bundle_selections",
+        "json_schema": {},
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "source_defined_cursor": true,
+        "default_cursor_field": ["updated_at"],
+        "source_defined_primary_key": [["id"]]
+      },
+      "sync_mode": "incremental",
+      "destination_sync_mode": "append",
+      "cursor_field": ["updated_at"]
     }
   ]
 }

--- a/airbyte-integrations/connectors/source-recharge/integration_tests/streams_with_output_records_catalog.json
+++ b/airbyte-integrations/connectors/source-recharge/integration_tests/streams_with_output_records_catalog.json
@@ -130,6 +130,19 @@
       },
       "sync_mode": "full_refresh",
       "destination_sync_mode": "overwrite"
+    },
+    {
+      "stream": {
+        "name": "bundle_selections",
+        "json_schema": {},
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "source_defined_cursor": true,
+        "default_cursor_field": ["updated_at"],
+        "source_defined_primary_key": [["id"]]
+      },
+      "sync_mode": "incremental",
+      "destination_sync_mode": "append",
+      "cursor_field": ["updated_at"]
     }
   ]
 }

--- a/airbyte-integrations/connectors/source-recharge/sample_files/sample_state.json
+++ b/airbyte-integrations/connectors/source-recharge/sample_files/sample_state.json
@@ -22,5 +22,8 @@
   },
   "events": {
     "created_at": "2021-04-02T00:00:00"
+  },
+  "bundle_selections": {
+    "updated_at": "2021-04-02T00:00:00"
   }
 }

--- a/airbyte-integrations/connectors/source-recharge/source_recharge/manifest.yaml
+++ b/airbyte-integrations/connectors/source-recharge/source_recharge/manifest.yaml
@@ -280,6 +280,14 @@ definitions:
     $parameters:
       name: "events"
       data_path: "events"
+  # BUNDLE SELECTIONS
+  bundle_selections_stream:
+    description: >-
+      Bundle Selections Stream: https://developer.rechargepayments.com/2021-11/bundle_selections/bundle_selection_list
+    $ref: "#/definitions/base_incremental_stream"
+    $parameters:
+      name: "bundle_selections"
+      data_path: "bundle_selections"
 
 streams:
   - "#/definitions/addresses_stream"
@@ -293,6 +301,7 @@ streams:
   - "#/definitions/shop_stream"
   - "#/definitions/subscriptions_stream"
   - "#/definitions/events_stream"
+  - "#/definitions/bundle_selections_stream"
   # The `orders` stream remains implemented in `streams.py` due to:
   # 1. Inability to resolve `$ref` conditionally
   # 2. Inability to dynamically switch between paginators (diff api versions, require diff pagination approach) (or create the CustomPaginator component)

--- a/airbyte-integrations/connectors/source-recharge/source_recharge/schemas/bundle_selections.json
+++ b/airbyte-integrations/connectors/source-recharge/source_recharge/schemas/bundle_selections.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": ["integer"]
+    },
+    "bundle_variant": {
+      "type": ["integer"]
+    },
+    "purchase_item_id": {
+      "type": ["integer"]
+    },
+    "created_at": {
+      "type": ["string"],
+      "format": "date-time"
+    },
+    "external_product_id": {
+      "type": ["string"]
+    },
+    "external_variant_id": {
+      "type": ["string"]
+    },
+    "items": {
+      "type": ["array"],
+      "items": {
+        "type": ["object"],
+        "properties": {
+          "id": {
+            "type": ["integer"]
+          },
+          "collection_id": {
+            "type": ["string"]
+          },
+          "collection_source": {
+            "type": ["string"]
+          },
+          "created_at": {
+            "type": ["string"],
+            "format": "date-time"
+          },
+          "external_product_id": {
+            "type": ["string"]
+          },
+          "external_variant_id": {
+            "type": ["string"]
+          },
+          "quantity": {
+            "type": ["integer"]
+          },
+          "updated_at": {
+            "type": ["string"],
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "updated_at": {
+      "type": ["string"],
+      "format": "date-time"
+    }
+  }
+}

--- a/airbyte-integrations/connectors/source-recharge/source_recharge/schemas/bundle_selections.json
+++ b/airbyte-integrations/connectors/source-recharge/source_recharge/schemas/bundle_selections.json
@@ -45,6 +45,9 @@
           "external_variant_id": {
             "type": ["string"]
           },
+          "price": {
+            "type": ["string"]
+          },
           "quantity": {
             "type": ["integer"]
           },

--- a/airbyte-integrations/connectors/source-recharge/unit_tests/integration/streams/test_bundle_selections.py
+++ b/airbyte-integrations/connectors/source-recharge/unit_tests/integration/streams/test_bundle_selections.py
@@ -1,0 +1,87 @@
+#
+# Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+#
+
+
+from unittest import TestCase
+
+import freezegun
+from airbyte_cdk.test.mock_http import HttpMocker
+
+from ..config import NOW, START_DATE
+from ..response_builder import NEXT_PAGE_TOKEN, get_stream_record, get_stream_response
+from ..utils import StreamTestCase, config, get_cursor_value_from_state_message, read_full_refresh, read_incremental
+
+_STREAM_NAME = "bundle_selections"
+_CURSOR_FIELD = "updated_at"
+
+
+@freezegun.freeze_time(NOW.isoformat())
+class TestFullRefresh(StreamTestCase):
+    _STREAM_NAME = "bundle_selections"
+
+    @HttpMocker()
+    def test_given_one_page_when_read_then_return_records(self, http_mocker: HttpMocker) -> None:
+        http_mocker.get(
+            self.stream_request().with_limit(250).with_updated_at_min(START_DATE).build(),
+            get_stream_response(_STREAM_NAME).with_record(get_stream_record(_STREAM_NAME, "id", _CURSOR_FIELD)).build(),
+        )
+        output = read_full_refresh(self._config, _STREAM_NAME)
+        assert len(output.records) == 1
+
+    @HttpMocker()
+    def test_given_multiple_pages_when_read_then_return_records(self, http_mocker: HttpMocker) -> None:
+
+        http_mocker.get(
+            self.stream_request().with_limit(250).with_next_page_token(NEXT_PAGE_TOKEN).build(),
+            get_stream_response(_STREAM_NAME).with_record(get_stream_record(_STREAM_NAME, "id", _CURSOR_FIELD)).build(),
+        )
+        http_mocker.get(
+            self.stream_request().with_limit(250).with_updated_at_min(START_DATE).build(),
+            get_stream_response(_STREAM_NAME).with_pagination().with_record(get_stream_record(_STREAM_NAME, "id", _CURSOR_FIELD)).build(),
+        )
+
+        output = read_full_refresh(self._config, _STREAM_NAME)
+        assert len(output.records) == 2
+
+
+@freezegun.freeze_time(NOW.isoformat())
+class TestIncremental(StreamTestCase):
+    _STREAM_NAME = "bundle_selections"
+
+    @HttpMocker()
+    def test_state_message_produced_while_read_and_state_match_latest_record(self, http_mocker: HttpMocker) -> None:
+        min_cursor_value = "2024-01-01T00:00:00+00:00"
+        max_cursor_value = "2024-02-01T00:00:00+00:00"
+
+        http_mocker.get(
+            self.stream_request().with_limit(250).with_updated_at_min(START_DATE).build(),
+            get_stream_response(_STREAM_NAME)
+            .with_record(get_stream_record(_STREAM_NAME, "id", _CURSOR_FIELD).with_cursor(min_cursor_value))
+            .with_record(get_stream_record(_STREAM_NAME, "id", _CURSOR_FIELD).with_cursor(max_cursor_value))
+            .build(),
+        )
+
+        output = read_incremental(self._config, _STREAM_NAME)
+        test_cursor_value = get_cursor_value_from_state_message(output, _CURSOR_FIELD)
+        assert test_cursor_value == max_cursor_value
+
+    @HttpMocker()
+    def test_given_multiple_pages_when_read_then_return_records_with_state(self, http_mocker: HttpMocker) -> None:
+        min_cursor_value = "2024-01-01T00:00:00+00:00"
+        max_cursor_value = "2024-02-01T00:00:00+00:00"
+        http_mocker.get(
+            self.stream_request().with_limit(250).with_next_page_token(NEXT_PAGE_TOKEN).build(),
+            get_stream_response(_STREAM_NAME).with_record(get_stream_record(_STREAM_NAME, "id", _CURSOR_FIELD)).build(),
+        )
+        http_mocker.get(
+            self.stream_request().with_limit(250).with_updated_at_min(START_DATE).build(),
+            get_stream_response(_STREAM_NAME)
+            .with_pagination()
+            .with_record(get_stream_record(_STREAM_NAME, "id", _CURSOR_FIELD).with_cursor(min_cursor_value))
+            .with_record(get_stream_record(_STREAM_NAME, "id", _CURSOR_FIELD).with_cursor(max_cursor_value))
+            .build(),
+        )
+
+        output = read_incremental(self._config, _STREAM_NAME)
+        assert len(output.records) == 3

--- a/airbyte-integrations/connectors/source-recharge/unit_tests/resource/http/response/bundle_selections.json
+++ b/airbyte-integrations/connectors/source-recharge/unit_tests/resource/http/response/bundle_selections.json
@@ -1,0 +1,89 @@
+{
+    "next_cursor": null,
+    "previous_cursor": null,
+    "bundle_selections": [
+    {
+        "id": 1,
+        "bundle_variant_id": 1,
+        "charge_id": null,
+        "order_id": null,
+        "purchase_item_id": 1,
+        "created_at": "2024-12-09T08:11:01+00:00",
+        "external_product_id": "1234567890123",
+        "external_variant_id": "12345",
+        "is_fallback": false,
+        "items": [
+            {
+                "id": 1,
+                "collection_id": "2",
+                "collection_source": "test",
+                "created_at": "2024-12-09T08:11:01+00:00",
+                "external_product_id": "1",
+                "external_variant_id": "2",
+                "price": "10.00",
+                "quantity": 1,
+                "updated_at": "2024-12-09T08:11:01+00:00"
+            },
+            {
+                "id": 2,
+                "collection_id": "2",
+                "collection_source": "test",
+                "created_at": "2024-12-09T08:11:01+00:00",
+                "external_product_id": "7625137913910",
+                "external_variant_id": "42941000745014",
+                "price": "11.00",
+                "quantity": 1,
+                "updated_at": "2024-12-09T08:11:01+00:00"
+            },
+            {
+                "id": 3,
+                "collection_id": "1",
+                "collection_source": "test",
+                "created_at": "2024-12-09T08:11:01+00:00",
+                "external_product_id": "1",
+                "external_variant_id": "2",
+                "price": "12.00",
+                "quantity": 2,
+                "updated_at": "2024-12-09T08:11:01+00:00"
+            },
+            {
+                "id": 4,
+                "collection_id": "3",
+                "collection_source": "test",
+                "created_at": "2024-12-09T08:11:01+00:00",
+                "external_product_id": "4",
+                "external_variant_id": "2",
+                "price": "13.00",
+                "quantity": 2,
+                "updated_at": "2024-12-09T08:11:01+00:00"
+            }
+        ],
+        "updated_at": "2024-12-09T08:11:01+00:00"
+    },
+    {
+        "id": 2,
+        "bundle_variant_id": 3,
+        "charge_id": null,
+        "order_id": null,
+        "purchase_item_id": 4,
+        "created_at": "2024-12-09T08:08:34+00:00",
+        "external_product_id": "1",
+        "external_variant_id": "2",
+        "is_fallback": false,
+        "items": [
+            {
+                "id": 6,
+                "collection_id": "4",
+                "collection_source": "test",
+                "created_at": "2024-12-09T08:08:34+00:00",
+                "external_product_id": "2",
+                "external_variant_id": "5",
+                "price": "14.00",
+                "quantity": 1,
+                "updated_at": "2024-12-09T08:08:34+00:00"
+            }
+        ],
+        "updated_at": "2024-12-09T08:08:34+00:00"
+        }
+    ]
+  }

--- a/airbyte-integrations/connectors/source-recharge/unit_tests/test_streams.py
+++ b/airbyte-integrations/connectors/source-recharge/unit_tests/test_streams.py
@@ -30,7 +30,7 @@ def test_get_auth_header(config) -> None:
 
 def test_streams(config) -> None:
     streams = SourceRecharge().streams(config)
-    assert len(streams) == 12
+    assert len(streams) == 13
 
 
 class TestCommon:


### PR DESCRIPTION
## What

This pull request adds a new Bundle Selections stream to the Recharge source connector, enabling it to retrieve data from Recharge’s API endpoint for Bundle Selections. Since the current Recharge connector does not support an Bundle Selections stream, this update ensures access to Bundle Selections data directly through the connector.

For details on the Bundle Selections documentation and response structure, refer to Recharge's official documentation: https://developer.rechargepayments.com/2021-11/bundle_selections/bundle_selection_list

## How
The structure of this stream is similar to some of the others (`discounts`, `onetimes`), so bundle_selections stream has been implemented the same way.

The version of the connector has not been changed yet to `2.6.0`.

## Review guide
1. `manifest.yaml`
2. `schemas/events.json`
3. `test_events.py`
4. `request_builder.py`
5. `unit_tests/*`
6. `integration tests/*`
7. `acceptance-test-config.yml`

## User Impact
If a user is on the Recharge Pro plan, they’ll be able to retrieve Bundle Selections data.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
