### PR TITLE
destination-iceberg: Use airbyte/java-connector-base:2.0.0

### DIFF
--- a/airbyte-integrations/connectors/destination-iceberg/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-iceberg/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: df65a8f3-9908-451b-aa9b-445462803560
-  dockerImageTag: 0.2.3
+  dockerImageTag: 0.2.4
   dockerRepository: airbyte/destination-iceberg
   githubIssueLabel: destination-iceberg
   icon: iceberg.svg
@@ -22,7 +22,7 @@ data:
     ql: 100
   supportLevel: community
   connectorBuildOptions:
-    baseImage: docker.io/airbyte/java-connector-base:1.0.0@sha256:be86e5684e1e6d9280512d3d8071b47153698fe08ad990949c8eeff02803201a
+    baseImage: docker.io/airbyte/java-connector-base:2.0.0@sha256:5a1a21c75c5e1282606de9fa539ba136520abe2fbd013058e988bb0297a9f454
   connectorTestSuitesOptions:
     - suite: unitTests
     - suite: integrationTests

--- a/docs/integrations/destinations/iceberg.md
+++ b/docs/integrations/destinations/iceberg.md
@@ -75,6 +75,7 @@ specify the target size of compacted Iceberg data file.
 
 | Version | Date       | Pull Request                                              | Subject                                                        |
 |:--------|:-----------|:----------------------------------------------------------|:---------------------------------------------------------------|
+| 0.2.4 | 2025-01-10 | [51492](https://github.com/airbytehq/airbyte/pull/51492) | Use a non root base image |
 | 0.2.3 | 2024-12-17 | [49841](https://github.com/airbytehq/airbyte/pull/49841) | Use a base image: airbyte/java-connector-base:1.0.0 |
 | 0.2.2 | 2024-09-23 | [45861](https://github.com/airbytehq/airbyte/pull/45861) | Keeping only S3 with Glue Catalog as config option |
 | 0.2.1 | 2024-09-20 | [45711](https://github.com/airbytehq/airbyte/pull/45711) | Initial Cloud version for registry purpose [UNTESTED ON CLOUD] |


### PR DESCRIPTION
Make the connector use our official non-root base image for java connectors