### PR TITLE
fix: (source-shopify) - Update the `deprecation deadline` for the change the change #51037

### DIFF
--- a/airbyte-integrations/connectors/source-shopify/metadata.yaml
+++ b/airbyte-integrations/connectors/source-shopify/metadata.yaml
@@ -11,7 +11,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 9da77001-af33-4bcd-be46-6252bf9342b9
-  dockerImageTag: 2.6.0
+  dockerImageTag: 2.6.1
   dockerRepository: airbyte/source-shopify
   documentationUrl: https://docs.airbyte.com/integrations/sources/shopify
   erdUrl: https://dbdocs.io/airbyteio/source-shopify?view=relationships
@@ -75,7 +75,7 @@ data:
         scopedImpact:
           - scopeType: stream
             impactedScopes: ["countries"]
-      2.6.0:
+      2.6.1:
         message:
           "The `ProductsGraphQL` and the `CustomerSavedSearch` streams have been deprecated by Shopify and removed from Airbyte.
           Use the `Products` stream instead. The data for the affected streams are no longer available. More details here: https://github.com/airbytehq/airbyte/pull/51037."

--- a/airbyte-integrations/connectors/source-shopify/metadata.yaml
+++ b/airbyte-integrations/connectors/source-shopify/metadata.yaml
@@ -78,8 +78,8 @@ data:
       2.6.1:
         message:
           "The `ProductsGraphQL` and the `CustomerSavedSearch` streams have been deprecated by Shopify and removed from Airbyte.
-          Use the `Products` stream instead. The data for the affected streams are no longer available. More details here: https://github.com/airbytehq/airbyte/pull/51037."
-        upgradeDeadline: "2025-02-16"
+          Please the `Products` stream instead. As of 2025-01-16, Spotify no longer provides data for the affected streams. More details here: https://github.com/airbytehq/airbyte/pull/51037."
+        upgradeDeadline: "2025-01-16"
         scopedImpact:
           - scopeType: stream
             impactedScopes: ["products_graph_ql", "customer_saved_search"]

--- a/airbyte-integrations/connectors/source-shopify/metadata.yaml
+++ b/airbyte-integrations/connectors/source-shopify/metadata.yaml
@@ -78,8 +78,8 @@ data:
       2.6.0:
         message:
           "The `ProductsGraphQL` and the `CustomerSavedSearch` streams have been deprecated by Shopify and removed from Airbyte.
-          Use the `Products` stream instead. More details here: https://github.com/airbytehq/airbyte/pull/51037."
-        upgradeDeadline: "2025-02-15"
+          Use the `Products` stream instead. The data for the affected streams are no longer available. More details here: https://github.com/airbytehq/airbyte/pull/51037."
+        upgradeDeadline: "2025-02-16"
         scopedImpact:
           - scopeType: stream
             impactedScopes: ["products_graph_ql", "customer_saved_search"]

--- a/airbyte-integrations/connectors/source-shopify/pyproject.toml
+++ b/airbyte-integrations/connectors/source-shopify/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "2.6.0"
+version = "2.6.1"
 name = "source-shopify"
 description = "Source CDK implementation for Shopify."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/docs/integrations/sources/shopify.md
+++ b/docs/integrations/sources/shopify.md
@@ -246,7 +246,8 @@ For all `Shopify GraphQL BULK` api requests these limitations are applied: https
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                                                                                                                                                                                                                                                                                   |
 |:--------|:-----------|:---------------------------------------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 2.6.0 | 2025-01-10 | [51037](https://github.com/airbytehq/airbyte/pull/51037) | Deprecated the `ProductsGraphQL` and `CustomerSavedSearch` streams from the stream catalog |
+| 2.6.1 | 2025-02-16 | [51602](https://github.com/airbytehq/airbyte/pull/51602) | Updated the `UpgradeDeadline` for the deprecation notice about [this change](https://github.com/airbytehq/airbyte/pull/51037) |
+| 2.6.0 | 2025-01-15 | [51037](https://github.com/airbytehq/airbyte/pull/51037) | Deprecated the `ProductsGraphQL` and `CustomerSavedSearch` stream from the stream catalog |
 | 2.5.18 | 2025-01-11 | [51326](https://github.com/airbytehq/airbyte/pull/51326) | Update dependencies |
 | 2.5.17 | 2025-01-06 | [50884](https://github.com/airbytehq/airbyte/pull/50884) | Add `moments` field `Customer Journey Summary` stream |
 | 2.5.16 | 2025-01-04 | [50938](https://github.com/airbytehq/airbyte/pull/50938) | Update dependencies |


### PR DESCRIPTION
## What
After the [products graph ql stream deprecation](https://github.com/airbytehq/airbyte/pull/51037) change, the `/products` rest endpoint stopped serving the requests for the `2023-07`, which the last one relies on. 

This created the situation when the new release is available, the old data is not available but the sync keeps spinning the older version that tries to pull the old data continuously. 

To solve this, we're pushing the `UpgradeDeadline` to the effective date of this PR created.

## How
- updated the `metadata.yaml`

## User Impact
The customers affected should be automatically upgraded to the `2.6.1` accepting the breaking change.

## Can this PR be safely reverted and rolled back?
- [ ] YES 💚
- [X] NO ❌
