### PR TITLE
destination-iceberg-v2: Use airbyte/java-connector-base:1.0.0

### DIFF
--- a/airbyte-integrations/connectors/destination-iceberg-v2/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-iceberg-v2/metadata.yaml
@@ -6,14 +6,14 @@ data:
     baseImage: docker.io/airbyte/java-connector-base:1.0.0@sha256:be86e5684e1e6d9280512d3d8071b47153698fe08ad990949c8eeff02803201a
   connectorSubtype: file
   connectorTestSuitesOptions:
-  - suite: unitTests
-  - suite: integrationTests
-    testSecrets:
-    - fileName: s3_dest_v2_minimal_required_config.json
-      name: SECRET_DESTINATION-S3-V2-MINIMAL-REQUIRED-CONFIG
-      secretStore:
-        alias: airbyte-connector-testing-secret-store
-        type: GSM
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - fileName: s3_dest_v2_minimal_required_config.json
+          name: SECRET_DESTINATION-S3-V2-MINIMAL-REQUIRED-CONFIG
+          secretStore:
+            alias: airbyte-connector-testing-secret-store
+            type: GSM
   connectorType: destination
   definitionId: 37a928c1-2d5c-431a-a97d-ae236bd1ea0c
   dockerImageTag: 0.1.15
@@ -32,5 +32,5 @@ data:
   supportLevel: community
   supportsRefreshes: true
   tags:
-  - language:java
-metadataSpecVersion: '1.0'
+    - language:java
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-iceberg-v2/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-iceberg-v2/metadata.yaml
@@ -1,9 +1,24 @@
 data:
+  ab_internal:
+    ql: 100
+    sl: 100
+  connectorBuildOptions:
+    baseImage: docker.io/airbyte/java-connector-base:1.0.0@sha256:be86e5684e1e6d9280512d3d8071b47153698fe08ad990949c8eeff02803201a
   connectorSubtype: file
+  connectorTestSuitesOptions:
+  - suite: unitTests
+  - suite: integrationTests
+    testSecrets:
+    - fileName: s3_dest_v2_minimal_required_config.json
+      name: SECRET_DESTINATION-S3-V2-MINIMAL-REQUIRED-CONFIG
+      secretStore:
+        alias: airbyte-connector-testing-secret-store
+        type: GSM
   connectorType: destination
   definitionId: 37a928c1-2d5c-431a-a97d-ae236bd1ea0c
   dockerImageTag: 0.1.15
   dockerRepository: airbyte/destination-iceberg-v2
+  documentationUrl: https://docs.airbyte.com/integrations/destinations/s3
   githubIssueLabel: destination-iceberg-v2
   icon: icon.svg
   license: ELv2
@@ -14,71 +29,8 @@ data:
     oss:
       enabled: false
   releaseStage: alpha
-  documentationUrl: https://docs.airbyte.com/integrations/destinations/s3
-  tags:
-    - language:java
-  ab_internal:
-    sl: 100
-    ql: 100
   supportLevel: community
   supportsRefreshes: true
-  connectorTestSuitesOptions:
-    - suite: unitTests
-    - suite: integrationTests
-      testSecrets:
-        - name: SECRET_DESTINATION-S3-V2-MINIMAL-REQUIRED-CONFIG
-          fileName: s3_dest_v2_minimal_required_config.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-#        - name: SECRET_DESTINATION-S3-V2-JSONL-ROOT-LEVEL-FLATTENING
-#          fileName: s3_dest_v2_jsonl_root_level_flattening_config.json
-#          secretStore:
-#            type: GSM
-#            alias: airbyte-connector-testing-secret-store
-#        - name: SECRET_DESTINATION-S3-V2-JSONL-GZIP
-#          fileName: s3_dest_v2_jsonl_gzip_config.json
-#          secretStore:
-#            type: GSM
-#            alias: airbyte-connector-testing-secret-store
-#        - name: SECRET_DESTINATION-S3-V2-JSONL-STAGING
-#          fileName: s3_dest_v2_jsonl_staging_config.json
-#          secretStore:
-#            type: GSM
-#            alias: airbyte-connector-testing-secret-store
-#        - name: SECRET_DESTINATION-S3-V2-CSV
-#          fileName: s3_dest_v2_csv_config.json
-#          secretStore:
-#            type: GSM
-#            alias: airbyte-connector-testing-secret-store
-#        - name: SECRET_DESTINATION-S3-V2-CSV-ROOT-LEVEL-FLATTENING
-#          fileName: s3_dest_v2_csv_root_level_flattening_config.json
-#          secretStore:
-#            type: GSM
-#            alias: airbyte-connector-testing-secret-store
-#        - name: SECRET_DESTINATION-S3-V2-CSV-GZIP
-#          fileName: s3_dest_v2_csv_gzip_config.json
-#          secretStore:
-#            type: GSM
-#            alias: airbyte-connector-testing-secret-store
-#        - name: SECRET_DESTINATION-S3-V2-AVRO
-#          fileName: s3_dest_v2_avro_config.json
-#          secretStore:
-#            type: GSM
-#            alias: airbyte-connector-testing-secret-store
-#        - name: SECRET_DESTINATION-S3-V2-AVRO-BZIP2
-#          fileName: s3_dest_v2_avro_bzip2_config.json
-#          secretStore:
-#            type: GSM
-#            alias: airbyte-connector-testing-secret-store
-#        - name: SECRET_DESTINATION-S3-V2-PARQUET
-#          fileName: s3_dest_v2_parquet_config.json
-#          secretStore:
-#            type: GSM
-#            alias: airbyte-connector-testing-secret-store
-#        - name: SECRET_DESTINATION-S3-V2-PARQUET-SNAPPY
-#          fileName: s3_dest_v2_parquet_snappy_config.json
-#          secretStore:
-#            type: GSM
-#            alias: airbyte-connector-testing-secret-store
-metadataSpecVersion: "1.0"
+  tags:
+  - language:java
+metadataSpecVersion: '1.0'

