### PR TITLE
Dest-MSSQL: MSSQL Standard Insert uses DirectLoader

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/DestinationMessage.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/DestinationMessage.kt
@@ -313,6 +313,7 @@ data class DestinationRecordRaw(
 ) {
     val fileReference: FileReference? =
         rawData.record?.fileReference?.let { FileReference.fromProtocol(it) }
+    val serializedSizeBytes = serialized.length
 
     fun asRawJson(): JsonNode {
         return rawData.record.data

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/pipeline/InputPartitioner.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/pipeline/InputPartitioner.kt
@@ -23,6 +23,6 @@ interface InputPartitioner {
 @Secondary
 class ByStreamInputPartitioner : InputPartitioner {
     override fun getPartition(record: DestinationRecordRaw, numParts: Int): Int {
-        return Math.floorMod(record.stream.hashCode(), numParts)
+        return Math.floorMod(record.stream.descriptor.hashCode(), numParts)
     }
 }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/LoadPipelineStepTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/LoadPipelineStepTask.kt
@@ -66,7 +66,8 @@ class LoadPipelineStepTask<S : AutoCloseable, K1 : WithStream, T, K2 : WithStrea
     private val numWorkers: Int,
     private val stepId: String,
     private val streamCompletions:
-        ConcurrentHashMap<Pair<String, DestinationStream.Descriptor>, AtomicInteger>
+        ConcurrentHashMap<Pair<String, DestinationStream.Descriptor>, AtomicInteger>,
+    private val maxNumConcurrentKeys: Int? = null,
 ) : Task {
     private val log = KotlinLogging.logger {}
 
@@ -94,6 +95,37 @@ class LoadPipelineStepTask<S : AutoCloseable, K1 : WithStream, T, K2 : WithStrea
                                 "$stepId[$part] received input for complete stream ${input.key.stream}. This indicates data was processed out of order and future bookkeeping might be corrupt. Failing hard."
                             )
                         }
+
+                        /**
+                         * Enforce the specified maximum number of concurrent keys. If this is a new
+                         * key, AND we are already at the max, force a call to finish on the key
+                         * whose state contains the most data, then evict it.
+                         */
+                        maxNumConcurrentKeys?.let { maxKeys ->
+                            if (
+                                !stateStore.stateWithCounts.contains(input.key) &&
+                                    stateStore.stateWithCounts.size >= maxKeys
+                            ) {
+                                // Pick the key with the highest input count
+                                val (key, state) =
+                                    stateStore.stateWithCounts.maxByOrNull { it.value.inputCount }!!
+                                stateStore.stateWithCounts.remove(key)
+                                log.info {
+                                    "Saw greater than $maxNumConcurrentKeys keys, evicting highest accumulating $key (inputs=${state.inputCount})"
+                                }
+
+                                val output = batchAccumulator.finish(state.accumulatorState)
+                                handleOutput(
+                                    key,
+                                    state.checkpointCounts,
+                                    output.output,
+                                    state.inputCount
+                                )
+
+                                state.close()
+                            }
+                        }
+
                         // Get or create the accumulator state associated w/ the input key.
                         val stateWithCounts =
                             stateStore.stateWithCounts
@@ -313,7 +345,8 @@ class LoadPipelineStepTaskFactory(
         flushStrategy: PipelineFlushStrategy?,
         part: Int,
         numWorkers: Int,
-        taskId: String,
+        stepId: String,
+        maxNumConcurrentKeys: Int? = null,
     ): LoadPipelineStepTask<S, K1, T, K2, U> {
         return LoadPipelineStepTask(
             batchAccumulator,
@@ -324,8 +357,9 @@ class LoadPipelineStepTaskFactory(
             flushStrategy,
             part,
             numWorkers,
-            taskId,
+            stepId,
             streamCompletions,
+            maxNumConcurrentKeys
         )
     }
 
@@ -335,6 +369,7 @@ class LoadPipelineStepTaskFactory(
         outputQueue: PartitionedQueue<PipelineEvent<K2, U>>?,
         part: Int,
         numWorkers: Int,
+        maxNumConcurrentKeys: Int? = null,
     ): LoadPipelineStepTask<S, StreamKey, DestinationRecordRaw, K2, U> {
         return create(
             batchAccumulator,
@@ -344,7 +379,8 @@ class LoadPipelineStepTaskFactory(
             flushStrategy,
             part,
             numWorkers,
-            taskId = "first-step"
+            stepId = "first-step",
+            maxNumConcurrentKeys = maxNumConcurrentKeys
         )
     }
 
@@ -362,7 +398,7 @@ class LoadPipelineStepTaskFactory(
             null,
             part,
             numWorkers,
-            taskId = "final-step"
+            stepId = "final-step"
         )
     }
 
@@ -370,8 +406,9 @@ class LoadPipelineStepTaskFactory(
         batchAccumulator: BatchAccumulator<S, StreamKey, DestinationRecordRaw, U>,
         part: Int,
         numWorkers: Int,
+        maxNumConcurrentKeys: Int? = null,
     ): LoadPipelineStepTask<S, StreamKey, DestinationRecordRaw, K2, U> {
-        return createFirstStep(batchAccumulator, null, null, part, numWorkers)
+        return createFirstStep(batchAccumulator, null, null, part, numWorkers, maxNumConcurrentKeys)
     }
 
     fun <S : AutoCloseable, K1 : WithStream, T, K2 : WithStream, U : Any> createIntermediateStep(
@@ -381,7 +418,7 @@ class LoadPipelineStepTaskFactory(
         outputQueue: PartitionedQueue<PipelineEvent<K2, U>>?,
         part: Int,
         numWorkers: Int,
-        taskId: String,
+        stepId: String,
     ): LoadPipelineStepTask<S, K1, T, K2, U> {
         return create(
             batchAccumulator,
@@ -391,7 +428,7 @@ class LoadPipelineStepTaskFactory(
             null,
             part,
             numWorkers,
-            taskId,
+            stepId,
         )
     }
 }

--- a/airbyte-cdk/bulk/toolkits/load-db/src/main/kotlin/io/airbyte/cdk/load/pipeline/db/BulkLoadCompletedUploadQueue.kt
+++ b/airbyte-cdk/bulk/toolkits/load-db/src/main/kotlin/io/airbyte/cdk/load/pipeline/db/BulkLoadCompletedUploadQueue.kt
@@ -4,7 +4,7 @@
 
 package io.airbyte.cdk.load.pipeline.db
 
-import io.airbyte.cdk.load.factory.object_storage.ObjectLoaderPartQueueFactory
+import io.airbyte.cdk.load.factory.object_storage.ObjectLoaderQueueBeanFactory
 import io.airbyte.cdk.load.file.object_storage.RemoteObject
 import io.airbyte.cdk.load.message.ChannelMessageQueue
 import io.airbyte.cdk.load.message.PartitionedQueue
@@ -34,7 +34,7 @@ class BulkLoadCompletedUploadQueue<K : WithStream, T : RemoteObject<*>> {
                 .map {
                     ChannelMessageQueue<
                         PipelineEvent<K, ObjectLoaderUploadCompleter.UploadResult<T>>>(
-                        Channel(ObjectLoaderPartQueueFactory.OBJECT_LOADER_MAX_ENQUEUED_COMPLETIONS)
+                        Channel(ObjectLoaderQueueBeanFactory.OBJECT_LOADER_MAX_ENQUEUED_COMPLETIONS)
                     )
                 }
                 .toTypedArray()

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/factory/object_storage/ObjectLoaderQueueBeanFactory.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/factory/object_storage/ObjectLoaderQueueBeanFactory.kt
@@ -27,7 +27,7 @@ import jakarta.inject.Singleton
 import kotlinx.coroutines.channels.Channel
 
 @Factory
-class ObjectLoaderPartQueueFactory(
+class ObjectLoaderQueueBeanFactory(
     val loader: ObjectLoader,
 ) {
     val log = KotlinLogging.logger {}

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/pipline/object_storage/ObjectLoaderLoadedPartPartitioner.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/pipline/object_storage/ObjectLoaderLoadedPartPartitioner.kt
@@ -15,6 +15,7 @@ import io.airbyte.cdk.load.pipeline.OutputPartitioner
  */
 class ObjectLoaderLoadedPartPartitioner<K : WithStream, T, U : RemoteObject<*>> :
     OutputPartitioner<K, T, ObjectKey, ObjectLoaderPartLoader.PartResult<U>> {
+
     override fun getOutputKey(
         inputKey: K,
         output: ObjectLoaderPartLoader.PartResult<U>

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/pipline/object_storage/ObjectLoaderPartFormatterStep.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/pipline/object_storage/ObjectLoaderPartFormatterStep.kt
@@ -20,7 +20,7 @@ class ObjectLoaderPartFormatterStep(
     private val outputQueue:
         PartitionedQueue<PipelineEvent<ObjectKey, ObjectLoaderPartFormatter.FormattedPart>>,
     private val taskFactory: LoadPipelineStepTaskFactory,
-    private val taskId: String,
+    private val stepId: String,
 ) : LoadPipelineStep {
     override val numWorkers: Int = objectLoader.numPartWorkers
 
@@ -32,7 +32,7 @@ class ObjectLoaderPartFormatterStep(
             outputQueue,
             partition,
             numWorkers,
-            taskId = taskId,
+            stepId = stepId,
         )
     }
 }

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/pipline/object_storage/ObjectLoaderPartLoaderStep.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/pipline/object_storage/ObjectLoaderPartLoaderStep.kt
@@ -20,7 +20,7 @@ class ObjectLoaderPartLoaderStep<T : RemoteObject<*>>(
     private val outputQueue:
         PartitionedQueue<PipelineEvent<ObjectKey, ObjectLoaderPartLoader.PartResult<T>>>,
     private val taskFactory: LoadPipelineStepTaskFactory,
-    private val taskId: String,
+    private val stepId: String,
 ) : LoadPipelineStep {
     override val numWorkers: Int = loader.numUploadWorkers
 
@@ -32,7 +32,7 @@ class ObjectLoaderPartLoaderStep<T : RemoteObject<*>>(
             outputQueue,
             partition,
             numWorkers,
-            taskId = taskId,
+            stepId = stepId,
         )
     }
 }

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/pipline/object_storage/ObjectLoaderUploadCompleterStep.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/pipline/object_storage/ObjectLoaderUploadCompleterStep.kt
@@ -23,7 +23,7 @@ class ObjectLoaderUploadCompleterStep<K : WithStream, T : RemoteObject<*>>(
         null,
     private val completedUploadPartitioner: ObjectLoaderCompletedUploadPartitioner<K, T>? = null,
     private val taskFactory: LoadPipelineStepTaskFactory,
-    private val taskId: String,
+    private val stepId: String,
 ) : LoadPipelineStep {
     override val numWorkers: Int = objectLoader.numUploadCompleters
 
@@ -38,7 +38,7 @@ class ObjectLoaderUploadCompleterStep<K : WithStream, T : RemoteObject<*>>(
                 completedUploadQueue,
                 partition,
                 numWorkers,
-                taskId = taskId,
+                stepId = stepId,
             )
         }
     }

--- a/airbyte-integrations/connectors/destination-mssql/build.gradle.kts
+++ b/airbyte-integrations/connectors/destination-mssql/build.gradle.kts
@@ -16,7 +16,17 @@ airbyteBulkConnector {
 application {
     mainClass = "io.airbyte.integrations.destination.mssql.v2.MSSQLDestination"
 
-    applicationDefaultJvmArgs = listOf("-XX:+ExitOnOutOfMemoryError", "-XX:MaxRAMPercentage=75.0")
+    applicationDefaultJvmArgs = listOf(
+        "-XX:+ExitOnOutOfMemoryError", "-XX:MaxRAMPercentage=75.0",
+        // Uncomment to attach a live profiler.
+//        "-Djava.rmi.server.hostname=localhost",
+//            "-Dcom.sun.management.jmxremote=true",
+//            "-Dcom.sun.management.jmxremote.port=6000",
+//            "-Dcom.sun.management.jmxremote.rmi.port=6000",
+//            "-Dcom.sun.management.jmxremote.local.only=false",
+//            "-Dcom.sun.management.jmxremote.authenticate=false",
+//            "-Dcom.sun.management.jmxremote.ssl=false",
+    )
 
     // Uncomment and replace to run locally
     //applicationDefaultJvmArgs = listOf("-XX:+ExitOnOutOfMemoryError", "-XX:MaxRAMPercentage=75.0", "--add-opens", "java.base/sun.nio.ch=ALL-UNNAMED", "--add-opens", "java.base/sun.security.action=ALL-UNNAMED", "--add-opens", "java.base/java.lang=ALL-UNNAMED")

--- a/airbyte-integrations/connectors/destination-mssql/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-mssql/metadata.yaml
@@ -16,7 +16,7 @@ data:
             type: GSM
   connectorType: destination
   definitionId: d4353156-9217-4cad-8dd7-c108fd4f74cf
-  dockerImageTag: 2.2.6
+  dockerImageTag: 2.2.7
   dockerRepository: airbyte/destination-mssql
   documentationUrl: https://docs.airbyte.com/integrations/destinations/mssql
   githubIssueLabel: destination-mssql

--- a/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLBulkLoadStreamLoader.kt
+++ b/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLBulkLoadStreamLoader.kt
@@ -70,7 +70,7 @@ class MSSQLBulkLoadStreamLoader(
     override suspend fun start() {
         super.start() // calls ensureTableExists()
         formatFilePath = mssqlFormatFileCreator.createAndUploadFormatFile(defaultSchema).key
-        val state = MSSQLStreamState(dataSource, formatFilePath)
+        val state = MSSQLBulkLoaderStreamState(dataSource, formatFilePath)
         streamStateStore.put(stream.descriptor, state)
     }
 
@@ -206,7 +206,16 @@ class MSSQLBulkLoadStreamLoader(
  * For use by the new interface (to pass stream state creating during `start` to the BulkLoad
  * loader.)
  */
-data class MSSQLStreamState(
-    val dataSource: DataSource,
-    val formatFilePath: String,
-)
+sealed interface MSSQLStreamState {
+    val dataSource: DataSource
+}
+
+data class MSSQLBulkLoaderStreamState(
+    override val dataSource: DataSource,
+    val formatFilePath: String
+) : MSSQLStreamState
+
+data class MSSQLDirectLoaderStreamState(
+    override val dataSource: DataSource,
+    val sqlBuilder: MSSQLQueryBuilder
+) : MSSQLStreamState

--- a/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLBulkLoader.kt
+++ b/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLBulkLoader.kt
@@ -135,11 +135,10 @@ class MSSQLBulkLoaderFactory(
                 bulkLoadConfig.dataSource,
                 MSSQLQueryBuilder(config.schema, stream)
             )
-        return MSSQLBulkLoader(
-            azureBlobClient,
-            stream,
-            mssqlBulkLoadHandler,
-            streamStateStore.get(key.stream)!!.formatFilePath
-        )
+        val state = streamStateStore.get(key.stream)
+        check(state != null && state is MSSQLBulkLoaderStreamState) {
+            "Stream state not properly initialized for stream ${key.stream}"
+        }
+        return MSSQLBulkLoader(azureBlobClient, stream, mssqlBulkLoadHandler, state.formatFilePath)
     }
 }

--- a/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLDirectLoader.kt
+++ b/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLDirectLoader.kt
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination.mssql.v2
+
+import io.airbyte.cdk.load.command.DestinationStream
+import io.airbyte.cdk.load.message.DestinationRecordRaw
+import io.airbyte.cdk.load.write.DirectLoader
+import io.airbyte.cdk.load.write.DirectLoaderFactory
+import io.airbyte.cdk.load.write.StreamStateStore
+import io.airbyte.integrations.destination.mssql.v2.config.MSSQLConfiguration
+import io.airbyte.integrations.destination.mssql.v2.config.MSSQLIsNotConfiguredForBulkLoad
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.micronaut.context.annotation.Requires
+import jakarta.inject.Singleton
+
+class MSSQLDirectLoader(
+    config: MSSQLConfiguration,
+    stateStore: StreamStateStore<MSSQLStreamState>,
+    private val streamDescriptor: DestinationStream.Descriptor,
+    private val batch: Int,
+    private val parent: MSSQLDirectLoaderFactory
+) : DirectLoader {
+    private val log = KotlinLogging.logger {}
+    private val recordCommitBatchSize = config.batchEveryNRecords
+    private val maxBatchDataSize = config.maxBatchSizeBytes
+
+    private var rows: Long = 0
+    private var dataSize: Long = 0
+
+    private val state =
+        (stateStore.get(streamDescriptor) as MSSQLDirectLoaderStreamState?)
+            ?: throw IllegalStateException("No state found for stream $streamDescriptor.")
+    private val sqlBuilder = state.sqlBuilder
+    private val connection = state.dataSource.connection.also { it.autoCommit = false }
+    private val preparedStatement =
+        connection.prepareStatement(state.sqlBuilder.getFinalTableInsertColumnHeader().trimIndent())
+
+    override fun accept(
+        record: DestinationRecordRaw,
+    ): DirectLoader.DirectLoadResult {
+        sqlBuilder.populateStatement(preparedStatement, record, sqlBuilder.finalTableSchema)
+        preparedStatement.addBatch()
+
+        // Periodically execute the batch to avoid too-large batches
+        if (++rows % recordCommitBatchSize == 0L) {
+            executeBatchSafely()
+        }
+
+        // Periodically complete the batch and ack underlying records.
+        dataSize += record.serializedSizeBytes
+
+        if (dataSize >= maxBatchDataSize) {
+            finish()
+            return DirectLoader.Complete
+        }
+
+        return DirectLoader.Incomplete
+    }
+
+    private fun executeBatchSafely() {
+        // This is to prevent deadlock errors that will nuke the transaction.
+        // TODO: Promote direct loader to use suspend functions so this can use a suspending mutex
+        synchronized(parent) {
+            preparedStatement.executeBatch()
+            preparedStatement.clearBatch()
+            preparedStatement.clearParameters()
+            connection.commit()
+        }
+    }
+
+    override fun finish() {
+        log.info { "Finishing batch $batch for stream $streamDescriptor" }
+
+        // Execute remaining records if any
+        executeBatchSafely()
+        preparedStatement.close()
+
+        // If CDC is enabled, remove stale records
+        if (sqlBuilder.hasCdc) {
+            sqlBuilder.deleteCdc(connection)
+        }
+
+        connection.commit()
+    }
+
+    override fun close() {
+        log.info { "Closing connection for batch $batch" }
+        connection.close()
+    }
+}
+
+@Singleton
+@Requires(condition = MSSQLIsNotConfiguredForBulkLoad::class)
+class MSSQLDirectLoaderFactory(
+    val config: MSSQLConfiguration,
+    val stateStore: StreamStateStore<MSSQLStreamState>,
+) : DirectLoaderFactory<MSSQLDirectLoader> {
+    private val log = KotlinLogging.logger {}
+
+    override val inputPartitions: Int =
+        config.numInputPartitions // Distribute work by stream, if interleaved
+    override val maxNumOpenLoaders: Int = config.maxNumOpenLoaders
+
+    private var batch: Int = 0
+    override fun create(
+        streamDescriptor: DestinationStream.Descriptor,
+        part: Int
+    ): MSSQLDirectLoader {
+        log.info { "Creating query builder for batch $batch of stream $streamDescriptor" }
+
+        return MSSQLDirectLoader(config, stateStore, streamDescriptor, batch++, this)
+    }
+}

--- a/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLWriter.kt
+++ b/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLWriter.kt
@@ -63,7 +63,8 @@ class MSSQLWriter(
                 MSSQLStreamLoader(
                     dataSource = dataSourceNotNull,
                     stream = stream,
-                    sqlBuilder = sqlBuilder
+                    sqlBuilder = sqlBuilder,
+                    streamStateStore = streamStateStore
                 )
             }
         }

--- a/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/config/MSSQLBulkLoadConfiguration.kt
+++ b/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/config/MSSQLBulkLoadConfiguration.kt
@@ -24,6 +24,13 @@ class MSSQLIsConfiguredForBulkLoad : Condition {
     }
 }
 
+class MSSQLIsNotConfiguredForBulkLoad : Condition {
+    override fun matches(context: ConditionContext<*>): Boolean {
+        val config = context.beanContext.getBean(MSSQLConfiguration::class.java)
+        return config.mssqlLoadTypeConfiguration.loadTypeConfiguration !is BulkLoadConfiguration
+    }
+}
+
 @Singleton
 @Requires(condition = MSSQLIsConfiguredForBulkLoad::class)
 class MSSQLBulkLoadConfiguration(

--- a/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/config/MSSQLConfiguration.kt
+++ b/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/config/MSSQLConfiguration.kt
@@ -24,10 +24,12 @@ data class MSSQLConfiguration(
     val sslMethod: EncryptionMethod,
     override val mssqlLoadTypeConfiguration: MSSQLLoadTypeConfiguration,
 ) : DestinationConfiguration(), MSSQLLoadTypeConfigurationProvider {
-    override val numProcessRecordsWorkers = 1
-    override val numProcessBatchWorkers: Int = 1
-    override val processEmptyFiles: Boolean = true
     override val recordBatchSizeBytes = ObjectStorageUploadConfiguration.DEFAULT_PART_SIZE_BYTES
+
+    val numInputPartitions: Int = 1 // this should not be raised without implementing a partitioner
+    val batchEveryNRecords: Int = 5_000
+    val maxBatchSizeBytes: Long = recordBatchSizeBytes
+    val maxNumOpenLoaders: Int = 8 // allows for 1 concurrent open and close + 8 concurrent keys
 
     /**
      * Azure requires blob metadata keys to be alphanumeric+underscores, so replace the dashes with
@@ -66,7 +68,7 @@ class MSSQLConfigurationFactory(private val featureFlags: Set<FeatureFlag>) :
             password = overrides.getOrDefault("password", spec.password),
             jdbcUrlParams = overrides.getOrDefault("jdbcUrlParams", spec.jdbcUrlParams),
             sslMethod = spec.sslMethod,
-            mssqlLoadTypeConfiguration = spec.toLoadConfiguration()
+            mssqlLoadTypeConfiguration = spec.toLoadConfiguration(),
         )
     }
 }

--- a/docs/integrations/destinations/mssql.md
+++ b/docs/integrations/destinations/mssql.md
@@ -158,6 +158,7 @@ See the [Getting Started: Configuration section](#configuration) of this guide f
 
 | Version    | Date       | Pull Request                                               | Subject                                                                                             |
 |:-----------|:-----------|:-----------------------------------------------------------|:----------------------------------------------------------------------------------------------------|
+| 2.2.7      | 2025-05-07 | [56444](https://github.com/airbytehq/airbyte/pull/56444)   | CDK: Internal refactor; perf improvements                                                           |
 | 2.2.6      | 2025-04-21 | [58146](https://github.com/airbytehq/airbyte/pull/58146)   | Fix numeric bounds-handling                                                                         |
 | 2.2.5      | 2025-04-18 | [58140](https://github.com/airbytehq/airbyte/pull/58140)   | Upgrade to latest CDK                                                                               |
 | 2.2.4      | 2025-04-11 | [57563](https://github.com/airbytehq/airbyte/pull/57563)   | Improve BULK INSERT documentation.                                                                  |


### PR DESCRIPTION
## What

This is the last piece of migrating connectors to the new interface (except file transfer). This puts MSSQL on DirectLoader. (It didn't make sense for InsertLoader, because it needs to keep an open connection while building its query.)

This adds a new feature to the direct loader where it will limit the number of open loaders if they are sharing some resource (in this case, a connection pool). In practical terms, this means that this connector could be feeding records to up to N active loaders, but any time it sees the Nth + 1 concurrent stream, it will force a `finish()` on the loader with the most aggregated records.

Local performance tests show a 30% to 100% perf increase, depending on the test.
<img width="505" alt="Screenshot 2025-03-27 at 3 50 30 PM" src="https://github.com/user-attachments/assets/a1d54836-6998-40cb-85b9-9a68c0657df3" />
