### PR TITLE
Source Mixpanel: Migrate portfolios stream to the latest endpoint

### DIFF
--- a/airbyte-integrations/connectors/source-mixpanel/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mixpanel/metadata.yaml
@@ -11,7 +11,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 12928b32-bf0a-4f1e-964f-07e12e37153a
-  dockerImageTag: 3.4.20
+  dockerImageTag: 3.4.21
   dockerRepository: airbyte/source-mixpanel
   documentationUrl: https://docs.airbyte.com/integrations/sources/mixpanel
   githubIssueLabel: source-mixpanel

--- a/airbyte-integrations/connectors/source-mixpanel/pyproject.toml
+++ b/airbyte-integrations/connectors/source-mixpanel/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "3.4.20"
+version = "3.4.21"
 name = "source-mixpanel"
 description = "Source implementation for Mixpanel."
 authors = ["Airbyte <contact@airbyte.io>"]

--- a/airbyte-integrations/connectors/source-mixpanel/source_mixpanel/manifest.yaml
+++ b/airbyte-integrations/connectors/source-mixpanel/source_mixpanel/manifest.yaml
@@ -288,7 +288,7 @@ definitions:
         url_base: "https://{{ '' if config.region == 'US' else config.region+'.' }}mixpanel.com/api/"
         path: |
           {% set project_id = config.credentials.project_id %}
-          {% if project_id %}app/projects/{{project_id}}{% else %}2.0{% endif %}/annotations
+          {% if project_id %}app/projects/{{project_id}}{% else %}query{% endif %}/annotations
         authenticator: "#/definitions/authenticator"
         error_handler:
           $ref: "#/definitions/default_error_handler"

--- a/airbyte-integrations/connectors/source-mixpanel/source_mixpanel/manifest.yaml
+++ b/airbyte-integrations/connectors/source-mixpanel/source_mixpanel/manifest.yaml
@@ -126,7 +126,7 @@ definitions:
     $ref: "#/definitions/stream_base"
     $parameters:
       name: cohorts
-      path: 2.0/cohorts/list
+      path: query/cohorts/list
       field_path: []
     retriever:
       $ref: "#/definitions/retriever"
@@ -177,7 +177,7 @@ definitions:
         type: CustomRequester
         class_name: "source_mixpanel.components.EngagesHttpRequester"
         url_base: "https://{{ '' if config.region == 'US' else config.region+'.' }}mixpanel.com/api/"
-        path: 2.0/engage
+        path: query/engage
         authenticator: "#/definitions/authenticator"
         error_handler:
           $ref: "#/definitions/default_error_handler"
@@ -217,7 +217,7 @@ definitions:
       - cohort_id
     $parameters:
       name: cohort_members
-      path: 2.0/engage
+      path: query/engage
       field_path: results
     retriever:
       $ref: "#/definitions/retriever"
@@ -260,7 +260,7 @@ definitions:
     primary_key: "date"
     $parameters:
       name: revenue
-      path: 2.0/engage/revenue
+      path: query/engage/revenue
       field_path: results
     retriever:
       $ref: "#/definitions/retriever"
@@ -309,7 +309,7 @@ definitions:
       type: SimpleRetriever
       requester:
         $ref: "#/definitions/requester"
-        path: 2.0/funnels/list
+        path: query/funnels/list
         http_method: GET
         request_parameters:
           project_id: "{{ config['credentials']['project_id'] }}"
@@ -342,7 +342,7 @@ definitions:
         type: CustomRequester
         class_name: "source_mixpanel.components.FunnelsHttpRequester"
         url_base: "https://{{ '' if config.region == 'US' else config.region+'.' }}mixpanel.com/api/"
-        path: 2.0/funnels
+        path: query/funnels
         authenticator: "#/definitions/authenticator"
         error_handler:
           $ref: "#/definitions/default_error_handler"

--- a/airbyte-integrations/connectors/source-mixpanel/source_mixpanel/streams/base.py
+++ b/airbyte-integrations/connectors/source-mixpanel/source_mixpanel/streams/base.py
@@ -39,7 +39,7 @@ class MixpanelStream(HttpStream, ABC):
     @property
     def url_base(self):
         prefix = "eu." if self.region == "EU" else ""
-        return f"https://{prefix}mixpanel.com/api/2.0/"
+        return f"https://{prefix}mixpanel.com/api/query/"
 
     @property
     def reqs_per_hour_limit(self):

