### PR TITLE
Destination S3: Don't drop trailing 0 in decimals in JSONL/CSV mode

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/integrationTest/kotlin/io/airbyte/cdk/load/mock_integration_test/MockBasicFunctionalityIntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/integrationTest/kotlin/io/airbyte/cdk/load/mock_integration_test/MockBasicFunctionalityIntegrationTest.kt
@@ -32,7 +32,6 @@ class MockBasicFunctionalityIntegrationTest :
         supportFileTransfer = false,
         commitDataIncrementally = false,
         allTypesBehavior = Untyped,
-        integralNumbersAreConvertedToInt = true,
     ) {
     @Test
     override fun testBasicWrite() {

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/util/JsonUtils.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/util/JsonUtils.kt
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.core.StreamReadConstraints
 import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.cfg.JsonNodeFeature
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.afterburner.AfterburnerModule
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
@@ -28,6 +29,7 @@ object Jsons : ObjectMapper() {
         configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
         configure(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS, true)
         configure(JsonGenerator.Feature.WRITE_BIGDECIMAL_AS_PLAIN, true)
+        configure(JsonNodeFeature.STRIP_TRAILING_BIGDECIMAL_ZEROES, false)
         factory.setStreamReadConstraints(
             StreamReadConstraints.builder().maxStringLength(JSON_MAX_LENGTH).build()
         )

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/write/BasicFunctionalityIntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/write/BasicFunctionalityIntegrationTest.kt
@@ -214,11 +214,6 @@ abstract class BasicFunctionalityIntegrationTest(
     val commitDataIncrementally: Boolean,
     val allTypesBehavior: AllTypesBehavior,
     val unknownTypesBehavior: UnknownTypesBehavior = UnknownTypesBehavior.PASS_THROUGH,
-    /**
-     * Some destinations implicitly convert numbers to int when it's lossless (e.g. converting 42.0
-     * to 42). Those destinations should set [integralNumbersAreConvertedToInt] to `true`.
-     */
-    val integralNumbersAreConvertedToInt: Boolean = false,
     nullEqualsUnset: Boolean = false,
     configUpdater: ConfigurationUpdater = FakeConfigurationUpdater,
 ) :
@@ -2243,12 +2238,7 @@ abstract class BasicFunctionalityIntegrationTest(
                         mapOf(
                             "id" to 8,
                             "integer" to 0,
-                            "number" to
-                                if (integralNumbersAreConvertedToInt) {
-                                    0
-                                } else {
-                                    0.0
-                                },
+                            "number" to 0.0,
                         ),
                     airbyteMeta = OutputRecord.Meta(syncId = 42),
                 ),
@@ -2259,12 +2249,7 @@ abstract class BasicFunctionalityIntegrationTest(
                         mapOf(
                             "id" to 9,
                             "integer" to -1,
-                            "number" to
-                                if (integralNumbersAreConvertedToInt) {
-                                    -1
-                                } else {
-                                    -1.0
-                                },
+                            "number" to -1.0,
                         ),
                     airbyteMeta = OutputRecord.Meta(syncId = 42),
                 ),

--- a/airbyte-integrations/connectors/destination-s3/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-s3/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: file
   connectorType: destination
   definitionId: 4816b78f-1489-44c1-9060-4b19d5fa9362
-  dockerImageTag: 1.5.8
+  dockerImageTag: 1.6.0
   dockerRepository: airbyte/destination-s3
   githubIssueLabel: destination-s3
   icon: s3.svg

--- a/airbyte-integrations/connectors/destination-s3/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2WriteTest.kt
+++ b/airbyte-integrations/connectors/destination-s3/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2WriteTest.kt
@@ -43,7 +43,6 @@ abstract class S3V2WriteTest(
     nullEqualsUnset: Boolean = false,
     unknownTypesBehavior: UnknownTypesBehavior = UnknownTypesBehavior.PASS_THROUGH,
     private val mergesUnions: Boolean = false,
-    integralNumbersAreConvertedToInt: Boolean,
 ) :
     BasicFunctionalityIntegrationTest(
         S3V2TestUtils.getConfig(path),
@@ -65,7 +64,6 @@ abstract class S3V2WriteTest(
         nullEqualsUnset = nullEqualsUnset,
         supportFileTransfer = true,
         unknownTypesBehavior = unknownTypesBehavior,
-        integralNumbersAreConvertedToInt = integralNumbersAreConvertedToInt,
     ) {
     @Disabled("Irrelevant for file destinations")
     @Test

--- a/airbyte-integrations/connectors/destination-s3/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2WriteTest.kt
+++ b/airbyte-integrations/connectors/destination-s3/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2WriteTest.kt
@@ -315,7 +315,6 @@ class S3V2WriteTestJsonUncompressed :
         schematizedArrayBehavior = SchematizedNestedValueBehavior.PASS_THROUGH,
         preserveUndeclaredFields = true,
         allTypesBehavior = Untyped,
-        integralNumbersAreConvertedToInt = true,
     )
 
 class S3V2WriteTestJsonRootLevelFlattening :
@@ -328,7 +327,6 @@ class S3V2WriteTestJsonRootLevelFlattening :
         schematizedArrayBehavior = SchematizedNestedValueBehavior.PASS_THROUGH,
         preserveUndeclaredFields = true,
         allTypesBehavior = Untyped,
-        integralNumbersAreConvertedToInt = true,
     )
 
 class S3V2WriteTestJsonGzip :
@@ -341,7 +339,6 @@ class S3V2WriteTestJsonGzip :
         schematizedArrayBehavior = SchematizedNestedValueBehavior.PASS_THROUGH,
         preserveUndeclaredFields = true,
         allTypesBehavior = Untyped,
-        integralNumbersAreConvertedToInt = true,
     )
 
 class S3V2WriteTestCsvUncompressed :
@@ -354,7 +351,6 @@ class S3V2WriteTestCsvUncompressed :
         schematizedArrayBehavior = SchematizedNestedValueBehavior.PASS_THROUGH,
         preserveUndeclaredFields = true,
         allTypesBehavior = Untyped,
-        integralNumbersAreConvertedToInt = true,
     ) {
     @Test
     override fun testBasicWriteFile() {
@@ -374,7 +370,6 @@ class S3V2WriteTestCsvRootLevelFlattening :
         allTypesBehavior = Untyped,
         nullEqualsUnset =
             true, // Technically true of unflattened as well, but no top-level fields are nullable
-        integralNumbersAreConvertedToInt = true,
     )
 
 class S3V2WriteTestCsvGzip :
@@ -387,7 +382,6 @@ class S3V2WriteTestCsvGzip :
         schematizedArrayBehavior = SchematizedNestedValueBehavior.PASS_THROUGH,
         preserveUndeclaredFields = true,
         allTypesBehavior = Untyped,
-        integralNumbersAreConvertedToInt = true,
     )
 
 class S3V2WriteTestAvroUncompressed :
@@ -403,7 +397,6 @@ class S3V2WriteTestAvroUncompressed :
         nullEqualsUnset = true,
         unknownTypesBehavior = UnknownTypesBehavior.FAIL,
         mergesUnions = true,
-        integralNumbersAreConvertedToInt = false,
     )
 
 class S3V2WriteTestAvroBzip2 :
