### PR TITLE
Bulk Load CDK: Break out InputMessage from DestinationMessage

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/AirbyteTypeToAirbyteTypeWithMeta.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/AirbyteTypeToAirbyteTypeWithMeta.kt
@@ -4,17 +4,15 @@
 
 package io.airbyte.cdk.load.data
 
-import io.airbyte.cdk.load.message.DestinationRecord
+import io.airbyte.cdk.load.message.Meta
 
 class AirbyteTypeToAirbyteTypeWithMeta(private val flatten: Boolean) {
     fun convert(schema: AirbyteType): ObjectType {
         val properties =
             linkedMapOf(
-                DestinationRecord.Meta.COLUMN_NAME_AB_RAW_ID to
-                    FieldType(StringType, nullable = false),
-                DestinationRecord.Meta.COLUMN_NAME_AB_EXTRACTED_AT to
-                    FieldType(IntegerType, nullable = false),
-                DestinationRecord.Meta.COLUMN_NAME_AB_META to
+                Meta.COLUMN_NAME_AB_RAW_ID to FieldType(StringType, nullable = false),
+                Meta.COLUMN_NAME_AB_EXTRACTED_AT to FieldType(IntegerType, nullable = false),
+                Meta.COLUMN_NAME_AB_META to
                     FieldType(
                         nullable = false,
                         type =
@@ -54,8 +52,7 @@ class AirbyteTypeToAirbyteTypeWithMeta(private val flatten: Boolean) {
                                 )
                             )
                     ),
-                DestinationRecord.Meta.COLUMN_NAME_AB_GENERATION_ID to
-                    FieldType(IntegerType, nullable = false)
+                Meta.COLUMN_NAME_AB_GENERATION_ID to FieldType(IntegerType, nullable = false)
             )
         if (flatten) {
             if (schema is ObjectType) {
@@ -68,8 +65,7 @@ class AirbyteTypeToAirbyteTypeWithMeta(private val flatten: Boolean) {
                 )
             }
         } else {
-            properties[DestinationRecord.Meta.COLUMN_NAME_DATA] =
-                FieldType(schema, nullable = false)
+            properties[Meta.COLUMN_NAME_DATA] = FieldType(schema, nullable = false)
         }
         return ObjectType(properties)
     }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/AirbyteValueIdentityMapper.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/AirbyteValueIdentityMapper.kt
@@ -4,7 +4,7 @@
 
 package io.airbyte.cdk.load.data
 
-import io.airbyte.cdk.load.message.DestinationRecord
+import io.airbyte.cdk.load.message.Meta
 import io.airbyte.protocol.models.v0.AirbyteRecordMessageMetaChange.Change
 import io.airbyte.protocol.models.v0.AirbyteRecordMessageMetaChange.Reason
 
@@ -12,8 +12,8 @@ interface AirbyteValueMapper {
     fun map(
         value: AirbyteValue,
         schema: AirbyteType,
-        changes: List<DestinationRecord.Change> = emptyList()
-    ): Pair<AirbyteValue, List<DestinationRecord.Change>>
+        changes: List<Meta.Change> = emptyList()
+    ): Pair<AirbyteValue, List<Meta.Change>>
 }
 
 /** An optimized identity mapper that just passes through. */
@@ -21,22 +21,22 @@ class AirbyteValueNoopMapper : AirbyteValueMapper {
     override fun map(
         value: AirbyteValue,
         schema: AirbyteType,
-        changes: List<DestinationRecord.Change>
-    ): Pair<AirbyteValue, List<DestinationRecord.Change>> = value to changes
+        changes: List<Meta.Change>
+    ): Pair<AirbyteValue, List<Meta.Change>> = value to changes
 }
 
 open class AirbyteValueIdentityMapper : AirbyteValueMapper {
     data class Context(
         val nullable: Boolean = false,
         val path: List<String> = emptyList(),
-        val changes: MutableSet<DestinationRecord.Change> = mutableSetOf(),
+        val changes: MutableSet<Meta.Change> = mutableSetOf(),
     )
 
     override fun map(
         value: AirbyteValue,
         schema: AirbyteType,
-        changes: List<DestinationRecord.Change>
-    ): Pair<AirbyteValue, List<DestinationRecord.Change>> =
+        changes: List<Meta.Change>
+    ): Pair<AirbyteValue, List<Meta.Change>> =
         mapInner(value, schema, Context(changes = changes.toMutableSet())).let {
             it.first to it.second.changes.toList()
         }
