### PR TITLE
Destination S3-V2: avro schema matches legacy CDK

### DIFF
--- a/airbyte-cdk/bulk/toolkits/load-avro/src/test/kotlin/AirbyteTypeToAvroSchemaTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-avro/src/test/kotlin/AirbyteTypeToAvroSchemaTest.kt
@@ -7,6 +7,11 @@ import io.airbyte.cdk.load.data.FieldType
 import io.airbyte.cdk.load.data.ObjectType
 import io.airbyte.cdk.load.data.StringType
 import io.airbyte.cdk.load.data.avro.toAvroSchema
+import io.airbyte.cdk.load.data.withAirbyteMeta
+import io.airbyte.cdk.load.message.Meta
+import org.apache.avro.LogicalTypes
+import org.apache.avro.Schema
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 
@@ -22,5 +27,51 @@ class AirbyteTypeToAvroSchemaTest {
             )
         val descriptor = DestinationStream.Descriptor("test", "stream")
         assertDoesNotThrow { schema.toAvroSchema(descriptor) }
+    }
+
+    @Test
+    fun `test airbyte meta schema`() {
+        val schema = ObjectType(linkedMapOf()).withAirbyteMeta()
+        val descriptor = DestinationStream.Descriptor("test", "stream")
+        val avroSchema = schema.toAvroSchema(descriptor)
+
+        assertEquals(
+            avroSchema.getField(Meta.COLUMN_NAME_AB_RAW_ID).schema().type,
+            Schema.Type.STRING
+        )
+        assertEquals(
+            avroSchema.getField(Meta.COLUMN_NAME_AB_RAW_ID).schema().logicalType,
+            LogicalTypes.uuid()
+        )
+        assertEquals(
+            avroSchema.getField(Meta.COLUMN_NAME_AB_EXTRACTED_AT).schema().type,
+            Schema.Type.LONG
+        )
+        assertEquals(
+            avroSchema.getField(Meta.COLUMN_NAME_AB_EXTRACTED_AT).schema().logicalType,
+            LogicalTypes.timestampMillis()
+        )
+        assertEquals(
+            avroSchema.getField(Meta.COLUMN_NAME_AB_GENERATION_ID).schema().type,
+            Schema.Type.LONG
+        )
+
+        val metaSchema = avroSchema.getField(Meta.COLUMN_NAME_AB_META).schema()
+        assertEquals(metaSchema.type, Schema.Type.RECORD)
+        assertEquals(metaSchema.fields.size, 2)
+
+        // Meta field 1
+        val changesSchema = metaSchema.getField("changes").schema()
+        assertEquals(changesSchema.type, Schema.Type.ARRAY)
+
+        val changeSchema = changesSchema.elementType
+        assertEquals(changeSchema.type, Schema.Type.RECORD)
+        assertEquals(changeSchema.fields.size, 3)
+        assertEquals(changeSchema.getField("field").schema().type, Schema.Type.STRING)
+        assertEquals(changeSchema.getField("change").schema().type, Schema.Type.STRING)
+        assertEquals(changeSchema.getField("reason").schema().type, Schema.Type.STRING)
+
+        // Meta field 2
+        assertEquals(metaSchema.getField("sync_id").schema().type, Schema.Type.LONG)
     }
 }


### PR DESCRIPTION
### What
Client reported that `_airbyte_extracted_at` was missing logical type `timestamp-millis`. During investigation I realized that `_airbyte_raw_id` was also missing logical type `uuid`.

Fixed both issues and added tests confirming that avro schemas match legacy schemas.

### Why
I'm hacking this in surgically for now. However, the correct fix is to introduce TimestampMillis and UUID as discrete extended types (assuming [this](https://docs.google.com/document/d/1qAjKRaoRaQUjHZ8n8j7OhA21xMbaztagXjVVcoIx91g/edit?tab=t.0#heading=h.u34ijf2omw34) gets approved).

### Also

For reference, a legacy schema pulled from the logs of the escalating client's previous runs:

```
{
         "name":"_airbyte_raw_id",
         "type":{
            "type":"string",
            "logicalType":"uuid"
         }
      },
      {
         "name":"_airbyte_extracted_at",
         "type":{
            "type":"long",
            "logicalType":"timestamp-millis"
         }
      },
      {
         "name":"_airbyte_generation_id",
         "type":"long"
      },
      {
         "name":"_airbyte_meta",
         "type":{
            "type":"record",
            "name":"_airbyte_meta",
            "namespace":"",
            "fields":[
               {
                  "name":"changes",
                  "type":{
                     "type":"array",
                     "items":{
                        "type":"record",
                        "name":"change",
                        "fields":[
                           {
                              "name":"field",
                              "type":"string"
                           },
                           {
                              "name":"change",
                              "type":"string"
                           },
                           {
                              "name":"reason",
                              "type":"string"
                           }
                        ]
                     }
                  }
               },
               {
                  "name":"sync_id",
                  "type":"long"
               }
            ]
         }
      },
```