### PR TITLE
fix(source-bigcommerce): replace pendulum with standard library parsing (do not merge)

### DIFF
--- a/airbyte-integrations/connectors/source-bigcommerce/components.py
+++ b/airbyte-integrations/connectors/source-bigcommerce/components.py
@@ -3,13 +3,14 @@
 #
 
 from dataclasses import dataclass
+from datetime import datetime
 from typing import Optional
 
 import dpath.util
-import pendulum
 
 from airbyte_cdk.sources.declarative.transformations.add_fields import AddFields
 from airbyte_cdk.sources.declarative.types import Config, Record, StreamSlice, StreamState
+from airbyte_cdk.utils.airbyte_datetime_helpers import AirbyteDateTime
 
 
 @dataclass
@@ -24,6 +25,9 @@ class DateTimeTransformer(AddFields):
         kwargs = {"record": record, "stream_state": stream_state, "stream_slice": stream_slice}
         for parsed_field in self._parsed_fields:
             date_time = parsed_field.value.eval(config, **kwargs)
-            new_date_time = str(pendulum.from_format(date_time, "ddd, D MMM YYYY HH:mm:ss ZZ"))
+            new_date_time = AirbyteDateTime.from_datetime(
+                # Expect non-standard date format, e.g. 'Fri, 01 Jan 2021 00:00:00 +0000'
+                datetime.strptime(date_time, "%a, %d %b %Y %H:%M:%S %z"),
+            )
             dpath.util.new(record, parsed_field.path, new_date_time)
         return record


### PR DESCRIPTION
Switches from using the Pendulum library for date parsing to the standard library's `datetime` module. Because `pendulum` is no longer shipped with the CDK and this connector doesn't have its own pyproject.toml (only manifest.yaml + components.py).