### PR TITLE
Bulk load CDK: Fix testUnknownTypes

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/json/AirbyteTypeToJsonSchema.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/json/AirbyteTypeToJsonSchema.kt
@@ -63,8 +63,7 @@ class AirbyteTypeToJsonSchema {
                 val timestampNode = ofType("string").put("format", "date-time")
                 timestampNode.put("airbyte_type", "timestamp_without_timezone")
             }
-            // In case of unknown type, just return {} (i.e. the accept-all JsonSchema)
-            is UnknownType -> JsonNodeFactory.instance.objectNode()
+            is UnknownType -> airbyteType.schema
         }
     }
 }

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/testFixtures/kotlin/io/airbyte/cdk/load/data/icerberg/parquet/IcebergWriteTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/testFixtures/kotlin/io/airbyte/cdk/load/data/icerberg/parquet/IcebergWriteTest.kt
@@ -21,6 +21,7 @@ import io.airbyte.cdk.load.write.BasicFunctionalityIntegrationTest
 import io.airbyte.cdk.load.write.SchematizedNestedValueBehavior
 import io.airbyte.cdk.load.write.StronglyTyped
 import io.airbyte.cdk.load.write.UnionBehavior
+import io.airbyte.cdk.load.write.UnknownTypesBehavior
 import kotlin.test.assertContains
 import org.apache.iceberg.catalog.Catalog
 import org.junit.jupiter.api.Assumptions
@@ -58,7 +59,7 @@ abstract class IcebergWriteTest(
                 // we stringify objects, so nested floats stay exact
                 nestedFloatLosesPrecision = false
             ),
