### PR TITLE
Bulk Load CDK: Queue between process records & batch; fixed num batch…

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/command/DestinationConfiguration.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/command/DestinationConfiguration.kt
@@ -85,6 +85,8 @@ abstract class DestinationConfiguration : Configuration {
     open val gracefulCancellationTimeoutMs: Long = 60 * 1000L // 1 minutes
 
     open val numProcessRecordsWorkers: Int = 2
+    open val numProcessBatchWorkers: Int = 5
+    open val batchQueueDepth: Int = 10
 
     /**
      * Micronaut factory which glues [ConfigurationSpecificationSupplier] and

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/config/SyncBeanFactory.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/config/SyncBeanFactory.kt
@@ -6,6 +6,7 @@ package io.airbyte.cdk.load.config
 
 import io.airbyte.cdk.load.command.DestinationCatalog
 import io.airbyte.cdk.load.command.DestinationConfiguration
+import io.airbyte.cdk.load.message.BatchEnvelope
 import io.airbyte.cdk.load.message.MultiProducerChannel
 import io.airbyte.cdk.load.state.ReservationManager
 import io.airbyte.cdk.load.task.implementor.FileAggregateMessage
@@ -68,5 +69,14 @@ class SyncBeanFactory {
         log.info { "Creating file aggregate queue with limit $capacity" }
         val channel = Channel<FileAggregateMessage>(capacity)
         return MultiProducerChannel(streamCount.toLong(), channel)
+    }
+
+    @Singleton
+    @Named("batchQueue")
+    fun batchQueue(
+        config: DestinationConfiguration,
+    ): MultiProducerChannel<BatchEnvelope<*>> {
+        val channel = Channel<BatchEnvelope<*>>(config.batchQueueDepth)
+        return MultiProducerChannel(config.numProcessRecordsWorkers.toLong(), channel)
     }
 }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/Batch.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/Batch.kt
@@ -7,6 +7,7 @@ package io.airbyte.cdk.load.message
 import com.google.common.collect.Range
 import com.google.common.collect.RangeSet
 import com.google.common.collect.TreeRangeSet
+import io.airbyte.cdk.load.command.DestinationStream
 
 /**
  * Represents an accumulated batch of records in some stage of processing.
@@ -66,6 +67,13 @@ interface Batch {
         }
 
     val state: State
+
+    /**
+     * If a [Batch] is [State.COMPLETE], there's nothing further to do. If it is part of a group,
+     * then its state will be updated by the next batch in the group that advances.
+     */
+    val requiresProcessing: Boolean
+        get() = state != State.COMPLETE && groupId == null
 }
 
 /** Simple batch: use if you need no other metadata for processing. */
@@ -80,14 +88,20 @@ data class SimpleBatch(
  */
 data class BatchEnvelope<B : Batch>(
     val batch: B,
-    val ranges: RangeSet<Long> = TreeRangeSet.create()
+    val ranges: RangeSet<Long> = TreeRangeSet.create(),
+    val streamDescriptor: DestinationStream.Descriptor
 ) {
     constructor(
         batch: B,
-        range: Range<Long>
-    ) : this(batch = batch, ranges = TreeRangeSet.create(listOf(range)))
+        range: Range<Long>,
+        streamDescriptor: DestinationStream.Descriptor
+    ) : this(
+        batch = batch,
+        ranges = TreeRangeSet.create(listOf(range)),
+        streamDescriptor = streamDescriptor
+    )
 
     fun <C : Batch> withBatch(newBatch: C): BatchEnvelope<C> {
-        return BatchEnvelope(newBatch, ranges)
+        return BatchEnvelope(newBatch, ranges, streamDescriptor)
     }
 }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/implementor/ProcessFileTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/implementor/ProcessFileTask.kt
@@ -31,7 +31,7 @@ class DefaultProcessFileTask(
 
         val batch = streamLoader.processFile(file)
 
-        val wrapped = BatchEnvelope(batch, Range.singleton(index))
+        val wrapped = BatchEnvelope(batch, Range.singleton(index), streamDescriptor)
         taskLauncher.handleNewBatch(streamDescriptor, wrapped)
     }
 }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/implementor/ProcessRecordsTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/implementor/ProcessRecordsTask.kt
@@ -13,20 +13,23 @@ import io.airbyte.cdk.load.message.DestinationRecordStreamComplete
 import io.airbyte.cdk.load.message.DestinationRecordStreamIncomplete
 import io.airbyte.cdk.load.message.DestinationStreamAffinedMessage
 import io.airbyte.cdk.load.message.MessageQueue
+import io.airbyte.cdk.load.message.MultiProducerChannel
 import io.airbyte.cdk.load.state.ReservationManager
 import io.airbyte.cdk.load.state.SyncManager
 import io.airbyte.cdk.load.task.DestinationTaskLauncher
-import io.airbyte.cdk.load.task.ImplementorScope
+import io.airbyte.cdk.load.task.KillableScope
 import io.airbyte.cdk.load.task.internal.SpilledRawMessagesLocalFile
 import io.airbyte.cdk.load.util.lineSequence
+import io.airbyte.cdk.load.util.use
 import io.airbyte.cdk.load.write.StreamLoader
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.micronaut.context.annotation.Secondary
 import jakarta.inject.Named
 import jakarta.inject.Singleton
+import java.io.InputStream
 import kotlin.io.path.inputStream
 
-interface ProcessRecordsTask : ImplementorScope
+interface ProcessRecordsTask : KillableScope
 
 /**
  * Wraps @[StreamLoader.processRecords] and feeds it a lazy iterator over the last batch of spooled
@@ -42,48 +45,57 @@ class DefaultProcessRecordsTask(
     private val syncManager: SyncManager,
     private val diskManager: ReservationManager,
     private val inputQueue: MessageQueue<FileAggregateMessage>,
+    private val outputQueue: MultiProducerChannel<BatchEnvelope<*>>
 ) : ProcessRecordsTask {
     private val log = KotlinLogging.logger {}
     override suspend fun execute() {
-        inputQueue.consume().collect { (streamDescriptor, file) ->
-            log.info { "Fetching stream loader for $streamDescriptor" }
-            val streamLoader = syncManager.getOrAwaitStreamLoader(streamDescriptor)
-            log.info { "Processing records from $file for stream $streamDescriptor" }
-            val batch =
-                try {
-                    file.localFile.inputStream().use { inputStream ->
-                        val records =
-                            inputStream
-                                .lineSequence()
-                                .map {
-                                    when (val message = deserializer.deserialize(it)) {
-                                        is DestinationStreamAffinedMessage -> message
-                                        else ->
-                                            throw IllegalStateException(
-                                                "Expected record message, got ${message::class}"
-                                            )
-                                    }
-                                }
-                                .takeWhile {
-                                    it !is DestinationRecordStreamComplete &&
-                                        it !is DestinationRecordStreamIncomplete
-                                }
-                                .map { it as DestinationRecord }
-                                .iterator()
-                        val batch = streamLoader.processRecords(records, file.totalSizeBytes)
-                        log.info { "Finished processing $file" }
-                        batch
+        outputQueue.use {
+            inputQueue.consume().collect { (streamDescriptor, file) ->
+                log.info { "Fetching stream loader for $streamDescriptor" }
+                val streamLoader = syncManager.getOrAwaitStreamLoader(streamDescriptor)
+                log.info { "Processing records from $file for stream $streamDescriptor" }
+                val batch =
+                    try {
+                        file.localFile.inputStream().use { inputStream ->
+                            val records = inputStream.toRecordIterator()
+                            val batch = streamLoader.processRecords(records, file.totalSizeBytes)
+                            log.info { "Finished processing $file" }
+                            batch
+                        }
+                    } finally {
+                        log.info { "Processing completed, deleting $file" }
+                        file.localFile.toFile().delete()
+                        diskManager.release(file.totalSizeBytes)
                     }
-                } finally {
-                    log.info { "Processing completed, deleting $file" }
-                    file.localFile.toFile().delete()
-                    diskManager.release(file.totalSizeBytes)
-                }
 
-            val wrapped = BatchEnvelope(batch, file.indexRange)
-            log.info { "Updating batch $wrapped for $streamDescriptor" }
-            taskLauncher.handleNewBatch(streamDescriptor, wrapped)
+                val wrapped = BatchEnvelope(batch, file.indexRange, streamDescriptor)
+                log.info { "Updating batch $wrapped for $streamDescriptor" }
+                taskLauncher.handleNewBatch(streamDescriptor, wrapped)
+                if (batch.requiresProcessing) {
+                    outputQueue.publish(wrapped)
+                } else {
+                    log.info { "Batch $wrapped requires no further processing." }
+                }
+            }
         }
+    }
+
+    private fun InputStream.toRecordIterator(): Iterator<DestinationRecord> {
+        return lineSequence()
+            .map {
+                when (val message = deserializer.deserialize(it)) {
+                    is DestinationStreamAffinedMessage -> message
+                    else ->
+                        throw IllegalStateException(
+                            "Expected record message, got ${message::class}"
+                        )
+                }
+            }
+            .takeWhile {
+                it !is DestinationRecordStreamComplete && it !is DestinationRecordStreamIncomplete
+            }
+            .map { it as DestinationRecord }
+            .iterator()
     }
 }
 
@@ -104,7 +116,8 @@ class DefaultProcessRecordsTaskFactory(
     private val deserializer: Deserializer<DestinationMessage>,
     private val syncManager: SyncManager,
     @Named("diskManager") private val diskManager: ReservationManager,
-    @Named("fileAggregateQueue") private val inputQueue: MessageQueue<FileAggregateMessage>
+    @Named("fileAggregateQueue") private val inputQueue: MessageQueue<FileAggregateMessage>,
+    @Named("batchQueue") private val outputQueue: MultiProducerChannel<BatchEnvelope<*>>,
 ) : ProcessRecordsTaskFactory {
     override fun make(
         taskLauncher: DestinationTaskLauncher,
@@ -115,6 +128,7 @@ class DefaultProcessRecordsTaskFactory(
             syncManager,
             diskManager,
             inputQueue,
+            outputQueue,
         )
     }
 }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/InputConsumerTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/InputConsumerTask.kt
@@ -100,7 +100,11 @@ class DefaultInputConsumerTask(
             is DestinationFileStreamComplete -> {
                 reserved.release() // safe because multiple calls conflate
                 manager.markEndOfStream(true)
-                val envelope = BatchEnvelope(SimpleBatch(Batch.State.COMPLETE))
+                val envelope =
+                    BatchEnvelope(
+                        SimpleBatch(Batch.State.COMPLETE),
+                        streamDescriptor = message.stream
+                    )
                 destinationTaskLauncher.handleNewBatch(stream, envelope)
             }
             is DestinationFileStreamIncomplete ->

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/SpillToDiskTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/SpillToDiskTask.kt
@@ -23,7 +23,7 @@ import io.airbyte.cdk.load.state.ReservationManager
 import io.airbyte.cdk.load.state.Reserved
 import io.airbyte.cdk.load.state.TimeWindowTrigger
 import io.airbyte.cdk.load.task.DestinationTaskLauncher
-import io.airbyte.cdk.load.task.InternalScope
+import io.airbyte.cdk.load.task.KillableScope
 import io.airbyte.cdk.load.task.implementor.FileAggregateMessage
 import io.airbyte.cdk.load.util.use
 import io.airbyte.cdk.load.util.withNextAdjacentValue
@@ -39,7 +39,7 @@ import kotlin.io.path.deleteExisting
 import kotlin.io.path.outputStream
 import kotlinx.coroutines.flow.fold
 
-interface SpillToDiskTask : InternalScope
+interface SpillToDiskTask : KillableScope
 
 /**
  * Reads records from the message queue and writes them to disk. Completes once the upstream
@@ -134,6 +134,7 @@ class DefaultSpillToDiskTask(
                 BatchEnvelope(
                     SimpleBatch(Batch.State.COMPLETE),
                     TreeRangeSet.create(),
+                    streamDescriptor
                 )
             taskLauncher.handleNewBatch(streamDescriptor, empty)
         } else {

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/state/CheckpointManagerTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/state/CheckpointManagerTest.kt
@@ -446,7 +446,12 @@ class CheckpointManagerTest {
                     it.persistedRanges.forEach { (stream, ranges) ->
                         val mockBatch = SimpleBatch(state = Batch.State.PERSISTED)
                         val rangeSet = TreeRangeSet.create(ranges)
-                        val mockBatchEnvelope = BatchEnvelope(batch = mockBatch, ranges = rangeSet)
+                        val mockBatchEnvelope =
+                            BatchEnvelope(
+                                batch = mockBatch,
+                                ranges = rangeSet,
+                                streamDescriptor = stream.descriptor
+                            )
                         syncManager
                             .getStreamManager(stream.descriptor)
                             .updateBatchState(mockBatchEnvelope)

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/state/StreamManagerTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/state/StreamManagerTest.kt
@@ -266,14 +266,16 @@ class StreamManagerTest {
                     manager.updateBatchState(
                         BatchEnvelope(
                             SimpleBatch(Batch.State.PERSISTED),
-                            Range.closed(event.firstIndex, event.lastIndex)
+                            Range.closed(event.firstIndex, event.lastIndex),
+                            stream.descriptor
                         )
                     )
                 is AddComplete ->
                     manager.updateBatchState(
                         BatchEnvelope(
                             SimpleBatch(Batch.State.COMPLETE),
-                            Range.closed(event.firstIndex, event.lastIndex)
+                            Range.closed(event.firstIndex, event.lastIndex),
+                            stream.descriptor
                         )
                     )
                 is ExpectPersistedUntil ->
@@ -323,10 +325,20 @@ class StreamManagerTest {
     fun `ranges with the same id conflate to latest state`() {
         val manager = DefaultStreamManager(stream1)
         val range1 = Range.closed(0L, 9L)
-        val batch1 = BatchEnvelope(SimpleBatch(Batch.State.LOCAL, groupId = "foo"), range1)
+        val batch1 =
+            BatchEnvelope(
+                SimpleBatch(Batch.State.LOCAL, groupId = "foo"),
+                range1,
+                stream1.descriptor
+            )
 
         val range2 = Range.closed(10, 19L)
-        val batch2 = BatchEnvelope(SimpleBatch(Batch.State.PERSISTED, groupId = "foo"), range2)
+        val batch2 =
+            BatchEnvelope(
+                SimpleBatch(Batch.State.PERSISTED, groupId = "foo"),
+                range2,
+                stream1.descriptor
+            )
 
         manager.updateBatchState(batch1)
         Assertions.assertFalse(manager.areRecordsPersistedUntil(10L), "local < persisted")
@@ -338,10 +350,20 @@ class StreamManagerTest {
     fun `ranges with a different id conflate to latest state`() {
         val manager = DefaultStreamManager(stream1)
         val range1 = Range.closed(0L, 9L)
-        val batch1 = BatchEnvelope(SimpleBatch(Batch.State.LOCAL, groupId = "foo"), range1)
+        val batch1 =
+            BatchEnvelope(
+                SimpleBatch(Batch.State.LOCAL, groupId = "foo"),
+                range1,
+                stream1.descriptor
+            )
 
         val range2 = Range.closed(10, 19L)
-        val batch2 = BatchEnvelope(SimpleBatch(Batch.State.PERSISTED, groupId = "bar"), range2)
+        val batch2 =
+            BatchEnvelope(
+                SimpleBatch(Batch.State.PERSISTED, groupId = "bar"),
+                range2,
+                stream1.descriptor
+            )
 
         manager.updateBatchState(batch1)
         Assertions.assertFalse(manager.areRecordsPersistedUntil(10L), "local < persisted")
@@ -356,10 +378,20 @@ class StreamManagerTest {
     fun `state does not conflate between id and no id`() {
         val manager = DefaultStreamManager(stream1)
         val range1 = Range.closed(0L, 9L)
-        val batch1 = BatchEnvelope(SimpleBatch(Batch.State.LOCAL, groupId = null), range1)
+        val batch1 =
+            BatchEnvelope(
+                SimpleBatch(Batch.State.LOCAL, groupId = null),
+                range1,
+                stream1.descriptor
+            )
 
         val range2 = Range.closed(10, 19L)
-        val batch2 = BatchEnvelope(SimpleBatch(Batch.State.PERSISTED, groupId = "bar"), range2)
+        val batch2 =
+            BatchEnvelope(
+                SimpleBatch(Batch.State.PERSISTED, groupId = "bar"),
+                range2,
+                stream1.descriptor
+            )
 
         manager.updateBatchState(batch1)
         Assertions.assertFalse(manager.areRecordsPersistedUntil(10L), "local < persisted")
@@ -374,10 +406,20 @@ class StreamManagerTest {
     fun `max of newer and older state is always used`() {
         val manager = DefaultStreamManager(stream1)
         val range1 = Range.closed(0L, 9L)
-        val batch1 = BatchEnvelope(SimpleBatch(Batch.State.PERSISTED, groupId = "foo"), range1)
+        val batch1 =
+            BatchEnvelope(
+                SimpleBatch(Batch.State.PERSISTED, groupId = "foo"),
+                range1,
+                stream1.descriptor
+            )
 
         val range2 = Range.closed(10, 19L)
-        val batch2 = BatchEnvelope(SimpleBatch(Batch.State.LOCAL, groupId = "foo"), range2)
+        val batch2 =
+            BatchEnvelope(
+                SimpleBatch(Batch.State.LOCAL, groupId = "foo"),
+                range2,
+                stream1.descriptor
+            )
 
         manager.updateBatchState(batch1)
         Assertions.assertFalse(manager.areRecordsPersistedUntil(20L), "local < persisted")
@@ -392,10 +434,20 @@ class StreamManagerTest {
     fun `max of older and newer state is always used`() {
         val manager = DefaultStreamManager(stream1)
         val range1 = Range.closed(0L, 9L)
-        val batch1 = BatchEnvelope(SimpleBatch(Batch.State.COMPLETE, groupId = "foo"), range1)
+        val batch1 =
+            BatchEnvelope(
+                SimpleBatch(Batch.State.COMPLETE, groupId = "foo"),
+                range1,
+                stream1.descriptor
+            )
 
         val range2 = Range.closed(10, 19L)
-        val batch2 = BatchEnvelope(SimpleBatch(Batch.State.PERSISTED, groupId = "foo"), range2)
+        val batch2 =
+            BatchEnvelope(
+                SimpleBatch(Batch.State.PERSISTED, groupId = "foo"),
+                range2,
+                stream1.descriptor
+            )
         manager.markEndOfStream(true)
 
         manager.updateBatchState(batch2)

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/state/SyncManagerUtils.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/state/SyncManagerUtils.kt
@@ -19,5 +19,7 @@ import io.airbyte.cdk.load.message.SimpleBatch
  */
 fun SyncManager.markPersisted(stream: DestinationStream, range: Range<Long>) {
     this.getStreamManager(stream.descriptor)
-        .updateBatchState(BatchEnvelope(SimpleBatch(Batch.State.PERSISTED), range))
+        .updateBatchState(
+            BatchEnvelope(SimpleBatch(Batch.State.PERSISTED), range, stream.descriptor)
+        )
 }

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/ProcessBatchTaskTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/ProcessBatchTaskTest.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.load.task
+
+import io.airbyte.cdk.load.command.DestinationStream
+import io.airbyte.cdk.load.message.Batch
+import io.airbyte.cdk.load.message.BatchEnvelope
+import io.airbyte.cdk.load.message.MultiProducerChannel
+import io.airbyte.cdk.load.message.SimpleBatch
+import io.airbyte.cdk.load.state.SyncManager
+import io.airbyte.cdk.load.task.implementor.DefaultProcessBatchTask
+import io.airbyte.cdk.load.write.StreamLoader
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class ProcessBatchTaskTest {
+    private lateinit var syncManager: SyncManager
+    private lateinit var streamLoaders: Map<DestinationStream.Descriptor, StreamLoader>
+    private lateinit var batchQueue: MultiProducerChannel<BatchEnvelope<*>>
+    private lateinit var taskLauncher: DestinationTaskLauncher
+
+    @BeforeEach
+    fun setup() {
+        val streams =
+            (0 until 3).map { DestinationStream.Descriptor(namespace = "test", name = "stream$it") }
+        syncManager = mockk(relaxed = true)
+        streamLoaders = streams.associateWith { mockk(relaxed = true) }
+        streamLoaders.values.forEach {
+            coEvery { it.processBatch(any()) } returns SimpleBatch(Batch.State.COMPLETE)
+        }
+        coEvery { syncManager.getOrAwaitStreamLoader(any()) } answers
+            {
+                streamLoaders[firstArg()]!!
+            }
+        batchQueue = mockk(relaxed = true)
+        taskLauncher = mockk(relaxed = true)
+    }
+
+    @Test
+    fun `test each enqueued batch passes through the associated processBatch`() = runTest {
+        val task = DefaultProcessBatchTask(syncManager, batchQueue, taskLauncher)
+        coEvery { batchQueue.consume() } returns
+            streamLoaders.keys
+                .map {
+                    BatchEnvelope(streamDescriptor = it, batch = SimpleBatch(Batch.State.LOCAL))
+                }
+                .asFlow()
+
+        task.execute()
+
+        streamLoaders.forEach { (descriptor, loader) ->
+            coVerify { loader.processBatch(match { it.state == Batch.State.LOCAL }) }
+            coVerify {
+                taskLauncher.handleNewBatch(
+                    descriptor,
+                    match {
+                        it.streamDescriptor == descriptor && it.batch.state == Batch.State.COMPLETE
+                    }
+                )
+            }
+        }
+    }
+}

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/implementor/ProcessFileTaskTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/implementor/ProcessFileTaskTest.kt
@@ -40,7 +40,10 @@ class ProcessFileTaskTest {
         defaultProcessFileTask.execute()
 
         coVerify {
-            taskLauncher.handleNewBatch(stream, BatchEnvelope(batch, Range.singleton(index)))
+            taskLauncher.handleNewBatch(
+                stream,
+                BatchEnvelope(batch, Range.singleton(index), stream)
+            )
         }
     }
 }

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/implementor/ProcessRecordsTaskTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/implementor/ProcessRecordsTaskTest.kt
@@ -5,159 +5,167 @@
 package io.airbyte.cdk.load.task.implementor
 
 import com.google.common.collect.Range
