### PR TITLE
feat: No longer make marketplace required reviewers for manifest-only and support level community 

### DIFF
--- a/airbyte-ci/connectors/connector_ops/connector_ops/required_reviewer_checks.py
+++ b/airbyte-ci/connectors/connector_ops/connector_ops/required_reviewer_checks.py
@@ -12,7 +12,6 @@ from connector_ops import utils
 # The breaking change reviewers is still in active use.
 BREAKING_CHANGE_REVIEWERS = {"breaking-change-reviewers"}
 CERTIFIED_MANIFEST_ONLY_CONNECTOR_REVIEWERS = {"dev-python"}
-COMMUNITY_MANIFEST_ONLY_CONNECTOR_REVIEWERS = {"dev-marketplace-contributions"}
 REVIEW_REQUIREMENTS_FILE_PATH = ".github/connector_org_review_requirements.yaml"
 
 

--- a/airbyte-ci/connectors/connector_ops/connector_ops/required_reviewer_checks.py
+++ b/airbyte-ci/connectors/connector_ops/connector_ops/required_reviewer_checks.py
@@ -46,11 +46,6 @@ def find_mandatory_reviewers() -> List[Dict[str, Union[str, Dict[str, List]]]]:
             "teams": list(CERTIFIED_MANIFEST_ONLY_CONNECTOR_REVIEWERS),
             "is_required": find_changed_manifest_only_connectors(support_level="certified"),
         },
-        {
-            "name": "Manifest-only community connectors",
-            "teams": list(COMMUNITY_MANIFEST_ONLY_CONNECTOR_REVIEWERS),
-            "is_required": find_changed_manifest_only_connectors(support_level="community"),
-        },
     ]
 
     return [{"name": r["name"], "teams": r["teams"]} for r in requirements if r["is_required"]]

--- a/airbyte-ci/connectors/connector_ops/tests/test_required_reviewer_checks.py
+++ b/airbyte-ci/connectors/connector_ops/tests/test_required_reviewer_checks.py
@@ -54,17 +54,6 @@ def test_breaking_change_release_expected_team(tmp_path, pokeapi_metadata_path) 
 
 
 @pytest.fixture
-def test_community_manifest_only_connector_expected_team(tmp_path, manifest_only_community_connector_path) -> List:
-    expected_teams = list(required_reviewer_checks.COMMUNITY_MANIFEST_ONLY_CONNECTOR_REVIEWERS)
-    backup_path = tmp_path / "backup_xkcd_metadata"
-    shutil.copyfile(manifest_only_community_connector_path, backup_path)
-    with open(manifest_only_community_connector_path, "a") as metadata_file:
-        metadata_file.write("anyKey: anyValue")
-    yield expected_teams
-    shutil.copyfile(backup_path, manifest_only_community_connector_path)
-
-
-@pytest.fixture
 def test_certified_manifest_only_connector_expected_team(tmp_path, manifest_only_community_connector_path) -> List:
     expected_teams = list(required_reviewer_checks.CERTIFIED_MANIFEST_ONLY_CONNECTOR_REVIEWERS)
     backup_path = tmp_path / "backup_xkcd_metadata"
@@ -111,10 +100,6 @@ def test_find_mandatory_reviewers_breaking_change_release(capsys, test_breaking_
 
 def test_find_mandatory_reviewers_no_tracked_changed(capsys, not_tracked_change_expected_team):
     check_review_requirements_file(capsys, not_tracked_change_expected_team)
-
-
-def test_find_reviewers_manifest_only_community_connector(capsys, test_community_manifest_only_connector_expected_team):
-    check_review_requirements_file(capsys, test_community_manifest_only_connector_expected_team)
 
 
 def test_find_reviewers_manifest_only_certified_connector(capsys, test_certified_manifest_only_connector_expected_team):


### PR DESCRIPTION
## What

It adds unnecessary paperwork and a bottleneck on the marketplace team to have to approve every PR that is manifest-only and community level. Let's just get rid of this and save everyone some time. I noticed this on `source-the-guardian-api`

As an alternative, we can make this category approvable by both marketplace and Python, but this still feels like too much busy work.

Certified connectors that are manifest-only still must be approved by the Python team.

## How

modify the CI script that is run on every connector PR
