### PR TITLE
pre-commit: require mvn in CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,7 +53,7 @@ repos:
 
       - id: spotless
         name: Format Java files with Spotless
-        entry: bash -c 'command -v mvn >/dev/null 2>&1 || { echo "Maven not installed, skipping spotless" >&2; exit 0; }; mvn -f spotless-maven-pom.xml spotless:apply'
+        entry: bash -c 'mvn -f spotless-maven-pom.xml spotless:apply; exit_code=$?; [ -z "$CI" ] && exit 0 || exit $exit_code'
         language: system
         files: \.(java|kt|gradle)$
         pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,7 +53,7 @@ repos:
 
       - id: spotless
         name: Format Java files with Spotless
-        entry: bash -c 'mvn -f spotless-maven-pom.xml spotless:apply; exit_code=$?; [ -z "$CI" ] && exit 0 || exit $exit_code'
+        entry: bash -c 'command -v mvn >/dev/null 2>&1 || { if [ -z "$CI" ]; then echo "Maven not installed, skipping spotless" >&2; exit 0; fi }; mvn -f spotless-maven-pom.xml spotless:apply'
         language: system
         files: \.(java|kt|gradle)$
         pass_filenames: false


### PR DESCRIPTION
## What
This PR makes `pre-commit` false positives less likely in CI.

## How
mvn is required in CI environments where `CI=true` which includes github workflows

## Review guide
n/a

## User Impact
None

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
