### PR TITLE
ci: use explicit ubuntu versioned ci runner

### DIFF
--- a/.github/workflows/airbyte-ci-tests.yml
+++ b/.github/workflows/airbyte-ci-tests.yml
@@ -17,7 +17,7 @@ on:
       - synchronize
 jobs:
   changes:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       internal_poetry_packages: ${{ steps.changes.outputs.internal_poetry_packages }}
 

--- a/.github/workflows/approve-and-merge-dispatch.yml
+++ b/.github/workflows/approve-and-merge-dispatch.yml
@@ -4,7 +4,7 @@ on:
     types: [created]
 jobs:
   approveAndMergeDispatch:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Auto Approve Slash Command Dispatch
         uses: peter-evans/slash-command-dispatch@v3

--- a/.github/workflows/approve-regression-tests-command.yml
+++ b/.github/workflows/approve-regression-tests-command.yml
@@ -31,7 +31,7 @@ run-name: "Approve Regression Tests #${{ github.event.inputs.pr }}"
 jobs:
   approve-regression-tests:
     name: "Approve Regression Tests"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Get job variables
         id: job-vars

--- a/.github/workflows/assign-issue-to-project.yaml
+++ b/.github/workflows/assign-issue-to-project.yaml
@@ -9,7 +9,7 @@ env:
 
 jobs:
   assign_one_project:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     name: Assign to Airbyte Github Project
     steps:
       - name: Assign documentation issues to the Documentation Roadmap project

--- a/.github/workflows/auto_merge.yml
+++ b/.github/workflows/auto_merge.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   run_auto_merge:
     name: Run auto-merge
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/bump-version-command.yml
+++ b/.github/workflows/bump-version-command.yml
@@ -41,7 +41,7 @@ concurrency:
 jobs:
   bump-version:
     name: "Bump version of connectors in this PR"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Get job variables
         id: job-vars

--- a/.github/workflows/community_ci.yml
+++ b/.github/workflows/community_ci.yml
@@ -19,7 +19,7 @@ jobs:
   fail_on_protected_path_changes:
     name: "Check fork do not change protected paths"
     if: github.event.pull_request.head.repo.fork == true
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       pull-requests: read
     steps:

--- a/.github/workflows/connector-performance-command.yml
+++ b/.github/workflows/connector-performance-command.yml
@@ -92,7 +92,7 @@ jobs:
   uuid:
     name: "Custom UUID of workflow run"
     timeout-minutes: 10
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: UUID ${{ inputs.uuid }}
         run: true
@@ -100,7 +100,7 @@ jobs:
     name: Start Build EC2 Runner
     needs: uuid
     timeout-minutes: 10
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       label: ${{ steps.start-ec2-runner.outputs.label }}
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
@@ -262,7 +262,7 @@ jobs:
       - start-test-runner # required to get output from the start-runner job
       - performance-test # required to wait when the main job is done
       - uuid
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: ${{ always() }} # required to stop the runner even if the error happened in the previous jobs
     steps:
       - name: Configure AWS credentials

--- a/.github/workflows/connector_code_freeze.yml
+++ b/.github/workflows/connector_code_freeze.yml
@@ -18,7 +18,7 @@ env:
   CODE_FREEZE_END_DATE: "2024-01-02"
 jobs:
   code-freeze-check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     name: Code freeze check
     permissions:
       # This is required to be able to comment on PRs and list changed files

--- a/.github/workflows/connector_teams_review_requirements.yml
+++ b/.github/workflows/connector_teams_review_requirements.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   check-review-requirements:
     name: "Check if a review is required from Connector teams"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     if: ${{ github.event.pull_request.head.repo.fork == false && github.event.pull_request.draft == false }}
     steps:

--- a/.github/workflows/connectors_tests.yml
+++ b/.github/workflows/connectors_tests.yml
@@ -23,7 +23,7 @@ on:
       - synchronize
 jobs:
   changes:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       connectors: ${{ steps.changes.outputs.connectors }}
     permissions:

--- a/.github/workflows/connectors_up_to_date.yml
+++ b/.github/workflows/connectors_up_to_date.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   generate_matrix:
     name: Generate matrix
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       generated_matrix: ${{ steps.generate_matrix.outputs.generated_matrix }}
     steps:

--- a/.github/workflows/contractors_review_requirements.yml
+++ b/.github/workflows/contractors_review_requirements.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   check-review-requirements:
     name: "Check if a review is required from Connector teams"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     if: ${{ github.event.pull_request.head.repo.fork == false }}
     # This workflow cannot run on forks, as the fork's github token does not have `read:org`

