### PR TITLE
Simplify CTID_TABLE_BLOCK_SIZE query for Postgres integration (#48126)

### DIFF
--- a/airbyte-integrations/connectors/source-postgres/metadata.yaml
+++ b/airbyte-integrations/connectors/source-postgres/metadata.yaml
@@ -9,7 +9,7 @@ data:
   connectorSubtype: database
   connectorType: source
   definitionId: decd338e-5647-4c0b-adf4-da0e75f5a750
-  dockerImageTag: 3.6.23
+  dockerImageTag: 3.6.24
   dockerRepository: airbyte/source-postgres
   documentationUrl: https://docs.airbyte.com/integrations/sources/postgres
   githubIssueLabel: source-postgres

--- a/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/PostgresQueryUtils.java
+++ b/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/PostgresQueryUtils.java
@@ -95,13 +95,13 @@ public class PostgresQueryUtils {
   public static final String TOTAL_BYTES_RESULT_COL = "totalbytes";
 
   /**
-   * Query returns the size table data takes on DB server disk (not incling any index or other
+   * Query returns the size table data takes on DB server disk (not including any index or other
    * metadata) And the size of each page used in (page, tuple) ctid. This helps us evaluate how many
    * pages we need to read to traverse the entire table.
    */
   public static final String CTID_TABLE_BLOCK_SIZE =
       """
-      WITH block_sz AS (SELECT current_setting('block_size')::int), rel_sz AS (select pg_relation_size('%s')) SELECT * from block_sz, rel_sz
+      SELECT current_setting('block_size')::int, pg_relation_size('%s')
       """;
 
   /**

--- a/docs/integrations/sources/postgres.md
+++ b/docs/integrations/sources/postgres.md
@@ -329,6 +329,7 @@ According to Postgres [documentation](https://www.postgresql.org/docs/14/datatyp
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                                                                   |
 |---------|------------|----------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 3.6.24 | 2024-12-16 | [49469](https://github.com/airbytehq/airbyte/pull/49469) | Simplify CTID_TABLE_BLOCK_SIZE query for Postgres integration |
 | 3.6.23  | 2024-11-13 | [\#48482](https://github.com/airbytehq/airbyte/pull/48482)  | Convert large integer typed using NUMERIC(X, 0) into a BigInteger.  l    
 | 3.6.22  | 2024-10-02 | [46900](https://github.com/airbytehq/airbyte/pull/46900) | Fixed a bug where source docs won't render on Airbyte 1.1 |
 | 3.6.21  | 2024-10-02 | [46322](https://github.com/airbytehq/airbyte/pull/46322) | Support CDC against a read-replica (continuation) |


### PR DESCRIPTION
## What
import https://github.com/airbytehq/airbyte/pull/48126

Simplify query to get around issue with edgedb.

h/t @tomnz 