### PR TITLE
docs: conflicting stream documentation

### DIFF
--- a/docs/using-airbyte/configuring-schema.md
+++ b/docs/using-airbyte/configuring-schema.md
@@ -44,9 +44,9 @@ Airbyte does not allow for the renaming of individual streams at this time.
 Stream identifiers must be unique across Airbyte connections that share the same destination. You should not configure more than one Airbyte connection to sync to the same destination stream. Doing so can cause job failures and will be disallowed in future versions of Airbyte.
 To prevent Airbyte from syncing to the same destination stream when setting up multiple connections to a single destination, each connection must have either a unique stream names or namespaces. To resolve this, you can:
 
-- provide streams in each connection with a unique stream prefix
-- provide namespaces in each connection with a unique namespace format
-- disable conflicting streams
+- Provide streams in each connection with a unique stream prefix
+- Provide namespaces in each connection with a unique namespace format
+- Disable conflicting streams
 
 ## Select Sync Mode
 

--- a/docs/using-airbyte/configuring-schema.md
+++ b/docs/using-airbyte/configuring-schema.md
@@ -6,11 +6,11 @@ products: all
 
 A connection's schema typically consists of one or many streams. Each stream is most commonly associated with a database table or an API endpoint. Within a stream, there are typically several fields or columns. You can sync specific data from your sources by selecting which stream or fields.
 
-To learn more about streams and fields, see our [Core Concepts](/using-airbyte/core-concepts/). 
+To learn more about streams and fields, see our [Core Concepts](/using-airbyte/core-concepts/).
 
 ## Select Streams
 
-On the "Schema" tab of a connection, you choose which streams to sync and how they are loaded to the destination. 
+On the "Schema" tab of a connection, you choose which streams to sync and how they are loaded to the destination.
 
 ![Enabled Streams](./assets/schema-tab-streams.png)
 
@@ -18,37 +18,47 @@ To modify which streams are enabled:
 
 1. In the Airbyte UI, click **Connections** and then click the connection you want to change.
 
-2. Click the **Schema** tab. All the streams Airbyte has discovered from your source will appear. 
+2. Click the **Schema** tab. All the streams Airbyte has discovered from your source will appear.
 
-3. Toggle the checkbox on or off for your selected stream. To select or deselect all streams at once, use the summary toggle for all the streams in the namespace. Most sources only have one namespace, so the summary toggle will be located in the header. To select or deselect an individual stream, use the toggle in its row. 
+3. Toggle the checkbox on or off for your selected stream. To select or deselect all streams at once, use the summary toggle for all the streams in the namespace. Most sources only have one namespace, so the summary toggle will be located in the header. To select or deselect an individual stream, use the toggle in its row.
 
 :::tip
-Use the tabs to show only enabled streams or all disabled streams. 
-::: 
+Use the tabs to show only enabled streams or all disabled streams.
+:::
 
 ## Modify Stream Names
+
 To modify the stream name in the destination, use the connection-wide setting **Stream prefix**. Entering text here prepends the same text to each stream name in the destination, allowing for you to easily differentiate between streams of the same name in your destination.
 
-By default, Airbyte does not add any text to the **Stream prefix**. Streams without a **Stream Prefix** are synced to the destination with the same table name found in the source. As an example: 
+By default, Airbyte does not add any text to the **Stream prefix**. Streams without a **Stream Prefix** are synced to the destination with the same table name found in the source. As an example:
 
 | Source stream name | Stream Prefix | Destination stream name |
-|--|--|--|
-| accounts |  | accounts |
-| accounts | salesforce_ | salesforce_accounts |
+| ------------------ | ------------- | ----------------------- |
+| accounts           |               | accounts                |
+| accounts           | salesforce\_  | salesforce_accounts     |
 
-Airbyte does not allow for the renaming of individual streams at this time. 
+Airbyte does not allow for the renaming of individual streams at this time.
+
+### Stream uniqueness
+
+Stream identifiers must be unique across Airbyte connections that share the same destination. You should not configure more than one Airbyte connection to sync to the same destination stream. Doing so can cause job failures and will be disallowed in future versions of Airbyte.
+To prevent Airbyte from syncing to the same destination stream when setting up multiple connections to a single destination, each connection must have either a unique stream names or namespaces. To resolve this, you can:
+
+- provide streams in each connection with a unique stream prefix
+- provide namespaces in each connection with a unique namespace format
+- disable conflicting streams
 
 ## Select Sync Mode
 
-Each stream syncs using a specific sync mode. The sync mode tells Airbyte how the data should be synced, and what shape it will take. 
+Each stream syncs using a specific sync mode. The sync mode tells Airbyte how the data should be synced, and what shape it will take.
 
-To learn more about sync modes, see our [Sync Mode documentation](/using-airbyte/core-concepts/sync-modes/). 
+To learn more about sync modes, see our [Sync Mode documentation](/using-airbyte/core-concepts/sync-modes/).
 
 ![Select Sync Mode](./assets/select-sync-mode.png)
 
-During connection creation, Airbyte will ask how you would like data to be synced to the destination, and automatically select a sync mode for each stream depending on your input. 
+During connection creation, Airbyte will ask how you would like data to be synced to the destination, and automatically select a sync mode for each stream depending on your input.
 
-Most users select "Replicate Source", which will simply copy the data from the source to the destination where you'll see one row in the destination for each row in the source. If you prefer to Append Historical Changes or take a Full Snapshot with each sync, you can optionally select those options, but keep in mind those will create duplicate records in your destination. 
+Most users select "Replicate Source", which will simply copy the data from the source to the destination where you'll see one row in the destination for each row in the source. If you prefer to Append Historical Changes or take a Full Snapshot with each sync, you can optionally select those options, but keep in mind those will create duplicate records in your destination.
 
 You can also modify a single stream's sync mode by navigating to the relevant stream and opening the sync mode dropdown. Depending on the sync mode you select, you may need to choose a cursor or primary key.
 
@@ -86,7 +96,7 @@ To select a partial set of fields:
 
 3. Click **Save changes**, or click **Cancel** to discard the changes.
 
-7. The **Stream configuration changed** dialog may display. This gives you the option to `Refresh` the edited streams when you save your changes. If your destination does not support `Refreshes`, you will need to `Clear` your data instead.
+4. The **Stream configuration changed** dialog may display. This gives you the option to `Refresh` the edited streams when you save your changes. If your destination does not support `Refreshes`, you will need to `Clear` your data instead.
 
 ![Refresh Modal](./assets/refresh-modal.png)
 


### PR DESCRIPTION
## What
Adds documentation for resolving errors related to https://github.com/airbytehq/airbyte-platform-internal/pull/15315

I believe the additional changes were from me installing the Vale vscode plugin perhaps.

## User Impact
We will be rolling out the above linked PR shortly.  These docs will provide a clear resolution path for users who run into the new validation rules when creating or updating connections in the UI or API.  I will modify the above PR to add a documentation link once this is merged!

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
