### PR TITLE
chore: use java sdk for state calls

### DIFF
--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/file/object_storage/StateObjectStorageLite.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/file/object_storage/StateObjectStorageLite.kt
@@ -1,0 +1,11 @@
+package io.airbyte.cdk.load.file.object_storage
+
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Just for testing old CDK in default open task.
+ */
+interface StateObjectStorageLite<T> {
+    fun list(prefix: String): Flow<T>
+    fun getMetadata(key: String): Map<String, String>
+}

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/state/object_storage/ObjectStorageDestinationStateManager.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/state/object_storage/ObjectStorageDestinationStateManager.kt
@@ -11,6 +11,7 @@ import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.file.object_storage.ObjectStorageClient
 import io.airbyte.cdk.load.file.object_storage.PathFactory
 import io.airbyte.cdk.load.file.object_storage.RemoteObject
+import io.airbyte.cdk.load.file.object_storage.StateObjectStorageLite
 import io.airbyte.cdk.load.state.DestinationState
 import io.airbyte.cdk.load.state.DestinationStatePersister
 import io.airbyte.cdk.load.state.object_storage.ObjectStorageDestinationState.Companion.OPTIONAL_ORDINAL_SUFFIX_PATTERN
@@ -146,7 +147,7 @@ class ObjectStorageStagingPersister(
     private val pathFactory: PathFactory
 ) : DestinationStatePersister<ObjectStorageDestinationState> {
     private val log = KotlinLogging.logger {}
-    private val fallbackPersister = ObjectStorageFallbackPersister(client, pathFactory)
+//    private val fallbackPersister = ObjectStorageFallbackPersister(client, pathFactory)
 
     companion object {
         const val STATE_FILENAME = "__airbyte_state.json"
@@ -164,7 +165,8 @@ class ObjectStorageStagingPersister(
             }
         } catch (e: Exception) {
             log.info { "No destination state found at $key: $e; falling back to metadata search" }
-            return fallbackPersister.load(stream)
+//            return fallbackPersister.load(stream)
+            throw e
         }
     }
 
