### PR TITLE
source_babelforce_add_new_streams : added new streams

### DIFF
--- a/airbyte-integrations/connectors/source-babelforce/manifest.yaml
+++ b/airbyte-integrations/connectors/source-babelforce/manifest.yaml
@@ -1,633 +1,1685 @@
 version: 4.3.0
+
 type: DeclarativeSource
+
 check:
   type: CheckStream
   stream_names:
+    - calls_simple
     - calls
+    - agents_presence
+    - agents__line_status
+    - session_logs
+    - agent_status_details
+    - agent_list
+
 definitions:
   streams:
     calls:
       type: DeclarativeStream
       name: calls
-      primary_key:
-        - id
       retriever:
         type: SimpleRetriever
+        paginator:
+          type: DefaultPaginator
+          page_size_option:
+            type: RequestOption
+            field_name: max
+            inject_into: request_parameter
+          page_token_option:
+            type: RequestOption
+            field_name: page
+            inject_into: request_parameter
+          pagination_strategy:
+            type: PageIncrement
+            page_size: 500
+            start_from_page: 1
         requester:
-          type: HttpRequester
-          url_base: https://{{ config['region'] }}.babelforce.com/api/v2
-          path: /calls/reporting/simple
+          $ref: '#/definitions/base_requester'
+          path: /calls/reporting
           http_method: GET
-          request_headers:
-            X-Auth-Access-ID: "{{ config['access_key_id'] }}"
-            X-Auth-Access-Token: "{{ config['access_token'] }}"
         record_selector:
           type: RecordSelector
           extractor:
             type: DpathExtractor
             field_path:
               - items
-        paginator:
-          type: DefaultPaginator
-          page_token_option:
-            type: RequestOption
-            inject_into: request_parameter
-            field_name: page
-          page_size_option:
-            type: RequestOption
-            inject_into: request_parameter
-            field_name: max
-          pagination_strategy:
-            type: CursorPagination
-            page_size: 102
-            cursor_value: "{{ response['pagination']['current'] + 1 }}"
-            stop_condition: "{{ 'current' not in response['pagination'] }}"
-      incremental_sync:
-        type: DatetimeBasedCursor
-        cursor_field: dateCreated
-        cursor_datetime_formats:
-          - "%s"
-        datetime_format: "%s"
-        start_datetime:
-          type: MinMaxDatetime
-          datetime: "{{ config['date_created_from'] }}"
-          datetime_format: "%Y-%m-%dT%H:%M:%SZ"
-        start_time_option:
-          type: RequestOption
-          inject_into: request_parameter
-          field_name: filters.dateCreated.from
-        end_time_option:
-          type: RequestOption
-          inject_into: request_parameter
-          field_name: filters.dateCreated.to
-        end_datetime:
-          type: MinMaxDatetime
-          datetime: "{{ config['date_created_to'] }}"
-          datetime_format: "%Y-%m-%dT%H:%M:%SZ"
       schema_loader:
         type: InlineSchemaLoader
         schema:
