### PR TITLE
[source-kafka] fix avro schema_registry_password as a secret in config 

### DIFF
--- a/airbyte-integrations/connectors/source-kafka/metadata.yaml
+++ b/airbyte-integrations/connectors/source-kafka/metadata.yaml
@@ -10,7 +10,7 @@ data:
     - suite: integrationTests
   connectorType: source
   definitionId: d917a47b-8537-4d0d-8c10-36a9928d4265
-  dockerImageTag: 0.2.7
+  dockerImageTag: 0.2.8
   dockerRepository: airbyte/source-kafka
   documentationUrl: https://docs.airbyte.com/integrations/sources/kafka
   githubIssueLabel: source-kafka

--- a/airbyte-integrations/connectors/source-kafka/src/main/resources/spec.json
+++ b/airbyte-integrations/connectors/source-kafka/src/main/resources/spec.json
@@ -48,7 +48,8 @@
               },
               "schema_registry_password": {
                 "type": "string",
-                "default": ""
+                "default": "",
+                "airbyte_secret": true
               }
             }
           }

--- a/docs/integrations/sources/kafka.md
+++ b/docs/integrations/sources/kafka.md
@@ -52,14 +52,15 @@ AVRO - deserialize Using confluent API. Please refer (https://docs.confluent.io/
   <summary>Expand to review</summary>
 
 | Version | Date       | Pull Request                                                                                       | Subject                                                              |
-| :------ | :--------- | :------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------- |
-| 0.2.7 | 2025-01-10 | [51480](https://github.com/airbytehq/airbyte/pull/51480) | Use a non root base image |
-| 0.2.6 | 2024-12-18 | [49907](https://github.com/airbytehq/airbyte/pull/49907) | Use a base image: airbyte/java-connector-base:1.0.0 |
-| 0.2.5 | 2024-06-12 | [32538](https://github.com/airbytehq/airbyte/pull/32538) | Fix empty airbyte data column |
-| 0.2.4 | 2024-02-13 | [35229](https://github.com/airbytehq/airbyte/pull/35229) | Adopt CDK 0.20.4 |
-| 0.2.4 | 2024-01-24 | [34453](https://github.com/airbytehq/airbyte/pull/34453) | bump CDK version |
-| 0.2.3 | 2022-12-06 | [19587](https://github.com/airbytehq/airbyte/pull/19587) | Fix missing data before consumer is closed |
-| 0.2.2 | 2022-11-04 | [18648](https://github.com/airbytehq/airbyte/pull/18648) | Add missing record_count increment for JSON |
+| :------ | :--------- | :------------------------------------------------------------------------------------------------- |:---------------------------------------------------------------------|
+| 0.2.8 | 2025-02-07 | | For AVRO MessageFormat, schema_registry_password is a secret         |
+| 0.2.7 | 2025-01-10 | [51480](https://github.com/airbytehq/airbyte/pull/51480) | Use a non root base image                                            |
+| 0.2.6 | 2024-12-18 | [49907](https://github.com/airbytehq/airbyte/pull/49907) | Use a base image: airbyte/java-connector-base:1.0.0                  |
+| 0.2.5 | 2024-06-12 | [32538](https://github.com/airbytehq/airbyte/pull/32538) | Fix empty airbyte data column                                        |
+| 0.2.4 | 2024-02-13 | [35229](https://github.com/airbytehq/airbyte/pull/35229) | Adopt CDK 0.20.4                                                     |
+| 0.2.4 | 2024-01-24 | [34453](https://github.com/airbytehq/airbyte/pull/34453) | bump CDK version                                                     |
+| 0.2.3 | 2022-12-06 | [19587](https://github.com/airbytehq/airbyte/pull/19587) | Fix missing data before consumer is closed                           |
+| 0.2.2 | 2022-11-04 | [18648](https://github.com/airbytehq/airbyte/pull/18648) | Add missing record_count increment for JSON                          |
 | 0.2.1   | 2022-11-04 | This version was the same as 0.2.0 and was committed so using 0.2.2 next to keep versions in order |
 | 0.2.0   | 2022-08-22 | [13864](https://github.com/airbytehq/airbyte/pull/13864)                                           | Added AVRO format support and Support for maximum records to process |
 | 0.1.7   | 2022-06-17 | [13864](https://github.com/airbytehq/airbyte/pull/13864)                                           | Updated stacktrace format for any trace message errors               |

--- a/docs/integrations/sources/kafka.md
+++ b/docs/integrations/sources/kafka.md
@@ -52,15 +52,15 @@ AVRO - deserialize Using confluent API. Please refer (https://docs.confluent.io/
   <summary>Expand to review</summary>
 
 | Version | Date       | Pull Request                                                                                       | Subject                                                              |
-| :------ | :--------- | :------------------------------------------------------------------------------------------------- |:---------------------------------------------------------------------|
-| 0.2.8 | 2025-02-07 | | For AVRO MessageFormat, schema_registry_password is a secret         |
-| 0.2.7 | 2025-01-10 | [51480](https://github.com/airbytehq/airbyte/pull/51480) | Use a non root base image                                            |
-| 0.2.6 | 2024-12-18 | [49907](https://github.com/airbytehq/airbyte/pull/49907) | Use a base image: airbyte/java-connector-base:1.0.0                  |
-| 0.2.5 | 2024-06-12 | [32538](https://github.com/airbytehq/airbyte/pull/32538) | Fix empty airbyte data column                                        |
-| 0.2.4 | 2024-02-13 | [35229](https://github.com/airbytehq/airbyte/pull/35229) | Adopt CDK 0.20.4                                                     |
-| 0.2.4 | 2024-01-24 | [34453](https://github.com/airbytehq/airbyte/pull/34453) | bump CDK version                                                     |
-| 0.2.3 | 2022-12-06 | [19587](https://github.com/airbytehq/airbyte/pull/19587) | Fix missing data before consumer is closed                           |
-| 0.2.2 | 2022-11-04 | [18648](https://github.com/airbytehq/airbyte/pull/18648) | Add missing record_count increment for JSON                          |
+| :------ | :--------- |:---------------------------------------------------------------------------------------------------|:---------------------------------------------------------------------|
+| 0.2.8 | 2025-02-07 | [53221](https://github.com/airbytehq/airbyte/pull/53221)                                           | For AVRO MessageFormat, schema_registry_password is a secret         |
+| 0.2.7 | 2025-01-10 | [51480](https://github.com/airbytehq/airbyte/pull/51480)                                           | Use a non root base image                                            |
+| 0.2.6 | 2024-12-18 | [49907](https://github.com/airbytehq/airbyte/pull/49907)                                           | Use a base image: airbyte/java-connector-base:1.0.0                  |
+| 0.2.5 | 2024-06-12 | [32538](https://github.com/airbytehq/airbyte/pull/32538)                                           | Fix empty airbyte data column                                        |
+| 0.2.4 | 2024-02-13 | [35229](https://github.com/airbytehq/airbyte/pull/35229)                                           | Adopt CDK 0.20.4                                                     |
+| 0.2.4 | 2024-01-24 | [34453](https://github.com/airbytehq/airbyte/pull/34453)                                           | bump CDK version                                                     |
+| 0.2.3 | 2022-12-06 | [19587](https://github.com/airbytehq/airbyte/pull/19587)                                           | Fix missing data before consumer is closed                           |
+| 0.2.2 | 2022-11-04 | [18648](https://github.com/airbytehq/airbyte/pull/18648)                                           | Add missing record_count increment for JSON                          |
 | 0.2.1   | 2022-11-04 | This version was the same as 0.2.0 and was committed so using 0.2.2 next to keep versions in order |
 | 0.2.0   | 2022-08-22 | [13864](https://github.com/airbytehq/airbyte/pull/13864)                                           | Added AVRO format support and Support for maximum records to process |
 | 0.1.7   | 2022-06-17 | [13864](https://github.com/airbytehq/airbyte/pull/13864)                                           | Updated stacktrace format for any trace message errors               |


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->

Fixes https://github.com/airbytehq/airbyte/issues/53219

## How
<!--
* Describe how code changes achieve the solution.
-->

set relevant property in spec.json

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

review spec.json

possibly needs updates to test values?


## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

With external secret manager integration, existing connections might break as secret won't be defined. Password could still be written to database in plaintext. Users should rotate password and update connection 

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
