### PR TITLE
source-mssql: use `airbyte/java-connector-base:1.0.0`

### DIFF
--- a/airbyte-integrations/connectors/destination-iceberg/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-iceberg/metadata.yaml
@@ -21,6 +21,8 @@ data:
     sl: 100
     ql: 100
   supportLevel: community
+  connectorBuildOptions:
+    baseImage: docker.io/airbyte/java-connector-base:1.0.0@sha256:be86e5684e1e6d9280512d3d8071b47153698fe08ad990949c8eeff02803201a
   connectorTestSuitesOptions:
     - suite: unitTests
     - suite: integrationTests


### PR DESCRIPTION
Make the connector use our official base image for java connectors