### PR TITLE
revert salesforce

### DIFF
--- a/airbyte-integrations/connectors/source-salesforce/metadata.yaml
+++ b/airbyte-integrations/connectors/source-salesforce/metadata.yaml
@@ -28,6 +28,7 @@ data:
   registryOverrides:
     cloud:
       enabled: true
+      dockerImageTag: 2.6.5
     oss:
       enabled: true
   releaseStage: generally_available


### PR DESCRIPTION
## What
Following release 2.7.0, we are getting datetime errors: https://airbytehq.sentry.io/issues/6432264489/?notification_uuid=8ab18ce9-64c2-496c-98f7-906fa81ad30f&project=6527718&referrer=pagerduty_integration

## How
Pin cloud version

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
