### PR TITLE
fix(source-typeform): pin typeform to 1.3.27

### DIFF
--- a/airbyte-integrations/connectors/source-typeform/metadata.yaml
+++ b/airbyte-integrations/connectors/source-typeform/metadata.yaml
@@ -24,6 +24,8 @@ data:
       packageName: airbyte-source-typeform
   registryOverrides:
     cloud:
+      # Pinned because manifest-only migration broke Cloud a bit
+      dockerImageTag: 1.3.27
       enabled: true
     oss:
       enabled: true


### PR DESCRIPTION
## What

Reverts source-typeform to pre-migraiton 1.3.27 because manifest-only migration broke things ;(

