### PR TITLE
JDBCsource/ filter tables in discover because of mssql null table

### DIFF
--- a/airbyte-cdk/java/airbyte-cdk/db-sources/src/main/kotlin/io/airbyte/cdk/integrations/source/jdbc/AbstractJdbcSource.kt
+++ b/airbyte-cdk/java/airbyte-cdk/db-sources/src/main/kotlin/io/airbyte/cdk/integrations/source/jdbc/AbstractJdbcSource.kt
@@ -576,6 +576,7 @@ abstract class AbstractJdbcSource<Datatype>(
             }
             .values
             .map { fields: List<JsonNode> -> jsonFieldListToTableInfo(fields) }
+            .filter { ti: TableInfo<CommonField<Datatype>> -> ti.name == tableName }
             .firstOrNull()
     }
 


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->
Fixing issue where the table returned is not the one selected in the sync for mssql
More detail here: https://github.com/airbytehq/airbyte/issues/53610#issuecomment-2715398642

https://github.com/airbytehq/airbyte/issues/53610


## How
<!--
* Describe how code changes achieve the solution.
-->
By filtering the table with the table name I'm able to remove the unwanted tables

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->
This will affect pretty much all JDBC connector.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
