### PR TITLE
Load CDK: Object Loader bugfixes

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/pipeline/InputPartitioner.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/pipeline/InputPartitioner.kt
@@ -7,7 +7,6 @@ package io.airbyte.cdk.load.pipeline
 import io.airbyte.cdk.load.message.DestinationRecordRaw
 import io.micronaut.context.annotation.Secondary
 import jakarta.inject.Singleton
-import kotlin.math.abs
 
 /**
  * A dev interface for expressing how incoming data is partitioned. By default, data will be
@@ -24,6 +23,6 @@ interface InputPartitioner {
 @Secondary
 class ByStreamInputPartitioner : InputPartitioner {
     override fun getPartition(record: DestinationRecordRaw, numParts: Int): Int {
-        return abs(record.stream.hashCode()) % numParts
+        return Math.floorMod(record.stream.hashCode(), numParts)
     }
 }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/LoadPipelineStepTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/LoadPipelineStepTask.kt
@@ -173,10 +173,6 @@ class LoadPipelineStepTask<S : AutoCloseable, K1 : WithStream, T, K2 : WithStrea
                         stateStore
                     }
                     is PipelineEndOfStream -> {
-                        val numWorkersSeenEos =
-                            streamCompletions
-                                .getOrPut(Pair(taskIndex, input.stream)) { AtomicInteger(0) }
-                                .incrementAndGet()
                         val inputCountEos = stateStore.streamCounts[input.stream] ?: 0
 
                         val keysToRemove =
@@ -198,6 +194,10 @@ class LoadPipelineStepTask<S : AutoCloseable, K1 : WithStream, T, K2 : WithStrea
                         }
 
                         // Only forward end-of-stream if ALL workers have seen end-of-stream.
+                        val numWorkersSeenEos =
+                            streamCompletions
+                                .getOrPut(Pair(taskIndex, input.stream)) { AtomicInteger(0) }
+                                .incrementAndGet()
                         if (numWorkersSeenEos == numWorkers) {
                             log.info {
                                 "$this saw end-of-stream for ${input.stream} after $inputCountEos inputs, all workers complete"


### PR DESCRIPTION
## What
1 is a technically incorrect hashing in the default partitioner. (I swear @frifriSF59 already corrected me on this?)

2 is a race condition where at end-of-stream a task decides whether it's the last one to close BEFORE it sends its final output. So
 - worker A decides it's the next-to-last
 - worker B decides it's last
 - worker B broadcasts end-of-stream
 - worker A sends its output finally

In practice if you run the S3 perf tests with object loader enabled and 1_000_000 records you run into this about once per 10 test cases. (Failure manifests as throwing the "saw data after end-of-stream" exception, fortunately.)

