### PR TITLE
Load CDK: ObjectLoader queue size derived from avail mem

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/integrationTest/kotlin/io/airbyte/cdk/load/mock_integration_test/MockDestinationWriter.kt
+++ b/airbyte-cdk/bulk/core/load/src/integrationTest/kotlin/io/airbyte/cdk/load/mock_integration_test/MockDestinationWriter.kt
@@ -10,6 +10,7 @@ import io.airbyte.cdk.load.command.Dedupe
 import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.data.ObjectValue
 import io.airbyte.cdk.load.message.Batch
+import io.airbyte.cdk.load.message.BatchState
 import io.airbyte.cdk.load.message.DestinationFile
 import io.airbyte.cdk.load.message.DestinationRecordAirbyteValue
 import io.airbyte.cdk.load.message.SimpleBatch
@@ -39,10 +40,10 @@ class MockStreamLoader(override val stream: DestinationStream) : StreamLoader {
     }
 
     data class LocalBatch(val records: List<DestinationRecordAirbyteValue>) : MockBatch() {
-        override val state = Batch.State.STAGED
+        override val state = BatchState.STAGED
     }
     data class LocalFileBatch(val file: DestinationFile) : MockBatch() {
-        override val state = Batch.State.STAGED
+        override val state = BatchState.STAGED
     }
 
     override suspend fun close(streamFailure: StreamProcessingFailed?) {
@@ -106,7 +107,7 @@ class MockStreamLoader(override val stream: DestinationStream) : StreamLoader {
                 // in a real sync, because we would always either get more
                 // data or an end-of-stream that would force a final flush.
                 delay(100L)
-                SimpleBatch(state = Batch.State.COMPLETE)
+                SimpleBatch(state = BatchState.COMPLETE)
             }
             else -> throw IllegalStateException("Unexpected batch type: $batch")
         }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/BatchState.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/BatchState.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.load.message
+
+/**
+ * Represents the state of a batch of records as it moves through processing. These are generic
+ * stages for bookkeeping, which CDK interface devs can assign to processing stages as they see fit.
+ * The only significant values are
+ * - [BatchState.PERSISTED] Records will be considered recoverably persisted and checkpoints will be
+ * acked to the orchestrator.
+ * - [BatchState.COMPLETE] All per-batch processing is done. (Post-processing may still occur during
+ * close-of-stream). Records are considered PERSISTED (ie, will be acked if not already). If all
+ * records are COMPLETE, and end-of-stream has been read, the stream will be considered complete and
+ * will be closed.
+ * - All other values are for bookkeeping convenience only.
+ */
+enum class BatchState {
+    PROCESSED, // records have been seen and transformed/formatted/validated (ie, create a part)
+    STAGED, // staged locally or remotely-but-not-yet-complete (ie, partial multi-part upload)
+    LOADED, // staged remotely but in a non-recoverable way (ie, a remote object in bulk load)
+    PERSISTED, // recoverable (framework can ack), but not yet complete
+    COMPLETE; // completely done; implies persisted (ie, framework can ack)
+
+    fun isPersisted(): Boolean =
+        when (this) {
+            PERSISTED,
+            COMPLETE -> true
+            else -> false
+        }
+}

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/WithBatchState.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/WithBatchState.kt
@@ -11,5 +11,5 @@ package io.airbyte.cdk.load.message
  * internal state.
  */
 interface WithBatchState {
-    val state: Batch.State
+    val state: BatchState
 }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/pipeline/BatchStateUpdate.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/pipeline/BatchStateUpdate.kt
@@ -5,20 +5,28 @@
 package io.airbyte.cdk.load.pipeline
 
 import io.airbyte.cdk.load.command.DestinationStream
-import io.airbyte.cdk.load.message.Batch
+import io.airbyte.cdk.load.message.BatchState
 import io.airbyte.cdk.load.state.CheckpointId
 
 /** Used internally by the CDK to track record ranges to ack. */
 sealed interface BatchUpdate {
     val stream: DestinationStream.Descriptor
+    val taskName: String
+    val part: Int
 }
 
 data class BatchStateUpdate(
     override val stream: DestinationStream.Descriptor,
     val checkpointCounts: Map<CheckpointId, Long>,
-    val state: Batch.State,
+    val state: BatchState,
+    override val taskName: String,
+    override val part: Int,
+    val inputCount: Long = 0L
 ) : BatchUpdate
 
 data class BatchEndOfStream(
     override val stream: DestinationStream.Descriptor,
+    override val taskName: String,
+    override val part: Int,
+    val totalInputCount: Long
 ) : BatchUpdate

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/pipeline/DirectLoadRecordAccumulator.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/pipeline/DirectLoadRecordAccumulator.kt
@@ -4,7 +4,7 @@
 
 package io.airbyte.cdk.load.pipeline
 
-import io.airbyte.cdk.load.message.Batch
+import io.airbyte.cdk.load.message.BatchState
 import io.airbyte.cdk.load.message.DestinationRecordRaw
 import io.airbyte.cdk.load.message.WithBatchState
 import io.airbyte.cdk.load.message.WithStream
@@ -14,7 +14,7 @@ import io.airbyte.cdk.load.write.DirectLoaderFactory
 import io.micronaut.context.annotation.Requires
 import jakarta.inject.Singleton
 
