### PR TITLE
airbyte-ci: correct mounted volumes ownership 

### DIFF
--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -854,7 +854,8 @@ airbyte-ci connectors --language=low-code migrate-to-manifest-only
 
 | Version | PR                                                         | Description                                                                                                                  |
 | ------- | ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| 4.48.8  | [#51609](https://github.com/airbytehq/airbyte/pull/51609)  | Fix typo in `migrate-to-inline-schemas` command                                                       |
+| 4.48.9  | [#51609](https://github.com/airbytehq/airbyte/pull/51609)  | Fix ownership of shared cache volume for non root connectors                                                                 |
+| 4.48.8  | [#51582](https://github.com/airbytehq/airbyte/pull/51582)  | Fix typo in `migrate-to-inline-schemas` command                                                       |
 | 4.48.7  | [#51579](https://github.com/airbytehq/airbyte/pull/51579)  | Give back the ownership of /tmp to the original user on finalize build                                                       |
 | 4.48.6  | [#51577](https://github.com/airbytehq/airbyte/pull/51577)  | Run finalize build scripts as root                                                                                           |
 | 4.48.5  | [#49827](https://github.com/airbytehq/airbyte/pull/49827)  | Bypasses CI checks for promoted release candidate PRs.                                                                       |

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/build_image/steps/python_connectors.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/build_image/steps/python_connectors.py
@@ -91,6 +91,8 @@ class BuildConnectorImages(BuildConnectorImagesBase):
 
         connector_container = build_customization.apply_airbyte_entrypoint(base_connector_container, self.context.connector)
         customized_connector = await build_customization.post_install_hooks(self.context.connector, connector_container, self.logger)
+        # Make sure the user has access to /tmp
+        customized_connector = customized_connector.with_exec(["chown", "-R", f"{user}:{user}", "/tmp"])
         return customized_connector.with_user(user)
 
     async def _build_from_dockerfile(self, platform: Platform) -> Container:

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/python_connectors.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/python_connectors.py
@@ -83,7 +83,7 @@ class PytestStep(Step, ABC):
         pytest_command = self.get_pytest_command(test_config_file_name)
 
         if self.bind_to_docker_host:
-            test_environment = pipelines.dagger.actions.system.docker.with_bound_docker_host(self.context, test_environment)
+            test_environment = await pipelines.dagger.actions.system.docker.with_bound_docker_host(self.context, test_environment)
 
         test_execution = test_environment.with_exec(pytest_command)
 

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/steps/gradle.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/steps/gradle.py
@@ -201,7 +201,7 @@ class GradleTask(Step, ABC):
             gradle_container = gradle_container.with_(await secrets.mounted_connector_secrets(self.context, secrets_dir, self.secrets))
         if self.bind_to_docker_host:
             # If this GradleTask subclass needs docker, then install it and bind it to the existing global docker host container.
-            gradle_container = pipelines.dagger.actions.system.docker.with_bound_docker_host(self.context, gradle_container)
+            gradle_container = await pipelines.dagger.actions.system.docker.with_bound_docker_host(self.context, gradle_container)
             # This installation should be cheap, as the package has already been downloaded, and its dependencies are already installed.
             gradle_container = gradle_container.with_exec(["yum", "install", "-y", "docker"], use_entrypoint=True)
 

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "4.48.8"
+version = "4.48.9"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 


### PR DESCRIPTION
This pull request includes several changes to improve the handling of Docker environments and permissions in the Airbyte CI pipelines. The most important changes include making functions asynchronous, ensuring proper permissions for the `/tmp` directory, and adding logging for storage driver selection.

Improvements to Docker environment handling:

* [`airbyte-ci/connectors/pipelines/pipelines/dagger/actions/system/docker.py`](diffhunk://#diff-d40249eb99e1032e94b872d433c46a4996c0e845a6af70929859ff548444bfb8L155-R163): Modified multiple functions (`with_bound_docker_host`, `with_docker_cli`, `load_image_to_docker_host`) to be asynchronous to be able to fetch the current image user. [[1]](diffhunk://#diff-d40249eb99e1032e94b872d433c46a4996c0e845a6af70929859ff548444bfb8L155-R163) [[2]](diffhunk://#diff-d40249eb99e1032e94b872d433c46a4996c0e845a6af70929859ff548444bfb8R176-R191) [[3]](diffhunk://#diff-d40249eb99e1032e94b872d433c46a4996c0e845a6af70929859ff548444bfb8L192-R201) [[4]](diffhunk://#diff-d40249eb99e1032e94b872d433c46a4996c0e845a6af70929859ff548444bfb8L205-R214)
* [`airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/steps/gradle.py`](diffhunk://#diff-822a5e53d898c9dc906b45015dee19c141b79c97cdbe0f76bd9e77c02ee15057L204-R204): Updated the `gradle_container` to use the asynchronous version of `with_bound_docker_host`.
* [`airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/python_connectors.py`](diffhunk://#diff-d041f28616e294a0620b51013686e54ad4ad9176dc68d1b3c8bdac7afeed0923L86-R86): Updated the `test_environment` to use the asynchronous version of `with_bound_docker_host`.

Permissions and logging improvements:

* [`airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/build_image/steps/python_connectors.py`](diffhunk://#diff-ab6fd5d12f532daca3ea98e6cd9dc8ccb4926af8780047e5c9330570b373c0eaR94-R95): Ensured the user has access to the `/tmp` directory by changing its ownership.
* [`airbyte-ci/connectors/pipelines/pipelines/dagger/actions/system/docker.py`](diffhunk://#diff-d40249eb99e1032e94b872d433c46a4996c0e845a6af70929859ff548444bfb8R84-R87): Added logging to indicate the storage driver being used based on the operating system.
* [`airbyte-ci/connectors/pipelines/pipelines/dagger/actions/system/docker.py`](diffhunk://#diff-d40249eb99e1032e94b872d433c46a4996c0e845a6af70929859ff548444bfb8R61-R71): Ensured the `/tmp` directory and Docker volumes are properly owned by the `airbyte` user and have appropriate permissions.