### PR TITLE
feat(source-google-drive): add missing label/flag

### DIFF
--- a/airbyte-integrations/connectors/source-google-drive/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-drive/metadata.yaml
@@ -31,6 +31,7 @@ data:
     - language:python
     - cdk:python-file-based
   supportLevel: community
+  supportsFileTransfer: true
   connectorTestSuitesOptions:
     - suite: acceptanceTests
       testSecrets:


### PR DESCRIPTION
## What
We are missing the file transfer support label

## How
Just add the label for tracking purposes.

## Review guide

1. `airbyte-integrations/connectors/source-google-drive/metadata.yaml`: add label to advertise file transfer support


## User Impact
Better tracking of feature.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
