### PR TITLE
fix: (source-monday) - fix the `oauth_connector_input_specification` structure

### DIFF
--- a/airbyte-integrations/connectors/source-monday/source_monday/spec.json
+++ b/airbyte-integrations/connectors/source-monday/source_monday/spec.json
@@ -117,14 +117,10 @@
         }
       },
       "oauth_connector_input_specification": {
-        "type": "object",
-        "additionalProperties": false,
-        "properties": {
-          "scope": "me:read boards:read workspaces:read users:read account:read updates:read assets:read tags:read teams:read",
-          "consent_url": "https://auth.monday.com/oauth2/authorize?{{client_id_param}}&{{redirect_uri_param}}&{{scope_param}}&{{state_param}}&subdomain={{subdomain}}",
-          "access_token_url": "https://auth.monday.com/oauth2/token?{{client_id_param}}&{{client_secret_param}}&{{auth_code_param}}&{{redirect_uri_param}}",
-          "extract_output": ["access_token"]
-        }
+        "scope": "me:read boards:read workspaces:read users:read account:read updates:read assets:read tags:read teams:read",
+        "consent_url": "https://auth.monday.com/oauth2/authorize?{{client_id_param}}&{{redirect_uri_param}}&{{scope_param}}&{{state_param}}&subdomain={{subdomain}}",
+        "access_token_url": "https://auth.monday.com/oauth2/token?{{client_id_param}}&{{client_secret_param}}&{{auth_code_param}}&{{redirect_uri_param}}",
+        "extract_output": ["access_token"]
       },
       "oauth_user_input_from_connector_config_specification": {
         "type": "object",


### PR DESCRIPTION
## What
Following this change: https://github.com/airbytehq/airbyte/pull/50984 , the declared structure of the `oauth_connector_input_specification` should not include the `properties`. 


