### PR TITLE
Bump DuckDB version

### DIFF
--- a/airbyte-integrations/connectors/destination-duckdb/pyproject.toml
+++ b/airbyte-integrations/connectors/destination-duckdb/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 [tool.poetry.dependencies]
 python = ">=3.8"
 airbyte-cdk = "^0.51.6"
-duckdb = "0.10.3"
+duckdb = "1.2.1"
 pyarrow = "15.0.2"
 
 [tool.poetry.group.dev.dependencies]

--- a/docs/integrations/destinations/duckdb.md
+++ b/docs/integrations/destinations/duckdb.md
@@ -116,7 +116,7 @@ This error may indicate that you are connecting with a `0.10.x` DuckDB client (a
 
 | Version | Date       | Pull Request                                              | Subject                                                                                                                                                                                                                                                                                                                                                                                                |
 |:--------| :--------- | :-------------------------------------------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 0.5.0 | 2024-10-29 | [47861](https://github.com/airbytehq/airbyte/pull/47861) | Upgrade DuckDB engine version to [`v1.2.1`](https://github.com/duckdb/duckdb/releases/tag/v1.2.1).                 
+| 0.5.0 | 2025-03-06 | [47861](https://github.com/airbytehq/airbyte/pull/47861) | Upgrade DuckDB engine version to [`v1.2.1`](https://github.com/duckdb/duckdb/releases/tag/v1.2.1).                 
 | 0.4.26 | 2024-10-29 | [47861](https://github.com/airbytehq/airbyte/pull/47861) | Update dependencies |
 | 0.4.25 | 2024-10-28 | [47070](https://github.com/airbytehq/airbyte/pull/47070) | Update dependencies |
 | 0.4.24 | 2024-10-12 | [46845](https://github.com/airbytehq/airbyte/pull/46845) | Update dependencies |

--- a/docs/integrations/destinations/duckdb.md
+++ b/docs/integrations/destinations/duckdb.md
@@ -116,6 +116,7 @@ This error may indicate that you are connecting with a `0.10.x` DuckDB client (a
 
 | Version | Date       | Pull Request                                              | Subject                                                                                                                                                                                                                                                                                                                                                                                                |
 |:--------| :--------- | :-------------------------------------------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 0.5.0 | 2024-10-29 | [47861](https://github.com/airbytehq/airbyte/pull/47861) | Upgrade DuckDB engine version to [`v1.2.1`](https://github.com/duckdb/duckdb/releases/tag/v1.2.1).                 
 | 0.4.26 | 2024-10-29 | [47861](https://github.com/airbytehq/airbyte/pull/47861) | Update dependencies |
 | 0.4.25 | 2024-10-28 | [47070](https://github.com/airbytehq/airbyte/pull/47070) | Update dependencies |
 | 0.4.24 | 2024-10-12 | [46845](https://github.com/airbytehq/airbyte/pull/46845) | Update dependencies |


### PR DESCRIPTION
## What
Fixes #[55235](https://github.com/airbytehq/airbyte/issues/55235)

## How
Bump DuckDB to the latest version 1.2.1

## Review guide
pyproject.toml file updated

## User Impact
This fix makes it possible to use the DuckDB connector with MotherDuck

## Can this PR be safely reverted and rolled back?
- [ ] YES 💚
- [ ] NO ❌
