### PR TITLE
🐛 Source Amazon Seller Partner: Fix token expiry for syncs > 1 hour

### DIFF
--- a/airbyte-integrations/connectors/source-amazon-seller-partner/source_amazon_seller_partner/auth.py
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/source_amazon_seller_partner/auth.py
@@ -2,12 +2,14 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 #
 
-
-from typing import Any, Mapping
-
+import logging
+import backoff
 import pendulum
+from typing import Any, Mapping, Tuple
 from airbyte_cdk.sources.streams.http.auth import Oauth2Authenticator
+from airbyte_cdk.sources.streams.http.exceptions import DefaultBackoffException
 
+logger = logging.getLogger("airbyte")
 
 class AWSAuthenticator(Oauth2Authenticator):
     def __init__(self, host: str, *args, **kwargs):
@@ -22,3 +24,19 @@ class AWSAuthenticator(Oauth2Authenticator):
             "x-amz-access-token": self.get_access_token(),
             "x-amz-date": pendulum.now("utc").strftime("%Y%m%dT%H%M%SZ"),
         }
+
+    @backoff.on_exception(
+        backoff.expo,
+        DefaultBackoffException,
+        on_backoff=lambda details: logger.info(
+            f"Caught retryable error after {details['tries']} tries. Waiting {details['wait']} seconds then retrying..."
+        ),
+        max_time=300,
+    )
+    def refresh_access_token(self) -> Tuple[str, int]:
+        """
+        returns a tuple of (access_token, token_lifespan_in_seconds). 
+        Add 5 minute buffer to access token refresh. 
+        """
+        access_token, expires_in = super().refresh_access_token()
+        return access_token, (expires_in - 300)

--- a/airbyte-integrations/connectors/source-amazon-seller-partner/source_amazon_seller_partner/auth.py
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/source_amazon_seller_partner/auth.py
@@ -3,13 +3,15 @@
 #
 
 import logging
+from typing import Any, Mapping, Tuple
+
 import backoff
 import pendulum
-from typing import Any, Mapping, Tuple
 from airbyte_cdk.sources.streams.http.auth import Oauth2Authenticator
 from airbyte_cdk.sources.streams.http.exceptions import DefaultBackoffException
 
 logger = logging.getLogger("airbyte")
+
 
 class AWSAuthenticator(Oauth2Authenticator):
     def __init__(self, host: str, *args, **kwargs):
@@ -35,8 +37,8 @@ class AWSAuthenticator(Oauth2Authenticator):
     )
     def refresh_access_token(self) -> Tuple[str, int]:
         """
-        returns a tuple of (access_token, token_lifespan_in_seconds). 
-        Add 5 minute buffer to access token refresh. 
+        returns a tuple of (access_token, token_lifespan_in_seconds).
+        Add 5 minute buffer to access token refresh.
         """
         access_token, expires_in = super().refresh_access_token()
         return access_token, (expires_in - 300)


### PR DESCRIPTION
## What

Fix token expiry with syncs running over 1 hour.  
Issue: https://github.com/airbytehq/airbyte/issues/21656

## How

This issue is manifesting because the retries just use the existing access token. This connector, in my experience, uses _a lot_ of retries with reasonably large backoff periods. I've ran this fix for a couple of weeks and have found that 5 minutes seems to be the sweet spot. It's obviously less than ideal to expire more often than necessary but 5 minutes over the course of an hour isn't all that bad. 

## Review guide
<!--
1. `airbyte-integrations/connectors/source-amazon-seller-partner/source_amazon_seller_partner/auth.py`
-->

## User Impact

There shouldn't be any adverse affects. To summarise: 
- For syncs under 1 hour, this change will make no difference. 
- For syncs that do not experience rate limiting or retries, this change won't make a difference, but access tokens will be refreshed every 55 minutes rather than every 60 minutes. 
- For syncs that experience rate limiting and retries, this change should improve reliability of the connector. 

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
