### PR TITLE
Bulk load CDK: integration test should log full exception

### DIFF
--- a/airbyte-cdk/bulk/core/load/build.gradle
+++ b/airbyte-cdk/bulk/core/load/build.gradle
@@ -44,8 +44,6 @@ def integrationTestTask = tasks.register('integrationTest', Test) {
     testLogging() {
         events 'skipped', 'started', 'passed', 'failed'
         exceptionFormat 'full'
-        // Swallow the logs when running in airbyte-ci, rely on test reports instead.
-        showStandardStreams = !System.getenv().containsKey("RUN_IN_AIRBYTE_CI")
     }
 }
 

--- a/airbyte-cdk/bulk/core/load/build.gradle
+++ b/airbyte-cdk/bulk/core/load/build.gradle
@@ -40,6 +40,10 @@ def integrationTestTask = tasks.register('integrationTest', Test) {
     systemProperties = project.test.systemProperties
     maxParallelForks = project.test.maxParallelForks
     maxHeapSize = project.test.maxHeapSize
+
+    testLogging() {
+        exceptionFormat 'full'
+    }
 }
 
 // These tests are lightweight enough to run on every PR.

--- a/airbyte-cdk/bulk/core/load/build.gradle
+++ b/airbyte-cdk/bulk/core/load/build.gradle
@@ -42,7 +42,10 @@ def integrationTestTask = tasks.register('integrationTest', Test) {
     maxHeapSize = project.test.maxHeapSize
 
     testLogging() {
+        events 'skipped', 'started', 'passed', 'failed'
         exceptionFormat 'full'
+        // Swallow the logs when running in airbyte-ci, rely on test reports instead.
+        showStandardStreams = !System.getenv().containsKey("RUN_IN_AIRBYTE_CI")
     }
 }
 

--- a/buildSrc/src/main/groovy/airbyte-bulk-connector.gradle
+++ b/buildSrc/src/main/groovy/airbyte-bulk-connector.gradle
@@ -179,6 +179,11 @@ class AirbyteBulkConnectorPlugin implements Plugin<Project> {
                 systemProperties = project.test.systemProperties
                 maxParallelForks = project.test.maxParallelForks
                 maxHeapSize = project.test.maxHeapSize
+
+                testLogging() {
+                    events 'skipped', 'started', 'passed', 'failed'
+                    exceptionFormat 'full'
+                }
             }
 
             // For historical reasons (i.e. airbyte-ci), this task is called integrationTestJava.
@@ -200,6 +205,13 @@ class AirbyteBulkConnectorPlugin implements Plugin<Project> {
                 systemProperties = project.test.systemProperties
                 maxParallelForks = project.test.maxParallelForks
                 maxHeapSize = project.test.maxHeapSize
+
+                testLogging() {
+                    events 'skipped', 'started', 'passed', 'failed'
+                    exceptionFormat 'full'
+                    // Swallow the logs when running in airbyte-ci, rely on test reports instead.
+                    showStandardStreams = !System.getenv().containsKey("RUN_IN_AIRBYTE_CI")
+                }
             }
 
             project.dependencies {


### PR DESCRIPTION
other test tasks inherit from the testLogging config defined in the root build.gradle (and the old java-connector integrationTestJava has copies that testLogging block into the plugin)

* copy that block into bulk connector plugin's integrationTestJava task
* copy relevant bits into integrationTestNonDocker, and load CDK's integrationTest - these tasks never run in airbyte-ci so they don't need the "don't log if CI" thing.