### PR TITLE
source-apple-search-ads contribution from Widecode

### DIFF
--- a/airbyte-integrations/connectors/source-apple-search-ads/manifest.yaml
+++ b/airbyte-integrations/connectors/source-apple-search-ads/manifest.yaml
@@ -1,6 +1,14 @@
-version: 5.7.5
+version: 6.36.3
 
 type: DeclarativeSource
+
+description: |
+  The fix to resolve Github issue:
+  https://github.com/airbytehq/airbyte/issues/55173.
+  Removed source-defined primary keys in the report streams:
+  - campaigns_report_daily
+  - adgroups_report_daily
+  - keywords_report_daily
 
 check:
   type: CheckStream
@@ -48,8 +56,8 @@ definitions:
           type: DefaultPaginator
           page_token_option:
             type: RequestOption
-            inject_into: request_parameter
             field_name: offset
+            inject_into: request_parameter
           page_size_option:
             type: RequestOption
             field_name: limit
@@ -100,8 +108,8 @@ definitions:
           type: DefaultPaginator
           page_token_option:
             type: RequestOption
-            inject_into: request_parameter
             field_name: offset
+            inject_into: request_parameter
           page_size_option:
             type: RequestOption
             field_name: limit
@@ -162,8 +170,8 @@ definitions:
           type: DefaultPaginator
           page_token_option:
             type: RequestOption
-            inject_into: request_parameter
             field_name: offset
+            inject_into: request_parameter
           page_size_option:
             type: RequestOption
             field_name: limit
@@ -192,9 +200,6 @@ definitions:
             - reportingDataResponse
             - row
       name: campaigns_report_daily
-      primary_key:
-        - date
-        - campaignId
       retriever:
         type: SimpleRetriever
         requester:
@@ -217,15 +222,15 @@ definitions:
             error_handlers:
               - type: DefaultErrorHandler
                 max_retries: 10
-                backoff_strategies:
-                  - type: ExponentialBackoffStrategy
-                    factor: "{{ config.backoff_factor }}"
                 response_filters:
                   - type: HttpResponseFilter
                     action: RETRY
                     http_codes:
                       - 500
                       - 429
+                backoff_strategies:
+                  - type: ExponentialBackoffStrategy
+                    factor: "{{ config.backoff_factor }}"
         record_selector:
           type: RecordSelector
           extractor:
@@ -238,25 +243,25 @@ definitions:
           type: DefaultPaginator
           page_token_option:
             type: RequestOption
-            inject_into: body_json
             field_path:
               - selector
               - pagination
               - offset
+            inject_into: body_json
           page_size_option:
             type: RequestOption
-            inject_into: body_json
             field_path:
               - selector
               - pagination
               - limit
+            inject_into: body_json
           pagination_strategy:
             type: OffsetIncrement
             page_size: 1000
       incremental_sync:
         type: DatetimeBasedCursor
         cursor_field: date
-        lookback_window: 'P{{ config.lookback_window}}D'
+        lookback_window: P{{ config.lookback_window}}D
         cursor_datetime_formats:
           - "%Y-%m-%d"
         datetime_format: "%Y-%m-%d"
@@ -294,9 +299,6 @@ definitions:
             - reportingDataResponse
             - row
       name: adgroups_report_daily
-      primary_key:
-        - date
-        - adGroupId
       retriever:
         type: SimpleRetriever
         requester:
@@ -319,15 +321,15 @@ definitions:
             error_handlers:
               - type: DefaultErrorHandler
                 max_retries: 10
-                backoff_strategies:
-                  - type: ExponentialBackoffStrategy
-                    factor: "{{ config.backoff_factor }}"
                 response_filters:
                   - type: HttpResponseFilter
                     action: RETRY
                     http_codes:
                       - 500
                       - 429
+                backoff_strategies:
+                  - type: ExponentialBackoffStrategy
+                    factor: "{{ config.backoff_factor }}"
         record_selector:
           type: RecordSelector
           extractor:
