### PR TITLE
Destination-S3: Enable optional fallback to legacy java SDK

### DIFF
--- a/airbyte-cdk/bulk/toolkits/load-s3/build.gradle
+++ b/airbyte-cdk/bulk/toolkits/load-s3/build.gradle
@@ -4,6 +4,10 @@ dependencies {
     api project(':airbyte-cdk:bulk:toolkits:bulk-cdk-toolkit-load-aws')
     api project(':airbyte-cdk:bulk:toolkits:bulk-cdk-toolkit-load-object-storage')
 
+    // For legacy AWS Java SDK Support
+    api 'com.amazonaws:aws-java-sdk-s3:1.12.772'
+    api 'com.amazonaws:aws-java-sdk-sts:1.12.772'
+
     testFixturesApi(testFixtures(project(":airbyte-cdk:bulk:toolkits:bulk-cdk-toolkit-load-object-storage")))
     implementation("aws.sdk.kotlin:s3:1.3.98")
     implementation("aws.smithy.kotlin:http-client-engine-crt:1.3.31")

--- a/airbyte-cdk/bulk/toolkits/load-s3/src/main/kotlin/io/airbyte/cdk/load/command/s3/S3ClientConfiguration.kt
+++ b/airbyte-cdk/bulk/toolkits/load-s3/src/main/kotlin/io/airbyte/cdk/load/command/s3/S3ClientConfiguration.kt
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.load.command.s3
+
+/**
+ * Add this to your destination configuration to provide S3 client configuration.
+ *
+ * Currently, this is optional and only serves to enable
+ * [io.airbyte.cdk.load.file.s3.S3LegacyJavaClient].
+ */
+interface S3ClientConfigurationProvider {
+    val s3ClientConfiguration: S3ClientConfiguration
+}
+
+data class S3ClientConfiguration(val useLegacyJavaClient: Boolean = false)

--- a/airbyte-cdk/bulk/toolkits/load-s3/src/main/kotlin/io/airbyte/cdk/load/file/s3/S3Client.kt
+++ b/airbyte-cdk/bulk/toolkits/load-s3/src/main/kotlin/io/airbyte/cdk/load/file/s3/S3Client.kt
@@ -24,10 +24,10 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 import io.airbyte.cdk.load.command.aws.AWSAccessKeyConfigurationProvider
 import io.airbyte.cdk.load.command.aws.AWSArnRoleConfigurationProvider
 import io.airbyte.cdk.load.command.aws.AwsAssumeRoleCredentials
-import io.airbyte.cdk.load.command.object_storage.ObjectStorageUploadConfiguration
 import io.airbyte.cdk.load.command.object_storage.ObjectStorageUploadConfigurationProvider
 import io.airbyte.cdk.load.command.s3.S3BucketConfiguration
 import io.airbyte.cdk.load.command.s3.S3BucketConfigurationProvider
+import io.airbyte.cdk.load.command.s3.S3ClientConfigurationProvider
 import io.airbyte.cdk.load.file.object_storage.ObjectStorageClient
 import io.airbyte.cdk.load.file.object_storage.RemoteObject
 import io.airbyte.cdk.load.file.object_storage.StreamingUpload
@@ -44,12 +44,18 @@ data class S3Object(override val key: String, override val storageConfig: S3Buck
         get() = "${storageConfig.s3BucketName}/$key"
 }
 
+interface S3Client : ObjectStorageClient<S3Object>
+
+/**
+ * The primary and recommended S3 client implementation -- kotlin-friendly with suspend functions.
+ * However, there's a bug that can cause hard failures under high-concurrency. (Partial workaround
+ * in place https://github.com/awslabs/aws-sdk-kotlin/issues/1214#issuecomment-2464831817).
+ */
 @SuppressFBWarnings("NP_NONNULL_PARAM_VIOLATION", justification = "Kotlin async continuation")
-class S3Client(
+class S3KotlinClient(
     private val client: aws.sdk.kotlin.services.s3.S3Client,
     val bucketConfig: S3BucketConfiguration,
-    private val uploadConfig: ObjectStorageUploadConfiguration?,
-) : ObjectStorageClient<S3Object> {
+) : S3Client {
     private val log = KotlinLogging.logger {}
 
     override suspend fun list(prefix: String) = flow {
@@ -159,7 +165,10 @@ class S3ClientFactory(
     private val bucketConfig: S3BucketConfigurationProvider,
     private val uploadConfig: ObjectStorageUploadConfigurationProvider? = null,
     private val assumeRoleCredentials: AwsAssumeRoleCredentials?,
+    private val s3ClientConfig: S3ClientConfigurationProvider? = null,
 ) {
+    private val log = KotlinLogging.logger {}
+
     companion object {
         const val AIRBYTE_STS_SESSION_NAME = "airbyte-sts-session"
 
@@ -174,6 +183,28 @@ class S3ClientFactory(
     @Singleton
     @Secondary
     fun make(): S3Client {
+        if (s3ClientConfig?.s3ClientConfiguration?.useLegacyJavaClient == true) {
+            log.info { "Creating S3 client using legacy Java SDK" }
+            return if (
+                arnRole.awsArnRoleConfiguration.roleArn != null && assumeRoleCredentials != null
+            ) {
+                S3LegacyJavaClientFactory()
+                    .createFromAssumeRole(
+                        arnRole.awsArnRoleConfiguration,
+                        assumeRoleCredentials,
+                        bucketConfig.s3BucketConfiguration
+                    )
+            } else {
+                S3LegacyJavaClientFactory()
+                    .createFromAccessKey(
+                        keyConfig.awsAccessKeyConfiguration,
+                        bucketConfig.s3BucketConfiguration
+                    )
+            }
+        }
+
+        log.info { "Creating S3 client using Kotlin SDK" }
+
         val credsProvider: CredentialsProvider =
             if (keyConfig.awsAccessKeyConfiguration.accessKeyId != null) {
                 StaticCredentialsProvider {
@@ -216,10 +247,9 @@ class S3ClientFactory(
                 httpClient(CrtHttpEngine)
             }
 
-        return S3Client(
+        return S3KotlinClient(
             s3SdkClient,
             bucketConfig.s3BucketConfiguration,
-            uploadConfig?.objectStorageUploadConfiguration
         )
     }
 }

--- a/airbyte-cdk/bulk/toolkits/load-s3/src/main/kotlin/io/airbyte/cdk/load/file/s3/S3LegacyJavaClient.kt
+++ b/airbyte-cdk/bulk/toolkits/load-s3/src/main/kotlin/io/airbyte/cdk/load/file/s3/S3LegacyJavaClient.kt
@@ -1,0 +1,221 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.load.file.s3
+
+import com.amazonaws.ClientConfiguration
+import com.amazonaws.Protocol
+import com.amazonaws.auth.AWSCredentials
+import com.amazonaws.auth.AWSStaticCredentialsProvider
+import com.amazonaws.auth.BasicAWSCredentials
+import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider
+import com.amazonaws.client.builder.AwsClientBuilder
+import com.amazonaws.endpointdiscovery.DaemonThreadFactory
+import com.amazonaws.regions.Regions
+import com.amazonaws.retry.RetryMode
+import com.amazonaws.services.s3.AmazonS3
+import com.amazonaws.services.s3.AmazonS3ClientBuilder
+import com.amazonaws.services.s3.model.CompleteMultipartUploadRequest
+import com.amazonaws.services.s3.model.InitiateMultipartUploadRequest
+import com.amazonaws.services.s3.model.InitiateMultipartUploadResult
+import com.amazonaws.services.s3.model.ObjectMetadata
+import com.amazonaws.services.s3.model.PartETag
+import com.amazonaws.services.s3.model.UploadPartRequest
+import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClient
+import io.airbyte.cdk.load.command.aws.AWSAccessKeyConfiguration
+import io.airbyte.cdk.load.command.aws.AWSArnRoleConfiguration
+import io.airbyte.cdk.load.command.aws.AwsAssumeRoleCredentials
+import io.airbyte.cdk.load.command.s3.S3BucketConfiguration
+import io.airbyte.cdk.load.file.object_storage.StreamingUpload
+import io.airbyte.cdk.load.file.s3.S3ClientFactory.Companion.AIRBYTE_STS_SESSION_NAME
+import io.airbyte.cdk.load.util.setOnce
+import io.github.oshai.kotlinlogging.KotlinLogging
+import java.io.InputStream
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.asFlow
+import org.apache.mina.util.ConcurrentHashSet
+
+/**
+ * A Java S3 SDK that is scheduled to be deprecated at the end of 2025. It was used by the old CDK
+ * and lacks a bug that (sometimes) prevents the new Kotlin SDK from running with max concurrency.
+ * (See https://github.com/awslabs/aws-sdk-kotlin/issues/1214#issuecomment-2464831817.)
+ *
+ * This can be enabled by injecting [io.airbyte.cdk.load.command.s3.S3ClientConfigurationProvider]
+ * with [io.airbyte.cdk.load.command.s3.S3ClientConfiguration.useLegacyJavaClient] set to `true`.
+ *
+ * Currently this exists only to facilitate performance testing, but it may be needed as a fallback
+ * if the new SDK cannot meet performance requirements.
+ */
+class S3LegacyJavaClient(val amazonS3: AmazonS3, val bucket: S3BucketConfiguration) : S3Client {
+    override suspend fun list(prefix: String): Flow<S3Object> {
+        return amazonS3
+            .listObjectsV2(bucket.s3BucketName, prefix)
+            .objectSummaries
+            .map { S3Object(it.key, bucket) }
+            .asFlow()
+    }
+
+    override suspend fun move(remoteObject: S3Object, toKey: String): S3Object {
+        amazonS3.copyObject(bucket.s3BucketName, remoteObject.key, bucket.s3BucketName, toKey)
+        amazonS3.deleteObject(bucket.s3BucketName, remoteObject.key)
+
+        return S3Object(toKey, bucket)
+    }
+
+    override suspend fun move(key: String, toKey: String): S3Object {
+        return move(S3Object(key, bucket), toKey)
+    }
+
+    override suspend fun <U> get(key: String, block: (InputStream) -> U): U {
+        val obj = amazonS3.getObject(bucket.s3BucketName, key)
+        return obj.objectContent.use(block)
+    }
+
+    override suspend fun getMetadata(key: String): Map<String, String> {
+        val obj = amazonS3.getObjectMetadata(bucket.s3BucketName, key)
+        return obj.userMetadata
+    }
+
+    override suspend fun put(key: String, bytes: ByteArray): S3Object {
+        amazonS3.putObject(bucket.s3BucketName, key, bytes.inputStream(), null)
+        return S3Object(key, bucket)
+    }
+
+    override suspend fun delete(remoteObject: S3Object) {
+        amazonS3.deleteObject(bucket.s3BucketName, remoteObject.key)
+    }
+
+    override suspend fun delete(key: String) {
+        amazonS3.deleteObject(bucket.s3BucketName, key)
+    }
+
+    override suspend fun startStreamingUpload(
+        key: String,
+        metadata: Map<String, String>
+    ): StreamingUpload<S3Object> {
+        val request =
+            InitiateMultipartUploadRequest(bucket.s3BucketName, key)
+                .withObjectMetadata(ObjectMetadata().also { it.userMetadata = metadata })
+        val response = amazonS3.initiateMultipartUpload(request)
+        return S3LegacyJavaStreamingUpload(amazonS3, bucket, response)
+    }
+}
+
+class S3LegacyJavaStreamingUpload(
+    private val amazonS3: AmazonS3,
+    private val bucket: S3BucketConfiguration,
+    private val response: InitiateMultipartUploadResult
+) : StreamingUpload<S3Object> {
+    private val log = KotlinLogging.logger {}
+
+    private val completed = AtomicBoolean(false)
+    private val eTags = ConcurrentHashSet<PartETag>()
+
+    override suspend fun uploadPart(part: ByteArray, index: Int) {
+        log.info { "Uploading part $index to ${response.key} (uploadId=${response.uploadId})" }
+        val uploadPartRequest =
+            UploadPartRequest()
+                .withPartNumber(index)
+                .withUploadId(response.uploadId)
+                .withBucketName(bucket.s3BucketName)
+                .withKey(response.key)
+                .withInputStream(part.inputStream())
+                .withPartSize(part.size.toLong())
+
+        val response = amazonS3.uploadPart(uploadPartRequest)
+        eTags.add(response.partETag)
+    }
+
+    override suspend fun complete(): S3Object {
+        if (!completed.setOnce()) {
+            log.warn {
+                "Multipart upload already completed to ${response.key} (uploadId=${response.uploadId})"
+            }
+        } else if (eTags.isEmpty()) {
+            log.warn { "Ignoring empty upload to ${response.key} (uploadId=${response.uploadId})" }
+        } else {
+            log.info {
+                "Completing multipart upload to ${response.key} (uploadId=${response.uploadId})"
+            }
+            val completeMultipartUploadRequest =
+                CompleteMultipartUploadRequest()
+                    .withUploadId(response.uploadId)
+                    .withPartETags(eTags.toList().sortedBy { it.partNumber })
+                    .withBucketName(bucket.s3BucketName)
+                    .withKey(response.key)
+            amazonS3.completeMultipartUpload(completeMultipartUploadRequest)
+        }
+
+        return S3Object(response.key, bucket)
+    }
+}
+
+class S3LegacyJavaClientFactory {
+    private val clientBuilder = AmazonS3ClientBuilder.standard()
+
+    fun createFromAssumeRole(
+        role: AWSArnRoleConfiguration,
+        creds: AwsAssumeRoleCredentials,
+        bucket: S3BucketConfiguration
+    ): S3LegacyJavaClient {
+        val provider =
+            STSAssumeRoleSessionCredentialsProvider.Builder(role.roleArn, AIRBYTE_STS_SESSION_NAME)
+                .withExternalId(creds.externalId)
+                .withStsClient(
+                    AWSSecurityTokenServiceClient.builder()
+                        .withRegion(Regions.DEFAULT_REGION)
+                        .withCredentials(
+                            AWSStaticCredentialsProvider(
+                                BasicAWSCredentials(creds.accessKey, creds.secretKey)
+                            )
+                        )
+                        .build()
+                )
+                .withAsyncRefreshExecutor(Executors.newSingleThreadExecutor(DaemonThreadFactory()))
+                .build()
+        val amazonS3 =
+            clientBuilder
+                .withCredentials(provider)
+                .withRegion(bucket.s3BucketRegion.region)
+                // the SDK defaults to RetryMode.LEGACY
+                // (https://docs.aws.amazon.com/sdkref/latest/guide/feature-retry-behavior.html)
+                // this _can_ be configured via environment variable, but it seems more reliable
+                // to
+                // configure it
+                // programmatically
+                .withClientConfiguration(ClientConfiguration().withRetryMode(RetryMode.STANDARD))
+                .build()
+        return S3LegacyJavaClient(amazonS3, bucket)
+    }
+
+    fun createFromAccessKey(
+        keys: AWSAccessKeyConfiguration,
+        bucket: S3BucketConfiguration
+    ): S3Client {
+        val awsCreds: AWSCredentials = BasicAWSCredentials(keys.accessKeyId, keys.secretAccessKey)
+        val provider = AWSStaticCredentialsProvider(awsCreds)
+        val builder = clientBuilder.withCredentials(provider)
+        val amazonS3 =
+            if (bucket.s3Endpoint.isNullOrEmpty()) {
+                    builder.withRegion(bucket.s3BucketRegion.region)
+                } else {
+                    val clientConfiguration = ClientConfiguration().withProtocol(Protocol.HTTPS)
+                    clientConfiguration.signerOverride = "AWSS3V4SignerType"
+
+                    builder
+                        .withEndpointConfiguration(
+                            AwsClientBuilder.EndpointConfiguration(
+                                bucket.s3Endpoint,
+                                bucket.s3BucketRegion.region
+                            )
+                        )
+                        .withPathStyleAccessEnabled(true)
+                        .withClientConfiguration(clientConfiguration)
+                }
+                .build()
+        return S3LegacyJavaClient(amazonS3, bucket)
+    }
+}

--- a/airbyte-integrations/connectors/destination-s3/build.gradle
+++ b/airbyte-integrations/connectors/destination-s3/build.gradle
@@ -6,7 +6,7 @@ plugins {
 airbyteBulkConnector {
     core = 'load'
     toolkits = ['load-s3', 'load-avro', 'load-aws']
-    cdk = '0.322'
+    cdk = 'local'
 }
 
 application {

--- a/airbyte-integrations/connectors/destination-s3/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-s3/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: file
   connectorType: destination
   definitionId: 4816b78f-1489-44c1-9060-4b19d5fa9362
-  dockerImageTag: 1.5.2
+  dockerImageTag: 1.5.3
   dockerRepository: airbyte/destination-s3
   githubIssueLabel: destination-s3
   icon: s3.svg

--- a/airbyte-integrations/connectors/destination-s3/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2PerformanceTest.kt
+++ b/airbyte-integrations/connectors/destination-s3/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2PerformanceTest.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination.s3_v2
+
+import io.airbyte.cdk.load.write.BasicPerformanceTest
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+
+@Disabled("We don't want this to run in CI")
+class S3V2JsonNoFrillsPerformanceTest :
+    BasicPerformanceTest(
+        configContents = S3V2TestUtils.getConfig(S3V2TestUtils.JSON_UNCOMPRESSED_CONFIG_PATH),
+        configSpecClass = S3V2Specification::class.java,
+        defaultRecordsToInsert = 1_000_000,
+        micronautProperties = S3V2TestUtils.PERFORMANCE_TEST_MICRONAUT_PROPERTIES
+    ) {
+    @Test
+    override fun testInsertRecords() {
+        super.testInsertRecords()
+    }
+
+    @Test
+    override fun testRefreshingRecords() {
+        super.testRefreshingRecords()
+    }
+}
+
+@Disabled("We don't want this to run in CI")
+class S3V2ParquetSnappyPerformanceTest :
+    BasicPerformanceTest(
+        configContents = S3V2TestUtils.getConfig(S3V2TestUtils.PARQUET_SNAPPY_CONFIG_PATH),
+        configSpecClass = S3V2Specification::class.java,
+        defaultRecordsToInsert = 1_000_000,
+        micronautProperties = S3V2TestUtils.PERFORMANCE_TEST_MICRONAUT_PROPERTIES,
+    ) {
+    @Test
+    override fun testInsertRecords() {
+        super.testInsertRecords()
+    }
+
+    @Test
+    override fun testRefreshingRecords() {
+        super.testRefreshingRecords()
+    }
+}

--- a/airbyte-integrations/connectors/destination-s3/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2TestUtils.kt
+++ b/airbyte-integrations/connectors/destination-s3/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2TestUtils.kt
@@ -4,6 +4,7 @@
 
 package io.airbyte.integrations.destination.s3_v2
 
+import io.airbyte.cdk.load.command.Property
 import io.airbyte.cdk.load.command.aws.AwsAssumeRoleCredentials
 import io.airbyte.cdk.load.util.Jsons
 import java.nio.file.Files
@@ -52,4 +53,11 @@ object S3V2TestUtils {
                 assumeRoleExternalId,
             )
     }
+
+    val PERFORMANCE_TEST_MICRONAUT_PROPERTIES =
+        mapOf(
+            Property("airbyte.destination.aws.assume-role.access-key", "FOO") to "foo",
+            Property("airbyte.destination.aws.assume-role.secret-key", "BAR") to "bar",
+            Property("airbyte.destination.aws.assume-role.external-id", "BAZ") to "baz",
+        )
 }

--- a/docs/integrations/destinations/s3.md
+++ b/docs/integrations/destinations/s3.md
@@ -544,6 +544,7 @@ To see connector limitations, or troubleshoot your S3 connector, see more [in ou
 
 | Version     | Date       | Pull Request                                               | Subject                                                                                                                                              |
 |:------------|:-----------|:-----------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| 1.5.3       | 2025-03-04 | [54661](https://github.com/airbytehq/airbyte/pull/54661)   | Nonfunctional changes to support performance testing                                                                                                 |
 | 1.5.2       | 2025-02-25 | [54661](https://github.com/airbytehq/airbyte/pull/54661)   | Nonfunctional cleanup; dropped unused staging code                                                                                                   |
 | 1.5.1       | 2025-02-11 | [53636](https://github.com/airbytehq/airbyte/pull/53636)   | Nonfunctional CDK version pin.                                                                                                                       |
 | 1.5.0       | 2025-02-11 | [53632](https://github.com/airbytehq/airbyte/pull/53632)   | Promoting release candidate 1.5.0-rc.20 to a main version.                                                                                           |


### PR DESCRIPTION
## What
Adds an option to enable the legacy S3 java SDK. This is to facilitate file transfer testing, but also to have it as an option for performance tuning the existing S3 destination. (There is evidence the new SDK artificially limits the amount of concurrent due to a bug in the underlying timeout retry protocol.)

The option is current disabled and not exposed on the configuration, but it can be set by setting `ObjectStorageUploadConfiguration.useLegacyJavaClient = true`.

Tested locally with the new S3 Destination connector, all ITs are green.

Initialization code / dependencies are copied from the old SDK.