-          type: object
-          $schema: http://json-schema.org/draft-07/schema#
-          additionalProperties: true
-          properties:
-            type:
-              type: string
-              maxLength: 256
-            anonymous:
-              type:
-                - boolean
-                - "null"
-            bridged:
-              type:
-                - object
-                - "null"
-              properties:
-                id:
-                  type:
-                    - string
-                    - "null"
-                name:
-                  type:
-                    - string
-                    - "null"
-                number:
-                  type:
-                    - string
-                    - "null"
-            conversationId:
-              type: string
-              maxLength: 32
-            dateCreated:
-              type: string
-              format: date-time
-            dateEstablished:
-              type:
-                - string
-                - "null"
-              format: date-time
-            dateFinished:
-              type:
-                - string
-                - "null"
-              format: date-time
-            domain:
-              type: string
-              maxLength: 256
-            duration:
-              type:
-                - integer
-                - "null"
-            finishReason:
-              type: string
-              maxLength: 256
-            from:
-              type:
-                - string
-                - "null"
-            id:
-              type: string
-              maxLength: 32
-            lastUpdated:
-              type: string
-              format: date-time
-            parentId:
-              type:
-                - string
-                - "null"
-              maxLength: 32
-            recordings:
-              type:
-                - array
-                - "null"
-              items:
-                type: object
-                properties:
-                  agent:
-                    type: object
-                    properties:
-                      id:
-                        type:
-                          - string
-                          - "null"
-                      name:
-                        type:
-                          - string
-                          - "null"
-                      number:
-                        type:
-                          - string
-                          - "null"
-                  dateCreated:
-                    type: string
-                    format: date-time
-                  duration:
-                    type: integer
-                  file:
-                    type:
-                      - object
-                      - "null"
-                    properties:
-                      contentType:
-                        type:
-                          - string
-                          - "null"
-                      id:
-                        type: string
-                        maxLength: 32
-                      name:
-                        type:
-                          - string
-                          - "null"
-                      size:
-                        type:
-                          - integer
-                          - "null"
-                      state:
-                        type:
-                          - string
-                          - "null"
-                  id:
-                    type: string
-                    maxLength: 32
-                  lastUpdated:
-                    type: string
-                    format: date-time
-                  state:
-                    type: string
-                    maxLength: 256
-                  tags:
-                    type: array
-                    items:
-                      type: string
-                  url:
-                    type: string
-            sessionId:
-              type: string
-              maxLength: 32
-            source:
-              type: string
-              maxLength: 256
-            state:
-              type: string
-              maxLength: 256
-            to:
-              type:
-                - string
-                - "null"
+          $ref: '#/schemas/calls'
+      incremental_sync:
+        type: DatetimeBasedCursor
+        cursor_field: lastUpdated
+        start_datetime:
+          type: MinMaxDatetime
+          datetime: '{{ config["start_date"] }}'
+          datetime_format: '%Y-%m-%dT%H:%M:%SZ'
+        datetime_format: '%s'
+        start_time_option:
+          type: RequestOption
+          field_name: time.start
+          inject_into: request_parameter
+        cursor_datetime_formats:
+          - '%Y-%m-%dT%H:%M:%S.%fZ'
+    agent_list:
+      type: DeclarativeStream
+      name: agent_list
+      retriever:
+        type: SimpleRetriever
+        paginator:
+          type: DefaultPaginator
+          page_size_option:
+            type: RequestOption
+            field_name: max
+            inject_into: request_parameter
+          page_token_option:
+            type: RequestOption
+            field_name: page
+            inject_into: request_parameter
+          pagination_strategy:
+            type: PageIncrement
+            page_size: 500
+            start_from_page: 1
+        requester:
+          $ref: '#/definitions/base_requester'
+          path: /agents
+          http_method: GET
+        record_selector:
+          type: RecordSelector
+          extractor:
+            type: DpathExtractor
+            field_path:
+              - items
+      schema_loader:
+        type: InlineSchemaLoader
+        schema:
+          $ref: '#/schemas/agent_list'
+    calls_simple:
+      type: DeclarativeStream
+      name: calls_simple
+      retriever:
+        type: SimpleRetriever
+        paginator:
+          type: DefaultPaginator
+          page_size_option:
+            type: RequestOption
+            field_name: max
+            inject_into: request_parameter
+          page_token_option:
+            type: RequestOption
+            field_name: page
+            inject_into: request_parameter
+          pagination_strategy:
+            type: PageIncrement
+            page_size: 500
+            start_from_page: 1
+        requester:
+          $ref: '#/definitions/base_requester'
+          path: /calls/reporting/simple
+          http_method: GET
+        record_selector:
+          type: RecordSelector
+          extractor:
+            type: DpathExtractor
+            field_path:
+              - items
+      schema_loader:
+        type: InlineSchemaLoader
+        schema:
+          $ref: '#/schemas/calls_simple'
+      incremental_sync:
+        type: DatetimeBasedCursor
+        cursor_field: lastUpdated
+        start_datetime:
+          type: MinMaxDatetime
+          datetime: '{{ config["start_date"] }}'
+          datetime_format: '%Y-%m-%dT%H:%M:%SZ'
+        datetime_format: '%s'
+        start_time_option:
+          type: RequestOption
+          field_name: filters.dateCreated.from
+          inject_into: request_parameter
+        cursor_datetime_formats:
+          - '%Y-%m-%dT%H:%M:%S.%fZ'
+    session_logs:
+      type: DeclarativeStream
+      name: session_logs
+      retriever:
+        type: SimpleRetriever
+        requester:
+          $ref: '#/definitions/base_requester'
+          path: /sessions/{{ stream_partition.parent_id }}
+          http_method: GET
+        record_selector:
+          type: RecordSelector
+          extractor:
+            type: DpathExtractor
+            field_path:
+              - item
+        partition_router:
+          type: SubstreamPartitionRouter
+          parent_stream_configs:
+            - type: ParentStreamConfig
+              stream:
+                $ref: '#/definitions/streams/calls'
+              parent_key: sessionId
+              partition_field: parent_id
+      schema_loader:
+        type: InlineSchemaLoader
+        schema:
+          $ref: '#/schemas/session_logs'
+      incremental_sync:
+        type: DatetimeBasedCursor
+        cursor_field: last_access
+        start_datetime:
+          type: MinMaxDatetime
+          datetime: '{{ config["start_date"] }}'
+          datetime_format: '%Y-%m-%dT%H:%M:%SZ'
+        datetime_format: '%ms'
+        start_time_option:
+          type: RequestOption
+          field_name: filters.time.start
+          inject_into: request_parameter
+        cursor_datetime_formats:
+          - '%ms'
+    agents_presence:
+      type: DeclarativeStream
+      name: agents_presence
+      retriever:
+        type: SimpleRetriever
+        requester:
+          $ref: '#/definitions/base_requester'
+          path: metrics/agents/presence/total?timeRange=YESTERDAY
+          http_method: GET
+        record_selector:
+          type: RecordSelector
+          extractor:
+            type: DpathExtractor
+            field_path:
+              - metric
+              - values
+      schema_loader:
+        type: InlineSchemaLoader
+        schema:
+          $ref: '#/schemas/agents_presence'
+    agents__line_status:
+      type: DeclarativeStream
+      name: agents__line_status
+      retriever:
+        type: SimpleRetriever
+        requester:
+          $ref: '#/definitions/base_requester'
+          path: metrics/agents/presence/total?timeRange=YESTERDAY
+          http_method: GET
+        record_selector:
+          type: RecordSelector
+          extractor:
+            type: DpathExtractor
+            field_path:
+              - metric
+              - values
+      schema_loader:
+        type: InlineSchemaLoader
+        schema:
+          $ref: '#/schemas/agents__line_status'
+      transformations:
+        - type: AddFields
+          fields:
+            - path:
+                - lastTimestamp
+              value: '{{ record[''presence''][''lastTimestamp'']}}'
+      incremental_sync:
+        type: DatetimeBasedCursor
+        cursor_field: lastTimestamp
+        start_datetime:
+          type: MinMaxDatetime
+          datetime: '{{ config["start_date"] }}'
+          datetime_format: '%Y-%m-%dT%H:%M:%SZ'
+        datetime_format: '%s'
+        start_time_option:
+          type: RequestOption
+          field_name: filters.time.start
+          inject_into: request_parameter
+        cursor_datetime_formats:
+          - '%ms'
+    agent_status_details:
+      type: DeclarativeStream
+      name: agent_status_details
+      retriever:
+        type: SimpleRetriever
+        paginator:
+          type: DefaultPaginator
+          page_size_option:
+            type: RequestOption
+            field_name: max
+            inject_into: request_parameter
+          page_token_option:
+            type: RequestOption
+            field_name: page
+            inject_into: request_parameter
+          pagination_strategy:
+            type: PageIncrement
+            page_size: 500
+            start_from_page: 1
+        requester:
+          $ref: '#/definitions/base_requester'
+          path: /agents/logs?id={{ stream_partition.parent_id }}
+          http_method: GET
+        record_selector:
+          type: RecordSelector
+          extractor:
+            type: DpathExtractor
+            field_path:
+              - items
+        partition_router:
+          type: SubstreamPartitionRouter
+          parent_stream_configs:
+            - type: ParentStreamConfig
+              stream:
+                $ref: '#/definitions/streams/agent_list'
+              parent_key: id
+              partition_field: parent_id
+      schema_loader:
+        type: InlineSchemaLoader
+        schema:
+          $ref: '#/schemas/agent_status_details'
   base_requester:
     type: HttpRequester
     url_base: https://{{ config['region'] }}.babelforce.com/api/v2
