### PR TITLE
Destination S3V2: Guard against name conflicts

### DIFF
--- a/airbyte-cdk/bulk/toolkits/load-object-storage/build.gradle
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/build.gradle
@@ -16,3 +16,12 @@ dependencies {
     testFixturesImplementation testFixtures(project(":airbyte-cdk:bulk:toolkits:bulk-cdk-toolkit-load-csv"))
     testFixturesImplementation testFixtures(project(":airbyte-cdk:bulk:toolkits:bulk-cdk-toolkit-load-parquet"))
 }
+
+project.tasks.matching {
+    it.name == 'spotbugsIntegrationTestLegacy' ||
+            it.name == 'spotbugsIntegrationTest' ||
+            it.name == 'spotbugsTest' ||
+            it.name == 'spotbugsMain'
+}.configureEach {
+    enabled = false
+}

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/write/object_storage/ObjectStorageStreamLoaderFactory.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/write/object_storage/ObjectStorageStreamLoaderFactory.kt
@@ -94,7 +94,7 @@ class ObjectStorageStreamLoader<T : RemoteObject<*>, U : OutputStream>(
             fileSizeBytes = fileSizeBytes,
             stream,
             fileNumber
-        )
+        ) { name -> destinationStateManager.getState(stream).ensureUnique(name) }
     }
 
     override suspend fun processFile(file: DestinationFile): Batch {

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/write/object_storage/RecordToPartAccumulator.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/write/object_storage/RecordToPartAccumulator.kt
@@ -30,6 +30,7 @@ class RecordToPartAccumulator<U : OutputStream>(
     private val fileSizeBytes: Long,
     private val stream: DestinationStream,
     private val fileNumber: AtomicLong,
+    private val fileNameMapper: suspend (String) -> String
 ) : BatchAccumulator {
     private val log = KotlinLogging.logger {}
 
@@ -50,10 +51,12 @@ class RecordToPartAccumulator<U : OutputStream>(
                     partFactory =
                         PartFactory(
                             key =
-                                pathFactory.getPathToFile(
-                                    stream,
-                                    fileNo,
-                                    isStaging = pathFactory.supportsStaging
+                                fileNameMapper(
+                                    pathFactory.getPathToFile(
+                                        stream,
+                                        fileNo,
+                                        isStaging = pathFactory.supportsStaging
+                                    )
                                 ),
                             fileNumber = fileNo
                         ),

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/test/kotlin/io/airbyte/cdk/load/file/object_storage/ObjectStoragePathFactoryUTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/test/kotlin/io/airbyte/cdk/load/file/object_storage/ObjectStoragePathFactoryUTest.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.load.file.object_storage
+
+import io.airbyte.cdk.load.command.DestinationStream
+import io.airbyte.cdk.load.command.object_storage.ObjectStoragePathConfiguration
+import io.airbyte.cdk.load.command.object_storage.ObjectStoragePathConfigurationProvider
+import io.airbyte.cdk.load.file.TimeProvider
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class ObjectStoragePathFactoryUTest {
+    @MockK lateinit var stream: DestinationStream
+    @MockK lateinit var pathConfigProvider: ObjectStoragePathConfigurationProvider
+    @MockK lateinit var timeProvider: TimeProvider
+
+    @BeforeEach
+    fun setup() {
+        every { stream.descriptor } returns DestinationStream.Descriptor("test", "stream")
+        every { timeProvider.syncTimeMillis() } returns 0
+        every { timeProvider.currentTimeMillis() } returns 1
+    }
+
+    @Test
+    fun `test matcher with suffix`() {
+        every { pathConfigProvider.objectStoragePathConfiguration } returns
+            ObjectStoragePathConfiguration(
+                "prefix",
+                null,
+                "path/",
+                "ambiguous_filename",
+                false,
+            )
+        val factory = ObjectStoragePathFactory(pathConfigProvider, null, null, timeProvider)
+
+        val matcher = factory.getPathMatcher(stream, "(-\\d+)?")
+        val match1 = matcher.match("prefix/path/ambiguous_filename")
+        assertNotNull(match1)
+        assertNull(match1?.customSuffix)
+        val match2 = matcher.match("prefix/path/ambiguous_filename-1")
+        assertNotNull(match2)
+        assertEquals(match2?.customSuffix, "-1")
+    }
+}

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/test/kotlin/io/airbyte/cdk/load/state/object_storage/ObjectStorageDestinationStateTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/test/kotlin/io/airbyte/cdk/load/state/object_storage/ObjectStorageDestinationStateTest.kt
@@ -34,7 +34,7 @@ class ObjectStorageDestinationStateTest {
     companion object {
         val stream1 = MockDestinationCatalogFactory.stream1
         const val PERSISTED =
-            """{"generations_by_state":{"FINALIZED":{"0":{"key1":0,"key2":1},"1":{"key3":0,"key4":1}}}}"""
+            """{"generations_by_state":{"FINALIZED":{"0":{"key1":0,"key2":1},"1":{"key3":0,"key4":1}}},"count_by_key":{}}"""
     }
 
     @Singleton

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/test/kotlin/io/airbyte/cdk/load/state/object_storage/ObjectStorageDestinationStateUTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/test/kotlin/io/airbyte/cdk/load/state/object_storage/ObjectStorageDestinationStateUTest.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.load.state.object_storage
+
+import io.airbyte.cdk.load.command.DestinationStream
+import io.airbyte.cdk.load.file.object_storage.ObjectStorageClient
+import io.airbyte.cdk.load.file.object_storage.ObjectStoragePathFactory
+import io.airbyte.cdk.load.file.object_storage.PathMatcher
+import io.airbyte.cdk.load.file.object_storage.RemoteObject
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class ObjectStorageDestinationStateUTest {
+    data class MockObj(override val key: String, override val storageConfig: Unit = Unit) :
+        RemoteObject<Unit>
+
+    @MockK lateinit var stream: DestinationStream
+    @MockK lateinit var client: ObjectStorageClient<*>
+    @MockK lateinit var pathFactory: ObjectStoragePathFactory
+
+    @BeforeEach
+    fun setup() {
+        every { stream.descriptor } returns DestinationStream.Descriptor("test", "stream")
+        every { pathFactory.getPathMatcher(any(), any()) } answers
+            {
+                val suffix = secondArg<String>()
+                PathMatcher(Regex("([a-z]+)$suffix"), mapOf("suffix" to 2))
+            }
+        every { pathFactory.getLongestStreamConstantPrefix(any(), any()) } returns "prefix/"
+    }
+
+    @Test
+    fun `test that the fallback persister correctly infers the unique key to ordinal count`() =
+        runTest {
+            coEvery { client.list(any()) } returns
+                flowOf(
+                    MockObj("dog"),
+                    MockObj("dog-1"),
+                    MockObj("dog-3"),
+                    MockObj("cat"),
+                    MockObj("turtle-100")
+                )
+            coEvery { client.getMetadata(any()) } returns mapOf("ab-generation-id" to "1")
+
+            val persister = ObjectStorageFallbackPersister(client, pathFactory)
+            val state = persister.load(stream)
+            assertEquals(state.countByKey["dog"], 3L)
+            assertEquals(state.countByKey["cat"], 0L)
+            assertEquals(state.countByKey["turtle"], 100L)
+
+            assertEquals(state.ensureUnique("dog"), "dog-4")
+            assertEquals(state.ensureUnique("dog"), "dog-5")
+            assertEquals(state.ensureUnique("cat"), "cat-1")
+            assertEquals(state.ensureUnique("turtle"), "turtle-101")
+            assertEquals(state.ensureUnique("turtle"), "turtle-102")
+            assertEquals(state.ensureUnique("spider"), "spider")
+        }
+}

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/test/kotlin/io/airbyte/cdk/load/write/object_storage/RecordToPartAccumulatorTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/test/kotlin/io/airbyte/cdk/load/write/object_storage/RecordToPartAccumulatorTest.kt
@@ -66,7 +66,8 @@ class RecordToPartAccumulatorTest {
                 partSizeBytes = partSizeBytes,
                 fileSizeBytes = fileSizeBytes,
                 stream = stream,
-                fileNumber = fileNumber
+                fileNumber = fileNumber,
+                fileNameMapper = { "$it!" },
             )
 
         val bufferSize = AtomicLong(0L)
@@ -102,7 +103,7 @@ class RecordToPartAccumulatorTest {
                 assert(batch.part.fileNumber == 111L)
                 assert(!batch.isPersisted())
                 assert(!batch.part.isFinal)
-                assert(batch.part.key == "path.111")
+                assert(batch.part.key == "path.111!")
             }
             else -> assert(false)
         }
@@ -115,7 +116,7 @@ class RecordToPartAccumulatorTest {
                 assert(batch.part.fileNumber == 111L)
                 assert(!batch.isPersisted())
                 assert(!batch.part.isFinal)
-                assert(batch.part.key == "path.111")
+                assert(batch.part.key == "path.111!")
             }
             else -> assert(false)
         }
@@ -128,7 +129,7 @@ class RecordToPartAccumulatorTest {
                 assert(batch.part.fileNumber == 111L)
                 assert(!batch.isPersisted())
                 assert(!batch.part.isFinal)
-                assert(batch.part.key == "path.111")
+                assert(batch.part.key == "path.111!")
             }
             else -> assert(false)
         }
@@ -142,7 +143,7 @@ class RecordToPartAccumulatorTest {
                 assert(batch.part.fileNumber == 111L)
                 assert(!batch.isPersisted())
                 assert(batch.part.isFinal)
-                assert(batch.part.key == "path.111")
+                assert(batch.part.key == "path.111!")
             }
             else -> assert(false)
         }
@@ -157,7 +158,7 @@ class RecordToPartAccumulatorTest {
                 assert(batch.part.fileNumber == 112L)
                 assert(!batch.isPersisted())
                 assert(batch.part.isFinal)
-                assert(batch.part.key == "path.112")
+                assert(batch.part.key == "path.112!")
             }
             else -> assert(false)
         }
