### PR TITLE
[source-facebook-marketing] Log Utilization type

### DIFF
--- a/airbyte-integrations/connectors/source-facebook-marketing/metadata.yaml
+++ b/airbyte-integrations/connectors/source-facebook-marketing/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: e7778cfc-e97c-4458-9ecb-b4f2bba8946c
-  dockerImageTag: 3.3.30
+  dockerImageTag: 3.3.31
   dockerRepository: airbyte/source-facebook-marketing
   documentationUrl: https://docs.airbyte.com/integrations/sources/facebook-marketing
   githubIssueLabel: source-facebook-marketing

--- a/airbyte-integrations/connectors/source-facebook-marketing/pyproject.toml
+++ b/airbyte-integrations/connectors/source-facebook-marketing/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "3.3.30"
+version = "3.3.31"
 name = "source-facebook-marketing"
 description = "Source implementation for Facebook Marketing."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/api.py
+++ b/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/api.py
@@ -128,7 +128,7 @@ class MyFacebookAdsApi(FacebookAdsApi):
 
         if usage >= self.MIN_RATE:
             sleep_time = self._compute_pause_interval(usage=usage, pause_interval=pause_interval)
-            logger.warning(f"Utilization is too high ({usage})%, pausing for {sleep_time}")
+            logger.warning(f"API Utilization is too high ({usage})%, pausing for {sleep_time}")
             sleep(sleep_time.total_seconds())
 
     def _update_insights_throttle_limit(self, response: FacebookResponse):

--- a/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/api.py
+++ b/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/api.py
@@ -128,7 +128,7 @@ class MyFacebookAdsApi(FacebookAdsApi):
 
         if usage >= self.MIN_RATE:
             sleep_time = self._compute_pause_interval(usage=usage, pause_interval=pause_interval)
-            logger.warning(f"API Utilization is too high ({usage})%, pausing for {sleep_time}")
+            logger.warning(f"Facebook API Utilization is too high ({usage})%, pausing for {sleep_time}")
             sleep(sleep_time.total_seconds())
 
     def _update_insights_throttle_limit(self, response: FacebookResponse):

--- a/airbyte-integrations/connectors/source-facebook-marketing/unit_tests/test_api.py
+++ b/airbyte-integrations/connectors/source-facebook-marketing/unit_tests/test_api.py
@@ -169,7 +169,7 @@ class TestMyFacebookAdsApi:
             fb_api._compute_pause_interval.assert_called_with(usage=usage, pause_interval=pause_interval)
             source_facebook_marketing.api.sleep.assert_called_with(fb_api._compute_pause_interval.return_value.total_seconds())
             source_facebook_marketing.api.logger.warning.assert_called_with(
-                f"Utilization is too high ({usage})%, pausing for {fb_api._compute_pause_interval.return_value}"
+                f"Facebook API Utilization is too high ({usage})%, pausing for {fb_api._compute_pause_interval.return_value}"
             )
 
     def test_find_account(self, api, account_id, requests_mock):

--- a/docs/integrations/sources/facebook-marketing.md
+++ b/docs/integrations/sources/facebook-marketing.md
@@ -269,6 +269,7 @@ This response indicates that the Facebook Graph API requires you to reduce the f
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                                                                                                                                                                                           |
 |:--------|:-----------|:---------------------------------------------------------|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 3.3.31 | 2025-02-11 | [53626](https://github.com/airbytehq/airbyte/pull/53626) | Log Utilization type |
 | 3.3.30 | 2025-02-08 | [53330](https://github.com/airbytehq/airbyte/pull/53330) | Update dependencies |
 | 3.3.29 | 2025-02-01 | [52835](https://github.com/airbytehq/airbyte/pull/52835) | Update dependencies |
 | 3.3.28 | 2025-01-27 | [52032](https://github.com/airbytehq/airbyte/pull/52032) | Update to API version 21


### PR DESCRIPTION
## What

Logging precisely utilization type.

There were some questions about this warning:
https://airbytehq.slack.com/archives/C021JANJ6TY/p1739242111784099
https://airbytehq.slack.com/archives/C021JANJ6TY/p1734513075065149

## How

Just added `Facebook API` in front of `Utilization` 😉 

## Review guide

1. `airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/api.py`

## User Impact

Tiny, but it helps people to know what this warning is all about.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌
