### PR TITLE
Destination S3-V2: Bug: Honor path variables in bucket prefix

### DIFF
--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/file/object_storage/ObjectStoragePathFactory.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/file/object_storage/ObjectStoragePathFactory.kt
@@ -39,7 +39,7 @@ interface PathFactory {
     fun getPathMatcher(stream: DestinationStream, suffixPattern: String? = null): PathMatcher
 
     val supportsStaging: Boolean
-    val prefix: String
+    val finalPrefix: String
 }
 
 data class PathMatcher(val regex: Regex, val variableToIndex: Map<String, Int>) {
@@ -63,23 +63,14 @@ class ObjectStoragePathFactory(
     compressionConfigProvider: ObjectStorageCompressionConfigurationProvider<*>? = null,
     private val timeProvider: TimeProvider,
 ) : PathFactory {
+    // Resolved configuration
     private val pathConfig = pathConfigProvider.objectStoragePathConfiguration
+    override val supportsStaging: Boolean = pathConfig.usesStagingDirectory
+
+    // Resolved bucket path prefixes
     private val stagingPrefixResolved =
         pathConfig.stagingPrefix
             ?: Paths.get(pathConfig.prefix, DEFAULT_STAGING_PREFIX_SUFFIX).toString()
-    private val pathPatternResolved = pathConfig.pathSuffixPattern ?: DEFAULT_PATH_FORMAT
-    private val filePatternResolved = pathConfig.fileNamePattern ?: DEFAULT_FILE_FORMAT
-    private val fileFormatExtension =
-        formatConfigProvider?.objectStorageFormatConfiguration?.extension
-    private val compressionExtension =
-        compressionConfigProvider?.objectStorageCompressionConfiguration?.compressor?.extension
-    private val defaultExtension =
-        if (fileFormatExtension != null && compressionExtension != null) {
-            "$fileFormatExtension.$compressionExtension"
-        } else {
-            fileFormatExtension ?: compressionExtension
-        }
-
     private val stagingPrefix: String
         get() =
             if (!pathConfig.usesStagingDirectory) {
@@ -89,13 +80,27 @@ class ObjectStoragePathFactory(
             } else {
                 stagingPrefixResolved
             }
-
-    override val supportsStaging: Boolean = pathConfig.usesStagingDirectory
-    override val prefix: String =
+    override val finalPrefix: String =
         if (pathConfig.prefix.endsWith('/')) {
             pathConfig.prefix.take(pathConfig.prefix.length - 1)
         } else {
             pathConfig.prefix
+        }
+
+    // Resolved path and filename patterns
+    private val pathPatternResolved = pathConfig.pathSuffixPattern ?: DEFAULT_PATH_FORMAT
+    private val filePatternResolved = pathConfig.fileNamePattern ?: DEFAULT_FILE_FORMAT
+
+    // Resolved file extensions
+    private val fileFormatExtension =
+        formatConfigProvider?.objectStorageFormatConfiguration?.extension
+    private val compressionExtension =
+        compressionConfigProvider?.objectStorageCompressionConfiguration?.compressor?.extension
+    private val defaultExtension =
+        if (fileFormatExtension != null && compressionExtension != null) {
+            "$fileFormatExtension.$compressionExtension"
+        } else {
+            fileFormatExtension ?: compressionExtension
         }
 
     /**
@@ -252,10 +257,17 @@ class ObjectStoragePathFactory(
         }
     }
 
+    /**
+     * This is to maintain parity with legacy code. Whether the path pattern ends with "/" is
+     * significant.
+     *
+     * * path: "{STREAM_NAME}/foo/" + "{part_number}{format_extension}" => "my_stream/foo/1.json"
+     * * path: "{STREAM_NAME}/foo" + "{part_number}{format_extension}" => "my_stream/foo1.json"
+     */
     private fun resolveRetainingTerminalSlash(prefix: String, path: String): String {
         val asPath = Paths.get(prefix, path)
         return if (path.endsWith('/')) {
-            asPath.toString() + "/"
+            "$asPath/"
         } else {
             asPath.toString()
         }
@@ -265,26 +277,24 @@ class ObjectStoragePathFactory(
         stream: DestinationStream,
         substituteStreamAndNamespaceOnly: Boolean
     ): String {
-        val path =
-            getFormattedPath(
-                stream,
-                if (substituteStreamAndNamespaceOnly) PATH_VARIABLES_STREAM_CONSTANT
-                else PATH_VARIABLES
-            )
-        return resolveRetainingTerminalSlash(stagingPrefix, path)
+        return getFormattedPath(
+            stream,
+            if (substituteStreamAndNamespaceOnly) PATH_VARIABLES_STREAM_CONSTANT
+            else PATH_VARIABLES,
+            isStaging = true
+        )
     }
 
     override fun getFinalDirectory(
         stream: DestinationStream,
         substituteStreamAndNamespaceOnly: Boolean
     ): String {
-        val path =
-            getFormattedPath(
-                stream,
-                if (substituteStreamAndNamespaceOnly) PATH_VARIABLES_STREAM_CONSTANT
-                else PATH_VARIABLES
-            )
-        return resolveRetainingTerminalSlash(prefix, path)
+        return getFormattedPath(
+            stream,
+            if (substituteStreamAndNamespaceOnly) PATH_VARIABLES_STREAM_CONSTANT
+            else PATH_VARIABLES,
+            isStaging = false
+        )
     }
 
     override fun getLongestStreamConstantPrefix(
@@ -323,9 +333,11 @@ class ObjectStoragePathFactory(
 
     private fun getFormattedPath(
         stream: DestinationStream,
-        variables: List<PathVariable> = PATH_VARIABLES
+        variables: List<PathVariable> = PATH_VARIABLES,
+        isStaging: Boolean
     ): String {
-        val pattern = pathPatternResolved
+        val selectedPrefix = if (isStaging) stagingPrefix else finalPrefix
+        val pattern = resolveRetainingTerminalSlash(selectedPrefix, pathPatternResolved)
         val context = VariableContext(stream)
         return variables.fold(pattern) { acc, variable -> variable.maybeApply(acc, context) }
     }
@@ -375,13 +387,10 @@ class ObjectStoragePathFactory(
         val pathVariableToPattern = getPathVariableToPattern(stream)
         val variableToIndex = mutableMapOf<String, Int>()
 
+        val pathPattern = resolveRetainingTerminalSlash(finalPrefix, pathPatternResolved)
+
         val replacedForPath =
-            buildPattern(
-                pathPatternResolved,
-                """\\\$\{(\w+)}""",
-                pathVariableToPattern,
-                variableToIndex
-            )
+            buildPattern(pathPattern, """\\\$\{(\w+)}""", pathVariableToPattern, variableToIndex)
         val replacedForFile =
             buildPattern(
                 filePatternResolved,
@@ -391,12 +400,9 @@ class ObjectStoragePathFactory(
             )
         // NOTE the old code does not actually resolve the path + filename,
         // even tho the documentation says it does.
-        val combined =
-            if (replacedForPath.startsWith('/')) {
-                "${prefix}$replacedForPath$replacedForFile"
-            } else {
-                "$prefix/$replacedForPath$replacedForFile"
-            }
+        val replacedForPathWithEmptyVariablesRemoved =
+            resolveRetainingTerminalSlash("", replacedForPath)
+        val combined = "$replacedForPathWithEmptyVariablesRemoved$replacedForFile"
         val withSuffix =
             if (suffixPattern != null) {
                 variableToIndex["suffix"] = variableToIndex.size + 1

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/test/kotlin/io/airbyte/cdk/load/file/object_storage/ObjectStoragePathFactoryUTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/test/kotlin/io/airbyte/cdk/load/file/object_storage/ObjectStoragePathFactoryUTest.kt
@@ -48,4 +48,41 @@ class ObjectStoragePathFactoryUTest {
         assertNotNull(match2)
         assertEquals(match2?.customSuffix, "-1")
     }
+
+    @Test
+    fun `test file pattern with variable in prefix`() {
+        every { pathConfigProvider.objectStoragePathConfiguration } returns
+            ObjectStoragePathConfiguration(
+                "prefix-\${NAMESPACE}",
+                "staging-\${NAMESPACE}",
+                "\${STREAM_NAME}/",
+                "any_filename",
+                true,
+            )
+        val factory = ObjectStoragePathFactory(pathConfigProvider, null, null, timeProvider)
+        assertEquals(
+            "prefix-test/stream/any_filename",
+            factory.getPathToFile(stream, 0L, isStaging = false)
+        )
+        assertEquals(
+            "staging-test/stream/any_filename",
+            factory.getPathToFile(stream, 0L, isStaging = true)
+        )
+    }
+
+    @Test
+    fun `test pattern matcher with variable in prefix`() {
+        every { pathConfigProvider.objectStoragePathConfiguration } returns
+            ObjectStoragePathConfiguration(
+                "prefix-\${NAMESPACE}",
+                "staging-\${NAMESPACE}",
+                "\${STREAM_NAME}/",
+                "any_filename",
+                true,
+            )
+        val factory = ObjectStoragePathFactory(pathConfigProvider, null, null, timeProvider)
+        val matcher = factory.getPathMatcher(stream, "(-foo)?")
+        assertNotNull(matcher.match("prefix-test/stream/any_filename"))
+        assertNotNull(matcher.match("prefix-test/stream/any_filename-foo"))
+    }
 }

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/test/kotlin/io/airbyte/cdk/load/state/object_storage/ObjectStorageDestinationStateTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/test/kotlin/io/airbyte/cdk/load/state/object_storage/ObjectStorageDestinationStateTest.kt
@@ -210,7 +210,7 @@ class ObjectStorageDestinationStateTest {
         ): List<Triple<Int, String, Long>> {
             val genIdKey = ObjectStorageDestinationState.METADATA_GENERATION_ID_KEY
             val prefix =
-                "${d.pathFactory.prefix}/${stream.descriptor.namespace}/${stream.descriptor.name}"
+                "${d.pathFactory.finalPrefix}/${stream.descriptor.namespace}/${stream.descriptor.name}"
             val generations =
                 listOf(
                     Triple(0, "$prefix/key1-0", 0L),

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/testFixtures/kotlin/io/airbyte/cdk/load/MockPathFactory.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/testFixtures/kotlin/io/airbyte/cdk/load/MockPathFactory.kt
@@ -17,7 +17,7 @@ open class MockPathFactory : PathFactory {
 
     override val supportsStaging: Boolean
         get() = doSupportStaging
-    override val prefix: String
+    override val finalPrefix: String
         get() = "prefix"
 
     private fun fromStream(stream: DestinationStream): String {
@@ -28,14 +28,14 @@ open class MockPathFactory : PathFactory {
         stream: DestinationStream,
         substituteStreamAndNamespaceOnly: Boolean
     ): String {
-        return "$prefix/staging/${fromStream(stream)}"
+        return "$finalPrefix/staging/${fromStream(stream)}"
     }
 
     override fun getFinalDirectory(
         stream: DestinationStream,
         substituteStreamAndNamespaceOnly: Boolean
     ): String {
-        return "$prefix/${fromStream(stream)}"
+        return "$finalPrefix/${fromStream(stream)}"
     }
 
     override fun getPathToFile(
@@ -66,7 +66,7 @@ open class MockPathFactory : PathFactory {
         return PathMatcher(
             regex =
                 Regex(
-                    "$prefix/(${stream.descriptor.namespace})/(${stream.descriptor.name})/(.*)-(.*)$"
+                    "$finalPrefix/(${stream.descriptor.namespace})/(${stream.descriptor.name})/(.*)-(.*)$"
                 ),
             variableToIndex = mapOf("part_number" to 4)
         )


### PR DESCRIPTION
## What
The old CDK honored variables in both the bucket prefix and the path. The documentation is a little ambiguous about this, but it's a reasonable expectation that they should work in both places. This gets parity with the old code.

I'll test against [this connection](https://cloud.airbyte.com/workspaces/d8c3f25f-65a7-46b6-b1ab-30a94e475219/destination/3cdc10c1-9b24-4e40-b89e-867149fa3bef) before releasing

I also modified the ambiguous filepath config secret to use this pattern, so there's an IT test case as well as a UTs:

```
{
...
  "s3_bucket_path": "s3-v2-test/${NAMESPACE}",
...
  "s3_path_format": "${STREAM_NAME}/",
  "file_name_pattern": "very_bad_practice"
}
``` 
