### PR TITLE
feat: add config update hook to cdk integration tests

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/spec/SpecTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/spec/SpecTest.kt
@@ -36,9 +36,9 @@ import org.junit.jupiter.api.assertAll
  */
 abstract class SpecTest :
     IntegrationTest(
-        FakeDataDumper,
-        NoopDestinationCleaner,
-        NoopExpectedRecordMapper,
+        dataDumper = FakeDataDumper,
+        destinationCleaner = NoopDestinationCleaner,
+        recordMangler = NoopExpectedRecordMapper,
     ) {
     private val testResourcesPath = Path.of("src/test-integration/resources")
 

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/ConfigurationUpdater.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/ConfigurationUpdater.kt
@@ -4,9 +4,7 @@
 
 package io.airbyte.cdk.load.test.util
 
-/**
- * Utility that may update/modify a connector configuration for test purposes.
- */
+/** Utility that may update/modify a connector configuration for test purposes. */
 interface ConfigurationUpdater {
 
     /**
@@ -18,8 +16,8 @@ interface ConfigurationUpdater {
 }
 
 /**
- * Basic implementation of the [ConfigurationUpdater] interface
- * that does not modify the configuration.
+ * Basic implementation of the [ConfigurationUpdater] interface that does not modify the
+ * configuration.
  */
 object FakeConfigurationUpdater : ConfigurationUpdater {
     override fun update(config: String): String = config

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/ConfigurationUpdater.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/ConfigurationUpdater.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.load.test.util
+
+/**
+ * Utility that may update/modify a connector configuration for test purposes.
+ */
+interface ConfigurationUpdater {
+
+    /**
+     * May modify one or more entry in the provided configuration.
+     * @param config The connector configuration.
+     * @return The potentially modified configuration.
+     */
+    fun update(config: String): String
+}
+
+/**
+ * Basic implementation of the [ConfigurationUpdater] interface
+ * that does not modify the configuration.
+ */
+object FakeConfigurationUpdater : ConfigurationUpdater {
+    override fun update(config: String): String = config
+}

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/IntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/IntegrationTest.kt
@@ -55,6 +55,7 @@ abstract class IntegrationTest(
     val nameMapper: NameMapper = NoopNameMapper,
     /** See [RecordDiffer.nullEqualsUnset]. */
     val nullEqualsUnset: Boolean = false,
+    val configUpdater: ConfigurationUpdater = FakeConfigurationUpdater,
 ) {
     // Intentionally don't inject the actual destination process - we need a full factory
     // because some tests want to run multiple syncs, so we need to run the destination
@@ -267,6 +268,8 @@ abstract class IntegrationTest(
             outputStateMessage
         }
     }
+
+    fun updateConfig(config: String): String = configUpdater.update(config)
 
     companion object {
         val randomizedNamespaceRegex = Regex("test(\\d{8})[A-Za-z]{4}")

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/write/BasicFunctionalityIntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/write/BasicFunctionalityIntegrationTest.kt
@@ -140,7 +140,8 @@ abstract class BasicFunctionalityIntegrationTest(
     nameMapper=nameMapper,
     nullEqualsUnset=nullEqualsUnset,
     configUpdater=configUpdater) {
-    val parsedConfig = ValidatedJsonUtils.parseOne(configSpecClass, configUpdater.update(configContents))
+    val parsedConfig =
+        ValidatedJsonUtils.parseOne(configSpecClass, configUpdater.update(configContents))
 
     @Test
     open fun testBasicWrite() {

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/write/BasicFunctionalityIntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/write/BasicFunctionalityIntegrationTest.kt
@@ -133,13 +133,15 @@ abstract class BasicFunctionalityIntegrationTest(
     val failOnUnknownTypes: Boolean = false,
     nullEqualsUnset: Boolean = false,
     configUpdater: ConfigurationUpdater = FakeConfigurationUpdater,
-) : IntegrationTest(
-    dataDumper=dataDumper,
-    destinationCleaner=destinationCleaner,
-    recordMangler=recordMangler,
-    nameMapper=nameMapper,
-    nullEqualsUnset=nullEqualsUnset,
-    configUpdater=configUpdater) {
+) :
+    IntegrationTest(
+        dataDumper = dataDumper,
+        destinationCleaner = destinationCleaner,
+        recordMangler = recordMangler,
+        nameMapper = nameMapper,
+        nullEqualsUnset = nullEqualsUnset,
+        configUpdater = configUpdater
+    ) {
     val parsedConfig =
         ValidatedJsonUtils.parseOne(configSpecClass, configUpdater.update(configContents))
 

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/write/BasicFunctionalityIntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/write/BasicFunctionalityIntegrationTest.kt
@@ -41,9 +41,11 @@ import io.airbyte.cdk.load.message.InputRecord
 import io.airbyte.cdk.load.message.InputStreamCheckpoint
 import io.airbyte.cdk.load.message.Meta.Change
 import io.airbyte.cdk.load.message.StreamCheckpoint
+import io.airbyte.cdk.load.test.util.ConfigurationUpdater
 import io.airbyte.cdk.load.test.util.DestinationCleaner
 import io.airbyte.cdk.load.test.util.DestinationDataDumper
 import io.airbyte.cdk.load.test.util.ExpectedRecordMapper
+import io.airbyte.cdk.load.test.util.FakeConfigurationUpdater
 import io.airbyte.cdk.load.test.util.IntegrationTest
 import io.airbyte.cdk.load.test.util.NameMapper
 import io.airbyte.cdk.load.test.util.NoopExpectedRecordMapper
@@ -130,8 +132,15 @@ abstract class BasicFunctionalityIntegrationTest(
     val allTypesBehavior: AllTypesBehavior,
     val failOnUnknownTypes: Boolean = false,
     nullEqualsUnset: Boolean = false,
-) : IntegrationTest(dataDumper, destinationCleaner, recordMangler, nameMapper, nullEqualsUnset) {
-    val parsedConfig = ValidatedJsonUtils.parseOne(configSpecClass, configContents)
+    configUpdater: ConfigurationUpdater = FakeConfigurationUpdater,
+) : IntegrationTest(
+    dataDumper=dataDumper,
+    destinationCleaner=destinationCleaner,
+    recordMangler=recordMangler,
+    nameMapper=nameMapper,
+    nullEqualsUnset=nullEqualsUnset,
+    configUpdater=configUpdater) {
+    val parsedConfig = ValidatedJsonUtils.parseOne(configSpecClass, configUpdater.update(configContents))
 
     @Test
     open fun testBasicWrite() {


### PR DESCRIPTION
## What
* Add hook to CDK integration tests to allow for config modification to support use of test containers

## How
* Add update hook to `IntegrationTest`

## Review guide
1. `ConfigurationUpdater.kt`
2. `IntegrationTest.kt`

## Can this PR be safely reverted and rolled back?
- [X] YES 💚
- [ ] NO ❌
