### PR TITLE
✨ Source Brevo: increase pagination page size to 1000

### DIFF
--- a/airbyte-integrations/connectors/source-brevo/manifest.yaml
+++ b/airbyte-integrations/connectors/source-brevo/manifest.yaml
@@ -57,7 +57,7 @@ definitions:
             inject_into: request_parameter
           pagination_strategy:
             type: OffsetIncrement
-            page_size: 500
+            page_size: 1000
             inject_on_first_request: true
       incremental_sync:
         type: DatetimeBasedCursor

--- a/airbyte-integrations/connectors/source-brevo/metadata.yaml
+++ b/airbyte-integrations/connectors/source-brevo/metadata.yaml
@@ -17,7 +17,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: e2276f19-1c19-4d4e-ae6c-7df3c9c4ad49
-  dockerImageTag: 0.2.0
+  dockerImageTag: 0.2.1
   dockerRepository: airbyte/source-brevo
   githubIssueLabel: source-brevo
   icon: icon.svg

--- a/docs/integrations/sources/brevo.md
+++ b/docs/integrations/sources/brevo.md
@@ -49,6 +49,7 @@ Visit `https://app.brevo.com/settings/keys/api` for getting your api key.
 
 | Version | Date | Pull Request | Subject |
 | ------------------ | ------------ | --- | ---------------- |
+| 0.2.1 | 2025-03-27 | [56437](https://github.com/airbytehq/airbyte/pull/56437) | Update contacts pagination page size to 1000 |
 | 0.2.0 | 2025-03-24 | [56369](https://github.com/airbytehq/airbyte/pull/56369) | Fix/Add incremental on Contacts/Crm deals |
 | 0.1.8 | 2025-03-22 | [55367](https://github.com/airbytehq/airbyte/pull/55367) | Update dependencies |
 | 0.1.7 | 2025-03-01 | [54874](https://github.com/airbytehq/airbyte/pull/54874) | Update dependencies |


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->
Update the pagination strategy in the Brevo source connector by increasing the page size from 500 to 1000 for improved data retrieval efficiency.

## How
<!--
* Describe how code changes achieve the solution.
-->
Increase page size to 1000 for contacts stream

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->
None

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
