### PR TITLE
ci: replace deprecated `::set-output` syntax

### DIFF
--- a/.github/actions/run-airbyte-ci/action.yml
+++ b/.github/actions/run-airbyte-ci/action.yml
@@ -199,7 +199,7 @@ runs:
       id: hash-subcommand
       shell: bash
       if: always()
-      run: echo "::set-output name=subcommand_hash::$(echo ${{ inputs.subcommand }} | sha256sum | cut -d ' ' -f 1)"
+      run: echo "subcommand_hash=$(echo ${{ inputs.subcommand }} | sha256sum | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT
 
     - name: Upload logs to GitHub
       id: upload-dagger-engine-logs

--- a/.github/workflows/airbyte-ci-release.yml
+++ b/.github/workflows/airbyte-ci-release.yml
@@ -87,7 +87,7 @@ jobs:
         if: github.ref == 'refs/heads/master'
         working-directory: airbyte-ci/connectors/pipelines/
         run: |
-          echo "::set-output name=version::$(poetry version --short)"
+          echo "version=$(poetry version --short)" >> $GITHUB_OUTPUT
 
       - name: Authenticate to Google Cloud Prod
         id: auth_prod

--- a/.github/workflows/bump-version-command.yml
+++ b/.github/workflows/bump-version-command.yml
@@ -100,7 +100,7 @@ jobs:
       - name: Check for changes
         id: git-diff
         run: |
-          git diff --quiet && echo "No changes to commit" || echo "::set-output name=changes::true"
+          git diff --quiet && echo "No changes to commit" || echo "changes=true" >> $GITHUB_OUTPUT
         shell: bash
 
       # Commit changes (if any)

--- a/.github/workflows/connector_code_freeze.yml
+++ b/.github/workflows/connector_code_freeze.yml
@@ -35,10 +35,10 @@ jobs:
 
           if [ "$current_date" -ge "$start_date" ] && [ "$current_date" -le "$end_date" ]; then
               echo "Code freeze is in effect"
-              echo "::set-output name=is_in_code_freeze::true"
+              echo "is_in_code_freeze=true" >> $GITHUB_OUTPUT
           else
               echo "Code freeze is not in effect"
-              echo "::set-output name=is_in_code_freeze::false"
+              echo "is_in_code_freeze=false" >> $GITHUB_OUTPUT
           fi
 
       # Use GitHub PR Api to get the list of changed files

--- a/.github/workflows/connectors_up_to_date.yml
+++ b/.github/workflows/connectors_up_to_date.yml
@@ -41,7 +41,7 @@ jobs:
         id: generate_matrix
         run: |
           matrix=$(jq -c -r '{include: [.[] | "--name=" + .] | to_entries | group_by(.key / 100 | floor) | map(map(.value) | {"connector_names": join(" ")})}' selected_connectors.json)
-          echo "::set-output name=generated_matrix::$matrix"
+          echo "generated_matrix=$matrix" >> $GITHUB_OUTPUT
 
   run_connectors_up_to_date:
     needs: generate_matrix

--- a/.github/workflows/format-fix-command.yml
+++ b/.github/workflows/format-fix-command.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Check for changes
         id: git-diff
         run: |
-          git diff --quiet && echo "No changes to commit" || echo "::set-output name=changes::true"
+          git diff --quiet && echo "No changes to commit" || echo "changes=true" >> $GITHUB_OUTPUT
         shell: bash
 
       # Commit changes (if any)


### PR DESCRIPTION
## What

Combined effort to remove deprecation warnings in github actions:

- https://github.com/airbytehq/airbyte/pull/49857

## How
<!--
* Describe how code changes achieve the solution.
-->

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
