### PR TITLE
Load CDK Tests: Expand coverage of funky characters

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/ExpectedRecordMapper.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/ExpectedRecordMapper.kt
@@ -4,6 +4,7 @@
 
 package io.airbyte.cdk.load.test.util
 
+import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.data.AirbyteType
 import io.airbyte.cdk.load.data.AirbyteValue
 import io.airbyte.cdk.load.data.ArrayValue
@@ -18,6 +19,7 @@ import java.time.format.DateTimeFormatter
 
 fun interface ExpectedRecordMapper {
     fun mapRecord(expectedRecord: OutputRecord, schema: AirbyteType): OutputRecord
+    fun mapStreamDescriptor(descriptor: DestinationStream.Descriptor) = descriptor
 }
 
 object NoopExpectedRecordMapper : ExpectedRecordMapper {

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/IntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/IntegrationTest.kt
@@ -106,6 +106,7 @@ abstract class IntegrationTest(
         val actualRecords: List<OutputRecord> = dataDumper.dumpRecords(config, stream)
         val expectedRecords: List<OutputRecord> =
             canonicalExpectedRecords.map { recordMangler.mapRecord(it, stream.schema) }
+        val descriptor = recordMangler.mapStreamDescriptor(stream.descriptor)
 
         RecordDiffer(
                 primaryKey = primaryKey.map { nameMapper.mapFieldName(it) },
@@ -116,7 +117,7 @@ abstract class IntegrationTest(
             .diffRecords(expectedRecords, actualRecords)
             ?.let {
                 var message =
-                    "Incorrect records for ${stream.descriptor.namespace}.${stream.descriptor.name}:\n$it"
+                    "Incorrect records for ${descriptor.namespace}.${descriptor.name}:\n$it"
                 if (reason != null) {
                     message = reason + "\n" + message
                 }

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/write/BasicFunctionalityIntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/write/BasicFunctionalityIntegrationTest.kt
@@ -543,6 +543,10 @@ abstract class BasicFunctionalityIntegrationTest(
                     makeStream("stream_with_underscores"),
                     makeStream("STREAM_WITH_ALL_CAPS"),
                     makeStream("CapitalCase"),
+                    makeStream("stream_with_spécial_character"),
+                    makeStream("stream_name_with_operator+1"),
+                    makeStream("stream_name_with_numbers_123"),
+                    makeStream("1stream_with_a_leading_number"),
                     makeStream(
                         "stream_with_edge_case_field_names_and_values",
                         linkedMapOf(
@@ -551,6 +555,9 @@ abstract class BasicFunctionalityIntegrationTest(
                             "field_with_underscore" to stringType,
                             "FIELD_WITH_ALL_CAPS" to stringType,
                             "field_with_spécial_character" to stringType,
+                            "field_name_with_operator+1" to stringType,
+                            "field_name_with_numbers_123" to stringType,
+                            "1field_with_a_leading_number" to stringType,
                             // "order" is a reserved word in many sql engines
                             "order" to stringType,
                             "ProperCase" to stringType,

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/file/object_storage/ObjectStoragePathFactory.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/file/object_storage/ObjectStoragePathFactory.kt
@@ -374,7 +374,22 @@ class ObjectStoragePathFactory(
 
     private fun getPathVariableToPattern(stream: DestinationStream): Map<String, String> {
         return PATH_VARIABLES.associate {
-            it.variable to (it.pattern ?: it.provider(VariableContext(stream)))
+            it.variable to
+                (
+                // Only escape the pattern if
+                //   A) it's not already provided
+                //   B) the value from context is not blank
+                // This is to ensure stream names/namespaces with special characters (foo+1) match
+                // correctly,
+                // but that blank patterns are ignored completely.
+                it.pattern
+                    ?: (it.provider(VariableContext(stream)).let { s ->
+                        if (s.isNotBlank()) {
+                            Regex.escape(s)
+                        } else {
+                            s
+                        }
+                    }))
         } +
             FILENAME_VARIABLES.associate {
                 it.variable to

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/test/kotlin/io/airbyte/cdk/load/file/object_storage/ObjectStoragePathFactoryUTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/test/kotlin/io/airbyte/cdk/load/file/object_storage/ObjectStoragePathFactoryUTest.kt
@@ -122,6 +122,28 @@ class ObjectStoragePathFactoryUTest {
         assertNotNull(matcher.match("prefix/stream/any_filename"))
     }
 
+    @Test
+    fun `test stream name contains legal regex`() {
+        every { pathConfigProvider.objectStoragePathConfiguration } returns
+            ObjectStoragePathConfiguration(
+                "prefix",
+                "staging",
+                "\${STREAM_NAME}/",
+                "any_filename",
+                true,
+            )
+        val streamWithLegalRegex = mockk<DestinationStream>()
+        every { streamWithLegalRegex.descriptor } returns
+            DestinationStream.Descriptor("test", "stream+1")
+        val factory = ObjectStoragePathFactory(pathConfigProvider, null, null, timeProvider)
+        assertEquals(
+            "prefix/stream+1/any_filename",
+            factory.getPathToFile(streamWithLegalRegex, 0L, isStaging = false)
+        )
+        val matcher = factory.getPathMatcher(streamWithLegalRegex, "(-foo)?")
+        assertNotNull(matcher.match("prefix/stream+1/any_filename"))
+    }
+
     @ParameterizedTest
     @MethodSource("pathTemplateMatrix")
     fun `handles duplicate vars in path templates`(

--- a/airbyte-integrations/connectors/destination-s3-data-lake/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_data_lake/S3DataLakeWriteTest.kt
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_data_lake/S3DataLakeWriteTest.kt
@@ -101,6 +101,12 @@ class GlueWriteTest :
     override fun testUnions() {
         super.testUnions()
     }
+
+    @Test
+    @Disabled("https://github.com/airbytehq/airbyte-internal-issues/issues/11439")
+    override fun testFunkyCharacters() {
+        super.testFunkyCharacters()
+    }
 }
 
 class GlueAssumeRoleWriteTest :
@@ -113,7 +119,13 @@ class GlueAssumeRoleWriteTest :
             )
         ),
         S3DataLakeTestUtil.getAWSSystemCredentialsAsMap()
-    )
+    ) {
+    @Test
+    @Disabled("https://github.com/airbytehq/airbyte-internal-issues/issues/11439")
+    override fun testFunkyCharacters() {
+        super.testFunkyCharacters()
+    }
+}
 
 @Disabled(
     "This is currently disabled until we are able to make it run via airbyte-ci. It works as expected locally"

--- a/airbyte-integrations/connectors/destination-s3/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2WriteTest.kt
+++ b/airbyte-integrations/connectors/destination-s3/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2WriteTest.kt
@@ -182,6 +182,11 @@ class S3V2WriteTestAvroUncompressed :
     override fun testUnknownTypes() {
         super.testUnknownTypes()
     }
+
+    @Test
+    override fun testFunkyCharacters() {
+        super.testFunkyCharacters()
+    }
 }
 
 class S3V2WriteTestAvroBzip2 :


### PR DESCRIPTION
**DO NOT MERGE UNTIL CI IS WORKING, THIS MAKES A LOT OF CHANGES TO TESTS**

## What
Expands coverage of `testFunkyCharacters` to include
* field names with operators and leading numerals
* stream names with special characters, operators, numbers, and leading numbers

I also found an issue in the path matching code that fails to properly escape the path matching stuff if the stream name contains legal regex. (This is also an issue with the old CDK.) I went ahead and fixed it

This breaks the recently reenabled test for glue, so I re-disabled it. @edgao I'll leave it to you to decide whether to bother renabling, and whether that means patching or adding parameters to the test.