### PR TITLE
[pg-source] Fix timestamp precision issue with debezium

### DIFF
--- a/airbyte-integrations/connectors/source-postgres/metadata.yaml
+++ b/airbyte-integrations/connectors/source-postgres/metadata.yaml
@@ -9,7 +9,7 @@ data:
   connectorSubtype: database
   connectorType: source
   definitionId: decd338e-5647-4c0b-adf4-da0e75f5a750
-  dockerImageTag: 3.6.28
+  dockerImageTag: 3.6.29
   dockerRepository: airbyte/source-postgres
   documentationUrl: https://docs.airbyte.com/integrations/sources/postgres
   githubIssueLabel: source-postgres

--- a/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/cdc/PostgresConverter.java
+++ b/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/cdc/PostgresConverter.java
@@ -269,13 +269,8 @@ public class PostgresConverter implements CustomConverter<SchemaBuilder, Relatio
           if (x.equals(PostgresValueConverter.POSITIVE_INFINITY_INSTANT)) {
             return POSITIVE_INFINITY_VALUE;
           }
-          if (x instanceof final Long l) {
-            if (getTimePrecision(field) <= 3) {
-              return convertToTimestamp(Conversions.toInstantFromMillis(l));
-            }
-            if (getTimePrecision(field) <= 6) {
-              return convertToTimestamp(Conversions.toInstantFromMicros(l));
-            }
+          if (x instanceof final Long l && getTimePrecision(field) <= 6) {
+            return convertToTimestamp(Conversions.toInstantFromMicros(l));
           }
           return convertToTimestamp(x);
         case "DATE":


### PR DESCRIPTION
## What
This PR is trying to fix the issue in https://github.com/airbytehq/oncall/issues/6857, which the timestamp data converter in pg connector use different precision for different length ts and it cause precision inconsistency with debezium

## How
I changed the precision to microsecond consistently for all ts that have precision less than microsecond

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
All ts have less precision than microsecond will be converted to microsecond for postgres source connector

## Can this PR be safely reverted and rolled back?
- [ ] YES 💚
- [ ] NO ❌
