### PR TITLE
[Load CDK] Fixed number of open stream workers

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/command/DestinationConfiguration.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/command/DestinationConfiguration.kt
@@ -86,6 +86,7 @@ abstract class DestinationConfiguration : Configuration {
      */
     open val gracefulCancellationTimeoutMs: Long = 10 * 60 * 1000L // 10 minutes
 
+    open val numOpenStreamWorkers: Int = 1
     open val numProcessRecordsWorkers: Int = 2
     open val numProcessBatchWorkers: Int = 5
     open val numProcessBatchWorkersForFileTransfer: Int = 3

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/config/SyncBeanFactory.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/config/SyncBeanFactory.kt
@@ -6,7 +6,9 @@ package io.airbyte.cdk.load.config
 
 import io.airbyte.cdk.load.command.DestinationCatalog
 import io.airbyte.cdk.load.command.DestinationConfiguration
+import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.message.BatchEnvelope
+import io.airbyte.cdk.load.message.ChannelMessageQueue
 import io.airbyte.cdk.load.message.MultiProducerChannel
 import io.airbyte.cdk.load.state.ReservationManager
 import io.airbyte.cdk.load.task.implementor.FileAggregateMessage
@@ -89,4 +91,8 @@ class SyncBeanFactory {
         val channel = Channel<FileTransferQueueMessage>(config.batchQueueDepth)
         return MultiProducerChannel(1, channel, "fileMessageQueue")
     }
+
+    @Singleton
+    @Named("openStreamQueue")
+    class OpenStreamQueue : ChannelMessageQueue<DestinationStream>()
 }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/implementor/OpenStreamTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/implementor/OpenStreamTask.kt
@@ -5,15 +5,18 @@
 package io.airbyte.cdk.load.task.implementor
 
 import io.airbyte.cdk.load.command.DestinationStream
+import io.airbyte.cdk.load.message.MessageQueue
 import io.airbyte.cdk.load.state.SyncManager
-import io.airbyte.cdk.load.task.DestinationTaskLauncher
 import io.airbyte.cdk.load.task.SelfTerminating
 import io.airbyte.cdk.load.task.Task
 import io.airbyte.cdk.load.task.TerminalCondition
 import io.airbyte.cdk.load.write.DestinationWriter
 import io.airbyte.cdk.load.write.StreamLoader
 import io.micronaut.context.annotation.Secondary
+import jakarta.inject.Named
 import jakarta.inject.Singleton
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.toList
 
 interface OpenStreamTask : Task
 
@@ -25,44 +28,43 @@ interface OpenStreamTask : Task
 class DefaultOpenStreamTask(
     private val destinationWriter: DestinationWriter,
     private val syncManager: SyncManager,
-    val streamDescriptor: DestinationStream.Descriptor,
-    private val taskLauncher: DestinationTaskLauncher,
-    private val stream: DestinationStream,
+    private val openStreamQueue: MessageQueue<DestinationStream>
 ) : OpenStreamTask {
     override val terminalCondition: TerminalCondition = SelfTerminating
 
     override suspend fun execute() {
-        val streamLoader = destinationWriter.createStreamLoader(stream)
-        val result = runCatching {
-            streamLoader.start()
-            streamLoader
-        }
-        syncManager.registerStartedStreamLoader(stream.descriptor, result)
-        result.getOrThrow() // throw after registering the failure
-        taskLauncher.handleStreamStarted(streamDescriptor)
+        val results =
+            openStreamQueue
+                .consume()
+                .map { stream ->
+                    val streamLoader = destinationWriter.createStreamLoader(stream)
+                    val result = runCatching {
+                        streamLoader.start()
+                        streamLoader
+                    }
+                    syncManager.registerStartedStreamLoader(
+                        stream.descriptor,
+                        result
+                    ) // throw after registering the failure
+                    result
+                }
+                .toList()
+        results.forEach { it.getOrThrow() }
     }
 }
 
 interface OpenStreamTaskFactory {
-    fun make(taskLauncher: DestinationTaskLauncher, stream: DestinationStream): OpenStreamTask
+    fun make(): OpenStreamTask
 }
 
 @Singleton
 @Secondary
 class DefaultOpenStreamTaskFactory(
     private val destinationWriter: DestinationWriter,
-    private val syncManager: SyncManager
+    private val syncManager: SyncManager,
+    @Named("openStreamQueue") private val openStreamQueue: MessageQueue<DestinationStream>
 ) : OpenStreamTaskFactory {
-    override fun make(
-        taskLauncher: DestinationTaskLauncher,
-        stream: DestinationStream
-    ): OpenStreamTask {
-        return DefaultOpenStreamTask(
-            destinationWriter,
-            syncManager,
-            stream.descriptor,
-            taskLauncher,
-            stream
-        )
+    override fun make(): OpenStreamTask {
+        return DefaultOpenStreamTask(destinationWriter, syncManager, openStreamQueue)
     }
 }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/implementor/SetupTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/implementor/SetupTask.kt
@@ -4,7 +4,6 @@
 
 package io.airbyte.cdk.load.task.implementor
 
-import io.airbyte.cdk.load.task.DestinationTaskLauncher
 import io.airbyte.cdk.load.task.SelfTerminating
 import io.airbyte.cdk.load.task.Task
 import io.airbyte.cdk.load.task.TerminalCondition
@@ -14,26 +13,19 @@ import jakarta.inject.Singleton
 
 interface SetupTask : Task
 
-/**
- * Wraps @[DestinationWriter.setup] and starts the open stream tasks.
- *
- * TODO: This should call something like "TaskLauncher.setupComplete" and let it decide what to do
- * next.
- */
+/** Wraps @[DestinationWriter.setup] and starts the open stream tasks. */
 class DefaultSetupTask(
     private val destination: DestinationWriter,
-    private val taskLauncher: DestinationTaskLauncher
 ) : SetupTask {
     override val terminalCondition: TerminalCondition = SelfTerminating
 
     override suspend fun execute() {
         destination.setup()
-        taskLauncher.handleSetupComplete()
     }
 }
 
 interface SetupTaskFactory {
-    fun make(taskLauncher: DestinationTaskLauncher): SetupTask
+    fun make(): SetupTask
 }
 
 @Singleton
@@ -41,7 +33,7 @@ interface SetupTaskFactory {
 class DefaultSetupTaskFactory(
     private val destination: DestinationWriter,
 ) : SetupTaskFactory {
-    override fun make(taskLauncher: DestinationTaskLauncher): SetupTask {
-        return DefaultSetupTask(destination, taskLauncher)
+    override fun make(): SetupTask {
+        return DefaultSetupTask(destination)
     }
 }

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/MockTaskLauncher.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/MockTaskLauncher.kt
@@ -16,14 +16,6 @@ import jakarta.inject.Singleton
 class MockTaskLauncher : DestinationTaskLauncher {
     val batchEnvelopes = mutableListOf<BatchEnvelope<*>>()
 
-    override suspend fun handleSetupComplete() {
-        throw NotImplementedError()
-    }
-
-    override suspend fun handleStreamStarted(stream: DestinationStream.Descriptor) {
-        throw NotImplementedError()
-    }
-
     override suspend fun handleNewBatch(
         stream: DestinationStream.Descriptor,
         wrapped: BatchEnvelope<*>

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/implementor/OpenStreamTaskTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/implementor/OpenStreamTaskTest.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.load.task.implementor
+
+import io.airbyte.cdk.load.command.DestinationCatalog
+import io.airbyte.cdk.load.command.DestinationStream
+import io.airbyte.cdk.load.message.MessageQueue
+import io.airbyte.cdk.load.state.SyncManager
+import io.airbyte.cdk.load.test.util.CoroutineTestUtils.Companion.assertThrows
+import io.airbyte.cdk.load.write.DestinationWriter
+import io.airbyte.cdk.load.write.StreamLoader
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.mockk
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+class OpenStreamTaskTest {
+    @MockK(relaxed = true) private lateinit var writer: DestinationWriter
+    @MockK(relaxed = true) private lateinit var catalog: DestinationCatalog
+    @MockK(relaxed = true) private lateinit var syncManager: SyncManager
+    @MockK(relaxed = true) private lateinit var openStreamQueue: MessageQueue<DestinationStream>
+
+    class MyException(message: String) : Exception(message)
+
+    @Test
+    fun `test that open stream opens every stream`() = runTest {
+        val stream1: DestinationStream = mockk(relaxed = true)
+        val stream2: DestinationStream = mockk(relaxed = true)
+        val stream3: DestinationStream = mockk(relaxed = true)
+
+        val loader1: StreamLoader = mockk(relaxed = true)
+        val loader2: StreamLoader = mockk(relaxed = true)
+        val loader3: StreamLoader = mockk(relaxed = true)
+
+        every { catalog.streams } returns listOf(stream1, stream2, stream3)
+
+        coEvery { writer.createStreamLoader(stream1) } returns loader1
+        coEvery { writer.createStreamLoader(stream2) } returns loader2
+        coEvery { writer.createStreamLoader(stream3) } returns loader3
+
+        coEvery { loader1.start() } returns Unit
+        coEvery { loader2.start() } throws MyException("stream2 failed")
+        coEvery { loader3.start() } returns Unit
+
+        coEvery { openStreamQueue.consume() } returns
+            listOf(stream1, stream2, stream3).asSequence().asFlow()
+
+        coEvery { syncManager.registerStartedStreamLoader(any(), any()) } returns Unit
+
+        val task = DefaultOpenStreamTask(writer, syncManager, openStreamQueue)
+
+        assertThrows(MyException::class) { task.execute() }
+
+        coVerify(exactly = 3) { syncManager.registerStartedStreamLoader(any(), any()) }
+    }
+}


### PR DESCRIPTION
## What
There were a couple of ways to do this: semaphores-v-queue of streams to open.

I chose the latter because it's one step closer to the ideal behavior (opening a stream only when we first see data for it).

Tests are complete