### PR TITLE
Remove credentials object from config, enable refresh token rewrite

### DIFF
--- a/airbyte-integrations/connectors/source-quickbooks/metadata.yaml
+++ b/airbyte-integrations/connectors/source-quickbooks/metadata.yaml
@@ -36,14 +36,14 @@ data:
           to fix normalization. You may need to refresh the connection schema for
           those streams (skipping the reset), and running a sync. Alternatively, you
           can just run a reset."
-        upgradeDeadline: 2023-10-04
+        upgradeDeadline: "2023-10-04"
       4.0.0:
         message:
           "The config no longer has a nested credentials field, while the config fields remain the same,
           they are now at the root level instead of being nested inside a credentials object
           You will need to repopulate the config fields to make the connector work again.
           This is done to fix the refresh token issue where it wasn't getting updated after 24 hours."
-        upgradeDeadline: 2025-02-15
+        upgradeDeadline: "2025-02-15"
   documentationUrl: https://docs.airbyte.com/integrations/sources/quickbooks
   tags:
     - cdk:low-code

--- a/airbyte-integrations/connectors/source-quickbooks/metadata.yaml
+++ b/airbyte-integrations/connectors/source-quickbooks/metadata.yaml
@@ -9,7 +9,7 @@ data:
     baseImage: docker.io/airbyte/python-connector-base:2.0.0@sha256:c44839ba84406116e8ba68722a0f30e8f6e7056c726f447681bb9e9ece8bd916
   connectorType: source
   definitionId: cf9c4355-b171-4477-8f2d-6c5cc5fc8b7e
-  dockerImageTag: 3.0.26
+  dockerImageTag: 4.0.0
   dockerRepository: airbyte/source-quickbooks
   githubIssueLabel: source-quickbooks
   icon: quickbooks.svg
@@ -37,6 +37,13 @@ data:
           those streams (skipping the reset), and running a sync. Alternatively, you
           can just run a reset."
         upgradeDeadline: 2023-10-04
+      4.0.0:
+        message:
+          "The config no longer has a nested credentials field, while the config fields remain the same,
+          they are now at the root level instead of being nested inside a credentials object
+          You will need to repopulate the config fields to make the connector work again.
+          This is done to fix the refresh token issue where it wasn't getting updated after 24 hours."
+        upgradeDeadline: 2025-02-15
   documentationUrl: https://docs.airbyte.com/integrations/sources/quickbooks
   tags:
     - cdk:low-code

--- a/airbyte-integrations/connectors/source-quickbooks/pyproject.toml
+++ b/airbyte-integrations/connectors/source-quickbooks/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "3.0.26"
+version = "4.0.0"
 name = "source-quickbooks"
 description = "Source implementation for quickbooks."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-quickbooks/source_quickbooks/manifest.yaml
+++ b/airbyte-integrations/connectors/source-quickbooks/source_quickbooks/manifest.yaml
@@ -18,7 +18,7 @@ definitions:
         type: SimpleRetriever
         requester:
           $ref: "#/definitions/base_requester"
-          path: /v3/company/{{ config.credentials.realm_id }}/query
+          path: /v3/company/{{ config.realm_id }}/query
           http_method: GET
           request_parameters:
             query: >-
@@ -71,7 +71,7 @@ definitions:
         type: SimpleRetriever
         requester:
           $ref: "#/definitions/base_requester"
-          path: /v3/company/{{ config.credentials.realm_id }}/query
+          path: /v3/company/{{ config.realm_id }}/query
           http_method: GET
           request_parameters:
             query: >-
@@ -124,7 +124,7 @@ definitions:
         type: SimpleRetriever
         requester:
           $ref: "#/definitions/base_requester"
-          path: /v3/company/{{ config.credentials.realm_id }}/query
+          path: /v3/company/{{ config.realm_id }}/query
           http_method: GET
           request_parameters:
             query: >-
@@ -177,7 +177,7 @@ definitions:
         type: SimpleRetriever
         requester:
           $ref: "#/definitions/base_requester"
-          path: /v3/company/{{ config.credentials.realm_id }}/query
+          path: /v3/company/{{ config.realm_id }}/query
           http_method: GET
           request_parameters:
             query: >-
