### PR TITLE
metadata-service[lib]: fix test_validation_pass_on_same_docker_image_tag

### DIFF
--- a/airbyte-ci/connectors/metadata_service/lib/tests/test_validators/test_metadata_validators.py
+++ b/airbyte-ci/connectors/metadata_service/lib/tests/test_validators/test_metadata_validators.py
@@ -5,6 +5,7 @@ import requests
 import semver
 import yaml
 
+from metadata_service.docker_hub import get_latest_version_on_dockerhub
 from metadata_service.models.generated.ConnectorMetadataDefinitionV0 import ConnectorMetadataDefinitionV0
 from metadata_service.validators import metadata_validator
 
@@ -133,7 +134,8 @@ def test_validation_pass_on_docker_image_tag_increment(metadata_definition, incr
     assert error_message is None
 
 
-def test_validation_pass_on_same_docker_image_tag(metadata_definition):
+def test_validation_pass_on_same_docker_image_tag(mocker, metadata_definition):
+    mocker.patch.object(metadata_validator, "get_latest_version_on_dockerhub", return_value=metadata_definition.data.dockerImageTag)
     success, error_message = metadata_validator.validate_docker_image_tag_is_not_decremented(metadata_definition, None)
     assert success
     assert error_message is None


### PR DESCRIPTION
## What
The `test_validation_pass_on_same_docker_image_tag` test was brittle as it relied on the released version of `source-faker` on dockerhub.
This PR addresses its failure / flakiness by patching the `get_latest_version_on_dockerhub` function at test time.
