### PR TITLE
fix(source-airtable): added new types to types mapping

### DIFF
--- a/airbyte-integrations/connectors/source-airtable/metadata.yaml
+++ b/airbyte-integrations/connectors/source-airtable/metadata.yaml
@@ -11,7 +11,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 14c6e7ea-97ed-4f5e-a7b5-25e9a80b8212
-  dockerImageTag: 4.5.0
+  dockerImageTag: 4.5.1
   dockerRepository: airbyte/source-airtable
   documentationUrl: https://docs.airbyte.com/integrations/sources/airtable
   githubIssueLabel: source-airtable

--- a/airbyte-integrations/connectors/source-airtable/pyproject.toml
+++ b/airbyte-integrations/connectors/source-airtable/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "4.5.0"
+version = "4.5.1"
 name = "source-airtable"
 description = "Source implementation for Airtable."
 authors = [ "Airbyte <anhtuan.nguyen@me.com>",]

--- a/airbyte-integrations/connectors/source-airtable/source_airtable/manifest.yaml
+++ b/airbyte-integrations/connectors/source-airtable/source_airtable/manifest.yaml
@@ -141,6 +141,7 @@ definitions:
               - path: ["_airtable_table_name"]
                 value: "{{ {'type': ['null', 'string']} }}"
         schema_type_identifier:
+          # https://airtable.com/developers/web/api/field-model
           type: SchemaTypeIdentifier
           key_pointer:
             - name
@@ -152,6 +153,9 @@ definitions:
             - type: TypesMap
               target_type: string
               current_type: multipleAttachments
+            - type: TypesMap
+              target_type: string
+              current_type: aiText
             - type: TypesMap
               target_type: string
               current_type: manualSort
@@ -210,6 +214,10 @@ definitions:
               target_type: date
               current_type: lastModifiedTime
               condition: "{{ raw_schema['options']['result']['type'] == 'date' }}"
+            - type: TypesMap
+              target_type: string
+              current_type: lastModifiedTime
+              condition: "{{ raw_schema['options']['result'] == None }}"
             - type: TypesMap
               target_type:
                 field_type: array

--- a/docs/integrations/sources/airtable.md
+++ b/docs/integrations/sources/airtable.md
@@ -137,7 +137,7 @@ See information about rate limits [here](https://airtable.com/developers/web/api
 
 | Version    | Date       | Pull Request                                             | Subject                                                                                 |
 |:-----------|:-----------|:---------------------------------------------------------|:----------------------------------------------------------------------------------------|
-| 4.5.1      | 2025-02-13 |                                                          | Add type for aiText and lastModifiedTime, when result type is null                      |
+| 4.5.1      | 2025-02-13 | [53672](https://github.com/airbytehq/airbyte/pull/53672) | Add type for aiText and lastModifiedTime, when result type is null                      |
 | 4.5.0      | 2025-02-12 | [53657](https://github.com/airbytehq/airbyte/pull/53657) | Promoting release candidate 4.5.0-rc.4 to a main version.                               |
 | 4.5.0-rc.4 | 2025-02-04 | [53156](https://github.com/airbytehq/airbyte/pull/53156) | Add default type for `rollup`, `lookuo` and `multiplelookup`, add new type `manualSort` |
 | 4.5.0-rc.3 | 2025-01-29 | [52624](https://github.com/airbytehq/airbyte/pull/52624) | Fix type for multipleLookupValues fields                                                |

--- a/docs/integrations/sources/airtable.md
+++ b/docs/integrations/sources/airtable.md
@@ -137,7 +137,8 @@ See information about rate limits [here](https://airtable.com/developers/web/api
 
 | Version    | Date       | Pull Request                                             | Subject                                                                                 |
 |:-----------|:-----------|:---------------------------------------------------------|:----------------------------------------------------------------------------------------|
-| 4.5.0 | 2025-02-12 | [53657](https://github.com/airbytehq/airbyte/pull/53657) | Promoting release candidate 4.5.0-rc.4 to a main version. |
+| 4.5.1      | 2025-02-13 |                                                          | Add type for aiText and lastModifiedTime, when result type is null                      |
+| 4.5.0      | 2025-02-12 | [53657](https://github.com/airbytehq/airbyte/pull/53657) | Promoting release candidate 4.5.0-rc.4 to a main version.                               |
 | 4.5.0-rc.4 | 2025-02-04 | [53156](https://github.com/airbytehq/airbyte/pull/53156) | Add default type for `rollup`, `lookuo` and `multiplelookup`, add new type `manualSort` |
 | 4.5.0-rc.3 | 2025-01-29 | [52624](https://github.com/airbytehq/airbyte/pull/52624) | Fix type for multipleLookupValues fields                                                |
 | 4.5.0-rc.2 | 2025-01-28 | [52595](https://github.com/airbytehq/airbyte/pull/52595) | Fix type for datetime fields                                                            |


### PR DESCRIPTION
## What
oc issue https://github.com/airbytehq/oncall/issues/7436
`aiText` and `lastModifiedTime`: invalid aribyte data types.

## How
added types to types_mapping

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
