### PR TITLE
Destination S3: Clarify that role ARN option is only usable in cloud

### DIFF
--- a/airbyte-integrations/connectors/destination-s3/build.gradle
+++ b/airbyte-integrations/connectors/destination-s3/build.gradle
@@ -6,7 +6,7 @@ plugins {
 airbyteBulkConnector {
     core = 'load'
     toolkits = ['load-s3', 'load-avro', 'load-aws']
-    cdk = '0.311'
+    cdk = 'local'
 }
 
 application {

--- a/airbyte-integrations/connectors/destination-s3/build.gradle
+++ b/airbyte-integrations/connectors/destination-s3/build.gradle
@@ -6,7 +6,7 @@ plugins {
 airbyteBulkConnector {
     core = 'load'
     toolkits = ['load-s3', 'load-avro', 'load-aws']
-    cdk = 'local'
+    cdk = '0.315'
 }
 
 application {

--- a/airbyte-integrations/connectors/destination-s3/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-s3/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: file
   connectorType: destination
   definitionId: 4816b78f-1489-44c1-9060-4b19d5fa9362
-  dockerImageTag: 1.5.0-rc.19
+  dockerImageTag: 1.5.0-rc.20
   dockerRepository: airbyte/destination-s3
   githubIssueLabel: destination-s3
   icon: s3.svg

--- a/airbyte-integrations/connectors/destination-s3/src/test-integration/resources/expected-spec-cloud.json
+++ b/airbyte-integrations/connectors/destination-s3/src/test-integration/resources/expected-spec-cloud.json
@@ -26,7 +26,7 @@
       },
       "role_arn" : {
         "type" : "string",
-        "description" : "The Role ARN.",
+        "description" : "The ARN of the AWS role to assume. Only usable in Airbyte Cloud.",
         "title" : "Role ARN",
         "examples" : [ "arn:aws:iam::123456789:role/ExternalIdIsYourWorkspaceId" ],
         "order" : 2

--- a/airbyte-integrations/connectors/destination-s3/src/test-integration/resources/expected-spec-oss.json
+++ b/airbyte-integrations/connectors/destination-s3/src/test-integration/resources/expected-spec-oss.json
@@ -26,7 +26,7 @@
       },
       "role_arn" : {
         "type" : "string",
-        "description" : "The Role ARN.",
+        "description" : "The ARN of the AWS role to assume. Only usable in Airbyte Cloud.",
         "title" : "Role ARN",
         "examples" : [ "arn:aws:iam::123456789:role/ExternalIdIsYourWorkspaceId" ],
         "order" : 2

--- a/docs/integrations/destinations/s3.md
+++ b/docs/integrations/destinations/s3.md
@@ -544,6 +544,7 @@ To see connector limitations, or troubleshoot your S3 connector, see more [in ou
 
 | Version     | Date       | Pull Request                                               | Subject                                                                                                                                              |
 |:------------|:-----------|:-----------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| 1.5.0-rc.20 | 2025-02-04 | [53173](https://github.com/airbytehq/airbyte/pull/53173)   | Tweak spec wording                                                                                                                                   |
 | 1.5.0-rc.19 | 2025-02-04 | [53163](https://github.com/airbytehq/airbyte/pull/53163)   | Various fixes to truncate sync                                                                                                                       |
 | 1.5.0-rc.18 | 2025-01-29 | [52703](https://github.com/airbytehq/airbyte/pull/52703)   | Force list call evaluation before making head calls                                                                                                  |
 | 1.5.0-rc.17 | 2025-01-29 | [52610](https://github.com/airbytehq/airbyte/pull/52642)   | Pin CDK 0.296                                                                                                                                        |


### PR DESCRIPTION
pulled out the destination-s3 changes from https://github.com/airbytehq/airbyte/pull/53173 into a separate PR, so that I can bump the CDK version without needing to merge to master with `local`

(I'll merge https://github.com/airbytehq/airbyte/pull/53173 + bump the CDK version here, just triggering CI for now)