### PR TITLE
Destination S3-V2: Release candidate with avro union fix

### DIFF
--- a/airbyte-integrations/connectors/destination-s3/build.gradle
+++ b/airbyte-integrations/connectors/destination-s3/build.gradle
@@ -6,7 +6,7 @@ plugins {
 airbyteBulkConnector {
     core = 'load'
     toolkits = ['load-s3']
-    cdk = 'local'
+    cdk = '0.252'
 }
 
 application {

--- a/airbyte-integrations/connectors/destination-s3/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-s3/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: file
   connectorType: destination
   definitionId: 4816b78f-1489-44c1-9060-4b19d5fa9362
-  dockerImageTag: 1.5.0-rc.2
+  dockerImageTag: 1.5.0-rc.3
   dockerRepository: airbyte/destination-s3
   githubIssueLabel: destination-s3
   icon: s3.svg

--- a/docs/integrations/destinations/s3.md
+++ b/docs/integrations/destinations/s3.md
@@ -544,6 +544,7 @@ To see connector limitations, or troubleshoot your S3 connector, see more [in ou
 
 | Version    | Date       | Pull Request                                               | Subject                                                                                                                                              |
 |:-----------|:-----------|:-----------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| 1.5.0-rc.3 | 2025-01-06 | [50949](https://github.com/airbytehq/airbyte/pull/50949)   | Bug fix: parquet types/values nested in union of objects do not convert properly                                                                     |
 | 1.5.0-rc.2 | 2025-01-02 | [50857](https://github.com/airbytehq/airbyte/pull/50857)   | Migrate to Bulk Load CDK: cost reduction, perf increase, bug fix for filename clashes                                                                |
 | 1.4.0      | 2024-10-23 | [46302](https://github.com/airbytehq/airbyte/pull/46302)   | add support for file transfer                                                                                                                        |
 | 1.3.0      | 2024-09-30 | [46281](https://github.com/airbytehq/airbyte/pull/46281)   | fix tests                                                                                                                                            |


### PR DESCRIPTION
## What
rc.3: picking up the latest avro fix before full rollout

this also pins s3's bulk CDK to the latest version
