### PR TITLE
fix: handle duplicate vars in obj storage path template

### DIFF
--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/file/object_storage/ObjectStoragePathFactory.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/file/object_storage/ObjectStoragePathFactory.kt
@@ -46,23 +46,27 @@ data class PathMatcher(val regex: Regex, val variableToIndex: Map<String, Int>) 
     fun match(path: String): PathMatcherResult? {
         val match = regex.matchEntire(path) ?: return null
 
-        val partNumber = try {
-            variableToIndex["part_number"]?.let { match.groupValues[it].toLong() }
-        } catch (e: Exception) {
-            throw PathMatcherException(
-                "Could not parse part number from $path with pattern: ${regex.pattern} at index: ${variableToIndex["part_number"]}",
-                e,
-            )
-        }
+        val partNumber =
+            try {
+                variableToIndex["part_number"]?.let { match.groupValues[it].toLong() }
+            } catch (e: Exception) {
+                throw PathMatcherException(
+                    "Could not parse part number from $path with pattern: ${regex.pattern} at index: ${variableToIndex["part_number"]}",
+                    e,
+                )
+            }
 
-        val suffix = try {
-            variableToIndex["suffix"]?.let { match.groupValues[it].let { g -> g.ifBlank { null } } }
-        } catch (e: Exception) {
-            throw PathMatcherException(
-                "Could not parse suffix from $path with pattern: ${regex.pattern} at index: ${variableToIndex["suffix"]}",
-                e,
-            )
-        }
+        val suffix =
+            try {
+                variableToIndex["suffix"]?.let {
+                    match.groupValues[it].let { g -> g.ifBlank { null } }
+                }
+            } catch (e: Exception) {
+                throw PathMatcherException(
+                    "Could not parse suffix from $path with pattern: ${regex.pattern} at index: ${variableToIndex["suffix"]}",
+                    e,
+                )
+            }
 
         return PathMatcherResult(path, partNumber, suffix)
     }
