### PR TITLE
fix(destination-firebolt): disable on-disk token caching

### DIFF
--- a/airbyte-integrations/connectors/destination-firebolt/destination_firebolt/destination.py
+++ b/airbyte-integrations/connectors/destination-firebolt/destination_firebolt/destination.py
@@ -9,15 +9,15 @@ from logging import getLogger
 from typing import Any, Dict, Iterable, Mapping, Optional
 from uuid import uuid4
 
+from airbyte_cdk.destinations import Destination
+from airbyte_cdk.models import (AirbyteConnectionStatus, AirbyteMessage,
+                                ConfiguredAirbyteCatalog, DestinationSyncMode,
+                                Status, Type)
 from firebolt.client import DEFAULT_API_URL
 from firebolt.client.auth import Auth, ClientCredentials, UsernamePassword
 from firebolt.db import Connection, connect
 
-from airbyte_cdk.destinations import Destination
-from airbyte_cdk.models import AirbyteConnectionStatus, AirbyteMessage, ConfiguredAirbyteCatalog, DestinationSyncMode, Status, Type
-
 from .writer import create_firebolt_wirter
-
 
 logger = getLogger("airbyte")
 
@@ -28,9 +28,9 @@ def _determine_auth(key: str, secret: str) -> Auth:
     """
     if "@" in key:
         # email auth can only be used with UsernamePassword
-        return UsernamePassword(key, secret)
+        return UsernamePassword(key, secret, use_token_cache=False)
     else:
-        return ClientCredentials(key, secret)
+        return ClientCredentials(key, secret, use_token_cache=False)
 
 
 def parse_config(config: json, logger: Optional[logging.Logger] = None) -> Dict[str, Any]:

--- a/airbyte-integrations/connectors/destination-firebolt/destination_firebolt/destination.py
+++ b/airbyte-integrations/connectors/destination-firebolt/destination_firebolt/destination.py
@@ -9,15 +9,15 @@ from logging import getLogger
 from typing import Any, Dict, Iterable, Mapping, Optional
 from uuid import uuid4
 
-from airbyte_cdk.destinations import Destination
-from airbyte_cdk.models import (AirbyteConnectionStatus, AirbyteMessage,
-                                ConfiguredAirbyteCatalog, DestinationSyncMode,
-                                Status, Type)
 from firebolt.client import DEFAULT_API_URL
 from firebolt.client.auth import Auth, ClientCredentials, UsernamePassword
 from firebolt.db import Connection, connect
 
+from airbyte_cdk.destinations import Destination
+from airbyte_cdk.models import AirbyteConnectionStatus, AirbyteMessage, ConfiguredAirbyteCatalog, DestinationSyncMode, Status, Type
+
 from .writer import create_firebolt_wirter
+
 
 logger = getLogger("airbyte")
 

--- a/airbyte-integrations/connectors/destination-firebolt/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-firebolt/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: 18081484-02a5-4662-8dba-b270b582f321
-  dockerImageTag: 0.2.25
+  dockerImageTag: 0.2.26
   dockerRepository: airbyte/destination-firebolt
   githubIssueLabel: destination-firebolt
   connectorBuildOptions:

--- a/airbyte-integrations/connectors/destination-firebolt/pyproject.toml
+++ b/airbyte-integrations/connectors/destination-firebolt/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "0.2.25"
+version = "0.2.26"
 name = "destination-firebolt"
 description = "Destination implementation for Firebolt."
 authors = [ "Airbyte <evan@airbyte.io>",]

--- a/docs/integrations/destinations/firebolt.md
+++ b/docs/integrations/destinations/firebolt.md
@@ -98,6 +98,7 @@ Firebolt. Each table will contain 3 columns:
 
 | Version | Date       | Pull Request                                             | Subject                                |
 |:--------| :--------- | :------------------------------------------------------- | :------------------------------------- |
+| 0.2.26 | 2025-01-17 | [51560](https://github.com/airbytehq/airbyte/pull/51560) | Fix connection issues |
 | 0.2.25 | 2024-11-25 | [48672](https://github.com/airbytehq/airbyte/pull/48672) | Update dependencies |
 | 0.2.24 | 2024-10-29 | [47780](https://github.com/airbytehq/airbyte/pull/47780) | Update dependencies |
 | 0.2.23 | 2024-10-28 | [47100](https://github.com/airbytehq/airbyte/pull/47100) | Update dependencies |


### PR DESCRIPTION
## What
Currently the latest(0.2.25) Firebolt destination version is failing to connect due to the disk access error from the OS.
![image](https://github.com/user-attachments/assets/88f2993a-b771-4775-92fc-ea556c6dbe00)
This is due to the SDK caching a token for future use on the file system. New `airbyte` user introduced in the latest python base does not have permissions to access the required directory.

## How
Setting the flag to False disables an attempt to cache on filesystem, designed specifically for constrained environments.

## User Impact
Firebolt destination will be usable again. Behind the scenes an additional http request will be run when establishing a connection, but this will barely impact timings overall.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
