### PR TITLE
Convert Docusaurus to multi-instance

### DIFF
--- a/docs/connector-development/tutorials/building-a-java-destination.md
+++ b/docs/connector-development/tutorials/building-a-java-destination.md
@@ -1,7 +1,3 @@
----
-displayed_sidebar: docs
----
-
 # Building a Java Destination
 
 :::warning

--- a/docs/home/readme.md
+++ b/docs/home/readme.md
@@ -1,0 +1,40 @@
+# Welcome to Airbyte Docs
+
+<Grid columns="1">
+
+<CardWithIcon title="What is Airbyte?" description="Airbyte is an open-source data movement infrastructure for building extract and load (EL) data pipelines. It is designed for versatility, scalability, and ease-of-use." icon="enterprise"/>
+
+</Grid>
+
+<Arcade id="8UUaeQOILatZ38Rjh8cs" title="Airbyte Demo: Get Started Creating Connections" paddingBottom="calc(61.416666666666664% + 41px)" />
+
+### Why Airbyte?
+ 
+Today, teams and organizations require efficient and timely data access to an ever-growing list of data sources. In-house data pipelines are brittle and costly to build and maintain. Airbyte's unique open-source approach enables your data stack to adapt as your data needs evolve.
+
+- **Wide connector availability:** Airbyte’s connector catalog comes “out-of-the-box” with over 500 pre-built connectors. These connectors can be used to start replicating data from a source to a destination in just a few minutes. 
+- **Long-tail connector coverage:** You can easily extend Airbyte’s functionality to support your custom use cases through Airbyte's [No-Code Connector Builder](./connector-development/connector-builder-ui/overview).
+
+- **Robust platform** provides horizontal scaling required for large-scale data movement operations, available as [Cloud-managed](https://airbyte.com/product/airbyte-cloud) or [Self-managed](https://airbyte.com/product/airbyte-enterprise).
+
+- **Accessible User Interfaces** through the UI, [**PyAirbyte**](./using-airbyte/pyairbyte/getting-started) (Python library), [**API**](./api-documentation), and [**Terraform Provider**](./terraform-documentation) to integrate with your preferred tooling and approach to infrastructure management.
+
+Airbyte is suitable for a wide range of data integration use cases, including AI data infrastructure and EL(T) workloads. Airbyte is also [embeddable](https://airbyte.com/product/powered-by-airbyte) within your own application or platform to power your product.
+
+
+## Get Started
+
+<Grid columns="3">
+
+<CardWithIcon title="Start Syncing Data" description="Deploy locally or sign up for Airbyte Cloud to sync data in minutes" ctaText="Get Started" ctaLink="./using-airbyte/getting-started/" icon="enterprise" />
+
+<CardWithIcon title="Connector Catalog" description="Browse the extensive Connector Catalog of over 500 sources and destinations" ctaText="Browse" ctaLink="./integrations/" icon="oss" ctaVariant="secondary" />
+
+<CardWithIcon title="Connector Development Guide" description="Learn how to build and customize connectors
+" ctaText="Learn More" ctaLink="./connector-development/" icon="cloud" ctaVariant="secondary" />
+
+</Grid>
+
+<br/><br/>
+
+[![GitHub stars](https://img.shields.io/github/stars/airbytehq/airbyte?style=social&label=Star&maxAge=2592000)](https://GitHub.com/airbytehq/airbyte/stargazers/) [![License](https://img.shields.io/static/v1?label=license&message=MIT&color=brightgreen)](https://github.com/airbytehq/airbyte/tree/a9b1c6c0420550ad5069aca66c295223e0d05e27/LICENSE/README.md) [![License](https://img.shields.io/static/v1?label=license&message=ELv2&color=brightgreen)](https://github.com/airbytehq/airbyte/tree/a9b1c6c0420550ad5069aca66c295223e0d05e27/LICENSE/README.md)

--- a/docs/integrations/locating-files-local-destination.md
+++ b/docs/integrations/locating-files-local-destination.md
@@ -1,7 +1,3 @@
----
-displayed_sidebar: docs
----
-
 # Windows - Browsing Local File Output
 
 ## Overview

--- a/docs/platform/readme.md
+++ b/docs/platform/readme.md
@@ -1,0 +1,7 @@
+---
+products: all
+---
+
+# Platform docs go here
+
+Some content.

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -1,7 +1,3 @@
----
-displayed_sidebar: docs
----
-
 # Welcome to Airbyte Docs
 
 <Grid columns="1">

--- a/docusaurus/docusaurus.config.js
+++ b/docusaurus/docusaurus.config.js
@@ -16,9 +16,9 @@ const connectorList = require("./src/remark/connectorList");
 const specDecoration = require("./src/remark/specDecoration");
 const docMetaTags = require("./src/remark/docMetaTags");
 
-const redirects = yaml.load(
-  fs.readFileSync(path.join(__dirname, "redirects.yml"), "utf-8")
-);
+// const redirects = yaml.load(
+//   fs.readFileSync(path.join(__dirname, "redirects.yml"), "utf-8")
+// );
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
@@ -33,8 +33,8 @@ const config = {
   // Assumed relative path.  If you are using airbytehq.github.io use /
   // anything else should match the repo name
   baseUrl: "/",
-  onBrokenLinks: "throw",
-  onBrokenMarkdownLinks: "throw",
+  onBrokenLinks: "warn",
+  onBrokenMarkdownLinks: "warn",
   favicon: "img/favicon.png",
   organizationName: "airbytehq", // Usually your GitHub org/user name.
   projectName: "airbyte", // Usually your repo name.
@@ -66,15 +66,77 @@ const config = {
       },
     },
   ],
-
-  plugins: [
+  // The preset is the "main" docs instance, though in reality, most content does not live under this preset. See the plugins array below, which defines the behavior of each docs instance.
+  presets: [
     [
-      "@docusaurus/plugin-client-redirects",
+      "classic",
+      /** @type {import('@docusaurus/preset-classic').Options} */
+      ({
+        docs: {
+          routeBasePath: "/",
+          sidebarCollapsible: true,
+          sidebarPath: require.resolve("./sidebar.js"),
+          editUrl: "https://github.com/airbytehq/airbyte/blob/master/docs",
+          path: "../docs/home",
+          beforeDefaultRemarkPlugins: [specDecoration, connectorList], // use before-default plugins so TOC rendering picks up inserted headings
+          remarkPlugins: [
+            docsHeaderDecoration,
+            enterpriseDocsHeaderInformation,
+            productInformation,
+            docMetaTags,
+          ],
+        },
+        blog: false,
+        theme: {
+          customCss: require.resolve("./src/css/custom.css"),
+        },
+      }),
+    ],
+  ],
+  plugins: [
+    // This plugin controls "platform" docs, which are to be versioned
+    [
+      '@docusaurus/plugin-content-docs',
       {
-        fromExtensions: ["html", "htm"], // /myPage.html -> /myPage
-        redirects: redirects,
+        id: 'platform',
+        path: '../docs/platform',
+        routeBasePath: '/platform',
+        sidebarPath: './sidebar-platform.js',
+        editUrl: "https://github.com/airbytehq/airbyte/blob/master/docs",
+        remarkPlugins: [
+          docsHeaderDecoration,
+          enterpriseDocsHeaderInformation,
+          productInformation,
+          docMetaTags,
+        ],
       },
     ],
+    // This plugin controls "connector/source/destination" docs, which are unversioned by Docusaurus and use their own versioning
+    [
+      '@docusaurus/plugin-content-docs',
+      {
+        id: 'connectors',
+        path: '../docs/integrations',
+        routeBasePath: '/integrations',
+        sidebarPath: './sidebar-connectors.js',
+        editUrl: "https://github.com/airbytehq/airbyte/blob/master/docs",
+        beforeDefaultRemarkPlugins: [specDecoration, connectorList], // use before-default plugins so TOC rendering picks up inserted headings
+        remarkPlugins: [
+          docsHeaderDecoration,
+          enterpriseDocsHeaderInformation,
+          productInformation,
+          docMetaTags,
+        ],
+      },
+    ],
+    // Client-side redirect plugin - turning off for now to replace with Vercel server-side redirects
+    // [
+    //   "@docusaurus/plugin-client-redirects",
+    //   {
+    //     fromExtensions: ["html", "htm"], // /myPage.html -> /myPage
+    //     redirects: redirects,
+    //   },
+    // ],
     () => ({
       name: "Yaml loader",
       configureWebpack() {
@@ -102,36 +164,6 @@ const config = {
     require.resolve("./src/scripts/cloudStatus.js"),
     require.resolve("./src/scripts/download-abctl-buttons.js"),
     require.resolve("./src/scripts/fontAwesomeIcons.js"),
-  ],
-
-  presets: [
-    [
-      "classic",
-      /** @type {import('@docusaurus/preset-classic').Options} */
-      ({
-        docs: {
-          routeBasePath: "/",
-          sidebarCollapsible: true,
-          sidebarPath: require.resolve("./sidebars.js"),
-          editUrl: "https://github.com/airbytehq/airbyte/blob/master/docs",
-          path: "../docs",
-          exclude: [
-            "**/*.inapp.md"
-          ],
-          beforeDefaultRemarkPlugins: [specDecoration, connectorList], // use before-default plugins so TOC rendering picks up inserted headings
-          remarkPlugins: [
-            docsHeaderDecoration,
-            enterpriseDocsHeaderInformation,
-            productInformation,
-            docMetaTags,
-          ],
-        },
-        blog: false,
-        theme: {
-          customCss: require.resolve("./src/css/custom.css"),
-        },
-      }),
-    ],
   ],
 
   themeConfig:

--- a/docusaurus/sidebar-connectors.js
+++ b/docusaurus/sidebar-connectors.js
@@ -1,0 +1,8 @@
+export default {
+    mySidebar: [
+        {
+            type: 'doc',
+            id: 'README', // document ID
+        },
+    ],
+};

--- a/docusaurus/sidebar-platform.js
+++ b/docusaurus/sidebar-platform.js
@@ -1,0 +1,9 @@
+export default {
+    mySidebar: [
+        {
+            type: 'doc',
+            id: 'readme', // document ID
+        },
+    ],
+};
+  

--- a/docusaurus/sidebar.js
+++ b/docusaurus/sidebar.js
@@ -1,0 +1,9 @@
+export default {
+    mySidebar: [
+        {
+            type: 'doc',
+            id: 'readme', // document ID
+        },
+    ],
+};
+  


### PR DESCRIPTION
## What

This change converts Docusaurus from a single docs instance to multiple docs instances, resolving [#11757](https://github.com/airbytehq/airbyte-internal-issues/issues/11757). 

This is the first step to enabling versioned platform documentation without versioning connector documentation too.

We need to complete a few separate steps to get to versioned docs, including populating the new sidebar files and adding new links to the navbar at the top of the page. We'll do that in future tasks before this goes into production. I thought it would be good to track/review individual milestones rather than asking someone to review a giant mass of changes.

## How

- Create two new docs instances in the Docusaurus configuration: one for platform content, and one for connector content.
- Create new, empty sidebar files: one for the home page, one for the platform, and one for connectors.
- Disable client-side redirects (we'll replace them with Vercel server-side redirects later before merging to master)
- Temporarily convert errors from 'throw' to 'warn' (future tasks will restore this, but right now, the site would not otherwise build, because we have many links missing from the sidebars). These errors are expected at this point and not of concern yet.
- Remove metadata in docs files that requested a specific sidebar for some reason.

## Review guide

Although this step is critical, it does not yield an outwardly impressive benefit yet. To test:

1. Go to the [root directory](https://airbyte-docs-git-docusaurus-multi-instance-airbyte-growth.vercel.app/). You should see the Airbyte docs home page as usual. It should have a side bar with 1 page. This is the "Preset", IE an instance that is outside the scope of either platform or connector docs.
2. Go to [`/platform`](https://airbyte-docs-git-docusaurus-multi-instance-airbyte-growth.vercel.app//platform). You should see a placeholder page for platform docs. It should have a sidebar with 1 page. This is the platform instance that we will later version.
3. Go to [`/integrations`](https://airbyte-docs-git-docusaurus-multi-instance-airbyte-growth.vercel.app//integrations/). You should see the home page for the connectors section. Again, the sidebar should show only this page. This is the connectors instance that will not be subject to versioning.

This will allow you to see each of the 3 instances, and they should all load normally/properly. That's basically it. We'll move the content into them later.

## User Impact

Since we are not merging this into master, there will be no user impact yet.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌
