### PR TITLE
✨ Source Hubspot: add associations stream

### DIFF
--- a/airbyte-integrations/connectors/source-hubspot/metadata.yaml
+++ b/airbyte-integrations/connectors/source-hubspot/metadata.yaml
@@ -1,52 +1,127 @@
+data:
+  ab_internal:
+    ql: 400
+    sl: 300
+  allowedHosts:
+    hosts:
+      - api.hubapi.com
+  connectorBuildOptions:
+    baseImage: docker.io/airbyte/python-connector-base:4.0.0@sha256:d9894b6895923b379f3006fa251147806919c62b7d9021b5cd125bb67d7bbe22
+  connectorSubtype: api
+  connectorType: source
+  definitionId: 36c891d9-4bd9-43ac-bad2-10e12756272c
+  dockerImageTag: 4.7.0
+  dockerRepository: airbyte/source-hubspot
+  documentationUrl: https://docs.airbyte.com/integrations/sources/hubspot
+  erdUrl: https://dbdocs.io/airbyteio/source-hubspot?view=relationships
+  githubIssueLabel: source-hubspot
+  icon: hubspot.svg
+  license: ELv2
+  maxSecondsBetweenMessages: 86400
+  name: HubSpot
+  remoteRegistries:
+    pypi:
+      enabled: true
+      packageName: airbyte-source-hubspot
+  registryOverrides:
+    cloud:
+      enabled: true
+    oss:
+      enabled: true
+  releaseStage: generally_available
+  releases:
+    rolloutConfiguration:
+      enableProgressiveRollout: true
+    breakingChanges:
+      4.0.0:
+        message: >-
+          This update brings extended schema with data type changes for the streams
+          `Deals Property History` and `Companies Property History`. Users will need
+          to refresh their schema and reset their streams after upgrading.
+        upgradeDeadline: 2024-03-10
+        scopedImpact:
+          - scopeType: stream
+            impactedScopes:
+              ["deals_property_history", "companies_property_history"]
+      3.0.0:
+        message: >-
+          This update brings extended schema with data type changes for the Marketing
+          Emails stream.
+          Users will need to refresh it and reset this stream after upgrading.
+        upgradeDeadline: 2024-02-12
+        scopedImpact:
+          - scopeType: stream
+            impactedScopes: ["marketing_emails"]
+      2.0.0:
+        message: >-
+          This version replaces the `Property History` stream in favor of creating
+          3 different streams: `Contacts`, `Companies`, and `Deals`, which can now
+          all fetch their property history.
+          It will affect only users who use `Property History` stream, who will need
+          to fix schema conflicts and sync `Contacts Property History` stream instead
+          of `Property History`.
+        upgradeDeadline: 2024-01-15
+  suggestedStreams:
+    streams:
+      - contacts
+      - companies
+      - deals
+  supportLevel: certified
+  tags:
+    - language:python
+    - cdk:python
+  connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: hubspot_config_dev_null
+          id: 52e28dc7-2245-4ebc-a591-0ef954ce4837
+        - name: hubspot_config_oauth_dev_null
+          id: 5a4058bf-0ab3-427e-92e4-9051c0abf655
+        - name: hubspot_config_oauth_no_start_date_dev_null
+          id: 67bf1886-3ae0-4fad-8c37-90eb51b2c748
+    - suite: unitTests
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_SOURCE-HUBSPOT_CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-HUBSPOT_OAUTH_CREDS
+          fileName: config_oauth.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-HUBSPOT_OAUTH_NO_START_DATE_CREDS
+          fileName: config_oauth_no_start_date.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-HUBSPOT_OAUTH_NO_START_DATE__CREDS
+          fileName: config_oauth_no_start_date.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-HUBSPOT_CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-HUBSPOT_OAUTH_CREDS
+          fileName: config_oauth.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-HUBSPOT_OAUTH_NO_START_DATE_CREDS
+          fileName: config_oauth_no_start_date.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+        - name: SECRET_SOURCE-HUBSPOT_OAUTH_NO_START_DATE__CREDS
+          fileName: config_oauth_no_start_date.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"
-connectorType: source
-name: HubSpot
-definitionId: 36c891d9-4bd9-43ac-bad2-10e12756272c
-dockerRepository: airbyte/source-hubspot
-dockerImageTag: 4.7.0
-documentationUrl: https://docs.airbyte.com/integrations/sources/hubspot
-icon: hubspot.svg
-license: ELv2
-releaseStage: generally_available
-supportLevel: certified
-registryOverrides:
-  cloud:
-    enabled: true
-  oss:
-    enabled: true
-
-spec:
-  type: object
-  properties:
-    credentials:
-      type: object
-      description: Authentication credentials for HubSpot
-      required: true
-    start_date:
-      type: string
-      description: Start date for incremental sync
-      format: date-time
-      default: "2006-06-01T00:00:00Z"
-    enable_experimental_streams:
-      type: boolean
-      description: Enable experimental streams
-      default: false
-
-suggestedStreams:
-  streams:
-    - contacts
-    - companies
-    - deals
-    - associations
-
-releases:
-  breakingChanges:
-    4.0.0:
-      message: >-
-        This update brings extended schema with data type changes for the streams
-        `Deals Property History` and `Companies Property History`. Users will need
-        to refresh their schema and reset their streams after upgrading.
-      upgradeDeadline: 2024-03-10
-      scopedImpact:
-        - scopeType: stream
-          impactedScopes: ["deals_property_history", "companies_property_history"]

--- a/airbyte-integrations/connectors/source-hubspot/metadata.yaml
+++ b/airbyte-integrations/connectors/source-hubspot/metadata.yaml
@@ -1,127 +1,52 @@
-data:
-  ab_internal:
-    ql: 400
-    sl: 300
-  allowedHosts:
-    hosts:
-      - api.hubapi.com
-  connectorBuildOptions:
-    baseImage: docker.io/airbyte/python-connector-base:4.0.0@sha256:d9894b6895923b379f3006fa251147806919c62b7d9021b5cd125bb67d7bbe22
-  connectorSubtype: api
-  connectorType: source
-  definitionId: 36c891d9-4bd9-43ac-bad2-10e12756272c
-  dockerImageTag: 4.6.0-rc.1
-  dockerRepository: airbyte/source-hubspot
-  documentationUrl: https://docs.airbyte.com/integrations/sources/hubspot
-  erdUrl: https://dbdocs.io/airbyteio/source-hubspot?view=relationships
-  githubIssueLabel: source-hubspot
-  icon: hubspot.svg
-  license: ELv2
-  maxSecondsBetweenMessages: 86400
-  name: HubSpot
-  remoteRegistries:
-    pypi:
-      enabled: true
-      packageName: airbyte-source-hubspot
-  registryOverrides:
-    cloud:
-      enabled: true
-    oss:
-      enabled: true
-  releaseStage: generally_available
-  releases:
-    rolloutConfiguration:
-      enableProgressiveRollout: true
-    breakingChanges:
-      4.0.0:
-        message: >-
-          This update brings extended schema with data type changes for the streams
-          `Deals Property History` and `Companies Property History`. Users will need
-          to refresh their schema and reset their streams after upgrading.
-        upgradeDeadline: 2024-03-10
-        scopedImpact:
-          - scopeType: stream
-            impactedScopes:
-              ["deals_property_history", "companies_property_history"]
-      3.0.0:
-        message: >-
-          This update brings extended schema with data type changes for the Marketing
-          Emails stream.
-          Users will need to refresh it and reset this stream after upgrading.
-        upgradeDeadline: 2024-02-12
-        scopedImpact:
-          - scopeType: stream
-            impactedScopes: ["marketing_emails"]
-      2.0.0:
-        message: >-
-          This version replaces the `Property History` stream in favor of creating
-          3 different streams: `Contacts`, `Companies`, and `Deals`, which can now
-          all fetch their property history.
-          It will affect only users who use `Property History` stream, who will need
-          to fix schema conflicts and sync `Contacts Property History` stream instead
-          of `Property History`.
-        upgradeDeadline: 2024-01-15
-  suggestedStreams:
-    streams:
-      - contacts
-      - companies
-      - deals
-  supportLevel: certified
-  tags:
-    - language:python
-    - cdk:python
-  connectorTestSuitesOptions:
-    - suite: liveTests
-      testConnections:
-        - name: hubspot_config_dev_null
-          id: 52e28dc7-2245-4ebc-a591-0ef954ce4837
-        - name: hubspot_config_oauth_dev_null
-          id: 5a4058bf-0ab3-427e-92e4-9051c0abf655
-        - name: hubspot_config_oauth_no_start_date_dev_null
-          id: 67bf1886-3ae0-4fad-8c37-90eb51b2c748
-    - suite: unitTests
-    - suite: integrationTests
-      testSecrets:
-        - name: SECRET_SOURCE-HUBSPOT_CREDS
-          fileName: config.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-        - name: SECRET_SOURCE-HUBSPOT_OAUTH_CREDS
-          fileName: config_oauth.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-        - name: SECRET_SOURCE-HUBSPOT_OAUTH_NO_START_DATE_CREDS
-          fileName: config_oauth_no_start_date.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-        - name: SECRET_SOURCE-HUBSPOT_OAUTH_NO_START_DATE__CREDS
-          fileName: config_oauth_no_start_date.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-    - suite: acceptanceTests
-      testSecrets:
-        - name: SECRET_SOURCE-HUBSPOT_CREDS
-          fileName: config.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-        - name: SECRET_SOURCE-HUBSPOT_OAUTH_CREDS
-          fileName: config_oauth.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-        - name: SECRET_SOURCE-HUBSPOT_OAUTH_NO_START_DATE_CREDS
-          fileName: config_oauth_no_start_date.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
-        - name: SECRET_SOURCE-HUBSPOT_OAUTH_NO_START_DATE__CREDS
-          fileName: config_oauth_no_start_date.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"
+connectorType: source
+name: HubSpot
+definitionId: 36c891d9-4bd9-43ac-bad2-10e12756272c
+dockerRepository: airbyte/source-hubspot
+dockerImageTag: 4.7.0
+documentationUrl: https://docs.airbyte.com/integrations/sources/hubspot
+icon: hubspot.svg
+license: ELv2
+releaseStage: generally_available
+supportLevel: certified
+registryOverrides:
+  cloud:
+    enabled: true
+  oss:
+    enabled: true
+
+spec:
+  type: object
+  properties:
+    credentials:
+      type: object
+      description: Authentication credentials for HubSpot
+      required: true
+    start_date:
+      type: string
+      description: Start date for incremental sync
+      format: date-time
+      default: "2006-06-01T00:00:00Z"
+    enable_experimental_streams:
+      type: boolean
+      description: Enable experimental streams
+      default: false
+
+suggestedStreams:
+  streams:
+    - contacts
+    - companies
+    - deals
+    - associations
+
+releases:
+  breakingChanges:
+    4.0.0:
+      message: >-
+        This update brings extended schema with data type changes for the streams
+        `Deals Property History` and `Companies Property History`. Users will need
+        to refresh their schema and reset their streams after upgrading.
+      upgradeDeadline: 2024-03-10
+      scopedImpact:
+        - scopeType: stream
+          impactedScopes: ["deals_property_history", "companies_property_history"]

