### PR TITLE
[Dest-S3] Release 1.7.0: S3 Uses ObjectLoader Interface

### DIFF
--- a/airbyte-integrations/connectors/destination-s3/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-s3/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: file
   connectorType: destination
   definitionId: 4816b78f-1489-44c1-9060-4b19d5fa9362
-  dockerImageTag: 1.7.0-rc.1
+  dockerImageTag: 1.7.0
   dockerRepository: airbyte/destination-s3
   githubIssueLabel: destination-s3
   icon: s3.svg
@@ -23,7 +23,7 @@ data:
           **This release includes breaking changes, including major revisions to the schema of stored data. Do not upgrade without reviewing the migration guide.**
         upgradeDeadline: "2024-10-08"
     rolloutConfiguration:
-      enableProgressiveRollout: true
+      enableProgressiveRollout: false
   resourceRequirements:
     jobSpecific:
       - jobType: sync

--- a/docs/integrations/destinations/s3.md
+++ b/docs/integrations/destinations/s3.md
@@ -544,6 +544,7 @@ To see connector limitations, or troubleshoot your S3 connector, see more [in ou
 
 | Version     | Date       | Pull Request                                               | Subject                                                                                                                                              |
 |:------------|:-----------|:-----------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| 1.7.0       | 2025-04-02 | [56974](https://github.com/airbytehq/airbyte/pull/56974)   | Release 1.7.0 release candidate                                                                                                                      |
 | 1.7.0-rc.1  | 2025-03-31 | [56935](https://github.com/airbytehq/airbyte/pull/56935)   | Internal performance refactor                                                                                                                        |
 | 1.6.0       | 2025-03-28 | [56458](https://github.com/airbytehq/airbyte/pull/56458)   | Do not drop trailing `.0` from decimals in CSV/JSONL data                                                                                            |
 | 1.5.8       | 2025-03-25 | [56398](https://github.com/airbytehq/airbyte/pull/56398)   | Internal CDK change to mark old Avro and Parquet formats as deprecated                                                                               |


### PR DESCRIPTION
## What
Release 1.7.0.

I had to push a second version of this b/c the previous one was coauthored by the rollout tool, which I think hasn't signed the license agreement 🤷 ?