@@ -340,18 +342,18 @@ definitions:
           type: DefaultPaginator
           page_token_option:
             type: RequestOption
-            inject_into: body_json
             field_path:
               - selector
               - pagination
               - offset
+            inject_into: body_json
           page_size_option:
             type: RequestOption
-            inject_into: body_json
             field_path:
               - selector
               - pagination
               - limit
+            inject_into: body_json
           pagination_strategy:
             type: OffsetIncrement
             page_size: 1000
@@ -366,7 +368,7 @@ definitions:
       incremental_sync:
         type: DatetimeBasedCursor
         cursor_field: date
-        lookback_window: 'P{{ config.lookback_window}}D'
+        lookback_window: P{{ config.lookback_window}}D
         cursor_datetime_formats:
           - "%Y-%m-%d"
         datetime_format: "%Y-%m-%d"
@@ -404,9 +406,6 @@ definitions:
             - reportingDataResponse
             - row
       name: keywords_report_daily
-      primary_key:
-        - date
-        - keywordId
       retriever:
         type: SimpleRetriever
         requester:
@@ -453,18 +452,18 @@ definitions:
           type: DefaultPaginator
           page_token_option:
             type: RequestOption
-            inject_into: body_json
             field_path:
               - selector
               - pagination
               - offset
+            inject_into: body_json
           page_size_option:
             type: RequestOption
-            inject_into: body_json
             field_path:
               - selector
               - pagination
               - limit
+            inject_into: body_json
           pagination_strategy:
             type: OffsetIncrement
             page_size: 1000
@@ -479,7 +478,7 @@ definitions:
       incremental_sync:
         type: DatetimeBasedCursor
         cursor_field: date
-        lookback_window: 'P{{ config.lookback_window }}D'
+        lookback_window: P{{ config.lookback_window }}D
         cursor_datetime_formats:
           - "%Y-%m-%d"
         datetime_format: "%Y-%m-%d"
@@ -514,8 +513,8 @@ definitions:
     authenticator:
       type: OAuthAuthenticator
       client_id: "{{ config.client_id }}"
-      client_secret: "{{ config.client_secret }}"
       grant_type: client_credentials
+      client_secret: "{{ config.client_secret }}"
       token_refresh_endpoint: >-
         https://appleid.apple.com/auth/oauth2/token?grant_type=client_credentials&scope=searchadsorg
 
@@ -543,62 +542,63 @@ spec:
         description: >-
           The identifier of the organization that owns the campaign. Your Org Id
           is the same as your account in the Apple Search Ads UI.
-        title: Org Id
         order: 0
+        title: Org Id
       end_date:
         type: string
         description: Data is retrieved until that date (included)
+        order: 1
         title: End Date
         pattern: ^[0-9]{4}-[0-9]{2}-[0-9]{2}$
         examples:
           - "2021-01-01"
-        order: 1
       client_id:
         type: string
         description: >-
           A user identifier for the token request. See <a
           href="https://developer.apple.com/documentation/apple_search_ads/implementing_oauth_for_the_apple_search_ads_api">here</a>
+        order: 2
         title: Client Id
         airbyte_secret: true
-        order: 2
       start_date:
         type: string
         description: Start getting data from that date.
+        order: 3
         title: Start Date
         pattern: ^[0-9]{4}-[0-9]{2}-[0-9]{2}$
         examples:
           - "2020-01-01"
-        order: 3
       client_secret:
         type: string
         description: >-
           A string that authenticates the user’s setup request. See <a
           href="https://developer.apple.com/documentation/apple_search_ads/implementing_oauth_for_the_apple_search_ads_api">here</a>
+        order: 4
         title: Client Secret
         airbyte_secret: true
-        order: 4
       lookback_window:
         type: integer
-        default: 30
         description: >-
