### PR TITLE
Bulk load CDK: use singleton hasThrown bean instead of static object

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/config/SyncBeanFactory.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/config/SyncBeanFactory.kt
@@ -26,6 +26,7 @@ import io.micronaut.context.annotation.Secondary
 import io.micronaut.context.annotation.Value
 import jakarta.inject.Named
 import jakarta.inject.Singleton
+import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.math.min
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.runBlocking
@@ -147,4 +148,8 @@ class SyncBeanFactory {
     fun batchStateUpdateQueue(): ChannelMessageQueue<BatchUpdate> {
         return ChannelMessageQueue(Channel(100))
     }
+
+    @Singleton
+    @Named("defaultDestinationTaskLauncherHasThrown")
+    fun defaultDestinationTaskLauncherHasThrown(): AtomicBoolean = AtomicBoolean(false)
 }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/DestinationTaskLauncher.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/DestinationTaskLauncher.kt
@@ -151,6 +151,7 @@ class DefaultDestinationTaskLauncher<K : WithStream>(
     private val loadPipeline: LoadPipeline?,
     private val partitioner: InputPartitioner,
     private val updateBatchTaskFactory: UpdateBatchStateTaskFactory,
+    @Named("defaultDestinationTaskLauncherHasThrown") private val hasThrown: AtomicBoolean,
 ) : DestinationTaskLauncher {
     private val log = KotlinLogging.logger {}
 
@@ -161,10 +162,6 @@ class DefaultDestinationTaskLauncher<K : WithStream>(
     private val failSyncIsEnqueued = AtomicBoolean(false)
 
     private val closeStreamHasRun = ConcurrentHashMap<DestinationStream.Descriptor, AtomicBoolean>()
-
-    companion object {
-        val hasThrown = AtomicBoolean(false)
-    }
 
     inner class WrappedTask(
         private val innerTask: Task,

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/DestinationTaskLauncherUTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/DestinationTaskLauncherUTest.kt
@@ -50,6 +50,7 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import java.util.concurrent.atomic.AtomicBoolean
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.BeforeEach
@@ -136,7 +137,8 @@ class DestinationTaskLauncherUTest {
             batchUpdateQueue,
             loadPipeline,
             partitioner,
-            updateBatchTaskFactory
+            updateBatchTaskFactory,
+            hasThrown = AtomicBoolean(false),
         )
     }
 


### PR DESCRIPTION
this was causing integrationTestNonDocker to hang locally, b/c if two test cases both caused a sync to throw an exception, only one of those tests cases would actually run exception handling - the other testcase would just hang.

this doesn't fix CI hanging, but at least helps local testing.