### PR TITLE
Destination Iceberg V2: new release

### DIFF
--- a/airbyte-integrations/connectors/destination-iceberg-v2/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-iceberg-v2/metadata.yaml
@@ -16,7 +16,7 @@ data:
             alias: airbyte-connector-testing-secret-store
   connectorType: destination
   definitionId: 37a928c1-2d5c-431a-a97d-ae236bd1ea0c
-  dockerImageTag: 0.2.4
+  dockerImageTag: 0.2.5
   dockerRepository: airbyte/destination-iceberg-v2
   documentationUrl: https://docs.airbyte.com/integrations/destinations/s3
   githubIssueLabel: destination-iceberg-v2

--- a/airbyte-integrations/connectors/destination-iceberg-v2/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-iceberg-v2/metadata.yaml
@@ -22,7 +22,7 @@ data:
   githubIssueLabel: destination-iceberg-v2
   icon: icon.svg
   license: ELv2
-  name: Iceberg V2 Destination
+  name: S3 Data Lake Destination
   registryOverrides:
     cloud:
       enabled: false


### PR DESCRIPTION
pull in https://github.com/airbytehq/airbyte/pull/49959 for improved timestamp handling. Also renames the connector to the new name.