### PR TITLE
source-db2: Use airbyte/java-connector-base:2.0.0

### DIFF
--- a/airbyte-integrations/connectors/source-db2/metadata.yaml
+++ b/airbyte-integrations/connectors/source-db2/metadata.yaml
@@ -6,14 +6,14 @@ data:
     hosts:
       - ${host}
   connectorBuildOptions:
-    baseImage: docker.io/airbyte/java-connector-base:1.0.0@sha256:be86e5684e1e6d9280512d3d8071b47153698fe08ad990949c8eeff02803201a
+    baseImage: docker.io/airbyte/java-connector-base:2.0.0@sha256:5a1a21c75c5e1282606de9fa539ba136520abe2fbd013058e988bb0297a9f454
   connectorSubtype: database
   connectorTestSuitesOptions:
     - suite: unitTests
     - suite: integrationTests
   connectorType: source
   definitionId: 447e0381-3780-4b46-bb62-00a4e3c8b8e2
-  dockerImageTag: 0.2.3
+  dockerImageTag: 0.2.4
   dockerRepository: airbyte/source-db2
   documentationUrl: https://docs.airbyte.com/integrations/sources/db2
   githubIssueLabel: source-db2

--- a/docs/integrations/sources/db2.md
+++ b/docs/integrations/sources/db2.md
@@ -63,6 +63,7 @@ You can also enter your own password for the keystore, but if you don't, the pas
 
 | Version | Date       | Pull Request                                                                                                  | Subject                                                                                                                                   |
 | :------ | :--------- | :------------------------------------------------------------------------------------------------------------ | :---------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| 0.2.4 | 2025-01-10 | [51502](https://github.com/airbytehq/airbyte/pull/51502) | Use a non root base image |
 | 0.2.3 | 2024-12-18 | [49909](https://github.com/airbytehq/airbyte/pull/49909) | Use a base image: airbyte/java-connector-base:1.0.0 |
 | 0.2.2 | 2024-02-13 | [35233](https://github.com/airbytehq/airbyte/pull/35233) | Adopt CDK 0.20.4 |
 | 0.2.1 | 2024-01-24 | [34453](https://github.com/airbytehq/airbyte/pull/34453) | bump CDK version |


### PR DESCRIPTION
Make the connector use our official non-root base image for java connectors