### PR TITLE
[Destination MSSQL] v2 rc9

### DIFF
--- a/airbyte-integrations/connectors/destination-mssql-v2/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-mssql-v2/metadata.yaml
@@ -16,7 +16,7 @@ data:
             type: GSM
   connectorType: destination
   definitionId: 37a928c1-2d5c-431a-a97d-ae236bd1ea0c
-  dockerImageTag: 0.1.10
+  dockerImageTag: 0.1.11
   dockerRepository: airbyte/destination-mssql-v2
   documentationUrl: https://docs.airbyte.com/integrations/destinations/mssql-v2
   githubIssueLabel: destination-mssql-v2

--- a/airbyte-integrations/connectors/destination-mssql-v2/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLQueryBuilder.kt
+++ b/airbyte-integrations/connectors/destination-mssql-v2/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLQueryBuilder.kt
@@ -433,7 +433,7 @@ class MSSQLQueryBuilder(
             name,
             outputSchema,
             tableName,
-            columns.joinToString(", ")
+            columns.joinToString(", ") { "[$it]" }
         )
     }
 

--- a/docs/integrations/destinations/mssql-v2.md
+++ b/docs/integrations/destinations/mssql-v2.md
@@ -13,6 +13,7 @@ This connector is in early access, and SHOULD NOT be used for production workloa
 
 | Version | Date       | Pull Request                                               | Subject                                              |
 |:--------|:-----------|:-----------------------------------------------------------|:-----------------------------------------------------|
+| 0.1.11  | 2025-02-21 | [54197](https://github.com/airbytehq/airbyte/pull/54197)   | RC9: Fix index column names with invalid characters. |
 | 0.1.10  | 2025-02-20 | [54186](https://github.com/airbytehq/airbyte/pull/54186)   | RC8: Fix String support.                             |
 | 0.1.9   | 2025-02-11 | [53364](https://github.com/airbytehq/airbyte/pull/53364)   | RC7: Revert deletion change.                         |
 | 0.1.8   | 2025-02-11 | [53364](https://github.com/airbytehq/airbyte/pull/53364)   | RC6: Break up deletes into loop to reduce locking.   |


### PR DESCRIPTION
## What

RC9:

* fix: escape the column name(s) in the create index statement

## Can this PR be safely reverted and rolled back?
- [X] YES 💚
- [ ] NO ❌
