### PR TITLE
bug(source-facebook-marketing): string indices must be integers, not 'str'

### DIFF
--- a/airbyte-integrations/connectors/source-facebook-marketing/metadata.yaml
+++ b/airbyte-integrations/connectors/source-facebook-marketing/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: e7778cfc-e97c-4458-9ecb-b4f2bba8946c
-  dockerImageTag: 3.4.4
+  dockerImageTag: 3.4.5
   dockerRepository: airbyte/source-facebook-marketing
   documentationUrl: https://docs.airbyte.com/integrations/sources/facebook-marketing
   githubIssueLabel: source-facebook-marketing

--- a/airbyte-integrations/connectors/source-facebook-marketing/pyproject.toml
+++ b/airbyte-integrations/connectors/source-facebook-marketing/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "3.4.4"
+version = "3.4.5"
 name = "source-facebook-marketing"
 description = "Source implementation for Facebook Marketing."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/docs/integrations/sources/facebook-marketing.md
+++ b/docs/integrations/sources/facebook-marketing.md
@@ -269,6 +269,7 @@ This response indicates that the Facebook Graph API requires you to reduce the f
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                                                                                                                                                                                           |
 |:--------|:-----------|:---------------------------------------------------------|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 3.4.5 | 2025-04-02 | [56981](https://github.com/airbytehq/airbyte/pull/56981) | Fix error with acync jobs |
 | 3.4.4 | 2025-03-29 | [56467](https://github.com/airbytehq/airbyte/pull/56467) | Update dependencies |
 | 3.4.3 | 2025-02-20 | [54171](https://github.com/airbytehq/airbyte/pull/54171) | Fix retry pattern |
 | 3.4.2 | 2025-03-22 | [55991](https://github.com/airbytehq/airbyte/pull/55991) | Update dependencies |


### PR DESCRIPTION
## What
We are getting 404s when trying to create async jobs for insights in different streams, which results in erros like:

```
  File "/usr/local/lib/python3.11/site-packages/facebook_business/api.py", line 679, in execute
    return self._response_parser.parse_single(response.json())
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/facebook_business/adobjects/objectparser.py", line 55, in parse_single
    elif 'images' in response and not isinstance(data['images'], list):
                                                 ~~~~^^^^^^^^^^
TypeError: string indices must be integers, not 'str'
```

This is because the error response is an HTML page; the Facebook business library API handles all this logic. And is result of hitting `act_ACCOOUNT_ID/insights endpoint for POST requests`. 

This error seems to be affecting other users:
[Community post](https://developers.facebook.com/community/threads/455519764253723/)
[Community](https://developers.facebook.com/community/threads/1172237680733843/)
[Bug](https://developers.facebook.com/support/bugs/3538756079762715/)
[This one has a nice definition of the problem](https://developers.facebook.com/community/threads/1190500462864367/)
## How
splits account-level insight jobs into smaller, more manageable chunks that seems to be skipping to hit the endpoint with POST calls.

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
We expect to gave successful syncs for FB-Marketing.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
