### PR TITLE
fix: Fixing the api endpoint used in check

### DIFF
--- a/airbyte-integrations/connectors/source-akeneo/manifest.yaml
+++ b/airbyte-integrations/connectors/source-akeneo/manifest.yaml
@@ -14,7 +14,7 @@ description: >-
 check:
   type: CheckStream
   stream_names:
-    - products
+    - categories
 
 definitions:
   streams:


### PR DESCRIPTION
## What
- Trying to change the check endpoint of Akeneo connector to `categories`.
- Default check endpoint `product` is raising a `RetriableError` whereas the other endpoints are able to fetch the data.

## How
<!--
* Describe how code changes achieve the solution.
-->
- None

## Review guide
<!--
1. `x.py`
2. `y.py`
-->
- None

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->
- None

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