-data class DirectLoadAccResult(override val state: Batch.State) : WithBatchState
+data class DirectLoadAccResult(override val state: BatchState) : WithBatchState
 
 /**
  * Used internally by the CDK to wrap the client-provided DirectLoader in a generic
@@ -37,13 +37,13 @@ class DirectLoadRecordAccumulator<S : DirectLoader, K : WithStream>(
         state.accept(input).let {
             return when (it) {
                 is Incomplete -> NoOutput(state)
-                is Complete -> FinalOutput(DirectLoadAccResult(Batch.State.COMPLETE))
+                is Complete -> FinalOutput(DirectLoadAccResult(BatchState.COMPLETE))
             }
         }
     }
 
     override suspend fun finish(state: S): FinalOutput<S, DirectLoadAccResult> {
         state.finish()
-        return FinalOutput(DirectLoadAccResult(Batch.State.COMPLETE))
+        return FinalOutput(DirectLoadAccResult(BatchState.COMPLETE))
     }
 }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/state/StreamManager.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/state/StreamManager.kt
@@ -10,6 +10,7 @@ import com.google.common.collect.TreeRangeSet
 import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.message.Batch
 import io.airbyte.cdk.load.message.BatchEnvelope
+import io.airbyte.cdk.load.message.BatchState
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.micronaut.context.annotation.Secondary
 import jakarta.inject.Singleton
@@ -25,6 +26,15 @@ data class StreamProcessingFailed(val streamException: Exception) : StreamResult
 data object StreamProcessingSucceeded : StreamResult
 
 @JvmInline value class CheckpointId(val id: Int)
+
+data class CheckpointValue(
+    val records: Long,
+// TODO: File bytes moved
+) {
+    operator fun plus(other: CheckpointValue): CheckpointValue {
+        return CheckpointValue(records + other.records)
+    }
+}
 
 /** Manages the state of a single stream. */
 interface StreamManager {
@@ -57,21 +67,24 @@ interface StreamManager {
     fun markCheckpoint(): Pair<Long, Long>
 
     /** Record that the given batch's state has been reached for the associated range(s). */
+    @Deprecated("Old interface. New interface uses incrementCheckpointCounts")
     fun <B : Batch> updateBatchState(batch: BatchEnvelope<B>)
 
     /**
      * True if all are true:
      * * all records have been seen (ie, we've counted an end-of-stream)
-     * * a [Batch.State.COMPLETE] batch range has been seen covering every record
+     * * a [BatchState.COMPLETE] batch range has been seen covering every record
      *
      * Does NOT require that the stream be closed.
      */
+    @Deprecated("Old interface. New interface uses isBatchProcessingCompleteForCheckpoints")
     fun isBatchProcessingComplete(): Boolean
 
     /**
-     * True if all records in [0, index] have at least reached [Batch.State.PERSISTED]. This is
-     * implicitly true if they have all reached [Batch.State.COMPLETE].
+     * True if all records in [0, index] have at least reached [BatchState.PERSISTED]. This is
+     * implicitly true if they have all reached [BatchState.COMPLETE].
      */
+    @Deprecated("Old interface. New interface uses areRecordsPersistedUntilCheckpoint")
     fun areRecordsPersistedUntil(index: Long): Boolean
 
     /**
@@ -101,11 +114,15 @@ interface StreamManager {
      */
     fun getCurrentCheckpointId(): CheckpointId
 
-    /** Update the counts of persisted for a given checkpoint. */
-    fun incrementPersistedCount(checkpointId: CheckpointId, count: Long)
+    fun incrementCheckpointCounts(
+        taskName: String,
+        part: Int,
+        state: BatchState,
+        checkpointCounts: Map<CheckpointId, Long>,
+        inputCount: Long
+    )
 
-    /** Update the counts of completed for a given checkpoint. */
-    fun incrementCompletedCount(checkpointId: CheckpointId, count: Long)
+    fun markTaskEndOfStream(taskName: String, part: Int, finalInputCount: Long)
 
     /**
      * True if persisted counts for each checkpoint up to and including [checkpointId] match the
@@ -125,7 +142,7 @@ class DefaultStreamManager(
 ) : StreamManager {
     private val streamResult = CompletableDeferred<StreamResult>()
 
-    data class CachedRanges(val state: Batch.State, val ranges: RangeSet<Long>)
+    data class CachedRanges(val state: BatchState, val ranges: RangeSet<Long>)
 
     private val cachedRangesById = ConcurrentHashMap<String, CachedRanges>()
 
@@ -136,20 +153,22 @@ class DefaultStreamManager(
     private val markedEndOfStream = AtomicBoolean(false)
     private val receivedComplete = AtomicBoolean(false)
 
-    private val rangesState: ConcurrentHashMap<Batch.State, RangeSet<Long>> = ConcurrentHashMap()
+    private val rangesState: ConcurrentHashMap<BatchState, RangeSet<Long>> = ConcurrentHashMap()
 
-    data class CheckpointCounts(
-        val recordsRead: Long = 0L,
-        val recordsPersisted: AtomicLong = AtomicLong(0L),
-        val recordsCompleted: AtomicLong = AtomicLong(0L),
-    )
     private val nextCheckpointId = AtomicLong(0L)
     private val lastCheckpointRecordIndex = AtomicLong(0L)
-    private val checkpointCounts: ConcurrentHashMap<CheckpointId, CheckpointCounts> =
+    private val recordsReadPerCheckpoint: ConcurrentHashMap<CheckpointId, CheckpointValue> =
         ConcurrentHashMap()
+    data class TaskKey(val name: String, val part: Int)
+    private val namedCheckpointCounts:
+        ConcurrentHashMap<
+            Pair<TaskKey, BatchState>, ConcurrentHashMap<CheckpointId, CheckpointValue>> =
+        ConcurrentHashMap()
+    private val taskInputCounts = ConcurrentHashMap<TaskKey, Long>()
+    private val taskCompletionCounts = ConcurrentHashMap<TaskKey, Long>()
 
     init {
-        Batch.State.entries.forEach { rangesState[it] = TreeRangeSet.create() }
+        BatchState.entries.forEach { rangesState[it] = TreeRangeSet.create() }
     }
 
     override fun incrementReadCount(): Long {
@@ -186,11 +205,11 @@ class DefaultStreamManager(
         val count = recordIndex - lastCheckpointRecordIndex.getAndSet(recordIndex)
 
         val checkpointId = CheckpointId(nextCheckpointId.getAndIncrement().toInt())
-        checkpointCounts.merge(checkpointId, CheckpointCounts(recordsRead = count)) { old, _ ->
-            if (old.recordsRead > 0) {
+        recordsReadPerCheckpoint.merge(checkpointId, CheckpointValue(records = count)) { old, _ ->
+            if (old.records > 0) {
                 throw IllegalStateException("Checkpoint $old already exists")
             }
-            old.copy(recordsRead = count)
+            old.copy(records = count)
         }
 
         return Pair(recordIndex, count)
@@ -220,10 +239,10 @@ class DefaultStreamManager(
 
         stateRangesToAdd.forEach { (stateToSet, rangesToUpdate) ->
             when (stateToSet) {
-                Batch.State.COMPLETE -> {
+                BatchState.COMPLETE -> {
                     // A COMPLETED state implies PERSISTED, so also mark PERSISTED.
-                    addAndMarge(Batch.State.PERSISTED, rangesToUpdate)
-                    addAndMarge(Batch.State.COMPLETE, rangesToUpdate)
+                    addAndMarge(BatchState.PERSISTED, rangesToUpdate)
+                    addAndMarge(BatchState.COMPLETE, rangesToUpdate)
                 }
                 else -> {
                     // For all other states, just mark the state.
@@ -247,10 +266,10 @@ class DefaultStreamManager(
             val readRange = TreeRangeSet.create(listOf(Range.closed(0, recordCount.get())))
             """ Added $stateRangesJoined to ${stream.descriptor.namespace}.${stream.descriptor.name}$groupLineMaybe
             READ:      $readRange (complete=${markedEndOfStream.get()})
-            PROCESSED: ${rangesState[Batch.State.PROCESSED]}
-            STAGED:    ${rangesState[Batch.State.STAGED]}
-            PERSISTED: ${rangesState[Batch.State.PERSISTED]}
-            COMPLETE:  ${rangesState[Batch.State.COMPLETE]}
+            PROCESSED: ${rangesState[BatchState.PROCESSED]}
+            STAGED:    ${rangesState[BatchState.STAGED]}
+            PERSISTED: ${rangesState[BatchState.PERSISTED]}
+            COMPLETE:  ${rangesState[BatchState.COMPLETE]}
         """.trimIndent()
         }
     }
@@ -274,7 +293,7 @@ class DefaultStreamManager(
         return TreeRangeSet.create(newRanges)
     }
 
-    private fun addAndMarge(state: Batch.State, ranges: RangeSet<Long>) {
+    private fun addAndMarge(state: BatchState, ranges: RangeSet<Long>) {
         rangesState[state] =
             (rangesState[state]?.let {
                     it.addAll(ranges)
@@ -285,7 +304,7 @@ class DefaultStreamManager(
     }
 
     /** True if all records in `[0, index)` have reached the given state. */
-    private fun isProcessingCompleteForState(index: Long, state: Batch.State): Boolean {
+    private fun isProcessingCompleteForState(index: Long, state: BatchState): Boolean {
         val completeRanges = rangesState[state]!!
 
         // Force the ranges to overlap at their endpoints, in order to work around
@@ -315,11 +334,11 @@ class DefaultStreamManager(
             return true
         }
 
-        return isProcessingCompleteForState(recordCount.get(), Batch.State.COMPLETE)
+        return isProcessingCompleteForState(recordCount.get(), BatchState.COMPLETE)
     }
 
     override fun areRecordsPersistedUntil(index: Long): Boolean {
-        return isProcessingCompleteForState(index, Batch.State.PERSISTED)
+        return isProcessingCompleteForState(index, BatchState.PERSISTED)
     }
 
     override fun markProcessingSucceeded() {
@@ -345,37 +364,70 @@ class DefaultStreamManager(
         return CheckpointId(nextCheckpointId.get().toInt())
     }
 
-    override fun incrementPersistedCount(checkpointId: CheckpointId, count: Long) {
-        checkpointCounts
-            .getOrPut(checkpointId) { CheckpointCounts() }
-            .recordsPersisted
-            .addAndGet(count)
+    override fun incrementCheckpointCounts(
+        taskName: String,
+        part: Int,
+        state: BatchState,
+        checkpointCounts: Map<CheckpointId, Long>,
+        inputCount: Long
+    ) {
+        checkpointCounts.forEach { (checkpointId, recordCount) ->
+            val taskKey = TaskKey(taskName, part)
+            if (taskCompletionCounts.containsKey(taskKey)) {
+                throw IllegalStateException(
+                    """"$taskKey received input after seeing end-of-stream
+                        (checkpointCounts=$checkpointCounts, inputCount=$inputCount, sawEosAt=${taskCompletionCounts[taskKey]})                         if (stateStore.streamsEnded.contains(input.key.stream)) {\n" +
+                        This indicates data was processed out of order and future bookkeeping might be corrupt. Failing hard."""
+                )
+            }
+            namedCheckpointCounts
+                .getOrPut(TaskKey(taskName, part) to state) { ConcurrentHashMap() }
+                .merge(checkpointId, CheckpointValue(recordCount)) { old, new -> old + new }
+        }
+        taskInputCounts.merge(TaskKey(taskName, part), inputCount) { old, new -> old + new }
     }
 
-    override fun incrementCompletedCount(checkpointId: CheckpointId, count: Long) {
-        checkpointCounts
-            .getOrPut(checkpointId) { CheckpointCounts() }
-            .recordsCompleted
-            .addAndGet(count)
+    override fun markTaskEndOfStream(taskName: String, part: Int, finalInputCount: Long) {
+        taskCompletionCounts.putIfAbsent(TaskKey(taskName, part), finalInputCount)?.let {
+            throw IllegalStateException(
+                "End-of-stream reported at $finalInputCount already seen for $taskName[$part] at $it"
+            )
+        }
     }
 
     override fun areRecordsPersistedUntilCheckpoint(checkpointId: CheckpointId): Boolean {
-        val counts = checkpointCounts.filter { it.key.id <= checkpointId.id }
+        val counts = recordsReadPerCheckpoint.filter { it.key.id <= checkpointId.id }
         if (counts.size < checkpointId.id + 1) {
             return false
         }
 
-        val (readCount, persistedCount, completedCount) =
-            counts.toList().fold(Triple(0L, 0L, 0L)) { acc, (_, checkpointCount) ->
-                Triple(
-                    acc.first + checkpointCount.recordsRead,
-                    acc.second + checkpointCount.recordsPersisted.get(),
-                    acc.third + checkpointCount.recordsCompleted.get(),
-                )
-            }
+        val readCount = counts.map { it.value.records }.sum()
+        val persistedCount =
+            namedCheckpointCounts
+                .filter { (key, _) -> key.second == BatchState.PERSISTED }
+                .values
+                .fold(0L) { acc, checkpointIdToValue ->
+                    acc +
+                        checkpointIdToValue
+                            .filterKeys { it.id <= checkpointId.id }
+                            .values
+                            .sumOf { it.records }
+                }
+        val completedCount =
+            namedCheckpointCounts
+                .filter { (key, _) -> key.second == BatchState.COMPLETE }
+                .values
+                .fold(0L) { acc, checkpointIdToValue ->
+                    acc +
+                        checkpointIdToValue
+                            .filterKeys { it.id <= checkpointId.id }
+                            .values
+                            .sumOf { it.records }
+                }
         if (persistedCount == readCount) {
             return true
         }
+
         // Completed implies persisted.
         return completedCount == readCount
     }
@@ -390,7 +442,64 @@ class DefaultStreamManager(
             return true
         }
 
-        val completedCount = checkpointCounts.values.sumOf { it.recordsCompleted.get() }
+        // Detailed debug logging for completeness checks. It's a little verbose but is only emitted
+        // per-batch (every 10-20mb in most cases).
+        // TODO: A more user-friendly aggregated version of this on a regular cadence?
+        log.debug {
+            val header =
+                "\nStream ${stream.descriptor.namespace}:${stream.descriptor.name}: Records Read: $readCount (done: ${markedEndOfStream.get()})"
+            val byPart =
+                namedCheckpointCounts.map { (key, value) ->
+                    val (taskKey, state) = key
+                    val recordCount = value.values.sumOf { it.records }
+                    val inputCount = taskInputCounts[taskKey] ?: 0L
+                    val isCompleteCount = taskCompletionCounts[taskKey]
+                    Triple(taskKey, state, Triple(recordCount, inputCount, isCompleteCount))
+                }
+            val byTask =
+                byPart
+                    .groupBy { TaskKey(it.first.name, 999) }
+                    .mapValues {
+                        it.value.fold(Triple(BatchState.PROCESSED, Pair(0L, 0L), null as Long?)) {
+                            z,
+                            x ->
+                            Triple(
+                                x.second,
+                                Pair(
+                                    z.second.first + x.third.first,
+                                    z.second.second + x.third.second
+                                ),
+                                (z.third?.plus(x.third.third ?: 0L)) ?: x.third.third
+                            )
+                        }
+                    }
+                    .map { (taskKey, stateAndCountsAndComplete) ->
+                        val (state, counts, isCompleteCount) = stateAndCountsAndComplete
+                        Triple(taskKey, state, Triple(counts.first, counts.second, isCompleteCount))
+                    }
+            val sortedAndFormatted =
+                (byPart + byTask)
+                    .sortedBy { (taskKey, state, _) -> state.ordinal * 1_000 + taskKey.part }
+                    .map { (taskKey, state, countsAndComplete) ->
+                        val (recordCount, inputCount, isCompleteCount) = countsAndComplete
+                        val partString = if (taskKey.part == 999) "[TOTAL]" else "[${taskKey.part}]"
+                        val inputString =
+                            if (recordCount == inputCount) "(" else " (inputs: $inputCount, "
+                        val completeString =
+                            if (isCompleteCount == null) "false"
+                            else "true, saw eos at input $isCompleteCount"
+                        "${taskKey.name}$partString($state): $recordCount records ${inputString}done: $completeString)"
+                    }
+            (listOf(header) + sortedAndFormatted).joinToString(separator = "\n")
+        }
+
+        val completedCount =
+            namedCheckpointCounts
+                .filter { (key, _) -> key.second == BatchState.COMPLETE }
+                .values
+                .flatMap { it.values }
+                .sumOf { it.records }
+
         return completedCount == readCount
     }
 }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/state/SyncManager.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/state/SyncManager.kt
@@ -56,6 +56,9 @@ interface SyncManager {
 
     suspend fun awaitInputProcessingComplete()
     suspend fun awaitDestinationResult(): DestinationResult
+
+    suspend fun markSetupComplete()
+    suspend fun awaitSetupComplete()
 }
 
 @SuppressFBWarnings(
@@ -70,6 +73,7 @@ class DefaultSyncManager(
         ConcurrentHashMap<DestinationStream.Descriptor, CompletableDeferred<Result<StreamLoader>>>()
     private val inputConsumed = CompletableDeferred<Boolean>()
     private val checkpointsProcessed = CompletableDeferred<Boolean>()
+    private val setupComplete = CompletableDeferred<Unit>()
 
     override fun getStreamManager(stream: DestinationStream.Descriptor): StreamManager {
         return streamManagers[stream] ?: throw IllegalArgumentException("Stream not found: $stream")
@@ -151,6 +155,14 @@ class DefaultSyncManager(
 
     override suspend fun markCheckpointsProcessed() {
         checkpointsProcessed.complete(true)
+    }
+
+    override suspend fun markSetupComplete() {
+        setupComplete.complete(Unit)
+    }
+
+    override suspend fun awaitSetupComplete() {
+        setupComplete.await()
     }
 }
 

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/DestinationTaskLauncher.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/DestinationTaskLauncher.kt
@@ -292,6 +292,7 @@ class DefaultDestinationTaskLauncher<K : WithStream>(
     }
 
     override suspend fun handleSetupComplete() {
+        syncManager.markSetupComplete()
         if (loadPipeline == null) {
             log.info { "Setup task complete, opening streams" }
             catalog.streams.forEach { openStreamQueue.publish(it) }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/InputConsumerTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/InputConsumerTask.kt
@@ -7,8 +7,8 @@ package io.airbyte.cdk.load.task.internal
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 import io.airbyte.cdk.load.command.DestinationCatalog
 import io.airbyte.cdk.load.command.DestinationStream
-import io.airbyte.cdk.load.message.Batch
 import io.airbyte.cdk.load.message.BatchEnvelope
+import io.airbyte.cdk.load.message.BatchState
 import io.airbyte.cdk.load.message.CheckpointMessage
 import io.airbyte.cdk.load.message.CheckpointMessageWrapped
 import io.airbyte.cdk.load.message.DestinationFile
@@ -134,7 +134,7 @@ class DefaultInputConsumerTask(
                 manager.markEndOfStream(true)
                 val envelope =
                     BatchEnvelope(
-                        SimpleBatch(Batch.State.COMPLETE),
+                        SimpleBatch(BatchState.COMPLETE),
                         streamDescriptor = message.stream.descriptor,
                     )
                 destinationTaskLauncher.handleNewBatch(stream.descriptor, envelope)
@@ -197,7 +197,7 @@ class DefaultInputConsumerTask(
                 manager.markEndOfStream(true)
                 val envelope =
                     BatchEnvelope(
-                        SimpleBatch(Batch.State.COMPLETE),
+                        SimpleBatch(BatchState.COMPLETE),
                         streamDescriptor = message.stream.descriptor,
                     )
                 destinationTaskLauncher.handleNewBatch(stream.descriptor, envelope)

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/InputConsumerTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/InputConsumerTask.kt
@@ -149,10 +149,12 @@ class DefaultInputConsumerTask(
     ) {
         val stream = reserved.value.stream
         unopenedStreams.remove(stream.descriptor)?.let {
-            log.info { "Saw first record for stream $stream; initializing" }
+            log.info { "Saw first record for stream $stream; awaiting setup complete" }
+            syncManager.awaitSetupComplete()
             // Note, since we're not spilling to disk, there is nothing to do with
             // any records before initialization is complete, so we'll wait here
             // for it to finish.
+            log.info { "Setup complete, starting stream $stream" }
             openStreamQueue.publish(it)
             syncManager.getOrAwaitStreamLoader(stream.descriptor)
             log.info { "Initialization for stream $stream complete" }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/LoadPipelineStepTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/LoadPipelineStepTask.kt
@@ -26,6 +26,7 @@ import io.airbyte.cdk.load.task.OnEndOfSync
 import io.airbyte.cdk.load.task.Task
 import io.airbyte.cdk.load.task.TerminalCondition
 import io.airbyte.cdk.load.write.LoadStrategy
+import io.github.oshai.kotlinlogging.KotlinLogging
 import io.micronaut.context.annotation.Requires
 import io.micronaut.context.annotation.Value
 import jakarta.inject.Named
@@ -35,6 +36,12 @@ import java.util.concurrent.atomic.AtomicInteger
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.fold
 
+/**
+ * Accumulator state with the checkpoint counts (Checkpoint Id -> Records Seen) seen since the state
+ * was created.
+ *
+ * Includes a count of the inputs seen since the state was created.
+ */
 data class StateWithCounts<S : AutoCloseable>(
     val accumulatorState: S,
     val checkpointCounts: MutableMap<CheckpointId, Long> = mutableMapOf(),
@@ -59,16 +66,32 @@ class LoadPipelineStepTask<S : AutoCloseable, K1 : WithStream, T, K2 : WithStrea
     private val streamCompletions:
         ConcurrentHashMap<Pair<Int, DestinationStream.Descriptor>, AtomicInteger>
 ) : Task {
+    private val log = KotlinLogging.logger {}
+
+    private val taskName = batchAccumulator::class.java.simpleName
+
     override val terminalCondition: TerminalCondition = OnEndOfSync
 
+    /**
+     * Task-global state. A map of all the keys seen with associated accumulator state and
+     * bookkeeping info. Also includes a global count of inputs seen per stream and fact of stream
+     * end (it is a critical error to receive input for a stream that has ended, as it means that
+     * something is likely wrong with our bookkeeping.)
+     */
+    data class StateStore<K1, S : AutoCloseable>(
+        val stateWithCounts: MutableMap<K1, StateWithCounts<S>> = mutableMapOf(),
+        val streamCounts: MutableMap<DestinationStream.Descriptor, Long> = mutableMapOf(),
+        val streamsEnded: MutableSet<DestinationStream.Descriptor> = mutableSetOf(),
+    )
+
     override suspend fun execute() {
-        inputFlow.fold(mutableMapOf<K1, StateWithCounts<S>>()) { stateStore, input ->
+        inputFlow.fold(StateStore<K1, S>()) { stateStore, input ->
             try {
                 when (input) {
                     is PipelineMessage -> {
                         // Get or create the accumulator state associated w/ the input key.
                         val stateWithCounts =
-                            stateStore
+                            stateStore.stateWithCounts
                                 .getOrPut(input.key) {
                                     StateWithCounts(
                                         accumulatorState = batchAccumulator.start(input.key, part),
@@ -116,7 +139,8 @@ class LoadPipelineStepTask<S : AutoCloseable, K1 : WithStream, T, K2 : WithStrea
                                 handleOutput(
                                     input.key,
                                     stateWithCounts.checkpointCounts,
-                                    finalAccOutput
+                                    finalAccOutput,
+                                    stateWithCounts.inputCount
                                 )
                                 stateWithCounts.checkpointCounts.clear()
                                 0
@@ -127,45 +151,73 @@ class LoadPipelineStepTask<S : AutoCloseable, K1 : WithStream, T, K2 : WithStrea
                         // Update the state if `accept` returned a new state, otherwise evict.
                         if (finalAccState != null) {
                             // If accept returned a new state, update the state store.
-                            stateStore[input.key] =
+                            stateStore.stateWithCounts[input.key] =
                                 stateWithCounts.copy(
                                     accumulatorState = finalAccState,
                                     inputCount = inputCount
                                 )
                         } else {
-                            stateStore.remove(input.key)?.close()
+                            stateStore.stateWithCounts.remove(input.key)?.let {
+                                if (inputCount > 0 || it.checkpointCounts.isNotEmpty()) {
+                                    throw IllegalStateException(
+                                        "State evicted with unhandled input ($inputCount) or checkpoint counts(${it.checkpointCounts})"
+                                    )
+                                }
+                                stateWithCounts.close()
+                            }
                         }
-
+                        stateStore.streamCounts.merge(input.key.stream, 1) { old, new -> old + new }
                         stateStore
                     }
                     is PipelineEndOfStream -> {
-                        // Give any key associated with the stream a chance to finish
-                        val keysToRemove = stateStore.keys.filter { it.stream == input.stream }
+                        val numWorkersSeenEos =
+                            streamCompletions
+                                .getOrPut(Pair(taskIndex, input.stream)) { AtomicInteger(0) }
+                                .incrementAndGet()
+                        val inputCountEos = stateStore.streamCounts[input.stream] ?: 0
+
+                        val keysToRemove =
+                            stateStore.stateWithCounts.keys.filter { it.stream == input.stream }
+
                         keysToRemove.forEach { key ->
-                            stateStore.remove(key)?.let { stored ->
-                                val output = batchAccumulator.finish(stored.accumulatorState).output
-                                handleOutput(key, stored.checkpointCounts, output)
-                                stored.close()
+                            log.warn { "Finishing state for $key remaining after end-of-stream" }
+                            stateStore.stateWithCounts.remove(key)?.let { stateWithCounts ->
+                                val output =
+                                    batchAccumulator.finish(stateWithCounts.accumulatorState).output
+                                handleOutput(
+                                    key,
+                                    stateWithCounts.checkpointCounts,
+                                    output,
+                                    stateWithCounts.inputCount
+                                )
+                                stateWithCounts.close()
                             }
                         }
 
                         // Only forward end-of-stream if ALL workers have seen end-of-stream.
-                        if (
-                            streamCompletions
-                                .getOrPut(Pair(taskIndex, input.stream)) { AtomicInteger(0) }
-                                .incrementAndGet() == numWorkers
-                        ) {
+                        if (numWorkersSeenEos == numWorkers) {
+                            log.info {
+                                "$this saw end-of-stream for ${input.stream} after $inputCountEos inputs, all workers complete"
+                            }
                             outputQueue?.broadcast(PipelineEndOfStream(input.stream))
+                        } else {
+                            log.info {
+                                "$this saw end-of-stream for ${input.stream} after $inputCountEos inputs, ${numWorkers - numWorkersSeenEos} workers remaining"
+                            }
                         }
 
-                        batchUpdateQueue.publish(BatchEndOfStream(input.stream))
+                        // Track which tasks are complete
+                        stateStore.streamsEnded.add(input.stream)
+                        batchUpdateQueue.publish(
+                            BatchEndOfStream(input.stream, taskName, part, inputCountEos)
+                        )
 
                         stateStore
                     }
                 }
             } catch (t: Throwable) {
                 // Close the local state associated with the current batch.
-                stateStore.values
+                stateStore.stateWithCounts.values
                     .map { runCatching { it.accumulatorState.close() } }
                     .forEach { it.getOrThrow() }
                 throw t
@@ -176,7 +228,8 @@ class LoadPipelineStepTask<S : AutoCloseable, K1 : WithStream, T, K2 : WithStrea
     private suspend fun handleOutput(
         inputKey: K1,
         checkpointCounts: Map<CheckpointId, Long>,
-        output: U
+        output: U,
+        inputCount: Long
     ) {
 
         // Only publish the output if there's a next step.
@@ -188,12 +241,15 @@ class LoadPipelineStepTask<S : AutoCloseable, K1 : WithStream, T, K2 : WithStrea
         }
 
         // If the output contained a global batch state, publish an update.
-        if (output is WithBatchState && output.state.isPersisted()) {
+        if (output is WithBatchState) {
             val update =
                 BatchStateUpdate(
                     stream = inputKey.stream,
                     checkpointCounts = checkpointCounts.toMap(),
-                    state = output.state
+                    state = output.state,
+                    taskName = taskName,
+                    part = part,
+                    inputCount = inputCount
                 )
             batchUpdateQueue.publish(update)
         }
@@ -213,7 +269,7 @@ class LoadPipelineStepTaskFactory(
     @Value("\${airbyte.destination.core.record-batch-size-override:null}")
     val batchSizeOverride: Long? = null,
 ) {
-    // A map of (TaskIndex, Stream) -> Count_of_closed streams to ensure eos is not forwared from
+    // A map of (TaskIndex, Stream) ->  streams to ensure eos is not forwared from
     // task N to N+1 until all workers have seen eos.
     private val streamCompletions =
         ConcurrentHashMap<Pair<Int, DestinationStream.Descriptor>, AtomicInteger>()

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/SpillToDiskTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/SpillToDiskTask.kt
@@ -9,8 +9,8 @@ import com.google.common.collect.TreeRangeSet
 import io.airbyte.cdk.load.command.DestinationConfiguration
 import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.file.SpillFileProvider
-import io.airbyte.cdk.load.message.Batch
 import io.airbyte.cdk.load.message.BatchEnvelope
+import io.airbyte.cdk.load.message.BatchState
 import io.airbyte.cdk.load.message.DestinationStreamEvent
 import io.airbyte.cdk.load.message.MessageQueueSupplier
 import io.airbyte.cdk.load.message.MultiProducerChannel
@@ -138,7 +138,7 @@ class DefaultSpillToDiskTask(
             // sync will hang forever. (Usually this happens because the entire stream was empty.)
             val empty =
                 BatchEnvelope(
-                    SimpleBatch(Batch.State.COMPLETE),
+                    SimpleBatch(BatchState.COMPLETE),
                     TreeRangeSet.create(),
                     streamDescriptor
                 )

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/UpdateBatchStateTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/UpdateBatchStateTask.kt
@@ -5,8 +5,8 @@
 package io.airbyte.cdk.load.task.internal
 
 import io.airbyte.cdk.load.command.DestinationStream
-import io.airbyte.cdk.load.message.Batch
 import io.airbyte.cdk.load.message.QueueReader
+import io.airbyte.cdk.load.pipeline.BatchEndOfStream
 import io.airbyte.cdk.load.pipeline.BatchStateUpdate
 import io.airbyte.cdk.load.pipeline.BatchUpdate
 import io.airbyte.cdk.load.state.CheckpointManager
@@ -32,25 +32,28 @@ class UpdateBatchStateTask(
     override suspend fun execute() {
         inputQueue.consume().collect { message ->
             val manager = syncManager.getStreamManager(message.stream)
-            if (message is BatchStateUpdate) {
-                when (message.state) {
-                    Batch.State.COMPLETE -> {
-                        message.checkpointCounts.forEach {
-                            manager.incrementCompletedCount(
-                                it.key,
-                                it.value,
-                            )
-                        }
+            when (message) {
+                is BatchStateUpdate -> {
+                    log.info {
+                        "Batch update for ${message.stream}: ${message.taskName}[${message.part}](${message.state}) += ${message.checkpointCounts} (inputs += ${message.inputCount})"
                     }
-                    Batch.State.PERSISTED -> {
-                        message.checkpointCounts.forEach {
-                            manager.incrementPersistedCount(
-                                it.key,
-                                it.value,
-                            )
-                        }
+                    manager.incrementCheckpointCounts(
+                        message.taskName,
+                        message.part,
+                        message.state,
+                        message.checkpointCounts,
+                        message.inputCount
+                    )
+                }
+                is BatchEndOfStream -> {
+                    log.info {
+                        "End-of-stream checks for ${message.stream}: ${message.taskName}[${message.part}]"
                     }
-                    else -> return@collect
+                    manager.markTaskEndOfStream(
+                        message.taskName,
+                        message.part,
+                        message.totalInputCount
+                    )
                 }
             }
             checkpointManager.flushReadyCheckpointMessages()

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/write/StreamLoader.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/write/StreamLoader.kt
@@ -7,6 +7,7 @@ package io.airbyte.cdk.load.write
 import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.message.Batch
 import io.airbyte.cdk.load.message.BatchEnvelope
+import io.airbyte.cdk.load.message.BatchState
 import io.airbyte.cdk.load.message.DestinationFile
 import io.airbyte.cdk.load.message.DestinationRecordAirbyteValue
 import io.airbyte.cdk.load.message.MultiProducerChannel
@@ -35,11 +36,11 @@ import io.airbyte.cdk.load.state.StreamProcessingFailed
  * [processBatch] is called once per incomplete batch returned by either [processRecords] or
  * [processBatch] itself. It must be thread-safe if
  * [io.airbyte.cdk.load.command.DestinationConfiguration.numProcessBatchWorkers] > 1. If
- * [processRecords] never returns a non-[Batch.State.COMPLETE] batch, [processBatch] will never be
- * called.
+ * [processRecords] never returns a non-[Batch.BatchState.COMPLETE] batch, [processBatch] will never
+ * be called.
  *
- * NOTE: even if [processBatch] returns a not-[Batch.State.COMPLETE] batch, it will be called again.
- * TODO: allow the client to specify subsequent processing stages instead.
+ * NOTE: even if [processBatch] returns a not-[Batch.BatchState.COMPLETE] batch, it will be called
+ * again. TODO: allow the client to specify subsequent processing stages instead.
  *
  * [close] is called once after all records have been processed, regardless of success or failure,
  * but only if [start] returned successfully. If any exception was thrown during processing, it is
@@ -55,7 +56,7 @@ interface StreamLoader : BatchAccumulator, FileBatchAccumulator {
         outputQueue: MultiProducerChannel<BatchEnvelope<*>>,
     ): FileBatchAccumulator = this
 
-    suspend fun processBatch(batch: Batch): Batch = SimpleBatch(Batch.State.COMPLETE)
+    suspend fun processBatch(batch: Batch): Batch = SimpleBatch(BatchState.COMPLETE)
     suspend fun close(streamFailure: StreamProcessingFailed? = null) {}
 }
 

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/state/CheckpointManagerTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/state/CheckpointManagerTest.kt
@@ -11,8 +11,8 @@ import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.command.MockDestinationCatalogFactory.Companion.stream1
 import io.airbyte.cdk.load.command.MockDestinationCatalogFactory.Companion.stream2
 import io.airbyte.cdk.load.file.TimeProvider
-import io.airbyte.cdk.load.message.Batch
 import io.airbyte.cdk.load.message.BatchEnvelope
+import io.airbyte.cdk.load.message.BatchState
 import io.airbyte.cdk.load.message.SimpleBatch
 import io.micronaut.context.annotation.Requires
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest
@@ -446,7 +446,7 @@ class CheckpointManagerTest {
                 is FlushPoint -> {
                     // Mock the persisted ranges by updating the state of the stream managers
                     it.persistedRanges.forEach { (stream, ranges) ->
-                        val mockBatch = SimpleBatch(state = Batch.State.PERSISTED)
+                        val mockBatch = SimpleBatch(state = BatchState.PERSISTED)
                         val rangeSet = TreeRangeSet.create(ranges)
                         val mockBatchEnvelope =
                             BatchEnvelope(

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/state/StreamManagerTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/state/StreamManagerTest.kt
@@ -8,8 +8,8 @@ import com.google.common.collect.Range
 import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.command.MockDestinationCatalogFactory.Companion.stream1
 import io.airbyte.cdk.load.command.MockDestinationCatalogFactory.Companion.stream2
-import io.airbyte.cdk.load.message.Batch
 import io.airbyte.cdk.load.message.BatchEnvelope
+import io.airbyte.cdk.load.message.BatchState
 import io.airbyte.cdk.load.message.SimpleBatch
 import java.util.stream.Stream
 import kotlinx.coroutines.channels.Channel
@@ -282,7 +282,7 @@ class StreamManagerTest {
                 is AddPersisted ->
                     manager.updateBatchState(
                         BatchEnvelope(
-                            SimpleBatch(Batch.State.PERSISTED),
+                            SimpleBatch(BatchState.PERSISTED),
                             Range.closed(event.firstIndex, event.lastIndex),
                             stream.descriptor
                         )
@@ -290,7 +290,7 @@ class StreamManagerTest {
                 is AddComplete ->
                     manager.updateBatchState(
                         BatchEnvelope(
-                            SimpleBatch(Batch.State.COMPLETE),
+                            SimpleBatch(BatchState.COMPLETE),
                             Range.closed(event.firstIndex, event.lastIndex),
                             stream.descriptor
                         )
@@ -344,7 +344,7 @@ class StreamManagerTest {
         val range1 = Range.closed(0L, 9L)
         val batch1 =
             BatchEnvelope(
-                SimpleBatch(Batch.State.STAGED, groupId = "foo"),
+                SimpleBatch(BatchState.STAGED, groupId = "foo"),
                 range1,
                 stream1.descriptor
             )
@@ -352,7 +352,7 @@ class StreamManagerTest {
         val range2 = Range.closed(10, 19L)
         val batch2 =
             BatchEnvelope(
-                SimpleBatch(Batch.State.PERSISTED, groupId = "foo"),
+                SimpleBatch(BatchState.PERSISTED, groupId = "foo"),
                 range2,
                 stream1.descriptor
             )
@@ -369,7 +369,7 @@ class StreamManagerTest {
         val range1 = Range.closed(0L, 9L)
         val batch1 =
             BatchEnvelope(
-                SimpleBatch(Batch.State.STAGED, groupId = "foo"),
+                SimpleBatch(BatchState.STAGED, groupId = "foo"),
                 range1,
                 stream1.descriptor
             )
@@ -377,7 +377,7 @@ class StreamManagerTest {
         val range2 = Range.closed(10, 19L)
         val batch2 =
             BatchEnvelope(
-                SimpleBatch(Batch.State.PERSISTED, groupId = "bar"),
+                SimpleBatch(BatchState.PERSISTED, groupId = "bar"),
                 range2,
                 stream1.descriptor
             )
@@ -397,7 +397,7 @@ class StreamManagerTest {
         val range1 = Range.closed(0L, 9L)
         val batch1 =
             BatchEnvelope(
-                SimpleBatch(Batch.State.STAGED, groupId = null),
+                SimpleBatch(BatchState.STAGED, groupId = null),
                 range1,
                 stream1.descriptor
             )
@@ -405,7 +405,7 @@ class StreamManagerTest {
         val range2 = Range.closed(10, 19L)
         val batch2 =
             BatchEnvelope(
-                SimpleBatch(Batch.State.PERSISTED, groupId = "bar"),
+                SimpleBatch(BatchState.PERSISTED, groupId = "bar"),
                 range2,
                 stream1.descriptor
             )
@@ -425,7 +425,7 @@ class StreamManagerTest {
         val range1 = Range.closed(0L, 9L)
         val batch1 =
             BatchEnvelope(
-                SimpleBatch(Batch.State.PERSISTED, groupId = "foo"),
+                SimpleBatch(BatchState.PERSISTED, groupId = "foo"),
                 range1,
                 stream1.descriptor
             )
@@ -433,7 +433,7 @@ class StreamManagerTest {
         val range2 = Range.closed(10, 19L)
         val batch2 =
             BatchEnvelope(
-                SimpleBatch(Batch.State.STAGED, groupId = "foo"),
+                SimpleBatch(BatchState.STAGED, groupId = "foo"),
                 range2,
                 stream1.descriptor
             )
@@ -453,7 +453,7 @@ class StreamManagerTest {
         val range1 = Range.closed(0L, 9L)
         val batch1 =
             BatchEnvelope(
-                SimpleBatch(Batch.State.COMPLETE, groupId = "foo"),
+                SimpleBatch(BatchState.COMPLETE, groupId = "foo"),
                 range1,
                 stream1.descriptor
             )
@@ -461,7 +461,7 @@ class StreamManagerTest {
         val range2 = Range.closed(10, 19L)
         val batch2 =
             BatchEnvelope(
-                SimpleBatch(Batch.State.PERSISTED, groupId = "foo"),
+                SimpleBatch(BatchState.PERSISTED, groupId = "foo"),
                 range2,
                 stream1.descriptor
             )
@@ -479,20 +479,36 @@ class StreamManagerTest {
     fun `test persisted counts`() {
         val manager = DefaultStreamManager(stream1)
         val checkpointId = manager.getCurrentCheckpointId()
+        val taskName = "foo"
+        val part = 1
 
         repeat(10) { manager.incrementReadCount() }
         manager.markCheckpoint()
 
         Assertions.assertFalse(manager.areRecordsPersistedUntilCheckpoint(checkpointId))
-        manager.incrementPersistedCount(checkpointId, 5)
+        manager.incrementCheckpointCounts(
+            taskName,
+            part,
+            BatchState.PERSISTED,
+            mapOf(checkpointId to 5),
+            1
+        )
         Assertions.assertFalse(manager.areRecordsPersistedUntilCheckpoint(checkpointId))
-        manager.incrementPersistedCount(checkpointId, 5)
+        manager.incrementCheckpointCounts(
+            taskName,
+            part,
+            BatchState.PERSISTED,
+            mapOf(checkpointId to 5),
+            1
+        )
         Assertions.assertTrue(manager.areRecordsPersistedUntilCheckpoint(checkpointId))
     }
 
     @Test
     fun `test persisted count for multiple checkpoints`() {
         val manager = DefaultStreamManager(stream1)
+        val taskName = "foo"
+        val part = 1
 
         val checkpointId1 = manager.getCurrentCheckpointId()
         repeat(10) { manager.incrementReadCount() }
@@ -505,11 +521,23 @@ class StreamManagerTest {
         Assertions.assertFalse(manager.areRecordsPersistedUntilCheckpoint(checkpointId1))
         Assertions.assertFalse(manager.areRecordsPersistedUntilCheckpoint(checkpointId2))
 
-        manager.incrementPersistedCount(checkpointId1, 10)
+        manager.incrementCheckpointCounts(
+            taskName,
+            part,
+            BatchState.PERSISTED,
+            mapOf(checkpointId1 to 10),
+            1
+        )
         Assertions.assertTrue(manager.areRecordsPersistedUntilCheckpoint(checkpointId1))
         Assertions.assertFalse(manager.areRecordsPersistedUntilCheckpoint(checkpointId2))
 
-        manager.incrementPersistedCount(checkpointId2, 15)
+        manager.incrementCheckpointCounts(
+            taskName,
+            part,
+            BatchState.PERSISTED,
+            mapOf(checkpointId2 to 15),
+            1
+        )
         Assertions.assertTrue(manager.areRecordsPersistedUntilCheckpoint(checkpointId1))
         Assertions.assertTrue(manager.areRecordsPersistedUntilCheckpoint(checkpointId2))
     }
@@ -517,6 +545,8 @@ class StreamManagerTest {
     @Test
     fun `test persisted count for multiple checkpoints out of order`() {
         val manager = DefaultStreamManager(stream1)
+        val taskName = "foo"
+        val part = 1
 
         val checkpointId1 = manager.getCurrentCheckpointId()
 
@@ -531,12 +561,23 @@ class StreamManagerTest {
         Assertions.assertFalse(manager.areRecordsPersistedUntilCheckpoint(checkpointId1))
         Assertions.assertFalse(manager.areRecordsPersistedUntilCheckpoint(checkpointId2))
 
-        manager.incrementPersistedCount(checkpointId2, 15)
+        manager.incrementCheckpointCounts(
+            taskName,
+            part,
+            BatchState.PERSISTED,
+            mapOf(checkpointId2 to 15),
+            1
+        )
         Assertions.assertFalse(manager.areRecordsPersistedUntilCheckpoint(checkpointId1))
         Assertions.assertFalse(manager.areRecordsPersistedUntilCheckpoint(checkpointId2))
 
-        manager.incrementPersistedCount(checkpointId1, 10)
-
+        manager.incrementCheckpointCounts(
+            taskName,
+            part,
+            BatchState.PERSISTED,
+            mapOf(checkpointId1 to 10),
+            1
+        )
         Assertions.assertTrue(manager.areRecordsPersistedUntilCheckpoint(checkpointId1))
         Assertions.assertTrue(manager.areRecordsPersistedUntilCheckpoint(checkpointId2))
     }
@@ -544,6 +585,7 @@ class StreamManagerTest {
     @Test
     fun `test completion implies persistence`() {
         val manager = DefaultStreamManager(stream1)
+        val taskName = "foo"
 
         val checkpointId1 = manager.getCurrentCheckpointId()
 
@@ -551,13 +593,31 @@ class StreamManagerTest {
         manager.markCheckpoint()
 
         Assertions.assertFalse(manager.areRecordsPersistedUntilCheckpoint(checkpointId1))
-        manager.incrementCompletedCount(checkpointId1, 4)
+        manager.incrementCheckpointCounts(
+            "foo",
+            1,
+            BatchState.COMPLETE,
+            mapOf(checkpointId1 to 4),
+            1
+        )
         Assertions.assertFalse(manager.areRecordsPersistedUntilCheckpoint(checkpointId1))
-        manager.incrementCompletedCount(checkpointId1, 6)
+        manager.incrementCheckpointCounts(
+            "foo",
+            2,
+            BatchState.COMPLETE,
+            mapOf(checkpointId1 to 6),
+            1
+        )
         Assertions.assertTrue(manager.areRecordsPersistedUntilCheckpoint(checkpointId1))
 
         // Can still count persisted (but without effect)
-        manager.incrementPersistedCount(checkpointId1, 10)
+        manager.incrementCheckpointCounts(
+            "bar",
+            1,
+            BatchState.PERSISTED,
+            mapOf(checkpointId1 to 10),
+            1
+        )
         Assertions.assertTrue(manager.areRecordsPersistedUntilCheckpoint(checkpointId1))
     }
 
@@ -587,8 +647,22 @@ class StreamManagerTest {
 
             steps.forEachIndexed { index, step ->
                 when (step) {
-                    "1" -> manager.incrementCompletedCount(checkpointId1, 10)
-                    "2" -> manager.incrementCompletedCount(checkpointId2, 20)
+                    "1" ->
+                        manager.incrementCheckpointCounts(
+                            "foo",
+                            1,
+                            BatchState.COMPLETE,
+                            mapOf(checkpointId1 to 10),
+                            1
+                        )
+                    "2" ->
+                        manager.incrementCheckpointCounts(
+                            "bar",
+                            1,
+                            BatchState.COMPLETE,
+                            mapOf(checkpointId2 to 20),
+                            1
+                        )
                     "end" -> manager.markEndOfStream(true)
                 }
                 if (index < 2) {
@@ -613,7 +687,13 @@ class StreamManagerTest {
         Assertions.assertEquals(0, manager1.getCurrentCheckpointId().id)
 
         repeat(10) { manager1.incrementReadCount() }
-        manager1.incrementPersistedCount(manager1.getCurrentCheckpointId(), 10)
+        manager1.incrementCheckpointCounts(
+            "foo",
+            1,
+            BatchState.PERSISTED,
+            mapOf(manager1.getCurrentCheckpointId() to 10),
+            1
+        )
         assertDoesNotThrow { manager1.markCheckpoint() }
     }
 }

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/state/SyncManagerUtils.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/state/SyncManagerUtils.kt
@@ -6,8 +6,8 @@ package io.airbyte.cdk.load.state
 
 import com.google.common.collect.Range
 import io.airbyte.cdk.load.command.DestinationStream
-import io.airbyte.cdk.load.message.Batch
 import io.airbyte.cdk.load.message.BatchEnvelope
+import io.airbyte.cdk.load.message.BatchState
 import io.airbyte.cdk.load.message.SimpleBatch
 
 /**
@@ -20,6 +20,6 @@ import io.airbyte.cdk.load.message.SimpleBatch
 fun SyncManager.markPersisted(stream: DestinationStream, range: Range<Long>) {
     this.getStreamManager(stream.descriptor)
         .updateBatchState(
-            BatchEnvelope(SimpleBatch(Batch.State.PERSISTED), range, stream.descriptor)
+            BatchEnvelope(SimpleBatch(BatchState.PERSISTED), range, stream.descriptor)
         )
 }

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/DestinationTaskLauncherUTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/DestinationTaskLauncherUTest.kt
@@ -7,8 +7,8 @@ package io.airbyte.cdk.load.task
 import io.airbyte.cdk.load.command.DestinationCatalog
 import io.airbyte.cdk.load.command.DestinationConfiguration
 import io.airbyte.cdk.load.command.DestinationStream
-import io.airbyte.cdk.load.message.Batch
 import io.airbyte.cdk.load.message.BatchEnvelope
+import io.airbyte.cdk.load.message.BatchState
 import io.airbyte.cdk.load.message.ChannelMessageQueue
 import io.airbyte.cdk.load.message.CheckpointMessageWrapped
 import io.airbyte.cdk.load.message.DestinationRecordRaw
@@ -194,11 +194,11 @@ class DestinationTaskLauncherUTest {
         val descriptor = DestinationStream.Descriptor("namespace", "name")
         destinationTaskLauncher.handleNewBatch(
             descriptor,
-            BatchEnvelope(SimpleBatch(Batch.State.COMPLETE), null, descriptor)
+            BatchEnvelope(SimpleBatch(BatchState.COMPLETE), null, descriptor)
         )
         destinationTaskLauncher.handleNewBatch(
             descriptor,
-            BatchEnvelope(SimpleBatch(Batch.State.COMPLETE), null, descriptor)
+            BatchEnvelope(SimpleBatch(BatchState.COMPLETE), null, descriptor)
         )
         coVerify(exactly = 1) { closeStreamTaskFactory.make(any(), any()) }
     }

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/implementor/ProcessRecordsTaskTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/implementor/ProcessRecordsTaskTest.kt
@@ -11,6 +11,7 @@ import io.airbyte.cdk.load.command.MockDestinationCatalogFactory
 import io.airbyte.cdk.load.data.IntegerValue
 import io.airbyte.cdk.load.message.Batch
 import io.airbyte.cdk.load.message.BatchEnvelope
+import io.airbyte.cdk.load.message.BatchState
 import io.airbyte.cdk.load.message.DestinationRecord
 import io.airbyte.cdk.load.message.DestinationRecordAirbyteValue
 import io.airbyte.cdk.load.message.MessageQueue
@@ -95,7 +96,7 @@ class ProcessRecordsTaskTest {
 
     class MockBatch(
         override val groupId: String?,
-        override val state: Batch.State,
+        override val state: BatchState,
         recordIterator: Iterator<DestinationRecordAirbyteValue>
     ) : Batch {
         val records = recordIterator.asSequence().toList()
@@ -129,19 +130,15 @@ class ProcessRecordsTaskTest {
         // Process records returns batches in 3 states.
         coEvery { batchAccumulator.processRecords(any(), any()) } answers
             {
-                MockBatch(
-                    groupId = null,
-                    state = Batch.State.PERSISTED,
-                    recordIterator = firstArg()
-                )
+                MockBatch(groupId = null, state = BatchState.PERSISTED, recordIterator = firstArg())
             } andThenAnswer
             {
-                MockBatch(groupId = null, state = Batch.State.COMPLETE, recordIterator = firstArg())
+                MockBatch(groupId = null, state = BatchState.COMPLETE, recordIterator = firstArg())
             } andThenAnswer
             {
                 MockBatch(
                     groupId = "foo",
-                    state = Batch.State.PERSISTED,
+                    state = BatchState.PERSISTED,
                     recordIterator = firstArg()
                 )
             }
@@ -154,7 +151,7 @@ class ProcessRecordsTaskTest {
 
         task.execute()
 
-        fun batchMatcher(groupId: String?, state: Batch.State): (BatchEnvelope<*>) -> Boolean = {
+        fun batchMatcher(groupId: String?, state: BatchState): (BatchEnvelope<*>) -> Boolean = {
             it.ranges.encloses(Range.closed(0, recordCount)) &&
                 it.streamDescriptor == descriptor &&
                 it.batch.groupId == groupId &&
@@ -169,20 +166,20 @@ class ProcessRecordsTaskTest {
         // Verify the batch was *handled* 3 times but *published* ONLY when it is not complete AND
         // group id is null.
         coVerify(exactly = 1) {
-            outputQueue.publish(match { batchMatcher(null, Batch.State.PERSISTED)(it) })
+            outputQueue.publish(match { batchMatcher(null, BatchState.PERSISTED)(it) })
         }
         coVerifySequence {
             launcher.handleNewBatch(
                 MockDestinationCatalogFactory.stream1.descriptor,
-                match { batchMatcher(null, Batch.State.PERSISTED)(it) }
+                match { batchMatcher(null, BatchState.PERSISTED)(it) }
             )
             launcher.handleNewBatch(
                 MockDestinationCatalogFactory.stream1.descriptor,
-                match { batchMatcher(null, Batch.State.COMPLETE)(it) }
+                match { batchMatcher(null, BatchState.COMPLETE)(it) }
             )
             launcher.handleNewBatch(
                 MockDestinationCatalogFactory.stream1.descriptor,
-                match { batchMatcher("foo", Batch.State.PERSISTED)(it) }
+                match { batchMatcher("foo", BatchState.PERSISTED)(it) }
             )
         }
 

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/internal/LoadPipelineStepTaskUTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/internal/LoadPipelineStepTaskUTest.kt
@@ -5,7 +5,7 @@
 package io.airbyte.cdk.load.task.internal
 
 import io.airbyte.cdk.load.command.DestinationStream
-import io.airbyte.cdk.load.message.Batch
+import io.airbyte.cdk.load.message.BatchState
 import io.airbyte.cdk.load.message.PartitionedQueue
 import io.airbyte.cdk.load.message.PipelineEndOfStream
 import io.airbyte.cdk.load.message.PipelineEvent
@@ -51,7 +51,7 @@ class LoadPipelineStepTaskUTest {
         override fun close() {}
     }
 
-    data class MyBatch(override val state: Batch.State) : WithBatchState
+    data class MyBatch(override val state: BatchState) : WithBatchState
 
     @BeforeEach
     fun setup() {
@@ -225,9 +225,9 @@ class LoadPipelineStepTaskUTest {
             {
                 when (acceptCalls++ % 4) {
                     0 -> NoOutput(Closeable())
-                    1 -> FinalOutput(MyBatch(Batch.State.PROCESSED))
-                    2 -> FinalOutput(MyBatch(Batch.State.PERSISTED))
-                    3 -> FinalOutput(MyBatch(Batch.State.COMPLETE))
+                    1 -> FinalOutput(MyBatch(BatchState.PROCESSED))
+                    2 -> FinalOutput(MyBatch(BatchState.PERSISTED))
+                    3 -> FinalOutput(MyBatch(BatchState.COMPLETE))
                     else -> error("unreachable")
                 }
             }
@@ -247,7 +247,7 @@ class LoadPipelineStepTaskUTest {
         } // only 1/4 are no output
         coVerify(exactly = 12) { batchAccumulatorWithUpdate.accept(any(), any()) } // all have data
         coVerify(exactly = 0) { batchAccumulatorWithUpdate.finish(any()) } // never end-of-stream
-        coVerify(exactly = 6) { batchUpdateQueue.publish(any()) } // half are PERSISTED/COMPLETE
+        coVerify(exactly = 9) { batchUpdateQueue.publish(any()) } // 3/4 are outputs w/ state
     }
 
     @Test
@@ -293,13 +293,13 @@ class LoadPipelineStepTaskUTest {
         repeat(10) {
             coEvery { batchAccumulatorWithUpdate.accept(any(), stream1States[it]) } returns
                 if (it % 3 == 0) {
-                    FinalOutput(MyBatch(Batch.State.PERSISTED))
+                    FinalOutput(MyBatch(BatchState.PERSISTED))
                 } else {
                     NoOutput(stream1States[it + 1])
                 }
             coEvery { batchAccumulatorWithUpdate.accept(any(), stream2States[it]) } returns
                 if (it % 2 == 0) {
-                    FinalOutput(MyBatch(Batch.State.PERSISTED))
+                    FinalOutput(MyBatch(BatchState.PERSISTED))
                 } else {
                     NoOutput(stream2States[it + 1])
                 }
@@ -319,7 +319,7 @@ class LoadPipelineStepTaskUTest {
             }
 
         coEvery { batchAccumulatorWithUpdate.finish(any()) } returns
-            FinalOutput(MyBatch(Batch.State.COMPLETE))
+            FinalOutput(MyBatch(BatchState.COMPLETE))
         coEvery { batchUpdateQueue.publish(any()) } returns Unit
 
         task.execute()
@@ -350,9 +350,9 @@ class LoadPipelineStepTaskUTest {
         coEvery { batchAccumulatorWithUpdate.accept("stream2_value", any()) } returns
             NoOutput(Closeable(2))
         coEvery { batchAccumulatorWithUpdate.finish(Closeable(1)) } returns
-            FinalOutput(MyBatch(Batch.State.COMPLETE))
+            FinalOutput(MyBatch(BatchState.COMPLETE))
         coEvery { batchAccumulatorWithUpdate.finish(Closeable(2)) } returns
-            FinalOutput(MyBatch(Batch.State.PERSISTED))
+            FinalOutput(MyBatch(BatchState.PERSISTED))
 
         coEvery { inputFlow.collect(any()) } coAnswers
             {
@@ -381,13 +381,19 @@ class LoadPipelineStepTaskUTest {
             BatchStateUpdate(
                 key1.stream,
                 mapOf(CheckpointId(0) to 15L, CheckpointId(1) to 51L),
-                Batch.State.COMPLETE
+                BatchState.COMPLETE,
+                batchAccumulatorNoUpdate::class.java.simpleName,
+                part,
+                inputCount = 12L
             )
         val expectedBatchUpdateStream2 =
             BatchStateUpdate(
                 key2.stream,
                 mapOf(CheckpointId(1) to 6L, CheckpointId(2) to 22L, CheckpointId(3) to 38L),
-                Batch.State.PERSISTED
+                BatchState.PERSISTED,
+                batchAccumulatorNoUpdate::class.java.simpleName,
+                part,
+                inputCount = 12L
             )
         coVerify(exactly = 1) { batchUpdateQueue.publish(expectedBatchUpdateStream1) }
         coVerify(exactly = 1) { batchUpdateQueue.publish(expectedBatchUpdateStream2) }

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/message/object_storage/ObjectStorageBatch.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/message/object_storage/ObjectStorageBatch.kt
@@ -7,6 +7,7 @@ package io.airbyte.cdk.load.message.object_storage
 import io.airbyte.cdk.load.file.object_storage.Part
 import io.airbyte.cdk.load.file.object_storage.RemoteObject
 import io.airbyte.cdk.load.message.Batch
+import io.airbyte.cdk.load.message.BatchState
 
 sealed interface ObjectStorageBatch : Batch
 
@@ -14,7 +15,7 @@ sealed interface ObjectStorageBatch : Batch
 // Returned by the batch accumulator after processing records.
 data class LoadablePart(val part: Part) : ObjectStorageBatch {
     override val groupId = null
-    override val state = Batch.State.PROCESSED
+    override val state = BatchState.PROCESSED
 
     // Hide the data from the logs
     override fun toString(): String {
@@ -25,7 +26,7 @@ data class LoadablePart(val part: Part) : ObjectStorageBatch {
 // An UploadablePart that has been uploaded to an incomplete object.
 // Returned by processBatch
 data class IncompletePartialUpload(val key: String) : ObjectStorageBatch {
-    override val state: Batch.State = Batch.State.STAGED
+    override val state: BatchState = BatchState.STAGED
     override val groupId: String = key
 }
 
@@ -35,6 +36,6 @@ data class LoadedObject<T : RemoteObject<*>>(
     val fileNumber: Long,
     val isEmpty: Boolean
 ) : ObjectStorageBatch {
-    override val state: Batch.State = Batch.State.COMPLETE
+    override val state: BatchState = BatchState.COMPLETE
     override val groupId = remoteObject.key
 }

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/pipline/object_storage/ObjectLoaderPartFormatter.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/pipline/object_storage/ObjectLoaderPartFormatter.kt
@@ -12,8 +12,10 @@ import io.airbyte.cdk.load.file.object_storage.ObjectStorageClient
 import io.airbyte.cdk.load.file.object_storage.Part
 import io.airbyte.cdk.load.file.object_storage.PartFactory
 import io.airbyte.cdk.load.file.object_storage.PathFactory
+import io.airbyte.cdk.load.message.BatchState
 import io.airbyte.cdk.load.message.DestinationRecordRaw
 import io.airbyte.cdk.load.message.StreamKey
+import io.airbyte.cdk.load.message.WithBatchState
 import io.airbyte.cdk.load.pipeline.BatchAccumulator
 import io.airbyte.cdk.load.pipeline.BatchAccumulatorResult
 import io.airbyte.cdk.load.pipeline.FinalOutput
@@ -62,7 +64,10 @@ class ObjectLoaderPartFormatter<T : OutputStream>(
         }
     }
 
-    @JvmInline value class FormattedPart(val part: Part)
+    data class FormattedPart(
+        val part: Part,
+        override val state: BatchState = BatchState.PROCESSED
+    ) : WithBatchState
 
     private suspend fun newState(stream: DestinationStream): State<T> {
         // Determine unique file name.

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/pipline/object_storage/ObjectLoaderPartLoader.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/pipline/object_storage/ObjectLoaderPartLoader.kt
@@ -7,6 +7,8 @@ package io.airbyte.cdk.load.pipline.object_storage
 import io.airbyte.cdk.load.command.DestinationCatalog
 import io.airbyte.cdk.load.file.object_storage.ObjectStorageClient
 import io.airbyte.cdk.load.file.object_storage.StreamingUpload
+import io.airbyte.cdk.load.message.BatchState
+import io.airbyte.cdk.load.message.WithBatchState
 import io.airbyte.cdk.load.pipeline.BatchAccumulator
 import io.airbyte.cdk.load.pipeline.BatchAccumulatorResult
 import io.airbyte.cdk.load.pipeline.FinalOutput
@@ -56,8 +58,10 @@ class ObjectLoaderPartLoader(
         }
     }
 
-    sealed interface PartResult {
+    sealed interface PartResult : WithBatchState {
         val objectKey: String
+        override val state: BatchState
+            get() = BatchState.STAGED
     }
     data class LoadedPart(
         val upload: Deferred<StreamingUpload<*>>,

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/pipline/object_storage/ObjectLoaderUploadCompleter.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/pipline/object_storage/ObjectLoaderUploadCompleter.kt
@@ -6,7 +6,7 @@ package io.airbyte.cdk.load.pipline.object_storage
 
 import io.airbyte.cdk.load.file.object_storage.Part
 import io.airbyte.cdk.load.file.object_storage.PartBookkeeper
-import io.airbyte.cdk.load.message.Batch
+import io.airbyte.cdk.load.message.BatchState
 import io.airbyte.cdk.load.message.WithBatchState
 import io.airbyte.cdk.load.pipeline.BatchAccumulator
 import io.airbyte.cdk.load.pipeline.BatchAccumulatorResult
@@ -34,7 +34,7 @@ class ObjectLoaderUploadCompleter :
         }
     }
 
-    data class UploadResult(override val state: Batch.State) : WithBatchState
+    data class UploadResult(override val state: BatchState) : WithBatchState
 
     override suspend fun start(key: ObjectKey, part: Int): State {
         val bookkeeper = PartBookkeeper()
@@ -61,7 +61,7 @@ class ObjectLoaderUploadCompleter :
                         "Loaded part ${input.partIndex} (isFinal=${input.isFinal}) completes ${state.objectKey}, finishing (state $state)"
                     }
                     input.upload.await().complete()
-                    FinalOutput(UploadResult(Batch.State.COMPLETE))
+                    FinalOutput(UploadResult(BatchState.COMPLETE))
                 } else {
                     log.info {
                         "After loaded part ${input.partIndex} (isFinal=${input.isFinal}), ${state.objectKey} still incomplete, not finishing (state $state)"
@@ -80,6 +80,6 @@ class ObjectLoaderUploadCompleter :
          * Should never be called until end-of-stream. There should ever be one completer worker,
          * and the enclosing step should be configured not to flush.
          */
-        return FinalOutput(UploadResult(Batch.State.COMPLETE))
+        return FinalOutput(UploadResult(BatchState.COMPLETE))
     }
 }

--- a/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLStreamLoader.kt
+++ b/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLStreamLoader.kt
@@ -6,6 +6,7 @@ package io.airbyte.integrations.destination.mssql.v2
 
 import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.message.Batch
+import io.airbyte.cdk.load.message.BatchState
 import io.airbyte.cdk.load.message.DestinationRecordAirbyteValue
 import io.airbyte.cdk.load.message.SimpleBatch
 import javax.sql.DataSource
@@ -53,6 +54,6 @@ class MSSQLStreamLoader(
         }
 
         // Indicate that the batch has been completely processed
-        return SimpleBatch(Batch.State.COMPLETE)
+        return SimpleBatch(BatchState.COMPLETE)
     }
 }

--- a/airbyte-integrations/connectors/destination-s3-data-lake/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/metadata.yaml
@@ -26,7 +26,7 @@ data:
             alias: airbyte-connector-testing-secret-store
   connectorType: destination
   definitionId: 716ca874-520b-4902-9f80-9fad66754b89
-  dockerImageTag: 0.3.19
+  dockerImageTag: 0.3.20
   dockerRepository: airbyte/destination-s3-data-lake
   documentationUrl: https://docs.airbyte.com/integrations/destinations/s3-data-lake
   githubIssueLabel: destination-s3-data-lake

--- a/airbyte-integrations/connectors/destination-s3/src/main/kotlin/S3V2ObjectLoader.kt
+++ b/airbyte-integrations/connectors/destination-s3/src/main/kotlin/S3V2ObjectLoader.kt
@@ -4,7 +4,6 @@
 
 package io.airbyte.integrations.destination.s3_v2
 
-import io.airbyte.cdk.load.pipeline.RoundRobinInputPartitioner
 import io.airbyte.cdk.load.write.object_storage.ObjectLoader
 
 /**
@@ -20,5 +19,4 @@ class S3V2ObjectLoader(config: S3V2Configuration<*>) : ObjectLoader {
     override val partSizeBytes: Long = config.partSizeBytes
 }
 
-// @Singleton
-class S3V2RoundRobinInputPartitioner : RoundRobinInputPartitioner()
+// @Singleton class S3V2RoundRobinInputPartitioner : RoundRobinInputPartitioner()

--- a/docs/integrations/destinations/s3-data-lake.md
+++ b/docs/integrations/destinations/s3-data-lake.md
@@ -306,7 +306,8 @@ Now, you can identify the latest version of the 'Alice' record by querying wheth
   <summary>Expand to review</summary>
 
 | Version | Date       | Pull Request                                               | Subject                                                                        |
-|:--------|:-----------| :--------------------------------------------------------- |:-------------------------------------------------------------------------------|
+|:--------|:-----------|:-----------------------------------------------------------|:-------------------------------------------------------------------------------|
+| 0.3.20  | 2025-03-22 | [\#56347](https://github.com/airbytehq/airbyte/pull/56347) | Bugfix: stream start does not always await iceberg setup                       |
 | 0.3.19  | 2025-03-19 | [\#55798](https://github.com/airbytehq/airbyte/pull/55798) | CDK: Typing improvements                                                       |
 | 0.3.18  | 2025-03-18 | [\#55811](https://github.com/airbytehq/airbyte/pull/55811) | CDK: Pass DestinationStream around vs Descriptor                               |
 | 0.3.17  | 2025-03-13 | [\#55737](https://github.com/airbytehq/airbyte/pull/55737) | CDK: Pass DestinationRecordRaw around instead of DestinationRecordAirbyteValue |


### PR DESCRIPTION
## What
1. fix to part queue allocation
2. dedicated shared global memory manager

Primarily this is a fix to how the capacity is allocated for the part queue. Before it would check whether the part size + number of workers could fit in memory. This was a giant PITA during testing, because it kept hard failing at sync time, and required a lot of tuning to get right.

Now it just clamps the part size if there is too much concurrency. It's still slightly brittle, but way less so.

This also fixes an obvious bug in memory allocations. Before I was taking X% of the sync memory manager used for input consumption, but that was actually already sized to X% of available memory. So I made a global memory manager and had each concern reserve its share of total.
