### PR TITLE
Fixing 5000 characters limit in google sheets

### DIFF
--- a/airbyte-integrations/connectors/destination-google-sheets/destination_google_sheets/writer.py
+++ b/airbyte-integrations/connectors/destination-google-sheets/destination_google_sheets/writer.py
@@ -57,6 +57,7 @@ class GoogleSheetsWriter(WriteBufferMixin):
 
         self.check_headers(stream_name)
         values: list = self.records_buffer[stream_name] or []
+        values = [value[:4991] + "TRuNCATED" if len(value) > 5000 else value for value in values]
         if values:
             stream: Worksheet = self.spreadsheet.open_worksheet(stream_name)
             self.logger.info(f"Writing data for stream: {stream_name}")


### PR DESCRIPTION
## What

Google Sheets destination fails when writing a cell value larger than 5000 characters long.
https://github.com/airbytehq/airbyte/issues/15500


## How

Truncated the value before writing to the google sheet. And adding Truncated to the end as suggested by @sherifnada 

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
