### PR TITLE
source-mysql: fix indentation level for rules defs

### DIFF
--- a/airbyte-integrations/connectors/source-mysql/build.gradle
+++ b/airbyte-integrations/connectors/source-mysql/build.gradle
@@ -9,7 +9,7 @@ application {
 airbyteBulkConnector {
     core = 'extract'
     toolkits = ['extract-jdbc', 'extract-cdc']
-    cdk = '0.234'
+    cdk = '0.249'
 }
 
 dependencies {

--- a/airbyte-integrations/connectors/source-mysql/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mysql/metadata.yaml
@@ -9,7 +9,7 @@ data:
   connectorSubtype: database
   connectorType: source
   definitionId: 435bb9a5-7887-4809-aa58-28c27df0d7ad
-  dockerImageTag: 3.10.0-rc.4
+  dockerImageTag: 3.10.0-rc.5
   dockerRepository: airbyte/source-mysql
   documentationUrl: https://docs.airbyte.com/integrations/sources/mysql
   githubIssueLabel: source-mysql

--- a/airbyte-integrations/connectors/source-mysql/src/main/resources/application.yml
+++ b/airbyte-integrations/connectors/source-mysql/src/main/resources/application.yml
@@ -20,104 +20,104 @@ airbyte:
           - >-
             SELECT 1 FROM dual WHERE 1 = 0;
 
-  exception-classifiers:
-    regex:
-      # The following rules are for the RegexExceptionClassifier [0] which are applied
-      # sequentially on a Throwable's message [1] and its nested messages by cause [2].
-      #
-      # This classifier's rules are applied ahead of the JdbcExceptionClassifier's further down.
-      #
-      # [0] https://github.com/airbytehq/airbyte/blob/master/airbyte-cdk/bulk/core/base/src/main/kotlin/io/airbyte/cdk/output/ExceptionClassifier.kt
-      # [1] https://docs.oracle.com/javase/8/docs/api/java/lang/Throwable.html#getMessage--
-      # [2] https://docs.oracle.com/javase/8/docs/api/java/lang/Throwable.html#getCause--
+    exception-classifiers:
+      regex:
+        # The following rules are for the RegexExceptionClassifier [0] which are applied
+        # sequentially on a Throwable's message [1] and its nested messages by cause [2].
+        #
+        # This classifier's rules are applied ahead of the JdbcExceptionClassifier's further down.
+        #
+        # [0] https://github.com/airbytehq/airbyte/blob/master/airbyte-cdk/bulk/core/base/src/main/kotlin/io/airbyte/cdk/output/ExceptionClassifier.kt
+        # [1] https://docs.oracle.com/javase/8/docs/api/java/lang/Throwable.html#getMessage--
+        # [2] https://docs.oracle.com/javase/8/docs/api/java/lang/Throwable.html#getCause--
 
-      rules:
-        ## REGEX RULE TEMPLATE:
-        # pattern: Required; regex pattern, c.f. https://www.freeformatter.com/java-regex-tester.html.
-        #          Note that regex patterns are not case-sensitive and are multiline.
-        # input-example: Required, string matching regex pattern.
-        # error: Required, one of (transient|config|system).
-        # group: Optional, string prefixing user-facing error message.
-        # output: Optional, user-facing error message; when not set, the exception message is used instead.
-        # reference-links: Optional, list of URLs appended to user-facing message after a newline.
+        rules:
+          ## REGEX RULE TEMPLATE:
+          # pattern: Required; regex pattern, c.f. https://www.freeformatter.com/java-regex-tester.html.
+          #          Note that regex patterns are not case-sensitive and are multiline.
+          # input-example: Required, string matching regex pattern.
+          # error: Required, one of (transient|config|system).
+          # group: Optional, string prefixing user-facing error message.
+          # output: Optional, user-facing error message; when not set, the exception message is used instead.
+          # reference-links: Optional, list of URLs appended to user-facing message after a newline.
 
-        - pattern: (?i).*can not read response from server\. expected to read ([1-9]\d*) bytes.*
-          input-example: >-
-            java.io.EOFException: Can not read response from server. 
-            Expected to read 10 bytes, read 5 bytes before connection was unexpectedly lost.
-          error: transient
-          group: MySQL EOF Exception
-          output: Can not read data from MySQL server, will retry.
-          reference-links: -https://docs.oracle.com/javase/8/docs/api/index.html?java/io/EOFException.html
+          - pattern: (?i).*can not read response from server\. expected to read ([1-9]\d*) bytes.*
+            input-example: >-
+              java.io.EOFException: Can not read response from server. 
+              Expected to read 10 bytes, read 5 bytes before connection was unexpectedly lost.
+            error: transient
+            group: MySQL EOF Exception
+            output: Can not read data from MySQL server, will retry.
+            reference-links: -https://docs.oracle.com/javase/8/docs/api/index.html?java/io/EOFException.html
 
-        - pattern: (?i).*connection is not available, request timed out after.*
-          input-example: >-
-            java.sql.SQLTransientConnectionException: HikariPool-x - 
-            Connection is not available, request timed out after 10 ms
-          error: transient
-          group: MySQL Hikari Connection Error
-          output: Database read failed due to connection timeout, will retry.
-          reference-links: -https://docs.oracle.com/javase/9/docs/api/java/sql/SQLTransientConnectionException.html
+          - pattern: (?i).*connection is not available, request timed out after.*
+            input-example: >-
+              java.sql.SQLTransientConnectionException: HikariPool-x - 
+              Connection is not available, request timed out after 10 ms
+            error: transient
+            group: MySQL Hikari Connection Error
+            output: Database read failed due to connection timeout, will retry.
+            reference-links: -https://docs.oracle.com/javase/9/docs/api/java/sql/SQLTransientConnectionException.html
 
-        - pattern: (?i).*is unrecognized or represents more than one time zone.*
-          input-example: >-
-            java.sql.SQLException: The server time zone value 'PDT' is unrecognized or represents more than one time zone. 
-            You must configure either the server or JDBC driver (via the serverTimezone configuration property) to use a more specifc time zone value 
-            if you want to utilize time zone support.
-          error: config
-          group: MySQL Timezone Error
-          output: >-
-            Please configure your database with the correct timezone found in the detailed error message. 
-            Please refer to the following documentation: https://dev.mysql.com/doc/refman/8.4/en/time-zone-support.html
-          reference-links: -https://docs.oracle.com/javase/8/docs/api/index.html?java/io/SQLException.html
+          - pattern: (?i).*is unrecognized or represents more than one time zone.*
+            input-example: >-
+              java.sql.SQLException: The server time zone value 'PDT' is unrecognized or represents more than one time zone. 
+              You must configure either the server or JDBC driver (via the serverTimezone configuration property) to use a more specifc time zone value 
+              if you want to utilize time zone support.
+            error: config
+            group: MySQL Timezone Error
+            output: >-
+              Please configure your database with the correct timezone found in the detailed error message. 
+              Please refer to the following documentation: https://dev.mysql.com/doc/refman/8.4/en/time-zone-support.html
+            reference-links: -https://docs.oracle.com/javase/8/docs/api/index.html?java/io/SQLException.html
 
-        - pattern: (?i).*exception occurred in the change event produce.*
-          input-example: >-
-            java.lang.RuntimeException: org.apache.kafka.connect.errors.ConnectException: 
-            An exception occurred in the change event producer. This connector will be stopped.
-          error: config
-          group: MySQL Schema Change Error
-          output: >-
-            Your connection could not be completed because changes were detected on an unknown table (see detailed error for the table name),
-            please refresh your schema or reset the connection.
-          reference-links: -https://kafka.apache.org/11/javadoc/org/apache/kafka/connect/errors/ConnectException.html
+          - pattern: (?i).*exception occurred in the change event produce.*
+            input-example: >-
+              java.lang.RuntimeException: org.apache.kafka.connect.errors.ConnectException: 
+              An exception occurred in the change event producer. This connector will be stopped.
+            error: config
+            group: MySQL Schema Change Error
+            output: >-
+              Your connection could not be completed because changes were detected on an unknown table (see detailed error for the table name),
+              please refresh your schema or reset the connection.
+            reference-links: -https://kafka.apache.org/11/javadoc/org/apache/kafka/connect/errors/ConnectException.html
 
-        - pattern: |
-            (?i).*vttablet: rpc error: code = Unavailable desc = error reading from server: EOF.*
-          input-example: >-
-            java.lang.RuntimeException: java.lang.RuntimeException: java.sql.SQLException: target: ai-solutions.-.primary: 
-            vttablet: rpc error: code = Unavailable desc = error reading from server: EOF
-          error: transient
-          group: MySQL Vitess Connection Error
-          output: Database read failed due to connection timeout, will retry.
-          reference-links: -https://docs.oracle.com/javase/8/docs/api/index.html?java/sql/SQLException.html
+          - pattern: |
+              (?i).*vttablet: rpc error: code = Unavailable desc = error reading from server: EOF.*
+            input-example: >-
+              java.lang.RuntimeException: java.lang.RuntimeException: java.sql.SQLException: target: ai-solutions.-.primary: 
+              vttablet: rpc error: code = Unavailable desc = error reading from server: EOF
+            error: transient
+            group: MySQL Vitess Connection Error
+            output: Database read failed due to connection timeout, will retry.
+            reference-links: -https://docs.oracle.com/javase/8/docs/api/index.html?java/sql/SQLException.html
 
-    jdbc:
-      # The following rules are for the JdbcExceptionClassifier [0] which are applied on a
-      # MySQL's error code [1]. The vendor error code is printed in the exception
-      # message, and is not to be confused with the SQLState [2] which is also in the message.
-      #
-      # [0] https://github.com/airbytehq/airbyte/blob/master/airbyte-cdk/bulk/toolkits/extract-jdbc/src/main/kotlin/io/airbyte/cdk/output/JdbcExceptionClassifier.kt
-      # [1] https://dev.mysql.com/doc/mysql-errors/5.7/en/server-error-reference.html
-      # [2] https://en.wikipedia.org/wiki/SQLSTATE
-      #
-      rules:
-        ## JDBC RULE TEMPLATE
-        # code: Required, MySQL vendor error code.
-        # error: Required, one of (transient|config|system).
-        # output: Optional, user-facing error message; the exception message is used instead when this is not defined.
-        # reference-links: Optional, list of URLs appended to user-facing message after newline.
+      jdbc:
+        # The following rules are for the JdbcExceptionClassifier [0] which are applied on a
+        # MySQL's error code [1]. The vendor error code is printed in the exception
+        # message, and is not to be confused with the SQLState [2] which is also in the message.
+        #
+        # [0] https://github.com/airbytehq/airbyte/blob/master/airbyte-cdk/bulk/toolkits/extract-jdbc/src/main/kotlin/io/airbyte/cdk/output/JdbcExceptionClassifier.kt
+        # [1] https://dev.mysql.com/doc/mysql-errors/5.7/en/server-error-reference.html
+        # [2] https://en.wikipedia.org/wiki/SQLSTATE
+        #
+        rules:
+          ## JDBC RULE TEMPLATE
+          # code: Required, MySQL vendor error code.
+          # error: Required, one of (transient|config|system).
+          # output: Optional, user-facing error message; the exception message is used instead when this is not defined.
+          # reference-links: Optional, list of URLs appended to user-facing message after newline.
 
-        - code: 1054
-          error: config
-          output: >-
-            A required column for the MySQL source connector is missing in the database. 
-            Please review your SQL statement to ensure it referencing existing columns.
-          group: MySQL Syntax Exception
-          reference-links: https://dev.mysql.com/doc/mysql-errors/9.1/en/server-error-reference.html#error_er_bad_field_error
+          - code: 1054
+            error: config
+            output: >-
+              A required column for the MySQL source connector is missing in the database. 
+              Please review your SQL statement to ensure it referencing existing columns.
+            group: MySQL Syntax Exception
+            reference-links: https://dev.mysql.com/doc/mysql-errors/9.1/en/server-error-reference.html#error_er_bad_field_error
 
-        - code: 3024
-          error: transient
-          output: The query took too long to return results, the database read was aborted. Will retry.
-          group: MySQL Limit Reached
-          reference-links: https://dev.mysql.com/doc/mysql-errors/5.7/en/server-error-reference.html#error_er_query_timeout
+          - code: 3024
+            error: transient
+            output: The query took too long to return results, the database read was aborted. Will retry.
+            group: MySQL Limit Reached
+            reference-links: https://dev.mysql.com/doc/mysql-errors/5.7/en/server-error-reference.html#error_er_query_timeout

--- a/docs/integrations/sources/mysql.md
+++ b/docs/integrations/sources/mysql.md
@@ -226,6 +226,7 @@ Any database or table encoding combination of charset and collation is supported
 
 | Version     | Date       | Pull Request                                               | Subject                                                                                                                                         |
 |:------------|:-----------|:-----------------------------------------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------|
+| 3.10.0-rc.5 | 2025-01-03 | [50868](https://github.com/airbytehq/airbyte/pull/50868)   | Fix exception handling rules declaration.                                                                                                       |
 | 3.10.0-rc.4 | 2024-12-23 | [48587](https://github.com/airbytehq/airbyte/pull/48587)   | Fix minor state counting mechanism.                                                                                                                    |
 | 3.10.0-rc.3 | 2024-12-20 | [49918](https://github.com/airbytehq/airbyte/pull/49918)   | Fix minor datatype handling and conversion bugs, maintain big number precision.                                                                 |
 | 3.10.0-rc.2 | 2024-12-20 | [49950](https://github.com/airbytehq/airbyte/pull/49950)   | Remove unused configuration field, streamline SSL certificate key store logic.                                                                  |


### PR DESCRIPTION
## What
The exception classification rules for source-mysql were not being applied because they were declared at the wrong indentation level. This PR fixes this and also uses the latest CDK for good measure. 

## How
n/a

## Review guide
n/a

## User Impact
Exceptions will get handled properly now.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