-streams:
-  - type: DeclarativeStream
-    name: calls
-    primary_key:
-      - id
-    retriever:
-      type: SimpleRetriever
-      requester:
+    authenticator:
+      type: SessionTokenAuthenticator
+      login_requester:
         type: HttpRequester
-        url_base: https://{{ config['region'] }}.babelforce.com/api/v2
-        path: /calls/reporting/simple
-        http_method: GET
+        path: token
+        url_base: https://{{ config['region'] }}.babelforce.com/oauth
+        http_method: POST
+        authenticator:
+          type: NoAuth
         request_headers:
-          X-Auth-Access-ID: "{{ config['access_key_id'] }}"
-          X-Auth-Access-Token: "{{ config['access_token'] }}"
-      record_selector:
-        type: RecordSelector
-        extractor:
-          type: DpathExtractor
-          field_path:
-            - items
-      paginator:
-        type: DefaultPaginator
-        page_token_option:
-          type: RequestOption
-          inject_into: request_parameter
-          field_name: page
-        page_size_option:
-          type: RequestOption
-          inject_into: request_parameter
-          field_name: max
-        pagination_strategy:
-          type: CursorPagination
-          page_size: 102
-          cursor_value: "{{ response['pagination']['current'] + 1 }}"
-          stop_condition: "{{ 'current' not in response['pagination'] }}"
-    incremental_sync:
-      type: DatetimeBasedCursor
-      cursor_field: dateCreated
-      cursor_datetime_formats:
-        - "%s"
-      datetime_format: "%s"
-      start_datetime:
-        type: MinMaxDatetime
-        datetime: "{{ config['date_created_from'] }}"
-        datetime_format: "%Y-%m-%dT%H:%M:%SZ"
-      start_time_option:
-        type: RequestOption
-        inject_into: request_parameter
-        field_name: filters.dateCreated.from
-      end_time_option:
-        type: RequestOption
-        inject_into: request_parameter
-        field_name: filters.dateCreated.to
-      end_datetime:
-        type: MinMaxDatetime
-        datetime: "{{ config['date_created_to'] }}"
-        datetime_format: "%Y-%m-%dT%H:%M:%SZ"
-    schema_loader:
-      type: InlineSchemaLoader
-      schema:
-        type: object
-        $schema: http://json-schema.org/draft-07/schema#
-        additionalProperties: true
-        properties:
-          type:
-            type: string
-            maxLength: 256
-          anonymous:
-            type:
-              - boolean
-              - "null"
-          bridged:
-            type:
-              - object
-              - "null"
-            properties:
-              id:
-                type:
-                  - string
-                  - "null"
-              name:
-                type:
-                  - string
-                  - "null"
-              number:
-                type:
-                  - string
-                  - "null"
-          conversationId:
-            type: string
-            maxLength: 32
-          dateCreated:
-            type: string
-            format: date-time
-          dateEstablished:
-            type:
-              - string
-              - "null"
-            format: date-time
-          dateFinished:
-            type:
-              - string
-              - "null"
-            format: date-time
-          domain:
-            type: string
-            maxLength: 256
-          duration:
-            type:
-              - integer
-              - "null"
-          finishReason:
-            type: string
-            maxLength: 256
-          from:
-            type:
-              - string
-              - "null"
-          id:
-            type: string
-            maxLength: 32
-          lastUpdated:
-            type: string
-            format: date-time
-          parentId:
-            type:
-              - string
-              - "null"
-            maxLength: 32
-          recordings:
-            type:
-              - array
-              - "null"
-            items:
-              type: object
-              properties:
-                agent:
-                  type: object
-                  properties:
-                    id:
-                      type:
-                        - string
-                        - "null"
-                    name:
-                      type:
-                        - string
-                        - "null"
-                    number:
-                      type:
-                        - string
-                        - "null"
-                dateCreated:
-                  type: string
-                  format: date-time
-                duration:
-                  type: integer
-                file:
-                  type:
-                    - object
-                    - "null"
-                  properties:
-                    contentType:
-                      type:
-                        - string
-                        - "null"
-                    id:
-                      type: string
-                      maxLength: 32
-                    name:
-                      type:
-                        - string
-                        - "null"
-                    size:
-                      type:
-                        - integer
-                        - "null"
-                    state:
-                      type:
-                        - string
-                        - "null"
-                id:
-                  type: string
-                  maxLength: 32
-                lastUpdated:
-                  type: string
-                  format: date-time
-                state:
-                  type: string
-                  maxLength: 256
-                tags:
-                  type: array
-                  items:
-                    type: string
-                url:
-                  type: string
-          sessionId:
-            type: string
-            maxLength: 32
-          source:
-            type: string
-            maxLength: 256
-          state:
-            type: string
-            maxLength: 256
-          to:
-            type:
-              - string
-              - "null"
+          Content-Type: application/x-www-form-urlencoded
+        request_body_data:
+          password: '{{ config["password"] }}'
+          username: '{{ config["username"] }}'
+          grant_type: password
+        request_parameters: {}
+      session_token_path:
+        - access_token
+      expiration_duration: PT1H
+      request_authentication:
+        type: Bearer
+
+streams:
+  - $ref: '#/definitions/streams/calls_simple'
+  - $ref: '#/definitions/streams/calls'
+  - $ref: '#/definitions/streams/agents_presence'
+  - $ref: '#/definitions/streams/agents__line_status'
+  - $ref: '#/definitions/streams/session_logs'
+  - $ref: '#/definitions/streams/agent_status_details'
+  - $ref: '#/definitions/streams/agent_list'
+
 spec:
   type: Spec
   connection_specification:
     type: object
     $schema: http://json-schema.org/draft-07/schema#
     required:
