### PR TITLE
[source-postgres] Fix issue #6857

### DIFF
--- a/airbyte-integrations/connectors/source-postgres/metadata.yaml
+++ b/airbyte-integrations/connectors/source-postgres/metadata.yaml
@@ -9,7 +9,7 @@ data:
   connectorSubtype: database
   connectorType: source
   definitionId: decd338e-5647-4c0b-adf4-da0e75f5a750
-  dockerImageTag: 3.6.28
+  dockerImageTag: 3.6.29
   dockerRepository: airbyte/source-postgres
   documentationUrl: https://docs.airbyte.com/integrations/sources/postgres
   githubIssueLabel: source-postgres

--- a/docs/integrations/sources/postgres.md
+++ b/docs/integrations/sources/postgres.md
@@ -343,7 +343,8 @@ According to Postgres [documentation](https://www.postgresql.org/docs/14/datatyp
   <summary>Expand to review</summary>
 
 | Version | Date       | Pull Request                                               | Subject                                                                                                                                                                    |
-| ------- | ---------- | ---------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|---------| ---------- | ---------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 3.6.29  | 2025-02-13 | [53649](https://github.com/airbytehq/airbyte/pull/53649) | Fix issue that column default value did not get converted |
 | 3.6.28  | 2024-12-23 | [50870](https://github.com/airbytehq/airbyte/pull/50870)   | Use airbyte/java-connector-base:2.0.0                                                                                                                                      |
 | 3.6.27  | 2024-12-23 | [50410](https://github.com/airbytehq/airbyte/pull/50410)   | Use a non root base image.                                                                                                                                                 |
 | 3.6.26  | 2024-12-20 | [48495](https://github.com/airbytehq/airbyte/pull/48495)   | Increase MAX_FIRST_RECORD_WAIT_TIME and use Debezium 3.0.1                                                                                                                 |


### PR DESCRIPTION
## What
Fixes https://github.com/airbytehq/oncall/issues/6857

We have issue in [#6857](https://github.com/airbytehq/oncall/issues/6857) about the data conversion error

Currently in our data type converter for debezium, we check if the value is null, if it is and column is non-nullable, we return the default value directly without conversion. Otherwise, return null as is.

Two issues here:

we should convert the default value as well then return it
it appears that we found null value in non-nullable column

## How
This PR check if the column is nullable, if so, return null as is
if not, we feed the default value to conversion logic and return the result.

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
