### PR TITLE
Source Pardot: Update documentation to align with latest connector version

### DIFF
--- a/docs/integrations/sources/pardot.md
+++ b/docs/integrations/sources/pardot.md
@@ -1,61 +1,95 @@
-# Pardot
+# Pardot (Salesforce Marketing Cloud Account Engagement)
 
 ## Overview
 
-The Airbyte Source for [Salesforce Pardot](https://www.pardot.com/)
+This page contains the setup guide and reference information for the [Pardot (Salesforce Marketing Cloud Account Engagement)](https://www.salesforce.com/marketing/b2b-automation/) source connector.
 
-The Pardot supports full refresh syncs
+## Prerequisites
 
-### Output schema
-
-Several output streams are available from this source:
-
-- [Campaigns](https://developer.salesforce.com/docs/marketing/pardot/guide/campaigns-v4.html)
-- [EmailClicks](https://developer.salesforce.com/docs/marketing/pardot/guide/batch-email-clicks-v4.html)
-- [ListMembership](https://developer.salesforce.com/docs/marketing/pardot/guide/list-memberships-v4.html)
-- [Lists](https://developer.salesforce.com/docs/marketing/pardot/guide/lists-v4.html)
-- [ProspectAccounts](https://developer.salesforce.com/docs/marketing/pardot/guide/prospect-accounts-v4.html)
-- [Prospects](https://developer.salesforce.com/docs/marketing/pardot/guide/prospects-v4.html)
-- [Users](https://developer.salesforce.com/docs/marketing/pardot/guide/users-v4.html)
-- [VisitorActivities](https://developer.salesforce.com/docs/marketing/pardot/guide/visitor-activities-v4.html)
-- [Visitors](https://developer.salesforce.com/docs/marketing/pardot/guide/visitors-v4.html)
-- [Visits](https://developer.salesforce.com/docs/marketing/pardot/guide/visits-v4.html)
-
-If there are more endpoints you'd like Airbyte to support, please [create an issue.](https://github.com/airbytehq/airbyte/issues/new/choose)
-
-### Features
-
-| Feature           | Supported? |
-| :---------------- | :--------- |
-| Full Refresh Sync | Yes        |
-| Incremental Sync  | No         |
-| SSL connection    | No         |
-| Namespaces        | No         |
-
-### Performance considerations
-
-The Pardot connector should not run into Pardot API limitations under normal usage. Please [create an issue](https://github.com/airbytehq/airbyte/issues) if you see any rate limit issues that are not automatically retried successfully.
-
-## Getting started
-
-### Requirements
-
-- Pardot Account
+- Pardot/Marketing Cloud Account Engagement account
 - Pardot Business Unit ID
 - Client ID
 - Client Secret
 - Refresh Token
-- Start Date
-- Is Sandbox environment?
 
-### Setup guide
+## Setup Guide
 
-- `pardot_business_unit_id`: Pardot Business ID, can be found at Setup > Pardot > Pardot Account Setup
-- `client_id`: The Consumer Key that can be found when viewing your app in Salesforce
-- `client_secret`: The Consumer Secret that can be found when viewing your app in Salesforce
-- `refresh_token`: Salesforce Refresh Token used for Airbyte to access your Salesforce account. If you don't know what this is, follow [this guide](https://medium.com/@bpmmendis94/obtain-access-refresh-tokens-from-salesforce-rest-api-a324fe4ccd9b) to retrieve it.
-- `start_date`: UTC date and time in the format 2017-01-25T00:00:00Z. Any data before this date will not be replicated. Leave blank to skip this filter
-- `is_sandbox`: Whether or not the app is in a Salesforce sandbox. If you do not know what this is, assume it is false.
+### Required configuration options
+- **Pardot Business Unit ID** (`pardot_business_unit_id`): This value uniquely identifies your account, and can be found at Setup > Pardot > Pardot Account Setup
+
+- **Client ID** (`client_id`): The Consumer Key that can be found when viewing your app in Salesforce
+
+- **Client Secret** (`client_secret`): The Consumer Secret that can be found when viewing your app in Salesforce
+
+- **Refresh Token** (`refresh_token`): Salesforce Refresh Token used for Airbyte to access your Salesforce account. If you don't know what this is, follow [this guide](https://medium.com/@bpmmendis94/obtain-access-refresh-tokens-from-salesforce-rest-api-a324fe4ccd9b) to retrieve it.
+
+### Optional configuration options
+- **Start Date** (`start_date`): UTC date and time in the format `2020-01-25T00:00:00Z`. Any data before this date will not be replicated. Defaults to `2007-01-01T00:00:00Z` (the year Pardot was launched)
+
+- **Page Size Limit** (`page_size`): The default page size to return; defaults to `1000` (which is Pardot's maximum). Does not apply to the Email Clicks stream which uses the v4 API and is limited to 200 per page.
+
+- **Default Split Up Interval** (`split_up_interval`): The default split up interval is used on incremental streams to prevent hitting Pardots limit of 100 pages per result (effectively 100K records on most endpoints). The default is `P3M`, which will break incremental requests into three-month groupings. If you expect more than 100K records to be modified between syncs in a single endpoint, you can increase the granularity to `P1M`, `P14D`, `P7D`, `P3D`, or `P1D` to reduce the maximum records to be paged through per split. For small accounts unlikely to hit the limit, decreasing the granularity to `P6M` or `P1Y` may increase the speed of those syncs, especially the initial backfill.
+
+- **Is Sandbox App?** (`is_sandbox`): Whether or not the app is in a Salesforce sandbox. If you do not know what this is, assume it is false.
+
+## Supported Sync Modes
+
+The Pardot source connector supports the following [sync modes](https://docs.airbyte.com/cloud/core-concepts/#connection-sync-modes):
+
+- Full Refresh
+- Incremental
+
+Incremental streams are based on the Pardot API's `UpdatedAt` field when the object is updateable and the API supports it; otherwise `CreatedAt` or `Id` are used in that order of preference.
+
+### Performance Considerations
+
+The Pardot connector should not run into Pardot API limitations under normal usage. Please [create an issue](https://github.com/airbytehq/airbyte/issues) if you see any rate limit issues that are not automatically retried successfully.
+
+:::tip
+
+Due to timeouts on large accounts, the Split Up Interval (the time period used to page through incrementally) is surfaced as a configuration option. While the default should work for most accounts, large accounts may need to increase the granularity from the default. Similarly, small accounts may see faster initial syncs with a longer interval. See the Optional Configuration Options section for more details.
+
+:::
+
+## Supported Streams
+
+Several output streams are available from this source. Unless noted otherwise, streams are from Pardot's v5 API:
+
+- [Account (Metadata)](https://developer.salesforce.com/docs/marketing/pardot/guide/account-v5.html) (full refresh)
+- [Campaigns](https://developer.salesforce.com/docs/marketing/pardot/guide/campaign-v5.html) (incremental)
+- [Custom Fields](https://developer.salesforce.com/docs/marketing/pardot/guide/custom-field-v5.html) (incremental)
+- [Custom Redirects](https://developer.salesforce.com/docs/marketing/pardot/guide/custom-redirect-v5.html) (full refresh)
+- [Dynamic Content](https://developer.salesforce.com/docs/marketing/pardot/guide/dynamic-content-v5.html) (incremental)
+- [Dynamic Content Variations](https://developer.salesforce.com/docs/marketing/pardot/guide/dynamic-content-variation.html) (incremental parent)
+- [Emails](https://developer.salesforce.com/docs/marketing/pardot/guide/email-v5.html) (incremental)
+- [Email Clicks (v4 API)](https://developer.salesforce.com/docs/marketing/pardot/guide/batch-email-clicks-v4.html) (incremental)
+- [Engagement Studio Programs](https://developer.salesforce.com/docs/marketing/pardot/guide/engagement-studio-program-v5.html) (incremental)
+- [Files](https://developer.salesforce.com/docs/marketing/pardot/guide/export-v5.html) (full refresh)
+- [Folders](https://developer.salesforce.com/docs/marketing/pardot/guide/folder-v5.html) (full refresh)
+- [Folder Contents](https://developer.salesforce.com/docs/marketing/pardot/guide/folder-contents-v5.html) (incremental)
+- [Forms](https://developer.salesforce.com/docs/marketing/pardot/guide/form-v5.html) (full refresh)
+- [Form Fields](https://developer.salesforce.com/docs/marketing/pardot/guide/form-field-v5.html) (incremental)
+- [Form Handlers](https://developer.salesforce.com/docs/marketing/pardot/guide/form-handler-v5.html) (full refresh)
+- [Form Handler Fields](https://developer.salesforce.com/docs/marketing/pardot/guide/form-handler-field-v5.html) (full refresh)
+- [Landing Pages](https://developer.salesforce.com/docs/marketing/pardot/guide/landing-page-v5.html) (incremental)
+- [Layout Templates](https://developer.salesforce.com/docs/marketing/pardot/guide/layout-template-v5.html) (full refresh)
+- [Lifecycle Stages](https://developer.salesforce.com/docs/marketing/pardot/guide/lifecycle-stage-v5.html) (incremental)
+- [Lifecycle Histories](https://developer.salesforce.com/docs/marketing/pardot/guide/lifecycle-history-v5.html) (incremental)
+- [Lists](https://developer.salesforce.com/docs/marketing/pardot/guide/list-v5.html) (incremental)
+- [List Emails](https://developer.salesforce.com/docs/marketing/pardot/guide/list-email-v5.html) (incremental)
+- [List Memberships](https://developer.salesforce.com/docs/marketing/pardot/guide/list-membership-v5.html) (incremental)
+- [Opportunities](https://developer.salesforce.com/docs/marketing/pardot/guide/opportunity-v5.html) (incremental)
+- [Prospects](https://developer.salesforce.com/docs/marketing/pardot/guide/prospect-v5.html) (incremental)
+- [Prospect Accounts](https://developer.salesforce.com/docs/marketing/pardot/guide/prospect-account-v5.html) (full refresh)
+- [Tags](https://developer.salesforce.com/docs/marketing/pardot/guide/tag-v5.html) (incremental)
+- [Tracker Domains](https://developer.salesforce.com/docs/marketing/pardot/guide/tracker-domain-v5.html) (full refresh)
+- [Users](https://developer.salesforce.com/docs/marketing/pardot/guide/user-v5.html) (incremental)
+- [Visitors](https://developer.salesforce.com/docs/marketing/pardot/guide/visitor-v5.html) (incremental)
+- [Visitor Activity](https://developer.salesforce.com/docs/marketing/pardot/guide/visitor-activity-v5.html) (incremental)
+- [Visitor Page Views](https://developer.salesforce.com/docs/marketing/pardot/guide/visitor-page-view-v5.html) (incremental)
+- [Visits](https://developer.salesforce.com/docs/marketing/pardot/guide/visit-v5.html) (incremental)
+
+If there are more endpoints you'd like Airbyte to support, please [create an issue](https://github.com/airbytehq/airbyte/issues/new/choose).
 
 ## Changelog
 


### PR DESCRIPTION
Source Pardot: Update documentation to align with latest connector version

## What
Update Pardot source docs to align with in-progress PR version (#49424) of Pardot connector

## How
- documented new optional config properties
- added streams to the list, including sync modes and docs links
- noted the one stream that still uses the v4 API
- tried to bring the docs in line with the styles of other connectors (e.g. HubSpot, Salesforce)
- added noted on performance tweaking based on account size, which was one of the reasons for this connector update

## Review guide
This should align with the connector

## User Impact
It should actually make sense :)

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌
