### PR TITLE
Load CDK: Improved new interface bookkeeping

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/integrationTest/kotlin/io/airbyte/cdk/load/mock_integration_test/MockDestinationWriter.kt
+++ b/airbyte-cdk/bulk/core/load/src/integrationTest/kotlin/io/airbyte/cdk/load/mock_integration_test/MockDestinationWriter.kt
@@ -10,6 +10,7 @@ import io.airbyte.cdk.load.command.Dedupe
 import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.data.ObjectValue
 import io.airbyte.cdk.load.message.Batch
+import io.airbyte.cdk.load.message.BatchState
 import io.airbyte.cdk.load.message.DestinationFile
 import io.airbyte.cdk.load.message.DestinationRecordRaw
 import io.airbyte.cdk.load.message.SimpleBatch
@@ -39,10 +40,10 @@ class MockStreamLoader(override val stream: DestinationStream) : StreamLoader {
     }
 
     data class LocalBatch(val records: List<DestinationRecordRaw>) : MockBatch() {
-        override val state = Batch.State.STAGED
+        override val state = BatchState.STAGED
     }
     data class LocalFileBatch(val file: DestinationFile) : MockBatch() {
-        override val state = Batch.State.STAGED
+        override val state = BatchState.STAGED
     }
 
     override suspend fun close(streamFailure: StreamProcessingFailed?) {
@@ -107,7 +108,7 @@ class MockStreamLoader(override val stream: DestinationStream) : StreamLoader {
                 // in a real sync, because we would always either get more
                 // data or an end-of-stream that would force a final flush.
                 delay(100L)
-                SimpleBatch(state = Batch.State.COMPLETE)
+                SimpleBatch(state = BatchState.COMPLETE)
             }
             else -> throw IllegalStateException("Unexpected batch type: $batch")
         }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/Batch.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/Batch.kt
@@ -10,22 +10,21 @@ import com.google.common.collect.TreeRangeSet
 import io.airbyte.cdk.load.command.DestinationStream
 
 /**
- * Represents an accumulated batch of records in some stage of processing.
- *
- * Emitted by @[io.airbyte.cdk.write.StreamLoader.processRecords] to describe the batch accumulated.
- * Non-[State.COMPLETE] batches are routed to @[io.airbyte.cdk.write.StreamLoader.processBatch]
+ * Represents an accumulated batch of records in some stage of processing. Emitted by @
+ * [io.airbyte.cdk.write.StreamLoader.processRecords] to describe the batch accumulated. Non-
+ * [BatchState.COMPLETE] batches are routed to @[io.airbyte.cdk.write.StreamLoader.processBatch]
  * re-entrantly until completion.
  *
  * The framework will track the association between the Batch and the range of records it
- * represents, by [Batch.State]s. The [State.PERSISTED] state has special meaning: it indicates that
- * the associated ranges have been persisted remotely, and that platform checkpoint messages can be
- * emitted.
+ * represents, by [Batch.BatchState]s. The [BatchState.PERSISTED] state has special meaning: it
+ * indicates that the associated ranges have been persisted remotely, and that platform checkpoint
+ * messages can be emitted.
  *
- * [State.STAGED] is used internally to indicate that records have been spooled to disk for
+ * [BatchState.STAGED] is used internally to indicate that records have been spooled to disk for
  * processing and should not be used by implementors.
  *
  * When a stream has been read to End-of-stream, and all ranges between 0 and End-of-stream are
- * [State.COMPLETE], then all records are considered to have been processed.
+ * [BatchState.COMPLETE], then all records are considered to have been processed.
  *
  * A [Batch] may contain an optional `groupId`. If provided, the most advanced state provided for
  * any batch will apply to all batches with the same `groupId`. This is useful for a case where each
@@ -53,35 +52,21 @@ import io.airbyte.cdk.load.command.DestinationStream
 interface Batch {
     val groupId: String?
 
-    enum class State {
-        PROCESSED,
-        STAGED,
-        PERSISTED,
-        COMPLETE;
-
-        fun isPersisted(): Boolean =
-            when (this) {
-                PERSISTED,
-                COMPLETE -> true
-                else -> false
-            }
-    }
-
     fun isPersisted(): Boolean = state.isPersisted()
 
-    val state: State
+    val state: BatchState
 
     /**
-     * If a [Batch] is [State.COMPLETE], there's nothing further to do. If it is part of a group,
-     * then its state will be updated by the next batch in the group that advances.
+     * If a [Batch] is [BatchState.COMPLETE], there's nothing further to do. If it is part of a
+     * group, then its state will be updated by the next batch in the group that advances.
      */
     val requiresProcessing: Boolean
