### PR TITLE
(fix: Amazon Seller Partner) - Extend Minimum Date Range

### DIFF
--- a/airbyte-integrations/connectors/source-amazon-seller-partner/metadata.yaml
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/metadata.yaml
@@ -15,7 +15,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: e55879a8-0ef8-4557-abcf-ab34c53ec460
-  dockerImageTag: 4.6.1
+  dockerImageTag: 4.6.2
   dockerRepository: airbyte/source-amazon-seller-partner
   documentationUrl: https://docs.airbyte.com/integrations/sources/amazon-seller-partner
   erdUrl: https://dbdocs.io/airbyteio/source-amazon-seller-partner?view=relationships

--- a/airbyte-integrations/connectors/source-amazon-seller-partner/pyproject.toml
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "4.6.1"
+version = "4.6.2"
 name = "source-amazon-seller-partner"
 description = "Source implementation for Amazon Seller Partner."
 authors = ["Airbyte <contact@airbyte.io>"]

--- a/airbyte-integrations/connectors/source-amazon-seller-partner/source_amazon_seller_partner/manifest.yaml
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/source_amazon_seller_partner/manifest.yaml
@@ -43,6 +43,7 @@ definitions:
           datetime_format: "%Y-%m-%dT%H:%M:%SZ"
         end_datetime:
           type: MinMaxDatetime
+          #- duration('PT2M') is so when start_date and end_date are the same, we can still get data. Otherwise, we will get this error from the API: HTTP 400 - please provide a date that is at least 2 minutes before current time and try again.
           datetime: "{{ format_datetime(config['replication_end_date'] if config.get('replication_end_date') else (now_utc() - duration('PT2M')).strftime('%Y-%m-%dT%H:%M:%SZ'), '%Y-%m-%dT%H:%M:%SZ') }}"
           datetime_format: "%Y-%m-%dT%H:%M:%SZ"
         start_time_option:
@@ -340,6 +341,7 @@ definitions:
           datetime_format: "%Y-%m-%dT%H:%M:%SZ"
         end_datetime:
           type: MinMaxDatetime
+          #- duration('PT2M') is so when start_date and end_date are the same, we can still get data. Otherwise, we will get this error from the API: HTTP 400 - please provide a date that is at least 2 minutes before current time and try again.
           datetime: "{{ format_datetime(config['replication_end_date'] if config.get('replication_end_date') else now_utc() - duration('PT2M') , '%Y-%m-%dT%H:%M:%SZ') }}"
           datetime_format: "%Y-%m-%dT%H:%M:%SZ"
         start_time_option:
@@ -410,6 +412,7 @@ definitions:
           datetime_format: "%Y-%m-%dT%H:%M:%SZ"
         end_datetime:
           type: MinMaxDatetime
+          #- duration('PT2M') is so when start_date and end_date are the same, we can still get data. Otherwise, we will get this error from the API: HTTP 400 - please provide a date that is at least 2 minutes before current time and try again.
           datetime: "{{ format_datetime(config['replication_end_date'] if config.get('replication_end_date') else now_utc() - duration('PT2M') , '%Y-%m-%dT%H:%M:%SZ') }}"
           datetime_format: "%Y-%m-%dT%H:%M:%SZ"
         start_time_option:

--- a/airbyte-integrations/connectors/source-amazon-seller-partner/source_amazon_seller_partner/manifest.yaml
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/source_amazon_seller_partner/manifest.yaml
@@ -43,7 +43,7 @@ definitions:
           datetime_format: "%Y-%m-%dT%H:%M:%SZ"
         end_datetime:
           type: MinMaxDatetime
-          datetime: "{{ format_datetime(config['replication_end_date'] if config.get('replication_end_date') else (now_utc() - duration('PT1S')).strftime('%Y-%m-%dT%H:%M:%SZ'), '%Y-%m-%dT%H:%M:%SZ') }}"
+          datetime: "{{ format_datetime(config['replication_end_date'] if config.get('replication_end_date') else (now_utc() - duration('PT2M')).strftime('%Y-%m-%dT%H:%M:%SZ'), '%Y-%m-%dT%H:%M:%SZ') }}"
           datetime_format: "%Y-%m-%dT%H:%M:%SZ"
         start_time_option:
           field_name: LastUpdatedAfter
