### PR TITLE
chore(pre-commit): fail if `mvn` is not installed, add `brew install maven` to Makefile

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,7 +53,7 @@ repos:
 
       - id: spotless
         name: Format Java files with Spotless
-        entry: bash -c 'command -v mvn >/dev/null 2>&1 || { if [ -z "$CI" ]; then echo "Maven not installed, skipping spotless" >&2; exit 0; fi }; mvn -f spotless-maven-pom.xml spotless:apply'
+        entry: bash -c 'command -v mvn >/dev/null 2>&1 || { echo "Maven not installed. Install with brew install maven" >&2; exit 1; }; mvn -f spotless-maven-pom.xml spotless:apply'
         language: system
         files: \.(java|kt|gradle)$
         pass_filenames: false

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ tools.pre-commit.install.Linux:
 
 tools.pre-commit.install.Darwin:
 	@echo "Installing pre-commit with brew..."
-	@brew install pre-commit
+	@brew install pre-commit maven
 	@echo "Pre-commit installation complete"
 
 tools.git-hooks.install: tools.airbyte-ci.install tools.pre-commit.install.$(OS) tools.git-hooks.clean ## Setup pre-commit hooks


### PR DESCRIPTION
## What

This PR changes `pre-commit` hook behavior to NOT pass when your system does not have Maven installed. 

@burakku stumbled into a sitation where local env passes `pre-commit run --all-files`, but CI does not, because locally it did not run Spotless. So this PR fixes it. 

If `mvn` is not found in `$PATH`, it will output a message inviting user to install it, and exiting with status `1`. 

`Makefile` will also install `maven` from Homebrew alongside pre-commit on Macs.

## Wait does everyone HAVE to do java formatters now!? 

No. If you never change java or kotlin files, pre-commit will skip Spotless by default and it won't error out or force you to install maven.