### PR TITLE
source-singlestore: Use airbyte/java-connector-base:2.0.0

### DIFF
--- a/airbyte-integrations/connectors/source-singlestore/metadata.yaml
+++ b/airbyte-integrations/connectors/source-singlestore/metadata.yaml
@@ -3,11 +3,11 @@ data:
     hosts:
       - ${host}
   connectorBuildOptions:
-    baseImage: docker.io/airbyte/java-connector-base:1.0.0@sha256:be86e5684e1e6d9280512d3d8071b47153698fe08ad990949c8eeff02803201a
+    baseImage: docker.io/airbyte/java-connector-base:2.0.0@sha256:5a1a21c75c5e1282606de9fa539ba136520abe2fbd013058e988bb0297a9f454
   connectorSubtype: database
   connectorType: source
   definitionId: 2e8ae725-0069-4452-afa0-d1848cf69676
-  dockerImageTag: 0.1.1
+  dockerImageTag: 0.1.2
   dockerRepository: airbyte/source-singlestore
   documentationUrl: https://docs.airbyte.com/integrations/sources/singlestore
   githubIssueLabel: source-singlestore

--- a/docs/integrations/sources/singlestore.md
+++ b/docs/integrations/sources/singlestore.md
@@ -172,6 +172,7 @@ SingleStore data types are mapped to the following data types when synchronizing
 
 | Version | Date       | Pull Request                                           | Subject                          |
 |:--------|:-----------|:-------------------------------------------------------|:---------------------------------|
+| 0.1.2 | 2025-01-10 | [51501](https://github.com/airbytehq/airbyte/pull/51501) | Use a non root base image |
 | 0.1.1 | 2024-12-18 | [49862](https://github.com/airbytehq/airbyte/pull/49862) | Use a base image: airbyte/java-connector-base:1.0.0 |
 | 0.1.0 | 2024-04-16 | [37337](https://github.com/airbytehq/airbyte/pull/37337) | Add SingleStore source connector |
  


### PR DESCRIPTION
Make the connector use our official non-root base image for java connectors