### PR TITLE
Source: amazon-seller-partner - list_financial_events: Reduce max days apart to 14 days

### DIFF
--- a/airbyte-integrations/connectors/source-amazon-seller-partner/metadata.yaml
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/metadata.yaml
@@ -15,7 +15,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: e55879a8-0ef8-4557-abcf-ab34c53ec460
-  dockerImageTag: 4.6.0
+  dockerImageTag: 4.7.0
   dockerRepository: airbyte/source-amazon-seller-partner
   documentationUrl: https://docs.airbyte.com/integrations/sources/amazon-seller-partner
   erdUrl: https://dbdocs.io/airbyteio/source-amazon-seller-partner?view=relationships

--- a/airbyte-integrations/connectors/source-amazon-seller-partner/pyproject.toml
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "4.6.0"
+version = "4.7.0"
 name = "source-amazon-seller-partner"
 description = "Source implementation for Amazon Seller Partner."
 authors = ["Airbyte <contact@airbyte.io>"]

--- a/airbyte-integrations/connectors/source-amazon-seller-partner/source_amazon_seller_partner/manifest.yaml
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/source_amazon_seller_partner/manifest.yaml
@@ -403,8 +403,8 @@ definitions:
         datetime_format: "%Y-%m-%dT%H:%M:%SZ"
         start_datetime:
           type: MinMaxDatetime
-          # start date and end date should not be more than 180 days apart.
-          datetime: "{{ format_datetime( max(config.get('replication_start_date', (now_utc() - duration('P180D')).strftime('%Y-%m-%dT%H:%M:%SZ') ), (now_utc() - duration('P180D')).strftime('%Y-%m-%dT%H:%M:%SZ')), '%Y-%m-%dT%H:%M:%SZ') }}"
+          # start date and end date should not be more than 180 days apart. In practice, it can be as low as 14 days.
+          datetime: "{{ format_datetime( max(config.get('replication_start_date', (now_utc() - duration('P14D')).strftime('%Y-%m-%dT%H:%M:%SZ') ), (now_utc() - duration('P14D')).strftime('%Y-%m-%dT%H:%M:%SZ')), '%Y-%m-%dT%H:%M:%SZ') }}"
           datetime_format: "%Y-%m-%dT%H:%M:%SZ"
         end_datetime:
           type: MinMaxDatetime

--- a/docs/integrations/sources/amazon-seller-partner.md
+++ b/docs/integrations/sources/amazon-seller-partner.md
@@ -228,6 +228,7 @@ Create a separate connection for streams which usually fail with error above "Fa
 
 | Version    | Date       | Pull Request                                              | Subject                                                                                                                                                                             |
 |:-----------|:-----------|:----------------------------------------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 4.7.0 | 2025-03-06 | [55170](https://github.com/airbytehq/airbyte/pull/55170) | reduce reports window from 180 to 14 days |
 | 4.6.0 | 2025-02-24 | [53225](https://github.com/airbytehq/airbyte/pull/53225) | Add API Budget |
 | 4.5.3 | 2025-02-22 | [53928](https://github.com/airbytehq/airbyte/pull/53928) | Update dependencies |
 | 4.5.2 | 2025-02-17 | [53693](https://github.com/airbytehq/airbyte/pull/53693) | Add app_id to server configuration (OAuth) |


### PR DESCRIPTION
## What

The documentation claims that days between PostedBefore and PostedAfter should be no more than 180 days. However I have observed this failing very quickly with any value above 14 days with the following error:

```json
{
  "type": "LOG",
  "log": {
    "level": "ERROR",
    "message": "'GET' request to 'https://sellingpartnerapi-eu.amazon.com/finances/v0/financialEvents?MaxResultsPerPage=100&PostedAfter=2024-09-02T22%3A20%3A45Z&PostedBefore=2025-03-01T22%3A15%3A46Z' failed with status code '400' and error message: 'Invalid Input'. Request (body): 'None'. Response (body): '{'errors': [{'code': 'InvalidInput', 'message': 'Invalid Input', 'details': ''}]}'. Response (headers): '{'Server': 'Server', 'Date': 'Sat, 01 Mar 2025 22:20:49 GMT', 'Content-Type': 'application/json', 'Content-Length': '117', 'Connection': 'keep-alive', 'x-amz-rid': 'xxx', 'x-amzn-RateLimit-Limit': '0.5', 'x-amzn-RequestId': 'xxx', 'x-amz-apigw-id': 'xxx', 'X-Amzn-Trace-Id': 'xxx', 'x-amzn-ErrorType': 'InvalidInputException', 'Vary': 'Content-Type,Accept-Encoding,User-Agent', 'Strict-Transport-Security': 'max-age=47474747; includeSubDomains; preload'}'."
  }
}
```

## How
Reduced the gap to 14 days

## Review guide
1. `airbyte-integrations/connectors/source-amazon-seller-partner/source_amazon_seller_partner/manifest.yaml`

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
