### PR TITLE
chore(source-partnerstack): make source-partnerstack available on Cloud

### DIFF
--- a/airbyte-integrations/connectors/source-partnerstack/metadata.yaml
+++ b/airbyte-integrations/connectors/source-partnerstack/metadata.yaml
@@ -14,7 +14,7 @@ data:
       packageName: airbyte-source-partnerstack
   registryOverrides:
     cloud:
-      enabled: false
+      enabled: true
     oss:
       enabled: true
   releaseStage: alpha


### PR DESCRIPTION
## What

Publishes Partnerstack connector to Airbyte Cloud registry.