### PR TITLE
source-elasticsearch: Use airbyte/java-connector-base:1.0.0

### DIFF
--- a/airbyte-integrations/connectors/source-elasticsearch/metadata.yaml
+++ b/airbyte-integrations/connectors/source-elasticsearch/metadata.yaml
@@ -6,8 +6,8 @@ data:
     baseImage: docker.io/airbyte/java-connector-base:1.0.0@sha256:be86e5684e1e6d9280512d3d8071b47153698fe08ad990949c8eeff02803201a
   connectorSubtype: api
   connectorTestSuitesOptions:
-  - suite: unitTests
-  - suite: integrationTests
+    - suite: unitTests
+    - suite: integrationTests
   connectorType: source
   definitionId: 7cf88806-25f5-4e1a-b422-b2fa9e1b0090
   dockerImageTag: 0.1.3
@@ -25,5 +25,5 @@ data:
   releaseStage: alpha
   supportLevel: community
   tags:
-  - language:java
-metadataSpecVersion: '1.0'
+    - language:java
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-elasticsearch/metadata.yaml
+++ b/airbyte-integrations/connectors/source-elasticsearch/metadata.yaml
@@ -1,9 +1,18 @@
 data:
+  ab_internal:
+    ql: 100
+    sl: 100
+  connectorBuildOptions:
+    baseImage: docker.io/airbyte/java-connector-base:1.0.0@sha256:be86e5684e1e6d9280512d3d8071b47153698fe08ad990949c8eeff02803201a
   connectorSubtype: api
+  connectorTestSuitesOptions:
+  - suite: unitTests
+  - suite: integrationTests
   connectorType: source
   definitionId: 7cf88806-25f5-4e1a-b422-b2fa9e1b0090
-  dockerImageTag: 0.1.2
+  dockerImageTag: 0.1.3
   dockerRepository: airbyte/source-elasticsearch
+  documentationUrl: https://docs.airbyte.com/integrations/sources/elasticsearch
   githubIssueLabel: source-elasticsearch
   icon: elasticsearch.svg
   license: MIT
@@ -14,14 +23,7 @@ data:
     oss:
       enabled: true
   releaseStage: alpha
-  documentationUrl: https://docs.airbyte.com/integrations/sources/elasticsearch
-  tags:
-    - language:java
-  ab_internal:
-    sl: 100
-    ql: 100
   supportLevel: community
-  connectorTestSuitesOptions:
-    - suite: unitTests
-    - suite: integrationTests
-metadataSpecVersion: "1.0"
+  tags:
+  - language:java
+metadataSpecVersion: '1.0'

--- a/docs/integrations/sources/elasticsearch.md
+++ b/docs/integrations/sources/elasticsearch.md
@@ -87,7 +87,8 @@ all values in the array must be of the same data type. Hence, every field can be
 
 | Version | Date       | Pull Request                                             | Subject                        |
 | :------ | :--------- | :------------------------------------------------------- | :----------------------------- |
-| 0.1.2   | 2024-02-13 | [35230](https://github.com/airbytehq/airbyte/pull/35230) | Adopt CDK 0.20.4               |
+| 0.1.3 | 2024-12-18 | [49863](https://github.com/airbytehq/airbyte/pull/49863) | Use a base image: airbyte/java-connector-base:1.0.0 |
+| 0.1.2 | 2024-02-13 | [35230](https://github.com/airbytehq/airbyte/pull/35230) | Adopt CDK 0.20.4 |
 | `0.1.2` | 2024-01-24 | [34453](https://github.com/airbytehq/airbyte/pull/34453) | bump CDK version               |
 | `0.1.1` | 2022-12-02 | [18118](https://github.com/airbytehq/airbyte/pull/18118) | Avoid too_long_frame_exception |
 | `0.1.0` | 2022-07-12 | [14118](https://github.com/airbytehq/airbyte/pull/14118) | Initial Release                |


### PR DESCRIPTION
Make the connector use our official base image for java connectors