### PR TITLE
destination-azure-blob-storage: Use airbyte/java-connector-base:2.0.0

### DIFF
--- a/airbyte-integrations/connectors/destination-azure-blob-storage/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-azure-blob-storage/metadata.yaml
@@ -3,7 +3,7 @@ data:
     ql: 100
     sl: 100
   connectorBuildOptions:
-    baseImage: docker.io/airbyte/java-connector-base:1.0.0@sha256:be86e5684e1e6d9280512d3d8071b47153698fe08ad990949c8eeff02803201a
+    baseImage: docker.io/airbyte/java-connector-base:2.0.0@sha256:5a1a21c75c5e1282606de9fa539ba136520abe2fbd013058e988bb0297a9f454
   connectorSubtype: file
   connectorTestSuitesOptions:
     - suite: unitTests
@@ -26,7 +26,7 @@ data:
             type: GSM
   connectorType: destination
   definitionId: b4c5d105-31fd-4817-96b6-cb923bfc04cb
-  dockerImageTag: 0.2.3
+  dockerImageTag: 0.2.4
   dockerRepository: airbyte/destination-azure-blob-storage
   documentationUrl: https://docs.airbyte.com/integrations/destinations/azure-blob-storage
   githubIssueLabel: destination-azure-blob-storage

--- a/docs/integrations/destinations/azure-blob-storage.md
+++ b/docs/integrations/destinations/azure-blob-storage.md
@@ -152,6 +152,7 @@ With the field `File Extension`, it is possible to save the output files with ex
 
 | Version | Date       | Pull Request                                               | Subject                                                                                                                                                         |
 |:--------|:-----------|:-----------------------------------------------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 0.2.4 | 2025-01-10 | [51507](https://github.com/airbytehq/airbyte/pull/51507) | Use a non root base image |
 | 0.2.3 | 2024-12-18 | [49910](https://github.com/airbytehq/airbyte/pull/49910) | Use a base image: airbyte/java-connector-base:1.0.0 |
 | 0.2.2   | 2024-06-12 | [\#38061](https://github.com/airbytehq/airbyte/pull/38061) | File Extensions added for the output files                                                                                                                      |
 | 0.2.1   | 2023-09-13 | [\#30412](https://github.com/airbytehq/airbyte/pull/30412) | Switch noisy logging to debug                                                                                                                                   |


### PR DESCRIPTION
Make the connector use our official non-root base image for java connectors