### PR TITLE
Remove Loom reference generating 404 error

### DIFF
--- a/docs/connector-development/connector-builder-ui/record-processing.mdx
+++ b/docs/connector-development/connector-builder-ui/record-processing.mdx
@@ -11,16 +11,6 @@ Connectors built with the connector builder always make HTTP requests, receive t
 
 ## Response Decoding
 
-<iframe
-  width="800"
-  height="490"
-  src="https://www.loom.com/embed/ae6dce06ccb24795a8eddcdf0fe33a84"
-  frameborder="0"
-  webkitallowfullscreen
-  mozallowfullscreen
-  allowfullscreen
-></iframe>
-
 The first step in converting an HTTP response into records is decoding the response body into normalized JSON objects, as the rest of the record processing logic performed by the connector expects to operate on JSON objects.
 
 The HTTP Response Format is used to configure this decoding by declaring what the encoding of the response body is.


### PR DESCRIPTION
## What

A missing Loom video on response decoding is causing a rather [large and apparent 404 error](https://docs.airbyte.com/connector-development/connector-builder-ui/record-processing#response-decoding). This change removes the video reference. 

## How

Removed reference to deleted video.

## Review guide

## User Impact

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌
