### PR TITLE
Update custom-image-registries.md to cover Per-Image Registry overrides

### DIFF
--- a/docs/deploying-airbyte/integrations/custom-image-registries.md
+++ b/docs/deploying-airbyte/integrations/custom-image-registries.md
@@ -109,3 +109,30 @@ docker push ghcr.io/NAMESPACE/destination-google-sheets:latest
 ```
 
 Now, when you install Airbyte, images will come from the custom image registry you configured.
+
+## Advanced configurations
+
+### Per-Image Registry overrides
+When implementing a custom global image registry, you may wish to overide your global configuration for one or more individual images for airbyte components referenced in the helm charts.
+
+For example:
+
+assuming you have set this global configuration:
+```yaml title="values.yaml"
+    global:
+      image:
+        registry: "my-registry.example.com"
+```
+you may want to configure a public AWS ECR for individual images in the chart.
+This can be achieved by setting the `image.registry`, `image.repository` and `image.tag` subkeys for the relevent airbyte component in the airbyte values.yaml.
+
+An example below shows what this looks like for the keycloak initDB container:
+```yaml title="values.yaml"
+keycloak:
+  initContainers:
+    initDb:
+      image:
+        registry: public.ecr.aws
+        repository: docker/library/postgres
+        tag: 13-alpine
+```


### PR DESCRIPTION
…overrides

This PR Adds an "Advanced configuration" section with examples of setting an Image registry override on a per container basis.

## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->
Solves:
https://airbytehq-team.slack.com/archives/C03GD9SV36E/p1740518680398539 
We do not yet have public examples of this.

## How
<!--
* Describe how code changes achieve the solution.
-->

## Review guide
<!--
1. `x.py`
2. `y.py`
-->
See the "Advanced Configuration" section at the bottom of the doc.
## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->
Users may now use configure images to pull from different registries instead of only using a global override.
## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x ] YES 💚
- [ ] NO ❌
