### PR TITLE
fix: avoid hyphens in index name

### DIFF
--- a/airbyte-integrations/connectors/destination-mssql-v2/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-mssql-v2/metadata.yaml
@@ -16,7 +16,7 @@ data:
             type: GSM
   connectorType: destination
   definitionId: 37a928c1-2d5c-431a-a97d-ae236bd1ea0c
-  dockerImageTag: 0.1.11
+  dockerImageTag: 0.1.12
   dockerRepository: airbyte/destination-mssql-v2
   documentationUrl: https://docs.airbyte.com/integrations/destinations/mssql-v2
   githubIssueLabel: destination-mssql-v2

--- a/airbyte-integrations/connectors/destination-mssql-v2/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLQueryBuilder.kt
+++ b/airbyte-integrations/connectors/destination-mssql-v2/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLQueryBuilder.kt
@@ -37,6 +37,7 @@ import java.sql.Connection
 import java.sql.PreparedStatement
 import java.sql.ResultSet
 import java.util.UUID
+import kotlin.math.absoluteValue
 
 private val logger = KotlinLogging.logger {}
 
@@ -426,7 +427,7 @@ class MSSQLQueryBuilder(
         columns: List<String>,
         clustered: Boolean = false
     ): String {
-        val name = "${fqTableName.replace('.', '_')}_${columns.hashCode()}"
+        val name = "${fqTableName.replace('.', '_')}_${columns.hashCode().absoluteValue}"
         val indexType = if (clustered) "CLUSTERED" else ""
         return CREATE_INDEX_QUERY.toQuery(
             indexType,

--- a/airbyte-integrations/connectors/destination-mssql-v2/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLQueryBuilder.kt
+++ b/airbyte-integrations/connectors/destination-mssql-v2/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLQueryBuilder.kt
@@ -428,7 +428,7 @@ class MSSQLQueryBuilder(
         columns: List<String>,
         clustered: Boolean = false
     ): String {
-        val name = "${fqTableName.replace('.', '_')}_${shortHash(columns.hashCode())}"
+        val name = "[${fqTableName.replace('.', '_')}_${shortHash(columns.hashCode())}]"
         val indexType = if (clustered) "CLUSTERED" else ""
         return CREATE_INDEX_QUERY.toQuery(
             indexType,

--- a/airbyte-integrations/connectors/destination-mssql-v2/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLQueryBuilder.kt
+++ b/airbyte-integrations/connectors/destination-mssql-v2/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLQueryBuilder.kt
@@ -37,7 +37,6 @@ import java.sql.Connection
 import java.sql.PreparedStatement
 import java.sql.ResultSet
 import java.util.UUID
-import kotlin.math.absoluteValue
 
 private val logger = KotlinLogging.logger {}
 
@@ -69,6 +68,8 @@ fun String.toQuery(context: Map<String, String>): String =
     this.trimIndent().replace(VAR_REGEX) {
         context[it.groupValues[1]] ?: throw IllegalStateException("Context is missing ${it.value}")
     }
+
+fun shortHash(hashCode: Int): String = "%02x".format(hashCode)
 
 private val VAR_REGEX = "\\?(\\w+)".toRegex()
 
@@ -427,7 +428,7 @@ class MSSQLQueryBuilder(
         columns: List<String>,
         clustered: Boolean = false
     ): String {
-        val name = "${fqTableName.replace('.', '_')}_${columns.hashCode().absoluteValue}"
+        val name = "${fqTableName.replace('.', '_')}_${shortHash(columns.hashCode())}"
         val indexType = if (clustered) "CLUSTERED" else ""
         return CREATE_INDEX_QUERY.toQuery(
             indexType,

--- a/docs/integrations/destinations/mssql-v2.md
+++ b/docs/integrations/destinations/mssql-v2.md
@@ -13,6 +13,7 @@ This connector is in early access, and SHOULD NOT be used for production workloa
 
 | Version | Date       | Pull Request                                               | Subject                                              |
 |:--------|:-----------|:-----------------------------------------------------------|:-----------------------------------------------------|
+| 0.1.12  | 2025-02-24 | [54648](https://github.com/airbytehq/airbyte/pull/54648)   | RC10: Fix index column names with hyphens |
 | 0.1.11  | 2025-02-21 | [54197](https://github.com/airbytehq/airbyte/pull/54197)   | RC9: Fix index column names with invalid characters. |
 | 0.1.10  | 2025-02-20 | [54186](https://github.com/airbytehq/airbyte/pull/54186)   | RC8: Fix String support.                             |
 | 0.1.9   | 2025-02-11 | [53364](https://github.com/airbytehq/airbyte/pull/53364)   | RC7: Revert deletion change.                         |


### PR DESCRIPTION
## What
* Avoid invalid characters in index names

## How
* Ensure that column hashcode value cannot contain hyphens.  While there is a risk of collisions, this should be minimal given that we are only dealing with a handful of columns at a time.

## Review guide
1. MSSQLQueryBuilder.kt

## Can this PR be safely reverted and rolled back?
- [X] YES 💚
- [ ] NO ❌