@@ -175,7 +177,8 @@ class ObjectStorageStagingPersister(
 
 @SuppressFBWarnings("NP_NONNULL_PARAM_VIOLATION", justification = "Kotlin async continuation")
 class ObjectStorageFallbackPersister(
-    private val client: ObjectStorageClient<*>,
+//    private val client: ObjectStorageClient<*>,
+    private val client: StateObjectStorageLite<RemoteObject<*>>,
     private val pathFactory: PathFactory
 ) : DestinationStatePersister<ObjectStorageDestinationState> {
     private val log = KotlinLogging.logger {}
@@ -231,15 +234,15 @@ class ObjectStorageFallbackPersister(
 
 @Factory
 class ObjectStorageDestinationStatePersisterFactory<T : RemoteObject<*>>(
-    private val client: ObjectStorageClient<T>,
+    private val client: StateObjectStorageLite<RemoteObject<*>>,
     private val pathFactory: PathFactory
 ) {
     @Singleton
     @Secondary
     fun create(): DestinationStatePersister<ObjectStorageDestinationState> =
-        if (pathFactory.supportsStaging) {
-            ObjectStorageStagingPersister(client, pathFactory)
-        } else {
+//        if (pathFactory.supportsStaging) {
+//            ObjectStorageStagingPersister(client, pathFactory)
+//        } else {
             ObjectStorageFallbackPersister(client, pathFactory)
-        }
+//        }
 }

--- a/airbyte-cdk/bulk/toolkits/load-s3/build.gradle
+++ b/airbyte-cdk/bulk/toolkits/load-s3/build.gradle
@@ -3,6 +3,8 @@ dependencies {
     implementation project(':airbyte-cdk:bulk:core:bulk-cdk-core-load')
     api project(':airbyte-cdk:bulk:toolkits:bulk-cdk-toolkit-load-aws')
     api project(':airbyte-cdk:bulk:toolkits:bulk-cdk-toolkit-load-object-storage')
+    api 'com.amazonaws:aws-java-sdk-s3:1.12.772'
+    api 'com.amazonaws:aws-java-sdk-sts:1.12.772'
 
     testFixturesApi(testFixtures(project(":airbyte-cdk:bulk:toolkits:bulk-cdk-toolkit-load-object-storage")))
     implementation("aws.sdk.kotlin:s3:1.3.98")

--- a/airbyte-cdk/bulk/toolkits/load-s3/src/main/kotlin/io/airbyte/cdk/load/file/s3/S3Client.kt
+++ b/airbyte-cdk/bulk/toolkits/load-s3/src/main/kotlin/io/airbyte/cdk/load/file/s3/S3Client.kt
@@ -29,7 +29,6 @@ import com.amazonaws.auth.DefaultAWSCredentialsProviderChain
 import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider
 import com.amazonaws.client.builder.AwsClientBuilder
 import com.amazonaws.endpointdiscovery.DaemonThreadFactory
-import com.amazonaws.metrics.AwsSdkMetrics.getCredentialProvider
 import com.amazonaws.regions.Regions
 import com.amazonaws.retry.RetryMode
 import com.amazonaws.services.s3.AmazonS3

--- a/airbyte-cdk/bulk/toolkits/load-s3/src/main/kotlin/io/airbyte/cdk/load/file/s3/S3ClientJavaSDK.kt
+++ b/airbyte-cdk/bulk/toolkits/load-s3/src/main/kotlin/io/airbyte/cdk/load/file/s3/S3ClientJavaSDK.kt
@@ -1,0 +1,48 @@
+package io.airbyte.cdk.load.file.s3
+
+import kotlinx.coroutines.flow.flow
+import com.amazonaws.services.s3.AmazonS3
+import com.amazonaws.services.s3.model.ListObjectsRequest
+import com.amazonaws.services.s3.model.ObjectListing
+import io.airbyte.cdk.load.command.s3.S3BucketConfiguration
+import io.airbyte.cdk.load.file.object_storage.StateObjectStorageLite
+import jakarta.inject.Singleton
+import kotlinx.coroutines.flow.Flow
+
+@Singleton
+class S3ClientJavaSDK(
+    private val s3Client: AmazonS3,
+    private val bucketConfig: S3BucketConfiguration,
+): StateObjectStorageLite<S3Object> {
+
+    override fun list(prefix: String): Flow<S3Object> = flow {
+        val bucket: String = bucketConfig.s3BucketName
+        var objects: ObjectListing =
+            s3Client.listObjects(
+                ListObjectsRequest()
+                    .withBucketName(bucket)
+                    .withPrefix(prefix)
+                    .withDelimiter("")
+                    .withMaxKeys(1000)
+            )
+
+        // not sure why we would want to suspend here but keeping it for parity
+        objects.objectSummaries.forEach {
+            emit(S3Object(it.key!!, bucketConfig))
+        }
+
+        while (objects.objectSummaries.size > 0) {
+            if (objects.isTruncated) {
+                objects = s3Client.listNextBatchOfObjects(objects)
+            } else {
+                break
+            }
+        }
+    }
+
+    override fun getMetadata(key: String): Map<String, String> {
+        val bucket: String = bucketConfig.s3BucketName
+        val objectMetadata = s3Client.getObjectMetadata(bucket, key)
+        return objectMetadata.userMetadata
+    }
+}

--- a/airbyte-cdk/bulk/toolkits/load-s3/src/main/kotlin/io/airbyte/cdk/load/file/s3/S3ClientJavaSDK.kt
+++ b/airbyte-cdk/bulk/toolkits/load-s3/src/main/kotlin/io/airbyte/cdk/load/file/s3/S3ClientJavaSDK.kt
@@ -4,7 +4,7 @@ import kotlinx.coroutines.flow.flow
 import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.model.ListObjectsRequest
 import com.amazonaws.services.s3.model.ObjectListing
-import io.airbyte.cdk.load.command.s3.S3BucketConfiguration
+import io.airbyte.cdk.load.command.s3.S3BucketConfigurationProvider
 import io.airbyte.cdk.load.file.object_storage.StateObjectStorageLite
 import jakarta.inject.Singleton
 import kotlinx.coroutines.flow.Flow
@@ -12,11 +12,11 @@ import kotlinx.coroutines.flow.Flow
 @Singleton
 class S3ClientJavaSDK(
     private val s3Client: AmazonS3,
-    private val bucketConfig: S3BucketConfiguration,
+    private val bucketConfigProvider: S3BucketConfigurationProvider,
 ): StateObjectStorageLite<S3Object> {
 
     override fun list(prefix: String): Flow<S3Object> = flow {
-        val bucket: String = bucketConfig.s3BucketName
+        val bucket: String = bucketConfigProvider.s3BucketConfiguration.s3BucketName
         var objects: ObjectListing =
             s3Client.listObjects(
                 ListObjectsRequest()
@@ -28,7 +28,7 @@ class S3ClientJavaSDK(
 
         // not sure why we would want to suspend here but keeping it for parity
         objects.objectSummaries.forEach {
-            emit(S3Object(it.key!!, bucketConfig))
+            emit(S3Object(it.key!!, bucketConfigProvider.s3BucketConfiguration))
         }
 
         while (objects.objectSummaries.size > 0) {
@@ -41,7 +41,7 @@ class S3ClientJavaSDK(
     }
 
     override fun getMetadata(key: String): Map<String, String> {
-        val bucket: String = bucketConfig.s3BucketName
+        val bucket: String = bucketConfigProvider.s3BucketConfiguration.s3BucketName
         val objectMetadata = s3Client.getObjectMetadata(bucket, key)
         return objectMetadata.userMetadata
     }


### PR DESCRIPTION
## What
Hack to replace Java s3 client to replace the kotlin s3 client for the state persister load method 

## How
Cribs from old and new s3 client / config code