### PR TITLE
fix: avoid okhttp idle connection handling errors.

### DIFF
--- a/airbyte-integrations/connectors/destination-s3/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-s3/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: file
   connectorType: destination
   definitionId: 4816b78f-1489-44c1-9060-4b19d5fa9362
-  dockerImageTag: 1.5.0-rc.6
+  dockerImageTag: 1.5.0-rc.7
   dockerRepository: airbyte/destination-s3
   githubIssueLabel: destination-s3
   icon: s3.svg

--- a/docs/integrations/destinations/s3.md
+++ b/docs/integrations/destinations/s3.md
@@ -544,6 +544,7 @@ To see connector limitations, or troubleshoot your S3 connector, see more [in ou
 
 | Version    | Date       | Pull Request                                               | Subject                                                                                                                                              |
 |:-----------|:-----------|:-----------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| 1.5.0-rc.7 | 2025-01-09 | [51021](https://github.com/airbytehq/airbyte/pull/51021)   | Bug fix: Use CRT HTTP client to avoid OkHttp idle connection handling errors                                                                         |
 | 1.5.0-rc.6 | 2025-01-06 | [50954](https://github.com/airbytehq/airbyte/pull/50954)   | Bug fix: transient failure due to bug in generation tracker                                                                                          |
 | 1.5.0-rc.5 | 2025-01-06 | [50954](https://github.com/airbytehq/airbyte/pull/50954)   | Bug fix: transient failure due to bug in filename clash prevention                                                                                   |
 | 1.5.0-rc.4 | 2025-01-06 | [50954](https://github.com/airbytehq/airbyte/pull/50954)   | Bug fix: StreamLoader::close dispatched multiple times per stream                                                                                    |


### PR DESCRIPTION
## What
Picks up latest CDK s3 toolkit that avoid okhttp idle connection handling errors.