-          Apple Search Ads uses a 30-day attribution window. However, you may consider smaller values in order
-          to shorten sync durations, at the cost of missing late data attributions.
+          Apple Search Ads uses a 30-day attribution window. However, you may
+          consider smaller values in order to shorten sync durations, at the
+          cost of missing late data attributions.
+        order: 5
         title: Lookback Window
+        default: 30
         pattern: ^(30|[1-2][0-9]|[1-9])$
         examples:
           - 7
-        order: 5
       backoff_factor:
         type: integer
-        default: 5
         description: >-
-          This factor factor determines the delay increase factor between retryable failures.
-          Valid values are integers between 1 and 20.
+          This factor factor determines the delay increase factor between
+          retryable failures. Valid values are integers between 1 and 20.
+        order: 6
         title: Exponential Backoff Factor
+        default: 5
         pattern: ^(20|1[0-9]|[1-9])$
         examples:
           - 10
-        order: 6
     additionalProperties: true
 
 metadata:
@@ -611,24 +611,58 @@ metadata:
     keywords_report_daily: false
   yamlComponents:
     streams:
+      campaigns_report_daily:
+        - errorHandler
+      adgroups_report_daily:
+        - errorHandler
       keywords_report_daily:
         - errorHandler
     global:
       - authenticator
   testedStreams:
     campaigns:
-      streamHash: feda30929d58abb1441b9a5a9fa676ac53732898
+      streamHash: 471be30065f2e627f876ceb64b765b1c9b144b3a
+      hasResponse: true
+      responsesAreSuccessful: true
+      hasRecords: true
+      primaryKeysArePresent: true
+      primaryKeysAreUnique: true
     adgroups:
-      streamHash: 4bee763630f2faa1e57b8fdecfb5ad2562a6f8e5
+      streamHash: 78700b260228ba45013dc89a6dc308ecb66c1493
+      hasResponse: true
+      responsesAreSuccessful: true
+      hasRecords: true
+      primaryKeysArePresent: true
+      primaryKeysAreUnique: true
     keywords:
-      streamHash: 8e9c01bded0da3421d384099ab66fe699e448558
+      streamHash: 41a8b9105965783ffb44bebddd40ef5e36b59da4
+      hasResponse: true
+      responsesAreSuccessful: true
+      hasRecords: true
+      primaryKeysArePresent: true
+      primaryKeysAreUnique: true
     campaigns_report_daily:
-      streamHash: b73b3a7fd009d515e31b6eae904bf925e45f4370
+      streamHash: 65c26f415b78932b495424c2da6b13d4408f02a4
+      hasResponse: true
+      responsesAreSuccessful: true
+      hasRecords: true
+      primaryKeysArePresent: true
+      primaryKeysAreUnique: true
     adgroups_report_daily:
-      streamHash: 5982b7f631f8bfc624b467b8e4b442f3beec34e6
+      streamHash: 236c631495a6c5d871069511422cf4ecccd45127
+      hasResponse: true
+      responsesAreSuccessful: true
+      hasRecords: true
+      primaryKeysArePresent: true
+      primaryKeysAreUnique: true
     keywords_report_daily:
-      streamHash: 642ee63980cc78adbe63e1008199574b282d846f
-  assist: { }
+      streamHash: 960877547a37e031d2b50197379b164fb42028c1
+      hasResponse: true
+      responsesAreSuccessful: true
+      hasRecords: true
+      primaryKeysArePresent: true
+      primaryKeysAreUnique: true
+  assist: {}
 
 schemas:
   campaigns:
@@ -950,13 +984,6 @@ schemas:
         items:
           type: object
           properties:
-            tapInstallCPI:
-              type: object
-              properties:
-                amount:
-                  type: string
-                currency:
-                  type: string
             avgCPM:
               type: object
               properties:
@@ -971,13 +998,9 @@ schemas:
                   type: string
                 currency:
                   type: string
-            tapInstallRate:
-              type: number
             date:
               type: string
             impressions:
-              type: integer
-            tapInstalls:
               type: integer
             latOffInstalls:
               type: integer