-        get() = state != State.COMPLETE && groupId == null
+        get() = state != BatchState.COMPLETE && groupId == null
 }
 
 /** Simple batch: use if you need no other metadata for processing. */
 data class SimpleBatch(
-    override val state: Batch.State,
+    override val state: BatchState,
     override val groupId: String? = null,
 ) : Batch
 

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/BatchState.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/BatchState.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.load.message
+
+/**
+ * Represents the state of a batch of records as it moves through processing. These are generic
+ * stages for bookkeeping, which CDK interface devs can assign to processing stages as they see fit.
+ * The only significant values are
+ * - [BatchState.PERSISTED] Records will be considered recoverably persisted and checkpoints will be
+ * acked to the orchestrator.
+ * - [BatchState.COMPLETE] All per-batch processing is done. (Post-processing may still occur during
+ * close-of-stream). Records are considered PERSISTED (ie, will be acked if not already). If all
+ * records are COMPLETE, and end-of-stream has been read, the stream will be considered complete and
+ * will be closed.
+ * - All other values are for bookkeeping convenience only.
+ */
+enum class BatchState {
+    PROCESSED, // records have been seen and transformed/formatted/validated (ie, create a part)
+    STAGED, // staged locally or remotely-but-not-yet-complete (ie, partial multi-part upload)
+    LOADED, // staged remotely but in a non-recoverable way (ie, a remote object in bulk load)
+    PERSISTED, // recoverable (framework can ack), but not yet complete
+    COMPLETE; // completely done; implies persisted (ie, framework can ack)
+
+    fun isPersisted(): Boolean =
+        when (this) {
+            PERSISTED,
+            COMPLETE -> true
+            else -> false
+        }
+}

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/WithBatchState.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/WithBatchState.kt
@@ -11,5 +11,5 @@ package io.airbyte.cdk.load.message
  * internal state.
  */
 interface WithBatchState {
-    val state: Batch.State
+    val state: BatchState
 }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/pipeline/BatchStateUpdate.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/pipeline/BatchStateUpdate.kt
@@ -5,20 +5,28 @@
 package io.airbyte.cdk.load.pipeline
 
 import io.airbyte.cdk.load.command.DestinationStream
-import io.airbyte.cdk.load.message.Batch
+import io.airbyte.cdk.load.message.BatchState
 import io.airbyte.cdk.load.state.CheckpointId
 
 /** Used internally by the CDK to track record ranges to ack. */
 sealed interface BatchUpdate {
     val stream: DestinationStream.Descriptor
+    val taskName: String
+    val part: Int
 }
 
 data class BatchStateUpdate(
     override val stream: DestinationStream.Descriptor,
     val checkpointCounts: Map<CheckpointId, Long>,
-    val state: Batch.State,
+    val state: BatchState,
+    override val taskName: String,
+    override val part: Int,
+    val inputCount: Long = 0L
 ) : BatchUpdate
 
 data class BatchEndOfStream(
     override val stream: DestinationStream.Descriptor,
+    override val taskName: String,
+    override val part: Int,
+    val totalInputCount: Long
 ) : BatchUpdate

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/pipeline/DirectLoadRecordAccumulator.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/pipeline/DirectLoadRecordAccumulator.kt
@@ -4,7 +4,7 @@
 
 package io.airbyte.cdk.load.pipeline
 
-import io.airbyte.cdk.load.message.Batch
+import io.airbyte.cdk.load.message.BatchState
 import io.airbyte.cdk.load.message.DestinationRecordRaw
 import io.airbyte.cdk.load.message.WithBatchState
 import io.airbyte.cdk.load.message.WithStream
@@ -14,7 +14,7 @@ import io.airbyte.cdk.load.write.DirectLoaderFactory
 import io.micronaut.context.annotation.Requires
 import jakarta.inject.Singleton
 
