### PR TITLE
[Azure Blob Storage] Add the AzureBlobStorageChecker

### DIFF
--- a/airbyte-integrations/connectors/destination-azure-blob-storage/src/main/kotlin/io/airbyte/integrations/destination/azure_blob_storage/AzureBlobStorageChecker.kt
+++ b/airbyte-integrations/connectors/destination-azure-blob-storage/src/main/kotlin/io/airbyte/integrations/destination/azure_blob_storage/AzureBlobStorageChecker.kt
@@ -5,13 +5,58 @@
 package io.airbyte.integrations.destination.azure_blob_storage
 
 import io.airbyte.cdk.load.check.DestinationChecker
-import io.airbyte.cdk.load.command.DestinationConfiguration
+import io.airbyte.cdk.load.file.azureBlobStorage.AzureBlobStorageClientFactory
+import java.io.OutputStream
 import javax.inject.Singleton
+import kotlinx.coroutines.runBlocking
 
-// TODO use actual azure config object once it exists
 @Singleton
-class AzureBlobStorageChecker : DestinationChecker<DestinationConfiguration> {
-    override fun check(config: DestinationConfiguration) {
-        // TODO check the config
+class AzureBlobStorageChecker<T : OutputStream> :
+    DestinationChecker<AzureBlobStorageConfiguration<T>> {
+    override fun check(config: AzureBlobStorageConfiguration<T>) {
+        val azureBlobClient = AzureBlobStorageClientFactory(config).make()
+
+        // Prepare test data
+        val testData = "test".toByteArray()
+        val checkFilePath = "check_test_data"
+
+        runBlocking {
+            // 1) Upload blob
+            val checkBlob = azureBlobClient.put(checkFilePath, testData)
+
+            try {
+                // 2) Verify the blob exists by attempting to get metadata
+                val metadata =
+                    try {
+                        azureBlobClient.getMetadata(checkFilePath)
+                        true // If we reach this point, the blob exists
+                    } catch (e: Exception) {
+                        false // The blob doesn't exist
+                    }
+
+                check(metadata) { "Failed to verify blob existence after upload" }
+
+                // 3) Download and verify content
+                azureBlobClient.get(checkFilePath) { inputStream ->
+                    val downloadedContent = inputStream.readBytes().toString(Charsets.UTF_8)
+                    check(downloadedContent == "test") {
+                        "Downloaded content doesn't match uploaded content"
+                    }
+                }
+
+                // 4) List blobs to verify the blob appears in the container
+                var blobFound = false
+                azureBlobClient.list(checkFilePath.substringBefore("/")).collect { blob ->
+                    if (blob.key == checkFilePath) {
+                        blobFound = true
+                    }
+                }
+
+                check(blobFound) { "Uploaded blob not found in blob listing" }
+            } finally {
+                // 5) Clean up remote files
+                azureBlobClient.delete(checkBlob)
+            }
+        }
     }
 }

--- a/airbyte-integrations/connectors/destination-azure-blob-storage/src/main/kotlin/io/airbyte/integrations/destination/azure_blob_storage/AzureBlobStorageChecker.kt
+++ b/airbyte-integrations/connectors/destination-azure-blob-storage/src/main/kotlin/io/airbyte/integrations/destination/azure_blob_storage/AzureBlobStorageChecker.kt
@@ -36,15 +36,7 @@ class AzureBlobStorageChecker<T : OutputStream> :
 
                 check(metadata) { "Failed to verify blob existence after upload" }
 
-                // 3) Download and verify content
-                azureBlobClient.get(checkFilePath) { inputStream ->
-                    val downloadedContent = inputStream.readBytes().toString(Charsets.UTF_8)
-                    check(downloadedContent == "test") {
-                        "Downloaded content doesn't match uploaded content"
-                    }
-                }
-
-                // 4) List blobs to verify the blob appears in the container
+                // 3) List blobs to verify the blob appears in the container
                 var blobFound = false
                 azureBlobClient.list(checkFilePath.substringBefore("/")).collect { blob ->
                     if (blob.key == checkFilePath) {
@@ -54,7 +46,7 @@ class AzureBlobStorageChecker<T : OutputStream> :
 
                 check(blobFound) { "Uploaded blob not found in blob listing" }
             } finally {
-                // 5) Clean up remote files
+                // 4) Clean up remote files
                 azureBlobClient.delete(checkBlob)
             }
         }

--- a/airbyte-integrations/connectors/destination-azure-blob-storage/src/test-integration/kotlin/io/airbyte/integrations/destination/azure_blob_storage/AzureBlobStorageCheckTest.kt
+++ b/airbyte-integrations/connectors/destination-azure-blob-storage/src/test-integration/kotlin/io/airbyte/integrations/destination/azure_blob_storage/AzureBlobStorageCheckTest.kt
@@ -8,6 +8,8 @@ import io.airbyte.cdk.load.check.CheckIntegrationTest
 import io.airbyte.cdk.load.check.CheckTestConfig
 import io.airbyte.cdk.load.command.object_storage.CSVFormatSpecification
 import io.airbyte.cdk.load.command.object_storage.JsonFormatSpecification
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
 
 class AzureBlobStorageCheckTest :
     CheckIntegrationTest<AzureBlobStorageSpecification>(
@@ -21,5 +23,14 @@ class AzureBlobStorageCheckTest :
                 ),
                 CheckTestConfig(AzureBlobStorageTestUtil.getSasConfig(CSVFormatSpecification())),
             ),
-        failConfigFilenamesAndFailureReasons = emptyMap(),
+        failConfigFilenamesAndFailureReasons =
+            mapOf(
+                CheckTestConfig(
+                    Files.readString(
+                        AzureBlobStorageTestUtil.invalidConfig,
+                        StandardCharsets.UTF_8
+                    ),
+                    name = "Bad hostname"
+                ) to "Server failed to authenticate the request".toPattern(),
+            ),
     )

