### PR TITLE
[Destination MSSQL] v2 rc6

### DIFF
--- a/airbyte-integrations/connectors/destination-mssql-v2/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-mssql-v2/metadata.yaml
@@ -16,7 +16,7 @@ data:
             type: GSM
   connectorType: destination
   definitionId: 37a928c1-2d5c-431a-a97d-ae236bd1ea0c
-  dockerImageTag: 0.1.7
+  dockerImageTag: 0.1.8
   dockerRepository: airbyte/destination-mssql-v2
   documentationUrl: https://docs.airbyte.com/integrations/destinations/mssql-v2
   githubIssueLabel: destination-mssql-v2

--- a/airbyte-integrations/connectors/destination-mssql-v2/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLQueryBuilder.kt
+++ b/airbyte-integrations/connectors/destination-mssql-v2/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLQueryBuilder.kt
@@ -122,7 +122,7 @@ const val DROP_TABLE_QUERY = """
 const val INSERT_INTO_QUERY =
     """
         SET NOCOUNT ON;
-        INSERT INTO [?$SCHEMA_KEY].[?$TABLE_KEY] WITH (ROWLOCK) (?$COLUMNS_KEY)
+        INSERT INTO [?$SCHEMA_KEY].[?$TABLE_KEY] WITH (TABLOCK) (?$COLUMNS_KEY)
             SELECT table_value.*
             FROM (VALUES (?$TEMPLATE_COLUMNS_KEY)) table_value(?$COLUMNS_KEY)
     """
@@ -130,7 +130,7 @@ const val INSERT_INTO_QUERY =
 const val MERGE_INTO_QUERY =
     """
         SET NOCOUNT ON;
-        MERGE INTO [?$SCHEMA_KEY].[?$TABLE_KEY] WITH (ROWLOCK) AS Target
+        MERGE INTO [?$SCHEMA_KEY].[?$TABLE_KEY] WITH (TABLOCK) AS Target
         USING (VALUES (?$TEMPLATE_COLUMNS_KEY)) AS Source (?$COLUMNS_KEY)
         ON ?$UNIQUENESS_CONSTRAINT_KEY
         WHEN MATCHED THEN
@@ -157,16 +157,22 @@ const val ALTER_TABLE_MODIFY =
 
 const val DELETE_WHERE_COL_IS_NOT_NULL =
     """
-        SET NOCOUNT ON;
-        DELETE FROM [?].[?] WITH (ROWLOCK)
+        deleteLoop:
+        DELETE TOP(5000) FROM [?].[?] WITH (TABLOCK)
         WHERE [?] is not NULL
+
+        IF @@ROWCOUNT > 0
+            GOTO deleteLoop
     """
 
 const val DELETE_WHERE_COL_LESS_THAN =
     """
-        SET NOCOUNT ON;
-        DELETE FROM [?].[?] WITH (ROWLOCK)
+        deleteLoop:
+        DELETE TOP(5000) FROM [?].[?] WITH (TABLOCK)
         WHERE [?] < ?
+
+        IF @@ROWCOUNT > 0
+            GOTO deleteLoop
     """
 
 const val SELECT_FROM = """

--- a/docs/integrations/destinations/mssql-v2.md
+++ b/docs/integrations/destinations/mssql-v2.md
@@ -13,6 +13,7 @@ This connector is in early access, and SHOULD NOT be used for production workloa
 
 | Version | Date       | Pull Request                                                | Subject                                              |
 |:--------|:-----------|:------------------------------------------------------------|:-----------------------------------------------------|
+| 0.1.8   | 2025-02-11 | [53236](https://github.com/airbytehq/airbyte/pull/53236)    | RC6: Break up deletes into loop to reduce locking.   |
 | 0.1.7   | 2025-02-07 | [53236](https://github.com/airbytehq/airbyte/pull/53236)    | RC5: Use rowlock hint.                               |
 | 0.1.6   | 2025-02-06 | [53192](https://github.com/airbytehq/airbyte/pull/53192)    | RC4: Fix config, timehandling and performance tweak. |
 | 0.1.5   | 2025-02-04 | [53174](https://github.com/airbytehq/airbyte/pull/53174)    | RC3: Fix metadata.yaml for publish                   |

--- a/docs/integrations/destinations/mssql-v2.md
+++ b/docs/integrations/destinations/mssql-v2.md
@@ -11,16 +11,16 @@ This connector is in early access, and SHOULD NOT be used for production workloa
 <details>
   <summary>Expand to review</summary>
 
-| Version | Date       | Pull Request                                                | Subject                                              |
-|:--------|:-----------|:------------------------------------------------------------|:-----------------------------------------------------|
-| 0.1.8   | 2025-02-11 | [53236](https://github.com/airbytehq/airbyte/pull/53236)    | RC6: Break up deletes into loop to reduce locking.   |
-| 0.1.7   | 2025-02-07 | [53236](https://github.com/airbytehq/airbyte/pull/53236)    | RC5: Use rowlock hint.                               |
-| 0.1.6   | 2025-02-06 | [53192](https://github.com/airbytehq/airbyte/pull/53192)    | RC4: Fix config, timehandling and performance tweak. |
-| 0.1.5   | 2025-02-04 | [53174](https://github.com/airbytehq/airbyte/pull/53174)    | RC3: Fix metadata.yaml for publish                   |
-| 0.1.4   | 2025-02-04 | [52704](https://github.com/airbytehq/airbyte/pull/52704)    | RC2: Performance improvement                         |
-| 0.1.3   | 2025-01-24 | [52096](https://github.com/airbytehq/airbyte/pull/52096)    | Release candidate                                    |
-| 0.1.2   | 2025-01-10 | [51508](https://github.com/airbytehq/airbyte/pull/51508)    | Use a non root base image                            |
-| 0.1.1   | 2024-12-18 | [49870](https://github.com/airbytehq/airbyte/pull/49870)    | Use a base image: airbyte/java-connector-base:1.0.0  |
-| 0.1.0   | 2024-12-16 | [\#49460](https://github.com/airbytehq/airbyte/pull/49460)  | Initial commit                                       |
+| Version | Date       | Pull Request                                               | Subject                                              |
+|:--------|:-----------|:-----------------------------------------------------------|:-----------------------------------------------------|
+| 0.1.8   | 2025-02-11 | [53364](https://github.com/airbytehq/airbyte/pull/53364)   | RC6: Break up deletes into loop to reduce locking.   |
+| 0.1.7   | 2025-02-07 | [53236](https://github.com/airbytehq/airbyte/pull/53236)   | RC5: Use rowlock hint.                               |
+| 0.1.6   | 2025-02-06 | [53192](https://github.com/airbytehq/airbyte/pull/53192)   | RC4: Fix config, timehandling and performance tweak. |
+| 0.1.5   | 2025-02-04 | [53174](https://github.com/airbytehq/airbyte/pull/53174)   | RC3: Fix metadata.yaml for publish                   |
+| 0.1.4   | 2025-02-04 | [52704](https://github.com/airbytehq/airbyte/pull/52704)   | RC2: Performance improvement                         |
+| 0.1.3   | 2025-01-24 | [52096](https://github.com/airbytehq/airbyte/pull/52096)   | Release candidate                                    |
+| 0.1.2   | 2025-01-10 | [51508](https://github.com/airbytehq/airbyte/pull/51508)   | Use a non root base image                            |
+| 0.1.1   | 2024-12-18 | [49870](https://github.com/airbytehq/airbyte/pull/49870)   | Use a base image: airbyte/java-connector-base:1.0.0  |
+| 0.1.0   | 2024-12-16 | [\#49460](https://github.com/airbytehq/airbyte/pull/49460) | Initial commit                                       |
 
 </details>


### PR DESCRIPTION
## What

* Change lock hints back to tablock
* Rework deletes into loops to avoid the giant lock when trimming old generations

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [X] YES 💚
- [ ] NO ❌
