### PR TITLE
Java connectors: echo junit test stdout to console

### DIFF
--- a/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/S3DataLakeDestination.kt
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/S3DataLakeDestination.kt
@@ -6,16 +6,12 @@ package io.airbyte.integrations.destination.s3_data_lake
 
 import io.airbyte.cdk.AirbyteDestinationRunner
 import io.airbyte.cdk.load.command.aws.AwsToolkitConstants
-import io.github.oshai.kotlinlogging.KotlinLogging
-
-private val logger = KotlinLogging.logger {}
 
 object S3DataLakeDestination {
     val additionalMicronautEnvs = listOf(AwsToolkitConstants.MICRONAUT_ENVIRONMENT)
 
     @JvmStatic
     fun main(args: Array<String>) {
-        logger.info { "EDGAO DEBUG" }
         AirbyteDestinationRunner.run(*args, additionalMicronautEnvs = additionalMicronautEnvs)
     }
 }

--- a/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/S3DataLakeDestination.kt
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/S3DataLakeDestination.kt
@@ -6,12 +6,16 @@ package io.airbyte.integrations.destination.s3_data_lake
 
 import io.airbyte.cdk.AirbyteDestinationRunner
 import io.airbyte.cdk.load.command.aws.AwsToolkitConstants
+import io.github.oshai.kotlinlogging.KotlinLogging
+
+private val logger = KotlinLogging.logger {}
 
 object S3DataLakeDestination {
     val additionalMicronautEnvs = listOf(AwsToolkitConstants.MICRONAUT_ENVIRONMENT)
 
     @JvmStatic
     fun main(args: Array<String>) {
+        logger.info { "EDGAO DEBUG" }
         AirbyteDestinationRunner.run(*args, additionalMicronautEnvs = additionalMicronautEnvs)
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -133,8 +133,7 @@ allprojects {
         testLogging() {
             events 'skipped', 'started', 'passed', 'failed'
             exceptionFormat 'full'
-            // Swallow the logs when running in airbyte-ci, rely on test reports instead.
-            showStandardStreams = !System.getenv().containsKey("RUN_IN_AIRBYTE_CI")
+            showStandardStreams = true
         }
         reports {
             junitXml {

--- a/buildSrc/src/main/groovy/airbyte-bulk-connector.gradle
+++ b/buildSrc/src/main/groovy/airbyte-bulk-connector.gradle
@@ -216,8 +216,7 @@ class AirbyteBulkConnectorPlugin implements Plugin<Project> {
                 testLogging() {
                     events 'skipped', 'started', 'passed', 'failed'
                     exceptionFormat 'full'
-                    // Swallow the logs when running in airbyte-ci, rely on test reports instead.
-                    showStandardStreams = !System.getenv().containsKey("RUN_IN_AIRBYTE_CI")
+                    showStandardStreams = true
                 }
 
                 // Always re-run integration tests no matter what.

--- a/buildSrc/src/main/groovy/airbyte-java-connector.gradle
+++ b/buildSrc/src/main/groovy/airbyte-java-connector.gradle
@@ -200,8 +200,7 @@ class AirbyteJavaConnectorPlugin implements Plugin<Project> {
             testLogging() {
                 events 'skipped', 'started', 'passed', 'failed'
                 exceptionFormat 'full'
-                // Swallow the logs when running in airbyte-ci, rely on test reports instead.
-                showStandardStreams = !System.getenv().containsKey("RUN_IN_AIRBYTE_CI")
+                showStandardStreams = true
             }
 
             jvmArgs = project.test.jvmArgs


### PR DESCRIPTION
grepped our gradle files for `showStandardStreams` and flipped them all to true. I'll revert the s3-data-lake change after getting approval, that's just so I could trigger connectors CI.

evidence:

gradle check is printing stuff to stdout https://github.com/airbytehq/airbyte/actions/runs/13315617826/job/37188772735?pr=53677#step:5:3159
<img width="1100" alt="image" src="https://github.com/user-attachments/assets/cfe3dc56-c844-465c-91b5-a7e48a3e2145" />


connectors CI is printing stuff to stdout https://github.com/airbytehq/airbyte/actions/runs/13315617823/job/37188775348?pr=53677#step:8:1755
<img width="1076" alt="image" src="https://github.com/user-attachments/assets/41338eef-fa16-4937-ae66-45ebf2e84c67" />


(output isn't _great_, but at least it's there)