### PR TITLE
Destinations Iceberg / S3 Glue: bump version to trigger doc publish

### DIFF
--- a/airbyte-integrations/connectors/destination-iceberg/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-iceberg/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: df65a8f3-9908-451b-aa9b-445462803560
-  dockerImageTag: 0.2.4
+  dockerImageTag: 0.2.5
   dockerRepository: airbyte/destination-iceberg
   githubIssueLabel: destination-iceberg
   icon: iceberg.svg

--- a/airbyte-integrations/connectors/destination-s3-glue/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-s3-glue/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: file
   connectorType: destination
   definitionId: 471e5cab-8ed1-49f3-ba11-79c687784737
-  dockerImageTag: 0.1.10
+  dockerImageTag: 0.1.11
   dockerRepository: airbyte/destination-s3-glue
   githubIssueLabel: destination-s3-glue
   icon: s3-glue.svg

--- a/docs/integrations/destinations/iceberg.md
+++ b/docs/integrations/destinations/iceberg.md
@@ -80,6 +80,7 @@ specify the target size of compacted Iceberg data file.
 
 | Version | Date       | Pull Request                                              | Subject                                                        |
 |:--------|:-----------|:----------------------------------------------------------|:---------------------------------------------------------------|
+| 0.2.5 | 2025-03-21 | [55908](https://github.com/airbytehq/airbyte/pull/55908) | Update docs to redirect users to destination-s3-data-lake |
 | 0.2.4 | 2025-01-10 | [51492](https://github.com/airbytehq/airbyte/pull/51492) | Use a non root base image |
 | 0.2.3 | 2024-12-17 | [49841](https://github.com/airbytehq/airbyte/pull/49841) | Use a base image: airbyte/java-connector-base:1.0.0 |
 | 0.2.2 | 2024-09-23 | [45861](https://github.com/airbytehq/airbyte/pull/45861) | Keeping only S3 with Glue Catalog as config option |

--- a/docs/integrations/destinations/s3-glue.md
+++ b/docs/integrations/destinations/s3-glue.md
@@ -309,6 +309,7 @@ the output filename will have an extra extension (GZIP: `.jsonl.gz`).
 
 | Version | Date       | Pull Request                                              | Subject                                                                                 |
 | :------ | :--------- | :-------------------------------------------------------- | :-------------------------------------------------------------------------------------- |
+| 0.1.11  | 2025-03-21 | [#55908](https://github.com/airbytehq/airbyte/pull/55908) | Update docs to redirect users to destination-s3-data-lake                               |
 | 0.1.10  | 2024-10-29 | [#48820](https://github.com/airbytehq/airbyte/pull/48820) | revert back to CDK 0.2.0                                                                |
 | 0.1.9   | 2024-10-28 | [#47201](https://github.com/airbytehq/airbyte/pull/47201) | build against latest CDK                                                                |
 | 0.1.8   | 2024-01-03 | [#33924](https://github.com/airbytehq/airbyte/pull/33924) | Add new ap-southeast-3 AWS region                                                       |


### PR DESCRIPTION
we added a note in the docs telling people to use s3-data-lake instead of destination iceberg / s3-glue in https://github.com/airbytehq/airbyte/pull/54724/

but that hasn't showed up yet, b/c the docs are tied to connector version >.> e.g. https://cloud.airbyte.com/workspaces/46b4844a-94a3-496f-af53-2050bf4141af/destination/new-destination/471e5cab-8ed1-49f3-ba11-79c687784737 still doesn't show the admonition

so just trigger a new version publish to get the new docs to show up