### PR TITLE
source linkedin-pages: bump LinkedIn API Version

### DIFF
--- a/airbyte-integrations/connectors/source-linkedin-pages/manifest.yaml
+++ b/airbyte-integrations/connectors/source-linkedin-pages/manifest.yaml
@@ -163,7 +163,7 @@ streams:
         http_method: GET
         request_parameters: {}
         request_headers:
-          Linkedin-Version: "20250301"
+          Linkedin-Version: "202503"
         authenticator:
           type: SelectiveAuthenticator
           authenticator_selection_path:
@@ -259,7 +259,7 @@ streams:
           q: organizationalEntity
           organizationalEntity: urn:li:organization:{{ config['org_id'] }}
         request_headers:
-          Linkedin-Version: "20250301"
+          Linkedin-Version: "202503"
         authenticator:
           type: SelectiveAuthenticator
           authenticator_selection_path:
@@ -369,7 +369,7 @@ streams:
           q: organizationalEntity
           organizationalEntity: urn:li:organization:{{ config['org_id'] }}
         request_headers:
-          Linkedin-Version: "20250301"
+          Linkedin-Version: "202503"
         authenticator:
           type: SelectiveAuthenticator
           authenticator_selection_path:
@@ -437,7 +437,7 @@ streams:
         request_parameters:
           edgeType: COMPANY_FOLLOWED_BY_MEMBER
         request_headers:
-          Linkedin-Version: "20250301"
+          Linkedin-Version: "202503"
         authenticator:
           type: SelectiveAuthenticator
           authenticator_selection_path:
@@ -561,7 +561,7 @@ streams:
             "{{ config['time_granularity_type'] or
             'DAY' }}"
         request_headers:
-          Linkedin-Version: "20250301"
+          Linkedin-Version: "202503"
         authenticator:
           type: SelectiveAuthenticator
           authenticator_selection_path:
@@ -736,7 +736,7 @@ streams:
             "{{ config['time_granularity_type'] or
             'DAY' }}"
         request_headers:
-          Linkedin-Version: "20250301"
+          Linkedin-Version: "202503"
         authenticator:
           type: SelectiveAuthenticator
           authenticator_selection_path:

--- a/airbyte-integrations/connectors/source-linkedin-pages/manifest.yaml
+++ b/airbyte-integrations/connectors/source-linkedin-pages/manifest.yaml
@@ -163,7 +163,7 @@ streams:
         http_method: GET
         request_parameters: {}
         request_headers:
-          Linkedin-Version: "202403"
+          Linkedin-Version: "20250301"
         authenticator:
           type: SelectiveAuthenticator
           authenticator_selection_path:
@@ -259,7 +259,7 @@ streams:
           q: organizationalEntity
           organizationalEntity: urn:li:organization:{{ config['org_id'] }}
         request_headers:
-          Linkedin-Version: "202403"
+          Linkedin-Version: "20250301"
         authenticator:
           type: SelectiveAuthenticator
           authenticator_selection_path:
@@ -369,7 +369,7 @@ streams:
           q: organizationalEntity
           organizationalEntity: urn:li:organization:{{ config['org_id'] }}
         request_headers:
-          Linkedin-Version: "202403"
+          Linkedin-Version: "20250301"
         authenticator:
           type: SelectiveAuthenticator
           authenticator_selection_path:
@@ -437,7 +437,7 @@ streams:
         request_parameters:
           edgeType: COMPANY_FOLLOWED_BY_MEMBER
         request_headers:
-          Linkedin-Version: "202403"
+          Linkedin-Version: "20250301"
         authenticator:
           type: SelectiveAuthenticator
           authenticator_selection_path:
@@ -561,7 +561,7 @@ streams:
             "{{ config['time_granularity_type'] or
             'DAY' }}"
         request_headers:
-          Linkedin-Version: "202403"
+          Linkedin-Version: "20250301"
         authenticator:
           type: SelectiveAuthenticator
           authenticator_selection_path:
@@ -736,7 +736,7 @@ streams:
             "{{ config['time_granularity_type'] or
             'DAY' }}"
         request_headers:
-          Linkedin-Version: "202403"
+          Linkedin-Version: "20250301"
         authenticator:
           type: SelectiveAuthenticator
           authenticator_selection_path:

--- a/airbyte-integrations/connectors/source-linkedin-pages/metadata.yaml
+++ b/airbyte-integrations/connectors/source-linkedin-pages/metadata.yaml
@@ -20,7 +20,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: af54297c-e8f8-4d63-a00d-a94695acc9d3
-  dockerImageTag: 1.1.17
+  dockerImageTag: 1.1.18
   dockerRepository: airbyte/source-linkedin-pages
   documentationUrl: https://docs.airbyte.com/integrations/sources/linkedin-pages
   githubIssueLabel: source-linkedin-pages

--- a/docs/integrations/sources/linkedin-pages.md
+++ b/docs/integrations/sources/linkedin-pages.md
@@ -113,6 +113,7 @@ The source LinkedIn Pages can use either the `client_id`, `client_secret` and `r
 
 | Version | Date       | Pull Request                                             | Subject                                              |
 |:--------|:-----------| :------------------------------------------------------- | :--------------------------------------------------- |
+| 1.1.18 | 2025-03-18 | [55441](https://github.com/airbytehq/airbyte/pull/55815) | Bump API version |
 | 1.1.17 | 2025-03-08 | [55441](https://github.com/airbytehq/airbyte/pull/55441) | Update dependencies |
 | 1.1.16 | 2025-03-01 | [54775](https://github.com/airbytehq/airbyte/pull/54775) | Update dependencies |
 | 1.1.15 | 2025-02-22 | [54339](https://github.com/airbytehq/airbyte/pull/54339) | Update dependencies |


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->

The LinkedIn API version currently being used by the LinkedIn-Pages connector has been deprecated, causing all existing LinkedIn Pages sources to fail #55794.

Following the proposed solution in #55794:
> Following the [documentation](https://learn.microsoft.com/en-us/linkedin/marketing/versioning?view=li-lms-2025-02) it is possible to use the 20250301 version without any schema or connector changes more than changing the version in the yaml file

The API version for linkedin-pages has been updated from `202403` to `20250301`

## How
<!--
* Describe how code changes achieve the solution.
-->

Within the manifest.yaml for LinkedIn Pages, finding and replacing 202403 with 20250301.

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

The values/schema returned from the API will be the same so there should be no impact.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌


