### PR TITLE
Destination DevNull: Use DirectLoader (no spill2disk)

### DIFF
--- a/airbyte-integrations/connectors/destination-dev-null/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-dev-null/metadata.yaml
@@ -10,7 +10,7 @@ data:
     - suite: integrationTests
   connectorType: destination
   definitionId: a7bcc9d8-13b3-4e49-b80d-d020b90045e3
-  dockerImageTag: 0.7.17
+  dockerImageTag: 0.7.18
   dockerRepository: airbyte/destination-dev-null
   documentationUrl: https://docs.airbyte.com/integrations/destinations/dev-null
   githubIssueLabel: destination-dev-null

--- a/airbyte-integrations/connectors/destination-dev-null/src/main/kotlin/io/airbyte/integrations/destination/dev_null/DevNullConfiguration.kt
+++ b/airbyte-integrations/connectors/destination-dev-null/src/main/kotlin/io/airbyte/integrations/destination/dev_null/DevNullConfiguration.kt
@@ -26,9 +26,8 @@ data class Failing(val numMessages: Int) : DevNullType
 
 data class Throttled(val millisPerRecord: Long) : DevNullType
 
-data class DevNullConfiguration(
-    val type: DevNullType,
-) : DestinationConfiguration()
+data class DevNullConfiguration(val type: DevNullType, val ackRatePerRecord: Int = 10_000) :
+    DestinationConfiguration()
 
 /**
  * This factory is injected into the initialization code and used to map from the client-provided

--- a/airbyte-integrations/connectors/destination-dev-null/src/main/kotlin/io/airbyte/integrations/destination/dev_null/DevNullDirectLoader.kt
+++ b/airbyte-integrations/connectors/destination-dev-null/src/main/kotlin/io/airbyte/integrations/destination/dev_null/DevNullDirectLoader.kt
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination.dev_null
+
+import io.airbyte.cdk.load.command.DestinationStream
+import io.airbyte.cdk.load.message.DestinationRecordAirbyteValue
+import io.airbyte.cdk.load.write.DirectLoader
+import io.airbyte.cdk.load.write.DirectLoaderFactory
+import io.github.oshai.kotlinlogging.KotlinLogging
+import jakarta.inject.Singleton
+import kotlin.random.Random
+
+/** Wraps the configured operation in logic that acks all state so far every N records. */
+abstract class DevNullDirectLoader(
+    private val config: DevNullConfiguration,
+) : DirectLoader {
+    private var recordCount: Long = 0L
+
+    abstract fun acceptInner(record: DestinationRecordAirbyteValue)
+
+    override fun accept(record: DestinationRecordAirbyteValue): DirectLoader.DirectLoadResult {
+        acceptInner(record)
+        return if (++recordCount % config.ackRatePerRecord == 0L) {
+            DirectLoader.Complete
+        } else {
+            DirectLoader.Incomplete
+        }
+    }
+
+    override fun finish() {
+        /* do nothing */
+    }
+
+    override fun close() {
+        /* do nothing */
+    }
+}
+
+@Singleton
+class DevNullDirectLoaderFactory(private val config: DevNullConfiguration) :
+    DirectLoaderFactory<DevNullDirectLoader> {
+    private val log = KotlinLogging.logger {}
+
+    override fun create(
+        streamDescriptor: DestinationStream.Descriptor,
+        part: Int
+    ): DevNullDirectLoader {
+        return when (config.type) {
+            is Logging -> {
+                log.info {
+                    "Creating LoggingDirectLoader for LoggingDestination. The File messages will be ignored"
+                }
+                LoggingDirectLoader(config, streamDescriptor, config.type)
+            }
+            is Silent -> {
+                log.info {
+                    "Creating SilentDirectLoader for SilentDestination. The File messages will be ignored"
+                }
+                SilentDirectLoader(config)
+            }
+            is Throttled -> {
+                log.info {
+                    "Creating ThrottledDirectLoader for ThrottledDestination. The File messages will be ignored"
+                }
+                ThrottledDirectLoader(config, config.type.millisPerRecord)
+            }
+            is Failing -> {
+                log.info {
+                    "Creating FailingDirectLoader for FailingDestination. The File messages will be ignored"
+                }
+                FailingDirectLoader(config, streamDescriptor, config.type.numMessages)
+            }
+        }
+    }
+}
+
+class LoggingDirectLoader(
+    config: DevNullConfiguration,
+    private val stream: DestinationStream.Descriptor,
+    private val loggingConfig: Logging,
+) : DevNullDirectLoader(config) {
+    private val log = KotlinLogging.logger {}
+
+    private var recordCount: Long = 0L
+    private var logCount: Long = 0L
+    private val prng: Random = loggingConfig.seed?.let { Random(it) } ?: Random.Default
+
+    override fun acceptInner(record: DestinationRecordAirbyteValue) {
+        if (recordCount++ % loggingConfig.logEvery == 0L) {
+            if (loggingConfig.sampleRate == 1.0 || prng.nextDouble() < loggingConfig.sampleRate) {
+                if (++logCount < loggingConfig.maxEntryCount) {
+                    log.info {
+                        "Logging Destination(stream=$stream, recordIndex=$recordCount, logEntry=$logCount/${loggingConfig.maxEntryCount}): $record"
+                    }
+                }
+            }
+        }
+    }
+}
+
+class SilentDirectLoader(config: DevNullConfiguration) : DevNullDirectLoader(config) {
+    override fun acceptInner(record: DestinationRecordAirbyteValue) {
+        /* Do nothing */
+    }
+}
+
+class ThrottledDirectLoader(config: DevNullConfiguration, private val millisPerRecord: Long) :
+    DevNullDirectLoader(config) {
+
+    override fun acceptInner(record: DestinationRecordAirbyteValue) {
+        Thread.sleep(millisPerRecord)
+    }
+}
+
+class FailingDirectLoader(
+    config: DevNullConfiguration,
+    private val stream: DestinationStream.Descriptor,
+    private val numMessages: Int
+) : DevNullDirectLoader(config) {
+    private val log = KotlinLogging.logger {}
+
+    private var messageCount: Long = 0L
+
+    override fun acceptInner(record: DestinationRecordAirbyteValue) {
+        if (messageCount++ > numMessages) {
+            val message =
+                "Failing Destination(stream=$stream, numMessages=$numMessages: failing at $record)"
+            log.info { message }
+            throw RuntimeException(message)
+        }
+    }
+}