--- a/airbyte-integrations/connectors/destination-azure-blob-storage/src/test-integration/kotlin/io/airbyte/integrations/destination/azure_blob_storage/AzureBlobStorageCheckTest.kt
+++ b/airbyte-integrations/connectors/destination-azure-blob-storage/src/test-integration/kotlin/io/airbyte/integrations/destination/azure_blob_storage/AzureBlobStorageCheckTest.kt
@@ -8,8 +8,6 @@ import io.airbyte.cdk.load.check.CheckIntegrationTest
 import io.airbyte.cdk.load.check.CheckTestConfig
 import io.airbyte.cdk.load.command.object_storage.CSVFormatSpecification
 import io.airbyte.cdk.load.command.object_storage.JsonFormatSpecification
-import java.nio.charset.StandardCharsets
-import java.nio.file.Files
 
 class AzureBlobStorageCheckTest :
     CheckIntegrationTest<AzureBlobStorageSpecification>(
@@ -26,10 +24,7 @@ class AzureBlobStorageCheckTest :
         failConfigFilenamesAndFailureReasons =
             mapOf(
                 CheckTestConfig(
-                    Files.readString(
-                        AzureBlobStorageTestUtil.invalidConfig,
-                        StandardCharsets.UTF_8
-                    ),
+                    AzureBlobStorageTestUtil.getInvalidConfig(CSVFormatSpecification()),
                     name = "Bad hostname"
                 ) to "Server failed to authenticate the request".toPattern(),
             ),

--- a/airbyte-integrations/connectors/destination-azure-blob-storage/src/test-integration/kotlin/io/airbyte/integrations/destination/azure_blob_storage/AzureBlobStorageTestUtil.kt
+++ b/airbyte-integrations/connectors/destination-azure-blob-storage/src/test-integration/kotlin/io/airbyte/integrations/destination/azure_blob_storage/AzureBlobStorageTestUtil.kt
@@ -24,6 +24,10 @@ object AzureBlobStorageTestUtil {
         return getConfig(sasConfigPath, format)
     }
 
+    fun getInvalidConfig(format: ObjectStorageFormatSpecification): String {
+        return getConfig(invalidConfig, format)
+    }
+
     fun getConfig(path: Path, format: ObjectStorageFormatSpecification): String {
         // slightly annoying - we can't easily _edit_ AzureBlobStorageSpecification objects
         // so we just work on raw jsonnode here

--- a/airbyte-integrations/connectors/destination-azure-blob-storage/src/test-integration/kotlin/io/airbyte/integrations/destination/azure_blob_storage/AzureBlobStorageTestUtil.kt
+++ b/airbyte-integrations/connectors/destination-azure-blob-storage/src/test-integration/kotlin/io/airbyte/integrations/destination/azure_blob_storage/AzureBlobStorageTestUtil.kt
@@ -13,6 +13,7 @@ import java.nio.file.Path
 
 object AzureBlobStorageTestUtil {
     val configPath = Path.of("secrets/config.json")
+    val invalidConfig = Path.of("src/test-integration/resources/check/invalid-config.json")
     val sasConfigPath = Path.of("secrets/config_sas.json")
 
     fun getAccountKeyConfig(format: ObjectStorageFormatSpecification): String {

--- a/airbyte-integrations/connectors/destination-azure-blob-storage/src/test-integration/resources/check/invalid-config.json
+++ b/airbyte-integrations/connectors/destination-azure-blob-storage/src/test-integration/resources/check/invalid-config.json
@@ -1,0 +1,7 @@
+{
+  "format": { "format_type": "JSONL" },
+  "azure_blob_storage_endpoint_domain_name": "blob.core.windows.net",
+  "azure_blob_storage_account_name": "airbyteteststorage",
+  "azure_blob_storage_account_key": "YmFkYWNjb3VudF9rZXkK",
+  "azure_blob_storage_container_name": "badcontainer"
+}


### PR DESCRIPTION
## What

Add a new `AzureBlobStorageChecker` for the `check` command.
This class runs through a few steps:
* Uploads a "blob"
* Verify the blob exists by attempting to get metadata
* Download and verify content
* List blobs to verify the blob appears in the container
* Clean up remote files

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [X] YES 💚
- [ ] NO ❌
