### PR TITLE
(Do Not Merge) Source-Google-Ads: GAQL TypeError on Check

### DIFF
--- a/airbyte-integrations/connectors/source-google-ads/source_google_ads/source.py
+++ b/airbyte-integrations/connectors/source-google-ads/source_google_ads/source.py
@@ -181,10 +181,22 @@ class SourceGoogleAds(AbstractSource):
         logger.info(f"Found {len(customers)} customers: {[customer.id for customer in customers]}")
 
         # Check custom query request validity by sending metric request with non-existent time window
-        for query in config.get("custom_queries_array", []):
-            for customer in customers:
+        custom_queries = config.get("custom_queries_array", [])
+        logger.info(f"custom_queries_array type: {type(custom_queries)}, length: {len(custom_queries) if isinstance(custom_queries, list) else 'N/A'}")
+        
+        for i, query in enumerate(custom_queries):
+            logger.info(f"Processing query item {i}, type: {type(query)}")
+            try:
                 table_name = query["table_name"]
                 query = query["query"]
+                logger.info(f"table_name: {table_name}, type: {type(table_name)}")
+                logger.info(f"query type: {type(query)}")
+            except TypeError as e:
+                logger.error(f"TypeError accessing query item {i}: {e}")
+                logger.error(f"query item {i} value: {query}")
+                raise  # Re-raise to maintain original error behavior
+            
+            for customer in customers:
                 if customer.is_manager_account and self.is_metrics_in_custom_query(query):
                     logger.warning(
                         f"Metrics are not available for manager account {customer.id}. "


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->
Debugging this: https://github.com/airbytehq/oncall/issues/7310 via Dev Image.
## How
<!--
* Describe how code changes achieve the solution.
-->
Getting this error on check:
Traceback (most recent call last):
File "/airbyte/integration_code/main.py", line 8, in <module>
run()
File "/airbyte/integration_code/source_google_ads/run.py", line 16, in run
launch(source, sys.argv[1:])
File "/usr/local/lib/python3.10/site-packages/airbyte_cdk/entrypoint.py", line 263, in launch
for message in source_entrypoint.run(parsed_args):
File "/usr/local/lib/python3.10/site-packages/airbyte_cdk/entrypoint.py", line 126, in run
yield from map(AirbyteEntrypoint.airbyte_message_to_string, self.check(source_spec, config))
File "/usr/local/lib/python3.10/site-packages/airbyte_cdk/entrypoint.py", line 155, in check
check_result = self.source.check(self.logger, config)
File "/usr/local/lib/python3.10/site-packages/airbyte_cdk/sources/abstract_source.py", line 81, in check
check_succeeded, error = self.check_connection(logger, config)
File "/airbyte/integration_code/source_google_ads/source.py", line 185, in check_connection
table_name = query["table_name"]
TypeError: 'GAQL' object is not subscriptable

I suspect something is off with their config, but it is hard to check since this is during source creation. Will ask the user to see if they can also provide more details. 

Also, not sure if we need to parse the table_name as well [here](https://github.com/airbytehq/airbyte/blob/14b5b260e50e0a594157de7299ddcb2bb8fc7ecb/airbyte-integrations/connectors/source-google-ads/source_google_ads/source.py#L62)?

I think once we have these debug logs we should be able to know for sure. 
## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