-import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.command.MockDestinationCatalogFactory
 import io.airbyte.cdk.load.data.IntegerValue
 import io.airbyte.cdk.load.message.Batch
+import io.airbyte.cdk.load.message.BatchEnvelope
 import io.airbyte.cdk.load.message.Deserializer
-import io.airbyte.cdk.load.message.DestinationFile
 import io.airbyte.cdk.load.message.DestinationMessage
 import io.airbyte.cdk.load.message.DestinationRecord
 import io.airbyte.cdk.load.message.MessageQueue
+import io.airbyte.cdk.load.message.MultiProducerChannel
 import io.airbyte.cdk.load.state.ReservationManager
 import io.airbyte.cdk.load.state.SyncManager
-import io.airbyte.cdk.load.task.MockTaskLauncher
+import io.airbyte.cdk.load.task.DefaultDestinationTaskLauncher
 import io.airbyte.cdk.load.task.internal.SpilledRawMessagesLocalFile
 import io.airbyte.cdk.load.util.write
 import io.airbyte.cdk.load.write.StreamLoader
-import io.micronaut.test.extensions.junit5.annotation.MicronautTest
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.coVerifySequence
 import io.mockk.mockk
-import jakarta.inject.Inject
 import java.nio.file.Files
 import kotlin.io.path.outputStream
