### PR TITLE
Destination MSSQL / bulk load CDK: tweak how we process metadata

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/command/DestinationConfiguration.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/command/DestinationConfiguration.kt
@@ -87,6 +87,7 @@ abstract class DestinationConfiguration : Configuration {
         const val DEFAULT_RECORD_BATCH_SIZE_BYTES = 200L * 1024L * 1024L
         const val DEFAULT_HEARTBEAT_INTERVAL_SECONDS = 60L
         const val DEFAULT_MAX_TIME_WITHOUT_FLUSHING_DATA_SECONDS = 15 * 60L
+        const val DEFAULT_GENERATION_ID_METADATA_KEY = "ab-generation-id"
     }
 
     // DEPRECATED: Old interface config. TODO: Drop when we're totally migrated.
@@ -97,6 +98,8 @@ abstract class DestinationConfiguration : Configuration {
     open val numProcessBatchWorkers: Int = 5
     open val numProcessBatchWorkersForFileTransfer: Int = 3
     open val batchQueueDepth: Int = 10
+
+    open val generationIdMetadataKey: String = DEFAULT_GENERATION_ID_METADATA_KEY
 
     /**
      * Micronaut factory which glues [ConfigurationSpecificationSupplier] and

--- a/airbyte-cdk/bulk/toolkits/load-azure-blob-storage/src/main/kotlin/io/airbyte/cdk/load/file/azureBlobStorage/AzureBlobStorageClient.kt
+++ b/airbyte-cdk/bulk/toolkits/load-azure-blob-storage/src/main/kotlin/io/airbyte/cdk/load/file/azureBlobStorage/AzureBlobStorageClient.kt
@@ -9,12 +9,9 @@ import com.azure.storage.blob.BlobServiceClient
 import com.azure.storage.blob.models.BlobStorageException
 import com.azure.storage.blob.models.ListBlobsOptions
 import io.airbyte.cdk.load.command.azureBlobStorage.AzureBlobStorageConfiguration
-import io.airbyte.cdk.load.data.Transformations
 import io.airbyte.cdk.load.file.object_storage.ObjectStorageClient
 import io.airbyte.cdk.load.file.object_storage.RemoteObject
 import io.airbyte.cdk.load.file.object_storage.StreamingUpload
-import io.airbyte.cdk.load.state.object_storage.MetadataKeyMapper
-import jakarta.inject.Singleton
 import java.io.InputStream
 import java.time.OffsetDateTime
 import kotlinx.coroutines.flow.Flow
@@ -135,23 +132,5 @@ class AzureBlobClient(
                 .getBlockBlobClient()
 
         return AzureBlobStreamingUpload(blobClient, blobConfig, metadata)
-    }
-}
-
-@Singleton
-class AzureBlobStorageMetadataKeyMapper : MetadataKeyMapper {
-    override fun map(key: String): String {
-        var mangledMetadataKey = key
-        // Key must start with a letter or underscore
-        if (mangledMetadataKey.isEmpty() || !mangledMetadataKey.contains(Regex("^[a-zA-Z_]"))) {
-            mangledMetadataKey = ESCAPE_PREFIX + mangledMetadataKey
-        }
-        // Key must be letters, numbers, or underscores
-        mangledMetadataKey = Transformations.toAlphanumericAndUnderscore(mangledMetadataKey)
-        return mangledMetadataKey
-    }
-
-    companion object {
-        private const val ESCAPE_PREFIX = "ab_"
     }
 }

--- a/airbyte-cdk/bulk/toolkits/load-azure-blob-storage/src/main/kotlin/io/airbyte/cdk/load/file/azureBlobStorage/AzureBlobStreamingUpload.kt
+++ b/airbyte-cdk/bulk/toolkits/load-azure-blob-storage/src/main/kotlin/io/airbyte/cdk/load/file/azureBlobStorage/AzureBlobStreamingUpload.kt
@@ -15,7 +15,6 @@ import java.util.concurrent.ConcurrentSkipListMap
 import java.util.concurrent.atomic.AtomicBoolean
 
 private const val BLOB_ID_PREFIX = "block"
-private const val RESERVED_PREFIX = "x-ms-"
 
 class AzureBlobStreamingUpload(
     private val blockBlobClient: BlockBlobClient,
@@ -26,7 +25,6 @@ class AzureBlobStreamingUpload(
     private val log = KotlinLogging.logger {}
     private val isComplete = AtomicBoolean(false)
     private val blockIds = ConcurrentSkipListMap<Int, String>()
-    private val invalidCharsRegex = Regex("[<>:\"/\\\\?#*\\-]")
 
     /**
      * Each part that arrives is treated as a new block. We must generate unique block IDs for each
@@ -68,15 +66,13 @@ class AzureBlobStreamingUpload(
             } else {
                 val blockList = blockIds.values.toList()
                 log.info { "Committing block list for ${blockBlobClient.blobName}: $blockList" }
-                blockBlobClient.commitBlockList(blockIds.values.toList(), true) // Overwrite = true
             }
+
+            blockBlobClient.commitBlockList(blockIds.values.toList(), true) // Overwrite = true
 
             // Set any metadata
             if (metadata.isNotEmpty()) {
-                val filteredMetadata = filterInvalidMetadata(metadata)
-                if (filteredMetadata.isNotEmpty()) {
-                    blockBlobClient.setMetadata(filteredMetadata)
-                }
+                blockBlobClient.setMetadata(metadata)
             }
         } else {
             log.warn { "Complete called multiple times for ${blockBlobClient.blobName}" }
@@ -101,44 +97,5 @@ class AzureBlobStreamingUpload(
 
         // Encode the entire fixed-length buffer to Base64
         return Base64.getEncoder().encodeToString(buffer.array())
-    }
-    /**
-     * Return a new map containing only valid key/value pairs according to Azure metadata
-     * constraints.
-     */
-    private fun filterInvalidMetadata(metadata: Map<String, String>): Map<String, String> {
-        return metadata.filter { (key, value) -> isValidKey(key) && isValidValue(value) }
-    }
-    /**
-     * Validates if the provided key string meets the required criteria.
-     *
-     * @param key The string to validate as a key
-     * @return Boolean indicating whether the key is valid
-     */
-    private fun isValidKey(key: String): Boolean {
-        // Reject empty keys or keys that start with reserved prefix
-        if (key.isBlank() || key.startsWith(RESERVED_PREFIX)) return false
-
-        // Reject keys containing any characters matching the invalid pattern
-        if (invalidCharsRegex.containsMatchIn(key)) return false
-
-        // Ensure all characters are within the printable ASCII range (32-126)
-        // This includes letters, numbers, and common symbols
-        return key.all { it.code in 32..126 }
-    }
-
-    /**
-     * Validates if the provided value string meets the required criteria.
-     *
-     * @param value The string to validate as a value
-     * @return Boolean indicating whether the value is valid
-     */
-    private fun isValidValue(value: String): Boolean {
-        // Reject values containing any characters matching the invalid pattern
-        if (invalidCharsRegex.containsMatchIn(value)) return false
-
-        // Ensure all characters are within the printable ASCII range (32-126)
-        // This includes letters, numbers, and common symbols
-        return value.all { it.code in 32..126 }
     }
 }

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/pipline/object_storage/ObjectLoaderPartLoader.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/pipline/object_storage/ObjectLoaderPartLoader.kt
@@ -41,7 +41,7 @@ class ObjectLoaderPartLoader<T : RemoteObject<*>>(
     private val client: ObjectStorageClient<T>,
     private val catalog: DestinationCatalog,
     private val uploads: UploadsInProgress<T>,
-    private val objectLoader: ObjectLoader?,
+    private val objectLoader: ObjectLoader,
 ) :
     BatchAccumulator<
         ObjectLoaderPartLoader.State<T>,

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/pipline/object_storage/ObjectLoaderPartLoader.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/pipline/object_storage/ObjectLoaderPartLoader.kt
@@ -14,8 +14,8 @@ import io.airbyte.cdk.load.pipeline.BatchAccumulator
 import io.airbyte.cdk.load.pipeline.BatchAccumulatorResult
 import io.airbyte.cdk.load.pipeline.FinalOutput
 import io.airbyte.cdk.load.pipeline.IntermediateOutput
