### PR TITLE
[source-xero] ParseDates.convert_dates - fix for datetime truncation

### DIFF
--- a/airbyte-integrations/connectors/source-xero/metadata.yaml
+++ b/airbyte-integrations/connectors/source-xero/metadata.yaml
@@ -31,7 +31,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 6fd1e833-dd6e-45ec-a727-ab917c5be892
-  dockerImageTag: 2.0.0
+  dockerImageTag: 2.0.1
   dockerRepository: airbyte/source-xero
   githubIssueLabel: source-xero
   icon: xero.svg

--- a/airbyte-integrations/connectors/source-xero/pyproject.toml
+++ b/airbyte-integrations/connectors/source-xero/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "2.0.0"
+version = "2.0.1"
 name = "source-xero"
 description = "Source implementation for xero."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-xero/source_xero/components.py
+++ b/airbyte-integrations/connectors/source-xero/source_xero/components.py
@@ -59,7 +59,7 @@ class ParseDates:
                 if isinstance(value, str):
                     parsed_value = ParseDates.parse_date(value)
                     if parsed_value:
-                        if isinstance(parsed_value, date):
+                        if type(parsed_value) == date:
                             parsed_value = datetime.combine(parsed_value, time.min)
                         parsed_value = parsed_value.replace(tzinfo=timezone.utc)
                         obj[key] = datetime.isoformat(parsed_value, timespec="seconds")

--- a/docs/integrations/sources/xero.md
+++ b/docs/integrations/sources/xero.md
@@ -118,18 +118,19 @@ The connector is restricted by Xero [API rate limits](https://developer.xero.com
 <details>
   <summary>Expand to review</summary>
 
-| Version    | Date       | Pull Request                                             | Subject                                 |
-|:-----------|:-----------|:---------------------------------------------------------|:----------------------------------------|
-| 2.0.0      | 2024-06-06 | [39316](https://github.com/airbytehq/airbyte/pull/39316) | Add OAuth and Bearer strategies         |
-| 1.0.1      | 2024-06-06 | [39264](https://github.com/airbytehq/airbyte/pull/39264) | [autopull] Upgrade base image to v1.2.2 |
-| 1.0.0      | 2024-04-30 | [36878](https://github.com/airbytehq/airbyte/pull/36878) | Migrate to low code                     |
-| 0.2.6      | 2024-05-17 | [38330](https://github.com/airbytehq/airbyte/pull/38330) | Updating python dependencies            |
-| 0.2.5      | 2024-01-11 | [34154](https://github.com/airbytehq/airbyte/pull/34154) | prepare for airbyte-lib                 |
-| 0.2.4      | 2023-11-24 | [32837](https://github.com/airbytehq/airbyte/pull/32837) | Handle 403 error                        |
-| 0.2.3      | 2023-06-19 | [27471](https://github.com/airbytehq/airbyte/pull/27471) | Update CDK to 0.40                      |
-| 0.2.2      | 2023-06-06 | [27007](https://github.com/airbytehq/airbyte/pull/27007) | Update CDK                              |
-| 0.2.1      | 2023-03-20 | [24217](https://github.com/airbytehq/airbyte/pull/24217) | Certify to Beta                         |
-| 0.2.0      | 2023-03-14 | [24005](https://github.com/airbytehq/airbyte/pull/24005) | Enable in Cloud                         |
-| 0.1.0      | 2021-11-11 | [18666](https://github.com/airbytehq/airbyte/pull/18666) | 🎉 New Source - Xero [python cdk]       |
+| Version | Date       | Pull Request                                             | Subject                                                   |
+|:--------|:-----------|:---------------------------------------------------------|:----------------------------------------------------------|
+| 2.0.1   | 2025-01-10 | [51034](https://github.com/airbytehq/airbyte/pull/51034) | Fix for time part being removed from all datetimes fields |
+| 2.0.0   | 2024-06-06 | [39316](https://github.com/airbytehq/airbyte/pull/39316) | Add OAuth and Bearer strategies                           |
+| 1.0.1   | 2024-06-06 | [39264](https://github.com/airbytehq/airbyte/pull/39264) | [autopull] Upgrade base image to v1.2.2                   |
+| 1.0.0   | 2024-04-30 | [36878](https://github.com/airbytehq/airbyte/pull/36878) | Migrate to low code                                       |
+| 0.2.6   | 2024-05-17 | [38330](https://github.com/airbytehq/airbyte/pull/38330) | Updating python dependencies                              |
+| 0.2.5   | 2024-01-11 | [34154](https://github.com/airbytehq/airbyte/pull/34154) | prepare for airbyte-lib                                   |
+| 0.2.4   | 2023-11-24 | [32837](https://github.com/airbytehq/airbyte/pull/32837) | Handle 403 error                                          |
+| 0.2.3   | 2023-06-19 | [27471](https://github.com/airbytehq/airbyte/pull/27471) | Update CDK to 0.40                                        |
+| 0.2.2   | 2023-06-06 | [27007](https://github.com/airbytehq/airbyte/pull/27007) | Update CDK                                                |
+| 0.2.1   | 2023-03-20 | [24217](https://github.com/airbytehq/airbyte/pull/24217) | Certify to Beta                                           |
+| 0.2.0   | 2023-03-14 | [24005](https://github.com/airbytehq/airbyte/pull/24005) | Enable in Cloud                                           |
+| 0.1.0   | 2021-11-11 | [18666](https://github.com/airbytehq/airbyte/pull/18666) | 🎉 New Source - Xero [python cdk]                         |
 
 </details>


### PR DESCRIPTION
Fixes https://github.com/airbytehq/airbyte/issues/51007

## What

The condition `if isinstance(parsed_value, date)` is always true even for datetime instances ( [Reproducible Example](https://www.online-python.com/hdg5trp4BM) )

So it always replaces time part of all datetime instances with 00:00:00

## How

Replaced isinstance with the exact type checking

## User Impact

`UpdatedDateUTC` field of all entities will finally have time part

## Can this PR be safely reverted and rolled back?

- [ ] YES 💚
- [ ] NO ❌
