### PR TITLE
Load CDK Tests: Generalize Microbatch Fix for State Ack-Dependent Tests

### DIFF
--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/write/object_storage/ObjectStorageStreamLoaderFactory.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/write/object_storage/ObjectStorageStreamLoaderFactory.kt
@@ -28,6 +28,7 @@ import io.airbyte.cdk.load.write.FileBatchAccumulator
 import io.airbyte.cdk.load.write.StreamLoader
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.micronaut.context.annotation.Secondary
+import io.micronaut.context.annotation.Value
 import jakarta.inject.Singleton
 import java.io.File
 import java.io.OutputStream
@@ -44,6 +45,8 @@ class ObjectStorageStreamLoaderFactory<T : RemoteObject<*>, U : OutputStream>(
         null,
     private val uploadConfigurationProvider: ObjectStorageUploadConfigurationProvider,
     private val destinationStateManager: DestinationStateManager<ObjectStorageDestinationState>,
+    @Value("\${airbyte.destination.record-batch-size-override}")
+    private val recordBatchSizeOverride: Long? = null
 ) {
     fun create(stream: DestinationStream): StreamLoader {
         return ObjectStorageStreamLoader(
@@ -54,7 +57,8 @@ class ObjectStorageStreamLoaderFactory<T : RemoteObject<*>, U : OutputStream>(
             bufferedWriterFactory,
             destinationStateManager,
             uploadConfigurationProvider.objectStorageUploadConfiguration.uploadPartSizeBytes,
-            uploadConfigurationProvider.objectStorageUploadConfiguration.fileSizeBytes
+            recordBatchSizeOverride
+                ?: uploadConfigurationProvider.objectStorageUploadConfiguration.fileSizeBytes
         )
     }
 }

--- a/airbyte-integrations/connectors/destination-dev-null/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-dev-null/metadata.yaml
@@ -10,7 +10,7 @@ data:
     - suite: integrationTests
   connectorType: destination
   definitionId: a7bcc9d8-13b3-4e49-b80d-d020b90045e3
-  dockerImageTag: 0.7.15
+  dockerImageTag: 0.7.16
   dockerRepository: airbyte/destination-dev-null
   documentationUrl: https://docs.airbyte.com/integrations/destinations/dev-null
   githubIssueLabel: destination-dev-null

--- a/airbyte-integrations/connectors/destination-dev-null/src/main/kotlin/io/airbyte/integrations/destination/dev_null/DevNullConfiguration.kt
+++ b/airbyte-integrations/connectors/destination-dev-null/src/main/kotlin/io/airbyte/integrations/destination/dev_null/DevNullConfiguration.kt
@@ -8,7 +8,6 @@ import io.airbyte.cdk.load.command.DestinationConfiguration
 import io.airbyte.cdk.load.command.DestinationConfigurationFactory
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.micronaut.context.annotation.Factory
-import io.micronaut.context.annotation.Value
 import jakarta.inject.Singleton
 
 /** This is the simplified configuration object actually used by the implementation. */
@@ -29,7 +28,6 @@ data class Throttled(val millisPerRecord: Long) : DevNullType
 
 data class DevNullConfiguration(
     val type: DevNullType,
-    override val recordBatchSizeBytes: Long = 200 * 1024 * 1024,
 ) : DestinationConfiguration()
 
 /**
@@ -40,14 +38,11 @@ data class DevNullConfiguration(
  * rest of the implementation.
  */
 @Singleton
-class DevNullConfigurationFactory(
-    @Value("\${airbyte.destination.record-batch-size-override}")
-    private val recordBatchSizeBytesOverride: Long?
-) : DestinationConfigurationFactory<DevNullSpecification, DevNullConfiguration> {
+class DevNullConfigurationFactory :
+    DestinationConfigurationFactory<DevNullSpecification, DevNullConfiguration> {
     private val log = KotlinLogging.logger {}
 
     override fun makeWithoutExceptionHandling(pojo: DevNullSpecification): DevNullConfiguration {
-        log.info { "Record batch size from environment: $recordBatchSizeBytesOverride" }
         return when (pojo) {
             is DevNullSpecificationOss -> {
                 when (pojo.testDestination) {
@@ -108,10 +103,7 @@ class DevNullConfigurationFactory(
                     }
                 }
             }
-        }.copy(
-            recordBatchSizeBytes = recordBatchSizeBytesOverride
-                    ?: DestinationConfiguration.DEFAULT_RECORD_BATCH_SIZE_BYTES
-        )
+        }
     }
 }
 

--- a/airbyte-integrations/connectors/destination-s3-data-lake/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_data_lake/S3DataLakeWriteTest.kt
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_data_lake/S3DataLakeWriteTest.kt
@@ -60,21 +60,16 @@ abstract class S3DataLakeWriteTest(
     }
 
     @Test
-    @Disabled(
-        "This is currently hanging forever and we should look into why https://github.com/airbytehq/airbyte-internal-issues/issues/11162"
-    )
     override fun testInterruptedTruncateWithPriorData() {
         super.testInterruptedTruncateWithPriorData()
     }
 
     @Test
-    @Disabled("This is currently hanging forever and we should look into why")
     override fun testInterruptedTruncateWithoutPriorData() {
         super.testInterruptedTruncateWithoutPriorData()
     }
 
     @Test
-    @Disabled("This is currently hanging forever and we should look into why")
     override fun resumeAfterCancelledTruncate() {
         super.resumeAfterCancelledTruncate()
     }

--- a/airbyte-integrations/connectors/destination-s3/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-s3/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: file
   connectorType: destination
   definitionId: 4816b78f-1489-44c1-9060-4b19d5fa9362
-  dockerImageTag: 1.5.0-rc.12
+  dockerImageTag: 1.5.0-rc.13
   dockerRepository: airbyte/destination-s3
   githubIssueLabel: destination-s3
   icon: s3.svg

--- a/airbyte-integrations/connectors/destination-s3/src/main/kotlin/S3V2Configuration.kt
+++ b/airbyte-integrations/connectors/destination-s3/src/main/kotlin/S3V2Configuration.kt
@@ -21,7 +21,6 @@ import io.airbyte.cdk.load.command.object_storage.ObjectStorageUploadConfigurati
 import io.airbyte.cdk.load.command.s3.S3BucketConfiguration
 import io.airbyte.cdk.load.command.s3.S3BucketConfigurationProvider
 import io.micronaut.context.annotation.Factory
-import io.micronaut.context.annotation.Value
 import jakarta.inject.Singleton
 import java.io.OutputStream
 
@@ -39,7 +38,6 @@ data class S3V2Configuration<T : OutputStream>(
         ObjectStorageUploadConfiguration(),
     override val numProcessRecordsWorkers: Int = 2,
     override val estimatedRecordMemoryOverheadRatio: Double = 5.0,
-    override val recordBatchSizeBytes: Long,
     override val processEmptyFiles: Boolean = true,
 ) :
     DestinationConfiguration(),
@@ -52,10 +50,8 @@ data class S3V2Configuration<T : OutputStream>(
     ObjectStorageCompressionConfigurationProvider<T>
 
 @Singleton
-class S3V2ConfigurationFactory(
-    @Value("\${airbyte.destination.record-batch-size-override}")
-    val recordBatchSizeOverride: Long? = null
-) : DestinationConfigurationFactory<S3V2Specification, S3V2Configuration<*>> {
+class S3V2ConfigurationFactory :
+    DestinationConfigurationFactory<S3V2Specification, S3V2Configuration<*>> {
     override fun makeWithoutExceptionHandling(pojo: S3V2Specification): S3V2Configuration<*> {
         return S3V2Configuration(
             awsAccessKeyConfiguration = pojo.toAWSAccessKeyConfiguration(),
@@ -64,13 +60,6 @@ class S3V2ConfigurationFactory(
             objectStoragePathConfiguration = pojo.toObjectStoragePathConfiguration(),
             objectStorageFormatConfiguration = pojo.toObjectStorageFormatConfiguration(),
             objectStorageCompressionConfiguration = pojo.toCompressionConfiguration(),
-            recordBatchSizeBytes = recordBatchSizeOverride
-                    ?: ObjectStorageUploadConfiguration.DEFAULT_PART_SIZE_BYTES,
-            objectStorageUploadConfiguration =
-                ObjectStorageUploadConfiguration(
-                    fileSizeBytes = recordBatchSizeOverride
-                            ?: ObjectStorageUploadConfiguration.DEFAULT_FILE_SIZE_BYTES,
-                )
         )
     }
 }

--- a/docs/integrations/destinations/dev-null.md
+++ b/docs/integrations/destinations/dev-null.md
@@ -49,7 +49,8 @@ The OSS and Cloud variants have the same version number starting from version `0
 
 | Version     | Date       | Pull Request                                             | Subject                                                                                      |
 |:------------|:-----------|:---------------------------------------------------------|:---------------------------------------------------------------------------------------------|
-| 0.7.15 | 2024-12-19 | [49899](https://github.com/airbytehq/airbyte/pull/49931) | Non-functional CDK changes                                                                                 |
+| 0.7.16      | 2024-12-19 | [52076](https://github.com/airbytehq/airbyte/pull/52076) | Test improvements                                                                            |
+| 0.7.15      | 2024-12-19 | [49899](https://github.com/airbytehq/airbyte/pull/49931) | Non-functional CDK changes                                                                   |
 | 0.7.14      | 2024-12-20 | [49974](https://github.com/airbytehq/airbyte/pull/49974) | Non-functional CDK changes                                                                   |
 | 0.7.13      | 2024-12-18 | [49899](https://github.com/airbytehq/airbyte/pull/49899) | Use a base image: airbyte/java-connector-base:1.0.0                                          |
 | 0.7.12      | 2024-12-04 | [48794](https://github.com/airbytehq/airbyte/pull/48794) | Promoting release candidate 0.7.12-rc.2 to a main version.                                   |

--- a/docs/integrations/destinations/s3.md
+++ b/docs/integrations/destinations/s3.md
@@ -544,6 +544,7 @@ To see connector limitations, or troubleshoot your S3 connector, see more [in ou
 
 | Version     | Date       | Pull Request                                               | Subject                                                                                                                                              |
 |:------------|:-----------|:-----------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| 1.5.0-rc.13 | 2025-01-22 | [52076](https://github.com/airbytehq/airbyte/pull/52076)   | Test improvements.                                                                                                                                   |
 | 1.5.0-rc.12 | 2025-01-22 | [52072](https://github.com/airbytehq/airbyte/pull/52072)   | Bug fix: Configure OpenStreamTask concurrency to handle connection to reduce http connection errors.                                                 |
 | 1.5.0-rc.11 | 2025-01-17 | [51051](https://github.com/airbytehq/airbyte/pull/51051)   | Input fully read before end-of-stream now correctly marked transient                                                                                 |
 | 1.5.0-rc.10 | 2025-01-15 | [50960](https://github.com/airbytehq/airbyte/pull/50960)   | Bug fixes: tolerate repeated path variables; avro meta field schema matches old cdk                                                                  |


### PR DESCRIPTION
## What
application.yaml `airbyte.destination.record-batch-size-override` is applied to the flush strategy, instead of threaded through s3 config. this generalizes the fix for all connectors. tests will microbatch (1b) and therefore always flush, always do work, always complete state, etc.

(additionally, for object storage toolkit users (currently only s3), it overrides the file size as well)

@gosusnp I verified that this fixes `resumeAfterCancelledTruncate` for you.


