### PR TITLE
chore: add codeowners for breaking connector changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -64,3 +64,7 @@
 /airbyte-integrations/connectors/source-salesforce/ @airbytehq/dev-extensibility
 /airbyte-integrations/connectors/source-shopify/ @airbytehq/dev-extensibility
 /airbyte-integrations/connectors/source-stripe/ @airbytehq/dev-extensibility
+
+# Breaking changes detection
+# This rule ensures that any changes to migration files are reviewed by the breaking-changes-reviewers team
+**/*-migrations.md @airbytehq/breaking-changes-reviewers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -66,6 +66,7 @@
 /airbyte-integrations/connectors/source-stripe/ @airbytehq/dev-extensibility
 
 # Breaking changes detection
-# This rule ensures that breaking changes to connectors (identified by migrations files) 
-# are reviewed by the breaking-changes-reviewers team to maintain compatibility
+# This rule ensures that breaking changes to connectors (identified by a required
+# update in the connnector's migration file) are reviewed by the 
+# `breaking-changes-reviewers` team to manage and help message breaking changes.
 docs/integrations/**/*-migrations.md @airbytehq/breaking-change-reviewers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -66,5 +66,6 @@
 /airbyte-integrations/connectors/source-stripe/ @airbytehq/dev-extensibility
 
 # Breaking changes detection
-# This rule ensures that any changes to migration files are reviewed by the breaking-changes-reviewers team
-**/*-migrations.md @airbytehq/breaking-changes-reviewers
+# This rule ensures that breaking changes to connectors (identified by migrations files) 
+# are reviewed by the breaking-changes-reviewers team to maintain compatibility
+docs/integrations/**/*-migrations.md @airbytehq/breaking-changes-reviewers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -68,4 +68,4 @@
 # Breaking changes detection
 # This rule ensures that breaking changes to connectors (identified by migrations files) 
 # are reviewed by the breaking-changes-reviewers team to maintain compatibility
-docs/integrations/**/*-migrations.md @airbytehq/breaking-changes-reviewers
+docs/integrations/**/*-migrations.md @airbytehq/breaking-change-reviewers


### PR DESCRIPTION
## Description
This PR adds a CODEOWNERS rule to require the 'breaking-changes-reviewers' team to approve any changes to migration files in the docs/integrations directory. This ensures that breaking changes to connectors receive proper review.

Context from Slack: https://airbytehq-team.slack.com/archives/C02U9R3AF37/p1744324990033789

**Note: We don't have CODEOWNERS approval set as a requirement for merging the `master`. I'll need to enable that in order to make this work. And enabling that may have some other side effects - especially if/where those declarations may have gone stale.**



## Changes
- Added a CODEOWNERS rule that matches files with the pattern `docs/integrations/**/*-migrations.md`
- Assigned the @airbytehq/breaking-changes-reviewers team as required reviewers for these files
- Added detailed comments explaining the purpose of this rule

## Implementation Notes
To fully implement this change, a repository admin will need to:
1. Enable CODEOWNERS enforcement in the repository settings
2. Navigate to Branches > Branch protection rules
3. Edit the protection rule for the master branch
4. Enable the option 'Require review from Code Owners'

Link to Devin run: https://app.devin.ai/sessions/82849da40958471982d83696596996dd
Requested by: Aaron ("AJ") Steers ([aj@airbyte.io](mailto:aj@airbyte.io))