### PR TITLE
bug(airbyte-ci:) fix publish connector flow with new runner

### DIFF
--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -20,7 +20,7 @@ on:
 jobs:
   publish_connectors:
     name: Publish connectors
-    runs-on: connector-publish-large
+    runs-on: ubuntu-24.04-4core
     steps:
       - name: Checkout Airbyte
         uses: actions/checkout@v4


### PR DESCRIPTION
## What
connector-publish-large runner that was depending un ubutnu latest was causing this error so we switch to a new runner created by @maxi297 

```
Run if [[ "refs/heads/aldogonzalez8/source-sftp-bulk/not-mirroring-paths" != "refs/heads/master" ]] && [[ "false" == "true" ]]; then
Run curl -sSL https://connectors.airbyte.com/airbyte-ci/releases/ubuntu/latest/airbyte-ci --output airbyte-ci-bin
Run dagger_engine_image=$(airbyte-ci --ci-requirements | tail -n 1 | jq -r '.dagger_engine_image')
[PYI-2141:ERROR] Failed to load Python shared library '/tmp/_MEIfZbHDW/libpython3.10.so.1.0': dlopen: /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.38' not found (required by /tmp/_MEIfZbHDW/libpython3.10.so.1.0)
```

## How
Switch to ubuntu-24.04-4core runner

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
Devs will be able to publish conectors

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
