### PR TITLE
Destination Azure Blob Storage: Fix overwrite mode

### DIFF
--- a/airbyte-integrations/connectors/destination-azure-blob-storage/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-azure-blob-storage/metadata.yaml
@@ -26,7 +26,7 @@ data:
             type: GSM
   connectorType: destination
   definitionId: b4c5d105-31fd-4817-96b6-cb923bfc04cb
-  dockerImageTag: 0.2.4
+  dockerImageTag: 0.3.0
   dockerRepository: airbyte/destination-azure-blob-storage
   documentationUrl: https://docs.airbyte.com/integrations/destinations/azure-blob-storage
   githubIssueLabel: destination-azure-blob-storage

--- a/docs/integrations/destinations/azure-blob-storage.md
+++ b/docs/integrations/destinations/azure-blob-storage.md
@@ -152,6 +152,7 @@ With the field `File Extension`, it is possible to save the output files with ex
 
 | Version | Date       | Pull Request                                               | Subject                                                                                                                                                         |
 |:--------|:-----------|:-----------------------------------------------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 0.3.0 | 2025-01-29 | [52610](https://github.com/airbytehq/airbyte/pull/52610) | Fix OVERWRITE behavior (do not delete files from streams with similar name) |
 | 0.2.4 | 2025-01-10 | [51507](https://github.com/airbytehq/airbyte/pull/51507) | Use a non root base image |
 | 0.2.3 | 2024-12-18 | [49910](https://github.com/airbytehq/airbyte/pull/49910) | Use a base image: airbyte/java-connector-base:1.0.0 |
 | 0.2.2   | 2024-06-12 | [\#38061](https://github.com/airbytehq/airbyte/pull/38061) | File Extensions added for the output files                                                                                                                      |


### PR DESCRIPTION
context: https://airbytehq-team.slack.com/archives/C083T7SUR0D/p1738094057451909?thread_ts=1738087568.864109&cid=C083T7SUR0D, https://github.com/airbytehq/oncall/issues/7315

previously:
* if you had two streams in OVERWRITE mode, where one stream's name was a suffix of the other (e.g. `users` and `foo_users`)
* during sync startup, we would delete `*foo_users/*`, then create a blob `foo_users/<timestamp>_0`
* and then delete `*users/*`... including the file we just created for foo_users

This PR (I think) fixes that behavior, so that setup for `users` only touches files that actually belong to the `users` stream.

(also, add a comment, b/c this destination is doing some dumb things in general)