-      - access_key_id
-      - access_token
       - region
+      - username
+      - password
+      - start_date
     properties:
-      access_key_id:
-        type: string
-        title: Access Key ID
-        description: The Babelforce access key ID
-        airbyte_secret: true
-        order: 0
-      access_token:
-        type: string
-        title: Access Token
-        description: The Babelforce access token
-        airbyte_secret: true
-        order: 1
-      date_created_from:
-        type: integer
-        title: Date Created from
-        description: >-
-          Timestamp in Unix the replication from Babelforce API will start from.
-          For example 1651363200 which corresponds to 2022-05-01 00:00:00.
-        examples:
-          - 1651363200
-        order: 2
-      date_created_to:
-        type: integer
-        title: Date Created to
-        description: >-
-          Timestamp in Unix the replication from Babelforce will be up to. For
-          example 1651363200 which corresponds to 2022-05-01 00:00:00.
-        examples:
-          - 1651363200
-        order: 3
       region:
         type: string
-        title: Region
-        description: Babelforce region
-        default: services
         enum:
+          - ista
           - services
           - us-east
           - ap-southeast
         order: 4
+        title: Region
+        default: services
+        description: Babelforce region
+      password:
+        type: string
+        order: 6
+        title: password
+        airbyte_secret: true
+      username:
+        type: string
+        order: 5
+        title: username
+      start_date:
+        type: string
+        order: 7
+        title: Start date
+        format: date-time
+        pattern: ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$
+      access_token:
+        type: string
+        order: 1
+        title: Access Token
+        description: The Babelforce access token
+        airbyte_secret: true
+      access_key_id:
+        type: string
+        order: 0
+        title: Access Key ID
+        description: The Babelforce access key ID
+        airbyte_secret: true
+      date_created_to:
+        type: integer
+        order: 3
+        title: Date Created to
+        examples:
+          - 1651363200
+        description: >-
+          Timestamp in Unix the replication from Babelforce will be up to. For
+          example 1651363200 which corresponds to 2022-05-01 00:00:00.
+      date_created_from:
+        type: integer
+        order: 2
+        title: Date Created from
+        examples:
+          - 1651363200
+        description: >-
+          Timestamp in Unix the replication from Babelforce API will start from.
+          For example 1651363200 which corresponds to 2022-05-01 00:00:00.
     additionalProperties: true
+
 metadata:
   autoImportSchema:
-    calls: false
+    calls: true
+    agent_list: true
+    calls_simple: true
+    session_logs: true
+    agents_presence: true
+    agents__line_status: true
+    agent_status_details: true
+
 schemas:
   calls:
     type: object
-    $schema: http://json-schema.org/draft-07/schema#
-    additionalProperties: true
+    $schema: http://json-schema.org/schema#
+    required:
+      - lastUpdated
     properties:
       type:
-        type: string
-        maxLength: 256
-      anonymous:
         type:
-          - boolean
-          - "null"
+          - string
+          - 'null'
+      id:
+        type:
+          - string
+          - 'null'
+      to:
+        type:
+          - string
+          - 'null'
+      _url:
+        type:
+          - string
+          - 'null'
+      from:
+        type:
+          - string
+          - 'null'
+      state:
+        type:
+          - string
+          - 'null'
+      domain:
+        type:
+          - string
+          - 'null'
+      source:
+        type:
+          - string
+          - 'null'
       bridged:
         type:
           - object
-          - "null"
+          - 'null'
         properties:
           id:
             type:
               - string
-              - "null"
+              - 'null'
           name:
             type:
               - string
-              - "null"
+              - 'null'
+          agent:
+            type:
+              - object
+              - 'null'
+            properties:
+              id:
+                type:
+                  - string
+                  - 'null'
+              name:
+                type:
+                  - string
+                  - 'null'
+              number:
+                type:
+                  - string
+                  - 'null'
+          queue:
+            type:
+              - object
+              - 'null'
+            properties:
+              id:
+                type:
+                  - string
+                  - 'null'
+              name:
+                type:
+                  - string
+                  - 'null'
           number:
             type:
               - string
