### PR TITLE
source-cockroachdb: Use airbyte/java-connector-base:2.0.0

### DIFF
--- a/airbyte-integrations/connectors/source-cockroachdb/metadata.yaml
+++ b/airbyte-integrations/connectors/source-cockroachdb/metadata.yaml
@@ -6,14 +6,14 @@ data:
     hosts:
       - ${host}
   connectorBuildOptions:
-    baseImage: docker.io/airbyte/java-connector-base:1.0.0@sha256:be86e5684e1e6d9280512d3d8071b47153698fe08ad990949c8eeff02803201a
+    baseImage: docker.io/airbyte/java-connector-base:2.0.0@sha256:5a1a21c75c5e1282606de9fa539ba136520abe2fbd013058e988bb0297a9f454
   connectorSubtype: database
   connectorTestSuitesOptions:
     - suite: unitTests
     - suite: integrationTests
   connectorType: source
   definitionId: 9fa5862c-da7c-11eb-8d19-0242ac130003
-  dockerImageTag: 0.2.3
+  dockerImageTag: 0.2.4
   dockerRepository: airbyte/source-cockroachdb
   documentationUrl: https://docs.airbyte.com/integrations/sources/cockroachdb
   githubIssueLabel: source-cockroachdb

--- a/docs/integrations/sources/cockroachdb.md
+++ b/docs/integrations/sources/cockroachdb.md
@@ -98,6 +98,7 @@ Your database user should now be ready for use with Airbyte.
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                                   |
 | :------ | :--------- | :------------------------------------------------------- | :---------------------------------------------------------------------------------------------------------------------------------------- |
+| 0.2.4 | 2025-01-10 | [51484](https://github.com/airbytehq/airbyte/pull/51484) | Use a non root base image |
 | 0.2.3 | 2024-12-18 | [49915](https://github.com/airbytehq/airbyte/pull/49915) | Use a base image: airbyte/java-connector-base:1.0.0 |
 | 0.2.2 | 2024-02-13 | [35234](https://github.com/airbytehq/airbyte/pull/35234) | Adopt CDK 0.20.4 |
 | 0.2.1 | 2024-01-24 | [34453](https://github.com/airbytehq/airbyte/pull/34453) | bump CDK version |


### PR DESCRIPTION
Make the connector use our official non-root base image for java connectors