### PR TITLE
Bulk Load CDK: Remove unnecessary initial marshaling

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/DestinationMessage.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/DestinationMessage.kt
@@ -8,10 +8,9 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.databind.JsonNode
 import io.airbyte.cdk.load.command.DestinationCatalog
 import io.airbyte.cdk.load.command.DestinationStream
+import io.airbyte.cdk.load.data.AirbyteType
 import io.airbyte.cdk.load.data.AirbyteValue
-import io.airbyte.cdk.load.data.ObjectValue
-import io.airbyte.cdk.load.data.json.JsonToAirbyteValue
-import io.airbyte.cdk.load.data.json.toJson
+import io.airbyte.cdk.load.data.json.toAirbyteValue
 import io.airbyte.cdk.load.message.CheckpointMessage.Checkpoint
 import io.airbyte.cdk.load.message.CheckpointMessage.Stats
 import io.airbyte.cdk.load.util.deserializeToNode
@@ -79,31 +78,45 @@ data class Meta(
     }
 }
 
-sealed interface DestinationRecord : DestinationRecordDomainMessage
-
-data class DestinationRecordAirbyteValue(
+data class DestinationRecord(
     override val stream: DestinationStream.Descriptor,
+    val message: AirbyteMessage,
+    val serialized: String,
+    val schema: AirbyteType
+) : DestinationRecordDomainMessage {
+    override fun asProtocolMessage(): AirbyteMessage = message
+
+    fun asRecordSerialized(): DestinationRecordSerialized =
+        DestinationRecordSerialized(stream, serialized)
+    fun asRecordMarshaledToAirbyteValue(): DestinationRecordAirbyteValue {
+        return DestinationRecordAirbyteValue(
+            stream,
+            message.record.data.toAirbyteValue(schema),
+            message.record.emittedAt,
+            Meta(
+                message.record.meta?.changes?.map { Meta.Change(it.field, it.change, it.reason) }
+                    ?: emptyList()
+            )
+        )
+    }
+}
+
+/**
+ * Represents a record already in its serialized state. The intended use is for conveying records
+ * from stdin to the spill file, where reserialization is not necessary.
+ */
+data class DestinationRecordSerialized(
+    val stream: DestinationStream.Descriptor,
+    val serialized: String
+)
+
+/** Represents a record both deserialized AND marshaled to airbyte value. The marshaling */
+data class DestinationRecordAirbyteValue(
+    val stream: DestinationStream.Descriptor,
     val data: AirbyteValue,
     val emittedAtMs: Long,
     val meta: Meta?,
-    val serialized: String,
-) : DestinationRecord {
-    override fun asProtocolMessage(): AirbyteMessage =
-        AirbyteMessage()
-            .withType(AirbyteMessage.Type.RECORD)
-            .withRecord(
-                AirbyteRecordMessage()
-                    .withStream(stream.name)
-                    .withNamespace(stream.namespace)
-                    .withEmittedAt(emittedAtMs)
-                    .withData(data.toJson())
-                    .also {
-                        if (meta != null) {
-                            it.withMeta(meta.asProtocolObject())
-                        }
-                    }
-            )
-}
+)
 
 data class DestinationFile(
     override val stream: DestinationStream.Descriptor,
@@ -396,31 +409,7 @@ class DestinationMessageFactory(
                             )
                     )
                 } else {
-                    DestinationRecordAirbyteValue(
-                        stream = stream.descriptor,
-                        data =
-                            message.record.data?.let {
-                                JsonToAirbyteValue().convert(it, stream.schema)
-                            }
-                                ?: ObjectValue(linkedMapOf()),
-                        emittedAtMs = message.record.emittedAt,
-                        meta =
-                            Meta(
-                                changes =
-                                    message.record.meta
-                                        ?.changes
-                                        ?.map {
-                                            Meta.Change(
-                                                field = it.field,
-                                                change = it.change,
-                                                reason = it.reason,
-                                            )
-                                        }
-                                        ?.toMutableList()
-                                        ?: mutableListOf()
-                            ),
-                        serialized = serialized
-                    )
+                    DestinationRecord(stream.descriptor, message, serialized, stream.schema)
                 }
             }
             AirbyteMessage.Type.TRACE -> {

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/DestinationMessageDeserializer.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/DestinationMessageDeserializer.kt
@@ -14,7 +14,7 @@ import jakarta.inject.Singleton
  */
 @Singleton
 class ProtocolMessageDeserializer(
-    private val destinationMessageFactory: DestinationMessageFactory
+    private val destinationMessageFactory: DestinationMessageFactory,
 ) {
     fun deserialize(
         serialized: String,

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/DestinationMessageQueues.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/DestinationMessageQueues.kt
@@ -30,7 +30,7 @@ sealed class DestinationStreamEvent : Sized
 data class StreamRecordEvent(
     val index: Long,
     override val sizeBytes: Long,
-    val payload: DestinationRecordAirbyteValue
+    val payload: DestinationRecordSerialized
 ) : DestinationStreamEvent()
 
 /**

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/implementor/ProcessRecordsTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/implementor/ProcessRecordsTask.kt
@@ -9,6 +9,7 @@ import io.airbyte.cdk.load.command.DestinationConfiguration
 import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.message.Batch
 import io.airbyte.cdk.load.message.BatchEnvelope
+import io.airbyte.cdk.load.message.DestinationRecord
 import io.airbyte.cdk.load.message.DestinationRecordAirbyteValue
 import io.airbyte.cdk.load.message.DestinationRecordStreamComplete
 import io.airbyte.cdk.load.message.DestinationRecordStreamIncomplete
@@ -130,7 +131,7 @@ class DefaultProcessRecordsTask(
             .takeWhile {
                 it !is DestinationRecordStreamComplete && it !is DestinationRecordStreamIncomplete
             }
-            .map { it as DestinationRecordAirbyteValue }
+            .map { (it as DestinationRecord).asRecordMarshaledToAirbyteValue() }
             .iterator()
     }
 }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/InputConsumerTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/InputConsumerTask.kt
@@ -14,7 +14,7 @@ import io.airbyte.cdk.load.message.CheckpointMessageWrapped
 import io.airbyte.cdk.load.message.DestinationFile
 import io.airbyte.cdk.load.message.DestinationFileStreamComplete
 import io.airbyte.cdk.load.message.DestinationFileStreamIncomplete
-import io.airbyte.cdk.load.message.DestinationRecordAirbyteValue
+import io.airbyte.cdk.load.message.DestinationRecord
 import io.airbyte.cdk.load.message.DestinationRecordStreamComplete
 import io.airbyte.cdk.load.message.DestinationRecordStreamIncomplete
 import io.airbyte.cdk.load.message.DestinationStreamAffinedMessage
@@ -71,12 +71,12 @@ class DefaultInputConsumerTask(
         val manager = syncManager.getStreamManager(stream)
         val recordQueue = recordQueueSupplier.get(stream)
         when (val message = reserved.value) {
-            is DestinationRecordAirbyteValue -> {
+            is DestinationRecord -> {
                 val wrapped =
                     StreamRecordEvent(
                         index = manager.countRecordIn(),
                         sizeBytes = sizeBytes,
-                        payload = message
+                        payload = message.asRecordSerialized()
                     )
                 recordQueue.publish(reserved.replace(wrapped))
             }

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/data/DestinationRecordAirbyteValueToAirbyteValueWithMetaTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/data/DestinationRecordAirbyteValueToAirbyteValueWithMetaTest.kt
@@ -41,8 +41,7 @@ class DestinationRecordAirbyteValueToAirbyteValueWithMetaTest {
             )
         val expected = LinkedHashMap(expectedMeta)
         expected[Meta.COLUMN_NAME_DATA] = data
-        val mockRecord =
-            DestinationRecordAirbyteValue(stream.descriptor, data, emittedAtMs, Meta(), "test")
+        val mockRecord = DestinationRecordAirbyteValue(stream.descriptor, data, emittedAtMs, Meta())
         val withMeta = mockRecord.dataWithAirbyteMeta(stream, flatten = false)
         val uuid = withMeta.values.remove(Meta.COLUMN_NAME_AB_RAW_ID) as StringValue
         Assertions.assertTrue(
@@ -65,8 +64,7 @@ class DestinationRecordAirbyteValueToAirbyteValueWithMetaTest {
             )
         val expected = LinkedHashMap(expectedMeta)
         data.values.forEach { (name, value) -> expected[name] = value }
-        val mockRecord =
-            DestinationRecordAirbyteValue(stream.descriptor, data, emittedAtMs, Meta(), "test")
+        val mockRecord = DestinationRecordAirbyteValue(stream.descriptor, data, emittedAtMs, Meta())
         val withMeta = mockRecord.dataWithAirbyteMeta(stream, flatten = true)
         withMeta.values.remove(Meta.COLUMN_NAME_AB_RAW_ID)
         Assertions.assertEquals(expected, withMeta.values)

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/internal/SpillToDiskTaskTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/internal/SpillToDiskTaskTest.kt
@@ -8,10 +8,9 @@ import com.google.common.collect.Range
 import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.command.MockDestinationCatalogFactory
 import io.airbyte.cdk.load.command.MockDestinationConfiguration
-import io.airbyte.cdk.load.data.NullValue
 import io.airbyte.cdk.load.file.DefaultSpillFileProvider
 import io.airbyte.cdk.load.file.SpillFileProvider
-import io.airbyte.cdk.load.message.DestinationRecordAirbyteValue
+import io.airbyte.cdk.load.message.DestinationRecordSerialized
 import io.airbyte.cdk.load.message.DestinationStreamEvent
 import io.airbyte.cdk.load.message.DestinationStreamEventQueue
 import io.airbyte.cdk.load.message.DestinationStreamQueueSupplier
@@ -27,7 +26,6 @@ import io.airbyte.cdk.load.state.TimeWindowTrigger
 import io.airbyte.cdk.load.task.DestinationTaskLauncher
 import io.airbyte.cdk.load.task.MockTaskLauncher
 import io.airbyte.cdk.load.task.implementor.FileAggregateMessage
-import io.airbyte.cdk.load.test.util.StubDestinationMessageFactory
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -94,9 +92,10 @@ class SpillToDiskTaskTest {
                     StreamRecordEvent(
                         3L,
                         2L,
-                        StubDestinationMessageFactory.makeRecord(
-                            MockDestinationCatalogFactory.stream1,
-                        ),
+                        DestinationRecordSerialized(
+                            MockDestinationCatalogFactory.stream1.descriptor,
+                            ""
+                        )
                     )
                 // flush strategy returns true, so we flush
                 coEvery { flushStrategy.shouldFlush(any(), any(), any()) } returns true
@@ -133,9 +132,10 @@ class SpillToDiskTaskTest {
                     StreamRecordEvent(
                         3L,
                         2L,
-                        StubDestinationMessageFactory.makeRecord(
-                            MockDestinationCatalogFactory.stream1,
-                        ),
+                        DestinationRecordSerialized(
+                            MockDestinationCatalogFactory.stream1.descriptor,
+                            ""
+                        )
                     )
 
                 // must publish 1 record message so range isn't empty
@@ -253,12 +253,9 @@ class SpillToDiskTaskTest {
                             index = index,
                             sizeBytes = Fixtures.SERIALIZED_SIZE_BYTES,
                             payload =
-                                DestinationRecordAirbyteValue(
-                                    stream = MockDestinationCatalogFactory.stream1.descriptor,
-                                    data = NullValue,
-                                    emittedAtMs = 0,
-                                    meta = null,
-                                    serialized = "test"
+                                DestinationRecordSerialized(
+                                    MockDestinationCatalogFactory.stream1.descriptor,
+                                    "",
                                 ),
                         ),
                     ),

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/test/util/StubDestinationMessageFactory.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/test/util/StubDestinationMessageFactory.kt
@@ -6,29 +6,34 @@ package io.airbyte.cdk.load.test.util
 
 import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import io.airbyte.cdk.load.command.DestinationStream
-import io.airbyte.cdk.load.data.NullValue
+import io.airbyte.cdk.load.data.ObjectTypeWithoutSchema
 import io.airbyte.cdk.load.message.CheckpointMessage
 import io.airbyte.cdk.load.message.DestinationFile
 import io.airbyte.cdk.load.message.DestinationFileStreamComplete
 import io.airbyte.cdk.load.message.DestinationFileStreamIncomplete
-import io.airbyte.cdk.load.message.DestinationRecordAirbyteValue
+import io.airbyte.cdk.load.message.DestinationRecord
 import io.airbyte.cdk.load.message.DestinationRecordStreamComplete
 import io.airbyte.cdk.load.message.DestinationRecordStreamIncomplete
 import io.airbyte.cdk.load.message.GlobalCheckpoint
 import io.airbyte.cdk.load.message.StreamCheckpoint
+import io.airbyte.protocol.models.v0.AirbyteMessage
+import io.airbyte.protocol.models.v0.AirbyteRecordMessage
 import io.airbyte.protocol.models.v0.AirbyteStateMessage
 
 /*
  * Shared factory methods for making stub destination messages for testing.
  */
 object StubDestinationMessageFactory {
-    fun makeRecord(stream: DestinationStream): DestinationRecordAirbyteValue {
-        return DestinationRecordAirbyteValue(
+    fun makeRecord(stream: DestinationStream): DestinationRecord {
+        return DestinationRecord(
             stream = stream.descriptor,
-            data = NullValue,
-            emittedAtMs = 0,
-            meta = null,
-            serialized = "test"
+            message =
+                AirbyteMessage()
+                    .withRecord(
+                        AirbyteRecordMessage().withData(JsonNodeFactory.instance.nullNode())
+                    ),
+            serialized = "",
+            schema = ObjectTypeWithoutSchema
         )
     }
 

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/test/kotlin/io/airbyte/cdk/load/write/object_storage/RecordToPartAccumulatorTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/test/kotlin/io/airbyte/cdk/load/write/object_storage/RecordToPartAccumulatorTest.kt
@@ -46,7 +46,6 @@ class RecordToPartAccumulatorTest {
             ObjectValue(linkedMapOf()),
             0L,
             null,
-            ""
         )
 
     private fun makeRecords(n: Int): Iterator<DestinationRecordAirbyteValue> =

--- a/airbyte-integrations/connectors/destination-iceberg-v2/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-iceberg-v2/metadata.yaml
@@ -16,7 +16,7 @@ data:
             alias: airbyte-connector-testing-secret-store
   connectorType: destination
   definitionId: 37a928c1-2d5c-431a-a97d-ae236bd1ea0c
-  dockerImageTag: 0.2.2
+  dockerImageTag: 0.2.3
   dockerRepository: airbyte/destination-iceberg-v2
   documentationUrl: https://docs.airbyte.com/integrations/destinations/s3
   githubIssueLabel: destination-iceberg-v2

--- a/airbyte-integrations/connectors/destination-iceberg-v2/src/test/kotlin/io/airbyte/integrations/destination/iceberg/v2/io/IcebergUtilTest.kt
+++ b/airbyte-integrations/connectors/destination-iceberg-v2/src/test/kotlin/io/airbyte/integrations/destination/iceberg/v2/io/IcebergUtilTest.kt
@@ -205,7 +205,6 @@ internal class IcebergUtilTest {
                     ),
                 emittedAtMs = System.currentTimeMillis(),
                 meta = Meta(),
-                serialized = "{\"id\":42, \"name\":\"John Doe\"}"
             )
         val pipeline = ParquetMapperPipelineFactory().create(airbyteStream)
         val columns =
@@ -257,7 +256,6 @@ internal class IcebergUtilTest {
                     ),
                 emittedAtMs = System.currentTimeMillis(),
                 meta = Meta(),
-                serialized = "{\"id\":42, \"name\":\"John Doe\"}"
             )
         val pipeline = ParquetMapperPipelineFactory().create(airbyteStream)
         val columns =
@@ -305,7 +303,6 @@ internal class IcebergUtilTest {
                     ),
                 emittedAtMs = System.currentTimeMillis(),
                 meta = Meta(),
-                serialized = "{\"id\":42, \"name\":\"John Doe\"}"
             )
         val pipeline = ParquetMapperPipelineFactory().create(airbyteStream)
         val columns =


### PR DESCRIPTION
## What
Avoids unnecessary marshaling to airbyte type during the initial deserialization.