-import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
-@MicronautTest(
-    environments =
-        [
-            "MockDestinationCatalog",
-        ]
-)
 class ProcessRecordsTaskTest {
     private lateinit var diskManager: ReservationManager
-    private lateinit var fileAggregateQueue: MessageQueue<FileAggregateMessage>
+    private lateinit var deserializer: Deserializer<DestinationMessage>
+    private lateinit var streamLoader: StreamLoader
+    private lateinit var inputQueue: MessageQueue<FileAggregateMessage>
     private lateinit var processRecordsTaskFactory: DefaultProcessRecordsTaskFactory
-    private lateinit var launcher: MockTaskLauncher
-    @Inject lateinit var syncManager: SyncManager
+    private lateinit var launcher: DefaultDestinationTaskLauncher
+    private lateinit var outputQueue: MultiProducerChannel<BatchEnvelope<*>>
+    private lateinit var syncManager: SyncManager
 
     @BeforeEach
     fun setup() {
         diskManager = mockk(relaxed = true)
-        fileAggregateQueue = mockk(relaxed = true)
-        launcher = MockTaskLauncher()
+        inputQueue = mockk(relaxed = true)
+        outputQueue = mockk(relaxed = true)
+        syncManager = mockk(relaxed = true)
+        streamLoader = mockk(relaxed = true)
+        coEvery { syncManager.getOrAwaitStreamLoader(any()) } returns streamLoader
+        launcher = mockk(relaxed = true)
+        deserializer = mockk(relaxed = true)
+        coEvery { deserializer.deserialize(any()) } answers
+            {
+                DestinationRecord(
+                    stream = MockDestinationCatalogFactory.stream1.descriptor,
+                    data = IntegerValue(firstArg<String>().toLong()),
+                    emittedAtMs = 0L,
+                    meta = null,
+                    serialized = firstArg(),
+                )
+            }
         processRecordsTaskFactory =
             DefaultProcessRecordsTaskFactory(
-                MockDeserializer(),
+                deserializer,
                 syncManager,
                 diskManager,
-                fileAggregateQueue,
+                inputQueue,
+                outputQueue,
             )
     }
 
     class MockBatch(
+        override val groupId: String?,
         override val state: Batch.State,
-        val reportedByteSize: Long,
-        val recordCount: Long,
-        val pmChecksum: Long,
-        override val groupId: String? = null
-    ) : Batch
-
-    class MockStreamLoader : StreamLoader {
-        override val stream: DestinationStream = MockDestinationCatalogFactory.stream1
-
-        data class SumAndCount(val sum: Long = 0, val count: Long = 0)
-
-        override suspend fun processRecords(
-            records: Iterator<DestinationRecord>,
-            totalSizeBytes: Long
-        ): Batch {
-            // Do a simple sum of the record values and count
-            // To demonstrate that the primed data was actually processed
-            val (sum, count) =
-                records.asSequence().fold(SumAndCount()) { acc, record ->
-                    SumAndCount(
-                        acc.sum + (record.data as IntegerValue).value.toLong(),
-                        acc.count + 1
-                    )
-                }
-            return MockBatch(
-                state = Batch.State.COMPLETE,
-                reportedByteSize = totalSizeBytes,
-                recordCount = count,
-                pmChecksum = sum
-            )
-        }
-
-        override suspend fun processFile(file: DestinationFile): Batch {
-            return MockBatch(
-                state = Batch.State.COMPLETE,
-                reportedByteSize = file.fileMessage.bytes ?: 0,
-                recordCount = 1,
-                pmChecksum = 1
-            )
-        }
+        recordIterator: Iterator<DestinationRecord>
+    ) : Batch {
+        val records = recordIterator.asSequence().toList()
     }
 
-    class MockDeserializer : Deserializer<DestinationMessage> {
-        override fun deserialize(serialized: String): DestinationMessage {
-            return DestinationRecord(
-                stream = MockDestinationCatalogFactory.stream1.descriptor,
-                data = IntegerValue(serialized.toLong()),
-                emittedAtMs = 0L,
-                meta = null,
-                serialized = serialized,
-            )
+    private val recordCount = 1024
+    private val serializedRecords = (0 until 1024).map { "$it" }
+    private fun makeFile(index: Int): SpilledRawMessagesLocalFile {
+        val mockFile = Files.createTempFile("test_$index", ".jsonl")
+        mockFile.outputStream().use { outputStream ->
+            serializedRecords.map { "$it\n" }.forEach { outputStream.write(it) }
         }
+        return SpilledRawMessagesLocalFile(
+            localFile = mockFile,
+            totalSizeBytes = 999L,
+            indexRange = Range.closed(0, recordCount.toLong())
+        )
     }
 
     @Test
-    fun testProcessRecordsTask() = runTest {
-        val stream1 = MockDestinationCatalogFactory.stream1
+    fun `test standard workflow`() = runTest {
         val byteSize = 999L
         val recordCount = 1024L
+        val descriptor = MockDestinationCatalogFactory.stream1.descriptor
 
-        val mockFile = Files.createTempFile("test", ".jsonl")
-        val file =
-            SpilledRawMessagesLocalFile(
-                localFile = mockFile,
-                totalSizeBytes = byteSize,
-                indexRange = Range.closed(0, recordCount)
-            )
-        mockFile.outputStream().use { outputStream ->
-            repeat(recordCount.toInt()) { outputStream.write("$it\n") }
-        }
-        coEvery { fileAggregateQueue.consume() } returns
-            flowOf(
-                FileAggregateMessage(
-                    MockDestinationCatalogFactory.stream1.descriptor,
-                    file,
+        // Put three files on the flow.
+        val files = (0 until 3).map { makeFile(it) }
+        coEvery { inputQueue.consume() } returns
+            files.map { FileAggregateMessage(descriptor, it) }.asFlow()
+
+        // Process records returns batches in 3 states.
+        coEvery { streamLoader.processRecords(any(), any()) } answers
+            {
+                MockBatch(
+                    groupId = null,
+                    state = Batch.State.PERSISTED,
+                    recordIterator = firstArg()
                 )
-            )
+            } andThenAnswer
+            {
+                MockBatch(groupId = null, state = Batch.State.COMPLETE, recordIterator = firstArg())
+            } andThenAnswer
+            {
+                MockBatch(
+                    groupId = "foo",
+                    state = Batch.State.PERSISTED,
+                    recordIterator = firstArg()
+                )
+            }
 
+        // Run the task.
         val task =
             processRecordsTaskFactory.make(
                 taskLauncher = launcher,
             )
 
-        syncManager.registerStartedStreamLoader(
-            stream1.descriptor,
-            Result.success(MockStreamLoader())
-        )
         task.execute()
 
-        Assertions.assertEquals(1, launcher.batchEnvelopes.size)
-        val batch = launcher.batchEnvelopes[0].batch as MockBatch
-        Assertions.assertEquals(Batch.State.COMPLETE, batch.state)
-        Assertions.assertEquals(999, batch.reportedByteSize)
-        Assertions.assertEquals(recordCount, batch.recordCount)
-        Assertions.assertEquals((0 until recordCount).sum(), batch.pmChecksum)
-        Assertions.assertFalse(Files.exists(mockFile), "ensure task deleted file")
-        coVerify { diskManager.release(byteSize) }
+        fun batchMatcher(groupId: String?, state: Batch.State): (BatchEnvelope<*>) -> Boolean = {
+            it.ranges.encloses(Range.closed(0, recordCount)) &&
+                it.streamDescriptor == descriptor &&
+                it.batch.groupId == groupId &&
+                it.batch.state == state &&
+                it.batch is MockBatch &&
+                (it.batch as MockBatch).records.map { record -> record.serialized }.toSet() ==
+                    serializedRecords.toSet()
+        }
+
+        // Verify the batch was *handled* 3 times but *published* ONLY when it is not complete AND
+        // group id is null.
+        coVerify(exactly = 1) {
+            outputQueue.publish(match { batchMatcher(null, Batch.State.PERSISTED)(it) })
+        }
+        coVerifySequence {
+            launcher.handleNewBatch(
+                MockDestinationCatalogFactory.stream1.descriptor,
+                match { batchMatcher(null, Batch.State.PERSISTED)(it) }
+            )
+            launcher.handleNewBatch(
+                MockDestinationCatalogFactory.stream1.descriptor,
+                match { batchMatcher(null, Batch.State.COMPLETE)(it) }
+            )
+            launcher.handleNewBatch(
+                MockDestinationCatalogFactory.stream1.descriptor,
+                match { batchMatcher("foo", Batch.State.PERSISTED)(it) }
+            )
+        }
+
+        files.forEach {
+            Assertions.assertFalse(Files.exists(it.localFile), "ensure task deleted file $it")
+        }
+        coVerify(exactly = 3) { diskManager.release(byteSize) }
     }
 }

--- a/airbyte-integrations/connectors/destination-s3-v2/build.gradle
+++ b/airbyte-integrations/connectors/destination-s3-v2/build.gradle
@@ -12,10 +12,20 @@ airbyteBulkConnector {
 application {
     mainClass = 'io.airbyte.integrations.destination.s3_v2.S3V2Destination'
 
-    applicationDefaultJvmArgs = ['-XX:+ExitOnOutOfMemoryError', '-XX:MaxRAMPercentage=75.0']
-
-    // Uncomment and replace to run locally
-    //applicationDefaultJvmArgs = ['-XX:+ExitOnOutOfMemoryError', '-XX:MaxRAMPercentage=75.0', '--add-opens', 'java.base/sun.nio.ch=ALL-UNNAMED', '--add-opens', 'java.base/sun.security.action=ALL-UNNAMED', '--add-opens', 'java.base/java.lang=ALL-UNNAMED']
+    applicationDefaultJvmArgs = [
+            '-XX:+ExitOnOutOfMemoryError', '-XX:MaxRAMPercentage=75.0',
+//            Uncomment to run locally:
+//          '--add-opens', 'java.base/java.lang=ALL-UNNAMED'
+//            Uncomment to enable remote profiling:
+//            '-XX:NativeMemoryTracking=detail',
+//            '-Djava.rmi.server.hostname=localhost',
+//            '-Dcom.sun.management.jmxremote=true',
+//            '-Dcom.sun.management.jmxremote.port=6000',
+//            '-Dcom.sun.management.jmxremote.rmi.port=6000',
+//            '-Dcom.sun.management.jmxremote.local.only=false',
+//            '-Dcom.sun.management.jmxremote.authenticate=false',
+//            '-Dcom.sun.management.jmxremote.ssl=false'
+    ]
 }
 
 // Uncomment to run locally


### PR DESCRIPTION
## What

There's now a queue between `ProcessRecordsTask` and `ProcessBatchTask`

The launcher sets up `numProcessBatchWorkers` tasks at the beginning that run until they've drained the queues.

I also moved the `MultiProducerChannel` registration into init scope on `SpillToDiskTask` and `ProcessRecordsTask` to avoid race conditions. (I got bitten by this once during testing.)