### PR TITLE
Bulk Load CDK: Improved Batch Update Logging

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/integrationTest/kotlin/io/airbyte/cdk/load/mock_integration_test/MockDestinationWriter.kt
+++ b/airbyte-cdk/bulk/core/load/src/integrationTest/kotlin/io/airbyte/cdk/load/mock_integration_test/MockDestinationWriter.kt
@@ -39,10 +39,10 @@ class MockStreamLoader(override val stream: DestinationStream) : StreamLoader {
     }
 
     data class LocalBatch(val records: List<DestinationRecord>) : MockBatch() {
-        override val state = Batch.State.LOCAL
+        override val state = Batch.State.STAGED
     }
     data class LocalFileBatch(val file: DestinationFile) : MockBatch() {
-        override val state = Batch.State.LOCAL
+        override val state = Batch.State.STAGED
     }
 
     override suspend fun close(streamFailure: StreamProcessingFailed?) {

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/Batch.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/Batch.kt
@@ -21,7 +21,7 @@ import io.airbyte.cdk.load.command.DestinationStream
  * the associated ranges have been persisted remotely, and that platform checkpoint messages can be
  * emitted.
  *
- * [State.LOCAL] is used internally to indicate that records have been spooled to disk for
+ * [State.STAGED] is used internally to indicate that records have been spooled to disk for
  * processing and should not be used by implementors.
  *
  * When a stream has been read to End-of-stream, and all ranges between 0 and End-of-stream are
@@ -55,7 +55,7 @@ interface Batch {
 
     enum class State {
         PROCESSED,
-        LOCAL,
+        STAGED,
         PERSISTED,
         COMPLETE
     }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/state/StreamManager.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/state/StreamManager.kt
@@ -153,16 +153,93 @@ class DefaultStreamManager(
         rangesState[batch.batch.state]
             ?: throw IllegalArgumentException("Invalid batch state: ${batch.batch.state}")
 
+        val stateRangesToAdd = mutableListOf(batch.batch.state to batch.ranges)
+
         // If the batch is part of a group, update all ranges associated with its groupId
         // to the most advanced state. Otherwise, just use the ranges provided.
-        val cachedRangesMaybe = batch.batch.groupId?.let { cachedRangesById[batch.batch.groupId] }
+        val fromCache =
+            batch.batch.groupId?.let { groupId ->
+                val cachedRangesMaybe = cachedRangesById[groupId]
+                val cachedSet = cachedRangesMaybe?.ranges?.asRanges() ?: emptySet()
+                val newRanges = TreeRangeSet.create(cachedSet + batch.ranges.asRanges()).merged()
+                val newCachedRanges = CachedRanges(state = batch.batch.state, ranges = newRanges)
+                cachedRangesById[groupId] = newCachedRanges
+                if (cachedRangesMaybe != null && cachedRangesMaybe.state != batch.batch.state) {
+                    stateRangesToAdd.add(batch.batch.state to newRanges)
+                    stateRangesToAdd.add(cachedRangesMaybe.state to batch.ranges)
+                }
+                cachedRangesMaybe
+            }
 
-        val stateToSet =
-            cachedRangesMaybe?.state?.let { maxOf(it, batch.batch.state) } ?: batch.batch.state
-        val rangesToUpdate = TreeRangeSet.create(batch.ranges)
-        cachedRangesMaybe?.ranges?.also { rangesToUpdate.addAll(it) }
+        stateRangesToAdd.forEach { (stateToSet, rangesToUpdate) ->
+            when (stateToSet) {
+                Batch.State.COMPLETE -> {
+                    // A COMPLETED state implies PERSISTED, so also mark PERSISTED.
+                    addAndMarge(Batch.State.PERSISTED, rangesToUpdate)
+                    addAndMarge(Batch.State.COMPLETE, rangesToUpdate)
+                }
+                else -> {
+                    // For all other states, just mark the state.
+                    addAndMarge(stateToSet, rangesToUpdate)
+                }
+            }
+        }
 
-        log.info { "Marking ranges for stream ${stream.descriptor} $rangesToUpdate as $stateToSet" }
+        log.info {
+            "Added ${batch.batch.state}->${batch.ranges} (groupId=${batch.batch.groupId}) to ${stream.descriptor.namespace}.${stream.descriptor.name}=>${rangesState[batch.batch.state]}"
+        }
+        log.debug {
+            val groupLineMaybe =
+                if (fromCache != null) {
+                    "\n                From group cache: ${fromCache.state}->${fromCache.ranges}"
+                } else {
+                    ""
+                }
+            val stateRangesJoined =
+                stateRangesToAdd.joinToString(",") { "${it.first}->${it.second}" }
+            val readRange = TreeRangeSet.create(listOf(Range.closed(0, recordCount.get())))
+            """ Added $stateRangesJoined to ${stream.descriptor.namespace}.${stream.descriptor.name}$groupLineMaybe
+                READ:      $readRange (complete=${markedEndOfStream.get()})
+                PROCESSED: ${rangesState[Batch.State.PROCESSED]}
+                STAGED:    ${rangesState[Batch.State.STAGED]}
+                PERSISTED: ${rangesState[Batch.State.PERSISTED]}
+                COMPLETE:  ${rangesState[Batch.State.COMPLETE]}
+            """.trimIndent()
+        }
+    }
+
+    private fun RangeSet<Long>.merged(): RangeSet<Long> {
+        val newRanges = this.asRanges().toMutableSet()
+        this.asRanges().forEach { oldRange ->
+            newRanges
+                .find { newRange ->
+                    oldRange.upperEndpoint() + 1 == newRange.lowerEndpoint() ||
+                        newRange.upperEndpoint() + 1 == oldRange.lowerEndpoint()
+                }
+                ?.let { newRange ->
+                    newRanges.remove(oldRange)
+                    newRanges.remove(newRange)
+                    val lower = minOf(oldRange.lowerEndpoint(), newRange.lowerEndpoint())
+                    val upper = maxOf(oldRange.upperEndpoint(), newRange.upperEndpoint())
+                    newRanges.add(Range.closed(lower, upper))
+                }
+        }
+        return TreeRangeSet.create(newRanges)
+    }
+
+    private fun addAndMarge(state: Batch.State, ranges: RangeSet<Long>) {
+        rangesState[state] =
+            (rangesState[state]?.let {
+                    it.addAll(ranges)
+                    it
+                }
+                    ?: ranges)
+                .merged()
+    }
+
+    /** True if all records in `[0, index)` have reached the given state. */
+    private fun isProcessingCompleteForState(index: Long, state: Batch.State): Boolean {
+        val completeRanges = rangesState[state]!!
 
         // Force the ranges to overlap at their endpoints, in order to work around
         // the behavior of `.encloses`, which otherwise would not consider adjacent ranges as
@@ -170,51 +247,14 @@ class DefaultStreamManager(
         // This ensures that a state message received at eg, index 10 (after messages 0..9 have
         // been received), will pass `{'[0..5]','[6..9]'}.encloses('[0..10)')`.
         val expanded =
-            rangesToUpdate.asRanges().map { it.span(Range.singleton(it.upperEndpoint() + 1)) }
-
-        when (stateToSet) {
-            Batch.State.COMPLETE -> {
-                // A COMPLETED state implies PERSISTED, so also mark PERSISTED.
-                rangesState[Batch.State.PERSISTED]?.addAll(expanded)
-                rangesState[Batch.State.COMPLETE]?.addAll(expanded)
-            }
-            else -> {
-                // For all other states, just mark the state.
-                rangesState[stateToSet]?.addAll(expanded)
-            }
-        }
-
-        batch.batch.groupId?.also {
-            cachedRangesById[it] = CachedRanges(stateToSet, rangesToUpdate)
-        }
-
-        log.info {
-            val groupLineMaybe =
-                if (cachedRangesMaybe != null) {
-                    "\n                (from group: ${cachedRangesMaybe.state}->${cachedRangesMaybe.ranges})\n"
-                } else {
-                    ""
-                }
-            """ For stream ${stream.descriptor.namespace}.${stream.descriptor.name}
-                From batch ${batch.batch.state}->${batch.ranges} (groupId ${batch.batch.groupId})$groupLineMaybe
-                Added $stateToSet->$rangesToUpdate to ${stream.descriptor.namespace}.${stream.descriptor.name}
-                PROCESSED: ${rangesState[Batch.State.PROCESSED]}
-                LOCAL:     ${rangesState[Batch.State.LOCAL]}
-                PERSISTED: ${rangesState[Batch.State.PERSISTED]}
-                COMPLETE:  ${rangesState[Batch.State.COMPLETE]}
-            """.trimIndent()
-        }
-    }
-
-    /** True if all records in `[0, index)` have reached the given state. */
-    private fun isProcessingCompleteForState(index: Long, state: Batch.State): Boolean {
-        val completeRanges = rangesState[state]!!
+            completeRanges.asRanges().map { it.span(Range.singleton(it.upperEndpoint() + 1)) }
+        val expandedSet = TreeRangeSet.create(expanded)
 
         if (index == 0L && recordCount.get() == 0L) {
             return true
         }
 
-        return completeRanges.encloses(Range.closedOpen(0L, index))
+        return expandedSet.encloses(Range.closedOpen(0L, index))
     }
 
     override fun isBatchProcessingComplete(): Boolean {

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/state/StreamManagerTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/state/StreamManagerTest.kt
@@ -327,7 +327,7 @@ class StreamManagerTest {
         val range1 = Range.closed(0L, 9L)
         val batch1 =
             BatchEnvelope(
-                SimpleBatch(Batch.State.LOCAL, groupId = "foo"),
+                SimpleBatch(Batch.State.STAGED, groupId = "foo"),
                 range1,
                 stream1.descriptor
             )
@@ -352,7 +352,7 @@ class StreamManagerTest {
         val range1 = Range.closed(0L, 9L)
         val batch1 =
             BatchEnvelope(
-                SimpleBatch(Batch.State.LOCAL, groupId = "foo"),
+                SimpleBatch(Batch.State.STAGED, groupId = "foo"),
                 range1,
                 stream1.descriptor
             )
@@ -380,7 +380,7 @@ class StreamManagerTest {
         val range1 = Range.closed(0L, 9L)
         val batch1 =
             BatchEnvelope(
-                SimpleBatch(Batch.State.LOCAL, groupId = null),
+                SimpleBatch(Batch.State.STAGED, groupId = null),
                 range1,
                 stream1.descriptor
             )
@@ -416,7 +416,7 @@ class StreamManagerTest {
         val range2 = Range.closed(10, 19L)
         val batch2 =
             BatchEnvelope(
-                SimpleBatch(Batch.State.LOCAL, groupId = "foo"),
+                SimpleBatch(Batch.State.STAGED, groupId = "foo"),
                 range2,
                 stream1.descriptor
             )

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/DestinationTaskLauncherTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/DestinationTaskLauncherTest.kt
@@ -389,7 +389,8 @@ class DestinationTaskLauncherTest<T : ScopedTask> {
         streamManager.markEndOfStream(true)
 
         // Verify incomplete batch triggers process batch
-        val incompleteBatch = BatchEnvelope(MockBatch(Batch.State.LOCAL), range, stream1.descriptor)
+        val incompleteBatch =
+            BatchEnvelope(MockBatch(Batch.State.STAGED), range, stream1.descriptor)
         taskLauncher.handleNewBatch(
             MockDestinationCatalogFactory.stream1.descriptor,
             incompleteBatch

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/ProcessBatchTaskTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/ProcessBatchTaskTest.kt
@@ -49,14 +49,14 @@ class ProcessBatchTaskTest {
         coEvery { batchQueue.consume() } returns
             streamLoaders.keys
                 .map {
-                    BatchEnvelope(streamDescriptor = it, batch = SimpleBatch(Batch.State.LOCAL))
+                    BatchEnvelope(streamDescriptor = it, batch = SimpleBatch(Batch.State.STAGED))
                 }
                 .asFlow()
 
         task.execute()
 
         streamLoaders.forEach { (descriptor, loader) ->
-            coVerify { loader.processBatch(match { it.state == Batch.State.LOCAL }) }
+            coVerify { loader.processBatch(match { it.state == Batch.State.STAGED }) }
             coVerify {
                 taskLauncher.handleNewBatch(
                     descriptor,

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/message/object_storage/ObjectStorageBatch.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/message/object_storage/ObjectStorageBatch.kt
@@ -25,7 +25,7 @@ data class LoadablePart(val part: Part) : ObjectStorageBatch {
 // An UploadablePart that has been uploaded to an incomplete object.
 // Returned by processBatch
 data class IncompletePartialUpload(val key: String) : ObjectStorageBatch {
-    override val state: Batch.State = Batch.State.LOCAL
+    override val state: Batch.State = Batch.State.STAGED
     override val groupId: String = key
 }
 


### PR DESCRIPTION
## What
A non-functional DX improvement I cranked out while debugging yesterday.

Creates logs like
```
INFO DefaultDispatcher-worker-5 i.a.c.l.s.DefaultStreamManager(updateBatchState):188 For stream johnny.users
               From batch PROCESSED->[[74670..149340]] (groupId null)
               Added PROCESSED->[[74670..149340]] to johnny.users
               READ:      [[0..2570478]] (complete=false)
               PROCESSED: [[74670..149340]]
               STAGED:    []
               PERSISTED: []
               COMPLETE:  []
...
INFO DefaultDispatcher-worker-5 i.a.c.l.s.DefaultStreamManager(updateBatchState):188 For stream johnny.users
               From batch PROCESSED->[[746689..821362]] (groupId null)
               Added PROCESSED->[[746689..821362]] to johnny.users
               READ:      [[0..3986242]] (complete=false)
               PROCESSED: [[0..821362]]
               STAGED:    [[0..448017], [597353..746688]]
               PERSISTED: []
               COMPLETE:  []
...
INFO DefaultDispatcher-worker-11 i.a.c.l.s.DefaultStreamManager(updateBatchState):188 For stream johnny.users
               From batch COMPLETE->[[9856463..9931133]] (groupId s3-v2-test/parquet-snappy/johnny/users/85.parquet)
               From group cache: STAGED->[[9483131..9557792], [9632463..9707126], [9781792..9856462]]
               Added COMPLETE->[[9856463..9931133]],COMPLETE->[[9483131..9557792], [9632463..9707126], [9781792..9931133]],STAGED->[[9856463..9931133]] to johnny.users
               READ:      [[0..10000000]] (complete=true)
               PROCESSED: [[0..10000000]]
               STAGED:    [[0..9931133]]
               PERSISTED: [[0..9408471], [9483131..9557792], [9632463..9707126], [9781792..9931133]]
               COMPLETE:  [[0..9408471], [9483131..9557792], [9632463..9707126], [9781792..9931133]]
INFO DefaultDispatcher-worker-1 i.a.c.l.s.DefaultStreamManager(updateBatchState):188 For stream johnny.users
               From batch COMPLETE->[[9931134..10000000]] (groupId s3-v2-test/parquet-snappy/johnny/users/84.parquet)
               From group cache: STAGED->[[9408472..9483130], [9557793..9632462], [9707127..9781791]]
               Added COMPLETE->[[9931134..10000000]],COMPLETE->[[9408472..9483130], [9557793..9632462], [9707127..9781791], [9931134..10000000]],STAGED->[[9931134..10000000]] to johnny.users
               READ:      [[0..10000000]] (complete=true)
               PROCESSED: [[0..10000000]]
               STAGED:    [[0..10000000]]
               PERSISTED: [[0..10000000]]
               COMPLETE:  [[0..10000000]]
```