--- a/.github/workflows/format-fix-command.yml
+++ b/.github/workflows/format-fix-command.yml
@@ -30,7 +30,7 @@ concurrency:
 jobs:
   format-fix:
     name: "Run airbyte-ci format fix all"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Get job variables
         id: job-vars

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   changes:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       java: ${{ steps.changes.outputs.java }}
 
@@ -81,7 +81,7 @@ jobs:
 
   set-instatus-incident-on-failure:
     name: Create Instatus Incident on Failure
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs:
       - run-check
     if: ${{ failure() && github.ref == 'refs/heads/master' }}
@@ -94,7 +94,7 @@ jobs:
 
   set-instatus-incident-on-success:
     name: Create Instatus Incident on Success
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs:
       - run-check
     if: ${{ success() && github.ref == 'refs/heads/master' }}
@@ -107,7 +107,7 @@ jobs:
 
   notify-failure-slack-channel:
     name: "Notify Slack Channel on Build Failures"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs:
       - run-check
     if: ${{ failure() && github.ref == 'refs/heads/master' }}
@@ -136,7 +136,7 @@ jobs:
 
   notify-failure-slack-channel-fixed-broken-build:
     name: "Notify Slack Channel on Build Fixes"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs:
       - run-check
     if: ${{ success() && github.event.pull_request.head.repo.fork != true }}

--- a/.github/workflows/label-github-issues-by-context.yml
+++ b/.github/workflows/label-github-issues-by-context.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   shared-issues:
     name: "Add Labels to Issues.  Safe to Merge on fail"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Run Issue Command from workflow-actions
         uses: nick-fields/private-action-loader@v3

--- a/.github/workflows/label-github-issues-by-path.yml
+++ b/.github/workflows/label-github-issues-by-path.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   add-label-based-on-file-changes:
     name: "Label PRs based on files changes"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: "Label PR based on changed files"
         uses: actions/labeler@v3

--- a/.github/workflows/label-prs-by-context.yml
+++ b/.github/workflows/label-prs-by-context.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   shared-pr-labeller:
     name: "Add Labels to PRs.  Safe to Merge on fail"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Run Issue Command from workflow-actions
         uses: nick-fields/private-action-loader@v3

--- a/.github/workflows/notify-on-push-to-master.yml
+++ b/.github/workflows/notify-on-push-to-master.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   repo-sync:
     name: "Fire a Repo Dispatch event to airbyte-cloud"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Repository Dispatch
         uses: peter-evans/repository-dispatch@v2

--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -72,7 +72,7 @@ jobs:
 
   notify-failure-slack-channel:
     name: "Notify Slack Channel on Publish Failures"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs:
       - publish_connectors
     if: ${{ always() && contains(needs.*.result, 'failure') && github.ref == 'refs/heads/master' }}
@@ -101,7 +101,7 @@ jobs:
 
   notify-failure-pager-duty:
     name: "Notify PagerDuty on Publish Failures"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs:
       - publish_connectors
     if: ${{ always() && contains(needs.*.result, 'failure') && github.ref == 'refs/heads/master' }}

--- a/.github/workflows/release-airbyte-os.yml
+++ b/.github/workflows/release-airbyte-os.yml
@@ -14,7 +14,7 @@ jobs:
   start-release-airbyte-runner:
     name: "Release Airbyte: Start EC2 Runner"
     timeout-minutes: 10
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       label: ${{ steps.start-ec2-runner.outputs.label }}
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
@@ -37,7 +37,7 @@ jobs:
           github-token: ${{ env.PAT }}
 
   release-airbyte-platform:
-    # In case of self-hosted EC2 errors, removed the `needs` line and switch back to running on ubuntu-latest.
+    # In case of self-hosted EC2 errors, removed the `needs` line and switch back to running on ubuntu-24.04.
     needs:
       - start-release-airbyte-runner
     runs-on: ${{ needs.start-release-airbyte-runner.outputs.label }} # run the job on the newly created runner
@@ -107,7 +107,7 @@ jobs:
           tag: v${{ env.NEW_VERSION }}
 
   release-airbyte:
-    # In case of self-hosted EC2 errors, removed the `needs` line and switch back to running on ubuntu-latest.
+    # In case of self-hosted EC2 errors, removed the `needs` line and switch back to running on ubuntu-24.04.
     needs:
       - start-release-airbyte-runner
       - release-airbyte-platform
