### PR TITLE
bump-version workflow: support forks

### DIFF
--- a/.github/workflows/bump-version-command.yml
+++ b/.github/workflows/bump-version-command.yml
@@ -86,6 +86,7 @@ jobs:
           gcs_credentials: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
           sentry_dsn: ${{ secrets.SENTRY_AIRBYTE_CI_DSN }}
           github_token: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}
+          git_repo_url: ${{ github.event.pull_request.head.repo.clone_url }}
           subcommand: |
             connectors --modified bump-version \
               ${{ github.event.inputs.type }} \


### PR DESCRIPTION
## What
Support bump version slash command on forks.

## How
Pass the target repo url to airbyte-ci in the related GHA workflow
