### PR TITLE
fix: sets emittedAt for trace messages to reflect actual emission time

### DIFF
--- a/airbyte-cdk/bulk/core/base/src/main/kotlin/io/airbyte/cdk/output/OutputConsumer.kt
+++ b/airbyte-cdk/bulk/core/base/src/main/kotlin/io/airbyte/cdk/output/OutputConsumer.kt
@@ -37,8 +37,9 @@ abstract class OutputConsumer(private val clock: Clock) : Consumer<AirbyteMessag
     /**
      * The constant emittedAt timestamp we use for record timestamps.
      *
-     * TODO: use the correct emittedAt time for each record.
-     * Ryan: not changing this now as it could have performance implications for sources given the delicate serialization logic in place here.
+     * TODO: use the correct emittedAt time for each record. Ryan: not changing this now as it could
+     * have performance implications for sources given the delicate serialization logic in place
+     * here.
      */
     val recordEmittedAt: Instant = Instant.ofEpochMilli(clock.millis())
 
@@ -72,7 +73,8 @@ abstract class OutputConsumer(private val clock: Clock) : Consumer<AirbyteMessag
     }
 
     fun accept(trace: AirbyteTraceMessage) {
-        // Use the correct emittedAt timestamp for trace messages. This allows platform and other downstream consumers to take emission time into account for error classification.
+        // Use the correct emittedAt timestamp for trace messages. This allows platform and other
+        // downstream consumers to take emission time into account for error classification.
         trace.emittedAt = clock.millis().toDouble()
         accept(AirbyteMessage().withType(AirbyteMessage.Type.TRACE).withTrace(trace))
     }

--- a/airbyte-cdk/bulk/core/base/src/main/kotlin/io/airbyte/cdk/output/OutputConsumer.kt
+++ b/airbyte-cdk/bulk/core/base/src/main/kotlin/io/airbyte/cdk/output/OutputConsumer.kt
@@ -33,11 +33,9 @@ import java.util.function.Consumer
 
 /** Emits the [AirbyteMessage] instances produced by the connector. */
 @DefaultImplementation(StdoutOutputConsumer::class)
