### PR TITLE
chore: lower http idle timeout to below serverside s3.

### DIFF
--- a/airbyte-cdk/bulk/toolkits/load-s3/src/main/kotlin/io/airbyte/cdk/load/file/s3/S3Client.kt
+++ b/airbyte-cdk/bulk/toolkits/load-s3/src/main/kotlin/io/airbyte/cdk/load/file/s3/S3Client.kt
@@ -39,6 +39,7 @@ import jakarta.inject.Singleton
 import java.io.ByteArrayOutputStream
 import java.io.InputStream
 import java.io.OutputStream
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.flow.flow
 
 data class S3Object(override val key: String, override val storageConfig: S3BucketConfiguration) :
@@ -249,7 +250,9 @@ class S3ClientFactory(
 
                 // Fix for connection reset issue:
                 // https://github.com/awslabs/aws-sdk-kotlin/issues/1214#issuecomment-2464831817
-                httpClient(CrtHttpEngine)
+                httpClient(CrtHttpEngine) {
+                    connectionIdleTimeout = 3.seconds
+                }
             }
 
         return S3Client(


### PR DESCRIPTION
## What
Configures the http client to use a lower idle connection timeout than the s3 service

## Why
We have seen a lot of transient errors due to closed connections and this is the maintainer sanctioned way of alleviating these issues.

See this [gh thread](https://github.com/awslabs/aws-sdk-kotlin/issues/1214#issuecomment-2464831817) for background.

## Downsides
The s3 server side timeout is not under our control
