### PR TITLE
destination-oracle-strict-encrypt: Use airbyte/java-connector-base:1.0.0

### DIFF
--- a/airbyte-integrations/connectors/destination-oracle-strict-encrypt/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-oracle-strict-encrypt/metadata.yaml
@@ -1,34 +1,38 @@
 data:
-  registryOverrides:
-    cloud:
-      enabled: false # strict encrypt connectors are deployed to Cloud by their non strict encrypt sibling.
-    oss:
-      enabled: false # strict encrypt connectors are not used on OSS.
+  connectorBuildOptions:
+    baseImage: docker.io/airbyte/java-connector-base:1.0.0@sha256:be86e5684e1e6d9280512d3d8071b47153698fe08ad990949c8eeff02803201a
   connectorSubtype: database
+  connectorTestSuitesOptions:
+  - suite: unitTests
+  - suite: integrationTests
   connectorType: destination
   definitionId: 3986776d-2319-4de9-8af8-db14c0996e72
-  dockerImageTag: 1.0.0
+  dockerImageTag: 1.0.1
   dockerRepository: airbyte/destination-oracle-strict-encrypt
+  documentationUrl: https://docs.airbyte.com/integrations/destinations/oracle
   githubIssueLabel: destination-oracle
   icon: oracle.svg
   license: ELv2
   name: Oracle
+  registryOverrides:
+    cloud:
+      enabled: false
+    oss:
+      enabled: false
   releaseStage: alpha
   releases:
     breakingChanges:
       1.0.0:
-        upgradeDeadline: "2024-05-01"
-        message: >
-          This version removes the option to use "normalization" with Oracle. It also changes
-          the schema and database of Airbyte's "raw" tables to be compatible with the new
-          [Destinations V2](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#what-is-destinations-v2)
-          format. These changes will likely require updates to downstream dbt / SQL models.
-          Selecting `Upgrade` will upgrade **all** connections using this destination at their next sync.
-  documentationUrl: https://docs.airbyte.com/integrations/destinations/oracle
+        message: 'This version removes the option to use "normalization" with Oracle.
+          It also changes the schema and database of Airbyte''s "raw" tables to be
+          compatible with the new [Destinations V2](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#what-is-destinations-v2)
+          format. These changes will likely require updates to downstream dbt / SQL
+          models. Selecting `Upgrade` will upgrade **all** connections using this
+          destination at their next sync.
+
+          '
+        upgradeDeadline: '2024-05-01'
   supportsDbt: true
   tags:
-    - language:java
-  connectorTestSuitesOptions:
-    - suite: unitTests
-    - suite: integrationTests
-metadataSpecVersion: "1.0"
+  - language:java
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/destination-oracle-strict-encrypt/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-oracle-strict-encrypt/metadata.yaml
@@ -3,8 +3,8 @@ data:
     baseImage: docker.io/airbyte/java-connector-base:1.0.0@sha256:be86e5684e1e6d9280512d3d8071b47153698fe08ad990949c8eeff02803201a
   connectorSubtype: database
   connectorTestSuitesOptions:
-  - suite: unitTests
-  - suite: integrationTests
+    - suite: unitTests
+    - suite: integrationTests
   connectorType: destination
   definitionId: 3986776d-2319-4de9-8af8-db14c0996e72
   dockerImageTag: 1.0.1
@@ -23,7 +23,8 @@ data:
   releases:
     breakingChanges:
       1.0.0:
-        message: 'This version removes the option to use "normalization" with Oracle.
+        message:
+          'This version removes the option to use "normalization" with Oracle.
           It also changes the schema and database of Airbyte''s "raw" tables to be
           compatible with the new [Destinations V2](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#what-is-destinations-v2)
           format. These changes will likely require updates to downstream dbt / SQL
@@ -31,8 +32,8 @@ data:
           destination at their next sync.
 
           '
-        upgradeDeadline: '2024-05-01'
+        upgradeDeadline: "2024-05-01"
   supportsDbt: true
   tags:
-  - language:java
-metadataSpecVersion: '1.0'
+    - language:java
+metadataSpecVersion: "1.0"

--- a/docs/integrations/destinations/oracle.md
+++ b/docs/integrations/destinations/oracle.md
@@ -94,6 +94,7 @@ Airbyte has the ability to connect to the Oracle source with 3 network connectiv
 
 | Version     | Date       | Pull Request                                               | Subject                                                                                             |
 | :---------- | :--------- | :--------------------------------------------------------- | :-------------------------------------------------------------------------------------------------- |
+| 1.0.1 | 2024-12-18 | [49877](https://github.com/airbytehq/airbyte/pull/49877) | Use a base image: airbyte/java-connector-base:1.0.0 |
 | 1.0.0       | 2024-04-11 | [\#36048](https://github.com/airbytehq/airbyte/pull/36048) | Removes Normalization, updates to V2 Raw Table Format                                               |
 | 0.2.0       | 2023-06-27 | [\#27781](https://github.com/airbytehq/airbyte/pull/27781) | License Update: Elv2                                                                                |
 | 0.1.19      | 2022-07-26 | [\#10719](https://github.com/airbytehq/airbyte/pull/)      | Destination Oracle: added custom JDBC parameters support.                                           |


### PR DESCRIPTION
Make the connector use our official base image for java connectors