### PR TITLE
source-apple-search-ads contribution from aalkuatova

### DIFF
--- a/airbyte-integrations/connectors/source-apple-search-ads/manifest.yaml
+++ b/airbyte-integrations/connectors/source-apple-search-ads/manifest.yaml
@@ -1,6 +1,11 @@
-version: 5.7.5
+version: 6.33.4
 
 type: DeclarativeSource
+
+description: >-
+  This connector syncs data from Apple Search Ads, allowing you to extract
+  campaign performance metrics, ad groups, and keyword data from your Apple
+  Search Ads account.
 
 check:
   type: CheckStream
@@ -48,8 +53,8 @@ definitions:
           type: DefaultPaginator
           page_token_option:
             type: RequestOption
-            inject_into: request_parameter
             field_name: offset
+            inject_into: request_parameter
           page_size_option:
             type: RequestOption
             field_name: limit
@@ -100,8 +105,8 @@ definitions:
           type: DefaultPaginator
           page_token_option:
             type: RequestOption
-            inject_into: request_parameter
             field_name: offset
+            inject_into: request_parameter
           page_size_option:
             type: RequestOption
             field_name: limit
@@ -162,8 +167,8 @@ definitions:
           type: DefaultPaginator
           page_token_option:
             type: RequestOption
-            inject_into: request_parameter
             field_name: offset
+            inject_into: request_parameter
           page_size_option:
             type: RequestOption
             field_name: limit
@@ -217,15 +222,15 @@ definitions:
             error_handlers:
               - type: DefaultErrorHandler
                 max_retries: 10
-                backoff_strategies:
-                  - type: ExponentialBackoffStrategy
-                    factor: "{{ config.backoff_factor }}"
                 response_filters:
                   - type: HttpResponseFilter
                     action: RETRY
                     http_codes:
                       - 500
                       - 429
+                backoff_strategies:
+                  - type: ExponentialBackoffStrategy
+                    factor: "{{ config.backoff_factor }}"
         record_selector:
           type: RecordSelector
           extractor:
@@ -238,25 +243,25 @@ definitions:
           type: DefaultPaginator
           page_token_option:
             type: RequestOption
-            inject_into: body_json
             field_path:
               - selector
               - pagination
               - offset
+            inject_into: body_json
           page_size_option:
             type: RequestOption
-            inject_into: body_json
             field_path:
               - selector
               - pagination
               - limit
+            inject_into: body_json
           pagination_strategy:
             type: OffsetIncrement
             page_size: 1000
       incremental_sync:
         type: DatetimeBasedCursor
         cursor_field: date
-        lookback_window: 'P{{ config.lookback_window}}D'
+        lookback_window: P{{ config.lookback_window}}D
         cursor_datetime_formats:
           - "%Y-%m-%d"
         datetime_format: "%Y-%m-%d"
@@ -319,15 +324,15 @@ definitions:
             error_handlers:
               - type: DefaultErrorHandler
                 max_retries: 10
-                backoff_strategies:
-                  - type: ExponentialBackoffStrategy
-                    factor: "{{ config.backoff_factor }}"
                 response_filters:
                   - type: HttpResponseFilter
                     action: RETRY
                     http_codes:
                       - 500
                       - 429
+                backoff_strategies:
+                  - type: ExponentialBackoffStrategy
+                    factor: "{{ config.backoff_factor }}"
         record_selector:
           type: RecordSelector
           extractor:
@@ -340,18 +345,18 @@ definitions:
           type: DefaultPaginator
           page_token_option:
             type: RequestOption
-            inject_into: body_json
             field_path:
               - selector
               - pagination
               - offset
+            inject_into: body_json
           page_size_option:
             type: RequestOption
-            inject_into: body_json
             field_path:
               - selector
               - pagination
               - limit
+            inject_into: body_json
           pagination_strategy:
             type: OffsetIncrement
             page_size: 1000
@@ -366,7 +371,7 @@ definitions:
       incremental_sync:
         type: DatetimeBasedCursor
         cursor_field: date
-        lookback_window: 'P{{ config.lookback_window}}D'
+        lookback_window: P{{ config.lookback_window}}D
         cursor_datetime_formats:
           - "%Y-%m-%d"
         datetime_format: "%Y-%m-%d"
@@ -453,18 +458,18 @@ definitions:
           type: DefaultPaginator
           page_token_option:
             type: RequestOption
