### PR TITLE
Destination S3V2: Fix: Avro names starting with numbers

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/Transformations.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/Transformations.kt
@@ -42,6 +42,13 @@ class Transformations {
                 .joinToString(separator = ".")
         }
 
-        fun toAvroSafeName(name: String) = toAlphanumericAndUnderscore(name)
+        fun toAvroSafeName(name: String): String {
+            val stripped = toAlphanumericAndUnderscore(name)
+            return if (stripped.substring(0, 1).matches("[A-Za-z_]".toRegex())) {
+                stripped
+            } else {
+                "_$stripped"
+            }
+        }
     }
 }

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/data/TransformationsTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/data/TransformationsTest.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.load.data
+
+import org.junit.jupiter.api.Test
+
+class TransformationsTest {
+    @Test
+    fun `test avro illegal start character`() {
+        val unsafeName = "1d_view"
+        assert(Transformations.toAvroSafeName(unsafeName) == "_1d_view")
+    }
+
+    @Test
+    fun `test avro special characters`() {
+        val unsafeName = "1d_view!@#$%^&*()"
+        assert(Transformations.toAvroSafeName(unsafeName) == "_1d_view__________")
+    }
+}


### PR DESCRIPTION
## What
Fix copy-pasted from the original code.

Not in the ideal place, but I think we need a discrete mapper / stage for stream/namespace mangling as part of our types roundup, so parking it here for now