@@ -990,6 +1013,17 @@ schemas:
                   type: string
                 currency:
                   type: string
+            tapInstallCPI:
+              type: object
+              properties:
+                amount:
+                  type: string
+                currency:
+                  type: string
+            tapInstallRate:
+              type: number
+            tapInstalls:
+              type: integer
             tapNewDownloads:
               type: integer
             tapRedownloads:
@@ -1056,13 +1090,6 @@ schemas:
         items:
           type: object
           properties:
-            tapInstallCPI:
-              type: object
-              properties:
-                amount:
-                  type: string
-                currency:
-                  type: string
             avgCPM:
               type: object
               properties:
@@ -1077,13 +1104,9 @@ schemas:
                   type: string
                 currency:
                   type: string
-            tapInstallRate:
-              type: number
             date:
               type: string
             impressions:
-              type: integer
-            tapInstalls:
               type: integer
             latOffInstalls:
               type: integer
@@ -1096,6 +1119,17 @@ schemas:
                   type: string
                 currency:
                   type: string
+            tapInstallCPI:
+              type: object
+              properties:
+                amount:
+                  type: string
+                currency:
+                  type: string
+            tapInstallRate:
+              type: number
+            tapInstalls:
+              type: integer
             tapNewDownloads:
               type: integer
             tapRedownloads:
@@ -1150,13 +1184,6 @@ schemas:
         items:
           type: object
           properties:
-            tapInstallCPI:
-              type: object
-              properties:
-                amount:
-                  type: string
-                currency:
-                  type: string
             avgCPT:
               type: object
               properties:
@@ -1164,13 +1191,9 @@ schemas:
                   type: string
                 currency:
                   type: string
-            tapInstallRate:
-              type: number
             date:
               type: string
             impressions:
-              type: integer
-            tapInstalls:
               type: integer
             latOffInstalls:
               type: integer
@@ -1183,6 +1206,17 @@ schemas:
                   type: string
                 currency:
                   type: string
+            tapInstallCPI:
+              type: object
+              properties:
+                amount:
+                  type: string
+                currency:
+                  type: string
+            tapInstallRate:
+              type: number
+            tapInstalls:
+              type: integer
             tapNewDownloads:
               type: integer
             tapRedownloads:
@@ -1197,15 +1231,6 @@ schemas:
           bidRecommendation:
             type: object
             properties:
-              suggestedBidAmount:
-                anyOf:
-                  - type: "null"
-                  - type: object
-                    properties:
-                      amount:
-                        type: string
-                      currency:
-                        type: string
               bidMax:
                 anyOf:
                   - type: "null"
@@ -1216,6 +1241,15 @@ schemas:
                       currency:
                         type: string
               bidMin:
+                anyOf:
+                  - type: "null"
+                  - type: object
+                    properties:
+                      amount:
+                        type: string
+                      currency:
+                        type: string
+              suggestedBidAmount:
                 anyOf:
                   - type: "null"
                   - type: object

--- a/airbyte-integrations/connectors/source-apple-search-ads/manifest.yaml
+++ b/airbyte-integrations/connectors/source-apple-search-ads/manifest.yaml
@@ -3,12 +3,7 @@ version: 6.36.3
 type: DeclarativeSource
 
 description: |
-  The fix to resolve Github issue:
-  https://github.com/airbytehq/airbyte/issues/55173.
-  Removed source-defined primary keys in the report streams:
-  - campaigns_report_daily
-  - adgroups_report_daily
-  - keywords_report_daily
+  Connector for Apple Search Ads.
 
 check:
   type: CheckStream

--- a/airbyte-integrations/connectors/source-apple-search-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-apple-search-ads/metadata.yaml
@@ -1,35 +1,39 @@
-metadataSpecVersion: "1.0"
 data:
