### PR TITLE
chore: Use CRT http engine.

### DIFF
--- a/airbyte-cdk/bulk/toolkits/load-s3/build.gradle
+++ b/airbyte-cdk/bulk/toolkits/load-s3/build.gradle
@@ -5,5 +5,6 @@ dependencies {
     api project(':airbyte-cdk:bulk:toolkits:bulk-cdk-toolkit-load-object-storage')
 
     testFixturesApi(testFixtures(project(":airbyte-cdk:bulk:toolkits:bulk-cdk-toolkit-load-object-storage")))
-    implementation("aws.sdk.kotlin:s3:1.3.94")
+    implementation("aws.sdk.kotlin:s3:1.3.98")
+    implementation("aws.smithy.kotlin:http-client-engine-crt:1.3.31")
 }

--- a/airbyte-cdk/bulk/toolkits/load-s3/src/main/kotlin/io/airbyte/cdk/load/file/s3/S3Client.kt
+++ b/airbyte-cdk/bulk/toolkits/load-s3/src/main/kotlin/io/airbyte/cdk/load/file/s3/S3Client.kt
@@ -18,6 +18,7 @@ import aws.sdk.kotlin.services.s3.model.PutObjectRequest
 import aws.smithy.kotlin.runtime.auth.awscredentials.CredentialsProvider
 import aws.smithy.kotlin.runtime.content.ByteStream
 import aws.smithy.kotlin.runtime.content.toInputStream
+import aws.smithy.kotlin.runtime.http.engine.crt.CrtHttpEngine
 import aws.smithy.kotlin.runtime.net.url.Url
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 import io.airbyte.cdk.load.command.aws.AWSAccessKeyConfigurationProvider
@@ -244,7 +245,12 @@ class S3ClientFactory(
                             Url.parse(it)
                         } else null
                     }
+
+                // Fix for connection reset issue:
+                // https://github.com/awslabs/aws-sdk-kotlin/issues/1214#issuecomment-2464831817
+                httpClient(CrtHttpEngine)
             }
+
 
         return S3Client(
             s3SdkClient,

--- a/airbyte-cdk/bulk/toolkits/load-s3/src/main/kotlin/io/airbyte/cdk/load/file/s3/S3Client.kt
+++ b/airbyte-cdk/bulk/toolkits/load-s3/src/main/kotlin/io/airbyte/cdk/load/file/s3/S3Client.kt
@@ -251,7 +251,6 @@ class S3ClientFactory(
                 httpClient(CrtHttpEngine)
             }
 
-
         return S3Client(
             s3SdkClient,
             bucketConfig.s3BucketConfiguration,


### PR DESCRIPTION
## What
Configures the s3 client to use the AWS CRT http client instead of OkHttp

## Why
We have seen a lot of transient errors due to closed connections and this is the maintainer sanctioned way of alleviating these issues.

See this [gh thread](https://github.com/awslabs/aws-sdk-kotlin/issues/1214#issuecomment-2464831817) for background.

## Downsides
We haven't used the CRT client before, so there is some unknown here
