### PR TITLE
Patch: AJ's pre-commit updates

### DIFF
--- a/.github/workflows/format-fix-command.yml
+++ b/.github/workflows/format-fix-command.yml
@@ -29,8 +29,8 @@ concurrency:
 
 jobs:
   format-fix:
-    name: "Run airbyte-ci format fix all"
-    runs-on: ubuntu-latest
+    name: "Run pre-commit fix"
+    runs-on: ubuntu-24.04
     steps:
       - name: Get job variables
         id: job-vars
@@ -67,16 +67,21 @@ jobs:
 
             [1]: ${{ steps.job-vars.outputs.run-url }}
 
-      - name: Run airbyte-ci format fix all
-        uses: ./.github/actions/run-airbyte-ci
-        continue-on-error: true
+      # Compare the below to the `format_check.yml` workflow
+      - uses: actions/checkout@v4
+      - name: Setup Java
+        uses: actions/setup-java@v3
         with:
-          context: "manual"
-          gcs_credentials: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
-          sentry_dsn: ${{ secrets.SENTRY_AIRBYTE_CI_DSN }}
-          github_token: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}
-          subcommand: "format fix all"
-          dagger_cloud_token: ${{ secrets.DAGGER_CLOUD_TOKEN_CACHE_2 }}
+          distribution: "zulu"
+          java-version: "21"
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: Run pre-commit
+        uses: pre-commit/action@v3.0.1
+        continue-on-error: true
+        id: format-fix
 
       # This is helpful in the case that we change a previously committed generated file to be ignored by git.
       - name: Remove any files that have been gitignored

--- a/.github/workflows/format_check.yml
+++ b/.github/workflows/format_check.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   format-check:
     name: "Check for formatting errors"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5.3.0

--- a/.github/workflows/format_check.yml
+++ b/.github/workflows/format_check.yml
@@ -10,53 +10,21 @@ on:
 
 jobs:
   format-check:
-    # IMPORTANT: This name must match the require check name on the branch protection settings
     name: "Check for formatting errors"
-    # Do not run this job on forks
-    # Forked PRs are handled by the community_ci.yml workflow
-    if: github.event.pull_request.head.repo.fork != true
-    runs-on: tooling-test-small
+    runs-on: ubuntu-latest
     steps:
-      - name: Checkout Airbyte (with credentials)
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5.3.0
+      - uses: pre-commit/action@v3.0.1
+        id: format-check
         with:
-          ref: ${{ github.head_ref }}
-          token: ${{ secrets.GH_PAT_APPROVINGTON_OCTAVIA }}
-          fetch-depth: 1
-      - name: Run airbyte-ci format check [MASTER]
-        id: airbyte_ci_format_check_all_master
-        if: github.ref == 'refs/heads/master'
-        uses: ./.github/actions/run-airbyte-ci
-        continue-on-error: true
-        with:
-          context: "master"
-          sentry_dsn: ${{ secrets.SENTRY_AIRBYTE_CI_DSN }}
-          subcommand: "format check all"
-
-      - name: Run airbyte-ci format check [PULL REQUEST]
-        id: airbyte_ci_format_check_all_pr
-        if: github.event_name == 'pull_request'
-        uses: ./.github/actions/run-airbyte-ci
-        continue-on-error: false
-        with:
-          context: "pull_request"
-          sentry_dsn: ${{ secrets.SENTRY_AIRBYTE_CI_DSN }}
-          subcommand: "format check all"
-          dagger_cloud_token: ${{ secrets.DAGGER_CLOUD_TOKEN_CACHE_2 }}
-
-      - name: Run airbyte-ci format check [WORKFLOW DISPATCH]
-        id: airbyte_ci_format_check_all_manual
-        if: github.event_name == 'workflow_dispatch'
-        uses: ./.github/actions/run-airbyte-ci
-        continue-on-error: false
-        with:
-          context: "manual"
-          sentry_dsn: ${{ secrets.SENTRY_AIRBYTE_CI_DSN }}
-          subcommand: "format check all"
-          dagger_cloud_token: ${{ secrets.DAGGER_CLOUD_TOKEN_CACHE_2 }}
+          extra_args: --all-files
 
       - name: Match GitHub User to Slack User [MASTER]
-        if: github.ref == 'refs/heads/master'
+        if: >
+          always() && steps.format-check.outcome == 'failure' &&
+          github.ref == 'refs/heads/master' &&
+          github.event.pull_request.head.repo.fork == false
         id: match-github-to-slack-user
         uses: ./.github/actions/match-github-to-slack-user
         env:
@@ -64,7 +32,10 @@ jobs:
           GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Format Failure on Master Slack Channel [MASTER]
-        if: steps.airbyte_ci_format_check_all_master.outcome == 'failure' && github.ref == 'refs/heads/master'
+        if: >
+          always() && steps.format-check.outcome == 'failure' &&
+          github.ref == 'refs/heads/master' &&
+          github.event.pull_request.head.repo.fork == false
         uses: abinoda/slack-action@master
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN_AIRBYTE_TEAM }}