--- a/airbyte-integrations/connectors/source-mixpanel/unit_tests/test_source.py
+++ b/airbyte-integrations/connectors/source-mixpanel/unit_tests/test_source.py
@@ -56,7 +56,9 @@ def test_streams(requests_mock, config_raw):
     requests_mock.register_uri("GET", "https://mixpanel.com/api/query/cohorts/list", setup_response(200, {"id": 123}))
     requests_mock.register_uri("GET", "https://mixpanel.com/api/query/engage/revenue", setup_response(200, {}))
     requests_mock.register_uri("GET", "https://mixpanel.com/api/query/funnels", setup_response(200, {}))
-    requests_mock.register_uri("GET", "https://mixpanel.com/api/query/funnels/list", setup_response(200, {"funnel_id": 123, "name": "name"}))
+    requests_mock.register_uri(
+        "GET", "https://mixpanel.com/api/query/funnels/list", setup_response(200, {"funnel_id": 123, "name": "name"})
+    )
     requests_mock.register_uri(
         "GET",
         "https://data.mixpanel.com/api/2.0/export",

--- a/airbyte-integrations/connectors/source-mixpanel/unit_tests/test_source.py
+++ b/airbyte-integrations/connectors/source-mixpanel/unit_tests/test_source.py
@@ -27,8 +27,8 @@ def check_connection_url(config):
 @pytest.mark.parametrize("response_code,expect_success,response_json", [(400, False, {"error": "Request error"})])
 def test_check_connection(requests_mock, check_connection_url, config_raw, response_code, expect_success, response_json):
     # requests_mock.register_uri("GET", check_connection_url, setup_response(response_code, response_json))
-    requests_mock.get("https://mixpanel.com/api/2.0/cohorts/list", status_code=response_code, json=response_json)
-    requests_mock.get("https://eu.mixpanel.com/api/2.0/cohorts/list", status_code=response_code, json=response_json)
+    requests_mock.get("https://mixpanel.com/api/query/cohorts/list", status_code=response_code, json=response_json)
+    requests_mock.get("https://eu.mixpanel.com/api/query/cohorts/list", status_code=response_code, json=response_json)
     ok, error = SourceMixpanel().check_connection(logger, config_raw)
     assert ok == expect_success
 
@@ -48,15 +48,15 @@ def test_check_connection_incomplete(config_raw):
 
 
 def test_streams(requests_mock, config_raw):
-    requests_mock.register_uri("POST", "https://mixpanel.com/api/2.0/engage?page_size=1000", setup_response(200, {}))
-    requests_mock.register_uri("GET", "https://mixpanel.com/api/2.0/engage/properties", setup_response(200, {}))
-    requests_mock.register_uri("GET", "https://mixpanel.com/api/2.0/events/properties/top", setup_response(200, {}))
-    requests_mock.register_uri("GET", "https://mixpanel.com/api/2.0/events/properties/top", setup_response(200, {}))
-    requests_mock.register_uri("GET", "https://mixpanel.com/api/2.0/annotations", setup_response(200, {}))
-    requests_mock.register_uri("GET", "https://mixpanel.com/api/2.0/cohorts/list", setup_response(200, {"id": 123}))
-    requests_mock.register_uri("GET", "https://mixpanel.com/api/2.0/engage/revenue", setup_response(200, {}))
-    requests_mock.register_uri("GET", "https://mixpanel.com/api/2.0/funnels", setup_response(200, {}))
-    requests_mock.register_uri("GET", "https://mixpanel.com/api/2.0/funnels/list", setup_response(200, {"funnel_id": 123, "name": "name"}))
+    requests_mock.register_uri("POST", "https://mixpanel.com/api/query/engage?page_size=1000", setup_response(200, {}))
+    requests_mock.register_uri("GET", "https://mixpanel.com/api/query/engage/properties", setup_response(200, {}))
+    requests_mock.register_uri("GET", "https://mixpanel.com/api/query/events/properties/top", setup_response(200, {}))
+    requests_mock.register_uri("GET", "https://mixpanel.com/api/query/events/properties/top", setup_response(200, {}))
+    requests_mock.register_uri("GET", "https://mixpanel.com/api/query/annotations", setup_response(200, {}))
+    requests_mock.register_uri("GET", "https://mixpanel.com/api/query/cohorts/list", setup_response(200, {"id": 123}))
+    requests_mock.register_uri("GET", "https://mixpanel.com/api/query/engage/revenue", setup_response(200, {}))
+    requests_mock.register_uri("GET", "https://mixpanel.com/api/query/funnels", setup_response(200, {}))
+    requests_mock.register_uri("GET", "https://mixpanel.com/api/query/funnels/list", setup_response(200, {"funnel_id": 123, "name": "name"}))
     requests_mock.register_uri(
         "GET",
         "https://data.mixpanel.com/api/2.0/export",
@@ -68,13 +68,13 @@ def test_streams(requests_mock, config_raw):
 
 
 def test_streams_string_date(requests_mock, config_raw):
-    requests_mock.register_uri("GET", "https://mixpanel.com/api/2.0/engage/properties", setup_response(200, {}))
-    requests_mock.register_uri("GET", "https://mixpanel.com/api/2.0/events/properties/top", setup_response(200, {}))
-    requests_mock.register_uri("GET", "https://mixpanel.com/api/2.0/annotations", setup_response(200, {}))
-    requests_mock.register_uri("GET", "https://mixpanel.com/api/2.0/cohorts/list", setup_response(200, {"id": 123}))
-    requests_mock.register_uri("GET", "https://mixpanel.com/api/2.0/engage/revenue", setup_response(200, {}))
-    requests_mock.register_uri("POST", "https://mixpanel.com/api/2.0/engage", setup_response(200, {}))
-    requests_mock.register_uri("GET", "https://mixpanel.com/api/2.0/funnels/list", setup_response(402, {"error": "Payment required"}))
+    requests_mock.register_uri("GET", "https://mixpanel.com/api/query/engage/properties", setup_response(200, {}))
+    requests_mock.register_uri("GET", "https://mixpanel.com/api/query/events/properties/top", setup_response(200, {}))
+    requests_mock.register_uri("GET", "https://mixpanel.com/api/query/annotations", setup_response(200, {}))
+    requests_mock.register_uri("GET", "https://mixpanel.com/api/query/cohorts/list", setup_response(200, {"id": 123}))
+    requests_mock.register_uri("GET", "https://mixpanel.com/api/query/engage/revenue", setup_response(200, {}))
+    requests_mock.register_uri("POST", "https://mixpanel.com/api/query/engage", setup_response(200, {}))
+    requests_mock.register_uri("GET", "https://mixpanel.com/api/query/funnels/list", setup_response(402, {"error": "Payment required"}))
     requests_mock.register_uri(
         "GET",
         "https://data.mixpanel.com/api/2.0/export",
@@ -140,9 +140,9 @@ def test_streams_string_date(requests_mock, config_raw):
     ),
 )
 def test_config_validation(config, success, expected_error_message, requests_mock):
-    requests_mock.get("https://mixpanel.com/api/2.0/cohorts/list", status_code=200, json=[{"a": 1, "created": "2021-02-11T00:00:00Z"}])
-    requests_mock.get("https://mixpanel.com/api/2.0/cohorts/list", status_code=200, json=[{"a": 1, "created": "2021-02-11T00:00:00Z"}])
-    requests_mock.get("https://eu.mixpanel.com/api/2.0/cohorts/list", status_code=200, json=[{"a": 1, "created": "2021-02-11T00:00:00Z"}])
+    requests_mock.get("https://mixpanel.com/api/query/cohorts/list", status_code=200, json=[{"a": 1, "created": "2021-02-11T00:00:00Z"}])
+    requests_mock.get("https://mixpanel.com/api/query/cohorts/list", status_code=200, json=[{"a": 1, "created": "2021-02-11T00:00:00Z"}])
+    requests_mock.get("https://eu.mixpanel.com/api/query/cohorts/list", status_code=200, json=[{"a": 1, "created": "2021-02-11T00:00:00Z"}])
     try:
         is_success, message = SourceMixpanel().check_connection(None, config)
     except AirbyteTracedException as e:

--- a/airbyte-integrations/connectors/source-mixpanel/unit_tests/test_streams.py
+++ b/airbyte-integrations/connectors/source-mixpanel/unit_tests/test_streams.py
@@ -22,7 +22,7 @@ from .utils import get_url_to_mock, read_incremental, setup_response
 
 logger = logging.getLogger("airbyte")
 
-MIXPANEL_BASE_URL = "https://mixpanel.com/api/2.0/"
+MIXPANEL_BASE_URL = "https://mixpanel.com/api/query/"
 
 
 @pytest.fixture
@@ -51,7 +51,7 @@ def time_sleep_mock(mocker):
 def test_url_base(patch_base_class, config):
     stream = MixpanelStream(authenticator=MagicMock(), **config)
 
-    assert stream.url_base == "https://mixpanel.com/api/2.0/"
+    assert stream.url_base == "https://mixpanel.com/api/query/"
 
 
 def test_request_headers(patch_base_class, config):
@@ -580,7 +580,7 @@ def annotations_response():
 
 def test_annotations_stream(requests_mock, annotations_response, config_raw):
     stream = init_stream("annotations", config=config_raw)
-    requests_mock.register_uri("GET", "https://mixpanel.com/api/2.0/annotations", annotations_response)
+    requests_mock.register_uri("GET", "https://mixpanel.com/api/query/annotations", annotations_response)
 
     stream_slice = StreamSlice(partition={}, cursor_slice={"start_time": "2021-01-25", "end_time": "2021-07-25"})
     # read records for single slice
@@ -609,7 +609,7 @@ def revenue_response():
 
 def test_revenue_stream(requests_mock, revenue_response, config_raw):
     stream = init_stream("revenue", config=config_raw)
-    requests_mock.register_uri("GET", "https://mixpanel.com/api/2.0/engage/revenue", revenue_response)
+    requests_mock.register_uri("GET", "https://mixpanel.com/api/query/engage/revenue", revenue_response)
     stream_slice = StreamSlice(partition={}, cursor_slice={"start_time": "2021-01-25", "end_time": "2021-07-25"})
     # read records for single slice
     records = stream.read_records(sync_mode=SyncMode.full_refresh, stream_slice=stream_slice)
@@ -640,7 +640,7 @@ def test_export_schema(requests_mock, export_schema_response, config):
 
 
 def test_export_get_json_schema(requests_mock, export_schema_response, config):
-    requests_mock.register_uri("GET", "https://mixpanel.com/api/2.0/events/properties/top", export_schema_response)
+    requests_mock.register_uri("GET", "https://mixpanel.com/api/query/events/properties/top", export_schema_response)
 
     stream = Export(authenticator=MagicMock(), **config)
     schema = stream.get_json_schema()

--- a/docs/integrations/sources/mixpanel.md
+++ b/docs/integrations/sources/mixpanel.md
@@ -58,7 +58,7 @@ Syncing huge date windows may take longer due to Mixpanel's low API rate-limits 
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                                                                                                                                                                                                                                                                                                                            |
 |:--------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 3.4.21  | 2025-03-06 | [00000](https://github.com/airbytehq/airbyte/pull/00000) | Migrate streams to latest endpoint |
+| 3.4.21  | 2025-03-06 | [55224](https://github.com/airbytehq/airbyte/pull/55224) | Migrate streams to latest endpoint |
 | 3.4.20 | 2025-03-01 | [54769](https://github.com/airbytehq/airbyte/pull/54769) | Update dependencies |
 | 3.4.19 | 2025-02-22 | [54319](https://github.com/airbytehq/airbyte/pull/54319) | Update dependencies |
 | 3.4.18 | 2025-02-15 | [53852](https://github.com/airbytehq/airbyte/pull/53852) | Update dependencies |

--- a/docs/integrations/sources/mixpanel.md
+++ b/docs/integrations/sources/mixpanel.md
@@ -58,6 +58,7 @@ Syncing huge date windows may take longer due to Mixpanel's low API rate-limits 
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                                                                                                                                                                                                                                                                                                                            |
 |:--------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 3.4.21  | 2025-03-06 | [00000](https://github.com/airbytehq/airbyte/pull/00000) | Migrate streams to latest endpoint |
 | 3.4.20 | 2025-03-01 | [54769](https://github.com/airbytehq/airbyte/pull/54769) | Update dependencies |
 | 3.4.19 | 2025-02-22 | [54319](https://github.com/airbytehq/airbyte/pull/54319) | Update dependencies |
 | 3.4.18 | 2025-02-15 | [53852](https://github.com/airbytehq/airbyte/pull/53852) | Update dependencies |


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->
Resolves https://github.com/airbytehq/airbyte-internal-issues/issues/10547
Migrates the streams to the newest endpoints
Note: The export stream will still have to use the old endpoint, as instead of `mixpanel.com`, it fetches data from `data-eu.mixpanel.com` and `data.mixpanel.com`, which don't support the new endpoint.

## How
<!--
* Describe how code changes achieve the solution.
-->

## Review guide
<!--
1. `x.py`
2. `y.py`
-->
1. `manifest.yaml`

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->
No impact, the schema and input parameters remain the same for the new endpoints.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
