### PR TITLE
[source volcano] Make sure metadata decoration is enabled for trigger based CDC

### DIFF
--- a/airbyte-cdk/bulk/core/extract/src/testFixtures/kotlin/io/airbyte/cdk/discover/TestMetaFieldDecorator.kt
+++ b/airbyte-cdk/bulk/core/extract/src/testFixtures/kotlin/io/airbyte/cdk/discover/TestMetaFieldDecorator.kt
@@ -8,7 +8,6 @@ import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.node.ObjectNode
 import io.airbyte.cdk.command.OpaqueStateValue
 import io.airbyte.cdk.read.Stream
-import io.airbyte.cdk.util.Jsons
 import io.micronaut.context.annotation.Requires
 import io.micronaut.context.env.Environment
 import jakarta.inject.Singleton
@@ -43,7 +42,7 @@ class TestMetaFieldDecorator : MetaFieldDecorator {
         recordData.set<JsonNode>(
             GlobalCursor.id,
             if (globalStateValue == null) {
-                Jsons.nullNode()
+                CdcOffsetDateTimeMetaFieldType.jsonEncoder.encode(timestamp)
             } else {
                 CdcStringMetaFieldType.jsonEncoder.encode(globalStateValue.toString())
             }


### PR DESCRIPTION
## What
We have issue that the trigger based CDC record message don't have metadata value included so destination won't update the destination table accordingly. This PR is to fix that

https://github.com/airbytehq/airbyte-internal-issues/issues/11300

## How
Before record message is sent to outputConsumer, we check if it's trigger CDC sync, if so we decorate the message like decorate debezium CDC

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
