### PR TITLE
Bulk load CDK: only microbatch in truncate tests

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/IntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/IntegrationTest.kt
@@ -236,6 +236,10 @@ abstract class IntegrationTest(
      *
      * A common pattern is to call [runSyncUntilStateAck], and then call `dumpAndDiffRecords(...,
      * allowUnexpectedRecord = true)` to verify that [records] were written to the destination.
+     *
+     * This forces the connector to run with microbatching enabled - without that option, tests
+     * using this method would take significantly longer, because they would need to push 100MB
+     * (ish) to the destination before it would ack a state message.
      */
     fun runSyncUntilStateAck(
         configContents: String,

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/IntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/IntegrationTest.kt
@@ -208,8 +208,7 @@ abstract class IntegrationTest(
                 configContents,
                 catalog.asProtocolObject(),
                 useFileTransfer = useFileTransfer,
-                micronautProperties =
-                    micronautProperties + fileTransferProperty + defaultMicronautProperties,
+                micronautProperties = micronautProperties + fileTransferProperty,
             )
         return runBlocking(Dispatchers.IO) {
             launch { destination.run() }
@@ -252,7 +251,7 @@ abstract class IntegrationTest(
                 configContents,
                 DestinationCatalog(listOf(stream)).asProtocolObject(),
                 useFileTransfer,
-                micronautProperties = micronautProperties + defaultMicronautProperties,
+                micronautProperties = micronautProperties + micronautPropertyEnableMicrobatching,
             )
         return runBlocking(Dispatchers.IO) {
             launch {
@@ -302,7 +301,12 @@ abstract class IntegrationTest(
         val randomizedNamespaceRegex = Regex("test(\\d{8})[A-Za-z]{4}")
         val randomizedNamespaceDateFormatter: DateTimeFormatter =
             DateTimeFormatter.ofPattern("yyyyMMdd")
-        val defaultMicronautProperties: Map<Property, String> =
+
+        /**
+         * When set, this property forces the CDK to invoke processRecords once per record. This
+         * allows tests which depend on state acks to run quickly.
+         */
+        val micronautPropertyEnableMicrobatching: Map<Property, String> =
             mapOf(EnvVarConstants.RECORD_BATCH_SIZE to "1")
 
         /**


### PR DESCRIPTION
as title. from https://airbytehq-team.slack.com/archives/C03AS1GAQV6/p1740779904185839:

> Johnny Schmidt
> FYI: I took a stab at ripping out the microbatching hack for destination ITs. It was trivial to fix. Tests no longer hang, but they end up running way longer by default (100x), because they're filling up a whole production-sized load before acking. Since batch sizes are dest-specific, this means every connector dev would have to do extra work to set test batch sizes, which is probably more work than occasionally tripping over a microbatch edge case. So I'm going to punt on this for now

> Edward Gao
> makes sense - I might try only enabling microbatching in the tests that depend on it, which probably alleviates some risk that microbatches mask actual problems