### PR TITLE
[source-mysql] pin to cdk 0.342

### DIFF
--- a/airbyte-integrations/connectors/source-mysql/build.gradle
+++ b/airbyte-integrations/connectors/source-mysql/build.gradle
@@ -9,7 +9,7 @@ application {
 airbyteBulkConnector {
     core = 'extract'
     toolkits = ['extract-jdbc', 'extract-cdc']
-    cdk = 'local'
+    cdk = '0.342'
 }
 
 dependencies {


### PR DESCRIPTION
## What
MySQL source was erroneously consuming a locally built CDK version. Here we pin it to the newest version instead.

## User Impact
None.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [x] NO ❌
