### PR TITLE
chore: increase decimal precision

### DIFF
--- a/airbyte-integrations/connectors/destination-mssql-v2/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-mssql-v2/metadata.yaml
@@ -16,7 +16,7 @@ data:
             type: GSM
   connectorType: destination
   definitionId: 37a928c1-2d5c-431a-a97d-ae236bd1ea0c
-  dockerImageTag: 0.1.12
+  dockerImageTag: 0.1.13
   dockerRepository: airbyte/destination-mssql-v2
   documentationUrl: https://docs.airbyte.com/integrations/destinations/mssql-v2
   githubIssueLabel: destination-mssql-v2

--- a/airbyte-integrations/connectors/destination-mssql-v2/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/convert/AirbyteTypeToMssqlType.kt
+++ b/airbyte-integrations/connectors/destination-mssql-v2/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/convert/AirbyteTypeToMssqlType.kt
@@ -28,7 +28,7 @@ enum class MssqlType(val sqlType: Int, val sqlStringOverride: String? = null) {
     BIT(Types.BOOLEAN),
     DATE(Types.DATE),
     BIGINT(Types.BIGINT),
-    DECIMAL(Types.DECIMAL, sqlStringOverride = "DECIMAL(18, 8)"),
+    DECIMAL(Types.DECIMAL, sqlStringOverride = "DECIMAL(38, 8)"),
     VARCHAR(Types.VARCHAR, sqlStringOverride = "VARCHAR(MAX)"),
     VARCHAR_INDEX(Types.VARCHAR, sqlStringOverride = "VARCHAR(200)"),
     DATETIMEOFFSET(Types.TIMESTAMP_WITH_TIMEZONE),

--- a/docs/integrations/destinations/mssql-v2.md
+++ b/docs/integrations/destinations/mssql-v2.md
@@ -13,7 +13,7 @@ This connector is in early access, and SHOULD NOT be used for production workloa
 
 | Version | Date       | Pull Request                                               | Subject                                              |
 |:--------|:-----------|:-----------------------------------------------------------|:-----------------------------------------------------|
-| 0.1.13  | 2025-03-04 | []()   | RC11: Increase decimal precision                     |
+| 0.1.13  | 2025-03-04 | [55193](https://github.com/airbytehq/airbyte/pull/55193)   | RC11: Increase decimal precision                     |
 | 0.1.12  | 2025-02-24 | [54648](https://github.com/airbytehq/airbyte/pull/54648)   | RC10: Fix index column names with hyphens            |
 | 0.1.11  | 2025-02-21 | [54197](https://github.com/airbytehq/airbyte/pull/54197)   | RC9: Fix index column names with invalid characters. |
 | 0.1.10  | 2025-02-20 | [54186](https://github.com/airbytehq/airbyte/pull/54186)   | RC8: Fix String support.                             |

--- a/docs/integrations/destinations/mssql-v2.md
+++ b/docs/integrations/destinations/mssql-v2.md
@@ -13,7 +13,8 @@ This connector is in early access, and SHOULD NOT be used for production workloa
 
 | Version | Date       | Pull Request                                               | Subject                                              |
 |:--------|:-----------|:-----------------------------------------------------------|:-----------------------------------------------------|
-| 0.1.12  | 2025-02-24 | [54648](https://github.com/airbytehq/airbyte/pull/54648)   | RC10: Fix index column names with hyphens |
+| 0.1.13  | 2025-03-04 | []()   | RC11: Increase decimal precision                     |
+| 0.1.12  | 2025-02-24 | [54648](https://github.com/airbytehq/airbyte/pull/54648)   | RC10: Fix index column names with hyphens            |
 | 0.1.11  | 2025-02-21 | [54197](https://github.com/airbytehq/airbyte/pull/54197)   | RC9: Fix index column names with invalid characters. |
 | 0.1.10  | 2025-02-20 | [54186](https://github.com/airbytehq/airbyte/pull/54186)   | RC8: Fix String support.                             |
 | 0.1.9   | 2025-02-11 | [53364](https://github.com/airbytehq/airbyte/pull/53364)   | RC7: Revert deletion change.                         |


### PR DESCRIPTION
## What
* Increase decimal precision to the [max allowed value](https://learn.microsoft.com/en-us/sql/t-sql/data-types/precision-scale-and-length-transact-sql?view=sql-server-ver16) for MSSQL

## How
* Increase decimal precision from 18 to 38 for MSSQL

## Review guide
1. `AirbyteTypeToMssqlType.kt`

## Can this PR be safely reverted and rolled back?
- [X] YES 💚
- [ ] NO ❌
