### PR TITLE
Bulk Load CDK: fix workdir in tests

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/destination_process/DockerizedDestination.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/destination_process/DockerizedDestination.kt
@@ -109,7 +109,8 @@ class DockerizedDestination(
                     "--init",
                     "-i",
                     "-w",
-                    "/data/job",
+                    // In real syncs, platform changes the workdir to /dest for destinations.
+                    "/dest",
                     "--log-driver",
                     "none",
                     "--name",

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/destination_process/DockerizedDestination.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/destination_process/DockerizedDestination.kt
@@ -75,9 +75,14 @@ class DockerizedDestination(
         // Certainly nothing in the bulk CDK's test suites is reading back
         // anything in this directory.
         val localRoot = Files.createTempDirectory(testDir, "output")
+
         // This directory will contain the actual inputs to the connector (config+catalog),
         // and is also mounted as a volume.
-        val jobRoot = Files.createDirectories(workspaceRoot.resolve("job"))
+        val jobDir = "job"
+        val jobRoot = Files.createDirectories(workspaceRoot.resolve(jobDir))
+
+        val containerDataRoot = "/data"
+        val containerJobRoot = "$containerDataRoot/$jobDir"
 
         // This directory is being used for the file transfer feature.
         if (useFileTransfer) {
@@ -118,7 +123,7 @@ class DockerizedDestination(
                     "--network",
                     "host",
                     "-v",
-                    String.format("%s:%s", workspaceRoot, "/data"),
+                    String.format("%s:%s", workspaceRoot, containerDataRoot),
                     "-v",
                     String.format("%s:%s", localRoot, "/local"),
                     "-v",
@@ -148,7 +153,7 @@ class DockerizedDestination(
                 fileContents,
             )
             cmd.add("--$paramName")
-            cmd.add("destination_$paramName.json")
+            cmd.add("$containerJobRoot/destination_$paramName.json")
         }
         configContents?.let { addInput("config", it.toByteArray(Charsets.UTF_8)) }
         catalog?.let { addInput("catalog", catalog.serializeToJsonBytes()) }


### PR DESCRIPTION
from https://airbytehq-team.slack.com/archives/C03AS1GAQV6/p1736971161781359, it seems like we've been running connectors from the wrong workdir in tests (.... probably this changed during megapod?)

this shouldn't matter for most destinations, but might as well fix it. There's some weird [situations](https://airbytehq-team.slack.com/archives/C06R5PUNCDV/p1736959728220079) where this causes spurious test failures.

tested this locally against destination-dev-null.