### PR TITLE
[Destination MSSQL] fix name escaping and dedup

### DIFF
--- a/airbyte-integrations/connectors/destination-mssql-v2/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLQueryBuilder.kt
+++ b/airbyte-integrations/connectors/destination-mssql-v2/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLQueryBuilder.kt
@@ -90,7 +90,7 @@ const val CREATE_SCHEMA_QUERY =
         DECLARE @Schema VARCHAR(MAX) = ?
         IF NOT EXISTS (SELECT name FROM sys.schemas WHERE name = @Schema)
         BEGIN
-            EXEC ('CREATE SCHEMA ' + @Schema);
+            EXEC ('CREATE SCHEMA [' + @Schema + ']');
         END
     """
 

--- a/airbyte-integrations/connectors/destination-mssql-v2/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLQueryBuilder.kt
+++ b/airbyte-integrations/connectors/destination-mssql-v2/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLQueryBuilder.kt
@@ -355,8 +355,8 @@ class MSSQLQueryBuilder(
             """
         } else {
             val uniquenessConstraint =
-                uniquenessKey.joinToString(" AND ") { "Target.$it = Source.$it" }
-            val updateStatement = schema.joinToString(", ") { "[${it.name}] = Source.${it.name}" }
+                uniquenessKey.joinToString(" AND ") { "Target.[$it] = Source.[$it]" }
+            val updateStatement = schema.joinToString(", ") { "Target.[${it.name}] = Source.[${it.name}]" }
             """
             MERGE INTO [$outputSchema].[$tableName] AS Target
             USING (VALUES ($templateColumns)) AS Source ($columns)

--- a/airbyte-integrations/connectors/destination-mssql-v2/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLStreamLoader.kt
+++ b/airbyte-integrations/connectors/destination-mssql-v2/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLStreamLoader.kt
@@ -38,17 +38,17 @@ class MSSQLStreamLoader(
         endOfStream: Boolean
     ): Batch {
         dataSource.connection.use { connection ->
-            val statement =
-                connection.prepareStatement(sqlBuilder.getFinalTableInsertColumnHeader())
-            records.forEach { record ->
-                sqlBuilder.populateStatement(statement, record, sqlBuilder.finalTableSchema)
-                statement.addBatch()
-            }
-            statement.executeLargeBatch()
+            sqlBuilder.getFinalTableInsertColumnHeader()
+                .executeUpdate(connection) { statement ->
+                    records.forEach { record ->
+                        sqlBuilder.populateStatement(statement, record, sqlBuilder.finalTableSchema)
+                        statement.addBatch()
+                    }
+                    statement.executeLargeBatch()
+                }
             if (sqlBuilder.hasCdc) {
                 sqlBuilder.deleteCdc(connection)
             }
-            connection.commit()
         }
         return SimpleBatch(Batch.State.COMPLETE)
     }

--- a/airbyte-integrations/connectors/destination-mssql-v2/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLStreamLoader.kt
+++ b/airbyte-integrations/connectors/destination-mssql-v2/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLStreamLoader.kt
@@ -38,14 +38,13 @@ class MSSQLStreamLoader(
         endOfStream: Boolean
     ): Batch {
         dataSource.connection.use { connection ->
-            sqlBuilder.getFinalTableInsertColumnHeader()
-                .executeUpdate(connection) { statement ->
-                    records.forEach { record ->
-                        sqlBuilder.populateStatement(statement, record, sqlBuilder.finalTableSchema)
-                        statement.addBatch()
-                    }
-                    statement.executeLargeBatch()
+            sqlBuilder.getFinalTableInsertColumnHeader().executeUpdate(connection) { statement ->
+                records.forEach { record ->
+                    sqlBuilder.populateStatement(statement, record, sqlBuilder.finalTableSchema)
+                    statement.addBatch()
                 }
+                statement.executeLargeBatch()
+            }
             if (sqlBuilder.hasCdc) {
                 sqlBuilder.deleteCdc(connection)
             }

--- a/airbyte-integrations/connectors/destination-mssql-v2/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/config/MSSQLConfiguration.kt
+++ b/airbyte-integrations/connectors/destination-mssql-v2/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/config/MSSQLConfiguration.kt
@@ -19,7 +19,9 @@ data class MSSQLConfiguration(
     val jdbcUrlParams: String?,
     val rawDataSchema: String,
     val sslMethod: EncryptionMethod,
-) : DestinationConfiguration()
+) : DestinationConfiguration() {
+    override val numProcessRecordsWorkers = 1
+}
 
 @Singleton
 class MSSQLConfigurationFactory :

--- a/airbyte-integrations/connectors/destination-mssql-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLWriterTest.kt
+++ b/airbyte-integrations/connectors/destination-mssql-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLWriterTest.kt
@@ -63,7 +63,9 @@ class MSSQLDataDumper : DestinationDataDumper {
         val dataSource = DataSourceFactory().dataSource(config)
         val output = mutableListOf<OutputRecord>()
         dataSource.connection.use { connection ->
-            SELECT_FROM.toQuery(sqlBuilder.fqTableName).executeQuery(connection) { rs ->
+            SELECT_FROM
+                .toQuery(sqlBuilder.outputSchema, sqlBuilder.tableName)
+                .executeQuery(connection) { rs ->
                 while (rs.next()) {
                     val objectValue = sqlBuilder.readResult(rs, sqlBuilder.finalTableSchema)
                     val record =

--- a/airbyte-integrations/connectors/destination-mssql-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLWriterTest.kt
+++ b/airbyte-integrations/connectors/destination-mssql-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLWriterTest.kt
@@ -63,9 +63,9 @@ class MSSQLDataDumper : DestinationDataDumper {
         val dataSource = DataSourceFactory().dataSource(config)
         val output = mutableListOf<OutputRecord>()
         dataSource.connection.use { connection ->
-            SELECT_FROM
-                .toQuery(sqlBuilder.outputSchema, sqlBuilder.tableName)
-                .executeQuery(connection) { rs ->
+            SELECT_FROM.toQuery(sqlBuilder.outputSchema, sqlBuilder.tableName).executeQuery(
+                connection
+            ) { rs ->
                 while (rs.next()) {
                     val objectValue = sqlBuilder.readResult(rs, sqlBuilder.finalTableSchema)
                     val record =


### PR DESCRIPTION
## What

* Escape schema, table and column names
* Constraint parallelism to avoid duplicates when running merge
* Some refactoring

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [X] YES 💚
- [ ] NO ❌
