### PR TITLE
fix(source-instagram): Disable cache for InstagramMediaChildrenTransformation

### DIFF
--- a/airbyte-integrations/connectors/source-instagram/metadata.yaml
+++ b/airbyte-integrations/connectors/source-instagram/metadata.yaml
@@ -7,7 +7,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 6acf6b55-4f1e-4fca-944e-1a3caef8aba8
-  dockerImageTag: 3.2.1
+  dockerImageTag: 3.2.2
   dockerRepository: airbyte/source-instagram
   githubIssueLabel: source-instagram
   icon: instagram.svg

--- a/airbyte-integrations/connectors/source-instagram/pyproject.toml
+++ b/airbyte-integrations/connectors/source-instagram/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "3.2.1"
+version = "3.2.2"
 name = "source-instagram"
 description = "Source implementation for Instagram."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-instagram/source_instagram/components.py
+++ b/airbyte-integrations/connectors/source-instagram/source_instagram/components.py
@@ -38,7 +38,7 @@ def get_http_response(name: str, path: str, request_params: Dict, config: Config
         http_client = HttpClient(
             name=name,
             logger=http_logger,
-            use_cache=True,
+            use_cache=False,
             error_handler=error_handler,
         )
         _, response = http_client.send_request(

--- a/docs/integrations/sources/instagram.md
+++ b/docs/integrations/sources/instagram.md
@@ -146,7 +146,7 @@ for more information.
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                   |
 |:--------|:-----------|:---------------------------------------------------------|:--------------------------------------------------------------------------------------------------------------------------|
-| 3.2.2 | 2025-03-10 | [55463](https://github.com/airbytehq/airbyte/pull/55463) | Disable cache for InstagramMediaChildrenTransformation |
+| 3.2.2 | 2025-03-10 | [55685](https://github.com/airbytehq/airbyte/pull/55685) | Disable cache for InstagramMediaChildrenTransformation |
 | 3.2.1 | 2025-03-08 | [55463](https://github.com/airbytehq/airbyte/pull/55463) | Update dependencies |
 | 3.2.0 | 2025-02-28 | [54364](https://github.com/airbytehq/airbyte/pull/54364) | Update to CDK v6 |
 | 3.1.9 | 2025-03-01 | [54789](https://github.com/airbytehq/airbyte/pull/54789) | Update dependencies |

--- a/docs/integrations/sources/instagram.md
+++ b/docs/integrations/sources/instagram.md
@@ -146,6 +146,7 @@ for more information.
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                   |
 |:--------|:-----------|:---------------------------------------------------------|:--------------------------------------------------------------------------------------------------------------------------|
+| 3.2.2 | 2025-03-10 | [55463](https://github.com/airbytehq/airbyte/pull/55463) | Disable cache for InstagramMediaChildrenTransformation |
 | 3.2.1 | 2025-03-08 | [55463](https://github.com/airbytehq/airbyte/pull/55463) | Update dependencies |
 | 3.2.0 | 2025-02-28 | [54364](https://github.com/airbytehq/airbyte/pull/54364) | Update to CDK v6 |
 | 3.1.9 | 2025-03-01 | [54789](https://github.com/airbytehq/airbyte/pull/54789) | Update dependencies |


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->
Disable cache for InstagramMediaChildrenTransformation to fix: `sqlite3.OperationalError: database is locked`

## How
<!--
* Describe how code changes achieve the solution.
-->

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
