### PR TITLE
use concurrent cursor

### DIFF
--- a/airbyte-integrations/connectors/source-google-drive/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-drive/metadata.yaml
@@ -7,7 +7,7 @@ data:
   connectorSubtype: file
   connectorType: source
   definitionId: 9f8dda77-1048-4368-815b-269bf54ee9b8
-  dockerImageTag: 0.2.1
+  dockerImageTag: 0.2.2
   dockerRepository: airbyte/source-google-drive
   githubIssueLabel: source-google-drive
   icon: google-drive.svg

--- a/airbyte-integrations/connectors/source-google-drive/pyproject.toml
+++ b/airbyte-integrations/connectors/source-google-drive/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "0.2.1"
+version = "0.2.2"
 name = "source-google-drive"
 description = "Source implementation for Google Drive."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-google-drive/source_google_drive/source.py
+++ b/airbyte-integrations/connectors/source-google-drive/source_google_drive/source.py
@@ -8,12 +8,16 @@ from typing import Any, Mapping, Optional
 from airbyte_cdk import AdvancedAuth, ConfiguredAirbyteCatalog, ConnectorSpecification, OAuthConfigSpecification, TState
 from airbyte_cdk.models import AuthFlowType, OauthConnectorInputSpecification
 from airbyte_cdk.sources.file_based.file_based_source import FileBasedSource
-from airbyte_cdk.sources.file_based.stream.cursor.default_file_based_cursor import DefaultFileBasedCursor
+from airbyte_cdk.sources.file_based.stream.concurrent.cursor.file_based_concurrent_cursor import (
+    FileBasedConcurrentCursor,
+)
 from source_google_drive.spec import SourceGoogleDriveSpec
 from source_google_drive.stream_reader import SourceGoogleDriveStreamReader
 
 
 class SourceGoogleDrive(FileBasedSource):
+    _concurrency_level = 1
+
     def __init__(self, catalog: Optional[ConfiguredAirbyteCatalog], config: Optional[Mapping[str, Any]], state: Optional[TState]):
         super().__init__(
             stream_reader=SourceGoogleDriveStreamReader(),
@@ -21,7 +25,7 @@ class SourceGoogleDrive(FileBasedSource):
             catalog=catalog,
             config=config,
             state=state,
-            cursor_cls=DefaultFileBasedCursor,
+            cursor_cls=FileBasedConcurrentCursor,
         )
 
     def spec(self, *args: Any, **kwargs: Any) -> ConnectorSpecification:

--- a/docs/integrations/sources/google-drive.md
+++ b/docs/integrations/sources/google-drive.md
@@ -320,6 +320,7 @@ By default, this stream is enabled and retrieves information about **users and g
 
 | Version | Date       | Pull Request                                             | Subject                                                                                      |
 |---------|------------|----------------------------------------------------------|----------------------------------------------------------------------------------------------|
+| 0.2.2 | 2025-02-20 | [](https://github.com/airbytehq/airbyte/pull/) | Use concurrent CDK with concurrency level of 1|
 | 0.2.1 | 2025-02-15 | [53774](https://github.com/airbytehq/airbyte/pull/53774) | Update dependencies |
 | 0.2.0 | 2025-02-14 | [52099](https://github.com/airbytehq/airbyte/pull/52099) | Introduce ACLs and Permissions streams |
 | 0.1.2 | 2025-02-08 | [53320](https://github.com/airbytehq/airbyte/pull/53320) | Update dependencies |

--- a/docs/integrations/sources/google-drive.md
+++ b/docs/integrations/sources/google-drive.md
@@ -320,7 +320,7 @@ By default, this stream is enabled and retrieves information about **users and g
 
 | Version | Date       | Pull Request                                             | Subject                                                                                      |
 |---------|------------|----------------------------------------------------------|----------------------------------------------------------------------------------------------|
-| 0.2.2 | 2025-02-20 | [](https://github.com/airbytehq/airbyte/pull/) | Use concurrent CDK with concurrency level of 1|
+| 0.2.2 | 2025-02-20 | [54184](https://github.com/airbytehq/airbyte/pull/54184) | Use concurrent CDK with concurrency level of 1|
 | 0.2.1 | 2025-02-15 | [53774](https://github.com/airbytehq/airbyte/pull/53774) | Update dependencies |
 | 0.2.0 | 2025-02-14 | [52099](https://github.com/airbytehq/airbyte/pull/52099) | Introduce ACLs and Permissions streams |
 | 0.1.2 | 2025-02-08 | [53320](https://github.com/airbytehq/airbyte/pull/53320) | Update dependencies |


### PR DESCRIPTION
## What
Update the Google Drive connector to use the concurrent CDK. The concurrency limit is still 1 so there should be no user-facing impact.

## Review guide
I wasn't able to run regression testing because no [suitable connections were found](https://github.com/airbytehq/airbyte/actions/runs/13444527851/job/37566707352).
## User Impact
The concurrency limit is still 1 so there should be no user-facing impact.

## Can this PR be safely reverted and rolled back?
- [X] YES 💚
