### PR TITLE
Destination S3V2: Avro name mangling fix (take two)

### DIFF
--- a/airbyte-cdk/bulk/toolkits/load-avro/src/main/kotlin/io/airbyte/cdk/load/data/avro/AirbyteTypeToAvroSchema.kt
+++ b/airbyte-cdk/bulk/toolkits/load-avro/src/main/kotlin/io/airbyte/cdk/load/data/avro/AirbyteTypeToAvroSchema.kt
@@ -42,7 +42,7 @@ class AirbyteTypeToAvroSchema {
                         .fold(builder) { acc, (name, field) ->
                             val converted = convert(field.type, path + name)
                             val propertySchema = maybeMakeNullable(field, converted)
-                            val nameMangled = Transformations.toAlphanumericAndUnderscore(name)
+                            val nameMangled = Transformations.toAvroSafeName(name)
                             acc.name(nameMangled).type(propertySchema).let {
                                 if (field.nullable) {
                                     it.withDefault(null)

--- a/airbyte-cdk/bulk/toolkits/load-avro/src/test/kotlin/AirbyteTypeToAvroSchemaTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-avro/src/test/kotlin/AirbyteTypeToAvroSchemaTest.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+import io.airbyte.cdk.load.command.DestinationStream
+import io.airbyte.cdk.load.data.FieldType
+import io.airbyte.cdk.load.data.ObjectType
+import io.airbyte.cdk.load.data.StringType
+import io.airbyte.cdk.load.data.avro.toAvroSchema
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+
+class AirbyteTypeToAvroSchemaTest {
+    @Test
+    fun `test name mangling`() {
+        val schema =
+            ObjectType(
+                properties =
+                    linkedMapOf(
+                        "1d_view" to FieldType(type = StringType, nullable = false),
+                    )
+            )
+        val descriptor = DestinationStream.Descriptor("test", "stream")
+        assertDoesNotThrow { schema.toAvroSchema(descriptor) }
+    }
+}


### PR DESCRIPTION
## What
I fixed the transformation but it wasn't being applied. This prevents the error I'm seeing in the release cohort.
