### PR TITLE
🐛bug(source-klaviyo): pin version to 2.11.9 avoid "ERROR Exception while syncing stream lists_detailed" too many requests

### DIFF
--- a/airbyte-integrations/connectors/source-klaviyo/metadata.yaml
+++ b/airbyte-integrations/connectors/source-klaviyo/metadata.yaml
@@ -22,6 +22,7 @@ data:
   registryOverrides:
     cloud:
       enabled: true
+      dockerImageTag: 2.11.9
     oss:
       enabled: true
   releaseStage: generally_available


### PR DESCRIPTION
## What
Errors in these connections with 2.11.10:
- https://cloud.airbyte.com/workspaces/964bbb5c-1200-41fa-833e-95f3370ba6e1/connections/bd51db89-6751-47c9-8499-905ffc3c76db/timeline
- https://cloud.airbyte.com/workspaces/fc270b5b-31a4-48cb-bc47-91c4be86e273/connections/a61b3064-756f-40bd-a5bb-1bc2d8b7707d/timeline
- https://cloud.airbyte.com/workspaces/0fa1d0a9-bef8-4ff7-8046-00955af9411f/connections/012f9b6c-b610-4218-91f5-0f4d0d6eb67c/timeline

I already pinned 2.11.9 through retool two connections and they passed, the other one keeps falining.

Related to:

https://airbyte.pagerduty.com/incidents/Q3B50TNCQFJGBJ
https://airbytehq.sentry.io/issues/6151892441/?notification_uuid=c907a9c0-8636-492e-a372-8687294a7f80&project=6527718&referrer=pagerduty_integration
## How
Pin prev version

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
