### PR TITLE
Destination S3V2: Restore Thread-Safety to Unique Key Counter

### DIFF
--- a/airbyte-integrations/connectors/destination-s3/build.gradle
+++ b/airbyte-integrations/connectors/destination-s3/build.gradle
@@ -6,7 +6,7 @@ plugins {
 airbyteBulkConnector {
     core = 'load'
     toolkits = ['load-s3', 'load-avro']
-    cdk = '0.254'
+    cdk = 'local'
 }
 
 application {

--- a/airbyte-integrations/connectors/destination-s3/gradle.properties
+++ b/airbyte-integrations/connectors/destination-s3/gradle.properties
@@ -1,2 +1,2 @@
 testExecutionConcurrency=-1
-JunitMethodExecutionTimeout=30 m
+JunitMethodExecutionTimeout=35 m

--- a/airbyte-integrations/connectors/destination-s3/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-s3/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: file
   connectorType: destination
   definitionId: 4816b78f-1489-44c1-9060-4b19d5fa9362
-  dockerImageTag: 1.5.0-rc.4
+  dockerImageTag: 1.5.0-rc.5
   dockerRepository: airbyte/destination-s3
   githubIssueLabel: destination-s3
   icon: s3.svg

--- a/airbyte-integrations/connectors/destination-s3/src/main/kotlin/S3V2Checker.kt
+++ b/airbyte-integrations/connectors/destination-s3/src/main/kotlin/S3V2Checker.kt
@@ -50,8 +50,7 @@ class S3V2Checker<T : OutputStream>(private val timeProvider: TimeProvider) :
                 log.info { "Successfully wrote test file: $results" }
             } finally {
                 s3Object?.also { s3Client.delete(it) }
-                val results = s3Client.list(path).toList()
-                log.info { "Successfully removed test tile: $results" }
+                log.info { "Successfully removed test file" }
             }
         }
     }

--- a/airbyte-integrations/connectors/destination-s3/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2WriteTest.kt
+++ b/airbyte-integrations/connectors/destination-s3/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2WriteTest.kt
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout
 
-@Timeout(30, unit = TimeUnit.MINUTES)
+@Timeout(35, unit = TimeUnit.MINUTES)
 abstract class S3V2WriteTest(
     path: String,
     expectedRecordMapper: ExpectedRecordMapper,

--- a/docs/integrations/destinations/s3.md
+++ b/docs/integrations/destinations/s3.md
@@ -544,6 +544,7 @@ To see connector limitations, or troubleshoot your S3 connector, see more [in ou
 
 | Version    | Date       | Pull Request                                               | Subject                                                                                                                                              |
 |:-----------|:-----------|:-----------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| 1.5.0-rc.5 | 2025-01-06 | [50954](https://github.com/airbytehq/airbyte/pull/50954)   | Bug fix: transient failure due to bug in filename clash prevention                                                                                   |
 | 1.5.0-rc.4 | 2025-01-06 | [50954](https://github.com/airbytehq/airbyte/pull/50954)   | Bug fix: StreamLoader::close dispatched multiple times per stream                                                                                    |
 | 1.5.0-rc.3 | 2025-01-06 | [50949](https://github.com/airbytehq/airbyte/pull/50949)   | Bug fix: parquet types/values nested in union of objects do not convert properly                                                                     |
 | 1.5.0-rc.2 | 2025-01-02 | [50857](https://github.com/airbytehq/airbyte/pull/50857)   | Migrate to Bulk Load CDK: cost reduction, perf increase, bug fix for filename clashes                                                                |


### PR DESCRIPTION
## What
The changes [here](https://github.com/airbytehq/airbyte/pull/50953) removed the access lock around the unique key counter as well as the one around the object list.

This likely caused the unique keys not to be visible across threads, resulting in this failure https://cloud.airbyte.com/workspaces/53a30509-28a4-4158-9c84-200cbad69a25/connections/1e5881b2-1745-437d-8420-d9957a3e4467/timeline?openLogs=true&eventId=403efe8f-a47b-4fb0-81ef-5bdd234394c3. (That exception indicates that multiple process records workers tried to write to the same filename.)

The bug itself caused no harm due to the extra uniqueness check, but it's a simple fix.

(I also cleaned up the alarming log message in the Checker that made me think this was worse than it was. : )
