### PR TITLE
chore(workflows): ping extensibility team instead of tooling

### DIFF
--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/github.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/github.py
@@ -19,7 +19,7 @@ from orchestrator.utils.dagster_helpers import OutputDataFrame, output_dataframe
 
 
 GROUP_NAME = "github"
-TOOLING_TEAM_SLACK_TEAM_ID = "S077R8636CV"
+EXTENSIBILITY_TEAM_SLACK_TEAM_ID = "S077U1TH43D"
 # We give 6 hours for the metadata to be updated
 # This is an empirical value that we can adjust if needed
 # When our auto-merge pipeline runs it can merge hundreds of up-to-date PRs following.
@@ -172,7 +172,9 @@ def stale_gcs_latest_metadata_file(context, github_metadata_definitions: list, l
     any_stale = len(stale_connectors_df) > 0
     if any_stale and stale_report_channel:
         stale_report_md = stale_connectors_df.to_markdown(index=False)
-        send_slack_message(context, stale_report_channel, f"🚨 Stale metadata detected! (cc. <!subteam^{TOOLING_TEAM_SLACK_TEAM_ID}>)")
+        send_slack_message(
+            context, stale_report_channel, f"🚨 Stale metadata detected! (cc. <!subteam^{EXTENSIBILITY_TEAM_SLACK_TEAM_ID}>)"
+        )
         send_slack_message(context, stale_report_channel, stale_report_md, enable_code_block_wrapping=True)
     if not any_stale and publish_update_channel:
         message = textwrap.dedent(

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/publish/context.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/publish/context.py
@@ -160,5 +160,5 @@ class PublishConnectorContext(ConnectorContext):
             assert self.report is not None, "Report should be set when state is successful"
             message += f"⏲️ Run duration: {format_duration(self.report.run_duration)}\n"
         if self.state is ContextState.FAILURE:
-            message += "\ncc. <!subteam^S077R8636CV>"
+            message += "\ncc. <!subteam^S077U1TH43D>"
         return message


### PR DESCRIPTION
This just renames our slack handle so we get the right pings.