-import io.airbyte.cdk.load.state.object_storage.ObjectStorageDestinationState
 import io.airbyte.cdk.load.write.object_storage.ObjectLoader
+import io.airbyte.cdk.load.write.object_storage.metadataFor
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.micronaut.context.annotation.Requires
 import jakarta.inject.Singleton
@@ -41,6 +41,7 @@ class ObjectLoaderPartLoader<T : RemoteObject<*>>(
     private val client: ObjectStorageClient<T>,
     private val catalog: DestinationCatalog,
     private val uploads: UploadsInProgress<T>,
+    private val objectLoader: ObjectLoader?,
 ) :
     BatchAccumulator<
         ObjectLoaderPartLoader.State<T>,
@@ -82,7 +83,7 @@ class ObjectLoaderPartLoader<T : RemoteObject<*>>(
                 CoroutineScope(Dispatchers.IO).async {
                     client.startStreamingUpload(
                         key.objectKey,
-                        metadata = ObjectStorageDestinationState.metadataFor(stream)
+                        metadata = objectLoader.metadataFor(stream)
                     )
                 },
             )

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/pipline/object_storage/ObjectLoaderPartLoader.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/pipline/object_storage/ObjectLoaderPartLoader.kt
@@ -5,6 +5,7 @@
 package io.airbyte.cdk.load.pipline.object_storage
 
 import io.airbyte.cdk.load.command.DestinationCatalog
+import io.airbyte.cdk.load.command.DestinationConfiguration
 import io.airbyte.cdk.load.file.object_storage.ObjectStorageClient
 import io.airbyte.cdk.load.file.object_storage.RemoteObject
 import io.airbyte.cdk.load.file.object_storage.StreamingUpload
