### PR TITLE
Destination S3 Data Lake: fix+document temporal types

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/write/BasicFunctionalityIntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/write/BasicFunctionalityIntegrationTest.kt
@@ -1643,9 +1643,9 @@ abstract class BasicFunctionalityIntegrationTest(
                           "number": 42.1,
                           "integer": 42,
                           "boolean": true,
-                          "timestamp_with_timezone": "2023-01-23T12:34:56Z",
+                          "timestamp_with_timezone": "2023-01-23T11:34:56-01:00",
                           "timestamp_without_timezone": "2023-01-23T12:34:56",
-                          "time_with_timezone": "12:34:56Z",
+                          "time_with_timezone": "11:34:56-01:00",
                           "time_without_timezone": "12:34:56",
                           "date": "2023-01-23"
                         }
@@ -1817,10 +1817,10 @@ abstract class BasicFunctionalityIntegrationTest(
                             "integer" to 42,
                             "boolean" to true,
                             "timestamp_with_timezone" to
-                                OffsetDateTime.parse("2023-01-23T12:34:56Z"),
+                                OffsetDateTime.parse("2023-01-23T11:34:56-01:00"),
                             "timestamp_without_timezone" to
                                 LocalDateTime.parse("2023-01-23T12:34:56"),
-                            "time_with_timezone" to OffsetTime.parse("12:34:56Z"),
+                            "time_with_timezone" to OffsetTime.parse("11:34:56-01:00"),
                             "time_without_timezone" to LocalTime.parse("12:34:56"),
                             "date" to LocalDate.parse("2023-01-23"),
                         ),

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/data/iceberg/parquet/AirbyteValueToIcebergRecord.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/data/iceberg/parquet/AirbyteValueToIcebergRecord.kt
@@ -69,7 +69,10 @@ class AirbyteValueToIcebergRecord {
             is StringValue -> return airbyteValue.value
             is TimeWithTimezoneValue ->
                 return when (type.typeId()) {
-                    Type.TypeID.TIME -> airbyteValue.value.toLocalTime()
+                    // Iceberg doesn't have a time_tz type.
+                    // So just convert this value to UTC, and then drop the offset.
+                    Type.TypeID.TIME ->
+                        airbyteValue.value.withOffsetSameInstant(ZoneOffset.UTC).toLocalTime()
                     else ->
                         throw IllegalArgumentException(
                             "${type.typeId()} type is not allowed for TimeValue"

--- a/airbyte-integrations/connectors/destination-s3-data-lake/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/metadata.yaml
@@ -26,7 +26,7 @@ data:
             alias: airbyte-connector-testing-secret-store
   connectorType: destination
   definitionId: 716ca874-520b-4902-9f80-9fad66754b89
-  dockerImageTag: 0.3.2
+  dockerImageTag: 0.3.3
   dockerRepository: airbyte/destination-s3-data-lake
   documentationUrl: https://docs.airbyte.com/integrations/destinations/s3-data-lake
   githubIssueLabel: destination-s3-data-lake

--- a/docs/integrations/destinations/s3-data-lake.md
+++ b/docs/integrations/destinations/s3-data-lake.md
@@ -10,6 +10,29 @@ for more information.
 
 :::
 
+## Iceberg schema generation
+
+The top-level fields of the stream will be mapped to Iceberg fields. Nested fields (objects, arrays, and unions) will be
+mapped to `STRING` columns, and written as serialized JSON. This is the full mapping between Airbyte types and Iceberg types:
+
+| Airbyte type               | Iceberg type                   |
+|----------------------------|--------------------------------|
+| Boolean                    | Boolean                        |
+| Date                       | Date                           |
+| Integer                    | Long                           |
+| Number                     | Double                         |
+| String                     | String                         |
+| Time with timezone         | Time                           |
+| Time without timezone      | Time                           |
+| Timestamp with timezone    | Timestamp with timezone        |
+| Timestamp without timezone | Timestamp without timezone     |
+| Object                     | String (JSON-serialized value) |
+| Array                      | String (JSON-serialized value) |
+| Union                      | String (JSON-serialized value) |
+
+Note that for the time/timestamp with timezone types, the value is first adjusted to UTC, and then
+written into the Iceberg file.
+
 ## Changelog
 
 <details>

--- a/docs/integrations/destinations/s3-data-lake.md
+++ b/docs/integrations/destinations/s3-data-lake.md
@@ -40,6 +40,7 @@ written into the Iceberg file.
 
 | Version | Date       | Pull Request                                               | Subject                                                                      |
 |:--------|:-----------|:-----------------------------------------------------------|:-----------------------------------------------------------------------------|
+| 0.3.3   | 2025-02-05 | [\#53176](https://github.com/airbytehq/airbyte/pull/53176) | Fix time_with_timezone handling (values are now adjusted to UTC)             |
 | 0.3.2   | 2025-02-04 | [\#52690](https://github.com/airbytehq/airbyte/pull/52690) | Handle special characters in stream name/namespace when using AWS Glue       |
 | 0.3.1   | 2025-02-03 | [\#52633](https://github.com/airbytehq/airbyte/pull/52633) | Fix dedup                                                                    |
 | 0.3.0   | 2025-01-31 | [\#52639](https://github.com/airbytehq/airbyte/pull/52639) | Make the database/namespace a required field                                 |


### PR DESCRIPTION
* update the basicTypes test case to exercise non-UTC offset
* update iceberg to handle timetz correctly (i.e. adjust to UTC)
    * iceberg already does this implicitly for timestamptz
* update iceberg tests
* add documentation