### PR TITLE
[Github Actions/Workflows] - update `actions/upload-artifact` to v4 due to v3 deprecation

### DIFF
--- a/.github/workflows/airbyte-ci-release.yml
+++ b/.github/workflows/airbyte-ci-release.yml
@@ -56,7 +56,7 @@ jobs:
         working-directory: airbyte-ci/connectors/pipelines/
         run: poetry run poe build-release-binary ${{ env.BINARY_FILE_NAME }}
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: airbyte-ci-${{ matrix.os }}-${{ steps.get_short_sha.outputs.sha }}
           path: airbyte-ci/connectors/pipelines/dist/${{ env.BINARY_FILE_NAME }}

--- a/.github/workflows/test-performance-command.yml
+++ b/.github/workflows/test-performance-command.yml
@@ -131,7 +131,7 @@ jobs:
           GCP_GSM_CREDENTIALS: ${{ secrets.GCP_GSM_CREDENTIALS }}
       - name: Archive test reports artifacts
         if: github.event.inputs.comment-id && failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-reports
           path: |
@@ -145,7 +145,7 @@ jobs:
 
       - name: Test coverage reports artifacts
         if: github.event.inputs.comment-id && success()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-reports
           path: |


### PR DESCRIPTION
## What
- `actions/upload-artifact` (and `actions/download-artifact`) v3 is being deprecated and as a result GHA are currently failing -- requiring an update to v4: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
- PR updates `actions/upload-artifact` to v4

## How
- ~actions/upload-artifact@v3~ -> actions/upload-artifact@v4
- The breaking changes from upgrading from v3 to v4 do not impact our use of the library and therefore a 1:1 swap w/o any other changes is possible.


## User Impact
- Faster artifact uploading!
- Working `airbyte-ci-release` workflow!

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [X] YES 💚
- [ ] NO ❌
