### PR TITLE
Load CDK: Restore test microbatching

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/state/FlushStrategy.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/state/FlushStrategy.kt
@@ -37,7 +37,7 @@ interface FlushStrategy {
 class DefaultFlushStrategy(
     private val config: DestinationConfiguration,
     private val eventQueue: QueueReader<ForceFlushEvent>,
-    @Value("\${airbyte.destination.record-batch-size-override}")
+    @Value("\${airbyte.destination.core.record-batch-size-override}")
     private val recordBatchSizeOverride: Long? = null
 ) : FlushStrategy {
     private val forceFlushIndexes = ConcurrentHashMap<DestinationStream.Descriptor, Long>()

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/state/DefaultFlushStrategyTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/state/DefaultFlushStrategyTest.kt
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.Test
 class DefaultFlushStrategyTest {
     val stream1 = MockDestinationCatalogFactory.stream1
 
-    @Value("\${airbyte.destination.record-batch-size-override}")
+    @Value("\${airbyte.destination.core.record-batch-size-override}")
     private var recordBatchSizeOverride: Long? = null
 
     @Singleton

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/resources/application-test.yaml
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/resources/application-test.yaml
@@ -1,0 +1,13 @@
+airbyte:
+  destination:
+    core:
+      record-batch-size-override: 1 # 1 byte for testing; 1 record => 1 upload
+      file-transfer:
+        enabled: ${USE_FILE_TRANSFER:false}
+        staging-path: ${AIRBYTE_STAGING_DIRECTORY:/staging/files}
+      resources:
+        disk:
+          bytes: ${CONNECTOR_STORAGE_LIMIT_BYTES:5368709120} # 5GB
+      flush:
+        rate-ms: 900000 # 15 minutes
+        window-ms: 900000 # 15 minutes

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/write/object_storage/ObjectStorageStreamLoaderFactory.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/write/object_storage/ObjectStorageStreamLoaderFactory.kt
@@ -42,7 +42,7 @@ class ObjectStorageStreamLoaderFactory<T : RemoteObject<*>, U : OutputStream>(
         null,
     private val uploadConfigurationProvider: ObjectStorageUploadConfigurationProvider,
     private val destinationStateManager: DestinationStateManager<ObjectStorageDestinationState>,
-    @Value("\${airbyte.destination.record-batch-size-override}")
+    @Value("\${airbyte.destination.core.record-batch-size-override}")
     private val recordBatchSizeOverride: Long? = null
 ) {
     fun create(stream: DestinationStream): StreamLoader {


### PR DESCRIPTION
## What
[This change](https://github.com/airbytehq/airbyte/pull/52093) remove the test yaml override and changed the path to the variables without updating them all in the code. This causes state-awaiting tests to hang again.

This fixes that.