-  allowedHosts:
-    hosts:
-      - "api.searchads.apple.com"
-  registryOverrides:
-    oss:
-      enabled: true
-    cloud:
-      enabled: true
-  remoteRegistries:
-    pypi:
-      enabled: false
-      packageName: airbyte-source-apple-search-ads
-  connectorBuildOptions:
-    baseImage: docker.io/airbyte/source-declarative-manifest:6.37.2@sha256:3825e6063ed17bca7d5df1e0a596ec80c28e7ccdf980cad6babf858cd9fd53a8
   connectorSubtype: api
   connectorType: source
   definitionId: e59c8416-c2fa-4bd3-9e95-52677ea281c1
-  dockerImageTag: 0.0.1
+  dockerImageTag: 0.5.0
   dockerRepository: airbyte/source-apple-search-ads
   githubIssueLabel: source-apple-search-ads
   icon: icon.svg
   license: MIT
   name: Apple Search Ads
-  releaseDate: 2025-03-05
+  remoteRegistries:
+    pypi:
+      enabled: false
+      packageName: airbyte-source-apple-search-ads
+  registryOverrides:
+    cloud:
+      enabled: true
+    oss:
+      enabled: true
   releaseStage: alpha
-  supportLevel: community
   documentationUrl: https://docs.airbyte.com/integrations/sources/apple-search-ads
   tags:
-    - language:manifest-only
     - cdk:low-code
+    - language:manifest-only
   ab_internal:
-    ql: 100
     sl: 100
+    ql: 100
+  connectorTestSuitesOptions:
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-APPLE-SEARCH-ADS__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+  supportLevel: community
+  connectorBuildOptions:
+    baseImage: docker.io/airbyte/source-declarative-manifest:6.37.2@sha256:3825e6063ed17bca7d5df1e0a596ec80c28e7ccdf980cad6babf858cd9fd53a8
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-apple-search-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-apple-search-ads/metadata.yaml
@@ -1,39 +1,35 @@
+metadataSpecVersion: "1.0"
 data:
-  connectorSubtype: api
-  connectorType: source
-  definitionId: e59c8416-c2fa-4bd3-9e95-52677ea281c1
-  dockerImageTag: 0.4.3
-  dockerRepository: airbyte/source-apple-search-ads
-  githubIssueLabel: source-apple-search-ads
-  icon: apple.svg
-  license: MIT
-  name: Apple Search Ads
+  allowedHosts:
+    hosts:
+      - "api.searchads.apple.com"
+  registryOverrides:
+    oss:
+      enabled: true
+    cloud:
+      enabled: true
   remoteRegistries:
     pypi:
       enabled: false
       packageName: airbyte-source-apple-search-ads
-  registryOverrides:
-    cloud:
-      enabled: true
-    oss:
-      enabled: true
+  connectorBuildOptions:
+    baseImage: docker.io/airbyte/source-declarative-manifest:6.37.2@sha256:3825e6063ed17bca7d5df1e0a596ec80c28e7ccdf980cad6babf858cd9fd53a8
+  connectorSubtype: api
+  connectorType: source
+  definitionId: e59c8416-c2fa-4bd3-9e95-52677ea281c1
+  dockerImageTag: 0.0.1
+  dockerRepository: airbyte/source-apple-search-ads
+  githubIssueLabel: source-apple-search-ads
+  icon: icon.svg
+  license: MIT
+  name: Apple Search Ads
+  releaseDate: 2025-03-05
   releaseStage: alpha
+  supportLevel: community
   documentationUrl: https://docs.airbyte.com/integrations/sources/apple-search-ads
   tags:
-    - cdk:low-code
     - language:manifest-only
+    - cdk:low-code
   ab_internal:
-    sl: 100
     ql: 100
-  connectorTestSuitesOptions:
-    - suite: acceptanceTests
-      testSecrets:
-        - name: SECRET_SOURCE-APPLE-SEARCH-ADS__CREDS
-          fileName: config.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-  supportLevel: community
-  connectorBuildOptions:
-    baseImage: docker.io/airbyte/source-declarative-manifest:6.36.4@sha256:a612db8bc977a46d7d2e0442f5c6be26da6039ee83a8aceb7be545e4cbdd7040
-metadataSpecVersion: "1.0"
+    sl: 100