@@ -171,7 +172,7 @@ class RecordToPartAccumulatorTest {
                 assert(batch.part.fileNumber == 113L)
                 assert(!batch.isPersisted())
                 assert(batch.part.isFinal)
-                assert(batch.part.key == "path.113")
+                assert(batch.part.key == "path.113!")
             }
             else -> assert(false)
         }

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/testFixtures/kotlin/io/airbyte/cdk/load/MockPathFactory.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/testFixtures/kotlin/io/airbyte/cdk/load/MockPathFactory.kt
@@ -59,7 +59,10 @@ open class MockPathFactory : PathFactory {
         }
     }
 
-    override fun getPathMatcher(stream: DestinationStream): PathMatcher {
+    override fun getPathMatcher(
+        stream: DestinationStream,
+        suffixPattern: String? // ignored
+    ): PathMatcher {
         return PathMatcher(
             regex =
                 Regex(

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/testFixtures/kotlin/io/airbyte/cdk/load/ObjectStorageDataDumper.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/testFixtures/kotlin/io/airbyte/cdk/load/ObjectStorageDataDumper.kt
@@ -25,6 +25,7 @@ import io.airbyte.cdk.load.file.object_storage.ObjectStorageClient
 import io.airbyte.cdk.load.file.object_storage.ObjectStoragePathFactory
 import io.airbyte.cdk.load.file.object_storage.RemoteObject
 import io.airbyte.cdk.load.file.parquet.toParquetReader
+import io.airbyte.cdk.load.state.object_storage.ObjectStorageDestinationState.Companion.OPTIONAL_ORDINAL_SUFFIX_PATTERN
 import io.airbyte.cdk.load.test.util.OutputRecord
 import io.airbyte.cdk.load.test.util.maybeUnflatten
 import io.airbyte.cdk.load.test.util.toOutputRecord
@@ -53,7 +54,8 @@ class ObjectStorageDataDumper(
         // and the path matcher, so a failure here might imply a bug in the metadata-based
         // destination state loader, which lists by `prefix` and filters against the matcher.
         val prefix = pathFactory.getLongestStreamConstantPrefix(stream, isStaging = false)
-        val matcher = pathFactory.getPathMatcher(stream)
+        val matcher =
+            pathFactory.getPathMatcher(stream, suffixPattern = OPTIONAL_ORDINAL_SUFFIX_PATTERN)
         return runBlocking {
             withContext(Dispatchers.IO) {
                 client

--- a/airbyte-integrations/connectors/destination-s3-v2/gradle.properties
+++ b/airbyte-integrations/connectors/destination-s3-v2/gradle.properties
@@ -1,2 +1,2 @@
 testExecutionConcurrency=-1
-JunitMethodExecutionTimeout=25 m
+JunitMethodExecutionTimeout=30 m

--- a/airbyte-integrations/connectors/destination-s3-v2/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-s3-v2/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: file
   connectorType: destination
   definitionId: d6116991-e809-4c7c-ae09-c64712df5b66
-  dockerImageTag: 0.3.5
+  dockerImageTag: 0.3.6
   dockerRepository: airbyte/destination-s3-v2
   githubIssueLabel: destination-s3-v2
   icon: s3.svg
@@ -113,6 +113,11 @@ data:
             alias: airbyte-connector-testing-secret-store
         - name: SECRET_DESTINATION-S3-V2-ENDPOINT_EMPTY_URL
           fileName: s3_dest_v2_endpoint_empty_url_config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_DESTINATION-S3-V2_AMBIGUOUS_FILEPATH
+          fileName: s3_dest_v2_ambiguous_filepath_config.json
           secretStore:
             type: GSM
             alias: airbyte-connector-testing-secret-store

--- a/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2TestUtils.kt
+++ b/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2TestUtils.kt
@@ -23,5 +23,6 @@ object S3V2TestUtils {
     const val PARQUET_SNAPPY_CONFIG_PATH = "secrets/s3_dest_v2_parquet_snappy_config.json"
     const val ENDPOINT_URL_CONFIG_PATH = "secrets/s3_dest_v2_endpoint_url_config.json"
     const val ENDPOINT_EMPTY_URL_CONFIG_PATH = "secrets/s3_dest_v2_endpoint_empty_url_config.json"
+    const val AMBIGUOUS_FILEPATH_CONFIG_PATH = "secrets/s3_dest_v2_ambiguous_filepath_config.json"
     fun getConfig(configPath: String): String = Files.readString(Path.of(configPath))
 }

--- a/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2WriteTest.kt
+++ b/airbyte-integrations/connectors/destination-s3-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2WriteTest.kt
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout
 
-@Timeout(25, unit = TimeUnit.MINUTES)
+@Timeout(30, unit = TimeUnit.MINUTES)
 abstract class S3V2WriteTest(
     path: String,
     stringifySchemalessObjects: Boolean,
@@ -195,4 +195,13 @@ class S3V2WriteTestEndpointURL :
         preserveUndeclaredFields = false,
         allTypesBehavior = Untyped,
         nullEqualsUnset = true,
+    )
+
+class S3V2AmbiguousFilepath :
+    S3V2WriteTest(
+        S3V2TestUtils.AMBIGUOUS_FILEPATH_CONFIG_PATH,
+        stringifySchemalessObjects = false,
+        promoteUnionToObject = false,
+        preserveUndeclaredFields = true,
+        allTypesBehavior = Untyped,
     )


### PR DESCRIPTION
## What
Gets us to parity with the intended (but bugged) old cdk behavior.

If the client has an ambiguous file path, we append `-1`,  `-2` etc to each subsequent file.

DestinationState infers the set of unique keys at the beginning and uses them to generate the new ordinals.

If the path does not contain `STREAM_NAME` and `NAMESPACE`, this will still break.