--- a/airbyte-integrations/connectors/source-hubspot/pyproject.toml
+++ b/airbyte-integrations/connectors/source-hubspot/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "4.6.0-rc.1"
+version = "4.7.0"
 name = "source-hubspot"
 description = "Source implementation for HubSpot."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-hubspot/source_hubspot/schemas/associations.json
+++ b/airbyte-integrations/connectors/source-hubspot/source_hubspot/schemas/associations.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "fromObjectId": {
+      "type": "string"
+    },
+    "toObjectId": {
+      "type": "string"
+    },
+    "fromObjectType": {
+      "type": "string"
+    },
+    "toObjectType": {
+      "type": "string"
+    },
+    "associationCategory": {
+      "type": "string"
+    },
+    "associationTypeId": {
+      "type": "integer"
+    },
+    "createdAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "updatedAt": {
+      "type": "string",
+      "format": "date-time"
+    }
+  },
+  "required": [
+    "id",
+    "fromObjectId",
+    "toObjectId",
+    "fromObjectType",
+    "toObjectType",
+    "associationTypeId"
+  ]
+} 

--- a/airbyte-integrations/connectors/source-hubspot/source_hubspot/source.py
+++ b/airbyte-integrations/connectors/source-hubspot/source_hubspot/source.py
@@ -67,6 +67,7 @@ from source_hubspot.streams import (
     TicketsWebAnalytics,
     WebAnalyticsStream,
     Workflows,
+    Associations,
 )
 
 
@@ -173,6 +174,7 @@ class SourceHubspot(AbstractSource):
             Tickets(**common_params),
             TicketPipelines(**common_params),
             Workflows(**common_params),
+            Associations(**common_params),
         ]
 
         enable_experimental_streams = "enable_experimental_streams" in config and config["enable_experimental_streams"]

