### PR TITLE
source-e2e-test-cloud: Use airbyte/java-connector-base:1.0.0

### DIFF
--- a/airbyte-integrations/connectors/source-e2e-test-cloud/metadata.yaml
+++ b/airbyte-integrations/connectors/source-e2e-test-cloud/metadata.yaml
@@ -1,9 +1,18 @@
 data:
+  ab_internal:
+    ql: 100
+    sl: 100
+  connectorBuildOptions:
+    baseImage: docker.io/airbyte/java-connector-base:1.0.0@sha256:be86e5684e1e6d9280512d3d8071b47153698fe08ad990949c8eeff02803201a
   connectorSubtype: api
+  connectorTestSuitesOptions:
+  - suite: unitTests
+  - suite: integrationTests
   connectorType: source
   definitionId: 50bd8338-7c4e-46f1-8c7f-3ef95de19fdd
-  dockerImageTag: 2.2.2
+  dockerImageTag: 2.2.3
   dockerRepository: airbyte/source-e2e-test-cloud
+  documentationUrl: https://docs.airbyte.com/integrations/sources/e2e-test
   githubIssueLabel: source-e2e-test-cloud
   icon: airbyte.svg
   license: MIT
@@ -14,14 +23,7 @@ data:
     oss:
       enabled: false
   releaseStage: alpha
-  documentationUrl: https://docs.airbyte.com/integrations/sources/e2e-test
-  tags:
-    - language:java
-  ab_internal:
-    sl: 100
-    ql: 100
   supportLevel: community
-  connectorTestSuitesOptions:
-    - suite: unitTests
-    - suite: integrationTests
-metadataSpecVersion: "1.0"
+  tags:
+  - language:java
+metadataSpecVersion: '1.0'

--- a/airbyte-integrations/connectors/source-e2e-test-cloud/metadata.yaml
+++ b/airbyte-integrations/connectors/source-e2e-test-cloud/metadata.yaml
@@ -6,8 +6,8 @@ data:
     baseImage: docker.io/airbyte/java-connector-base:1.0.0@sha256:be86e5684e1e6d9280512d3d8071b47153698fe08ad990949c8eeff02803201a
   connectorSubtype: api
   connectorTestSuitesOptions:
-  - suite: unitTests
-  - suite: integrationTests
+    - suite: unitTests
+    - suite: integrationTests
   connectorType: source
   definitionId: 50bd8338-7c4e-46f1-8c7f-3ef95de19fdd
   dockerImageTag: 2.2.3
@@ -25,5 +25,5 @@ data:
   releaseStage: alpha
   supportLevel: community
   tags:
-  - language:java
-metadataSpecVersion: '1.0'
+    - language:java
+metadataSpecVersion: "1.0"


### PR DESCRIPTION
Make the connector use our official base image for java connectors