### PR TITLE
[workflows] set Poetry version to 1.8.5 when installing via `snok/install-poetry`

### DIFF
--- a/.github/workflows/airbyte-ci-release.yml
+++ b/.github/workflows/airbyte-ci-release.yml
@@ -43,6 +43,8 @@ jobs:
       - name: Install Poetry
         id: install_poetry
         uses: snok/install-poetry@v1
+        with:
+          version: 1.8.5
 
       - name: Install Dependencies
         id: install_dependencies

--- a/.github/workflows/auto_merge.yml
+++ b/.github/workflows/auto_merge.yml
@@ -18,6 +18,8 @@ jobs:
           python-version: "3.10"
       - name: Install and configure Poetry
         uses: snok/install-poetry@v1
+        with:
+          version: 1.8.5
       - name: Run auto merge
         shell: bash
         working-directory: airbyte-ci/connectors/auto_merge

--- a/.github/workflows/connectors_insights.yml
+++ b/.github/workflows/connectors_insights.yml
@@ -31,6 +31,7 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:
+          version: 1.8.5
           virtualenvs-create: true
           virtualenvs-in-project: true
           installer-parallel: true

--- a/.github/workflows/live_tests.yml
+++ b/.github/workflows/live_tests.yml
@@ -63,6 +63,8 @@ jobs:
       - name: Install Poetry
         id: install_poetry
         uses: snok/install-poetry@v1
+        with:
+          version: 1.8.5
 
       - name: Make poetry venv in project
         id: poetry_venv

--- a/.github/workflows/regression_tests.yml
+++ b/.github/workflows/regression_tests.yml
@@ -63,6 +63,8 @@ jobs:
       - name: Install Poetry
         id: install_poetry
         uses: snok/install-poetry@v1
+        with:
+          version: 1.8.5
 
       - name: Make poetry venv in project
         id: poetry_venv


### PR DESCRIPTION
## What
- Poetry v2.0.0 was published on 1/5/25. The https://github.com/snok/install-poetry workflow is now installing Poetry v2.0.0 during GHA workflows, causing failures during pyproject installation due to incorrectly formatted `pyproject.toml` files
    - See https://github.com/airbytehq/airbyte/actions/runs/12619358567/job/35163810532 for failed run w/ 2.0.0
    - See https://github.com/airbytehq/airbyte/actions/runs/12659835322 for successful run w/ 1.8.5 using this branch
- This is a quick fix to resolve these failures until we migrate to Poetry v2.0.0.
- See https://python-poetry.org/blog/announcing-poetry-2.0.0

## How
- Explictily sets the Poetry version to v1.8.5 when installing via `snok/install-poetry@1`:
```yaml
      - name: Install Poetry
        id: install_poetry
        uses: snok/install-poetry@v1
        with:
          version: 1.8.5
```

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
