### PR TITLE
✨feat(source-sftp-bulk): increase individual file size limit to 1.5 GB

### DIFF
--- a/airbyte-integrations/connectors/source-sftp-bulk/metadata.yaml
+++ b/airbyte-integrations/connectors/source-sftp-bulk/metadata.yaml
@@ -7,7 +7,7 @@ data:
   connectorSubtype: file
   connectorType: source
   definitionId: 31e3242f-dee7-4cdc-a4b8-8e06c5458517
-  dockerImageTag: 1.5.0
+  dockerImageTag: 1.6.0
   dockerRepository: airbyte/source-sftp-bulk
   documentationUrl: https://docs.airbyte.com/integrations/sources/sftp-bulk
   githubIssueLabel: source-sftp-bulk

--- a/airbyte-integrations/connectors/source-sftp-bulk/pyproject.toml
+++ b/airbyte-integrations/connectors/source-sftp-bulk/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "1.5.0"
+version = "1.6.0"
 name = "source-sftp-bulk"
 description = "Source implementation for SFTP Bulk."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-sftp-bulk/source_sftp_bulk/stream_reader.py
+++ b/airbyte-integrations/connectors/source-sftp-bulk/source_sftp_bulk/stream_reader.py
@@ -19,7 +19,7 @@ from typing_extensions import override
 
 
 class SourceSFTPBulkStreamReader(AbstractFileBasedStreamReader):
-    FILE_SIZE_LIMIT = 1_000_000_000
+    FILE_SIZE_LIMIT = 1_500_000_000
 
     def __init__(self):
         super().__init__()

--- a/docs/integrations/sources/sftp-bulk.md
+++ b/docs/integrations/sources/sftp-bulk.md
@@ -156,6 +156,7 @@ This source provides a single stream per file with a dynamic schema. The current
 
 | Version | Date       | Pull Request                                             | Subject                                                     |
 |:--------|:-----------|:---------------------------------------------------------|:------------------------------------------------------------|
+| 1.6.0   | 2024-12-17 | [49826](https://github.com/airbytehq/airbyte/pull/49826) | Increase individual file size limit.                        |
 | 1.5.0   | 2024-12-02 | [48434](https://github.com/airbytehq/airbyte/pull/48434) | Add get_file method for file-transfer feature.              |
 | 1.4.0   | 2024-10-31 | [46739](https://github.com/airbytehq/airbyte/pull/46739) | make private key an airbyte secret.                         |
 | 1.3.0   | 2024-10-31 | [47703](https://github.com/airbytehq/airbyte/pull/47703) | Update dependency to CDK v6 with ability to transfer files. |


### PR DESCRIPTION
## What
Alex requested we increase our backend file size limit to 1.5 GB to accommodate files just slightly over our 1GB limit today (the external 1GB limit still remains, this is for the edge case of a file being 1.01 GB).

## How
Increase file size limit variable to 1.5 GB

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
