### PR TITLE
Load-CDK/Dest-S3: Sync Hangs on OOM sometimes

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/DestinationTaskLauncher.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/DestinationTaskLauncher.kt
@@ -5,6 +5,7 @@
 package io.airbyte.cdk.load.task
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
+import io.airbyte.cdk.SystemErrorException
 import io.airbyte.cdk.load.command.DestinationCatalog
 import io.airbyte.cdk.load.command.DestinationConfiguration
 import io.airbyte.cdk.load.command.DestinationStream
@@ -180,6 +181,13 @@ class DefaultDestinationTaskLauncher<K : WithStream>(
                 log.error(e) { "Caught exception in task $innerTask" }
                 if (hasThrown.setOnce()) {
                     handleException(e)
+                } else {
+                    log.info { "Skipping exception handling, because it has already run." }
+                }
+            } catch (t: Throwable) {
+                log.error(t) { "Critical error in task $innerTask" }
+                if (hasThrown.setOnce()) {
+                    handleException(SystemErrorException(t.message, t))
                 } else {
                     log.info { "Skipping exception handling, because it has already run." }
                 }

--- a/airbyte-integrations/connectors/destination-s3/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-s3/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: file
   connectorType: destination
   definitionId: 4816b78f-1489-44c1-9060-4b19d5fa9362
-  dockerImageTag: 1.5.4
+  dockerImageTag: 1.5.5
   dockerRepository: airbyte/destination-s3
   githubIssueLabel: destination-s3
   icon: s3.svg

--- a/docs/integrations/destinations/s3.md
+++ b/docs/integrations/destinations/s3.md
@@ -544,6 +544,7 @@ To see connector limitations, or troubleshoot your S3 connector, see more [in ou
 
 | Version     | Date       | Pull Request                                               | Subject                                                                                                                                              |
 |:------------|:-----------|:-----------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| 1.5.5       | 2025-03-20 | [55875](https://github.com/airbytehq/airbyte/pull/55875)   | Bugfix: Sync Can Hang on OOM                                                                                                                         |
 | 1.5.4       | 2025-03-05 | [54695](https://github.com/airbytehq/airbyte/pull/54695)   | Nonfunctional changes to support performance testing                                                                                                 |
 | 1.5.3       | 2025-03-04 | [54661](https://github.com/airbytehq/airbyte/pull/54661)   | Nonfunctional changes to support performance testing                                                                                                 |
 | 1.5.2       | 2025-02-25 | [54661](https://github.com/airbytehq/airbyte/pull/54661)   | Nonfunctional cleanup; dropped unused staging code                                                                                                   |


### PR DESCRIPTION
## What
Addresses https://github.com/airbytehq/oncall/issues/7133

If a Throwable (not Exception) is thrown from a load CDK task, exception handling won't run and won't shut down tasks. It seems like under some conditions this results in the process not shutting down properly after an OOM.

Artificially injecting a throwable into the worker tasks or the open-stream task will cause ITs to hang.

Alarmingly, injecting any exception into the close-stream task might not cause tests to fail. Opened https://github.com/airbytehq/airbyte-internal-issues/issues/12115 to track.