### PR TITLE
Destination S3: reenable assume role test; fix file transfer test?

### DIFF
--- a/airbyte-cdk/java/airbyte-cdk/s3-destinations/src/testFixtures/kotlin/io/airbyte/cdk/integrations/destination/s3/S3DestinationAcceptanceTest.kt
+++ b/airbyte-cdk/java/airbyte-cdk/s3-destinations/src/testFixtures/kotlin/io/airbyte/cdk/integrations/destination/s3/S3DestinationAcceptanceTest.kt
@@ -805,7 +805,10 @@ protected constructor(
                 )
             fail("sync should have failed. Instead got output $destinationOutput")
         } catch (e: TestHarnessException) {
-            assertContains(e.outputMessages!![0].trace.error.internalMessage, "File does not exist")
+            assertContains(
+                e.outputMessages!![0].trace.error.internalMessage,
+                "java.io.FileNotFoundException: /staging/files/fakeFile (No such file or directory)"
+            )
         }
     }
 

--- a/airbyte-integrations/connectors/destination-s3/src/test-integration-legacy/kotlin/io/airbyte/integrations/destination/s3/S3V2AvroDestinationAcceptanceTest.kt
+++ b/airbyte-integrations/connectors/destination-s3/src/test-integration-legacy/kotlin/io/airbyte/integrations/destination/s3/S3V2AvroDestinationAcceptanceTest.kt
@@ -21,9 +21,4 @@ class S3V2AvroDestinationAcceptanceTest : S3BaseAvroDestinationAcceptanceTest() 
 
     override val baseConfigJson: JsonNode
         get() = S3V2DestinationTestUtils.baseConfigJsonFilePath
-
-    // Disable these tests until we fix the incomplete stream handling behavior.
-    override fun testOverwriteSyncMultipleFailedGenerationsFilesPreserved() {}
-    override fun testOverwriteSyncFailedResumedGeneration() {}
-    override fun testFakeFileTransfer() {}
 }

--- a/airbyte-integrations/connectors/destination-s3/src/test-integration-legacy/kotlin/io/airbyte/integrations/destination/s3/S3V2CsvAssumeRoleDestinationAcceptanceTest.kt
+++ b/airbyte-integrations/connectors/destination-s3/src/test-integration-legacy/kotlin/io/airbyte/integrations/destination/s3/S3V2CsvAssumeRoleDestinationAcceptanceTest.kt
@@ -20,8 +20,4 @@ class S3V2CsvAssumeRoleDestinationAcceptanceTest : S3BaseCsvDestinationAcceptanc
     override fun testFakeFileTransfer() {
         super.testFakeFileTransfer()
     }
-
-    // Disable these tests until we fix the incomplete stream handling behavior.
-    override fun testOverwriteSyncMultipleFailedGenerationsFilesPreserved() {}
-    override fun testOverwriteSyncFailedResumedGeneration() {}
 }

--- a/airbyte-integrations/connectors/destination-s3/src/test-integration-legacy/kotlin/io/airbyte/integrations/destination/s3/S3V2CsvAssumeRoleDestinationAcceptanceTest.kt
+++ b/airbyte-integrations/connectors/destination-s3/src/test-integration-legacy/kotlin/io/airbyte/integrations/destination/s3/S3V2CsvAssumeRoleDestinationAcceptanceTest.kt
@@ -5,10 +5,8 @@ package io.airbyte.integrations.destination.s3
 
 import com.fasterxml.jackson.databind.JsonNode
 import io.airbyte.cdk.integrations.destination.s3.S3BaseCsvDestinationAcceptanceTest
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 
-@Disabled
 class S3V2CsvAssumeRoleDestinationAcceptanceTest : S3BaseCsvDestinationAcceptanceTest() {
     override val imageName: String = "airbyte/destination-s3:dev"
     override val baseConfigJson: JsonNode

--- a/airbyte-integrations/connectors/destination-s3/src/test-integration-legacy/kotlin/io/airbyte/integrations/destination/s3/S3V2CsvDestinationAcceptanceTest.kt
+++ b/airbyte-integrations/connectors/destination-s3/src/test-integration-legacy/kotlin/io/airbyte/integrations/destination/s3/S3V2CsvDestinationAcceptanceTest.kt
@@ -15,9 +15,4 @@ class S3V2CsvDestinationAcceptanceTest : S3BaseCsvDestinationAcceptanceTest() {
 
     override val baseConfigJson: JsonNode
         get() = S3V2DestinationTestUtils.baseConfigJsonFilePath
-
-    // Disable these tests until we fix the incomplete stream handling behavior.
-    override fun testOverwriteSyncMultipleFailedGenerationsFilesPreserved() {}
-    override fun testOverwriteSyncFailedResumedGeneration() {}
-    override fun testFakeFileTransfer() {}
 }

--- a/airbyte-integrations/connectors/destination-s3/src/test-integration-legacy/kotlin/io/airbyte/integrations/destination/s3/S3V2CsvGzipDestinationAcceptanceTest.kt
+++ b/airbyte-integrations/connectors/destination-s3/src/test-integration-legacy/kotlin/io/airbyte/integrations/destination/s3/S3V2CsvGzipDestinationAcceptanceTest.kt
@@ -15,10 +15,4 @@ class S3V2CsvGzipDestinationAcceptanceTest : S3BaseCsvGzipDestinationAcceptanceT
 
     override val baseConfigJson: JsonNode
         get() = S3V2DestinationTestUtils.baseConfigJsonFilePath
-
-    // Disable these tests until we fix the incomplete stream handling behavior.
-    override fun testOverwriteSyncMultipleFailedGenerationsFilesPreserved() {}
-    override fun testOverwriteSyncFailedResumedGeneration() {}
-
-    override fun testFakeFileTransfer() {}
 }

