### PR TITLE
source-teradata: Use airbyte/java-connector-base:2.0.0

### DIFF
--- a/airbyte-integrations/connectors/source-teradata/metadata.yaml
+++ b/airbyte-integrations/connectors/source-teradata/metadata.yaml
@@ -6,7 +6,7 @@ data:
     hosts:
       - ${host}
   connectorBuildOptions:
-    baseImage: docker.io/airbyte/java-connector-base:1.0.0@sha256:be86e5684e1e6d9280512d3d8071b47153698fe08ad990949c8eeff02803201a
+    baseImage: docker.io/airbyte/java-connector-base:2.0.0@sha256:5a1a21c75c5e1282606de9fa539ba136520abe2fbd013058e988bb0297a9f454
   connectorSubtype: database
   connectorTestSuitesOptions:
     - suite: unitTests
@@ -19,7 +19,7 @@ data:
             type: GSM
   connectorType: source
   definitionId: aa8ba6fd-4875-d94e-fc8d-4e1e09aa2503
-  dockerImageTag: 0.2.4
+  dockerImageTag: 0.2.5
   dockerRepository: airbyte/source-teradata
   documentationUrl: https://docs.airbyte.com/integrations/sources/teradata
   githubIssueLabel: source-teradata

--- a/docs/integrations/sources/teradata.md
+++ b/docs/integrations/sources/teradata.md
@@ -66,7 +66,8 @@ You need a Teradata user which has read permissions on the database
 
 | Version | Date       | Pull Request                                             | Subject                     |
 | :------ | :--------- | :------------------------------------------------------- | :-------------------------- |
-| 0.2.4   | 2024-09-05 | [45158](https://github.com/airbytehq/airbyte/pull/45158) | Fix bug in source teradata  |
+| 0.2.5 | 2025-01-10 | [51485](https://github.com/airbytehq/airbyte/pull/51485) | Use a non root base image |
+| 0.2.4 | 2024-09-05 | [45158](https://github.com/airbytehq/airbyte/pull/45158) | Fix bug in source teradata |
 | 0.2.3 | 2024-12-18 | [49894](https://github.com/airbytehq/airbyte/pull/49894) | Use a base image: airbyte/java-connector-base:1.0.0 |
 | 0.2.2 | 2024-02-13 | [35219](https://github.com/airbytehq/airbyte/pull/35219) | Adopt CDK 0.20.4 |
 | 0.2.1 | 2024-01-24 | [34453](https://github.com/airbytehq/airbyte/pull/34453) | bump CDK version |


### PR DESCRIPTION
Make the connector use our official non-root base image for java connectors