### PR TITLE
Bulk Load CDK: Guard against multiple runs of close stream

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/DestinationTaskLauncher.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/DestinationTaskLauncher.kt
@@ -39,6 +39,7 @@ import io.micronaut.context.annotation.Secondary
 import io.micronaut.context.annotation.Value
 import jakarta.inject.Named
 import jakarta.inject.Singleton
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.channels.Channel
@@ -137,6 +138,8 @@ class DefaultDestinationTaskLauncher(
 
     private val teardownIsEnqueued = AtomicBoolean(false)
     private val failSyncIsEnqueued = AtomicBoolean(false)
+
+    private val closeStreamHasRun = ConcurrentHashMap<DestinationStream.Descriptor, AtomicBoolean>()
 
     inner class TaskWrapper(
         override val innerTask: ScopedTask,
@@ -277,10 +280,13 @@ class DefaultDestinationTaskLauncher(
             }
 
             if (streamManager.isBatchProcessingComplete()) {
-                log.info { "Batch processing complete: Starting close stream task for $stream" }
-
-                val task = closeStreamTaskFactory.make(this, stream)
-                enqueue(task)
+                if (closeStreamHasRun.getOrPut(stream) { AtomicBoolean(false) }.setOnce()) {
+                    log.info { "Batch processing complete: Starting close stream task for $stream" }
+                    val task = closeStreamTaskFactory.make(this, stream)
+                    enqueue(task)
+                } else {
+                    log.info { "Close stream task has already run, skipping." }
+                }
             } else {
                 log.info { "Batch processing not complete: nothing else to do." }
             }


### PR DESCRIPTION
## What
After moving to a fixed number of workers, we introduced the possibility of calling close stream more than once.

Specifically
* WORKER 1 consumes the entire stream and pushes a complete batch
* WORKER 2 only gets an end-of-stream and pushes an empty batch
* Both workers triggers the `isBatchProcessingComplete == true` check
* Close runs twice

This adds an explicit guard against this.
