### PR TITLE
Fix gradle check

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -51,6 +51,14 @@ dependencyResolutionManagement {
 
         // Maven Central has most of everything.
         mavenCentral()
+        // TODO remove this after jsonschemafriend is republished to jitpack https://github.com/jimblackler/jsonschemafriend/issues/124
+        maven {
+            name 'scijava'
+            url 'https://maven.scijava.org/content/repositories/public'
+            content {
+                includeGroup 'net.jimblackler.jsonschemafriend'
+            }
+        }
         // Jitpack is used to pull dependencies directly from github.
         maven {
             name 'jitpack'


### PR DESCRIPTION
source-e2e-test's build is broken, because jsonschemafriend 0.12.4 got pulled from jitpack - https://github.com/jimblackler/jsonschemafriend/issues/124

this is causing the `gradle check` PR check to fail. So switch to the scijava repo for now (https://mvnrepository.com/artifact/net.jimblackler.jsonschemafriend/core/0.12.4)