### PR TITLE
Bulk load CDK: files test validates file path; make this work in azure

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/integrationTest/kotlin/io/airbyte/cdk/load/mock_integration_test/MockDestinationBackend.kt
+++ b/airbyte-cdk/bulk/core/load/src/integrationTest/kotlin/io/airbyte/cdk/load/mock_integration_test/MockDestinationBackend.kt
@@ -129,7 +129,7 @@ object MockDestinationDataDumper : DestinationDataDumper {
     override fun dumpFile(
         spec: ConfigurationSpecification,
         stream: DestinationStream
-    ): List<String> {
+    ): Map<String, String> {
         // Not needed since the test is disabled for file transfer
         throw NotImplementedError()
     }

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/DestinationDataDumper.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/DestinationDataDumper.kt
@@ -9,7 +9,7 @@ import io.airbyte.cdk.load.command.DestinationStream
 
 interface DestinationDataDumper {
     fun dumpRecords(spec: ConfigurationSpecification, stream: DestinationStream): List<OutputRecord>
-    fun dumpFile(spec: ConfigurationSpecification, stream: DestinationStream): List<String>
+    fun dumpFile(spec: ConfigurationSpecification, stream: DestinationStream): Map<String, String>
 }
 
 /**
@@ -27,7 +27,7 @@ object FakeDataDumper : DestinationDataDumper {
     override fun dumpFile(
         spec: ConfigurationSpecification,
         stream: DestinationStream
-    ): List<String> {
+    ): Map<String, String> {
         throw NotImplementedError()
     }
 }

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/write/BasicFunctionalityIntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/write/BasicFunctionalityIntegrationTest.kt
@@ -403,7 +403,7 @@ abstract class BasicFunctionalityIntegrationTest(
         val config = ValidatedJsonUtils.parseOne(configSpecClass, updatedConfig)
         val fileContent = dataDumper.dumpFile(config, stream)
 
-        assertEquals(listOf("123"), fileContent)
+        assertEquals(mapOf("path/to/file" to "123"), fileContent)
     }
 
     @Disabled("https://github.com/airbytehq/airbyte-internal-issues/issues/10413")

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/testFixtures/kotlin/io/airbyte/cdk/load/data/icerberg/parquet/IcebergDataDumper.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/testFixtures/kotlin/io/airbyte/cdk/load/data/icerberg/parquet/IcebergDataDumper.kt
@@ -113,7 +113,7 @@ class IcebergDataDumper(
     override fun dumpFile(
         spec: ConfigurationSpecification,
         stream: DestinationStream
-    ): List<String> {
+    ): Map<String, String> {
         throw NotImplementedError("Iceberg doesn't support universal file transfer")
     }
 }

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/testFixtures/kotlin/io/airbyte/cdk/load/ObjectStorageDataDumper.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/testFixtures/kotlin/io/airbyte/cdk/load/ObjectStorageDataDumper.kt
@@ -29,6 +29,7 @@ import io.airbyte.cdk.load.test.util.toOutputRecord
 import io.airbyte.cdk.load.util.deserializeToNode
 import java.io.BufferedReader
 import java.io.InputStream
+import java.util.stream.Collectors.toMap
 import java.util.zip.GZIPInputStream
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.filter
@@ -76,8 +77,8 @@ class ObjectStorageDataDumper(
         }
     }
 
-    fun dumpFile(): List<String> {
-        val prefix = pathFactory.getLongestStreamConstantPrefix(stream).toString()
+    fun dumpFile(): Map<String, String> {
+        val prefix = pathFactory.getLongestStreamConstantPrefix(stream)
         return runBlocking {
             withContext(Dispatchers.IO) {
                 client
@@ -91,10 +92,13 @@ class ObjectStorageDataDumper(
                                     null -> objectData
                                     else -> error("Unsupported compressor")
                                 }
-                            BufferedReader(decompressed.reader()).readText()
+                            // Remove the "namespace/name/" prefix from the object key
+                            val truncatedKey = listedObject.key.replace(prefix, "")
+                            truncatedKey to BufferedReader(decompressed.reader()).readText()
                         }
                     }
                     .toList()
+                    .toMap()
             }
         }
     }

--- a/airbyte-integrations/connectors/destination-azure-blob-storage/src/main/kotlin/io/airbyte/integrations/destination/azure_blob_storage/AzureBlobStorageConfiguration.kt
+++ b/airbyte-integrations/connectors/destination-azure-blob-storage/src/main/kotlin/io/airbyte/integrations/destination/azure_blob_storage/AzureBlobStorageConfiguration.kt
@@ -54,8 +54,13 @@ class AzureBlobStorageConfiguration<T : OutputStream>(
     override val objectStoragePathConfiguration =
         ObjectStoragePathConfiguration(
             prefix = "",
-            pathPattern = null,
-            fileNamePattern = null,
+            // This is equivalent to the default,
+            // but is nicer for tests,
+            // and also matches user intuition more closely.
+            // The default puts the `<date>_<epoch>_` into the path format,
+            // which is (a) confusing, and (b) makes the file transfer tests more annoying.
+            pathPattern = "\${NAMESPACE}/\${STREAM_NAME}/",
+            fileNamePattern = "{date}_{timestamp}_{part_number}{format_extension}",
         )
 
     override val generationIdMetadataKey = GENERATION_ID_METADATA_KEY_OVERRIDE

--- a/airbyte-integrations/connectors/destination-azure-blob-storage/src/test-integration/kotlin/io/airbyte/integrations/destination/azure_blob_storage/AzureBlobStorageDataDumper.kt
+++ b/airbyte-integrations/connectors/destination-azure-blob-storage/src/test-integration/kotlin/io/airbyte/integrations/destination/azure_blob_storage/AzureBlobStorageDataDumper.kt
@@ -21,7 +21,7 @@ class AzureBlobStorageDataDumper : DestinationDataDumper {
     override fun dumpFile(
         spec: ConfigurationSpecification,
         stream: DestinationStream
-    ): List<String> = getObjectStorageDataDumper(spec, stream).dumpFile()
+    ): Map<String, String> = getObjectStorageDataDumper(spec, stream).dumpFile()
 
     private fun getObjectStorageDataDumper(
         spec: ConfigurationSpecification,

--- a/airbyte-integrations/connectors/destination-mssql/src/test-integration/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLWriterTest.kt
+++ b/airbyte-integrations/connectors/destination-mssql/src/test-integration/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLWriterTest.kt
@@ -132,7 +132,7 @@ class MSSQLDataDumper(private val configProvider: (MSSQLSpecification) -> MSSQLC
     override fun dumpFile(
         spec: ConfigurationSpecification,
         stream: DestinationStream,
-    ): List<String> {
+    ): Map<String, String> {
         throw UnsupportedOperationException("destination-mssql doesn't support file transfer")
     }
 }

--- a/airbyte-integrations/connectors/destination-s3/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2DataDumper.kt
+++ b/airbyte-integrations/connectors/destination-s3/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2DataDumper.kt
@@ -23,7 +23,7 @@ object S3V2DataDumper : DestinationDataDumper {
     override fun dumpFile(
         spec: ConfigurationSpecification,
         stream: DestinationStream
-    ): List<String> {
+    ): Map<String, String> {
         return getObjectStorageDataDumper(spec, stream).dumpFile()
     }
 


### PR DESCRIPTION
two commits:
* update the core cdk + azure to work nicely
* fix compilation in the other tests

(verified locally that S3V2WriteTestCsvRootLevelFlattening still passes)