### PR TITLE
[source-mssql, docs] add Script for CDC on Transaction Replication Enabled DB

### DIFF
--- a/docs/integrations/sources/mssql.md
+++ b/docs/integrations/sources/mssql.md
@@ -235,6 +235,27 @@ For further detail, see the
   EXEC sys.sp_cdc_start_job @job_type = 'cleanup';
 ```
 
+- If you were are using Transaction Replication then the retention has to be changed using below scripts :
+```text
+
+EXEC sp_changedistributiondb
+  @database = 'distribution',
+  @property = 'max_distretention',
+  @value = 14400 -- 14400 minutes (10 days)
+
+EXEC sp_changedistributiondb
+  @database = 'distribution',
+  @property = 'history_retention',
+  @value = 14400 -- 14400 minutes (10 days)
+
+USE [msdb]
+GO
+EXEC msdb.dbo.sp_update_jobstep @job_name=N'Distribution clean up: distribution', @step_id=1 ,
+		@command=N'EXEC dbo.sp_MSdistribution_cleanup @min_distretention = 0, @max_distretention = 14400'
+GO
+
+```
+
 #### 5. Ensure the SQL Server Agent is running
 
 - MSSQL uses the SQL Server Agent


### PR DESCRIPTION
## What
<!--
* If CDC is being enabled on an existing DB which is being used for Transaction Replication, then the CDC is tracked using log reader agent instead of CDC capture job.
* Using the CDC retention scripts does not give the desired effect and causes "Saved offset no longer present on the server" error even though CDC retention is set for 10 days.
-->

## How
<!--
* The retention has to be changed for replication as well using the given script as well else the log reader removes the max lsn being tracked defined as per the replication setting.
-->

## User Impact
<!--
* Retention will respect the time given for retention for replication.
-->

## Can this PR be safely reverted and rolled back?

- [ ] YES 💚
- [ ] NO ❌
