### PR TITLE
🐛 Source Jira: Improve doc and increase duration between messages

### DIFF
--- a/airbyte-integrations/connectors/source-jira/metadata.yaml
+++ b/airbyte-integrations/connectors/source-jira/metadata.yaml
@@ -17,7 +17,7 @@ data:
   githubIssueLabel: source-jira
   icon: jira.svg
   license: MIT
-  maxSecondsBetweenMessages: 5400
+  maxSecondsBetweenMessages: 10800
   name: Jira
   remoteRegistries:
     pypi:

--- a/docs/integrations/sources/jira.md
+++ b/docs/integrations/sources/jira.md
@@ -126,6 +126,15 @@ This connector outputs the following incremental streams:
 
 If there are more endpoints you'd like Airbyte to support, please [create an issue.](https://github.com/airbytehq/airbyte/issues/new/choose)
 
+### Streams on I/O Usage
+
+In the list above, there is a subset of streams which requires to make one HTTP request per issue. Those streams can significantly slow down that a sync given a high number of issues. If you have one or many of those streams and experience slowness, we recommend filtering the list of issues using the list of projects in the configuration or simply removing those streams from the sync.
+* Issue properties
+* Issue remote links
+* Issue transactions
+* Issue votes
+* Issue watchers
+
 ### Entity-Relationship Diagram (ERD)
 <EntityRelationshipDiagram></EntityRelationshipDiagram>
 

--- a/docs/integrations/sources/jira.md
+++ b/docs/integrations/sources/jira.md
@@ -129,11 +129,13 @@ If there are more endpoints you'd like Airbyte to support, please [create an iss
 ### Streams on I/O Usage
 
 In the list above, there is a subset of streams which requires to make one HTTP request per issue. Those streams can significantly slow down that a sync given a high number of issues. If you have one or many of those streams and experience slowness, we recommend filtering the list of issues using the list of projects in the configuration or simply removing those streams from the sync.
+* Issue comments
 * Issue properties
 * Issue remote links
 * Issue transactions
 * Issue votes
 * Issue watchers
+* Issue worklogs
 
 ### Entity-Relationship Diagram (ERD)
 <EntityRelationshipDiagram></EntityRelationshipDiagram>


### PR DESCRIPTION
## What
Following https://github.com/airbytehq/oncall/issues/6953, we wanted to clarify the implications of syncing issue_X streams when having a lot of issues. 

We also had [one case](https://cloud.airbyte.com/workspaces/ba19895b-0469-4c6c-a12a-dec6e67dab61/connections/6b78e0f7-015c-4dc6-8b45-1648fae1dd0b/timeline?openLogs=true&eventId=91729990-9f9e-4525-82fe-daff56b2cb26) which highlighted that the duration between messages needs to be higher than the rate limiting threshold because the child stream might not return records on each of the parent stream entry. This happened for `issue_worklogs` and should occur less often when we will onboard these on the Concurrent CDK but we still want to fix that in the short term.

## User Impact
We should see less `Airbyte detected that the Source didn't send any records in the last 1 hour 30 minutes`

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
