### PR TITLE
Inline code uses correct color in a table's header row

### DIFF
--- a/docusaurus/src/css/custom.css
+++ b/docusaurus/src/css/custom.css
@@ -261,7 +261,9 @@ table tr:last-child td:last-child {
   border-bottom-right-radius: 10px;
 }
 
-
+table th code {
+  color: var(--ifm-color-content);
+}
 
 table td code {
   background-color: var(--color-blue-30);


### PR DESCRIPTION
## What

Fixes an edge case where inline code in table header cells used the wrong font color, which made that font illegible.

Before:
![image](https://github.com/user-attachments/assets/41c6d258-49ce-4b3b-99f7-de092df57379)

After:

![image](https://github.com/user-attachments/assets/aede44d2-39ef-4285-b17c-976d33bf13c7)

## How

Minor CSS update

## Review guide

integrations/destinations/r2#csv - check the color of text in table headings. It should be legible both as regular text and as inline code, both in light and dark mode.

## User Impact

Unreadable text is now readable.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
