### PR TITLE
🐛 Enabling support for other SASL mechanisms when SASL_PLAINTEXT is chosen 

### DIFF
--- a/airbyte-integrations/connectors/destination-kafka/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-kafka/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: 9f760101-60ae-462f-9ee6-b7a9dafd454d
-  dockerImageTag: 0.1.10
+  dockerImageTag: 0.1.11
   dockerRepository: airbyte/destination-kafka
   githubIssueLabel: destination-kafka
   icon: kafka.svg

--- a/airbyte-integrations/connectors/destination-kafka/src/main/resources/spec.json
+++ b/airbyte-integrations/connectors/destination-kafka/src/main/resources/spec.json
@@ -90,7 +90,13 @@
                 "description": "SASL mechanism used for client connections. This may be any mechanism for which a security provider is available.",
                 "type": "string",
                 "default": "PLAIN",
-                "enum": ["PLAIN"]
+                "enum": [
+                  "GSSAPI",
+                  "OAUTHBEARER",
+                  "SCRAM-SHA-256",
+                  "SCRAM-SHA-512",
+                  "PLAIN"
+                ]
               },
               "sasl_jaas_config": {
                 "title": "SASL JAAS Config",

--- a/docs/integrations/destinations/kafka.md
+++ b/docs/integrations/destinations/kafka.md
@@ -103,17 +103,18 @@ _NOTE_: Some configurations for SSL are not available yet.
 <details>
   <summary>Expand to review</summary>
 
-| Version | Date       | Pull Request                                             | Subject                                                                       |
-| :------ | :--------- | :------------------------------------------------------- | :---------------------------------------------------------------------------- |
-| 0.1.10  | 2022-08-04 | [15287](https://github.com/airbytehq/airbyte/pull/15287) | Update Kafka destination to use outputRecordCollector to properly store state |
-| 0.1.9   | 2022-06-17 | [13864](https://github.com/airbytehq/airbyte/pull/13864) | Updated stacktrace format for any trace message errors                        |
-| 0.1.7   | 2022-04-19 | [12134](https://github.com/airbytehq/airbyte/pull/12134) | Add PLAIN Auth                                                                |
-| 0.1.6   | 2022-02-15 | [10186](https://github.com/airbytehq/airbyte/pull/10186) | Add SCRAM-SHA-512 Auth                                                        |
-| 0.1.5   | 2022-02-14 | [10256](https://github.com/airbytehq/airbyte/pull/10256) | Add `-XX:+ExitOnOutOfMemoryError` JVM option                                  |
-| 0.1.4   | 2022-01-31 | [9905](https://github.com/airbytehq/airbyte/pull/9905)   | Fix SASL config read issue                                                    |
-| 0.1.3   | 2021-12-30 | [8809](https://github.com/airbytehq/airbyte/pull/8809)   | Update connector fields title/description                                     |
-| 0.1.2   | 2021-09-14 | [6040](https://github.com/airbytehq/airbyte/pull/6040)   | Change spec.json and config parser                                            |
-| 0.1.1   | 2021-07-30 | [5125](https://github.com/airbytehq/airbyte/pull/5125)   | Enable `additionalPropertities` in spec.json                                  |
-| 0.1.0   | 2021-07-21 | [3746](https://github.com/airbytehq/airbyte/pull/3746)   | Initial Release                                                               |
+| Version | Date       | Pull Request                                             | Subject                                                                        |
+| :------ | :--------- | :------------------------------------------------------- | :----------------------------------------------------------------------------  |
+| 0.1.11  | 2025-03-28 | [56450](https://github.com/airbytehq/airbyte/pull/56450) | Add support for other SASL Mechanisms when SASL_PLAINTEXT protocol is selected |
+| 0.1.10  | 2022-08-04 | [15287](https://github.com/airbytehq/airbyte/pull/15287) | Update Kafka destination to use outputRecordCollector to properly store state  |
+| 0.1.9   | 2022-06-17 | [13864](https://github.com/airbytehq/airbyte/pull/13864) | Updated stacktrace format for any trace message errors                         |
+| 0.1.7   | 2022-04-19 | [12134](https://github.com/airbytehq/airbyte/pull/12134) | Add PLAIN Auth                                                                 |
+| 0.1.6   | 2022-02-15 | [10186](https://github.com/airbytehq/airbyte/pull/10186) | Add SCRAM-SHA-512 Auth                                                         |
+| 0.1.5   | 2022-02-14 | [10256](https://github.com/airbytehq/airbyte/pull/10256) | Add `-XX:+ExitOnOutOfMemoryError` JVM option                                   |
+| 0.1.4   | 2022-01-31 | [9905](https://github.com/airbytehq/airbyte/pull/9905)   | Fix SASL config read issue                                                     |
+| 0.1.3   | 2021-12-30 | [8809](https://github.com/airbytehq/airbyte/pull/8809)   | Update connector fields title/description                                      |
+| 0.1.2   | 2021-09-14 | [6040](https://github.com/airbytehq/airbyte/pull/6040)   | Change spec.json and config parser                                             |
+| 0.1.1   | 2021-07-30 | [5125](https://github.com/airbytehq/airbyte/pull/5125)   | Enable `additionalPropertities` in spec.json                                   |
+| 0.1.0   | 2021-07-21 | [3746](https://github.com/airbytehq/airbyte/pull/3746)   | Initial Release                                                                |
 
 </details>


### PR DESCRIPTION
Currently, both the backend and frontend support multiple SASL mechanisms when the SASL_SSL protocol is selected. However, when SASL_PLAINTEXT is chosen on the frontend, the option to select a SASL mechanism is missing, and it silently defaults to PLAIN. Additionally, SASL_SSL and SASL_PLAINTEXT rely on common configuration logic in the backend.
This limitation is inconsistent because SASL_PLAINTEXT and SASL_SSL are functionally similar, differing only in SSL encryption for transit. Adding new values to the enum has no negative impact, and all tests continue to pass.

## What

Check Issue: #56390 
![Screenshot From 2025-03-28 14-50-23](https://github.com/user-attachments/assets/30c48a47-5d57-4264-8a88-37acbbde895b)


## How

Added new values to the SASL mechanism enum in spec.json when selected security protocol is SASL_PLAINTEXT

![kafka-destination-airbyte](https://github.com/user-attachments/assets/3988b252-a089-4f0a-8d8b-072f7a707ca9)

## Review guide

1. spec.json
2.  metadata.json

## User Impact

There will be no impact on users relying on PLAIN, since it continues to be the default mechanism.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌
