### PR TITLE
fix: escape dots in google drive regexp

### DIFF
--- a/airbyte-integrations/connectors/source-google-drive/source_google_drive/spec.py
+++ b/airbyte-integrations/connectors/source-google-drive/source_google_drive/spec.py
@@ -56,7 +56,7 @@ class SourceGoogleDriveSpec(AbstractFileBasedSpec, BaseModel):
         description="URL for the folder you want to sync. Using individual streams and glob patterns, it's possible to only sync a subset of all files located in the folder.",
         examples=["https://drive.google.com/drive/folders/1Xaz0vXXXX2enKnNYU5qSt9NS70gvMyYn"],
         order=0,
-        pattern="^https://drive.google.com/.+",
+        pattern="^https://drive\.google\.com/.+",
         pattern_descriptor="https://drive.google.com/drive/folders/MY-FOLDER-ID",
     )
 


### PR DESCRIPTION
## What
Escape the `.` character in `drive.google.com`.

This shows up in our security scanner in the TF provider: https://github.com/airbytehq/terraform-provider-airbyte/pull/174#pullrequestreview-2609660859

## User Impact
None

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
