### PR TITLE
[source mysql] Fix integration test

### DIFF
--- a/airbyte-integrations/connectors/source-mysql/src/test/kotlin/io/airbyte/integrations/source/mysql/MySqlSourceCdcIntegrationTest.kt
+++ b/airbyte-integrations/connectors/source-mysql/src/test/kotlin/io/airbyte/integrations/source/mysql/MySqlSourceCdcIntegrationTest.kt
@@ -115,7 +115,7 @@ class MySqlSourceCdcIntegrationTest {
             JdbcConnectionFactory(MySqlSourceConfigurationFactory().make(config()))
         }
 
-        val configuredCatalog: ConfiguredAirbyteCatalog = run {
+        val configuredCatalog: ConfiguredAirbyteCatalog by lazy {
             val desc = StreamDescriptor().withName("tbl").withNamespace("test")
             val discoveredStream =
                 DiscoveredStream(


### PR DESCRIPTION
## What
CDC integration test fails because it need test container to initialize config. However container was not initialized when creating test class.

## How
Change configuredCatalog to lazy initialization so container will be ready to use

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
