### PR TITLE
destination-mssql-v2: Use airbyte/java-connector-base:2.0.0

### DIFF
--- a/airbyte-integrations/connectors/destination-mssql-v2/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-mssql-v2/metadata.yaml
@@ -3,7 +3,7 @@ data:
     ql: 100
     sl: 100
   connectorBuildOptions:
-    baseImage: docker.io/airbyte/java-connector-base:1.0.0@sha256:be86e5684e1e6d9280512d3d8071b47153698fe08ad990949c8eeff02803201a
+    baseImage: docker.io/airbyte/java-connector-base:2.0.0@sha256:5a1a21c75c5e1282606de9fa539ba136520abe2fbd013058e988bb0297a9f454
   connectorSubtype: database
   connectorTestSuitesOptions:
     - suite: unitTests
@@ -16,7 +16,7 @@ data:
             type: GSM
   connectorType: destination
   definitionId: 37a928c1-2d5c-431a-a97d-ae236bd1ea0c
-  dockerImageTag: 0.1.1
+  dockerImageTag: 0.1.2
   dockerRepository: airbyte/destination-mssql-v2
   documentationUrl: https://docs.airbyte.com/integrations/destinations/mssql-v2
   githubIssueLabel: destination-mssql-v2

--- a/docs/integrations/destinations/mssql-v2.md
+++ b/docs/integrations/destinations/mssql-v2.md
@@ -7,6 +7,7 @@
 
 | Version | Date       | Pull Request                                               | Subject        |
 |:--------|:-----------| :--------------------------------------------------------- |:---------------|
+| 0.1.2 | 2025-01-10 | [51508](https://github.com/airbytehq/airbyte/pull/51508) | Use a non root base image |
 | 0.1.1 | 2024-12-18 | [49870](https://github.com/airbytehq/airbyte/pull/49870) | Use a base image: airbyte/java-connector-base:1.0.0 |
 | 0.1.0   | 2024-12-16 | [\#49460](https://github.com/airbytehq/airbyte/pull/49460)   | Initial commit |
 


### PR DESCRIPTION
Make the connector use our official non-root base image for java connectors