-              - "null"
-      conversationId:
-        type: string
-        maxLength: 32
-      dateCreated:
-        type: string
-        format: date-time
-      dateEstablished:
-        type:
-          - string
-          - "null"
-        format: date-time
-      dateFinished:
-        type:
-          - string
-          - "null"
-        format: date-time
-      domain:
-        type: string
-        maxLength: 256
+              - 'null'
+          queueId:
+            type:
+              - string
+              - 'null'
+          queueName:
+            type:
+              - string
+              - 'null'
       duration:
         type:
-          - integer
-          - "null"
-      finishReason:
-        type: string
-        maxLength: 256
-      from:
-        type:
-          - string
-          - "null"
-      id:
-        type: string
-        maxLength: 32
-      lastUpdated:
-        type: string
-        format: date-time
+          - number
+          - 'null'
       parentId:
         type:
           - string
-          - "null"
-        maxLength: 32
+          - 'null'
+      anonymous:
+        type:
+          - boolean
+          - 'null'
+      sessionId:
+        type:
+          - string
+          - 'null'
       recordings:
         type:
           - array
-          - "null"
+          - 'null'
         items:
-          type: object
+          type:
+            - object
+            - 'null'
           properties:
-            agent:
-              type: object
+            id:
+              type:
+                - string
+                - 'null'
+            url:
+              type:
+                - string
+                - 'null'
+            call:
+              type:
+                - object
+                - 'null'
               properties:
+                type:
+                  type:
+                    - string
+                    - 'null'
                 id:
                   type:
                     - string
-                    - "null"
-                name:
+                    - 'null'
+                to:
                   type:
                     - string
-                    - "null"
-                number:
+                    - 'null'
+                from:
                   type:
                     - string
-                    - "null"
-            dateCreated:
-              type: string
-              format: date-time
-            duration:
-              type: integer
+                    - 'null'
+                conversationId:
+                  type:
+                    - string
+                    - 'null'
             file:
               type:
                 - object
-                - "null"
+                - 'null'
               properties:
-                contentType:
+                id:
                   type:
                     - string
-                    - "null"
-                id:
-                  type: string
-                  maxLength: 32
+                    - 'null'
                 name:
                   type:
                     - string
-                    - "null"
+                    - 'null'
                 size:
                   type:
-                    - integer
-                    - "null"
+                    - number
+                    - 'null'
                 state:
                   type:
                     - string
-                    - "null"
-            id:
-              type: string
-              maxLength: 32
-            lastUpdated:
-              type: string
-              format: date-time
-            state:
-              type: string
-              maxLength: 256
+                    - 'null'
+                contentType:
+                  type:
+                    - string
+                    - 'null'
             tags:
-              type: array
-              items:
-                type: string
-            url:
-              type: string
-      sessionId:
+              type:
+                - array
+                - 'null'
+            agent:
+              type:
+                - object
+                - 'null'
+              properties:
+                id:
+                  type:
+                    - string
+                    - 'null'
+                name:
+                  type:
+                    - string
+                    - 'null'
+                number:
+                  type:
+                    - string
+                    - 'null'
+            state:
+              type:
+                - string
+                - 'null'
+            duration:
+              type:
+                - number
+                - 'null'
+            dateCreated:
+              type:
+                - string
+                - 'null'
+            lastUpdated:
+              type:
+                - string
+                - 'null'
+      dateCreated:
+        type:
+          - string
+          - 'null'
+      lastUpdated:
         type: string
-        maxLength: 32
-      source:
-        type: string
-        maxLength: 256
+      dateFinished:
+        type:
+          - string
+          - 'null'
+      finishReason:
+        type:
+          - string
+          - 'null'
+      conversationId:
+        type:
+          - string
+          - 'null'
+      dateEstablished:
+        type:
+          - string
+          - 'null'
+    additionalProperties: true
+  agent_list:
+    type: object
+    $schema: http://json-schema.org/schema#
+    properties:
+      id:
+        type:
+          - string
+          - 'null'
+      _url:
+        type:
+          - string
+          - 'null'
+      name:
+        type:
+          - string
+          - 'null'
+      tags:
+        type:
+          - array
+          - 'null'
+        items:
+          type:
+            - string
+            - 'null'
+      email:
+        type:
+          - string
+          - 'null'
       state:
