### PR TITLE
Load CDK: Drop vestigial obj storage staging stuff

### DIFF
--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/command/object_storage/ObjectStoragePathConfiguration.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/command/object_storage/ObjectStoragePathConfiguration.kt
@@ -6,10 +6,8 @@ package io.airbyte.cdk.load.command.object_storage
 
 data class ObjectStoragePathConfiguration(
     val prefix: String,
-    val stagingPrefix: String?,
-    val pathSuffixPattern: String?,
+    val pathPattern: String?,
     val fileNamePattern: String?,
-    val usesStagingDirectory: Boolean
 )
 
 interface ObjectStoragePathConfigurationProvider {

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/state/object_storage/ObjectStorageDestinationStateManager.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/state/object_storage/ObjectStorageDestinationStateManager.kt
@@ -53,7 +53,7 @@ class ObjectStorageDestinationState(
             return emptyList()
         }
 
-        val prefix = pathFactory.getLongestStreamConstantPrefix(stream, isStaging = false)
+        val prefix = pathFactory.getLongestStreamConstantPrefix(stream)
         log.info {
             "Searching $prefix for objects to delete (minGenId=${stream.minimumGenerationId}; matcher=${matcher.regex})"
         }

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/write/object_storage/RecordToPartAccumulator.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/write/object_storage/RecordToPartAccumulator.kt
@@ -55,7 +55,6 @@ class RecordToPartAccumulator<U : OutputStream>(
                                     pathFactory.getPathToFile(
                                         stream,
                                         fileNo,
-                                        isStaging = pathFactory.supportsStaging
                                     )
                                 ),
                             fileNumber = fileNo

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/test/kotlin/io/airbyte/cdk/load/file/object_storage/ObjectStoragePathFactoryTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/test/kotlin/io/airbyte/cdk/load/file/object_storage/ObjectStoragePathFactoryTest.kt
@@ -4,8 +4,6 @@
 
 package io.airbyte.cdk.load.file.object_storage
 
-import io.airbyte.cdk.load.command.Append
-import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.command.MockDestinationCatalogFactory
 import io.airbyte.cdk.load.command.object_storage.JsonFormatConfiguration
 import io.airbyte.cdk.load.command.object_storage.ObjectStorageCompressionConfiguration
@@ -14,7 +12,6 @@ import io.airbyte.cdk.load.command.object_storage.ObjectStorageFormatConfigurati
 import io.airbyte.cdk.load.command.object_storage.ObjectStorageFormatConfigurationProvider
 import io.airbyte.cdk.load.command.object_storage.ObjectStoragePathConfiguration
 import io.airbyte.cdk.load.command.object_storage.ObjectStoragePathConfigurationProvider
-import io.airbyte.cdk.load.data.StringType
 import io.airbyte.cdk.load.file.GZIPProcessor
 import io.airbyte.cdk.load.file.MockTimeProvider
 import io.airbyte.cdk.load.file.TimeProvider
@@ -57,12 +54,10 @@ class ObjectStoragePathFactoryTest {
         override val objectStoragePathConfiguration: ObjectStoragePathConfiguration =
             ObjectStoragePathConfiguration(
                 prefix = "prefix",
-                stagingPrefix = "staging/prefix",
-                pathSuffixPattern =
+                pathPattern =
                     "\${NAMESPACE}/\${STREAM_NAME}/\${YEAR}/\${MONTH}/\${DAY}/\${HOUR}/\${MINUTE}/\${SECOND}/\${MILLISECOND}/\${EPOCH}/",
                 fileNamePattern =
                     "{date}-{date:yyyy_MM}-{timestamp}-{part_number}-{sync_id}{format_extension}",
-                usesStagingDirectory = true
             )
     }
 
@@ -75,7 +70,7 @@ class ObjectStoragePathFactoryTest {
             MockPathConfigProvider()
                 .objectStoragePathConfiguration
                 .copy(
-                    pathSuffixPattern =
+                    pathPattern =
                         "\${NAMESPACE}/\${STREAM_NAME}/\${YEAR}/\${MONTH}/\${DAY}/\${HOUR}/\${MINUTE}/\${SECOND}/\${MILLISECOND}/\${EPOCH}_"
                 )
     }
@@ -86,9 +81,7 @@ class ObjectStoragePathFactoryTest {
     @Requires(property = "object-storage-path-factory-test.use-staging", value = "false")
     class MockPathConfigProviderWithoutStaging : ObjectStoragePathConfigurationProvider {
         override val objectStoragePathConfiguration: ObjectStoragePathConfiguration =
-            MockPathConfigProvider()
-                .objectStoragePathConfiguration
-                .copy(usesStagingDirectory = false)
+            MockPathConfigProvider().objectStoragePathConfiguration
     }
 
     @Singleton
@@ -117,112 +110,6 @@ class ObjectStoragePathFactoryTest {
                 "MockDestinationCatalog",
             ],
     )
-    @Property(name = "object-storage-path-factory-test.use-staging", value = "true")
-    inner class ObjectStoragePathFactoryTestWithStaging {
-        @Test
-        fun testBasicBehavior(pathFactory: ObjectStoragePathFactory, timeProvider: TimeProvider) {
-            val syncTime = timeProvider.syncTimeMillis()
-            val wallTime = timeProvider.currentTimeMillis()
-            val stream1 = MockDestinationCatalogFactory.stream1
-            val (namespace, name) = stream1.descriptor
-            val prefixOnly = "prefix/$namespace/$name/2020/01/02/03/04/05/0678/$syncTime/"
-            val fileName = "2020_01_02-2020_01-$wallTime-173-42.jsonl.gz"
-            Assertions.assertEquals(
-                "staging/$prefixOnly",
-                pathFactory.getStagingDirectory(stream1).toString(),
-            )
-            Assertions.assertEquals(
-                prefixOnly,
-                pathFactory.getFinalDirectory(stream1).toString(),
-            )
-            Assertions.assertEquals(
-                "staging/$prefixOnly$fileName",
-                pathFactory.getPathToFile(stream1, 173, true).toString(),
-            )
-            Assertions.assertEquals(
-                "$prefixOnly$fileName",
-                pathFactory.getPathToFile(stream1, 173, false).toString(),
-            )
-        }
-
-        @Test
-        fun testPathMatchingPattern(
-            pathFactory: ObjectStoragePathFactory,
-            timeProvider: TimeProvider
-        ) {
-            val syncTime = timeProvider.syncTimeMillis()
-            val stream1 = MockDestinationCatalogFactory.stream1
-            val (namespace, name) = stream1.descriptor
-            val expectedToMatch =
-                "prefix/$namespace/$name/2020/01/02/03/04/05/0678/$syncTime/2020_01_02-2020_01-1577934245678-173-42.jsonl.gz"
-            val match = pathFactory.getPathMatcher(stream1).match(expectedToMatch)
-            Assertions.assertTrue(match != null)
-            Assertions.assertTrue(match?.partNumber == 173L)
-        }
-
-        @Test
-        fun testPathMatchingPatternWithEmptyStream(
-            pathFactory: ObjectStoragePathFactory,
-            timeProvider: TimeProvider
-        ) {
-            val epochMilli = timeProvider.currentTimeMillis()
-            val stream1 = MockDestinationCatalogFactory.stream1
-            val (_, name) = stream1.descriptor
-            val emptyNamespaceStream =
-                stream1.copy(descriptor = stream1.descriptor.copy(namespace = null))
-            val expectedToMatch =
-                "prefix/$name/2020/01/02/03/04/05/0678/$epochMilli/2020_01_02-2020_01-1577934245678-173-42.jsonl.gz"
-            val match = pathFactory.getPathMatcher(emptyNamespaceStream).match(expectedToMatch)
-            Assertions.assertTrue(match != null)
-            Assertions.assertTrue(match?.partNumber == 173L)
-        }
-
-        @Test
-        fun testSpecialCharacterInStream(
-            pathFactory: ObjectStoragePathFactory,
-            timeProvider: TimeProvider
-        ) {
-            val epochMilli = timeProvider.syncTimeMillis()
-            val streamWithSpecial =
-                DestinationStream(
-                    DestinationStream.Descriptor(
-                        "namespace",
-                        "stream_with:spécial:characters",
-                    ),
-                    generationId = 0,
-                    minimumGenerationId = 0,
-                    syncId = 0,
-                    schema = StringType,
-                    importType = Append
-                )
-            val expectedPath =
-                "prefix/namespace/stream_with:special:characters/2020/01/02/03/04/05/0678/$epochMilli/"
-            Assertions.assertEquals(
-                expectedPath,
-                pathFactory.getFinalDirectory(streamWithSpecial),
-            )
-        }
-
-        @Test
-        fun testLongestConstantPrefix(pathFactory: ObjectStoragePathFactory) {
-            val stream1 = MockDestinationCatalogFactory.stream1
-            val (namespace, name) = stream1.descriptor
-            val prefixOnly = "prefix/$namespace/$name/"
-            Assertions.assertEquals(
-                prefixOnly,
-                pathFactory.getLongestStreamConstantPrefix(stream1, false)
-            )
-        }
-    }
-
-    @Nested
-    @MicronautTest(
-        environments =
-            [
-                "ObjectStoragePathFactoryTest",
-                "MockDestinationCatalog",
-            ],
-    )
     @Property(name = "object-storage-path-factory-test.use-staging", value = "false")
     inner class ObjectStoragePathFactoryTestWithoutStaging {
         @Test
@@ -239,15 +126,8 @@ class ObjectStoragePathFactoryTest {
             )
             Assertions.assertEquals(
                 "$prefixOnly$fileName",
-                pathFactory.getPathToFile(stream1, 173, false),
+                pathFactory.getPathToFile(stream1, 173),
             )
-
-            Assertions.assertThrows(UnsupportedOperationException::class.java) {
-                pathFactory.getStagingDirectory(stream1)
-            }
-            Assertions.assertThrows(UnsupportedOperationException::class.java) {
-                pathFactory.getPathToFile(stream1, 173, true)
-            }
         }
     }
 