--- a/docs/integrations/sources/apple-search-ads.md
+++ b/docs/integrations/sources/apple-search-ads.md
@@ -22,8 +22,8 @@ This page contains the setup guide and reference information for the Apple Searc
 7. For **Start Date** and **End Date**, enter the date in YYYY-MM-DD format. For DAILY reports, the Start Date can't be
    earlier than 90 days from today. If the End Date field is left blank, Airbyte will replicate data to today.
 8. When syncing large amounts of data over vast durations, you can customize **Exponential Backoff Factor** in order to
-   reduce the chance of synchronization failures in case of Apple's rate limit kicking in. 
-9. You can also decrease the **Lookback Window** in order to sync smaller amounts of data on each incremental sync, 
+   reduce the chance of synchronization failures in case of Apple's rate limit kicking in.
+9. You can also decrease the **Lookback Window** in order to sync smaller amounts of data on each incremental sync,
    at the cost of missing late data attributions.
 10. Click **Set up source**.
 
@@ -48,6 +48,12 @@ The Apple Ads source connector supports the following streams. For more informat
 
 ### Report Streams
 
+::: note
+The usual primary keys for reports are `date` and `campaignId`.
+However, there are cases where active fields must be selected as primary keys to ensure data deduplication is correct.
+One example is `countryOrRegion`.
+:::
+
 - [campaigns_report_daily](https://developer.apple.com/documentation/apple_search_ads/get_campaign-level_reports)
 - [adgroups_report_daily](https://developer.apple.com/documentation/apple_search_ads/get__ad_group-level_reports)
 - [keywords_report_daily](https://developer.apple.com/documentation/apple_search_ads/get_keyword-level_reports)
@@ -65,6 +71,7 @@ However, at this moment and as indicated in the stream names, the connector only
 
 | Version | Date       | Pull Request                                             | Subject                                                                              |
 |:--------|:-----------|:---------------------------------------------------------|:-------------------------------------------------------------------------------------|
+| 0.5.0 | 2025-03-05 | [55210](https://github.com/airbytehq/airbyte/pull/55210) | Remove primary keys |
 | 0.4.3 | 2025-03-01 | [54873](https://github.com/airbytehq/airbyte/pull/54873) | Update dependencies |
 | 0.4.2 | 2025-02-24 | [54646](https://github.com/airbytehq/airbyte/pull/54646) | Fix paginator settings for incremental report streams |
 | 0.4.1 | 2025-02-22 | [54284](https://github.com/airbytehq/airbyte/pull/54284) | Update dependencies |


### PR DESCRIPTION
## What

This PR updates source Apple Search Ads (source-apple-search-ads).

The contributor provided the following description of the change:

The fix to resolve Github issue:
https://github.com/airbytehq/airbyte/issues/55173.
Removed source-defined primary keys in the report streams:
- campaigns_report_daily
- adgroups_report_daily
- keywords_report_daily

## Reviewer checklist
- [ ] Resolve any merge conflicts and validate file diffs (make sure the PR only includes changes intended by the contributor)
- [ ] After reviewing the changes, run the [`bump-version` Airbyte-CI command](https://github.com/airbytehq/airbyte/blob/master/airbyte-ci/connectors/pipelines/README.md#connectors-bump-version-command) locally to update the version of the connector according to the [versioning guidelines](https://docs.airbyte.io/contributor-guide/versioning-guidelines). Add `breakingChanges` to metadata if necessary.
- [ ] Ensure connector docs are up to date with any changes
- [ ] Run `/format-fix` to resolve any formatting errors
- [ ] Click into the CI workflows that wait for a maintainer to run them, which should trigger CI runs

<!-- DO NOT REMOVE: connector-builder-edit-connector-contribution -->
