### PR TITLE
source-mysql: Add Support for MySQL 8.4 and Above

### DIFF
--- a/airbyte-integrations/connectors/source-mysql/src/main/kotlin/io/airbyte/integrations/source/mysql/MySqlSourceDebeziumOperations.kt
+++ b/airbyte-integrations/connectors/source-mysql/src/main/kotlin/io/airbyte/integrations/source/mysql/MySqlSourceDebeziumOperations.kt
@@ -40,6 +40,7 @@ import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.sql.Connection
 import java.sql.ResultSet
+import java.sql.SQLException
 import java.sql.Statement
 import java.time.Instant
 import java.time.OffsetDateTime
@@ -244,7 +245,7 @@ class MySqlSourceDebeziumOperations(
         val gtidsField = "Executed_Gtid_Set"
         val queries = listOf("SHOW BINARY LOG STATUS", "SHOW MASTER STATUS")
 
-        jdbcConnectionFactory.get().use { connection ->
+        return jdbcConnectionFactory.get().use { connection ->
             connection.createStatement().use { stmt ->
                 queries.firstNotNullOfOrNull { sql ->
                     try {

--- a/airbyte-integrations/connectors/source-mysql/src/main/kotlin/io/airbyte/integrations/source/mysql/MySqlSourceDebeziumOperations.kt
+++ b/airbyte-integrations/connectors/source-mysql/src/main/kotlin/io/airbyte/integrations/source/mysql/MySqlSourceDebeziumOperations.kt
@@ -280,7 +280,7 @@ class MySqlSourceDebeziumOperations(
                 }
                 
                 throw ConfigErrorException(
-                    "Failed to get CDC position"
+                    "Failed to retrieve CDC position: Unable to execute 'SHOW BINARY LOG STATUS' or 'SHOW MASTER STATUS' queries."
                 )
             }
         }

--- a/airbyte-integrations/connectors/source-mysql/src/main/kotlin/io/airbyte/integrations/source/mysql/MySqlSourceDebeziumOperations.kt
+++ b/airbyte-integrations/connectors/source-mysql/src/main/kotlin/io/airbyte/integrations/source/mysql/MySqlSourceDebeziumOperations.kt
@@ -15,7 +15,6 @@ import io.airbyte.cdk.data.TextCodec
 import io.airbyte.cdk.discover.CommonMetaField
 import io.airbyte.cdk.discover.Field
 import io.airbyte.cdk.jdbc.JdbcConnectionFactory
-import io.airbyte.cdk.jdbc.LongFieldType
 import io.airbyte.cdk.jdbc.StringFieldType
 import io.airbyte.cdk.read.Stream
 import io.airbyte.cdk.read.cdc.CdcPartitionsCreator.OffsetInvalidNeedsResyncIllegalStateException

--- a/airbyte-integrations/connectors/source-mysql/src/main/kotlin/io/airbyte/integrations/source/mysql/MySqlSourceDebeziumOperations.kt
+++ b/airbyte-integrations/connectors/source-mysql/src/main/kotlin/io/airbyte/integrations/source/mysql/MySqlSourceDebeziumOperations.kt
@@ -240,47 +240,39 @@ class MySqlSourceDebeziumOperations(
     }
 
     private fun queryPositionAndGtids(): Pair<MySqlSourceCdcPosition, String?> {
-        val file = Field("File", StringFieldType)
-        val pos = Field("Position", LongFieldType)
-        val gtids = Field("Executed_Gtid_Set", StringFieldType)
-        
-        jdbcConnectionFactory.get().use { connection: Connection ->
-            connection.createStatement().use { stmt: Statement ->
-                val queries = listOf("SHOW MASTER STATUS", "SHOW BINARY LOG STATUS")
-                for (sql in queries) {
+        val fileField = "File"
+        val posField = "Position"
+        val gtidsField = "Executed_Gtid_Set"
+        val queries = listOf("SHOW BINARY LOG STATUS", "SHOW MASTER STATUS")
+
+        jdbcConnectionFactory.get().use { connection ->
+            connection.createStatement().use { stmt ->
+                queries.firstNotNullOfOrNull { sql ->
                     try {
-                        stmt.executeQuery(sql).use { rs: ResultSet ->
-                            if (!rs.next()) throw ConfigErrorException("No results for query: $sql")
-                            val mySqlSourceCdcPosition =
-                                MySqlSourceCdcPosition(
-                                    fileName = rs.getString(file.id)?.takeUnless { rs.wasNull() }
-                                            ?: throw ConfigErrorException(
-                                                "No value for ${file.id} in: $sql",
-                                            ),
-                                    position = rs.getLong(pos.id).takeUnless { rs.wasNull() || it <= 0 }
-                                            ?: throw ConfigErrorException(
-                                                "No value for ${pos.id} in: $sql",
-                                            ),
-                                )
-                            if (rs.metaData.columnCount <= 4) {
-                                // This value exists only in MySQL 5.6.5 or later.
-                                return mySqlSourceCdcPosition to null
-                            }
-                            val gtidSet: String? =
-                                rs.getString(gtids.id)
-                                    ?.takeUnless { rs.wasNull() || it.isBlank() }
-                                    ?.trim()
-                                    ?.replace("\n", "")
-                                    ?.replace("\r", "")
-                            return mySqlSourceCdcPosition to gtidSet
+                        val rs = stmt.executeQuery(sql)
+                        if (!rs.next()) {
+                            throw ConfigErrorException("No results for query: $sql")
                         }
+    
+                        val fileName = rs.getString(fileField)?.takeUnless { rs.wasNull() }
+                            ?: throw ConfigErrorException("No value for $fileField in: $sql")
+                        val position = rs.getLong(posField).takeUnless { rs.wasNull() || it <= 0 }
+                            ?: throw ConfigErrorException("No value for $posField in: $sql")
+    
+                        val cdcPosition = MySqlSourceCdcPosition(fileName, position)
+    
+                        val gtidSet = if (rs.metaData.columnCount > 4) {
+                            rs.getString(gtidsField)?.takeUnless { rs.wasNull() || it.isBlank() }
+                                ?.trim()?.replace("\n", "")?.replace("\r", "")
+                        } else null
+    
+                        cdcPosition to gtidSet
                     } catch (e: SQLException) {
-                        println("Failed to execute query '$sql': ${e.message}")
+                        log.info(e) { "Failed to execute query: $sql" }
+                        null
                     }
-                }
-                
-                throw ConfigErrorException(
-                    "Failed to retrieve CDC position: Unable to execute 'SHOW BINARY LOG STATUS' or 'SHOW MASTER STATUS' queries."
+                } ?: throw ConfigErrorException(
+                    "Failed to retrieve CDC position: Unable to execute queries: ${queries.joinToString(", ")}."
                 )
             }
         }

--- a/airbyte-integrations/connectors/source-mysql/src/main/kotlin/io/airbyte/integrations/source/mysql/MySqlSourceDebeziumOperations.kt
+++ b/airbyte-integrations/connectors/source-mysql/src/main/kotlin/io/airbyte/integrations/source/mysql/MySqlSourceDebeziumOperations.kt
@@ -270,7 +270,7 @@ class MySqlSourceDebeziumOperations(
                                     ?.trim()
                                     ?.replace("\n", "")
                                     ?.replace("\r", "")
-                            // This value exists only in MySQL 5.6.5 or later.
+                                // This value exists only in MySQL 5.6.5 or later.
                             } else null
 
                         cdcPosition to gtidSet


### PR DESCRIPTION
## What

This PR updates the CDC position retrieval to use SHOW BINARY LOG STATUS for MySQL versions 8.4 and newer, while retaining SHOW MASTER STATUS for older versions. This ensures compatibility with the latest MySQL releases where SHOW MASTER STATUS is deprecated.

## How
•	Query Update:
•	Primary: Attempt SHOW MASTER STATUS.
•	Fallback: If the primary query fails, use SHOW BINARY LOG STATUS.
•	Error Handling: If both queries fail, throw a ConfigErrorException.
•	Data Processing: Extract fileName, position, and gtidSet from the result set with necessary validations.

## Review guide
1.	File to Review:
•	MySqlSourceDebeziumOperations.kt
2.	Key Changes:
•	queryPositionAndGtids function logic.
•	Exception handling for both SQL queries.

## User Impact
Supports both MySQL 8.4+ and older versions.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
