### PR TITLE
chore(makefile): update `Make` to run `pre-commit` formatters and decouple `pre-commit` install from git-hook install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,6 @@ tools.git-hooks.install: tools.airbyte-ci.install tools.pre-commit.install.$(OS)
 	@pre-commit install --hook-type pre-push
 	@echo "Pre-push hooks installed."
 
-tools.install: tools.airbyte-ci.install.$(OS) tools.pre-commit.install
+tools.install: tools.airbyte-ci.install tools.pre-commit.install.$(OS)
 
 .PHONY: tools.install tools.pre-commit.install tools.git-hooks.install tools.git-hooks.clean tools.airbyte-ci.install tools.airbyte-ci-dev.install tools.airbyte-ci.check tools.airbyte-ci.clean

--- a/Makefile
+++ b/Makefile
@@ -39,11 +39,11 @@ tools.pre-commit.install.Darwin:
 	@brew install pre-commit
 	@echo "Pre-commit installation complete"
 
-tools.pre-commit.setup: tools.airbyte-ci.install tools.pre-commit.install.$(OS) tools.git-hooks.clean ## Setup pre-commit hooks
+tools.git-hooks.install: tools.airbyte-ci.install tools.pre-commit.install.$(OS) tools.git-hooks.clean ## Setup pre-commit hooks
 	@echo "Installing pre-commit hooks..."
 	@pre-commit install --hook-type pre-push
 	@echo "Pre-push hooks installed."
 
-tools.install: tools.airbyte-ci.install tools.pre-commit.setup
+tools.install: tools.airbyte-ci.install.$(OS) tools.pre-commit.install
 
-.PHONY: tools.install tools.pre-commit.setup tools.airbyte-ci.install tools.airbyte-ci-dev.install tools.airbyte-ci.check tools.airbyte-ci.clean
+.PHONY: tools.install tools.pre-commit.install tools.git-hooks.install tools.git-hooks.clean tools.airbyte-ci.install tools.airbyte-ci-dev.install tools.airbyte-ci.check tools.airbyte-ci.clean

--- a/docs/contributing-to-airbyte/developing-locally.md
+++ b/docs/contributing-to-airbyte/developing-locally.md
@@ -286,23 +286,21 @@ The command to run formatting varies slightly depending on which part of the cod
 
 ### Connector
 
