### PR TITLE
airbyte-ci: fix ownership issues while using `--use-local-cdk`

### DIFF
--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -854,6 +854,7 @@ airbyte-ci connectors --language=low-code migrate-to-manifest-only
 
 | Version | PR                                                         | Description                                                                                                                  |
 | ------- | ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| 4.45.2  | [#48868](https://github.com/airbytehq/airbyte/pull/48868)  | Fix ownership issues while using `--use-local-cdk`                                                                           |
 | 4.45.1  | [#48872](https://github.com/airbytehq/airbyte/pull/48872)  | Make the `connectors list` command write its output to a JSON file.                                                          |
 | 4.45.0  | [#48866](https://github.com/airbytehq/airbyte/pull/48866)  | Adds `--rc` option to `bump-version` command                                                   |
 | 4.44.2  | [#48725](https://github.com/airbytehq/airbyte/pull/48725)  | up-to-date: specific changelog comment for base image upgrade to rootless.                                                   |

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/build_image/steps/manifest_only_connectors.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/build_image/steps/manifest_only_connectors.py
@@ -46,7 +46,7 @@ class BuildConnectorImages(BuildConnectorImagesBase):
 
         # Mount manifest file
         base_container = self._get_base_container(platform)
-        user = await self._get_image_user(base_container)
+        user = await self.get_image_user(base_container)
         base_container = base_container.with_file(
             f"source_declarative_manifest/{MANIFEST_FILE_PATH}",
             (await self.context.get_connector_dir(include=[MANIFEST_FILE_PATH])).file(MANIFEST_FILE_PATH),
@@ -62,7 +62,7 @@ class BuildConnectorImages(BuildConnectorImagesBase):
                 owner=user,
             )
         connector_container = build_customization.apply_airbyte_entrypoint(base_container, self.context.connector)
-        connector_container = await apply_python_development_overrides(self.context, connector_container)
+        connector_container = await apply_python_development_overrides(self.context, connector_container, user)
         return connector_container
 
 

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/migrate_to_poetry/pipeline.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/migrate_to_poetry/pipeline.py
@@ -177,6 +177,7 @@ class PoetryInit(Step):
             self.context,
             base_container,
             str(self.context.connector.code_directory),
+            "airbyte",
         )
         with_egg_info = await connector_container.with_exec(["python", "setup.py", "egg_info"], use_entrypoint=True)
 

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/python_connectors.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/python_connectors.py
@@ -150,14 +150,15 @@ class PytestStep(Step, ABC):
             Container: The container with the test environment installed.
         """
         secret_mounting_function = await secrets.mounted_connector_secrets(self.context, "secrets", self.secrets)
-
+        user = await BuildConnectorImages.get_image_user(built_connector_container)
         container_with_test_deps = (
             # Install the connector python package in /test_environment with the extra dependencies
             await pipelines.dagger.actions.python.common.with_python_connector_installed(
                 self.context,
-                # Reset the entrypoint to run non airbyte commands and set the user to root to install the dependencies and access secrets
-                built_connector_container.with_entrypoint([]).with_user("root"),
+                # Reset the entrypoint to run non airbyte commands
+                built_connector_container.with_entrypoint([]),
                 str(self.context.connector.code_directory),
+                user,
                 additional_dependency_groups=extra_dependencies_names,
             )
         )

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "4.45.1"
+version = "4.45.2"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 

--- a/airbyte-ci/connectors/pipelines/tests/test_actions/test_environments.py
+++ b/airbyte-ci/connectors/pipelines/tests/test_actions/test_environments.py
@@ -41,20 +41,25 @@ async def test_apply_python_development_overrides(
             str(local_cdk_path)
         )
     connector_context.use_local_cdk = use_local_cdk
-    fake_connector_container = connector_context.dagger_client.container().from_("airbyte/python-connector-base:2.0.0")
+    fake_connector_container = connector_context.dagger_client.container().from_("airbyte/python-connector-base:3.0.0")
     before_override_pip_freeze = await fake_connector_container.with_exec(["pip", "freeze"], use_entrypoint=True).stdout()
     assert "airbyte-cdk" not in before_override_pip_freeze.splitlines(), "The base image should not have the airbyte-cdk installed."
     if use_local_cdk and not local_cdk_is_available:
         # We assume the local cdk is not available so a UsageError should be raised.
         with pytest.raises(UsageError):
-            await common.apply_python_development_overrides(connector_context, fake_connector_container)
+            await common.apply_python_development_overrides(connector_context, fake_connector_container, "airbyte")
     else:
-        overriden_container = await common.apply_python_development_overrides(connector_context, fake_connector_container)
+        overriden_container = await common.apply_python_development_overrides(connector_context, fake_connector_container, "airbyte")
         after_override_pip_freeze = await overriden_container.with_exec(["pip", "freeze"], use_entrypoint=True).stdout()
 
         if use_local_cdk and local_cdk_is_available:
             assert (
                 "airbyte-cdk @ file:///airbyte-cdk/python" in after_override_pip_freeze.splitlines()
             ), "The override should install the airbyte-cdk package."
+            ls_ld_output = await overriden_container.with_exec(["ls", "-ld", "/airbyte-cdk/python"]).stdout()
+            airbyte_cdk_owner_user, airbyte_cdk_owner_group = ls_ld_output.split()[2], ls_ld_output.split()[3]
+            assert (
+                airbyte_cdk_owner_user == "airbyte" and airbyte_cdk_owner_group == "airbyte"
+            ), "The airbyte-cdk directory should be owned by the airbyte user."
         else:
             assert after_override_pip_freeze == before_override_pip_freeze, "The override should not change the pip freeze output."

--- a/airbyte-ci/connectors/pipelines/tests/test_build_image/test_manifest_only_connectors.py
+++ b/airbyte-ci/connectors/pipelines/tests/test_build_image/test_manifest_only_connectors.py
@@ -93,7 +93,7 @@ class TestBuildConnectorImage:
 
         mocker.patch.object(
             manifest_only_connectors.BuildConnectorImages,
-            "_get_image_user",
+            "get_image_user",
             return_value="airbyte",
         )
 

--- a/airbyte-ci/connectors/pipelines/tests/test_dagger/test_actions/test_python/test_common.py
+++ b/airbyte-ci/connectors/pipelines/tests/test_dagger/test_actions/test_python/test_common.py
@@ -6,6 +6,7 @@ import datetime
 import asyncclick as click
 import pytest
 import requests
+from pipelines.airbyte_ci.connectors.build_image.steps.python_connectors import BuildConnectorImages
 from pipelines.airbyte_ci.connectors.context import ConnectorContext
 from pipelines.dagger.actions.python import common
 
@@ -64,9 +65,9 @@ def python_connector_base_image_address(python_connector_with_setup_not_latest_c
 async def test_with_python_connector_installed_from_setup(context_with_setup, python_connector_base_image_address, latest_cdk_version):
 
     python_container = context_with_setup.dagger_client.container().from_(python_connector_base_image_address)
-
+    user = await BuildConnectorImages.get_image_user(python_container)
     container = await common.with_python_connector_installed(
-        context_with_setup, python_container, str(context_with_setup.connector.code_directory)
+        context_with_setup, python_container, str(context_with_setup.connector.code_directory), user
     )
     # Uninstall and reinstall the latest cdk version
     cdk_install_latest_output = (

--- a/airbyte-ci/connectors/pipelines/tests/test_publish.py
+++ b/airbyte-ci/connectors/pipelines/tests/test_publish.py
@@ -95,7 +95,7 @@ class TestUploadSpecToCache:
         step = publish_pipeline.UploadSpecToCache(publish_context)
         step_result = await step.run(connector_container)
         if valid_spec:
-            publish_pipeline.upload_to_gcs.assert_called_once_with(
+            publish_pipeline.upload_to_gcs.assert_called_with(
                 publish_context.dagger_client,
                 mocker.ANY,
                 f"specs/{image_name.replace(':', '/')}/spec.json",


### PR DESCRIPTION
## What
We mount the "local" CDK to `/airbyte-cdk` but non-root image this path is not owned by the `airbyte` user, causing errors on local CDK install.

## How
* Mount `/airbyte-cdk` to a directory on which the current image user is the owner. Do the same for other "local dependencies" that are sometime installed at test time in `PytestStep`.
* Install the python `airbyte-cdk` as root user to avoid issues with installs in the current user home directory (which does not exists when using the airbyte user).
* Refactor code paths to explicitely pass the name of the current image user.

## Manual testing
* [Running a couple of connector tests to confirm tests are still working](https://github.com/airbytehq/airbyte/actions/runs/12253769493)
* [Running a couple of publish to confirm publish is not impacted by these changes](https://github.com/airbytehq/airbyte/actions/runs/12253797681)