-interface OutputConsumer : Consumer<AirbyteMessage>, AutoCloseable {
-    val emittedAt: Instant
-
-    fun accept(record: AirbyteRecordMessage) {
-        record.emittedAt = emittedAt.toEpochMilli()
+abstract class OutputConsumer(private val clock: Clock) : Consumer<AirbyteMessage>, AutoCloseable {
+    open fun accept(record: AirbyteRecordMessage) {
+        record.emittedAt = clock.millis()
         accept(AirbyteMessage().withType(AirbyteMessage.Type.RECORD).withRecord(record))
     }
 
@@ -66,7 +64,8 @@ interface OutputConsumer : Consumer<AirbyteMessage>, AutoCloseable {
     }
 
     fun accept(trace: AirbyteTraceMessage) {
-        trace.emittedAt = emittedAt.toEpochMilli().toDouble()
+        // Use the correct emittedAt timestamp for trace messages. This allows platform and other downstream consumers to take emission time into account for error classification.
+        trace.emittedAt = clock.millis().toDouble()
         accept(AirbyteMessage().withType(AirbyteMessage.Type.TRACE).withTrace(trace))
     }
 
@@ -107,7 +106,7 @@ const val CONNECTOR_OUTPUT_PREFIX = "airbyte.connector.output"
 @Secondary
 private class StdoutOutputConsumer(
     val stdout: PrintStream,
-    clock: Clock,
+    private val clock: Clock,
     /**
      * [bufferByteSizeThresholdForFlush] triggers flushing the record buffer to stdout once the
      * buffer's size (in bytes) grows past this value.
@@ -132,8 +131,14 @@ private class StdoutOutputConsumer(
      */
     @Value("\${$CONNECTOR_OUTPUT_PREFIX.buffer-byte-size-threshold-for-flush:4096}")
     val bufferByteSizeThresholdForFlush: Int,
-) : OutputConsumer {
-    override val emittedAt: Instant = Instant.now(clock)
+) : OutputConsumer(clock) {
+    /**
+     * The constant emittedAt timestamp we use for record timestamps.
+     *
+     * TODO: use the correct emittedAt time for each record.
+     * Ryan: not changing this now as it could have performance implications for sources given the delicate serialization logic in place here.
+     */
+    private val recordEmittedAt = Instant.ofEpochMilli(clock.millis())
 
     private val buffer = ByteArrayOutputStream() // TODO: replace this with a StringWriter?
     private val jsonGenerator: JsonGenerator = Jsons.createGenerator(buffer)
@@ -233,7 +238,7 @@ private class StdoutOutputConsumer(
                 namespacedTemplates.getOrPut(namespace) { StreamToTemplateMap() }
             }
         return streamToTemplateMap.getOrPut(stream) {
-            RecordTemplate.create(stream, namespace, emittedAt)
+            RecordTemplate.create(stream, namespace, recordEmittedAt)
         }
     }
 

--- a/airbyte-cdk/bulk/core/base/src/testFixtures/kotlin/io/airbyte/cdk/output/BufferingOutputConsumer.kt
+++ b/airbyte-cdk/bulk/core/base/src/testFixtures/kotlin/io/airbyte/cdk/output/BufferingOutputConsumer.kt
@@ -15,7 +15,6 @@ import io.micronaut.context.annotation.Requires
 import io.micronaut.context.env.Environment
 import jakarta.inject.Singleton
 import java.time.Clock
-import java.time.Instant
 
 /** [OutputConsumer] implementation for unit tests. Collects everything into thread-safe buffers. */
 @Singleton
@@ -23,8 +22,7 @@ import java.time.Instant
 @Replaces(OutputConsumer::class)
 class BufferingOutputConsumer(
     clock: Clock,
-) : OutputConsumer {
-    override val emittedAt: Instant = Instant.now(clock)
+) : OutputConsumer(clock) {
 
     private val records = mutableListOf<AirbyteRecordMessage>()
     private val states = mutableListOf<AirbyteStateMessage>()

--- a/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/read/FeedBootstrap.kt
+++ b/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/read/FeedBootstrap.kt
@@ -108,7 +108,7 @@ sealed class FeedBootstrap<T : Feed>(
                 stream.schema.forEach { recordData.putNull(it.id) }
                 if (feed is Stream && precedingGlobalFeed != null) {
                     metaFieldDecorator.decorateRecordData(
-                        timestamp = outputConsumer.emittedAt.atOffset(ZoneOffset.UTC),
+                        timestamp = outputConsumer.recordEmittedAt.atOffset(ZoneOffset.UTC),
                         globalStateValue = stateQuerier.current(precedingGlobalFeed),
                         stream,
                         recordData,
@@ -125,7 +125,7 @@ sealed class FeedBootstrap<T : Feed>(
                     AirbyteRecordMessage()
                         .withStream(stream.name)
                         .withNamespace(stream.namespace)
-                        .withEmittedAt(outputConsumer.emittedAt.toEpochMilli())
+                        .withEmittedAt(outputConsumer.recordEmittedAt.toEpochMilli())
                         .withData(reusedRecordData)
                 )
 
@@ -138,7 +138,7 @@ sealed class FeedBootstrap<T : Feed>(
                     AirbyteRecordMessage()
                         .withStream(stream.name)
                         .withNamespace(stream.namespace)
-                        .withEmittedAt(outputConsumer.emittedAt.toEpochMilli())
+                        .withEmittedAt(outputConsumer.recordEmittedAt.toEpochMilli())
                         .withData(reusedRecordData)
                         .withMeta(reusedRecordMeta)
                 )

--- a/airbyte-cdk/bulk/core/extract/src/test/kotlin/io/airbyte/cdk/read/FeedBootstrapTest.kt
+++ b/airbyte-cdk/bulk/core/extract/src/test/kotlin/io/airbyte/cdk/read/FeedBootstrapTest.kt
@@ -70,7 +70,7 @@ class FeedBootstrapTest {
         FeedBootstrap.create(outputConsumer, metaFieldDecorator, stateQuerier, this)
 
     fun expected(vararg data: String): List<String> {
-        val ts = outputConsumer.emittedAt.toEpochMilli()
+        val ts = outputConsumer.recordEmittedAt.toEpochMilli()
         return data.map { """{"namespace":"ns","stream":"tbl","data":$it,"emitted_at":$ts}""" }
     }
 


### PR DESCRIPTION
## What
Improve downstream error classification by using accurate `emittedAt` for `TRACE` messages
Aligns with expectations of protocol as defined [here](https://docs.airbyte.com/understanding-airbyte/airbyte-protocol#airbytetracemessage)

## How
* Sets `emittedAt` for `TRACE` messages to reflect actual emission time
* `emittedAt` for `RECORD` messages stays the same

```
AirbyteTraceMessage:
    ...
    emitted_at:
      description: "the time in ms that the message was emitted"
```

## Notes
I'm not sure where unit tests live for this class for me to update—but would like to define this behavior somewhere

cc @postamar 

## Background
Platform (UI, metrics, etc) consider the error trace with the earliest `emittedAt` to be the root cause of a job failure. Because of the existing logic here to base the `emittedAt` off initialization time, the fact the destination is always started before the source, and that connectors always emit error traces on early shutdown, any source failures will be "overridden" by destination failures, breaking the expected attribution logic. [Thread for context](https://airbytehq-team.slack.com/archives/C03A8CSANPQ/p1736985988250899).