### PR TITLE
destination-local-json: Use airbyte/java-connector-base:2.0.0

### DIFF
--- a/airbyte-integrations/connectors/destination-local-json/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-local-json/metadata.yaml
@@ -3,14 +3,14 @@ data:
     ql: 100
     sl: 100
   connectorBuildOptions:
-    baseImage: docker.io/airbyte/java-connector-base:1.0.0@sha256:be86e5684e1e6d9280512d3d8071b47153698fe08ad990949c8eeff02803201a
+    baseImage: docker.io/airbyte/java-connector-base:2.0.0@sha256:5a1a21c75c5e1282606de9fa539ba136520abe2fbd013058e988bb0297a9f454
   connectorSubtype: file
   connectorTestSuitesOptions:
     - suite: unitTests
     - suite: integrationTests
   connectorType: destination
   definitionId: a625d593-bba5-4a1c-a53d-2d246268a816
-  dockerImageTag: 0.2.12
+  dockerImageTag: 0.2.13
   dockerRepository: airbyte/destination-local-json
   documentationUrl: https://docs.airbyte.com/integrations/destinations/local-json
   githubIssueLabel: destination-local-json

--- a/docs/integrations/destinations/local-json.md
+++ b/docs/integrations/destinations/local-json.md
@@ -78,6 +78,7 @@ Note: If you are running Airbyte on Windows with Docker backed by WSL2, you have
 
 | Version | Date       | Pull Request                                             | Subject                      |
 | :------ | :--------- | :------------------------------------------------------- | :--------------------------- |
+| 0.2.13 | 2025-01-10 | [51486](https://github.com/airbytehq/airbyte/pull/51486) | Use a non root base image |
 | 0.2.12 | 2024-12-18 | [49908](https://github.com/airbytehq/airbyte/pull/49908) | Use a base image: airbyte/java-connector-base:1.0.0 |
 | 0.2.11 | 2022-02-14 | [14641](https://github.com/airbytehq/airbyte/pull/14641) | Include lifecycle management |
 


### PR DESCRIPTION
Make the connector use our official non-root base image for java connectors