### PR TITLE
up-to-date: use dedicated runner to control job  concurrency

### DIFF
--- a/.github/workflows/connectors_up_to_date.yml
+++ b/.github/workflows/connectors_up_to_date.yml
@@ -46,7 +46,7 @@ jobs:
   run_connectors_up_to_date:
     needs: generate_matrix
     name: Connectors up-to-date
-    runs-on: connector-nightly-xlarge
+    runs-on: connector-up-to-date-small
     continue-on-error: true
     strategy:
       matrix: ${{fromJson(needs.generate_matrix.outputs.generated_matrix)}}


### PR DESCRIPTION
## What
Running up_to_date with high concurrency can lead to rate limiting issue on the GitHub API.
I created a runner type that would be dedicated to up-to-date and forced its concurrency to 1.

