### PR TITLE
chore: use ruff.toml instead of global pyproject

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -1,89 +1,12 @@
-[tool.poetry]
-name = "airbyte"
-version = "0.1.0"
-description = "Airbyte open source connector code"
-authors = ["Airbyte <contact@airbyte.io>"]
-
-[tool.poetry.dependencies]
-python = "~3.10"
-jsonschema = "^4.22.0"
-
-[tool.poetry.group.dev.dependencies]
-isort = "5.6.4"
-black = "~22.3.0"
-ruff = "^0.4"
-poethepoet = "^0.26.1"
-
-[tool.poe.tasks]
-isort = { cmd = "poetry run isort --settings-file pyproject.toml ." }
-black = { cmd = "poetry run black --config pyproject.toml ." }
-format = { sequence = [
-    "isort",
-    "black",
-], help = "Format Python code in the repository. This command is invoked in airbyte-ci format." }
-
-[tool.black]
-line-length = 140
-target-version = ["py310"]
-extend-exclude = """
-/(
-    build
-    | integration_tests
-    | unit_tests
-    | generated
-    | invalid
-    | non_formatted_code
-    | airbyte-integrations/connectors/destination-duckdb
-    | airbyte-integrations/connectors/destination-snowflake-cortex
-)/
-"""
-
-[tool.coverage.report]
-fail_under = 0
-skip_empty = true
-sort = "-cover"
-omit = [
-    ".venv/*",
-    "main.py",
-    "setup.py",
-    "unit_tests/*",
-    "integration_tests/*",
-    "**/generated/*",
-]
-
-# TODO: This will be removed in favor of the section below.
-[tool.isort]
-profile = "black"
-color_output = false
-# skip_gitignore = true
-line_length = 140
-multi_line_output = 3
-include_trailing_comma = true
-force_grid_wrap = 0
-use_parentheses = true
-skip_glob = [
-    "**/invalid/**",
-    "**/non_formatted_code/**",
-    "**/connector_builder/generated/**",
-    # TODO: Remove this after we move to Ruff. Ruff is mono-repo-aware and
-    # correctly handles first-party imports in subdirectories.
-
-    # Migrated to Ruff:
-    "airbyte-integrations/connectors/destination-duckdb/**",
-    "airbyte-integrations/connectors/destination-snowflake-cortex/**"
-]
-
-[tool.ruff.lint.pylint]
-max-args = 8      # Relaxed from default of 5
-max-branches = 15 # Relaxed from default of 12
-
-[tool.ruff]
 target-version = "py310"
 line-length = 140
 extend-exclude = ["docs", "test", "tests"]
 
-[tool.ruff.lint]
+[lint.pylint]
+max-args = 8      # Relaxed from default of 5
+max-branches = 15 # Relaxed from default of 12
 
+[lint]
 select = [
     "I",    # isort replacement
 ]
@@ -185,7 +108,7 @@ unfixable = [
 
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 
-[tool.ruff.lint.isort]
+[lint.isort]
 force-sort-within-sections = false
 lines-after-imports = 2
 known-first-party = [
@@ -205,56 +128,23 @@ section-order = [
     "local-folder",
 ]
 
-[tool.ruff.lint.mccabe]
+[lint.mccabe]
 max-complexity = 24
 
-[tool.ruff.lint.pycodestyle]
+[lint.pycodestyle]
 ignore-overlong-task-comments = true
 
-[tool.ruff.lint.pydocstyle]
+[lint.pydocstyle]
 convention = "google"
 
-[tool.ruff.lint.flake8-annotations]
+[lint.flake8-annotations]
 allow-star-arg-any = false
 ignore-fully-untyped = false
 
-[tool.ruff.format]
+[format]
 quote-style = "double"
 indent-style = "space"
 skip-magic-trailing-comma = false
 line-ending = "auto"
 preview = false
 docstring-code-format = true
-
-[tool.mypy]
-platform = "linux"
-exclude = "(build|integration_tests|unit_tests|generated)"
-
-# Optionals
-ignore_missing_imports = true
-
-# Strictness
-allow_untyped_globals = false
-allow_redefinition = false
-implicit_reexport = false
-strict_equality = true
-
-# Warnings
-warn_unused_ignores = true
-warn_no_return = true
-warn_return_any = true
-warn_redundant_casts = true
-warn_unreachable = true
-
-# Error output
-show_column_numbers = true
-show_error_context = true
-show_error_codes = true
-show_traceback = true
-pretty = true
-color_output = true
-error_summary = true
-
-[tool.pytest.ini_options]
-minversion = "6.2.5"
-addopts = "-r a --capture=no -vv --color=yes"


### PR DESCRIPTION
## What

This PR removes the global `pyproject.toml` file, and replaces it with `ruff.toml` that holds our formatting and linting rules. 

Why: 
- `pre-commit` manages ruff installation, so we don't have to have `pyproject` to manage dependencies.
- We don't use other things in there, including pytest configs, coverage, isort, and black.
- It's confusing to have a `pyproject.toml` if it does not in fact represent a project.
