### PR TITLE
Dest-MSSQL: MSSQL Uses BulkLoader Interface

### DIFF
--- a/airbyte-integrations/connectors/destination-mssql/build.gradle.kts
+++ b/airbyte-integrations/connectors/destination-mssql/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 
 airbyteBulkConnector {
     core = "load"
-    toolkits = listOf("load-azure-blob-storage")
+    toolkits = listOf("load-azure-blob-storage", "load-db")
     cdk = "local"
 }
 

--- a/airbyte-integrations/connectors/destination-mssql/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-mssql/metadata.yaml
@@ -16,7 +16,7 @@ data:
             type: GSM
   connectorType: destination
   definitionId: d4353156-9217-4cad-8dd7-c108fd4f74cf
-  dockerImageTag: 2.1.2
+  dockerImageTag: 2.2.0
   dockerRepository: airbyte/destination-mssql
   documentationUrl: https://docs.airbyte.com/integrations/destinations/mssql
   githubIssueLabel: destination-mssql

--- a/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLBulkLoadStreamLoader.kt
+++ b/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLBulkLoadStreamLoader.kt
@@ -23,6 +23,7 @@ import io.airbyte.cdk.load.message.Batch
 import io.airbyte.cdk.load.message.object_storage.LoadedObject
 import io.airbyte.cdk.load.state.StreamProcessingFailed
 import io.airbyte.cdk.load.write.BatchAccumulator
+import io.airbyte.cdk.load.write.StreamStateStore
 import io.airbyte.cdk.load.write.object_storage.PartToObjectAccumulator
 import io.airbyte.cdk.load.write.object_storage.RecordToPartAccumulator
 import java.io.ByteArrayOutputStream
@@ -39,7 +40,8 @@ class MSSQLBulkLoadStreamLoader(
     private val defaultSchema: String,
     private val azureBlobClient: AzureBlobClient,
     private val validateValuesPreLoad: Boolean,
-    private val recordBatchSizeOverride: Long? = null
+    private val recordBatchSizeOverride: Long? = null,
+    private val streamStateStore: StreamStateStore<MSSQLStreamState>
 ) : AbstractMSSQLStreamLoader(dataSource, stream, sqlBuilder) {
 
     // Bulk-load related collaborators
@@ -64,6 +66,8 @@ class MSSQLBulkLoadStreamLoader(
     override suspend fun start() {
         super.start() // calls ensureTableExists()
         formatFilePath = mssqlFormatFileCreator.createAndUploadFormatFile(defaultSchema).key
+        val state = MSSQLStreamState(dataSource, formatFilePath)
+        streamStateStore.put(stream.descriptor, state)
     }
 
     /**
@@ -193,3 +197,12 @@ class MSSQLBulkLoadStreamLoader(
             )
     }
 }
+
+/**
+ * For use by the new interface (to pass stream state creating during `start` to the BulkLoad
+ * loader.)
+ */
+data class MSSQLStreamState(
+    val dataSource: DataSource,
+    val formatFilePath: String,
+)

--- a/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLBulkLoader.kt
+++ b/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLBulkLoader.kt
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination.mssql.v2
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
+import io.airbyte.cdk.load.command.Dedupe
+import io.airbyte.cdk.load.command.DestinationCatalog
+import io.airbyte.cdk.load.command.DestinationStream
+import io.airbyte.cdk.load.data.csv.toCsvHeader
+import io.airbyte.cdk.load.data.withAirbyteMeta
+import io.airbyte.cdk.load.file.azureBlobStorage.AzureBlob
+import io.airbyte.cdk.load.file.azureBlobStorage.AzureBlobClient
+import io.airbyte.cdk.load.message.StreamKey
+import io.airbyte.cdk.load.pipeline.RoundRobinInputPartitioner
+import io.airbyte.cdk.load.write.StreamStateStore
+import io.airbyte.cdk.load.write.db.BulkLoader
+import io.airbyte.cdk.load.write.db.BulkLoaderFactory
+import io.airbyte.integrations.destination.mssql.v2.config.MSSQLBulkLoadConfiguration
+import io.airbyte.integrations.destination.mssql.v2.config.MSSQLConfiguration
+import io.airbyte.integrations.destination.mssql.v2.config.MSSQLIsConfiguredForBulkLoad
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.micronaut.context.annotation.Requires
+import jakarta.inject.Singleton
+
+@Singleton class MSSQLInputPartitioner : RoundRobinInputPartitioner()
+
+@SuppressFBWarnings(value = ["NP_NONNULL_PARAM_VIOLATION"], justification = "Kotlin coroutines")
+class MSSQLBulkLoader(
+    private val azureBlobClient: AzureBlobClient,
+    private val stream: DestinationStream,
+    private val mssqlBulkLoadHandler: MSSQLBulkLoadHandler,
+    private val formatFilePath: String
+) : BulkLoader<AzureBlob> {
+    private val log = KotlinLogging.logger {}
+
+    override suspend fun load(remoteObject: AzureBlob) {
+        val dataFilePath = remoteObject.key
+        try {
+            if (stream.importType is Dedupe) {
+                handleDedup(dataFilePath)
+            } else {
+                handleAppendOverwrite(dataFilePath)
+            }
+        } finally {
+            // Best-effort cleanup of the data blob
+            deleteBlobSafe(dataFilePath)
+        }
+    }
+
+    /**
+     * Merges upsert data by creating a temporary table, bulk-loading the CSV, and then MERGEing
+     * into the destination table using the PK columns.
+     */
+    private fun handleDedup(dataFilePath: String) {
+        log.info { "Deduplicating $dataFilePath into table for ${stream.descriptor}" }
+        val importType = stream.importType as Dedupe
+        val primaryKey =
+            if (importType.primaryKey.isNotEmpty()) {
+                importType.primaryKey.flatten()
+            } else {
+                // If no dedicated PK is provided, use the cursor as the PK
+                importType.cursor
+            }
+
+        // Build the full list of columns, including the Airbyte metadata columns
+        val allColumns = stream.schema.withAirbyteMeta(true).toCsvHeader().toList()
+
+        val nonPkColumns = allColumns - primaryKey.toSet()
+
+        mssqlBulkLoadHandler.bulkLoadAndUpsertForDedup(
+            primaryKeyColumns = primaryKey,
+            cursorColumns = importType.cursor,
+            nonPkColumns = nonPkColumns,
+            dataFilePath = dataFilePath,
+            formatFilePath = formatFilePath
+        )
+    }
+
+    /** Performs a simple bulk insert (append-overwrite behavior). */
+    private fun handleAppendOverwrite(dataFilePath: String) {
+        log.info { "Loading $dataFilePath into table for ${stream.descriptor}" }
+        mssqlBulkLoadHandler.bulkLoadForAppendOverwrite(
+            dataFilePath = dataFilePath,
+            formatFilePath = formatFilePath
+        )
+    }
+
+    /**
+     * Safely attempts to delete the provided blob path, logging any errors but not rethrowing by
+     * default.
+     */
+    private suspend fun deleteBlobSafe(path: String) {
+        try {
+            log.info { "Deleting blob at path=$path" }
+            azureBlobClient.delete(path)
+        } catch (e: Exception) {
+            log.error(e) { "Failed to delete blob at path=$path. Cause: ${e.message}" }
+        }
+    }
+
+    override fun close() {
+        /* Do nothing */
+    }
+}
+
+@Singleton
+@Requires(condition = MSSQLIsConfiguredForBulkLoad::class)
+class MSSQLBulkLoaderFactory(
+    private val azureBlobClient: AzureBlobClient,
+    private val catalog: DestinationCatalog,
+    private val config: MSSQLConfiguration,
+    private val bulkLoadConfig: MSSQLBulkLoadConfiguration,
+    private val streamStateStore: StreamStateStore<MSSQLStreamState>
+) : BulkLoaderFactory<StreamKey, AzureBlob> {
+    override val numPartWorkers: Int = 2
+    override val numUploadWorkers: Int = 10
+    override val maxNumConcurrentLoads: Int = 1
+
+    override val objectSizeBytes: Long = 200 * 1024 * 1024 // 200 MB
+    override val partSizeBytes: Long = 10 * 1024 * 1024 // 10 MB
+    override val maxMemoryRatioReservedForParts: Double = 0.6
+
+    private val defaultSchema = config.schema
+    // This cast is guaranteed to succeed by the `Requires` condition
+
+    override fun create(key: StreamKey, partition: Int): BulkLoader<AzureBlob> {
+        val stream = catalog.getStream(key.stream)
+        val mssqlBulkLoadHandler =
+            MSSQLBulkLoadHandler(
+                streamStateStore.get(key.stream)!!.dataSource,
+                stream.descriptor.namespace ?: defaultSchema,
+                stream.descriptor.name,
+                bulkLoadConfig.dataSource,
+                MSSQLQueryBuilder(config.schema, stream)
+            )
+        return MSSQLBulkLoader(
+            azureBlobClient,
+            stream,
+            mssqlBulkLoadHandler,
+            streamStateStore.get(key.stream)!!.formatFilePath
+        )
+    }
+}

--- a/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLWriter.kt
+++ b/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLWriter.kt
@@ -8,6 +8,7 @@ import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.state.DestinationFailure
 import io.airbyte.cdk.load.write.DestinationWriter
 import io.airbyte.cdk.load.write.StreamLoader
+import io.airbyte.cdk.load.write.StreamStateStore
 import io.airbyte.integrations.destination.mssql.v2.config.AzureBlobStorageClientCreator
 import io.airbyte.integrations.destination.mssql.v2.config.BulkLoadConfiguration
 import io.airbyte.integrations.destination.mssql.v2.config.InsertLoadTypeConfiguration
@@ -22,7 +23,8 @@ class MSSQLWriter(
     private val config: MSSQLConfiguration,
     private val dataSourceFactory: MSSQLDataSourceFactory,
     @Value("\${airbyte.destination.core.record-batch-size-override:null}")
-    private val recordBatchSizeOverride: Long? = null
+    private val recordBatchSizeOverride: Long? = null,
+    private val streamStateStore: StreamStateStore<MSSQLStreamState>
 ) : DestinationWriter {
 
     /** Lazily initialized when [setup] is called. */
@@ -50,7 +52,8 @@ class MSSQLWriter(
                     azureBlobClient =
                         AzureBlobStorageClientCreator.createAzureBlobClient(loadConfig),
                     validateValuesPreLoad = loadConfig.validateValuesPreLoad ?: false,
-                    recordBatchSizeOverride = recordBatchSizeOverride
+                    recordBatchSizeOverride = recordBatchSizeOverride,
+                    streamStateStore = streamStateStore
                 )
             }
             is InsertLoadTypeConfiguration -> {

--- a/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/config/MSSQLBulkLoadConfiguration.kt
+++ b/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/config/MSSQLBulkLoadConfiguration.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination.mssql.v2.config
+
+import io.airbyte.cdk.load.command.azureBlobStorage.AzureBlobStorageConfiguration
+import io.airbyte.cdk.load.command.azureBlobStorage.AzureBlobStorageConfigurationProvider
+import io.airbyte.cdk.load.command.object_storage.ObjectStorageCompressionConfiguration
+import io.airbyte.cdk.load.command.object_storage.ObjectStorageCompressionConfigurationProvider
+import io.airbyte.cdk.load.command.object_storage.ObjectStoragePathConfiguration
+import io.airbyte.cdk.load.command.object_storage.ObjectStoragePathConfigurationProvider
+import io.airbyte.cdk.load.file.NoopProcessor
+import io.micronaut.context.annotation.Requires
+import io.micronaut.context.condition.Condition
+import io.micronaut.context.condition.ConditionContext
+import jakarta.inject.Singleton
+import java.io.ByteArrayOutputStream
+
+class MSSQLIsConfiguredForBulkLoad : Condition {
+    override fun matches(context: ConditionContext<*>): Boolean {
+        val config = context.beanContext.getBean(MSSQLConfiguration::class.java)
+        return config.mssqlLoadTypeConfiguration.loadTypeConfiguration is BulkLoadConfiguration
+    }
+}
+
+@Singleton
+@Requires(condition = MSSQLIsConfiguredForBulkLoad::class)
+class MSSQLBulkLoadConfiguration(
+    private val config: MSSQLConfiguration,
+) :
+    ObjectStoragePathConfigurationProvider,
+    ObjectStorageCompressionConfigurationProvider<ByteArrayOutputStream>,
+    AzureBlobStorageConfigurationProvider {
+
+    // Cast is guaranteed to succeed by the `Requires` guard.
+    private val bulkLoadConfig =
+        config.mssqlLoadTypeConfiguration.loadTypeConfiguration as BulkLoadConfiguration
+
+    val dataSource: String = bulkLoadConfig.bulkLoadDataSource
+    override val objectStoragePathConfiguration =
+        ObjectStoragePathConfiguration(
+            prefix = "blob",
+            pathPattern = "\${NAMESPACE}/\${STREAM_NAME}/\${YEAR}/\${MONTH}/\${DAY}/\${EPOCH}/",
+            fileNamePattern = "{part_number}{format_extension}",
+        )
+    override val objectStorageCompressionConfiguration:
+        ObjectStorageCompressionConfiguration<ByteArrayOutputStream> =
+        ObjectStorageCompressionConfiguration(NoopProcessor)
+    override val azureBlobStorageConfiguration: AzureBlobStorageConfiguration
+        get() =
+            AzureBlobStorageConfiguration(
+                accountName = bulkLoadConfig.accountName,
+                containerName = bulkLoadConfig.containerName,
+                sharedAccessSignature = bulkLoadConfig.sharedAccessSignature,
+            )
+}

--- a/docs/integrations/destinations/mssql.md
+++ b/docs/integrations/destinations/mssql.md
@@ -158,6 +158,7 @@ See the [Getting Started: Configuration section](#configuration) of this guide f
 
 | Version    | Date       | Pull Request                                               | Subject                                                                                             |
 |:-----------|:-----------|:-----------------------------------------------------------|:----------------------------------------------------------------------------------------------------|
+| 2.2.0      | 2025-03-23 | [56353](https://github.com/airbytehq/airbyte/pull/56353)   | Bulk Load performance improvements                                                                  |
 | 2.1.2      | 2025-03-25 | [56346](https://github.com/airbytehq/airbyte/pull/56346)   | Internal refactor                                                                                   |
 | 2.1.1      | 2025-03-24 | [56355](https://github.com/airbytehq/airbyte/pull/56355)   | Upgrade to airbyte/java-connector-base:2.0.1 to be M4 compatible.                                   |
 | 2.1.0      | 2025-03-24 | [55849](https://github.com/airbytehq/airbyte/pull/55849)   | Misc. bugfixes in type-handling (esp. in complex types)                                             |


### PR DESCRIPTION
## What
MSSQL Uses the BulkLoader interface described [here ](https://github.com/airbytehq/airbyte/pull/56352).

This basically just moves the work that was being done for bulk load in the BulkLoaderStreamLoader into `MSSQLBulkLoader`. Start/close still live in the stream loader. A small statestore is broken out to pass info from start/close to the factory. Additionally there's some micronaut magic to make it possible to conditionally inject a bean based on whether we're configured for BulkLoad.

This has been heavily tested, all relevant fixes and improvements are in underlying PRs. Expect a slight perf improvement in the cloud. (Also I verified that I didn't break StandardInsert.)