### PR TITLE
bulk-cdk-toolkit-extract-cdc: fix CustomConverter bug

### DIFF
--- a/airbyte-cdk/bulk/toolkits/extract-cdc/src/main/kotlin/io/airbyte/cdk/read/cdc/RelationalColumnCustomConverter.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-cdc/src/main/kotlin/io/airbyte/cdk/read/cdc/RelationalColumnCustomConverter.kt
@@ -7,10 +7,10 @@ package io.airbyte.cdk.read.cdc
 import io.debezium.spi.converter.CustomConverter
 import io.debezium.spi.converter.RelationalColumn
 import java.util.Properties
-import org.apache.kafka.connect.data.Schema
+import org.apache.kafka.connect.data.SchemaBuilder
 
 /** Used by Debezium to transform record values into their expected format. */
-interface RelationalColumnCustomConverter : CustomConverter<Schema, RelationalColumn> {
+interface RelationalColumnCustomConverter : CustomConverter<SchemaBuilder, RelationalColumn> {
 
     /** A nice name for use in Debezium properties. */
     val debeziumPropertiesKey: String
@@ -18,30 +18,29 @@ interface RelationalColumnCustomConverter : CustomConverter<Schema, RelationalCo
     /** Fall-through list of handlers to try to match and register for each column. */
     val handlers: List<Handler>
 
-    data class Handler(
+    interface Handler {
         /** Predicate to match the column by. */
-        val predicate: (RelationalColumn) -> Boolean,
+        fun matches(column: RelationalColumn): Boolean
+
         /** Schema of the output values. */
-        val outputSchema: Schema,
+        fun outputSchemaBuilder(): SchemaBuilder
+
         /** Partial conversion functions, applied in sequence until conversion occurs. */
         val partialConverters: List<PartialConverter>
-    )
+    }
 
     override fun configure(props: Properties?) {}
 
     override fun converterFor(
         column: RelationalColumn?,
-        registration: CustomConverter.ConverterRegistration<Schema>?
+        registration: CustomConverter.ConverterRegistration<SchemaBuilder>?
     ) {
         if (column == null || registration == null) {
             return
         }
-        for (handler in handlers) {
-            if (!handler.predicate(column)) continue
-            val converter: CustomConverter.Converter =
-                ConverterFactory(javaClass).build(column, handler.partialConverters)
-            registration.register(handler.outputSchema, converter)
-            return
-        }
+        val handler: Handler = handlers.find { it.matches(column) } ?: return
+        val converter: CustomConverter.Converter =
+            ConverterFactory(javaClass).build(column, handler.partialConverters)
+        registration.register(handler.outputSchemaBuilder(), converter)
     }
 }


### PR DESCRIPTION
## What
I made a mistake in assuming that the `outputSchema` value could be re-used for multiple columns, but that turns out to not be the case. What debezium really wants is a new instance of a `SchemaBuilder` for each column for which we register a `CustomConverter`.

This bug becomes apparent when applying the same converter logic to two columns of the same type in the same table and with default values. This isn't covered in any test and I'm not sure that this can be tested adequately in the CDK.

## How
This requires turning `outputSchema` from a value to a function, at which point I felt it made more sense to turn `Handler` into an interface.

## Review guide
See accompanying PR https://github.com/airbytehq/airbyte/pull/50965 which applies these changes to source-mysql.

## User Impact
Should unblock the source-mysql rollout.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
