### PR TITLE
fix: bump version to re-release source mysql

### DIFF
--- a/airbyte-integrations/connectors/source-mysql/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mysql/metadata.yaml
@@ -9,7 +9,7 @@ data:
   connectorSubtype: database
   connectorType: source
   definitionId: 435bb9a5-7887-4809-aa58-28c27df0d7ad
-  dockerImageTag: 3.9.0
+  dockerImageTag: 3.9.1
   dockerRepository: airbyte/source-mysql
   documentationUrl: https://docs.airbyte.com/integrations/sources/mysql
   githubIssueLabel: source-mysql

--- a/docs/integrations/sources/mysql.md
+++ b/docs/integrations/sources/mysql.md
@@ -226,7 +226,8 @@ Any database or table encoding combination of charset and collation is supported
 
 | Version  | Date       | Pull Request                                               | Subject                                                                                                                                         |
 |:---------|:-----------|:-----------------------------------------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------|
-| 3.9.0 | 2024-12-12 | [49423](https://github.com/airbytehq/airbyte/pull/49423) | Promoting release candidate 3.9.0-rc.27 to a main version. |
+| 3.9.1    | 2024-12-12 | [49423](https://github.com/airbytehq/airbyte/pull/49423) | Bump version to re-relase                                                                                                                       |
+| 3.9.0    | 2024-12-12 | [49423](https://github.com/airbytehq/airbyte/pull/49423) | Promoting release candidate 3.9.0-rc.27 to a main version.                                                                                      |
 | 3.9.0-rc | 2024-11-05 | [48369](https://github.com/airbytehq/airbyte/pull/48369)   | Progressive rollout test.                                                                                                                       |
 | 3.7.3    | 2024-09-17 | [45639](https://github.com/airbytehq/airbyte/pull/45639)   | Adopt latest CDK to use the latest apache sshd mina to handle tcpkeepalive requests.                                                            |
 | 3.7.2    | 2024-09-05 | [45181](https://github.com/airbytehq/airbyte/pull/45181)   | Fix incorrect categorizing resumable/nonresumable full refresh streams.                                                                         |

--- a/docs/integrations/sources/mysql.md
+++ b/docs/integrations/sources/mysql.md
@@ -226,7 +226,7 @@ Any database or table encoding combination of charset and collation is supported
 
 | Version  | Date       | Pull Request                                               | Subject                                                                                                                                         |
 |:---------|:-----------|:-----------------------------------------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------|
-| 3.9.1    | 2024-12-12 | [49423](https://github.com/airbytehq/airbyte/pull/49423) | Bump version to re-relase                                                                                                                       |
+| 3.9.1    | 2024-12-12 | [49456](https://github.com/airbytehq/airbyte/pull/49456) | Bump version to re-relase                                                                                                                       |
 | 3.9.0    | 2024-12-12 | [49423](https://github.com/airbytehq/airbyte/pull/49423) | Promoting release candidate 3.9.0-rc.27 to a main version.                                                                                      |
 | 3.9.0-rc | 2024-11-05 | [48369](https://github.com/airbytehq/airbyte/pull/48369)   | Progressive rollout test.                                                                                                                       |
 | 3.7.3    | 2024-09-17 | [45639](https://github.com/airbytehq/airbyte/pull/45639)   | Adopt latest CDK to use the latest apache sshd mina to handle tcpkeepalive requests.                                                            |


### PR DESCRIPTION
## What
Bumps the version and adds a changelog message to re-release source mysql.

## Can this PR be safely reverted and rolled back?
- [X] YES 💚
- [ ] NO ❌