-        nullUnknownTypes = true,
+        unknownTypesBehavior = UnknownTypesBehavior.SERIALIZE,
         nullEqualsUnset = true,
         configUpdater = IcebergConfigUpdater,
     ) {

--- a/airbyte-integrations/connectors/destination-mssql/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-mssql/metadata.yaml
@@ -16,7 +16,7 @@ data:
             type: GSM
   connectorType: destination
   definitionId: d4353156-9217-4cad-8dd7-c108fd4f74cf
-  dockerImageTag: 2.0.4
+  dockerImageTag: 2.0.5
   dockerRepository: airbyte/destination-mssql
   documentationUrl: https://docs.airbyte.com/integrations/destinations/mssql
   githubIssueLabel: destination-mssql

--- a/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/convert/AirbyteValueToStatement.kt
+++ b/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/convert/AirbyteValueToStatement.kt
@@ -20,6 +20,7 @@ import io.airbyte.cdk.load.data.TimeWithoutTimezoneValue
 import io.airbyte.cdk.load.data.TimestampWithTimezoneValue
 import io.airbyte.cdk.load.data.TimestampWithoutTimezoneValue
 import io.airbyte.cdk.load.data.UnionType
+import io.airbyte.cdk.load.data.UnknownType
 import io.airbyte.cdk.load.data.UnknownValue
 import io.airbyte.integrations.destination.mssql.v2.MSSQLQueryBuilder
 import io.airbyte.protocol.models.Jsons
@@ -43,7 +44,11 @@ class AirbyteValueToStatement {
             value: AirbyteValue?,
             field: MSSQLQueryBuilder.NamedField
         ) {
-            if (value != null && value !is NullValue && field.type.type is UnionType) {
+            if (
+                value != null &&
+                    value !is NullValue &&
+                    (field.type.type is UnionType || field.type.type is UnknownType)
+            ) {
                 setAsJsonString(idx, value)
             } else {
                 when (value) {

--- a/airbyte-integrations/connectors/destination-mssql/src/test-integration/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLWriterTest.kt
+++ b/airbyte-integrations/connectors/destination-mssql/src/test-integration/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLWriterTest.kt
@@ -23,6 +23,7 @@ import io.airbyte.cdk.load.write.BasicFunctionalityIntegrationTest
 import io.airbyte.cdk.load.write.SchematizedNestedValueBehavior
 import io.airbyte.cdk.load.write.StronglyTyped
 import io.airbyte.cdk.load.write.UnionBehavior
+import io.airbyte.cdk.load.write.UnknownTypesBehavior
 import io.airbyte.integrations.destination.mssql.v2.config.AzureBlobStorageClientCreator
 import io.airbyte.integrations.destination.mssql.v2.config.BulkLoadConfiguration
 import io.airbyte.integrations.destination.mssql.v2.config.DataSourceFactory
@@ -42,6 +43,7 @@ import java.util.UUID
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
 
 abstract class MSSQLWriterTest(
     configPath: Path,
@@ -64,7 +66,7 @@ abstract class MSSQLWriterTest(
         supportFileTransfer = false,
         commitDataIncrementally = true,
         allTypesBehavior = StronglyTyped(integerCanBeLarge = false),
-        nullUnknownTypes = false,
+        unknownTypesBehavior = UnknownTypesBehavior.SERIALIZE,
         nullEqualsUnset = true,
         configUpdater = configUpdater,
     )
@@ -259,6 +261,11 @@ internal class StandardInsert :
                 MSSQLConfigurationFactory().makeWithOverrides(spec, configOverrides)
             },
     ) {
+
+    @Test
+    override fun testUnknownTypes() {
+        super.testUnknownTypes()
+    }
 
     companion object {
         @JvmStatic

--- a/airbyte-integrations/connectors/destination-mssql/src/test-integration/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLWriterTest.kt
+++ b/airbyte-integrations/connectors/destination-mssql/src/test-integration/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLWriterTest.kt
@@ -43,6 +43,7 @@ import java.util.UUID
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 
 abstract class MSSQLWriterTest(
@@ -301,6 +302,14 @@ internal class BulkInsert :
                     )
             ) { spec -> MSSQLConfigurationFactory().makeWithOverrides(spec, emptyMap()) },
     ) {
+
+    @Disabled(
+        "temporarily disabling while I work on implementing better type handling in bulk inserts - https://github.com/airbytehq/airbyte-internal-issues/issues/12128 / https://github.com/airbytehq/airbyte/pull/55884"
+    )
+    @Test
+    override fun testUnknownTypes() {
+        super.testUnknownTypes()
+    }
 
     companion object {
         const val CONFIG_FILE = "secrets/bulk_upload_config.json"

--- a/airbyte-integrations/connectors/destination-s3-data-lake/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_data_lake/S3DataLakeWriteTest.kt
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_data_lake/S3DataLakeWriteTest.kt
@@ -92,8 +92,8 @@ class GlueWriteTest :
     }
 
     @Test
-    override fun testBasicWrite() {
-        super.testBasicWrite()
+    override fun testUnknownTypes() {
+        super.testUnknownTypes()
     }
 }
 

--- a/airbyte-integrations/connectors/destination-s3/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2WriteTest.kt
+++ b/airbyte-integrations/connectors/destination-s3/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2WriteTest.kt
@@ -20,6 +20,7 @@ import io.airbyte.cdk.load.write.BasicFunctionalityIntegrationTest
 import io.airbyte.cdk.load.write.SchematizedNestedValueBehavior
 import io.airbyte.cdk.load.write.StronglyTyped
 import io.airbyte.cdk.load.write.UnionBehavior
+import io.airbyte.cdk.load.write.UnknownTypesBehavior
 import io.airbyte.cdk.load.write.Untyped
 import java.util.concurrent.TimeUnit
 import org.junit.jupiter.api.Assumptions
@@ -40,7 +41,7 @@ abstract class S3V2WriteTest(
     commitDataIncrementally: Boolean = true,
     allTypesBehavior: AllTypesBehavior,
     nullEqualsUnset: Boolean = false,
-    nullUnknownTypes: Boolean = false,
+    unknownTypesBehavior: UnknownTypesBehavior = UnknownTypesBehavior.PASS_THROUGH,
     private val mergesUnions: Boolean = false
 ) :
     BasicFunctionalityIntegrationTest(
@@ -62,7 +63,7 @@ abstract class S3V2WriteTest(
         allTypesBehavior = allTypesBehavior,
         nullEqualsUnset = nullEqualsUnset,
         supportFileTransfer = true,
-        nullUnknownTypes = nullUnknownTypes,
+        unknownTypesBehavior = unknownTypesBehavior,
     ) {
     @Disabled("Irrelevant for file destinations")
     @Test
@@ -394,7 +395,7 @@ class S3V2WriteTestAvroUncompressed :
         preserveUndeclaredFields = false,
         allTypesBehavior = StronglyTyped(integerCanBeLarge = false),
         nullEqualsUnset = true,
-        nullUnknownTypes = true,
+        unknownTypesBehavior = UnknownTypesBehavior.NULL,
         mergesUnions = true
     )
 
@@ -409,7 +410,7 @@ class S3V2WriteTestAvroBzip2 :
         preserveUndeclaredFields = false,
         allTypesBehavior = StronglyTyped(integerCanBeLarge = false),
         nullEqualsUnset = true,
-        nullUnknownTypes = true,
+        unknownTypesBehavior = UnknownTypesBehavior.NULL,
         mergesUnions = true
     )
 
@@ -424,7 +425,7 @@ class S3V2WriteTestParquetUncompressed :
         preserveUndeclaredFields = false,
         allTypesBehavior = StronglyTyped(integerCanBeLarge = false),
         nullEqualsUnset = true,
-        nullUnknownTypes = true,
+        unknownTypesBehavior = UnknownTypesBehavior.NULL,
         mergesUnions = true
     )
 
@@ -439,7 +440,7 @@ class S3V2WriteTestParquetSnappy :
         preserveUndeclaredFields = false,
         allTypesBehavior = StronglyTyped(integerCanBeLarge = false),
         nullEqualsUnset = true,
-        nullUnknownTypes = true,
+        unknownTypesBehavior = UnknownTypesBehavior.NULL,
         mergesUnions = true
     )
 

--- a/airbyte-integrations/connectors/destination-s3/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2WriteTest.kt
+++ b/airbyte-integrations/connectors/destination-s3/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2WriteTest.kt
@@ -395,7 +395,7 @@ class S3V2WriteTestAvroUncompressed :
         preserveUndeclaredFields = false,
         allTypesBehavior = StronglyTyped(integerCanBeLarge = false),
         nullEqualsUnset = true,
-        unknownTypesBehavior = UnknownTypesBehavior.NULL,
+        unknownTypesBehavior = UnknownTypesBehavior.FAIL,
         mergesUnions = true
     )
 
@@ -410,7 +410,7 @@ class S3V2WriteTestAvroBzip2 :
         preserveUndeclaredFields = false,
         allTypesBehavior = StronglyTyped(integerCanBeLarge = false),
         nullEqualsUnset = true,
-        unknownTypesBehavior = UnknownTypesBehavior.NULL,
+        unknownTypesBehavior = UnknownTypesBehavior.FAIL,
         mergesUnions = true
     )
 
@@ -425,7 +425,7 @@ class S3V2WriteTestParquetUncompressed :
         preserveUndeclaredFields = false,
         allTypesBehavior = StronglyTyped(integerCanBeLarge = false),
         nullEqualsUnset = true,
-        unknownTypesBehavior = UnknownTypesBehavior.NULL,
+        unknownTypesBehavior = UnknownTypesBehavior.FAIL,
         mergesUnions = true
     )
 