@@ -419,7 +412,6 @@ class S3V2WriteTestAvroBzip2 :
         nullEqualsUnset = true,
         unknownTypesBehavior = UnknownTypesBehavior.FAIL,
         mergesUnions = true,
-        integralNumbersAreConvertedToInt = false,
     )
 
 class S3V2WriteTestParquetUncompressed :
@@ -435,7 +427,6 @@ class S3V2WriteTestParquetUncompressed :
         nullEqualsUnset = true,
         unknownTypesBehavior = UnknownTypesBehavior.FAIL,
         mergesUnions = true,
-        integralNumbersAreConvertedToInt = false,
     )
 
 class S3V2WriteTestParquetSnappy :
@@ -451,7 +442,6 @@ class S3V2WriteTestParquetSnappy :
         nullEqualsUnset = true,
         unknownTypesBehavior = UnknownTypesBehavior.FAIL,
         mergesUnions = true,
-        integralNumbersAreConvertedToInt = false,
     )
 
 class S3V2WriteTestEndpointURL :
@@ -466,7 +456,6 @@ class S3V2WriteTestEndpointURL :
         preserveUndeclaredFields = false,
         allTypesBehavior = Untyped,
         nullEqualsUnset = true,
-        integralNumbersAreConvertedToInt = true,
     )
 
 class S3V2AmbiguousFilepath :
@@ -480,7 +469,6 @@ class S3V2AmbiguousFilepath :
         schematizedArrayBehavior = SchematizedNestedValueBehavior.PASS_THROUGH,
         preserveUndeclaredFields = true,
         allTypesBehavior = Untyped,
-        integralNumbersAreConvertedToInt = true,
     )
 
 class S3V2CsvAssumeRole :
@@ -493,5 +481,4 @@ class S3V2CsvAssumeRole :
         schematizedArrayBehavior = SchematizedNestedValueBehavior.PASS_THROUGH,
         preserveUndeclaredFields = true,
         allTypesBehavior = Untyped,
-        integralNumbersAreConvertedToInt = true,
     )

--- a/docs/integrations/destinations/s3.md
+++ b/docs/integrations/destinations/s3.md
@@ -544,6 +544,7 @@ To see connector limitations, or troubleshoot your S3 connector, see more [in ou
 
 | Version     | Date       | Pull Request                                               | Subject                                                                                                                                              |
 |:------------|:-----------|:-----------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| 1.6.0       | 2025-03-28 | [56458](https://github.com/airbytehq/airbyte/pull/56458)   | Do not drop trailing `.0` from decimals in CSV/JSONL data                                                                                            |
 | 1.5.8       | 2025-03-25 | [56398](https://github.com/airbytehq/airbyte/pull/56398)   | Internal CDK change to mark old Avro and Parquet formats as deprecated                                                                               |
 | 1.5.7       | 2025-03-24 | [56355](https://github.com/airbytehq/airbyte/pull/56355)   | Upgrade to airbyte/java-connector-base:2.0.1 to be M4 compatible.                                                                                    |
 | 1.5.6       | 2025-03-24 | [55849](https://github.com/airbytehq/airbyte/pull/55849)   | Internal refactoring                                                                                                                                 |


### PR DESCRIPTION
closes https://github.com/airbytehq/airbyte-internal-issues/issues/12265

We're currently writing `0.0` as `0` in CSV/JSONL mode.

* I thought this was coming from the old-style type stuff (i.e somewhere in the mapper pipeline we were converting a number -> intValue)
* turns out it's actually how we JSON-serialize stuff in general
* this also broke stuff on the _input_ side of tests: the conversion from InputRecord -> AirbyteValue -> JsonNode -> String was turning `0.0` into `0`

other connectors are unaffected, b/c they're strongly typed. E.g. in s3datalake, we write a parquet double, not a string. I guess technically decimals inside JSON objects are affected? but that feels pretty narrow