### PR TITLE
12148 metadata accessibility issues

### DIFF
--- a/docusaurus/src/components/Chip.module.css
+++ b/docusaurus/src/components/Chip.module.css
@@ -2,14 +2,12 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 0.125rem 0.375rem;
+  padding: 4px 8px;
   background-color: var(--color-grey-100);
-  border-radius: 0.625rem;
-  font-size: 0.625rem;
+  border-radius: 4px;
+  font-size: 12px;
   line-height: 0.8rem;
-  text-transform: uppercase;
   font-weight: var(--ifm-font-weight-semibold);
-  color: var(--color-grey-900);
 }
 a .chip:hover {
   text-decoration: none;

--- a/docusaurus/src/components/HeaderDecoration.jsx
+++ b/docusaurus/src/components/HeaderDecoration.jsx
@@ -211,7 +211,7 @@ const MetricIcon = ({ iconComponent, level }) => {
 
 const MetadataStat = ({ label, children }) => (
   <div className={styles.metadataStat}>
-    <dt className={styles.metadataStatLabel}>{`${label}: `}</dt>
+    <dt className={styles.metadataStatLabel}>{`${label}`}</dt>
     <dd className={styles.metadataStatValue}>{children}</dd>
   </div>
 );
@@ -261,11 +261,11 @@ const ConnectorMetadataCallout = ({
               <Chip className={isOss ? styles.available : styles.unavailable}>
                 <EnabledIcon isEnabled={isOss} /> Self-Managed Community
               </Chip>
-              <Chip className={styles.available}>
+              <Chip className={isOss ? styles.available : styles.unavailable}>
                 <EnabledIcon isEnabled={isOss} /> Self-Managed Enterprise
               </Chip>
-              <Chip className={styles.available}>
-                <EnabledIcon isEnabled={true} /> PyAirbyte
+              <Chip className={isOss ? styles.available : styles.unavailable}>
+                <EnabledIcon isEnabled={isOss} /> PyAirbyte
               </Chip>
             </>
           )}
@@ -279,10 +279,10 @@ const ConnectorMetadataCallout = ({
       {supportLevel !== "archived" && (
         <MetadataStat label="Connector Version">
           <a href={github_url} target="_blank">
-            {dockerImageTag}
+            {dockerImageTag}&nbsp;
           </a>
           {lastUpdated && (
-            <span>{`(Last updated ${dayjs(
+            <span>{`(last updated ${dayjs(
               lastUpdated,
             ).fromNow()})`}</span>
           )}

--- a/docusaurus/src/components/HeaderDecoration.jsx
+++ b/docusaurus/src/components/HeaderDecoration.jsx
@@ -240,8 +240,8 @@ const ConnectorMetadataCallout = ({
         <div className={styles.availability}>
           {isEnterprise ? (
             <>
-              <Chip className={isCloud ? styles.available : styles.unavailable}>
-                <EnabledIcon isEnabled={isCloud} /> Cloud
+              <Chip className={styles.available}>
+                <EnabledIcon isEnabled={true} /> Cloud <b>with Teams add-on</b>
               </Chip>
               <Chip className={isOss ? styles.available : styles.unavailable}>
                 <EnabledIcon isEnabled={isOss} /> Self-Managed Community
@@ -305,6 +305,11 @@ const ConnectorMetadataCallout = ({
         <MetadataStat label="Usage Rate">
           <MetricIcon iconComponent={USAGE_ICON} level={usageRate} />
         </MetadataStat>
+      )}
+      {isEnterprise && (
+        <MetadataStat label="Enterprise Connector">
+          This premium connector is only available with a license. <a href="https://airbyte.com/company/talk-to-sales" target="_blank">Talk to Sales </a>.
+        </MetadataStat> 
       )}
     </dl>
   </Callout>

--- a/docusaurus/src/components/HeaderDecoration.jsx
+++ b/docusaurus/src/components/HeaderDecoration.jsx
@@ -12,21 +12,19 @@ dayjs.extend(relativeTime);
 // ICONS
 
 const CHECK_ICON = (
-  <svg xmlns="http://www.w3.org/2000/svg" height="1em" viewBox="0 0 512 512">
+  <svg xmlns="http://www.w3.org/2000/svg" height="1em" viewBox="0 0 448 512">
     <title>Available</title>
-    <path
+    <path 
       fill="currentColor"
-      d="M256 48a208 208 0 1 1 0 416 208 208 0 1 1 0-416zm0 464A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM369 209c9.4-9.4 9.4-24.6 0-33.9s-24.6-9.4-33.9 0l-111 111-47-47c-9.4-9.4-24.6-9.4-33.9 0s-9.4 24.6 0 33.9l64 64c9.4 9.4 24.6 9.4 33.9 0L369 209z"
-    />
-  </svg>
+      d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/>
+    </svg>
 );
 const CROSS_ICON = (
-  <svg xmlns="http://www.w3.org/2000/svg" height="1em" viewBox="0 0 512 512">
+  <svg xmlns="http://www.w3.org/2000/svg" height="1em" viewBox="0 0 384 512">
     <title>Not available</title>
-    <path
+    <path 
       fill="currentColor"
-      d="M256 48a208 208 0 1 1 0 416 208 208 0 1 1 0-416zm0 464A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM175 175c-9.4 9.4-9.4 24.6 0 33.9l47 47-47 47c-9.4 9.4-9.4 24.6 0 33.9s24.6 9.4 33.9 0l47-47 47 47c9.4 9.4 24.6 9.4 33.9 0s9.4-24.6 0-33.9l-47-47 47-47c9.4-9.4 9.4-24.6 0-33.9s-24.6-9.4-33.9 0l-47 47-47-47c-9.4-9.4-24.6-9.4-33.9 0z"
-    />
+      d="M342.6 150.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L192 210.7 86.6 105.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L146.7 256 41.4 361.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L192 301.3 297.4 406.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L237.3 256 342.6 150.6z"/>
   </svg>
 );
 
@@ -242,17 +240,29 @@ const ConnectorMetadataCallout = ({
         <div className={styles.availability}>
           {isEnterprise ? (
             <>
+              <Chip className={isCloud ? styles.available : styles.unavailable}>
+                <EnabledIcon isEnabled={isCloud} /> Cloud
+              </Chip>
+              <Chip className={isOss ? styles.available : styles.unavailable}>
+                <EnabledIcon isEnabled={isOss} /> Self-Managed Community
+              </Chip>
               <Chip className={styles.available}>
-                <EnabledIcon isEnabled={true} /> Enterprise License
+                <EnabledIcon isEnabled={true} /> Self-Managed Enterprise
+              </Chip>
+              <Chip className={styles.unavailable}>
+                <EnabledIcon isEnabled={false} /> PyAirbyte
               </Chip>
             </>
           ) : (
             <>
               <Chip className={isCloud ? styles.available : styles.unavailable}>
-                <EnabledIcon isEnabled={isCloud} /> Airbyte Cloud
+                <EnabledIcon isEnabled={isCloud} /> Cloud
               </Chip>
               <Chip className={isOss ? styles.available : styles.unavailable}>
-                <EnabledIcon isEnabled={isOss} /> Airbyte OSS
+                <EnabledIcon isEnabled={isOss} /> Self-Managed Community
+              </Chip>
+              <Chip className={styles.available}>
+                <EnabledIcon isEnabled={isOss} /> Self-Managed Enterprise
               </Chip>
               <Chip className={styles.available}>
                 <EnabledIcon isEnabled={true} /> PyAirbyte
@@ -263,7 +273,7 @@ const ConnectorMetadataCallout = ({
       </MetadataStat>
       <MetadataStat label="Support Level">
         <a href="/integrations/connector-support-levels/">
-          <Chip>{getSupportLevelDisplay(supportLevel)}</Chip>
+          {getSupportLevelDisplay(supportLevel)}
         </a>
       </MetadataStat>
       {supportLevel !== "archived" && (
@@ -272,7 +282,7 @@ const ConnectorMetadataCallout = ({
             {dockerImageTag}
           </a>
           {lastUpdated && (
-            <span className={styles.deemphasizeText}>{`(Last updated ${dayjs(
+            <span>{`(Last updated ${dayjs(
               lastUpdated,
             ).fromNow()})`}</span>
           )}
@@ -283,7 +293,7 @@ const ConnectorMetadataCallout = ({
           <a target="_blank" href={cdkVersionUrl}>
             {cdkVersion}
           </a>
-          {isLatestCDK && <span className={styles.deemphasizeText}>{"(Latest)"}</span>}
+          {isLatestCDK && <span>{"(Latest)"}</span>}
         </MetadataStat>
       )}
       {syncSuccessRate && (

--- a/docusaurus/src/components/HeaderDecoration.module.css
+++ b/docusaurus/src/components/HeaderDecoration.module.css
@@ -20,6 +20,14 @@ div.connectorMetadataCallout  {
   row-gap: 8px;
 }
 
+.connectorMetadata dt, .connectorMetadata dd {
+  display: inline-block;
+}
+
+.connectorMetadata dt {
+  width: 150px;
+}
+
 .metadataStat {
   display: flex;
   align-items: center;

--- a/docusaurus/src/components/HeaderDecoration.module.css
+++ b/docusaurus/src/components/HeaderDecoration.module.css
@@ -7,6 +7,9 @@
 
 div.connectorMetadataCallout  {
   margin-bottom: 15px;
+  padding: 14px 20px;
+  background-color: var(--color-grey-40);
+  border-radius: 0px;
 }
 
 .connectorMetadata {
@@ -14,13 +17,13 @@ div.connectorMetadataCallout  {
   margin: 0;
   display: flex;
   flex-direction: column;
-  row-gap: 2px;
+  row-gap: 8px;
 }
 
 .metadataStat {
   display: flex;
   align-items: center;
-  font-size: 0.75rem;
+  font-size: 12px;
   font-weight: var(--ifm-font-weight-normal);
   flex-wrap: wrap;
 }
@@ -42,11 +45,6 @@ div.connectorMetadataCallout  {
   width: fit-content;
 }
 
-.deemphasizeText {
-  color: var(--color-grey-400);
-  white-space: nowrap;
-}
-
 .metadataStatValue > * {
   display: inline-flex;
   align-items: center;
@@ -59,15 +57,38 @@ div.connectorMetadataCallout  {
   flex-wrap: wrap;
 }
 
+
 .connectorMetadata .availability > span {
   display: inline-flex;
   align-items: center;
   column-gap: 2px;
   flex: 0 1 auto;
+  background-color: var(--color-green-40);
+  border: 1px solid var(--color-green-600);
+  color: var(--color-green-600);
+  font-size: 12px;
 }
 
 .connectorMetadata .availability .unavailable {
   color: var(--ifm-color-emphasis-600);
+  background-color: var(--color-dark-blue-40);
+  border: 1px solid var(--color-dark-blue-40);
+}
+
+html[data-theme="dark"] .connectorMetadata .availability > span {
+  display: inline-flex;
+  align-items: center;
+  column-gap: 2px;
+  flex: 0 1 auto;
+  background-color: var(--color-grey-40);
+  border: 1px solid var(--color-green-40);
+  color: var(--color-gray-40);
+  font-size: 12px;
+}
+
+html[data-theme="dark"] .connectorMetadata .availability .unavailable {
+  color: var(--ifm-color-emphasis-600);
+  border: none;
 }
 
 [data-theme="dark"] .connectorMetadata .availability .unavailable {

--- a/docusaurus/src/components/HeaderDecoration.module.css
+++ b/docusaurus/src/components/HeaderDecoration.module.css
@@ -53,6 +53,10 @@ div.connectorMetadataCallout  {
   width: fit-content;
 }
 
+.metadataStatValue a {
+  color: var(--ifm-color-primary-dark);
+}
+
 .metadataStatValue > * {
   display: inline-flex;
   align-items: center;
@@ -78,7 +82,7 @@ div.connectorMetadataCallout  {
 }
 
 .connectorMetadata .availability .unavailable {
-  color: var(--ifm-color-emphasis-600);
+  color: var(--color-dark-blue-700);
   background-color: var(--color-dark-blue-40);
   border: 1px solid var(--color-dark-blue-40);
 }

--- a/docusaurus/src/components/HeaderDecoration.module.css
+++ b/docusaurus/src/components/HeaderDecoration.module.css
@@ -57,6 +57,10 @@ div.connectorMetadataCallout  {
   color: var(--ifm-color-primary-dark);
 }
 
+html[data-theme="dark"] .metadataStatValue a {
+  color: var(--ifm-link-color);
+}
+
 .metadataStatValue > * {
   display: inline-flex;
   align-items: center;

--- a/docusaurus/src/components/HeaderDecoration.module.css
+++ b/docusaurus/src/components/HeaderDecoration.module.css
@@ -72,8 +72,8 @@ div.connectorMetadataCallout  {
   column-gap: 2px;
   flex: 0 1 auto;
   background-color: var(--color-green-40);
-  border: 1px solid var(--color-green-600);
-  color: var(--color-green-600);
+  border: 1px solid var(--color-green-800);
+  color: var(--color-green-800);
   font-size: 12px;
 }
 

--- a/docusaurus/src/components/ProductInformation.jsx
+++ b/docusaurus/src/components/ProductInformation.jsx
@@ -3,12 +3,12 @@ import classNames from "classnames";
 
 import styles from "./ProductInformation.module.css";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faCheckCircle, faQuestionCircle, faXmarkCircle } from "@fortawesome/free-regular-svg-icons";
+import { faCheck, faQuestionCircle, faXmark } from "@fortawesome/free-solid-svg-icons";
 
 const Badge = ({ available, children }) => {
   return (
     <span className={classNames(styles.badge, { [styles.available]: available })}>
-      <FontAwesomeIcon icon={available ? faCheckCircle : faXmarkCircle} title={available ? "Available" : "Not available"} />
+      <FontAwesomeIcon icon={available ? faCheck : faXmark} title={available ? "Available" : "Not available"} />
       <span>{children}</span>
     </span>
   );
@@ -30,11 +30,11 @@ export const ProductInformation = ({ products }) => {
   return (
     <div className={styles.badges}>
       <Badge available={cloud}>Cloud {cloudTeams ? <span className={styles.withAddon}>with Teams add-on</span> : ""}</Badge>
-      <Badge available={ossCommunity}>Self-Managed Community (OSS)</Badge>
+      <Badge available={ossCommunity}>Self-Managed Community</Badge>
       <Badge available={ossEnterprise}>Self-Managed Enterprise</Badge>
       {embedded && <Badge available={true}>Embedded</Badge>}
-      <a href="https://airbyte.com/product/features" target="_blank" className={styles.helpIcon} title="Feature comparison">
-        <FontAwesomeIcon icon={faQuestionCircle} />
+      <a href="https://airbyte.com/product/features" target="_blank" className={styles.helpIcon}>
+        <FontAwesomeIcon icon={faQuestionCircle} /> Compare
       </a>
     </div>
   );

--- a/docusaurus/src/components/ProductInformation.module.css
+++ b/docusaurus/src/components/ProductInformation.module.css
@@ -8,10 +8,11 @@
 }
 
 .badge {
-  background: var(--color-grey-40);
+  background: var(--color-dark-blue-40);
   color: var(--color-grey-400);
   padding: 3px 8px;
-  border-radius: 32px;
+  border: 1px solid var(--color-dark-blue-40);
+  border-radius: 4px;
   font-size: 0.75rem;
   display: inline-flex;
   align-items: center;
@@ -29,13 +30,15 @@
 }
 
 .available {
-  background:var(--color-green-50);
-  color: var(--ifm-font-color-base);
+  background: var(--color-green-40);
+  color: var(--color-green-800);
+  border: 1px solid var(--color-green-600);
 }
 
 .helpIcon {
-  color: var(--color-grey-400);
+  color: var(--ifm-font-color-base);
   transition: color 0.2s ease;
+  font-size: 0.75rem;
 }
 
 .helpIcon:hover {

--- a/docusaurus/src/components/ProductInformation.module.css
+++ b/docusaurus/src/components/ProductInformation.module.css
@@ -9,7 +9,7 @@
 
 .badge {
   background: var(--color-dark-blue-40);
-  color: var(--color-grey-400);
+  color: var(--color-dark-blue-700);
   padding: 3px 8px;
   border: 1px solid var(--color-dark-blue-40);
   border-radius: 4px;
@@ -38,7 +38,7 @@ html[data-theme="dark"] .badge {
 .available {
   background: var(--color-green-40);
   color: var(--color-green-800);
-  border: 1px solid var(--color-green-600);
+  border: 1px solid var(--color-green-800);
 }
 
 html[data-theme="dark"] .available {

--- a/docusaurus/src/components/ProductInformation.module.css
+++ b/docusaurus/src/components/ProductInformation.module.css
@@ -21,6 +21,12 @@
   white-space: nowrap;
 }
 
+html[data-theme="dark"] .badge {
+  background: var(--color-grey-40);
+  color: var(--ifm-color-emphasis-400);
+  border: none;
+}
+
 .badge:hover {
   text-decoration: none;
 }
@@ -33,6 +39,12 @@
   background: var(--color-green-40);
   color: var(--color-green-800);
   border: 1px solid var(--color-green-600);
+}
+
+html[data-theme="dark"] .available {
+  background: var(--color-grey-40);
+  color: var(--color-gray-40);
+  border: 1px solid var(--color-dark-blue-40);
 }
 
 .helpIcon {

--- a/docusaurus/src/components/SpecSchema.jsx
+++ b/docusaurus/src/components/SpecSchema.jsx
@@ -18,7 +18,7 @@ export const SpecSchema = ({
 
 function JSONSchemaViewer(props) {
   return <div>
-    <Heading as="h4">Config fields reference</Heading>
+    <Heading as="h3">Config fields reference</Heading>
     <div class={styles.grid}>
       <div class={className(styles.headerItem, styles.tableHeader)}>
         Field

--- a/docusaurus/src/css/custom.css
+++ b/docusaurus/src/css/custom.css
@@ -172,6 +172,19 @@ html[data-theme="dark"] {
   display: none;
 }
 
+nav.theme-doc-breadcrumbs {
+  margin-top: 8px !important;
+}
+
+ul.breadcrumbs > li.breadcrumbs__item > a.breadcrumbs__link {
+  color: var(--ifm-color-primary);
+}
+
+ul.breadcrumbs > li.breadcrumbs__item > span.breadcrumbs__link {
+  color: var(--ifm-font-color-base);
+  background: none;
+}
+
 .cloudStatusLink {
   display: flex;
   gap: 4px;

--- a/docusaurus/src/css/custom.css
+++ b/docusaurus/src/css/custom.css
@@ -38,8 +38,12 @@
   --color-grey-400: hsl(240, 10%, 59%);
   --color-grey-500: hsl(240, 10%, 49%);
   --color-grey-900: hsl(240, 19%, 18%);
+  --color-green-40: hsl(185, 76%, 97%);
   --color-green-50: hsl(184, 67%, 92%);
+  --color-green-600: hsl(185, 100%, 35%);
+  --color-green-800: hsl(184, 100%, 26%);
   --color-blue-30: hsl(240, 100%, 98%);
+  --color-dark-blue-40: hsl(230, 23%, 95%);
   --color-dark-blue-700: hsl(236, 43%, 31%);
   --color-red-400: hsl(0, 73%, 50%);
 

--- a/docusaurus/src/css/custom.css
+++ b/docusaurus/src/css/custom.css
@@ -35,7 +35,7 @@
   --color-white: hsl(0, 0%, 100%);
   --color-grey-40: hsl(240, 25%, 98%);
   --color-grey-100: hsl(240, 12%, 92%);
-  --color-grey-400: hsl(240, 10%, 59%);
+  --color-grey-400: hsl(239, 10%, 59%);
   --color-grey-500: hsl(240, 10%, 49%);
   --color-grey-900: hsl(240, 19%, 18%);
   --color-green-40: hsl(185, 76%, 97%);

--- a/docusaurus/src/css/custom.css
+++ b/docusaurus/src/css/custom.css
@@ -97,6 +97,10 @@ html[data-theme="dark"] {
   transform: translateY(-2px);
 }
 
+span.DocSearch-Button-Placeholder {
+  color: var(--ifm-menu-color);
+}
+
 .navbar__items--right {
   gap: 4px;
 }


### PR DESCRIPTION
## What

This change addresses a variety of minor accessibility issues with product metadata, breadcrumbs, search, and repeated components in the Airbyte docs.

- Breadcrumbs did not have sufficient color contrast for WCAG 2 AA.

- Connector metadata did not have sufficient color contrast for WCAG 2 AA, and clickable areas did not meet WCAG 2 AAA size requirements for touch devices.

- Search button placeholder did not have sufficient color contrast.

- Schema configuration field reference always used an out-of-order heading level.

In total, this change solves something like 3000 accessibility problems if you count all the different manifestations of these handful of problems. While it doesn't fix all our accessibility problems, it fixes the most obvious ones that occur over and over on most or all pages.

The change also addresses a variety of design decisions with the way these components are rendered.

Nora's design here https://www.figma.com/design/9aw3VYwgM8Dcm3Nz9VhOM5/Documentation-2.0?node-id=3-2098&t=ig19CdzdH1ZPllKv-0 was the inspiration. Though I did depart from it in a couple of places because the color contrast wasn't quite enough in a couple of places.

- The design for the platform chips and connector chips was totally different. The design for the connector chips made it difficult to know which were enabled and which were disabled because they all used the same gray. The new design is much clearer and more vibrant.

- The two sets of docs used different names to describe the same products. Both sets of chips use the same product names, which are the trade names we use with our customers and in our marketing.

- PyAirbyte was always enabled, even when the connector was archived.

- In connectors, We now have separate chips for Self-Managed Community and Self-Managed Enterprise. The introduction of Enterprise connectors has disconnected these two products in that regard.

- Enterprise connectors now list all products in the Availability list, and mark unsupported ones as not supported. They also show a new "Enterprise Connector" field, referring the user to sales if they want to learn more.

- Clickable breadcrumb links now have the colors of links. (Non-clickable breadcrumbs are normal text)

## How

I made the changes in 3 stages. 

The breadcrumbs were addressed purely as CSS. 

Then, the platform metadata was addressed through the **ProductInformation** component. 

Then, the connector metadata was addressed through the **HeaderDecoration** component and to a lesser extent the **Chip** component, which is used by HeaderDecoration.

I realized later on that it might make more sense to update ProductInformation to use the Chip component too, since these are effectively doing the same thing. However, this code are virtually never modified and they actually work great as they are. Redoing the whole thing seemed not to be worth the time investment right now. Plus I have a sneaky suspicion some of our future plans will require us to rethink our product/plan markings on a deeper level.

## Review guide

The changes are almost 100% visual changes. Functionally the only real change is the logic around how we deal with and label Enterprise connectors. Right now something is or is not an enterprise connector. If it is, we do one set of things. If it's not, we do another. This seems to be the best way to handle these at the moment because the connectors themselves are pretty different.

There probably isn't a correct reading order per se, but generally, here's how the changes shake out.

### Breadcrumbs:

- docusaurus/src/css/custom.css

Example URL: https://airbyte-docs-git-12148-metadata-accessibi-f367c5-airbyte-growth.vercel.app/using-airbyte/core-concepts/sync-modes/incremental-append-deduped

### Schema configuration field heading level

- docusaurus/src/components/SpecSchema.jsx

Example URL: https://airbyte-docs-git-12148-metadata-accessibi-f367c5-airbyte-growth.vercel.app/integrations/sources/adjust#reference (see bottom of page)

### Platform product chips:

- docusaurus/src/components/ProductInformation.jsx
- docusaurus/src/components/ProductInformation.module.css

Example URL: https://airbyte-docs-git-12148-metadata-accessibi-f367c5-airbyte-growth.vercel.app/using-airbyte/getting-started/oss-quickstart (see under title)

### Connector page metadata:

- docusaurus/src/components/HeaderDecoration.jsx
- docusaurus/src/components/HeaderDecoration.module.css
- docusaurus/src/components/Chip.module.css - this was changed because HeaderDecoration makes use of it. It seemed better to modify the root chip component where possible, instead of trying to override it, since it's only really used in this one place.

Example URL: https://airbyte-docs-git-12148-metadata-accessibi-f367c5-airbyte-growth.vercel.app/integrations/sources/adjust

Example Enterprise Connector URL: https://airbyte-docs-git-12148-metadata-accessibi-f367c5-airbyte-growth.vercel.app/integrations/enterprise-connectors/source-netsuite 

## User Impact

The accessibility change alone is huge for a minority of people. However, finally standardizing on what we call things probably matters just as much. This should be way more clear, both because of simplicity and the more vibrant colors.

![image](https://github.com/user-attachments/assets/47bade88-9a77-42f9-a9fa-004fb7a3f881)

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌
