### PR TITLE
[source-akeneo] Fix typo in description

### DIFF
--- a/airbyte-integrations/connectors/source-akeneo/README.md
+++ b/airbyte-integrations/connectors/source-akeneo/README.md
@@ -1,7 +1,7 @@
 # Akeneo
 This directory contains the manifest-only connector for `source-akeneo`.
 
-The Akeneo Airbyte connector enables seamless data synchronization between Akeneo PIM (Product Information Management) and other platforms. It allows you to easily extract, transform, and load product information from Akeneo to a desired data destination, facilitating efficient management and integration of product catalogs across systems. This connector supports bidirectional data flows, helping businesses maintain accurate and up-to-date product information for various sales channels.
+The Akeneo Airbyte connector enables seamless data synchronization between Akeneo PIM (Product Information Management) and other platforms. It allows you to easily extract, transform, and load product information from Akeneo to a desired data destination, facilitating efficient management and integration of product catalogs across systems. 
 
 ## Usage
 There are multiple ways to use this connector:

--- a/airbyte-integrations/connectors/source-akeneo/manifest.yaml
+++ b/airbyte-integrations/connectors/source-akeneo/manifest.yaml
@@ -7,9 +7,7 @@ description: >-
   Akeneo PIM (Product Information Management) and other platforms. It allows you
   to easily extract, transform, and load product information from Akeneo to a
   desired data destination, facilitating efficient management and integration of
-  product catalogs across systems. This connector supports bidirectional data
-  flows, helping businesses maintain accurate and up-to-date product information
-  for various sales channels.
+  product catalogs across systems. 
 
 check:
   type: CheckStream

--- a/airbyte-integrations/connectors/source-akeneo/metadata.yaml
+++ b/airbyte-integrations/connectors/source-akeneo/metadata.yaml
@@ -16,7 +16,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: d6754ed7-dd8a-4a0a-a07e-e768fbac420c
-  dockerImageTag: 0.0.9
+  dockerImageTag: 0.0.10
   dockerRepository: airbyte/source-akeneo
   githubIssueLabel: source-akeneo
   icon: icon.svg

--- a/docs/integrations/sources/akeneo.md
+++ b/docs/integrations/sources/akeneo.md
@@ -33,6 +33,7 @@ The Akeneo Airbyte connector enables seamless data synchronization between Akene
 
 | Version          | Date              | Pull Request | Subject        |
 |------------------|-------------------|--------------|----------------|
+| 0.0.10 | 2025-02-04 | [53151](https://github.com/airbytehq/airbyte/pull/53151) | fix typoe in manifest description |
 | 0.0.9 | 2025-02-01 | [52924](https://github.com/airbytehq/airbyte/pull/52924) | Update dependencies |
 | 0.0.8 | 2025-01-25 | [52200](https://github.com/airbytehq/airbyte/pull/52200) | Update dependencies |
 | 0.0.7 | 2025-01-18 | [51763](https://github.com/airbytehq/airbyte/pull/51763) | Update dependencies |


### PR DESCRIPTION
## What
* Removed the mention of "bidirectional data flow" from the Akeneo connector documentation, as it seemed misleading in the context of the Airbyte connector. 
 
Closes #53150 


## How
* Updated the documentation by removing the specific line referring to bidirectional data flow to better reflect the actual functionality of the Akeneo connector.



## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
* Users will no longer be misled by the incorrect implication of bidirectional data flow in the Akeneo connector.
* No functional impact on the connector itself.


## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌
