### PR TITLE
[source-tiktok-marketing] - fix state format issue

### DIFF
--- a/airbyte-integrations/connectors/source-tiktok-marketing/metadata.yaml
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/metadata.yaml
@@ -11,7 +11,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 4bfac00d-ce15-44ff-95b9-9e3c3e8fbd35
-  dockerImageTag: 4.4.0-rc2
+  dockerImageTag: 4.4.0-rc3
   dockerRepository: airbyte/source-tiktok-marketing
   documentationUrl: https://docs.airbyte.com/integrations/sources/tiktok-marketing
   githubIssueLabel: source-tiktok-marketing

--- a/airbyte-integrations/connectors/source-tiktok-marketing/poetry.lock
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/poetry.lock
@@ -2,19 +2,20 @@
 
 [[package]]
 name = "airbyte-cdk"
-version = "6.36.2"
+version = "6.37.1"
 description = "A framework for writing Airbyte Connectors."
 optional = false
 python-versions = "<3.13,>=3.10"
 groups = ["main"]
 markers = "python_version <= \"3.11\""
 files = [
-    {file = "airbyte_cdk-6.36.2-py3-none-any.whl", hash = "sha256:ec11a60b665d37074346297ac5e4faf7a228c0ac5b018757493c01f965c74307"},
-    {file = "airbyte_cdk-6.36.2.tar.gz", hash = "sha256:dfa03e151e1f43654dadcda519fe530f4f2211c2261b0d7e0cf58eb6a45aad10"},
+    {file = "airbyte_cdk-6.37.1-py3-none-any.whl", hash = "sha256:0806bb74a71c442edc2731af7d32c2f39b5b235a5a697367a991995a007e738d"},
+    {file = "airbyte_cdk-6.37.1.tar.gz", hash = "sha256:c794a2ef16b864a0fc1200607f02653805a1bdf423ee0bb2149772318a29dde9"},
 ]
 
 [package.dependencies]
 airbyte-protocol-models-dataclasses = ">=0.14,<0.15"
+anyascii = ">=0.3.2,<0.4.0"
 backoff = "*"
 cachetools = "*"
 cryptography = ">=42.0.5,<44.0.0"
@@ -42,7 +43,6 @@ rapidfuzz = ">=3.10.1,<4.0.0"
 requests = "*"
 requests_cache = "*"
 serpyco-rs = ">=1.10.2,<2.0.0"
-Unidecode = ">=1.3,<2.0"
 wcmatch = "10.0"
 whenever = ">=0.6.16,<0.7.0"
 xmltodict = ">=0.13,<0.15"
@@ -76,6 +76,19 @@ markers = "python_version <= \"3.11\""
 files = [
     {file = "annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53"},
     {file = "annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89"},
+]
+
+[[package]]
+name = "anyascii"
+version = "0.3.2"
+description = "Unicode to ASCII transliteration"
+optional = false
+python-versions = ">=3.3"
+groups = ["main"]
+markers = "python_version <= \"3.11\""
+files = [
+    {file = "anyascii-0.3.2-py3-none-any.whl", hash = "sha256:3b3beef6fc43d9036d3b0529050b0c48bfad8bc960e9e562d7223cfb94fe45d4"},
+    {file = "anyascii-0.3.2.tar.gz", hash = "sha256:9d5d32ef844fe225b8bc7cba7f950534fae4da27a9bf3a6bea2cb0ea46ce4730"},
 ]
 
 [[package]]
@@ -2071,19 +2084,6 @@ markers = "python_version <= \"3.11\""
 files = [
     {file = "tzdata-2025.1-py2.py3-none-any.whl", hash = "sha256:7e127113816800496f027041c570f50bcd464a020098a3b6b199517772303639"},
     {file = "tzdata-2025.1.tar.gz", hash = "sha256:24894909e88cdb28bd1636c6887801df64cb485bd593f2fd83ef29075a81d694"},
-]
-
-[[package]]
-name = "unidecode"
-version = "1.3.8"
-description = "ASCII transliterations of Unicode text"
-optional = false
-python-versions = ">=3.5"
-groups = ["main"]
-markers = "python_version <= \"3.11\""
-files = [
-    {file = "Unidecode-1.3.8-py3-none-any.whl", hash = "sha256:d130a61ce6696f8148a3bd8fe779c99adeb4b870584eeb9526584e9aa091fd39"},
-    {file = "Unidecode-1.3.8.tar.gz", hash = "sha256:cfdb349d46ed3873ece4586b96aa75258726e2fa8ec21d6f00a591d98806c2f4"},
 ]
 
 [[package]]

--- a/airbyte-integrations/connectors/source-tiktok-marketing/pyproject.toml
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "4.4.0-rc2"
+version = "4.4.0-rc3"
 name = "source-tiktok-marketing"
 description = "Source implementation for Tiktok Marketing."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-tiktok-marketing/source_tiktok_marketing/manifest.yaml
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/source_tiktok_marketing/manifest.yaml
@@ -404,6 +404,7 @@ definitions:
     cursor_datetime_formats:
       - "%Y-%m-%d %H:%M:%S"
       - "%Y-%m-%dT%H:%M:%SZ"
+      - "%Y-%m-%d"
     datetime_format: "%Y-%m-%d"
     start_datetime:
       type: MinMaxDatetime

--- a/airbyte-integrations/connectors/source-tiktok-marketing/source_tiktok_marketing/manifest.yaml
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/source_tiktok_marketing/manifest.yaml
@@ -404,7 +404,6 @@ definitions:
     cursor_datetime_formats:
       - "%Y-%m-%d %H:%M:%S"
       - "%Y-%m-%dT%H:%M:%SZ"
-      - "%Y-%m-%d"
     datetime_format: "%Y-%m-%d"
     start_datetime:
       type: MinMaxDatetime
@@ -424,6 +423,7 @@ definitions:
     cursor_datetime_formats:
       - "%Y-%m-%d %H:%M:%S"
       - "%Y-%m-%dT%H:%M:%SZ"
+      - "%Y-%m-%d"
     datetime_format: "%Y-%m-%d %H:%M:%S"
     start_datetime:
       type: MinMaxDatetime

--- a/airbyte-integrations/connectors/source-tiktok-marketing/source_tiktok_marketing/manifest.yaml
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/source_tiktok_marketing/manifest.yaml
@@ -421,9 +421,8 @@ definitions:
     cursor_granularity: "PT1H"
     step: P1D
     cursor_datetime_formats:
-      - "%Y-%m-%d %H:%M:%S"
-      - "%Y-%m-%dT%H:%M:%SZ"
       - "%Y-%m-%d"
+      - "%Y-%m-%dT%H:%M:%SZ"
     datetime_format: "%Y-%m-%d %H:%M:%S"
     start_datetime:
       type: MinMaxDatetime

--- a/airbyte-integrations/connectors/source-tiktok-marketing/unit_tests/integration/test_reports_hourly.py
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/unit_tests/integration/test_reports_hourly.py
@@ -21,7 +21,8 @@ EMPTY_LIST_RESPONSE = {"code": 0, "message": "ok", "data": {"list": []}}
 class TestAdsReportHourly(TestCase):
     stream_name = "ads_reports_hourly"
     advertiser_id = "872746382648"