@@ -230,7 +230,7 @@ definitions:
         type: SimpleRetriever
         requester:
           $ref: "#/definitions/base_requester"
-          path: /v3/company/{{ config.credentials.realm_id }}/query
+          path: /v3/company/{{ config.realm_id }}/query
           http_method: GET
           request_parameters:
             query: >-
@@ -283,7 +283,7 @@ definitions:
         type: SimpleRetriever
         requester:
           $ref: "#/definitions/base_requester"
-          path: /v3/company/{{ config.credentials.realm_id }}/query
+          path: /v3/company/{{ config.realm_id }}/query
           http_method: GET
           request_parameters:
             query: >-
@@ -336,7 +336,7 @@ definitions:
         type: SimpleRetriever
         requester:
           $ref: "#/definitions/base_requester"
-          path: /v3/company/{{ config.credentials.realm_id }}/query
+          path: /v3/company/{{ config.realm_id }}/query
           http_method: GET
           request_parameters:
             query: >-
@@ -389,7 +389,7 @@ definitions:
         type: SimpleRetriever
         requester:
           $ref: "#/definitions/base_requester"
-          path: /v3/company/{{ config.credentials.realm_id }}/query
+          path: /v3/company/{{ config.realm_id }}/query
           http_method: GET
           request_parameters:
             query: >-
@@ -442,7 +442,7 @@ definitions:
         type: SimpleRetriever
         requester:
           $ref: "#/definitions/base_requester"
-          path: /v3/company/{{ config.credentials.realm_id }}/query
+          path: /v3/company/{{ config.realm_id }}/query
           http_method: GET
           request_parameters:
             query: >-
@@ -495,7 +495,7 @@ definitions:
         type: SimpleRetriever
         requester:
           $ref: "#/definitions/base_requester"
-          path: /v3/company/{{ config.credentials.realm_id }}/query
+          path: /v3/company/{{ config.realm_id }}/query
           http_method: GET
           request_parameters:
             query: >-
@@ -548,7 +548,7 @@ definitions:
         type: SimpleRetriever
         requester:
           $ref: "#/definitions/base_requester"
-          path: /v3/company/{{ config.credentials.realm_id }}/query
+          path: /v3/company/{{ config.realm_id }}/query
           http_method: GET
           request_parameters:
             query: >-
@@ -601,7 +601,7 @@ definitions:
         type: SimpleRetriever
         requester:
           $ref: "#/definitions/base_requester"
-          path: /v3/company/{{ config.credentials.realm_id }}/query
+          path: /v3/company/{{ config.realm_id }}/query
           http_method: GET
           request_parameters:
             query: >-
@@ -654,7 +654,7 @@ definitions:
         type: SimpleRetriever
         requester:
           $ref: "#/definitions/base_requester"
-          path: /v3/company/{{ config.credentials.realm_id }}/query
+          path: /v3/company/{{ config.realm_id }}/query
           http_method: GET
           request_parameters:
             query: >-
@@ -707,7 +707,7 @@ definitions:
         type: SimpleRetriever
         requester:
           $ref: "#/definitions/base_requester"
-          path: /v3/company/{{ config.credentials.realm_id }}/query
+          path: /v3/company/{{ config.realm_id }}/query
           http_method: GET
           request_parameters:
             query: >-
@@ -760,7 +760,7 @@ definitions:
         type: SimpleRetriever
         requester:
           $ref: "#/definitions/base_requester"
-          path: /v3/company/{{ config.credentials.realm_id }}/query
+          path: /v3/company/{{ config.realm_id }}/query
           http_method: GET
           request_parameters:
             query: >-
@@ -813,7 +813,7 @@ definitions:
         type: SimpleRetriever
         requester:
           $ref: "#/definitions/base_requester"
-          path: /v3/company/{{ config.credentials.realm_id }}/query
+          path: /v3/company/{{ config.realm_id }}/query
           http_method: GET
           request_parameters:
             query: >-
@@ -866,7 +866,7 @@ definitions:
         type: SimpleRetriever
         requester:
           $ref: "#/definitions/base_requester"
-          path: /v3/company/{{ config.credentials.realm_id }}/query
+          path: /v3/company/{{ config.realm_id }}/query
           http_method: GET
           request_parameters:
             query: >-
