### PR TITLE
Load CDK: BulkLoader Interface

### DIFF
--- a/airbyte-cdk/bulk/toolkits/load-db/build.gradle
+++ b/airbyte-cdk/bulk/toolkits/load-db/build.gradle
@@ -1,0 +1,6 @@
+dependencies {
+    implementation project(':airbyte-cdk:bulk:core:bulk-cdk-core-base')
+    implementation project(':airbyte-cdk:bulk:core:bulk-cdk-core-load')
+
+    api project(':airbyte-cdk:bulk:toolkits:bulk-cdk-toolkit-load-object-storage')
+}

--- a/airbyte-cdk/bulk/toolkits/load-db/src/main/kotlin/io/airbyte/cdk/load/pipeline/db/BulkLoadCompletedUploadPartitioner.kt
+++ b/airbyte-cdk/bulk/toolkits/load-db/src/main/kotlin/io/airbyte/cdk/load/pipeline/db/BulkLoadCompletedUploadPartitioner.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.load.pipeline.db
+
+import io.airbyte.cdk.load.file.object_storage.RemoteObject
+import io.airbyte.cdk.load.message.StreamKey
+import io.airbyte.cdk.load.pipline.object_storage.ObjectKey
+import io.airbyte.cdk.load.pipline.object_storage.ObjectLoaderCompletedUploadPartitioner
+import io.airbyte.cdk.load.pipline.object_storage.ObjectLoaderUploadCompleter
+import io.airbyte.cdk.load.write.db.BulkLoaderFactory
+import io.micronaut.context.annotation.Requires
+import io.micronaut.context.annotation.Secondary
+import jakarta.inject.Singleton
+
+@Singleton
+@Secondary
+@Requires(bean = BulkLoaderFactory::class)
+class BulkLoadCompletedUploadPartitioner<T : RemoteObject<*>> :
+    ObjectLoaderCompletedUploadPartitioner<StreamKey, T> {
+    override fun getOutputKey(
+        inputKey: ObjectKey,
+        output: ObjectLoaderUploadCompleter.UploadResult<T>
+    ): StreamKey {
+        return StreamKey(inputKey.stream)
+    }
+
+    override fun getPart(outputKey: StreamKey, numParts: Int): Int {
+        return Math.floorMod(outputKey.stream.hashCode(), numParts)
+    }
+}

--- a/airbyte-cdk/bulk/toolkits/load-db/src/main/kotlin/io/airbyte/cdk/load/pipeline/db/BulkLoadCompletedUploadQueue.kt
+++ b/airbyte-cdk/bulk/toolkits/load-db/src/main/kotlin/io/airbyte/cdk/load/pipeline/db/BulkLoadCompletedUploadQueue.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.load.pipeline.db
+
+import io.airbyte.cdk.load.file.object_storage.RemoteObject
+import io.airbyte.cdk.load.message.ChannelMessageQueue
+import io.airbyte.cdk.load.message.PartitionedQueue
+import io.airbyte.cdk.load.message.PipelineEvent
+import io.airbyte.cdk.load.message.StrictPartitionedQueue
+import io.airbyte.cdk.load.message.WithStream
+import io.airbyte.cdk.load.pipline.object_storage.ObjectLoaderPartQueueFactory
+import io.airbyte.cdk.load.pipline.object_storage.ObjectLoaderUploadCompleter
+import io.airbyte.cdk.load.write.db.BulkLoaderFactory
+import io.micronaut.context.annotation.Factory
+import io.micronaut.context.annotation.Requires
+import io.micronaut.context.annotation.Secondary
+import jakarta.inject.Named
+import jakarta.inject.Singleton
+import kotlinx.coroutines.channels.Channel
+
+@Factory
+class BulkLoadCompletedUploadQueue<K : WithStream, T : RemoteObject<*>> {
+    @Singleton
+    @Secondary
+    @Requires(bean = BulkLoaderFactory::class)
+    @Named("objectLoaderCompletedUploadQueue")
+    fun bulkLoadCompletedUploadQueue(
+        bulkLoader: BulkLoaderFactory<K, T>
+    ): PartitionedQueue<PipelineEvent<K, ObjectLoaderUploadCompleter.UploadResult<T>>> =
+        StrictPartitionedQueue(
+            (0 until bulkLoader.maxNumConcurrentLoads)
+                .map {
+                    ChannelMessageQueue<
+                        PipelineEvent<K, ObjectLoaderUploadCompleter.UploadResult<T>>>(
+                        Channel(ObjectLoaderPartQueueFactory.OBJECT_LOADER_MAX_ENQUEUED_COMPLETIONS)
+                    )
+                }
+                .toTypedArray()
+        )
+}

