### PR TITLE
airbyte-ci: fix `determine_changelog_entry_comment`

### DIFF
--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -854,7 +854,7 @@ airbyte-ci connectors --language=low-code migrate-to-manifest-only
 
 | Version | PR                                                         | Description                                                                                                                  |
 | ------- | ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| 4.45.3  | [#TBD](https://github.com/airbytehq/airbyte/pull/TBD)      | Fix bug in determine_changelog_entry_comment                                                                                 |
+| 4.45.3  | [#48927](https://github.com/airbytehq/airbyte/pull/48927)      | Fix bug in determine_changelog_entry_comment                                                                                 |
 | 4.45.2  | [#48868](https://github.com/airbytehq/airbyte/pull/48868)  | Fix ownership issues while using `--use-local-cdk`                                                                           |
 | 4.45.1  | [#48872](https://github.com/airbytehq/airbyte/pull/48872)  | Make the `connectors list` command write its output to a JSON file.                                                          |
 | 4.45.0  | [#48866](https://github.com/airbytehq/airbyte/pull/48866)  | Adds `--rc` option to `bump-version` command                                                                                 |

--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -854,9 +854,10 @@ airbyte-ci connectors --language=low-code migrate-to-manifest-only
 
 | Version | PR                                                         | Description                                                                                                                  |
 | ------- | ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| 4.45.3  | [#TBD](https://github.com/airbytehq/airbyte/pull/TBD)      | Fix bug in determine_changelog_entry_comment                                                                                 |
 | 4.45.2  | [#48868](https://github.com/airbytehq/airbyte/pull/48868)  | Fix ownership issues while using `--use-local-cdk`                                                                           |
 | 4.45.1  | [#48872](https://github.com/airbytehq/airbyte/pull/48872)  | Make the `connectors list` command write its output to a JSON file.                                                          |
-| 4.45.0  | [#48866](https://github.com/airbytehq/airbyte/pull/48866)  | Adds `--rc` option to `bump-version` command                                                   |
+| 4.45.0  | [#48866](https://github.com/airbytehq/airbyte/pull/48866)  | Adds `--rc` option to `bump-version` command                                                                                 |
 | 4.44.2  | [#48725](https://github.com/airbytehq/airbyte/pull/48725)  | up-to-date: specific changelog comment for base image upgrade to rootless.                                                   |
 | 4.44.1  | [#48836](https://github.com/airbytehq/airbyte/pull/48836)  | Manifest-only connector build: give ownership of copied file to the current user.                                            |
 | 4.44.0  | [#48818](https://github.com/airbytehq/airbyte/pull/48818)  | Use local CDK or CDK ref for manifest only connector build.                                                                  |

--- a/airbyte-ci/connectors/pipelines/pipelines/hacks.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/hacks.py
@@ -131,7 +131,9 @@ def determine_changelog_entry_comment(upgrade_base_image_in_metadata_result: Ste
     assert isinstance(
         upgrade_base_image_in_metadata_result.step, UpdateBaseImageMetadata
     ), "StepResult's step must be instance of UpdateBaseImageMetadata"
-    if upgrade_base_image_in_metadata_result.output is not None and upgrade_base_image_in_metadata_result.output.get("updated_base_image_address"):
+    if upgrade_base_image_in_metadata_result.output is not None and upgrade_base_image_in_metadata_result.output.get(
+        "updated_base_image_address"
+    ):
         updated_base_image_address = upgrade_base_image_in_metadata_result.output.get("updated_base_image_address")
         if (
             "airbyte/python-connector-base:3.0.0" in updated_base_image_address

--- a/airbyte-ci/connectors/pipelines/pipelines/hacks.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/hacks.py
@@ -131,7 +131,7 @@ def determine_changelog_entry_comment(upgrade_base_image_in_metadata_result: Ste
     assert isinstance(
         upgrade_base_image_in_metadata_result.step, UpdateBaseImageMetadata
     ), "StepResult's step must be instance of UpdateBaseImageMetadata"
-    if upgrade_base_image_in_metadata_result.output.get("updated_base_image_address"):
+    if upgrade_base_image_in_metadata_result.output is not None and upgrade_base_image_in_metadata_result.output.get("updated_base_image_address"):
         updated_base_image_address = upgrade_base_image_in_metadata_result.output.get("updated_base_image_address")
         if (
             "airbyte/python-connector-base:3.0.0" in updated_base_image_address

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "4.45.2"
+version = "4.45.3"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 


### PR DESCRIPTION
This pull request includes updates to the `airbyte-ci` connectors pipeline documentation and a bug fix in the `determine_changelog_entry_comment` function. The most important changes are summarized below:

Documentation updates:

* [`airbyte-ci/connectors/pipelines/README.md`](diffhunk://#diff-62eccd92928fbcd3d285983bfdaa2b0d4ca49016cb9c2f63d6d9fc968c59c541R857): Added a new entry for version 4.45.3 to document the bug fix related to `determine_changelog_entry_comment`.

Bug fixes:

* [`airbyte-ci/connectors/pipelines/pipelines/hacks.py`](diffhunk://#diff-869b05f4d5d307773cdc3fa2d115f1814e8e41df1654976b6e54c56153c8b7efL134-R136): Fixed a bug in the `determine_changelog_entry_comment` function by adding a check to ensure `output` is not `None` before accessing its properties