### PR TITLE
bulk-cdk: fix ConnectorUncleanExitException message

### DIFF
--- a/airbyte-cdk/bulk/core/base/src/main/kotlin/io/airbyte/cdk/ConnectorUncleanExitException.kt
+++ b/airbyte-cdk/bulk/core/base/src/main/kotlin/io/airbyte/cdk/ConnectorUncleanExitException.kt
@@ -6,4 +6,4 @@ package io.airbyte.cdk
 
 /** This is used only in tests. */
 class ConnectorUncleanExitException(val exitCode: Int) :
-    Exception("Destination process exited uncleanly: $exitCode")
+    Exception("Connector process exited uncleanly: $exitCode")

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/destination_process/DestinationUncleanExitException.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/destination_process/DestinationUncleanExitException.kt
@@ -19,7 +19,7 @@ class DestinationUncleanExitException(
 ) :
     Exception(
         """
-        Destination process exited uncleanly: $exitCode
+        Connector process exited uncleanly: $exitCode
         Trace messages:
         """.trimIndent()
         // explicit concat because otherwise trimIndent behaves badly


### PR DESCRIPTION
## What
The message talks about destinations but this exception can be thrown by sources just the same. This PR fixes this

## How
s/Destination/Connector

## Review guide
n/a

## User Impact
None whatsoever, test-only change

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
