### PR TITLE
Destinatino S3 Data Lake: parallelize data cleaner; handle failure case

### DIFF
--- a/airbyte-integrations/connectors/destination-s3-data-lake/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_data_lake/S3DataLakeDestinationCleaner.kt
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_data_lake/S3DataLakeDestinationCleaner.kt
@@ -37,8 +37,7 @@ class S3DataLakeDestinationCleaner(private val catalog: Catalog) : DestinationCl
                         } catch (e: Exception) {
                             // catalog.loadTable will fail if the table has no files.
                             // In this case, we can just hard drop the table, because we know it has
-                            // no
-                            // corresponding files.
+                            // no corresponding files.
                             catalog.dropTable(tableId)
                         }
                     }

--- a/airbyte-integrations/connectors/destination-s3-data-lake/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_data_lake/S3DataLakeDestinationCleaner.kt
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_data_lake/S3DataLakeDestinationCleaner.kt
@@ -9,6 +9,9 @@ import io.airbyte.cdk.load.test.util.IntegrationTest.Companion.isNamespaceOld
 import io.airbyte.cdk.load.test.util.IntegrationTest.Companion.randomizedNamespaceRegex
 import io.airbyte.integrations.destination.s3_data_lake.io.S3DataLakeTableCleaner
 import io.airbyte.integrations.destination.s3_data_lake.io.S3DataLakeUtil
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import org.apache.iceberg.catalog.Catalog
 import org.apache.iceberg.catalog.Namespace
 import org.apache.iceberg.catalog.SupportsNamespaces
@@ -24,12 +27,24 @@ class S3DataLakeDestinationCleaner(private val catalog: Catalog) : DestinationCl
         // we're passing explicit TableIdentifier to clearTable, so just use SimpleTableIdGenerator
         val tableCleaner = S3DataLakeTableCleaner(S3DataLakeUtil(SimpleTableIdGenerator()))
 
-        namespaces.forEach { namespace ->
-            catalog.listTables(namespace).forEach { tableId ->
-                val table = catalog.loadTable(tableId)
-                tableCleaner.clearTable(catalog, tableId, table.io(), table.location())
+        runBlocking(Dispatchers.IO) {
+            namespaces.forEach { namespace ->
+                launch {
+                    catalog.listTables(namespace).forEach { tableId ->
+                        try {
+                            val table = catalog.loadTable(tableId)
+                            tableCleaner.clearTable(catalog, tableId, table.io(), table.location())
+                        } catch (e: Exception) {
+                            // catalog.loadTable will fail if the table has no files.
+                            // In this case, we can just hard drop the table, because we know it has
+                            // no
+                            // corresponding files.
+                            catalog.dropTable(tableId)
+                        }
+                    }
+                    catalog.dropNamespace(namespace)
+                }
             }
-            catalog.dropNamespace(namespace)
         }
     }
 }


### PR DESCRIPTION
previously
* cleaner was super slow, b/c it did everything in series
* if a table had no files (e.g. b/c you killed the test partway through creating a table), the cleaner would crash on `catalog.loadTable` - this is now handled in a try-catch