### PR TITLE
Destination Iceberg: integration test for glue

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/DestinationTaskLauncher.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/DestinationTaskLauncher.kt
@@ -148,7 +148,7 @@ class DefaultDestinationTaskLauncher(
                 log.info { "Task $innerTask was cancelled." }
                 throw e
             } catch (e: Exception) {
-                log.error { "Caught exception in task $innerTask: $e" }
+                log.error(e) { "Caught exception in task $innerTask" }
                 handleException(e)
             }
         }

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/DestinationCleaner.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/DestinationCleaner.kt
@@ -8,6 +8,10 @@ fun interface DestinationCleaner {
     /**
      * Search the test destination for old test data and delete it. This should leave recent data
      * (e.g. from the last week) untouched, to avoid causing failures in actively-running tests.
+     *
+     * Implementers should generally list all namespaces in the destination, filter for namespace
+     * which match [IntegrationTest.randomizedNamespaceRegex], and then use
+     * [IntegrationTest.isNamespaceOld] to filter down to namespaces which can be deleted.
      */
     fun cleanup()
 }

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/IntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/IntegrationTest.kt
@@ -63,7 +63,8 @@ abstract class IntegrationTest(
 
     @Suppress("DEPRECATION") private val randomSuffix = RandomStringUtils.randomAlphabetic(4)
     private val timestampString =
-        LocalDateTime.ofInstant(Instant.now(), ZoneOffset.UTC).format(randomizedNamespaceDateFormatter)
+        LocalDateTime.ofInstant(Instant.now(), ZoneOffset.UTC)
+            .format(randomizedNamespaceDateFormatter)
     // stream name doesn't need to be randomized, only the namespace.
     val randomizedNamespace = "test$timestampString$randomSuffix"
 
@@ -274,10 +275,8 @@ abstract class IntegrationTest(
         fun isNamespaceOld(namespace: String, retentionDays: Long = 30): Boolean {
             val cleanupCutoffDate = LocalDate.now().minusDays(retentionDays)
             val matchResult = randomizedNamespaceRegex.find(namespace)
-            val namespaceCreationDate = LocalDate.parse(
-                matchResult!!.groupValues[1],
-                randomizedNamespaceDateFormatter
-            )
+            val namespaceCreationDate =
+                LocalDate.parse(matchResult!!.groupValues[1], randomizedNamespaceDateFormatter)
             return namespaceCreationDate.isBefore(cleanupCutoffDate)
         }
 

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/IntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/IntegrationTest.kt
@@ -62,8 +62,7 @@ abstract class IntegrationTest(
 
     @Suppress("DEPRECATION") private val randomSuffix = RandomStringUtils.randomAlphabetic(4)
     private val timestampString =
-        LocalDateTime.ofInstant(Instant.now(), ZoneOffset.UTC)
-            .format(DateTimeFormatter.ofPattern("YYYYMMDD"))
+        LocalDateTime.ofInstant(Instant.now(), ZoneOffset.UTC).format(randomizedNamespaceDateFormatter)
     // stream name doesn't need to be randomized, only the namespace.
     val randomizedNamespace = "test$timestampString$randomSuffix"
 
@@ -262,6 +261,9 @@ abstract class IntegrationTest(
     }
 
     companion object {
+        val randomizedNamespaceRegex = Regex("test(\\d{8})[A-Za-z]{4}")
+        val randomizedNamespaceDateFormatter = DateTimeFormatter.ofPattern("yyyyMMdd")
+
         private val hasRunCleaner = AtomicBoolean(false)
 
         // Connectors are calling System.getenv rather than using micronaut-y properties,

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/command/iceberg/parquet/IcebergCatalogSpecifications.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/command/iceberg/parquet/IcebergCatalogSpecifications.kt
@@ -181,7 +181,7 @@ class GlueCatalogSpecification(
     @get:JsonPropertyDescription(
         "The AWS Account ID associated with the Glue service used by the Iceberg catalog."
     )
-    @get:JsonProperty("glue_id")
+    @JsonProperty("glue_id")
     @JsonSchemaInject(json = """{"order":1}""")
     val glueId: String,
 ) : CatalogType(catalogType)

--- a/airbyte-integrations/connectors/destination-iceberg-v2/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-iceberg-v2/metadata.yaml
@@ -33,4 +33,13 @@ data:
   supportsRefreshes: true
   tags:
     - language:java
+  connectorTestSuitesOptions:
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_DESTINATION-ICEBERG_V2_S3_GLUE_CONFIG
+          fileName: glue.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-iceberg-v2/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-iceberg-v2/metadata.yaml
@@ -9,11 +9,11 @@ data:
     - suite: unitTests
     - suite: integrationTests
       testSecrets:
-        - fileName: s3_dest_v2_minimal_required_config.json
-          name: SECRET_DESTINATION-S3-V2-MINIMAL-REQUIRED-CONFIG
+        - name: SECRET_DESTINATION-ICEBERG_V2_S3_GLUE_CONFIG
+          fileName: glue.json
           secretStore:
-            alias: airbyte-connector-testing-secret-store
             type: GSM
+            alias: airbyte-connector-testing-secret-store
   connectorType: destination
   definitionId: 37a928c1-2d5c-431a-a97d-ae236bd1ea0c
   dockerImageTag: 0.2.1
@@ -33,13 +33,4 @@ data:
   supportsRefreshes: true
   tags:
     - language:java
-  connectorTestSuitesOptions:
-    - suite: unitTests
-    - suite: integrationTests
-      testSecrets:
-        - name: SECRET_DESTINATION-ICEBERG_V2_S3_GLUE_CONFIG
-          fileName: glue.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-iceberg-v2/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-iceberg-v2/metadata.yaml
@@ -16,7 +16,7 @@ data:
             type: GSM
   connectorType: destination
   definitionId: 37a928c1-2d5c-431a-a97d-ae236bd1ea0c
-  dockerImageTag: 0.2.0
+  dockerImageTag: 0.2.1
   dockerRepository: airbyte/destination-iceberg-v2
   documentationUrl: https://docs.airbyte.com/integrations/destinations/s3
   githubIssueLabel: destination-iceberg-v2

--- a/airbyte-integrations/connectors/destination-iceberg-v2/src/main/kotlin/io/airbyte/integrations/destination/iceberg/v2/IcebergV2Checker.kt
+++ b/airbyte-integrations/connectors/destination-iceberg-v2/src/main/kotlin/io/airbyte/integrations/destination/iceberg/v2/IcebergV2Checker.kt
@@ -8,7 +8,6 @@ import io.airbyte.cdk.load.check.DestinationChecker
 import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.integrations.destination.iceberg.v2.io.IcebergTableCleaner
 import io.airbyte.integrations.destination.iceberg.v2.io.IcebergUtil
-import io.airbyte.integrations.destination.iceberg.v2.io.toIcebergTableIdentifier
 import javax.inject.Singleton
 import org.apache.iceberg.Schema
 import org.apache.iceberg.types.Types
@@ -16,7 +15,8 @@ import org.apache.iceberg.types.Types
 @Singleton
 class IcebergV2Checker(
     private val icebergTableCleaner: IcebergTableCleaner,
-    private val icebergUtil: IcebergUtil
+    private val icebergUtil: IcebergUtil,
+    private val tableIdGenerator: TableIdGenerator,
 ) : DestinationChecker<IcebergV2Configuration> {
 
     override fun check(config: IcebergV2Configuration) {
@@ -43,7 +43,7 @@ class IcebergV2Checker(
 
         icebergTableCleaner.clearTable(
             catalog,
-            testTableIdentifier.toIcebergTableIdentifier(),
+            tableIdGenerator.toTableIdentifier(testTableIdentifier),
             table.io(),
             table.location()
         )

--- a/airbyte-integrations/connectors/destination-iceberg-v2/src/main/kotlin/io/airbyte/integrations/destination/iceberg/v2/TableIdGenerator.kt
+++ b/airbyte-integrations/connectors/destination-iceberg-v2/src/main/kotlin/io/airbyte/integrations/destination/iceberg/v2/TableIdGenerator.kt
@@ -1,0 +1,44 @@
+package io.airbyte.integrations.destination.iceberg.v2
+
+import io.airbyte.cdk.load.command.DestinationStream
+import io.airbyte.cdk.load.command.iceberg.parquet.GlueCatalogConfiguration
+import io.micronaut.context.annotation.Factory
+import javax.inject.Singleton
+import org.apache.iceberg.catalog.Namespace
+import org.apache.iceberg.catalog.TableIdentifier
+
+/**
+ * Convert our internal stream descriptor to an Iceberg [TableIdentifier].
+ * Implementations should handle catalog-specific naming restrictions.
+ */
+// TODO accept default namespace in config as a val here
+interface TableIdGenerator {
+    fun toTableIdentifier(stream: DestinationStream.Descriptor): TableIdentifier
+}
+
+class SimpleTableIdGenerator : TableIdGenerator {
+    override fun toTableIdentifier(stream: DestinationStream.Descriptor): TableIdentifier =
+        tableIdOf(stream.namespace!!, stream.name)
+}
+
+/**
+ * AWS Glue requires lowercase database+table names.
+ */
+class GlueTableIdGenerator : TableIdGenerator {
+    override fun toTableIdentifier(stream: DestinationStream.Descriptor): TableIdentifier =
+        tableIdOf(stream.namespace!!.lowercase(), stream.name.lowercase())
+}
+
+@Factory
+class TableIdGeneratorFactory(private val icebergConfiguration: IcebergV2Configuration) {
+    @Singleton
+    fun create() =
+        when (icebergConfiguration.icebergCatalogConfiguration.catalogConfiguration) {
+            is GlueCatalogConfiguration -> GlueTableIdGenerator()
+            else -> SimpleTableIdGenerator()
+        }
+}
+
+// iceberg namespace+name must both be nonnull.
+private fun tableIdOf(namespace: String, name: String) =
+    TableIdentifier.of(Namespace.of(namespace), name)

--- a/airbyte-integrations/connectors/destination-iceberg-v2/src/main/kotlin/io/airbyte/integrations/destination/iceberg/v2/TableIdGenerator.kt
+++ b/airbyte-integrations/connectors/destination-iceberg-v2/src/main/kotlin/io/airbyte/integrations/destination/iceberg/v2/TableIdGenerator.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
 package io.airbyte.integrations.destination.iceberg.v2
 
 import io.airbyte.cdk.load.command.DestinationStream
@@ -8,8 +12,8 @@ import org.apache.iceberg.catalog.Namespace
 import org.apache.iceberg.catalog.TableIdentifier
 
 /**
- * Convert our internal stream descriptor to an Iceberg [TableIdentifier].
- * Implementations should handle catalog-specific naming restrictions.
+ * Convert our internal stream descriptor to an Iceberg [TableIdentifier]. Implementations should
+ * handle catalog-specific naming restrictions.
  */
 // TODO accept default namespace in config as a val here
 interface TableIdGenerator {
@@ -21,9 +25,7 @@ class SimpleTableIdGenerator : TableIdGenerator {
         tableIdOf(stream.namespace!!, stream.name)
 }
 
-/**
- * AWS Glue requires lowercase database+table names.
- */
+/** AWS Glue requires lowercase database+table names. */
 class GlueTableIdGenerator : TableIdGenerator {
     override fun toTableIdentifier(stream: DestinationStream.Descriptor): TableIdentifier =
         tableIdOf(stream.namespace!!.lowercase(), stream.name.lowercase())

--- a/airbyte-integrations/connectors/destination-iceberg-v2/src/main/kotlin/io/airbyte/integrations/destination/iceberg/v2/io/IcebergUtil.kt
+++ b/airbyte-integrations/connectors/destination-iceberg-v2/src/main/kotlin/io/airbyte/integrations/destination/iceberg/v2/io/IcebergUtil.kt
@@ -47,6 +47,7 @@ import org.apache.iceberg.catalog.TableIdentifier
 import org.apache.iceberg.data.Record
 import org.apache.iceberg.exceptions.AlreadyExistsException
 import org.projectnessie.client.NessieConfigConstants
+import software.amazon.awssdk.services.glue.model.ConcurrentModificationException
 
 private val logger = KotlinLogging.logger {}
 
@@ -123,6 +124,11 @@ class IcebergUtil(private val tableIdGenerator: TableIdGenerator) {
                     // One thread may create the namespace successfully, causing the other threads
                     // to encounter this exception
                     // when they also try to create the namespace.
+                    logger.info {
+                        "Namespace '${tableIdentifier.namespace()}' was likely created by another thread during parallel operations."
+                    }
+                } catch (e: ConcurrentModificationException) {
+                    // do the same for AWS Glue
                     logger.info {
                         "Namespace '${tableIdentifier.namespace()}' was likely created by another thread during parallel operations."
                     }

--- a/airbyte-integrations/connectors/destination-iceberg-v2/src/main/kotlin/io/airbyte/integrations/destination/iceberg/v2/io/IcebergUtil.kt
+++ b/airbyte-integrations/connectors/destination-iceberg-v2/src/main/kotlin/io/airbyte/integrations/destination/iceberg/v2/io/IcebergUtil.kt
@@ -41,9 +41,7 @@ import org.apache.iceberg.aws.AwsProperties
 import org.apache.iceberg.aws.s3.S3FileIO
 import org.apache.iceberg.aws.s3.S3FileIOProperties
 import org.apache.iceberg.catalog.Catalog
-import org.apache.iceberg.catalog.Namespace
 import org.apache.iceberg.catalog.SupportsNamespaces
-import org.apache.iceberg.catalog.TableIdentifier
 import org.apache.iceberg.data.Record
 import org.apache.iceberg.exceptions.AlreadyExistsException
 import org.projectnessie.client.NessieConfigConstants

--- a/airbyte-integrations/connectors/destination-iceberg-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/iceberg/v2/IcebergDestinationCleaner.kt
+++ b/airbyte-integrations/connectors/destination-iceberg-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/iceberg/v2/IcebergDestinationCleaner.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
 package io.airbyte.integrations.destination.iceberg.v2
 
 import io.airbyte.cdk.load.test.util.DestinationCleaner
@@ -9,7 +13,9 @@ import org.apache.iceberg.catalog.Namespace
 import org.apache.iceberg.catalog.SupportsNamespaces
 
 class IcebergDestinationCleaner(private val catalog: Catalog) : DestinationCleaner {
-    constructor(configuration: IcebergV2Configuration) : this(
+    constructor(
+        configuration: IcebergV2Configuration
+    ) : this(
         IcebergUtil(SimpleTableIdGenerator()).let { icebergUtil ->
             val props = icebergUtil.toCatalogProperties(configuration)
             icebergUtil.createCatalog(DEFAULT_CATALOG_NAME, props)
@@ -18,15 +24,14 @@ class IcebergDestinationCleaner(private val catalog: Catalog) : DestinationClean
 
     override fun cleanup() {
         val namespaces: List<Namespace> =
-            (catalog as SupportsNamespaces)
-                .listNamespaces()
-                .filter {
-                    val namespace = it.level(0)
-                    randomizedNamespaceRegex.matches(namespace) && isNamespaceOld(namespace)
-                }
+            (catalog as SupportsNamespaces).listNamespaces().filter {
+                val namespace = it.level(0)
+                randomizedNamespaceRegex.matches(namespace) && isNamespaceOld(namespace)
+            }
         namespaces.forEach { namespace ->
-            catalog.listTables(namespace)
-                .forEach { table -> catalog.dropTable(table, /* purge = */ true) }
+            catalog.listTables(namespace).forEach { table ->
+                catalog.dropTable(table, /* purge = */ true)
+            }
             catalog.dropNamespace(namespace)
         }
     }

--- a/airbyte-integrations/connectors/destination-iceberg-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/iceberg/v2/IcebergDestinationCleaner.kt
+++ b/airbyte-integrations/connectors/destination-iceberg-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/iceberg/v2/IcebergDestinationCleaner.kt
@@ -1,10 +1,9 @@
 package io.airbyte.integrations.destination.iceberg.v2
 
 import io.airbyte.cdk.load.test.util.DestinationCleaner
-import io.airbyte.cdk.load.test.util.IntegrationTest.Companion.randomizedNamespaceDateFormatter
+import io.airbyte.cdk.load.test.util.IntegrationTest.Companion.isNamespaceOld
 import io.airbyte.cdk.load.test.util.IntegrationTest.Companion.randomizedNamespaceRegex
 import io.airbyte.integrations.destination.iceberg.v2.io.IcebergUtil
-import java.time.LocalDate
 import org.apache.iceberg.catalog.Catalog
 import org.apache.iceberg.catalog.Namespace
 import org.apache.iceberg.catalog.SupportsNamespaces
@@ -18,21 +17,12 @@ class IcebergDestinationCleaner(private val catalog: Catalog) : DestinationClean
     )
 
     override fun cleanup() {
-        val cleanupCutoffDate = LocalDate.now().minusDays(15)
         val namespaces: List<Namespace> =
             (catalog as SupportsNamespaces)
                 .listNamespaces()
                 .filter {
-                    val matchResult = randomizedNamespaceRegex.find(it.level(0))
-                    if (matchResult == null) {
-                        false
-                    } else {
-                        val namespaceCreationDate = LocalDate.parse(
-                            matchResult.groupValues[1],
-                            randomizedNamespaceDateFormatter
-                        )
-                        namespaceCreationDate.isBefore(cleanupCutoffDate)
-                    }
+                    val namespace = it.level(0)
+                    randomizedNamespaceRegex.matches(namespace) && isNamespaceOld(namespace)
                 }
         namespaces.forEach { namespace ->
             catalog.listTables(namespace)

--- a/airbyte-integrations/connectors/destination-iceberg-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/iceberg/v2/IcebergDestinationCleaner.kt
+++ b/airbyte-integrations/connectors/destination-iceberg-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/iceberg/v2/IcebergDestinationCleaner.kt
@@ -7,6 +7,8 @@ package io.airbyte.integrations.destination.iceberg.v2
 import io.airbyte.cdk.load.test.util.DestinationCleaner
 import io.airbyte.cdk.load.test.util.IntegrationTest.Companion.isNamespaceOld
 import io.airbyte.cdk.load.test.util.IntegrationTest.Companion.randomizedNamespaceRegex
+import io.airbyte.integrations.destination.iceberg.v2.io.IcebergTableCleaner
+import io.airbyte.integrations.destination.iceberg.v2.io.IcebergUtil
 import org.apache.iceberg.catalog.Catalog
 import org.apache.iceberg.catalog.Namespace
 import org.apache.iceberg.catalog.SupportsNamespaces
@@ -18,9 +20,14 @@ class IcebergDestinationCleaner(private val catalog: Catalog) : DestinationClean
                 val namespace = it.level(0)
                 randomizedNamespaceRegex.matches(namespace) && isNamespaceOld(namespace)
             }
+
+        // we're passing explicit TableIdentifier to clearTable, so just use SimpleTableIdGenerator
+        val tableCleaner = IcebergTableCleaner(IcebergUtil(SimpleTableIdGenerator()))
+
         namespaces.forEach { namespace ->
-            catalog.listTables(namespace).forEach { table ->
-                catalog.dropTable(table, /* purge = */ true)
+            catalog.listTables(namespace).forEach { tableId ->
+                val table = catalog.loadTable(tableId)
+                tableCleaner.clearTable(catalog, tableId, table.io(), table.location())
             }
             catalog.dropNamespace(namespace)
         }

--- a/airbyte-integrations/connectors/destination-iceberg-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/iceberg/v2/IcebergDestinationCleaner.kt
+++ b/airbyte-integrations/connectors/destination-iceberg-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/iceberg/v2/IcebergDestinationCleaner.kt
@@ -1,0 +1,43 @@
+package io.airbyte.integrations.destination.iceberg.v2
+
+import io.airbyte.cdk.load.test.util.DestinationCleaner
+import io.airbyte.cdk.load.test.util.IntegrationTest.Companion.randomizedNamespaceDateFormatter
+import io.airbyte.cdk.load.test.util.IntegrationTest.Companion.randomizedNamespaceRegex
+import io.airbyte.integrations.destination.iceberg.v2.io.IcebergUtil
+import java.time.LocalDate
+import org.apache.iceberg.catalog.Catalog
+import org.apache.iceberg.catalog.Namespace
+import org.apache.iceberg.catalog.SupportsNamespaces
+
+class IcebergDestinationCleaner(private val catalog: Catalog) : DestinationCleaner {
+    constructor(configuration: IcebergV2Configuration) : this(
+        IcebergUtil(SimpleTableIdGenerator()).let { icebergUtil ->
+            val props = icebergUtil.toCatalogProperties(configuration)
+            icebergUtil.createCatalog(DEFAULT_CATALOG_NAME, props)
+        }
+    )
+
+    override fun cleanup() {
+        val cleanupCutoffDate = LocalDate.now().minusDays(15)
+        val namespaces: List<Namespace> =
+            (catalog as SupportsNamespaces)
+                .listNamespaces()
+                .filter {
+                    val matchResult = randomizedNamespaceRegex.find(it.level(0))
+                    if (matchResult == null) {
+                        false
+                    } else {
+                        val namespaceCreationDate = LocalDate.parse(
+                            matchResult.groupValues[1],
+                            randomizedNamespaceDateFormatter
+                        )
+                        namespaceCreationDate.isBefore(cleanupCutoffDate)
+                    }
+                }
+        namespaces.forEach { namespace ->
+            catalog.listTables(namespace)
+                .forEach { table -> catalog.dropTable(table, /* purge = */ true) }
+            catalog.dropNamespace(namespace)
+        }
+    }
+}

--- a/airbyte-integrations/connectors/destination-iceberg-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/iceberg/v2/IcebergDestinationCleaner.kt
+++ b/airbyte-integrations/connectors/destination-iceberg-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/iceberg/v2/IcebergDestinationCleaner.kt
@@ -7,21 +7,11 @@ package io.airbyte.integrations.destination.iceberg.v2
 import io.airbyte.cdk.load.test.util.DestinationCleaner
 import io.airbyte.cdk.load.test.util.IntegrationTest.Companion.isNamespaceOld
 import io.airbyte.cdk.load.test.util.IntegrationTest.Companion.randomizedNamespaceRegex
-import io.airbyte.integrations.destination.iceberg.v2.io.IcebergUtil
 import org.apache.iceberg.catalog.Catalog
 import org.apache.iceberg.catalog.Namespace
 import org.apache.iceberg.catalog.SupportsNamespaces
 
 class IcebergDestinationCleaner(private val catalog: Catalog) : DestinationCleaner {
-    constructor(
-        configuration: IcebergV2Configuration
-    ) : this(
-        IcebergUtil(SimpleTableIdGenerator()).let { icebergUtil ->
-            val props = icebergUtil.toCatalogProperties(configuration)
-            icebergUtil.createCatalog(DEFAULT_CATALOG_NAME, props)
-        }
-    )
-
     override fun cleanup() {
         val namespaces: List<Namespace> =
             (catalog as SupportsNamespaces).listNamespaces().filter {

--- a/airbyte-integrations/connectors/destination-iceberg-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/iceberg/v2/IcebergV2CheckTest.kt
+++ b/airbyte-integrations/connectors/destination-iceberg-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/iceberg/v2/IcebergV2CheckTest.kt
@@ -7,16 +7,13 @@ package io.airbyte.integrations.destination.iceberg.v2
 import io.airbyte.cdk.load.check.CheckIntegrationTest
 import io.airbyte.cdk.load.check.CheckTestConfig
 import io.airbyte.integrations.destination.iceberg.v2.IcebergV2TestUtil.GLUE_CONFIG_PATH
-import io.airbyte.integrations.destination.iceberg.v2.IcebergV2TestUtil.MINIMAL_CONFIG_PATH
-import org.junit.jupiter.api.Disabled
 
-@Disabled
 class IcebergV2CheckTest :
     CheckIntegrationTest<IcebergV2Specification>(
-        successConfigFilenames = listOf(
-            CheckTestConfig(MINIMAL_CONFIG_PATH),
-            CheckTestConfig(GLUE_CONFIG_PATH),
-        ),
+        successConfigFilenames =
+            listOf(
+                CheckTestConfig(GLUE_CONFIG_PATH),
+            ),
         // TODO we maybe should add some configs that are expected to fail `check`
         failConfigFilenamesAndFailureReasons = mapOf(),
     )

--- a/airbyte-integrations/connectors/destination-iceberg-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/iceberg/v2/IcebergV2CheckTest.kt
+++ b/airbyte-integrations/connectors/destination-iceberg-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/iceberg/v2/IcebergV2CheckTest.kt
@@ -6,13 +6,13 @@ package io.airbyte.integrations.destination.iceberg.v2
 
 import io.airbyte.cdk.load.check.CheckIntegrationTest
 import io.airbyte.cdk.load.check.CheckTestConfig
-import io.airbyte.integrations.destination.iceberg.v2.IcebergV2TestUtil.PATH
+import io.airbyte.integrations.destination.iceberg.v2.IcebergV2TestUtil.MINIMAL_CONFIG_PATH
 import org.junit.jupiter.api.Disabled
 
 @Disabled
 class IcebergV2CheckTest :
     CheckIntegrationTest<IcebergV2Specification>(
-        successConfigFilenames = listOf(CheckTestConfig(PATH)),
+        successConfigFilenames = listOf(CheckTestConfig(MINIMAL_CONFIG_PATH)),
         // TODO we maybe should add some configs that are expected to fail `check`
         failConfigFilenamesAndFailureReasons = mapOf(),
     )

--- a/airbyte-integrations/connectors/destination-iceberg-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/iceberg/v2/IcebergV2CheckTest.kt
+++ b/airbyte-integrations/connectors/destination-iceberg-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/iceberg/v2/IcebergV2CheckTest.kt
@@ -6,13 +6,17 @@ package io.airbyte.integrations.destination.iceberg.v2
 
 import io.airbyte.cdk.load.check.CheckIntegrationTest
 import io.airbyte.cdk.load.check.CheckTestConfig
+import io.airbyte.integrations.destination.iceberg.v2.IcebergV2TestUtil.GLUE_CONFIG_PATH
 import io.airbyte.integrations.destination.iceberg.v2.IcebergV2TestUtil.MINIMAL_CONFIG_PATH
 import org.junit.jupiter.api.Disabled
 
 @Disabled
 class IcebergV2CheckTest :
     CheckIntegrationTest<IcebergV2Specification>(
-        successConfigFilenames = listOf(CheckTestConfig(MINIMAL_CONFIG_PATH)),
+        successConfigFilenames = listOf(
+            CheckTestConfig(MINIMAL_CONFIG_PATH),
+            CheckTestConfig(GLUE_CONFIG_PATH),
+        ),
         // TODO we maybe should add some configs that are expected to fail `check`
         failConfigFilenamesAndFailureReasons = mapOf(),
     )

--- a/airbyte-integrations/connectors/destination-iceberg-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/iceberg/v2/IcebergV2DataDumper.kt
+++ b/airbyte-integrations/connectors/destination-iceberg-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/iceberg/v2/IcebergV2DataDumper.kt
@@ -126,7 +126,7 @@ object IcebergV2DataDumper : DestinationDataDumper {
     }
 
     private fun getNessieCatalog(config: IcebergV2Configuration): NessieCatalog {
-        val catalogProperties = IcebergUtil().toCatalogProperties(config)
+        val catalogProperties = IcebergUtil(SimpleTableIdGenerator()).toCatalogProperties(config)
 
         val catalog = NessieCatalog()
         catalog.setConf(Configuration())

--- a/airbyte-integrations/connectors/destination-iceberg-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/iceberg/v2/IcebergV2DataDumper.kt
+++ b/airbyte-integrations/connectors/destination-iceberg-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/iceberg/v2/IcebergV2DataDumper.kt
@@ -11,17 +11,13 @@ import io.airbyte.cdk.load.data.parquet.ParquetMapperPipelineFactory
 import io.airbyte.cdk.load.message.Meta
 import io.airbyte.cdk.load.test.util.DestinationDataDumper
 import io.airbyte.cdk.load.test.util.OutputRecord
-import io.airbyte.integrations.destination.iceberg.v2.io.IcebergUtil
 import io.airbyte.protocol.models.v0.AirbyteRecordMessageMetaChange
 import java.math.BigDecimal
 import java.time.Instant
 import java.util.LinkedHashMap
 import java.util.UUID
-import org.apache.hadoop.conf.Configuration
-import org.apache.iceberg.catalog.TableIdentifier
 import org.apache.iceberg.data.IcebergGenerics
 import org.apache.iceberg.data.Record
-import org.apache.iceberg.nessie.NessieCatalog
 
 object IcebergV2DataDumper : DestinationDataDumper {
 

--- a/airbyte-integrations/connectors/destination-iceberg-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/iceberg/v2/IcebergV2DataDumper.kt
+++ b/airbyte-integrations/connectors/destination-iceberg-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/iceberg/v2/IcebergV2DataDumper.kt
@@ -112,6 +112,7 @@ object IcebergV2DataDumper : DestinationDataDumper {
             }
         }
 
+        // some catalogs (e.g. Nessie) have a close() method. Call it here.
         if (catalog is AutoCloseable) {
             catalog.close()
         }

--- a/airbyte-integrations/connectors/destination-iceberg-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/iceberg/v2/IcebergV2TestUtil.kt
+++ b/airbyte-integrations/connectors/destination-iceberg-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/iceberg/v2/IcebergV2TestUtil.kt
@@ -7,14 +7,10 @@ package io.airbyte.integrations.destination.iceberg.v2
 import io.airbyte.cdk.command.ConfigurationSpecification
 import io.airbyte.cdk.command.ValidatedJsonUtils
 import io.airbyte.integrations.destination.iceberg.v2.io.IcebergUtil
-import java.net.URI
 import java.nio.file.Files
 import java.nio.file.Path
 
 object IcebergV2TestUtil {
-    // TODO this is just here as an example, we should remove it + add real configs
-    val MINIMAL_CONFIG_PATH: Path =
-        Path.of(getResourceUri("iceberg_dest_v2_minimal_required_config.json"))
     val GLUE_CONFIG_PATH: Path = Path.of("secrets/glue.json")
 
     fun parseConfig(path: Path) =
@@ -30,8 +26,4 @@ object IcebergV2TestUtil {
             val props = icebergUtil.toCatalogProperties(config)
             icebergUtil.createCatalog(DEFAULT_CATALOG_NAME, props)
         }
-
-    private fun getResourceUri(path: String): URI =
-        this::class.java.classLoader.getResource(path)?.toURI()
-            ?: throw IllegalArgumentException("File not found in resources")
 }

--- a/airbyte-integrations/connectors/destination-iceberg-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/iceberg/v2/IcebergV2TestUtil.kt
+++ b/airbyte-integrations/connectors/destination-iceberg-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/iceberg/v2/IcebergV2TestUtil.kt
@@ -4,15 +4,15 @@
 
 package io.airbyte.integrations.destination.iceberg.v2
 
-import java.nio.file.Files
+import java.net.URI
 import java.nio.file.Path
 
 object IcebergV2TestUtil {
     // TODO this is just here as an example, we should remove it + add real configs
-    private val resource =
-        this::class.java.classLoader.getResource("iceberg_dest_v2_minimal_required_config.json")
-            ?: throw IllegalArgumentException("File not found in resources")
-    val PATH: Path = Path.of(resource.toURI())
+    val MINIMAL_CONFIG_PATH: Path = Path.of(getResourceUri("iceberg_dest_v2_minimal_required_config.json"))
+    val GLUE_CONFIG_PATH: Path = Path.of("secrets/glue.json")
 
-    fun getConfig(configPath: String): String = Files.readString(Path.of(configPath))
+    private fun getResourceUri(path: String): URI =
+        this::class.java.classLoader.getResource(path)?.toURI()
+            ?: throw IllegalArgumentException("File not found in resources")
 }

--- a/airbyte-integrations/connectors/destination-iceberg-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/iceberg/v2/IcebergV2TestUtil.kt
+++ b/airbyte-integrations/connectors/destination-iceberg-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/iceberg/v2/IcebergV2TestUtil.kt
@@ -4,13 +4,20 @@
 
 package io.airbyte.integrations.destination.iceberg.v2
 
+import io.airbyte.cdk.command.ValidatedJsonUtils
 import java.net.URI
+import java.nio.file.Files
 import java.nio.file.Path
 
 object IcebergV2TestUtil {
     // TODO this is just here as an example, we should remove it + add real configs
     val MINIMAL_CONFIG_PATH: Path = Path.of(getResourceUri("iceberg_dest_v2_minimal_required_config.json"))
     val GLUE_CONFIG_PATH: Path = Path.of("secrets/glue.json")
+
+    fun parseConfig(path: Path) =
+        IcebergV2ConfigurationFactory().makeWithoutExceptionHandling(
+            ValidatedJsonUtils.parseOne(IcebergV2Specification::class.java, Files.readString(path))
+        )
 
     private fun getResourceUri(path: String): URI =
         this::class.java.classLoader.getResource(path)?.toURI()

--- a/airbyte-integrations/connectors/destination-iceberg-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/iceberg/v2/IcebergV2TestUtil.kt
+++ b/airbyte-integrations/connectors/destination-iceberg-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/iceberg/v2/IcebergV2TestUtil.kt
@@ -13,11 +13,14 @@ import java.nio.file.Path
 
 object IcebergV2TestUtil {
     // TODO this is just here as an example, we should remove it + add real configs
-    val MINIMAL_CONFIG_PATH: Path = Path.of(getResourceUri("iceberg_dest_v2_minimal_required_config.json"))
+    val MINIMAL_CONFIG_PATH: Path =
+        Path.of(getResourceUri("iceberg_dest_v2_minimal_required_config.json"))
     val GLUE_CONFIG_PATH: Path = Path.of("secrets/glue.json")
 
     fun parseConfig(path: Path) =
-        getConfig(ValidatedJsonUtils.parseOne(IcebergV2Specification::class.java, Files.readString(path)))
+        getConfig(
+            ValidatedJsonUtils.parseOne(IcebergV2Specification::class.java, Files.readString(path))
+        )
 
     fun getConfig(spec: ConfigurationSpecification) =
         IcebergV2ConfigurationFactory().makeWithoutExceptionHandling(spec as IcebergV2Specification)

--- a/airbyte-integrations/connectors/destination-iceberg-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/iceberg/v2/IcebergV2WriteTest.kt
+++ b/airbyte-integrations/connectors/destination-iceberg-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/iceberg/v2/IcebergV2WriteTest.kt
@@ -11,14 +11,14 @@ import io.airbyte.cdk.load.test.util.NoopDestinationCleaner
 import io.airbyte.cdk.load.test.util.NoopExpectedRecordMapper
 import io.airbyte.cdk.load.write.BasicFunctionalityIntegrationTest
 import io.airbyte.cdk.load.write.StronglyTyped
+import java.nio.file.Files
+import java.util.Base64
 import okhttp3.FormBody
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
-import java.nio.file.Files
-import java.util.Base64
 
 abstract class IcebergV2WriteTest(
     configContents: String,
@@ -88,19 +88,23 @@ abstract class IcebergV2WriteTest(
     }
 }
 
-class IcebergGlueWriteTest : IcebergV2WriteTest(
-    Files.readString(IcebergV2TestUtil.GLUE_CONFIG_PATH),
-    IcebergDestinationCleaner(IcebergV2TestUtil.parseConfig(IcebergV2TestUtil.GLUE_CONFIG_PATH)),
-)
+class IcebergGlueWriteTest :
+    IcebergV2WriteTest(
+        Files.readString(IcebergV2TestUtil.GLUE_CONFIG_PATH),
+        IcebergDestinationCleaner(
+            IcebergV2TestUtil.parseConfig(IcebergV2TestUtil.GLUE_CONFIG_PATH)
+        ),
+    )
 
 @Disabled(
     "This is currently disabled until we are able to make it run via airbyte-ci. It works as expected locally"
 )
-class IcebergNessieMinioWriteTest : IcebergV2WriteTest(
-    getConfig(),
-    // we're writing to ephemeral testcontainers, so no need to clean up after ourselves
-    NoopDestinationCleaner
-) {
+class IcebergNessieMinioWriteTest :
+    IcebergV2WriteTest(
+        getConfig(),
+        // we're writing to ephemeral testcontainers, so no need to clean up after ourselves
+        NoopDestinationCleaner
+    ) {
     companion object {
         private fun getToken(): String {
             val client = OkHttpClient()

--- a/airbyte-integrations/connectors/destination-iceberg-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/iceberg/v2/IcebergV2WriteTest.kt
+++ b/airbyte-integrations/connectors/destination-iceberg-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/iceberg/v2/IcebergV2WriteTest.kt
@@ -92,7 +92,9 @@ class IcebergGlueWriteTest :
     IcebergV2WriteTest(
         Files.readString(IcebergV2TestUtil.GLUE_CONFIG_PATH),
         IcebergDestinationCleaner(
-            IcebergV2TestUtil.parseConfig(IcebergV2TestUtil.GLUE_CONFIG_PATH)
+            IcebergV2TestUtil.getCatalog(
+                IcebergV2TestUtil.parseConfig(IcebergV2TestUtil.GLUE_CONFIG_PATH)
+            )
         ),
     )
 

--- a/airbyte-integrations/connectors/destination-iceberg-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/iceberg/v2/IcebergV2WriteTest.kt
+++ b/airbyte-integrations/connectors/destination-iceberg-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/iceberg/v2/IcebergV2WriteTest.kt
@@ -38,26 +38,7 @@ abstract class IcebergV2WriteTest(
         commitDataIncrementally = false,
         supportFileTransfer = false,
         allTypesBehavior = StronglyTyped(),
-    )
-
-class IcebergGlueWriteTest : IcebergV2WriteTest(
-    Files.readString(IcebergV2TestUtil.GLUE_CONFIG_PATH),
-    IcebergDestinationCleaner(IcebergV2TestUtil.parseConfig(IcebergV2TestUtil.GLUE_CONFIG_PATH)),
-) {
-    @Test
-    override fun testBasicWrite() {
-        super.testBasicWrite()
-    }
-}
-
-@Disabled(
-    "This is currently disabled until we are able to make it run via airbyte-ci. It works as expected locally"
-)
-class IcebergNessieMinioWriteTest : IcebergV2WriteTest(
-    getConfig(),
-    // we're writing to ephemeral testcontainers, so no need to clean up after ourselves
-    NoopDestinationCleaner
-) {
+    ) {
     @Test
     @Disabled(
         "Expected because we seem to be mapping timestamps to long when we should be mapping them to an OffsetDateTime"
@@ -105,7 +86,21 @@ class IcebergNessieMinioWriteTest : IcebergV2WriteTest(
     override fun testUnions() {
         super.testUnions()
     }
+}
 
+class IcebergGlueWriteTest : IcebergV2WriteTest(
+    Files.readString(IcebergV2TestUtil.GLUE_CONFIG_PATH),
+    IcebergDestinationCleaner(IcebergV2TestUtil.parseConfig(IcebergV2TestUtil.GLUE_CONFIG_PATH)),
+)
+
+@Disabled(
+    "This is currently disabled until we are able to make it run via airbyte-ci. It works as expected locally"
+)
+class IcebergNessieMinioWriteTest : IcebergV2WriteTest(
+    getConfig(),
+    // we're writing to ephemeral testcontainers, so no need to clean up after ourselves
+    NoopDestinationCleaner
+) {
     companion object {
         private fun getToken(): String {
             val client = OkHttpClient()

--- a/airbyte-integrations/connectors/destination-iceberg-v2/src/test-integration/resources/iceberg_dest_v2_minimal_required_config.json
+++ b/airbyte-integrations/connectors/destination-iceberg-v2/src/test-integration/resources/iceberg_dest_v2_minimal_required_config.json
@@ -1,7 +1,0 @@
-{
-  "s3_bucket_name": "bucket",
-  "s3_bucket_region": "us-east-1",
-  "server_uri": "http://localhost:19120/api/v1",
-  "warehouse_location": "s3://demobucket/",
-  "main_branch_name": "main"
-}

--- a/airbyte-integrations/connectors/destination-iceberg-v2/src/test/kotlin/io/airbyte/integrations/destination/iceberg/v2/io/IcebergUtilTest.kt
+++ b/airbyte-integrations/connectors/destination-iceberg-v2/src/test/kotlin/io/airbyte/integrations/destination/iceberg/v2/io/IcebergUtilTest.kt
@@ -89,11 +89,13 @@ internal class IcebergUtilTest {
             every { create() } returns mockk()
         }
         val catalog: NessieCatalog = mockk {
-            every { buildTable(tableIdGenerator.toTableIdentifier(streamDescriptor), any()) } returns
-                tableBuilder
+            every {
+                buildTable(tableIdGenerator.toTableIdentifier(streamDescriptor), any())
+            } returns tableBuilder
             every { createNamespace(any()) } returns Unit
             every { namespaceExists(any()) } returns false
-            every { tableExists(tableIdGenerator.toTableIdentifier(streamDescriptor)) } returns false
+            every { tableExists(tableIdGenerator.toTableIdentifier(streamDescriptor)) } returns
+                false
         }
         val table =
             icebergUtil.createTable(
@@ -104,7 +106,9 @@ internal class IcebergUtilTest {
             )
         assertNotNull(table)
         verify(exactly = 1) {
-            catalog.createNamespace(tableIdGenerator.toTableIdentifier(streamDescriptor).namespace())
+            catalog.createNamespace(
+                tableIdGenerator.toTableIdentifier(streamDescriptor).namespace()
+            )
         }
         verify(exactly = 1) { tableBuilder.create() }
     }
@@ -122,10 +126,12 @@ internal class IcebergUtilTest {
             every { create() } returns mockk()
         }
         val catalog: NessieCatalog = mockk {
-            every { buildTable(tableIdGenerator.toTableIdentifier(streamDescriptor), any()) } returns
-                tableBuilder
+            every {
+                buildTable(tableIdGenerator.toTableIdentifier(streamDescriptor), any())
+            } returns tableBuilder
             every { namespaceExists(any()) } returns true
-            every { tableExists(tableIdGenerator.toTableIdentifier(streamDescriptor)) } returns false
+            every { tableExists(tableIdGenerator.toTableIdentifier(streamDescriptor)) } returns
+                false
         }
         val table =
             icebergUtil.createTable(
@@ -136,7 +142,9 @@ internal class IcebergUtilTest {
             )
         assertNotNull(table)
         verify(exactly = 0) {
-            catalog.createNamespace(tableIdGenerator.toTableIdentifier(streamDescriptor).namespace())
+            catalog.createNamespace(
+                tableIdGenerator.toTableIdentifier(streamDescriptor).namespace()
+            )
         }
         verify(exactly = 1) { tableBuilder.create() }
     }
@@ -147,7 +155,8 @@ internal class IcebergUtilTest {
         val streamDescriptor = DestinationStream.Descriptor("namespace", "name")
         val schema = Schema()
         val catalog: NessieCatalog = mockk {
-            every { loadTable(tableIdGenerator.toTableIdentifier(streamDescriptor)) } returns mockk()
+            every { loadTable(tableIdGenerator.toTableIdentifier(streamDescriptor)) } returns
+                mockk()
             every { namespaceExists(any()) } returns true
             every { tableExists(tableIdGenerator.toTableIdentifier(streamDescriptor)) } returns true
         }
@@ -160,9 +169,13 @@ internal class IcebergUtilTest {
             )
         assertNotNull(table)
         verify(exactly = 0) {
-            catalog.createNamespace(tableIdGenerator.toTableIdentifier(streamDescriptor).namespace())
+            catalog.createNamespace(
+                tableIdGenerator.toTableIdentifier(streamDescriptor).namespace()
+            )
         }
-        verify(exactly = 1) { catalog.loadTable(tableIdGenerator.toTableIdentifier(streamDescriptor)) }
+        verify(exactly = 1) {
+            catalog.loadTable(tableIdGenerator.toTableIdentifier(streamDescriptor))
+        }
     }
 
     @Test

--- a/airbyte-integrations/connectors/destination-iceberg-v2/src/test/kotlin/io/airbyte/integrations/destination/iceberg/v2/io/IcebergUtilTest.kt
+++ b/airbyte-integrations/connectors/destination-iceberg-v2/src/test/kotlin/io/airbyte/integrations/destination/iceberg/v2/io/IcebergUtilTest.kt
@@ -28,6 +28,7 @@ import io.airbyte.cdk.load.message.Meta.Companion.COLUMN_NAME_AB_GENERATION_ID
 import io.airbyte.cdk.load.message.Meta.Companion.COLUMN_NAME_AB_META
 import io.airbyte.cdk.load.message.Meta.Companion.COLUMN_NAME_AB_RAW_ID
 import io.airbyte.integrations.destination.iceberg.v2.IcebergV2Configuration
+import io.airbyte.integrations.destination.iceberg.v2.SimpleTableIdGenerator
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -53,10 +54,11 @@ import org.junit.jupiter.api.assertThrows
 internal class IcebergUtilTest {
 
     private lateinit var icebergUtil: IcebergUtil
+    private val tableIdGenerator = SimpleTableIdGenerator()
 
     @BeforeEach
     fun setup() {
-        icebergUtil = IcebergUtil()
+        icebergUtil = IcebergUtil(tableIdGenerator)
     }
 
     @Test
@@ -87,11 +89,11 @@ internal class IcebergUtilTest {
             every { create() } returns mockk()
         }
         val catalog: NessieCatalog = mockk {
-            every { buildTable(streamDescriptor.toIcebergTableIdentifier(), any()) } returns
+            every { buildTable(tableIdGenerator.toTableIdentifier(streamDescriptor), any()) } returns
                 tableBuilder
             every { createNamespace(any()) } returns Unit
             every { namespaceExists(any()) } returns false
-            every { tableExists(streamDescriptor.toIcebergTableIdentifier()) } returns false
+            every { tableExists(tableIdGenerator.toTableIdentifier(streamDescriptor)) } returns false
         }
         val table =
             icebergUtil.createTable(
@@ -102,7 +104,7 @@ internal class IcebergUtilTest {
             )
         assertNotNull(table)
         verify(exactly = 1) {
-            catalog.createNamespace(streamDescriptor.toIcebergTableIdentifier().namespace())
+            catalog.createNamespace(tableIdGenerator.toTableIdentifier(streamDescriptor).namespace())
         }
         verify(exactly = 1) { tableBuilder.create() }
     }
@@ -120,10 +122,10 @@ internal class IcebergUtilTest {
             every { create() } returns mockk()
         }
         val catalog: NessieCatalog = mockk {
-            every { buildTable(streamDescriptor.toIcebergTableIdentifier(), any()) } returns
+            every { buildTable(tableIdGenerator.toTableIdentifier(streamDescriptor), any()) } returns
                 tableBuilder
             every { namespaceExists(any()) } returns true
-            every { tableExists(streamDescriptor.toIcebergTableIdentifier()) } returns false
+            every { tableExists(tableIdGenerator.toTableIdentifier(streamDescriptor)) } returns false
         }
         val table =
             icebergUtil.createTable(
@@ -134,7 +136,7 @@ internal class IcebergUtilTest {
             )
         assertNotNull(table)
         verify(exactly = 0) {
-            catalog.createNamespace(streamDescriptor.toIcebergTableIdentifier().namespace())
+            catalog.createNamespace(tableIdGenerator.toTableIdentifier(streamDescriptor).namespace())
         }
         verify(exactly = 1) { tableBuilder.create() }
     }
@@ -145,9 +147,9 @@ internal class IcebergUtilTest {
         val streamDescriptor = DestinationStream.Descriptor("namespace", "name")
         val schema = Schema()
         val catalog: NessieCatalog = mockk {
-            every { loadTable(streamDescriptor.toIcebergTableIdentifier()) } returns mockk()
+            every { loadTable(tableIdGenerator.toTableIdentifier(streamDescriptor)) } returns mockk()
             every { namespaceExists(any()) } returns true
-            every { tableExists(streamDescriptor.toIcebergTableIdentifier()) } returns true
+            every { tableExists(tableIdGenerator.toTableIdentifier(streamDescriptor)) } returns true
         }
         val table =
             icebergUtil.createTable(
@@ -158,9 +160,9 @@ internal class IcebergUtilTest {
             )
         assertNotNull(table)
         verify(exactly = 0) {
-            catalog.createNamespace(streamDescriptor.toIcebergTableIdentifier().namespace())
+            catalog.createNamespace(tableIdGenerator.toTableIdentifier(streamDescriptor).namespace())
         }
-        verify(exactly = 1) { catalog.loadTable(streamDescriptor.toIcebergTableIdentifier()) }
+        verify(exactly = 1) { catalog.loadTable(tableIdGenerator.toTableIdentifier(streamDescriptor)) }
     }
 
     @Test


### PR DESCRIPTION
closes https://github.com/airbytehq/airbyte-internal-issues/issues/11140

key changes
* Handle uppercase stream name/namespace (glue requires lowercase here). The TableIdGenerator thing is... kind of dumb, but it works I guess (we should eventually plug in the default namespace stuff there)
    * killed the `DestinationStream.Descriptor.toIcebergTableIdentifier` extension function
* implement a destination cleaner. It just nukes any tables older than 30 days. (only needed for glue, since nessie is all ephemeral test container stuff)
* update data dumper to use the correct catalog, instead of hardcoding nessie
* enable the `check` test, targeting the glue config