-data class DirectLoadAccResult(override val state: Batch.State) : WithBatchState
+data class DirectLoadAccResult(override val state: BatchState) : WithBatchState
 
 /**
  * Used internally by the CDK to wrap the client-provided DirectLoader in a generic
@@ -37,13 +37,13 @@ class DirectLoadRecordAccumulator<S : DirectLoader, K : WithStream>(
         state.accept(input).let {
             return when (it) {
                 is Incomplete -> NoOutput(state)
-                is Complete -> FinalOutput(DirectLoadAccResult(Batch.State.COMPLETE))
+                is Complete -> FinalOutput(DirectLoadAccResult(BatchState.COMPLETE))
             }
         }
     }
 
     override suspend fun finish(state: S): FinalOutput<S, DirectLoadAccResult> {
         state.finish()
-        return FinalOutput(DirectLoadAccResult(Batch.State.COMPLETE))
+        return FinalOutput(DirectLoadAccResult(BatchState.COMPLETE))
     }
 }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/InputConsumerTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/InputConsumerTask.kt
@@ -7,8 +7,8 @@ package io.airbyte.cdk.load.task.internal
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 import io.airbyte.cdk.load.command.DestinationCatalog
 import io.airbyte.cdk.load.command.DestinationStream
-import io.airbyte.cdk.load.message.Batch
 import io.airbyte.cdk.load.message.BatchEnvelope
+import io.airbyte.cdk.load.message.BatchState
 import io.airbyte.cdk.load.message.CheckpointMessage
 import io.airbyte.cdk.load.message.CheckpointMessageWrapped
 import io.airbyte.cdk.load.message.DestinationFile
@@ -134,7 +134,7 @@ class DefaultInputConsumerTask(
                 manager.markEndOfStream(true)
                 val envelope =
                     BatchEnvelope(
-                        SimpleBatch(Batch.State.COMPLETE),
+                        SimpleBatch(BatchState.COMPLETE),
                         streamDescriptor = message.stream.descriptor,
                     )
                 destinationTaskLauncher.handleNewBatch(stream.descriptor, envelope)
@@ -197,7 +197,7 @@ class DefaultInputConsumerTask(
                 manager.markEndOfStream(true)
                 val envelope =
                     BatchEnvelope(
-                        SimpleBatch(Batch.State.COMPLETE),
+                        SimpleBatch(BatchState.COMPLETE),
                         streamDescriptor = message.stream.descriptor,
                     )
                 destinationTaskLauncher.handleNewBatch(stream.descriptor, envelope)

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/LoadPipelineStepTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/LoadPipelineStepTask.kt
@@ -26,6 +26,7 @@ import io.airbyte.cdk.load.task.OnEndOfSync
 import io.airbyte.cdk.load.task.Task
 import io.airbyte.cdk.load.task.TerminalCondition
 import io.airbyte.cdk.load.write.LoadStrategy
+import io.github.oshai.kotlinlogging.KotlinLogging
 import io.micronaut.context.annotation.Requires
 import io.micronaut.context.annotation.Value
 import jakarta.inject.Named
@@ -35,6 +36,12 @@ import java.util.concurrent.atomic.AtomicInteger
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.fold
 
+/**
+ * Accumulator state with the checkpoint counts (Checkpoint Id -> Records Seen) seen since the state
+ * was created.
+ *
+ * Includes a count of the inputs seen since the state was created.
+ */
 data class StateWithCounts<S : AutoCloseable>(
     val accumulatorState: S,
     val checkpointCounts: MutableMap<CheckpointId, Long> = mutableMapOf(),
@@ -59,16 +66,32 @@ class LoadPipelineStepTask<S : AutoCloseable, K1 : WithStream, T, K2 : WithStrea
     private val streamCompletions:
         ConcurrentHashMap<Pair<Int, DestinationStream.Descriptor>, AtomicInteger>
 ) : Task {
+    private val log = KotlinLogging.logger {}
+
+    private val taskName = batchAccumulator::class.java.simpleName
+
     override val terminalCondition: TerminalCondition = OnEndOfSync
 
+    /**
+     * Task-global state. A map of all the keys seen with associated accumulator state and
+     * bookkeeping info. Also includes a global count of inputs seen per stream and fact of stream
+     * end (it is a critical error to receive input for a stream that has ended, as it means that
+     * something is likely wrong with our bookkeeping.)
+     */
+    data class StateStore<K1, S : AutoCloseable>(
+        val stateWithCounts: MutableMap<K1, StateWithCounts<S>> = mutableMapOf(),
+        val streamCounts: MutableMap<DestinationStream.Descriptor, Long> = mutableMapOf(),
+        val streamsEnded: MutableSet<DestinationStream.Descriptor> = mutableSetOf(),
+    )
+
     override suspend fun execute() {
-        inputFlow.fold(mutableMapOf<K1, StateWithCounts<S>>()) { stateStore, input ->
+        inputFlow.fold(StateStore<K1, S>()) { stateStore, input ->
             try {
                 when (input) {
                     is PipelineMessage -> {
                         // Get or create the accumulator state associated w/ the input key.
                         val stateWithCounts =
-                            stateStore
+                            stateStore.stateWithCounts
                                 .getOrPut(input.key) {
                                     StateWithCounts(
                                         accumulatorState = batchAccumulator.start(input.key, part),
@@ -116,7 +139,8 @@ class LoadPipelineStepTask<S : AutoCloseable, K1 : WithStream, T, K2 : WithStrea
                                 handleOutput(
                                     input.key,
                                     stateWithCounts.checkpointCounts,
-                                    finalAccOutput
+                                    finalAccOutput,
+                                    stateWithCounts.inputCount
                                 )
                                 stateWithCounts.checkpointCounts.clear()
                                 0
@@ -127,45 +151,71 @@ class LoadPipelineStepTask<S : AutoCloseable, K1 : WithStream, T, K2 : WithStrea
                         // Update the state if `accept` returned a new state, otherwise evict.
                         if (finalAccState != null) {
                             // If accept returned a new state, update the state store.
-                            stateStore[input.key] =
+                            stateStore.stateWithCounts[input.key] =
                                 stateWithCounts.copy(
                                     accumulatorState = finalAccState,
                                     inputCount = inputCount
                                 )
                         } else {
-                            stateStore.remove(input.key)?.close()
+                            stateStore.stateWithCounts.remove(input.key)?.let {
+                                check(inputCount == 0L || it.checkpointCounts.isEmpty()) {
+                                    "State evicted with unhandled input ($inputCount) or checkpoint counts(${it.checkpointCounts})"
+                                }
+                                stateWithCounts.close()
+                            }
                         }
-
+                        stateStore.streamCounts.merge(input.key.stream, 1) { old, new -> old + new }
                         stateStore
                     }
                     is PipelineEndOfStream -> {
-                        // Give any key associated with the stream a chance to finish
-                        val keysToRemove = stateStore.keys.filter { it.stream == input.stream }
+                        val numWorkersSeenEos =
+                            streamCompletions
+                                .getOrPut(Pair(taskIndex, input.stream)) { AtomicInteger(0) }
+                                .incrementAndGet()
+                        val inputCountEos = stateStore.streamCounts[input.stream] ?: 0
+
+                        val keysToRemove =
+                            stateStore.stateWithCounts.keys.filter { it.stream == input.stream }
+
                         keysToRemove.forEach { key ->
-                            stateStore.remove(key)?.let { stored ->
-                                val output = batchAccumulator.finish(stored.accumulatorState).output
-                                handleOutput(key, stored.checkpointCounts, output)
-                                stored.close()
+                            log.info { "Finishing state for $key remaining at end-of-stream" }
+                            stateStore.stateWithCounts.remove(key)?.let { stateWithCounts ->
+                                val output =
+                                    batchAccumulator.finish(stateWithCounts.accumulatorState).output
+                                handleOutput(
+                                    key,
+                                    stateWithCounts.checkpointCounts,
+                                    output,
+                                    stateWithCounts.inputCount
+                                )
+                                stateWithCounts.close()
                             }
                         }
 
                         // Only forward end-of-stream if ALL workers have seen end-of-stream.
-                        if (
-                            streamCompletions
-                                .getOrPut(Pair(taskIndex, input.stream)) { AtomicInteger(0) }
-                                .incrementAndGet() == numWorkers
-                        ) {
+                        if (numWorkersSeenEos == numWorkers) {
+                            log.info {
+                                "$this saw end-of-stream for ${input.stream} after $inputCountEos inputs, all workers complete"
+                            }
                             outputQueue?.broadcast(PipelineEndOfStream(input.stream))
+                        } else {
+                            log.info {
+                                "$this saw end-of-stream for ${input.stream} after $inputCountEos inputs, ${numWorkers - numWorkersSeenEos} workers remaining"
+                            }
                         }
 
-                        batchUpdateQueue.publish(BatchEndOfStream(input.stream))
+                        // Track which tasks are complete
+                        stateStore.streamsEnded.add(input.stream)
+                        batchUpdateQueue.publish(
+                            BatchEndOfStream(input.stream, taskName, part, inputCountEos)
+                        )
 
                         stateStore
                     }
                 }
             } catch (t: Throwable) {
                 // Close the local state associated with the current batch.
-                stateStore.values
+                stateStore.stateWithCounts.values
                     .map { runCatching { it.accumulatorState.close() } }
                     .forEach { it.getOrThrow() }
                 throw t
@@ -176,7 +226,8 @@ class LoadPipelineStepTask<S : AutoCloseable, K1 : WithStream, T, K2 : WithStrea
     private suspend fun handleOutput(
         inputKey: K1,
         checkpointCounts: Map<CheckpointId, Long>,
-        output: U
+        output: U,
+        inputCount: Long
     ) {
 
         // Only publish the output if there's a next step.
@@ -188,12 +239,15 @@ class LoadPipelineStepTask<S : AutoCloseable, K1 : WithStream, T, K2 : WithStrea
         }
 
         // If the output contained a global batch state, publish an update.
-        if (output is WithBatchState && output.state.isPersisted()) {
+        if (output is WithBatchState) {
             val update =
                 BatchStateUpdate(
                     stream = inputKey.stream,
                     checkpointCounts = checkpointCounts.toMap(),
-                    state = output.state
+                    state = output.state,
+                    taskName = taskName,
+                    part = part,
+                    inputCount = inputCount
                 )
             batchUpdateQueue.publish(update)
         }
@@ -213,7 +267,7 @@ class LoadPipelineStepTaskFactory(
     @Value("\${airbyte.destination.core.record-batch-size-override:null}")
     val batchSizeOverride: Long? = null,
 ) {
-    // A map of (TaskIndex, Stream) -> Count_of_closed streams to ensure eos is not forwared from
+    // A map of (TaskIndex, Stream) ->  streams to ensure eos is not forwarded from
     // task N to N+1 until all workers have seen eos.
     private val streamCompletions =
         ConcurrentHashMap<Pair<Int, DestinationStream.Descriptor>, AtomicInteger>()

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/SpillToDiskTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/SpillToDiskTask.kt
@@ -9,8 +9,8 @@ import com.google.common.collect.TreeRangeSet
 import io.airbyte.cdk.load.command.DestinationConfiguration
 import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.file.SpillFileProvider
-import io.airbyte.cdk.load.message.Batch
 import io.airbyte.cdk.load.message.BatchEnvelope
+import io.airbyte.cdk.load.message.BatchState
 import io.airbyte.cdk.load.message.DestinationStreamEvent
 import io.airbyte.cdk.load.message.MessageQueueSupplier
 import io.airbyte.cdk.load.message.MultiProducerChannel
@@ -138,7 +138,7 @@ class DefaultSpillToDiskTask(
             // sync will hang forever. (Usually this happens because the entire stream was empty.)
             val empty =
                 BatchEnvelope(
-                    SimpleBatch(Batch.State.COMPLETE),
+                    SimpleBatch(BatchState.COMPLETE),
                     TreeRangeSet.create(),
                     streamDescriptor
                 )

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/write/StreamLoader.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/write/StreamLoader.kt
@@ -7,6 +7,7 @@ package io.airbyte.cdk.load.write
 import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.message.Batch
 import io.airbyte.cdk.load.message.BatchEnvelope
+import io.airbyte.cdk.load.message.BatchState
 import io.airbyte.cdk.load.message.DestinationFile
 import io.airbyte.cdk.load.message.DestinationRecordRaw
 import io.airbyte.cdk.load.message.MultiProducerChannel
@@ -35,11 +36,11 @@ import io.airbyte.cdk.load.state.StreamProcessingFailed
  * [processBatch] is called once per incomplete batch returned by either [processRecords] or
  * [processBatch] itself. It must be thread-safe if
  * [io.airbyte.cdk.load.command.DestinationConfiguration.numProcessBatchWorkers] > 1. If
- * [processRecords] never returns a non-[Batch.State.COMPLETE] batch, [processBatch] will never be
- * called.
+ * [processRecords] never returns a non-[Batch.BatchState.COMPLETE] batch, [processBatch] will never
+ * be called.
  *
- * NOTE: even if [processBatch] returns a not-[Batch.State.COMPLETE] batch, it will be called again.
- * TODO: allow the client to specify subsequent processing stages instead.
+ * NOTE: even if [processBatch] returns a not-[Batch.BatchState.COMPLETE] batch, it will be called
+ * again. TODO: allow the client to specify subsequent processing stages instead.
  *
  * [close] is called once after all records have been processed, regardless of success or failure,
  * but only if [start] returned successfully. If any exception was thrown during processing, it is
@@ -55,7 +56,7 @@ interface StreamLoader : BatchAccumulator, FileBatchAccumulator {
         outputQueue: MultiProducerChannel<BatchEnvelope<*>>,
     ): FileBatchAccumulator = this
 
-    suspend fun processBatch(batch: Batch): Batch = SimpleBatch(Batch.State.COMPLETE)
+    suspend fun processBatch(batch: Batch): Batch = SimpleBatch(BatchState.COMPLETE)
     suspend fun close(streamFailure: StreamProcessingFailed? = null) {}
 }
 

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/state/CheckpointManagerTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/state/CheckpointManagerTest.kt
@@ -11,8 +11,8 @@ import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.command.MockDestinationCatalogFactory.Companion.stream1
 import io.airbyte.cdk.load.command.MockDestinationCatalogFactory.Companion.stream2
 import io.airbyte.cdk.load.file.TimeProvider
-import io.airbyte.cdk.load.message.Batch
 import io.airbyte.cdk.load.message.BatchEnvelope
+import io.airbyte.cdk.load.message.BatchState
 import io.airbyte.cdk.load.message.SimpleBatch
 import io.micronaut.context.annotation.Requires
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest
@@ -446,7 +446,7 @@ class CheckpointManagerTest {
                 is FlushPoint -> {
                     // Mock the persisted ranges by updating the state of the stream managers
                     it.persistedRanges.forEach { (stream, ranges) ->
-                        val mockBatch = SimpleBatch(state = Batch.State.PERSISTED)
+                        val mockBatch = SimpleBatch(state = BatchState.PERSISTED)
                         val rangeSet = TreeRangeSet.create(ranges)
                         val mockBatchEnvelope =
                             BatchEnvelope(

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/state/SyncManagerUtils.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/state/SyncManagerUtils.kt
@@ -6,8 +6,8 @@ package io.airbyte.cdk.load.state
 
 import com.google.common.collect.Range
 import io.airbyte.cdk.load.command.DestinationStream
-import io.airbyte.cdk.load.message.Batch
 import io.airbyte.cdk.load.message.BatchEnvelope
+import io.airbyte.cdk.load.message.BatchState
 import io.airbyte.cdk.load.message.SimpleBatch
 
 /**
@@ -20,6 +20,6 @@ import io.airbyte.cdk.load.message.SimpleBatch
 fun SyncManager.markPersisted(stream: DestinationStream, range: Range<Long>) {
     this.getStreamManager(stream.descriptor)
         .updateBatchState(
-            BatchEnvelope(SimpleBatch(Batch.State.PERSISTED), range, stream.descriptor)
+            BatchEnvelope(SimpleBatch(BatchState.PERSISTED), range, stream.descriptor)
         )
 }

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/DestinationTaskLauncherUTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/DestinationTaskLauncherUTest.kt
@@ -7,8 +7,8 @@ package io.airbyte.cdk.load.task
 import io.airbyte.cdk.load.command.DestinationCatalog
 import io.airbyte.cdk.load.command.DestinationConfiguration
 import io.airbyte.cdk.load.command.DestinationStream
-import io.airbyte.cdk.load.message.Batch
 import io.airbyte.cdk.load.message.BatchEnvelope
+import io.airbyte.cdk.load.message.BatchState
 import io.airbyte.cdk.load.message.ChannelMessageQueue
 import io.airbyte.cdk.load.message.CheckpointMessageWrapped
 import io.airbyte.cdk.load.message.DestinationRecordRaw
@@ -194,11 +194,11 @@ class DestinationTaskLauncherUTest {
         val descriptor = DestinationStream.Descriptor("namespace", "name")
         destinationTaskLauncher.handleNewBatch(
             descriptor,
-            BatchEnvelope(SimpleBatch(Batch.State.COMPLETE), null, descriptor)
+            BatchEnvelope(SimpleBatch(BatchState.COMPLETE), null, descriptor)
         )
         destinationTaskLauncher.handleNewBatch(
             descriptor,
-            BatchEnvelope(SimpleBatch(Batch.State.COMPLETE), null, descriptor)
+            BatchEnvelope(SimpleBatch(BatchState.COMPLETE), null, descriptor)
         )
         coVerify(exactly = 1) { closeStreamTaskFactory.make(any(), any()) }
     }

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/internal/LoadPipelineStepTaskUTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/internal/LoadPipelineStepTaskUTest.kt
@@ -5,7 +5,7 @@
 package io.airbyte.cdk.load.task.internal
 
 import io.airbyte.cdk.load.command.DestinationStream
-import io.airbyte.cdk.load.message.Batch
+import io.airbyte.cdk.load.message.BatchState
 import io.airbyte.cdk.load.message.PartitionedQueue
 import io.airbyte.cdk.load.message.PipelineEndOfStream
 import io.airbyte.cdk.load.message.PipelineEvent
@@ -51,7 +51,7 @@ class LoadPipelineStepTaskUTest {
         override fun close() {}
     }
 
-    data class MyBatch(override val state: Batch.State) : WithBatchState
+    data class MyBatch(override val state: BatchState) : WithBatchState
 
     @BeforeEach
     fun setup() {
@@ -225,9 +225,9 @@ class LoadPipelineStepTaskUTest {
             {
                 when (acceptCalls++ % 4) {
                     0 -> NoOutput(Closeable())
-                    1 -> FinalOutput(MyBatch(Batch.State.PROCESSED))
-                    2 -> FinalOutput(MyBatch(Batch.State.PERSISTED))
-                    3 -> FinalOutput(MyBatch(Batch.State.COMPLETE))
+                    1 -> FinalOutput(MyBatch(BatchState.PROCESSED))
+                    2 -> FinalOutput(MyBatch(BatchState.PERSISTED))
+                    3 -> FinalOutput(MyBatch(BatchState.COMPLETE))
                     else -> error("unreachable")
                 }
             }
@@ -247,7 +247,7 @@ class LoadPipelineStepTaskUTest {
         } // only 1/4 are no output
         coVerify(exactly = 12) { batchAccumulatorWithUpdate.accept(any(), any()) } // all have data
         coVerify(exactly = 0) { batchAccumulatorWithUpdate.finish(any()) } // never end-of-stream
-        coVerify(exactly = 6) { batchUpdateQueue.publish(any()) } // half are PERSISTED/COMPLETE
+        coVerify(exactly = 9) { batchUpdateQueue.publish(any()) } // 3/4 are outputs w/ state
     }
 
     @Test
@@ -293,13 +293,13 @@ class LoadPipelineStepTaskUTest {
         repeat(10) {
             coEvery { batchAccumulatorWithUpdate.accept(any(), stream1States[it]) } returns
                 if (it % 3 == 0) {
-                    FinalOutput(MyBatch(Batch.State.PERSISTED))
+                    FinalOutput(MyBatch(BatchState.PERSISTED))
                 } else {
                     NoOutput(stream1States[it + 1])
                 }
             coEvery { batchAccumulatorWithUpdate.accept(any(), stream2States[it]) } returns
                 if (it % 2 == 0) {
-                    FinalOutput(MyBatch(Batch.State.PERSISTED))
+                    FinalOutput(MyBatch(BatchState.PERSISTED))
                 } else {
                     NoOutput(stream2States[it + 1])
                 }
@@ -319,7 +319,7 @@ class LoadPipelineStepTaskUTest {
             }
 
         coEvery { batchAccumulatorWithUpdate.finish(any()) } returns
-            FinalOutput(MyBatch(Batch.State.COMPLETE))
+            FinalOutput(MyBatch(BatchState.COMPLETE))
         coEvery { batchUpdateQueue.publish(any()) } returns Unit
 
         task.execute()
@@ -350,9 +350,9 @@ class LoadPipelineStepTaskUTest {
         coEvery { batchAccumulatorWithUpdate.accept("stream2_value", any()) } returns
             NoOutput(Closeable(2))
         coEvery { batchAccumulatorWithUpdate.finish(Closeable(1)) } returns
-            FinalOutput(MyBatch(Batch.State.COMPLETE))
+            FinalOutput(MyBatch(BatchState.COMPLETE))
         coEvery { batchAccumulatorWithUpdate.finish(Closeable(2)) } returns
-            FinalOutput(MyBatch(Batch.State.PERSISTED))
+            FinalOutput(MyBatch(BatchState.PERSISTED))
 
         coEvery { inputFlow.collect(any()) } coAnswers
             {
@@ -381,13 +381,19 @@ class LoadPipelineStepTaskUTest {
             BatchStateUpdate(
                 key1.stream,
                 mapOf(CheckpointId(0) to 15L, CheckpointId(1) to 51L),
-                Batch.State.COMPLETE
+                BatchState.COMPLETE,
+                batchAccumulatorNoUpdate::class.java.simpleName,
+                part,
+                inputCount = 12L
             )
         val expectedBatchUpdateStream2 =
             BatchStateUpdate(
                 key2.stream,
                 mapOf(CheckpointId(1) to 6L, CheckpointId(2) to 22L, CheckpointId(3) to 38L),
-                Batch.State.PERSISTED
+                BatchState.PERSISTED,
+                batchAccumulatorNoUpdate::class.java.simpleName,
+                part,
+                inputCount = 12L
             )
         coVerify(exactly = 1) { batchUpdateQueue.publish(expectedBatchUpdateStream1) }
         coVerify(exactly = 1) { batchUpdateQueue.publish(expectedBatchUpdateStream2) }

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/message/object_storage/ObjectStorageBatch.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/message/object_storage/ObjectStorageBatch.kt
@@ -7,6 +7,7 @@ package io.airbyte.cdk.load.message.object_storage
 import io.airbyte.cdk.load.file.object_storage.Part
 import io.airbyte.cdk.load.file.object_storage.RemoteObject
 import io.airbyte.cdk.load.message.Batch
+import io.airbyte.cdk.load.message.BatchState
 
 sealed interface ObjectStorageBatch : Batch
 
@@ -14,7 +15,7 @@ sealed interface ObjectStorageBatch : Batch
 // Returned by the batch accumulator after processing records.
 data class LoadablePart(val part: Part) : ObjectStorageBatch {
     override val groupId = null
-    override val state = Batch.State.PROCESSED
+    override val state = BatchState.PROCESSED
 
     // Hide the data from the logs
     override fun toString(): String {
@@ -25,7 +26,7 @@ data class LoadablePart(val part: Part) : ObjectStorageBatch {
 // An UploadablePart that has been uploaded to an incomplete object.
 // Returned by processBatch
 data class IncompletePartialUpload(val key: String) : ObjectStorageBatch {
-    override val state: Batch.State = Batch.State.STAGED
+    override val state: BatchState = BatchState.STAGED
     override val groupId: String = key
 }
 
@@ -35,6 +36,6 @@ data class LoadedObject<T : RemoteObject<*>>(
     val fileNumber: Long,
     val isEmpty: Boolean
 ) : ObjectStorageBatch {
-    override val state: Batch.State = Batch.State.COMPLETE
+    override val state: BatchState = BatchState.COMPLETE
     override val groupId = remoteObject.key
 }

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/pipline/object_storage/ObjectLoaderPartFormatter.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/pipline/object_storage/ObjectLoaderPartFormatter.kt
@@ -12,8 +12,10 @@ import io.airbyte.cdk.load.file.object_storage.ObjectStorageClient
 import io.airbyte.cdk.load.file.object_storage.Part
 import io.airbyte.cdk.load.file.object_storage.PartFactory
 import io.airbyte.cdk.load.file.object_storage.PathFactory
+import io.airbyte.cdk.load.message.BatchState
 import io.airbyte.cdk.load.message.DestinationRecordRaw
 import io.airbyte.cdk.load.message.StreamKey
+import io.airbyte.cdk.load.message.WithBatchState
 import io.airbyte.cdk.load.pipeline.BatchAccumulator
 import io.airbyte.cdk.load.pipeline.BatchAccumulatorResult
 import io.airbyte.cdk.load.pipeline.FinalOutput
@@ -62,7 +64,10 @@ class ObjectLoaderPartFormatter<T : OutputStream>(
         }
     }
 
-    @JvmInline value class FormattedPart(val part: Part)
+    data class FormattedPart(
+        val part: Part,
+        override val state: BatchState = BatchState.PROCESSED
+    ) : WithBatchState
 
     private suspend fun newState(stream: DestinationStream): State<T> {
         // Determine unique file name.

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/pipline/object_storage/ObjectLoaderUploadCompleter.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/pipline/object_storage/ObjectLoaderUploadCompleter.kt
@@ -6,7 +6,7 @@ package io.airbyte.cdk.load.pipline.object_storage
 
 import io.airbyte.cdk.load.file.object_storage.Part
 import io.airbyte.cdk.load.file.object_storage.PartBookkeeper
-import io.airbyte.cdk.load.message.Batch
+import io.airbyte.cdk.load.message.BatchState
 import io.airbyte.cdk.load.message.WithBatchState
 import io.airbyte.cdk.load.pipeline.BatchAccumulator
 import io.airbyte.cdk.load.pipeline.BatchAccumulatorResult
@@ -34,7 +34,7 @@ class ObjectLoaderUploadCompleter :
         }
     }
 
-    data class UploadResult(override val state: Batch.State) : WithBatchState
+    data class UploadResult(override val state: BatchState) : WithBatchState
 
     override suspend fun start(key: ObjectKey, part: Int): State {
         val bookkeeper = PartBookkeeper()
@@ -61,7 +61,7 @@ class ObjectLoaderUploadCompleter :
                         "Loaded part ${input.partIndex} (isFinal=${input.isFinal}) completes ${state.objectKey}, finishing (state $state)"
                     }
                     input.upload.await().complete()
-                    FinalOutput(UploadResult(Batch.State.COMPLETE))
+                    FinalOutput(UploadResult(BatchState.COMPLETE))
                 } else {
                     log.info {
                         "After loaded part ${input.partIndex} (isFinal=${input.isFinal}), ${state.objectKey} still incomplete, not finishing (state $state)"
@@ -80,6 +80,6 @@ class ObjectLoaderUploadCompleter :
          * Should never be called until end-of-stream. There should ever be one completer worker,
          * and the enclosing step should be configured not to flush.
          */
-        return FinalOutput(UploadResult(Batch.State.COMPLETE))
+        return FinalOutput(UploadResult(BatchState.COMPLETE))
     }
 }

--- a/airbyte-integrations/connectors/destination-mssql/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-mssql/metadata.yaml
@@ -16,7 +16,7 @@ data:
             type: GSM
   connectorType: destination
   definitionId: d4353156-9217-4cad-8dd7-c108fd4f74cf
-  dockerImageTag: 2.1.1
+  dockerImageTag: 2.1.2
   dockerRepository: airbyte/destination-mssql
   documentationUrl: https://docs.airbyte.com/integrations/destinations/mssql
   githubIssueLabel: destination-mssql

--- a/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLStreamLoader.kt
+++ b/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLStreamLoader.kt
@@ -6,6 +6,7 @@ package io.airbyte.integrations.destination.mssql.v2
 
 import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.message.Batch
+import io.airbyte.cdk.load.message.BatchState
 import io.airbyte.cdk.load.message.DestinationRecordRaw
 import io.airbyte.cdk.load.message.SimpleBatch
 import javax.sql.DataSource
@@ -53,6 +54,6 @@ class MSSQLStreamLoader(
         }
 
         // Indicate that the batch has been completely processed
-        return SimpleBatch(Batch.State.COMPLETE)
+        return SimpleBatch(BatchState.COMPLETE)
     }
 }

--- a/docs/integrations/destinations/mssql.md
+++ b/docs/integrations/destinations/mssql.md
@@ -158,6 +158,7 @@ See the [Getting Started: Configuration section](#configuration) of this guide f
 
 | Version    | Date       | Pull Request                                               | Subject                                                                                             |
 |:-----------|:-----------|:-----------------------------------------------------------|:----------------------------------------------------------------------------------------------------|
+| 2.1.2      | 2025-03-25 | [56346](https://github.com/airbytehq/airbyte/pull/56346)   | Internal refactor                                                                                   |
 | 2.1.1      | 2025-03-24 | [56355](https://github.com/airbytehq/airbyte/pull/56355)   | Upgrade to airbyte/java-connector-base:2.0.1 to be M4 compatible.                                   |
 | 2.1.0      | 2025-03-24 | [55849](https://github.com/airbytehq/airbyte/pull/55849)   | Misc. bugfixes in type-handling (esp. in complex types)                                             |
 | 2.0.5      | 2025-03-24 | [55904](https://github.com/airbytehq/airbyte/pull/55904)   | Fix handling of invalid schemas (correctly JSON-serialize values)                                   |


### PR DESCRIPTION
## What
This is all quality-of-life. Before we were just counting COMPLETE and PERSISTED (ackable) records. Now we keep detailed information per stage/partition about exactly what we've counted. Additionally I cleaned up Batch.State (now BatchState) and deprecated all the old stuff.

It also adds some detailed opt-in debug logging that can be turned on when needed. Similar to the detailed logging in the old interface, but more user-friendly. Ie:

```
Stream test20250322ozzl:testInsertRecords: Records Read: 1000000 (done: true)
ObjectLoaderPartFormatter[0](PROCESSED): 500000 records (done: true, saw eos at input 500000)
ObjectLoaderPartFormatter[1](PROCESSED): 500000 records (done: true, saw eos at input 500000)
ObjectLoaderPartFormatter[TOTAL](PROCESSED): 1000000 records (done: true, saw eos at input 1000000)
ObjectLoaderPartLoader[0](STAGED): 148798 records  (inputs: 6, done: false)
ObjectLoaderPartLoader[1](STAGED): 198378 records  (inputs: 8, done: true, saw eos at input 8)
ObjectLoaderPartLoader[2](STAGED): 202489 records  (inputs: 9, done: true, saw eos at input 9)
ObjectLoaderPartLoader[3](STAGED): 148740 records  (inputs: 6, done: false)
ObjectLoaderPartLoader[4](STAGED): 198378 records  (inputs: 8, done: true, saw eos at input 8)
ObjectLoaderPartLoader[TOTAL](STAGED): 896783 records  (inputs: 37, done: true, saw eos at input 25)
ObjectLoaderUploadCompleter[0](COMPLETE): 4084 records  (inputs: 1, done: false)
ObjectLoaderUploadCompleter[TOTAL](COMPLETE): 4084 records  (inputs: 1, done: false)
```

I found this critical for debugging an issue exposed by the bulk loader work. It also enables asserting against bad counts / out-of-order processing, which caused a specific issue during testing. (Bug-fix/guards for that impending. The issue doesn't effect anyone using DirectLoader, which is currently all our production connectors.)

## Review guide
Mostly name changes. The functional stuff & new logging is in the StreamManager. Also `LoadPipelineStepTask` and `UpdateBatchStateTask` are tweaked to collect/pass the new information, and I added `BatchState` to all of the steps in `ObjectLoader.`

`StreamManager` already had rigorous tests, which still pass. I also re-tested S3, S3DataLake, and the (unmerged) MSSQL changes with this, both ITs and Perf Tests.

(NOTE: This is on top of the [S3 Data Lake setup fix](https://github.com/airbytehq/airbyte/pull/56347/files) because the impending bulk load PR depends on both.)
