### PR TITLE
Load CDK: Line counter is a long not an int

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/ReservingDeserializingInputFlow.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/ReservingDeserializingInputFlow.kt
@@ -32,9 +32,10 @@ class ReservingDeserializingInputFlow(
             "Reserved ${memoryManager.totalCapacityBytes/1024}mb memory for input processing"
         }
 
-        inputStream.bufferedReader().lineSequence().forEachIndexed { index, line ->
+        var index = 0L
+        inputStream.bufferedReader().lineSequence().forEach { line ->
             if (line.isEmpty()) {
-                return@forEachIndexed
+                return@forEach
             }
 
             val lineSize = line.length.toLong()
@@ -43,7 +44,7 @@ class ReservingDeserializingInputFlow(
             val message = deserializer.deserialize(line)
             collector.emit(Pair(lineSize, reserved.replace(message)))
 
-            if (index % 10_000 == 0) {
+            if (++index % 10_000L == 0L) {
                 log.info { "Processed $index lines" }
             }
         }


### PR DESCRIPTION
## What
I tried to write a test for this, but it turns out `bufferedReader` OOMs when you push a million newlines through it in a test environment.


