### PR TITLE
Use amazonlinux 2023 for amazoncorretto

### DIFF
--- a/airbyte-integrations/bases/base-java/Dockerfile
+++ b/airbyte-integrations/bases/base-java/Dockerfile
@@ -6,7 +6,7 @@
 
 # If you need to add a custom logic to build your connector image, you can do it by adding a finalize_build.sh or finalize_build.py script in the connector folder.
 # Please reach out to the Connectors Operations team if you have any question.
-ARG JDK_VERSION=17.0.8
+ARG JDK_VERSION=17.0.8-al2023
 FROM amazoncorretto:${JDK_VERSION}
 COPY --from=airbyte/integration-base:dev /airbyte /airbyte
 


### PR DESCRIPTION
## What
This removed an EOL version of python that is not needed.
https://github.com/airbytehq/airbyte/issues/55874

## How
The amazon linux 2023 version of amazoncorretto removes the EOL version of python https://docs.aws.amazon.com/linux/al2023/ug/python2.7-no-more.html

## Review guide
Make sure there is no requirements on python2 for any images using amazoncorretto.

## User Impact
There should be no impact for the users as long as python2 is not used.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌
