### PR TITLE
Destination S3V2: Tolerate empty endpoint urls

### DIFF
--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/test/kotlin/io/airbyte/cdk/load/write/object_storage/RecordToPartAccumulatorTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/test/kotlin/io/airbyte/cdk/load/write/object_storage/RecordToPartAccumulatorTest.kt
@@ -137,7 +137,6 @@ class RecordToPartAccumulatorTest {
         // should be second part and final (and not empty)
         when (val batch = acc.processRecords(makeRecords(1), 0L, false) as ObjectStorageBatch) {
             is LoadablePart -> {
-                println(batch.part.bytes.contentToString())
                 assert(batch.part.bytes.contentEquals(makeBytes(1)))
                 assert(batch.part.partIndex == 2)
                 assert(batch.part.fileNumber == 111L)

--- a/airbyte-cdk/bulk/toolkits/load-s3/src/main/kotlin/io/airbyte/cdk/load/file/s3/S3Client.kt
+++ b/airbyte-cdk/bulk/toolkits/load-s3/src/main/kotlin/io/airbyte/cdk/load/file/s3/S3Client.kt
@@ -207,7 +207,6 @@ class S3ClientFactory(
     @Singleton
     @Secondary
     fun make(): S3Client {
-
         val credsProvider: CredentialsProvider =
             if (keyConfig.awsAccessKeyConfiguration.accessKeyId != null) {
                 StaticCredentialsProvider {
@@ -240,7 +239,12 @@ class S3ClientFactory(
             aws.sdk.kotlin.services.s3.S3Client {
                 region = bucketConfig.s3BucketConfiguration.s3BucketRegion.name
                 credentialsProvider = credsProvider
-                endpointUrl = bucketConfig.s3BucketConfiguration.s3Endpoint?.let { Url.parse(it) }
+                endpointUrl =
+                    bucketConfig.s3BucketConfiguration.s3Endpoint?.let {
+                        if (it.isNotBlank()) {
+                            Url.parse(it)
+                        } else null
+                    }
             }
 
         return S3Client(

--- a/airbyte-integrations/connectors/destination-s3-v2/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-s3-v2/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: file
   connectorType: destination
   definitionId: d6116991-e809-4c7c-ae09-c64712df5b66
-  dockerImageTag: 0.3.4
+  dockerImageTag: 0.3.5
   dockerRepository: airbyte/destination-s3-v2
   githubIssueLabel: destination-s3-v2
   icon: s3.svg
@@ -108,6 +108,11 @@ data:
             alias: airbyte-connector-testing-secret-store
         - name: SECRET_DESTINATION-S3-V2-ENDPOINT_URL
           fileName: s3_dest_v2_endpoint_url_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION-S3-V2-ENDPOINT_EMPTY_URL
+          fileName: s3_dest_v2_endpoint_empty_url_config.json
           secretStore:
             type: GSM
             alias: airbyte-connector-testing-secret-store

--- a/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2CheckTest.kt
+++ b/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2CheckTest.kt
@@ -37,6 +37,10 @@ class S3V2CheckTest :
                     Path.of(S3V2TestUtils.CSV_GZIP_CONFIG_PATH),
                     setOf(FeatureFlag.AIRBYTE_CLOUD_DEPLOYMENT),
                 ),
+                CheckTestConfig(
+                    Path.of(S3V2TestUtils.ENDPOINT_EMPTY_URL_CONFIG_PATH),
+                    setOf(FeatureFlag.AIRBYTE_CLOUD_DEPLOYMENT),
+                )
             ),
         failConfigFilenamesAndFailureReasons = emptyMap()
     ) {

--- a/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2TestUtils.kt
+++ b/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2TestUtils.kt
@@ -22,5 +22,6 @@ object S3V2TestUtils {
     const val PARQUET_UNCOMPRESSED_CONFIG_PATH = "secrets/s3_dest_v2_parquet_config.json"
     const val PARQUET_SNAPPY_CONFIG_PATH = "secrets/s3_dest_v2_parquet_snappy_config.json"
     const val ENDPOINT_URL_CONFIG_PATH = "secrets/s3_dest_v2_endpoint_url_config.json"
+    const val ENDPOINT_EMPTY_URL_CONFIG_PATH = "secrets/s3_dest_v2_endpoint_empty_url_config.json"
     fun getConfig(configPath: String): String = Files.readString(Path.of(configPath))
 }


### PR DESCRIPTION
## What
Another bug from the release: client had an empty string instead of null for `s3_endpoint`, which broke the url parser.