--- a/airbyte-integrations/connectors/source-hubspot/source_hubspot/streams.py
+++ b/airbyte-integrations/connectors/source-hubspot/source_hubspot/streams.py
@@ -2634,3 +2634,33 @@ class ProductsWebAnalytics(WebAnalyticsStream):
 class FeedbackSubmissionsWebAnalytics(WebAnalyticsStream):
     def __init__(self, **kwargs: Any):
         super().__init__(parent=FeedbackSubmissions(**kwargs), **kwargs)
+
+
+class Associations(CRMSearchStream):
+    """Associations between CRM objects, API v3
+    Docs: https://developers.hubspot.com/docs/api/crm/associations
+    """
+
+    entity = "associations"
+    last_modified_field = "updatedAt"
+    primary_key = "id"
+    scopes = {"crm.objects.contacts.read"}  # Base scope, will be expanded based on object types
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.scopes = self._get_required_scopes()
+
+    def _get_required_scopes(self) -> Set[str]:
+        """Get required scopes based on all possible CRM object types"""
+        base_scopes = {
+            "crm.objects.contacts.read",
+            "crm.objects.companies.read",
+            "crm.objects.deals.read",
+            "tickets",
+            "e-commerce"
+        }
+        return base_scopes
+
+    @property
+    def url(self):
+        return f"/crm/v3/associations"

--- a/airbyte-integrations/connectors/source-hubspot/unit_tests/test_source.py
+++ b/airbyte-integrations/connectors/source-hubspot/unit_tests/test_source.py
@@ -88,14 +88,14 @@ def test_check_connection_invalid_start_date_exception(config_invalid_date):
 def test_streams(requests_mock, config):
     streams = SourceHubspot().streams(config)
 
-    assert len(streams) == 35
+    assert len(streams) == 36
 
 
 @mock.patch("source_hubspot.source.SourceHubspot.get_custom_object_streams")
 def test_streams_incremental(requests_mock, config_experimental):
     streams = SourceHubspot().streams(config_experimental)
 
-    assert len(streams) == 47
+    assert len(streams) == 48
 
 
 def test_custom_streams(config_experimental):

--- a/docs/integrations/sources/hubspot.md
+++ b/docs/integrations/sources/hubspot.md
@@ -57,6 +57,7 @@ To set up a Private App, you must manually configure scopes to ensure Airbyte ca
 
 | Stream                      | Required Scope                                                                                               |
 | :-------------------------- | :----------------------------------------------------------------------------------------------------------- |
+| `associations`              | `crm.objects.contacts.read`, `crm.objects.companies.read`, `crm.objects.deals.read`, `tickets`, `e-commerce` |
 | `campaigns`                 | `content`                                                                                                    |
 | `companies`                 | `crm.objects.companies.read`, `crm.schemas.companies.read`                                                   |
 | `contact_lists`             | `crm.lists.read`                                                                                             |
@@ -155,6 +156,7 @@ There are two types of incremental sync:
 
 The HubSpot source connector supports the following streams:
 
+- [Associations](https://developers.hubspot.com/docs/api/crm/associations) \(Incremental\)
 - [Campaigns](https://developers.hubspot.com/docs/methods/email/get_campaign_data) \(Client-Side Incremental\)
 - [Companies](https://developers.hubspot.com/docs/api/crm/companies) \(Incremental\)
 - [Contact Lists](http://developers.hubspot.com/docs/methods/lists/get_lists) \(Incremental\)


### PR DESCRIPTION
## What
This change introduces the `associations` stream to the Hubspot connector, enhancing its data integration capabilities. This addition allows users to sync association data, which is crucial for understanding relationships between different Hubspot entities. 

## How
The code changes involve updating the stream definitions in the Hubspot connector to include the new `associations` stream. This required modifications to the stream configuration and adjustments to the mock setups in the unit tests to account for the additional stream. The expected stream counts in the tests were updated to reflect this change.

## Review guide
1. `source_hubspot/source.py`: Check the updated stream definitions and ensure the `associations` stream is correctly implemented.
2. `unit_tests/test_source.py`: Review the changes in the test file to verify that the mock setups and expected counts are updated for the new stream.

## User Impact
Users will now have access to the `associations` stream, allowing them to sync additional data from Hubspot. This enhancement provides a more complete view of their Hubspot data, enabling better insights and decision-making. There are no negative side effects anticipated from this change.

## Can this PR be safely reverted and rolled back?
- [ ] YES 💚
- [x] NO ❌

Reverting this PR would remove the `associations` stream, potentially disrupting users who rely on this new data. It's recommended that any issues be addressed through follow-up patches rather than rolling back the entire change.