@@ -46,9 +46,7 @@ open class AirbyteValueIdentityMapper : AirbyteValueMapper {
         context: Context,
         reason: Reason = Reason.DESTINATION_SERIALIZATION_ERROR
     ): Pair<AirbyteValue, Context> {
-        context.changes.add(
-            DestinationRecord.Change(context.path.joinToString("."), Change.NULLED, reason)
-        )
+        context.changes.add(Meta.Change(context.path.joinToString("."), Change.NULLED, reason))
         return mapInner(NullValue, schema, context)
     }
 

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/DestinationRecordToAirbyteValueWithMeta.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/DestinationRecordToAirbyteValueWithMeta.kt
@@ -6,7 +6,7 @@ package io.airbyte.cdk.load.data
 
 import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.message.DestinationRecord
-import io.airbyte.cdk.load.message.DestinationRecord.Meta
+import io.airbyte.cdk.load.message.Meta
 import java.util.*
 
 class DestinationRecordToAirbyteValueWithMeta(
@@ -51,7 +51,7 @@ class DestinationRecordToAirbyteValueWithMeta(
     }
 }
 
-fun Pair<AirbyteValue, List<DestinationRecord.Change>>.withAirbyteMeta(
+fun Pair<AirbyteValue, List<Meta.Change>>.withAirbyteMeta(
     stream: DestinationStream,
     emittedAtMs: Long,
     flatten: Boolean = false

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/MapperPipeline.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/MapperPipeline.kt
@@ -5,7 +5,7 @@
 package io.airbyte.cdk.load.data
 
 import io.airbyte.cdk.load.command.DestinationStream
-import io.airbyte.cdk.load.message.DestinationRecord.Change
+import io.airbyte.cdk.load.message.Meta.Change
 
 class MapperPipeline(
     inputSchema: AirbyteType,

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/data/AirbyteTypeToAirbyteTypeWithMetaTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/data/AirbyteTypeToAirbyteTypeWithMetaTest.kt
@@ -4,17 +4,16 @@
 
 package io.airbyte.cdk.load.data
 
-import io.airbyte.cdk.load.message.DestinationRecord
+import io.airbyte.cdk.load.message.Meta
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 internal class AirbyteTypeToAirbyteTypeWithMetaTest {
     private val expectedMeta =
         linkedMapOf(
-            DestinationRecord.Meta.COLUMN_NAME_AB_RAW_ID to FieldType(StringType, nullable = false),
-            DestinationRecord.Meta.COLUMN_NAME_AB_EXTRACTED_AT to
-                FieldType(IntegerType, nullable = false),
-            DestinationRecord.Meta.COLUMN_NAME_AB_META to
+            Meta.COLUMN_NAME_AB_RAW_ID to FieldType(StringType, nullable = false),
+            Meta.COLUMN_NAME_AB_EXTRACTED_AT to FieldType(IntegerType, nullable = false),
+            Meta.COLUMN_NAME_AB_META to
                 FieldType(
                     ObjectType(
                         linkedMapOf(
@@ -42,8 +41,7 @@ internal class AirbyteTypeToAirbyteTypeWithMetaTest {
                     ),
                     nullable = false
                 ),
-            DestinationRecord.Meta.COLUMN_NAME_AB_GENERATION_ID to
-                FieldType(IntegerType, nullable = false)
+            Meta.COLUMN_NAME_AB_GENERATION_ID to FieldType(IntegerType, nullable = false)
         )
 
     @Test
@@ -58,8 +56,7 @@ internal class AirbyteTypeToAirbyteTypeWithMetaTest {
             )
         val withMeta = schema.withAirbyteMeta(flatten = false)
         val expected = ObjectType(expectedMeta)
-        expected.properties[DestinationRecord.Meta.COLUMN_NAME_DATA] =
-            FieldType(schema, nullable = false)
+        expected.properties[Meta.COLUMN_NAME_DATA] = FieldType(schema, nullable = false)
         assertEquals(expected, withMeta)
     }
 

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/data/DestinationRecordToAirbyteValueWithMetaTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/data/DestinationRecordToAirbyteValueWithMetaTest.kt
@@ -6,6 +6,7 @@ package io.airbyte.cdk.load.data
 
 import io.airbyte.cdk.load.command.MockDestinationCatalogFactory
 import io.airbyte.cdk.load.message.DestinationRecord
+import io.airbyte.cdk.load.message.Meta
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 
@@ -17,15 +18,15 @@ class DestinationRecordToAirbyteValueWithMetaTest {
     val expectedMeta =
         linkedMapOf(
             // Don't do raw_id, we'll evict it and validate that it's a uuid
-            DestinationRecord.Meta.COLUMN_NAME_AB_EXTRACTED_AT to IntegerValue(emittedAtMs),
-            DestinationRecord.Meta.COLUMN_NAME_AB_META to
+            Meta.COLUMN_NAME_AB_EXTRACTED_AT to IntegerValue(emittedAtMs),
+            Meta.COLUMN_NAME_AB_META to
                 ObjectValue(
                     linkedMapOf(
                         "sync_id" to IntegerValue(syncId),
                         "changes" to ArrayValue(emptyList())
                     )
                 ),
-            DestinationRecord.Meta.COLUMN_NAME_AB_GENERATION_ID to IntegerValue(generationId)
+            Meta.COLUMN_NAME_AB_GENERATION_ID to IntegerValue(generationId)
         )
 
     @Test
@@ -39,18 +40,10 @@ class DestinationRecordToAirbyteValueWithMetaTest {
                 )
             )
         val expected = LinkedHashMap(expectedMeta)
-        expected[DestinationRecord.Meta.COLUMN_NAME_DATA] = data
-        val mockRecord =
-            DestinationRecord(
-                stream.descriptor,
-                data,
-                emittedAtMs,
-                DestinationRecord.Meta(),
-                "dummy"
-            )
+        expected[Meta.COLUMN_NAME_DATA] = data
+        val mockRecord = DestinationRecord(stream.descriptor, data, emittedAtMs, Meta(), "dummy")
         val withMeta = mockRecord.dataWithAirbyteMeta(stream, flatten = false)
-        val uuid =
-            withMeta.values.remove(DestinationRecord.Meta.COLUMN_NAME_AB_RAW_ID) as StringValue
+        val uuid = withMeta.values.remove(Meta.COLUMN_NAME_AB_RAW_ID) as StringValue
         Assertions.assertTrue(
             uuid.value.matches(
                 Regex("[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}")
@@ -71,16 +64,9 @@ class DestinationRecordToAirbyteValueWithMetaTest {
             )
         val expected = LinkedHashMap(expectedMeta)
         data.values.forEach { (name, value) -> expected[name] = value }
-        val mockRecord =
-            DestinationRecord(
-                stream.descriptor,
-                data,
-                emittedAtMs,
-                DestinationRecord.Meta(),
-                "dummy"
-            )
+        val mockRecord = DestinationRecord(stream.descriptor, data, emittedAtMs, Meta(), "dummy")
         val withMeta = mockRecord.dataWithAirbyteMeta(stream, flatten = true)
-        withMeta.values.remove(DestinationRecord.Meta.COLUMN_NAME_AB_RAW_ID)
+        withMeta.values.remove(Meta.COLUMN_NAME_AB_RAW_ID)
         Assertions.assertEquals(expected, withMeta.values)
     }
 }

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/data/NullOutOfRangeIntegersTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/data/NullOutOfRangeIntegersTest.kt
@@ -4,7 +4,7 @@
 
 package io.airbyte.cdk.load.data
 
-import io.airbyte.cdk.load.message.DestinationRecord
+import io.airbyte.cdk.load.message.Meta
 import io.airbyte.cdk.load.test.util.Root
 import io.airbyte.cdk.load.test.util.ValueTestBuilder
 import io.airbyte.protocol.models.v0.AirbyteRecordMessageMetaChange.Change
@@ -31,7 +31,7 @@ class NullOutOfRangeIntegersTest {
         Assertions.assertEquals(expectedValue, actualValue)
         Assertions.assertEquals(1, changes.size)
         Assertions.assertEquals(
-            DestinationRecord.Change(
+            Meta.Change(
                 "big_integer",
                 Change.NULLED,
                 Reason.DESTINATION_FIELD_SIZE_LIMITATION,
@@ -67,12 +67,12 @@ class NullOutOfRangeIntegersTest {
         Assertions.assertEquals(expectedValue, actualValue)
         Assertions.assertEquals(
             setOf(
-                DestinationRecord.Change(
+                Meta.Change(
                     "too_small",
                     Change.NULLED,
                     Reason.DESTINATION_FIELD_SIZE_LIMITATION,
                 ),
-                DestinationRecord.Change(
+                Meta.Change(
                     "too_big",
                     Change.NULLED,
                     Reason.DESTINATION_FIELD_SIZE_LIMITATION,

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/message/InputMessage.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/message/InputMessage.kt
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.load.message
+
+import io.airbyte.cdk.load.command.DestinationStream
+import io.airbyte.cdk.load.data.AirbyteValue
+import io.airbyte.cdk.load.data.ObjectTypeWithoutSchema
+import io.airbyte.cdk.load.data.json.JsonToAirbyteValue
+import io.airbyte.cdk.load.data.json.toJson
+import io.airbyte.cdk.load.message.CheckpointMessage.Checkpoint
+import io.airbyte.cdk.load.message.CheckpointMessage.Stats
+import io.airbyte.cdk.load.util.deserializeToNode
+import io.airbyte.protocol.models.v0.AirbyteMessage
+import io.airbyte.protocol.models.v0.AirbyteRecordMessage
+
+sealed interface InputMessage {
+    fun asProtocolMessage(): AirbyteMessage
+}
+
+data class InputRecord(
+    val stream: DestinationStream.Descriptor,
+    val data: AirbyteValue,
+    val emittedAtMs: Long,
+    val meta: Meta?,
+    val serialized: String,
+) : InputMessage {
+    /** Convenience constructor, primarily intended for use in tests. */
+    constructor(
+        namespace: String?,
+        name: String,
+        data: String,
+        emittedAtMs: Long,
+        changes: MutableList<Meta.Change> = mutableListOf(),
+    ) : this(
+        stream = DestinationStream.Descriptor(namespace, name),
+        data = JsonToAirbyteValue().convert(data.deserializeToNode(), ObjectTypeWithoutSchema),
+        emittedAtMs = emittedAtMs,
+        meta = Meta(changes),
+        serialized = "",
+    )
+
+    override fun asProtocolMessage(): AirbyteMessage =
+        AirbyteMessage()
+            .withType(AirbyteMessage.Type.RECORD)
+            .withRecord(
+                AirbyteRecordMessage()
+                    .withStream(stream.name)
+                    .withNamespace(stream.namespace)
+                    .withEmittedAt(emittedAtMs)
+                    .withData(data.toJson())
+                    .also {
+                        if (meta != null) {
+                            it.withMeta(meta.asProtocolObject())
+                        }
+                    }
+            )
+}
+
+data class InputFile(
+    val file: DestinationFile,
+) : InputMessage {
+    constructor(
+        stream: DestinationStream.Descriptor,
+        emittedAtMs: Long,
+        fileMessage: DestinationFile.AirbyteRecordMessageFile,
+        serialized: String = ""
+    ) : this(
+        DestinationFile(
+            stream,
+            emittedAtMs,
+            serialized,
+            fileMessage,
+        )
+    )
+    override fun asProtocolMessage(): AirbyteMessage = file.asProtocolMessage()
+}
+
+sealed interface InputCheckpoint : InputMessage
+
+data class InputStreamCheckpoint(val checkpoint: StreamCheckpoint) : InputCheckpoint {
+    constructor(
+        streamNamespace: String?,
+        streamName: String,
+        blob: String,
+        sourceRecordCount: Long,
+        destinationRecordCount: Long? = null,
+    ) : this(
+        StreamCheckpoint(
+            Checkpoint(
+                DestinationStream.Descriptor(streamNamespace, streamName),
+                state = blob.deserializeToNode()
+            ),
+            Stats(sourceRecordCount),
+            destinationRecordCount?.let { Stats(it) },
+            emptyMap(),
+        )
+    )
+    override fun asProtocolMessage(): AirbyteMessage = checkpoint.asProtocolMessage()
+}

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/AirbyteValueWithMetaToOutputRecord.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/AirbyteValueWithMetaToOutputRecord.kt
@@ -9,7 +9,7 @@ import io.airbyte.cdk.load.data.ArrayValue
 import io.airbyte.cdk.load.data.IntegerValue
 import io.airbyte.cdk.load.data.ObjectValue
 import io.airbyte.cdk.load.data.StringValue
-import io.airbyte.cdk.load.message.DestinationRecord
+import io.airbyte.cdk.load.message.Meta
 import io.airbyte.protocol.models.v0.AirbyteRecordMessageMetaChange
 import java.time.Instant
 import java.util.*
@@ -17,26 +17,18 @@ import kotlin.collections.LinkedHashMap
 
 class AirbyteValueWithMetaToOutputRecord {
     fun convert(value: ObjectValue): OutputRecord {
-        val meta = value.values[DestinationRecord.Meta.COLUMN_NAME_AB_META] as ObjectValue
+        val meta = value.values[Meta.COLUMN_NAME_AB_META] as ObjectValue
         return OutputRecord(
             rawId =
-                UUID.fromString(
-                    (value.values[DestinationRecord.Meta.COLUMN_NAME_AB_RAW_ID] as StringValue)
-                        .value
-                ),
+                UUID.fromString((value.values[Meta.COLUMN_NAME_AB_RAW_ID] as StringValue).value),
             extractedAt =
                 Instant.ofEpochMilli(
-                    (value.values[DestinationRecord.Meta.COLUMN_NAME_AB_EXTRACTED_AT]
-                            as IntegerValue)
-                        .value
-                        .toLong()
+                    (value.values[Meta.COLUMN_NAME_AB_EXTRACTED_AT] as IntegerValue).value.toLong()
                 ),
             loadedAt = null,
-            data = value.values[DestinationRecord.Meta.COLUMN_NAME_DATA] as ObjectValue,
+            data = value.values[Meta.COLUMN_NAME_DATA] as ObjectValue,
             generationId =
-                (value.values[DestinationRecord.Meta.COLUMN_NAME_AB_GENERATION_ID] as IntegerValue)
-                    .value
-                    .toLong(),
+                (value.values[Meta.COLUMN_NAME_AB_GENERATION_ID] as IntegerValue).value.toLong(),
             airbyteMeta =
                 OutputRecord.Meta(
                     syncId = (meta.values["sync_id"] as IntegerValue).value.toLong(),
@@ -44,7 +36,7 @@ class AirbyteValueWithMetaToOutputRecord {
                         (meta.values["changes"] as ArrayValue)
                             .values
                             .map {
-                                DestinationRecord.Change(
+                                Meta.Change(
                                     field =
                                         ((it as ObjectValue).values["field"] as StringValue).value,
                                     change =
@@ -68,11 +60,10 @@ fun AirbyteValue.maybeUnflatten(wasFlattened: Boolean): ObjectValue {
     if (!wasFlattened) {
         return this
     }
-    val (meta, data) =
-        this.values.toList().partition { DestinationRecord.Meta.COLUMN_NAMES.contains(it.first) }
+    val (meta, data) = this.values.toList().partition { Meta.COLUMN_NAMES.contains(it.first) }
     val properties = LinkedHashMap(meta.toMap())
     val dataObject = ObjectValue(LinkedHashMap(data.toMap()))
-    properties[DestinationRecord.Meta.COLUMN_NAME_DATA] = dataObject
+    properties[Meta.COLUMN_NAME_DATA] = dataObject
     return ObjectValue(properties)
 }
 

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/IntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/IntegrationTest.kt
@@ -8,9 +8,9 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 import io.airbyte.cdk.command.ConfigurationSpecification
 import io.airbyte.cdk.load.command.DestinationCatalog
 import io.airbyte.cdk.load.command.DestinationStream
-import io.airbyte.cdk.load.message.DestinationMessage
-import io.airbyte.cdk.load.message.DestinationRecord
 import io.airbyte.cdk.load.message.DestinationRecordStreamComplete
+import io.airbyte.cdk.load.message.InputMessage
+import io.airbyte.cdk.load.message.InputRecord
 import io.airbyte.cdk.load.message.StreamCheckpoint
 import io.airbyte.cdk.load.test.util.destination_process.DestinationProcessFactory
 import io.airbyte.cdk.load.test.util.destination_process.DestinationUncleanExitException
@@ -125,7 +125,7 @@ abstract class IntegrationTest(
     fun runSync(
         configContents: String,
         stream: DestinationStream,
-        messages: List<DestinationMessage>,
+        messages: List<InputMessage>,
         streamStatus: AirbyteStreamStatus? = AirbyteStreamStatus.COMPLETE,
         useFileTransfer: Boolean = false,
     ): List<AirbyteMessage> =
@@ -146,7 +146,7 @@ abstract class IntegrationTest(
     fun runSync(
         configContents: String,
         catalog: DestinationCatalog,
-        messages: List<DestinationMessage>,
+        messages: List<InputMessage>,
         /**
          * If you set this to anything other than `COMPLETE`, you may run into a race condition.
          * It's recommended that you send an explicit state message in [messages], and run the sync
@@ -207,7 +207,7 @@ abstract class IntegrationTest(
     fun runSyncUntilStateAck(
         configContents: String,
         stream: DestinationStream,
-        records: List<DestinationRecord>,
+        records: List<InputRecord>,
         inputStateMessage: StreamCheckpoint,
         allowGracefulShutdown: Boolean,
         useFileTransfer: Boolean = false,

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/OutputRecord.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/OutputRecord.kt
@@ -5,7 +5,7 @@
 package io.airbyte.cdk.load.test.util
 
 import io.airbyte.cdk.load.data.ObjectValue
-import io.airbyte.cdk.load.message.DestinationRecord.Change
+import io.airbyte.cdk.load.message.Meta.Change
 import java.time.Instant
 import java.util.UUID
 

--- a/airbyte-integrations/connectors/destination-iceberg-v2/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-iceberg-v2/metadata.yaml
@@ -16,7 +16,7 @@ data:
             type: GSM
   connectorType: destination
   definitionId: 37a928c1-2d5c-431a-a97d-ae236bd1ea0c
-  dockerImageTag: 0.1.16
+  dockerImageTag: 0.2.0
   dockerRepository: airbyte/destination-iceberg-v2
   documentationUrl: https://docs.airbyte.com/integrations/destinations/s3
   githubIssueLabel: destination-iceberg-v2

--- a/airbyte-integrations/connectors/destination-iceberg-v2/src/test/kotlin/io/airbyte/integrations/destination/iceberg/v2/IcebergV2WriterTest.kt
+++ b/airbyte-integrations/connectors/destination-iceberg-v2/src/test/kotlin/io/airbyte/integrations/destination/iceberg/v2/IcebergV2WriterTest.kt
@@ -19,10 +19,10 @@ import io.airbyte.cdk.load.data.ObjectType
 import io.airbyte.cdk.load.data.StringType
 import io.airbyte.cdk.load.data.iceberg.parquet.toIcebergSchema
 import io.airbyte.cdk.load.data.withAirbyteMeta
-import io.airbyte.cdk.load.message.DestinationRecord.Meta.Companion.COLUMN_NAME_AB_EXTRACTED_AT
-import io.airbyte.cdk.load.message.DestinationRecord.Meta.Companion.COLUMN_NAME_AB_GENERATION_ID
-import io.airbyte.cdk.load.message.DestinationRecord.Meta.Companion.COLUMN_NAME_AB_META
-import io.airbyte.cdk.load.message.DestinationRecord.Meta.Companion.COLUMN_NAME_AB_RAW_ID
+import io.airbyte.cdk.load.message.Meta.Companion.COLUMN_NAME_AB_EXTRACTED_AT
+import io.airbyte.cdk.load.message.Meta.Companion.COLUMN_NAME_AB_GENERATION_ID
+import io.airbyte.cdk.load.message.Meta.Companion.COLUMN_NAME_AB_META
+import io.airbyte.cdk.load.message.Meta.Companion.COLUMN_NAME_AB_RAW_ID
 import io.airbyte.integrations.destination.iceberg.v2.io.IcebergTableWriterFactory
 import io.airbyte.integrations.destination.iceberg.v2.io.IcebergUtil
 import io.mockk.every

--- a/airbyte-integrations/connectors/destination-iceberg-v2/src/test/kotlin/io/airbyte/integrations/destination/iceberg/v2/io/IcebergUtilTest.kt
+++ b/airbyte-integrations/connectors/destination-iceberg-v2/src/test/kotlin/io/airbyte/integrations/destination/iceberg/v2/io/IcebergUtilTest.kt
@@ -22,10 +22,11 @@ import io.airbyte.cdk.load.data.StringValue
 import io.airbyte.cdk.load.data.TimestampValue
 import io.airbyte.cdk.load.data.parquet.ParquetMapperPipelineFactory
 import io.airbyte.cdk.load.message.DestinationRecord
-import io.airbyte.cdk.load.message.DestinationRecord.Meta.Companion.COLUMN_NAME_AB_EXTRACTED_AT
-import io.airbyte.cdk.load.message.DestinationRecord.Meta.Companion.COLUMN_NAME_AB_GENERATION_ID
-import io.airbyte.cdk.load.message.DestinationRecord.Meta.Companion.COLUMN_NAME_AB_META
-import io.airbyte.cdk.load.message.DestinationRecord.Meta.Companion.COLUMN_NAME_AB_RAW_ID
+import io.airbyte.cdk.load.message.Meta
+import io.airbyte.cdk.load.message.Meta.Companion.COLUMN_NAME_AB_EXTRACTED_AT
+import io.airbyte.cdk.load.message.Meta.Companion.COLUMN_NAME_AB_GENERATION_ID
+import io.airbyte.cdk.load.message.Meta.Companion.COLUMN_NAME_AB_META
+import io.airbyte.cdk.load.message.Meta.Companion.COLUMN_NAME_AB_RAW_ID
 import io.airbyte.integrations.destination.iceberg.v2.IcebergV2Configuration
 import io.mockk.every
 import io.mockk.mockk
@@ -188,7 +189,7 @@ internal class IcebergUtilTest {
                         linkedMapOf("id" to IntegerValue(42L), "name" to StringValue("John Doe"))
                     ),
                 emittedAtMs = System.currentTimeMillis(),
-                meta = DestinationRecord.Meta(),
+                meta = Meta(),
                 serialized = "{\"id\":42, \"name\":\"John Doe\"}"
             )
         val pipeline = ParquetMapperPipelineFactory().create(airbyteStream)
@@ -240,7 +241,7 @@ internal class IcebergUtilTest {
                         )
                     ),
                 emittedAtMs = System.currentTimeMillis(),
-                meta = DestinationRecord.Meta(),
+                meta = Meta(),
                 serialized = "{\"id\":42, \"name\":\"John Doe\"}"
             )
         val pipeline = ParquetMapperPipelineFactory().create(airbyteStream)
@@ -288,7 +289,7 @@ internal class IcebergUtilTest {
                         linkedMapOf("id" to IntegerValue(42L), "name" to StringValue("John Doe"))
                     ),
                 emittedAtMs = System.currentTimeMillis(),
-                meta = DestinationRecord.Meta(),
+                meta = Meta(),
                 serialized = "{\"id\":42, \"name\":\"John Doe\"}"
             )
         val pipeline = ParquetMapperPipelineFactory().create(airbyteStream)


### PR DESCRIPTION
## What
**Nonfuctional refactor in preparation for another change.**

Preliminary refactor separating out an `InputMessage` from `DestinationMessage` so we can iterate on them independently.

They have very different domains:

`DestinationMessage` is the first step of deserialization in production
`InputMessage` is a convenience class for creating something that can be quickly converted into a protocol message for integration testing only

The main reason this is painful is that exactly what we deserialize records into depends on the use case
* if we're spilling to disk, we don't want to do any marshaling, because it's wasted work we'll have to do again; all we want is the unserialized payload for appending to the file
* if all we need for the first stage of processing is an unvalidated json string, we don't want to marshal ever

So DestinationRecord should probably be a case class representing different use cases. That's hard to do if we have to share domain with a test utility.