### PR TITLE
source-mysql: pin CDK version

### DIFF
--- a/airbyte-integrations/connectors/source-mysql/build.gradle
+++ b/airbyte-integrations/connectors/source-mysql/build.gradle
@@ -9,7 +9,7 @@ application {
 airbyteBulkConnector {
     core = 'extract'
     toolkits = ['extract-jdbc', 'extract-cdc']
-    cdk = 'local'
+    cdk = '0.277'
 }
 
 dependencies {


### PR DESCRIPTION
Someone merged a PR where `cdk = 'local'` for source-mysql, which makes it impossible to make changes to the CDK independently of source-mysql. This PR fixes this.