### PR TITLE
[source-gcs] Fix io.UnsupportedOperation: underlying stream is not seekable

### DIFF
--- a/airbyte-integrations/connectors/source-gcs/metadata.yaml
+++ b/airbyte-integrations/connectors/source-gcs/metadata.yaml
@@ -11,7 +11,7 @@ data:
   connectorSubtype: file
   connectorType: source
   definitionId: 2a8c41ae-8c23-4be0-a73f-2ab10ca1a820
-  dockerImageTag: 0.8.7
+  dockerImageTag: 0.8.8
   dockerRepository: airbyte/source-gcs
   documentationUrl: https://docs.airbyte.com/integrations/sources/gcs
   githubIssueLabel: source-gcs

--- a/airbyte-integrations/connectors/source-gcs/pyproject.toml
+++ b/airbyte-integrations/connectors/source-gcs/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "0.8.7"
+version = "0.8.8"
 name = "source-gcs"
 description = "Source implementation for Gcs."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-gcs/source_gcs/stream_reader.py
+++ b/airbyte-integrations/connectors/source-gcs/source_gcs/stream_reader.py
@@ -6,7 +6,7 @@ import json
 import logging
 import tempfile
 from datetime import datetime, timedelta
-from io import IOBase
+from io import IOBase, StringIO
 from typing import Iterable, List, Optional
 
 import pytz
@@ -139,6 +139,8 @@ class SourceGCSStreamReader(AbstractFileBasedStreamReader):
             result = smart_open.open(
                 file.uri, mode=mode.value, compression=compression, encoding=encoding, transport_params={"client": self.gcs_client}
             )
+            if not result.seekable():
+                result = StringIO(result.read())
         except OSError as oe:
             logger.warning(ERROR_MESSAGE_ACCESS.format(uri=file.uri, bucket=self.config.bucket))
             logger.exception(oe)

--- a/docs/integrations/sources/gcs.md
+++ b/docs/integrations/sources/gcs.md
@@ -236,6 +236,7 @@ Google Cloud Storage (GCS) supports following file formats:
 
 | Version | Date       | Pull Request                                             | Subject                                                                 |
 |:--------|:-----------|:---------------------------------------------------------|:------------------------------------------------------------------------|
+| 0.8.8 | 2025-02-25 | [54677](https://github.com/airbytehq/airbyte/pull/54677) | Fix io.UnsupportedOperation: underlying stream is not seekable |
 | 0.8.7 | 2025-02-22 | [54458](https://github.com/airbytehq/airbyte/pull/54458) | Update dependencies |
 | 0.8.6 | 2025-02-15 | [53712](https://github.com/airbytehq/airbyte/pull/53712) | Update dependencies |
 | 0.8.5 | 2025-02-08 | [53365](https://github.com/airbytehq/airbyte/pull/53365) | Update dependencies |


### PR DESCRIPTION
## What

Fixes `io.UnsupportedOperation: underlying stream is not seekable` error.
This error occurs while reading CSV files from `pubsite_prod_rev_*` buckets. Reports from Google Play are stored in those buckets https://support.google.com/googleplay/android-developer/answer/6135870?hl=en

```
Traceback (most recent call last): 
  File "/usr/local/lib/python3.11/site-packages/airbyte_cdk/sources/file_based/availability_strategy/default_file_based_availability_strategy.py", line 98, in _check_parse_record record = next(iter(parser.parse_records(stream.config, file, self.stream_reader, logger, discovered_schema=None)))
  File "/usr/local/lib/python3.11/site-packages/airbyte_cdk/sources/file_based/file_types/csv_parser.py", line 212, in parse_records for row in data_generator: 
  File "/usr/local/lib/python3.11/site-packages/airbyte_cdk/sources/file_based/file_types/csv_parser.py", line 57, in read_data headers = self._get_headers(fp, config_format, dialect_name)
  File "/usr/local/lib/python3.11/site-packages/airbyte_cdk/sources/file_based/file_types/csv_parser.py", line 116, in _get_headers fp.seek(0) io.UnsupportedOperation: underlying stream is not seekable The above exception was the direct cause of the following exception: Traceback (most recent call last): 
  File "/usr/local/lib/python3.11/site-packages/airbyte_cdk/sources/file_based/availability_strategy/default_file_based_availability_strategy.py", line 65, in check_availability_and_parsability self._check_parse_record(stream, file, logger) 
  File "/usr/local/lib/python3.11/site-packages/airbyte_cdk/sources/file_based/availability_strategy/default_file_based_availability_strategy.py", line 107, in _check_parse_record raise CheckAvailabilityError(FileBasedSourceError.ERROR_READING_FILE, stream=stream.name, file=file.uri) from exc airbyte_cdk.sources.file_based.exceptions.CheckAvailabilityError: Error opening file. Please check the credentials provided in the config and verify that they provide permission to read files. Contact Support if you need assistance. stream=<redacted stream name> file=<redacted file name>
```

![image](https://github.com/user-attachments/assets/c5d34e87-868e-4a5f-8faf-5d0ab60007ac)

## How

Code checks is handler is seekable. If not, reads the data and wraps it with StringIO.

## Review guide

1. `airbyte-integrations/connectors/source-gcs/source_gcs/stream_reader.py`


## User Impact

Error `io.UnsupportedOperation: underlying stream is not seekable` will be gone.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
