### PR TITLE
fix(source-airtable): added new mapping for multipleLookupValues

### DIFF
--- a/airbyte-integrations/connectors/source-airtable/metadata.yaml
+++ b/airbyte-integrations/connectors/source-airtable/metadata.yaml
@@ -11,7 +11,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 14c6e7ea-97ed-4f5e-a7b5-25e9a80b8212
-  dockerImageTag: 4.5.1
+  dockerImageTag: 4.5.2
   dockerRepository: airbyte/source-airtable
   documentationUrl: https://docs.airbyte.com/integrations/sources/airtable
   githubIssueLabel: source-airtable

--- a/airbyte-integrations/connectors/source-airtable/pyproject.toml
+++ b/airbyte-integrations/connectors/source-airtable/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "4.5.1"
+version = "4.5.2"
 name = "source-airtable"
 description = "Source implementation for Airtable."
 authors = [ "Airbyte <anhtuan.nguyen@me.com>",]

--- a/airbyte-integrations/connectors/source-airtable/source_airtable/manifest.yaml
+++ b/airbyte-integrations/connectors/source-airtable/source_airtable/manifest.yaml
@@ -359,6 +359,12 @@ definitions:
                 field_type: array
                 items: string
               current_type: multipleLookupValues
+              condition: "{{ raw_schema['options']['result']['type'] in ['multipleAttachments', 'barcode', 'button', 'singleCollaborator', 'createdBy', 'email', 'lastModifiedBy', 'multilineText', 'phoneNumber', 'richText', 'singleLineText', 'singleSelect', 'externalSyncSource', 'url', 'simpleText', 'linkToRecord'] }}"
+            - type: TypesMap
+              target_type:
+                field_type: array
+                items: string
+              current_type: multipleLookupValues
               condition: "{{ raw_schema['options']['result']['type'] in ['multipleAttachments', 'barcode', 'button', 'singleCollaborator', 'createdBy', 'email', 'lastModifiedBy', 'multilineText', 'phoneNumber', 'richText', 'singleLineText', 'singleSelect', 'externalSyncSource', 'url', 'simpleText'] }}"
             - type: TypesMap
               target_type:

--- a/docs/integrations/sources/airtable.md
+++ b/docs/integrations/sources/airtable.md
@@ -137,6 +137,7 @@ See information about rate limits [here](https://airtable.com/developers/web/api
 
 | Version    | Date       | Pull Request                                             | Subject                                                                                 |
 |:-----------|:-----------|:---------------------------------------------------------|:----------------------------------------------------------------------------------------|
+| 4.5.2      | 2025-02-24 | [XXXXX](https://github.com/airbytehq/airbyte/pull/XXXXX) | Add type for multipleLookupValues for linkToRecord|
 | 4.5.1      | 2025-02-13 | [53672](https://github.com/airbytehq/airbyte/pull/53672) | Add type for aiText and lastModifiedTime, when result type is null                      |
 | 4.5.0      | 2025-02-12 | [53657](https://github.com/airbytehq/airbyte/pull/53657) | Promoting release candidate 4.5.0-rc.4 to a main version.                               |
 | 4.5.0-rc.4 | 2025-02-04 | [53156](https://github.com/airbytehq/airbyte/pull/53156) | Add default type for `rollup`, `lookuo` and `multiplelookup`, add new type `manualSort` |


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->
Follow up to: https://github.com/airbytehq/oncall/issues/7436
```
2025-02-21 06:58:26 source ERROR Invalid Airbyte data type: multipleLookupValues
Traceback (most recent call last):
  File "/airbyte/integration_code/main.py", line 9, in <module>
    run()
  File "/airbyte/integration_code/source_airtable/run.py", line 57, in run
    launch(source, _args)
  File "/usr/local/lib/python3.10/site-packages/airbyte_cdk/entrypoint.py", line 341, in launch
    for message in source_entrypoint.run(parsed_args):
  File "/usr/local/lib/python3.10/site-packages/airbyte_cdk/entrypoint.py", line 171, in run
    yield from map(
  File "/usr/local/lib/python3.10/site-packages/airbyte_cdk/entrypoint.py", line 244, in read
    for message in self.source.read(self.logger, config, catalog, state):
  File "/usr/local/lib/python3.10/site-packages/airbyte_cdk/sources/declarative/concurrent_declarative_source.py", line 131, in read
    concurrent_streams, _ = self._group_streams(config=config)
  File "/usr/local/lib/python3.10/site-packages/airbyte_cdk/sources/declarative/concurrent_declarative_source.py", line 294, in _group_streams
    declarative_stream.get_json_schema(),
  File "/usr/local/lib/python3.10/site-packages/airbyte_cdk/sources/declarative/declarative_stream.py", line 163, in get_json_schema
    return self._schema_loader.get_json_schema()
  File "/usr/local/lib/python3.10/site-packages/airbyte_cdk/sources/declarative/schema/dynamic_schema_loader.py", line 148, in get_json_schema
    value = self._get_type(
  File "/usr/local/lib/python3.10/site-packages/airbyte_cdk/sources/declarative/schema/dynamic_schema_loader.py", line 213, in _get_type
    return self._get_airbyte_type(mapped_field_type)
  File "/usr/local/lib/python3.10/site-packages/airbyte_cdk/sources/declarative/schema/dynamic_schema_loader.py", line 263, in _get_airbyte_type
    raise ValueError(f"Invalid Airbyte data type: {field_type}")
ValueError: Invalid Airbyte data type: multipleLookupValues 
```
## How
<!--
* Describe how code changes achieve the solution.
-->
Add type mapping for linkToRecord (Array of strings)

## Review guide
<!--
1. `x.py`
2. `y.py`
-->
Test via dev image & run regressions

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
