### PR TITLE
Update documentation around secrets for GCP

### DIFF
--- a/docs/deploying-airbyte/integrations/secrets.md
+++ b/docs/deploying-airbyte/integrations/secrets.md
@@ -40,7 +40,7 @@ stringData:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: airbyte-config-secrets
+  name: airbyte-abctl-gcs-log-creds
 type: Opaque
 stringData:
   gcp.json: ## {
@@ -112,7 +112,7 @@ Ensure you've already created a Kubernetes secret containing the credentials blo
 global:
   secretsManager:
     type: googleSecretManager
-    secretName: "airbyte-config-secrets" # Name of your Kubernetes secret.
+    secretName: "airbyte-abctl-gcs-log-creds" # Name of your Kubernetes secret.
     googleSecretManager:
       projectId: <project-id>
       credentialsSecretKey: gcp.json


### PR DESCRIPTION

## What
Updating docs around secret name

## How
Updates the secret name in the docs to match the secret name that Airbyte looks for

## Review guide
1. Confirm if the same change is needed for AWS
2. Confirm if the same change is needed for Azure

## User Impact
This PR corrects a documentation error

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌
