### PR TITLE
airbyte-ci: speed up get_connector_modified_files

### DIFF
--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -854,6 +854,7 @@ airbyte-ci connectors --language=low-code migrate-to-manifest-only
 
 | Version | PR                                                         | Description                                                                                                                  |
 |---------|------------------------------------------------------------| ---------------------------------------------------------------------------------------------------------------------------- |
+| 4.48.2  | [#50871](https://github.com/airbytehq/airbyte/pull/50871)  | Speed up connector modification detection.                                                                                   |
 | 4.48.1  | [#50410](https://github.com/airbytehq/airbyte/pull/50410)  | Java connector build: give ownership of built artifacts to the current image user.                                                                                          |
 | 4.48.0  | [#49960](https://github.com/airbytehq/airbyte/pull/49960)  | Deprecate airbyte-ci format command                                                                                          |
 | 4.47.0  | [#49832](https://github.com/airbytehq/airbyte/pull/49462)  | Build java connectors from the base image declared in `metadata.yaml`.                                                       |

--- a/airbyte-ci/connectors/pipelines/pipelines/helpers/connectors/modifed.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/helpers/connectors/modifed.py
@@ -21,9 +21,7 @@ def get_connector_modified_files(connector: Connector, all_modified_files: Set[P
     return frozenset(connector_modified_files)
 
 
-def _is_connector_modified_directly(
-    connector: Connector, modified_files: Set[Union[str, Path]]
-) -> bool:
+def _is_connector_modified_directly(connector: Connector, modified_files: Set[Union[str, Path]]) -> bool:
     """Test if the connector is being impacted by file changes in the connector itself."""
     result = False
     for file_path in modified_files:
@@ -37,9 +35,7 @@ def _is_connector_modified_directly(
     return result
 
 
-def _is_connector_modified_indirectly(
-    connector: Connector, modified_files: Set[Union[str, Path]]
-) -> bool:
+def _is_connector_modified_indirectly(connector: Connector, modified_files: Set[Union[str, Path]]) -> bool:
     """Test if the connector is being impacted by file changes in the connector's dependencies."""
     connector_dependencies = connector.get_local_dependency_paths()
     result = False

--- a/airbyte-ci/connectors/pipelines/pipelines/helpers/connectors/modifed.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/helpers/connectors/modifed.py
@@ -23,22 +23,20 @@ def get_connector_modified_files(connector: Connector, all_modified_files: Set[P
 
 def _is_connector_modified_directly(connector: Connector, modified_files: Set[Union[str, Path]]) -> bool:
     """Test if the connector is being impacted by file changes in the connector itself."""
-    result = False
     for file_path in modified_files:
         if _is_ignored_file(file_path):
             continue
 
         if Path(file_path).is_relative_to(Path(connector.code_directory)) or file_path == connector.documentation_file_path:
             main_logger.info(f"Adding connector '{connector}' due to connector file modification: {file_path}.")
-            result = True
+            return True
 
-    return result
+    return False
 
 
 def _is_connector_modified_indirectly(connector: Connector, modified_files: Set[Union[str, Path]]) -> bool:
     """Test if the connector is being impacted by file changes in the connector's dependencies."""
     connector_dependencies = connector.get_local_dependency_paths()
-    result = False
 
     for file_path in modified_files:
         if _is_ignored_file(file_path):
@@ -47,11 +45,9 @@ def _is_connector_modified_indirectly(connector: Connector, modified_files: Set[
         for connector_dependency in connector_dependencies:
             if Path(file_path).is_relative_to(Path(connector_dependency)):
                 main_logger.info(f"Adding connector '{connector}' due to dependency modification: '{file_path}'.")
-                result = True
-                # Exit inner loop to avoid spamming the logs with redundant messages.
-                break
+                return True
 
-    return result
+    return False
 
 
 def _is_ignored_file(file_path: Union[str, Path]) -> bool:

--- a/airbyte-ci/connectors/pipelines/pipelines/helpers/connectors/modifed.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/helpers/connectors/modifed.py
@@ -21,7 +21,7 @@ def get_connector_modified_files(connector: Connector, all_modified_files: Set[P
     return frozenset(connector_modified_files)
 
 
-def _is_connector_modified_directly(connector: Connector, modified_files: Set[Union[str, Path]]) -> bool:
+def _is_connector_modified_directly(connector: Connector, modified_files: Set[Path]) -> bool:
     """Test if the connector is being impacted by file changes in the connector itself."""
     for file_path in modified_files:
         if _is_ignored_file(file_path):
@@ -34,7 +34,7 @@ def _is_connector_modified_directly(connector: Connector, modified_files: Set[Un
     return False
 
 
-def _is_connector_modified_indirectly(connector: Connector, modified_files: Set[Union[str, Path]]) -> bool:
+def _is_connector_modified_indirectly(connector: Connector, modified_files: Set[Path]) -> bool:
     """Test if the connector is being impacted by file changes in the connector's dependencies."""
     connector_dependencies = connector.get_local_dependency_paths()
 

--- a/airbyte-ci/connectors/pipelines/pipelines/helpers/connectors/modifed.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/helpers/connectors/modifed.py
@@ -21,24 +21,41 @@ def get_connector_modified_files(connector: Connector, all_modified_files: Set[P
     return frozenset(connector_modified_files)
 
 
-def _find_modified_connectors(
-    file_path: Union[str, Path], active_connectors: Set[Connector], dependency_scanning: bool = True
-) -> Set[Connector]:
-    """Find all connectors impacted by the file change."""
-    modified_connectors = set()
+def _is_connector_modified_directly(
+    connector: Connector, modified_files: Set[Union[str, Path]]
+) -> bool:
+    """Test if the connector is being impacted by file changes in the connector itself."""
+    result = False
+    for file_path in modified_files:
+        if _is_ignored_file(file_path):
+            continue
 
-    for connector in active_connectors:
         if Path(file_path).is_relative_to(Path(connector.code_directory)) or file_path == connector.documentation_file_path:
             main_logger.info(f"Adding connector '{connector}' due to connector file modification: {file_path}.")
-            modified_connectors.add(connector)
+            result = True
 
-        if dependency_scanning:
-            for connector_dependency in connector.get_local_dependency_paths():
-                if Path(file_path).is_relative_to(Path(connector_dependency)):
-                    # Add the connector to the modified connectors
-                    modified_connectors.add(connector)
-                    main_logger.info(f"Adding connector '{connector}' due to dependency modification: '{file_path}'.")
-    return modified_connectors
+    return result
+
+
+def _is_connector_modified_indirectly(
+    connector: Connector, modified_files: Set[Union[str, Path]]
+) -> bool:
+    """Test if the connector is being impacted by file changes in the connector's dependencies."""
+    connector_dependencies = connector.get_local_dependency_paths()
+    result = False
+
+    for file_path in modified_files:
+        if _is_ignored_file(file_path):
+            continue
+
+        for connector_dependency in connector_dependencies:
+            if Path(file_path).is_relative_to(Path(connector_dependency)):
+                main_logger.info(f"Adding connector '{connector}' due to dependency modification: '{file_path}'.")
+                result = True
+                # Exit inner loop to avoid spamming the logs with redundant messages.
+                break
+
+    return result
 
 
 def _is_ignored_file(file_path: Union[str, Path]) -> bool:
@@ -54,15 +71,20 @@ def get_modified_connectors(modified_files: Set[Path], all_connectors: Set[Conne
     Or to tests all jdbc connectors when a change is made to source-jdbc or base-java.
     We'll consider extending the dependency resolution to Python connectors once we confirm that it's needed and feasible in term of scale.
     """
-    # Ignore files with certain extensions
     modified_connectors = set()
     active_connectors = {conn for conn in all_connectors if conn.support_level != "archived"}
     main_logger.info(
         f"Checking for modified files. Skipping {len(all_connectors) - len(active_connectors)} connectors with support level 'archived'."
     )
-    for modified_file in modified_files:
-        if not _is_ignored_file(modified_file):
-            modified_connectors.update(_find_modified_connectors(modified_file, active_connectors, dependency_scanning))
+    # Ignore files with certain extensions
+    active_modified_files = {f for f in modified_files if not _is_ignored_file(f)}
+
+    for connector in active_connectors:
+        if _is_connector_modified_directly(connector, active_modified_files):
+            modified_connectors.add(connector)
+        elif dependency_scanning and _is_connector_modified_indirectly(connector, active_modified_files):
+            modified_connectors.add(connector)
+
     return modified_connectors
 
 

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "4.48.1"
+version = "4.48.2"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 


### PR DESCRIPTION
## What
I noticed recently that airbyte-ci is painfully slow at detecting the set of connectors which have changed in a PR when there are a lot of file changes. 

## How
Swap the inner loop with the outer loop

## Review guide
n/a

## User Impact
CI should be noticeably faster now; no functional changes.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
