### PR TITLE
[source-mysql] More meaningful errors for variables used in extra checks for CDC

### DIFF
--- a/airbyte-integrations/connectors/source-mysql/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mysql/metadata.yaml
@@ -9,7 +9,7 @@ data:
   connectorSubtype: database
   connectorType: source
   definitionId: 435bb9a5-7887-4809-aa58-28c27df0d7ad
-  dockerImageTag: 3.11.8
+  dockerImageTag: 3.11.9
   dockerRepository: airbyte/source-mysql
   documentationUrl: https://docs.airbyte.com/integrations/sources/mysql
   githubIssueLabel: source-mysql

--- a/airbyte-integrations/connectors/source-mysql/src/main/kotlin/io/airbyte/integrations/source/mysql/MySqlSourceMetadataQuerier.kt
+++ b/airbyte-integrations/connectors/source-mysql/src/main/kotlin/io/airbyte/integrations/source/mysql/MySqlSourceMetadataQuerier.kt
@@ -32,24 +32,14 @@ class MySqlSourceMetadataQuerier(
         base.extraChecks()
         if (base.config.global) {
             // Extra checks for CDC
-            var cdcVariableCheckQueries: List<Triple<String, String, String>> =
+            var cdcVariables: List<Pair<String, String>> =
                 listOf(
-                    Triple("log_bin", "show variables where Variable_name = 'log_bin'", "ON"),
-                    Triple(
-                        "binlog_format",
-                        "show variables where Variable_name = 'binlog_format'",
-                        "ROW"
-                    ),
-                    Triple(
-                        "binlog_row_image",
-                        "show variables where Variable_name = 'binlog_row_image'",
-                        "FULL"
-                    ),
+                    Pair("log_bin", "ON"),
+                    Pair("binlog_format", "ROW"),
+                    Pair("binlog_row_image", "FULL"),
                 )
 
-            cdcVariableCheckQueries.forEach {
-                runVariableCheckSql(it.first, it.second, it.third, base.conn)
-            }
+            cdcVariables.forEach { runVariableCheckSql(it.first, it.second, base.conn) }
 
             // Note: SHOW MASTER STATUS has been deprecated in latest mysql (8.4) and going forward
             // it should be SHOW BINARY LOG STATUS. We will run both - if both have been failed we
@@ -72,14 +62,10 @@ class MySqlSourceMetadataQuerier(
         }
     }
 
-    private fun runVariableCheckSql(
-        variable: String,
-        sql: String,
-        expectedValue: String,
-        conn: Connection
-    ) {
+    private fun runVariableCheckSql(variable: String, expectedValue: String, conn: Connection) {
         try {
             conn.createStatement().use { stmt: Statement ->
+                val sql: String = "show variables where Variable_name = '$variable'"
                 stmt.executeQuery(sql).use { rs: ResultSet ->
                     if (!rs.next()) {
                         throw ConfigErrorException("Could not query the variable $sql")

--- a/docs/integrations/sources/mysql.md
+++ b/docs/integrations/sources/mysql.md
@@ -226,6 +226,7 @@ Any database or table encoding combination of charset and collation is supported
 
 | Version     | Date       | Pull Request                                               | Subject                                                                                                                                         |
 |:------------|:-----------|:-----------------------------------------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------|
+| 3.11.9 | 2025-03-14 | [55731](https://github.com/airbytehq/airbyte/pull/55731) | More meaningful errors for variables used in extra checks for CDC |
 | 3.11.8 | 2025-03-14 | [55761](https://github.com/airbytehq/airbyte/pull/55761) | Do not perform complex sampling for source-mysql |
 | 3.11.7 | 2025-03-12 | [55734](https://github.com/airbytehq/airbyte/pull/55734) | Expose additional stream context for debezium properties at startup |
 | 3.11.6 | 2025-03-06 | [55237](https://github.com/airbytehq/airbyte/pull/55237) | [Fix fetching binlog status for version >=8.4](https://github.com/airbytehq/airbyte/pull/55237#top) |


### PR DESCRIPTION
## What

More meaningful errors for source-mysql connector.

Motivation:
https://airbytehq.slack.com/archives/C021JANJ6TY/p1741784591500319

Instead of

![image](https://github.com/user-attachments/assets/e25e6118-c186-442c-9bae-d9746ab6d8c5)

it's way better to provide the name of variable

![image](https://github.com/user-attachments/assets/0cfc5a06-5648-4e2c-964e-0288341a2408)


## How

Passing variable name to an exception.

## Review guide

1. `airbyte-integrations/connectors/source-mysql/src/main/kotlin/io/airbyte/integrations/source/mysql/MySqlSourceMetadataQuerier.kt`

## User Impact

Improvement for connector users.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
