### PR TITLE
ci: up-to-date, continue on error in matrix job

### DIFF
--- a/.github/workflows/connectors_up_to_date.yml
+++ b/.github/workflows/connectors_up_to_date.yml
@@ -47,6 +47,7 @@ jobs:
     needs: generate_matrix
     name: Connectors up-to-date
     runs-on: connector-nightly-xlarge
+    continue-on-error: true
     strategy:
       matrix: ${{fromJson(needs.generate_matrix.outputs.generated_matrix)}}
     permissions:


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/connectors_up_to_date.yml` file. The change allows the job to continue running even if an error occurs.

* [`.github/workflows/connectors_up_to_date.yml`](diffhunk://#diff-2d17c6d9c0d58a040bfab9725e36051d4330b78f1a76e2f9fb024f673b7a74d4R50): Added `continue-on-error: true` to the `Connectors up-to-date` job.