### PR TITLE
fix(airbyte-ci): reference to test_report.html.j2 template

### DIFF
--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/templates/test_report.html.j2
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/templates/test_report.html.j2
@@ -196,6 +196,6 @@ function copyToClipBoard(htmlElement) {
     </div>
   </div>
   {% endfor %}
-  <p style="margin-top: 50px"><em>These reports are generated from <a href="https://github.com/airbytehq/airbyte/blob/master/airbyte-ci/connectors/pipelines/pipelines/tests/templates/test_report.html.j2">this code</a>, please reach out to the Connector Operations team for support.</em></p>
+  <p style="margin-top: 50px"><em>These reports are generated from <a href="https://github.com/airbytehq/airbyte/blob/master/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/templates/test_report.html.j2">this code</a>, please reach out to the Connector Operations team for support.</em></p>
 </body>
 </html>


### PR DESCRIPTION
## What

Fixed reference to test_report.html.j2 template.

![image](https://github.com/user-attachments/assets/9057440d-901c-494b-ae76-55050f47bedc)


## How

Updated href attribute for link.

## Review guide

1. `airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/templates/test_report.html.j2`


## User Impact

Small improvement for connectors' developers that would like to improve report page.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌
