### PR TITLE
airbyte-ci: remove deprecated --no-update flag from poetry commands

### DIFF
--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -854,6 +854,7 @@ airbyte-ci connectors --language=low-code migrate-to-manifest-only
 
 | Version | PR                                                         | Description                                                                                                                  |
 |---------|------------------------------------------------------------| ---------------------------------------------------------------------------------------------------------------------------- |
+| 4.48.3  | [#50988](https://github.com/airbytehq/airbyte/pull/50988)  | Remove deprecated `--no-update` flag from poetry commands |
 | 4.48.2  | [#50871](https://github.com/airbytehq/airbyte/pull/50871)  | Speed up connector modification detection.                                                                                   |
 | 4.48.1  | [#50410](https://github.com/airbytehq/airbyte/pull/50410)  | Java connector build: give ownership of built artifacts to the current image user.                                                                                          |
 | 4.48.0  | [#49960](https://github.com/airbytehq/airbyte/pull/49960)  | Deprecate airbyte-ci format command                                                                                          |

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/generate_erd/pipeline.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/generate_erd/pipeline.py
@@ -100,9 +100,7 @@ class GenerateDbml(Step):
             .with_workdir("/app")
         )
 
-        return container.with_exec(["poetry", "lock"], use_entrypoint=True).with_exec(
-            ["poetry", "install"], use_entrypoint=True
-        )
+        return container.with_exec(["poetry", "lock"], use_entrypoint=True).with_exec(["poetry", "install"], use_entrypoint=True)
 
 
 class UploadDbmlSchema(Step):

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/generate_erd/pipeline.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/generate_erd/pipeline.py
@@ -100,7 +100,7 @@ class GenerateDbml(Step):
             .with_workdir("/app")
         )
 
-        return container.with_exec(["poetry", "lock", "--no-update"], use_entrypoint=True).with_exec(
+        return container.with_exec(["poetry", "lock"], use_entrypoint=True).with_exec(
             ["poetry", "install"], use_entrypoint=True
         )
 

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/common.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/common.py
@@ -828,7 +828,5 @@ class LiveTests(Step):
                 )
             )
 
-        container = container.with_exec(["poetry", "lock"], use_entrypoint=True).with_exec(
-            ["poetry", "install"], use_entrypoint=True
-        )
+        container = container.with_exec(["poetry", "lock"], use_entrypoint=True).with_exec(["poetry", "install"], use_entrypoint=True)
         return container

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/common.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/common.py
@@ -828,7 +828,7 @@ class LiveTests(Step):
                 )
             )
 
-        container = container.with_exec(["poetry", "lock", "--no-update"], use_entrypoint=True).with_exec(
+        container = container.with_exec(["poetry", "lock"], use_entrypoint=True).with_exec(
             ["poetry", "install"], use_entrypoint=True
         )
         return container

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/upgrade_cdk/pipeline.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/upgrade_cdk/pipeline.py
@@ -139,7 +139,7 @@ class SetCDKVersion(Step):
         connector_container = base_container.with_mounted_directory("/connector", updated_connector_dir).with_workdir("/connector")
 
         poetry_lock_file = await connector_container.file(POETRY_LOCK_FILENAME).contents()
-        updated_container = await connector_container.with_exec(["poetry", "lock", "--no-update"], use_entrypoint=True)
+        updated_container = await connector_container.with_exec(["poetry", "lock"], use_entrypoint=True)
         updated_poetry_lock_file = await updated_container.file(POETRY_LOCK_FILENAME).contents()
 
         if poetry_lock_file != updated_poetry_lock_file:

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/test/pipeline.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/test/pipeline.py
@@ -239,7 +239,7 @@ def prepare_container_for_poe_tasks(
                 ],
                 use_entrypoint=True,
             )
-            .with_exec(["poetry", "lock", "--no-update"], use_entrypoint=True)
+            .with_exec(["poetry", "lock"], use_entrypoint=True)
         )
 
     # Install the poetry package

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "4.48.2"
+version = "4.48.3"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 


### PR DESCRIPTION
## What

The `--no-update` flag has [been deprecated in poetry version 2.0.0](https://python-poetry.org/blog/announcing-poetry-2.0.0#poetry-lock-defaults-to---no-update), causing issues with poetry builds in our regression tests (and likely affecting other airbyte-ci commands). This PR removes the flag from our commands in airbyte-ci.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
