### PR TITLE
base-images: make /config writable by the airbyte user

### DIFF
--- a/airbyte-ci/connectors/base_images/base_images/bases.py
+++ b/airbyte-ci/connectors/base_images/base_images/bases.py
@@ -24,6 +24,7 @@ class AirbyteConnectorBaseImage(ABC):
     USER_ID: int = 1000
     CACHE_DIR_PATH: str = "/custom_cache"
     AIRBYTE_DIR_PATH: str = "/airbyte"
+    CONFIG_PATH: str = "/config"
 
     @final
     def __init__(self, dagger_client: dagger.Client, version: semver.VersionInfo):
@@ -116,6 +117,7 @@ class AirbyteConnectorBaseImage(ABC):
             # Create the cache airbyte directories and set the right permissions
             .with_exec(["mkdir", "--mode", "755", self.CACHE_DIR_PATH])
             .with_exec(["mkdir", "--mode", "755", self.AIRBYTE_DIR_PATH])
-            # Change the owner of the airbyte directory to the user 'airbyte'
+            # Change the owner of the airbyte directory and config to the user 'airbyte'
             .with_exec(["chown", f"{self.USER}:{self.USER}", self.AIRBYTE_DIR_PATH])
+            .with_exec(["chown", f"{self.USER}:{self.USER}", self.CONFIG_PATH])
         )

--- a/airbyte-ci/connectors/base_images/base_images/python/bases.py
+++ b/airbyte-ci/connectors/base_images/base_images/python/bases.py
@@ -131,6 +131,7 @@ class AirbytePythonConnectorBaseImage(bases.AirbyteConnectorBaseImage):
         await base_sanity_checks.check_user_can_read_dir(container, self.USER, self.nltk_data_path)
         await base_sanity_checks.check_user_can_read_dir(container, self.USER, self.CACHE_DIR_PATH)
         await base_sanity_checks.check_user_can_write_dir(container, self.USER, self.AIRBYTE_DIR_PATH)
+        await base_sanity_checks.check_user_can_write_dir(container, self.USER, self.CONFIG_PATH)
         await base_sanity_checks.check_user_cant_write_dir(container, self.USER, self.CACHE_DIR_PATH)
         await python_sanity_checks.check_poetry_version(container, "1.6.1")
         await python_sanity_checks.check_python_image_has_expected_env_vars(container)


### PR DESCRIPTION
## What
Relates to https://github.com/airbytehq/airbyte/issues/49468

Cut a new base image version where /config is writable by the airbyte user