--- a/airbyte-integrations/connectors/destination-s3/src/test-integration-legacy/kotlin/io/airbyte/integrations/destination/s3/S3V2JsonlDestinationAcceptanceTest.kt
+++ b/airbyte-integrations/connectors/destination-s3/src/test-integration-legacy/kotlin/io/airbyte/integrations/destination/s3/S3V2JsonlDestinationAcceptanceTest.kt
@@ -15,9 +15,4 @@ class S3V2JsonlDestinationAcceptanceTest : S3BaseJsonlDestinationAcceptanceTest(
 
     override val baseConfigJson: JsonNode
         get() = S3V2DestinationTestUtils.baseConfigJsonFilePath
-
-    // Disable these tests until we fix the incomplete stream handling behavior.
-    override fun testOverwriteSyncMultipleFailedGenerationsFilesPreserved() {}
-    override fun testOverwriteSyncFailedResumedGeneration() {}
-    override fun testFakeFileTransfer() {}
 }

--- a/airbyte-integrations/connectors/destination-s3/src/test-integration-legacy/kotlin/io/airbyte/integrations/destination/s3/S3V2JsonlGzipDestinationAcceptanceTest.kt
+++ b/airbyte-integrations/connectors/destination-s3/src/test-integration-legacy/kotlin/io/airbyte/integrations/destination/s3/S3V2JsonlGzipDestinationAcceptanceTest.kt
@@ -15,9 +15,4 @@ class S3V2JsonlGzipDestinationAcceptanceTest : S3BaseJsonlGzipDestinationAccepta
 
     override val baseConfigJson: JsonNode
         get() = S3V2DestinationTestUtils.baseConfigJsonFilePath
-
-    // Disable these tests until we fix the incomplete stream handling behavior.
-    override fun testOverwriteSyncMultipleFailedGenerationsFilesPreserved() {}
-    override fun testOverwriteSyncFailedResumedGeneration() {}
-    override fun testFakeFileTransfer() {}
 }

--- a/airbyte-integrations/connectors/destination-s3/src/test-integration-legacy/kotlin/io/airbyte/integrations/destination/s3/S3V2ParquetDestinationAcceptanceTest.kt
+++ b/airbyte-integrations/connectors/destination-s3/src/test-integration-legacy/kotlin/io/airbyte/integrations/destination/s3/S3V2ParquetDestinationAcceptanceTest.kt
@@ -73,9 +73,4 @@ class S3V2ParquetDestinationAcceptanceTest : S3BaseParquetDestinationAcceptanceT
 
         runSyncAndVerifyStateOutput(config, messages, configuredCatalog, false)
     }
-
-    // Disable these tests until we fix the incomplete stream handling behavior.
-    override fun testOverwriteSyncMultipleFailedGenerationsFilesPreserved() {}
-    override fun testOverwriteSyncFailedResumedGeneration() {}
-    override fun testFakeFileTransfer() {}
 }


### PR DESCRIPTION
(just looking for a rubberstamp, will merge on green CI)

* update the base fakeFileTransfer test to match the new error message
* reenable the assume role legacy DAT
* reenable a bunch of disabled test cases?