### PR TITLE
bulk-cdk: fix loss of numerical precision when deserializing JSON

### DIFF
--- a/airbyte-cdk/bulk/core/base/src/main/kotlin/io/airbyte/cdk/util/Jsons.kt
+++ b/airbyte-cdk/bulk/core/base/src/main/kotlin/io/airbyte/cdk/util/Jsons.kt
@@ -25,6 +25,7 @@ object Jsons : ObjectMapper() {
         registerModule(AfterburnerModule())
         setSerializationInclusion(JsonInclude.Include.NON_NULL)
         configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+        configure(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS, true)
         configure(JsonGenerator.Feature.WRITE_BIGDECIMAL_AS_PLAIN, true)
     }
 

--- a/airbyte-cdk/bulk/core/extract/src/test/kotlin/io/airbyte/cdk/command/ConfigurationSpecificationSupplierTest.kt
+++ b/airbyte-cdk/bulk/core/extract/src/test/kotlin/io/airbyte/cdk/command/ConfigurationSpecificationSupplierTest.kt
@@ -24,8 +24,12 @@ class ConfigurationSpecificationSupplierTest {
             FakeSourceConfigurationSpecification::class.java,
             supplier.javaClass
         )
-        val expected: String = ResourceUtils.readResource("fakesource/expected-schema.json")
-        Assertions.assertEquals(Jsons.readTree(expected), supplier.jsonSchema)
+        val expected: String =
+            ResourceUtils.readResource("fakesource/expected-schema.json")
+                .let(Jsons::readTree)
+                .let(Jsons::writeValueAsString)
+        val actual: String = Jsons.writeValueAsString(supplier.jsonSchema)
+        Assertions.assertEquals(expected, actual)
     }
 
     @Test

--- a/airbyte-cdk/bulk/core/load/src/integrationTest/kotlin/io/airbyte/cdk/load/mock_integration_test/MockDestinationBackend.kt
+++ b/airbyte-cdk/bulk/core/load/src/integrationTest/kotlin/io/airbyte/cdk/load/mock_integration_test/MockDestinationBackend.kt
@@ -23,6 +23,7 @@ object MockDestinationBackend {
         getFile(filename).addAll(records)
     }
 
+    @Synchronized
     fun upsert(
         filename: String,
         primaryKey: List<List<String>>,

--- a/airbyte-integrations/connectors/source-mysql/src/test/kotlin/io/airbyte/integrations/source/mysql/MySqlDatatypeIntegrationTest.kt
+++ b/airbyte-integrations/connectors/source-mysql/src/test/kotlin/io/airbyte/integrations/source/mysql/MySqlDatatypeIntegrationTest.kt
@@ -4,7 +4,6 @@
 
 package io.airbyte.integrations.source.mysql
 
-import com.fasterxml.jackson.databind.JsonNode
 import io.airbyte.cdk.data.AirbyteSchemaType
 import io.airbyte.cdk.data.LeafAirbyteSchemaType
 import io.airbyte.cdk.discover.MetaField
@@ -12,7 +11,6 @@ import io.airbyte.cdk.jdbc.JdbcConnectionFactory
 import io.airbyte.cdk.read.DatatypeTestCase
 import io.airbyte.cdk.read.DatatypeTestOperations
 import io.airbyte.cdk.read.DynamicDatatypeTestFactory
-import io.airbyte.cdk.util.Jsons
 import io.github.oshai.kotlinlogging.KotlinLogging
 import java.sql.Connection
 import org.junit.jupiter.api.BeforeAll
@@ -145,7 +143,7 @@ object MySqlDatatypeTestOperations :
 
     val zeroPrecisionDecimalCdcValues =
         mapOf(
-            "2" to """2.0""",
+            "2" to """2""",
         )
 
     val tinyintValues =
@@ -230,13 +228,6 @@ object MySqlDatatypeTestOperations :
                     "DECIMAL UNSIGNED",
                     zeroPrecisionDecimalValues,
                     LeafAirbyteSchemaType.INTEGER,
-                    isGlobal = false,
-                ),
-                MySqlDatatypeTestCase(
-                    "DECIMAL UNSIGNED",
-                    zeroPrecisionDecimalCdcValues,
-                    LeafAirbyteSchemaType.INTEGER,
-                    isStream = false,
                 ),
                 MySqlDatatypeTestCase("FLOAT", floatValues, LeafAirbyteSchemaType.NUMBER),
                 MySqlDatatypeTestCase(
@@ -379,9 +370,8 @@ data class MySqlDatatypeTestCase(
     override val fieldName: String
         get() = "col_$typeName"
 
-    override val expectedData: List<JsonNode>
-        get() =
-            sqlToAirbyte.values.map { Jsons.readTree("""{"${fieldName}":$it}""").get(fieldName) }
+    override val expectedData: List<String>
+        get() = sqlToAirbyte.values.map { """{"${fieldName}":$it}""" }
 
     val ddl: List<String>
         get() =


### PR DESCRIPTION
This PR fixes a bug in `Jsons` that adds the missing `USE_BIG_DECIMAL_FOR_FLOATS` setting. This enables fixing bugs in source-mysql. 

This PR surfaced an otherwise-unrelated Bulk Load CDK thread safety bug.