@@ -174,7 +174,7 @@ jobs:
   # We are releasing octavia from a separate job because:
   # - The self hosted runner used in releaseAirbyte does not have the docker buildx command to build multi-arch images
   release-octavia:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -205,7 +205,7 @@ jobs:
     needs:
       - start-release-airbyte-runner # required to get output from the start-runner job
       - release-airbyte # required to wait when the main job is done
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: ${{ always() }} # required to stop the runner even if the error happened in the previous jobs
     steps:
       - name: Configure AWS credentials

--- a/.github/workflows/slash-commands.yml
+++ b/.github/workflows/slash-commands.yml
@@ -6,7 +6,7 @@ jobs:
   slashCommandDispatch:
     # Only allow slash commands on pull request (not on issues)
     if: ${{ github.event.issue.pull_request }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Get PR repo and ref
         id: getref

--- a/.github/workflows/stale-community-issues.yaml
+++ b/.github/workflows/stale-community-issues.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   close-issues:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       issues: write
     steps:
@@ -19,8 +19,8 @@ jobs:
           operations-per-run: 100
           ascending: true
           stale-issue-message: >
-            At Airbyte, we seek to be clear about the project priorities and roadmap. 
-            This issue has not had any activity for 180 days, suggesting that it's not as critical as others. 
+            At Airbyte, we seek to be clear about the project priorities and roadmap.
+            This issue has not had any activity for 180 days, suggesting that it's not as critical as others.
             It's possible it has already been fixed. It is being marked as stale and will be closed in 20 days if there is no activity.
             To keep it open, please comment to let us know why it is important to you and if it is still reproducible on recent versions of Airbyte.
           close-issue-message: "This issue was closed because it has been inactive for 20 days since being marked as stale."

--- a/.github/workflows/stale-routed-issues.yaml
+++ b/.github/workflows/stale-routed-issues.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   close-issues:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       issues: write
       pull-requests: write
@@ -17,8 +17,8 @@ jobs:
           days-before-issue-close: 20
           stale-issue-label: "stale"
           stale-issue-message: >
-            At Airbyte, we seek to be clear about the project priorities and roadmap. 
-            This issue has not had any activity for 365 days, suggesting that it's not as critical as others. 
+            At Airbyte, we seek to be clear about the project priorities and roadmap.
+            This issue has not had any activity for 365 days, suggesting that it's not as critical as others.
             It's possible it has already been fixed. It is being marked as stale and will be closed in 20 days if there is no activity.
             To keep it open, please comment to let us know why it is important to you and if it is still reproducible on recent versions of Airbyte.
           close-issue-message: "This issue was closed because it has been inactive for 20 days since being marked as stale."

--- a/.github/workflows/terminate-zombie-build-instances.yml
+++ b/.github/workflows/terminate-zombie-build-instances.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   terminate:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: List and Terminate Instances Older Than 4 Hours
         env:
@@ -38,7 +38,7 @@ jobs:
           # See https://docs.aws.amazon.com/cli/latest/reference/ec2/terminate-instances.html for terminate command.
           echo $to_terminate |  jq '.[]  | .InstanceId' | xargs --no-run-if-empty --max-args=1 aws ec2 terminate-instances --instance-ids
   terminate-github-instances:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout Airbyte
         uses: actions/checkout@v3

--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -33,7 +33,7 @@ on:
 
 jobs:
   write-deprecation-message:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Print deprecation message
         uses: peter-evans/create-or-update-comment@v1

--- a/.github/workflows/test-performance-command.yml
+++ b/.github/workflows/test-performance-command.yml
@@ -33,7 +33,7 @@ jobs:
   start-test-runner:
     name: Start Build EC2 Runner
     timeout-minutes: 10
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       label: ${{ steps.start-ec2-runner.outputs.label }}
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
@@ -174,7 +174,7 @@ jobs:
     needs:
       - start-test-runner # required to get output from the start-runner job
       - performance-test # required to wait when the main job is done
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: ${{ always() }} # required to stop the runner even if the error happened in the previous jobs
     steps:
       - name: Configure AWS credentials

--- a/.github/workflows/upload-metadata-files.yml
+++ b/.github/workflows/upload-metadata-files.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   deploy-catalog-to-stage:
     name: "Upload Metadata Files to Metadata Service"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout Airbyte Cloud
         uses: actions/checkout@v2

--- a/.github/workflows/workflow-cleanup.yml
+++ b/.github/workflows/workflow-cleanup.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: checkout repo content
         uses: actions/checkout@v3 # checkout the repository content to github runner


### PR DESCRIPTION
## What

Addresses upcoming ubuntu-latest replacement warning:

- https://github.com/actions/runner-images/issues/10636

Combined effort to remove deprecation warnings in CI:

- #49856 

## How
<!--
* Describe how code changes achieve the solution.
-->

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
