### PR TITLE
fix(airbyte-ci): running CATs container in python 3.11

### DIFF
--- a/airbyte-integrations/bases/connector-acceptance-test/Dockerfile
+++ b/airbyte-integrations/bases/connector-acceptance-test/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10.12 as base
+FROM python:3.11.9 as base
 
 
 ENV ACCEPTANCE_TEST_DOCKER_CONTAINER 1
@@ -12,8 +12,7 @@ RUN apt-get update \
 RUN curl -fsSL https://get.docker.com | sh
 
 
-
-RUN pip install poetry==1.5.1
+RUN pip install poetry==1.8.4
 RUN poetry config virtualenvs.create false
 RUN echo "Etc/UTC" > /etc/timezone
 


### PR DESCRIPTION
## What

This is pretty wild. So it turns out that we are running CATs in a special container (but connector itself runs in it's own container still). I have not bumped it to 3.11 when I bumped the rest of our CI things and it led to errors:

- https://github.com/airbytehq/airbyte/actions/runs/13122272274/job/36610797825?pr=52625
- https://github.com/airbytehq/airbyte/actions/runs/13121985077/job/36609892698?pr=48751

The failures I've seen are all caused by the CATs not writing their report after `python -m pytest ... --report-log=/tmp/report_log.jsonl`. 

This bump seems to fix it locally.

## How

This changes the dev version of CATs container to run Python 3.11. This does NOT mean connectors themselves run 3.11 yet. 

