### PR TITLE
Destination bigquery: partition raw table on extracted_at; upgrade to latest cdk

### DIFF
--- a/airbyte-integrations/connectors/destination-bigquery/build.gradle
+++ b/airbyte-integrations/connectors/destination-bigquery/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 airbyteJavaConnector {
-    cdkVersionRequired = '0.46.0'
+    cdkVersionRequired = '0.48.8'
     features = [
             'db-destinations',
             'datastore-bigquery',

--- a/airbyte-integrations/connectors/destination-bigquery/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-bigquery/metadata.yaml
@@ -5,7 +5,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: 22f6c74f-5699-40ff-833c-4a879ea40133
-  dockerImageTag: 2.9.3
+  dockerImageTag: 2.10.0
   dockerRepository: airbyte/destination-bigquery
   documentationUrl: https://docs.airbyte.com/integrations/destinations/bigquery
   githubIssueLabel: destination-bigquery

--- a/docs/integrations/destinations/bigquery.md
+++ b/docs/integrations/destinations/bigquery.md
@@ -213,6 +213,7 @@ tutorials:
 
 | Version | Date       | Pull Request                                               | Subject                                                                                                                                                                          |
 | :------ | :--------- | :--------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2.10.0  | 2025-04-02 | [56982](https://github.com/airbytehq/airbyte/pull/56982) | Change default raw table partitioning scheme to be on `_airbyte_extracted_at`; upgrade CDK |
 | 2.9.3 | 2025-03-24 | [56355](https://github.com/airbytehq/airbyte/pull/56355) | Upgrade to airbyte/java-connector-base:2.0.1 to be M4 compatible. |
 | 2.9.2 | 2025-01-10 | [51482](https://github.com/airbytehq/airbyte/pull/51482) | Use a non root base image |
 | 2.9.1 | 2024-12-18 | [49902](https://github.com/airbytehq/airbyte/pull/49902) | Use a base image: airbyte/java-connector-base:1.0.0 |


### PR DESCRIPTION
* change the raw table partitioning scheme - user wanted this in https://airbytehq-team.slack.com/archives/C03GD9SV36E/p1742992301658739
    * we won't migrate existing tables, but that's fine
    * partitioning on generation_id is probably not useful
* upgrade to the latest CDK (not strictly necessary, but feels like the right move)