### PR TITLE
chore: make manifest-only sources available on Cloud

### DIFF
--- a/airbyte-integrations/connectors/source-alpha-vantage/metadata.yaml
+++ b/airbyte-integrations/connectors/source-alpha-vantage/metadata.yaml
@@ -14,7 +14,7 @@ data:
       packageName: airbyte-source-alpha-vantage
   registryOverrides:
     cloud:
-      enabled: false
+      enabled: true
     oss:
       enabled: true
   releaseStage: alpha

--- a/airbyte-integrations/connectors/source-babelforce/metadata.yaml
+++ b/airbyte-integrations/connectors/source-babelforce/metadata.yaml
@@ -1,7 +1,7 @@
 data:
   allowedHosts:
     hosts:
-      - ${region}.babelforce.com
+      - "*.babelforce.com"
   remoteRegistries:
     pypi:
       enabled: false
@@ -10,7 +10,7 @@ data:
     oss:
       enabled: true
     cloud:
-      enabled: false
+      enabled: true
   connectorSubtype: api
   connectorType: source
   definitionId: 971c3e1e-78a5-411e-ad56-c4052b50876b

--- a/airbyte-integrations/connectors/source-breezometer/metadata.yaml
+++ b/airbyte-integrations/connectors/source-breezometer/metadata.yaml
@@ -14,7 +14,7 @@ data:
       packageName: airbyte-source-breezometer
   registryOverrides:
     cloud:
-      enabled: false
+      enabled: true
     oss:
       enabled: true
   releaseStage: alpha

--- a/airbyte-integrations/connectors/source-captain-data/metadata.yaml
+++ b/airbyte-integrations/connectors/source-captain-data/metadata.yaml
@@ -14,7 +14,7 @@ data:
       packageName: airbyte-source-captain-data
   registryOverrides:
     cloud:
-      enabled: false
+      enabled: true
     oss:
       enabled: true
   releaseStage: alpha

--- a/airbyte-integrations/connectors/source-coingecko-coins/metadata.yaml
+++ b/airbyte-integrations/connectors/source-coingecko-coins/metadata.yaml
@@ -16,7 +16,7 @@ data:
       packageName: airbyte-source-coingecko-coins
   registryOverrides:
     cloud:
-      enabled: false # Did not pass acceptance tests
+      enabled: true
     oss:
       enabled: true
   releaseStage: alpha

--- a/airbyte-integrations/connectors/source-everhour/metadata.yaml
+++ b/airbyte-integrations/connectors/source-everhour/metadata.yaml
@@ -7,7 +7,7 @@ data:
     ql: 100
   registryOverrides:
     cloud:
-      enabled: false
+      enabled: true
     oss:
       enabled: true
   remoteRegistries:

--- a/airbyte-integrations/connectors/source-fastbill/metadata.yaml
+++ b/airbyte-integrations/connectors/source-fastbill/metadata.yaml
@@ -16,7 +16,7 @@ data:
   name: Fastbill
   registryOverrides:
     cloud:
-      enabled: false
+      enabled: true
     oss:
       enabled: true
   releaseDate: "2022-11-08"

--- a/airbyte-integrations/connectors/source-fullstory/metadata.yaml
+++ b/airbyte-integrations/connectors/source-fullstory/metadata.yaml
@@ -14,7 +14,7 @@ data:
       packageName: airbyte-source-fullstory
   registryOverrides:
     cloud:
-      enabled: false
+      enabled: true
     oss:
       enabled: true
   releaseStage: alpha

--- a/airbyte-integrations/connectors/source-hellobaton/metadata.yaml
+++ b/airbyte-integrations/connectors/source-hellobaton/metadata.yaml
@@ -10,7 +10,7 @@ data:
     oss:
       enabled: true
     cloud:
-      enabled: false
+      enabled: true
   connectorSubtype: api
   connectorType: source
   definitionId: 492b56d1-937c-462e-8076-21ad2031e784

--- a/airbyte-integrations/connectors/source-intruder/metadata.yaml
+++ b/airbyte-integrations/connectors/source-intruder/metadata.yaml
@@ -14,7 +14,7 @@ data:
       packageName: airbyte-source-intruder
   registryOverrides:
     cloud:
-      enabled: false
+      enabled: true
     oss:
       enabled: true
   releaseStage: alpha

--- a/airbyte-integrations/connectors/source-mailersend/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mailersend/metadata.yaml
@@ -14,7 +14,7 @@ data:
       packageName: airbyte-source-mailersend
   registryOverrides:
     cloud:
-      enabled: false
+      enabled: true
     oss:
       enabled: true
   releaseStage: alpha

--- a/airbyte-integrations/connectors/source-merge/metadata.yaml
+++ b/airbyte-integrations/connectors/source-merge/metadata.yaml
@@ -14,7 +14,7 @@ data:
       packageName: airbyte-source-merge
   registryOverrides:
     cloud:
-      enabled: false
+      enabled: true
     oss:
       enabled: true
   releaseStage: alpha

--- a/airbyte-integrations/connectors/source-newsdata/metadata.yaml
+++ b/airbyte-integrations/connectors/source-newsdata/metadata.yaml
@@ -15,7 +15,7 @@ data:
   name: Newsdata
   registryOverrides:
     cloud:
-      enabled: false
+      enabled: true
     oss:
       enabled: true
   releaseStage: alpha

--- a/airbyte-integrations/connectors/source-ringcentral/metadata.yaml
+++ b/airbyte-integrations/connectors/source-ringcentral/metadata.yaml
@@ -14,7 +14,7 @@ data:
       packageName: airbyte-source-ringcentral
   registryOverrides:
     cloud:
-      enabled: false
+      enabled: true
     oss:
       enabled: true
   releaseStage: alpha

--- a/airbyte-integrations/connectors/source-rocket-chat/metadata.yaml
+++ b/airbyte-integrations/connectors/source-rocket-chat/metadata.yaml
@@ -14,7 +14,7 @@ data:
       packageName: airbyte-source-rocket-chat
   registryOverrides:
     cloud:
-      enabled: false
+      enabled: true
     oss:
       enabled: true
   releaseStage: alpha

--- a/airbyte-integrations/connectors/source-serpstat/metadata.yaml
+++ b/airbyte-integrations/connectors/source-serpstat/metadata.yaml
@@ -7,6 +7,8 @@ data:
       enabled: false
       packageName: airbyte-source-serpstat
   registryOverrides:
+    cloud:
+      enabled: true
     oss:
       enabled: true
   connectorBuildOptions:

--- a/airbyte-integrations/connectors/source-tmdb/metadata.yaml
+++ b/airbyte-integrations/connectors/source-tmdb/metadata.yaml
@@ -14,7 +14,7 @@ data:
       packageName: airbyte-source-tmdb
   registryOverrides:
     cloud:
-      enabled: false
+      enabled: true
     oss:
       enabled: true
   releases:

--- a/airbyte-integrations/connectors/source-toggl/metadata.yaml
+++ b/airbyte-integrations/connectors/source-toggl/metadata.yaml
@@ -3,7 +3,7 @@ data:
     oss:
       enabled: true
     cloud:
-      enabled: false
+      enabled: true
   remoteRegistries:
     pypi:
       enabled: false

--- a/airbyte-integrations/connectors/source-tyntec-sms/metadata.yaml
+++ b/airbyte-integrations/connectors/source-tyntec-sms/metadata.yaml
@@ -14,7 +14,7 @@ data:
       packageName: airbyte-source-tyntec-sms
   registryOverrides:
     cloud:
-      enabled: false
+      enabled: true
     oss:
       enabled: true
   releaseStage: alpha

--- a/airbyte-integrations/connectors/source-younium/metadata.yaml
+++ b/airbyte-integrations/connectors/source-younium/metadata.yaml
@@ -7,7 +7,7 @@ data:
     oss:
       enabled: true
     cloud:
-      enabled: false
+      enabled: true
   connectorBuildOptions:
     # Please update to the latest version of the connector base image.
     # https://hub.docker.com/r/airbyte/python-connector-base


### PR DESCRIPTION
## What

Makes 19 sources that are manifest-only and community available on Cloud.

Mo code changes, just the metadata, hence no version bumps.