--- a/airbyte-cdk/bulk/toolkits/load-db/src/main/kotlin/io/airbyte/cdk/load/pipeline/db/BulkLoadPipeline.kt
+++ b/airbyte-cdk/bulk/toolkits/load-db/src/main/kotlin/io/airbyte/cdk/load/pipeline/db/BulkLoadPipeline.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.load.pipeline.db
+
+import io.airbyte.cdk.load.file.object_storage.RemoteObject
+import io.airbyte.cdk.load.message.WithStream
+import io.airbyte.cdk.load.pipeline.LoadPipeline
+import io.airbyte.cdk.load.pipline.object_storage.ObjectLoaderPartFormatterStep
+import io.airbyte.cdk.load.pipline.object_storage.ObjectLoaderPartLoaderStep
+import io.airbyte.cdk.load.pipline.object_storage.ObjectLoaderPipeline
+import io.airbyte.cdk.load.pipline.object_storage.ObjectLoaderUploadCompleterStep
+import io.airbyte.cdk.load.write.db.BulkLoaderFactory
+import io.micronaut.context.annotation.Replaces
+import io.micronaut.context.annotation.Requires
+import jakarta.inject.Singleton
+
+@Singleton
+@Requires(bean = BulkLoaderFactory::class)
+@Replaces(ObjectLoaderPipeline::class)
+class BulkLoadPipeline<K : WithStream, T : RemoteObject<*>>(
+    formatterStep: ObjectLoaderPartFormatterStep,
+    loaderStep: ObjectLoaderPartLoaderStep<T>,
+    completerStep: ObjectLoaderUploadCompleterStep<K, T>,
+    loadIntoTableStep: BulkLoaderLoadIntoTableStep<K, T>,
+) : LoadPipeline(listOf(formatterStep, loaderStep, completerStep, loadIntoTableStep))

--- a/airbyte-cdk/bulk/toolkits/load-db/src/main/kotlin/io/airbyte/cdk/load/pipeline/db/BulkLoaderLoadIntoTableStep.kt
+++ b/airbyte-cdk/bulk/toolkits/load-db/src/main/kotlin/io/airbyte/cdk/load/pipeline/db/BulkLoaderLoadIntoTableStep.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.load.pipeline.db
+
+import io.airbyte.cdk.load.file.object_storage.RemoteObject
+import io.airbyte.cdk.load.message.PartitionedQueue
+import io.airbyte.cdk.load.message.PipelineEvent
+import io.airbyte.cdk.load.message.WithStream
+import io.airbyte.cdk.load.pipeline.LoadPipelineStep
+import io.airbyte.cdk.load.pipline.object_storage.ObjectLoaderUploadCompleter
+import io.airbyte.cdk.load.task.internal.LoadPipelineStepTask
+import io.airbyte.cdk.load.task.internal.LoadPipelineStepTaskFactory
+import io.airbyte.cdk.load.write.db.BulkLoaderFactory
+import io.micronaut.context.annotation.Requires
+import jakarta.inject.Named
+import jakarta.inject.Singleton
+
+@Singleton
+@Requires(bean = BulkLoaderFactory::class)
+class BulkLoaderLoadIntoTableStep<K : WithStream, T : RemoteObject<*>>(
+    val bulkLoader: BulkLoaderFactory<K, T>,
+    val tableLoader: BulkLoaderTableLoader<K, T>,
+    @Named("objectLoaderCompletedUploadQueue")
+    val inputQueue: PartitionedQueue<PipelineEvent<K, ObjectLoaderUploadCompleter.UploadResult<T>>>,
+    val taskFactory: LoadPipelineStepTaskFactory,
+) : LoadPipelineStep {
+    override val numWorkers: Int = bulkLoader.maxNumConcurrentLoads
+    override fun taskForPartition(partition: Int): LoadPipelineStepTask<*, *, *, *, *> {
+        return taskFactory.createFinalStep(tableLoader, inputQueue, partition, numWorkers)
+    }
+}

