### PR TITLE
airbyte-ci: wire the `--enable-report-auto-open` option to connector tests

### DIFF
--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -854,6 +854,7 @@ airbyte-ci connectors --language=low-code migrate-to-manifest-only
 
 | Version | PR                                                         | Description                                                                                                                  |
 | ------- | ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| 4.49.1  | [#52087](https://github.com/airbytehq/airbyte/pull/52087)  | Wire the `--enable-report-auto-open` correctly for connector tests                                                           |
 | 4.49.0  | [#52033](https://github.com/airbytehq/airbyte/pull/52033)  | Run gradle as a subprocess and not via Dagger                                                                                |
 | 4.48.9  | [#51609](https://github.com/airbytehq/airbyte/pull/51609)  | Fix ownership of shared cache volume for non root connectors                                                                 |
 | 4.48.8  | [#51582](https://github.com/airbytehq/airbyte/pull/51582)  | Fix typo in `migrate-to-inline-schemas` command                                                                              |

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/commands.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/commands.py
@@ -166,6 +166,7 @@ async def test(
             run_step_options=run_step_options,
             targeted_platforms=[LOCAL_BUILD_PLATFORM],
             secret_stores=ctx.obj["secret_stores"],
+            enable_report_auto_open=ctx.obj.get("enable_report_auto_open", True),
         )
         for connector in ctx.obj["selected_connectors_with_modified_files"]
     ]

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "4.49.0"
+version = "4.49.1"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 


### PR DESCRIPTION
This pull request includes several important updates to the `airbyte-ci` connectors, particularly focusing on the `--enable-report-auto-open` feature and version bump. The most important changes are summarized below:

### Feature Enhancements:

* Correctly wired the `--enable-report-auto-open` option for connector tests to ensure it functions as expected.

### Code Updates:

* Added the `enable_report_auto_open` parameter to the `test` command in `airbyte_ci/connectors/test/commands.py` to enable the auto-opening of reports by default.

### Versioning:

* Updated the version of the `pipelines` package from `4.49.0` to `4.49.1` in `pyproject.toml` to reflect the new changes and enhancements.