### PR TITLE
chore: extensibility code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -59,8 +59,8 @@
 /airbyte-integrations/connectors/destination-redshift/ @airbytehq/move-destinations
 
 # Python critical connectors
-/airbyte-integrations/connectors/source-facebook-marketing/ @airbytehq/extensibility
-/airbyte-integrations/connectors/source-hubspot/ @airbytehq/extensibility
-/airbyte-integrations/connectors/source-salesforce/ @airbytehq/extensibility
-/airbyte-integrations/connectors/source-shopify/ @airbytehq/extensibility
-/airbyte-integrations/connectors/source-stripe/ @airbytehq/extensibility
+/airbyte-integrations/connectors/source-facebook-marketing/ @airbytehq/dev-extensibility
+/airbyte-integrations/connectors/source-hubspot/ @airbytehq/dev-extensibility
+/airbyte-integrations/connectors/source-salesforce/ @airbytehq/dev-extensibility
+/airbyte-integrations/connectors/source-shopify/ @airbytehq/dev-extensibility
+/airbyte-integrations/connectors/source-stripe/ @airbytehq/dev-extensibility

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,15 +7,15 @@
 /airbyte-integrations/connectors/destination-snowflake-cortex @airbytehq/ai-language-models
 
 # CI/CD
-/.github/ @airbytehq/dev-tooling
-/airbyte-ci/ @airbytehq/dev-tooling
+/.github/ @airbytehq/dev-extensibility
+/airbyte-ci/ @airbytehq/dev-extensibility
 
 # Python CDK and Connector Acceptance Tests
-/airbyte-integrations/connector-templates/ @airbytehq/dev-marketplace-contributions
-/airbyte-integrations/bases/connector-acceptance-test/ @airbytehq/dev-tooling
+/airbyte-integrations/connector-templates/ @airbytehq/dev-extensibility
+/airbyte-integrations/bases/connector-acceptance-test/ @airbytehq/dev-extensibility
 
 # Build customization file change
-/airbyte-integrations/connectors/**/build_customization.py @airbytehq/dev-tooling
+/airbyte-integrations/connectors/**/build_customization.py @airbytehq/dev-extensibility
 
 # Protocol related items
 /docs/understanding-airbyte/airbyte-protocol.md @airbytehq/protocol-reviewers
@@ -59,8 +59,8 @@
 /airbyte-integrations/connectors/destination-redshift/ @airbytehq/move-destinations
 
 # Python critical connectors
-/airbyte-integrations/connectors/source-facebook-marketing/ @airbytehq/python-team
-/airbyte-integrations/connectors/source-hubspot/ @airbytehq/python-team
-/airbyte-integrations/connectors/source-salesforce/ @airbytehq/python-team
-/airbyte-integrations/connectors/source-shopify/ @airbytehq/python-team
-/airbyte-integrations/connectors/source-stripe/ @airbytehq/python-team
+/airbyte-integrations/connectors/source-facebook-marketing/ @airbytehq/extensibility
+/airbyte-integrations/connectors/source-hubspot/ @airbytehq/extensibility
+/airbyte-integrations/connectors/source-salesforce/ @airbytehq/extensibility
+/airbyte-integrations/connectors/source-shopify/ @airbytehq/extensibility
+/airbyte-integrations/connectors/source-stripe/ @airbytehq/extensibility


### PR DESCRIPTION
## What

This makes sure all extensibility members get pinged on connector PRs and marketplace PRs. This will be controversial, but I think it's the right thing to do. It's okay if some folks want to filter some of the notifications in whatever way they receive them, but the ownership of the underlying code is shared within the team intentionally.

/cc @bnchrch 