### PR TITLE
Destination MSSQL: bulk load uses new typing interface

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/DestinationMessage.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/DestinationMessage.kt
@@ -23,6 +23,7 @@ import io.airbyte.cdk.load.data.ObjectType
 import io.airbyte.cdk.load.data.ObjectValue
 import io.airbyte.cdk.load.data.StringType
 import io.airbyte.cdk.load.data.StringValue
+import io.airbyte.cdk.load.data.TimestampTypeWithTimezone
 import io.airbyte.cdk.load.data.TimestampWithTimezoneValue
 import io.airbyte.cdk.load.data.json.toAirbyteValue
 import io.airbyte.cdk.load.data.toAirbyteValues
@@ -310,6 +311,13 @@ data class DestinationRecordRaw(
         )
     }
 
+    /**
+     * Convert this record to an EnrichedRecord. Crucially, after this conversion, all entries in
+     * [EnrichedDestinationRecordAirbyteValue.allTypedFields] are guaranteed to have
+     * [EnrichedAirbyteValue.value] either be [NullValue], or match [EnrichedAirbyteValue.type]
+     * (e.g. if `type` is [TimestampTypeWithTimezone], then `value` is either `NullValue`, or
+     * [TimestampWithTimezoneValue]).
+     */
     fun asEnrichedDestinationRecordAirbyteValue(): EnrichedDestinationRecordAirbyteValue {
         val rawJson = asRawJson()
 

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/write/BasicFunctionalityIntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/write/BasicFunctionalityIntegrationTest.kt
@@ -2000,6 +2000,20 @@ abstract class BasicFunctionalityIntegrationTest(
                         }
                     """.trimIndent(),
                 ),
+                // A record with truncated timestamps (i.e. the seconds value is 0).
+                // Some destinations have specific formatting requirements, and it's easy
+                // to mess these values up.
+                makeRecord(
+                    """
+                        {
+                          "id": 7,
+                          "timestamp_with_timezone": "2023-01-23T11:34:00-01:00",
+                          "timestamp_without_timezone": "2023-01-23T12:34:00",
+                          "time_with_timezone": "11:34:00-01:00",
+                          "time_without_timezone": "12:34:00"
+                        }
+                    """.trimIndent()
+                ),
             ),
         )
 
@@ -2179,6 +2193,21 @@ abstract class BasicFunctionalityIntegrationTest(
                             "integer" to negativeBigInt,
                         ),
                     airbyteMeta = OutputRecord.Meta(syncId = 42, changes = bigIntChanges),
+                ),
+                OutputRecord(
+                    extractedAt = 100,
+                    generationId = 42,
+                    data =
+                        mapOf(
+                            "id" to 7,
+                            "timestamp_with_timezone" to
+                                OffsetDateTime.parse("2023-01-23T11:34:00-01:00"),
+                            "timestamp_without_timezone" to
+                                LocalDateTime.parse("2023-01-23T12:34:00"),
+                            "time_with_timezone" to OffsetTime.parse("11:34:00-01:00"),
+                            "time_without_timezone" to LocalTime.parse("12:34:00"),
+                        ),
+                    airbyteMeta = OutputRecord.Meta(syncId = 42),
                 ),
             ),
             stream,

--- a/airbyte-cdk/bulk/toolkits/load-csv/src/main/kotlin/io/airbyte/cdk/load/data/csv/AirbyteValueToCsvRow.kt
+++ b/airbyte-cdk/bulk/toolkits/load-csv/src/main/kotlin/io/airbyte/cdk/load/data/csv/AirbyteValueToCsvRow.kt
@@ -4,6 +4,7 @@
 
 package io.airbyte.cdk.load.data.csv
 
+import io.airbyte.cdk.load.data.AirbyteValue
 import io.airbyte.cdk.load.data.ArrayValue
 import io.airbyte.cdk.load.data.BooleanValue
 import io.airbyte.cdk.load.data.DateValue
@@ -22,24 +23,26 @@ import io.airbyte.cdk.load.data.json.toJson
 import io.airbyte.cdk.load.util.serializeToString
 
 fun ObjectValue.toCsvRecord(schema: ObjectType): List<Any> {
-    return schema.properties.map { (key, _) ->
-        values[key]?.let {
-            when (it) {
-                is ObjectValue -> it.toJson().serializeToString()
-                is ArrayValue -> it.toJson().serializeToString()
-                is StringValue -> it.value
-                is IntegerValue -> it.value
-                is NumberValue -> it.value
-                is NullValue -> ""
-                is TimestampWithTimezoneValue -> it.value
-                is TimestampWithoutTimezoneValue -> it.value
-                is BooleanValue -> it.value
-                is DateValue -> it.value
-                is TimeWithTimezoneValue -> it.value
-                is TimeWithoutTimezoneValue -> it.value
-                is UnknownValue -> ""
-            }
+    return schema.properties.map { (key, _) -> values[key].toCsvValue() }
+}
+
+fun AirbyteValue?.toCsvValue(): Any {
+    return this?.let {
+        when (it) {
+            is ObjectValue -> it.toJson().serializeToString()
+            is ArrayValue -> it.toJson().serializeToString()
+            is StringValue -> it.value
+            is IntegerValue -> it.value
+            is NumberValue -> it.value
+            is NullValue -> ""
+            is TimestampWithTimezoneValue -> it.value
+            is TimestampWithoutTimezoneValue -> it.value
+            is BooleanValue -> it.value
+            is DateValue -> it.value
+            is TimeWithTimezoneValue -> it.value
+            is TimeWithoutTimezoneValue -> it.value
+            is UnknownValue -> ""
         }
-            ?: ""
     }
+        ?: ""
 }

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/file/object_storage/ObjectStorageFormattingWriter.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/file/object_storage/ObjectStorageFormattingWriter.kt
@@ -24,7 +24,7 @@ import io.airbyte.cdk.load.file.avro.toAvroWriter
 import io.airbyte.cdk.load.file.csv.toCsvPrinterWithHeader
 import io.airbyte.cdk.load.file.parquet.ParquetWriter
 import io.airbyte.cdk.load.file.parquet.toParquetWriter
-import io.airbyte.cdk.load.message.DestinationRecordAirbyteValue
+import io.airbyte.cdk.load.message.DestinationRecordRaw
 import io.airbyte.cdk.load.util.serializeToString
 import io.airbyte.cdk.load.util.write
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -37,7 +37,7 @@ import java.util.concurrent.atomic.AtomicLong
 import org.apache.avro.Schema
 
 interface ObjectStorageFormattingWriter : Closeable {
-    fun accept(record: DestinationRecordAirbyteValue)
+    fun accept(record: DestinationRecordRaw)
     fun flush()
 }
 
@@ -86,9 +86,13 @@ class JsonFormattingWriter(
     private val rootLevelFlattening: Boolean,
 ) : ObjectStorageFormattingWriter {
 
-    override fun accept(record: DestinationRecordAirbyteValue) {
+    override fun accept(record: DestinationRecordRaw) {
         val data =
-            record.dataWithAirbyteMeta(stream, rootLevelFlattening).toJson().serializeToString()
+            record
+                .asDestinationRecordAirbyteValue()
+                .dataWithAirbyteMeta(stream, rootLevelFlattening)
+                .toJson()
+                .serializeToString()
         outputStream.write(data)
         outputStream.write("\n")
     }
@@ -110,9 +114,12 @@ class CSVFormattingWriter(
 
     private val finalSchema = stream.schema.withAirbyteMeta(rootLevelFlattening)
     private val printer = finalSchema.toCsvPrinterWithHeader(outputStream)
-    override fun accept(record: DestinationRecordAirbyteValue) {
+    override fun accept(record: DestinationRecordRaw) {
         printer.printRecord(
-            record.dataWithAirbyteMeta(stream, rootLevelFlattening).toCsvRecord(finalSchema)
+            record
+                .asDestinationRecordAirbyteValue()
+                .dataWithAirbyteMeta(stream, rootLevelFlattening)
+                .toCsvRecord(finalSchema)
         )
     }
 
@@ -143,9 +150,11 @@ class AvroFormattingWriter(
         log.info { "Generated avro schema: $avroSchema" }
     }
 
-    override fun accept(record: DestinationRecordAirbyteValue) {
-        val dataMapped = pipeline.map(record.data, record.meta?.changes)
-        val withMeta = dataMapped.withAirbyteMeta(stream, record.emittedAtMs, rootLevelFlattening)
+    override fun accept(record: DestinationRecordRaw) {
+        val marshalledRecord = record.asDestinationRecordAirbyteValue()
+        val dataMapped = pipeline.map(marshalledRecord.data, marshalledRecord.meta?.changes)
+        val withMeta =
+            dataMapped.withAirbyteMeta(stream, marshalledRecord.emittedAtMs, rootLevelFlattening)
         writer.write(withMeta.toAvroRecord(mappedSchema, avroSchema))
     }
 
@@ -176,9 +185,11 @@ class ParquetFormattingWriter(
         log.info { "Generated avro schema: $avroSchema" }
     }
 
-    override fun accept(record: DestinationRecordAirbyteValue) {
-        val dataMapped = pipeline.map(record.data, record.meta?.changes)
-        val withMeta = dataMapped.withAirbyteMeta(stream, record.emittedAtMs, rootLevelFlattening)
+    override fun accept(record: DestinationRecordRaw) {
+        val marshalledRecord = record.asDestinationRecordAirbyteValue()
+        val dataMapped = pipeline.map(marshalledRecord.data, marshalledRecord.meta?.changes)
+        val withMeta =
+            dataMapped.withAirbyteMeta(stream, marshalledRecord.emittedAtMs, rootLevelFlattening)
         writer.write(withMeta.toAvroRecord(mappedSchema, avroSchema))
     }
 
@@ -224,7 +235,7 @@ class BufferedFormattingWriter<T : OutputStream>(
                 0
             } else buffer.size()
 
-    override fun accept(record: DestinationRecordAirbyteValue) {
+    override fun accept(record: DestinationRecordRaw) {
         writer.accept(record)
         rowsAdded.incrementAndGet()
     }

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/pipline/object_storage/ObjectLoaderPartFormatter.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/pipline/object_storage/ObjectLoaderPartFormatter.kt
@@ -104,7 +104,7 @@ class ObjectLoaderPartFormatter<T : OutputStream>(
         input: DestinationRecordRaw,
         state: State<T>
     ): BatchAccumulatorResult<State<T>, FormattedPart> {
-        state.writer.accept(input.asDestinationRecordAirbyteValue())
+        state.writer.accept(input)
         val dataSufficient = state.writer.bufferSize >= partSizeBytes || batchSizeOverride != null
         return if (dataSufficient) {
             val part = makePart(state)

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/write/object_storage/RecordToPartAccumulator.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/write/object_storage/RecordToPartAccumulator.kt
@@ -65,7 +65,7 @@ class RecordToPartAccumulator<U : OutputStream>(
 
         // Add all the records to the formatting writer.
         log.info { "Accumulating ${totalSizeBytes}b records for ${partialUpload.partFactory.key}" }
-        records.forEach { partialUpload.writer.accept(it.asDestinationRecordAirbyteValue()) }
+        records.forEach { partialUpload.writer.accept(it) }
         partialUpload.writer.flush()
 
         // Check if we have reached the target size.

--- a/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLChecker.kt
+++ b/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLChecker.kt
@@ -9,14 +9,15 @@ import io.airbyte.cdk.load.command.Append
 import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.data.FieldType
 import io.airbyte.cdk.load.data.IntegerType
-import io.airbyte.cdk.load.data.IntegerValue
 import io.airbyte.cdk.load.data.ObjectType
-import io.airbyte.cdk.load.data.ObjectValue
-import io.airbyte.cdk.load.message.DestinationRecordAirbyteValue
+import io.airbyte.cdk.load.message.DestinationRecordRaw
+import io.airbyte.cdk.load.util.Jsons
 import io.airbyte.integrations.destination.mssql.v2.config.AzureBlobStorageClientCreator
 import io.airbyte.integrations.destination.mssql.v2.config.BulkLoadConfiguration
 import io.airbyte.integrations.destination.mssql.v2.config.MSSQLConfiguration
 import io.airbyte.integrations.destination.mssql.v2.config.MSSQLDataSourceFactory
+import io.airbyte.protocol.models.v0.AirbyteMessage
+import io.airbyte.protocol.models.v0.AirbyteRecordMessage
 import jakarta.inject.Singleton
 import java.io.ByteArrayOutputStream
 import java.sql.Connection
@@ -130,15 +131,23 @@ class MSSQLChecker(private val dataSourceFactory: MSSQLDataSourceFactory) :
     private fun createTestCsvData(stream: DestinationStream): ByteArray {
         return ByteArrayOutputStream().use { outputStream ->
             MSSQLCSVFormattingWriter(stream, outputStream, true).use { csvWriter ->
+                // TODO this is kind of dumb
                 val destinationRecord =
-                    DestinationRecordAirbyteValue(
-                        stream,
-                        ObjectValue(
-                            linkedMapOf(COLUMN_NAME to IntegerValue(TEST_ID_VALUE.toBigInteger()))
-                        ),
-                        0L,
-                        null,
-                    )
+                    AirbyteMessage()
+                        .withType(AirbyteMessage.Type.RECORD)
+                        .withRecord(
+                            AirbyteRecordMessage()
+                                .withEmittedAt(0)
+                                .withData(Jsons.valueToTree(mapOf(COLUMN_NAME to TEST_ID_VALUE)))
+                        )
+                        .let { message ->
+                            DestinationRecordRaw(
+                                stream,
+                                message,
+                                Jsons.writeValueAsString(message),
+                                stream.schema
+                            )
+                        }
                 csvWriter.accept(destinationRecord)
                 csvWriter.flush()
             }

--- a/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLCsvRowGenerator.kt
+++ b/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLCsvRowGenerator.kt
@@ -55,9 +55,9 @@ object LIMITS {
  *                             Only enable if strict data validation is required.
  * ```
  */
-class MSSQLCsvRowValidator(private val validateValuesPreLoad: Boolean) {
+class MSSQLCsvRowGenerator(private val validateValuesPreLoad: Boolean) {
 
-    fun validate(record: DestinationRecordRaw, schema: ObjectType): DestinationRecordAirbyteValue {
+    fun generate(record: DestinationRecordRaw, schema: ObjectType): DestinationRecordAirbyteValue {
         val marshalledRecord = record.asDestinationRecordAirbyteValue()
         val objectValue = marshalledRecord.data as? ObjectValue ?: return marshalledRecord
         val values = objectValue.values

--- a/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLCsvRowValidator.kt
+++ b/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLCsvRowValidator.kt
@@ -34,9 +34,10 @@ import java.time.LocalTime
 import java.time.OffsetDateTime
 import java.time.OffsetTime
 
-private object LIMITS {
+object LIMITS {
     // Maximum value for BIGINT in SQL Server
     val MAX_BIGINT = BigInteger("9223372036854775807")
+    val MIN_BIGINT = BigInteger("-9223372036854775808")
 
     val TRUE = IntegerValue(1)
     val FALSE = IntegerValue(0)
@@ -155,8 +156,8 @@ class MSSQLCsvRowValidator(private val validateValuesPreLoad: Boolean) {
         value: IntegerValue,
         meta: Meta
     ): AirbyteValue {
-        // If the integer is bigger than BIGINT, then we must nullify it.
-        if (value.value > LIMITS.MAX_BIGINT) {
+        // If the integer exceeds BIGINT range, then we must nullify it.
+        if (value.value < LIMITS.MIN_BIGINT || LIMITS.MAX_BIGINT < value.value) {
             meta.nullify(
                 columnName,
                 AirbyteRecordMessageMetaChange.Reason.DESTINATION_FIELD_SIZE_LIMITATION

--- a/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLQueryBuilder.kt
+++ b/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLQueryBuilder.kt
@@ -52,7 +52,6 @@ import io.airbyte.integrations.destination.mssql.v2.convert.MssqlType
 import io.airbyte.integrations.destination.mssql.v2.convert.ResultSetToAirbyteValue.Companion.getAirbyteNamedValue
 import io.airbyte.protocol.models.v0.AirbyteRecordMessageMetaChange.Reason
 import io.github.oshai.kotlinlogging.KotlinLogging
-import java.math.BigInteger
 import java.sql.Connection
 import java.sql.Date
 import java.sql.PreparedStatement
@@ -377,11 +376,7 @@ class MSSQLQueryBuilder(
                     )
                 IntegerType -> {
                     val intValue = (value.value as IntegerValue).value
-                    // TODO use existing LIMITS constants
-                    if (
-                        intValue < BigInteger("-9223372036854775808") ||
-                            BigInteger("9223372036854775807") < intValue
-                    ) {
+                    if (intValue < LIMITS.MIN_BIGINT || LIMITS.MAX_BIGINT < intValue) {
                         value.nullify(Reason.DESTINATION_FIELD_SIZE_LIMITATION)
                     } else {
                         statement.setLong(statementIndex, intValue.longValueExact())

--- a/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MssqlObjectStorageFormattingWriter.kt
+++ b/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MssqlObjectStorageFormattingWriter.kt
@@ -11,7 +11,7 @@ import io.airbyte.cdk.load.data.withAirbyteMeta
 import io.airbyte.cdk.load.file.csv.toCsvPrinterWithHeader
 import io.airbyte.cdk.load.file.object_storage.ObjectStorageFormattingWriter
 import io.airbyte.cdk.load.file.object_storage.ObjectStorageFormattingWriterFactory
-import io.airbyte.cdk.load.message.DestinationRecordAirbyteValue
+import io.airbyte.cdk.load.message.DestinationRecordRaw
 import java.io.OutputStream
 import javax.inject.Singleton
 
@@ -23,7 +23,7 @@ class MSSQLCSVFormattingWriter(
     private val finalSchema = stream.schema.withAirbyteMeta(true)
     private val printer = finalSchema.toCsvPrinterWithHeader(outputStream)
     private val mssqlRowValidator = MSSQLCsvRowValidator(validateValuesPreLoad)
-    override fun accept(record: DestinationRecordAirbyteValue) {
+    override fun accept(record: DestinationRecordRaw) {
         printer.printRecord(
             mssqlRowValidator
                 .validate(record, this.finalSchema)

--- a/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MssqlObjectStorageFormattingWriter.kt
+++ b/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MssqlObjectStorageFormattingWriter.kt
@@ -22,11 +22,11 @@ class MSSQLCSVFormattingWriter(
 ) : ObjectStorageFormattingWriter {
     private val finalSchema = stream.schema.withAirbyteMeta(true)
     private val printer = finalSchema.toCsvPrinterWithHeader(outputStream)
-    private val mssqlRowValidator = MSSQLCsvRowValidator(validateValuesPreLoad)
+    private val mssqlRowGenerator = MSSQLCsvRowGenerator(validateValuesPreLoad)
     override fun accept(record: DestinationRecordRaw) {
         printer.printRecord(
-            mssqlRowValidator
-                .validate(record, this.finalSchema)
+            mssqlRowGenerator
+                .generate(record, this.finalSchema)
                 .dataWithAirbyteMeta(stream, true)
                 .toCsvRecord(finalSchema),
         )

--- a/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MssqlObjectStorageFormattingWriter.kt
+++ b/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MssqlObjectStorageFormattingWriter.kt
@@ -5,8 +5,6 @@
 package io.airbyte.integrations.destination.mssql.v2
 
 import io.airbyte.cdk.load.command.DestinationStream
-import io.airbyte.cdk.load.data.csv.toCsvRecord
-import io.airbyte.cdk.load.data.dataWithAirbyteMeta
 import io.airbyte.cdk.load.data.withAirbyteMeta
 import io.airbyte.cdk.load.file.csv.toCsvPrinterWithHeader
 import io.airbyte.cdk.load.file.object_storage.ObjectStorageFormattingWriter
@@ -16,7 +14,7 @@ import java.io.OutputStream
 import javax.inject.Singleton
 
 class MSSQLCSVFormattingWriter(
-    private val stream: DestinationStream,
+    stream: DestinationStream,
     outputStream: OutputStream,
     validateValuesPreLoad: Boolean,
 ) : ObjectStorageFormattingWriter {
@@ -24,12 +22,7 @@ class MSSQLCSVFormattingWriter(
     private val printer = finalSchema.toCsvPrinterWithHeader(outputStream)
     private val mssqlRowGenerator = MSSQLCsvRowGenerator(validateValuesPreLoad)
     override fun accept(record: DestinationRecordRaw) {
-        printer.printRecord(
-            mssqlRowGenerator
-                .generate(record, this.finalSchema)
-                .dataWithAirbyteMeta(stream, true)
-                .toCsvRecord(finalSchema),
-        )
+        printer.printRecord(mssqlRowGenerator.generate(record, finalSchema))
     }
     override fun flush() {
         printer.flush()

--- a/airbyte-integrations/connectors/destination-mssql/src/test-integration/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLWriterTest.kt
+++ b/airbyte-integrations/connectors/destination-mssql/src/test-integration/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLWriterTest.kt
@@ -43,7 +43,6 @@ import java.util.UUID
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.BeforeAll
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 
 abstract class MSSQLWriterTest(
@@ -303,15 +302,6 @@ internal class BulkInsert :
                     )
             ) { spec -> MSSQLConfigurationFactory().makeWithOverrides(spec, emptyMap()) },
     ) {
-
-    @Disabled(
-        "temporarily disabling while I work on implementing better type handling in bulk inserts - https://github.com/airbytehq/airbyte-internal-issues/issues/12128 / https://github.com/airbytehq/airbyte/pull/55884"
-    )
-    @Test
-    override fun testUnknownTypes() {
-        super.testUnknownTypes()
-    }
-
     companion object {
         const val CONFIG_FILE = "secrets/bulk_upload_config.json"
     }


### PR DESCRIPTION
(github thinks 34dd5aec977296065b414d31b4ea64a34c27b840 is on this branch for some reason :/ even though it's actually the last commit on https://github.com/airbytehq/airbyte/pull/55849, which this branch is stacked on top of)

5 commits, probably easier to review them one by one:

* switch CDK load-object-storage toolkit to use RecordRaw
* rename MssqlCsvRowValidator -> Generator
* use new typing interface
    * the diff is terrible, might be easier to just read the new version on its own
    * read MSSQLCsvRowGenerator after reading all the other files - notably, I'm effectively moving the `dataWithAirbyteMeta(stream, true).toCsvRecord(finalSchema)` logic into CsvRowGenerator.generate)
* reenable the test I disabled in https://github.com/airbytehq/airbyte/pull/55904
* fix timestamp handling specifically