### PR TITLE
(source-sendgrid) - Configure max concurrent async job count

### DIFF
--- a/airbyte-integrations/connectors/source-sendgrid/manifest.yaml
+++ b/airbyte-integrations/connectors/source-sendgrid/manifest.yaml
@@ -7,6 +7,7 @@ check:
   stream_names:
     - bounces
 
+max_concurrent_async_job_count: 2
 definitions:
   streams:
     bounces:

--- a/airbyte-integrations/connectors/source-sendgrid/metadata.yaml
+++ b/airbyte-integrations/connectors/source-sendgrid/metadata.yaml
@@ -6,7 +6,7 @@ data:
     hosts:
       - api.sendgrid.com
   connectorBuildOptions:
-    baseImage: docker.io/airbyte/source-declarative-manifest:6.38.3@sha256:fcba02266f262aabc2f37e4f14574aa1c8c5cffd018504bab28803e405c93afe
+    baseImage: docker.io/airbyte/source-declarative-manifest:6.39.3@sha256:ff59661ef3ad9e87da0ff35c36230acb138a5fb0900608b61449bef25d5ebc7b
   connectorSubtype: api
   connectorType: source
   definitionId: fbb5fbe2-16ad-4cf4-af7d-ff9d9c316c87

--- a/airbyte-integrations/connectors/source-sendgrid/metadata.yaml
+++ b/airbyte-integrations/connectors/source-sendgrid/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: fbb5fbe2-16ad-4cf4-af7d-ff9d9c316c87
-  dockerImageTag: 1.3.0
+  dockerImageTag: 1.3.1
   releases:
     breakingChanges:
       1.0.0:

--- a/docs/integrations/sources/sendgrid.md
+++ b/docs/integrations/sources/sendgrid.md
@@ -89,7 +89,7 @@ The connector is restricted by normal Sendgrid [requests limitation](https://doc
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                                                                                                                                           |
 |:--------|:-----------| :------------------------------------------------------- |:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 1.3.1 | 2025-03-13 | [XXXXX](https://github.com/airbytehq/airbyte/pull/XXXXX) | Increase max concurrent async job count to 2 |
+| 1.3.1 | 2025-03-13 | [55744](https://github.com/airbytehq/airbyte/pull/55744) | Increase max concurrent async job count to 2 |
 | 1.3.0 | 2025-03-04 | [55185](https://github.com/airbytehq/airbyte/pull/55185) | Update manifest for adapting changes with AsyncRetriever |
 | 1.2.9 | 2025-02-23 | [54625](https://github.com/airbytehq/airbyte/pull/54625) | Update dependencies |
 | 1.2.8 | 2025-02-15 | [54013](https://github.com/airbytehq/airbyte/pull/54013) | Update dependencies |

--- a/docs/integrations/sources/sendgrid.md
+++ b/docs/integrations/sources/sendgrid.md
@@ -89,6 +89,7 @@ The connector is restricted by normal Sendgrid [requests limitation](https://doc
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                                                                                                                                           |
 |:--------|:-----------| :------------------------------------------------------- |:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 1.3.1 | 2025-03-13 | [XXXXX](https://github.com/airbytehq/airbyte/pull/XXXXX) | Increase max concurrent async job count to 2 |
 | 1.3.0 | 2025-03-04 | [55185](https://github.com/airbytehq/airbyte/pull/55185) | Update manifest for adapting changes with AsyncRetriever |
 | 1.2.9 | 2025-02-23 | [54625](https://github.com/airbytehq/airbyte/pull/54625) | Update dependencies |
 | 1.2.8 | 2025-02-15 | [54013](https://github.com/airbytehq/airbyte/pull/54013) | Update dependencies |


### PR DESCRIPTION
## What
- Sets `max_concurrent_async_job_count` to 2
    - This property/configuration was enabled with [airbyte-cdk v6.39.0](https://github.com/airbytehq/airbyte-python-cdk/releases/tag/v6.39.0)
## User Impact
- Theoretically the `contacts` stream should be 100% faster.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
