### PR TITLE
Load CDK: Prevent sync hanging on setup failure

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/implementor/FailStreamTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/implementor/FailStreamTask.kt
@@ -34,6 +34,7 @@ class DefaultFailStreamTask(
 
     override suspend fun execute() {
         val streamManager = syncManager.getStreamManager(stream)
+        syncManager.registerStartedStreamLoader(stream, Result.failure(exception))
         streamManager.markProcessingFailed(exception)
         when (val streamResult = streamManager.awaitStreamResult()) {
             is StreamProcessingSucceeded -> {


### PR DESCRIPTION
## What
Fixes syncs hanging due to failure in setup. This was two issues
* stream loader initialization was not in a succeeded or failed state, so tasks awaiting it waited forever
* the open stream queue wasn't being closed, so the open stream task was never terminating

Also adds some logging to help debug hanging tasks

Also adds some safety latches
* closing channel queues is idempotent
* exception handling workflow runs exactly once