### PR TITLE
Load CDK: Re-enable funky characters test

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/write/BasicFunctionalityIntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/write/BasicFunctionalityIntegrationTest.kt
@@ -520,7 +520,6 @@ abstract class BasicFunctionalityIntegrationTest(
     }
 
     @Test
-    @Disabled
     open fun testFunkyCharacters() {
         assumeTrue(verifyDataWriting)
         fun makeStream(


### PR DESCRIPTION
**DO NOT MERGE UNTIL CI IS REENABLED**

This just the minimum to re-enable the "funky characters" test and keep CI passing. I'll add more coverage to the test case in a subsequent PR.

