### PR TITLE
[source-mysql] don't do sampling for source-mysql

### DIFF
--- a/airbyte-integrations/connectors/source-mysql/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mysql/metadata.yaml
@@ -9,7 +9,7 @@ data:
   connectorSubtype: database
   connectorType: source
   definitionId: 435bb9a5-7887-4809-aa58-28c27df0d7ad
-  dockerImageTag: 3.11.7
+  dockerImageTag: 3.11.8
   dockerRepository: airbyte/source-mysql
   documentationUrl: https://docs.airbyte.com/integrations/sources/mysql
   githubIssueLabel: source-mysql

--- a/airbyte-integrations/connectors/source-mysql/src/main/kotlin/io/airbyte/integrations/source/mysql/MySqlSourceOperations.kt
+++ b/airbyte-integrations/connectors/source-mysql/src/main/kotlin/io/airbyte/integrations/source/mysql/MySqlSourceOperations.kt
@@ -201,27 +201,8 @@ class MySqlSourceOperations :
         when (this) {
             NoFrom -> ""
             is From -> if (this.namespace == null) "FROM `$name`" else "FROM `$namespace`.`$name`"
-            is FromSample -> {
-                val from: String = From(name, namespace).sql()
-                // On a table that is very big we limit sampling to no less than 0.05%
-                // chance of a row getting picked. This comes at a price of bias to the beginning
-                // of table on very large tables ( > 100s million of rows)
-                val greatestRate: String = 0.00005.toString()
-                // We only do a full count in case information schema contains no row count.
-                // This is the case for views.
-                val fullCount = "SELECT COUNT(*) FROM `$namespace`.`$name`"
-                // Quick approximation to "select count(*) from table" which doesn't require
-                // full table scan. However, note this could give delayed summary info about a table
-                // and thus a new table could be treated as empty despite we recently added rows.
-                // To prevent that from happening and resulted for skipping the table altogether,
-                // the minimum count is set to 10.
-                val quickCount =
-                    "SELECT GREATEST(10, COALESCE(table_rows, ($fullCount))) FROM information_schema.tables WHERE table_schema = '$namespace' AND table_name = '$name'"
-                val greatest = "GREATEST($greatestRate, $sampleSize / ($quickCount))"
-                // Rand returns a value between 0 and 1
-                val where = "WHERE RAND() < $greatest "
-                "$from $where"
-            }
+            // just return the first sample_size of rows from the table for the best performance
+            is FromSample -> From(name, namespace).sql()
         }
 
     fun WhereNode.sql(): String =

--- a/docs/integrations/sources/mysql.md
+++ b/docs/integrations/sources/mysql.md
@@ -226,6 +226,7 @@ Any database or table encoding combination of charset and collation is supported
 
 | Version     | Date       | Pull Request                                               | Subject                                                                                                                                         |
 |:------------|:-----------|:-----------------------------------------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------|
+| 3.11.8 | 2025-03-14 | [55761](https://github.com/airbytehq/airbyte/pull/55761) | Do not perform complex sampling for source-mysql |
 | 3.11.7 | 2025-03-12 | [55734](https://github.com/airbytehq/airbyte/pull/55734) | Expose additional stream context for debezium properties at startup |
 | 3.11.6 | 2025-03-06 | [55237](https://github.com/airbytehq/airbyte/pull/55237) | [Fix fetching binlog status for version >=8.4](https://github.com/airbytehq/airbyte/pull/55237#top) |
 | 3.11.5 | 2025-03-06 | [55234](https://github.com/airbytehq/airbyte/pull/55234) | Update base image version for certified DB source connectors |


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->

Fixes https://github.com/airbytehq/oncall/issues/7509

A MySQL table with a large number of entries, especially when some columns contain large data, current sampling will take a long time to finish. 

For instance, in the customer use case above, the table contains 2M entries. Most importantly, two of the columns have the type 'long text`, which stores large JSON objects. The first sampling iteration takes ~1.5h to finish, making our sync timeout frequently. 

We decided not to do sampling for MySQL. Instead, we just return the first 1024 entries of the table. Assuming the data in the table follows a uniform distribution, this method should provide a good enough set of samples on average. 
