### PR TITLE
fix(source-airtable): add condition in schema for multipleLookupValues

### DIFF
--- a/airbyte-integrations/connectors/source-airtable/metadata.yaml
+++ b/airbyte-integrations/connectors/source-airtable/metadata.yaml
@@ -11,7 +11,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 14c6e7ea-97ed-4f5e-a7b5-25e9a80b8212
-  dockerImageTag: 4.5.0-rc.2
+  dockerImageTag: 4.5.0-rc.3
   dockerRepository: airbyte/source-airtable
   documentationUrl: https://docs.airbyte.com/integrations/sources/airtable
   githubIssueLabel: source-airtable

--- a/airbyte-integrations/connectors/source-airtable/pyproject.toml
+++ b/airbyte-integrations/connectors/source-airtable/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "4.5.0-rc.2"
+version = "4.5.0-rc.3"
 name = "source-airtable"
 description = "Source implementation for Airtable."
 authors = [ "Airbyte <anhtuan.nguyen@me.com>",]

--- a/airbyte-integrations/connectors/source-airtable/source_airtable/manifest.yaml
+++ b/airbyte-integrations/connectors/source-airtable/source_airtable/manifest.yaml
@@ -336,7 +336,7 @@ definitions:
                 field_type: array
                 items: string
               current_type: multipleLookupValues
-              condition: "{{ raw_schema['options']['result']['type'] in ['multipleAttachments', 'barcode', 'button', 'singleCollaborator', 'createdBy', 'email', 'lastModifiedBy', 'multilineText', 'phoneNumber', 'richText', 'singleLineText', 'singleSelect', 'externalSyncSource', 'url', 'simpleText'] }}"
+              condition: "{{ raw_schema['options']['result']['type'] in ['multipleAttachments', 'barcode', 'button', 'singleCollaborator', 'createdBy', 'email', 'lastModifiedBy', 'multilineText', 'phoneNumber', 'richText', 'singleLineText', 'singleSelect', 'externalSyncSource', 'url', 'simpleText'] or not raw_schema['options']['result']  }}"
             - type: TypesMap
               target_type:
                 field_type: array

--- a/docs/integrations/sources/airtable.md
+++ b/docs/integrations/sources/airtable.md
@@ -137,6 +137,7 @@ See information about rate limits [here](https://airtable.com/developers/web/api
 
 | Version    | Date       | Pull Request                                             | Subject                                                                                |
 |:-----------|:-----------|:---------------------------------------------------------|:---------------------------------------------------------------------------------------|
+| 4.5.0-rc.2 | 2025-01-29 | [52595](https://github.com/airbytehq/airbyte/pull/52595) | Fix type for multipleLookupValues fields                                               |
 | 4.5.0-rc.2 | 2025-01-28 | [52595](https://github.com/airbytehq/airbyte/pull/52595) | Fix type for datetime fields                                                           |
 | 4.5.0-rc.1 | 2025-01-27 | [49813](https://github.com/airbytehq/airbyte/pull/49813) | Update to low-code                                                                     |
 | 4.4.0      | 2024-07-16 | [41160](https://github.com/airbytehq/airbyte/pull/41160) | Update CDK version to v3.5.2                                                           |

--- a/docs/integrations/sources/airtable.md
+++ b/docs/integrations/sources/airtable.md
@@ -137,7 +137,7 @@ See information about rate limits [here](https://airtable.com/developers/web/api
 
 | Version    | Date       | Pull Request                                             | Subject                                                                                |
 |:-----------|:-----------|:---------------------------------------------------------|:---------------------------------------------------------------------------------------|
-| 4.5.0-rc.2 | 2025-01-29 | [52595](https://github.com/airbytehq/airbyte/pull/52595) | Fix type for multipleLookupValues fields                                               |
+| 4.5.0-rc.3 | 2025-01-29 | [52624](https://github.com/airbytehq/airbyte/pull/52624) | Fix type for multipleLookupValues fields                                               |
 | 4.5.0-rc.2 | 2025-01-28 | [52595](https://github.com/airbytehq/airbyte/pull/52595) | Fix type for datetime fields                                                           |
 | 4.5.0-rc.1 | 2025-01-27 | [49813](https://github.com/airbytehq/airbyte/pull/49813) | Update to low-code                                                                     |
 | 4.4.0      | 2024-07-16 | [41160](https://github.com/airbytehq/airbyte/pull/41160) | Update CDK version to v3.5.2                                                           |


### PR DESCRIPTION
## What
failed to set up type in Dynamic Schema Loader when `multipleLookupValues` and `raw_schema['options']['result'] is None`

## How
Updated condition in types mapping.

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