@@ -411,7 +415,12 @@ class ObjectStoragePathFactory(
         val pathPattern = resolveRetainingTerminalSlash(finalPrefix, pathPatternResolved)
 
         val replacedForPath =
-            buildPattern(pathPattern, """\\\$\{(\w+)}""", pathVariableToPattern, variableIndexTuples)
+            buildPattern(
+                pathPattern,
+                """\\\$\{(\w+)}""",
+                pathVariableToPattern,
+                variableIndexTuples
+            )
         val replacedForFile =
             buildPattern(
                 filePatternResolved,

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/file/object_storage/PathMatcherException.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/file/object_storage/PathMatcherException.kt
@@ -1,6 +1,10 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
 package io.airbyte.cdk.load.file.object_storage
 
 class PathMatcherException(
-  override val message: String,
-  override val cause: Throwable,
+    override val message: String,
+    override val cause: Throwable,
 ) : Throwable(message, cause)

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/file/object_storage/PathMatcherException.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/file/object_storage/PathMatcherException.kt
@@ -1,0 +1,6 @@
+package io.airbyte.cdk.load.file.object_storage
+
+class PathMatcherException(
+  override val message: String,
+  override val cause: Throwable,
+) : Throwable(message, cause)

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/test/kotlin/io/airbyte/cdk/load/file/object_storage/ObjectStoragePathFactoryUTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/test/kotlin/io/airbyte/cdk/load/file/object_storage/ObjectStoragePathFactoryUTest.kt
@@ -13,12 +13,12 @@ import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.mockk
 import java.util.stream.Stream
-import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 
@@ -188,7 +188,6 @@ class ObjectStoragePathFactoryUTest {
                     0,
                 ),
             )
-
         }
     }
 }

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/test/kotlin/io/airbyte/cdk/load/file/object_storage/ObjectStoragePathFactoryUTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/test/kotlin/io/airbyte/cdk/load/file/object_storage/ObjectStoragePathFactoryUTest.kt
@@ -12,12 +12,15 @@ import io.airbyte.cdk.load.state.object_storage.ObjectStorageDestinationState.Co
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.mockk
-import java.time.Instant
+import java.util.stream.Stream
+import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
 
 class ObjectStoragePathFactoryUTest {
     @MockK lateinit var stream: DestinationStream
@@ -116,14 +119,21 @@ class ObjectStoragePathFactoryUTest {
         assertNotNull(matcher.match("prefix/stream/any_filename"))
     }
 
-    @Test
-    fun `handles duplicate vars in path templates`() {
+    @ParameterizedTest
+    @MethodSource("pathTemplateMatrix")
+    fun `handles duplicate vars in path templates`(
+        bucketPathTemplate: String,
+        filePathTemplate: String,
+        fileNameTemplate: String,
+        remoteFileKey: String,
+        expectedPartNumber: Long,
+    ) {
         every { pathConfigProvider.objectStoragePathConfiguration } returns
             ObjectStoragePathConfiguration(
-                "\${NAMESPACE}/\${STREAM_NAME}",
+                bucketPathTemplate,
                 null,
-                "\${YEAR}/\${MONTH}/\${DAY}/\${NAMESPACE}_\${STREAM_NAME}_\${YEAR}_\${MONTH}_\${DAY}_\${EPOCH}_",
-                "{part_number}{format_extension}",
+                filePathTemplate,
+                fileNameTemplate,
                 false,
             )
         val stream = mockk<DestinationStream>()
@@ -132,11 +142,53 @@ class ObjectStoragePathFactoryUTest {
 
         val matcher = factory.getPathMatcher(stream, OPTIONAL_ORDINAL_SUFFIX_PATTERN)
 
-        val remoteFileKey = "namespace1/stream_abc/2024/08/30/namespace1_stream_abc_2024_08_30_1736900845782_1"
-
         val result = matcher.match(remoteFileKey)
 
         assertNotNull(result)
-        assertEquals(1, result!!.partNumber)
+        assertEquals(expectedPartNumber, result!!.partNumber)
+    }
+
+    companion object {
+        @JvmStatic
+        private fun pathTemplateMatrix(): Stream<Arguments> {
+            return Stream.of(
+                Arguments.arguments(
+                    "\${NAMESPACE}/\${STREAM_NAME}",
+                    "\${YEAR}/\${MONTH}/\${DAY}/\${NAMESPACE}_\${BIRD_DOG}_\${STREAM_NAME}_\${YEAR}_\${MONTH}_\${DAY}_\${EPOCH}_",
+                    "{part_number}{format_extension}",
+                    "namespace1/stream_abc/2024/08/30/namespace1_BIRD_DOG_stream_abc_2024_08_30_1736900845782_1",
+                    1L,
+                ),
+                Arguments.arguments(
+                    "\${NAMESPACE}/\${STREAM_NAME}",
+                    "\${YEAR}/\${MONTH}/\${DAY}/\${NAMESPACE}_\${STREAM_NAME}_\${YEAR}_\${MONTH}_\${DAY}_\${EPOCH}_",
+                    "{part_number}{format_extension}",
+                    "namespace1/stream_abc/2024/08/30/namespace1_stream_abc_2024_08_30_1736900845782_5",
+                    5L,
+                ),
+                Arguments.arguments(
+                    "\${NAMESPACE}/\${STREAM_NAME}",
+                    "\${YEAR}/\${MONTH}/\${DAY}/\${NAMESPACE}_\${STREAM_NAME}_\${YEAR}_\${MONTH}_\${DAY}_\${EPOCH}_",
+                    "{part_number}{format_extension}",
+                    "namespace1/stream_abc/2024/08/30/namespace1_stream_abc_2024_08_30_1736900845782_7",
+                    7L,
+                ),
+                Arguments.arguments(
+                    "\${NAMESPACE}/\${STREAM_NAME}/\${STREAM_NAME}/\${STREAM_NAME}/\${STREAM_NAME}",
+                    "_",
+                    "{part_number}{format_extension}",
+                    "namespace1/stream_abc/stream_abc/stream_abc/stream_abc/_0",
+                    0,
+                ),
+                Arguments.arguments(
+                    "\${NAMESPACE}/\${STREAM_NAME}/\${STREAM_NAME}/\${STREAM_NAME}/\${STREAM_NAME}",
+                    "",
+                    "{part_number}{format_extension}",
+                    "namespace1/stream_abc/stream_abc/stream_abc/stream_abc0",
+                    0,
+                ),
+            )
+
+        }
     }
 }


### PR DESCRIPTION
## What
Handles duplicate template variables in object storage path templates
- Respects duplicates across bucket / path template strings
- Respects duplicates within individual template strings

Improves error messaging around part number / suffix parsing in path matcher logic

## How
* Properly tracks part number and suffix indexes by not using map structure