### PR TITLE
bulk-cdk-toolkit-extract-cdc: bump debezium shutdown timeout

### DIFF
--- a/airbyte-cdk/bulk/toolkits/extract-cdc/src/main/kotlin/io/airbyte/cdk/read/cdc/DebeziumPropertiesBuilder.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-cdc/src/main/kotlin/io/airbyte/cdk/read/cdc/DebeziumPropertiesBuilder.kt
@@ -57,7 +57,8 @@ class DebeziumPropertiesBuilder(private val props: Properties = Properties()) {
         // unless we set the following.
         with("value.converter.replace.null.with.default", "false")
         // Timeout for DebeziumEngine's close() method.
-        with("debezium.embedded.shutdown.pause.before.interrupt.ms", "10000")
+        // We find that in production, substantial time is in fact legitimately required here.
+        with("debezium.embedded.shutdown.pause.before.interrupt.ms", "60000")
         // Unblock CDC syncs by skipping errors caused by unparseable DDLs
         with("schema.history.internal.skip.unparseable.ddl", "true")
     }


### PR DESCRIPTION
## What
10s is not always enough for MySQL in production. Bumping to 60s.

## How
n/a

## Review guide
n/a

## User Impact
More successful syncs.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
