### PR TITLE
source-oracle: Use airbyte/java-connector-base:2.0.0

### DIFF
--- a/airbyte-integrations/connectors/source-oracle/metadata.yaml
+++ b/airbyte-integrations/connectors/source-oracle/metadata.yaml
@@ -7,7 +7,7 @@ data:
       - ${host}
       - ${tunnel_method.tunnel_host}
   connectorBuildOptions:
-    baseImage: docker.io/airbyte/java-connector-base:1.0.0@sha256:be86e5684e1e6d9280512d3d8071b47153698fe08ad990949c8eeff02803201a
+    baseImage: docker.io/airbyte/java-connector-base:2.0.0@sha256:5a1a21c75c5e1282606de9fa539ba136520abe2fbd013058e988bb0297a9f454
   connectorSubtype: database
   connectorTestSuitesOptions:
     - suite: unitTests
@@ -20,7 +20,7 @@ data:
             type: GSM
   connectorType: source
   definitionId: b39a7370-74c3-45a6-ac3a-380d48520a83
-  dockerImageTag: 0.5.3
+  dockerImageTag: 0.5.4
   dockerRepository: airbyte/source-oracle
   documentationUrl: https://docs.airbyte.com/integrations/sources/oracle
   githubIssueLabel: source-oracle
@@ -29,7 +29,7 @@ data:
   name: Oracle DB
   registryOverrides:
     cloud:
-      dockerImageTag: 0.5.3
+      dockerImageTag: 0.5.4
       dockerRepository: airbyte/source-oracle-strict-encrypt
       enabled: true
     oss:

--- a/docs/integrations/sources/oracle.md
+++ b/docs/integrations/sources/oracle.md
@@ -135,6 +135,7 @@ Airbyte has the ability to connect to the Oracle source with 3 network connectiv
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                                   |
 | :------ | :--------- | :------------------------------------------------------- | :---------------------------------------------------------------------------------------------------------------------------------------- |
+| 0.5.4 | 2025-01-10 | [51487](https://github.com/airbytehq/airbyte/pull/51487) | Use a non root base image |
 | 0.5.3 | 2024-12-18 | [49883](https://github.com/airbytehq/airbyte/pull/49883) | Use a base image: airbyte/java-connector-base:1.0.0 |
 | 0.5.2 | 2024-02-13 | [35225](https://github.com/airbytehq/airbyte/pull/35225) | Adopt CDK 0.20.4 |
 | 0.5.1 | 2024-01-24 | [34453](https://github.com/airbytehq/airbyte/pull/34453) | bump CDK version |


### PR DESCRIPTION
Make the connector use our official non-root base image for java connectors