### PR TITLE
airbyte-ci: fix `--use-cdk-ref`

### DIFF
--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -854,6 +854,7 @@ airbyte-ci connectors --language=low-code migrate-to-manifest-only
 
 | Version | PR                                                         | Description                                                                                                                  |
 |---------|------------------------------------------------------------| ---------------------------------------------------------------------------------------------------------------------------- |
+| 4.48.4  | [#51003](https://github.com/airbytehq/airbyte/pull/51003)  | Install git in the build / test connector container when `--use-cdk-ref` is passed. |
 | 4.48.3  | [#50988](https://github.com/airbytehq/airbyte/pull/50988)  | Remove deprecated `--no-update` flag from poetry commands |
 | 4.48.2  | [#50871](https://github.com/airbytehq/airbyte/pull/50871)  | Speed up connector modification detection.                                                                                   |
 | 4.48.1  | [#50410](https://github.com/airbytehq/airbyte/pull/50410)  | Java connector build: give ownership of built artifacts to the current image user.                                                                                          |

--- a/airbyte-ci/connectors/pipelines/pipelines/dagger/actions/python/common.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/dagger/actions/python/common.py
@@ -288,6 +288,14 @@ def apply_python_development_overrides(context: ConnectorContext, connector_cont
             connector_container.with_user("root")
             .with_exec(
                 [
+                    "apt-get",
+                    "install",
+                    "-y",
+                    "git",
+                ]
+            )
+            .with_exec(
+                [
                     "pip",
                     "install",
                     f"git+https://github.com/airbytehq/airbyte-python-cdk.git#{cdk_ref}",

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "4.48.3"
+version = "4.48.4"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 


### PR DESCRIPTION
## What
When using `--use-cdk-ref` we install the CDK package via a git url. Git has to be available in the build/test containers to correctly perform the install.
This PR installs Git in the container when `--use-cdk-ref` option is passed by the CLI.

