### PR TITLE
Various documentation corrections

### DIFF
--- a/docs/integrations/enterprise-connectors/source-oracle.md
+++ b/docs/integrations/enterprise-connectors/source-oracle.md
@@ -5,7 +5,7 @@ Airbyte Enterprise Connectors are a selection of premium connectors available ex
 :::
 
 
-Airbyte's incubating Oracle enterprise source connector offers the following features:
+Airbyte's Oracle enterprise source connector offers the following features:
 
 - Incremental as well as Full Refresh
   [sync modes](https://docs.airbyte.com/cloud/core-concepts#connection-sync-modes), providing

--- a/docs/integrations/sources/mssql.md
+++ b/docs/integrations/sources/mssql.md
@@ -35,7 +35,7 @@ for more details.
 #### Requirements
 
 1. MSSQL Server `Azure SQL Database`, `Azure Synapse Analytics`, `Azure SQL Managed Instance`,
-   `SQL Server 2019`, `SQL Server 2017`, `SQL Server 2016`, `SQL Server 2014`, `SQL Server 2012`,
+   `SQL Server 2022`, `SQL Server 2019`, `SQL Server 2017`, `SQL Server 2016`, `SQL Server 2014`, `SQL Server 2012`,
    `PDW 2008R2 AU34`.
 2. Create a dedicated read-only Airbyte user with access to all tables needed for replication
 3. If you want to use CDC, please see [the relevant section below](mssql.md#change-data-capture-cdc)

--- a/docs/integrations/sources/postgres/postgres-troubleshooting.md
+++ b/docs/integrations/sources/postgres/postgres-troubleshooting.md
@@ -7,7 +7,6 @@ import TabItem from '@theme/TabItem';
 
 ### General Limitations
 
-- The Postgres source connector currently does not handle schemas larger than 4MB.
 - The Postgres source connector does not alter the schema present in your database. Depending on the destination connected to this source, however, the schema may be altered. See the destination's documentation for more details.
 - The following two schema evolution actions are currently supported:
   - Adding/removing tables without resetting the entire connection at the destination


### PR DESCRIPTION
## What
Update docs to:
- Include reference to support for MS SQL 2022
- Remove limitation that no longer exists from Postgres troubleshooting
- Remove reference to Oracle Enterprise Connector being "incubating"

## How
Minor tweaks on each reference documentation page

## Review guide
1. `enterprise-connectors/source-oracle.md`
2. `mssql.md`
3. `postgres/postgres-troubleshooting.md`

## User Impact
More correct and helpful documentation

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌
