### PR TITLE
Fix reversed assertions in MySQL source tests

### DIFF
--- a/airbyte-integrations/connectors/source-mysql/src/test/kotlin/io/airbyte/integrations/source/mysql/MySqlSourceCdcIntegrationTest.kt
+++ b/airbyte-integrations/connectors/source-mysql/src/test/kotlin/io/airbyte/integrations/source/mysql/MySqlSourceCdcIntegrationTest.kt
@@ -37,10 +37,10 @@ class MySqlSourceCdcIntegrationTest {
     fun testCheck() {
         val run1: BufferingOutputConsumer = CliRunner.source("check", config(), null).run()
 
-        assertEquals(run1.messages().size, 1)
+        assertEquals(1, run1.messages().size)
         assertEquals(
-            run1.messages().first().connectionStatus.status,
-            AirbyteConnectionStatus.Status.SUCCEEDED
+            AirbyteConnectionStatus.Status.SUCCEEDED,
+            run1.messages().first().connectionStatus.status
         )
 
         MySqlContainerFactory.exclusive(

--- a/airbyte-integrations/connectors/source-mysql/src/test/kotlin/io/airbyte/integrations/source/mysql/MySqlSourceCursorBasedIntegrationTest.kt
+++ b/airbyte-integrations/connectors/source-mysql/src/test/kotlin/io/airbyte/integrations/source/mysql/MySqlSourceCursorBasedIntegrationTest.kt
@@ -76,7 +76,7 @@ class MySqlSourceCursorBasedIntegrationTest {
         val run2: BufferingOutputConsumer =
             CliRunner.source("read", config, getConfiguredCatalog(), run2InputState).run()
         val recordMessageFromRun2: List<AirbyteRecordMessage> = run2.records()
-        assertEquals(recordMessageFromRun2.size, 1)
+        assertEquals(1, recordMessageFromRun2.size)
     }
 
     @Test
@@ -85,7 +85,7 @@ class MySqlSourceCursorBasedIntegrationTest {
         val run1: BufferingOutputConsumer =
             CliRunner.source("read", config, getConfiguredCatalog(), listOf(state)).run()
         val recordMessageFromRun1: List<AirbyteRecordMessage> = run1.records()
-        assertEquals(recordMessageFromRun1.size, 1)
+        assertEquals(1, recordMessageFromRun1.size)
     }
 
     @Test
@@ -95,7 +95,7 @@ class MySqlSourceCursorBasedIntegrationTest {
         val run1: BufferingOutputConsumer =
             CliRunner.source("read", config, getConfiguredCatalog(), listOf(state)).run()
         val recordMessageFromRun1: List<AirbyteRecordMessage> = run1.records()
-        assertEquals(recordMessageFromRun1.size, 2)
+        assertEquals(2, recordMessageFromRun1.size)
     }
 
     @Test
@@ -105,14 +105,14 @@ class MySqlSourceCursorBasedIntegrationTest {
         val run1: BufferingOutputConsumer =
             CliRunner.source("read", config, fullRefreshCatalog).run()
         val recordMessageFromRun1: List<AirbyteRecordMessage> = run1.records()
-        assertEquals(recordMessageFromRun1.size, 2)
+        assertEquals(2, recordMessageFromRun1.size)
         val lastStateMessageFromRun1 = run1.states().last()
 
         val run2: BufferingOutputConsumer =
             CliRunner.source("read", config, fullRefreshCatalog, listOf(lastStateMessageFromRun1))
                 .run()
         val recordMessageFromRun2: List<AirbyteRecordMessage> = run2.records()
-        assertEquals(recordMessageFromRun2.size, 0)
+        assertEquals(0, recordMessageFromRun2.size)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Fixed 5 instances in MySqlSourceCursorBasedIntegrationTest where assertEquals had actual.size as the first parameter
- Fixed 2 instances of reversed assertions in MySqlSourceCdcIntegrationTest
- All assertions now follow assertEquals(expected, actual) pattern

## Test plan
- The fixes only rearranged the order of parameters in assertEquals calls, ensuring that expected values come first and actual values second
- No functionality change, just better failure messages if assertions ever fail

🤖 Generated with [Claude Code](https://claude.ai/code)