### PR TITLE
source-amazon-seller-parter add VendorOrdersStatus stream

### DIFF
--- a/airbyte-integrations/connectors/source-amazon-seller-partner/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/acceptance-test-config.yml
@@ -95,6 +95,8 @@ acceptance_tests:
             bypass_reason: "Data cannot be seeded in the test account, integration tests added for the stream instead"
           - name: VendorOrders
             bypass_reason: "Data cannot be seeded in the test account, integration tests added for the stream instead"
+          - name: VendorOrdersStatus
+            bypass_reason: "Data cannot be seeded in the test account, integration tests added for the stream instead"
           - name: GET_VENDOR_FORECASTING_FRESH_REPORT
             bypass_reason: "Data cannot be seeded in the test account, integration tests added for the stream instead"
           - name: GET_VENDOR_FORECASTING_RETAIL_REPORT

--- a/airbyte-integrations/connectors/source-amazon-seller-partner/metadata.yaml
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/metadata.yaml
@@ -15,7 +15,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: e55879a8-0ef8-4557-abcf-ab34c53ec460
-  dockerImageTag: 4.5.0-rc.5
+  dockerImageTag: 4.6.0
   dockerRepository: airbyte/source-amazon-seller-partner
   documentationUrl: https://docs.airbyte.com/integrations/sources/amazon-seller-partner
   erdUrl: https://dbdocs.io/airbyteio/source-amazon-seller-partner?view=relationships

--- a/airbyte-integrations/connectors/source-amazon-seller-partner/pyproject.toml
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "4.5.0-rc.5"
+version = "4.6.0"
 name = "source-amazon-seller-partner"
 description = "Source implementation for Amazon Seller Partner."
 authors = ["Airbyte <contact@airbyte.io>"]

--- a/airbyte-integrations/connectors/source-amazon-seller-partner/source_amazon_seller_partner/schemas/VendorOrdersStatus.json
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/source_amazon_seller_partner/schemas/VendorOrdersStatus.json
@@ -1,235 +1,275 @@
 {
-    "title": "Vendor Orders Status",
-    "description": "All vendor purchase orders status that were created after a specified date",
-    "type": "object",
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "properties": {
-        "purchaseOrderNumber": {
-            "description": "Purchase order number",
-            "type": ["null", "string"]
+  "title": "Vendor Orders Status",
+  "description": "All vendor purchase orders status that were created after a specified date",
+  "type": "object",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "properties": {
+    "purchaseOrderNumber": {
+      "description": "Purchase order number",
+      "type": ["null", "string"]
+    },
+    "purchaseOrderStatus": {
+      "description": "Purchase order status",
+      "type": ["null", "string"]
+    },
+    "purchaseOrderDate": {
+      "description": "Purchase order creation date and time",
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "lastUpdatedDate": {
+      "description": "Purchase order last updated date and time",
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "sellingParty": {
+      "description": "Information about the party selling the products",
+      "type": ["null", "object"],
+      "properties": {
+        "partyId": {
+          "description": "ID of the selling party",
+          "type": ["null", "string"]
         },
-        "purchaseOrderStatus": {
-            "description": "Purchase order status",
-            "type": ["null", "string"]
-        },
-        "purchaseOrderDate": {
-            "description": "Purchase order creation date and time",
-            "type": ["null", "string"],
-            "format": "date-time"
-        },
-        "lastUpdatedDate": {
-            "description": "Purchase order last updated date and time",
-            "type": ["null", "string"],
-            "format": "date-time"
-        },
-        "sellingParty": {
-            "description": "Information about the party selling the products",
-            "type": ["null", "object"],
-            "properties": {
-              "partyId": {
-                "description": "ID of the selling party",
-                "type": ["null", "string"]
-              },
-              "address": {
-                "description": "The address details of the selling party",
-                "type": ["null", "object"],
-                "properties": {
-                  "name": {
-                    "description": "Name of the party",
-                    "type": ["null", "string"]
-                  },
-                  "addressLine1": {
-                    "description": "Address Line 1",
-                    "type": ["null", "string"]
-                  },
-                  "addressLine2": {
-                    "description": "Address Line 2",
-                    "type": ["null", "string"]
-                  },
-                  "addressLine3": {
-                    "description": "Address Line 3",
-                    "type": ["null", "string"]
-                  },
-                  "city": {
-                    "description": "City name",
-                    "type": ["null", "string"]
-                  },
-                  "county": {
-                    "description": "County name",
-                    "type": ["null", "string"]
-                  },
-                  "district": {
-                    "description": "District name",
-                    "type": ["null", "string"]
-                  },
-                  "stateOrRegion": {
-                    "description": "State or region",
-                    "type": ["null", "string"]
-                  },
-                  "postalCode": {
-                    "description": "Postal code",
-                    "type": ["null", "string"]
-                  },
-                  "countryCode": {
-                    "description": "Country code",
-                    "type": ["null", "string"]
-                  },
-                  "phone": {
-                    "description": "Phone number",
-                    "type": ["null", "string"]
-                  }
-                }
-              },
-              "taxInfo": {
-                "description": "Tax information of the selling party",
-                "type": ["null", "object"],
-                "properties": {
-                  "taxType": {
-                    "description": "Type of tax",
-                    "type": ["null", "string"]
-                  },
-                  "taxRegistrationNumber": {
-                    "description": "Tax registration number",
-                    "type": ["null", "string"]
-                  }
-                }
-              }
-            }
-        },
-        "shipToParty": {
-            "description": "Information about the party to which the order is shipped",
-            "type": ["null", "object"],
-            "properties": {
-              "partyId": {
-                "description": "ID of the ship-to party",
-                "type": ["null", "string"]
-              },
-              "address": {
-                "description": "The address details of the ship-to party",
-                "type": ["null", "object"],
-                "properties": {
-                  "name": {
-                    "description": "Name of the party",
-                    "type": ["null", "string"]
-                  },
-                  "addressLine1": {
-                    "description": "Address Line 1",
-                    "type": ["null", "string"]
-                  },
-                  "addressLine2": {
-                    "description": "Address Line 2",
-                    "type": ["null", "string"]
-                  },
-                  "addressLine3": {
-                    "description": "Address Line 3",
-                    "type": ["null", "string"]
-                  },
-                  "city": {
-                    "description": "City name",
-                    "type": ["null", "string"]
-                  },
-                  "county": {
-                    "description": "County name",
-                    "type": ["null", "string"]
-                  },
-                  "district": {
-                    "description": "District name",
-                    "type": ["null", "string"]
-                  },
-                  "stateOrRegion": {
-                    "description": "State or region",
-                    "type": ["null", "string"]
-                  },
-                  "postalCode": {
-                    "description": "Postal code",
-                    "type": ["null", "string"]
-                  },
-                  "countryCode": {
-                    "description": "Country code",
-                    "type": ["null", "string"]
-                  },
-                  "phone": {
-                    "description": "Phone number",
-                    "type": ["null", "string"]
-                  }
-                }
-              },
-              "taxInfo": {
-                "description": "Tax information of the ship-to party",
-                "type": ["null", "object"],
-                "properties": {
-                  "taxType": {
-                    "description": "Type of tax",
-                    "type": ["null", "string"]
-                  },
-                  "taxRegistrationNumber": {
-                    "description": "Tax registration number",
-                    "type": ["null", "string"]
-                  }
-                }
-              }
-            }
-        },
-        "itemStatus": {
-          "description": "Detailed description of items order status",
+        "address": {
+          "description": "The address details of the selling party",
           "type": ["null", "object"],
           "properties": {
-            "itemSequenceNumber": {
-              "description": "Numbering of the item on the purchase order. The first item will be 1, the second 2, and so on.",
+            "name": {
+              "description": "Name of the party",
               "type": ["null", "string"]
             },
-            "buyerProductIdentifier": {
-              "description": "Buyer's Standard Identification Number (ASIN) of an item.",
+            "addressLine1": {
+              "description": "Address Line 1",
               "type": ["null", "string"]
             },
-            "vendorProductIdentifier": {
-              "description": "The vendor selected product identification of the item.",
+            "addressLine2": {
+              "description": "Address Line 2",
               "type": ["null", "string"]
             },
-            "netCost": {
-              "description": "The net cost of an item per each or weight unit.",
-              "type": ["null", "object"],
-                "properties": {
-                  "amount": {
-                    "description": "Cost amount",
-                    "type": ["null", "string"]
-                  },
-                  "currencyCode": {
-                    "description": "Currency code",
-                    "type": ["null", "string"]
-                  },
-                  "unitOfMeasure": {
-                    "description": "Unit of measure",
-                    "type": ["null", "string"]
-                  }
-                }
+            "addressLine3": {
+              "description": "Address Line 3",
+              "type": ["null", "string"]
             },
-            "listPrice": {
-              "description": "The list price of an item per each or weight unit.",
-              "type": ["null", "object"],
-                "properties": {
-                  "amount": {
-                    "description": "Cost amount",
-                    "type": ["null", "string"]
-                  },
-                  "currencyCode": {
-                    "description": "Currency code",
-                    "type": ["null", "string"]
-                  },
-                  "unitOfMeasure": {
-                    "description": "Unit of measure",
-                    "type": ["null", "string"]
-                  }
-                }
+            "city": {
+              "description": "City name",
+              "type": ["null", "string"]
             },
+            "county": {
+              "description": "County name",
+              "type": ["null", "string"]
+            },
+            "district": {
+              "description": "District name",
+              "type": ["null", "string"]
+            },
+            "stateOrRegion": {
+              "description": "State or region",
+              "type": ["null", "string"]
+            },
+            "postalCode": {
+              "description": "Postal code",
+              "type": ["null", "string"]
+            },
+            "countryCode": {
+              "description": "Country code",
+              "type": ["null", "string"]
+            },
+            "phone": {
+              "description": "Phone number",
+              "type": ["null", "string"]
+            }
+          }
+        },
+        "taxInfo": {
+          "description": "Tax information of the selling party",
+          "type": ["null", "object"],
+          "properties": {
+            "taxType": {
+              "description": "Type of tax",
+              "type": ["null", "string"]
+            },
+            "taxRegistrationNumber": {
+              "description": "Tax registration number",
+              "type": ["null", "string"]
+            }
+          }
+        }
+      }
+    },
+    "shipToParty": {
+      "description": "Information about the party to which the order is shipped",
+      "type": ["null", "object"],
+      "properties": {
+        "partyId": {
+          "description": "ID of the ship-to party",
+          "type": ["null", "string"]
+        },
+        "address": {
+          "description": "The address details of the ship-to party",
+          "type": ["null", "object"],
+          "properties": {
+            "name": {
+              "description": "Name of the party",
+              "type": ["null", "string"]
+            },
+            "addressLine1": {
+              "description": "Address Line 1",
+              "type": ["null", "string"]
+            },
+            "addressLine2": {
+              "description": "Address Line 2",
+              "type": ["null", "string"]
+            },
+            "addressLine3": {
+              "description": "Address Line 3",
+              "type": ["null", "string"]
+            },
+            "city": {
+              "description": "City name",
+              "type": ["null", "string"]
+            },
+            "county": {
+              "description": "County name",
+              "type": ["null", "string"]
+            },
+            "district": {
+              "description": "District name",
+              "type": ["null", "string"]
+            },
+            "stateOrRegion": {
+              "description": "State or region",
+              "type": ["null", "string"]
+            },
+            "postalCode": {
+              "description": "Postal code",
+              "type": ["null", "string"]
+            },
+            "countryCode": {
+              "description": "Country code",
+              "type": ["null", "string"]
+            },
+            "phone": {
+              "description": "Phone number",
+              "type": ["null", "string"]
+            }
+          }
+        },
+        "taxInfo": {
+          "description": "Tax information of the ship-to party",
+          "type": ["null", "object"],
+          "properties": {
+            "taxType": {
+              "description": "Type of tax",
+              "type": ["null", "string"]
+            },
+            "taxRegistrationNumber": {
+              "description": "Tax registration number",
+              "type": ["null", "string"]
+            }
+          }
+        }
+      }
+    },
+    "itemStatus": {
+      "description": "Detailed description of items order status",
+      "type": ["null", "object"],
+      "properties": {
+        "itemSequenceNumber": {
+          "description": "Numbering of the item on the purchase order. The first item will be 1, the second 2, and so on.",
+          "type": ["null", "string"]
+        },
+        "buyerProductIdentifier": {
+          "description": "Buyer's Standard Identification Number (ASIN) of an item.",
+          "type": ["null", "string"]
+        },
+        "vendorProductIdentifier": {
+          "description": "The vendor selected product identification of the item.",
+          "type": ["null", "string"]
+        },
+        "netCost": {
+          "description": "The net cost of an item per each or weight unit.",
+          "type": ["null", "object"],
+          "properties": {
+            "amount": {
+              "description": "Cost amount",
+              "type": ["null", "string"]
+            },
+            "currencyCode": {
+              "description": "Currency code",
+              "type": ["null", "string"]
+            },
+            "unitOfMeasure": {
+              "description": "Unit of measure",
+              "type": ["null", "string"]
+            }
+          }
+        },
+        "listPrice": {
+          "description": "The list price of an item per each or weight unit.",
+          "type": ["null", "object"],
+          "properties": {
+            "amount": {
+              "description": "Cost amount",
+              "type": ["null", "string"]
+            },
+            "currencyCode": {
+              "description": "Currency code",
+              "type": ["null", "string"]
+            },
+            "unitOfMeasure": {
+              "description": "Unit of measure",
+              "type": ["null", "string"]
+            }
+          }
+        },
+        "orderedQuantity": {
+          "description": "Ordered quantity information.",
+          "type": ["null", "object"],
+          "properties": {
             "orderedQuantity": {
-              "description": "Ordered quantity information.",
+              "description": "Item quantity ordered.",
               "type": ["null", "object"],
               "properties": {
-                "orderedQuantity": {
-                  "description": "Item quantity ordered.",
-                  "type": ["null", "object"],
-                  "properties": {
+                "amount": {
+                  "description": "Quantity amount",
+                  "type": ["null", "integer"]
+                },
+                "unitOfMeasure": {
+                  "description": "Unit of measurement",
+                  "type": ["null", "string"]
+                },
+                "unitSize": {
+                  "description": "Size of the unit",
+                  "type": ["null", "integer"]
+                }
+              }
+            },
+            "orderedQuantityDetails": {
+              "description": "Details of item quantity ordered.",
+              "type": ["null", "array"],
+              "items": {
+                "type": ["null", "object"],
+                "properties": {
+                  "updatedDate": {
+                    "description": "The date when the line item quantity was updated by buyer.",
+                    "type": ["null", "string"],
+                    "format": "date-time"
+                  },
+                  "orderedQuantity": {
+                    "amount": {
+                      "description": "Quantity amount",
+                      "type": ["null", "integer"]
+                    },
+                    "unitOfMeasure": {
+                      "description": "Unit of measurement",
+                      "type": ["null", "string"]
+                    },
+                    "unitSize": {
+                      "description": "Size of the unit",
+                      "type": ["null", "integer"]
+                    }
+                  },
+                  "cancelledQuantity": {
                     "amount": {
                       "description": "Quantity amount",
                       "type": ["null", "integer"]
@@ -243,58 +283,18 @@
                       "type": ["null", "integer"]
                     }
                   }
-                },
-                "orderedQuantityDetails": {
-                  "description": "Details of item quantity ordered.",
-                  "type": ["null", "array"],
-                  "items": {
-                    "type": ["null", "object"],
-                    "properties": {
-                      "updatedDate": {
-                        "description": "The date when the line item quantity was updated by buyer.",
-                        "type": ["null", "string"],
-                        "format": "date-time"
-                      },
-                      "orderedQuantity": {
-                        "amount": {
-                          "description": "Quantity amount",
-                          "type": ["null", "integer"]
-                        },
-                        "unitOfMeasure": {
-                          "description": "Unit of measurement",
-                          "type": ["null", "string"]
-                        },
-                        "unitSize": {
-                          "description": "Size of the unit",
-                          "type": ["null", "integer"]
-                        }
-                      },
-                      "cancelledQuantity": {
-                        "amount": {
-                          "description": "Quantity amount",
-                          "type": ["null", "integer"]
-                        },
-                        "unitOfMeasure": {
-                          "description": "Unit of measurement",
-                          "type": ["null", "string"]
-                        },
-                        "unitSize": {
-                          "description": "Size of the unit",
-                          "type": ["null", "integer"]
-                        }
-                      }
-                    }
-                  }
                 }
               }
-            },
-            "acknowledgementStatus": {
-              "description": "Acknowledgement status information."
-            },
-            "receivingStatus": {
-              "description": "Item receive status at the buyer's warehouse."
             }
           }
+        },
+        "acknowledgementStatus": {
+          "description": "Acknowledgement status information."
+        },
+        "receivingStatus": {
+          "description": "Item receive status at the buyer's warehouse."
         }
+      }
     }
+  }
 }

--- a/airbyte-integrations/connectors/source-amazon-seller-partner/source_amazon_seller_partner/schemas/VendorOrdersStatus.json
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/source_amazon_seller_partner/schemas/VendorOrdersStatus.json
@@ -1,0 +1,300 @@
+{
+    "title": "Vendor Orders Status",
+    "description": "All vendor purchase orders status that were created after a specified date",
+    "type": "object",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "properties": {
+        "purchaseOrderNumber": {
+            "description": "Purchase order number",
+            "type": ["null", "string"]
+        },
+        "purchaseOrderStatus": {
+            "description": "Purchase order status",
+            "type": ["null", "string"]
+        },
+        "purchaseOrderDate": {
+            "description": "Purchase order creation date and time",
+            "type": ["null", "string"],
+            "format": "date-time"
+        },
+        "lastUpdatedDate": {
+            "description": "Purchase order last updated date and time",
+            "type": ["null", "string"],
+            "format": "date-time"
+        },
+        "sellingParty": {
+            "description": "Information about the party selling the products",
+            "type": ["null", "object"],
+            "properties": {
+              "partyId": {
+                "description": "ID of the selling party",
+                "type": ["null", "string"]
+              },
+              "address": {
+                "description": "The address details of the selling party",
+                "type": ["null", "object"],
+                "properties": {
+                  "name": {
+                    "description": "Name of the party",
+                    "type": ["null", "string"]
+                  },
+                  "addressLine1": {
+                    "description": "Address Line 1",
+                    "type": ["null", "string"]
+                  },
+                  "addressLine2": {
+                    "description": "Address Line 2",
+                    "type": ["null", "string"]
+                  },
+                  "addressLine3": {
+                    "description": "Address Line 3",
+                    "type": ["null", "string"]
+                  },
+                  "city": {
+                    "description": "City name",
+                    "type": ["null", "string"]
+                  },
+                  "county": {
+                    "description": "County name",
+                    "type": ["null", "string"]
+                  },
+                  "district": {
+                    "description": "District name",
+                    "type": ["null", "string"]
+                  },
+                  "stateOrRegion": {
+                    "description": "State or region",
+                    "type": ["null", "string"]
+                  },
+                  "postalCode": {
+                    "description": "Postal code",
+                    "type": ["null", "string"]
+                  },
+                  "countryCode": {
+                    "description": "Country code",
+                    "type": ["null", "string"]
+                  },
+                  "phone": {
+                    "description": "Phone number",
+                    "type": ["null", "string"]
+                  }
+                }
+              },
+              "taxInfo": {
+                "description": "Tax information of the selling party",
+                "type": ["null", "object"],
+                "properties": {
+                  "taxType": {
+                    "description": "Type of tax",
+                    "type": ["null", "string"]
+                  },
+                  "taxRegistrationNumber": {
+                    "description": "Tax registration number",
+                    "type": ["null", "string"]
+                  }
+                }
+              }
+            }
+        },
+        "shipToParty": {
+            "description": "Information about the party to which the order is shipped",
+            "type": ["null", "object"],
+            "properties": {
+              "partyId": {
+                "description": "ID of the ship-to party",
+                "type": ["null", "string"]
+              },
+              "address": {
+                "description": "The address details of the ship-to party",
+                "type": ["null", "object"],
+                "properties": {
+                  "name": {
+                    "description": "Name of the party",
+                    "type": ["null", "string"]
+                  },
+                  "addressLine1": {
+                    "description": "Address Line 1",
+                    "type": ["null", "string"]
+                  },
+                  "addressLine2": {
+                    "description": "Address Line 2",
+                    "type": ["null", "string"]
+                  },
+                  "addressLine3": {
+                    "description": "Address Line 3",
+                    "type": ["null", "string"]
+                  },
+                  "city": {
+                    "description": "City name",
+                    "type": ["null", "string"]
+                  },
+                  "county": {
+                    "description": "County name",
+                    "type": ["null", "string"]
+                  },
+                  "district": {
+                    "description": "District name",
+                    "type": ["null", "string"]
+                  },
+                  "stateOrRegion": {
+                    "description": "State or region",
+                    "type": ["null", "string"]
+                  },
+                  "postalCode": {
+                    "description": "Postal code",
+                    "type": ["null", "string"]
+                  },
+                  "countryCode": {
+                    "description": "Country code",
+                    "type": ["null", "string"]
+                  },
+                  "phone": {
+                    "description": "Phone number",
+                    "type": ["null", "string"]
+                  }
+                }
+              },
+              "taxInfo": {
+                "description": "Tax information of the ship-to party",
+                "type": ["null", "object"],
+                "properties": {
+                  "taxType": {
+                    "description": "Type of tax",
+                    "type": ["null", "string"]
+                  },
+                  "taxRegistrationNumber": {
+                    "description": "Tax registration number",
+                    "type": ["null", "string"]
+                  }
+                }
+              }
+            }
+        },
+        "itemStatus": {
+          "description": "Detailed description of items order status",
+          "type": ["null", "object"],
+          "properties": {
+            "itemSequenceNumber": {
+              "description": "Numbering of the item on the purchase order. The first item will be 1, the second 2, and so on.",
+              "type": ["null", "string"]
+            },
+            "buyerProductIdentifier": {
+              "description": "Buyer's Standard Identification Number (ASIN) of an item.",
+              "type": ["null", "string"]
+            },
+            "vendorProductIdentifier": {
+              "description": "The vendor selected product identification of the item.",
+              "type": ["null", "string"]
+            },
+            "netCost": {
+              "description": "The net cost of an item per each or weight unit.",
+              "type": ["null", "object"],
+                "properties": {
+                  "amount": {
+                    "description": "Cost amount",
+                    "type": ["null", "string"]
+                  },
+                  "currencyCode": {
+                    "description": "Currency code",
+                    "type": ["null", "string"]
+                  },
+                  "unitOfMeasure": {
+                    "description": "Unit of measure",
+                    "type": ["null", "string"]
+                  }
+                }
+            },
+            "listPrice": {
+              "description": "The list price of an item per each or weight unit.",
+              "type": ["null", "object"],
+                "properties": {
+                  "amount": {
+                    "description": "Cost amount",
+                    "type": ["null", "string"]
+                  },
+                  "currencyCode": {
+                    "description": "Currency code",
+                    "type": ["null", "string"]
+                  },
+                  "unitOfMeasure": {
+                    "description": "Unit of measure",
+                    "type": ["null", "string"]
+                  }
+                }
+            },
+            "orderedQuantity": {
+              "description": "Ordered quantity information.",
+              "type": ["null", "object"],
+              "properties": {
+                "orderedQuantity": {
+                  "description": "Item quantity ordered.",
+                  "type": ["null", "object"],
+                  "properties": {
+                    "amount": {
+                      "description": "Quantity amount",
+                      "type": ["null", "integer"]
+                    },
+                    "unitOfMeasure": {
+                      "description": "Unit of measurement",
+                      "type": ["null", "string"]
+                    },
+                    "unitSize": {
+                      "description": "Size of the unit",
+                      "type": ["null", "integer"]
+                    }
+                  }
+                },
+                "orderedQuantityDetails": {
+                  "description": "Details of item quantity ordered.",
+                  "type": ["null", "array"],
+                  "items": {
+                    "type": ["null", "object"],
+                    "properties": {
+                      "updatedDate": {
+                        "description": "The date when the line item quantity was updated by buyer.",
+                        "type": ["null", "string"],
+                        "format": "date-time"
+                      },
+                      "orderedQuantity": {
+                        "amount": {
+                          "description": "Quantity amount",
+                          "type": ["null", "integer"]
+                        },
+                        "unitOfMeasure": {
+                          "description": "Unit of measurement",
+                          "type": ["null", "string"]
+                        },
+                        "unitSize": {
+                          "description": "Size of the unit",
+                          "type": ["null", "integer"]
+                        }
+                      },
+                      "cancelledQuantity": {
+                        "amount": {
+                          "description": "Quantity amount",
+                          "type": ["null", "integer"]
+                        },
+                        "unitOfMeasure": {
+                          "description": "Unit of measurement",
+                          "type": ["null", "string"]
+                        },
+                        "unitSize": {
+                          "description": "Size of the unit",
+                          "type": ["null", "integer"]
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "acknowledgementStatus": {
+              "description": "Acknowledgement status information."
+            },
+            "receivingStatus": {
+              "description": "Item receive status at the buyer's warehouse."
+            }
+          }
+        }
+    }
+}

--- a/airbyte-integrations/connectors/source-amazon-seller-partner/unit_tests/integration/request_builder.py
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/unit_tests/integration/request_builder.py
@@ -52,6 +52,10 @@ class RequestBuilder:
     def vendor_orders_endpoint(cls) -> RequestBuilder:
         return cls("vendor/orders/v1/purchaseOrders")
 
+    @classmethod
+    def vendor_orders_status_endpoint(cls) -> RequestBuilder:
+        return cls("vendor/orders/v1/purchaseOrdersStatus")
+
     def __init__(self, resource: str) -> None:
         self._resource = resource
         self._base_url = "https://sellingpartnerapi-na.amazon.com"

--- a/airbyte-integrations/connectors/source-amazon-seller-partner/unit_tests/integration/test_vendor_orders_status.py
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/unit_tests/integration/test_vendor_orders_status.py
@@ -1,0 +1,215 @@
+#
+# Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+#
+
+
+from http import HTTPStatus
+from typing import List, Optional
+
+import freezegun
+import pendulum
+from airbyte_cdk.test.entrypoint_wrapper import EntrypointOutput
+from airbyte_cdk.test.mock_http import HttpMocker
+from airbyte_cdk.test.mock_http.response_builder import (
+    FieldPath,
+    HttpResponseBuilder,
+    NestedPath,
+    RecordBuilder,
+    create_record_builder,
+    create_response_builder,
+    find_template,
+)
+from airbyte_cdk.test.state_builder import StateBuilder
+from airbyte_protocol.models import AirbyteStateMessage, FailureType, SyncMode
+
+from .config import NOW, TIME_FORMAT, ConfigBuilder
+from .pagination import NEXT_TOKEN_STRING, VendorFulfillmentPaginationStrategy
+from .request_builder import RequestBuilder
+from .response_builder import response_with_status
+from .utils import config, mock_auth, read_output
+
+_START_DATE = pendulum.datetime(year=2023, month=1, day=1)
+_END_DATE = pendulum.datetime(year=2023, month=1, day=5)
+_REPLICATION_START_FIELD = "createdAfter"
+_REPLICATION_END_FIELD = "createdBefore"
+_CURSOR_FIELD = "createdBefore"
+_STREAM_NAME = "VendorOrdersStatus"
+
+
+def _vendor_orders_status_request() -> RequestBuilder:
+    return RequestBuilder.vendor_orders_status_endpoint().with_query_params(
+        {
+            _REPLICATION_START_FIELD: _START_DATE.strftime(TIME_FORMAT),
+            _REPLICATION_END_FIELD: _END_DATE.strftime(TIME_FORMAT),
+        }
+    )
+
+
+def _vendor_orders_status_response() -> HttpResponseBuilder:
+    return create_response_builder(
+        response_template=find_template(_STREAM_NAME, __file__),
+        records_path=NestedPath(["payload", "orders"]),
+        pagination_strategy=VendorFulfillmentPaginationStrategy(),
+    )
+
+
+def _order_status_record() -> RecordBuilder:
+    return create_record_builder(
+        response_template=find_template(_STREAM_NAME, __file__),
+        records_path=NestedPath(["payload", "ordersStatus"]),
+        record_id_path=FieldPath("purchaseOrderNumber"),
+    )
+
+
+@freezegun.freeze_time(NOW.isoformat())
+class TestFullRefresh:
+    @staticmethod
+    def _read(config_: ConfigBuilder, expecting_exception: bool = False) -> EntrypointOutput:
+        return read_output(
+            config_builder=config_,
+            stream_name=_STREAM_NAME,
+            sync_mode=SyncMode.full_refresh,
+            expecting_exception=expecting_exception,
+        )
+
+    @HttpMocker()
+    def test_given_one_page_when_read_then_return_records(self, http_mocker: HttpMocker) -> None:
+        mock_auth(http_mocker)
+        http_mocker.get(_vendor_orders_status_request().build(), _vendor_orders_status_response().with_record(_order_status_record()).build())
+
+        output = self._read(config().with_start_date(_START_DATE).with_end_date(_END_DATE))
+        assert len(output.records) == 1
+
+    @HttpMocker()
+    def test_given_two_pages_when_read_then_return_records(self, http_mocker: HttpMocker) -> None:
+        mock_auth(http_mocker)
+        http_mocker.get(
+            _vendor_orders_status_request().build(),
+            _vendor_orders_status_response().with_pagination().with_record(_order_status_record()).build(),
+        )
+        query_params_with_next_page_token = {
+            _REPLICATION_START_FIELD: _START_DATE.strftime(TIME_FORMAT),
+            _REPLICATION_END_FIELD: _END_DATE.strftime(TIME_FORMAT),
+            "nextToken": NEXT_TOKEN_STRING,
+        }
+        http_mocker.get(
+            _vendor_orders_status_request().with_query_params(query_params_with_next_page_token).build(),
+            _vendor_orders_status_response().with_record(_order_status_record()).with_record(_order_status_record()).build(),
+        )
+
+        output = self._read(config().with_start_date(_START_DATE).with_end_date(_END_DATE))
+        assert len(output.records) == 3
+
+    @HttpMocker()
+    def test_given_two_slices_when_read_then_return_records(self, http_mocker: HttpMocker) -> None:
+        end_date = _START_DATE.add(days=8)
+        mock_auth(http_mocker)
+
+        query_params_first_slice = {
+            _REPLICATION_START_FIELD: _START_DATE.strftime(TIME_FORMAT),
+            _REPLICATION_END_FIELD: _START_DATE.add(days=7).strftime(TIME_FORMAT),
+        }
+        http_mocker.get(
+            _vendor_orders_status_request().with_query_params(query_params_first_slice).build(),
+            _vendor_orders_status_response().with_record(_order_status_record()).build(),
+        )
+
+        query_params_second_slice = {
+            _REPLICATION_START_FIELD: query_params_first_slice[_REPLICATION_END_FIELD],
+            _REPLICATION_END_FIELD: end_date.strftime(TIME_FORMAT),
+        }
+        http_mocker.get(
+            _vendor_orders_status_request().with_query_params(query_params_second_slice).build(),
+            _vendor_orders_status_response().with_record(_order_status_record()).build(),
+        )
+
+        output = self._read(config().with_start_date(_START_DATE).with_end_date(end_date))
+        assert len(output.records) == 2
+
+    @HttpMocker()
+    def test_given_http_status_500_then_200_when_read_then_retry_and_return_records(self, http_mocker: HttpMocker) -> None:
+        mock_auth(http_mocker)
+        http_mocker.get(
+            _vendor_orders_status_request().build(),
+            [
+                response_with_status(status_code=HTTPStatus.INTERNAL_SERVER_ERROR),
+                _vendor_orders_status_response().with_record(_order_status_record()).build(),
+            ],
+        )
+
+        output = self._read(config().with_start_date(_START_DATE).with_end_date(_END_DATE))
+        assert len(output.records) == 1
+
+    @HttpMocker()
+    def test_given_http_status_500_on_availability_when_read_then_raise_system_error(self, http_mocker: HttpMocker) -> None:
+        mock_auth(http_mocker)
+        http_mocker.get(_vendor_orders_status_request().build(), response_with_status(status_code=HTTPStatus.INTERNAL_SERVER_ERROR))
+
+        output = self._read(config().with_start_date(_START_DATE).with_end_date(_END_DATE), expecting_exception=True)
+        assert output.errors[-1].trace.error.failure_type == FailureType.config_error
+
+
+@freezegun.freeze_time(NOW.isoformat())
+class TestIncremental:
+    @staticmethod
+    def _read(
+        config_: ConfigBuilder, state: Optional[List[AirbyteStateMessage]] = None, expecting_exception: bool = False
+    ) -> EntrypointOutput:
+        return read_output(
+            config_builder=config_,
+            stream_name=_STREAM_NAME,
+            sync_mode=SyncMode.incremental,
+            state=state,
+            expecting_exception=expecting_exception,
+        )
+
+    @HttpMocker()
+    def test_when_read_then_add_cursor_field(self, http_mocker: HttpMocker) -> None:
+        mock_auth(http_mocker)
+        http_mocker.get(_vendor_orders_status_request().build(), _vendor_orders_status_response().with_record(_order_status_record()).build())
+
+        output = self._read(config().with_start_date(_START_DATE).with_end_date(_END_DATE))
+        expected_cursor_value = _END_DATE.strftime(TIME_FORMAT)
+        assert output.records[0].record.data[_CURSOR_FIELD] == expected_cursor_value
+
+    @HttpMocker()
+    def test_when_read_then_state_message_produced_and_state_match_latest_record(self, http_mocker: HttpMocker) -> None:
+        mock_auth(http_mocker)
+        http_mocker.get(
+            _vendor_orders_status_request().build(),
+            _vendor_orders_status_response().with_record(_order_status_record()).with_record(_order_status_record()).build(),
+        )
+
+        output = self._read(config().with_start_date(_START_DATE).with_end_date(_END_DATE))
+        assert len(output.state_messages) == 1
+
+        cursor_value_from_latest_record = output.records[-1].record.data.get(_CURSOR_FIELD)
+
+        most_recent_state = output.most_recent_state.stream_state
+        assert most_recent_state == {_CURSOR_FIELD: cursor_value_from_latest_record}
+
+    @HttpMocker()
+    def test_given_state_when_read_then_state_value_is_created_after_query_param(self, http_mocker: HttpMocker) -> None:
+        mock_auth(http_mocker)
+        state_value = _START_DATE.add(days=1).strftime(TIME_FORMAT)
+
+        query_params_first_read = {
+            _REPLICATION_START_FIELD: _START_DATE.strftime(TIME_FORMAT),
+            _REPLICATION_END_FIELD: _END_DATE.strftime(TIME_FORMAT),
+        }
+        query_params_incremental_read = {_REPLICATION_START_FIELD: state_value, _REPLICATION_END_FIELD: _END_DATE.strftime(TIME_FORMAT)}
+
+        http_mocker.get(
+            _vendor_orders_status_request().with_query_params(query_params_first_read).build(),
+            _vendor_orders_status_response().with_record(_order_status_record()).with_record(_order_status_record()).build(),
+        )
+        http_mocker.get(
+            _vendor_orders_status_request().with_query_params(query_params_incremental_read).build(),
+            _vendor_orders_status_response().with_record(_order_status_record()).with_record(_order_status_record()).build(),
+        )
+
+        output = self._read(
+            config_=config().with_start_date(_START_DATE).with_end_date(_END_DATE),
+            state=StateBuilder().with_stream_state(_STREAM_NAME, {_CURSOR_FIELD: state_value}).build(),
+        )
+        assert output.most_recent_state.stream_state == {_CURSOR_FIELD: _END_DATE.strftime(TIME_FORMAT)}

--- a/airbyte-integrations/connectors/source-amazon-seller-partner/unit_tests/integration/test_vendor_orders_status.py
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/unit_tests/integration/test_vendor_orders_status.py
@@ -8,6 +8,7 @@ from typing import List, Optional
 
 import freezegun
 import pendulum
+
 from airbyte_cdk.test.entrypoint_wrapper import EntrypointOutput
 from airbyte_cdk.test.mock_http import HttpMocker
 from airbyte_cdk.test.mock_http.response_builder import (
@@ -27,6 +28,7 @@ from .pagination import NEXT_TOKEN_STRING, VendorFulfillmentPaginationStrategy
 from .request_builder import RequestBuilder
 from .response_builder import response_with_status
 from .utils import config, mock_auth, read_output
+
 
 _START_DATE = pendulum.datetime(year=2023, month=1, day=1)
 _END_DATE = pendulum.datetime(year=2023, month=1, day=5)
@@ -75,7 +77,9 @@ class TestFullRefresh:
     @HttpMocker()
     def test_given_one_page_when_read_then_return_records(self, http_mocker: HttpMocker) -> None:
         mock_auth(http_mocker)
-        http_mocker.get(_vendor_orders_status_request().build(), _vendor_orders_status_response().with_record(_order_status_record()).build())
+        http_mocker.get(
+            _vendor_orders_status_request().build(), _vendor_orders_status_response().with_record(_order_status_record()).build()
+        )
 
         output = self._read(config().with_start_date(_START_DATE).with_end_date(_END_DATE))
         assert len(output.records) == 1
@@ -166,7 +170,9 @@ class TestIncremental:
     @HttpMocker()
     def test_when_read_then_add_cursor_field(self, http_mocker: HttpMocker) -> None:
         mock_auth(http_mocker)
-        http_mocker.get(_vendor_orders_status_request().build(), _vendor_orders_status_response().with_record(_order_status_record()).build())
+        http_mocker.get(
+            _vendor_orders_status_request().build(), _vendor_orders_status_response().with_record(_order_status_record()).build()
+        )
 
         output = self._read(config().with_start_date(_START_DATE).with_end_date(_END_DATE))
         expected_cursor_value = _END_DATE.strftime(TIME_FORMAT)

--- a/airbyte-integrations/connectors/source-amazon-seller-partner/unit_tests/resource/http/response/VendorOrders.json
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/unit_tests/resource/http/response/VendorOrders.json
@@ -1,6 +1,6 @@
 {
   "payload": {
-    "orders": [
+    "ordersStatus": [
       {
         "purchaseOrderNumber": "L8266355",
         "purchaseOrderState": "New",

--- a/airbyte-integrations/connectors/source-amazon-seller-partner/unit_tests/resource/http/response/VendorOrders.json
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/unit_tests/resource/http/response/VendorOrders.json
@@ -1,6 +1,6 @@
 {
   "payload": {
-    "ordersStatus": [
+    "orders": [
       {
         "purchaseOrderNumber": "L8266355",
         "purchaseOrderState": "New",

--- a/airbyte-integrations/connectors/source-amazon-seller-partner/unit_tests/resource/http/response/VendorOrdersStatus.json
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/unit_tests/resource/http/response/VendorOrdersStatus.json
@@ -1,0 +1,81 @@
+{
+    "payload": {
+        "ordersStatus": [
+            {
+                "itemStatus": [
+                    {
+                        "orderedQuantity": {
+                            "orderedQuantityDetails": [
+                                {
+                                    "orderedQuantity": {
+                                        "unitSize": 1,
+                                        "amount": 2,
+                                        "unitOfMeasure": "Eaches"
+                                    },
+                                    "cancelledQuantity": {
+                                        "unitSize": 1,
+                                        "amount": 1,
+                                        "unitOfMeasure": "Eaches"
+                                    },
+                                    "updatedDate": "2024-08-31T15:16:17Z"
+                                }
+                            ],
+                            "orderedQuantity": {
+                                "unitSize": 1,
+                                "amount": 2,
+                                "unitOfMeasure": "Eaches"
+                            }
+                        },
+                        "acknowledgementStatus": {
+                            "rejectedQuantity": {
+                                "unitSize": 1,
+                                "amount": 2,
+                                "unitOfMeasure": "Eaches"
+                            },
+                            "acknowledgementStatusDetails": [
+                                {
+                                    "rejectedQuantity": {
+                                        "unitSize": 1,
+                                        "amount": 0,
+                                        "unitOfMeasure": "Eaches"
+                                    },
+                                    "acceptedQuantity": {
+                                        "unitSize": 1,
+                                        "amount": 2,
+                                        "unitOfMeasure": "Eaches"
+                                    },
+                                    "acknowledgementDate": "2024-08-01T16:00:00Z"
+                                }
+                            ],
+                            "confirmationStatus": "APPROVED"
+                        },
+                        "netCost": {
+                            "currencyCode": "USD",
+                            "amount": 27.37
+                        },
+                        "itemSequenceNumber": "1",
+                        "vendorProductIdentifier": "123456ABC",
+                        "buyerProductIdentifier": "123456ABC",
+                        "listPrice": {
+                            "currencyCode": "GBP",
+                            "amount": 19.99
+                        },
+                        "receivingStatus": {
+                            "receiveStatus": "NOT_RECEIVED"
+                        }
+                    }
+                ],
+                "lastUpdatedDate": "2024-09-10T11:12:13Z",
+                "purchaseOrderDate": "2024-09-01T15:16:17Z",
+                "purchaseOrderNumber": "123ABC",
+                "purchaseOrderStatus": "OPEN",
+                "sellingParty": {
+                    "partyId": "MOO"
+                },
+                "shipToParty": {
+                    "partyId": "BAA"
+                }
+            }
+        ]
+    }
+}

--- a/airbyte-integrations/connectors/source-amazon-seller-partner/unit_tests/resource/http/response/VendorOrdersStatus.json
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/unit_tests/resource/http/response/VendorOrdersStatus.json
@@ -1,81 +1,81 @@
 {
-    "payload": {
-        "ordersStatus": [
-            {
-                "itemStatus": [
-                    {
-                        "orderedQuantity": {
-                            "orderedQuantityDetails": [
-                                {
-                                    "orderedQuantity": {
-                                        "unitSize": 1,
-                                        "amount": 2,
-                                        "unitOfMeasure": "Eaches"
-                                    },
-                                    "cancelledQuantity": {
-                                        "unitSize": 1,
-                                        "amount": 1,
-                                        "unitOfMeasure": "Eaches"
-                                    },
-                                    "updatedDate": "2024-08-31T15:16:17Z"
-                                }
-                            ],
-                            "orderedQuantity": {
-                                "unitSize": 1,
-                                "amount": 2,
-                                "unitOfMeasure": "Eaches"
-                            }
-                        },
-                        "acknowledgementStatus": {
-                            "rejectedQuantity": {
-                                "unitSize": 1,
-                                "amount": 2,
-                                "unitOfMeasure": "Eaches"
-                            },
-                            "acknowledgementStatusDetails": [
-                                {
-                                    "rejectedQuantity": {
-                                        "unitSize": 1,
-                                        "amount": 0,
-                                        "unitOfMeasure": "Eaches"
-                                    },
-                                    "acceptedQuantity": {
-                                        "unitSize": 1,
-                                        "amount": 2,
-                                        "unitOfMeasure": "Eaches"
-                                    },
-                                    "acknowledgementDate": "2024-08-01T16:00:00Z"
-                                }
-                            ],
-                            "confirmationStatus": "APPROVED"
-                        },
-                        "netCost": {
-                            "currencyCode": "USD",
-                            "amount": 27.37
-                        },
-                        "itemSequenceNumber": "1",
-                        "vendorProductIdentifier": "123456ABC",
-                        "buyerProductIdentifier": "123456ABC",
-                        "listPrice": {
-                            "currencyCode": "GBP",
-                            "amount": 19.99
-                        },
-                        "receivingStatus": {
-                            "receiveStatus": "NOT_RECEIVED"
-                        }
-                    }
-                ],
-                "lastUpdatedDate": "2024-09-10T11:12:13Z",
-                "purchaseOrderDate": "2024-09-01T15:16:17Z",
-                "purchaseOrderNumber": "123ABC",
-                "purchaseOrderStatus": "OPEN",
-                "sellingParty": {
-                    "partyId": "MOO"
-                },
-                "shipToParty": {
-                    "partyId": "BAA"
+  "payload": {
+    "ordersStatus": [
+      {
+        "itemStatus": [
+          {
+            "orderedQuantity": {
+              "orderedQuantityDetails": [
+                {
+                  "orderedQuantity": {
+                    "unitSize": 1,
+                    "amount": 2,
+                    "unitOfMeasure": "Eaches"
+                  },
+                  "cancelledQuantity": {
+                    "unitSize": 1,
+                    "amount": 1,
+                    "unitOfMeasure": "Eaches"
+                  },
+                  "updatedDate": "2024-08-31T15:16:17Z"
                 }
+              ],
+              "orderedQuantity": {
+                "unitSize": 1,
+                "amount": 2,
+                "unitOfMeasure": "Eaches"
+              }
+            },
+            "acknowledgementStatus": {
+              "rejectedQuantity": {
+                "unitSize": 1,
+                "amount": 2,
+                "unitOfMeasure": "Eaches"
+              },
+              "acknowledgementStatusDetails": [
+                {
+                  "rejectedQuantity": {
+                    "unitSize": 1,
+                    "amount": 0,
+                    "unitOfMeasure": "Eaches"
+                  },
+                  "acceptedQuantity": {
+                    "unitSize": 1,
+                    "amount": 2,
+                    "unitOfMeasure": "Eaches"
+                  },
+                  "acknowledgementDate": "2024-08-01T16:00:00Z"
+                }
+              ],
+              "confirmationStatus": "APPROVED"
+            },
+            "netCost": {
+              "currencyCode": "USD",
+              "amount": 27.37
+            },
+            "itemSequenceNumber": "1",
+            "vendorProductIdentifier": "123456ABC",
+            "buyerProductIdentifier": "123456ABC",
+            "listPrice": {
+              "currencyCode": "GBP",
+              "amount": 19.99
+            },
+            "receivingStatus": {
+              "receiveStatus": "NOT_RECEIVED"
             }
-        ]
-    }
+          }
+        ],
+        "lastUpdatedDate": "2024-09-10T11:12:13Z",
+        "purchaseOrderDate": "2024-09-01T15:16:17Z",
+        "purchaseOrderNumber": "123ABC",
+        "purchaseOrderStatus": "OPEN",
+        "sellingParty": {
+          "partyId": "MOO"
+        },
+        "shipToParty": {
+          "partyId": "BAA"
+        }
+      }
+    ]
+  }
 }

--- a/docs/integrations/sources/amazon-seller-partner.md
+++ b/docs/integrations/sources/amazon-seller-partner.md
@@ -229,7 +229,7 @@ Create a separate connection for streams which usually fail with error above "Fa
 
 | Version    | Date       | Pull Request                                              | Subject                                                                                                                                                                             |
 |:-----------|:-----------|:----------------------------------------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 4.6.0   | 2024-02-15 | [#](https://github.com/airbytehq/airbyte/pull/) | Add `VendorOrdersStatus` stream  
+| 4.6.0      | 2025-02-03 | [53138](https://github.com/airbytehq/airbyte/pull/53138)  | Add `VendorOrdersStatus` stream  
 | 4.5.0-rc.5 | 2025-01-31 | [52700](https://github.com/airbytehq/airbyte/pull/52700)      | Use incremental_dependency for the OrderItems substream                                                                                                                             |
 | 4.5.0-rc.4 | 2025-01-31 | [52683](https://github.com/airbytehq/airbyte/pull/52683)  | Fix Rate Limiting issue; disable concurrency                                                                                                                                        |
 | 4.5.0-rc.3 | 2025-01-28 | [52619](https://github.com/airbytehq/airbyte/pull/52619)  | Fix `Orders` pagination                                                                                                                                                             |

--- a/docs/integrations/sources/amazon-seller-partner.md
+++ b/docs/integrations/sources/amazon-seller-partner.md
@@ -137,6 +137,7 @@ The Amazon Seller Partner source connector supports the following [sync modes](h
 - [Vendor Direct Fulfillment Shipping](https://developer-docs.amazon.com/sp-api/docs/vendor-direct-fulfillment-shipping-api-v1-reference) \(incremental\)
 - [Vendor Forecasting Report](https://developer-docs.amazon.com/sp-api/docs/report-type-values-analytics#vendor-retail-analytics-reports) \(full-refresh\)
 - [Vendor Orders](https://developer-docs.amazon.com/sp-api/docs/vendor-orders-api-v1-reference#get-vendorordersv1purchaseorders) \(incremental\)
+- [Vendor Order Status](https://developer-docs.amazon.com/sp-api/docs/vendor-orders-api-v1-reference#get-vendorordersv1purchaseOrdersStatus) \(incremental\)
 - [XML Orders By Order Date Report](https://developer-docs.amazon.com/sp-api/docs/report-type-values-order#order-tracking-reports) \(incremental\)
 <!-- env:oss -->
 - [Amazon Search Terms Report](https://developer-docs.amazon.com/sp-api/docs/report-type-values-analytics#brand-analytics-reports) \(only available in OSS, incremental\)
@@ -228,6 +229,7 @@ Create a separate connection for streams which usually fail with error above "Fa
 
 | Version    | Date       | Pull Request                                              | Subject                                                                                                                                                                             |
 |:-----------|:-----------|:----------------------------------------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 4.6.0   | 2024-02-15 | [#](https://github.com/airbytehq/airbyte/pull/) | Add `VendorOrdersStatus` stream  
 | 4.5.0-rc.5 | 2025-01-31 | [52700](https://github.com/airbytehq/airbyte/pull/52700)      | Use incremental_dependency for the OrderItems substream                                                                                                                             |
 | 4.5.0-rc.4 | 2025-01-31 | [52683](https://github.com/airbytehq/airbyte/pull/52683)  | Fix Rate Limiting issue; disable concurrency                                                                                                                                        |
 | 4.5.0-rc.3 | 2025-01-28 | [52619](https://github.com/airbytehq/airbyte/pull/52619)  | Fix `Orders` pagination                                                                                                                                                             |


### PR DESCRIPTION
## What
Add VendorOrdersStatus stream to source Amazon Seller Partner, closes #46331 

## How
Added stream and testing to mimic VendorOrders stream

## Review guide
streams.py
test_vendor_status_orders.py
others...

It's quite difficult to know if I've covered all relevant files? Please guide me if not! 😅 

## User Impact
New stream available for Amazon Seller Partner

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌
