### PR TITLE
source-mysql: fix converter bug

### DIFF
--- a/airbyte-integrations/connectors/source-mysql/build.gradle
+++ b/airbyte-integrations/connectors/source-mysql/build.gradle
@@ -9,7 +9,7 @@ application {
 airbyteBulkConnector {
     core = 'extract'
     toolkits = ['extract-jdbc', 'extract-cdc']
-    cdk = '0.249'
+    cdk = '0.255'
 }
 
 dependencies {

--- a/airbyte-integrations/connectors/source-mysql/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mysql/metadata.yaml
@@ -9,7 +9,7 @@ data:
   connectorSubtype: database
   connectorType: source
   definitionId: 435bb9a5-7887-4809-aa58-28c27df0d7ad
-  dockerImageTag: 3.10.0-rc.7
+  dockerImageTag: 3.10.0-rc.8
   dockerRepository: airbyte/source-mysql
   documentationUrl: https://docs.airbyte.com/integrations/sources/mysql
   githubIssueLabel: source-mysql

--- a/airbyte-integrations/connectors/source-mysql/src/main/kotlin/io/airbyte/integrations/source/mysql/MySqlSourceCdcBooleanConverter.kt
+++ b/airbyte-integrations/connectors/source-mysql/src/main/kotlin/io/airbyte/integrations/source/mysql/MySqlSourceCdcBooleanConverter.kt
@@ -9,27 +9,27 @@ import io.airbyte.cdk.read.cdc.NoConversion
 import io.airbyte.cdk.read.cdc.NullFallThrough
 import io.airbyte.cdk.read.cdc.PartialConverter
 import io.airbyte.cdk.read.cdc.RelationalColumnCustomConverter
+import io.debezium.spi.converter.RelationalColumn
 import org.apache.kafka.connect.data.SchemaBuilder
 
 class MySqlSourceCdcBooleanConverter : RelationalColumnCustomConverter {
 
     override val debeziumPropertiesKey: String = "boolean"
-    override val handlers: List<RelationalColumnCustomConverter.Handler> = listOf(tinyint1Handler)
+    override val handlers: List<RelationalColumnCustomConverter.Handler> = listOf(TinyInt1Handler)
 
-    companion object {
-        val tinyint1Handler =
-            RelationalColumnCustomConverter.Handler(
-                predicate = {
-                    it.typeName().equals("TINYINT", ignoreCase = true) &&
-                        it.length().isPresent &&
-                        it.length().asInt == 1
-                },
-                outputSchema = SchemaBuilder.bool(),
-                partialConverters =
-                    listOf(
-                        NullFallThrough,
-                        PartialConverter { if (it is Number) Converted(it != 0) else NoConversion }
-                    )
+    data object TinyInt1Handler : RelationalColumnCustomConverter.Handler {
+
+        override fun matches(column: RelationalColumn): Boolean =
+            column.typeName().equals("TINYINT", ignoreCase = true) &&
+                column.length().isPresent &&
+                column.length().asInt == 1
+
+        override fun outputSchemaBuilder(): SchemaBuilder = SchemaBuilder.bool()
+
+        override val partialConverters: List<PartialConverter> =
+            listOf(
+                NullFallThrough,
+                PartialConverter { if (it is Number) Converted(it != 0) else NoConversion }
             )
     }
 }

--- a/docs/integrations/sources/mysql.md
+++ b/docs/integrations/sources/mysql.md
@@ -226,6 +226,7 @@ Any database or table encoding combination of charset and collation is supported
 
 | Version     | Date       | Pull Request                                               | Subject                                                                                                                                         |
 |:------------|:-----------|:-----------------------------------------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------|
+| 3.10.0-rc.8 | 2025-01-07 | [50965](https://github.com/airbytehq/airbyte/pull/50965)   | Fix bug introduced in 3.10.0-rc.3.                                                                                                              |
 | 3.10.0-rc.7 | 2024-12-27 | [50437](https://github.com/airbytehq/airbyte/pull/50437)   | Compatibility with MySQL Views.                                                                                                                 |
 | 3.10.0-rc.6 | 2024-12-18 | [49892](https://github.com/airbytehq/airbyte/pull/49892)   | Use a base image: airbyte/java-connector-base:1.0.0                                                                                             |
 | 3.10.0-rc.5 | 2025-01-03 | [50868](https://github.com/airbytehq/airbyte/pull/50868)   | Fix exception handling rules declaration.                                                                                                       |


### PR DESCRIPTION
## What
Based on https://github.com/airbytehq/airbyte/pull/50967
This PR applies CDK changes in that PR on source-mysql.

Presently there is a bug in the CDK which will cause a CDC sync on the following table to fail:
```
CREATE TABLE test.tbl(k INT PRIMARY KEY, v1 DATE NOT NULL DEFAULT '2022-02-22', v2 DATE NOT NULL DEFAULT '2023-03-23')
```
All it takes is two columns with (1) default values and (2) for which Debezium CustomConverters get applied. It blows up instantly with some debezium exception complaining about default values being set twice.

I tested manually that this PR fixes the issue.

## How

Use the latest version of the CDK which includes https://github.com/airbytehq/airbyte/pull/50967

## Review guide
The CDK PR changes the type definition of `Handler` from a data class to an interface so most code changes reflect this. The only significant FUNCTIONAL change is that `val outputSchema` got turned into `fun outputSchema`.

## User Impact
Hopefully this unblocks rolling out the latest batch of changes in source-mysql

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
