### PR TITLE
Load CDK: Bugfix: ObjectLoader eos can arrive out-of-order

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/state/StreamManager.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/state/StreamManager.kt
@@ -369,13 +369,10 @@ class DefaultStreamManager(
         inputCount: Long
     ) {
         val taskKey = TaskKey(taskName, part)
-        if (taskCompletionCounts.containsKey(taskKey)) {
-            // TODO: Promote this to a hard failure as part of the subsequent bugfix.
-            log.warn {
-                """"$taskKey received input after seeing end-of-stream
-                        (checkpointCounts=$checkpointCounts, inputCount=$inputCount, sawEosAt=${taskCompletionCounts[taskKey]})
-                        This indicates data was processed out of order and future bookkeeping might be corrupt. Failing hard."""
-            }
+        check(!taskCompletionCounts.containsKey(taskKey)) {
+            """"$taskKey received input after seeing end-of-stream
+                    (checkpointCounts=$checkpointCounts, inputCount=$inputCount, sawEosAt=${taskCompletionCounts[taskKey]})
+                    This indicates data was processed out of order and future bookkeeping might be corrupt. Failing hard."""
         }
         val idToValue =
             namedCheckpointCounts.getOrPut(TaskKey(taskName, part) to state) { ConcurrentHashMap() }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/LoadPipelineStepTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/LoadPipelineStepTask.kt
@@ -89,6 +89,11 @@ class LoadPipelineStepTask<S : AutoCloseable, K1 : WithStream, T, K2 : WithStrea
             try {
                 when (input) {
                     is PipelineMessage -> {
+                        if (stateStore.streamsEnded.contains(input.key.stream)) {
+                            throw IllegalStateException(
+                                "$taskName[$part] received input for complete stream ${input.key.stream}. This indicates data was processed out of order and future bookkeeping might be corrupt. Failing hard."
+                            )
+                        }
                         // Get or create the accumulator state associated w/ the input key.
                         val stateWithCounts =
                             stateStore.stateWithCounts

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/pipline/object_storage/ObjectLoaderFormattedPartPartitioner.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/pipline/object_storage/ObjectLoaderFormattedPartPartitioner.kt
@@ -6,14 +6,15 @@ package io.airbyte.cdk.load.pipline.object_storage
 
 import io.airbyte.cdk.load.message.WithStream
 import io.airbyte.cdk.load.pipeline.OutputPartitioner
+import kotlin.random.Random
 
 /**
- * The technically correct partitioning is round-robin, but since we use
- * [io.airbyte.cdk.load.message.SinglePartitionQueueWithMultiPartitionBroadcast], the partition is
- * immaterial, so it's simpler just to return 0 here.
+ * Distribute the parts randomly across loaders. (Testing shows this is the most efficient pattern.)
  */
 class ObjectLoaderFormattedPartPartitioner<K : WithStream, T> :
     OutputPartitioner<K, T, ObjectKey, ObjectLoaderPartFormatter.FormattedPart> {
+    private val prng = Random(System.currentTimeMillis())
+
     override fun getOutputKey(
         inputKey: K,
         output: ObjectLoaderPartFormatter.FormattedPart
@@ -22,6 +23,6 @@ class ObjectLoaderFormattedPartPartitioner<K : WithStream, T> :
     }
 
     override fun getPart(outputKey: ObjectKey, numParts: Int): Int {
-        return 0
+        return prng.nextInt(numParts)
     }
 }

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/pipline/object_storage/ObjectLoaderLoadedPartPartitioner.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/pipline/object_storage/ObjectLoaderLoadedPartPartitioner.kt
@@ -8,17 +8,19 @@ import io.airbyte.cdk.load.message.WithStream
 import io.airbyte.cdk.load.pipeline.OutputPartitioner
 
 /**
- * The technically correct partitioning is round-robin, but since we use
- * [io.airbyte.cdk.load.message.SinglePartitionQueueWithMultiPartitionBroadcast], the partition is
- * immaterial, so it's simpler just to return 0 here.
+ * Distribute the loaded parts to the upload completers by key. (Distributing the completes
+ * efficiently is not as important as not forcing the uploaders to coordinate with each other, so
+ * instead we focus on operational simplicity: all fact-of-loaded part signals for the same key go
+ * to the same upload completer.)
  */
 class ObjectLoaderLoadedPartPartitioner<K : WithStream, T> :
     OutputPartitioner<K, T, ObjectKey, ObjectLoaderPartLoader.PartResult> {
+
     override fun getOutputKey(inputKey: K, output: ObjectLoaderPartLoader.PartResult): ObjectKey {
         return ObjectKey(inputKey.stream, output.objectKey)
     }
 
     override fun getPart(outputKey: ObjectKey, numParts: Int): Int {
-        return 0
+        return Math.floorMod(outputKey.objectKey.hashCode(), numParts)
     }
 }

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/test/kotlin/io/airbyte/cdk/load/pipeline/object_storage/ObjectLoaderPartPartitionerTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/test/kotlin/io/airbyte/cdk/load/pipeline/object_storage/ObjectLoaderPartPartitionerTest.kt
@@ -16,19 +16,6 @@ import org.junit.jupiter.api.Test
 
 class ObjectLoaderPartPartitionerTest<K : WithStream, T> {
     @Test
-    fun `partitioner always assigns 0`() {
-        val partitioner = ObjectLoaderFormattedPartPartitioner<K, T>()
-        val stream = DestinationStream.Descriptor("test", "stream")
-        val numParts = 3
-        var lastPartition: Int? = null
-        (0 until 12).forEach {
-            val partition = partitioner.getPart(ObjectKey(stream, it.toString()), numParts)
-            lastPartition?.let { _ -> assertEquals(0, partition) }
-            lastPartition = partition
-        }
-    }
-
-    @Test
     fun `partitioner uses object key as accumulator key`() {
         val keys = listOf("foo", "bar", "baz")
         val parts =

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/test/kotlin/io/airbyte/cdk/load/pipeline/object_storage/ObjectLoaderPartQueueTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/test/kotlin/io/airbyte/cdk/load/pipeline/object_storage/ObjectLoaderPartQueueTest.kt
@@ -34,19 +34,19 @@ class ObjectLoaderPartQueueTest {
     fun `part queue clamps part size if too many workers`() {
         val beanFactory = ObjectLoaderPartQueueFactory(objectLoader)
         every { objectLoader.numPartWorkers } returns 5
-        every { objectLoader.numUploadWorkers } returns 3
+        every { objectLoader.numUploadWorkers } returns 3 // this will be doubled for calcs
         every { objectLoader.partSizeBytes } returns 100
         val memoryReservation = mockk<Reserved<ObjectLoader>>(relaxed = true)
         every { memoryReservation.bytesReserved } returns 800
         val clampedSize = beanFactory.objectLoaderClampedPartSizeBytes(memoryReservation)
-        Assertions.assertEquals(800 / 9, clampedSize)
+        Assertions.assertEquals(800 / 11, clampedSize)
     }
 
     @Test
     fun `part queue does not clamp part size if not too many workers`() {
         val beanFactory = ObjectLoaderPartQueueFactory(objectLoader)
         every { objectLoader.numPartWorkers } returns 5
-        every { objectLoader.numUploadWorkers } returns 1
+        every { objectLoader.numUploadWorkers } returns 1 // this will be doubled for calcs
         every { objectLoader.partSizeBytes } returns 100
         val memoryReservation = mockk<Reserved<ObjectLoader>>(relaxed = true)
         every { memoryReservation.bytesReserved } returns 800
@@ -58,7 +58,7 @@ class ObjectLoaderPartQueueTest {
     fun `queue capacity is derived from clamped size and available memory`() {
         val beanFactory = ObjectLoaderPartQueueFactory(objectLoader)
         every { objectLoader.numPartWorkers } returns 3
-        every { objectLoader.numUploadWorkers } returns 1
+        every { objectLoader.numUploadWorkers } returns 1 // this will be doubled for calcs
         val clampedPartSize = 150L
         val memoryReservation = mockk<Reserved<ObjectLoader>>(relaxed = true)
         every { memoryReservation.bytesReserved } returns 910


### PR DESCRIPTION
## What
This issue was exposed by the BulkLoader work, tho technically it can affect S3 also.

The optimization to put single-channel queues between the part formatter, loader, and completer backfired because `merge`ing flows doesn't respect ordering. So if you merge A and B, even if A[1] is pushed before B[1], you might end up consuming B[1] first. The practical effect is that end-of-stream messages might arrive before messages for that stream.

This 
* reverts back to using a multi-channel queue
* changes the memory calculations for the queue to respect that
* adds an explicit hard fail to catch the issue if it arises by other means.

Since the issue is transient and rare, it's hard to write a deterministic unit test for it.

ALSO: this only affects objectloader, which isn't in production yet, so there's no way this could affect S3DataLake. I did rerun the S3DataLake ITs and perf tests a few times to make sure the exception wasn't triggered.