@@ -278,7 +158,7 @@ class ObjectStoragePathFactoryTest {
             )
             Assertions.assertEquals(
                 "$prefixOnly$fileName",
-                pathFactory.getPathToFile(stream1, 173, false),
+                pathFactory.getPathToFile(stream1, 173),
             )
         }
     }

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/test/kotlin/io/airbyte/cdk/load/file/object_storage/ObjectStoragePathFactoryUTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/test/kotlin/io/airbyte/cdk/load/file/object_storage/ObjectStoragePathFactoryUTest.kt
@@ -42,10 +42,8 @@ class ObjectStoragePathFactoryUTest {
         coEvery { pathConfigProvider.objectStoragePathConfiguration } returns
             ObjectStoragePathConfiguration(
                 "prefix",
-                null,
                 "path/",
                 "ambiguous_filename",
-                false,
             )
         val factory = ObjectStoragePathFactory(pathConfigProvider, null, null, timeProvider)
 
@@ -63,20 +61,11 @@ class ObjectStoragePathFactoryUTest {
         coEvery { pathConfigProvider.objectStoragePathConfiguration } returns
             ObjectStoragePathConfiguration(
                 "prefix-\${NAMESPACE}",
-                "staging-\${NAMESPACE}",
                 "\${STREAM_NAME}/",
                 "any_filename",
-                true,
             )
         val factory = ObjectStoragePathFactory(pathConfigProvider, null, null, timeProvider)
-        assertEquals(
-            "prefix-test/stream/any_filename",
-            factory.getPathToFile(stream, 0L, isStaging = false)
-        )
-        assertEquals(
-            "staging-test/stream/any_filename",
-            factory.getPathToFile(stream, 0L, isStaging = true)
-        )
+        assertEquals("prefix-test/stream/any_filename", factory.getPathToFile(stream, 0L))
     }
 
     @Test
@@ -84,10 +73,8 @@ class ObjectStoragePathFactoryUTest {
         coEvery { pathConfigProvider.objectStoragePathConfiguration } returns
             ObjectStoragePathConfiguration(
                 "prefix-\${NAMESPACE}",
-                "staging-\${NAMESPACE}",
                 "\${STREAM_NAME}/",
                 "any_filename",
-                true,
             )
         val factory = ObjectStoragePathFactory(pathConfigProvider, null, null, timeProvider)
         val matcher = factory.getPathMatcher(stream, "(-foo)?")
@@ -100,10 +87,8 @@ class ObjectStoragePathFactoryUTest {
         coEvery { pathConfigProvider.objectStoragePathConfiguration } returns
             ObjectStoragePathConfiguration(
                 "prefix",
-                "staging",
                 "\${NAMESPACE}/\${STREAM_NAME}/",
                 "any_filename",
-                true,
             )
         val streamWithNullNamespace = mockk<DestinationStream>()
         coEvery { streamWithNullNamespace.descriptor } returns
@@ -111,11 +96,7 @@ class ObjectStoragePathFactoryUTest {
         val factory = ObjectStoragePathFactory(pathConfigProvider, null, null, timeProvider)
         assertEquals(
             "prefix/stream/any_filename",
-            factory.getPathToFile(streamWithNullNamespace, 0L, isStaging = false)
-        )
-        assertEquals(
-            "staging/stream/any_filename",
-            factory.getPathToFile(streamWithNullNamespace, 0L, isStaging = true)
+            factory.getPathToFile(streamWithNullNamespace, 0L)
         )
 
         val matcher = factory.getPathMatcher(streamWithNullNamespace, "(-foo)?")
@@ -127,10 +108,8 @@ class ObjectStoragePathFactoryUTest {
         coEvery { pathConfigProvider.objectStoragePathConfiguration } returns
             ObjectStoragePathConfiguration(
                 "prefix",
-                "staging",
                 "\${STREAM_NAME}/",
                 "any_filename",
-                true,
             )
         val streamWithLegalRegex = mockk<DestinationStream>()
         coEvery { streamWithLegalRegex.descriptor } returns
@@ -138,7 +117,7 @@ class ObjectStoragePathFactoryUTest {
         val factory = ObjectStoragePathFactory(pathConfigProvider, null, null, timeProvider)
         assertEquals(
             "prefix/stream+1/any_filename",
-            factory.getPathToFile(streamWithLegalRegex, 0L, isStaging = false)
+            factory.getPathToFile(streamWithLegalRegex, 0L)
         )
         val matcher = factory.getPathMatcher(streamWithLegalRegex, "(-foo)?")
         assertNotNull(matcher.match("prefix/stream+1/any_filename"))
@@ -158,10 +137,8 @@ class ObjectStoragePathFactoryUTest {
         coEvery { pathConfigProvider.objectStoragePathConfiguration } returns
             ObjectStoragePathConfiguration(
                 bucketPathTemplate,
-                null,
                 filePathTemplate,
                 fileNameTemplate,
-                false,
             )
         val stream = mockk<DestinationStream>()
         coEvery { stream.descriptor } returns DestinationStream.Descriptor(namespace, name)

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/test/kotlin/io/airbyte/cdk/load/state/object_storage/ObjectStorageDestinationStateUTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/test/kotlin/io/airbyte/cdk/load/state/object_storage/ObjectStorageDestinationStateUTest.kt
@@ -32,7 +32,7 @@ class ObjectStorageDestinationStateUTest {
     @BeforeEach
     fun setup() {
         every { stream.descriptor } returns DestinationStream.Descriptor("test", "stream")
-        every { pathFactory.getLongestStreamConstantPrefix(any(), any()) } returns ""
+        every { pathFactory.getLongestStreamConstantPrefix(any()) } returns ""
     }
 
     @Test

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/test/kotlin/io/airbyte/cdk/load/write/object_storage/RecordToPartAccumulatorTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/test/kotlin/io/airbyte/cdk/load/write/object_storage/RecordToPartAccumulatorTest.kt
@@ -91,7 +91,6 @@ class RecordToPartAccumulatorTest {
             }
 
         coEvery { pathFactory.getPathToFile(any(), any()) } answers { "path.${secondArg<Long>()}" }
-        coEvery { pathFactory.supportsStaging } returns false
 
         // Object 1
 

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/testFixtures/kotlin/io/airbyte/cdk/load/MockPathFactory.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/testFixtures/kotlin/io/airbyte/cdk/load/MockPathFactory.kt
@@ -13,22 +13,11 @@ import jakarta.inject.Singleton
 @Singleton
 @Requires(env = ["MockPathFactory"])
 open class MockPathFactory : PathFactory {
-    open var doSupportStaging = false
-
-    override val supportsStaging: Boolean
-        get() = doSupportStaging
     override val finalPrefix: String
         get() = "prefix"
 
     private fun fromStream(stream: DestinationStream): String {
         return "${stream.descriptor.namespace}/${stream.descriptor.name}"
-    }
-
-    override fun getStagingDirectory(
-        stream: DestinationStream,
-        substituteStreamAndNamespaceOnly: Boolean
-    ): String {
-        return "$finalPrefix/staging/${fromStream(stream)}"
     }
 
     override fun getFinalDirectory(
@@ -41,22 +30,16 @@ open class MockPathFactory : PathFactory {
     override fun getPathToFile(
         stream: DestinationStream,
         partNumber: Long?,
-        isStaging: Boolean,
         extension: String?
     ): String {
-        val prefix = if (isStaging) getStagingDirectory(stream) else getFinalDirectory(stream)
+        val prefix = getFinalDirectory(stream)
         return "${prefix}file"
     }
 
     override fun getLongestStreamConstantPrefix(
         stream: DestinationStream,
-        isStaging: Boolean
     ): String {
-        return if (isStaging) {
-            getStagingDirectory(stream)
-        } else {
-            getFinalDirectory(stream)
-        }
+        return getFinalDirectory(stream)
     }
 
     override fun getPathMatcher(

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/testFixtures/kotlin/io/airbyte/cdk/load/ObjectStorageDataDumper.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/testFixtures/kotlin/io/airbyte/cdk/load/ObjectStorageDataDumper.kt
@@ -50,7 +50,7 @@ class ObjectStorageDataDumper(
         // Note: this is implicitly a test of the `streamConstant` final directory
         // and the path matcher, so a failure here might imply a bug in the metadata-based
         // destination state loader, which lists by `prefix` and filters against the matcher.
-        val prefix = pathFactory.getLongestStreamConstantPrefix(stream, isStaging = false)
+        val prefix = pathFactory.getLongestStreamConstantPrefix(stream)
         val matcher =
             pathFactory.getPathMatcher(stream, suffixPattern = OPTIONAL_ORDINAL_SUFFIX_PATTERN)
         return runBlocking {

--- a/airbyte-cdk/bulk/toolkits/load-s3/src/main/kotlin/io/airbyte/cdk/load/command/s3/S3PathSpecification.kt
+++ b/airbyte-cdk/bulk/toolkits/load-s3/src/main/kotlin/io/airbyte/cdk/load/command/s3/S3PathSpecification.kt
@@ -72,9 +72,7 @@ interface S3PathSpecification {
     fun toObjectStoragePathConfiguration(): ObjectStoragePathConfiguration =
         ObjectStoragePathConfiguration(
             prefix = s3BucketPath,
-            stagingPrefix = null,
-            pathSuffixPattern = s3PathFormat,
+            pathPattern = s3PathFormat,
             fileNamePattern = fileNamePattern,
-            usesStagingDirectory = false
         )
 }

--- a/airbyte-integrations/connectors/destination-s3/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-s3/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: file
   connectorType: destination
   definitionId: 4816b78f-1489-44c1-9060-4b19d5fa9362
-  dockerImageTag: 1.5.1
+  dockerImageTag: 1.5.2
   dockerRepository: airbyte/destination-s3
   githubIssueLabel: destination-s3
   icon: s3.svg

--- a/airbyte-integrations/connectors/destination-s3/src/main/kotlin/S3V2Checker.kt
+++ b/airbyte-integrations/connectors/destination-s3/src/main/kotlin/S3V2Checker.kt
@@ -30,12 +30,7 @@ class S3V2Checker<T : OutputStream>(
         runBlocking {
             val s3Client = S3ClientFactory.make(config, assumeRoleCredentials)
             val pathFactory = ObjectStoragePathFactory.from(config, timeProvider)
-            val path =
-                if (pathFactory.supportsStaging) {
-                    pathFactory.getStagingDirectory(mockStream())
-                } else {
-                    pathFactory.getFinalDirectory(mockStream())
-                }
+            val path = pathFactory.getFinalDirectory(mockStream())
             val key = Paths.get(path, "_EXAMPLE").toString()
             log.info { "Checking if destination can write to $path" }
             var s3Object: S3Object? = null

--- a/airbyte-integrations/connectors/destination-s3/src/main/kotlin/S3V2Specification.kt
+++ b/airbyte-integrations/connectors/destination-s3/src/main/kotlin/S3V2Specification.kt
@@ -74,13 +74,6 @@ class S3V2Specification :
             "{\"examples\":[\"{date}\",\"{date:yyyy_MM}\",\"{timestamp}\",\"{part_number}\",\"{sync_id}\"],\"order\":9}"
     )
     override val fileNamePattern: String? = null
-
-    //    Uncomment to re-enable staging
-    //    @get:JsonSchemaInject(json = """{"order":10}""")
-    //    override val useStagingDirectory: Boolean? = null
-    //
-    //    @get:JsonSchemaInject(json = """{"examples":["__staging/data_sync/test"],"order":11}""")
-    //    override val s3StagingPrefix: String? = null
 }
 
 @Singleton

--- a/airbyte-integrations/connectors/destination-s3/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2WriteTest.kt
+++ b/airbyte-integrations/connectors/destination-s3/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2WriteTest.kt
@@ -37,7 +37,6 @@ abstract class S3V2WriteTest(
     schematizedArrayBehavior: SchematizedNestedValueBehavior,
     unionBehavior: UnionBehavior,
     preserveUndeclaredFields: Boolean,
-    /** This is false for staging mode, and true for non-staging mode. */
     commitDataIncrementally: Boolean = true,
     allTypesBehavior: AllTypesBehavior,
     nullEqualsUnset: Boolean = false,

--- a/docs/integrations/destinations/s3.md
+++ b/docs/integrations/destinations/s3.md
@@ -544,6 +544,7 @@ To see connector limitations, or troubleshoot your S3 connector, see more [in ou
 
 | Version     | Date       | Pull Request                                               | Subject                                                                                                                                              |
 |:------------|:-----------|:-----------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| 1.5.2       | 2025-02-25 | [54661](https://github.com/airbytehq/airbyte/pull/54661)   | Nonfunctional cleanup; dropped unused staging code                                                                                                   |
 | 1.5.1       | 2025-02-11 | [53636](https://github.com/airbytehq/airbyte/pull/53636)   | Nonfunctional CDK version pin.                                                                                                                       |
 | 1.5.0       | 2025-02-11 | [53632](https://github.com/airbytehq/airbyte/pull/53632)   | Promoting release candidate 1.5.0-rc.20 to a main version.                                                                                           |
 | 1.5.0-rc.20 | 2025-02-04 | [53173](https://github.com/airbytehq/airbyte/pull/53173)   | Tweak spec wording                                                                                                                                   |


### PR DESCRIPTION
## What
**NON-FUNCTIONAL CODE CLEANUP**

This drops the remaining references to staging in the object storage toolkit. (Staging was an abortive attempt at fixing the issues with metadata search as part of the S3V2 release. We disabled it, and subsequent changes have rendered the existing code moot, so it's better to drop it than to give the false impression that it is useful.)

## Why
In addition to cleanup
* we are approaching the point where object storage is used by more than one use case
* i'm about to rewrite s3 for the files speed test

So I'm going to clean up / simplify the configuration a little bit so that not everybody is burdened by S3's insane legacy path rules.