### PR TITLE
✨ Source Cin7: add new stream product_availability

### DIFF
--- a/airbyte-integrations/connectors/source-cin7/CHANGELOG.md
+++ b/airbyte-integrations/connectors/source-cin7/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+
+## 5.18.0
+Add new stream: `product_availability`

--- a/airbyte-integrations/connectors/source-cin7/manifest.yaml
+++ b/airbyte-integrations/connectors/source-cin7/manifest.yaml
@@ -1,4 +1,4 @@
-version: 5.17.0
+version: 5.18.0
 
 type: DeclarativeSource
 
@@ -6,7 +6,7 @@ description: >
   This is the Cin7 source that ingests data from the Cin7 API.
 
 
-  Cin7 (Connector Inventory Performance), If you’re a business that wants to
+  Cin7 (Connector Inventory Performance), If you're a business that wants to
   grow, you need an inventory solution you can count on - both now and in the
   future. With Cin7 you get a real-time picture of your products across systems,
   channels, marketplaces and regions, plus NEW ForesightAI advanced inventory
@@ -632,6 +632,45 @@ definitions:
         type: InlineSchemaLoader
         schema:
           $ref: "#/schemas/product_family"
+    product_availability:
+      type: DeclarativeStream
+      name: product_availability
+      primary_key:
+        - ID
+      retriever:
+        type: SimpleRetriever
+        requester:
+          $ref: "#/definitions/base_requester"
+          path: v2/ref/productavailability
+          http_method: GET
+          request_headers:
+            api-auth-accountid: "{{ config[\"accountid\"] }}"
+            api-auth-applicationkey: "{{ config[\"api_key\"] }}"
+        record_selector:
+          type: RecordSelector
+          extractor:
+            type: DpathExtractor
+            field_path:
+              - ProductAvailabilityList
+        paginator:
+          type: DefaultPaginator
+          page_token_option:
+            type: RequestOption
+            inject_into: request_parameter
+            field_name: page
+          page_size_option:
+            type: RequestOption
+            field_name: limit
+            inject_into: request_parameter
+          pagination_strategy:
+            type: PageIncrement
+            page_size: 100
+            start_from_page: 1
+            inject_on_first_request: true
+      schema_loader:
+        type: InlineSchemaLoader
+        schema:
+          $ref: "#/schemas/product_availability"
   base_requester:
     type: HttpRequester
     url_base: https://inventory.dearsystems.com/externalapi/
@@ -653,6 +692,7 @@ streams:
   - $ref: "#/definitions/streams/taxes"
   - $ref: "#/definitions/streams/product_categories"
   - $ref: "#/definitions/streams/product_family"
+  - $ref: "#/definitions/streams/product_availability"
 
 spec:
   type: Spec
@@ -693,6 +733,7 @@ metadata:
     taxes: true
     product_categories: true
     product_family: true
+    product_availability: true
   testedStreams:
     bank_accounts:
       hasRecords: true
@@ -806,7 +847,6 @@ metadata:
       hasRecords: true
       primaryKeysArePresent: true
       primaryKeysAreUnique: true
-  assist: {}
 
 schemas:
   bank_accounts:
@@ -2281,6 +2321,71 @@ schemas:
           - string
           - "null"
       UOM:
+        type:
+          - string
+          - "null"
+    required:
+      - ID
+  product_availability:
+    type: object
+    $schema: http://json-schema.org/schema#
+    additionalProperties: true
+    properties:
+      ID:
+        type: string
+      SKU:
+        type:
+          - string
+          - "null"
+      Name:
+        type:
+          - string
+          - "null"
+      Barcode:
+        type:
+          - string
+          - "null"
+      Location:
+        type:
+          - string
+          - "null"
+      Bin:
+        type:
+          - string
+          - "null"
+      Batch:
+        type:
+          - number
+          - "null"
+      ExpiryDate:
+        type:
+          - string
+          - "null"
+      OnHand:
+        type:
+          - number
+          - "null"
+      Allocated:
+        type:
+          - number
+          - "null"
+      Available:
+        type:
+          - number
+          - "null"
+      OnOrder:
+        type:
+          - number
+          - "null"
+      StockOnHand:
+        type:
+          - number
+          - "null"
+      InTransit:
+        type:
+          - number
+          - "null"
+      NextDeliveryDate:
         type:
           - string
           - "null"

--- a/airbyte-integrations/connectors/source-cin7/manifest.yaml
+++ b/airbyte-integrations/connectors/source-cin7/manifest.yaml
@@ -6,7 +6,7 @@ description: >
   This is the Cin7 source that ingests data from the Cin7 API.
 
 
-  Cin7 (Connector Inventory Performance), If you're a business that wants to
+  Cin7 (Connector Inventory Performance), If you’re a business that wants to
   grow, you need an inventory solution you can count on - both now and in the
   future. With Cin7 you get a real-time picture of your products across systems,
   channels, marketplaces and regions, plus NEW ForesightAI advanced inventory
@@ -847,6 +847,7 @@ metadata:
       hasRecords: true
       primaryKeysArePresent: true
       primaryKeysAreUnique: true
+  assist: {}
 
 schemas:
   bank_accounts:


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->
This PR adds a new stream `product_availability` to the Cin7 source connector to retrieve product inventory levels across locations.

## How
<!--
* Describe how code changes achieve the solution.
-->
- Added a new stream definition in the manifest.yaml file for product_availability
- Implemented the stream with appropriate API endpoint (v2/ref/productavailability)
- Added JSON schema for the stream with inventory-related fields (OnHand, Available, Allocated, etc.)
- Updated the connector version from 5.17.0 to 5.18.0 following semantic versioning (minor version bump for new feature)
- Added autoImportSchema entry for the stream
- Added the stream reference to the streams list

## Review guide
<!--
1. `x.py`
2. `y.py`
-->
1. `manifest.yaml`: Check the new stream definition under `definitions.streams.product_availability`
2. `manifest.yaml`: Verify the schema defined in `schemas.product_availability`
3. `manifest.yaml`: Confirm stream reference is added to the streams list
4. `CHANGELOG.md`: New entry for version 5.18.0 documenting the new stream

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->
Users can now sync inventory availability data from Cin7, enabling:
- Real-time monitoring of stock levels across different locations
- Better inventory management with access to allocated, available, and on-order quantities
- More complete view of their Cin7 data in their destination systems

No negative side effects as this is an additive change that doesn't modify existing functionality.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