### PR TITLE
[Dest-S3DataLake]: Bugfix: New interface setup does not always await …

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/state/SyncManager.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/state/SyncManager.kt
@@ -56,6 +56,9 @@ interface SyncManager {
 
     suspend fun awaitInputProcessingComplete()
     suspend fun awaitDestinationResult(): DestinationResult
+
+    suspend fun markSetupComplete()
+    suspend fun awaitSetupComplete()
 }
 
 @SuppressFBWarnings(
@@ -70,6 +73,7 @@ class DefaultSyncManager(
         ConcurrentHashMap<DestinationStream.Descriptor, CompletableDeferred<Result<StreamLoader>>>()
     private val inputConsumed = CompletableDeferred<Boolean>()
     private val checkpointsProcessed = CompletableDeferred<Boolean>()
+    private val setupComplete = CompletableDeferred<Unit>()
 
     override fun getStreamManager(stream: DestinationStream.Descriptor): StreamManager {
         return streamManagers[stream] ?: throw IllegalArgumentException("Stream not found: $stream")
@@ -151,6 +155,14 @@ class DefaultSyncManager(
 
     override suspend fun markCheckpointsProcessed() {
         checkpointsProcessed.complete(true)
+    }
+
+    override suspend fun markSetupComplete() {
+        setupComplete.complete(Unit)
+    }
+
+    override suspend fun awaitSetupComplete() {
+        setupComplete.await()
     }
 }
 

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/DestinationTaskLauncher.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/DestinationTaskLauncher.kt
@@ -292,6 +292,7 @@ class DefaultDestinationTaskLauncher<K : WithStream>(
     }
 
     override suspend fun handleSetupComplete() {
+        syncManager.markSetupComplete()
         if (loadPipeline == null) {
             log.info { "Setup task complete, opening streams" }
             catalog.streams.forEach { openStreamQueue.publish(it) }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/InputConsumerTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/InputConsumerTask.kt
@@ -149,10 +149,12 @@ class DefaultInputConsumerTask(
     ) {
         val stream = reserved.value.stream
         unopenedStreams.remove(stream.descriptor)?.let {
-            log.info { "Saw first record for stream $stream; initializing" }
+            log.info { "Saw first record for stream $stream; awaiting setup complete" }
+            syncManager.awaitSetupComplete()
             // Note, since we're not spilling to disk, there is nothing to do with
             // any records before initialization is complete, so we'll wait here
             // for it to finish.
+            log.info { "Setup complete, starting stream $stream" }
             openStreamQueue.publish(it)
             syncManager.getOrAwaitStreamLoader(stream.descriptor)
             log.info { "Initialization for stream $stream complete" }

--- a/airbyte-integrations/connectors/destination-s3-data-lake/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/metadata.yaml
@@ -26,7 +26,7 @@ data:
             alias: airbyte-connector-testing-secret-store
   connectorType: destination
   definitionId: 716ca874-520b-4902-9f80-9fad66754b89
-  dockerImageTag: 0.3.20
+  dockerImageTag: 0.3.21
   dockerRepository: airbyte/destination-s3-data-lake
   documentationUrl: https://docs.airbyte.com/integrations/destinations/s3-data-lake
   githubIssueLabel: destination-s3-data-lake

--- a/docs/integrations/destinations/s3-data-lake.md
+++ b/docs/integrations/destinations/s3-data-lake.md
@@ -306,7 +306,8 @@ Now, you can identify the latest version of the 'Alice' record by querying wheth
   <summary>Expand to review</summary>
 
 | Version | Date       | Pull Request                                               | Subject                                                                        |
-|:--------|:-----------| :--------------------------------------------------------- |:-------------------------------------------------------------------------------|
+|:--------|:-----------|:-----------------------------------------------------------|:-------------------------------------------------------------------------------|
+| 0.3.21  | 2025-03-22 | [\#56347](https://github.com/airbytehq/airbyte/pull/56347) | Bugfix: stream start does not always await iceberg setup                       |
 | 0.3.20  | 2025-03-24 | [\#55849](https://github.com/airbytehq/airbyte/pull/55849) | Internal refactoring                                                           |
 | 0.3.19  | 2025-03-19 | [\#55798](https://github.com/airbytehq/airbyte/pull/55798) | CDK: Typing improvements                                                       |
 | 0.3.18  | 2025-03-18 | [\#55811](https://github.com/airbytehq/airbyte/pull/55811) | CDK: Pass DestinationStream around vs Descriptor                               |


### PR DESCRIPTION
## What
The load pipeline new interface waits to start a stream (StreamLoader::start) until the first time it sees data for it. However, it does not wait on setup (DestitionWriter::setup) to complete running start. This caused issues in the new BulkLoader. It really *should* cause issues in S3DataLake, which relies on setup, but I can't find any sign that it does. Tests all pass before and after this. However I thought I'd go ahead and break this out as a bugfix for S3DataLake specifically.


