### PR TITLE
[ISSUE 48459] Source-Instagram: Remove Unsupported Fields in media_insights and user_insights

### DIFF
--- a/airbyte-integrations/connectors/source-instagram/erd/discovered_catalog.json
+++ b/airbyte-integrations/connectors/source-instagram/erd/discovered_catalog.json
@@ -187,10 +187,6 @@
             "description": "The number of times users have saved the media.",
             "type": ["null", "integer"]
           },
-          "video_views": {
-            "description": "The total number of views on video media.",
-            "type": ["null", "integer"]
-          },
           "comments": {
             "description": "The number of comments received on the media.",
             "type": ["null", "integer"]
@@ -505,32 +501,12 @@
             "description": "The total number of followers for the user's account.",
             "type": ["null", "integer"]
           },
-          "get_directions_clicks": {
-            "description": "The number of clicks to get directions to the user's business location.",
-            "type": ["null", "integer"]
-          },
           "impressions": {
             "description": "The total number of times the user's content has been displayed.",
             "type": ["null", "integer"]
           },
-          "phone_call_clicks": {
-            "description": "The number of clicks to call the user's business phone number.",
-            "type": ["null", "integer"]
-          },
-          "profile_views": {
-            "description": "The total number of views on the user's profile.",
-            "type": ["null", "integer"]
-          },
           "reach": {
             "description": "The total number of unique accounts that have seen the user's content.",
-            "type": ["null", "integer"]
-          },
-          "text_message_clicks": {
-            "description": "The number of clicks to send text messages to the user.",
-            "type": ["null", "integer"]
-          },
-          "website_clicks": {
-            "description": "The number of clicks on the website link in the user's profile.",
             "type": ["null", "integer"]
           },
           "impressions_week": {
@@ -552,10 +528,6 @@
           "online_followers": {
             "description": "The number of followers who are currently online.",
             "type": ["null", "object"]
-          },
-          "email_contacts": {
-            "description": "The number of email contacts associated with the user's account.",
-            "type": ["null", "integer"]
           }
         }
       },

--- a/airbyte-integrations/connectors/source-instagram/source_instagram/manifest.yaml
+++ b/airbyte-integrations/connectors/source-instagram/source_instagram/manifest.yaml
@@ -123,12 +123,12 @@ definitions:
               }}{% elif stream_partition.media_insights_info.media_type ==
               "VIDEO" and
               stream_partition.media_insights_info.media_product_type == "FEED"
-              %}{{  'impressions,reach,saved,video_views'}}{% elif
+              %}{{  'impressions,reach,saved'}}{% elif
               stream_partition.media_insights_info.media_type == "VIDEO" %}{{
-              'impressions,reach,saved,video_views,likes,comments,shares,follows,profile_visits'
+              'impressions,reach,saved,likes,comments,shares,follows,profile_visits'
               }}{%elif stream_partition.media_insights_info.media_type ==
-              "CAROUSEL_ALBUM"%}{{ 'impressions,reach,saved,video_views,shares,follows,profile_visits' }}{% else %}{{
-              'impressions,reach,saved,video_views,likes,comments,shares,follows,profile_visits' }}{%
+              "CAROUSEL_ALBUM"%}{{ 'impressions,reach,saved,shares,follows,profile_visits' }}{% else %}{{
+              'impressions,reach,saved,likes,comments,shares,follows,profile_visits' }}{%
               endif %}
           error_handler:
             type: CompositeErrorHandler
@@ -821,11 +821,6 @@ schemas:
           - integer
       saved:
         description: The number of times users have saved the media.
-        type:
-          - "null"
-          - integer
-      video_views:
-        description: The total number of views on video media.
         type:
           - "null"
           - integer

--- a/airbyte-integrations/connectors/source-instagram/source_instagram/schemas/media_insights.json
+++ b/airbyte-integrations/connectors/source-instagram/source_instagram/schemas/media_insights.json
@@ -33,10 +33,6 @@
       "description": "The number of times users have saved the media.",
       "type": ["null", "integer"]
     },
-    "video_views": {
-      "description": "The total number of views on video media.",
-      "type": ["null", "integer"]
-    },
     "comments": {
       "description": "The number of comments received on the media.",
       "type": ["null", "integer"]

--- a/airbyte-integrations/connectors/source-instagram/source_instagram/schemas/user_insights.json
+++ b/airbyte-integrations/connectors/source-instagram/source_instagram/schemas/user_insights.json
@@ -19,32 +19,12 @@
       "description": "The total number of followers for the user's account.",
       "type": ["null", "integer"]
     },
-    "get_directions_clicks": {
-      "description": "The number of clicks to get directions to the user's business location.",
-      "type": ["null", "integer"]
-    },
     "impressions": {
       "description": "The total number of times the user's content has been displayed.",
       "type": ["null", "integer"]
     },
-    "phone_call_clicks": {
-      "description": "The number of clicks to call the user's business phone number.",
-      "type": ["null", "integer"]
-    },
-    "profile_views": {
-      "description": "The total number of views on the user's profile.",
-      "type": ["null", "integer"]
-    },
     "reach": {
       "description": "The total number of unique accounts that have seen the user's content.",
-      "type": ["null", "integer"]
-    },
-    "text_message_clicks": {
-      "description": "The number of clicks to send text messages to the user.",
-      "type": ["null", "integer"]
-    },
-    "website_clicks": {
-      "description": "The number of clicks on the website link in the user's profile.",
       "type": ["null", "integer"]
     },
     "impressions_week": {
@@ -66,10 +46,6 @@
     "online_followers": {
       "description": "The number of followers who are currently online.",
       "type": ["null", "object"]
-    },
-    "email_contacts": {
-      "description": "The number of email contacts associated with the user's account.",
-      "type": ["null", "integer"]
     }
   }
 }

--- a/airbyte-integrations/connectors/source-instagram/source_instagram/streams.py
+++ b/airbyte-integrations/connectors/source-instagram/source_instagram/streams.py
@@ -127,15 +127,9 @@ class UserInsights(DatetimeTransformerMixin, InstagramIncrementalStream):
 
     METRICS_BY_PERIOD = {
         "day": [
-            "email_contacts",
             "follower_count",
-            "get_directions_clicks",
             "impressions",
-            "phone_call_clicks",
-            "profile_views",
             "reach",
-            "text_message_clicks",
-            "website_clicks",
         ],
         "week": ["impressions", "reach"],
         "days_28": ["impressions", "reach"],


### PR DESCRIPTION
## What
Solves https://github.com/airbytehq/airbyte/issues/48459
Starting January 8, 2025, the following fields are no longer supported in the following streams. Here are the Facebook docs as a reference: https://developers.facebook.com/docs/graph-api/changelog/version21.0

user_insights: `video_views`
user_insights: `email_contacts, get_direction_clicks, profile_views, text_message_clicks, website_clicks,  phone_call_clicks`

Including these fields results in a bad request and causes these streams to fail syncs.

## How
Unsupported fields have been removed from requests. Schemas and ERDs have been updated

## Review guide
Ensure All unsupported fields are removed from requests

## User Impact
These metrics are no longer available, and will no longer be fetched in records. If users depend on these fields they will need to migrate away from them as Facebook will no longer provide them

## Can this PR be safely reverted and rolled back?

- [ ] YES 💚
- [ x] NO ❌

Because rolling back this PR will produce bad requests and cause syncs to fail. 
