### PR TITLE
fix(Source-LinkedIn-Ads): Update outdated schema

### DIFF
--- a/airbyte-integrations/connectors/source-linkedin-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-linkedin-ads/metadata.yaml
@@ -11,7 +11,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 137ece28-5434-455c-8f34-69dc3782f451
-  dockerImageTag: 5.3.2
+  dockerImageTag: 5.3.3
   dockerRepository: airbyte/source-linkedin-ads
   documentationUrl: https://docs.airbyte.com/integrations/sources/linkedin-ads
   githubIssueLabel: source-linkedin-ads

--- a/airbyte-integrations/connectors/source-linkedin-ads/pyproject.toml
+++ b/airbyte-integrations/connectors/source-linkedin-ads/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "5.3.2"
+version = "5.3.3"
 name = "source-linkedin-ads"
 description = "Source implementation for Linkedin Ads."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-linkedin-ads/source_linkedin_ads/manifest.yaml
+++ b/airbyte-integrations/connectors/source-linkedin-ads/source_linkedin_ads/manifest.yaml
@@ -2890,7 +2890,7 @@ schemas:
         type:
           - "null"
           - number
-      approximateUniqueImpressions:
+      approximateMemberReach:
         description: "An approximation of unique ad impressions."
         type:
           - "null"
@@ -3397,7 +3397,7 @@ schemas:
         type:
           - "null"
           - number
-      approximateUniqueImpressions:
+      approximateMemberReach:
         description: "An approximation of unique ad impressions."
         type:
           - "null"
@@ -3904,7 +3904,7 @@ schemas:
         type:
           - "null"
           - number
-      approximateUniqueImpressions:
+      approximateMemberReach:
         description: "An approximation of unique ad impressions."
         type:
           - "null"
@@ -4411,7 +4411,7 @@ schemas:
         type:
           - "null"
           - number
-      approximateUniqueImpressions:
+      approximateMemberReach:
         description: "An approximation of unique ad impressions."
         type:
           - "null"
@@ -4918,7 +4918,7 @@ schemas:
         type:
           - "null"
           - number
-      approximateUniqueImpressions:
+      approximateMemberReach:
         description: "An approximation of unique ad impressions."
         type:
           - "null"
@@ -5425,7 +5425,7 @@ schemas:
         type:
           - "null"
           - number
-      approximateUniqueImpressions:
+      approximateMemberReach:
         description: "An approximation of unique ad impressions."
         type:
           - "null"
@@ -5932,7 +5932,7 @@ schemas:
         type:
           - "null"
           - number
-      approximateUniqueImpressions:
+      approximateMemberReach:
         description: "An approximation of unique ad impressions."
         type:
           - "null"
@@ -6439,7 +6439,7 @@ schemas:
         type:
           - "null"
           - number
-      approximateUniqueImpressions:
+      approximateMemberReach:
         description: "An approximation of unique ad impressions."
         type:
           - "null"
@@ -6946,7 +6946,7 @@ schemas:
         type:
           - "null"
           - number
-      approximateUniqueImpressions:
+      approximateMemberReach:
         description: "An approximation of unique ad impressions."
         type:
           - "null"
@@ -7453,7 +7453,7 @@ schemas:
         type:
           - "null"
           - number
-      approximateUniqueImpressions:
+      approximateMemberReach:
         description: "An approximation of unique ad impressions."
         type:
           - "null"
@@ -7960,7 +7960,7 @@ schemas:
         type:
           - "null"
           - number
-      approximateUniqueImpressions:
+      approximateMemberReach:
         description: "An approximation of unique ad impressions."
         type:
           - "null"

--- a/docs/integrations/sources/linkedin-ads.md
+++ b/docs/integrations/sources/linkedin-ads.md
@@ -202,7 +202,7 @@ No workaround has been identified to manage this issue as of 2025, February.
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                         |
 |:--------|:-----------|:---------------------------------------------------------|:----------------------------------------------------------------------------------------------------------------|
-| 5.3.3 | 2025-03-12 | [XXXXX](https://github.com/airbytehq/airbyte/pull/XXXXX) | Update outdated schema `approximateUniqueImpressions` to new `approximateMemberReach` for `adAnalytics` streams. |
+| 5.3.3 | 2025-03-12 | [55724](https://github.com/airbytehq/airbyte/pull/55724) | Update outdated schema `approximateUniqueImpressions` to new `approximateMemberReach` for `adAnalytics` streams. |
 | 5.3.2 | 2025-03-08 | [55447](https://github.com/airbytehq/airbyte/pull/55447) | Update dependencies |
 | 5.3.1 | 2025-03-05 | [55211](https://github.com/airbytehq/airbyte/pull/55211) | Update dependencies |
 | 5.3.0 | 2025-03-02 | [55171](https://github.com/airbytehq/airbyte/pull/55171) | Migrate API to v202502 |

--- a/docs/integrations/sources/linkedin-ads.md
+++ b/docs/integrations/sources/linkedin-ads.md
@@ -202,6 +202,7 @@ No workaround has been identified to manage this issue as of 2025, February.
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                         |
 |:--------|:-----------|:---------------------------------------------------------|:----------------------------------------------------------------------------------------------------------------|
+| 5.3.3 | 2025-03-12 | [XXXXX](https://github.com/airbytehq/airbyte/pull/XXXXX) | Update outdated schema `approximateUniqueImpressions` to new `approximateMemberReach` for `adAnalytics` streams. |
 | 5.3.2 | 2025-03-08 | [55447](https://github.com/airbytehq/airbyte/pull/55447) | Update dependencies |
 | 5.3.1 | 2025-03-05 | [55211](https://github.com/airbytehq/airbyte/pull/55211) | Update dependencies |
 | 5.3.0 | 2025-03-02 | [55171](https://github.com/airbytehq/airbyte/pull/55171) | Migrate API to v202502 |


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->
Solves: https://github.com/airbytehq/oncall/issues/7595
## How
<!--
* Describe how code changes achieve the solution.
-->
https://learn.microsoft.com/en-us/linkedin/marketing/integrations/recent-changes?view=li-lms-2024-06#reminders-6
Schema needs to be changed from `approximateUniqueImpressions` to `approximateMemberReach` so records actually populate for these fields on all `adAnalytics` streams.

## Review guide
<!--
1. `x.py`
2. `y.py`
-->
Check that no schema fields were missed.

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ X] YES 💚
- [ ] NO ❌