-        type: string
-        maxLength: 256
+        type:
+          - string
+          - 'null'
+      groups:
+        type:
+          - array
+          - 'null'
+        items:
+          type:
+            - object
+            - 'null'
+          properties:
+            id:
+              type:
+                - string
+                - 'null'
+            name:
+              type:
+                - string
+                - 'null'
+            tags:
+              type:
+                - array
+                - 'null'
+              items:
+                type:
+                  - string
+                  - 'null'
+            dateCreated:
+              type:
+                - string
+                - 'null'
+      number:
+        type:
+          - string
+          - 'null'
+      status:
+        type:
+          - object
+          - 'null'
+        properties:
+          enabled:
+            type:
+              - boolean
+              - 'null'
+          presence:
+            type:
+              - object
+              - 'null'
+            properties:
+              name:
+                type:
+                  - string
+                  - 'null'
+              label:
+                type:
+                  - string
+                  - 'null'
+              available:
+                type:
+                  - boolean
+                  - 'null'
+          available:
+            type:
+              - boolean
+              - 'null'
+          line_status:
+            type:
+              - string
+              - 'null'
+          display_status:
+            type:
+              - string
+              - 'null'
+          outbound_status:
+            type:
+              - string
+              - 'null'
+      webrtc:
+        type:
+          - boolean
+          - 'null'
+      enabled:
+        type:
+          - boolean
+          - 'null'
+      features:
+        type:
+          - array
+          - 'null'
+        items:
+          type:
+            - string
+            - 'null'
+      presence:
+        type:
+          - object
+          - 'null'
+        properties:
+          name:
+            type:
+              - string
+              - 'null'
+          label:
+            type:
+              - string
+              - 'null'
+          available:
+            type:
+              - boolean
+              - 'null'
+      sourceId:
+        type:
+          - string
+          - 'null'
+      agentSource:
+        type:
+          - string
+          - 'null'
+      dateCreated:
+        type:
+          - string
+          - 'null'
+      integration:
+        type:
+          - object
+          - 'null'
+        properties:
+          type:
+            type:
+              - string
+              - 'null'
+          id:
+            type:
+              - string
+              - 'null'
+          name:
+            type:
+              - string
+              - 'null'
+          tags:
+            type:
+              - array
+              - 'null'
+          color:
+            type:
+              - string
+              - 'null'
+          label:
+            type:
+              - string
+              - 'null'
+          enabled:
+            type:
+              - boolean
+              - 'null'
+          provider:
+            type:
+              - string
+              - 'null'
+      lastUpdated:
+        type:
+          - string
+          - 'null'
+    additionalProperties: true
+  calls_simple:
+    type: object
+    $schema: http://json-schema.org/schema#
+    required:
+      - lastUpdated
+    properties:
+      type:
+        type:
+          - string
+          - 'null'
+      id:
+        type:
+          - string
+          - 'null'
       to:
         type:
           - string
