### PR TITLE
source-tidb: Use airbyte/java-connector-base:2.0.0

### DIFF
--- a/airbyte-integrations/connectors/source-tidb/metadata.yaml
+++ b/airbyte-integrations/connectors/source-tidb/metadata.yaml
@@ -7,14 +7,14 @@ data:
       - ${host}
       - ${tunnel_method.tunnel_host}
   connectorBuildOptions:
-    baseImage: docker.io/airbyte/java-connector-base:1.0.0@sha256:be86e5684e1e6d9280512d3d8071b47153698fe08ad990949c8eeff02803201a
+    baseImage: docker.io/airbyte/java-connector-base:2.0.0@sha256:5a1a21c75c5e1282606de9fa539ba136520abe2fbd013058e988bb0297a9f454
   connectorSubtype: database
   connectorTestSuitesOptions:
     - suite: unitTests
     - suite: integrationTests
   connectorType: source
   definitionId: 0dad1a35-ccf8-4d03-b73e-6788c00b13ae
-  dockerImageTag: 0.3.3
+  dockerImageTag: 0.3.4
   dockerRepository: airbyte/source-tidb
   documentationUrl: https://docs.airbyte.com/integrations/sources/tidb
   githubIssueLabel: source-tidb

--- a/docs/integrations/sources/tidb.md
+++ b/docs/integrations/sources/tidb.md
@@ -130,6 +130,7 @@ Now that you have set up the TiDB source connector, check out the following TiDB
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                                   |
 | :------ | :--------- | :------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| 0.3.4 | 2025-01-10 | [51499](https://github.com/airbytehq/airbyte/pull/51499) | Use a non root base image |
 | 0.3.3 | 2024-12-18 | [49896](https://github.com/airbytehq/airbyte/pull/49896) | Use a base image: airbyte/java-connector-base:1.0.0 |
 | 0.3.2 | 2024-02-13 | [35218](https://github.com/airbytehq/airbyte/pull/35218) | Adopt CDK 0.20.4 |
 | 0.3.1 | 2024-01-24 | [34453](https://github.com/airbytehq/airbyte/pull/34453) | bump CDK version |


### PR DESCRIPTION
Make the connector use our official non-root base image for java connectors