--- a/docs/integrations/destinations/s3.md
+++ b/docs/integrations/destinations/s3.md
@@ -544,17 +544,18 @@ To see connector limitations, or troubleshoot your S3 connector, see more [in ou
 
 | Version | Date       | Pull Request                                               | Subject                                                                                                                                              |
 |:--------|:-----------|:-----------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------|
-| 1.4.0   | 2024-10-23 | [46302](https://github.com/airbytehq/airbyte/pull/46302)   | add support for file transfer                                                                                                                                            |
-| 1.3.0   | 2024-09-30 | [46281](https://github.com/airbytehq/airbyte/pull/46281)   | fix tests                                                                                                                                            |
-| 1.2.1   | 2024-09-20 | [45700](https://github.com/airbytehq/airbyte/pull/45700)   | Improve resiliency to jsonschema fields                                                                                                              |
-| 1.2.0   | 2024-09-18 | [45402](https://github.com/airbytehq/airbyte/pull/45402)   | fix exception with columnless streams                                                                                                                |
-| 1.1.0   | 2024-09-18 | [45436](https://github.com/airbytehq/airbyte/pull/45436)   | upgrade all dependencies                                                                                                                             |
-| 1.0.5   | 2024-09-05 | [45143](https://github.com/airbytehq/airbyte/pull/45143)   | don't overwrite (and delete) existing files, skip indexes instead                                                                                    |
-| 1.0.4   | 2024-08-30 | [44933](https://github.com/airbytehq/airbyte/pull/44933)   | Fix: Avro/Parquet: handle empty schemas in nested objects/lists                                                                                      |
-| 1.0.3   | 2024-08-20 | [44476](https://github.com/airbytehq/airbyte/pull/44476)   | Increase message parsing limit to 100mb                                                                                                              |
-| 1.0.2   | 2024-08-19 | [44401](https://github.com/airbytehq/airbyte/pull/44401)   | Fix: S3 Avro/Parquet: handle nullable top-level schema                                                                                               |
-| 1.0.1   | 2024-08-14 | [42579](https://github.com/airbytehq/airbyte/pull/42579)   | OVERWRITE MODE: Deletes deferred until successful sync.                                                                                              |
-| 1.0.0   | 2024-08-08 | [42409](https://github.com/airbytehq/airbyte/pull/42409)   | Major breaking changes: new destination schema, change capture, Avro/Parquet improvements, bugfixes                                                  |
+| 1.4.0 | 2024-10-23 | [46302](https://github.com/airbytehq/airbyte/pull/46302) | add support for file transfer |
+| 1.3.0 | 2024-09-30 | [46281](https://github.com/airbytehq/airbyte/pull/46281) | fix tests |
+| 1.2.1 | 2024-09-20 | [45700](https://github.com/airbytehq/airbyte/pull/45700) | Improve resiliency to jsonschema fields |
+| 1.2.0 | 2024-09-18 | [45402](https://github.com/airbytehq/airbyte/pull/45402) | fix exception with columnless streams |
+| 1.1.0 | 2024-09-18 | [45436](https://github.com/airbytehq/airbyte/pull/45436) | upgrade all dependencies |
+| 1.0.5 | 2024-09-05 | [45143](https://github.com/airbytehq/airbyte/pull/45143) | don't overwrite (and delete) existing files, skip indexes instead |
+| 1.0.4 | 2024-08-30 | [44933](https://github.com/airbytehq/airbyte/pull/44933) | Fix: Avro/Parquet: handle empty schemas in nested objects/lists |
+| 1.0.3 | 2024-08-20 | [44476](https://github.com/airbytehq/airbyte/pull/44476) | Increase message parsing limit to 100mb |
+| 1.0.2 | 2024-08-19 | [44401](https://github.com/airbytehq/airbyte/pull/44401) | Fix: S3 Avro/Parquet: handle nullable top-level schema |
+| 1.0.1 | 2024-08-14 | [42579](https://github.com/airbytehq/airbyte/pull/42579) | OVERWRITE MODE: Deletes deferred until successful sync. |
+| 1.0.0 | 2024-08-08 | [42409](https://github.com/airbytehq/airbyte/pull/42409) | Major breaking changes: new destination schema, change capture, Avro/Parquet improvements, bugfixes |
+| 0.1.15 | 2024-12-18 | [49879](https://github.com/airbytehq/airbyte/pull/49879) | Use a base image: airbyte/java-connector-base:1.0.0 |
 | 0.6.7   | 2024-08-11 | [43713](https://github.com/airbytehq/airbyte/issues/43713) | Decreased memory ratio (0.7 -> 0.5) and thread allocation (5 -> 2) for async S3 uploads.                                                             |
 | 0.6.6   | 2024-08-06 | [43343](https://github.com/airbytehq/airbyte/pull/43343)   | Use Kotlin 2.0.0                                                                                                                                     |
 | 0.6.5   | 2024-08-01 | [42405](https://github.com/airbytehq/airbyte/pull/42405)   | S3 parallelizes workloads, checkpoints, submits counts, support for generationId in metadata for refreshes.                                          |


### PR DESCRIPTION
Make the connector use our official base image for java connectors