### PR TITLE
Azure blob storage: make it all work?

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/integrationTest/kotlin/io/airbyte/cdk/load/mock_integration_test/MockDestinationBackend.kt
+++ b/airbyte-cdk/bulk/core/load/src/integrationTest/kotlin/io/airbyte/cdk/load/mock_integration_test/MockDestinationBackend.kt
@@ -129,7 +129,7 @@ object MockDestinationDataDumper : DestinationDataDumper {
     override fun dumpFile(
         spec: ConfigurationSpecification,
         stream: DestinationStream
-    ): List<String> {
+    ): Map<String, String> {
         // Not needed since the test is disabled for file transfer
         throw NotImplementedError()
     }

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/DestinationDataDumper.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/DestinationDataDumper.kt
@@ -9,7 +9,7 @@ import io.airbyte.cdk.load.command.DestinationStream
 
 interface DestinationDataDumper {
     fun dumpRecords(spec: ConfigurationSpecification, stream: DestinationStream): List<OutputRecord>
-    fun dumpFile(spec: ConfigurationSpecification, stream: DestinationStream): List<String>
+    fun dumpFile(spec: ConfigurationSpecification, stream: DestinationStream): Map<String, String>
 }
 
 /**
@@ -27,7 +27,7 @@ object FakeDataDumper : DestinationDataDumper {
     override fun dumpFile(
         spec: ConfigurationSpecification,
         stream: DestinationStream
-    ): List<String> {
+    ): Map<String, String> {
         throw NotImplementedError()
     }
 }

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/write/BasicFunctionalityIntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/write/BasicFunctionalityIntegrationTest.kt
@@ -403,7 +403,7 @@ abstract class BasicFunctionalityIntegrationTest(
         val config = ValidatedJsonUtils.parseOne(configSpecClass, updatedConfig)
         val fileContent = dataDumper.dumpFile(config, stream)
 
-        assertEquals(listOf("123"), fileContent)
+        assertEquals(mapOf("path/to/file" to "123"), fileContent)
     }
 
     @Disabled("https://github.com/airbytehq/airbyte-internal-issues/issues/10413")

--- a/airbyte-cdk/bulk/toolkits/load-azure-blob-storage/src/main/kotlin/io/airbyte/cdk/load/file/azureBlobStorage/AzureBlobStorageClient.kt
+++ b/airbyte-cdk/bulk/toolkits/load-azure-blob-storage/src/main/kotlin/io/airbyte/cdk/load/file/azureBlobStorage/AzureBlobStorageClient.kt
@@ -17,6 +17,12 @@ import java.time.OffsetDateTime
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 
+/**
+ * Azure requires blob metadata keys to be alphanumeric+underscores, so replace the dashes with
+ * underscores.
+ */
+const val GENERATION_ID_METADATA_KEY_OVERRIDE = "ab_generation_id"
+
 /** Represents a single blob in Azure. */
 data class AzureBlob(
     override val key: String,

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/testFixtures/kotlin/io/airbyte/cdk/load/data/icerberg/parquet/IcebergDataDumper.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/testFixtures/kotlin/io/airbyte/cdk/load/data/icerberg/parquet/IcebergDataDumper.kt
@@ -113,7 +113,7 @@ class IcebergDataDumper(
     override fun dumpFile(
         spec: ConfigurationSpecification,
         stream: DestinationStream
-    ): List<String> {
+    ): Map<String, String> {
         throw NotImplementedError("Iceberg doesn't support universal file transfer")
     }
 }

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/command/object_storage/ObjectStorageFormatSpecification.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/command/object_storage/ObjectStorageFormatSpecification.kt
@@ -23,14 +23,6 @@ interface ObjectStorageFormatSpecificationProvider {
     @get:JsonProperty("format")
     val format: ObjectStorageFormatSpecification
 
-    fun toObjectStoragePathConfiguration(): ObjectStoragePathConfiguration {
-        return ObjectStoragePathConfiguration(
-            prefix = "",
-            pathPattern = null,
-            fileNamePattern = null,
-        )
-    }
-
     fun toObjectStorageFormatConfiguration(): ObjectStorageFormatConfiguration {
         return when (format) {
             is JsonFormatSpecification ->

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/command/object_storage/ObjectStorageFormatSpecification.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/command/object_storage/ObjectStorageFormatSpecification.kt
@@ -64,22 +64,20 @@ sealed class ObjectStorageFormatSpecification(
 class CSVFormatSpecification(
     @JsonSchemaTitle("Format Type")
     @JsonProperty("format_type")
-    override val formatType: Type = Type.CSV
-) : ObjectStorageFormatSpecification(formatType), FlatteningSpecificationProvider {
+    override val formatType: Type = Type.CSV,
     override val flattening: FlatteningSpecificationProvider.Flattening =
         FlatteningSpecificationProvider.Flattening.NO_FLATTENING
-}
+) : ObjectStorageFormatSpecification(formatType), FlatteningSpecificationProvider
 
 /** JSONL */
 @JsonSchemaTitle("JSON Lines: Newline-delimited JSON")
 class JsonFormatSpecification(
     @JsonSchemaTitle("Format Type")
     @JsonProperty("format_type")
-    override val formatType: Type = Type.JSONL
-) : ObjectStorageFormatSpecification(formatType), FlatteningSpecificationProvider {
+    override val formatType: Type = Type.JSONL,
     override val flattening: FlatteningSpecificationProvider.Flattening? =
         FlatteningSpecificationProvider.Flattening.NO_FLATTENING
-}
+) : ObjectStorageFormatSpecification(formatType), FlatteningSpecificationProvider
 
 interface FlatteningSpecificationProvider {
     @get:JsonSchemaTitle("Flattening")

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/command/object_storage/ObjectStorageFormatSpecification.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/command/object_storage/ObjectStorageFormatSpecification.kt
@@ -23,6 +23,14 @@ interface ObjectStorageFormatSpecificationProvider {
     @get:JsonProperty("format")
     val format: ObjectStorageFormatSpecification
 
+    fun toObjectStoragePathConfiguration(): ObjectStoragePathConfiguration {
+        return ObjectStoragePathConfiguration(
+            prefix = "",
+            pathPattern = null,
+            fileNamePattern = null,
+        )
+    }
+
     fun toObjectStorageFormatConfiguration(): ObjectStorageFormatConfiguration {
         return when (format) {
             is JsonFormatSpecification ->

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/testFixtures/kotlin/io/airbyte/cdk/load/ObjectStorageDataDumper.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/testFixtures/kotlin/io/airbyte/cdk/load/ObjectStorageDataDumper.kt
@@ -77,7 +77,7 @@ class ObjectStorageDataDumper(
     }
 
     fun dumpFile(): List<String> {
-        val prefix = pathFactory.getFinalDirectory(stream).toString()
+        val prefix = pathFactory.getLongestStreamConstantPrefix(stream).toString()
         return runBlocking {
             withContext(Dispatchers.IO) {
                 client

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/testFixtures/kotlin/io/airbyte/cdk/load/ObjectStorageDataDumper.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/testFixtures/kotlin/io/airbyte/cdk/load/ObjectStorageDataDumper.kt
@@ -29,6 +29,7 @@ import io.airbyte.cdk.load.test.util.toOutputRecord
 import io.airbyte.cdk.load.util.deserializeToNode
 import java.io.BufferedReader
 import java.io.InputStream
+import java.util.stream.Collectors.toMap
 import java.util.zip.GZIPInputStream
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.filter
@@ -76,8 +77,8 @@ class ObjectStorageDataDumper(
         }
     }
 
-    fun dumpFile(): List<String> {
-        val prefix = pathFactory.getLongestStreamConstantPrefix(stream).toString()
+    fun dumpFile(): Map<String, String> {
+        val prefix = pathFactory.getLongestStreamConstantPrefix(stream)
         return runBlocking {
             withContext(Dispatchers.IO) {
                 client
@@ -91,10 +92,13 @@ class ObjectStorageDataDumper(
                                     null -> objectData
                                     else -> error("Unsupported compressor")
                                 }
-                            BufferedReader(decompressed.reader()).readText()
+                            // Remove the "namespace/name/" prefix from the object key
+                            val truncatedKey = listedObject.key.replace(prefix, "")
+                            truncatedKey to BufferedReader(decompressed.reader()).readText()
                         }
                     }
                     .toList()
+                    .toMap()
             }
         }
     }

--- a/airbyte-integrations/connectors/destination-azure-blob-storage/gradle.properties
+++ b/airbyte-integrations/connectors/destination-azure-blob-storage/gradle.properties
@@ -1,0 +1,1 @@
+testExecutionConcurrency=-1

--- a/airbyte-integrations/connectors/destination-azure-blob-storage/src/main/kotlin/io/airbyte/integrations/destination/azure_blob_storage/AzureBlobStorageConfiguration.kt
+++ b/airbyte-integrations/connectors/destination-azure-blob-storage/src/main/kotlin/io/airbyte/integrations/destination/azure_blob_storage/AzureBlobStorageConfiguration.kt
@@ -34,7 +34,8 @@ class AzureBlobStorageConfiguration<T : OutputStream>(
     override val estimatedRecordMemoryOverheadRatio: Double = 5.0,
     override val processEmptyFiles: Boolean = true,
 
-    /** Below has no effect until [AzureBlobStorageObjectLoader] is enabled. */
+    // TODO remove these from config and hardcode them in AzureBlobStorageObjectLoader
+    //   after we finish performance tuning
     val numPartWorkers: Int = 2,
     val numUploadWorkers: Int = 5,
     val maxMemoryRatioReservedForParts: Double = 0.4,

--- a/airbyte-integrations/connectors/destination-azure-blob-storage/src/main/kotlin/io/airbyte/integrations/destination/azure_blob_storage/AzureBlobStorageConfiguration.kt
+++ b/airbyte-integrations/connectors/destination-azure-blob-storage/src/main/kotlin/io/airbyte/integrations/destination/azure_blob_storage/AzureBlobStorageConfiguration.kt
@@ -54,8 +54,13 @@ class AzureBlobStorageConfiguration<T : OutputStream>(
     override val objectStoragePathConfiguration =
         ObjectStoragePathConfiguration(
             prefix = "",
-            pathPattern = null,
-            fileNamePattern = null,
+            // This is equivalent to the default,
+            // but is nicer for tests,
+            // and also matches user intuition more closely.
+            // The default puts the `<date>_<epoch>_` into the path format,
+            // which is (a) confusing, and (b) makes the file transfer tests more annoying.
+            pathPattern = "\${NAMESPACE}/\${STREAM_NAME}/",
+            fileNamePattern = "{date}_{timestamp}_{part_number}{format_extension}",
         )
 
     override val generationIdMetadataKey = GENERATION_ID_METADATA_KEY_OVERRIDE

--- a/airbyte-integrations/connectors/destination-azure-blob-storage/src/main/kotlin/io/airbyte/integrations/destination/azure_blob_storage/AzureBlobStorageConfiguration.kt
+++ b/airbyte-integrations/connectors/destination-azure-blob-storage/src/main/kotlin/io/airbyte/integrations/destination/azure_blob_storage/AzureBlobStorageConfiguration.kt
@@ -24,7 +24,6 @@ import java.io.OutputStream
 class AzureBlobStorageConfiguration<T : OutputStream>(
     // Client-facing configuration
     override val azureBlobStorageClientConfiguration: AzureBlobStorageClientConfiguration,
-    override val objectStoragePathConfiguration: ObjectStoragePathConfiguration,
     override val objectStorageFormatConfiguration: ObjectStorageFormatConfiguration,
     override val objectStorageCompressionConfiguration: ObjectStorageCompressionConfiguration<T>,
 
@@ -47,7 +46,16 @@ class AzureBlobStorageConfiguration<T : OutputStream>(
     ObjectStoragePathConfigurationProvider,
     ObjectStorageFormatConfigurationProvider,
     ObjectStorageUploadConfigurationProvider,
-    ObjectStorageCompressionConfigurationProvider<T>
+    ObjectStorageCompressionConfigurationProvider<T> {
+    // for now, we're not exposing this as a user-configurable option
+    // so just return a hardcoded default path config
+    override val objectStoragePathConfiguration =
+        ObjectStoragePathConfiguration(
+            prefix = "",
+            pathPattern = null,
+            fileNamePattern = null,
+        )
+}
 
 @Singleton
 class AzureBlobStorageConfigurationFactory :
@@ -62,12 +70,6 @@ class AzureBlobStorageConfigurationFactory :
         azureBlobStorageClientConfiguration.spillSize = pojo.azureBlobStorageSpillSize
         return AzureBlobStorageConfiguration(
             azureBlobStorageClientConfiguration = azureBlobStorageClientConfiguration,
-            objectStoragePathConfiguration =
-                ObjectStoragePathConfiguration(
-                    prefix = "",
-                    pathPattern = null,
-                    fileNamePattern = null,
-                ),
             objectStorageFormatConfiguration = pojo.toObjectStorageFormatConfiguration(),
             objectStorageCompressionConfiguration =
                 ObjectStorageCompressionConfiguration(NoopProcessor),

--- a/airbyte-integrations/connectors/destination-azure-blob-storage/src/main/kotlin/io/airbyte/integrations/destination/azure_blob_storage/AzureBlobStorageConfiguration.kt
+++ b/airbyte-integrations/connectors/destination-azure-blob-storage/src/main/kotlin/io/airbyte/integrations/destination/azure_blob_storage/AzureBlobStorageConfiguration.kt
@@ -12,6 +12,8 @@ import io.airbyte.cdk.load.command.object_storage.ObjectStorageCompressionConfig
 import io.airbyte.cdk.load.command.object_storage.ObjectStorageCompressionConfigurationProvider
 import io.airbyte.cdk.load.command.object_storage.ObjectStorageFormatConfiguration
 import io.airbyte.cdk.load.command.object_storage.ObjectStorageFormatConfigurationProvider
+import io.airbyte.cdk.load.command.object_storage.ObjectStoragePathConfiguration
+import io.airbyte.cdk.load.command.object_storage.ObjectStoragePathConfigurationProvider
 import io.airbyte.cdk.load.command.object_storage.ObjectStorageUploadConfiguration
 import io.airbyte.cdk.load.command.object_storage.ObjectStorageUploadConfigurationProvider
 import io.airbyte.cdk.load.file.NoopProcessor
@@ -22,6 +24,7 @@ import java.io.OutputStream
 class AzureBlobStorageConfiguration<T : OutputStream>(
     // Client-facing configuration
     override val azureBlobStorageClientConfiguration: AzureBlobStorageClientConfiguration,
+    override val objectStoragePathConfiguration: ObjectStoragePathConfiguration,
     override val objectStorageFormatConfiguration: ObjectStorageFormatConfiguration,
     override val objectStorageCompressionConfiguration: ObjectStorageCompressionConfiguration<T>,
 
@@ -41,6 +44,7 @@ class AzureBlobStorageConfiguration<T : OutputStream>(
 ) :
     DestinationConfiguration(),
     AzureBlobStorageClientConfigurationProvider,
+    ObjectStoragePathConfigurationProvider,
     ObjectStorageFormatConfigurationProvider,
     ObjectStorageUploadConfigurationProvider,
     ObjectStorageCompressionConfigurationProvider<T>
@@ -58,6 +62,7 @@ class AzureBlobStorageConfigurationFactory :
         azureBlobStorageClientConfiguration.spillSize = pojo.azureBlobStorageSpillSize
         return AzureBlobStorageConfiguration(
             azureBlobStorageClientConfiguration = azureBlobStorageClientConfiguration,
+            objectStoragePathConfiguration = pojo.toObjectStoragePathConfiguration(),
             objectStorageFormatConfiguration = pojo.toObjectStorageFormatConfiguration(),
             objectStorageCompressionConfiguration =
                 ObjectStorageCompressionConfiguration(NoopProcessor),

--- a/airbyte-integrations/connectors/destination-azure-blob-storage/src/main/kotlin/io/airbyte/integrations/destination/azure_blob_storage/AzureBlobStorageConfiguration.kt
+++ b/airbyte-integrations/connectors/destination-azure-blob-storage/src/main/kotlin/io/airbyte/integrations/destination/azure_blob_storage/AzureBlobStorageConfiguration.kt
@@ -62,7 +62,12 @@ class AzureBlobStorageConfigurationFactory :
         azureBlobStorageClientConfiguration.spillSize = pojo.azureBlobStorageSpillSize
         return AzureBlobStorageConfiguration(
             azureBlobStorageClientConfiguration = azureBlobStorageClientConfiguration,
-            objectStoragePathConfiguration = pojo.toObjectStoragePathConfiguration(),
+            objectStoragePathConfiguration =
+                ObjectStoragePathConfiguration(
+                    prefix = "",
+                    pathPattern = null,
+                    fileNamePattern = null,
+                ),
             objectStorageFormatConfiguration = pojo.toObjectStorageFormatConfiguration(),
             objectStorageCompressionConfiguration =
                 ObjectStorageCompressionConfiguration(NoopProcessor),

--- a/airbyte-integrations/connectors/destination-azure-blob-storage/src/main/kotlin/io/airbyte/integrations/destination/azure_blob_storage/AzureBlobStorageConfiguration.kt
+++ b/airbyte-integrations/connectors/destination-azure-blob-storage/src/main/kotlin/io/airbyte/integrations/destination/azure_blob_storage/AzureBlobStorageConfiguration.kt
@@ -17,6 +17,7 @@ import io.airbyte.cdk.load.command.object_storage.ObjectStoragePathConfiguration
 import io.airbyte.cdk.load.command.object_storage.ObjectStorageUploadConfiguration
 import io.airbyte.cdk.load.command.object_storage.ObjectStorageUploadConfigurationProvider
 import io.airbyte.cdk.load.file.NoopProcessor
+import io.airbyte.cdk.load.file.azureBlobStorage.GENERATION_ID_METADATA_KEY_OVERRIDE
 import io.micronaut.context.annotation.Factory
 import jakarta.inject.Singleton
 import java.io.OutputStream
@@ -56,6 +57,8 @@ class AzureBlobStorageConfiguration<T : OutputStream>(
             pathPattern = null,
             fileNamePattern = null,
         )
+
+    override val generationIdMetadataKey = GENERATION_ID_METADATA_KEY_OVERRIDE
 }
 
 @Singleton

--- a/airbyte-integrations/connectors/destination-azure-blob-storage/src/main/kotlin/io/airbyte/integrations/destination/azure_blob_storage/AzureBlobStorageObjectLoader.kt
+++ b/airbyte-integrations/connectors/destination-azure-blob-storage/src/main/kotlin/io/airbyte/integrations/destination/azure_blob_storage/AzureBlobStorageObjectLoader.kt
@@ -4,7 +4,6 @@
 
 package io.airbyte.integrations.destination.azure_blob_storage
 
-import io.airbyte.cdk.load.file.azureBlobStorage.GENERATION_ID_METADATA_KEY_OVERRIDE
 import io.airbyte.cdk.load.pipeline.RoundRobinInputPartitioner
 import io.airbyte.cdk.load.write.object_storage.ObjectLoader
 import io.micronaut.context.annotation.Requires
@@ -13,8 +12,6 @@ import javax.inject.Singleton
 @Requires(property = "airbyte.destination.core.file-transfer.enabled", value = "false")
 @Singleton
 class AzureBlobStorageObjectLoader(config: AzureBlobStorageConfiguration<*>) : ObjectLoader {
-    override val generationIdMetadataKeyOverride: String = GENERATION_ID_METADATA_KEY_OVERRIDE
-
     override val numPartWorkers: Int = config.numPartWorkers
     override val numUploadWorkers: Int = config.numUploadWorkers
     override val maxMemoryRatioReservedForParts: Double = config.maxMemoryRatioReservedForParts

--- a/airbyte-integrations/connectors/destination-azure-blob-storage/src/main/kotlin/io/airbyte/integrations/destination/azure_blob_storage/AzureBlobStorageObjectLoader.kt
+++ b/airbyte-integrations/connectors/destination-azure-blob-storage/src/main/kotlin/io/airbyte/integrations/destination/azure_blob_storage/AzureBlobStorageObjectLoader.kt
@@ -9,11 +9,16 @@ import io.airbyte.cdk.load.pipeline.RoundRobinInputPartitioner
 import io.airbyte.cdk.load.write.object_storage.ObjectLoader
 import javax.inject.Singleton
 
-// TODO we'll eventually want to override various performance values here, maybe
 @Singleton
-class AzureBlobStorageObjectLoader : ObjectLoader {
-    override val generationIdMetadataKeyOverride: String?
+class AzureBlobStorageObjectLoader(config: AzureBlobStorageConfiguration<*>) : ObjectLoader {
+    override val generationIdMetadataKeyOverride: String
         get() = GENERATION_ID_METADATA_KEY_OVERRIDE
+
+    override val numPartWorkers: Int = config.numPartWorkers
+    override val numUploadWorkers: Int = config.numUploadWorkers
+    override val maxMemoryRatioReservedForParts: Double = config.maxMemoryRatioReservedForParts
+    override val objectSizeBytes: Long = config.objectSizeBytes
+    override val partSizeBytes: Long = config.partSizeBytes
 }
 
 @Singleton class AzureRoundRobinInputPartitioner : RoundRobinInputPartitioner()

--- a/airbyte-integrations/connectors/destination-azure-blob-storage/src/main/kotlin/io/airbyte/integrations/destination/azure_blob_storage/AzureBlobStorageObjectLoader.kt
+++ b/airbyte-integrations/connectors/destination-azure-blob-storage/src/main/kotlin/io/airbyte/integrations/destination/azure_blob_storage/AzureBlobStorageObjectLoader.kt
@@ -11,8 +11,7 @@ import javax.inject.Singleton
 
 @Singleton
 class AzureBlobStorageObjectLoader(config: AzureBlobStorageConfiguration<*>) : ObjectLoader {
-    override val generationIdMetadataKeyOverride: String
-        get() = GENERATION_ID_METADATA_KEY_OVERRIDE
+    override val generationIdMetadataKeyOverride: String = GENERATION_ID_METADATA_KEY_OVERRIDE
 
     override val numPartWorkers: Int = config.numPartWorkers
     override val numUploadWorkers: Int = config.numUploadWorkers

--- a/airbyte-integrations/connectors/destination-azure-blob-storage/src/main/kotlin/io/airbyte/integrations/destination/azure_blob_storage/AzureBlobStorageObjectLoader.kt
+++ b/airbyte-integrations/connectors/destination-azure-blob-storage/src/main/kotlin/io/airbyte/integrations/destination/azure_blob_storage/AzureBlobStorageObjectLoader.kt
@@ -7,8 +7,10 @@ package io.airbyte.integrations.destination.azure_blob_storage
 import io.airbyte.cdk.load.file.azureBlobStorage.GENERATION_ID_METADATA_KEY_OVERRIDE
 import io.airbyte.cdk.load.pipeline.RoundRobinInputPartitioner
 import io.airbyte.cdk.load.write.object_storage.ObjectLoader
+import io.micronaut.context.annotation.Requires
 import javax.inject.Singleton
 
+@Requires(property = "airbyte.destination.core.file-transfer.enabled", value = "false")
 @Singleton
 class AzureBlobStorageObjectLoader(config: AzureBlobStorageConfiguration<*>) : ObjectLoader {
     override val generationIdMetadataKeyOverride: String = GENERATION_ID_METADATA_KEY_OVERRIDE
@@ -20,4 +22,6 @@ class AzureBlobStorageObjectLoader(config: AzureBlobStorageConfiguration<*>) : O
     override val partSizeBytes: Long = config.partSizeBytes
 }
 
-@Singleton class AzureRoundRobinInputPartitioner : RoundRobinInputPartitioner()
+@Requires(property = "airbyte.destination.core.file-transfer.enabled", value = "false")
+@Singleton
+class AzureRoundRobinInputPartitioner : RoundRobinInputPartitioner()

--- a/airbyte-integrations/connectors/destination-azure-blob-storage/src/main/kotlin/io/airbyte/integrations/destination/azure_blob_storage/AzureBlobStorageObjectLoader.kt
+++ b/airbyte-integrations/connectors/destination-azure-blob-storage/src/main/kotlin/io/airbyte/integrations/destination/azure_blob_storage/AzureBlobStorageObjectLoader.kt
@@ -4,11 +4,16 @@
 
 package io.airbyte.integrations.destination.azure_blob_storage
 
+import io.airbyte.cdk.load.file.azureBlobStorage.GENERATION_ID_METADATA_KEY_OVERRIDE
 import io.airbyte.cdk.load.pipeline.RoundRobinInputPartitioner
 import io.airbyte.cdk.load.write.object_storage.ObjectLoader
 import javax.inject.Singleton
 
 // TODO we'll eventually want to override various performance values here, maybe
-@Singleton class AzureBlobStorageObjectLoader : ObjectLoader
+@Singleton
+class AzureBlobStorageObjectLoader : ObjectLoader {
+    override val generationIdMetadataKeyOverride: String?
+        get() = GENERATION_ID_METADATA_KEY_OVERRIDE
+}
 
 @Singleton class AzureRoundRobinInputPartitioner : RoundRobinInputPartitioner()

--- a/airbyte-integrations/connectors/destination-azure-blob-storage/src/test-integration/kotlin/io/airbyte/integrations/destination/azure_blob_storage/AzureBlobStorageCheckTest.kt
+++ b/airbyte-integrations/connectors/destination-azure-blob-storage/src/test-integration/kotlin/io/airbyte/integrations/destination/azure_blob_storage/AzureBlobStorageCheckTest.kt
@@ -6,9 +6,15 @@ package io.airbyte.integrations.destination.azure_blob_storage
 
 import io.airbyte.cdk.load.check.CheckIntegrationTest
 import io.airbyte.cdk.load.check.CheckTestConfig
+import io.airbyte.cdk.load.command.object_storage.CSVFormatSpecification
+import io.airbyte.cdk.load.command.object_storage.JsonFormatSpecification
 
 class AzureBlobStorageCheckTest :
     CheckIntegrationTest<AzureBlobStorageSpecification>(
-        successConfigFilenames = listOf(CheckTestConfig(AzureBlobStorageTestUtil.configPath)),
+        successConfigFilenames =
+            listOf(
+                CheckTestConfig(AzureBlobStorageTestUtil.getConfig(JsonFormatSpecification())),
+                CheckTestConfig(AzureBlobStorageTestUtil.getConfig(CSVFormatSpecification()))
+            ),
         failConfigFilenamesAndFailureReasons = emptyMap(),
     )

--- a/airbyte-integrations/connectors/destination-azure-blob-storage/src/test-integration/kotlin/io/airbyte/integrations/destination/azure_blob_storage/AzureBlobStorageDataDumper.kt
+++ b/airbyte-integrations/connectors/destination-azure-blob-storage/src/test-integration/kotlin/io/airbyte/integrations/destination/azure_blob_storage/AzureBlobStorageDataDumper.kt
@@ -21,7 +21,7 @@ class AzureBlobStorageDataDumper : DestinationDataDumper {
     override fun dumpFile(
         spec: ConfigurationSpecification,
         stream: DestinationStream
-    ): List<String> = getObjectStorageDataDumper(spec, stream).dumpFile()
+    ): Map<String, String> = getObjectStorageDataDumper(spec, stream).dumpFile()
 
     private fun getObjectStorageDataDumper(
         spec: ConfigurationSpecification,

--- a/airbyte-integrations/connectors/destination-azure-blob-storage/src/test-integration/kotlin/io/airbyte/integrations/destination/azure_blob_storage/AzureBlobStorageDataDumper.kt
+++ b/airbyte-integrations/connectors/destination-azure-blob-storage/src/test-integration/kotlin/io/airbyte/integrations/destination/azure_blob_storage/AzureBlobStorageDataDumper.kt
@@ -7,8 +7,6 @@ package io.airbyte.integrations.destination.azure_blob_storage
 import io.airbyte.cdk.command.ConfigurationSpecification
 import io.airbyte.cdk.load.ObjectStorageDataDumper
 import io.airbyte.cdk.load.command.DestinationStream
-import io.airbyte.cdk.load.command.azureBlobStorage.AzureBlobStorageClientConfiguration
-import io.airbyte.cdk.load.command.azureBlobStorage.AzureBlobStorageClientConfigurationProvider
 import io.airbyte.cdk.load.file.azureBlobStorage.AzureBlobStorageClientFactory
 import io.airbyte.cdk.load.file.object_storage.ObjectStoragePathFactory
 import io.airbyte.cdk.load.test.util.DestinationDataDumper
@@ -29,21 +27,17 @@ class AzureBlobStorageDataDumper : DestinationDataDumper {
         spec: ConfigurationSpecification,
         stream: DestinationStream
     ): ObjectStorageDataDumper {
-        val config: AzureBlobStorageClientConfiguration = TODO()
-        val configProvider =
-            object : AzureBlobStorageClientConfigurationProvider {
-                override val azureBlobStorageClientConfiguration:
-                    AzureBlobStorageClientConfiguration
-                    get() = config
-            }
-        val pathFactory = ObjectStoragePathFactory.from(TODO())
-        val client = AzureBlobStorageClientFactory(configProvider).make()
+        val config: AzureBlobStorageConfiguration<*> =
+            AzureBlobStorageConfigurationFactory()
+                .makeWithoutExceptionHandling(spec as AzureBlobStorageSpecification)
+        val pathFactory = ObjectStoragePathFactory.from(config)
+        val client = AzureBlobStorageClientFactory(config).make()
         return ObjectStorageDataDumper(
             stream,
             client,
             pathFactory,
-            TODO(),
-            TODO(),
+            config.objectStorageFormatConfiguration,
+            config.objectStorageCompressionConfiguration,
         )
     }
 }

--- a/airbyte-integrations/connectors/destination-azure-blob-storage/src/test-integration/kotlin/io/airbyte/integrations/destination/azure_blob_storage/AzureBlobStorageTestContainer.kt
+++ b/airbyte-integrations/connectors/destination-azure-blob-storage/src/test-integration/kotlin/io/airbyte/integrations/destination/azure_blob_storage/AzureBlobStorageTestContainer.kt
@@ -14,6 +14,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 import org.testcontainers.azure.AzuriteContainer
 import org.testcontainers.utility.DockerImageName
 
+// Not actually used currently, but it's pretty cool?
 object AzureBlobStorageTestContainer {
     private const val ACCOUNT_NAME = "devstoreaccount1"
     private const val CONTAINER_NAME = "container-name"

--- a/airbyte-integrations/connectors/destination-azure-blob-storage/src/test-integration/kotlin/io/airbyte/integrations/destination/azure_blob_storage/AzureBlobStorageTestUtil.kt
+++ b/airbyte-integrations/connectors/destination-azure-blob-storage/src/test-integration/kotlin/io/airbyte/integrations/destination/azure_blob_storage/AzureBlobStorageTestUtil.kt
@@ -4,6 +4,9 @@
 
 package io.airbyte.integrations.destination.azure_blob_storage
 
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.node.ObjectNode
+import io.airbyte.cdk.load.command.object_storage.ObjectStorageFormatSpecification
 import io.airbyte.cdk.load.util.Jsons
 import java.nio.file.Files
 import java.nio.file.Path
@@ -11,10 +14,11 @@ import java.nio.file.Path
 object AzureBlobStorageTestUtil {
     val configPath = Path.of("secrets/config.json")
 
-    private val baseConfigContents = Jsons.readTree(Files.readString(configPath))
-
-    fun getConfig(): String {
-        // TODO accept params (csv vs jsonl, etc)
-        return Jsons.writeValueAsString(baseConfigContents)
+    fun getConfig(format: ObjectStorageFormatSpecification): String {
+        // slightly annoying - we can't easily _edit_ AzureBlobStorageSpecification objects
+        // so we just work on raw jsonnode here
+        val config = Jsons.readTree(Files.readString(configPath)) as ObjectNode
+        config.set<JsonNode>("format", Jsons.valueToTree(format))
+        return Jsons.writeValueAsString(config)
     }
 }

--- a/airbyte-integrations/connectors/destination-azure-blob-storage/src/test-integration/kotlin/io/airbyte/integrations/destination/azure_blob_storage/AzureBlobStorageWriteTest.kt
+++ b/airbyte-integrations/connectors/destination-azure-blob-storage/src/test-integration/kotlin/io/airbyte/integrations/destination/azure_blob_storage/AzureBlobStorageWriteTest.kt
@@ -7,6 +7,7 @@ package io.airbyte.integrations.destination.azure_blob_storage
 import io.airbyte.cdk.load.command.object_storage.CSVFormatSpecification
 import io.airbyte.cdk.load.command.object_storage.FlatteningSpecificationProvider.Flattening
 import io.airbyte.cdk.load.test.util.NoopDestinationCleaner
+import io.airbyte.cdk.load.test.util.UncoercedExpectedRecordMapper
 import io.airbyte.cdk.load.write.BasicFunctionalityIntegrationTest
 import io.airbyte.cdk.load.write.SchematizedNestedValueBehavior
 import io.airbyte.cdk.load.write.UnionBehavior
@@ -19,6 +20,7 @@ abstract class AzureBlobStorageWriteTest(configContents: String) :
         configContents = configContents,
         configSpecClass = AzureBlobStorageSpecification::class.java,
         dataDumper = AzureBlobStorageDataDumper(),
+        recordMangler = UncoercedExpectedRecordMapper,
         destinationCleaner = NoopDestinationCleaner,
         isStreamSchemaRetroactive = false,
         supportsDedup = false,

--- a/airbyte-integrations/connectors/destination-azure-blob-storage/src/test-integration/kotlin/io/airbyte/integrations/destination/azure_blob_storage/AzureBlobStorageWriteTest.kt
+++ b/airbyte-integrations/connectors/destination-azure-blob-storage/src/test-integration/kotlin/io/airbyte/integrations/destination/azure_blob_storage/AzureBlobStorageWriteTest.kt
@@ -13,7 +13,6 @@ import io.airbyte.cdk.load.write.BasicFunctionalityIntegrationTest
 import io.airbyte.cdk.load.write.SchematizedNestedValueBehavior
 import io.airbyte.cdk.load.write.UnionBehavior
 import io.airbyte.cdk.load.write.Untyped
-import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 
 abstract class AzureBlobStorageWriteTest(configContents: String) :
@@ -33,15 +32,7 @@ abstract class AzureBlobStorageWriteTest(configContents: String) :
         supportFileTransfer = true,
         commitDataIncrementally = true,
         allTypesBehavior = Untyped,
-    ) {
-    companion object {
-        @BeforeAll
-        @JvmStatic
-        fun setup() {
-            AzureBlobStorageTestContainer.start()
-        }
-    }
-}
+    )
 
 class AzureBlobStorageCsvNoFlatteningWriteTest :
     AzureBlobStorageWriteTest(

--- a/airbyte-integrations/connectors/destination-azure-blob-storage/src/test-integration/kotlin/io/airbyte/integrations/destination/azure_blob_storage/AzureBlobStorageWriteTest.kt
+++ b/airbyte-integrations/connectors/destination-azure-blob-storage/src/test-integration/kotlin/io/airbyte/integrations/destination/azure_blob_storage/AzureBlobStorageWriteTest.kt
@@ -44,6 +44,11 @@ class AzureBlobStorageCsvNoFlatteningWriteTest :
     override fun testBasicWriteFile() {
         super.testBasicWriteFile()
     }
+
+    @Test
+    override fun testBasicWrite() {
+        super.testBasicWrite()
+    }
 }
 
 class AzureBlobStorageCsvWithFlatteningWriteTest :

--- a/airbyte-integrations/connectors/destination-azure-blob-storage/src/test-integration/kotlin/io/airbyte/integrations/destination/azure_blob_storage/AzureBlobStorageWriteTest.kt
+++ b/airbyte-integrations/connectors/destination-azure-blob-storage/src/test-integration/kotlin/io/airbyte/integrations/destination/azure_blob_storage/AzureBlobStorageWriteTest.kt
@@ -4,6 +4,8 @@
 
 package io.airbyte.integrations.destination.azure_blob_storage
 
+import io.airbyte.cdk.load.command.object_storage.CSVFormatSpecification
+import io.airbyte.cdk.load.command.object_storage.FlatteningSpecificationProvider.Flattening
 import io.airbyte.cdk.load.test.util.NoopDestinationCleaner
 import io.airbyte.cdk.load.write.BasicFunctionalityIntegrationTest
 import io.airbyte.cdk.load.write.SchematizedNestedValueBehavior
@@ -38,6 +40,11 @@ abstract class AzureBlobStorageWriteTest(configContents: String) :
     }
 }
 
-@Disabled class AzureBlobStorageCsvWriteTest : AzureBlobStorageWriteTest(TODO())
+class AzureBlobStorageCsvNoFlatteningWriteTest :
+    AzureBlobStorageWriteTest(
+        AzureBlobStorageTestUtil.getConfig(
+            CSVFormatSpecification(flattening = Flattening.NO_FLATTENING)
+        )
+    )
 
 @Disabled class AzureBlobStorageJsonlWriteTest : AzureBlobStorageWriteTest(TODO())

--- a/airbyte-integrations/connectors/destination-azure-blob-storage/src/test-integration/kotlin/io/airbyte/integrations/destination/azure_blob_storage/AzureBlobStorageWriteTest.kt
+++ b/airbyte-integrations/connectors/destination-azure-blob-storage/src/test-integration/kotlin/io/airbyte/integrations/destination/azure_blob_storage/AzureBlobStorageWriteTest.kt
@@ -6,6 +6,7 @@ package io.airbyte.integrations.destination.azure_blob_storage
 
 import io.airbyte.cdk.load.command.object_storage.CSVFormatSpecification
 import io.airbyte.cdk.load.command.object_storage.FlatteningSpecificationProvider.Flattening
+import io.airbyte.cdk.load.command.object_storage.JsonFormatSpecification
 import io.airbyte.cdk.load.test.util.NoopDestinationCleaner
 import io.airbyte.cdk.load.test.util.UncoercedExpectedRecordMapper
 import io.airbyte.cdk.load.write.BasicFunctionalityIntegrationTest
@@ -13,7 +14,7 @@ import io.airbyte.cdk.load.write.SchematizedNestedValueBehavior
 import io.airbyte.cdk.load.write.UnionBehavior
 import io.airbyte.cdk.load.write.Untyped
 import org.junit.jupiter.api.BeforeAll
-import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
 
 abstract class AzureBlobStorageWriteTest(configContents: String) :
     BasicFunctionalityIntegrationTest(
@@ -47,6 +48,30 @@ class AzureBlobStorageCsvNoFlatteningWriteTest :
         AzureBlobStorageTestUtil.getConfig(
             CSVFormatSpecification(flattening = Flattening.NO_FLATTENING)
         )
+    ) {
+    @Test
+    override fun testBasicWriteFile() {
+        super.testBasicWriteFile()
+    }
+}
+
+class AzureBlobStorageCsvWithFlatteningWriteTest :
+    AzureBlobStorageWriteTest(
+        AzureBlobStorageTestUtil.getConfig(
+            CSVFormatSpecification(flattening = Flattening.ROOT_LEVEL_FLATTENING)
+        )
     )
 
-@Disabled class AzureBlobStorageJsonlWriteTest : AzureBlobStorageWriteTest(TODO())
+class AzureBlobStorageJsonlNoFlatteningWriteTest :
+    AzureBlobStorageWriteTest(
+        AzureBlobStorageTestUtil.getConfig(
+            JsonFormatSpecification(flattening = Flattening.NO_FLATTENING)
+        )
+    )
+
+class AzureBlobStorageJsonlWithFlatteningWriteTest :
+    AzureBlobStorageWriteTest(
+        AzureBlobStorageTestUtil.getConfig(
+            JsonFormatSpecification(flattening = Flattening.ROOT_LEVEL_FLATTENING)
+        )
+    )

--- a/airbyte-integrations/connectors/destination-azure-blob-storage/src/test-integration/kotlin/io/airbyte/integrations/destination/azure_blob_storage/AzureBlobStorageWriteTest.kt
+++ b/airbyte-integrations/connectors/destination-azure-blob-storage/src/test-integration/kotlin/io/airbyte/integrations/destination/azure_blob_storage/AzureBlobStorageWriteTest.kt
@@ -15,7 +15,11 @@ import io.airbyte.cdk.load.write.UnionBehavior
 import io.airbyte.cdk.load.write.Untyped
 import org.junit.jupiter.api.Test
 
-abstract class AzureBlobStorageWriteTest(configContents: String) :
+abstract class AzureBlobStorageWriteTest(
+    configContents: String,
+    preserveUndeclaredFields: Boolean = true,
+    nullEqualsUnset: Boolean,
+) :
     BasicFunctionalityIntegrationTest(
         configContents = configContents,
         configSpecClass = AzureBlobStorageSpecification::class.java,
@@ -28,17 +32,19 @@ abstract class AzureBlobStorageWriteTest(configContents: String) :
         schematizedObjectBehavior = SchematizedNestedValueBehavior.PASS_THROUGH,
         schematizedArrayBehavior = SchematizedNestedValueBehavior.PASS_THROUGH,
         unionBehavior = UnionBehavior.PASS_THROUGH,
-        preserveUndeclaredFields = true,
+        preserveUndeclaredFields = preserveUndeclaredFields,
         supportFileTransfer = true,
         commitDataIncrementally = true,
         allTypesBehavior = Untyped,
+        nullEqualsUnset = nullEqualsUnset,
     )
 
 class AzureBlobStorageCsvNoFlatteningWriteTest :
     AzureBlobStorageWriteTest(
         AzureBlobStorageTestUtil.getConfig(
             CSVFormatSpecification(flattening = Flattening.NO_FLATTENING)
-        )
+        ),
+        nullEqualsUnset = true,
     ) {
     @Test
     override fun testBasicWriteFile() {
@@ -55,19 +61,23 @@ class AzureBlobStorageCsvWithFlatteningWriteTest :
     AzureBlobStorageWriteTest(
         AzureBlobStorageTestUtil.getConfig(
             CSVFormatSpecification(flattening = Flattening.ROOT_LEVEL_FLATTENING)
-        )
+        ),
+        preserveUndeclaredFields = false,
+        nullEqualsUnset = true,
     )
 
 class AzureBlobStorageJsonlNoFlatteningWriteTest :
     AzureBlobStorageWriteTest(
         AzureBlobStorageTestUtil.getConfig(
             JsonFormatSpecification(flattening = Flattening.NO_FLATTENING)
-        )
+        ),
+        nullEqualsUnset = false,
     )
 
 class AzureBlobStorageJsonlWithFlatteningWriteTest :
     AzureBlobStorageWriteTest(
         AzureBlobStorageTestUtil.getConfig(
             JsonFormatSpecification(flattening = Flattening.ROOT_LEVEL_FLATTENING)
-        )
+        ),
+        nullEqualsUnset = false,
     )

--- a/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLBulkLoader.kt
+++ b/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLBulkLoader.kt
@@ -4,6 +4,7 @@
 
 package io.airbyte.integrations.destination.mssql.v2
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 import io.airbyte.cdk.load.command.Dedupe
 import io.airbyte.cdk.load.command.DestinationCatalog
 import io.airbyte.cdk.load.command.DestinationStream
@@ -25,6 +26,7 @@ import jakarta.inject.Singleton
 
 @Singleton class MSSQLInputPartitioner : RoundRobinInputPartitioner()
 
+@SuppressFBWarnings(value = ["NP_NONNULL_PARAM_VIOLATION"], justification = "Kotlin coroutines")
 class MSSQLBulkLoader(
     private val azureBlobClient: AzureBlobClient,
     private val stream: DestinationStream,

--- a/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLBulkLoader.kt
+++ b/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLBulkLoader.kt
@@ -11,7 +11,6 @@ import io.airbyte.cdk.load.data.csv.toCsvHeader
 import io.airbyte.cdk.load.data.withAirbyteMeta
 import io.airbyte.cdk.load.file.azureBlobStorage.AzureBlob
 import io.airbyte.cdk.load.file.azureBlobStorage.AzureBlobClient
-import io.airbyte.cdk.load.file.azureBlobStorage.GENERATION_ID_METADATA_KEY_OVERRIDE
 import io.airbyte.cdk.load.message.StreamKey
 import io.airbyte.cdk.load.pipeline.RoundRobinInputPartitioner
 import io.airbyte.cdk.load.write.StreamStateStore

--- a/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLBulkLoader.kt
+++ b/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLBulkLoader.kt
@@ -11,6 +11,7 @@ import io.airbyte.cdk.load.data.csv.toCsvHeader
 import io.airbyte.cdk.load.data.withAirbyteMeta
 import io.airbyte.cdk.load.file.azureBlobStorage.AzureBlob
 import io.airbyte.cdk.load.file.azureBlobStorage.AzureBlobClient
+import io.airbyte.cdk.load.file.azureBlobStorage.GENERATION_ID_METADATA_KEY_OVERRIDE
 import io.airbyte.cdk.load.message.StreamKey
 import io.airbyte.cdk.load.pipeline.RoundRobinInputPartitioner
 import io.airbyte.cdk.load.write.StreamStateStore

--- a/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/config/MSSQLConfiguration.kt
+++ b/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/config/MSSQLConfiguration.kt
@@ -9,6 +9,7 @@ import io.airbyte.cdk.command.FeatureFlag
 import io.airbyte.cdk.load.command.DestinationConfiguration
 import io.airbyte.cdk.load.command.DestinationConfigurationFactory
 import io.airbyte.cdk.load.command.object_storage.ObjectStorageUploadConfiguration
+import io.airbyte.cdk.load.file.azureBlobStorage.GENERATION_ID_METADATA_KEY_OVERRIDE
 import io.micronaut.context.annotation.Factory
 import jakarta.inject.Singleton
 
@@ -33,7 +34,7 @@ data class MSSQLConfiguration(
      * underscores.
      */
     override val generationIdMetadataKey: String
-        get() = "ab_generation_id"
+        get() = GENERATION_ID_METADATA_KEY_OVERRIDE
 }
 
 @Singleton

--- a/airbyte-integrations/connectors/destination-mssql/src/test-integration/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLWriterTest.kt
+++ b/airbyte-integrations/connectors/destination-mssql/src/test-integration/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLWriterTest.kt
@@ -132,7 +132,7 @@ class MSSQLDataDumper(private val configProvider: (MSSQLSpecification) -> MSSQLC
     override fun dumpFile(
         spec: ConfigurationSpecification,
         stream: DestinationStream,
-    ): List<String> {
+    ): Map<String, String> {
         throw UnsupportedOperationException("destination-mssql doesn't support file transfer")
     }
 }

--- a/airbyte-integrations/connectors/destination-s3/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2DataDumper.kt
+++ b/airbyte-integrations/connectors/destination-s3/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2DataDumper.kt
@@ -23,7 +23,7 @@ object S3V2DataDumper : DestinationDataDumper {
     override fun dumpFile(
         spec: ConfigurationSpecification,
         stream: DestinationStream
-    ): List<String> {
+    ): Map<String, String> {
         return getObjectStorageDataDumper(spec, stream).dumpFile()
     }
 


### PR DESCRIPTION
CDK changes:
* load-object-storage:
  * make it possible to instantiate CSVFormatSpecification / JsonFormatSpecification with a custom flattening option (see AzureBlobStorageWriteTest for usage)
  * ObjectStorageDataDumper correctly dumps files (s3's secrets all use a `NAMESPACE/NAME` path format, but in azure we include timestamps in the path format - so we need to use getLongestStreamConstantPrefix)
* load-azure-blob-storage:
  * pull the `ab_generation_id` string to a constant, so we can share it between mssql / azure-blob-storage

destination changes:
* mssql: use the new ab_generation_id constant
* azure:
  * config also implements ObjectStoragePathConfigurationProvider, using the default settings
  * objectloader
    * only use the new interface for records, don't use it for files
    * pass the perf options through to the CDK
  * add some check test configs (TODO: we should add some failure configs later)
  * implement the data dumper
  * TestUtil - we can now generate all the relevant configs. The GSM secret just contains the common info (auth, etc.)
  * WriteTest - use the correct RecordMangler, add+enable test classes