### PR TITLE
Destination Iceberg: Fix object type handling

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/integrationTest/kotlin/io/airbyte/cdk/load/mock_integration_test/MockBasicFunctionalityIntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/integrationTest/kotlin/io/airbyte/cdk/load/mock_integration_test/MockBasicFunctionalityIntegrationTest.kt
@@ -94,6 +94,4 @@ class MockBasicFunctionalityIntegrationTest :
     override fun testBasicTypes() {
         super.testBasicTypes()
     }
-
-    @Test @Disabled override fun testBasicWriteFile() {}
 }

--- a/airbyte-cdk/bulk/core/load/src/integrationTest/kotlin/io/airbyte/cdk/load/mock_integration_test/MockDestinationBackend.kt
+++ b/airbyte-cdk/bulk/core/load/src/integrationTest/kotlin/io/airbyte/cdk/load/mock_integration_test/MockDestinationBackend.kt
@@ -56,13 +56,17 @@ object MockDestinationBackend {
             // Assume that in dedup mode, we don't have duplicates - so we can just find the first
             // record with the same PK as the incoming record
             val existingRecord =
-                file.firstOrNull { RecordDiffer.comparePks(incomingPk, getPk(it)) == 0 }
+                file.firstOrNull {
+                    RecordDiffer.comparePks(incomingPk, getPk(it), nullEqualsUnset = false) == 0
+                }
             if (existingRecord == null) {
                 file.add(incomingRecord)
             } else {
                 val incomingCursor = getCursor(incomingRecord)
                 val existingCursor = getCursor(existingRecord)
-                val compare = RecordDiffer.valueComparator.compare(incomingCursor, existingCursor)
+                val compare =
+                    RecordDiffer.getValueComparator(nullEqualsUnset = false)
+                        .compare(incomingCursor, existingCursor)
                 // If the incoming record has a later cursor,
                 // or the same cursor but a later extractedAt,
                 // then upsert. (otherwise discard the incoming record.)

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/test/util/RecordDifferTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/test/util/RecordDifferTest.kt
@@ -6,6 +6,7 @@ package io.airbyte.cdk.load.test.util
 
 import java.time.OffsetDateTime
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 
@@ -155,7 +156,7 @@ class RecordDifferTest {
                         ),
                     )
                 )
-        assertEquals(null, diff)
+        assertNull(diff)
     }
 
     /** Verify that the differ can sort records which are identical other than the cursor */
@@ -193,7 +194,7 @@ class RecordDifferTest {
                         ),
                     ),
                 )
-        assertEquals(null, diff)
+        assertNull(diff)
     }
 
     /** Verify that the differ can sort records which are identical other than extractedAt */
@@ -231,6 +232,49 @@ class RecordDifferTest {
                         ),
                     )
                 )
-        assertEquals(null, diff)
+        assertNull(diff)
+    }
+
+    @Test
+    fun testNullEqualsUnset() {
+        val diff =
+            RecordDiffer(primaryKey = listOf(listOf("id")), cursor = null, nullEqualsUnset = true)
+                .diffRecords(
+                    listOf(
+                        OutputRecord(
+                            extractedAt = 1,
+                            generationId = 0,
+                            data =
+                                mapOf(
+                                    "id" to 1,
+                                    "sub_object" to
+                                        mapOf(
+                                            "foo" to "bar",
+                                            "sub_list" to listOf(mapOf<String, Any?>()),
+                                        )
+                                ),
+                            airbyteMeta = null,
+                        ),
+                    ),
+                    listOf(
+                        OutputRecord(
+                            extractedAt = 1,
+                            generationId = 0,
+                            data =
+                                mapOf(
+                                    "id" to 1,
+                                    "name" to null,
+                                    "sub_object" to
+                                        mapOf(
+                                            "foo" to "bar",
+                                            "bar" to null,
+                                            "sub_list" to listOf(mapOf("foo" to null)),
+                                        )
+                                ),
+                            airbyteMeta = null,
+                        ),
+                    ),
+                )
+        assertNull(diff)
     }
 }

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/ExpectedRecordMapper.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/ExpectedRecordMapper.kt
@@ -4,10 +4,13 @@
 
 package io.airbyte.cdk.load.test.util
 
