### PR TITLE
Destination S3-V2: Parquet mappings propagate into converted unions

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/SchemalessTypesToJsonString.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/SchemalessTypesToJsonString.kt
@@ -58,28 +58,4 @@ class SchemalessValuesToJsonString : AirbyteValueIdentityMapper() {
         value.toJson().serializeToString().let(::StringValue) to context
     override fun mapUnknown(value: AirbyteValue, context: Context): Pair<AirbyteValue, Context> =
         value.toJson().serializeToString().let(::StringValue) to context
-
-    override fun mapUnion(
-        value: AirbyteValue,
-        schema: UnionType,
-        context: Context
-    ): Pair<AirbyteValue, Context> {
-        if (ObjectTypeWithEmptySchema in schema.options && value is ObjectValue) {
-            return mapObjectWithEmptySchema(value, ObjectTypeWithEmptySchema, context)
-        }
-
-        if (ObjectTypeWithoutSchema in schema.options && value is ObjectValue) {
-            return mapObjectWithoutSchema(value, ObjectTypeWithoutSchema, context)
-        }
-
-        if (ArrayTypeWithoutSchema in schema.options && value is ArrayValue) {
-            return mapArrayWithoutSchema(value, ArrayTypeWithoutSchema, context)
-        }
-
-        if (schema.options.any { it is UnknownType } && value is UnknownValue) {
-            return mapUnknown(value, context)
-        }
-
-        return super.mapUnion(value, schema, context)
-    }
 }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/UnionTypeToDisjointRecord.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/UnionTypeToDisjointRecord.kt
@@ -11,12 +11,14 @@ class UnionTypeToDisjointRecord : AirbyteSchemaIdentityMapper {
         }
         /* Create a schema of { "type": "string", "<typename(option1)>": <type(option1)>, etc... } */
         val properties = linkedMapOf("type" to FieldType(StringType, nullable = false))
-        schema.options.forEach {
-            val name = typeName(it)
+        schema.options.forEach { unmappedType ->
+            /* Necessary because the type might contain a nested union that needs mapping to a disjoint record. */
+            val mappedType = map(unmappedType)
+            val name = typeName(mappedType)
             if (name in properties) {
                 throw IllegalArgumentException("Union of types with same name: $name")
             }
-            properties[typeName(it)] = FieldType(it, nullable = true)
+            properties[typeName(mappedType)] = FieldType(mappedType, nullable = true)
         }
         return ObjectType(properties)
     }

--- a/airbyte-cdk/bulk/toolkits/load-parquet/src/test/kotlin/ParquetMapperPipelineTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-parquet/src/test/kotlin/ParquetMapperPipelineTest.kt
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+import io.airbyte.cdk.load.command.DestinationStream
+import io.airbyte.cdk.load.data.*
+import io.airbyte.cdk.load.data.parquet.ParquetMapperPipelineFactory
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+
+class ParquetMapperPipelineTest {
+    @Test
+    fun `test conversions nested in unions`() {
+        val stream = mockk<DestinationStream>()
+        val schema =
+            ObjectType(
+                linkedMapOf(
+                    "id" to FieldType(StringType, true),
+                    "plan" to
+                        FieldType(
+                            UnionType(
+                                setOf(
+                                    ObjectType(
+                                        linkedMapOf(
+                                            "id" to FieldType(StringType, true),
+                                            "price" to FieldType(NumberType, true),
+                                            "tiers" to
+                                                FieldType(
+                                                    UnionType(
+                                                        setOf(
+                                                            ObjectType(
+                                                                linkedMapOf(
+                                                                    "up_to" to
+                                                                        FieldType(
+                                                                            IntegerType,
+                                                                            true
+                                                                        ),
+                                                                    "name" to
+                                                                        FieldType(StringType, true),
+                                                                )
+                                                            ),
+                                                            StringType
+                                                        )
+                                                    ),
+                                                    true
+                                                ),
+                                            "metadata" to FieldType(ObjectTypeWithEmptySchema, true)
+                                        )
+                                    ),
+                                    StringType
+                                )
+                            ),
+                            true
+                        )
+                )
+            )
+        every { stream.schema } returns schema
+        every { stream.syncId } returns 101L
+        every { stream.generationId } returns 202L
+
+        val record =
+            ObjectValue(
+                linkedMapOf(
+                    "id" to StringValue("1"),
+                    "plan" to
+                        ObjectValue(
+                            linkedMapOf(
+                                "id" to StringValue("2"),
+                                "price" to NumberValue(10.0.toBigDecimal()),
+                                "tiers" to
+                                    ObjectValue(
+                                        linkedMapOf(
+                                            "up_to" to IntegerValue(10),
+                                            "name" to StringValue("tier1")
+                                        )
+                                    ),
+                                "metadata" to
+                                    ObjectValue(linkedMapOf("key" to StringValue("value")))
+                            )
+                        ),
+                )
+            )
+        val pipeline = ParquetMapperPipelineFactory().create(stream)
+        val schemaMapped = pipeline.finalSchema as ObjectType
+        val (recordMapped, _) = pipeline.map(record)
+
+        val planSchema = schemaMapped.properties["plan"]?.type as ObjectType
+        val planObjectOption = planSchema.properties["object"]?.type as ObjectType
+        assert(planObjectOption.properties["tiers"]?.type is ObjectType) {
+            "Unions nested within converted unions should also be converted"
+        }
+
+        val planValue = (recordMapped as ObjectValue).values["plan"] as ObjectValue
+        val planObjectValue = planValue.values["object"] as ObjectValue
+        assert(planObjectValue.values["metadata"] is StringValue) {
+            "Schemaless types values nested within converted unions should be converted"
+        }
+    }
+}


### PR DESCRIPTION
# What
Fixes an error in parquet connections where fields nested inside objects inside unions were not getting schema/value mapped properly.

Specifically
* a nested union wasn't being transformed into a disjoin union
* an object type w/empty schema nested inside a union wasn't getting converted into a string

Failing connection: https://cloud.airbyte.com/workspaces/fc1429ab-ac6d-415b-aedc-440b2557d65a/connections/44076bec-d3f4-407f-87cd-0956e63a8239/timeline?openLogs=true&eventId=3b9e64aa-df73-4cc9-8614-129d41836e1a&attemptNumber=21
The schema is massive, but basically:

```
ObjectType(properties={
	id=FieldType(type=StringType, nullable=true),
	plan=FieldType(type=ObjectType(properties={
		id=FieldType(type=StringType, nullable=true),
...
		tiers=FieldType(type=ArrayType(items=FieldType(type=UnionType(options=[
			IntegerType,
			ObjectType(properties={
				up_to=FieldType(type=IntegerType, nullable=true),
				flat_amount=FieldType(type=IntegerType, nullable=true),
				unit_amount=FieldType(type=IntegerType, nullable=true)
			})]), nullable=true)), nullable=true),
...
		metadata=FieldType(type=ObjectTypeWithEmptySchema, nullable=true),
...
	}), nullable=true),
...
}),
```
Neither `tiers` nor `metadata` were being mapped properly. The latter caused a casting error when the converter expected a string but found an object.

Successful run w/ fix: https://cloud.airbyte.com/workspaces/fc1429ab-ac6d-415b-aedc-440b2557d65a/connections/44076bec-d3f4-407f-87cd-0956e63a8239/timeline?openLogs=true&eventId=72c6e45a-3611-4a29-8152-3e1a38dff7f8