@@ -440,7 +440,7 @@ class S3V2WriteTestParquetSnappy :
         preserveUndeclaredFields = false,
         allTypesBehavior = StronglyTyped(integerCanBeLarge = false),
         nullEqualsUnset = true,
-        unknownTypesBehavior = UnknownTypesBehavior.NULL,
+        unknownTypesBehavior = UnknownTypesBehavior.FAIL,
         mergesUnions = true
     )
 

--- a/docs/integrations/destinations/mssql.md
+++ b/docs/integrations/destinations/mssql.md
@@ -158,8 +158,9 @@ See the [Getting Started: Configuration section](#configuration) of this guide f
 
 | Version    | Date       | Pull Request                                               | Subject                                                                                             |
 |:-----------|:-----------|:-----------------------------------------------------------|:----------------------------------------------------------------------------------------------------|
+| 2.0.5      | 2025-03-24 | [55904](https://github.com/airbytehq/airbyte/pull/55904)   | Fix handling of invalid schemas (correctly JSON-serialize values)                                   |
 | 2.0.4      | 2025-03-20 | [55886](https://github.com/airbytehq/airbyte/pull/55886)   | Internal refactor                                                                                   |
-| 2.0.3      | 2025-03-18 | [55811](https://github.com/airbytehq/airbyte/pull/55811)   | CDK: Pass DestinationStream around vs Descriptor                                                                               |
+| 2.0.3      | 2025-03-18 | [55811](https://github.com/airbytehq/airbyte/pull/55811)   | CDK: Pass DestinationStream around vs Descriptor                                                    |
 | 2.0.2      | 2025-03-12 | [55720](https://github.com/airbytehq/airbyte/pull/55720)   | Restore definition ID                                                                               |
 | 2.0.1      | 2025-03-12 | [55718](https://github.com/airbytehq/airbyte/pull/55718)   | Fix breaking change information in metadata.yaml                                                    |
 | 2.0.0      | 2025-03-11 | [55684](https://github.com/airbytehq/airbyte/pull/55684)   | Release 2.0.0                                                                                       |


### PR DESCRIPTION
AirbyteTypeToJsonSchema was previously discarding the input schema, so we ran with a field of type `{}`. Which for some reason we treat as ObjectWithEmptySchema? but w/e

this meant that testUnknownTypes was actually testing behavior on ObjectWithEmptySchema. 

Also, update mssql to actually serialize UNKNOWN values in standard inserts mode. IMO we can release this without doing a breaking change. (I'll implement bulk inserts in https://github.com/airbytehq/airbyte/pull/55884)