### PR TITLE
airbyte-ci: give back ownership of /tmp to the original user when running finalize in build

### DIFF
--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -351,7 +351,7 @@ flowchart TD
 | `--code-tests-only`                                     | True     | False         | Skip any tests not directly related to code updates. For instance, metadata checks, version bump checks, changelog verification, etc. Use this setting to help focus on code quality during development. |
 | `--concurrent-cat`                                      | False    | False         | Make CAT tests run concurrently using pytest-xdist. Be careful about source or destination API rate limits.                                                                                              |
 | `--<step-id>.<extra-parameter>=<extra-parameter-value>` | True     |               | You can pass extra parameters for specific test steps. More details in the extra parameters section below                                                                                                |
-| `--ci-requirements`                                     | False    |               |                                                                                                                                                                                                          | Output the CI requirements as a JSON payload. It is used to determine the CI runner to use. 
+| `--ci-requirements`                                     | False    |               |                                                                                                                                                                                                          | Output the CI requirements as a JSON payload. It is used to determine the CI runner to use.
 
 Note:
 
@@ -854,7 +854,8 @@ airbyte-ci connectors --language=low-code migrate-to-manifest-only
 
 | Version | PR                                                         | Description                                                                                                                  |
 | ------- | ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| 4.48.6  | [#51577](https://github.com/airbytehq/airbyte/pull/51577)      | Run finalize build scripts as root                                                                                           |
+| 4.48.7  | [#51579](https://github.com/airbytehq/airbyte/pull/51579)  | Give back the ownership of /tmp to the original user on finalize build                                                       |
+| 4.48.6  | [#51577](https://github.com/airbytehq/airbyte/pull/51577)  | Run finalize build scripts as root                                                                                           |
 | 4.48.5  | [#49827](https://github.com/airbytehq/airbyte/pull/49827)  | Bypasses CI checks for promoted release candidate PRs.                                                                       |
 | 4.48.4  | [#51003](https://github.com/airbytehq/airbyte/pull/51003)  | Install git in the build / test connector container when `--use-cdk-ref` is passed.                                          |
 | 4.48.3  | [#50988](https://github.com/airbytehq/airbyte/pull/50988)  | Remove deprecated `--no-update` flag from poetry commands                                                                    |

--- a/airbyte-ci/connectors/pipelines/pipelines/dagger/actions/connector/hooks.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/dagger/actions/connector/hooks.py
@@ -64,5 +64,6 @@ async def finalize_build(context: ConnectorContext, connector_container: Contain
             .with_exec(["/tmp/finalize_build.sh"], use_entrypoint=True)
         )
     # Switch back to the original user
+    connector_container = connector_container.with_exec(["chown", "-R", f"{original_user}:{original_user}", "/tmp"])
     connector_container = connector_container.with_user(original_user)
     return connector_container.with_entrypoint(original_entrypoint)

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "4.48.6"
+version = "4.48.7"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 


### PR DESCRIPTION
This pull request includes changes to the `airbyte-ci/connectors/pipelines` to update the version, modify the changelog, and ensure proper permissions management during the build process. The most important changes are:

### Changelog Update:
* [`airbyte-ci/connectors/pipelines/README.md`](diffhunk://#diff-62eccd92928fbcd3d285983bfdaa2b0d4ca49016cb9c2f63d6d9fc968c59c541L852-R857): Updated the changelog to include version 4.48.7, which gives back ownership of `/tmp` to the original user on finalize build.

### Permissions Management:
* [`airbyte-ci/connectors/pipelines/pipelines/dagger/actions/connector/hooks.py`](diffhunk://#diff-86ccda36407905a566fc7d56155e23e7e9b4445037d802c7da4155b064dca3b6R67): Added a step to change the ownership of `/tmp` back to the original user after running the finalize build script.

### Version Update:
* [`airbyte-ci/connectors/pipelines/pyproject.toml`](diffhunk://#diff-087e2c37602bbd6824f875004abddcb4e1a374da12bf84201671ed0900882ce0L7-R7): Updated the version from 4.48.6 to 4.48.7.