--- a/.github/workflows/format_check.yml
+++ b/.github/workflows/format_check.yml
@@ -14,8 +14,17 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5.3.0
-      - uses: pre-commit/action@v3.0.1
+      - name: Setup Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: "zulu"
+          java-version: "21"
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: Run pre-commit
+        uses: pre-commit/action@v3.0.1
         id: format-check
         with:
           extra_args: --all-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,8 +15,9 @@ exclude: |
     # Generated/test files
     ^airbyte-ci/connectors/metadata_service/lib/metadata_service/models/generated/.*$|
     ^.*?/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/.*/invalid/.*$|
-    ^airbyte-ci/connectors/pipelines/tests/test_format/non_formatted_code/.*$|
+    ^airbyte-ci/connectors/metadata_service/lib/tests/fixtures/.*/invalid/.*$|
     ^.*?/airbyte-ci/connectors/pipelines/tests/test_format/non_formatted_code/.*$|
+    ^airbyte-ci/connectors/pipelines/tests/test_format/non_formatted_code/.*$|
     ^.*?/airbyte-integrations/connectors/destination-.*/expected-spec\.json$
   )
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,6 @@ repos:
       - id: isort
         files: \.py$
         require_serial: true
-        # args: [--settings-file=pyproject.toml]
 
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v3.0.3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,18 +4,19 @@ exclude: |
     ^.*/__init__\.py$|
     ^.*?/\.venv/.*$|
     ^.*?/node_modules/.*$|
-    
+
     ^.*?/charts/.*$|
     ^airbyte-integrations/bases/base-normalization/.*$|
     ^.*?/normalization_test_output/.*$|
-    
+
     ^.*?/pnpm-lock\.yaml$|
     ^.*?/source-amplitude/unit_tests/api_data/zipped\.json$|
-    
+
     # Generated/test files
     ^airbyte-ci/connectors/metadata_service/lib/metadata_service/models/generated/.*$|
     ^.*?/airbyte-ci/connectors/metadata_service/lib/tests/fixtures/.*/invalid/.*$|
     ^airbyte-ci/connectors/pipelines/tests/test_format/non_formatted_code/.*$|
+    ^.*?/airbyte-ci/connectors/pipelines/tests/test_format/non_formatted_code/.*$|
     ^.*?/airbyte-integrations/connectors/destination-.*/expected-spec\.json$
   )
 
@@ -25,8 +26,7 @@ repos:
     hooks:
       - id: black
         language_version: python3.10
-        verbose: true
-        args: ["--verbose"]
+        args: [--config=pyproject.toml]
 
   - repo: https://github.com/pycqa/isort
     rev: 5.12.0
@@ -34,6 +34,7 @@ repos:
       - id: isort
         files: \.py$
         require_serial: true
+        # args: [--settings-file=pyproject.toml]
 
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v3.0.3

--- a/airbyte-integrations/connectors/destination-chroma/destination_chroma/destination.py
+++ b/airbyte-integrations/connectors/destination-chroma/destination_chroma/destination.py
@@ -25,6 +25,7 @@ from destination_chroma.no_embedder import NoEmbedder
 
 BATCH_SIZE = 128
 
+
 class DestinationChroma(Destination):
 
     indexer: Indexer

--- a/airbyte-integrations/connectors/destination-chroma/destination_chroma/destination.py
+++ b/airbyte-integrations/connectors/destination-chroma/destination_chroma/destination.py
@@ -25,7 +25,6 @@ from destination_chroma.no_embedder import NoEmbedder
 
 BATCH_SIZE = 128
 
-
 class DestinationChroma(Destination):
 
     indexer: Indexer

--- a/spotless-maven-pom.xml
+++ b/spotless-maven-pom.xml
@@ -26,6 +26,9 @@
                             <includes>
                                 <include>**/*.java</include>
                             </includes>
+                            <excludes>
+                                <exclude>**/non_formatted_code/*</exclude>
+                            </excludes>
                             <importOrder />
                             <eclipse>
                                 <version>4.21</version>


### PR DESCRIPTION
## What

Patches and stacks with

- #49806 

## How

- Replaces `airbyte-ci` with `pre-commit` in the format check and format fix CI workflows.
- Fixes some "excludes" so that intentionally mis-formatted files do not get formatted with `--all-files` arg is used.
- Removes all the extra secret refs that were previously sent to `airbyte-ci` so format check and fix can run without escalated privileges.
- Allows format checks to run on forks with no privilege escalation. This is preferrable to having a separate CI workflow for forks and non-forks.
- Allows `/format-fix` to run on forks (in theory, but will needs to be tested post-merge).

Example Workflow Runs:

- Failure when bad formatting is introduced: https://github.com/airbytehq/airbyte/actions/runs/12383482302/job/34566244107?pr=49846
- No-op when running /format-fix with healthy branch: https://github.com/airbytehq/airbyte/actions/runs/12383432973
- Fix when running /format-fix when bad formatting exists: https://github.com/airbytehq/airbyte/actions/runs/12383519391/job/34566354092

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
