### PR TITLE
airbyte-ci: run finalize build script as root

### DIFF
--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -344,14 +344,14 @@ flowchart TD
 #### Options
 
 | Option                                                  | Multiple | Default value | Description                                                                                                                                                                                              |
-| ------------------------------------------------------- | -------- | ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| ------------------------------------------------------- | -------- | ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `--skip-step/-x`                                        | True     |               | Skip steps by id e.g. `-x unit -x acceptance`                                                                                                                                                            |
 | `--only-step/-k`                                        | True     |               | Only run specific steps by id e.g. `-k unit -k acceptance`                                                                                                                                               |
 | `--fail-fast`                                           | False    | False         | Abort after any tests fail, rather than continuing to run additional tests. Use this setting to confirm a known bug is fixed (or not), or when you only require a pass/fail result.                      |
 | `--code-tests-only`                                     | True     | False         | Skip any tests not directly related to code updates. For instance, metadata checks, version bump checks, changelog verification, etc. Use this setting to help focus on code quality during development. |
 | `--concurrent-cat`                                      | False    | False         | Make CAT tests run concurrently using pytest-xdist. Be careful about source or destination API rate limits.                                                                                              |
 | `--<step-id>.<extra-parameter>=<extra-parameter-value>` | True     |               | You can pass extra parameters for specific test steps. More details in the extra parameters section below                                                                                                |
-| `--ci-requirements`                                     | False    |               |                                                                                                                                                                                                          | Output the CI requirements as a JSON payload. It is used to determine the CI runner to use. |
+| `--ci-requirements`                                     | False    |               |                                                                                                                                                                                                          | Output the CI requirements as a JSON payload. It is used to determine the CI runner to use. 
 
 Note:
 
@@ -854,11 +854,12 @@ airbyte-ci connectors --language=low-code migrate-to-manifest-only
 
 | Version | PR                                                         | Description                                                                                                                  |
 | ------- | ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| 4.48.5  | [#49827](https://github.com/airbytehq/airbyte/pull/49827)  | Bypasses CI checks for promoted release candidate PRs.                                                         |
-| 4.48.4  | [#51003](https://github.com/airbytehq/airbyte/pull/51003)  | Install git in the build / test connector container when `--use-cdk-ref` is passed. |
-| 4.48.3  | [#50988](https://github.com/airbytehq/airbyte/pull/50988)  | Remove deprecated `--no-update` flag from poetry commands |
+| 4.48.6  | [#51577](https://github.com/airbytehq/airbyte/pull/51577)      | Run finalize build scripts as root                                                                                           |
+| 4.48.5  | [#49827](https://github.com/airbytehq/airbyte/pull/49827)  | Bypasses CI checks for promoted release candidate PRs.                                                                       |
+| 4.48.4  | [#51003](https://github.com/airbytehq/airbyte/pull/51003)  | Install git in the build / test connector container when `--use-cdk-ref` is passed.                                          |
+| 4.48.3  | [#50988](https://github.com/airbytehq/airbyte/pull/50988)  | Remove deprecated `--no-update` flag from poetry commands                                                                    |
 | 4.48.2  | [#50871](https://github.com/airbytehq/airbyte/pull/50871)  | Speed up connector modification detection.                                                                                   |
-| 4.48.1  | [#50410](https://github.com/airbytehq/airbyte/pull/50410)  | Java connector build: give ownership of built artifacts to the current image user.                                                                                          |
+| 4.48.1  | [#50410](https://github.com/airbytehq/airbyte/pull/50410)  | Java connector build: give ownership of built artifacts to the current image user.                                           |
 | 4.48.0  | [#49960](https://github.com/airbytehq/airbyte/pull/49960)  | Deprecate airbyte-ci format command                                                                                          |
 | 4.47.0  | [#49832](https://github.com/airbytehq/airbyte/pull/49462)  | Build java connectors from the base image declared in `metadata.yaml`.                                                       |
 | 4.46.5  | [#49835](https://github.com/airbytehq/airbyte/pull/49835)  | Fix connector language discovery for projects with Kotlin Gradle build scripts.                                              |

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "4.48.5"
+version = "4.48.6"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 


### PR DESCRIPTION
This pull request includes several updates and improvements to the `airbyte-ci` project, particularly focusing on the `connectors/pipelines` component. The changes include documentation updates, version bumps, and modifications to the build process.

Documentation updates:

* [`airbyte-ci/connectors/pipelines/README.md`](diffhunk://#diff-62eccd92928fbcd3d285983bfdaa2b0d4ca49016cb9c2f63d6d9fc968c59c541L347-R354): Fixed table formatting in the options section and added a new version entry for 4.48.6, which includes running finalize build scripts as root. [[1]](diffhunk://#diff-62eccd92928fbcd3d285983bfdaa2b0d4ca49016cb9c2f63d6d9fc968c59c541L347-R354) [[2]](diffhunk://#diff-62eccd92928fbcd3d285983bfdaa2b0d4ca49016cb9c2f63d6d9fc968c59c541R857)

Build process improvements:

* [`airbyte-ci/connectors/pipelines/pipelines/dagger/actions/connector/hooks.py`](diffhunk://#diff-86ccda36407905a566fc7d56155e23e7e9b4445037d802c7da4155b064dca3b6R23-R25): Modified the `finalize_build` function to switch to the root user for finalizing the build with superuser permissions and then switch back to the original user. [[1]](diffhunk://#diff-86ccda36407905a566fc7d56155e23e7e9b4445037d802c7da4155b064dca3b6R23-R25) [[2]](diffhunk://#diff-86ccda36407905a566fc7d56155e23e7e9b4445037d802c7da4155b064dca3b6L63-R67)

Version bump:

* [`airbyte-ci/connectors/pipelines/pyproject.toml`](diffhunk://#diff-087e2c37602bbd6824f875004abddcb4e1a374da12bf84201671ed0900882ce0L7-R7): Updated the version from 4.48.5 to 4.48.6.