### PR TITLE
source-e2e-test: Use airbyte/java-connector-base:1.0.0

### DIFF
--- a/airbyte-integrations/connectors/source-e2e-test/metadata.yaml
+++ b/airbyte-integrations/connectors/source-e2e-test/metadata.yaml
@@ -6,8 +6,8 @@ data:
     baseImage: docker.io/airbyte/java-connector-base:1.0.0@sha256:be86e5684e1e6d9280512d3d8071b47153698fe08ad990949c8eeff02803201a
   connectorSubtype: api
   connectorTestSuitesOptions:
-  - suite: unitTests
-  - suite: integrationTests
+    - suite: unitTests
+    - suite: integrationTests
   connectorType: source
   definitionId: d53f9084-fa6b-4a5a-976c-5b8392f4ad8a
   dockerImageTag: 2.2.3
@@ -25,5 +25,5 @@ data:
   releaseStage: alpha
   supportLevel: community
   tags:
-  - language:java
-metadataSpecVersion: '1.0'
+    - language:java
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-e2e-test/metadata.yaml
+++ b/airbyte-integrations/connectors/source-e2e-test/metadata.yaml
@@ -1,9 +1,18 @@
 data:
+  ab_internal:
+    ql: 100
+    sl: 100
+  connectorBuildOptions:
+    baseImage: docker.io/airbyte/java-connector-base:1.0.0@sha256:be86e5684e1e6d9280512d3d8071b47153698fe08ad990949c8eeff02803201a
   connectorSubtype: api
+  connectorTestSuitesOptions:
+  - suite: unitTests
+  - suite: integrationTests
   connectorType: source
   definitionId: d53f9084-fa6b-4a5a-976c-5b8392f4ad8a
-  dockerImageTag: 2.2.2
+  dockerImageTag: 2.2.3
   dockerRepository: airbyte/source-e2e-test
+  documentationUrl: https://docs.airbyte.com/integrations/sources/e2e-test
   githubIssueLabel: source-e2e-test
   icon: airbyte.svg
   license: MIT
@@ -14,14 +23,7 @@ data:
     oss:
       enabled: true
   releaseStage: alpha
-  documentationUrl: https://docs.airbyte.com/integrations/sources/e2e-test
-  tags:
-    - language:java
-  ab_internal:
-    sl: 100
-    ql: 100
   supportLevel: community
-  connectorTestSuitesOptions:
-    - suite: unitTests
-    - suite: integrationTests
-metadataSpecVersion: "1.0"
+  tags:
+  - language:java
+metadataSpecVersion: '1.0'

--- a/docs/integrations/sources/e2e-test.md
+++ b/docs/integrations/sources/e2e-test.md
@@ -74,6 +74,7 @@ The OSS and Cloud variants have the same version number. The Cloud variant was i
 
 | Version | Date       | Pull request                                                                                                      | Subject                                                                                               |
 | ------- | ---------- | ----------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| 2.2.3   | 2024-12-19 | [49874](https://github.com/airbytehq/airbyte/pull/49874)                                                          | Use airbyte/java-connector-base:1.0.0                                                                 |
 | 2.2.2   | 2024-04-25 | [37581](https://github.com/airbytehq/airbyte/pull/37581)                                                          | bump jsonschemafriend to 0.12.4                                                                       |
 | 2.2.1   | 2024-02-13 | [35231](https://github.com/airbytehq/airbyte/pull/35231)                                                          | Adopt JDK 0.20.4.                                                                                     |
 | 2.2.0   | 2023-12-18 | [33485](https://github.com/airbytehq/airbyte/pull/33485)                                                          | Remove LEGACY state                                                                                   |


### PR DESCRIPTION
Make the connector use our official base image for java connectors