--- a/airbyte-cdk/bulk/toolkits/load-db/src/main/kotlin/io/airbyte/cdk/load/pipeline/db/BulkLoaderTableLoader.kt
+++ b/airbyte-cdk/bulk/toolkits/load-db/src/main/kotlin/io/airbyte/cdk/load/pipeline/db/BulkLoaderTableLoader.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.load.pipeline.db
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
+import io.airbyte.cdk.load.file.object_storage.RemoteObject
+import io.airbyte.cdk.load.message.BatchState
+import io.airbyte.cdk.load.message.WithBatchState
+import io.airbyte.cdk.load.message.WithStream
+import io.airbyte.cdk.load.pipeline.BatchAccumulator
+import io.airbyte.cdk.load.pipeline.BatchAccumulatorResult
+import io.airbyte.cdk.load.pipeline.FinalOutput
+import io.airbyte.cdk.load.pipeline.IntermediateOutput
+import io.airbyte.cdk.load.pipeline.NoOutput
+import io.airbyte.cdk.load.pipline.object_storage.ObjectLoaderUploadCompleter
+import io.airbyte.cdk.load.write.db.BulkLoader
+import io.airbyte.cdk.load.write.db.BulkLoaderFactory
+import io.micronaut.context.annotation.Requires
+import jakarta.inject.Singleton
+
+@Singleton
+@Requires(bean = BulkLoaderFactory::class)
+@SuppressFBWarnings(value = ["NP_NONNULL_PARAM_VIOLATION"], justification = "Kotlin coroutines")
+class BulkLoaderTableLoader<K : WithStream, T : RemoteObject<*>>(
+    val bulkLoader: BulkLoaderFactory<K, T>
+) :
+    BatchAccumulator<
+        BulkLoader<T>,
+        K,
+        ObjectLoaderUploadCompleter.UploadResult<T>,
+        BulkLoaderTableLoader.LoadResult
+    > {
+    data object LoadResult : WithBatchState {
+        override val state: BatchState = BatchState.COMPLETE
+    }
+
+    override suspend fun start(key: K, part: Int): BulkLoader<T> {
+        return bulkLoader.create(key, part)
+    }
+
+    override suspend fun accept(
+        input: ObjectLoaderUploadCompleter.UploadResult<T>,
+        state: BulkLoader<T>
+    ): BatchAccumulatorResult<BulkLoader<T>, LoadResult> {
+        if (input.remoteObject == null) {
+            return NoOutput(state)
+        }
+
+        state.load(input.remoteObject!!)
+        return IntermediateOutput(state, LoadResult)
+    }
+
+    override suspend fun finish(state: BulkLoader<T>): FinalOutput<BulkLoader<T>, LoadResult> {
+        return FinalOutput(LoadResult)
+    }
+}

--- a/airbyte-cdk/bulk/toolkits/load-db/src/main/kotlin/io/airbyte/cdk/load/write/db/BulkLoader.kt
+++ b/airbyte-cdk/bulk/toolkits/load-db/src/main/kotlin/io/airbyte/cdk/load/write/db/BulkLoader.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.load.write.db
+
+import io.airbyte.cdk.load.file.object_storage.RemoteObject
+import io.airbyte.cdk.load.message.BatchState
+import io.airbyte.cdk.load.message.WithStream
+import io.airbyte.cdk.load.write.object_storage.ObjectLoader
+
+/**
+ * [BulkLoader] is for the use case in which a destination first stages records in a temporary
+ * location, usually cloud object storage, then loads them into the destination database in bulk.
+ *
+ * To use, declare a singleton of type [BulkLoaderFactory] and implement the
+ * [BulkLoaderFactory.create] method.
+ *
+ * This strategy composes [ObjectLoader] with a post-processing step provided by the [load] method.
+ * As [ObjectLoader] makes loaded objects available, [load] is called on each one in sequence.
+ *
+ * [BulkLoaderFactory.maxNumConcurrentLoads] determines the number of concurrent loads that can be
+ * in progress at once.
+ *
+ * The key type [K] determines how the destination will partition the work. By default,
+ * [io.airbyte.cdk.load.message.StreamKey] is provided and an interface using this type will just
+ * work. Specifically, no more than one [load] will ever be in progress per stream, but up to
+ * [BulkLoaderFactory.maxNumConcurrentLoads] can be in progress at once.
+ *
+ * Additionally, the configuration values provided by [ObjectLoader] can be overridden on the
+ * factory and will work as documented.
+ *
+ * The factory method [BulkLoaderFactory.create] will be called once per key the first time a key is
+ * seen. It is guaranteed to be closed if created.
+ *
+ * To adjust this behavior, declare a named singleton "objectLoaderOutputPartitioner" using the
+ * desired key and/or partition strategy. (See
+ * [io.airbyte.cdk.load.pipline.object_storage.ObjectLoaderUploadCompleterStep])
+ *
+ * TODO: provide a method that allows the user to check for an available connection and defer work
+ * if it is not available.
+ */
+interface BulkLoader<T> : AutoCloseable {
+    suspend fun load(remoteObject: T)
+}
+
+interface BulkLoaderFactory<K : WithStream, T : RemoteObject<*>> : ObjectLoader {
+    val maxNumConcurrentLoads: Int
+
+    fun create(key: K, partition: Int): BulkLoader<T>
+
+    // Override the bookkeeping state for objects in object storage
+    // from the default of "COMPLETE". Connector devs can ignore this.
+    override val stateAfterUpload: BatchState
+        get() = BatchState.LOADED
+}

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/pipline/object_storage/ObjectLoaderCompletedUploadPartitioner.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/pipline/object_storage/ObjectLoaderCompletedUploadPartitioner.kt
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.load.pipline.object_storage
+
+import io.airbyte.cdk.load.file.object_storage.RemoteObject
+import io.airbyte.cdk.load.message.WithStream
+import io.airbyte.cdk.load.pipeline.OutputPartitioner
+
+interface ObjectLoaderCompletedUploadPartitioner<K : WithStream, T : RemoteObject<*>> :
+    OutputPartitioner<
+        ObjectKey,
+        ObjectLoaderPartLoader.PartResult<T>,
+        K,
+        ObjectLoaderUploadCompleter.UploadResult<T>
+    >

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/pipline/object_storage/ObjectLoaderLoadedPartPartitioner.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/pipline/object_storage/ObjectLoaderLoadedPartPartitioner.kt
@@ -4,6 +4,7 @@
 
 package io.airbyte.cdk.load.pipline.object_storage
 
+import io.airbyte.cdk.load.file.object_storage.RemoteObject
 import io.airbyte.cdk.load.message.WithStream
 import io.airbyte.cdk.load.pipeline.OutputPartitioner
 
@@ -13,10 +14,13 @@ import io.airbyte.cdk.load.pipeline.OutputPartitioner
  * instead we focus on operational simplicity: all fact-of-loaded part signals for the same key go
  * to the same upload completer.)
  */
-class ObjectLoaderLoadedPartPartitioner<K : WithStream, T> :
-    OutputPartitioner<K, T, ObjectKey, ObjectLoaderPartLoader.PartResult> {
+class ObjectLoaderLoadedPartPartitioner<K : WithStream, T, U : RemoteObject<*>> :
+    OutputPartitioner<K, T, ObjectKey, ObjectLoaderPartLoader.PartResult<U>> {
 
-    override fun getOutputKey(inputKey: K, output: ObjectLoaderPartLoader.PartResult): ObjectKey {
+    override fun getOutputKey(
+        inputKey: K,
+        output: ObjectLoaderPartLoader.PartResult<U>
+    ): ObjectKey {
         return ObjectKey(inputKey.stream, output.objectKey)
     }
 

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/pipline/object_storage/ObjectLoaderPartQueueFactory.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/pipline/object_storage/ObjectLoaderPartQueueFactory.kt
@@ -5,6 +5,7 @@
 package io.airbyte.cdk.load.pipline.object_storage
 
 import io.airbyte.cdk.load.command.DestinationStream
+import io.airbyte.cdk.load.file.object_storage.RemoteObject
 import io.airbyte.cdk.load.message.ChannelMessageQueue
 import io.airbyte.cdk.load.message.PartitionedQueue
 import io.airbyte.cdk.load.message.PipelineEvent
@@ -129,13 +130,13 @@ class ObjectLoaderPartQueueFactory(
     @Singleton
     @Named("objectLoaderLoadedPartQueue")
     @Requires(bean = ObjectLoader::class)
-    fun objectLoaderLoadedPartQueue():
-        PartitionedQueue<PipelineEvent<ObjectKey, ObjectLoaderPartLoader.PartResult>> {
+    fun <T : RemoteObject<*>> objectLoaderLoadedPartQueue():
+        PartitionedQueue<PipelineEvent<ObjectKey, ObjectLoaderPartLoader.PartResult<T>>> {
         return StrictPartitionedQueue(
             (0 until loader.numUploadCompleters)
                 .map {
                     ChannelMessageQueue(
-                        Channel<PipelineEvent<ObjectKey, ObjectLoaderPartLoader.PartResult>>(
+                        Channel<PipelineEvent<ObjectKey, ObjectLoaderPartLoader.PartResult<T>>>(
                             OBJECT_LOADER_MAX_ENQUEUED_COMPLETIONS / loader.numUploadWorkers
                         )
                     )

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/pipline/object_storage/ObjectLoaderPipeline.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/pipline/object_storage/ObjectLoaderPipeline.kt
@@ -4,6 +4,8 @@
 
 package io.airbyte.cdk.load.pipline.object_storage
 
+import io.airbyte.cdk.load.file.object_storage.RemoteObject
+import io.airbyte.cdk.load.message.WithStream
 import io.airbyte.cdk.load.pipeline.LoadPipeline
 import io.airbyte.cdk.load.write.object_storage.ObjectLoader
 import io.micronaut.context.annotation.Requires
@@ -27,8 +29,8 @@ import jakarta.inject.Singleton
  */
 @Singleton
 @Requires(bean = ObjectLoader::class)
-class ObjectLoaderPipeline(
+class ObjectLoaderPipeline<K : WithStream, T : RemoteObject<*>>(
     partStep: ObjectLoaderPartFormatterStep,
-    uploadStep: ObjectLoaderPartLoaderStep,
-    completerStep: ObjectLoaderUploadCompleterStep,
+    uploadStep: ObjectLoaderPartLoaderStep<T>,
+    completerStep: ObjectLoaderUploadCompleterStep<K, T>,
 ) : LoadPipeline(listOf(partStep, uploadStep, completerStep))

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/pipline/object_storage/ObjectLoaderUploadCompleter.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/pipline/object_storage/ObjectLoaderUploadCompleter.kt
@@ -6,6 +6,7 @@ package io.airbyte.cdk.load.pipline.object_storage
 
 import io.airbyte.cdk.load.file.object_storage.Part
 import io.airbyte.cdk.load.file.object_storage.PartBookkeeper
+import io.airbyte.cdk.load.file.object_storage.RemoteObject
 import io.airbyte.cdk.load.message.BatchState
 import io.airbyte.cdk.load.message.WithBatchState
 import io.airbyte.cdk.load.pipeline.BatchAccumulator
@@ -19,12 +20,12 @@ import jakarta.inject.Singleton
 
 @Singleton
 @Requires(bean = ObjectLoader::class)
-class ObjectLoaderUploadCompleter :
+class ObjectLoaderUploadCompleter<T : RemoteObject<*>>(val objectLoader: ObjectLoader) :
     BatchAccumulator<
         ObjectLoaderUploadCompleter.State,
         ObjectKey,
-        ObjectLoaderPartLoader.PartResult,
-        ObjectLoaderUploadCompleter.UploadResult
+        ObjectLoaderPartLoader.PartResult<T>,
+        ObjectLoaderUploadCompleter.UploadResult<T>
     > {
     private val log = KotlinLogging.logger {}
 
@@ -34,7 +35,8 @@ class ObjectLoaderUploadCompleter :
         }
     }
 
-    data class UploadResult(override val state: BatchState) : WithBatchState
+    data class UploadResult<T>(override val state: BatchState, val remoteObject: T?) :
+        WithBatchState
 
     override suspend fun start(key: ObjectKey, part: Int): State {
         val bookkeeper = PartBookkeeper()
@@ -42,9 +44,9 @@ class ObjectLoaderUploadCompleter :
     }
 
     override suspend fun accept(
-        input: ObjectLoaderPartLoader.PartResult,
+        input: ObjectLoaderPartLoader.PartResult<T>,
         state: State
-    ): BatchAccumulatorResult<State, UploadResult> {
+    ): BatchAccumulatorResult<State, UploadResult<T>> {
         return when (input) {
             is ObjectLoaderPartLoader.LoadedPart -> {
                 val part =
@@ -60,8 +62,8 @@ class ObjectLoaderUploadCompleter :
                     log.info {
                         "Loaded part ${input.partIndex} (isFinal=${input.isFinal}) completes ${state.objectKey}, finishing (state $state)"
                     }
-                    input.upload.await().complete()
-                    FinalOutput(UploadResult(BatchState.COMPLETE))
+                    val obj = input.upload.await().complete()
+                    FinalOutput(UploadResult(objectLoader.stateAfterUpload, obj))
                 } else {
                     log.info {
                         "After loaded part ${input.partIndex} (isFinal=${input.isFinal}), ${state.objectKey} still incomplete, not finishing (state $state)"
@@ -75,11 +77,15 @@ class ObjectLoaderUploadCompleter :
         }
     }
 
-    override suspend fun finish(state: State): FinalOutput<State, UploadResult> {
+    override suspend fun finish(state: State): FinalOutput<State, UploadResult<T>> {
         /**
-         * Should never be called until end-of-stream. There should ever be one completer worker,
-         * and the enclosing step should be configured not to flush.
+         * This method should never be called, because fact-of-uploaded-parts are partitioned and
+         * keyed by the object key, so each upload completer should see all messages for the
+         * object(s) it manages. So there should be no unfinished objects when the completer
+         * receives end-of-stream.
          */
-        return FinalOutput(UploadResult(BatchState.COMPLETE))
+        throw IllegalStateException(
+            "Upload completers had unfinished work at end-of-stream. This should not happen."
+        )
     }
 }

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/pipline/object_storage/ObjectLoaderUploadCompleterStep.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/pipline/object_storage/ObjectLoaderUploadCompleterStep.kt
@@ -4,8 +4,10 @@
 
 package io.airbyte.cdk.load.pipline.object_storage
 
+import io.airbyte.cdk.load.file.object_storage.RemoteObject
 import io.airbyte.cdk.load.message.PartitionedQueue
 import io.airbyte.cdk.load.message.PipelineEvent
+import io.airbyte.cdk.load.message.WithStream
 import io.airbyte.cdk.load.pipeline.LoadPipelineStep
 import io.airbyte.cdk.load.task.internal.LoadPipelineStepTask
 import io.airbyte.cdk.load.task.internal.LoadPipelineStepTaskFactory
@@ -16,21 +18,34 @@ import jakarta.inject.Singleton
 
 @Singleton
 @Requires(bean = ObjectLoader::class)
-class ObjectLoaderUploadCompleterStep(
+class ObjectLoaderUploadCompleterStep<K : WithStream, T : RemoteObject<*>>(
     val objectLoader: ObjectLoader,
-    val uploadCompleter: ObjectLoaderUploadCompleter,
+    val uploadCompleter: ObjectLoaderUploadCompleter<T>,
     @Named("objectLoaderLoadedPartQueue")
-    val inputQueue: PartitionedQueue<PipelineEvent<ObjectKey, ObjectLoaderPartLoader.PartResult>>,
-    val taskFactory: LoadPipelineStepTaskFactory
+    val inputQueue:
+        PartitionedQueue<PipelineEvent<ObjectKey, ObjectLoaderPartLoader.PartResult<T>>>,
+    @Named("objectLoaderCompletedUploadQueue")
+    val completedUploadQueue:
+        PartitionedQueue<PipelineEvent<K, ObjectLoaderUploadCompleter.UploadResult<T>>>? =
+        null,
+    val completedUploadPartitioner: ObjectLoaderCompletedUploadPartitioner<K, T>? = null,
+    val taskFactory: LoadPipelineStepTaskFactory,
 ) : LoadPipelineStep {
     override val numWorkers: Int = objectLoader.numUploadCompleters
 
     override fun taskForPartition(partition: Int): LoadPipelineStepTask<*, *, *, *, *> {
-        return taskFactory.createFinalStep(
-            uploadCompleter,
-            inputQueue,
-            partition,
-            numWorkers,
-        )
+        return if (completedUploadQueue == null) {
+            taskFactory.createFinalStep(uploadCompleter, inputQueue, partition, numWorkers)
+        } else {
+            taskFactory.createIntermediateStep(
+                uploadCompleter,
+                inputQueue,
+                completedUploadPartitioner!!,
+                completedUploadQueue,
+                partition,
+                numWorkers,
+                3
+            )
+        }
     }
 }


### PR DESCRIPTION
## What
BulkLoader interface.

Extends the `ObjectLoader` interface to allow for a final step that loads the object into a table.

## How
Changes to `ObjectLoader`
* adds support for an optional injectable output queue (and partitioner)
* adds support for overriding the state of the object (for example, it's COMPLETE for S3, but only LOADED for MSSQL)
* adds some type parameters so the pipeline can "know" about its output type (so it can be added to the load interface)

New BulkLoader interface
* Composes object loader, exposing all the config for loading objects
* Adds a `load` method for loading objects into the db as they become available

## Next
Nothing is wired to this yet. I've already set it for MSSQL Bulk load in [a separate PR](https://github.com/airbytehq/airbyte/pull/56353/files) and tested it, but I wanted to do the PRs as small as possible.