### PR TITLE
base_images: change ownership of /tmp to the airbyte user on the python base image

### DIFF
--- a/airbyte-ci/connectors/base_images/README.md
+++ b/airbyte-ci/connectors/base_images/README.md
@@ -33,6 +33,7 @@ ENV POETRY_NO_INTERACTION=1
 RUN pip install poetry==1.6.1
 RUN sh -c apt-get update && apt-get upgrade -y && apt-get dist-upgrade -y && apt-get clean
 RUN sh -c apt-get install -y socat=1.7.4.4-2
+RUN chown -R airbyte:airbyte /tmp
 RUN sh -c apt-get update && apt-get install -y tesseract-ocr=5.3.0-2 poppler-utils=22.12.0-2+b1
 RUN mkdir -p 755 /usr/share/nltk_data
 ```
@@ -60,6 +61,7 @@ ENV AIRBYTE_ENTRYPOINT=/airbyte/base.sh
 
 | Version | Published | Docker Image Address | Changelog | 
 |---------|-----------|--------------|-----------|
+|  3.0.1-rc.1 | ✅| docker.io/airbyte/python-connector-base:3.0.1-rc.1@sha256:5b5cbe613691cc61d643a347ee4ba21d6358252f274ebb040ef820c7b9f4a5a7 | Make the airbyte user owner of /tmp |
 |  3.0.0 | ✅| docker.io/airbyte/python-connector-base:3.0.0@sha256:1a0845ff2b30eafa793c6eee4e8f4283c2e52e1bbd44eed6cb9e9abd5d34d844 | Create airbyte user |
 |  3.0.0-rc.1 | ✅| docker.io/airbyte/python-connector-base:3.0.0-rc.1@sha256:ee046486af9ad90b1b248afe5e92846b51375a21463dff1cd377c4f06abb55b5 | Update Python 3.10.4 image + create airbyte user |
 |  2.0.0 | ✅| docker.io/airbyte/python-connector-base:2.0.0@sha256:c44839ba84406116e8ba68722a0f30e8f6e7056c726f447681bb9e9ece8bd916 | Use Python 3.10 |

--- a/airbyte-ci/connectors/base_images/base_images/python/bases.py
+++ b/airbyte-ci/connectors/base_images/base_images/python/bases.py
@@ -110,6 +110,8 @@ class AirbytePythonConnectorBaseImage(bases.AirbyteConnectorBaseImage):
             .with_exec(["pip", "install", "poetry==1.6.1"])
             .with_exec(["sh", "-c", "apt-get update && apt-get upgrade -y && apt-get dist-upgrade -y && apt-get clean"])
             .with_exec(["sh", "-c", "apt-get install -y socat=1.7.4.4-2"])
+            # Give the user ownership of the /tmp directory
+            .with_exec(["chown", "-R", f"{self.USER}:{self.USER}", "/tmp"])
             # Install CDK system dependencies
             .with_(self.install_cdk_system_dependencies())
         )
@@ -133,6 +135,8 @@ class AirbytePythonConnectorBaseImage(bases.AirbyteConnectorBaseImage):
         await base_sanity_checks.check_user_can_read_dir(container, self.USER, self.CACHE_DIR_PATH)
         await base_sanity_checks.check_user_can_write_dir(container, self.USER, self.AIRBYTE_DIR_PATH)
         await base_sanity_checks.check_user_cant_write_dir(container, self.USER, self.CACHE_DIR_PATH)
+        await base_sanity_checks.check_user_can_write_dir(container, self.USER, "/tmp")
+        await base_sanity_checks.check_user_can_read_dir(container, self.USER, "/tmp")
         await python_sanity_checks.check_poetry_version(container, "1.6.1")
         await python_sanity_checks.check_python_image_has_expected_env_vars(container)
         await base_sanity_checks.check_a_command_is_available_using_version_option(container, "socat", "-V")

--- a/airbyte-ci/connectors/base_images/generated/changelogs/airbyte_python_connector_base.json
+++ b/airbyte-ci/connectors/base_images/generated/changelogs/airbyte_python_connector_base.json
@@ -1,5 +1,10 @@
 [
   {
+    "version": "3.0.1-rc.1",
+    "changelog_entry": "Make the airbyte user owner of /tmp",
+    "dockerfile_example": "FROM docker.io/python:3.10.14-slim-bookworm@sha256:2407c61b1a18067393fecd8a22cf6fceede893b6aaca817bf9fbfe65e33614a3\nRUN ln -snf /usr/share/zoneinfo/Etc/UTC /etc/localtime\nRUN adduser --uid 1000 --system --group --no-create-home airbyte\nRUN mkdir --mode 755 /custom_cache\nRUN mkdir --mode 755 /airbyte\nRUN chown airbyte:airbyte /airbyte\nENV PIP_CACHE_DIR=/custom_cache/pip\nRUN pip install --upgrade pip==24.0 setuptools==70.0.0\nENV POETRY_VIRTUALENVS_CREATE=false\nENV POETRY_VIRTUALENVS_IN_PROJECT=false\nENV POETRY_NO_INTERACTION=1\nRUN pip install poetry==1.6.1\nRUN sh -c apt-get update && apt-get upgrade -y && apt-get dist-upgrade -y && apt-get clean\nRUN sh -c apt-get install -y socat=1.7.4.4-2\nRUN chown -R airbyte:airbyte /tmp\nRUN sh -c apt-get update && apt-get install -y tesseract-ocr=5.3.0-2 poppler-utils=22.12.0-2+b1\nRUN mkdir -p 755 /usr/share/nltk_data"
+  },
+  {
     "version": "3.0.0",
     "changelog_entry": "Create airbyte user",
     "dockerfile_example": "FROM docker.io/python:3.10.14-slim-bookworm@sha256:2407c61b1a18067393fecd8a22cf6fceede893b6aaca817bf9fbfe65e33614a3\nRUN ln -snf /usr/share/zoneinfo/Etc/UTC /etc/localtime\nRUN adduser --uid 1000 --system --group --no-create-home airbyte\nRUN mkdir --mode 755 /custom_cache\nRUN mkdir --mode 755 /airbyte\nRUN chown airbyte:airbyte /airbyte\nENV PIP_CACHE_DIR=/custom_cache/pip\nRUN pip install --upgrade pip==24.0 setuptools==70.0.0\nENV POETRY_VIRTUALENVS_CREATE=false\nENV POETRY_VIRTUALENVS_IN_PROJECT=false\nENV POETRY_NO_INTERACTION=1\nRUN pip install poetry==1.6.1\nRUN sh -c apt-get update && apt-get upgrade -y && apt-get dist-upgrade -y && apt-get clean\nRUN sh -c apt-get install -y socat=1.7.4.4-2\nRUN sh -c apt-get update && apt-get install -y tesseract-ocr=5.3.0-2 poppler-utils=22.12.0-2+b1\nRUN mkdir -p 755 /usr/share/nltk_data"


### PR DESCRIPTION
This pull request includes changes to ensure the `airbyte` user has ownership of the `/tmp` directory and to update the related documentation and tests. The most important changes include adding commands to change the ownership of the `/tmp` directory and updating the sanity checks to verify the user's permissions.

Changes to ensure user ownership and permissions:

* [`airbyte-ci/connectors/base_images/README.md`](diffhunk://#diff-2e343fda68ecd85f5023c98f7f9a41af2125e7e1cc12d545bc13ace788a4d075R36): Added a command to change the ownership of the `/tmp` directory to the `airbyte` user and updated the changelog to reflect this change. [[1]](diffhunk://#diff-2e343fda68ecd85f5023c98f7f9a41af2125e7e1cc12d545bc13ace788a4d075R36) [[2]](diffhunk://#diff-2e343fda68ecd85f5023c98f7f9a41af2125e7e1cc12d545bc13ace788a4d075R64)
* [`airbyte-ci/connectors/base_images/base_images/python/bases.py`](diffhunk://#diff-8f8cef8a8e95bb7c2929f45bb6e27c753140a00d82e154798782e7285e9f2153R113-R114): Added a command in the `get_container` method to change the ownership of the `/tmp` directory to the `airbyte` user.
* [`airbyte-ci/connectors/base_images/base_images/python/bases.py`](diffhunk://#diff-8f8cef8a8e95bb7c2929f45bb6e27c753140a00d82e154798782e7285e9f2153R138-R139): Updated the `run_sanity_checks` method to include checks that verify the `airbyte` user can read and write to the `/tmp` directory.