### PR TITLE
connectors-tests: set RUN_IN_AIRBYTE_CI env var

### DIFF
--- a/.github/actions/run-airbyte-ci/action.yml
+++ b/.github/actions/run-airbyte-ci/action.yml
@@ -158,6 +158,7 @@ runs:
         PRODUCTION: ${{ inputs.production }}
         PYTHON_REGISTRY_TOKEN: ${{ inputs.python_registry_token }}
         PYTHON_REGISTRY_URL: ${{ inputs.python_registry_url }}
+        RUN_IN_AIRBYTE_CI: "True"
         S3_BUILD_CACHE_ACCESS_KEY_ID: ${{ inputs.s3_build_cache_access_key_id }}
         S3_BUILD_CACHE_SECRET_KEY: ${{ inputs.s3_build_cache_secret_key }}
         SENTRY_DSN: ${{ inputs.sentry_dsn }}


### PR DESCRIPTION
This pull request includes a small change to the `.github/actions/run-airbyte-ci/action.yml` file. The change adds a new environment variable `RUN_IN_AIRBYTE_CI` set to "True".

* [`.github/actions/run-airbyte-ci/action.yml`](diffhunk://#diff-ce432ff29f2547c1bfdfd6d8080fc9798498b6a7bcf12c1206c9a82592b3e461R161): Added `RUN_IN_AIRBYTE_CI` environment variable.