-            inject_into: body_json
             field_path:
               - selector
               - pagination
               - offset
+            inject_into: body_json
           page_size_option:
             type: RequestOption
-            inject_into: body_json
             field_path:
               - selector
               - pagination
               - limit
+            inject_into: body_json
           pagination_strategy:
             type: OffsetIncrement
             page_size: 1000
@@ -479,7 +484,7 @@ definitions:
       incremental_sync:
         type: DatetimeBasedCursor
         cursor_field: date
-        lookback_window: 'P{{ config.lookback_window }}D'
+        lookback_window: P{{ config.lookback_window }}D
         cursor_datetime_formats:
           - "%Y-%m-%d"
         datetime_format: "%Y-%m-%d"
@@ -513,11 +518,12 @@ definitions:
     url_base: https://api.searchads.apple.com/api/v5
     authenticator:
       type: OAuthAuthenticator
-      client_id: "{{ config.client_id }}"
-      client_secret: "{{ config.client_secret }}"
+      client_id: "{{ config[\"client_id\"] }}"
       grant_type: client_credentials
+      client_secret: "{{ config[\"client_secret\"] }}"
       token_refresh_endpoint: >-
         https://appleid.apple.com/auth/oauth2/token?grant_type=client_credentials&scope=searchadsorg
+      refresh_request_body: {}
 
 streams:
   - $ref: "#/definitions/streams/campaigns"
@@ -537,68 +543,81 @@ spec:
       - client_id
       - start_date
       - client_secret
+      - time_zone
     properties:
       org_id:
         type: integer
         description: >-
           The identifier of the organization that owns the campaign. Your Org Id
           is the same as your account in the Apple Search Ads UI.
-        title: Org Id
         order: 0
+        title: Org Id
       end_date:
         type: string
         description: Data is retrieved until that date (included)
+        order: 1
         title: End Date
         pattern: ^[0-9]{4}-[0-9]{2}-[0-9]{2}$
         examples:
           - "2021-01-01"
-        order: 1
       client_id:
         type: string
         description: >-
           A user identifier for the token request. See <a
           href="https://developer.apple.com/documentation/apple_search_ads/implementing_oauth_for_the_apple_search_ads_api">here</a>
+        order: 2
         title: Client Id
         airbyte_secret: true
-        order: 2
       start_date:
         type: string
         description: Start getting data from that date.
+        order: 3
         title: Start Date
         pattern: ^[0-9]{4}-[0-9]{2}-[0-9]{2}$
         examples:
           - "2020-01-01"
-        order: 3
       client_secret:
         type: string
         description: >-
           A string that authenticates the user’s setup request. See <a
           href="https://developer.apple.com/documentation/apple_search_ads/implementing_oauth_for_the_apple_search_ads_api">here</a>
+        order: 4
         title: Client Secret
         airbyte_secret: true
-        order: 4
       lookback_window:
         type: integer
-        default: 30
         description: >-
-          Apple Search Ads uses a 30-day attribution window. However, you may consider smaller values in order
-          to shorten sync durations, at the cost of missing late data attributions.
+          Apple Search Ads uses a 30-day attribution window. However, you may
+          consider smaller values in order to shorten sync durations, at the
+          cost of missing late data attributions.
+        order: 5
         title: Lookback Window
+        default: 30
         pattern: ^(30|[1-2][0-9]|[1-9])$
         examples:
           - 7
-        order: 5
       backoff_factor:
         type: integer
-        default: 5
         description: >-
-          This factor factor determines the delay increase factor between retryable failures.
-          Valid values are integers between 1 and 20.
+          This factor factor determines the delay increase factor between
+          retryable failures. Valid values are integers between 1 and 20.
+        order: 6
         title: Exponential Backoff Factor
+        default: 5
         pattern: ^(20|1[0-9]|[1-9])$
         examples:
           - 10
-        order: 6
+      time_zone:
+        type: string
+        description: >-
+          The timezone for the reporting data. Use 'ORTZ' for Organization Time
+          Zone or 'UTC' for Coordinated Universal Time.
+        title: Time Zone
+        default: UTC
+        enum:
+          - ORTZ
+          - UTC
+        order: 7
     additionalProperties: true
 
 metadata:
@@ -611,24 +630,56 @@ metadata:
     keywords_report_daily: false
   yamlComponents:
     streams:
+      campaigns_report_daily:
+        - errorHandler
+      adgroups_report_daily:
+        - errorHandler
       keywords_report_daily:
         - errorHandler
-    global:
-      - authenticator
   testedStreams:
     campaigns:
-      streamHash: feda30929d58abb1441b9a5a9fa676ac53732898
+      streamHash: 695200dfcda5d952c3d0c21948db4780caa38393
+      hasResponse: true
+      responsesAreSuccessful: true
+      hasRecords: true
+      primaryKeysArePresent: true
+      primaryKeysAreUnique: true
     adgroups:
-      streamHash: 4bee763630f2faa1e57b8fdecfb5ad2562a6f8e5
+      streamHash: fbb8ad75715d80b1a3265d3c4ca997d29fbacf4b
+      hasResponse: true
+      responsesAreSuccessful: true
+      hasRecords: true
+      primaryKeysArePresent: true
+      primaryKeysAreUnique: true
     keywords:
-      streamHash: 8e9c01bded0da3421d384099ab66fe699e448558
+      streamHash: b818ab658fc4e091d02f0ddab5bca161b8a0d0c1
+      hasResponse: true
+      responsesAreSuccessful: true
+      hasRecords: true
+      primaryKeysArePresent: true
+      primaryKeysAreUnique: true
     campaigns_report_daily:
-      streamHash: b73b3a7fd009d515e31b6eae904bf925e45f4370
+      streamHash: 66114c399013c45e85797adadfb9caf1f73976a5
+      hasResponse: true
+      responsesAreSuccessful: true
+      hasRecords: true
+      primaryKeysArePresent: true
+      primaryKeysAreUnique: true
     adgroups_report_daily:
-      streamHash: 5982b7f631f8bfc624b467b8e4b442f3beec34e6
+      streamHash: 0d25df876cf211075f175b58dec28fd68f275dfe
+      hasResponse: true
+      responsesAreSuccessful: true
+      hasRecords: true
+      primaryKeysArePresent: true
+      primaryKeysAreUnique: true
     keywords_report_daily:
-      streamHash: 642ee63980cc78adbe63e1008199574b282d846f
-  assist: { }
+      streamHash: cbe37517a01a2552d694948dd3bc22247a066cd3
+      hasResponse: true
+      responsesAreSuccessful: true
+      hasRecords: true
+      primaryKeysArePresent: true
+      primaryKeysAreUnique: true
+  assist: {}
 
 schemas:
   campaigns:
@@ -715,6 +766,8 @@ schemas:
         type: array
         items:
           type: string
+    required:
+      - id
   adgroups:
     type: object
     $schema: http://json-schema.org/draft-07/schema#
@@ -950,13 +1003,6 @@ schemas:
         items:
           type: object
           properties:
-            tapInstallCPI:
-              type: object
-              properties:
-                amount:
-                  type: string
-                currency:
-                  type: string
             avgCPM:
               type: object
               properties:
@@ -971,13 +1017,9 @@ schemas:
                   type: string
                 currency:
                   type: string
-            tapInstallRate:
-              type: number
             date:
               type: string
             impressions:
-              type: integer
-            tapInstalls:
               type: integer
             latOffInstalls:
               type: integer
@@ -990,16 +1032,71 @@ schemas:
                   type: string
                 currency:
                   type: string
+            tapInstallCPI:
+              type: object
+              properties:
+                amount:
+                  type: string
+                currency:
+                  type: string
+            tapInstallRate:
+              type: number
+            tapInstalls:
+              type: integer
             tapNewDownloads:
               type: integer
             tapRedownloads:
               type: integer
             taps:
               type: integer
+            totalAvgCPI:
+              type:
+                - object
+                - "null"
+              properties:
+                amount:
+                  type:
+                    - string
+                    - "null"
+                currency:
+                  type:
+                    - string
+                    - "null"
+            totalInstallRate:
+              type:
+                - number
+                - "null"
+            totalInstalls:
+              type:
+                - number
+                - "null"
+            totalNewDownloads:
+              type:
+                - number
+                - "null"
+            totalRedownloads:
+              type:
+                - number
+                - "null"
             ttr:
               type: number
+            viewInstalls:
+              type:
+                - number
+                - "null"
+            viewNewDownloads:
+              type:
+                - number
+                - "null"
+            viewRedownloads:
+              type:
+                - number
+                - "null"
       other:
         type: boolean