@@ -919,7 +919,7 @@ definitions:
         type: SimpleRetriever
         requester:
           $ref: "#/definitions/base_requester"
-          path: /v3/company/{{ config.credentials.realm_id }}/query
+          path: /v3/company/{{ config.realm_id }}/query
           http_method: GET
           request_parameters:
             query: >-
@@ -972,7 +972,7 @@ definitions:
         type: SimpleRetriever
         requester:
           $ref: "#/definitions/base_requester"
-          path: /v3/company/{{ config.credentials.realm_id }}/query
+          path: /v3/company/{{ config.realm_id }}/query
           http_method: GET
           request_parameters:
             query: >-
@@ -1025,7 +1025,7 @@ definitions:
         type: SimpleRetriever
         requester:
           $ref: "#/definitions/base_requester"
-          path: /v3/company/{{ config.credentials.realm_id }}/query
+          path: /v3/company/{{ config.realm_id }}/query
           http_method: GET
           request_parameters:
             query: >-
@@ -1078,7 +1078,7 @@ definitions:
         type: SimpleRetriever
         requester:
           $ref: "#/definitions/base_requester"
-          path: /v3/company/{{ config.credentials.realm_id }}/query
+          path: /v3/company/{{ config.realm_id }}/query
           http_method: GET
           request_parameters:
             query: >-
@@ -1131,7 +1131,7 @@ definitions:
         type: SimpleRetriever
         requester:
           $ref: "#/definitions/base_requester"
-          path: /v3/company/{{ config.credentials.realm_id }}/query
+          path: /v3/company/{{ config.realm_id }}/query
           http_method: GET
           request_parameters:
             query: >-
@@ -1184,7 +1184,7 @@ definitions:
         type: SimpleRetriever
         requester:
           $ref: "#/definitions/base_requester"
-          path: /v3/company/{{ config.credentials.realm_id }}/query
+          path: /v3/company/{{ config.realm_id }}/query
           http_method: GET
           request_parameters:
             query: >-
@@ -1237,7 +1237,7 @@ definitions:
         type: SimpleRetriever
         requester:
           $ref: "#/definitions/base_requester"
-          path: /v3/company/{{ config.credentials.realm_id }}/query
+          path: /v3/company/{{ config.realm_id }}/query
           http_method: GET
           request_parameters:
             query: >-
@@ -1290,7 +1290,7 @@ definitions:
         type: SimpleRetriever
         requester:
           $ref: "#/definitions/base_requester"
-          path: /v3/company/{{ config.credentials.realm_id }}/query
+          path: /v3/company/{{ config.realm_id }}/query
           http_method: GET
           request_parameters:
             query: >-
@@ -1343,7 +1343,7 @@ definitions:
         type: SimpleRetriever
         requester:
           $ref: "#/definitions/base_requester"
-          path: /v3/company/{{ config.credentials.realm_id }}/query
+          path: /v3/company/{{ config.realm_id }}/query
           http_method: GET
           request_parameters:
             query: >-
@@ -1396,7 +1396,7 @@ definitions:
         type: SimpleRetriever
         requester:
           $ref: "#/definitions/base_requester"
-          path: /v3/company/{{ config.credentials.realm_id }}/query
+          path: /v3/company/{{ config.realm_id }}/query
           http_method: GET
           request_parameters:
             query: >-
@@ -1449,7 +1449,7 @@ definitions:
         type: SimpleRetriever
         requester:
           $ref: "#/definitions/base_requester"
-          path: /v3/company/{{ config.credentials.realm_id }}/query
+          path: /v3/company/{{ config.realm_id }}/query
           http_method: GET
           request_parameters:
             query: >-
@@ -1500,10 +1500,19 @@ definitions:
       'https://quickbooks.api.intuit.com' }}
     authenticator:
       type: OAuthAuthenticator
