### PR TITLE
[source-hibob] Changed check stream from payrolls to profiles #55674

### DIFF
--- a/airbyte-integrations/connectors/source-hibob/manifest.yaml
+++ b/airbyte-integrations/connectors/source-hibob/manifest.yaml
@@ -2334,7 +2334,7 @@ streams:
 check:
   type: CheckStream
   stream_names:
-    - "payroll"
+    - "profiles"
 spec:
   type: Spec
   connection_specification:

--- a/airbyte-integrations/connectors/source-hibob/metadata.yaml
+++ b/airbyte-integrations/connectors/source-hibob/metadata.yaml
@@ -20,7 +20,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 4dc991ed-3dcc-4c40-ac28-9402836709f1
-  dockerImageTag: 0.2.15
+  dockerImageTag: 0.2.16
   dockerRepository: airbyte/source-hibob
   githubIssueLabel: source-hibob
   icon: icon.svg

--- a/docs/integrations/sources/hibob.md
+++ b/docs/integrations/sources/hibob.md
@@ -80,6 +80,7 @@ Link to HiBob API documentation [here](https://apidocs.hibob.com/docs/).
 
 | Version  | Date       | Pull Request                                             | Subject                                                                                                                              |
 |:---------|:-----------|:---------------------------------------------------------|:-------------------------------------------------------------------------------------------------------------------------------------|
+| 0.2.16 | 2025-03-10 | [55674](https://github.com/airbytehq/airbyte/pull/55674) | Change check stream from payrolls to profiles |
 | 0.2.15 | 2025-03-08 | [55484](https://github.com/airbytehq/airbyte/pull/55484) | Update dependencies |
 | 0.2.14 | 2025-03-01 | [54742](https://github.com/airbytehq/airbyte/pull/54742) | Update dependencies |
 | 0.2.13 | 2025-02-22 | [54314](https://github.com/airbytehq/airbyte/pull/54314) | Update dependencies |


### PR DESCRIPTION
## What
Resolves raised issue: [#55674](https://github.com/airbytehq/airbyte/issues/55674)
With this MR, I changed source-hibob connector's check stream from payrolls to profiles due to the nature of the data - "payrolls" data is more sensitive and having additional accesses to confidential / sensitive data just for a connector's check brings a lot more risk rather than having an overall "profiles" stream as a check stream. Therefore, only changing which stream is used as a check.

## How
Nothing changes apart from the check stream itself - it will now use "profiles" instead of "payrolls" stream.

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
Should be none - only check stream is changed.

## Can this PR be safely reverted and rolled back?
- [X] YES 💚