+    required:
+      - date
+      - campaignId
   adgroups_report_daily:
     type: object
     $schema: http://json-schema.org/draft-07/schema#
@@ -1056,13 +1153,6 @@ schemas:
         items:
           type: object
           properties:
-            tapInstallCPI:
-              type: object
-              properties:
-                amount:
-                  type: string
-                currency:
-                  type: string
             avgCPM:
               type: object
               properties:
@@ -1077,13 +1167,9 @@ schemas:
                   type: string
                 currency:
                   type: string
-            tapInstallRate:
-              type: number
             date:
               type: string
             impressions:
-              type: integer
-            tapInstalls:
               type: integer
             latOffInstalls:
               type: integer
@@ -1096,16 +1182,71 @@ schemas:
                   type: string
                 currency:
                   type: string
+            tapInstallCPI:
+              type: object
+              properties:
+                amount:
+                  type: string
+                currency:
+                  type: string
+            tapInstallRate:
+              type: number
+            tapInstalls:
+              type: integer
             tapNewDownloads:
               type: integer
             tapRedownloads:
               type: integer
             taps:
               type: integer
+            totalAvgCPI:
+              type:
+                - object
+                - "null"
+              properties:
+                amount:
+                  type:
+                    - string
+                    - "null"
+                currency:
+                  type:
+                    - string
+                    - "null"
+            totalInstallRate:
+              type:
+                - number
+                - "null"
+            totalInstalls:
+              type:
+                - number
+                - "null"
+            totalNewDownloads:
+              type:
+                - number
+                - "null"
+            totalRedownloads:
+              type:
+                - number
+                - "null"
             ttr:
               type: number
+            viewInstalls:
+              type:
+                - number
+                - "null"
+            viewNewDownloads:
+              type:
+                - number
+                - "null"
+            viewRedownloads:
+              type:
+                - number
+                - "null"
       other:
         type: boolean
+    required:
+      - date
+      - adGroupId
   keywords_report_daily:
     type: object
     $schema: http://json-schema.org/draft-07/schema#
@@ -1127,6 +1268,10 @@ schemas:
                 type: string
               currency:
                 type: string
+          campaignId:
+            type:
+              - number
+              - "null"
           countryOrRegion:
             type: string
           deleted:
@@ -1143,6 +1288,10 @@ schemas:
             type: string
           modificationTime:
             type: string
+          orgId:
+            type:
+              - number
+              - "null"
       date:
         type: string
       granularity:
@@ -1150,13 +1299,6 @@ schemas:
         items:
           type: object
           properties:
-            tapInstallCPI:
-              type: object
-              properties:
-                amount:
-                  type: string
-                currency:
-                  type: string
             avgCPT:
               type: object
               properties:
@@ -1164,13 +1306,9 @@ schemas:
                   type: string
                 currency:
                   type: string
-            tapInstallRate:
-              type: number
             date:
               type: string
             impressions:
-              type: integer
-            tapInstalls:
               type: integer
             latOffInstalls:
               type: integer
@@ -1183,29 +1321,72 @@ schemas:
                   type: string
                 currency:
                   type: string
+            tapInstallCPI:
+              type: object
+              properties:
+                amount:
+                  type: string
+                currency:
+                  type: string
+            tapInstallRate:
+              type: number
+            tapInstalls:
+              type: integer
             tapNewDownloads:
               type: integer
             tapRedownloads:
               type: integer
             taps:
               type: integer
+            totalAvgCPI:
+              type:
+                - object
+                - "null"
+              properties:
+                amount:
+                  type:
+                    - string
+                    - "null"
+                currency:
+                  type:
+                    - string
+                    - "null"
+            totalInstallRate:
+              type:
+                - number
+                - "null"
+            totalInstalls:
+              type:
+                - number
+                - "null"
+            totalNewDownloads:
+              type:
+                - number
+                - "null"
+            totalRedownloads:
+              type:
+                - number
+                - "null"
             ttr:
               type: number
+            viewInstalls:
+              type:
+                - number
+                - "null"
+            viewNewDownloads:
+              type:
+                - number
+                - "null"
+            viewRedownloads:
+              type:
+                - number
+                - "null"
       insights:
         type: object
         properties:
           bidRecommendation:
             type: object
             properties:
