### PR TITLE
Re-enable test

### DIFF
--- a/airbyte-integrations/connectors/destination-dev-null/src/test-integration/kotlin/io/airbyte/integrations/destination/dev_null/DevNullBasicFunctionalityIntegrationTest.kt
+++ b/airbyte-integrations/connectors/destination-dev-null/src/test-integration/kotlin/io/airbyte/integrations/destination/dev_null/DevNullBasicFunctionalityIntegrationTest.kt
@@ -40,6 +40,4 @@ class DevNullBasicFunctionalityIntegrationTest :
     }
 
     @Test @Disabled("File transfer is not supported") override fun testBasicWriteFile() {}
-
-    @Test @Disabled("DevNull does not support Unknown types") override fun testUnknownTypes() {}
 }

--- a/airbyte-integrations/connectors/destination-iceberg-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/iceberg/v2/IcebergV2WriteTest.kt
+++ b/airbyte-integrations/connectors/destination-iceberg-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/iceberg/v2/IcebergV2WriteTest.kt
@@ -92,9 +92,6 @@ class IcebergGlueWriteTest :
             )
         )
     ) {
-    @Test
-    @Disabled("dest iceberge-v2 doesn't support unknown types")
-    override fun testUnknownTypes() {}
 
     @Test
     override fun testBasicWrite() {


### PR DESCRIPTION
## What
Those test were disable because they were failing when the file needed to be merged.
They are now passing, likely thanks to a fix in the CDK.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌
