### PR TITLE
Bulk Load CDK: delete unknownvalue

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/AirbyteValue.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/AirbyteValue.kt
@@ -6,7 +6,6 @@ package io.airbyte.cdk.load.data
 
 import com.fasterxml.jackson.annotation.JsonValue
 import com.fasterxml.jackson.core.JsonGenerator
-import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.JsonSerializer
 import com.fasterxml.jackson.databind.SerializerProvider
 import com.fasterxml.jackson.databind.annotation.JsonSerialize
@@ -153,8 +152,6 @@ private class ObjectValueSerializer : JsonSerializer<ObjectValue>() {
         gen.writePOJO(value.values)
     }
 }
-
-@JvmInline value class UnknownValue(val value: JsonNode) : AirbyteValue
 
 /**
  * Represents an "enriched" (/augmented) Airbyte value with additional metadata.

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/AirbyteValueCoercer.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/AirbyteValueCoercer.kt
@@ -95,8 +95,7 @@ object AirbyteValueCoercer {
                 is TimeWithTimezoneValue,
                 is TimeWithoutTimezoneValue,
                 is TimestampWithTimezoneValue,
-                is TimestampWithoutTimezoneValue,
-                is UnknownValue ->
+                is TimestampWithoutTimezoneValue ->
                     throw IllegalArgumentException(
                         "Invalid value type ${value.javaClass.canonicalName}"
                     )

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/json/AirbyteValueToJson.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/json/AirbyteValueToJson.kt
@@ -6,7 +6,19 @@ package io.airbyte.cdk.load.data.json
 
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.node.JsonNodeFactory
-import io.airbyte.cdk.load.data.*
+import io.airbyte.cdk.load.data.AirbyteValue
+import io.airbyte.cdk.load.data.ArrayValue
+import io.airbyte.cdk.load.data.BooleanValue
+import io.airbyte.cdk.load.data.DateValue
+import io.airbyte.cdk.load.data.IntegerValue
+import io.airbyte.cdk.load.data.NullValue
+import io.airbyte.cdk.load.data.NumberValue
+import io.airbyte.cdk.load.data.ObjectValue
+import io.airbyte.cdk.load.data.StringValue
+import io.airbyte.cdk.load.data.TimeWithTimezoneValue
+import io.airbyte.cdk.load.data.TimeWithoutTimezoneValue
+import io.airbyte.cdk.load.data.TimestampWithTimezoneValue
+import io.airbyte.cdk.load.data.TimestampWithoutTimezoneValue
 
 class AirbyteValueToJson {
     fun convert(value: AirbyteValue): JsonNode {
@@ -30,7 +42,6 @@ class AirbyteValueToJson {
                 JsonNodeFactory.instance.textNode(value.value.toString())
             is TimestampWithoutTimezoneValue ->
                 JsonNodeFactory.instance.textNode(value.value.toString())
-            is UnknownValue -> value.value
         }
     }
 }

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/data/json/AirbyteValueToJsonTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/data/json/AirbyteValueToJsonTest.kt
@@ -17,7 +17,6 @@ import io.airbyte.cdk.load.data.TimeWithTimezoneValue
 import io.airbyte.cdk.load.data.TimeWithoutTimezoneValue
 import io.airbyte.cdk.load.data.TimestampWithTimezoneValue
 import io.airbyte.cdk.load.data.TimestampWithoutTimezoneValue
-import io.airbyte.cdk.load.data.UnknownValue
 import io.airbyte.cdk.load.util.Jsons
 import io.airbyte.cdk.load.util.serializeToString
 import java.math.BigDecimal
@@ -81,7 +80,6 @@ class AirbyteValueToJsonTest {
                 ArrayValue(listOf(NullValue, ArrayValue(listOf(NullValue)))) to "[null,[null]]",
                 ObjectValue(linkedMapOf("foo" to ObjectValue(linkedMapOf("bar" to NullValue)))) to
                     """{"foo":{"bar":null}}""",
-                UnknownValue(Jsons.readTree("""{"foo": "bar"}""")) to """{"foo":"bar"}"""
             )
         testCases.forEach { (value, expectedSerialization) ->
             val actual =

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/RecordDiffer.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/RecordDiffer.kt
@@ -9,8 +9,6 @@ import io.airbyte.cdk.load.data.ArrayValue
 import io.airbyte.cdk.load.data.IntegerValue
 import io.airbyte.cdk.load.data.NullValue
 import io.airbyte.cdk.load.data.ObjectValue
-import io.airbyte.cdk.load.data.UnknownValue
-import io.airbyte.cdk.load.data.json.JsonToAirbyteValue
 import kotlin.reflect.jvm.jvmName
 
 class RecordDiffer(
@@ -292,21 +290,6 @@ class RecordDiffer(
         }
 
         private fun compare(v1: AirbyteValue, v2: AirbyteValue, nullEqualsUnset: Boolean): Int {
-            if (v1 is UnknownValue) {
-                return compare(
-                    JsonToAirbyteValue().convert(v1.value),
-                    v2,
-                    nullEqualsUnset,
-                )
-            }
-            if (v2 is UnknownValue) {
-                return compare(
-                    v1,
-                    JsonToAirbyteValue().convert(v2.value),
-                    nullEqualsUnset,
-                )
-            }
-
             // when comparing values of different types, just sort by their class name.
             // in theory, we could check for numeric types and handle them smartly...
             // that's a lot of work though

--- a/airbyte-cdk/bulk/toolkits/load-csv/src/main/kotlin/io/airbyte/cdk/load/data/csv/AirbyteValueToCsvRow.kt
+++ b/airbyte-cdk/bulk/toolkits/load-csv/src/main/kotlin/io/airbyte/cdk/load/data/csv/AirbyteValueToCsvRow.kt
@@ -18,7 +18,6 @@ import io.airbyte.cdk.load.data.TimeWithTimezoneValue
 import io.airbyte.cdk.load.data.TimeWithoutTimezoneValue
 import io.airbyte.cdk.load.data.TimestampWithTimezoneValue
 import io.airbyte.cdk.load.data.TimestampWithoutTimezoneValue
-import io.airbyte.cdk.load.data.UnknownValue
 import io.airbyte.cdk.load.data.json.toJson
 import io.airbyte.cdk.load.util.serializeToString
 
@@ -41,7 +40,6 @@ fun AirbyteValue?.toCsvValue(): Any {
             is DateValue -> it.value
             is TimeWithTimezoneValue -> it.value
             is TimeWithoutTimezoneValue -> it.value
-            is UnknownValue -> ""
         }
     }
         ?: ""

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/data/iceberg/parquet/AirbyteValueToIcebergRecord.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/data/iceberg/parquet/AirbyteValueToIcebergRecord.kt
@@ -17,7 +17,6 @@ import io.airbyte.cdk.load.data.TimeWithTimezoneValue
 import io.airbyte.cdk.load.data.TimeWithoutTimezoneValue
 import io.airbyte.cdk.load.data.TimestampWithTimezoneValue
 import io.airbyte.cdk.load.data.TimestampWithoutTimezoneValue
-import io.airbyte.cdk.load.data.UnknownValue
 import java.time.ZoneOffset
 import org.apache.iceberg.Schema
 import org.apache.iceberg.data.GenericRecord
@@ -121,7 +120,6 @@ class AirbyteValueToIcebergRecord {
                             "${type.typeId()} type is not allowed for TimestampValue"
                         )
                 }
-            is UnknownValue -> throw IllegalArgumentException("Unknown type is not supported")
         }
     }
 }

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/testFixtures/kotlin/io/airbyte/cdk/load/data/icerberg/parquet/AirbyteValueToIcebergRecordTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/testFixtures/kotlin/io/airbyte/cdk/load/data/icerberg/parquet/AirbyteValueToIcebergRecordTest.kt
@@ -19,12 +19,10 @@ import io.airbyte.cdk.load.data.TimeWithTimezoneValue
 import io.airbyte.cdk.load.data.TimeWithoutTimezoneValue
 import io.airbyte.cdk.load.data.TimestampWithTimezoneValue
 import io.airbyte.cdk.load.data.TimestampWithoutTimezoneValue
-import io.airbyte.cdk.load.data.UnknownValue
 import io.airbyte.cdk.load.data.iceberg.parquet.AirbyteValueToIcebergRecord
 import io.airbyte.cdk.load.data.iceberg.parquet.toIcebergRecord
 import io.airbyte.cdk.load.message.EnrichedDestinationRecordAirbyteValue
 import io.airbyte.cdk.load.message.Meta
-import io.airbyte.protocol.models.Jsons
 import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -162,13 +160,6 @@ class AirbyteValueToIcebergRecordTest {
                 Types.TimestampType.withZone()
             )
         assertEquals(OffsetDateTime.parse("2024-11-18T12:34:56Z"), result)
-    }
-
-    @Test
-    fun `convert throws exception for UnknownValue`() {
-        assertThrows<IllegalArgumentException> {
-            converter.convert(UnknownValue(Jsons.emptyObject()), Types.StringType.get())
-        }
     }
 
     @Test


### PR DESCRIPTION
afaict we never construct this object, and it's irrelevant in the new typing interface. Delete it.