### PR TITLE
feat(airbyte-ci) add `--rc` option to airbyte-ci bump-version command

### DIFF
--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -552,7 +552,7 @@ Bump source-openweather:
 
 | Argument          | Description                                                            |
 | ----------------- | ---------------------------------------------------------------------- |
-| `BUMP_TYPE`       | major, minor, patch, or version:<explicit-version>                     |
+| `BUMP_TYPE`       | major, minor, patch, rc, or version:<explicit-version>                 |
 | `CHANGELOG_ENTRY` | The changelog entry that will get added to the connector documentation |
 
 #### Options
@@ -560,6 +560,7 @@ Bump source-openweather:
 | Option      | Description                                                                               |
 | ----------- | ----------------------------------------------------------------------------------------- |
 | --pr-number | Explicitly set the PR number in the changelog entry, a placeholder will be set otherwise. |
+| --rc        | Bump the version by the specified bump type and append the release candidate suffix.      |
 
 ### <a id="connectors-upgrade-cdk"></a>`connectors upgrade-cdk` command
 

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/bump_version/commands.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/bump_version/commands.py
@@ -35,12 +35,14 @@ class BumpType(click.ParamType):
 @click.argument("bump-type", type=BumpType())
 @click.argument("changelog-entry", type=str)
 @click.option("--pr-number", type=int, help="Pull request number.")
+@click.option("--rc", is_flag=True, help="Bumps version number and appends a release candidate suffix")
 @click.pass_context
 async def bump_version(
     ctx: click.Context,
     bump_type: str,
     changelog_entry: str,
     pr_number: int | None,
+    rc: bool,
 ) -> bool:
     """Bump a connector version: update metadata.yaml and changelog."""
 
@@ -80,6 +82,7 @@ async def bump_version(
         ctx.obj["execute_timeout"],
         bump_type,
         changelog_entry,
+        rc,
         pr_number,
     )
 

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/bump_version/commands.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/bump_version/commands.py
@@ -35,7 +35,7 @@ class BumpType(click.ParamType):
 @click.argument("bump-type", type=BumpType())
 @click.argument("changelog-entry", type=str)
 @click.option("--pr-number", type=int, help="Pull request number.")