+import io.airbyte.cdk.load.data.AirbyteType
+
 fun interface ExpectedRecordMapper {
-    fun mapRecord(expectedRecord: OutputRecord): OutputRecord
+    fun mapRecord(expectedRecord: OutputRecord, schema: AirbyteType): OutputRecord
 }
 
 object NoopExpectedRecordMapper : ExpectedRecordMapper {
-    override fun mapRecord(expectedRecord: OutputRecord): OutputRecord = expectedRecord
+    override fun mapRecord(expectedRecord: OutputRecord, schema: AirbyteType): OutputRecord =
+        expectedRecord
 }

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/IntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/IntegrationTest.kt
@@ -103,7 +103,7 @@ abstract class IntegrationTest(
     ) {
         val actualRecords: List<OutputRecord> = dataDumper.dumpRecords(config, stream)
         val expectedRecords: List<OutputRecord> =
-            canonicalExpectedRecords.map { recordMangler.mapRecord(it) }
+            canonicalExpectedRecords.map { recordMangler.mapRecord(it, stream.schema) }
 
         RecordDiffer(
                 primaryKey = primaryKey.map { nameMapper.mapFieldName(it) },

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/data/iceberg/parquet/IcebergParquetPipelineFactory.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/data/iceberg/parquet/IcebergParquetPipelineFactory.kt
@@ -20,7 +20,8 @@ class IcebergParquetPipelineFactory : MapperPipelineFactory {
         MapperPipeline(
             stream.schema,
             listOf(
-                AirbyteSchemaNoopMapper() to SchemalessValuesToJsonString(),
+                // TODO not sure why base parquet was doing this as a noop
+                SchemalessTypesToStringType() to SchemalessValuesToJsonString(),
                 AirbyteSchemaNoopMapper() to NullOutOfRangeIntegers(),
                 MergeUnions() to AirbyteValueNoopMapper(),
                 UnionTypeToDisjointRecord() to UnionValueToDisjointRecord(),

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/data/iceberg/parquet/SchemalessTypesToStringType.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/data/iceberg/parquet/SchemalessTypesToStringType.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.load.data.iceberg.parquet
+
+import io.airbyte.cdk.load.data.AirbyteSchemaIdentityMapper
+import io.airbyte.cdk.load.data.ArrayTypeWithoutSchema
+import io.airbyte.cdk.load.data.ObjectTypeWithEmptySchema
+import io.airbyte.cdk.load.data.ObjectTypeWithoutSchema
+import io.airbyte.cdk.load.data.StringType
+import io.airbyte.cdk.load.data.UnknownType
+
+class SchemalessTypesToStringType : AirbyteSchemaIdentityMapper {
+    override fun mapArrayWithoutSchema(schema: ArrayTypeWithoutSchema) = StringType
+    override fun mapObjectWithEmptySchema(schema: ObjectTypeWithEmptySchema) = StringType
+    override fun mapObjectWithoutSchema(schema: ObjectTypeWithoutSchema) = StringType
+    override fun mapUnknown(schema: UnknownType) = StringType
+}

--- a/airbyte-integrations/connectors/destination-iceberg-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/iceberg/v2/IcebergV2DataDumper.kt
+++ b/airbyte-integrations/connectors/destination-iceberg-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/iceberg/v2/IcebergV2DataDumper.kt
@@ -7,12 +7,10 @@ package io.airbyte.integrations.destination.iceberg.v2
 import io.airbyte.cdk.command.ConfigurationSpecification
 import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.data.*
-import io.airbyte.cdk.load.data.parquet.ParquetMapperPipelineFactory
 import io.airbyte.cdk.load.message.Meta
 import io.airbyte.cdk.load.test.util.DestinationDataDumper
 import io.airbyte.cdk.load.test.util.OutputRecord
 import io.airbyte.protocol.models.v0.AirbyteRecordMessageMetaChange
-import java.math.BigDecimal
 import java.time.Instant
 import java.util.LinkedHashMap
 import java.util.UUID
@@ -21,28 +19,22 @@ import org.apache.iceberg.data.Record
 
 object IcebergV2DataDumper : DestinationDataDumper {
 
-    private fun convert(value: Any?, type: AirbyteType): AirbyteValue {
-        return if (value == null) {
-            NullValue
-        } else {
-            when (type) {
-                StringType -> StringValue(value as String)
-                is ArrayType -> ArrayValue((value as List<*>).map { convert(it, type.items.type) })
-                BooleanType -> BooleanValue(value as Boolean)
-                IntegerType -> IntegerValue(value as Long)
-                NumberType -> NumberValue(BigDecimal(value as Double))
-                else ->
-                    throw IllegalArgumentException("Object type with empty schema is not supported")
-            }
-        }
-    }
-
-    private fun getCastedData(schema: ObjectType, record: Record): ObjectValue {
+    private fun toAirbyteValue(record: Record): ObjectValue {
         return ObjectValue(
             LinkedHashMap(
-                schema.properties
-                    .map { (name, field) -> name to convert(record.getField(name), field.type) }
-                    .toMap()
+                record
+                    .struct()
+                    .fields()
+                    .filterNot { Meta.COLUMN_NAMES.contains(it.name()) }
+                    .associate { field ->
+                        val name = field.name()
+                        val airbyteValue =
+                            when (val value = record.getField(field.name())) {
+                                is Record -> toAirbyteValue(value)
+                                else -> AirbyteValue.from(value)
+                            }
+                        name to airbyteValue
+                    }
             )
         )
     }
@@ -80,8 +72,6 @@ object IcebergV2DataDumper : DestinationDataDumper {
         stream: DestinationStream
     ): List<OutputRecord> {
         val config = IcebergV2TestUtil.getConfig(spec)
-        val pipeline = ParquetMapperPipelineFactory().create(stream)
-        val schema = pipeline.finalSchema as ObjectType
         val catalog = IcebergV2TestUtil.getCatalog(config)
         val table =
             catalog.loadTable(
@@ -101,7 +91,7 @@ object IcebergV2DataDumper : DestinationDataDumper {
                             ),
                         loadedAt = null,
                         generationId = record.getField(Meta.COLUMN_NAME_AB_GENERATION_ID) as Long,
-                        data = getCastedData(schema, record),
+                        data = toAirbyteValue(record),
                         airbyteMeta = getMetaData(record)
                     )
                 )

--- a/airbyte-integrations/connectors/destination-iceberg-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/iceberg/v2/IcebergV2WriteTest.kt
+++ b/airbyte-integrations/connectors/destination-iceberg-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/iceberg/v2/IcebergV2WriteTest.kt
@@ -8,7 +8,6 @@ import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.airbyte.cdk.load.test.util.DestinationCleaner
 import io.airbyte.cdk.load.test.util.NoopDestinationCleaner
-import io.airbyte.cdk.load.test.util.NoopExpectedRecordMapper
 import io.airbyte.cdk.load.write.BasicFunctionalityIntegrationTest
 import io.airbyte.cdk.load.write.StronglyTyped
 import java.nio.file.Files
@@ -142,15 +141,18 @@ class IcebergNessieMinioWriteTest :
             val authToken = getToken()
             return """
             {
+                "catalog_type": {
+                  "catalog_type": "NESSIE",
+                  "server_uri": "http://$nessieEndpoint:19120/api/v1",
+                  "access_token": "$authToken"
+                },
                 "s3_bucket_name": "demobucket",
                 "s3_bucket_region": "us-east-1",
                 "access_key_id": "minioadmin",
                 "secret_access_key": "minioadmin",
                 "s3_endpoint": "http://$minioEndpoint:9002",
-                "server_uri": "http://$nessieEndpoint:19120/api/v1",
                 "warehouse_location": "s3://demobucket/",
-                "main_branch_name": "main",
-                "access_token": "$authToken"
+                "main_branch_name": "main"
             }
             """.trimIndent()
         }

--- a/airbyte-integrations/connectors/destination-iceberg-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/iceberg/v2/IcebergV2WriteTest.kt
+++ b/airbyte-integrations/connectors/destination-iceberg-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/iceberg/v2/IcebergV2WriteTest.kt
@@ -41,16 +41,14 @@ abstract class IcebergV2WriteTest(
         nullEqualsUnset = true,
     ) {
     @Test
-    @Disabled(
-        "Expected because we seem to be mapping timestamps to long when we should be mapping them to an OffsetDateTime"
-    )
+    @Disabled("bad values handling for timestamps is currently broken")
     override fun testBasicTypes() {
         super.testBasicTypes()
     }
 
     @Test
     @Disabled(
-        "Expected because we seem to be mapping timestamps to long when we should be mapping them to an OffsetDateTime"
+        "This is currently hanging forever and we should look into why https://github.com/airbytehq/airbyte-internal-issues/issues/11162"
     )
     override fun testInterruptedTruncateWithPriorData() {
         super.testInterruptedTruncateWithPriorData()
@@ -63,29 +61,15 @@ abstract class IcebergV2WriteTest(
     }
 
     @Test
-    //    @Disabled
-    override fun testContainerTypes() {
-        super.testContainerTypes()
-    }
-
-    @Test
-    @Disabled(
-        "Expected because we seem to be mapping timestamps to long when we should be mapping them to an OffsetDateTime"
-    )
+    @Disabled("This is currently hanging forever and we should look into why")
     override fun resumeAfterCancelledTruncate() {
         super.resumeAfterCancelledTruncate()
     }
 
     @Test
-    @Disabled("This is expected")
+    @Disabled("This is expected (dest-iceberg-v2 doesn't yet support schema evolution)")
     override fun testAppendSchemaEvolution() {
         super.testAppendSchemaEvolution()
-    }
-
-    @Test
-    //    @Disabled
-    override fun testUnions() {
-        super.testUnions()
     }
 }
 
@@ -97,17 +81,7 @@ class IcebergGlueWriteTest :
                 IcebergV2TestUtil.parseConfig(IcebergV2TestUtil.GLUE_CONFIG_PATH)
             )
         ),
-    ) {
-    @Test
-    override fun testContainerTypes() {
-        super.testContainerTypes()
-    }
-
-    @Test
-    override fun testUnions() {
-        super.testUnions()
-    }
-}
+    )
 
 @Disabled(
     "This is currently disabled until we are able to make it run via airbyte-ci. It works as expected locally"

--- a/airbyte-integrations/connectors/destination-iceberg-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/iceberg/v2/IcebergV2WriteTest.kt
+++ b/airbyte-integrations/connectors/destination-iceberg-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/iceberg/v2/IcebergV2WriteTest.kt
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.airbyte.cdk.load.test.util.DestinationCleaner
 import io.airbyte.cdk.load.test.util.NoopDestinationCleaner
+import io.airbyte.cdk.load.test.util.NoopExpectedRecordMapper
 import io.airbyte.cdk.load.write.BasicFunctionalityIntegrationTest
 import io.airbyte.cdk.load.write.StronglyTyped
 import java.nio.file.Files
@@ -37,6 +38,7 @@ abstract class IcebergV2WriteTest(
         commitDataIncrementally = false,
         supportFileTransfer = false,
         allTypesBehavior = StronglyTyped(),
+        nullEqualsUnset = true,
     ) {
     @Test
     @Disabled(
@@ -61,7 +63,7 @@ abstract class IcebergV2WriteTest(
     }
 
     @Test
-    @Disabled
+    //    @Disabled
     override fun testContainerTypes() {
         super.testContainerTypes()
     }
@@ -81,7 +83,7 @@ abstract class IcebergV2WriteTest(
     }
 
     @Test
-    @Disabled
+    //    @Disabled
     override fun testUnions() {
         super.testUnions()
     }
@@ -95,7 +97,17 @@ class IcebergGlueWriteTest :
                 IcebergV2TestUtil.parseConfig(IcebergV2TestUtil.GLUE_CONFIG_PATH)
             )
         ),
-    )
+    ) {
+    @Test
+    override fun testContainerTypes() {
+        super.testContainerTypes()
+    }
+
+    @Test
+    override fun testUnions() {
+        super.testUnions()
+    }
+}
 
 @Disabled(
     "This is currently disabled until we are able to make it run via airbyte-ci. It works as expected locally"


### PR DESCRIPTION
closes https://github.com/airbytehq/airbyte-internal-issues/issues/11038

Probably easiest to review by commit:
1. Fix the nessie test config. Nessie tests were just hard crashing :/
2. Fix all the issues with schemaless types (object with empty schema, etc)
    * some incidental changes to ExpectedRecordMapper - ended up not needing these, but they'll be useful in a future PR
    * update the mapper pipeline to actually convert schemaless types to StringType
        * the parquet pipeline doesn't do this for some reason :/ johnny ran into a bug related to this at some point, but I can't seem to repro here :shrug:
        * if we _do_ have issues later on, we can just do what parquet does (i.e. have the AirbyteValueToIcebergRecord explicitly handle ObjectWithoutSchema/etc instead of just crashing)
    * update the data dumper to coerce values by their actual type, rather than by the declared schema - previously the data dumper _also_ crashed on these types
3. Update the RecordDiffer to correctly handle `nullEqualsUnset` in nested structs
4. cleanup + formatting