@@ -41,7 +42,7 @@ class ObjectLoaderPartLoader<T : RemoteObject<*>>(
     private val client: ObjectStorageClient<T>,
     private val catalog: DestinationCatalog,
     private val uploads: UploadsInProgress<T>,
-    private val objectLoader: ObjectLoader,
+    private val destinationConfig: DestinationConfiguration,
 ) :
     BatchAccumulator<
         ObjectLoaderPartLoader.State<T>,
@@ -83,7 +84,7 @@ class ObjectLoaderPartLoader<T : RemoteObject<*>>(
                 CoroutineScope(Dispatchers.IO).async {
                     client.startStreamingUpload(
                         key.objectKey,
-                        metadata = objectLoader.metadataFor(stream)
+                        metadata = destinationConfig.metadataFor(stream)
                     )
                 },
             )

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/state/object_storage/ObjectStorageDestinationStateManager.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/state/object_storage/ObjectStorageDestinationStateManager.kt
@@ -27,7 +27,7 @@ class ObjectStorageDestinationState(
     private val stream: DestinationStream,
     private val client: ObjectStorageClient<*>,
     private val pathFactory: PathFactory,
-    private val objectLoader: ObjectLoader? = null,
+    private val objectLoader: ObjectLoader?,
 ) : DestinationState {
     private val log = KotlinLogging.logger {}
 

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/write/object_storage/ObjectLoader.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/write/object_storage/ObjectLoader.kt
@@ -4,6 +4,7 @@
 
 package io.airbyte.cdk.load.write.object_storage
 
+import io.airbyte.cdk.load.command.DestinationConfiguration
 import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.message.BatchState
 import io.airbyte.cdk.load.write.LoadStrategy
@@ -88,15 +89,7 @@ interface ObjectLoader : LoadStrategy {
 
     val stateAfterUpload: BatchState
         get() = BatchState.COMPLETE
-
-    val generationIdMetadataKeyOverride: String?
-        get() = null
 }
 
-const val METADATA_GENERATION_ID_KEY = "ab-generation-id"
-
-val ObjectLoader?.generationIdMetadataKey: String
-    get() = this?.generationIdMetadataKeyOverride ?: METADATA_GENERATION_ID_KEY
-
-fun ObjectLoader?.metadataFor(stream: DestinationStream): Map<String, String> =
+fun DestinationConfiguration.metadataFor(stream: DestinationStream): Map<String, String> =
     mapOf(this.generationIdMetadataKey to stream.generationId.toString())

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/write/object_storage/ObjectLoader.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/write/object_storage/ObjectLoader.kt
@@ -4,8 +4,8 @@
 
 package io.airbyte.cdk.load.write.object_storage
 
-import io.airbyte.cdk.load.message.BatchState
 import io.airbyte.cdk.load.command.DestinationStream
+import io.airbyte.cdk.load.message.BatchState
 import io.airbyte.cdk.load.write.LoadStrategy
 
 /**

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/write/object_storage/ObjectLoader.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/write/object_storage/ObjectLoader.kt
@@ -5,6 +5,7 @@
 package io.airbyte.cdk.load.write.object_storage
 
 import io.airbyte.cdk.load.message.BatchState
+import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.write.LoadStrategy
 
 /**
@@ -87,4 +88,15 @@ interface ObjectLoader : LoadStrategy {
 
     val stateAfterUpload: BatchState
         get() = BatchState.COMPLETE
+
+    val generationIdMetadataKeyOverride: String?
+        get() = null
 }
+
+const val METADATA_GENERATION_ID_KEY = "ab-generation-id"
+
+val ObjectLoader?.generationIdMetadataKey: String
+    get() = this?.generationIdMetadataKeyOverride ?: METADATA_GENERATION_ID_KEY
+
+fun ObjectLoader?.metadataFor(stream: DestinationStream): Map<String, String> =
+    mapOf(this.generationIdMetadataKey to stream.generationId.toString())

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/write/object_storage/ObjectStorageStreamLoaderFactory.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/write/object_storage/ObjectStorageStreamLoaderFactory.kt
@@ -17,10 +17,8 @@ import io.airbyte.cdk.load.file.object_storage.RemoteObject
 import io.airbyte.cdk.load.message.Batch
 import io.airbyte.cdk.load.message.BatchEnvelope
 import io.airbyte.cdk.load.message.MultiProducerChannel
-import io.airbyte.cdk.load.message.object_storage.*
 import io.airbyte.cdk.load.state.DestinationStateManager
 import io.airbyte.cdk.load.state.StreamProcessingFailed
-import io.airbyte.cdk.load.state.object_storage.MetadataKeyMapper
 import io.airbyte.cdk.load.state.object_storage.ObjectStorageDestinationState
 import io.airbyte.cdk.load.write.BatchAccumulator
 import io.airbyte.cdk.load.write.FileBatchAccumulator
@@ -45,7 +43,6 @@ class ObjectStorageStreamLoaderFactory<T : RemoteObject<*>, U : OutputStream>(
     private val destinationStateManager: DestinationStateManager<ObjectStorageDestinationState>,
     @Value("\${airbyte.destination.core.record-batch-size-override}")
     private val recordBatchSizeOverride: Long? = null,
-    private val metadataKeyMapper: MetadataKeyMapper,
 ) {
     fun create(stream: DestinationStream): StreamLoader {
         return ObjectStorageStreamLoader(
@@ -58,7 +55,6 @@ class ObjectStorageStreamLoaderFactory<T : RemoteObject<*>, U : OutputStream>(
             uploadConfigurationProvider.objectStorageUploadConfiguration.uploadPartSizeBytes,
             recordBatchSizeOverride
                 ?: uploadConfigurationProvider.objectStorageUploadConfiguration.fileSizeBytes,
-            metadataKeyMapper,
         )
     }
 }
@@ -76,11 +72,10 @@ class ObjectStorageStreamLoader<T : RemoteObject<*>, U : OutputStream>(
     private val destinationStateManager: DestinationStateManager<ObjectStorageDestinationState>,
     private val partSizeBytes: Long,
     private val fileSizeBytes: Long,
-    metadataKeyMapper: MetadataKeyMapper,
 ) : StreamLoader {
     private val log = KotlinLogging.logger {}
 
-    private val objectAccumulator = PartToObjectAccumulator(stream, client, metadataKeyMapper)
+    private val objectAccumulator = PartToObjectAccumulator(stream, client)
 
     override suspend fun createBatchAccumulator(): BatchAccumulator {
         val state = destinationStateManager.getState(stream)

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/write/object_storage/PartToObjectAccumulator.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/write/object_storage/PartToObjectAccumulator.kt
@@ -14,7 +14,7 @@ import io.airbyte.cdk.load.message.Batch
 import io.airbyte.cdk.load.message.object_storage.IncompletePartialUpload
 import io.airbyte.cdk.load.message.object_storage.LoadablePart
 import io.airbyte.cdk.load.message.object_storage.LoadedObject
-import io.airbyte.cdk.load.state.object_storage.ObjectStorageDestinationState
+import io.airbyte.cdk.load.state.object_storage.MetadataKeyMapper
 import io.airbyte.cdk.load.util.setOnce
 import io.github.oshai.kotlinlogging.KotlinLogging
 import java.util.concurrent.ConcurrentHashMap
@@ -25,6 +25,7 @@ import kotlinx.coroutines.CompletableDeferred
 class PartToObjectAccumulator<T : RemoteObject<*>>(
     private val stream: DestinationStream,
     private val client: ObjectStorageClient<T>,
+    private val metadataKeyMapper: MetadataKeyMapper,
 ) {
     private val log = KotlinLogging.logger {}
 
@@ -41,7 +42,7 @@ class PartToObjectAccumulator<T : RemoteObject<*>>(
         if (upload.hasStarted.setOnce()) {
             // Start the upload if we haven't already. Note that the `complete`
             // here refers to the completable deferred, not the streaming upload.
-            val metadata = ObjectStorageDestinationState.metadataFor(stream)
+            val metadata = metadataKeyMapper.metadataFor(stream)
             val streamingUpload = client.startStreamingUpload(batch.part.key, metadata)
             upload.streamingUpload.complete(streamingUpload)
         }

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/write/object_storage/PartToObjectAccumulator.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/write/object_storage/PartToObjectAccumulator.kt
@@ -5,6 +5,7 @@
 package io.airbyte.cdk.load.write.object_storage
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
+import io.airbyte.cdk.load.command.DestinationConfiguration
 import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.file.object_storage.ObjectStorageClient
 import io.airbyte.cdk.load.file.object_storage.PartBookkeeper
@@ -24,6 +25,7 @@ import kotlinx.coroutines.CompletableDeferred
 class PartToObjectAccumulator<T : RemoteObject<*>>(
     private val stream: DestinationStream,
     private val client: ObjectStorageClient<T>,
+    private val destinationConfig: DestinationConfiguration,
 ) {
     private val log = KotlinLogging.logger {}
 
@@ -40,7 +42,7 @@ class PartToObjectAccumulator<T : RemoteObject<*>>(
         if (upload.hasStarted.setOnce()) {
             // Start the upload if we haven't already. Note that the `complete`
             // here refers to the completable deferred, not the streaming upload.
-            val metadata = (null as ObjectLoader?).metadataFor(stream)
+            val metadata = destinationConfig.metadataFor(stream)
             val streamingUpload = client.startStreamingUpload(batch.part.key, metadata)
             upload.streamingUpload.complete(streamingUpload)
         }

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/write/object_storage/PartToObjectAccumulator.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/write/object_storage/PartToObjectAccumulator.kt
@@ -14,7 +14,6 @@ import io.airbyte.cdk.load.message.Batch
 import io.airbyte.cdk.load.message.object_storage.IncompletePartialUpload
 import io.airbyte.cdk.load.message.object_storage.LoadablePart
 import io.airbyte.cdk.load.message.object_storage.LoadedObject
-import io.airbyte.cdk.load.state.object_storage.MetadataKeyMapper
 import io.airbyte.cdk.load.util.setOnce
 import io.github.oshai.kotlinlogging.KotlinLogging
 import java.util.concurrent.ConcurrentHashMap
@@ -25,7 +24,6 @@ import kotlinx.coroutines.CompletableDeferred
 class PartToObjectAccumulator<T : RemoteObject<*>>(
     private val stream: DestinationStream,
     private val client: ObjectStorageClient<T>,
-    private val metadataKeyMapper: MetadataKeyMapper,
 ) {
     private val log = KotlinLogging.logger {}
 
@@ -42,7 +40,7 @@ class PartToObjectAccumulator<T : RemoteObject<*>>(
         if (upload.hasStarted.setOnce()) {
             // Start the upload if we haven't already. Note that the `complete`
             // here refers to the completable deferred, not the streaming upload.
-            val metadata = metadataKeyMapper.metadataFor(stream)
+            val metadata = (null as ObjectLoader?).metadataFor(stream)
             val streamingUpload = client.startStreamingUpload(batch.part.key, metadata)
             upload.streamingUpload.complete(streamingUpload)
         }

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/test/kotlin/io/airbyte/cdk/load/state/object_storage/ObjectStorageDestinationStateUTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/test/kotlin/io/airbyte/cdk/load/state/object_storage/ObjectStorageDestinationStateUTest.kt
@@ -4,12 +4,12 @@
 
 package io.airbyte.cdk.load.state.object_storage
 
+import io.airbyte.cdk.load.command.DestinationConfiguration
 import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.file.object_storage.ObjectStorageClient
 import io.airbyte.cdk.load.file.object_storage.ObjectStoragePathFactory
 import io.airbyte.cdk.load.file.object_storage.PathMatcher
 import io.airbyte.cdk.load.file.object_storage.RemoteObject
-import io.airbyte.cdk.load.write.object_storage.ObjectLoader
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
@@ -26,10 +26,9 @@ class ObjectStorageDestinationStateUTest {
     data class MockObj(override val key: String, override val storageConfig: Unit = Unit) :
         RemoteObject<Unit>
 
-    private val objectLoader =
-        object : ObjectLoader {
-            override val generationIdMetadataKeyOverride: String
-                get() = "test-ab-generation-id"
+    private val destinationConfig =
+        object : DestinationConfiguration() {
+            override val generationIdMetadataKey = "test-ab-generation-id"
         }
 
     @MockK lateinit var stream: DestinationStream
@@ -66,8 +65,7 @@ class ObjectStorageDestinationStateUTest {
                 PathMatcher(Regex("(dog|cat|turtle-1)$suffix"), mapOf("suffix" to 2))
             }
 
-        val persister =
-            ObjectStorageFallbackPersister(client, pathFactory, objectLoader = objectLoader)
+        val persister = ObjectStorageFallbackPersister(client, pathFactory, destinationConfig)
         val state = persister.load(stream)
 
         assertEquals("dog-4", state.ensureUnique("dog"))
@@ -105,7 +103,7 @@ class ObjectStorageDestinationStateUTest {
                 )
             }
 
-        val persister = ObjectStorageFallbackPersister(client, pathFactory, objectLoader)
+        val persister = ObjectStorageFallbackPersister(client, pathFactory, destinationConfig)
         val state = persister.load(stream)
 
         assertEquals(2L, state.getPartIdCounter("dog/").get())
@@ -148,12 +146,12 @@ class ObjectStorageDestinationStateUTest {
         coEvery { client.getMetadata(any()) } answers
             {
                 val key = firstArg<String>()
-                // Note that because we overrode ObjectLoader.generationIdMetadataKeyOverride, the
+                // Note that because we the generation ID metadata key, so the
                 // "ab-generation-id" key is replaced with "test-ab-generation-id"
                 mapOf("test-ab-generation-id" to key.split("/").last())
             }
 
-        val persister = ObjectStorageFallbackPersister(client, pathFactory, objectLoader)
+        val persister = ObjectStorageFallbackPersister(client, pathFactory, destinationConfig)
 
         val dogStream = mockk<DestinationStream>(relaxed = true)
         every { dogStream.descriptor } returns DestinationStream.Descriptor("test", "dog")

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/test/kotlin/io/airbyte/cdk/load/write/object_storage/PartToObjectAccumulatorTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/test/kotlin/io/airbyte/cdk/load/write/object_storage/PartToObjectAccumulatorTest.kt
@@ -4,6 +4,7 @@
 
 package io.airbyte.cdk.load.write.object_storage
 
+import io.airbyte.cdk.load.command.DestinationConfiguration
 import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.file.object_storage.ObjectStorageClient
 import io.airbyte.cdk.load.file.object_storage.Part
@@ -18,6 +19,7 @@ import org.junit.jupiter.api.Test
 
 class PartToObjectAccumulatorTest {
     private val streamDescriptor = DestinationStream.Descriptor("test", "stream")
+    private val destinationConfig = object : DestinationConfiguration() {}
 
     private lateinit var stream: DestinationStream
     private lateinit var client: ObjectStorageClient<*>
@@ -30,7 +32,7 @@ class PartToObjectAccumulatorTest {
         client = mockk(relaxed = true)
         streamingUpload = mockk(relaxed = true)
         coEvery { stream.descriptor } returns streamDescriptor
-        metadata = (null as ObjectLoader?).metadataFor(stream)
+        metadata = destinationConfig.metadataFor(stream)
         coEvery { client.startStreamingUpload(any(), any()) } returns streamingUpload
         coEvery { streamingUpload.uploadPart(any(), any()) } returns Unit
         coEvery { streamingUpload.complete() } returns mockk(relaxed = true)
@@ -58,7 +60,7 @@ class PartToObjectAccumulatorTest {
 
     @Test
     fun `test part accumulation`() = runTest {
-        val acc = PartToObjectAccumulator(stream, client)
+        val acc = PartToObjectAccumulator(stream, client, destinationConfig)
 
         // First part triggers starting the upload
         val firstPartFile1 = makePart(1, 1)

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/test/kotlin/io/airbyte/cdk/load/write/object_storage/PartToObjectAccumulatorTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/test/kotlin/io/airbyte/cdk/load/write/object_storage/PartToObjectAccumulatorTest.kt
@@ -9,7 +9,7 @@ import io.airbyte.cdk.load.file.object_storage.ObjectStorageClient
 import io.airbyte.cdk.load.file.object_storage.Part
 import io.airbyte.cdk.load.file.object_storage.StreamingUpload
 import io.airbyte.cdk.load.message.object_storage.LoadablePart
-import io.airbyte.cdk.load.state.object_storage.ObjectStorageDestinationState
+import io.airbyte.cdk.load.state.object_storage.IdentityMetadataKeyMapper
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
@@ -31,7 +31,7 @@ class PartToObjectAccumulatorTest {
         client = mockk(relaxed = true)
         streamingUpload = mockk(relaxed = true)
         coEvery { stream.descriptor } returns streamDescriptor
-        metadata = ObjectStorageDestinationState.metadataFor(stream)
+        metadata = IdentityMetadataKeyMapper().metadataFor(stream)
         coEvery { client.startStreamingUpload(any(), any()) } returns streamingUpload
         coEvery { streamingUpload.uploadPart(any(), any()) } returns Unit
         coEvery { streamingUpload.complete() } returns mockk(relaxed = true)
@@ -59,7 +59,7 @@ class PartToObjectAccumulatorTest {
 
     @Test
     fun `test part accumulation`() = runTest {
-        val acc = PartToObjectAccumulator(stream, client)
+        val acc = PartToObjectAccumulator(stream, client, IdentityMetadataKeyMapper())
 
         // First part triggers starting the upload
         val firstPartFile1 = makePart(1, 1)

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/test/kotlin/io/airbyte/cdk/load/write/object_storage/PartToObjectAccumulatorTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/test/kotlin/io/airbyte/cdk/load/write/object_storage/PartToObjectAccumulatorTest.kt
@@ -9,7 +9,6 @@ import io.airbyte.cdk.load.file.object_storage.ObjectStorageClient
 import io.airbyte.cdk.load.file.object_storage.Part
 import io.airbyte.cdk.load.file.object_storage.StreamingUpload
 import io.airbyte.cdk.load.message.object_storage.LoadablePart
-import io.airbyte.cdk.load.state.object_storage.IdentityMetadataKeyMapper
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
@@ -31,7 +30,7 @@ class PartToObjectAccumulatorTest {
         client = mockk(relaxed = true)
         streamingUpload = mockk(relaxed = true)
         coEvery { stream.descriptor } returns streamDescriptor
-        metadata = IdentityMetadataKeyMapper().metadataFor(stream)
+        metadata = (null as ObjectLoader?).metadataFor(stream)
         coEvery { client.startStreamingUpload(any(), any()) } returns streamingUpload
         coEvery { streamingUpload.uploadPart(any(), any()) } returns Unit
         coEvery { streamingUpload.complete() } returns mockk(relaxed = true)
@@ -59,7 +58,7 @@ class PartToObjectAccumulatorTest {
 
     @Test
     fun `test part accumulation`() = runTest {
-        val acc = PartToObjectAccumulator(stream, client, IdentityMetadataKeyMapper())
+        val acc = PartToObjectAccumulator(stream, client)
 
         // First part triggers starting the upload
         val firstPartFile1 = makePart(1, 1)

--- a/airbyte-integrations/connectors/destination-mssql/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-mssql/metadata.yaml
@@ -16,7 +16,7 @@ data:
             type: GSM
   connectorType: destination
   definitionId: d4353156-9217-4cad-8dd7-c108fd4f74cf
-  dockerImageTag: 2.2.0
+  dockerImageTag: 2.2.1
   dockerRepository: airbyte/destination-mssql
   documentationUrl: https://docs.airbyte.com/integrations/destinations/mssql
   githubIssueLabel: destination-mssql

--- a/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLBulkLoadStreamLoader.kt
+++ b/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLBulkLoadStreamLoader.kt
@@ -22,6 +22,7 @@ import io.airbyte.cdk.load.file.object_storage.ObjectStoragePathFactory
 import io.airbyte.cdk.load.message.Batch
 import io.airbyte.cdk.load.message.object_storage.LoadedObject
 import io.airbyte.cdk.load.state.StreamProcessingFailed
+import io.airbyte.cdk.load.state.object_storage.MetadataKeyMapper
 import io.airbyte.cdk.load.write.BatchAccumulator
 import io.airbyte.cdk.load.write.StreamStateStore
 import io.airbyte.cdk.load.write.object_storage.PartToObjectAccumulator
@@ -46,7 +47,8 @@ class MSSQLBulkLoadStreamLoader(
 
     // Bulk-load related collaborators
     private val mssqlFormatFileCreator = MSSQLFormatFileCreator(dataSource, stream, azureBlobClient)
-    private val objectAccumulator = PartToObjectAccumulator(stream, azureBlobClient)
+    private val objectAccumulator =
+        PartToObjectAccumulator(stream, azureBlobClient, metadataKeyMapper)
     private val mssqlBulkLoadHandler =
         MSSQLBulkLoadHandler(
             dataSource,

--- a/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLBulkLoadStreamLoader.kt
+++ b/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLBulkLoadStreamLoader.kt
@@ -22,7 +22,6 @@ import io.airbyte.cdk.load.file.object_storage.ObjectStoragePathFactory
 import io.airbyte.cdk.load.message.Batch
 import io.airbyte.cdk.load.message.object_storage.LoadedObject
 import io.airbyte.cdk.load.state.StreamProcessingFailed
-import io.airbyte.cdk.load.state.object_storage.MetadataKeyMapper
 import io.airbyte.cdk.load.write.BatchAccumulator
 import io.airbyte.cdk.load.write.StreamStateStore
 import io.airbyte.cdk.load.write.object_storage.PartToObjectAccumulator
@@ -47,8 +46,7 @@ class MSSQLBulkLoadStreamLoader(
 
     // Bulk-load related collaborators
     private val mssqlFormatFileCreator = MSSQLFormatFileCreator(dataSource, stream, azureBlobClient)
-    private val objectAccumulator =
-        PartToObjectAccumulator(stream, azureBlobClient, metadataKeyMapper)
+    private val objectAccumulator = PartToObjectAccumulator(stream, azureBlobClient)
     private val mssqlBulkLoadHandler =
         MSSQLBulkLoadHandler(
             dataSource,

--- a/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLBulkLoadStreamLoader.kt
+++ b/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLBulkLoadStreamLoader.kt
@@ -6,6 +6,7 @@ package io.airbyte.integrations.destination.mssql.v2
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 import io.airbyte.cdk.load.command.Dedupe
+import io.airbyte.cdk.load.command.DestinationConfiguration
 import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.command.object_storage.ObjectStorageCompressionConfiguration
 import io.airbyte.cdk.load.command.object_storage.ObjectStorageCompressionConfigurationProvider
@@ -41,12 +42,14 @@ class MSSQLBulkLoadStreamLoader(
     private val azureBlobClient: AzureBlobClient,
     private val validateValuesPreLoad: Boolean,
     private val recordBatchSizeOverride: Long? = null,
-    private val streamStateStore: StreamStateStore<MSSQLStreamState>
+    private val streamStateStore: StreamStateStore<MSSQLStreamState>,
+    destinationConfig: DestinationConfiguration,
 ) : AbstractMSSQLStreamLoader(dataSource, stream, sqlBuilder) {
 
     // Bulk-load related collaborators
     private val mssqlFormatFileCreator = MSSQLFormatFileCreator(dataSource, stream, azureBlobClient)
-    private val objectAccumulator = PartToObjectAccumulator(stream, azureBlobClient)
+    private val objectAccumulator =
+        PartToObjectAccumulator(stream, azureBlobClient, destinationConfig)
     private val mssqlBulkLoadHandler =
         MSSQLBulkLoadHandler(
             dataSource,

--- a/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLBulkLoader.kt
+++ b/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLBulkLoader.kt
@@ -142,4 +142,11 @@ class MSSQLBulkLoaderFactory(
             streamStateStore.get(key.stream)!!.formatFilePath
         )
     }
+
+    /**
+     * Azure requires blob metadata keys to be alphanumeric+underscores, so replace the dashes with
+     * underscores.
+     */
+    override val generationIdMetadataKeyOverride: String
+        get() = "ab_generation_id"
 }

