### PR TITLE
Load CDK: ObjectLoader queue size derived from avail mem

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/state/ReservationManager.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/state/ReservationManager.kt
@@ -75,6 +75,17 @@ class ReservationManager(val totalCapacityBytes: Long) {
         }
     }
 
+    suspend fun <T> reserveOrThrow(bytes: Long, reservedFor: T): Reserved<T> {
+        reserveLock.withLock {
+            check(usedBytes.get() + bytes <= totalCapacityBytes) {
+                "Not enough memory to reserve $bytes bytes"
+            }
+            usedBytes.addAndGet(bytes)
+        }
+
+        return Reserved(this, bytes, reservedFor)
+    }
+
     suspend fun release(bytes: Long) {
         updateChannel.value = usedBytes.addAndGet(-bytes)
     }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/ReservingDeserializingInputFlow.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/ReservingDeserializingInputFlow.kt
@@ -20,7 +20,7 @@ import kotlinx.coroutines.flow.FlowCollector
 class ReservingDeserializingInputFlow(
     val config: DestinationConfiguration,
     val deserializer: ProtocolMessageDeserializer,
-    @Named("memoryManager") val memoryManager: ReservationManager,
+    @Named("queueMemoryManager") val memoryManager: ReservationManager,
     val inputStream: InputStream,
 ) : Flow<Pair<Long, Reserved<DestinationMessage>>> {
     val log = KotlinLogging.logger {}
@@ -29,7 +29,7 @@ class ReservingDeserializingInputFlow(
         collector: FlowCollector<Pair<Long, Reserved<DestinationMessage>>>
     ) {
         log.info {
-            "Reserved ${memoryManager.totalCapacityBytes/1024}mb memory for input processing"
+            "Reserved ${memoryManager.totalCapacityBytes/1024/1024}mb memory for input processing"
         }
 
         var index = 0L

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/test/kotlin/io/airbyte/cdk/load/pipeline/object_storage/ObjectLoaderPartQueueTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/test/kotlin/io/airbyte/cdk/load/pipeline/object_storage/ObjectLoaderPartQueueTest.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.load.pipeline.object_storage
+
+import io.airbyte.cdk.load.pipline.object_storage.ObjectLoaderPartQueueFactory
+import io.airbyte.cdk.load.state.ReservationManager
+import io.airbyte.cdk.load.state.Reserved
+import io.airbyte.cdk.load.write.object_storage.ObjectLoader
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+class ObjectLoaderPartQueueTest {
+    @MockK(relaxed = true) lateinit var objectLoader: ObjectLoader
+
+    @Test
+    fun `part queue factory respects memory available`() {
+        val beanFactory = ObjectLoaderPartQueueFactory(objectLoader)
+        val globalMemoryManager = mockk<ReservationManager>(relaxed = true)
+        every { globalMemoryManager.totalCapacityBytes } returns 1000
+        coEvery { globalMemoryManager.reserveOrThrow(any(), objectLoader) } returns mockk()
+        every { objectLoader.maxMemoryRatioReservedForParts } returns 0.5
+        beanFactory.objectLoaderMemoryReservation(globalMemoryManager)
+        coVerify { globalMemoryManager.reserveOrThrow(500, objectLoader) }
+    }
+
+    @Test
+    fun `part queue clamps part size if too many workers`() {
+        val beanFactory = ObjectLoaderPartQueueFactory(objectLoader)
+        every { objectLoader.numPartWorkers } returns 5
+        every { objectLoader.numUploadWorkers } returns 3
+        every { objectLoader.partSizeBytes } returns 100
+        val memoryReservation = mockk<Reserved<ObjectLoader>>(relaxed = true)
+        every { memoryReservation.bytesReserved } returns 800
+        val clampedSize = beanFactory.objectLoaderClampedPartSizeBytes(memoryReservation)
+        Assertions.assertEquals(800 / 9, clampedSize)
+    }
+
+    @Test
+    fun `part queue does not clamp part size if not too many workers`() {
+        val beanFactory = ObjectLoaderPartQueueFactory(objectLoader)
+        every { objectLoader.numPartWorkers } returns 5
+        every { objectLoader.numUploadWorkers } returns 1
+        every { objectLoader.partSizeBytes } returns 100
+        val memoryReservation = mockk<Reserved<ObjectLoader>>(relaxed = true)
+        every { memoryReservation.bytesReserved } returns 800
+        val clampedSize = beanFactory.objectLoaderClampedPartSizeBytes(memoryReservation)
+        Assertions.assertEquals(100, clampedSize)
+    }
+
+    @Test
+    fun `queue capacity is derived from clamped size and available memory`() {
+        val beanFactory = ObjectLoaderPartQueueFactory(objectLoader)
+        every { objectLoader.numPartWorkers } returns 3
+        every { objectLoader.numUploadWorkers } returns 1
+        val clampedPartSize = 150L
+        val memoryReservation = mockk<Reserved<ObjectLoader>>(relaxed = true)
+        every { memoryReservation.bytesReserved } returns 910
+        val capacity = beanFactory.objectLoaderPartQueueCapacity(clampedPartSize, memoryReservation)
+        // Expected capacity is total number of parts minus number of workers
+        Assertions.assertEquals(2, capacity)
+    }
+}


### PR DESCRIPTION
# What
Primarily this fixes an issue with the object queue, where we would hard fail if there wasn't enough memory to hold partSize * numWorkers. In practice, this was a huge pain, requiring lots of tweaking and checking against sync failures.

This just clamps the part size if there isn't enough memory. It still might fail at runtime if the part size gets less than the client-specific minimum (i think 1mb for S3). But it's way less likely to fail.

This also fixes an obvious bug with memory allocation. Before I was taking `maxMemoryRatioReservedForParts` * whatever was available in the record queue memory manager. However, it was already scaled down to X% of total. Now there's a first-class global memory manager that everybody takes their share of. This should greatly improve runtime performance because we won't be artificially limiting the queue size. (TODO: Test this in prod before re-enabling S3.)