-          - "null"
+          - 'null'
+      from:
+        type:
+          - string
+          - 'null'
+      bridged:
+        type:
+          - boolean
+          - 'null'
+      duration:
+        type:
+          - number
+          - 'null'
+      holdTime:
+        type:
+          - number
+          - 'null'
+      talkTime:
+        type:
+          - number
+          - 'null'
+      waitTime:
+        type:
+          - number
+          - 'null'
+      agentName:
+        type:
+          - string
+          - 'null'
+      queueName:
+        type:
+          - string
+          - 'null'
+      sessionId:
+        type:
+          - string
+          - 'null'
+      bridgeTime:
+        type:
+          - number
+          - 'null'
+      handleTime:
+        type:
+          - number
+          - 'null'
+      wrapupTime:
+        type:
+          - number
+          - 'null'
+      dateCreated:
+        type:
+          - string
+          - 'null'
+      lastUpdated:
+        type: string
+      queueWaitTime:
+        type:
+          - number
+          - 'null'
+    additionalProperties: true
+  session_logs:
+    type: object
+    $schema: http://json-schema.org/schema#
+    required:
+      - last_access
+    properties:
+      id:
+        type:
+          - string
+          - 'null'
+      data:
+        type:
+          - object
+          - 'null'
+        properties:
+          ivr.v2_enabled:
+            type:
+              - string
+              - 'null'
+          ivr.isp1_geschlossen:
+            type:
+              - string
+              - 'null'
+      valid:
+        type:
+          - boolean
+          - 'null'
+      created:
+        type:
+          - number
+          - 'null'
+      last_access:
+        type: number
+    additionalProperties: true
+  agents_presence:
+    type: object
+    $schema: http://json-schema.org/schema#
+    properties:
+      id:
+        type:
+          - string
+          - 'null'
+      name:
+        type:
+          - string
+          - 'null'
+      states:
+        type:
+          - object
+          - 'null'
+        properties:
+          busy:
+            type:
+              - object
+              - 'null'
+            properties:
+              label:
+                type:
+                  - string
+                  - 'null'
+              available:
+                type:
+                  - boolean
+                  - 'null'
+              totalTime:
+                type:
+                  - number
+                  - 'null'
+              lastTimestamp:
+                type:
+                  - number
+                  - 'null'
+              totalTransitions:
+                type:
+                  - number
+                  - 'null'
+          0-pause:
+            type:
+              - object
+              - 'null'
+            properties:
+              label:
+                type:
+                  - string
+                  - 'null'
+              available:
+                type:
+                  - boolean
+                  - 'null'
+              totalTime:
+                type:
+                  - number
+                  - 'null'
+              lastTimestamp:
+                type:
+                  - number
+                  - 'null'
+              totalTransitions:
+                type:
+                  - number
+                  - 'null'
+          1-meldung:
+            type:
+              - object
+              - 'null'
+            properties:
+              name:
+                type:
+                  - string
+                  - 'null'
+              label:
+                type:
+                  - string
+                  - 'null'
+              available:
+                type:
+                  - boolean
+                  - 'null'
+              totalTime:
+                type:
+                  - number
+                  - 'null'
+              lastTimestamp:
+                type:
+                  - number
+                  - 'null'
+              totalTransitions:
+                type:
+                  - number
+                  - 'null'
+          5-projekt:
+            type:
+              - object
+              - 'null'
+            properties:
+              label:
+                type:
+                  - string
+                  - 'null'
+              available:
+                type:
+                  - boolean
+                  - 'null'
+              totalTime:
+                type:
+                  - number
+                  - 'null'
+              lastTimestamp:
+                type:
+                  - number
+                  - 'null'
+              totalTransitions:
+                type:
+                  - number
+                  - 'null'
+          7-meeting:
+            type:
+              - object
+              - 'null'
+            properties:
+              label:
+                type:
+                  - string
+                  - 'null'
+              available:
+                type:
+                  - boolean
+                  - 'null'
+              totalTime:
+                type:
+                  - number
+                  - 'null'
+              lastTimestamp:
+                type:
+                  - number
+                  - 'null'
+              totalTransitions:
+                type:
+                  - number
+                  - 'null'
+          available:
+            type:
+              - object
+              - 'null'
+            properties:
+              name:
+                type:
+                  - string
+                  - 'null'
+              label:
+                type:
+                  - string
+                  - 'null'
+              available:
+                type:
+                  - boolean
+                  - 'null'
+              totalTime:
+                type:
+                  - number
+                  - 'null'
+              lastTimestamp:
+                type:
+                  - number
+                  - 'null'
+              totalTransitions:
+                type:
+                  - number
+                  - 'null'
+          2-vorgaenge:
+            type:
+              - object
+              - 'null'
+            properties:
+              label:
+                type:
+                  - string
+                  - 'null'
+              available:
+                type:
+                  - boolean
+                  - 'null'
+              totalTime:
+                type:
+                  - number
+                  - 'null'
+              lastTimestamp:
+                type:
+                  - number
+                  - 'null'
+              totalTransitions:
+                type:
+                  - number
+                  - 'null'
+          3-backoffice:
+            type:
+              - object
+              - 'null'
+            properties:
+              label:
+                type:
+                  - string
+                  - 'null'
+              available:
+                type:
+                  - boolean
+                  - 'null'
+              totalTime:
+                type:
+                  - number
+                  - 'null'
+              lastTimestamp:
+                type:
+                  - number
+                  - 'null'
+              totalTransitions:
+                type:
+                  - number
+                  - 'null'
+          4-sonderrolle:
+            type:
+              - object
+              - 'null'
+            properties:
+              name:
+                type:
+                  - string
+                  - 'null'
+              label:
+                type:
+                  - string
+                  - 'null'
+              available:
+                type:
+                  - boolean
+                  - 'null'
+              totalTime:
+                type:
+                  - number
+                  - 'null'
+              lastTimestamp:
+                type:
+                  - number
+                  - 'null'
+              totalTransitions:
+                type:
+                  - number
+                  - 'null'
+          6-weiterbildung:
+            type:
+              - object
+              - 'null'
+            properties:
+              name:
+                type:
+                  - string
+                  - 'null'
+              label:
+                type:
+                  - string
+                  - 'null'
+              available:
+                type:
+                  - boolean
+                  - 'null'
+              totalTime:
+                type:
+                  - number
+                  - 'null'
+              lastTimestamp:
+                type:
+                  - number
+                  - 'null'
+              totalTransitions:
+                type:
+                  - number
+                  - 'null'
+          8-nachbearbeitung:
+            type:
+              - object
+              - 'null'
+            properties:
+              label:
+                type:
+                  - string
+                  - 'null'
+              available:
+                type:
+                  - boolean
+                  - 'null'
+              totalTime:
+                type:
+                  - number
+                  - 'null'
+              lastTimestamp:
+                type:
+                  - number
+                  - 'null'
+              totalTransitions:
+                type:
+                  - number
+                  - 'null'
+      presence:
+        type:
+          - object
+          - 'null'
+        properties:
+          name:
+            type:
+              - string
+              - 'null'
+          label:
+            type:
+              - string
+              - 'null'
+          available:
+            type:
+              - boolean
+              - 'null'
+          totalTime:
+            type:
+              - number
+              - 'null'
+          lastTimestamp:
+            type:
+              - number
+              - 'null'
+          totalTransitions:
+            type:
+              - number
+              - 'null'
+    additionalProperties: true
+  agents__line_status:
+    type: object
+    $schema: http://json-schema.org/schema#
+    required:
+      - lastTimestamp
+    properties:
+      id:
+        type:
+          - string
+          - 'null'
+      name:
+        type:
+          - string
+          - 'null'
+      states:
+        type:
+          - object
+          - 'null'
+        properties:
+          busy:
+            type:
+              - object
+              - 'null'
+            properties:
+              label:
+                type:
+                  - string
+                  - 'null'
+              available:
+                type:
+                  - boolean
+                  - 'null'
+              totalTime:
+                type:
+                  - number
+                  - 'null'
+              lastTimestamp:
+                type:
+                  - number
+                  - 'null'
+              totalTransitions:
+                type:
+                  - number
+                  - 'null'
+          0-pause:
+            type:
+              - object
+              - 'null'
+            properties:
+              label:
+                type:
+                  - string
+                  - 'null'
+              available:
+                type:
+                  - boolean
+                  - 'null'
+              totalTime:
+                type:
+                  - number
+                  - 'null'
+              lastTimestamp:
+                type:
+                  - number
+                  - 'null'
+              totalTransitions:
+                type:
+                  - number
+                  - 'null'
+          1-meldung:
+            type:
+              - object
+              - 'null'
+            properties:
+              name:
+                type:
+                  - string
+                  - 'null'
+              label:
+                type:
+                  - string
+                  - 'null'
+              available:
+                type:
+                  - boolean
+                  - 'null'
+              totalTime:
+                type:
+                  - number
+                  - 'null'
+              lastTimestamp:
+                type:
+                  - number
+                  - 'null'
+              totalTransitions:
+                type:
+                  - number
+                  - 'null'
+          5-projekt:
+            type:
+              - object
+              - 'null'
+            properties:
+              label:
+                type:
+                  - string
+                  - 'null'
+              available:
+                type:
+                  - boolean
+                  - 'null'
+              totalTime:
+                type:
+                  - number
+                  - 'null'
+              lastTimestamp:
+                type:
+                  - number
+                  - 'null'
+              totalTransitions:
+                type:
+                  - number
+                  - 'null'
+          7-meeting:
+            type:
+              - object
+              - 'null'
+            properties:
+              label:
+                type:
+                  - string
+                  - 'null'
+              available:
+                type:
+                  - boolean
+                  - 'null'
+              totalTime:
+                type:
+                  - number
+                  - 'null'
+              lastTimestamp:
+                type:
+                  - number
+                  - 'null'
+              totalTransitions:
+                type:
+                  - number
+                  - 'null'
+          available:
+            type:
+              - object
+              - 'null'
+            properties:
+              name:
+                type:
+                  - string
+                  - 'null'
+              label:
+                type:
+                  - string
+                  - 'null'
+              available:
+                type:
+                  - boolean
+                  - 'null'
+              totalTime:
+                type:
+                  - number
+                  - 'null'
+              lastTimestamp:
+                type:
+                  - number
+                  - 'null'
+              totalTransitions:
+                type:
+                  - number
+                  - 'null'
+          2-vorgaenge:
+            type:
+              - object
+              - 'null'
+            properties:
+              label:
+                type:
+                  - string
+                  - 'null'
+              available:
+                type:
+                  - boolean
+                  - 'null'
+              totalTime:
+                type:
+                  - number
+                  - 'null'
+              lastTimestamp:
+                type:
+                  - number
+                  - 'null'
+              totalTransitions:
+                type:
+                  - number
+                  - 'null'
+          3-backoffice:
+            type:
+              - object
+              - 'null'
+            properties:
+              label:
+                type:
+                  - string
+                  - 'null'
+              available:
+                type:
+                  - boolean
+                  - 'null'
+              totalTime:
+                type:
+                  - number
+                  - 'null'
+              lastTimestamp:
+                type:
+                  - number
+                  - 'null'
+              totalTransitions:
+                type:
+                  - number
+                  - 'null'
+          4-sonderrolle:
+            type:
+              - object
+              - 'null'
+            properties:
+              name:
+                type:
+                  - string
+                  - 'null'
+              label:
+                type:
+                  - string
+                  - 'null'
+              available:
+                type:
+                  - boolean
+                  - 'null'
+              totalTime:
+                type:
+                  - number
+                  - 'null'
+              lastTimestamp:
+                type:
+                  - number
+                  - 'null'
+              totalTransitions:
+                type:
+                  - number
+                  - 'null'
+          6-weiterbildung:
+            type:
+              - object
+              - 'null'
+            properties:
+              name:
+                type:
+                  - string
+                  - 'null'
+              label:
+                type:
+                  - string
+                  - 'null'
+              available:
+                type:
+                  - boolean
+                  - 'null'
+              totalTime:
+                type:
+                  - number
+                  - 'null'
+              lastTimestamp:
+                type:
+                  - number
+                  - 'null'
+              totalTransitions:
+                type:
+                  - number
+                  - 'null'
+          8-nachbearbeitung:
+            type:
+              - object
+              - 'null'
+            properties:
+              label:
+                type:
+                  - string
+                  - 'null'
+              available:
+                type:
+                  - boolean
+                  - 'null'
+              totalTime:
+                type:
+                  - number
+                  - 'null'
+              lastTimestamp:
+                type:
+                  - number
+                  - 'null'
+              totalTransitions:
+                type:
+                  - number
+                  - 'null'
+      presence:
+        type:
+          - object
+          - 'null'
+        properties:
+          name:
+            type:
+              - string
+              - 'null'
+          label:
+            type:
+              - string
+              - 'null'
+          available:
+            type:
+              - boolean
+              - 'null'
+          totalTime:
+            type:
+              - number
+              - 'null'
+          lastTimestamp:
+            type:
+              - number
+              - 'null'
+          totalTransitions:
+            type:
+              - number
+              - 'null'
+      lastTimestamp:
+        type: number
+    additionalProperties: true
+  agent_status_details:
+    type: object
+    $schema: http://json-schema.org/schema#
+    properties:
+      type:
+        type:
+          - string
+          - 'null'
+      call:
+        type:
+          - object
+          - 'null'
+        properties:
+          type:
+            type:
+              - string
+              - 'null'
+          id:
+            type:
+              - string
+              - 'null'
+          to:
+            type:
+              - string
+              - 'null'
+          from:
+            type:
+              - string
+              - 'null'
+      date:
+        type:
+          - string
+          - 'null'
+      agent:
+        type:
+          - object
+          - 'null'
+        properties:
+          id:
+            type:
+              - string
+              - 'null'
+          name:
+            type:
+              - string
+              - 'null'
+      queue:
+        type:
+          - object
+          - 'null'
+        properties:
+          id:
+            type:
+              - string
+              - 'null'
+          name:
+            type:
+              - string
+              - 'null'
+      presence:
+        type:
+          - string
+          - 'null'
+    additionalProperties: true

--- a/airbyte-integrations/connectors/source-babelforce/metadata.yaml
+++ b/airbyte-integrations/connectors/source-babelforce/metadata.yaml
@@ -14,7 +14,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 971c3e1e-78a5-411e-ad56-c4052b50876b
-  dockerImageTag: 0.3.5
+  dockerImageTag: 0.3.6
   dockerRepository: airbyte/source-babelforce
   githubIssueLabel: source-babelforce
   icon: babelforce.svg


### PR DESCRIPTION
## What
Several new streams were added to the connector. Streams now enabled are:
    - calls_simple
    - calls
    - agents_presence
    - agents__line_status
    - session_logs
    - agent_status_details
    - agent_list


## How
Code was changed using the UI in airbyte 0.63

## Review guide
1.  'get credentials to use babelforce api'
2. 'make sure to set a start date and the region'
3. `run tests`


## User Impact
No impact, just more streams to choose from

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
