### PR TITLE
airbyte-ci: stream gradle output to step logger

### DIFF
--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -854,6 +854,7 @@ airbyte-ci connectors --language=low-code migrate-to-manifest-only
 
 | Version | PR                                                         | Description                                                                                                                  |
 | ------- | ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| 4.49.4  | [#52104](https://github.com/airbytehq/airbyte/pull/52104)  | Stream Gradle task output to the step logger                                                                 |
 | 4.49.3  | [#52102](https://github.com/airbytehq/airbyte/pull/52102)  | Load docker image to local docker host for java connectors                                                                 |
 | 4.49.2  | [#52090](https://github.com/airbytehq/airbyte/pull/52090)  | Re-add custom task parameters in GradleTask                                                                                  |
 | 4.49.1  | [#52087](https://github.com/airbytehq/airbyte/pull/52087)  | Wire the `--enable-report-auto-open` correctly for connector tests                                                           |

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "4.49.3"
+version = "4.49.4"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 


### PR DESCRIPTION
## What

Changes to stream the gradle output to the airbyte-ci step logger:
[Test workflow example
](https://github.com/airbytehq/airbyte/actions/runs/12926099254/job/36048431890)
<img width="1536" alt="Screenshot 2025-01-23 at 10 29 54" src="https://github.com/user-attachments/assets/8141996d-57e4-4cb3-a5c4-5918fb314b4e" />


## How

This pull request includes several changes to the `airbyte-ci` connectors to improve logging and error handling. The most important changes include streaming Gradle task output in real-time, handling multiple exception types in a single block, and updating the package version.

### Improvements to logging:

* [`airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/steps/gradle.py`](diffhunk://#diff-822a5e53d898c9dc906b45015dee19c141b79c97cdbe0f76bd9e77c02ee15057L165-L179): Modified the `_run_gradle_in_subprocess` method to stream Gradle task output in real-time using non-blocking reads.

### Error handling improvements:

* [`airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/steps/gradle.py`](diffhunk://#diff-822a5e53d898c9dc906b45015dee19c141b79c97cdbe0f76bd9e77c02ee15057L211-R249): Combined the `GradleTimeoutError` and `InvalidGradleEnvironment` exceptions into a single `except` block in the `_run` method.

### Dependency updates:

* [`airbyte-ci/connectors/pipelines/pyproject.toml`](diffhunk://#diff-087e2c37602bbd6824f875004abddcb4e1a374da12bf84201671ed0900882ce0L7-R7): Updated the package version from `4.49.3` to `4.49.4`.

### Documentation updates:

* [`airbyte-ci/connectors/pipelines/README.md`](diffhunk://#diff-62eccd92928fbcd3d285983bfdaa2b0d4ca49016cb9c2f63d6d9fc968c59c541R857): Added a new entry for version `4.49.4` to document the change of streaming Gradle task output to the step logger.

### Codebase maintenance:

* [`airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/steps/gradle.py`](diffhunk://#diff-822a5e53d898c9dc906b45015dee19c141b79c97cdbe0f76bd9e77c02ee15057R5): Added the `select` module import to support non-blocking reads.