### PR TITLE
Update the short licence year to 2025

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -14,7 +14,7 @@ If you have any question regarding licenses, just visit our [FAQ](https://airbyt
 
 MIT License
 
-Copyright (c) 2020 Airbyte, Inc.
+Copyright (c) 2025 Airbyte, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE_SHORT
+++ b/LICENSE_SHORT
@@ -1,1 +1,1 @@
-Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+Copyright (c) 2025 Airbyte, Inc., all rights reserved.


### PR DESCRIPTION
## What
See title. Right now it was still set to 2024.
There was an attempt to make it dynamic that can be found here: https://github.com/airbytehq/airbyte/pull/56400
But honestly I cannot be bothered to get this fixed
