### PR TITLE
destination-s3: use the non root base image

### DIFF
--- a/airbyte-integrations/connectors/destination-s3/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-s3/metadata.yaml
@@ -2,14 +2,14 @@ data:
   connectorSubtype: file
   connectorType: destination
   definitionId: 4816b78f-1489-44c1-9060-4b19d5fa9362
-  dockerImageTag: 1.5.0-rc.12
+  dockerImageTag: 1.5.0-rc.13
   dockerRepository: airbyte/destination-s3
   githubIssueLabel: destination-s3
   icon: s3.svg
   license: ELv2
   name: S3
   connectorBuildOptions:
-    baseImage: docker.io/airbyte/java-connector-base:1.0.0@sha256:be86e5684e1e6d9280512d3d8071b47153698fe08ad990949c8eeff02803201a
+    baseImage: docker.io/airbyte/java-connector-base:2.0.0@sha256:5a1a21c75c5e1282606de9fa539ba136520abe2fbd013058e988bb0297a9f454
   registryOverrides:
     cloud:
       enabled: true

--- a/docs/integrations/destinations/s3.md
+++ b/docs/integrations/destinations/s3.md
@@ -544,6 +544,7 @@ To see connector limitations, or troubleshoot your S3 connector, see more [in ou
 
 | Version     | Date       | Pull Request                                               | Subject                                                                                                                                              |
 |:------------|:-----------|:-----------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| 1.5.0-rc.13 | 2025-01-23 | [52103](https://github.com/airbytehq/airbyte/pull/52103)   | Make the connector use our non root base image.                                                                                                       |
 | 1.5.0-rc.12 | 2025-01-22 | [52072](https://github.com/airbytehq/airbyte/pull/52072)   | Bug fix: Configure OpenStreamTask concurrency to handle connection to reduce http connection errors.                                                 |
 | 1.5.0-rc.11 | 2025-01-17 | [51051](https://github.com/airbytehq/airbyte/pull/51051)   | Input fully read before end-of-stream now correctly marked transient                                                                                 |
 | 1.5.0-rc.10 | 2025-01-15 | [50960](https://github.com/airbytehq/airbyte/pull/50960)   | Bug fixes: tolerate repeated path variables; avro meta field schema matches old cdk                                                                  |


### PR DESCRIPTION
This pull request updates the S3 destination connector to use a new base image and version. It also includes documentation updates to reflect these changes.

### Connector updates:

* [`airbyte-integrations/connectors/destination-s3/metadata.yaml`](diffhunk://#diff-e611ec8ddb6481867be5202bb43f85fdb36c2b2102ea56f6b91217dffda63c1dL5-R12): Updated the `dockerImageTag` to `1.5.0-rc.12` and changed the `baseImage` to `docker.io/airbyte/java-connector-base:2.0.0@sha256:5a1a21c75c5e1282606de9fa539ba136520abe2fbd013058e988bb0297a9f454`.

### Documentation updates:

* [`docs/integrations/destinations/s3.md`](diffhunk://#diff-69de65b90934b0e7e8f813cfa8298d11e6cc1104e9f64e3a010eee0441b81db9R547): Added a new entry for version `1.5.0-rc.12` in the version history table, indicating the change to use a non-root base image.