-    cursor = "2024-01-01 10:00:00"
+    cursor = "2024-01-01"
+    legacy_cursor = "2024-01-01 10:00:00"
     cursor_field = "stat_time_hour"
     metrics = [
         "campaign_name",
@@ -100,14 +101,14 @@ class TestAdsReportHourly(TestCase):
             config_to_build = config_to_build.with_include_deleted()
         return config_to_build.build()
 
-    def state(self):
+    def state(self, cursor: str = None):
         return (
             StateBuilder()
             .with_stream_state(
                 stream_name=self.stream_name,
                 state={
                     "states": [
-                        {"partition": {"advertiser_id": self.advertiser_id, "parent_slice": {}}, "cursor": {self.cursor_field: self.cursor}}
+                        {"partition": {"advertiser_id": self.advertiser_id, "parent_slice": {}}, "cursor": {self.cursor_field: cursor}}
                     ]
                 },
             )
@@ -161,15 +162,32 @@ class TestAdsReportHourly(TestCase):
         self.mock_response(http_mocker)
 
         output = read(
-            source=SourceTiktokMarketing(config=self.config(), catalog=None, state=self.state()),
+            source=SourceTiktokMarketing(config=self.config(), catalog=None, state=self.state(cursor=self.cursor)),
             config=self.config(),
             catalog=self.catalog(sync_mode=SyncMode.incremental),
-            state=self.state(),
+            state=self.state(cursor=self.cursor),
+        )
+
+        assert len(output.records) == 2
+        assert output.state_messages[0].state.stream.stream_state.states == [
+            {"cursor": {"stat_time_hour": self.legacy_cursor}, "partition": {"advertiser_id": self.advertiser_id, "parent_slice": {}}}
+        ]
+
+    @HttpMocker()
+    def test_read_with_legacy_state(self, http_mocker: HttpMocker):
+        mock_advertisers_slices(http_mocker, self.config())
+        self.mock_response(http_mocker)
+
+        output = read(
+            source=SourceTiktokMarketing(config=self.config(), catalog=None, state=self.state(cursor=self.legacy_cursor)),
+            config=self.config(),
+            catalog=self.catalog(sync_mode=SyncMode.incremental),
+            state=self.state(cursor=self.legacy_cursor),
         )
 
         assert len(output.records) == 1
         assert output.state_messages[0].state.stream.stream_state.states == [
-            {"cursor": {"stat_time_hour": self.cursor}, "partition": {"advertiser_id": self.advertiser_id, "parent_slice": {}}}
+            {"cursor": {"stat_time_hour": self.legacy_cursor}, "partition": {"advertiser_id": self.advertiser_id, "parent_slice": {}}}
         ]
 
     @HttpMocker()

--- a/airbyte-integrations/connectors/source-tiktok-marketing/unit_tests/integration/test_reports_hourly.py
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/unit_tests/integration/test_reports_hourly.py
@@ -169,7 +169,7 @@ class TestAdsReportHourly(TestCase):
         )
 
         assert len(output.records) == 2
-        assert output.state_messages[0].state.stream.stream_state.states == [
+        assert output.state_messages[1].state.stream.stream_state.states == [
             {"cursor": {"stat_time_hour": self.legacy_cursor}, "partition": {"advertiser_id": self.advertiser_id, "parent_slice": {}}}
         ]
 
@@ -186,7 +186,7 @@ class TestAdsReportHourly(TestCase):
         )
 
         assert len(output.records) == 1
-        assert output.state_messages[0].state.stream.stream_state.states == [
+        assert output.state_messages[1].state.stream.stream_state.states == [
             {"cursor": {"stat_time_hour": self.legacy_cursor}, "partition": {"advertiser_id": self.advertiser_id, "parent_slice": {}}}
         ]
 
@@ -370,7 +370,7 @@ class TestAdGroupsReportsHourly(TestCase):
         )
 
         assert len(output.records) == 1
-        assert output.state_messages[0].state.stream.stream_state.states == [
+        assert output.state_messages[1].state.stream.stream_state.states == [
             {"cursor": {"stat_time_hour": self.cursor}, "partition": {"advertiser_id": self.advertiser_id, "parent_slice": {}}}
         ]
 
@@ -531,7 +531,7 @@ class TestAdvertisersReportsHourly(TestCase):
         )
 
         assert len(output.records) == 1
-        assert output.state_messages[0].state.stream.stream_state.states == [
+        assert output.state_messages[1].state.stream.stream_state.states == [
             {"cursor": {"stat_time_hour": self.cursor}, "partition": {"advertiser_id": self.advertiser_id, "parent_slice": {}}}
         ]
 
@@ -649,7 +649,7 @@ class TestCampaignsReportsHourly(TestCase):
         )
 
         assert len(output.records) == 1
-        assert output.state_messages[0].state.stream.stream_state.states == [
+        assert output.state_messages[1].state.stream.stream_state.states == [
             {"cursor": {"stat_time_hour": self.cursor}, "partition": {"advertiser_id": self.advertiser_id, "parent_slice": {}}}
         ]
 

--- a/airbyte-integrations/connectors/source-tiktok-marketing/unit_tests/test_source.py
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/unit_tests/test_source.py
@@ -100,6 +100,10 @@ def test_source_check_connection_ok(config, requests_mock):
 @pytest.mark.usefixtures("mock_sleep")
 def test_source_check_connection_failed(config, requests_mock, capsys, json_response, expected_result, expected_message):
     requests_mock.get("https://business-api.tiktok.com/open_api/v1.3/oauth2/advertiser/get/", json=json_response)
+    requests_mock.get(
+        "https://business-api.tiktok.com/open_api/v1.3/advertiser/info/?page_size=100&advertiser_ids=%5B%22917429327%22%5D",
+        json=json_response,
+    )
 
     logger_mock = MagicMock()
     result = SourceTiktokMarketing(config=config, catalog=None, state=None).check_connection(logger_mock, config)

--- a/docs/integrations/sources/tiktok-marketing.md
+++ b/docs/integrations/sources/tiktok-marketing.md
@@ -138,7 +138,7 @@ The connector is restricted by [requests limitation](https://business-api.tiktok
 
 | Version   | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |:----------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 4.4.0-rc3 | 2025-03-04 | [*PR_NUMBER_PLACEHOLDER*](https://github.com/airbytehq/airbyte/pull/*PR_NUMBER_PLACEHOLDER*) | Resolve state format issue |
+| 4.4.0-rc3 | 2025-03-04 | [55194](https://github.com/airbytehq/airbyte/pull/55194) | Resolve state format issue |
 | 4.4.0-rc2 | 2025-02-20 | [53645)](https://github.com/airbytehq/airbyte/pull/53645) | Remove stream_state interpolation and custom cursors |
 | 4.4.0-rc1 | 2025-01-29 | [51584](https://github.com/airbytehq/airbyte/pull/51584) | Update to concurrent CDK                                                                                                                                               |
 | 4.3.7     | 2025-01-11 | [47118](https://github.com/airbytehq/airbyte/pull/47118) | Starting with this version, the Docker image is now rootless. Please note that this and future versions will not be compatible with Airbyte versions earlier than 0.64 |

--- a/docs/integrations/sources/tiktok-marketing.md
+++ b/docs/integrations/sources/tiktok-marketing.md
@@ -138,6 +138,7 @@ The connector is restricted by [requests limitation](https://business-api.tiktok
 
 | Version   | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |:----------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 4.4.0-rc3 | 2025-03-04 | [*PR_NUMBER_PLACEHOLDER*](https://github.com/airbytehq/airbyte/pull/*PR_NUMBER_PLACEHOLDER*) | Resolve state format issue |
 | 4.4.0-rc2 | 2025-02-20 | [53645)](https://github.com/airbytehq/airbyte/pull/53645) | Remove stream_state interpolation and custom cursors |
 | 4.4.0-rc1 | 2025-01-29 | [51584](https://github.com/airbytehq/airbyte/pull/51584) | Update to concurrent CDK                                                                                                                                               |
 | 4.3.7     | 2025-01-11 | [47118](https://github.com/airbytehq/airbyte/pull/47118) | Starting with this version, the Docker image is now rootless. Please note that this and future versions will not be compatible with Airbyte versions earlier than 0.64 |


### PR DESCRIPTION
## What
- Resolves an error w/ `source-tiktok-marketing` where incoming state cursor values failed to be parsed
    - Was not caught as mock server tests only tested legacy format (`%Y-%m-%d %H:%M:%S`). 
    - Adds new mock server test to verify running sync w/ `%Y-%m-%d` works.

- Example sync failure during progressive rollout: https://cloud.airbyte.com/workspaces/2cd8895c-af1f-4de4-8126-e928a2b32501/connections/4270568e-e93c-4a03-be52-af9dddb56a59/status

```
No format in ['%Y-%m-%d %H:%M:%S', '%Y-%m-%dT%H:%M:%SZ', '%Y-%m-%d %H:%M:%S'] matching 2024-03-25
Traceback (most recent call last):
  File "/airbyte/integration_code/main.py", line 9, in <module>
    run()
  File "/airbyte/integration_code/source_tiktok_marketing/run.py", line 53, in run
    launch(source, _args)
  File "/usr/local/lib/python3.10/site-packages/airbyte_cdk/entrypoint.py", line 341, in launch
    for message in source_entrypoint.run(parsed_args):
  File "/usr/local/lib/python3.10/site-packages/airbyte_cdk/entrypoint.py", line 171, in run
    yield from map(
  File "/usr/local/lib/python3.10/site-packages/airbyte_cdk/entrypoint.py", line 244, in read
    for message in self.source.read(self.logger, config, catalog, state):
  File "/usr/local/lib/python3.10/site-packages/airbyte_cdk/sources/declarative/concurrent_declarative_source.py", line 135, in read
    concurrent_streams, _ = self._group_streams(config=config)
  File "/usr/local/lib/python3.10/site-packages/airbyte_cdk/sources/declarative/concurrent_declarative_source.py", line 341, in _group_streams
    self._constructor.create_concurrent_cursor_from_perpartition_cursor(
  File "/usr/local/lib/python3.10/site-packages/airbyte_cdk/sources/declarative/parsers/model_to_component_factory.py", line 1276, in create_concurrent_cursor_from_perpartition_cursor
    return ConcurrentPerPartitionCursor(
  File "/usr/local/lib/python3.10/site-packages/airbyte_cdk/sources/declarative/incremental/concurrent_partition_cursor.py", line 114, in __init__
    self._set_initial_state(stream_state)
  File "/usr/local/lib/python3.10/site-packages/airbyte_cdk/sources/declarative/incremental/concurrent_partition_cursor.py", line 398, in _set_initial_state
    self._set_global_state(stream_state)
  File "/usr/local/lib/python3.10/site-packages/airbyte_cdk/sources/declarative/incremental/concurrent_partition_cursor.py", line 433, in _set_global_state
    self._connector_state_converter.parse_value(global_state_value)
  File "/usr/local/lib/python3.10/site-packages/airbyte_cdk/sources/streams/concurrent/state_converters/datetime_stream_state_converter.py", line 52, in parse_value
    return self.parse_timestamp(value)
  File "/usr/local/lib/python3.10/site-packages/airbyte_cdk/sources/streams/concurrent/state_converters/datetime_stream_state_converter.py", line 223, in parse_timestamp
    raise ValueError(f"No format in {self._input_datetime_formats} matching {timestamp}")
ValueError: No format in ['%Y-%m-%d %H:%M:%S', '%Y-%m-%dT%H:%M:%SZ', '%Y-%m-%d %H:%M:%S'] matching 2024-03-25
```

## How
- Adds `%Y-%m-%d` as possible `cursor_datetime_format` for hourly syncs
- Confirmed working w/ additional mock server test

## Review guide
1. manifest.yaml
2. test_report_hourly.py

## User Impact


## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
