### PR TITLE
airbyte-ci: fix root use when installing local CDK

### DIFF
--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -854,6 +854,7 @@ airbyte-ci connectors --language=low-code migrate-to-manifest-only
 
 | Version | PR                                                         | Description                                                                                                                  |
 | ------- | ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| 4.46.3  | [#49465](https://github.com/airbytehq/airbyte/pull/49465)  | Fix `--use-local-cdk` on rootless connectors.                                                                                |
 | 4.46.2  | [#49136](https://github.com/airbytehq/airbyte/pull/49136)  | Fix failed install of python components due to non-root permissions.                                                         |
 | 4.46.1  | [#49146](https://github.com/airbytehq/airbyte/pull/49146)  | Update `crane` image address as the one we were using has been deleted by the maintainer.                                    |
 | 4.46.0  | [#48790](https://github.com/airbytehq/airbyte/pull/48790)  | Add unit tests step for manifest-only connectors                                                                             |

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/manifest_only_connectors.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/manifest_only_connectors.py
@@ -82,10 +82,6 @@ class ManifestOnlyConnectorUnitTests(PytestStep):
             ["ln", "-s", "/source-declarative-manifest", connector_path]
         )
 
-        # Specify the root user for installation of dependencies.
-        # This is necessary to install poetry dependencies in rootless containers.
-        test_environment = test_environment.with_user("root")
-
         return await super().install_testing_environment(
             test_environment,
             test_config_file_name,

--- a/airbyte-ci/connectors/pipelines/pipelines/dagger/actions/python/common.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/dagger/actions/python/common.py
@@ -273,6 +273,8 @@ def apply_python_development_overrides(context: ConnectorContext, connector_cont
                 # TODO: Consider moving to Poetry-native installation:
                 # ["poetry", "add", cdk_mount_dir]
             )
+            # Switch back to the original user
+            .with_user(current_user)
         )
     elif context.use_cdk_ref:
         cdk_ref = context.use_cdk_ref
@@ -281,12 +283,16 @@ def apply_python_development_overrides(context: ConnectorContext, connector_cont
 
         context.logger.info("Using CDK ref: '{cdk_ref}'")
         # Install the airbyte-cdk package from provided ref
-        connector_container = connector_container.with_exec(
-            [
-                "pip",
-                "install",
-                f"git+https://github.com/airbytehq/airbyte-python-cdk.git#{cdk_ref}",
-            ],
+        connector_container = (
+            connector_container.with_user("root")
+            .with_exec(
+                [
+                    "pip",
+                    "install",
+                    f"git+https://github.com/airbytehq/airbyte-python-cdk.git#{cdk_ref}",
+                ],
+            )
+            .with_user(current_user)
         )
     return connector_container
 

--- a/airbyte-ci/connectors/pipelines/pipelines/helpers/utils.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/helpers/utils.py
@@ -376,11 +376,15 @@ def dagger_directory_as_zip_file(dagger_client: Client, directory: Directory, di
     )
 
 
-async def raise_if_not_user(container: Container, user: str) -> None:
+async def raise_if_not_user(container: Container, expected_user: str) -> None:
     """Raise an error if the container is not running as the specified user.
 
     Args:
         container (Container): The container to check.
-        user (str): The user to check.
+        expected_user (str): The expected user.
     """
-    assert (await container.with_exec(["whoami"]).stdout()).strip() == user, f"Container is not running as {user}."
+    actual_user = (await container.with_exec(["whoami"]).stdout()).strip()
+
+    assert (
+        actual_user == expected_user
+    ), f"Container is not running as the expected user '{expected_user}', it is running as '{actual_user}'."

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "4.46.2"
+version = "4.46.3"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 


### PR DESCRIPTION
## What
We added a check to make sure that after test environment provisioning the container user is still the original one.
This check was failing becaue when installing the local CDK we forgot to switch back from root to the original user (`airbyte`).
This PR addresses this.
