### PR TITLE
[1.6] Document the use of the Copy JSON button

### DIFF
--- a/docs/terraform-documentation.md
+++ b/docs/terraform-documentation.md
@@ -5,11 +5,11 @@ products: all
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-# Terraform Provider
+# Terraform provider
 
 Follow this tutorial to learn how to use Airbyte's Terraform Provider. 
 
-[Terraform](https://www.terraform.io/), developed by HashiCorp, is an Infrastructure as Code (IaC) tool that empowers you to define and provision infrastructure using a declarative configuration language. If you use Terraform to manage your infrastructure, you can use Airbyte's Terraform provider to automate and version control your Airbyte configuration as code. Airbyte's Terraform provider is built off [our API](https://reference.airbyte.com).
+[Terraform](https://www.terraform.io/), developed by HashiCorp, is an Infrastructure as Code (IaC) tool that empowers you to define and provision infrastructure using a declarative configuration language. If you use Terraform to manage your infrastructure, you can use Airbyte's Terraform provider to automate and version control your Airbyte configuration as code. Airbyte's Terraform provider is built off [Airbyte's API](https://reference.airbyte.com).
 
 If you don't need a tutorial, go straight to the [Terraform docs](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs).
 
@@ -39,25 +39,27 @@ Before starting this tutorial, make sure you have the following:
 
 ## Strongly typed versus weakly typed {#typing}
 
-The Airbyte provider offers two types of resources. There are benefits and drawbacks to both methods. Review this information before creating your sources and destinations.
+The Airbyte provider offers two types of resources, and there are benefits and drawbacks to both. Review this information before creating your sources and destinations.
 
 ### Strongly typed configurations
 
-Resources with strongly typed configurations have strict rules about how configuration attributes are written. If they're written incorrectly, these resources prevent `terraform apply` from running.
+Resources with strongly typed configurations have strict rules about how you write configuration attributes. If they're written incorrectly, these resources prevent `terraform apply` from running.
 
 These resources depend on the underlying Airbyte connectors. Connectors are continually updated as third-party APIs change. This creates two primary points of failure for Terraform.
 
-- You upgrade the Terraform provider version, and fetch a new version of the config block. However, you do not upgrade your version of the connector in your Airbyte instance. The setup now crashes because there is a mismatch between the Terraform provider and the connector itself.
+- You upgrade the Terraform provider version, and fetch a new version of the `config` block. However, you don't upgrade your version of the connector in your Airbyte instance. The setup now crashes because there is a mismatch between the Terraform provider and the connector itself.
 
-- The Terraform SDK is built at a given time. Then, the connector has a breaking change (for example, a third-party removes an API endpoint). You upgrade your connector, but now the Terraform provider hasn't been upgraded yet and doesn't work as expected.
+- Airbyte builds the Terraform SDK at a given time. Then, the connector has a breaking change, like a third-party deprecating an API endpoint. You upgrade your connector, but Airbyte hasn't upgraded the Terraform provider yet and it doesn't work as expected.
 
 Essentially, using this option creates an ongoing risk that upgrading the Terraform provider or a connector causes a breaking change.
 
 ### Weakly typed (JSON) configurations
 
-Instead of using a connector-specific resource, you can use Airbyte's resources for custom connectors with an Airbyte or Marketplace connector, but write configurations as JSON strings. These configurations are more robust when connectors change. Mismatches between a Terraform provider and a connector do not prevent `terraform apply` from running. The absence of a newly added configuration option might have no impact at all on your data and your use of that connector.
+Instead of using a connector-specific resource, you can use [`airbyte_source_custom`](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs/resources/source_custom) and [`airbyte_destination_custom`](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs/resources/destination_custom). These are normally Airbyte's resources for custom connectors, but you can use them with any existing Airbyte or Marketplace connector and write your configurations as JSON strings. These configurations are more robust when connectors change. Mismatches between a Terraform provider and a connector do not prevent `terraform apply` from running. The absence of a newly added configuration option might have no impact at all on your data and your use of that connector.
 
-The main issue with this method is that JSON strings can technically contain anything, and you could make a mistake that Terraform doesn't warn you about. Currently, the best way to verify the correctness of your JSON string is to review the documentation for the strongly-typed resource for the source or destination you are creating. This method for getting the JSON string is undesirable, and Airbyte is exploring ways to surface the right JSON string in a more obvious way.
+The main issue with this method is that JSON strings can technically contain anything, and you could make a mistake that Terraform doesn't warn you about. 
+
+The best way to get a valid JSON string is to set up a new connector in Airbyte's UI, fill out all the fields, then click **Copy JSON**. You don't actually need to create the connector. Terraform can do that. You just need to get the right JSON string.
 
 ### How to choose
 
@@ -316,6 +318,6 @@ Terraform adds the connection to Airbyte. To see your new connection, open your 
 
 Congratulations! You created your first source, your first destination, and a connection between the two.
 
-- Continue building your sources, destinations, and connections for all your data using our [Terraform docs](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs).
+- Continue building your sources, destinations, and connections for all your data using Airbyte's [Terraform docs](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs).
 
 - Check out the [Quickstarts repository](https://github.com/airbytehq/quickstarts). It's full of templates and shortcuts to help you build common data stacks using Terraform and Python.

--- a/docs/terraform-documentation.md
+++ b/docs/terraform-documentation.md
@@ -55,11 +55,11 @@ Essentially, using this option creates an ongoing risk that upgrading the Terraf
 
 ### Weakly typed (JSON) configurations
 
-Instead of using a connector-specific resource, you can use [`airbyte_source_custom`](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs/resources/source_custom) and [`airbyte_destination_custom`](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs/resources/destination_custom). These are normally Airbyte's resources for custom connectors, but you can use them with any existing Airbyte or Marketplace connector and write your configurations as JSON strings. These configurations are more robust when connectors change. Mismatches between a Terraform provider and a connector do not prevent `terraform apply` from running. The absence of a newly added configuration option might have no impact at all on your data and your use of that connector.
+Instead of using a connector-specific resource, you can use [`airbyte_source_custom`](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs/resources/source_custom) and [`airbyte_destination_custom`](https://registry.terraform.io/providers/airbytehq/airbyte/latest/docs/resources/destination_custom). These are normally Airbyte's resources for custom connectors, but you can use them with any existing Airbyte or Marketplace connector and write your configurations as JSON objects. These configurations are more robust when connectors change. Mismatches between a Terraform provider and a connector do not prevent `terraform apply` from running. The absence of a newly added configuration option might have no impact at all on your data and your use of that connector.
 
-The main issue with this method is that JSON strings can technically contain anything, and you could make a mistake that Terraform doesn't warn you about. 
+The main issue with this method is that JSON can technically contain anything, and you could make a mistake that Terraform doesn't warn you about. 
 
-The best way to get a valid JSON string is to set up a new connector in Airbyte's UI, fill out all the fields, then click **Copy JSON**. You don't actually need to create the connector. Terraform can do that. You just need to get the right JSON string.
+The best way to get a JSON object is to set up a new connector in Airbyte's UI, fill out all the fields, then click **Copy JSON**. You don't actually need to create the connector in the UI since you want to do this with Terraform, but you do need to get the JSON. Currently, Airbyte optimizes this JSON object for the API, and you need to make some adjustments to use it in Terraform. The examples later in this article demonstrate the expected format.
 
 ### How to choose
 
@@ -153,7 +153,7 @@ Add a source from which you want to get data. In this example, you add Stripe as
     <Tabs>
     <TabItem value="JSON" label="JSON">
         
-        For this and any other Airbyte or Marketplace connector, you can define the source type in the JSON string.
+        For this and any other Airbyte or Marketplace connector, you can define the source type in the JSON object.
         
         ```hcl title="main.tf"
         resource "airbyte_source_custom" "my_source_stripe" {

--- a/docs/using-airbyte/getting-started/add-a-destination.md
+++ b/docs/using-airbyte/getting-started/add-a-destination.md
@@ -52,6 +52,6 @@ Each destination will have its own set of required fields to configure during se
 Some destinations will also have an **Optional Fields** tab located beneath the required fields. You can open this tab to view and configure any additional optional parameters that exist for the source. These fields generally grant you more fine-grained control over your data replication, but you can safely ignore them.
 :::
 
-Once you've filled out the required fields, select **Set up destination**. A connection check will run to verify that a successful connection can be established. If you're using [Terraform](../../terraform-documentation) to manage your infrastructure, use the **Copy JSON** button to copy your configuration as a JSON string that you can paste into your Terraform code.
+Once you've filled out the required fields, select **Set up destination**. A connection check will run to verify that a successful connection can be established. If you're using the [API](https://reference.airbyte.com/reference/createdestination#/) or [Terraform](../../terraform-documentation) to manage your infrastructure, use the **Copy JSON** button to copy your configuration as a JSON string that you can paste into your Terraform code.
 
 Now you're ready to [set up your first connection](./set-up-a-connection)!

--- a/docs/using-airbyte/getting-started/add-a-destination.md
+++ b/docs/using-airbyte/getting-started/add-a-destination.md
@@ -52,4 +52,6 @@ Each destination will have its own set of required fields to configure during se
 Some destinations will also have an **Optional Fields** tab located beneath the required fields. You can open this tab to view and configure any additional optional parameters that exist for the source. These fields generally grant you more fine-grained control over your data replication, but you can safely ignore them.
 :::
 
-Once you've filled out the required fields, select **Set up destination**. A connection check will run to verify that a successful connection can be established. Now you're ready to [set up your first connection](./set-up-a-connection)!
+Once you've filled out the required fields, select **Set up destination**. A connection check will run to verify that a successful connection can be established. If you're using [Terraform](../../terraform-documentation) to manage your infrastructure, use the **Copy JSON** button to copy your configuration as a JSON string that you can paste into your Terraform code.
+
+Now you're ready to [set up your first connection](./set-up-a-connection)!

--- a/docs/using-airbyte/getting-started/add-a-destination.md
+++ b/docs/using-airbyte/getting-started/add-a-destination.md
@@ -52,6 +52,6 @@ Each destination will have its own set of required fields to configure during se
 Some destinations will also have an **Optional Fields** tab located beneath the required fields. You can open this tab to view and configure any additional optional parameters that exist for the source. These fields generally grant you more fine-grained control over your data replication, but you can safely ignore them.
 :::
 
-Once you've filled out the required fields, select **Set up destination**. A connection check will run to verify that a successful connection can be established. If you're using the [API](https://reference.airbyte.com/reference/createdestination#/) or [Terraform](../../terraform-documentation) to manage your infrastructure, use the **Copy JSON** button to copy your configuration as a JSON string that you can paste into your Terraform code.
+Once you've filled out the required fields, select **Set up destination**. A connection check will run to verify that a successful connection can be established. If you're using the [API](https://reference.airbyte.com/reference/createdestination#/) or [Terraform](../../terraform-documentation) to manage your infrastructure, use the **Copy JSON** button to copy your configuration as a JSON string that you can paste into your code.
 
 Now you're ready to [set up your first connection](./set-up-a-connection)!

--- a/docs/using-airbyte/getting-started/add-a-source.md
+++ b/docs/using-airbyte/getting-started/add-a-source.md
@@ -17,9 +17,11 @@ The left half of the page contains a set of fields that you will have to fill ou
 Each connector in Airbyte will have its own set of authentication methods and configurable parameters. In the case of Sample Data (Faker), you can adjust the number of records you want returned in your `Users` data, and optionally adjust additional configuration settings. You can always refer to your source's provided setup guide for specific instructions on filling out each field.
 
 :::info
-Some sources will have an **Optional Fields** tab. You can open this tab to view and configure any additional optional parameters that exist for the souce, but you do not have to do so to successfully set up the connector.
+Some sources will have an **Optional Fields** tab. You can open this tab to view and configure any additional optional parameters that exist for the source, but you do not have to do so to successfully set up the connector.
 :::
 
-Once you've filled out all the required fields, click on the **Set up source** button and Airbyte will run a check to verify the connection. Happy replicating!
+Once you've filled out all the required fields, click on the **Set up source** button and Airbyte will run a check to verify the connection. If you're using [Terraform](../../terraform-documentation) to manage your infrastructure, use the **Copy JSON** button to copy your configuration as a JSON string that you can paste into your Terraform code.
+
+Happy replicating!
 
 Can't find the connectors that you want? Try your hand at easily building one yourself using our [Connector Builder](../../connector-development/connector-builder-ui/overview.md)!

--- a/docs/using-airbyte/getting-started/add-a-source.md
+++ b/docs/using-airbyte/getting-started/add-a-source.md
@@ -20,7 +20,7 @@ Each connector in Airbyte will have its own set of authentication methods and co
 Some sources will have an **Optional Fields** tab. You can open this tab to view and configure any additional optional parameters that exist for the source, but you do not have to do so to successfully set up the connector.
 :::
 
-Once you've filled out all the required fields, click on the **Set up source** button and Airbyte will run a check to verify the connection. If you're using [Terraform](../../terraform-documentation) to manage your infrastructure, use the **Copy JSON** button to copy your configuration as a JSON string that you can paste into your Terraform code.
+Once you've filled out all the required fields, click the **Set up source** button and Airbyte will run a check to verify the connection. If you're using the [API](https://reference.airbyte.com/reference/createsource#/) or [Terraform](../../terraform-documentation) to manage your infrastructure, click the **Copy JSON** button to copy your configuration as a JSON string that you can paste into your code.
 
 Happy replicating!
 


### PR DESCRIPTION
## What

Adds docs about using the Copy JSON button to get a configuration block for a connector.

## How

Update the Add a Source, Add a Destination, and Terraform pages.

Ran the Terraform page through the docs style linter.

## Review guide

## User Impact

This is a good quality of life feature to mention, for those who want to do this. But impact should be minor.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌
