### PR TITLE
Remove bad CSS selector in Airbyte docs

### DIFF
--- a/docusaurus/src/css/custom.css
+++ b/docusaurus/src/css/custom.css
@@ -280,7 +280,3 @@ table tr:hover {
 table thead tr:hover {
   background-color: transparent;
 }
-
-.markdown li > p {
-  margin: 0px !important;
-}


### PR DESCRIPTION
## What

Fixes issues with line spacing between list items.

## How

https://github.com/airbytehq/airbyte/commit/08923613b99fa9d82db6ebfe9c3c95ab3272331b introduced a poorly thought-out CSS change that caused more issues than it solved. This change reverts it back to its original state.

## Review guide



## User Impact

List item line spacing will be better and make things more readable.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌
