### PR TITLE
Bulk Load CDK: add test for no data truncate refresh

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/write/BasicFunctionalityIntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/write/BasicFunctionalityIntegrationTest.kt
@@ -2866,6 +2866,41 @@ abstract class BasicFunctionalityIntegrationTest(
     }
 
     @Test
+    open fun testTruncateRefreshNoData() {
+        assumeTrue(verifyDataWriting)
+        fun makeStream(generationId: Long, minimumGenerationId: Long, syncId: Long) =
+            DestinationStream(
+                DestinationStream.Descriptor(randomizedNamespace, "test_stream"),
+                Append,
+                ObjectType(linkedMapOf("id" to intType, "name" to stringType)),
+                generationId,
+                minimumGenerationId,
+                syncId,
+            )
+        runSync(
+            updatedConfig,
+            makeStream(generationId = 12, minimumGenerationId = 0, syncId = 42),
+            listOf(
+                InputRecord(
+                    randomizedNamespace,
+                    "test_stream",
+                    """{"id": 42, "name": "first_value"}""",
+                    emittedAtMs = 1234L,
+                )
+            )
+        )
+        val finalStream = makeStream(generationId = 13, minimumGenerationId = 13, syncId = 43)
+        runSync(updatedConfig, finalStream, emptyList())
+        dumpAndDiffRecords(
+            parsedConfig,
+            emptyList(),
+            finalStream,
+            primaryKey = listOf(listOf("id")),
+            cursor = null,
+        )
+    }
+
+    @Test
     open fun testClear() {
         val stream =
             DestinationStream(

--- a/airbyte-integrations/connectors/destination-s3-data-lake/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_data_lake/S3DataLakeWriteTest.kt
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_data_lake/S3DataLakeWriteTest.kt
@@ -100,8 +100,8 @@ class GlueWriteTest :
     }
 
     @Test
-    override fun testUnknownTypes() {
-        super.testUnknownTypes()
+    override fun testTruncateRefreshNoData() {
+        super.testTruncateRefreshNoData()
     }
 
     /**


### PR DESCRIPTION
pretty straightforward - run a sync with 1 record, run a truncate refresh with 0 records, verify that the destination has no data

no connector actually had a bug here AFAIK, but our azure blob storage implementation might have misbehaved here - should be fixed in a separate PR, https://github.com/airbytehq/airbyte/pull/56402 / https://github.com/airbytehq/airbyte/pull/56402/commits/def6164e06c39d0be73a9ab086770d370e33e5c9