-We wrapped all our code formatting tools in [airbyte-ci](https://github.com/airbytehq/airbyte/blob/master/airbyte-ci/connectors/pipelines/README.md).
-Follow the instructions on the `airbyte-ci` page to install `airbyte-ci`.
+We wrapped our code formatting tools in [pre-commit](https://pre-commit.com). You can install this and other local dev tools by running `make tools.install`.
 
-You can run `airbyte-ci format fix all` to format all the code your local `airbyte` repository.
-We wrapped this command in a pre-push hook so that you can't push code that is not formatted.
+You can run `pre-commit` to format modified files, or `pre-commit run --all-files` to format all the code your local `airbyte` repository.
 
-To install the pre-push hook, run:
+We wrapped this command in a pre-push hook which you can enable with:
 
 ```bash
-make tools.pre-commit.setup
+make tools.git-hooks.install
 ```
 
-This will install `airbyte-ci` and the pre-push hook.
+You can also uninstall git hooks with:
 
-The pre-push hook runs formatting on all the repo files.
-If the hook attempts to format a file that is not part of your contribution, it means that formatting is also broken in
-the master branch. Please open a separate PR to fix the formatting in the master branch.
+```bash
+make tools.git-hooks.clean
+```
 
 ### Platform
 

--- a/docs/contributing-to-airbyte/resources/code-formatting.md
+++ b/docs/contributing-to-airbyte/resources/code-formatting.md
@@ -4,12 +4,11 @@
 
 ### 🐍 Python
 
-We format our Python code using:
+We use [Ruff](https://docs.astral.sh) for Python code formatting and import sorting. Our Ruff configuration is in the [pyproject.toml](https://github.com/airbytehq/airbyte/blob/master/pyproject.toml) file.
 
-- [Black](https://github.com/psf/black) for code formatting
-- [isort](https://pycqa.github.io/isort/) for import sorting
+Ruff is monorepo-friendly and supports nested inherited configuration; each sub-project can optionally override Ruff lint and formatting settings in their own `pyproject.toml` files, as needed per project.
 
-Our configuration for both tools is in the [pyproject.toml](https://github.com/airbytehq/airbyte/blob/master/pyproject.toml) file.
+Ruff [auto-detects the proper package classification]((https://docs.astral.sh/ruff/faq/#how-does-ruff-determine-which-of-my-imports-are-first-party-third-party-etc)) so that "local", "first party" and "third party" imports are sorted and grouped correctly, even within subprojects of the monorepo.
 
 ### ☕ Java
 
@@ -20,28 +19,28 @@ Our configuration for Spotless is in the [spotless-maven-pom.xml](https://github
 
 We format our Json and Yaml files using [prettier](https://prettier.io/).
 
-## Pre-push hooks and CI
+### Local Formatting
 
-We wrapped all our code formatting tools in [airbyte-ci](https://github.com/airbytehq/airbyte/blob/master/airbyte-ci/connectors/pipelines/README.md).
 
-### Local formatting
+We wrapped our code formatting tools in [pre-commit](https://pre-commit.com). You can install this and other local dev tools by running `make tools.install`.
 
-You can run `airbyte-ci format fix all` to format all the code in the repository.
-We wrapped this command in a pre-push hook so that you can't push code that is not formatted.
+You can execute `pre-commit` to format modified files, or `pre-commit run --all-files` to format all the code your local `airbyte` repository.
 
-To install the pre-push hook, run:
+## Pre-push Git Hooks
+
+A pre-push git hook is available, which you can enable with:
 
 ```bash
-make tools.pre-commit.setup
+make tools.git-hooks.install
 ```
 
-This will install `airbyte-ci` and the pre-push hook.
+You can also uninstall git hooks with:
 
-The pre-push hook runs formatting on all the repo files.
-If the hook attempts to format a file that is not part of your contribution, it means that formatting is also broken in the master branch. Please open a separate PR to fix the formatting in the master branch.
+```bash
+make tools.git-hooks.clean
+```
 
-### CI checks
+### CI Checks and `/format-fix` Slash Command
 
-In the CI we run the `airbyte-ci format check all` command to check that all the code is formatted.
-If it is not, the CI will fail and you will have to run `airbyte-ci format fix all` locally to fix the formatting issues.
-Failure on the CI is not expected if you installed the pre-push hook.
+In the CI we run the `pre-commit run --all-files` command to check that all the code is formatted.
+If it is not, CI will fail and you will have to run `pre-commit run --all-files` locally to fix the formatting issues. Alternatively, maintainers with write permissions can run the `/format-fix` GitHub slash command to auto-format the entire repo and commit the result back to the open PR.

--- a/docs/contributing-to-airbyte/resources/code-formatting.md
+++ b/docs/contributing-to-airbyte/resources/code-formatting.md
@@ -8,7 +8,7 @@ We use [Ruff](https://docs.astral.sh) for Python code formatting and import sort
 
 Ruff is monorepo-friendly and supports nested inherited configuration; each sub-project can optionally override Ruff lint and formatting settings in their own `pyproject.toml` files, as needed per project.
 
-Ruff [auto-detects the proper package classification]((https://docs.astral.sh/ruff/faq/#how-does-ruff-determine-which-of-my-imports-are-first-party-third-party-etc)) so that "local", "first party" and "third party" imports are sorted and grouped correctly, even within subprojects of the monorepo.
+Ruff [auto-detects the proper package classification](https://docs.astral.sh/ruff/faq/#how-does-ruff-determine-which-of-my-imports-are-first-party-third-party-etc) so that "local", "first party" and "third party" imports are sorted and grouped correctly, even within subprojects of the monorepo.
 
 ### ☕ Java
 


### PR DESCRIPTION
## What

As we promote `pre-commit` and as we add more tasks to it, we want to decouple auto-install git-hooks from installation of `pre-commit` itself. Many people will need to use `pre-commit` (basically everyone) but git hooks can create instability and frustration, because they can block core functions unless code passes all checks. This PR decouples the installation of pre-commit (required) from the installation of git-hooks (optional, and not necessarily 'recommended'). Also, some IDEs do not always render the failure log in a helpful way, causing churn while the dev tries to diagnose the failure or locate the failure reason.

The worst-case scenario if we do not decouple these is that a Python developer could be blocked from committing and pushing python code due to an unrelated Java spotless issue, and vice versa: a Java developer could be blocked from committing/pushing their code because of an unrelated Python issue. Although these scenarios like this are unlikely and rare, they are nevertheless costly - which is why decoupling by default is generally a good idea.

Devs who opt-in to installing the git hooks will also know how to debug and skip checks during commit+push.

## How

This command installs tools:

```bash
make tools.install
```

These commands install/uninstall git hooks:

```bash
make tools.git-hooks.install
make tools.git-hooks.clean
```

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