-      client_id: "{{ config['credentials']['client_id'] }}"
-      client_secret: "{{ config['credentials']['client_secret'] }}"
-      refresh_token: "{{ config['credentials']['refresh_token'] }}"
-      refresh_token_updater: {}
+      client_id: "{{ config['client_id'] }}"
+      client_secret: "{{ config['client_secret'] }}"
+      refresh_token: "{{ config['refresh_token'] }}"
+      expires_in_name: expires_in
+      access_token_name: access_token
+      refresh_token_updater:
+        refresh_token_name: refresh_token
+        access_token_config_path:
+          - access_token
+        token_expiry_date_config_path:
+          - token_expiry_date
+        refresh_token_config_path:
+          - refresh_token
       token_refresh_endpoint: https://oauth.platform.intuit.com/oauth2/v1/tokens/bearer
 
 streams:
@@ -1542,66 +1551,63 @@ spec:
     type: object
     $schema: http://json-schema.org/draft-07/schema#
     required:
-      - credentials
+      - client_id
+      - client_secret
+      - refresh_token
+      - access_token
+      - token_expiry_date
+      - realm_id
       - start_date
       - sandbox
     properties:
-      credentials:
-        type: object
-        oneOf:
-          - type: object
-            title: OAuth2.0
-            required:
-              - client_id
-              - client_secret
-              - refresh_token
-              - access_token
-              - token_expiry_date
-              - realm_id
-            properties:
-              realm_id:
-                type: string
-                title: Realm ID
-                description: >-
-                  Labeled Company ID. The Make API Calls panel is populated with
-                  the realm id and the current access token.
-                airbyte_secret: true
-              auth_type:
-                type: string
-                const: oauth2.0
-              client_id:
-                type: string
-                title: Client ID
-                description: >-
-                  Identifies which app is making the request. Obtain this value
-                  from the Keys tab on the app profile via My Apps on the
-                  developer site. There are two versions of this key:
-                  development and production.
-              access_token:
-                type: string
-                title: Access Token
-                description: Access token for making authenticated requests.
-                airbyte_secret: true
-              client_secret:
-                type: string
-                title: Client Secret
-                description: " Obtain this value from the Keys tab on the app profile via My Apps on the developer site. There are two versions of this key: development and production."
-                airbyte_secret: true
-              refresh_token:
-                type: string
-                title: Refresh Token
-                description: A token used when refreshing the access token.
-                airbyte_secret: true
-              token_expiry_date:
-                type: string
-                title: Token Expiry Date
-                format: date-time
-                description: The date-time when the access token should be refreshed.
+      realm_id:
+        type: string
         order: 0
-        title: Authorization Method
-      start_date:
+        title: Realm ID
+        description: >-
+          Labeled Company ID. The Make API Calls panel is populated with
+          the realm id and the current access token.
+        airbyte_secret: true
+      auth_type:
         type: string
         order: 1
+        const: oauth2.0
+      client_id:
+        type: string
+        order: 2
+        title: Client ID
+        description: >-
+          Identifies which app is making the request. Obtain this value
+          from the Keys tab on the app profile via My Apps on the
+          developer site. There are two versions of this key:
+          development and production.
+      access_token:
+        type: string
+        order: 3
+        title: Access Token
+        description: Access token for making authenticated requests.
+        airbyte_secret: true
+      client_secret:
+        type: string
+        order: 4
+        title: Client Secret
+        description: " Obtain this value from the Keys tab on the app profile via My Apps on the developer site. There are two versions of this key: development and production."
+        airbyte_secret: true
+      refresh_token:
+        type: string
+        order: 5
+        title: Refresh Token
+        description: A token used when refreshing the access token.
+        airbyte_secret: true
+      token_expiry_date:
+        type: string
+        order: 6
+        title: Token Expiry Date
+        format: date-time
+        description: The date-time when the access token should be refreshed.
+      start_date:
+        type: string
+        order: 7
         title: Start Date
         format: date-time
         pattern: ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$
@@ -1613,7 +1619,7 @@ spec:
           date will not be replicated.
       sandbox:
         type: boolean
-        order: 2
+        order: 8
         title: Sandbox
         default: false
         description: Determines whether to use the sandbox or production environment.

--- a/docs/integrations/sources/quickbooks-migrations.md
+++ b/docs/integrations/sources/quickbooks-migrations.md
@@ -1,5 +1,9 @@
 # QuickBooks Migration Guide
 
