### PR TITLE
Load CDK: FIX: Open waits on setup

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/implementor/SetupTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/implementor/SetupTask.kt
@@ -4,6 +4,7 @@
 
 package io.airbyte.cdk.load.task.implementor
 
+import io.airbyte.cdk.load.task.DestinationTaskLauncher
 import io.airbyte.cdk.load.task.SelfTerminating
 import io.airbyte.cdk.load.task.Task
 import io.airbyte.cdk.load.task.TerminalCondition
@@ -16,16 +17,18 @@ interface SetupTask : Task
 /** Wraps @[DestinationWriter.setup] and starts the open stream tasks. */
 class DefaultSetupTask(
     private val destination: DestinationWriter,
+    private val taskLauncher: DestinationTaskLauncher,
 ) : SetupTask {
     override val terminalCondition: TerminalCondition = SelfTerminating
 
     override suspend fun execute() {
         destination.setup()
+        taskLauncher.handleSetupComplete()
     }
 }
 
 interface SetupTaskFactory {
-    fun make(): SetupTask
+    fun make(taskLauncher: DestinationTaskLauncher): SetupTask
 }
 
 @Singleton
@@ -33,7 +36,7 @@ interface SetupTaskFactory {
 class DefaultSetupTaskFactory(
     private val destination: DestinationWriter,
 ) : SetupTaskFactory {
-    override fun make(): SetupTask {
-        return DefaultSetupTask(destination)
+    override fun make(taskLauncher: DestinationTaskLauncher): SetupTask {
+        return DefaultSetupTask(destination, taskLauncher)
     }
 }

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/DestinationTaskLauncherTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/DestinationTaskLauncherTest.kt
@@ -171,7 +171,7 @@ class DestinationTaskLauncherTest {
     class MockSetupTaskFactory : SetupTaskFactory {
         val hasRun: Channel<Unit> = Channel(Channel.UNLIMITED)
 
-        override fun make(): SetupTask {
+        override fun make(taskLauncher: DestinationTaskLauncher): SetupTask {
             return object : SetupTask {
                 override val terminalCondition: TerminalCondition = SelfTerminating
 

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/DestinationTaskLauncherUTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/DestinationTaskLauncherUTest.kt
@@ -242,5 +242,18 @@ class DestinationTaskLauncherUTest {
         job.join()
 
         coVerify(exactly = numOpenStreamWorkers) { openStreamTaskFactory.make() }
+
+        coVerify(exactly = 0) { openStreamQueue.publish(any()) }
+    }
+
+    @Test
+    fun `test streams opened when setup completes`() = runTest {
+        val launcher = getDefaultDestinationTaskLauncher(false)
+
+        coEvery { openStreamQueue.publish(any()) } returns Unit
+
+        launcher.handleSetupComplete()
+
+        coVerify(exactly = catalog.streams.size) { openStreamQueue.publish(any()) }
     }
 }

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/MockTaskLauncher.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/MockTaskLauncher.kt
@@ -16,6 +16,10 @@ import jakarta.inject.Singleton
 class MockTaskLauncher : DestinationTaskLauncher {
     val batchEnvelopes = mutableListOf<BatchEnvelope<*>>()
 
+    override suspend fun handleSetupComplete() {
+        throw NotImplementedError()
+    }
+
     override suspend fun handleNewBatch(
         stream: DestinationStream.Descriptor,
         wrapped: BatchEnvelope<*>


### PR DESCRIPTION
## What
When we switched to a fixed # of open stream workers, I removed the callback that made sure running open stream waited on setup.

This restores it