### PR TITLE
fix(source-instagram): unhide oauth fields

### DIFF
--- a/airbyte-integrations/connectors/source-instagram/metadata.yaml
+++ b/airbyte-integrations/connectors/source-instagram/metadata.yaml
@@ -7,7 +7,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 6acf6b55-4f1e-4fca-944e-1a3caef8aba8
-  dockerImageTag: 3.1.4
+  dockerImageTag: 3.1.5
   dockerRepository: airbyte/source-instagram
   githubIssueLabel: source-instagram
   icon: instagram.svg

--- a/airbyte-integrations/connectors/source-instagram/pyproject.toml
+++ b/airbyte-integrations/connectors/source-instagram/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "3.1.4"
+version = "3.1.5"
 name = "source-instagram"
 description = "Source implementation for Instagram."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-instagram/source_instagram/spec.json
+++ b/airbyte-integrations/connectors/source-instagram/source_instagram/spec.json
@@ -23,14 +23,12 @@
         "title": "Client Id",
         "description": "The Client ID for your Oauth application",
         "airbyte_secret": true,
-        "airbyte_hidden": true,
         "type": "string"
       },
       "client_secret": {
         "title": "Client Secret",
         "description": "The Client Secret for your Oauth application",
         "airbyte_secret": true,
-        "airbyte_hidden": true,
         "type": "string"
       }
     },

--- a/airbyte-integrations/connectors/source-instagram/source_instagram/spec.json
+++ b/airbyte-integrations/connectors/source-instagram/source_instagram/spec.json
@@ -32,7 +32,7 @@
         "type": "string"
       }
     },
-    "required": ["client_id", "client_secret", "access_token"]
+    "required": ["access_token"]
   },
   "supportsIncremental": true,
   "supported_destination_sync_modes": ["append"],

--- a/airbyte-integrations/connectors/source-instagram/source_instagram/spec.json
+++ b/airbyte-integrations/connectors/source-instagram/source_instagram/spec.json
@@ -32,7 +32,7 @@
         "type": "string"
       }
     },
-    "required": ["access_token"]
+    "required": ["client_id", "client_secret", "access_token"]
   },
   "supportsIncremental": true,
   "supported_destination_sync_modes": ["append"],

--- a/docs/integrations/sources/instagram.md
+++ b/docs/integrations/sources/instagram.md
@@ -146,6 +146,7 @@ for more information.
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                   |
 |:--------|:-----------|:---------------------------------------------------------|:--------------------------------------------------------------------------------------------------------------------------|
+| 3.1.5 | 2025-02-06 | [todo](https://github.com/airbytehq/airbyte/pull/todo) | Fix missing OAuth fields |
 | 3.1.4 | 2025-02-01 | [52260](https://github.com/airbytehq/airbyte/pull/52260) | Update dependencies |
 | 3.1.3 | 2025-01-20 | [52035](https://github.com/airbytehq/airbyte/pull/52035) | Upgrade to API v21.0 |
 | 3.1.2 | 2025-01-11 | [44223](https://github.com/airbytehq/airbyte/pull/44223) | Starting with this version, the Docker image is now rootless. Please note that this and future versions will not be compatible with Airbyte versions earlier than 0.64 |

--- a/docs/integrations/sources/instagram.md
+++ b/docs/integrations/sources/instagram.md
@@ -146,7 +146,7 @@ for more information.
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                   |
 |:--------|:-----------|:---------------------------------------------------------|:--------------------------------------------------------------------------------------------------------------------------|
-| 3.1.5 | 2025-02-06 | [todo](https://github.com/airbytehq/airbyte/pull/todo) | Fix missing OAuth fields |
+| 3.1.5 | 2025-02-06 | [53171](https://github.com/airbytehq/airbyte/pull/53171) | Fix missing OAuth fields |
 | 3.1.4 | 2025-02-01 | [52260](https://github.com/airbytehq/airbyte/pull/52260) | Update dependencies |
 | 3.1.3 | 2025-01-20 | [52035](https://github.com/airbytehq/airbyte/pull/52035) | Upgrade to API v21.0 |
 | 3.1.2 | 2025-01-11 | [44223](https://github.com/airbytehq/airbyte/pull/44223) | Starting with this version, the Docker image is now rootless. Please note that this and future versions will not be compatible with Airbyte versions earlier than 0.64 |


### PR DESCRIPTION
## What
Fixes https://github.com/airbytehq/airbyte/issues/53158

## How
Unhides client id and client secret and makes them required