+## Upgrading to 4.0.0
+
+The config no longer has a nested credentials field, while the config fields remain the same, they are now at the root level instead of being nested inside a credentials object. You will need to repopulate the config fields to make the connector work again. This is done to fix the refresh token issue where it wasn't getting updated after 24 hours.
+
 ## Upgrading to 3.0.0
 
 Some fields in `bills`, `credit_memos`, `items`, `refund_receipts`, and `sales_receipts` streams have been changed from `integer` to `number` to fix normalization. You may need to refresh the connection schema for those streams (skipping the reset), and running a sync. Alternatively, you can just run a reset.

--- a/docs/integrations/sources/quickbooks.md
+++ b/docs/integrations/sources/quickbooks.md
@@ -108,7 +108,7 @@ This Source is capable of syncing the following [Streams](https://developer.intu
 
 | Version     | Date       | Pull Request                                             | Subject                                                            |
 |:------------|:-----------|:---------------------------------------------------------| :----------------------------------------------------------------- |
-| 4.0.0       | 2025-01-18 | [00000](https://github.com/airbytehq/airbyte/pull/00000) | Remove nested credentials object from config to enable overwriting of new refresh token in config |
+| 4.0.0       | 2025-01-18 | [51615](https://github.com/airbytehq/airbyte/pull/51615) | Remove nested credentials object from config to enable overwriting of new refresh token in config |
 | 3.0.26      | 2024-11-01 | [48089](https://github.com/airbytehq/airbyte/pull/48089) | Promoting release candidate 3.0.26-rc.1 to a main version. |
 | 3.0.26-rc.1 | 2024-09-10 | [44560](https://github.com/airbytehq/airbyte/pull/44560) | Replace Custom Components with Airbyte CDK features                |
 | 3.0.25      | 2024-10-05 | [46424](https://github.com/airbytehq/airbyte/pull/46424) | Update dependencies                                                |

--- a/docs/integrations/sources/quickbooks.md
+++ b/docs/integrations/sources/quickbooks.md
@@ -107,8 +107,9 @@ This Source is capable of syncing the following [Streams](https://developer.intu
   <summary>Expand to review</summary>
 
 | Version     | Date       | Pull Request                                             | Subject                                                            |
-| :---------- | :--------- | :------------------------------------------------------- | :----------------------------------------------------------------- |
-| 3.0.26 | 2024-11-01 | [48089](https://github.com/airbytehq/airbyte/pull/48089) | Promoting release candidate 3.0.26-rc.1 to a main version. |
+|:------------|:-----------|:---------------------------------------------------------| :----------------------------------------------------------------- |
+| 4.0.0       | 2025-01-18 | [00000](https://github.com/airbytehq/airbyte/pull/00000) | Remove nested credentials object from config to enable overwriting of new refresh token in config |
+| 3.0.26      | 2024-11-01 | [48089](https://github.com/airbytehq/airbyte/pull/48089) | Promoting release candidate 3.0.26-rc.1 to a main version. |
 | 3.0.26-rc.1 | 2024-09-10 | [44560](https://github.com/airbytehq/airbyte/pull/44560) | Replace Custom Components with Airbyte CDK features                |
 | 3.0.25      | 2024-10-05 | [46424](https://github.com/airbytehq/airbyte/pull/46424) | Update dependencies                                                |
 | 3.0.24      | 2024-09-28 | [46142](https://github.com/airbytehq/airbyte/pull/46142) | Update dependencies                                                |


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->
Resolves [#49842](https://github.com/airbytehq/airbyte/issues/49842)

## How
<!--
* Describe how code changes achieve the solution.
-->
QB refreshes the refresh_token every time a new refresh token is requested or after 24 hours whichever is earlier. This caused problems in clients where the connector stopped working after 24 hours. 
This is solved by the refresh_token_updater field in the yaml, but that requires the refresh_token path to be non nested, so the credentials object was removed from the config in this PR (since QB had only 1 auth type) and all the config fields were moved to root level.
Once the config was no longer nested, refresh_token_updater was used to overwrite the refresh_token in the config with the new refresh token which is returned whenever the "old" refresh token is used to request for a new access token. 
![image](https://github.com/user-attachments/assets/a9bf7fae-5d2f-4d32-9098-60e8421e6570)

## Review guide
<!--
1. `x.py`
2. `y.py`
-->
1. manifest.yaml

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->
Breaking change, user will have to repopulate their config fields since we removed the nested credentials object.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