### PR TITLE
bulk-cdk-toolkits-extract-jdbc: SelectQuerier improvements

### DIFF
--- a/airbyte-cdk/bulk/toolkits/extract-jdbc/src/main/kotlin/io/airbyte/cdk/read/JdbcPartitionsCreator.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-jdbc/src/main/kotlin/io/airbyte/cdk/read/JdbcPartitionsCreator.kt
@@ -67,7 +67,7 @@ sealed class JdbcPartitionsCreator<
         log.info { "Querying maximum cursor column value." }
         val record: ObjectNode? =
             selectQuerier.executeQuery(cursorUpperBoundQuery).use {
-                if (it.hasNext()) it.next() else null
+                if (it.hasNext()) it.next().data else null
             }
         if (record == null) {
             streamState.cursorUpperBound = Jsons.nullNode()
@@ -102,8 +102,8 @@ sealed class JdbcPartitionsCreator<
             values.clear()
             val samplingQuery: SelectQuery = partition.samplingQuery(sampleRateInvPow2)
             selectQuerier.executeQuery(samplingQuery).use {
-                for (record in it) {
-                    values.add(recordMapper(record))
+                for (row in it) {
+                    values.add(recordMapper(row.data))
                 }
             }
             if (values.size < sharedState.maxSampleSize) {

--- a/airbyte-cdk/bulk/toolkits/extract-jdbc/src/main/kotlin/io/airbyte/cdk/read/SelectQuerier.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-jdbc/src/main/kotlin/io/airbyte/cdk/read/SelectQuerier.kt
@@ -24,12 +24,23 @@ interface SelectQuerier {
     data class Parameters(
         /** When set, the [ObjectNode] in the [Result] is reused; take care with this! */
         val reuseResultObject: Boolean = false,
-        /** JDBC fetchSize value. */
-        val fetchSize: Int? = null,
-    )
+        /** JDBC [PreparedStatement] fetchSize value. */
+        val statementFetchSize: Int? = null,
+        /** JDBC [ResultSet] fetchSize value. */
+        val resultSetFetchSize: Int? = null,
+    ) {
+        constructor() : this(false, null, null)
+        constructor(
+            reuseResultObject: Boolean,
+            fetchSize: Int?
+        ) : this(reuseResultObject, fetchSize, fetchSize)
+    }
 
-    interface Result : Iterator<ObjectNode>, AutoCloseable {
-        val changes: Map<Field, FieldValueChange>?
+    interface Result : Iterator<ResultRow>, AutoCloseable
+
+    interface ResultRow {
+        val data: ObjectNode
+        val changes: Map<Field, FieldValueChange>
     }
 }
 
@@ -43,7 +54,12 @@ class JdbcSelectQuerier(
         parameters: SelectQuerier.Parameters,
     ): SelectQuerier.Result = Result(jdbcConnectionFactory, q, parameters)
 
-    open class Result(
+    data class ResultRow(
+        override var data: ObjectNode = Jsons.objectNode(),
+        override var changes: MutableMap<Field, FieldValueChange> = mutableMapOf(),
+    ) : SelectQuerier.ResultRow
+
+    class Result(
         val jdbcConnectionFactory: JdbcConnectionFactory,
         val q: SelectQuery,
         val parameters: SelectQuerier.Parameters,
@@ -53,10 +69,7 @@ class JdbcSelectQuerier(
         var conn: Connection? = null
         var stmt: PreparedStatement? = null
         var rs: ResultSet? = null
-        val reusable: ObjectNode? = Jsons.objectNode().takeIf { parameters.reuseResultObject }
-        val metaChanges: MutableMap<Field, FieldValueChange> = mutableMapOf()
-        override val changes: Map<Field, FieldValueChange>?
-            get() = metaChanges
+        val reusable: ResultRow? = ResultRow().takeIf { parameters.reuseResultObject }
 
         init {
             log.info { "Querying ${q.sql}" }
@@ -73,11 +86,11 @@ class JdbcSelectQuerier(
         var hasLoggedResultsReceived = false
 
         /** Initializes a connection and readies the resultset. */
-        open fun initQueryExecution() {
+        fun initQueryExecution() {
             conn = jdbcConnectionFactory.get()
             stmt = conn!!.prepareStatement(q.sql)
-            parameters.fetchSize?.let { fetchSize: Int ->
-                log.info { "Setting fetchSize to $fetchSize." }
+            parameters.statementFetchSize?.let { fetchSize: Int ->
+                log.info { "Setting Statement fetchSize to $fetchSize." }
                 stmt!!.fetchSize = fetchSize
             }
             var paramIdx = 1
@@ -87,6 +100,10 @@ class JdbcSelectQuerier(
                 paramIdx++
             }
             rs = stmt!!.executeQuery()
+            parameters.resultSetFetchSize?.let { fetchSize: Int ->
+                log.info { "Setting ResultSet fetchSize to $fetchSize." }
+                rs!!.fetchSize = fetchSize
+            }
         }
 
         override fun hasNext(): Boolean {
@@ -105,31 +122,31 @@ class JdbcSelectQuerier(
             return hasNext
         }
 
-        override fun next(): ObjectNode {
-            metaChanges.clear()
+        override fun next(): SelectQuerier.ResultRow {
             // Ensure that the current row in the ResultSet hasn't been read yet; advance if
             // necessary.
             if (!hasNext()) throw NoSuchElementException()
             // Read the current row in the ResultSet
-            val record: ObjectNode = reusable ?: Jsons.objectNode()
+            val resultRow: ResultRow = reusable ?: ResultRow()
+            resultRow.changes.clear()
             var colIdx = 1
             for (column in q.columns) {
                 log.debug { "Getting value #$colIdx for $column." }
                 val jdbcFieldType: JdbcFieldType<*> = column.type as JdbcFieldType<*>
                 try {
-                    record.set<JsonNode>(column.id, jdbcFieldType.get(rs!!, colIdx))
+                    resultRow.data.set<JsonNode>(column.id, jdbcFieldType.get(rs!!, colIdx))
                 } catch (e: Exception) {
-                    record.set<JsonNode>(column.id, Jsons.nullNode())
+                    resultRow.data.set<JsonNode>(column.id, Jsons.nullNode())
                     log.info {
                         "Failed to serialize column: ${column.id}, of type ${column.type}, with error ${e.message}"
                     }
-                    metaChanges.set(column, FieldValueChange.RETRIEVAL_FAILURE_TOTAL)
+                    resultRow.changes.set(column, FieldValueChange.RETRIEVAL_FAILURE_TOTAL)
                 }
                 colIdx++
             }
             // Flag that the current row has been read before returning.
             isReady = false
-            return record
+            return resultRow
         }
 
         override fun close() {

--- a/airbyte-cdk/bulk/toolkits/extract-jdbc/src/main/kotlin/io/airbyte/cdk/read/SelectQuerier.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-jdbc/src/main/kotlin/io/airbyte/cdk/read/SelectQuerier.kt
@@ -23,16 +23,15 @@ interface SelectQuerier {
 
     data class Parameters(
         /** When set, the [ObjectNode] in the [Result] is reused; take care with this! */
-        val reuseResultObject: Boolean = false,
+        val reuseResultObject: Boolean,
         /** JDBC [PreparedStatement] fetchSize value. */
-        val statementFetchSize: Int? = null,
+        val statementFetchSize: Int?,
         /** JDBC [ResultSet] fetchSize value. */
-        val resultSetFetchSize: Int? = null,
+        val resultSetFetchSize: Int?,
     ) {
-        constructor() : this(false, null, null)
         constructor(
-            reuseResultObject: Boolean,
-            fetchSize: Int?
+            reuseResultObject: Boolean = false,
+            fetchSize: Int? = null
         ) : this(reuseResultObject, fetchSize, fetchSize)
     }
 

--- a/airbyte-cdk/bulk/toolkits/extract-jdbc/src/test/kotlin/io/airbyte/cdk/read/JdbcSelectQuerierTest.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-jdbc/src/test/kotlin/io/airbyte/cdk/read/JdbcSelectQuerierTest.kt
@@ -89,18 +89,19 @@ class JdbcSelectQuerierTest {
         val querier: SelectQuerier = JdbcSelectQuerier(JdbcConnectionFactory(config))
         // Vanilla query
         val expected: List<JsonNode> = expectedJson.map(Jsons::readTree)
-        val actual: List<ObjectNode> = querier.executeQuery(q).use { it.asSequence().toList() }
+        val actual: List<ObjectNode> =
+            querier.executeQuery(q).use { it.asSequence().toList().map { it.data } }
         Assertions.assertIterableEquals(expected, actual)
         // Query with reuseResultObject = true
         querier.executeQuery(q, SelectQuerier.Parameters(reuseResultObject = true)).use {
             var i = 0
             var previous: ObjectNode? = null
-            for (record in it) {
+            for (row in it) {
                 if (i > 0) {
-                    Assertions.assertTrue(previous === record)
+                    Assertions.assertTrue(previous === row.data)
                 }
-                Assertions.assertEquals(expected[i++], record)
-                previous = record
+                Assertions.assertEquals(expected[i++], row.data)
+                previous = row.data
             }
         }
     }

--- a/airbyte-cdk/bulk/toolkits/extract-jdbc/src/test/kotlin/io/airbyte/cdk/read/TestFixtures.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-jdbc/src/test/kotlin/io/airbyte/cdk/read/TestFixtures.kt
@@ -160,10 +160,12 @@ object TestFixtures {
             return object : SelectQuerier.Result {
                 val wrapped: Iterator<ObjectNode> = mockedQuery.results.iterator()
                 override fun hasNext(): Boolean = wrapped.hasNext()
-                override fun next(): ObjectNode = wrapped.next()
+                override fun next(): SelectQuerier.ResultRow =
+                    object : SelectQuerier.ResultRow {
+                        override val data: ObjectNode = wrapped.next()
+                        override val changes: Map<Field, FieldValueChange> = emptyMap()
+                    }
                 override fun close() {}
-                override val changes: Map<Field, FieldValueChange>?
-                    get() = null
             }
         }
     }


### PR DESCRIPTION
## What
This PR splits up the `fetchSize` parameter for the `SelectQuerier` in the Bulk CDK into a `statementFetchSize` and a `resultSetFetchSize`.

## How
n/a

## Review guide
Understand the motivation of this change by looking at https://github.com/airbytehq/airbyte/pull/49948 then look at this

## User Impact
None, backward-compatible change.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
