### PR TITLE
airbyte-ci: re-add custom params to gradle command

### DIFF
--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -854,6 +854,7 @@ airbyte-ci connectors --language=low-code migrate-to-manifest-only
 
 | Version | PR                                                         | Description                                                                                                                  |
 | ------- | ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| 4.49.2  | [#52090](https://github.com/airbytehq/airbyte/pull/52090)  | Re-add custom task parameters in GradleTask                                                                                  |
 | 4.49.1  | [#52087](https://github.com/airbytehq/airbyte/pull/52087)  | Wire the `--enable-report-auto-open` correctly for connector tests                                                           |
 | 4.49.0  | [#52033](https://github.com/airbytehq/airbyte/pull/52033)  | Run gradle as a subprocess and not via Dagger                                                                                |
 | 4.48.9  | [#51609](https://github.com/airbytehq/airbyte/pull/51609)  | Fix ownership of shared cache volume for non root connectors                                                                 |

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/steps/gradle.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/steps/gradle.py
@@ -80,7 +80,7 @@ class GradleTask(Step, ABC):
     @property
     def gradle_command(self) -> str:
         connector_gradle_task = f":airbyte-integrations:connectors:{self.context.connector.technical_name}:{self.gradle_task_name}"
-        return self._get_gradle_command(connector_gradle_task)
+        return self._get_gradle_command(connector_gradle_task, task_options=self.params_as_cli_options)
 
     def timeout_handler(self, signum: int, frame: Any) -> None:
         raise GradleTimeoutError(f"Gradle operation timed out after {self.GRADLE_TIMEOUT} seconds")

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "4.49.1"
+version = "4.49.2"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 


### PR DESCRIPTION
This pull request includes several updates to the `airbyte-ci` connectors, focusing on re-adding custom task parameters, updating system requirements, and version bumping. The most important changes are summarized below:


### Code Update:

* [`airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/steps/gradle.py`](diffhunk://#diff-822a5e53d898c9dc906b45015dee19c141b79c97cdbe0f76bd9e77c02ee15057L83-R83): Modified the `gradle_command` property to include `task_options` when calling `_get_gradle_command`.

### Test
Running `destination-s3` test workflow on this branch https://github.com/airbytehq/airbyte/actions/runs/12915239962
