### PR TITLE
docs(destination-clickhouse): add warn note about connector

### DIFF
--- a/docs/integrations/destinations/clickhouse.md
+++ b/docs/integrations/destinations/clickhouse.md
@@ -3,7 +3,7 @@
 :::warning
 The Clickhouse connector is outdated and does not use Destination v2 (typing and deduplication). 
 As a result, it may not work well with large datasets or could have performance issues. 
-If this connector is critical to your project, please consider upvoting and adding comments to the [discussion]([url](https://github.com/airbytehq/airbyte/discussions/35339)) about transitioning Clickhouse to the Destination v2 format. 
+Subscribe to the [discussion](https://github.com/airbytehq/airbyte/discussions/35339) to receive updates and learn more.
 :::
 
 ## Features

--- a/docs/integrations/destinations/clickhouse.md
+++ b/docs/integrations/destinations/clickhouse.md
@@ -1,12 +1,18 @@
 # ClickHouse
 
+:::warning
+The Clickhouse connector is outdated and does not use Destination v2 (typing and deduplication). 
+As a result, it may not work well with large datasets or could have performance issues. 
+If this connector is critical to your project, please consider upvoting and adding comments to the [discussion]([url](https://github.com/airbytehq/airbyte/discussions/35339)) about transitioning Clickhouse to the Destination v2 format. 
+:::
+
 ## Features
 
 | Feature                        | Supported?\(Yes/No\) | Notes |
 | :----------------------------- | :------------------- | :---- |
 | Full Refresh Sync              | Yes                  |       |
 | Incremental - Append Sync      | Yes                  |       |
-| Incremental - Append + Deduped | Yes                  |       |
+| Incremental - Append + Deduped | No                   |       |
 | Namespaces                     | Yes                  |       |
 
 #### Output Schema


### PR DESCRIPTION
Add a note to the ClickHouse destination connector documentation to inform users about the ongoing discussion to move it to the DV2 format. Also, include a reminder about performance considerations.