### PR TITLE
🐛 Source Apple  Search Ads: fix daily stream granularity

### DIFF
--- a/airbyte-integrations/connectors/source-apple-search-ads/manifest.yaml
+++ b/airbyte-integrations/connectors/source-apple-search-ads/manifest.yaml
@@ -211,7 +211,7 @@ definitions:
               "ASCENDING" } ] }
             timeZone: UTC
             startTime: "{{ stream_slice.start_time }}"
-            granularity: "{{ parameters.granularity }}"
+            granularity: DAILY
           error_handler:
             type: CompositeErrorHandler
             error_handlers:
@@ -292,7 +292,7 @@ definitions:
               "ASCENDING" } ] }
             timeZone: UTC
             startTime: "{{ stream_slice.start_time }}"
-            granularity: "{{ parameters.granularity }}"
+            granularity: DAILY
           error_handler:
             type: CompositeErrorHandler
             error_handlers:
@@ -381,7 +381,7 @@ definitions:
               "ASCENDING" } ] }
             timeZone: UTC
             startTime: "{{ stream_slice.start_time }}"
-            granularity: "{{ parameters.granularity }}"
+            granularity: DAILY
           error_handler:
             type: DefaultErrorHandler
             response_filters:

--- a/airbyte-integrations/connectors/source-apple-search-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-apple-search-ads/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: e59c8416-c2fa-4bd3-9e95-52677ea281c1
-  dockerImageTag: 0.3.1
+  dockerImageTag: 0.3.2
   dockerRepository: airbyte/source-apple-search-ads
   githubIssueLabel: source-apple-search-ads
   icon: apple.svg

--- a/docs/integrations/sources/apple-search-ads.md
+++ b/docs/integrations/sources/apple-search-ads.md
@@ -60,6 +60,7 @@ However, at this moment and as indicated in the stream names, the connector only
 
 | Version | Date       | Pull Request                                             | Subject                                                                              |
 | :------ | :--------- | :------------------------------------------------------- | :----------------------------------------------------------------------------------- |
+| 0.3.2 | 2025-02-14 | [53685](https://github.com/airbytehq/airbyte/pull/53685) | Fix granularity to daily |
 | 0.3.1 | 2025-02-08 | [53422](https://github.com/airbytehq/airbyte/pull/53422) | Update dependencies |
 | 0.3.0 | 2025-02-03 | [53136](https://github.com/airbytehq/airbyte/pull/53136) | Update API version to V5 |
 | 0.2.9 | 2025-02-01 | [52899](https://github.com/airbytehq/airbyte/pull/52899) | Update dependencies |


### PR DESCRIPTION
## What
<!--
-->
Fixes broken daily granularity stream (See #48573)

## How
<!--
-->
Granularity for daily streams is paramaterized, it should just be set to daily

## Review guide
<!--
-->
`manifest.yaml` has been updated to refelect no parameterized granularity

## User Impact
<!--
-->
Daily breakdown streams  will work (they are currently broken)

## Can this PR be safely reverted and rolled back?
<!--
-->
- [x] YES 💚
- [ ] NO ❌