-@click.option("--rc", is_flag=True, help="Bumps version number and appends a release candidate suffix")
+@click.option("--rc", is_flag=True, help="Bumps version number and appends a release candidate suffix.")
 @click.pass_context
 async def bump_version(
     ctx: click.Context,
@@ -45,6 +45,9 @@ async def bump_version(
     rc: bool,
 ) -> bool:
     """Bump a connector version: update metadata.yaml and changelog."""
+
+    if rc and bump_type == "rc":
+        raise click.BadParameter("The `--rc` flag cannot be used when the specified `bump-type` is `rc`.")
 
     connectors_contexts = [
         ConnectorContext(

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/bump_version/pipeline.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/bump_version/pipeline.py
@@ -62,6 +62,7 @@ async def run_connector_version_bump_pipeline(
     semaphore: "Semaphore",
     bump_type: str,
     changelog_entry: str,
+    rc: bool,
     pull_request_number: str | int | None = None,
 ) -> Report:
     """Run a pipeline to upgrade for a single connector.
@@ -77,7 +78,7 @@ async def run_connector_version_bump_pipeline(
         steps_results = []
         async with context:
             connector_directory = await context.get_connector_dir()
-            bump_version = BumpConnectorVersion(context, connector_directory, bump_type)
+            bump_version = BumpConnectorVersion(context, connector_directory, bump_type, rc)
             bump_version_result = await bump_version.run()
             steps_results.append(bump_version_result)
             if not bump_version_result.success:

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/up_to_date/pipeline.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/up_to_date/pipeline.py
@@ -75,7 +75,6 @@ async def run_connector_up_to_date_pipeline(
     auto_merge: bool = False,
     specific_dependencies: List[str] = [],
     bump_connector_version: bool = True,
-    rc: bool = False,
 ) -> ConnectorReport:
     async with semaphore:
         async with context:
@@ -111,7 +110,7 @@ async def run_connector_up_to_date_pipeline(
             # NOTE:
             # BumpConnectorVersion will already work for manifest-only and Java connectors too
             if bump_connector_version and one_previous_step_is_successful:
-                bump_version = BumpConnectorVersion(context, connector_directory, BUMP_TYPE, rc)
+                bump_version = BumpConnectorVersion(context, connector_directory, BUMP_TYPE)
                 bump_version_result = await bump_version.run()
                 step_results.append(bump_version_result)
                 if bump_version_result.success:

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/up_to_date/pipeline.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/up_to_date/pipeline.py
@@ -75,6 +75,7 @@ async def run_connector_up_to_date_pipeline(
     auto_merge: bool = False,
     specific_dependencies: List[str] = [],
     bump_connector_version: bool = True,
+    rc: bool = False,
 ) -> ConnectorReport:
     async with semaphore:
         async with context:
@@ -110,7 +111,7 @@ async def run_connector_up_to_date_pipeline(
             # NOTE:
             # BumpConnectorVersion will already work for manifest-only and Java connectors too
             if bump_connector_version and one_previous_step_is_successful:
-                bump_version = BumpConnectorVersion(context, connector_directory, BUMP_TYPE)
+                bump_version = BumpConnectorVersion(context, connector_directory, BUMP_TYPE, rc)
                 bump_version_result = await bump_version.run()
                 step_results.append(bump_version_result)
                 if bump_version_result.success:

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/steps/bump_version.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/steps/bump_version.py
@@ -117,7 +117,7 @@ class SetConnectorVersion(StepModifyingFiles):
 
 
 class BumpConnectorVersion(SetConnectorVersion):
-    def __init__(self, context: ConnectorContext, connector_directory: dagger.Directory, bump_type: str, rc: bool) -> None:
+    def __init__(self, context: ConnectorContext, connector_directory: dagger.Directory, bump_type: str, rc: bool = False) -> None:
         self.bump_type = bump_type
         new_version = self.get_bumped_version(context.connector.version, bump_type, rc)
         super().__init__(

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/steps/bump_version.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/steps/bump_version.py
@@ -3,7 +3,7 @@
 #
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Mapping
 
 import dagger
 import semver
@@ -13,6 +13,13 @@ from pipelines.airbyte_ci.connectors.context import ConnectorContext
 from pipelines.dagger.actions.python.poetry import with_poetry
 from pipelines.helpers.connectors.dagger_fs import dagger_read_file, dagger_write_file
 from pipelines.models.steps import StepModifyingFiles, StepResult, StepStatus
+
+BUMP_VERSION_METHOD_MAPPING: Mapping[str, callable] = {
+    "patch": semver.Version.bump_patch,
+    "minor": semver.Version.bump_minor,
+    "major": semver.Version.bump_major,
+    "rc": semver.Version.bump_prerelease,
+}
 
 if TYPE_CHECKING:
     pass
@@ -115,9 +122,10 @@ class BumpConnectorVersion(SetConnectorVersion):
         context: ConnectorContext,
         connector_directory: dagger.Directory,
         bump_type: str,
+        rc: bool
     ) -> None:
         self.bump_type = bump_type
-        new_version = self.get_bumped_version(context.connector.version, bump_type)
+        new_version = self.get_bumped_version(context.connector.version, bump_type, rc)
         super().__init__(
             context,
             connector_directory,
@@ -129,18 +137,14 @@ class BumpConnectorVersion(SetConnectorVersion):
         return f"{self.bump_type.upper()} bump {self.context.connector.technical_name} version to {self.new_version}"
 
     @staticmethod
-    def get_bumped_version(version: str | None, bump_type: str) -> str:
+    def get_bumped_version(version: str | None, bump_type: str, rc: bool) -> str:
         if version is None:
             raise ValueError("Version is not set")
         current_version = semver.VersionInfo.parse(version)
-        if bump_type == "patch":
-            new_version = current_version.bump_patch()
-        elif bump_type == "minor":
-            new_version = current_version.bump_minor()
-        elif bump_type == "major":
-            new_version = current_version.bump_major()
-        elif bump_type == "rc":
-            new_version = current_version.bump_prerelease()
+        if bump_type in BUMP_VERSION_METHOD_MAPPING:
+            new_version = BUMP_VERSION_METHOD_MAPPING[bump_type](current_version)
+            if rc:
+                new_version = new_version.bump_prerelease()
         elif bump_type.startswith("version:"):
             version_str = bump_type.split("version:", 1)[1]
             if semver.VersionInfo.is_valid(version_str):

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/steps/bump_version.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/steps/bump_version.py
@@ -117,13 +117,7 @@ class SetConnectorVersion(StepModifyingFiles):
 
 
 class BumpConnectorVersion(SetConnectorVersion):
-    def __init__(
-        self,
-        context: ConnectorContext,
-        connector_directory: dagger.Directory,
-        bump_type: str,
-        rc: bool
-    ) -> None:
+    def __init__(self, context: ConnectorContext, connector_directory: dagger.Directory, bump_type: str, rc: bool) -> None:
         self.bump_type = bump_type
         new_version = self.get_bumped_version(context.connector.version, bump_type, rc)
         super().__init__(

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/steps/bump_version.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/steps/bump_version.py
@@ -3,7 +3,7 @@
 #
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Mapping
+from typing import TYPE_CHECKING, Mapping, Any
 
 import dagger
 import semver
@@ -14,7 +14,7 @@ from pipelines.dagger.actions.python.poetry import with_poetry
 from pipelines.helpers.connectors.dagger_fs import dagger_read_file, dagger_write_file
 from pipelines.models.steps import StepModifyingFiles, StepResult, StepStatus
 
-BUMP_VERSION_METHOD_MAPPING: Mapping[str, callable] = {
+BUMP_VERSION_METHOD_MAPPING: Mapping[str, Any] = {
     "patch": semver.Version.bump_patch,
     "minor": semver.Version.bump_minor,
     "major": semver.Version.bump_major,

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/steps/bump_version.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/steps/bump_version.py
@@ -3,7 +3,7 @@
 #
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Mapping, Any
+from typing import TYPE_CHECKING, Any, Mapping
 
 import dagger
 import semver


### PR DESCRIPTION
## What
- Currently there is the option to specify an `rc` (release candidate) bump type for the `bump-version` command, but this command bumps the *current* version to a release candidate. In practice, we want to bump to the next planned version and specify it as a release candidate.
- This PR adds the `--rc` option to the `bump-version` command enabling a user to specify, for example, that a proposed changed would be a release candidate for a new minor version., run with the following command:
```bash
airbyte-ci connectors --name=source-pokeapi bump-version minor "New example feature" --rc
``` 

## How
- Adds `--rc` click option
- Reformats the version bump method selection
- Adds check to confirm both --rc and "rc" bump types are not selected simultaenously

## Review guide
1. bump_version/commands.py
2. bump_version/pipeline.py
3. steps/bump_version.py

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [X] YES 💚
- [ ] NO ❌
