### PR TITLE
destination-gcs: Use airbyte/java-connector-base:2.0.0

### DIFF
--- a/airbyte-integrations/connectors/destination-gcs/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-gcs/metadata.yaml
@@ -3,7 +3,7 @@ data:
     ql: 300
     sl: 100
   connectorBuildOptions:
-    baseImage: docker.io/airbyte/java-connector-base:1.0.0@sha256:be86e5684e1e6d9280512d3d8071b47153698fe08ad990949c8eeff02803201a
+    baseImage: docker.io/airbyte/java-connector-base:2.0.0@sha256:5a1a21c75c5e1282606de9fa539ba136520abe2fbd013058e988bb0297a9f454
   connectorSubtype: file
   connectorTestSuitesOptions:
     - suite: integrationTests
@@ -20,7 +20,7 @@ data:
             type: GSM
   connectorType: destination
   definitionId: ca8f6566-e555-4b40-943a-545bf123117a
-  dockerImageTag: 0.4.7
+  dockerImageTag: 0.4.8
   dockerRepository: airbyte/destination-gcs
   documentationUrl: https://docs.airbyte.com/integrations/destinations/gcs
   githubIssueLabel: destination-gcs

--- a/docs/integrations/destinations/gcs.md
+++ b/docs/integrations/destinations/gcs.md
@@ -242,6 +242,7 @@ Under the hood, an Airbyte data stream in Json schema is first converted to an A
 
 | Version | Date       | Pull Request                                               | Subject                                                                                                                    |
 | :------ | :--------- | :--------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------- |
+| 0.4.8 | 2025-01-10 | [51479](https://github.com/airbytehq/airbyte/pull/51479) | Use a non root base image |
 | 0.4.7 | 2024-12-18 | [49884](https://github.com/airbytehq/airbyte/pull/49884) | Use a base image: airbyte/java-connector-base:1.0.0 |
 | 0.4.6 | 2024-02-15 | [35285](https://github.com/airbytehq/airbyte/pull/35285) | Adopt CDK 0.20.8 |
 | 0.4.5 | 2024-02-08 | [34745](https://github.com/airbytehq/airbyte/pull/34745) | Adopt CDK 0.19.0 |


### PR DESCRIPTION
Make the connector use our official non-root base image for java connectors