### PR TITLE
[auto-merge] fix github pr search for auto-merge label

### DIFF
--- a/airbyte-ci/connectors/auto_merge/pyproject.toml
+++ b/airbyte-ci/connectors/auto_merge/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "auto-merge"
-version = "0.1.3"
+version = "0.1.4"
 description = ""
 authors = ["Airbyte <contact@airbyte.io>"]
 readme = "README.md"

--- a/airbyte-ci/connectors/auto_merge/src/auto_merge/main.py
+++ b/airbyte-ci/connectors/auto_merge/src/auto_merge/main.py
@@ -153,7 +153,7 @@ def auto_merge() -> None:
         main_branch = repo.get_branch(BASE_BRANCH)
         logger.info(f"Fetching required passing contexts for {BASE_BRANCH}")
         required_passing_contexts = set(main_branch.get_required_status_checks().contexts)
-        candidate_issues = gh_client.search_issues(f"repo:{AIRBYTE_REPO} is:pr label:{AUTO_MERGE_LABEL} base:{BASE_BRANCH} state:open")
+        candidate_issues = gh_client.search_issues(f"repo:{AIRBYTE_REPO} is:pr label:{AUTO_MERGE_LABEL},{AUTO_MERGE_BYPASS_CI_CHECKS_LABEL} base:{BASE_BRANCH} state:open")
         prs = [issue.as_pull_request() for issue in candidate_issues]
         logger.info(f"Found {len(prs)} open PRs targeting {BASE_BRANCH} with the {AUTO_MERGE_LABEL} label")
         merged_prs = []

--- a/airbyte-ci/connectors/auto_merge/src/auto_merge/main.py
+++ b/airbyte-ci/connectors/auto_merge/src/auto_merge/main.py
@@ -153,7 +153,9 @@ def auto_merge() -> None:
         main_branch = repo.get_branch(BASE_BRANCH)
         logger.info(f"Fetching required passing contexts for {BASE_BRANCH}")
         required_passing_contexts = set(main_branch.get_required_status_checks().contexts)
-        candidate_issues = gh_client.search_issues(f"repo:{AIRBYTE_REPO} is:pr label:{AUTO_MERGE_LABEL},{AUTO_MERGE_BYPASS_CI_CHECKS_LABEL} base:{BASE_BRANCH} state:open")
+        candidate_issues = gh_client.search_issues(
+            f"repo:{AIRBYTE_REPO} is:pr label:{AUTO_MERGE_LABEL},{AUTO_MERGE_BYPASS_CI_CHECKS_LABEL} base:{BASE_BRANCH} state:open"
+        )
         prs = [issue.as_pull_request() for issue in candidate_issues]
         logger.info(f"Found {len(prs)} open PRs targeting {BASE_BRANCH} with the {AUTO_MERGE_LABEL} label")
         merged_prs = []


### PR DESCRIPTION
## What
- Add `auto-merge/bypass-ci-checks` to github pr search
- Bump auto_merge by patch version

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [X] YES 💚
- [ ] NO ❌
