### PR TITLE
Update api-documentation.md to reflect Airbyte Embedded rather than Powered by Airbyte

### DIFF
--- a/docs/api-documentation.md
+++ b/docs/api-documentation.md
@@ -9,7 +9,7 @@ The Airbyte API provides a way for developers to programmatically interact with 
 Our API is a reliable, easy-to-use interface for programmatically controlling the Airbyte platform. It can be extended to:
 
 - Enable users to control Airbyte programmatically and use with Orchestration tools (ex: Airflow)
-- Enable [Powered by Airbyte](https://reference.airbyte.com/reference/powered-by-airbyte)
+- Enable [Airbyte Embedded](https://airbyte.com/ai)
 
 ## Configuring API Access
 


### PR DESCRIPTION
We are releasing a new product, Airbyte Embedded, that fulfills the same use case as Powered by Airbyte. 

While this is incubated, we should remove references to Powered by Airbyte so as to not confuse customers. I've also routed people to the marketing page for Airbyte Embedded.

## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->

## How
<!--
* Describe how code changes achieve the solution.
-->

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