-              suggestedBidAmount:
-                anyOf:
-                  - type: "null"
-                  - type: object
-                    properties:
-                      amount:
-                        type: string
-                      currency:
-                        type: string
               bidMax:
                 anyOf:
                   - type: "null"
@@ -1224,7 +1405,31 @@ schemas:
                         type: string
                       currency:
                         type: string
+              suggestedBidAmount:
+                type:
+                  - object
+                  - "null"
+                anyOf:
+                  - type: "null"
+                  - type: object
+                    properties:
+                      amount:
+                        type: string
+                      currency:
+                        type: string
+                properties:
+                  amount:
+                    type:
+                      - string
+                      - "null"
+                  currency:
+                    type:
+                      - string
+                      - "null"
       keywordId:
         type: integer
       other:
         type: boolean
+    required:
+      - date
+      - keywordId

--- a/airbyte-integrations/connectors/source-apple-search-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-apple-search-ads/metadata.yaml
@@ -1,39 +1,35 @@
+metadataSpecVersion: "1.0"
 data:
-  connectorSubtype: api
-  connectorType: source
-  definitionId: e59c8416-c2fa-4bd3-9e95-52677ea281c1
-  dockerImageTag: 0.4.3
-  dockerRepository: airbyte/source-apple-search-ads
-  githubIssueLabel: source-apple-search-ads
-  icon: apple.svg
-  license: MIT
-  name: Apple Search Ads
+  allowedHosts:
+    hosts:
+      - "api.searchads.apple.com"
+  registryOverrides:
+    oss:
+      enabled: true
+    cloud:
+      enabled: true
   remoteRegistries:
     pypi:
       enabled: false
       packageName: airbyte-source-apple-search-ads
-  registryOverrides:
-    cloud:
-      enabled: true
-    oss:
-      enabled: true
+  connectorBuildOptions:
+    baseImage: docker.io/airbyte/source-declarative-manifest:6.39.3@sha256:ff59661ef3ad9e87da0ff35c36230acb138a5fb0900608b61449bef25d5ebc7b
+  connectorSubtype: api
+  connectorType: source
+  definitionId: e59c8416-c2fa-4bd3-9e95-52677ea281c1
+  dockerImageTag: 0.0.1
+  dockerRepository: airbyte/source-apple-search-ads
+  githubIssueLabel: source-apple-search-ads
+  icon: icon.svg
+  license: MIT
+  name: Apple Search Ads
+  releaseDate: 2025-03-13
   releaseStage: alpha
+  supportLevel: community
   documentationUrl: https://docs.airbyte.com/integrations/sources/apple-search-ads
   tags:
-    - cdk:low-code
     - language:manifest-only
+    - cdk:low-code
   ab_internal:
-    sl: 100
     ql: 100
-  connectorTestSuitesOptions:
-    - suite: acceptanceTests
-      testSecrets:
-        - name: SECRET_SOURCE-APPLE-SEARCH-ADS__CREDS
-          fileName: config.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-  supportLevel: community
-  connectorBuildOptions:
-    baseImage: docker.io/airbyte/source-declarative-manifest:6.36.4@sha256:a612db8bc977a46d7d2e0442f5c6be26da6039ee83a8aceb7be545e4cbdd7040
-metadataSpecVersion: "1.0"
+    sl: 100


### PR DESCRIPTION
## What

This PR updates source Apple Search Ads (source-apple-search-ads).

The contributor provided the following description of the change:

This connector syncs data from Apple Search Ads, allowing you to extract campaign performance metrics, ad groups, and keyword data from your Apple Search Ads account.
## Reviewer checklist
- [ ] Resolve any merge conflicts and validate file diffs (make sure the PR only includes changes intended by the contributor)
- [ ] After reviewing the changes, run the [`bump-version` Airbyte-CI command](https://github.com/airbytehq/airbyte/blob/master/airbyte-ci/connectors/pipelines/README.md#connectors-bump-version-command) locally to update the version of the connector according to the [versioning guidelines](https://docs.airbyte.io/contributor-guide/versioning-guidelines). Add `breakingChanges` to metadata if necessary.
- [ ] Ensure connector docs are up to date with any changes
- [ ] Run `/format-fix` to resolve any formatting errors
- [ ] Click into the CI workflows that wait for a maintainer to run them, which should trigger CI runs

<!-- DO NOT REMOVE: connector-builder-edit-connector-contribution -->
