### PR TITLE
[source-xero] ParseDates.convert_dates - fix for datetime truncation

### DIFF
--- a/airbyte-integrations/connectors/source-xero/source_xero/components.py
+++ b/airbyte-integrations/connectors/source-xero/source_xero/components.py
@@ -59,7 +59,7 @@ class ParseDates:
                 if isinstance(value, str):
                     parsed_value = ParseDates.parse_date(value)
                     if parsed_value:
-                        if isinstance(parsed_value, date):
+                        if type(parsed_value) == date:
                             parsed_value = datetime.combine(parsed_value, time.min)
                         parsed_value = parsed_value.replace(tzinfo=timezone.utc)
                         obj[key] = datetime.isoformat(parsed_value, timespec="seconds")


### PR DESCRIPTION
Fixes #51007

## What

The condition `if isinstance(parsed_value, date)` is always true even for datetime instances ( [Reproducible Example](https://www.online-python.com/hdg5trp4BM) )

So it always replaces time part of all datetime instances with 00:00:00

## How

Replaced isinstance with the exact type checking

## User Impact

`UpdatedDateUTC` field of all entities will finally have time part

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
