### PR TITLE
fix(cdc) no streams means include no tables

### DIFF
--- a/airbyte-cdk/bulk/toolkits/extract-cdc/src/main/kotlin/io/airbyte/cdk/read/cdc/DebeziumPropertiesBuilder.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-cdc/src/main/kotlin/io/airbyte/cdk/read/cdc/DebeziumPropertiesBuilder.kt
@@ -117,6 +117,12 @@ class DebeziumPropertiesBuilder(private val props: Properties = Properties()) {
 
     /** Tells Debezium which tables and columns we care about. */
     fun withStreams(streams: List<Stream>): DebeziumPropertiesBuilder {
+        if (streams.isEmpty()) {
+            return apply {
+                with("table.include.list", "$^")
+                with("column.include.list", "$^")
+            }
+        }
         val tableIncludeList: List<String> =
             streams.map { Pattern.quote("${it.namespace}.${it.name}") }
         val columnIncludeList: List<String> =

--- a/airbyte-integrations/connectors/source-mysql/src/main/kotlin/io/airbyte/integrations/source/mysql/MySqlSourceDebeziumOperations.kt
+++ b/airbyte-integrations/connectors/source-mysql/src/main/kotlin/io/airbyte/integrations/source/mysql/MySqlSourceDebeziumOperations.kt
@@ -350,7 +350,6 @@ class MySqlSourceDebeziumOperations(
             // construct the db schema history. Note that we used to use schema_only_recovery mode
             // instead, but this mode has been deprecated.
             .with("snapshot.mode", "recovery")
-            .withStreams(listOf())
             .buildMap()
 
     override fun generateWarmStartProperties(streams: List<Stream>): Map<String, String> =


### PR DESCRIPTION
The `withStreams(List<Stream>)` method in the CDK's debezium properties builder sets a `table.include.list` and `column.include.list` property populated with regular expressions matching the specified streams and their fields. This PR fixes a bug where an empty list of streams creates an empty regex, which actually matches *ALL* tables. With this fix, it matches no tables instead.

The only existing usage of the method with an empty list occurs in the MySQL source connector. We preserve the existing behavior there by omitting the property. Without this optional property set, all tables are included.


## User Impact
None.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
