### PR TITLE
disable werr locally

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,16 +55,16 @@ allprojects {
         sourceCompatibility = JavaVersion.VERSION_21
         targetCompatibility = JavaVersion.VERSION_21
         compileJava {
-            options.compilerArgs += ["-Werror", "-Xlint:all,-serial,-processing"]
+            options.compilerArgs += ["-Xlint:all,-serial,-processing"] + getJavaCompilerArgs()
         }
         compileTestJava {
             //rawtypes and unchecked are necessary for mockito
             //deprecation and removal are removed from error since we should still test those constructs.
-            options.compilerArgs += ["-Werror", "-Xlint:all,-serial,-processing,-rawtypes,-unchecked,-deprecation,-removal"]
+            options.compilerArgs += ["-Xlint:all,-serial,-processing,-rawtypes,-unchecked,-deprecation,-removal"] + getJavaCompilerArgs()
         }
         compileTestFixturesJava {
             //rawtypes and unchecked are necessary for mockito
-            options.compilerArgs += ["-Werror", "-Xlint:all,-serial,-processing,-rawtypes,-unchecked"]
+            options.compilerArgs += ["-Xlint:all,-serial,-processing,-rawtypes,-unchecked"] + getJavaCompilerArgs()
         }
     }
 
@@ -76,7 +76,7 @@ allprojects {
         compilerOptions {
             jvmTarget = JvmTarget.JVM_21
             languageVersion = KotlinVersion.KOTLIN_1_9
-            allWarningsAsErrors = true
+            allWarningsAsErrors = isInCi()
             freeCompilerArgs = ["-Xjvm-default=all"]
         }
         dependsOn {
@@ -87,7 +87,7 @@ allprojects {
         compilerOptions {
             jvmTarget = JvmTarget.JVM_21
             languageVersion = KotlinVersion.KOTLIN_1_9
-            allWarningsAsErrors = true
+            allWarningsAsErrors = isInCi()
             freeCompilerArgs = ["-Xjvm-default=all"]
         }
         dependsOn {
@@ -98,7 +98,7 @@ allprojects {
         compilerOptions {
             jvmTarget = JvmTarget.JVM_21
             languageVersion = KotlinVersion.KOTLIN_1_9
-            allWarningsAsErrors = true
+            allWarningsAsErrors = isInCi()
             freeCompilerArgs = ["-Xjvm-default=all"]
         }
         dependsOn {
@@ -234,5 +234,17 @@ allprojects {
 
     javadoc {
         options.addStringOption('Xdoclint:none', '-quiet')
+    }
+}
+
+static def isInCi() {
+    return System.getenv("CI") == "true"
+}
+
+static def getJavaCompilerArgs() {
+    if (isInCi()) {
+        return ["-Werror"]
+    } else {
+        return []
     }
 }


### PR DESCRIPTION
it's incredibly annoying to comment out some code locally to test something, and have the compiler complain that there are now unused variables everywhere. Keep this behavior in CI, but disable it locally.

(we set this env var on the gradle check PR check https://github.com/airbytehq/airbyte/blob/0b62b7cf23a0c52f1c7047be129262fca4509da4/.github/workflows/gradle.yml#L73)