### PR TITLE
Bulk load CDK: support `group` in spec

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/spec/DestinationSpecificationInternal.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/spec/DestinationSpecificationInternal.kt
@@ -44,6 +44,14 @@ class DestinationSpecificationExtender(private val spec: DestinationSpecificatio
 }
 
 interface DestinationSpecificationExtension {
+    /**
+     * A connector's spec can specify "groups", which the UI will use to put related spec options in
+     * the same place. To do this, you should:
+     * * add a [Group] to the [groups] list (e.g. `Group(id = "foo", title = "Foo")`
+     * * inject `{"group": "foo"}` to the generated JSONSchema for the relevant spec options
+     * (`@JsonSchemaInject(json = """{"group": "foo"}""") val theOption: String`
+     * * note that this should be the id of the group, not the title.
+     */
     data class Group(
         /** A computer-friendly ID for the group */
         val id: String,

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/spec/DestinationSpecificationInternal.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/spec/DestinationSpecificationInternal.kt
@@ -4,8 +4,10 @@
 
 package io.airbyte.cdk.load.spec
 
+import com.fasterxml.jackson.databind.node.ObjectNode
 import io.airbyte.cdk.spec.IdentitySpecificationExtender
 import io.airbyte.cdk.spec.SpecificationExtender
+import io.airbyte.cdk.util.Jsons
 import io.airbyte.protocol.models.v0.ConnectorSpecification
 import io.airbyte.protocol.models.v0.DestinationSyncMode
 import io.micronaut.context.annotation.Replaces
@@ -18,6 +20,23 @@ import jakarta.inject.Singleton
 class DestinationSpecificationExtender(private val spec: DestinationSpecificationExtension) :
     SpecificationExtender {
     override fun invoke(specification: ConnectorSpecification): ConnectorSpecification {
+        if (spec.groups.isNotEmpty()) {
+            val schema = specification.connectionSpecification as ObjectNode
+            schema.set<ObjectNode>(
+                "groups",
+                Jsons.arrayNode().apply {
+                    spec.groups.forEach { group ->
+                        add(
+                            Jsons.objectNode().apply {
+                                put("id", group.id)
+                                put("title", group.title)
+                            }
+                        )
+                    }
+                }
+            )
+        }
+
         return specification
             .withSupportedDestinationSyncModes(spec.supportedSyncModes)
             .withSupportsIncremental(spec.supportsIncremental)
@@ -25,6 +44,15 @@ class DestinationSpecificationExtender(private val spec: DestinationSpecificatio
 }
 
 interface DestinationSpecificationExtension {
+    data class Group(
+        /** A computer-friendly ID for the group */
+        val id: String,
+        /** A human-readable name for the group */
+        val title: String
+    )
+
     val supportedSyncModes: List<DestinationSyncMode>
     val supportsIncremental: Boolean
+    val groups: List<Group>
+        get() = emptyList()
 }


### PR DESCRIPTION
The UI supports a `groups` thing in connector specs. E.g. in bigquery:
* https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connectors/destination-bigquery/src/main/resources/spec.json#L17
* https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connectors/destination-bigquery/src/main/resources/spec.json#L228-L237

Add this to the DestinationSpecExtender. (it could probably go into the base CDK, but I didn't want to figure out that plumbing).

tested with this diff https://github.com/airbytehq/airbyte/pull/56976/commits/946febc3160cb7c1133b481e86784c2164a392ae;  it correctly generated this UI:
<img width="519" alt="image" src="https://github.com/user-attachments/assets/2c3fe903-9de4-4f7f-823c-f89bc0dec3c3" />
