### PR TITLE
[source volcano] Allow field to be used as CDC cursor

### DIFF
--- a/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/discover/MetaFieldDecorator.kt
+++ b/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/discover/MetaFieldDecorator.kt
@@ -14,7 +14,7 @@ import java.time.OffsetDateTime
 interface MetaFieldDecorator {
 
     /** [MetaField] to use as a global cursor, if applicable. */
-    val globalCursor: MetaField?
+    val globalCursor: FieldOrMetaField?
 
     /**
      * All [MetaField]s to be found in [Global] stream records.

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/write/BasicFunctionalityIntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/write/BasicFunctionalityIntegrationTest.kt
@@ -143,7 +143,7 @@ enum class UnionBehavior {
 
 abstract class BasicFunctionalityIntegrationTest(
     /** The config to pass into the connector, as a serialized JSON blob */
-    configContents: String,
+    val configContents: String,
     val configSpecClass: Class<out ConfigurationSpecification>,
     dataDumper: DestinationDataDumper,
     destinationCleaner: DestinationCleaner,


### PR DESCRIPTION
## What
As we add trigger based CDC for Sap Hana, existing CDK does not support this use case.
Here is the conflict in CDK:

- we need to query trigger table to get changes, trigger table schema is in either field type or meta field type. 
- we need to define cursor at discovery phase for stream. CDC cursor currently is defined as meta field type.

If we define trigger table schema using meta field type, we cannot query the table. If we define trigger table schema using field type, we cannot define the cursor at discovery phase.

https://github.com/airbytehq/airbyte-internal-issues/issues/11298

## How
So we either change SelectQuerySpec to support meta field type or we change MetaFieldDecorator to support field type as cursor.

I would prefer to change SelectQuerySpec but that involves much larger scope of change so I'm only update MetaFieldDecorator for now

## Review guide

## User Impact
No

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