--- a/airbyte-integrations/connectors/destination-dev-null/src/main/kotlin/io/airbyte/integrations/destination/dev_null/DevNullWriter.kt
+++ b/airbyte-integrations/connectors/destination-dev-null/src/main/kotlin/io/airbyte/integrations/destination/dev_null/DevNullWriter.kt
@@ -4,154 +4,17 @@
 
 package io.airbyte.integrations.destination.dev_null
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 import io.airbyte.cdk.load.command.DestinationStream
-import io.airbyte.cdk.load.message.Batch
-import io.airbyte.cdk.load.message.DestinationRecordAirbyteValue
-import io.airbyte.cdk.load.message.SimpleBatch
 import io.airbyte.cdk.load.write.DestinationWriter
 import io.airbyte.cdk.load.write.StreamLoader
-import io.github.oshai.kotlinlogging.KotlinLogging
 import jakarta.inject.Singleton
-import java.util.concurrent.atomic.AtomicInteger
-import java.util.concurrent.atomic.AtomicLong
-import kotlin.random.Random
-import kotlinx.coroutines.delay
 
 @Singleton
-class DevNullWriter(private val config: DevNullConfiguration) : DestinationWriter {
-    private val log = KotlinLogging.logger {}
-
+class DevNullWriter : DestinationWriter {
     override fun createStreamLoader(stream: DestinationStream): StreamLoader {
-        return when (config.type) {
-            is Logging -> {
-                log.info {
-                    "Creating LoggingStreamLoader for LoggingDestination. The File messages will be ignored"
-                }
-                LoggingStreamLoader(stream, config.type)
-            }
-            is Silent -> {
-                log.info {
-                    "Creating SilentStreamLoader for SilentDestination. The File messages will be ignored"
-                }
-                SilentStreamLoader(stream)
-            }
-            is Throttled -> {
-                log.info {
-                    "Creating ThrottledStreamLoader for ThrottledDestination. The File messages will be ignored"
-                }
-                ThrottledStreamLoader(stream, config.type.millisPerRecord)
-            }
-            is Failing -> {
-                log.info {
-                    "Creating FailingStreamLoader for FailingDestination. The File messages will be ignored"
-                }
-                FailingStreamLoader(stream, config.type.numMessages)
-            }
+        /* Do nothing. Work is done by the DirectLoader. TODO: Remove StreamLoader entirely. */
+        return object : StreamLoader {
+            override val stream: DestinationStream = stream
         }
-    }
-}
-
-class LoggingStreamLoader(override val stream: DestinationStream, loggingConfig: Logging) :
-    StreamLoader {
-    private val log = KotlinLogging.logger {}
-
-    private val maxEntryCount: Int = loggingConfig.maxEntryCount
-    private val logEvery: Int = loggingConfig.logEvery
-    private val sampleRate: Double = loggingConfig.sampleRate
-    private val prng: Random = loggingConfig.seed?.let { Random(it) } ?: Random.Default
-
-    companion object {
-        private val recordCount = AtomicLong()
-        private val logCount = AtomicLong()
-    }
-
-    override suspend fun processRecords(
-        records: Iterator<DestinationRecordAirbyteValue>,
-        totalSizeBytes: Long,
-        endOfStream: Boolean,
-    ): Batch {
-        log.info { "Processing record batch with logging" }
-
-        records.forEach { record ->
-            if (recordCount.getAndIncrement() % logEvery == 0L) {
-                if (sampleRate == 1.0 || prng.nextDouble() < sampleRate) {
-                    if (logCount.incrementAndGet() < maxEntryCount) {
-                        log.info {
-                            "Logging Destination(stream=$stream, recordIndex=$recordCount, logEntry=$logCount/$maxEntryCount): $record"
-                        }
-                    }
-                }
-            }
-        }
-
-        log.info { "Completed record batch." }
-
-        return SimpleBatch(state = Batch.State.COMPLETE)
-    }
-}
-
-class SilentStreamLoader(override val stream: DestinationStream) : StreamLoader {
-    override suspend fun processRecords(
-        records: Iterator<DestinationRecordAirbyteValue>,
-        totalSizeBytes: Long,
-        endOfStream: Boolean
-    ): Batch {
-        return SimpleBatch(state = Batch.State.COMPLETE)
-    }
-}
-
-@SuppressFBWarnings(
-    "NP_NONNULL_PARAM_VIOLATION",
-    justification = "message is guaranteed to be non-null by Kotlin's type system"
-)
-class ThrottledStreamLoader(
-    override val stream: DestinationStream,
-    private val millisPerRecord: Long
-) : StreamLoader {
-    private val log = KotlinLogging.logger {}
-
-    override suspend fun processRecords(
-        records: Iterator<DestinationRecordAirbyteValue>,
-        totalSizeBytes: Long,
-        endOfStream: Boolean
-    ): Batch {
-        log.info { "Processing record batch with delay of $millisPerRecord per record" }
-
-        records.forEach { _ -> delay(millisPerRecord) }
-        log.info { "Completed record batch." }
-
-        return SimpleBatch(state = Batch.State.COMPLETE)
-    }
-}
-
-class FailingStreamLoader(override val stream: DestinationStream, private val numMessages: Int) :
-    StreamLoader {
-    private val log = KotlinLogging.logger {}
-
-    companion object {
-        private val messageCount = AtomicInteger(0)
-    }
-
-    override suspend fun processRecords(
-        records: Iterator<DestinationRecordAirbyteValue>,
-        totalSizeBytes: Long,
-        endOfStream: Boolean
-    ): Batch {
-        log.info { "Processing record batch with failure after $numMessages messages" }
-
-        records.forEach { record ->
-            messageCount.getAndIncrement().let { messageCount ->
-                if (messageCount > numMessages) {
-                    val message =
-                        "Failing Destination(stream=$stream, numMessages=$numMessages: failing at $record"
-                    log.info { message }
-                    throw RuntimeException(message)
-                }
-            }
-        }
-        log.info { "Completed record batch." }
-
-        return SimpleBatch(state = Batch.State.COMPLETE)
     }
 }

--- a/airbyte-integrations/connectors/destination-dev-null/src/test-integration/kotlin/io/airbyte/integrations/destination/dev_null/DevNullBasicFunctionalityIntegrationTest.kt
+++ b/airbyte-integrations/connectors/destination-dev-null/src/test-integration/kotlin/io/airbyte/integrations/destination/dev_null/DevNullBasicFunctionalityIntegrationTest.kt
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.Test
 
 class DevNullBasicFunctionalityIntegrationTest :
     BasicFunctionalityIntegrationTest(
-        DevNullTestUtils.loggingConfigContents,
+        DevNullTestUtils.configContents(DevNullTestUtils.loggingConfigPath),
         DevNullSpecificationOss::class.java,
         DevNullDestinationDataDumper,
         NoopDestinationCleaner,

--- a/airbyte-integrations/connectors/destination-dev-null/src/test-integration/kotlin/io/airbyte/integrations/destination/dev_null/DevNullPerformanceTest.kt
+++ b/airbyte-integrations/connectors/destination-dev-null/src/test-integration/kotlin/io/airbyte/integrations/destination/dev_null/DevNullPerformanceTest.kt
@@ -9,9 +9,9 @@ import org.junit.jupiter.api.Test
 
 class DevNullPerformanceTest :
     BasicPerformanceTest(
-        configContents = DevNullTestUtils.loggingConfigContents,
+        configContents = DevNullTestUtils.configContents(DevNullTestUtils.silentConfigPath),
         configSpecClass = DevNullSpecification::class.java,
-        defaultRecordsToInsert = 1000000,
+        defaultRecordsToInsert = 1_000_000,
     ) {
     @Test
     override fun testInsertRecords() {

--- a/airbyte-integrations/connectors/destination-dev-null/src/test-integration/kotlin/io/airbyte/integrations/destination/dev_null/DevNullTestUtils.kt
+++ b/airbyte-integrations/connectors/destination-dev-null/src/test-integration/kotlin/io/airbyte/integrations/destination/dev_null/DevNullTestUtils.kt
@@ -24,7 +24,8 @@ object DevNullTestUtils {
      * so their paths would be `secrets/blah.json`.
      */
     val loggingConfigPath: Path = Path.of("test_configs/logging.json")
-    val loggingConfigContents: String = Files.readString(loggingConfigPath, Charsets.UTF_8)
+    val silentConfigPath: Path = Path.of("test_configs/silent.json")
+    fun configContents(configPath: Path): String = Files.readString(configPath, Charsets.UTF_8)
     val loggingConfig: DevNullSpecification =
         ValidatedJsonUtils.parseOne(
             DevNullSpecificationOss::class.java,

--- a/airbyte-integrations/connectors/destination-dev-null/test_configs/silent.json
+++ b/airbyte-integrations/connectors/destination-dev-null/test_configs/silent.json
@@ -1,0 +1,5 @@
+{
+  "test_destination": {
+    "test_destination_type": "SILENT"
+  }
+}

--- a/docs/integrations/destinations/dev-null.md
+++ b/docs/integrations/destinations/dev-null.md
@@ -49,6 +49,7 @@ The OSS and Cloud variants have the same version number starting from version `0
 
 | Version     | Date       | Pull Request                                             | Subject                                                                                      |
 |:------------|:-----------|:---------------------------------------------------------|:---------------------------------------------------------------------------------------------|
+| 0.7.18      | 2025-02-25 | [54179](https://github.com/airbytehq/airbyte/pull/54179) | Use new CDK interface; perf improvements, skip initial staging                               |
 | 0.7.17      | 2025-01-24 | [51600](https://github.com/airbytehq/airbyte/pull/51600) | Internal refactor                                                                            |
 | 0.7.16      | 2024-12-19 | [52076](https://github.com/airbytehq/airbyte/pull/52076) | Test improvements                                                                            |
 | 0.7.15      | 2024-12-19 | [49899](https://github.com/airbytehq/airbyte/pull/49931) | Non-functional CDK changes                                                                   |


### PR DESCRIPTION
## What
Migrates DevNull to use the `DirectLoader` interface. This skips "spill-to-disk", improving performance against the benchmark source by ~37%.,
