### PR TITLE
Load CDK: Stream Manager Support for Id-Based Checkpointing

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/InputConsumerTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/InputConsumerTask.kt
@@ -83,7 +83,7 @@ class DefaultInputConsumerTask(
             is DestinationRecord -> {
                 val wrapped =
                     StreamRecordEvent(
-                        index = manager.countRecordIn(),
+                        index = manager.incrementReadCount(),
                         sizeBytes = sizeBytes,
                         payload = message.asRecordSerialized()
                     )
@@ -104,7 +104,7 @@ class DefaultInputConsumerTask(
                 recordQueue.close()
             }
             is DestinationFile -> {
-                val index = manager.countRecordIn()
+                val index = manager.incrementReadCount()
                 // destinationTaskLauncher.handleFile(stream, message, index)
                 fileTransferQueue.publish(FileTransferQueueMessage(stream, message, index))
             }

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/state/CheckpointManagerTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/state/CheckpointManagerTest.kt
@@ -428,9 +428,9 @@ class CheckpointManagerTest {
                      * the index of the message.
                      */
                     val streamManager = syncManager.getStreamManager(it.stream.descriptor)
-                    val recordCount = streamManager.recordCount()
+                    val recordCount = streamManager.readCount()
                     (recordCount until it.index).forEach { _ ->
-                        syncManager.getStreamManager(it.stream.descriptor).countRecordIn()
+                        syncManager.getStreamManager(it.stream.descriptor).incrementReadCount()
                     }
                     checkpointManager.addStreamCheckpoint(
                         it.stream.descriptor,

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/state/StreamManagerTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/state/StreamManagerTest.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtensionContext
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
@@ -30,12 +31,18 @@ class StreamManagerTest {
         val manager1 = DefaultStreamManager(stream1)
         val manager2 = DefaultStreamManager(stream2)
 
+        Assertions.assertEquals(0L, manager1.getNextCheckpointId().id)
+        Assertions.assertEquals(0L, manager2.getNextCheckpointId().id)
+
         // Incrementing once yields (n, n)
         repeat(10) { manager1.countRecordIn() }
         val (index, count) = manager1.markCheckpoint()
 
         Assertions.assertEquals(10, index)
         Assertions.assertEquals(10, count)
+
+        Assertions.assertEquals(1L, manager1.getNextCheckpointId().id)
+        Assertions.assertEquals(0L, manager2.getNextCheckpointId().id)
 
         // Incrementing a second time yields (n + m, m)
         repeat(5) { manager1.countRecordIn() }
@@ -44,14 +51,23 @@ class StreamManagerTest {
         Assertions.assertEquals(15, index2)
         Assertions.assertEquals(5, count2)
 
+        Assertions.assertEquals(2L, manager1.getNextCheckpointId().id)
+        Assertions.assertEquals(0L, manager2.getNextCheckpointId().id)
+
         // Never incrementing yields (0, 0)
         val (index3, count3) = manager2.markCheckpoint()
+
+        Assertions.assertEquals(2L, manager1.getNextCheckpointId().id)
+        Assertions.assertEquals(1L, manager2.getNextCheckpointId().id)
 
         Assertions.assertEquals(0, index3)
         Assertions.assertEquals(0, count3)
 
         // Incrementing twice in a row yields (n + m + 0, 0)
         val (index4, count4) = manager1.markCheckpoint()
+
+        Assertions.assertEquals(3L, manager1.getNextCheckpointId().id)
+        Assertions.assertEquals(1L, manager2.getNextCheckpointId().id)
 
         Assertions.assertEquals(15, index4)
         Assertions.assertEquals(0, count4)
@@ -249,6 +265,7 @@ class StreamManagerTest {
         val name: String,
         val events: List<Pair<DestinationStream, TestEvent>>,
     )
+
     @ParameterizedTest
     @ArgumentsSource(TestUpdateBatchStateProvider::class)
     fun testUpdateBatchState(testCase: TestCase) {
@@ -456,5 +473,145 @@ class StreamManagerTest {
             manager.isBatchProcessingComplete(),
             "max of older and newer state is used"
         )
+    }
+
+    @Test
+    fun `test persisted counts`() {
+        val manager = DefaultStreamManager(stream1)
+        val checkpointId = manager.getNextCheckpointId()
+
+        repeat(10) { manager.countRecordIn() }
+        manager.markCheckpoint()
+
+        Assertions.assertFalse(manager.areRecordsPersistedUntilCheckpoint(checkpointId))
+        manager.countPersisted(checkpointId, 5)
+        Assertions.assertFalse(manager.areRecordsPersistedUntilCheckpoint(checkpointId))
+        manager.countPersisted(checkpointId, 5)
+        Assertions.assertTrue(manager.areRecordsPersistedUntilCheckpoint(checkpointId))
+
+        // Should throw if we try to persist more than the total count
+        assertThrows<IllegalStateException> { manager.countPersisted(checkpointId, 1) }
+    }
+
+    @Test
+    fun `test persisting un unmarked checkpoint throws`() {
+        val manager = DefaultStreamManager(stream1)
+        val checkpointId = manager.getNextCheckpointId()
+
+        assertThrows<IllegalStateException> { manager.countPersisted(checkpointId, 1) }
+    }
+
+    @Test
+    fun `test persisted count for multiple checkpoints`() {
+        val manager = DefaultStreamManager(stream1)
+
+        val checkpointId1 = manager.getNextCheckpointId()
+        repeat(10) { manager.countRecordIn() }
+        manager.markCheckpoint()
+
+        val checkpointId2 = manager.getNextCheckpointId()
+        repeat(15) { manager.countRecordIn() }
+        manager.markCheckpoint()
+
+        Assertions.assertFalse(manager.areRecordsPersistedUntilCheckpoint(checkpointId1))
+        Assertions.assertFalse(manager.areRecordsPersistedUntilCheckpoint(checkpointId2))
+
+        manager.countPersisted(checkpointId1, 10)
+        Assertions.assertTrue(manager.areRecordsPersistedUntilCheckpoint(checkpointId1))
+        Assertions.assertFalse(manager.areRecordsPersistedUntilCheckpoint(checkpointId2))
+
+        manager.countPersisted(checkpointId2, 15)
+        Assertions.assertTrue(manager.areRecordsPersistedUntilCheckpoint(checkpointId1))
+        Assertions.assertTrue(manager.areRecordsPersistedUntilCheckpoint(checkpointId2))
+    }
+
+    @Test
+    fun `test persisted count for multiple checkpoints out of order`() {
+        val manager = DefaultStreamManager(stream1)
+
+        val checkpointId1 = manager.getNextCheckpointId()
+        repeat(10) { manager.countRecordIn() }
+        manager.markCheckpoint()
+
+        val checkpointId2 = manager.getNextCheckpointId()
+        repeat(15) { manager.countRecordIn() }
+        manager.markCheckpoint()
+
+        Assertions.assertFalse(manager.areRecordsPersistedUntilCheckpoint(checkpointId1))
+        Assertions.assertFalse(manager.areRecordsPersistedUntilCheckpoint(checkpointId2))
+
+        manager.countPersisted(checkpointId2, 15)
+        Assertions.assertFalse(manager.areRecordsPersistedUntilCheckpoint(checkpointId1))
+        Assertions.assertFalse(manager.areRecordsPersistedUntilCheckpoint(checkpointId2))
+
+        manager.countPersisted(checkpointId1, 10)
+        Assertions.assertTrue(manager.areRecordsPersistedUntilCheckpoint(checkpointId1))
+        Assertions.assertTrue(manager.areRecordsPersistedUntilCheckpoint(checkpointId2))
+    }
+
+    @Test
+    fun `test completion implies persistence`() {
+        val manager = DefaultStreamManager(stream1)
+
+        val checkpointId1 = manager.getNextCheckpointId()
+        repeat(10) { manager.countRecordIn() }
+        manager.markCheckpoint()
+
+        Assertions.assertFalse(manager.areRecordsPersistedUntilCheckpoint(checkpointId1))
+        manager.countCompleted(checkpointId1, 4)
+        Assertions.assertFalse(manager.areRecordsPersistedUntilCheckpoint(checkpointId1))
+        manager.countCompleted(checkpointId1, 6)
+        Assertions.assertTrue(manager.areRecordsPersistedUntilCheckpoint(checkpointId1))
+
+        // Can still count persisted (but without effect)
+        manager.countPersisted(checkpointId1, 10)
+        Assertions.assertTrue(manager.areRecordsPersistedUntilCheckpoint(checkpointId1))
+
+        // Completed should also throw if we try to complete more than the total count
+        assertThrows<IllegalStateException> { manager.countCompleted(checkpointId1, 1) }
+    }
+
+    @Test
+    fun `test completion check`() {
+        // All three steps are required, but they can happen in any order.
+        val cases =
+            listOf(
+                listOf("1", "2", "end"),
+                listOf("1", "end", "2"),
+                listOf("end", "1", "2"),
+                listOf("end", "2", "1"),
+                listOf("2", "1", "end"),
+                listOf("2", "end", "1"),
+            )
+
+        cases.forEach { steps ->
+            val manager = DefaultStreamManager(stream1)
+            val checkpointId1 = manager.getNextCheckpointId()
+            repeat(10) { manager.countRecordIn() }
+            manager.markCheckpoint()
+
+            val checkpointId2 = manager.getNextCheckpointId()
+            repeat(20) { manager.countRecordIn() }
+            manager.markCheckpoint()
+
+            steps.forEachIndexed { index, step ->
+                when (step) {
+                    "1" -> manager.countCompleted(checkpointId1, 10)
+                    "2" -> manager.countCompleted(checkpointId2, 20)
+                    "end" -> manager.markEndOfStream(true)
+                }
+                if (index < 2) {
+                    Assertions.assertFalse(
+                        manager.isBatchProcessingCompleteForCheckpoints(),
+                        "steps: $steps; step: $index"
+                    )
+                } else {
+                    Assertions.assertTrue(
+                        manager.isBatchProcessingCompleteForCheckpoints(),
+                        "steps: $steps; final step"
+                    )
+                }
+            }
+        }
     }
 }

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/DestinationTaskLauncherTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/DestinationTaskLauncherTest.kt
@@ -364,7 +364,7 @@ class DestinationTaskLauncherTest {
         val range = TreeRangeSet.create(listOf(Range.closed(0L, 100L)))
         val stream1 = MockDestinationCatalogFactory.stream1
         val streamManager = syncManager.getStreamManager(stream1.descriptor)
-        repeat(100) { streamManager.countRecordIn() }
+        repeat(100) { streamManager.incrementReadCount() }
 
         streamManager.markEndOfStream(true)
 

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/internal/InputConsumerTaskTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/internal/InputConsumerTaskTest.kt
@@ -119,8 +119,8 @@ class InputConsumerTaskTest {
                 }
             )
         }
-        assert(syncManager.getStreamManager(stream1.descriptor).recordCount() == 1L)
-        assert(syncManager.getStreamManager(stream2.descriptor).recordCount() == 2L)
+        assert(syncManager.getStreamManager(stream1.descriptor).readCount() == 1L)
+        assert(syncManager.getStreamManager(stream2.descriptor).readCount() == 2L)
     }
 
     @Test
@@ -164,9 +164,9 @@ class InputConsumerTaskTest {
             memoryManager.release(3L)
         }
 
-        assert(syncManager.getStreamManager(stream1.descriptor).recordCount() == 1L)
+        assert(syncManager.getStreamManager(stream1.descriptor).readCount() == 1L)
         assert(syncManager.getStreamManager(stream1.descriptor).endOfStreamRead())
-        assert(syncManager.getStreamManager(stream2.descriptor).recordCount() == 0L)
+        assert(syncManager.getStreamManager(stream2.descriptor).readCount() == 0L)
         assert(syncManager.getStreamManager(stream2.descriptor).endOfStreamRead())
     }
 


### PR DESCRIPTION
## What
**This is a nonfunctional change**, as nothing is wired into the CDK pipeline yet.

This adds support for index-based checkpointing.

Currently we use range-based, which works like:
* each record has an associated index
* the indexes are aggregated into ranges for batches, then into rangesets in the stream manager
* when all contiguous rangesets up to record X have been persisted, state for up to that index can be evicted
* when all have been completed (and all the records have been read) then the stream can be closed

This causes some issues:
* managing rangesets is inefficient
* managing rangesets is error-prone

Changes for the new interface make bookkeeping a little more generic, which increases the costs of the above enough that they actually start having performance implications. (25% perf hit hacking around it in my POC PR).

This adds partial support for checkpointing by checkpoint id:
* each time we checkpoint a stream, we increment a monotonic id
* all records up to the checkpoint are associated with that id
* when we persist, we just count the persisted records against that id
* when we complete, we count completed records against that id

Sufficiency checks then are just
* persisted for id N: sum of all persisted counts up to id N == sum of all read counts up to id N
* completed: sum of all completed counts == total records read, and we've seen EOS

This is way easier than trying to manage rangesets, though we lose idempotence.