--- a/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLBulkLoader.kt
+++ b/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLBulkLoader.kt
@@ -142,11 +142,4 @@ class MSSQLBulkLoaderFactory(
             streamStateStore.get(key.stream)!!.formatFilePath
         )
     }
-
-    /**
-     * Azure requires blob metadata keys to be alphanumeric+underscores, so replace the dashes with
-     * underscores.
-     */
-    override val generationIdMetadataKeyOverride: String
-        get() = "ab_generation_id"
 }

--- a/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLWriter.kt
+++ b/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLWriter.kt
@@ -6,7 +6,6 @@ package io.airbyte.integrations.destination.mssql.v2
 
 import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.state.DestinationFailure
-import io.airbyte.cdk.load.state.object_storage.MetadataKeyMapper
 import io.airbyte.cdk.load.write.DestinationWriter
 import io.airbyte.cdk.load.write.StreamLoader
 import io.airbyte.cdk.load.write.StreamStateStore

--- a/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLWriter.kt
+++ b/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLWriter.kt
@@ -4,6 +4,7 @@
 
 package io.airbyte.integrations.destination.mssql.v2
 
+import io.airbyte.cdk.load.command.DestinationConfiguration
 import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.state.DestinationFailure
 import io.airbyte.cdk.load.write.DestinationWriter
@@ -24,7 +25,8 @@ class MSSQLWriter(
     private val dataSourceFactory: MSSQLDataSourceFactory,
     @Value("\${airbyte.destination.core.record-batch-size-override:null}")
     private val recordBatchSizeOverride: Long? = null,
-    private val streamStateStore: StreamStateStore<MSSQLStreamState>
+    private val streamStateStore: StreamStateStore<MSSQLStreamState>,
+    private val destinationConfig: DestinationConfiguration,
 ) : DestinationWriter {
 
     /** Lazily initialized when [setup] is called. */
@@ -53,7 +55,8 @@ class MSSQLWriter(
                         AzureBlobStorageClientCreator.createAzureBlobClient(loadConfig),
                     validateValuesPreLoad = loadConfig.validateValuesPreLoad ?: false,
                     recordBatchSizeOverride = recordBatchSizeOverride,
-                    streamStateStore = streamStateStore
+                    streamStateStore = streamStateStore,
+                    destinationConfig,
                 )
             }
             is InsertLoadTypeConfiguration -> {

--- a/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLWriter.kt
+++ b/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLWriter.kt
@@ -6,6 +6,7 @@ package io.airbyte.integrations.destination.mssql.v2
 
 import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.state.DestinationFailure
+import io.airbyte.cdk.load.state.object_storage.MetadataKeyMapper
 import io.airbyte.cdk.load.write.DestinationWriter
 import io.airbyte.cdk.load.write.StreamLoader
 import io.airbyte.cdk.load.write.StreamStateStore

--- a/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/config/MSSQLConfiguration.kt
+++ b/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/config/MSSQLConfiguration.kt
@@ -27,6 +27,13 @@ data class MSSQLConfiguration(
     override val numProcessBatchWorkers: Int = 1
     override val processEmptyFiles: Boolean = true
     override val recordBatchSizeBytes = ObjectStorageUploadConfiguration.DEFAULT_PART_SIZE_BYTES
+
+    /**
+     * Azure requires blob metadata keys to be alphanumeric+underscores, so replace the dashes with
+     * underscores.
+     */
+    override val generationIdMetadataKey: String
+        get() = "ab_generation_id"
 }
 
 @Singleton

--- a/docs/integrations/destinations/mssql.md
+++ b/docs/integrations/destinations/mssql.md
@@ -158,6 +158,7 @@ See the [Getting Started: Configuration section](#configuration) of this guide f
 
 | Version    | Date       | Pull Request                                               | Subject                                                                                             |
 |:-----------|:-----------|:-----------------------------------------------------------|:----------------------------------------------------------------------------------------------------|
+| 2.2.1      | 2025-03-27 | [56402](https://github.com/airbytehq/airbyte/pull/56402)   | Improve Azure blob storage load logic.                                                              |
 | 2.2.0      | 2025-03-23 | [56353](https://github.com/airbytehq/airbyte/pull/56353)   | Bulk Load performance improvements                                                                  |
 | 2.1.2      | 2025-03-25 | [56346](https://github.com/airbytehq/airbyte/pull/56346)   | Internal refactor                                                                                   |
 | 2.1.1      | 2025-03-24 | [56355](https://github.com/airbytehq/airbyte/pull/56355)   | Upgrade to airbyte/java-connector-base:2.0.1 to be M4 compatible.                                   |


### PR DESCRIPTION
* azure blob storage now correctly writes empty blobs (previously we didn't create the blob at all, so attempting to write metadata would fail b/c the blob doesn't exist)
* azure blob storage no longer validates metadata, and requires callers to provide valid metadata
* ObjectLoader exposes a generationIdMetadataKeyOverride option
* MSSQLBulkLoaderFactory overrides the generation ID metadata key to `ab_generation_id`, which is valid in azure blob storage