### PR TITLE
chore: config aws s3 sdk to avoid connection closed error 2

### DIFF
--- a/airbyte-cdk/bulk/toolkits/load-s3/build.gradle
+++ b/airbyte-cdk/bulk/toolkits/load-s3/build.gradle
@@ -5,5 +5,6 @@ dependencies {
     api project(':airbyte-cdk:bulk:toolkits:bulk-cdk-toolkit-load-object-storage')
 
     testFixturesApi(testFixtures(project(":airbyte-cdk:bulk:toolkits:bulk-cdk-toolkit-load-object-storage")))
-    implementation("aws.sdk.kotlin:s3:1.3.94")
+    implementation("aws.sdk.kotlin:s3:1.3.98")
+    implementation("aws.smithy.kotlin:http-client-engine-okhttp:1.3.31")
 }

--- a/airbyte-cdk/bulk/toolkits/load-s3/src/main/kotlin/io/airbyte/cdk/load/file/s3/S3Client.kt
+++ b/airbyte-cdk/bulk/toolkits/load-s3/src/main/kotlin/io/airbyte/cdk/load/file/s3/S3Client.kt
@@ -18,6 +18,7 @@ import aws.sdk.kotlin.services.s3.model.PutObjectRequest
 import aws.smithy.kotlin.runtime.auth.awscredentials.CredentialsProvider
 import aws.smithy.kotlin.runtime.content.ByteStream
 import aws.smithy.kotlin.runtime.content.toInputStream
+import aws.smithy.kotlin.runtime.http.engine.okhttp.OkHttpEngine
 import aws.smithy.kotlin.runtime.net.url.Url
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 import io.airbyte.cdk.load.command.aws.AWSAccessKeyConfigurationProvider
@@ -38,6 +39,7 @@ import jakarta.inject.Singleton
 import java.io.ByteArrayOutputStream
 import java.io.InputStream
 import java.io.OutputStream
+import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.flow.flow
 
 data class S3Object(override val key: String, override val storageConfig: S3BucketConfiguration) :
@@ -244,6 +246,10 @@ class S3ClientFactory(
                             Url.parse(it)
                         } else null
                     }
+                // Should fix connection reset issue: https://github.com/awslabs/aws-sdk-kotlin/issues/1214#issuecomment-2464831817
+                httpClient(OkHttpEngine) {
+                    connectionIdlePollingInterval = 200.milliseconds
+                }
             }
 
         return S3Client(

--- a/airbyte-cdk/bulk/toolkits/load-s3/src/main/kotlin/io/airbyte/cdk/load/file/s3/S3Client.kt
+++ b/airbyte-cdk/bulk/toolkits/load-s3/src/main/kotlin/io/airbyte/cdk/load/file/s3/S3Client.kt
@@ -246,10 +246,9 @@ class S3ClientFactory(
                             Url.parse(it)
                         } else null
                     }
-                // Should fix connection reset issue: https://github.com/awslabs/aws-sdk-kotlin/issues/1214#issuecomment-2464831817
-                httpClient(OkHttpEngine) {
-                    connectionIdlePollingInterval = 200.milliseconds
-                }
+                // Fix for connection reset issue:
+                // https://github.com/awslabs/aws-sdk-kotlin/issues/1214#issuecomment-2464831817
+                httpClient(OkHttpEngine) { connectionIdlePollingInterval = 200.milliseconds }
             }
 
         return S3Client(

--- a/airbyte-integrations/connectors/destination-s3/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-s3/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: file
   connectorType: destination
   definitionId: 4816b78f-1489-44c1-9060-4b19d5fa9362
-  dockerImageTag: 1.5.0-rc.4
+  dockerImageTag: 1.5.0-rc.5
   dockerRepository: airbyte/destination-s3
   githubIssueLabel: destination-s3
   icon: s3.svg

--- a/airbyte-integrations/connectors/destination-s3/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-s3/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: file
   connectorType: destination
   definitionId: 4816b78f-1489-44c1-9060-4b19d5fa9362
-  dockerImageTag: 1.5.0-rc.5
+  dockerImageTag: 1.5.0-rc.4
   dockerRepository: airbyte/destination-s3
   githubIssueLabel: destination-s3
   icon: s3.svg


### PR DESCRIPTION
Same as other [PR](https://github.com/airbytehq/airbyte/pull/50993/files) but avoids vercel issue.

## What
Configures the okhttp client wrapper inside the s3 client to poll for idle connections

## Why
We have seen a lot of transient errors due to closed connections and this is the maintainer sanctioned way of alleviating these issues.

See this [gh thread](https://github.com/awslabs/aws-sdk-kotlin/issues/1214#issuecomment-2464831817) for background.

We may switch to a different workaround if this doesn't reduce failures appreciably.
