### PR TITLE
live-tests: use mutliple connections returned by the connection retriever

### DIFF
--- a/airbyte-ci/connectors/live-tests/poetry.lock
+++ b/airbyte-ci/connectors/live-tests/poetry.lock
@@ -804,7 +804,7 @@ files = [
 
 [[package]]
 name = "connection-retriever"
-version = "0.7.4"
+version = "1.0.0"
 description = "A tool to retrieve connection information from our Airbyte Cloud config api database"
 optional = false
 python-versions = "^3.10"
@@ -818,7 +818,7 @@ dpath = "^2.1.6"
 google-cloud-iam = "^2.14.3"
 google-cloud-logging = "^3.9.0"
 google-cloud-secret-manager = "^2.18.3"
-inquirer = "^3.2.4"
+inquirer = "^3.4"
 jinja2 = "^3.1.3"
 pandas-gbq = "^0.22.0"
 python-dotenv = "^1.0.1"
@@ -829,8 +829,8 @@ tqdm = "^4.66.2"
 [package.source]
 type = "git"
 url = "git@github.com:airbytehq/airbyte-platform-internal"
-reference = "f7359106b28e5197e45b3c8524c4f72a314805a2"
-resolved_reference = "f7359106b28e5197e45b3c8524c4f72a314805a2"
+reference = "HEAD"
+resolved_reference = "d71a5ae1f1621628f49d88832d7496949b89e1c7"
 subdirectory = "tools/connection-retriever"
 
 [[package]]

--- a/airbyte-ci/connectors/live-tests/pyproject.toml
+++ b/airbyte-ci/connectors/live-tests/pyproject.toml
@@ -29,8 +29,7 @@ pytest = "^8.1.1"
 pydash = "~=7.0.7"
 docker = ">=6,<7"
 asyncclick = "^8.1.7.1"
-# Pinning until we can manage multiple connections returned by the new connection-retriever version
-connection-retriever = {git = "git@github.com:airbytehq/airbyte-platform-internal", subdirectory = "tools/connection-retriever", rev = "f7359106b28e5197e45b3c8524c4f72a314805a2"}
+connection-retriever = {git = "git@github.com:airbytehq/airbyte-platform-internal", subdirectory = "tools/connection-retriever"}
 duckdb = "<=0.10.1"  # Pinned due to this issue https://github.com/duckdb/duckdb/issues/11152
 pandas = "^2.2.1"
 pytest-sugar = "^1.0.0"

--- a/airbyte-ci/connectors/live-tests/src/live_tests/commons/connection_objects_retrieval.py
+++ b/airbyte-ci/connectors/live-tests/src/live_tests/commons/connection_objects_retrieval.py
@@ -2,20 +2,21 @@
 from __future__ import annotations
 
 import json
-import logging
 import os
+import textwrap
 from pathlib import Path
-from typing import Dict, List, Optional, Set
+from typing import Dict, List, Optional, Set, Tuple
 
 import rich
 from connection_retriever import ConnectionObject, retrieve_objects  # type: ignore
-from connection_retriever.errors import NotPermittedError  # type: ignore
+from connection_retriever.retrieval import TestingCandidate, retrieve_testing_candidates
+from live_tests.commons import hacks
 from live_tests.commons.models import ConnectionSubset
 from live_tests.commons.utils import build_connection_url
+from pydantic import ValidationError
 
 from .models import AirbyteCatalog, Command, ConfiguredAirbyteCatalog, ConnectionObjects, SecretDict
 
-LOGGER = logging.getLogger(__name__)
 console = rich.get_console()
 
 
@@ -47,9 +48,9 @@ def parse_configured_catalog(
     if not configured_catalog:
         return None
     if isinstance(configured_catalog, str):
-        catalog = ConfiguredAirbyteCatalog.parse_obj(json.loads(configured_catalog))
-    else:
-        catalog = ConfiguredAirbyteCatalog.parse_obj(configured_catalog)
+        configured_catalog = json.loads(configured_catalog)
+    patched_catalog = hacks.patch_configured_catalog(configured_catalog)
+    catalog = ConfiguredAirbyteCatalog.parse_obj(patched_catalog)
     if selected_streams:
         return ConfiguredAirbyteCatalog(streams=[stream for stream in catalog.streams if stream.stream.name in selected_streams])
     return catalog
@@ -96,12 +97,12 @@ def get_connection_objects(
     custom_configured_catalog_path: Optional[Path],
     custom_state_path: Optional[Path],
     retrieval_reason: Optional[str],
-    fail_if_missing_objects: bool = True,
     connector_image: Optional[str] = None,
     connector_version: Optional[str] = None,
     auto_select_connections: bool = False,
     selected_streams: Optional[set[str]] = None,
     connection_subset: ConnectionSubset = ConnectionSubset.SANDBOXES,
+    max_connections: Optional[int] = None,
 ) -> List[ConnectionObjects]:
     """This function retrieves the connection objects values.
     It checks that the required objects are available and raises a UsageError if they are not.
@@ -121,6 +122,7 @@ def get_connection_objects(
         auto_select_connections (bool, optional): Whether to automatically select connections if no connection id is passed. Defaults to False.
         selected_streams (Optional[Set[str]]): The set of selected streams to use when auto selecting a connection.
         connection_subset (ConnectionSubset): The subset of connections to select from.
+        max_connections (Optional[int]): The maximum number of connections to retrieve.
     Raises:
         click.UsageError: If a required object is missing for the command.
         click.UsageError: If a retrieval reason is missing when passing a connection id.
@@ -143,62 +145,80 @@ def get_connection_objects(
         if not retrieval_reason:
             raise ValueError("A retrieval reason is required to access the connection objects when passing a connection id.")
 
-        connection_object = _get_connection_objects_from_retrieved_objects(
+        connection_objects = _get_connection_objects_from_retrieved_objects(
             requested_objects,
             retrieval_reason=retrieval_reason,
             source_docker_repository=connector_image,
             source_docker_image_tag=connector_version,
-            prompt_for_connection_selection=False,
             selected_streams=selected_streams,
             connection_id=connection_id,
             custom_config=custom_config,
             custom_configured_catalog=custom_configured_catalog,
             custom_state=custom_state,
             connection_subset=connection_subset,
+            max_connections=max_connections,
         )
 
     else:
         if auto_select_connections:
-            connection_object = _get_connection_objects_from_retrieved_objects(
+
+            connection_objects = _get_connection_objects_from_retrieved_objects(
                 requested_objects,
                 retrieval_reason=retrieval_reason,
                 source_docker_repository=connector_image,
                 source_docker_image_tag=connector_version,
-                prompt_for_connection_selection=not is_ci,
                 selected_streams=selected_streams,
                 custom_config=custom_config,
                 custom_configured_catalog=custom_configured_catalog,
                 custom_state=custom_state,
                 connection_subset=connection_subset,
+                max_connections=max_connections,
             )
 
         else:
             # We don't make any requests to the connection-retriever; it is expected that config/catalog/state have been provided if needed for the commands being run.
-            connection_object = ConnectionObjects(
-                source_config=custom_config,
-                destination_config=custom_config,
-                catalog=None,
-                configured_catalog=custom_configured_catalog,
-                state=custom_state,
-                workspace_id=None,
-                source_id=None,
-                destination_id=None,
-                connection_id=None,
-                source_docker_image=None,
-            )
+            connection_objects = [
+                ConnectionObjects(
+                    source_config=custom_config,
+                    destination_config=custom_config,
+                    catalog=None,
+                    configured_catalog=custom_configured_catalog,
+                    state=custom_state,
+                    workspace_id=None,
+                    source_id=None,
+                    destination_id=None,
+                    connection_id=None,
+                    source_docker_image=None,
+                )
+            ]
+    if not connection_objects:
+        raise ValueError("No connection objects could be fetched.")
 
-    if fail_if_missing_objects:
-        if not connection_object.source_config and ConnectionObject.SOURCE_CONFIG in requested_objects:
-            raise ValueError("A source config is required to run the command.")
-        if not connection_object.catalog and ConnectionObject.CONFIGURED_CATALOG in requested_objects:
-            raise ValueError("A catalog is required to run the command.")
-        if not connection_object.state and ConnectionObject.STATE in requested_objects:
-            raise ValueError("A state is required to run the command.")
-    # TODO: remove this once the connection-retriever is updated to return multiple connection objects
-    all_connection_objects = [connection_object]
-    all_connection_ids = [connection_object.connection_id for connection_object in all_connection_objects]
+    all_connection_ids = [connection_object.connection_id for connection_object in connection_objects]
     assert len(set(all_connection_ids)) == len(all_connection_ids), "Connection IDs must be unique."
-    return all_connection_objects
+    return connection_objects
+
+
+def _find_best_candidates_subset(candidates: List[TestingCandidate]) -> List[Tuple[TestingCandidate, List[str]]]:
+    """
+    This function reduces the list of candidates to the best subset of candidates.
+    The best subset is the one which maximizes the number of streams tested and minimizes the number of candidates.
+    """
+    candidates_sorted_by_duration = sorted(candidates, key=lambda x: x.last_attempt_duration_in_microseconds)
+
+    tested_streams = set()
+    candidates_and_streams_to_test = []
+
+    for candidate in candidates_sorted_by_duration:
+        candidate_streams_to_test = []
+        for stream in candidate.streams_with_data:
+            # The candidate is selected if one of its streams has not been tested yet
+            if stream not in tested_streams:
+                candidate_streams_to_test.append(stream)
+                tested_streams.add(stream)
+        if candidate_streams_to_test:
+            candidates_and_streams_to_test.append((candidate, candidate_streams_to_test))
+    return candidates_and_streams_to_test
 
 
 def _get_connection_objects_from_retrieved_objects(
@@ -206,56 +226,93 @@ def _get_connection_objects_from_retrieved_objects(
     retrieval_reason: str,
     source_docker_repository: str,
     source_docker_image_tag: str,
-    prompt_for_connection_selection: bool,
     selected_streams: Optional[Set[str]],
     connection_id: Optional[str] = None,
     custom_config: Optional[Dict] = None,
     custom_configured_catalog: Optional[ConfiguredAirbyteCatalog] = None,
     custom_state: Optional[Dict] = None,
     connection_subset: ConnectionSubset = ConnectionSubset.SANDBOXES,
+    max_connections: Optional[int] = None,
 ):
-    LOGGER.info("Retrieving connection objects from the database...")
-    connection_id, retrieved_objects = retrieve_objects(
-        requested_objects,
-        retrieval_reason=retrieval_reason,
-        source_docker_repository=source_docker_repository,
-        source_docker_image_tag=source_docker_image_tag,
-        prompt_for_connection_selection=prompt_for_connection_selection,
-        with_streams=selected_streams,
-        connection_id=connection_id,
-        connection_subset=connection_subset,
+    console.log(
+        textwrap.dedent(
+            """
+        Retrieving connection objects from the database. 
+        We will build a subset of candidates to test. 
+        This subset should minimize the number of candidates and sync duration while maximizing the number of streams tested. 
+        We patch configured catalogs to only test streams once.
+        If the max_connections parameter is set, we will only keep the top connections with the most streams to test.
+        """
+        )
     )
-
-    retrieved_source_config = parse_config(retrieved_objects.get(ConnectionObject.SOURCE_CONFIG))
-    retrieved_destination_config = parse_config(retrieved_objects.get(ConnectionObject.DESTINATION_CONFIG))
-    retrieved_catalog = parse_catalog(retrieved_objects.get(ConnectionObject.CATALOG))
-    retrieved_configured_catalog = parse_configured_catalog(retrieved_objects.get(ConnectionObject.CONFIGURED_CATALOG), selected_streams)
-    retrieved_state = parse_state(retrieved_objects.get(ConnectionObject.STATE))
-
-    retrieved_source_docker_image = retrieved_objects.get(ConnectionObject.SOURCE_DOCKER_IMAGE)
-    connection_url = build_connection_url(retrieved_objects.get(ConnectionObject.WORKSPACE_ID), connection_id)
-    if retrieved_source_docker_image is None:
-        raise InvalidConnectionError(
-            f"No docker image was found for connection ID {connection_id}. Please double check that the latest job run used version {source_docker_image_tag}. Connection URL: {connection_url}"
+    try:
+        candidates = retrieve_testing_candidates(
+            source_docker_repository=source_docker_repository,
+            source_docker_image_tag=source_docker_image_tag,
+            with_streams=selected_streams,
+            connection_subset=connection_subset,
         )
-    elif retrieved_source_docker_image.split(":")[0] != source_docker_repository:
+    except IndexError:
         raise InvalidConnectionError(
-            f"The provided docker image ({source_docker_repository}) does not match the image for connection ID {connection_id}. Please double check that this connection is using the correct image. Connection URL: {connection_url}"
+            f"No candidates were found for the provided source docker image ({source_docker_repository}:{source_docker_image_tag})."
         )
-    elif retrieved_source_docker_image.split(":")[1] != source_docker_image_tag:
-        raise InvalidConnectionError(
-            f"The provided docker image tag ({source_docker_image_tag}) does not match the image tag for connection ID {connection_id}. Please double check that this connection is using the correct image tag and the latest job ran using this version. Connection URL: {connection_url}"
-        )
+    # If the connection_id is provided, we filter the candidates to only keep the ones with the same connection_id
+    if connection_id:
+        candidates = [candidate for candidate in candidates if candidate.connection_id == connection_id]
 
-    return ConnectionObjects(
-        source_config=custom_config if custom_config else retrieved_source_config,
-        destination_config=custom_config if custom_config else retrieved_destination_config,
-        catalog=retrieved_catalog,
-        configured_catalog=custom_configured_catalog if custom_configured_catalog else retrieved_configured_catalog,
-        state=custom_state if custom_state else retrieved_state,
-        workspace_id=retrieved_objects.get(ConnectionObject.WORKSPACE_ID),
-        source_id=retrieved_objects.get(ConnectionObject.SOURCE_ID),
-        destination_id=retrieved_objects.get(ConnectionObject.DESTINATION_ID),
-        source_docker_image=retrieved_source_docker_image,
-        connection_id=connection_id,
-    )
+    candidates_and_streams_to_test = _find_best_candidates_subset(candidates)
+    candidates_and_streams_to_test = sorted(candidates_and_streams_to_test, key=lambda x: len(x[1]), reverse=True)
+    if max_connections:
+        candidates_and_streams_to_test = candidates_and_streams_to_test[:max_connections]
+
+    number_of_streams_tested = sum([len(streams_to_test) for _, streams_to_test in candidates_and_streams_to_test])
+    console.log(f"Selected {len(candidates_and_streams_to_test)} candidates to test {number_of_streams_tested} streams.")
+
+    all_connection_objects = []
+    for candidate, streams_to_test in candidates_and_streams_to_test:
+
+        retrieved_objects = retrieve_objects(
+            requested_objects,
+            retrieval_reason=retrieval_reason,
+            source_docker_repository=source_docker_repository,
+            source_docker_image_tag=source_docker_image_tag,
+            connection_id=candidate.connection_id,
+            connection_subset=connection_subset,
+        )
+        retrieved_objects = retrieved_objects[0]
+        retrieved_source_config = parse_config(retrieved_objects.source_config)
+        retrieved_destination_config = parse_config(retrieved_objects.destination_config)
+        retrieved_catalog = parse_catalog(retrieved_objects.catalog)
+        retrieved_configured_catalog = parse_configured_catalog(retrieved_objects.configured_catalog, streams_to_test)
+        retrieved_state = parse_state(retrieved_objects.state)
+
+        retrieved_source_docker_image = retrieved_objects.source_docker_image
+        connection_url = build_connection_url(retrieved_objects.workspace_id, retrieved_objects.connection_id)
+        if retrieved_source_docker_image is None:
+            raise InvalidConnectionError(
+                f"No docker image was found for connection ID {retrieved_objects.connection_id}. Please double check that the latest job run used version {source_docker_image_tag}. Connection URL: {connection_url}"
+            )
+        elif retrieved_source_docker_image.split(":")[0] != source_docker_repository:
+            raise InvalidConnectionError(
+                f"The provided docker image ({source_docker_repository}) does not match the image for connection ID {retrieved_objects.connection_id}. Please double check that this connection is using the correct image. Connection URL: {connection_url}"
+            )
+        elif retrieved_source_docker_image.split(":")[1] != source_docker_image_tag:
+            raise InvalidConnectionError(
+                f"The provided docker image tag ({source_docker_image_tag}) does not match the image tag for connection ID {retrieved_objects.connection_id}. Please double check that this connection is using the correct image tag and the latest job ran using this version. Connection URL: {connection_url}"
+            )
+
+        all_connection_objects.append(
+            ConnectionObjects(
+                source_config=custom_config if custom_config else retrieved_source_config,
+                destination_config=custom_config if custom_config else retrieved_destination_config,
+                catalog=retrieved_catalog,
+                configured_catalog=custom_configured_catalog if custom_configured_catalog else retrieved_configured_catalog,
+                state=custom_state if custom_state else retrieved_state,
+                workspace_id=retrieved_objects.workspace_id,
+                source_id=retrieved_objects.source_id,
+                destination_id=retrieved_objects.destination_id,
+                source_docker_image=retrieved_source_docker_image,
+                connection_id=retrieved_objects.connection_id,
+            )
+        )
+    return all_connection_objects

--- a/airbyte-ci/connectors/live-tests/src/live_tests/commons/hacks.py
+++ b/airbyte-ci/connectors/live-tests/src/live_tests/commons/hacks.py
@@ -1,0 +1,23 @@
+# Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+
+import copy
+
+import rich
+
+console = rich.get_console()
+
+
+def patch_configured_catalog(configured_catalog: dict) -> dict:
+    """
+    The configured catalog extracted from the platform can be incompatible with the airbyte-protocol.
+    This leads to validation error when we serialize the configured catalog into a ConfiguredAirbyteCatalog object.
+    This functions is a best effort to patch the configured catalog to make it compatible with the airbyte-protocol.
+    """
+    patched_catalog = copy.deepcopy(configured_catalog)
+    for stream in patched_catalog["streams"]:
+        if stream.get("destination_sync_mode") == "overwrite_dedup":
+            stream["destination_sync_mode"] = "overwrite"
+            console.log(
+                f"Stream {stream['stream']['name']} destination_sync_mode has been patched from 'overwrite_dedup' to 'overwrite' to guarantee compatibility with the airbyte-protocol."
+            )
+    return patched_catalog

--- a/airbyte-ci/connectors/live-tests/src/live_tests/commons/proxy.py
+++ b/airbyte-ci/connectors/live-tests/src/live_tests/commons/proxy.py
@@ -8,6 +8,7 @@ import dagger
 
 from . import mitm_addons
 
+
 class Proxy:
     """
     This class is a wrapper around a mitmproxy container. It allows to declare a mitmproxy container,
@@ -45,18 +46,16 @@ class Proxy:
         return self.dagger_client.cache_volume(self.MITMPROXY_IMAGE)
 
     def generate_mitmconfig(self):
-         return (
-             self.dagger_client.container()
-             .from_(self.MITMPROXY_IMAGE)
+        return (
+            self.dagger_client.container()
+            .from_(self.MITMPROXY_IMAGE)
             # Mitmproxy generates its self signed certs at first run, we need to run it once to generate the certs
             # They are stored in /root/.mitmproxy
-             .with_exec(["timeout", "--preserve-status", "1" , "mitmdump"])
-             .directory("/root/.mitmproxy")
-            )
-    
-    async def get_container(
-        self, mitm_config: dagger.Directory
-    ) -> dagger.Container:
+            .with_exec(["timeout", "--preserve-status", "1", "mitmdump"])
+            .directory("/root/.mitmproxy")
+        )
+
+    async def get_container(self, mitm_config: dagger.Directory) -> dagger.Container:
         """Get a container for the mitmproxy service.
         If a stream for server replay is provided, it will be used to replay requests to the same URL.
 
@@ -134,11 +133,10 @@ class Proxy:
         requests_cert_path = f"/usr/local/lib/python{python_version_minor_only}/site-packages/certifi/cacert.pem"
         current_user = (await container.with_exec(["whoami"]).stdout()).strip()
         try:
-            return  await (
-                container
-                .with_user("root")
+            return await (
+                container.with_user("root")
                 # Overwrite the requests cert file with the mitmproxy self-signed certificate
-                .with_file(requests_cert_path, pem, owner=current_user)   
+                .with_file(requests_cert_path, pem, owner=current_user)
                 .with_env_variable("http_proxy", f"{self.hostname}:{self.PROXY_PORT}")
                 .with_env_variable("https_proxy", f"{self.hostname}:{self.PROXY_PORT}")
                 .with_user(current_user)

--- a/airbyte-ci/connectors/live-tests/src/live_tests/commons/proxy.py
+++ b/airbyte-ci/connectors/live-tests/src/live_tests/commons/proxy.py
@@ -8,7 +8,6 @@ import dagger
 
 from . import mitm_addons
 
-
 class Proxy:
     """
     This class is a wrapper around a mitmproxy container. It allows to declare a mitmproxy container,
@@ -45,29 +44,40 @@ class Proxy:
     def mitmproxy_dir_cache(self) -> dagger.CacheVolume:
         return self.dagger_client.cache_volume(self.MITMPROXY_IMAGE)
 
+    def generate_mitmconfig(self):
+         return (
+             self.dagger_client.container()
+             .from_(self.MITMPROXY_IMAGE)
+            # Mitmproxy generates its self signed certs at first run, we need to run it once to generate the certs
+            # They are stored in /root/.mitmproxy
+             .with_exec(["timeout", "--preserve-status", "1" , "mitmdump"])
+             .directory("/root/.mitmproxy")
+            )
+    
     async def get_container(
-        self,
+        self, mitm_config: dagger.Directory
     ) -> dagger.Container:
         """Get a container for the mitmproxy service.
         If a stream for server replay is provided, it will be used to replay requests to the same URL.
 
         Returns:
             dagger.Container: The container for the mitmproxy service.
+            mitm_config (dagger.Directory): The directory containing the mitmproxy configuration.
         """
         container_addons_path = "/addons.py"
         proxy_container = (
             self.dagger_client.container()
             .from_(self.MITMPROXY_IMAGE)
-            .with_exec(["mkdir", "-p", "/home/mitmproxy/.mitmproxy"])
+            .with_exec(["mkdir", "/dumps"])
             # This is caching the mitmproxy stream files, which can contain sensitive information
             # We want to nuke this cache after test suite execution.
             .with_mounted_cache("/dumps", self.dump_cache_volume)
             # This is caching the mitmproxy self-signed certificate, no sensitive information is stored in it
-            .with_mounted_cache("/home/mitmproxy/.mitmproxy", self.mitmproxy_dir_cache)
             .with_file(
                 container_addons_path,
                 self.dagger_client.host().file(self.MITM_ADDONS_PATH),
             )
+            .with_directory("/root/.mitmproxy", mitm_config)
         )
 
         # If the proxy was instantiated with a stream for server replay from a previous run, we want to use it.
@@ -99,8 +109,8 @@ class Proxy:
 
         return proxy_container.with_exec(command)
 
-    async def get_service(self) -> dagger.Service:
-        return (await self.get_container()).with_exposed_port(self.PROXY_PORT).as_service()
+    async def get_service(self, mitm_config: dagger.Directory) -> dagger.Service:
+        return (await self.get_container(mitm_config)).with_exposed_port(self.PROXY_PORT).as_service()
 
     async def bind_container(self, container: dagger.Container) -> dagger.Container:
         """Bind a container to the proxy service and set environment variables to use the proxy for HTTP(S) traffic.
@@ -111,24 +121,28 @@ class Proxy:
         Returns:
             dagger.Container: The container with the proxy service bound and environment variables set.
         """
-        cert_path_in_volume = "/mitmproxy_dir/mitmproxy-ca.pem"
-        ca_certificate_path = "/usr/local/share/ca-certificates/mitmproxy.crt"
+        mitmconfig_dir = self.generate_mitmconfig()
+        pem = mitmconfig_dir.file("mitmproxy-ca.pem")
 
+        # Find the python version in the container to get the correct path for the requests cert file
+        # We will overwrite this file with the mitmproxy self-signed certificate
+        # I could not find a less brutal way to make Requests trust the mitmproxy self-signed certificate
+        # I tried running update-ca-certificates + setting REQUESTS_CA_BUNDLE in the container but it did not work
         python_version_output = (await container.with_exec(["python", "--version"]).stdout()).strip()
         python_version = python_version_output.split(" ")[-1]
         python_version_minor_only = ".".join(python_version.split(".")[:-1])
         requests_cert_path = f"/usr/local/lib/python{python_version_minor_only}/site-packages/certifi/cacert.pem"
+        current_user = (await container.with_exec(["whoami"]).stdout()).strip()
         try:
-            return await (
-                container.with_service_binding(self.hostname, await self.get_service())
-                .with_mounted_cache("/mitmproxy_dir", self.mitmproxy_dir_cache)
-                .with_exec(["cp", cert_path_in_volume, requests_cert_path])
-                .with_exec(["cp", cert_path_in_volume, ca_certificate_path])
-                # The following command make the container use the proxy for all outgoing HTTP requests
-                .with_env_variable("REQUESTS_CA_BUNDLE", requests_cert_path)
-                .with_exec(["update-ca-certificates"])
+            return  await (
+                container
+                .with_user("root")
+                # Overwrite the requests cert file with the mitmproxy self-signed certificate
+                .with_file(requests_cert_path, pem, owner=current_user)   
                 .with_env_variable("http_proxy", f"{self.hostname}:{self.PROXY_PORT}")
                 .with_env_variable("https_proxy", f"{self.hostname}:{self.PROXY_PORT}")
+                .with_user(current_user)
+                .with_service_binding(self.hostname, await self.get_service(mitmconfig_dir))
             )
         except dagger.DaggerError as e:
             # This is likely hapenning on Java connector images whose certificates location is different

--- a/airbyte-ci/connectors/live-tests/src/live_tests/conftest.py
+++ b/airbyte-ci/connectors/live-tests/src/live_tests/conftest.py
@@ -135,6 +135,7 @@ def pytest_configure(config: Config) -> None:
     private_details_path = test_artifacts_directory / "private_details.html"
     config.stash[stash_keys.TEST_ARTIFACT_DIRECTORY] = test_artifacts_directory
     dagger_log_path.touch()
+    LOGGER.info("Dagger log path: %s", dagger_log_path)
     config.stash[stash_keys.DAGGER_LOG_PATH] = dagger_log_path
     config.stash[stash_keys.PR_URL] = get_option_or_fail(config, "--pr-url")
     _connection_id = config.getoption("--connection-id")
@@ -515,7 +516,10 @@ async def run_command_and_add_to_report(
         duckdb_path,
         runs_in_ci,
     )
-    test_report.add_control_execution_result(execution_result)
+    if connector.target_or_control is TargetOrControl.CONTROL:
+        test_report.add_control_execution_result(execution_result)
+    if connector.target_or_control is TargetOrControl.TARGET:
+        test_report.add_target_execution_result(execution_result)
     return execution_result, proxy
 
 

--- a/airbyte-ci/connectors/live-tests/src/live_tests/stash_keys.py
+++ b/airbyte-ci/connectors/live-tests/src/live_tests/stash_keys.py
@@ -34,3 +34,4 @@ TEST_ARTIFACT_DIRECTORY = pytest.StashKey[Path]()
 USER = pytest.StashKey[str]()
 WORKSPACE_ID = pytest.StashKey[str]()
 TEST_EVALUATION_MODE = pytest.StashKey[TestEvaluationMode]
+MAX_CONNECTIONS = pytest.StashKey[int | None]()


### PR DESCRIPTION
## What
https://github.com/airbytehq/airbyte-platform-internal/pull/14726 updates the connection retriever to return multiple connections for a given source docker image.
This PR updates live tests to:
* Consume the multiple testing candidates returned by the connection retriever
* Build an optimal subset of connection to test: We want to minimize the number of connection to test and the run duration while maximizing the stream coverage.
