### PR TITLE
gradle: bulk-cdk connector junit tests should respect withSlowTests

### DIFF
--- a/buildSrc/src/main/groovy/airbyte-bulk-connector.gradle
+++ b/buildSrc/src/main/groovy/airbyte-bulk-connector.gradle
@@ -241,6 +241,15 @@ class AirbyteBulkConnectorPlugin implements Plugin<Project> {
             dependsOn project.tasks.matching { it.name ==~ /(compile|spotbugs)[a-zA-Z]*Java/ }
         }
 
+        boolean withSlowTests = System.getProperty('skipSlowTests', 'false') == 'false'
+        project.tasks.matching {
+                it.name == 'test' ||
+                it.name == 'integrationTestNonDocker' ||
+                it.name == 'integrationTestJava'
+            }.configureEach {
+            onlyIf { withSlowTests }
+        }
+
         project.configurations {
             testFixturesImplementation.extendsFrom implementation
             testFixturesRuntimeOnly.extendsFrom runtimeOnly


### PR DESCRIPTION
## What
I noticed that the Gradle Check github workflow runs connector unit tests for connectors built using the Bulk CDK. This is because the `withSlowTests` property is ignored by the `airbyte-bulk-connector` gradle plugin, unlike the `airbyte-java-connector` plugin for legacy java connectors.

## How
Adds support for `withSlowTests` in the `airbyte-bulk-connector` gradle plugin.

## Review guide
n/t

## User Impact
No difference for end users. Airbyte engineers get faster CI runs.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