@@ -340,7 +340,7 @@ definitions:
           datetime_format: "%Y-%m-%dT%H:%M:%SZ"
         end_datetime:
           type: MinMaxDatetime
-          datetime: "{{ format_datetime(config['replication_end_date'] if config.get('replication_end_date') else now_utc() - duration('PT1S') , '%Y-%m-%dT%H:%M:%SZ') }}"
+          datetime: "{{ format_datetime(config['replication_end_date'] if config.get('replication_end_date') else now_utc() - duration('PT2M') , '%Y-%m-%dT%H:%M:%SZ') }}"
           datetime_format: "%Y-%m-%dT%H:%M:%SZ"
         start_time_option:
           field_name: FinancialEventGroupStartedAfter
@@ -410,7 +410,7 @@ definitions:
           datetime_format: "%Y-%m-%dT%H:%M:%SZ"
         end_datetime:
           type: MinMaxDatetime
-          datetime: "{{ format_datetime(config['replication_end_date'] if config.get('replication_end_date') else now_utc() - duration('PT1S') , '%Y-%m-%dT%H:%M:%SZ') }}"
+          datetime: "{{ format_datetime(config['replication_end_date'] if config.get('replication_end_date') else now_utc() - duration('PT2M') , '%Y-%m-%dT%H:%M:%SZ') }}"
           datetime_format: "%Y-%m-%dT%H:%M:%SZ"
         start_time_option:
           field_name: PostedAfter

--- a/airbyte-integrations/connectors/source-amazon-seller-partner/unit_tests/test_source.py
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/unit_tests/test_source.py
@@ -275,10 +275,10 @@ STREAM_NAMES = [
 
 
 END_DATETIME_LOGIC = {
-    "Orders": "now_minus_1s",  # now_utc() - PT1S
+    "Orders": "now_minus_2m",  # now_utc() - PT2M
     "OrderItems": "now",  # now_utc()
-    "ListFinancialEventGroups": "now_minus_1s",  # now_utc() - PT1S
-    "ListFinancialEvents": "now_minus_1s",  # now_utc() - PT1S
+    "ListFinancialEventGroups": "now_minus_2m",  # now_utc() - PT2M
+    "ListFinancialEvents": "now_minus_2m",  # now_utc() - PT2M
     "VendorDirectFulfillmentShipping": "now",  # now_utc()
     "VendorOrders": "now",  # now_utc()
 }
@@ -291,8 +291,8 @@ def default_start_date(now):
 
 # Helper function to calculate default end date based on stream logic
 def default_end_date(stream_name, now):
-    if END_DATETIME_LOGIC[stream_name] == "now_minus_1s":
-        return (now - timedelta(seconds=1)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    if END_DATETIME_LOGIC[stream_name] == "now_minus_2m":
+        return (now - timedelta(minutes=2)).strftime("%Y-%m-%dT%H:%M:%SZ")
     return now.strftime("%Y-%m-%dT%H:%M:%SZ")
 
 

--- a/docs/integrations/sources/amazon-seller-partner.md
+++ b/docs/integrations/sources/amazon-seller-partner.md
@@ -248,6 +248,8 @@ Create a separate connection for streams which usually fail with error above "Fa
 
 | Version    | Date       | Pull Request                                              | Subject                                                                                                                                                                             |
 |:-----------|:-----------|:----------------------------------------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+
+| 4.6.2 | 2025-04-09 | [57537](https://github.com/airbytehq/airbyte/pull/57537)     |Fix Extend Minimum Date Range|
 | 4.6.1 | 2025-04-08 | [55238](https://github.com/airbytehq/airbyte/pull/55238)     |Fix daterange in `DatetimeBasedCursor` and Added configurable step size for financial events streams (`list_financial_event_groups`, `list_financial_events`)|
 | 4.6.0 | 2025-02-24 | [53225](https://github.com/airbytehq/airbyte/pull/53225) | Add API Budget |
 | 4.5.3 | 2025-02-22 | [53928](https://github.com/airbytehq/airbyte/pull/53928) | Update dependencies |


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->
Some syncs are failing with `please provide a date that is at least 2 minutes before current time and try again.'.`

## How
<!--
* Describe how code changes achieve the solution.
-->
Update unit tests and enddate dattime logic to deduct 2M instead of 1S in cases where no config is supplied. 

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
