### PR TITLE
bulk-cdk-extract*: remove StateQuerier

### DIFF
--- a/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/read/FeedBootstrap.kt
+++ b/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/read/FeedBootstrap.kt
@@ -21,7 +21,7 @@ import java.time.ZoneOffset
 /**
  * [FeedBootstrap] is the input to a [PartitionsCreatorFactory].
  *
- * This object conveniently packages the [StateQuerier] singleton with the [feed] for which the
+ * This object conveniently packages the [StateManager] singleton with the [feed] for which the
  * [PartitionsCreatorFactory] is to operate on, eventually causing the emission of Airbyte RECORD
  * messages for the [Stream]s in the [feed]. For this purpose, [FeedBootstrap] provides
  * [StreamRecordConsumer] instances which essentially provide a layer of caching over
@@ -34,15 +34,30 @@ sealed class FeedBootstrap<T : Feed>(
      * The [MetaFieldDecorator] instance which [StreamRecordConsumer] will use to decorate records.
      */
     val metaFieldDecorator: MetaFieldDecorator,
-    /** [StateQuerier] singleton for use by [PartitionsCreatorFactory]. */
-    val stateQuerier: StateQuerier,
+    /** [StateManager] singleton which is encapsulated by this [FeedBootstrap]. */
+    private val stateManager: StateManager,
     /** [Feed] to emit records for. */
     val feed: T
 ) {
 
-    /** Convenience getter for the current state value for the [feed]. */
+    /** Delegates to [StateManager.feeds]. */
+    val feeds: List<Feed>
+        get() = stateManager.feeds
+
+    /** Deletages to [StateManager] to return the current state value for any [Feed]. */
+    fun currentState(feed: Feed): OpaqueStateValue? = stateManager.scoped(feed).current()
+
+    /** Convenience getter for the current state value for this [feed]. */
     val currentState: OpaqueStateValue?
-        get() = stateQuerier.current(feed)
+        get() = currentState(feed)
+
+    /** Resets the state value of this feed and the streams in it to zero. */
+    fun resetAll() {
+        stateManager.scoped(feed).reset()
+        for (stream in feed.streams) {
+            stateManager.scoped(stream).reset()
+        }
+    }
 
     /** A map of all [StreamRecordConsumer] for this [feed]. */
     fun streamRecordConsumers(): Map<StreamIdentifier, StreamRecordConsumer> =
@@ -98,7 +113,7 @@ sealed class FeedBootstrap<T : Feed>(
         }
 
         private val precedingGlobalFeed: Global? =
-            stateQuerier.feeds
+            stateManager.feeds
                 .filterIsInstance<Global>()
                 .filter { it.streams.contains(stream) }
                 .firstOrNull()
@@ -109,7 +124,7 @@ sealed class FeedBootstrap<T : Feed>(
                 if (feed is Stream && precedingGlobalFeed != null) {
                     metaFieldDecorator.decorateRecordData(
                         timestamp = outputConsumer.recordEmittedAt.atOffset(ZoneOffset.UTC),
-                        globalStateValue = stateQuerier.current(precedingGlobalFeed),
+                        globalStateValue = stateManager.scoped(precedingGlobalFeed).current(),
                         stream,
                         recordData,
                     )
@@ -192,14 +207,14 @@ sealed class FeedBootstrap<T : Feed>(
         fun create(
             outputConsumer: OutputConsumer,
             metaFieldDecorator: MetaFieldDecorator,
-            stateQuerier: StateQuerier,
+            stateManager: StateManager,
             feed: Feed,
         ): FeedBootstrap<*> =
             when (feed) {
                 is Global ->
-                    GlobalFeedBootstrap(outputConsumer, metaFieldDecorator, stateQuerier, feed)
+                    GlobalFeedBootstrap(outputConsumer, metaFieldDecorator, stateManager, feed)
                 is Stream ->
-                    StreamFeedBootstrap(outputConsumer, metaFieldDecorator, stateQuerier, feed)
+                    StreamFeedBootstrap(outputConsumer, metaFieldDecorator, stateManager, feed)
             }
     }
 }
@@ -241,17 +256,17 @@ enum class FieldValueChange {
 class GlobalFeedBootstrap(
     outputConsumer: OutputConsumer,
     metaFieldDecorator: MetaFieldDecorator,
-    stateQuerier: StateQuerier,
+    stateManager: StateManager,
     global: Global,
-) : FeedBootstrap<Global>(outputConsumer, metaFieldDecorator, stateQuerier, global)
+) : FeedBootstrap<Global>(outputConsumer, metaFieldDecorator, stateManager, global)
 
 /** [FeedBootstrap] implementation for [Stream] feeds. */
 class StreamFeedBootstrap(
     outputConsumer: OutputConsumer,
     metaFieldDecorator: MetaFieldDecorator,
-    stateQuerier: StateQuerier,
+    stateManager: StateManager,
     stream: Stream,
-) : FeedBootstrap<Stream>(outputConsumer, metaFieldDecorator, stateQuerier, stream) {
+) : FeedBootstrap<Stream>(outputConsumer, metaFieldDecorator, stateManager, stream) {
 
     /** A [StreamRecordConsumer] instance for this [Stream]. */
     fun streamRecordConsumer(): StreamRecordConsumer = streamRecordConsumers()[feed.id]!!

--- a/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/read/Partitions.kt
+++ b/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/read/Partitions.kt
@@ -12,10 +12,10 @@ import io.airbyte.cdk.read.PartitionsCreator.TryAcquireResourcesStatus
 interface PartitionsCreatorFactory {
     /**
      * Returns a [PartitionsCreator] which will cause the READ to advance for the [Feed] for which
-     * the [FeedBootstrap] argument is associated to. The latter exposes a [StateQuerier] to obtain
-     * the current [OpaqueStateValue] for this [feed] but may also be used to peek at the state of
-     * other [Feed]s. This may be useful for synchronizing the READ for this [feed] by waiting for
-     * other [Feed]s to reach a desired state before proceeding; the waiting may be triggered by
+     * the [FeedBootstrap] argument is associated to. The latter exposes methods to obtain the
+     * current [OpaqueStateValue] for this [feed] but also to peek at the state of other [Feed]s.
+     * This may be useful for synchronizing the READ for this [feed] by waiting for other [Feed]s to
+     * reach a desired state before proceeding; the waiting may be triggered by
      * [PartitionsCreator.tryAcquireResources] or [PartitionReader.tryAcquireResources].
      *
      * Returns null when the factory is unable to generate a [PartitionsCreator]. This causes

--- a/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/read/StateManager.kt
+++ b/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/read/StateManager.kt
@@ -10,24 +10,12 @@ import io.airbyte.protocol.models.v0.AirbyteStateMessage
 import io.airbyte.protocol.models.v0.AirbyteStateStats
 import io.airbyte.protocol.models.v0.AirbyteStreamState
 
-/** A [StateQuerier] is like a read-only [StateManager]. */
-interface StateQuerier {
-    /** [feeds] is all the [Feed]s in the configured catalog passed via the CLI. */
-    val feeds: List<Feed>
-
-    /** Returns the current state value for the given [feed]. */
-    fun current(feed: Feed): OpaqueStateValue?
-
-    /** Rolls back each feed state. This is required when resyncing CDC from scratch */
-    fun resetFeedStates()
-}
-
 /** Singleton object which tracks the state of an ongoing READ operation. */
 class StateManager(
     global: Global? = null,
     initialGlobalState: OpaqueStateValue? = null,
     initialStreamStates: Map<Stream, OpaqueStateValue?> = mapOf(),
-) : StateQuerier {
+) {
     private val global: GlobalStateManager?
     private val nonGlobal: Map<StreamIdentifier, NonGlobalStreamStateManager>
 
@@ -52,16 +40,14 @@ class StateManager(
         }
     }
 
-    override val feeds: List<Feed> =
+    /** [feeds] is all the [Feed]s in the configured catalog passed via the CLI. */
+    val feeds: List<Feed> =
         listOfNotNull(this.global?.feed) +
             (this.global?.streamStateManagers?.values?.map { it.feed } ?: listOf()) +
             nonGlobal.values.map { it.feed }
 
-    override fun current(feed: Feed): OpaqueStateValue? = scoped(feed).current()
-
-    override fun resetFeedStates() {
-        feeds.forEach { f -> scoped(f).set(Jsons.objectNode(), 0) }
-    }
+    /** Returns the current state value for the given [feed]. */
+    fun current(feed: Feed): OpaqueStateValue? = scoped(feed).current()
 
     /** Returns a [StateManagerScopedToFeed] instance scoped to this [feed]. */
     fun scoped(feed: Feed): StateManagerScopedToFeed =
@@ -86,6 +72,9 @@ class StateManager(
             state: OpaqueStateValue,
             numRecords: Long,
         )
+
+        /** Resets the current state value in the [StateManager] for this [feed] to zero. */
+        fun reset()
     }
 
     /**
@@ -117,6 +106,13 @@ class StateManager(
         ) {
             pendingStateValue = state
             pendingNumRecords += numRecords
+        }
+
+        @Synchronized
+        override fun reset() {
+            currentStateValue = null
+            pendingStateValue = null
+            pendingNumRecords = 0L
         }
 
         /**

--- a/airbyte-cdk/bulk/toolkits/extract-cdc/src/main/kotlin/io/airbyte/cdk/read/cdc/CdcPartitionsCreator.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-cdc/src/main/kotlin/io/airbyte/cdk/read/cdc/CdcPartitionsCreator.kt
@@ -46,7 +46,7 @@ class CdcPartitionsCreator<T : Comparable<T>>(
             )
         }
         val activeStreams: List<Stream> by lazy {
-            feedBootstrap.feed.streams.filter { feedBootstrap.stateQuerier.current(it) != null }
+            feedBootstrap.feed.streams.filter { feedBootstrap.currentState(it) != null }
         }
         val syntheticOffset: DebeziumOffset by lazy { creatorOps.generateColdStartOffset() }
         // Ensure that the WAL position upper bound has been computed for this sync.
@@ -96,7 +96,7 @@ class CdcPartitionsCreator<T : Comparable<T>>(
                 // TransientErrorException. The next sync will then snapshot the tables.
                 resetReason.set(warmStartState.reason)
                 log.info { "Resetting invalid incumbent CDC state with synthetic state." }
-                feedBootstrap.stateQuerier.resetFeedStates()
+                feedBootstrap.resetAll()
                 debeziumProperties = creatorOps.generateColdStartProperties()
                 startingOffset = syntheticOffset
                 startingSchemaHistory = null

--- a/airbyte-cdk/bulk/toolkits/extract-jdbc/src/test/kotlin/io/airbyte/cdk/read/TestFixtures.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-jdbc/src/test/kotlin/io/airbyte/cdk/read/TestFixtures.kt
@@ -190,14 +190,6 @@ object TestFixtures {
             SelectQuery(ast.toString(), listOf(), listOf())
     }
 
-    object MockStateQuerier : StateQuerier {
-        override val feeds: List<Feed> = listOf()
-        override fun current(feed: Feed): OpaqueStateValue? = null
-        override fun resetFeedStates() {
-            // no-op
-        }
-    }
-
     object MockMetaFieldDecorator : MetaFieldDecorator {
         override val globalCursor: MetaField? = null
         override val globalMetaFields: Set<MetaField> = emptySet()
@@ -214,14 +206,7 @@ object TestFixtures {
         StreamFeedBootstrap(
             outputConsumer = BufferingOutputConsumer(ClockFactory().fixed()),
             metaFieldDecorator = MockMetaFieldDecorator,
-            stateQuerier =
-                object : StateQuerier {
-                    override val feeds: List<Feed> = listOf(this@bootstrap)
-                    override fun current(feed: Feed): OpaqueStateValue? = opaqueStateValue
-                    override fun resetFeedStates() {
-                        // no-op
-                    }
-                },
+            stateManager = StateManager(initialStreamStates = mapOf(this to opaqueStateValue)),
             stream = this
         )
 }


### PR DESCRIPTION
## What

Based on https://github.com/airbytehq/airbyte/pull/52040

This PR gets rid of the `StateQuerier` interface which has become pointless ever since the `CdcPartitionsCreator` needed to be able to mutate the `StateManager` internals, in order to be able to reset a sync state following a CDC failure.

## How
n/a

## Review guide
n/a

## User Impact
None

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
