### PR TITLE
Chore: bump to archive.

### DIFF
--- a/airbyte-integrations/connectors/destination-iceberg/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-iceberg/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: df65a8f3-9908-451b-aa9b-445462803560
-  dockerImageTag: 0.2.5
+  dockerImageTag: 0.2.6
   dockerRepository: airbyte/destination-iceberg
   githubIssueLabel: destination-iceberg
   icon: iceberg.svg

--- a/airbyte-integrations/connectors/destination-s3-glue/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-s3-glue/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: file
   connectorType: destination
   definitionId: 471e5cab-8ed1-49f3-ba11-79c687784737
-  dockerImageTag: 0.1.11
+  dockerImageTag: 0.1.12
   dockerRepository: airbyte/destination-s3-glue
   githubIssueLabel: destination-s3-glue
   icon: s3-glue.svg


### PR DESCRIPTION
## What
For some reason Iceberg and S3-Glue aren't archiving and still show in the Marketplace. Does this fix it?

## How
Bump the version.

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
