### PR TITLE
Load CDK: Tolerate null global state

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/DestinationMessage.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/DestinationMessage.kt
@@ -359,7 +359,7 @@ data class StreamCheckpoint(
 }
 
 data class GlobalCheckpoint(
-    val state: JsonNode,
+    val state: JsonNode?,
     override val sourceStats: Stats?,
     override val destinationStats: Stats? = null,
     val checkpoints: List<Checkpoint> = emptyList(),

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/message/InputMessage.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/message/InputMessage.kt
@@ -4,6 +4,7 @@
 
 package io.airbyte.cdk.load.message
 
+import com.fasterxml.jackson.databind.JsonNode
 import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.data.AirbyteValue
 import io.airbyte.cdk.load.data.json.JsonToAirbyteValue
@@ -11,8 +12,10 @@ import io.airbyte.cdk.load.data.json.toJson
 import io.airbyte.cdk.load.message.CheckpointMessage.Checkpoint
 import io.airbyte.cdk.load.message.CheckpointMessage.Stats
 import io.airbyte.cdk.load.util.deserializeToNode
+import io.airbyte.protocol.models.v0.AirbyteGlobalState
 import io.airbyte.protocol.models.v0.AirbyteMessage
 import io.airbyte.protocol.models.v0.AirbyteRecordMessage
+import io.airbyte.protocol.models.v0.AirbyteStateMessage
 
 sealed interface InputMessage {
     fun asProtocolMessage(): AirbyteMessage
@@ -97,4 +100,15 @@ data class InputStreamCheckpoint(val checkpoint: StreamCheckpoint) : InputCheckp
         )
     )
     override fun asProtocolMessage(): AirbyteMessage = checkpoint.asProtocolMessage()
+}
+
+data class InputGlobalCheckpoint(val sharedState: JsonNode?) : InputCheckpoint {
+    override fun asProtocolMessage(): AirbyteMessage =
+        AirbyteMessage()
+            .withType(AirbyteMessage.Type.STATE)
+            .withState(
+                AirbyteStateMessage()
+                    .withType(AirbyteStateMessage.AirbyteStateType.GLOBAL)
+                    .withGlobal(AirbyteGlobalState().withSharedState(sharedState))
+            )
 }

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/write/BasicFunctionalityIntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/write/BasicFunctionalityIntegrationTest.kt
@@ -36,6 +36,7 @@ import io.airbyte.cdk.load.data.UnionType
 import io.airbyte.cdk.load.data.UnknownType
 import io.airbyte.cdk.load.message.DestinationFile
 import io.airbyte.cdk.load.message.InputFile
+import io.airbyte.cdk.load.message.InputGlobalCheckpoint
 import io.airbyte.cdk.load.message.InputRecord
 import io.airbyte.cdk.load.message.InputStreamCheckpoint
 import io.airbyte.cdk.load.message.Meta.Change
@@ -2469,6 +2470,22 @@ abstract class BasicFunctionalityIntegrationTest(
             primaryKey = listOf(listOf("id")),
             cursor = null,
         )
+    }
+
+    @Test
+    open fun testClear() {
+        val stream =
+            DestinationStream(
+                DestinationStream.Descriptor(randomizedNamespace, "test_stream"),
+                Append,
+                ObjectType(linkedMapOf("id" to intType)),
+                generationId = 1,
+                minimumGenerationId = 1,
+                syncId = 42,
+            )
+        assertDoesNotThrow {
+            runSync(configContents, stream, messages = listOf(InputGlobalCheckpoint(null)))
+        }
     }
 
     private fun schematizedObject(


### PR DESCRIPTION
## What
We've observed an NPE in the release that is possibly related to deletes on CDC syncs, however I was unable to reproduce the issue due to [lacking a working CDC source](https://cloud.airbyte.com/workspaces/a0cc325a-d358-4df4-bdd4-c09d753b6afb/connections/new-connection/configure?sourceId=b0324c3d-5529-49c4-b7e5-8a980c636b2f&destinationId=7abb7d94-0f81-4481-bb1e-a6ae8ba317d4) in our test env.

However the IT case added here does fail with the same error from production w/o the fix:

```
Trace messages:[io.airbyte.protocol.models.v0.AirbyteErrorTraceMessage@437f7da6[message=<null>,internalMessage=java.lang.NullPointerException,stackTrace=java.lang.NullPointerException
	at io.airbyte.cdk.load.message.DestinationMessageFactory.fromAirbyteMessage(DestinationMessage.kt:527)
	at io.airbyte.cdk.load.message.ProtocolMessageDeserializer.deserialize(DestinationMessageDeserializer.kt:50)
	at io.airbyte.cdk.load.task.internal.ReservingDeserializingInputFlow.collect(ReservingDeserializingInputFlow.kt:44)
	at io.airbyte.cdk.load.task.internal.DefaultInputConsumerTask$execute$3.invokeSuspend(InputConsumerTask.kt:181)
	at io.airbyte.cdk.load.task.internal.DefaultInputConsumerTask$execute$3.invoke(InputConsumerTask.kt)
	at io.airbyte.cdk.load.task.internal.DefaultInputConsumerTask$execute$3.invoke(InputConsumerTask.kt)
	at io.airbyte.cdk.load.util.CoroutineUtilsKt.use(CoroutineUtils.kt:22)
	at io.airbyte.cdk.load.task.internal.DefaultInputConsumerTask.execute(InputConsumerTask.kt:180)
	at io.airbyte.cdk.load.task.DefaultDestinationTaskLauncher$WrappedTask.execute(DestinationTaskLauncher.kt:153)
	at io.airbyte.cdk.load.task.TaskScopeProvider$launch$job$1.invokeSuspend(TaskScopeProvider.kt:33)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:101)
	at kotlinx.coroutines.internal.LimitedDispatcher$Worker.run(LimitedDispatcher.kt:113)
	at kotlinx.coroutines.scheduling.TaskImpl.run(Tasks.kt:89)
	at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:589)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:823)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:720)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:707)
```
(Note that this is different than the exception that is thrown if the whole globalState message is null.)