### PR TITLE
🐛 Source Pardot: fix `prospect-accounts` not being able to sync >100k records

### DIFF
--- a/airbyte-integrations/connectors/source-pardot/manifest.yaml
+++ b/airbyte-integrations/connectors/source-pardot/manifest.yaml
@@ -391,8 +391,11 @@ definitions:
             type: RequestPath
           pagination_strategy:
             type: CursorPagination
-            cursor_value: "{{ response.get(\"nextPageUrl\", {}) }}"
-            stop_condition: "{{ not response.get(\"nextPageUrl\", {}) }}"
+            cursor_value: >-
+              {{ response['nextPageUrl'] if response['nextPageUrl'] is not none
+              else "v5/objects/prospect-accounts?idGreaterThan=" ~
+              last_record.id }}
+            stop_condition: "{{ not last_record.id }}"
         partition_router:
           type: ListPartitionRouter
           values:

--- a/airbyte-integrations/connectors/source-pardot/metadata.yaml
+++ b/airbyte-integrations/connectors/source-pardot/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: ad15c7ba-72a7-440b-af15-b9a963dc1a8a
-  dockerImageTag: 1.0.9
+  dockerImageTag: 1.0.10
   dockerRepository: airbyte/source-pardot
   githubIssueLabel: source-pardot
   icon: salesforcepardot.svg

--- a/docs/integrations/sources/pardot.md
+++ b/docs/integrations/sources/pardot.md
@@ -93,6 +93,7 @@ If there are more endpoints you'd like Airbyte to support, please [create an iss
 
 | Version | Date       | Pull Request                                             | Subject               |
 | :------ | :--------- | :------------------------------------------------------- | :-------------------- |
+| 1.0.10 | 2025-04-14 | [57875](https://github.com/airbytehq/airbyte/pull/58067) | Fix `prospect-accounts` not being able to sync >100k records |
 | 1.0.9 | 2025-04-12 | [57875](https://github.com/airbytehq/airbyte/pull/57875) | Update dependencies |
 | 1.0.8 | 2025-04-05 | [57321](https://github.com/airbytehq/airbyte/pull/57321) | Update dependencies |
 | 1.0.7 | 2025-03-29 | [56777](https://github.com/airbytehq/airbyte/pull/56777) | Update dependencies |


### PR DESCRIPTION
## What
Fixes #56370, the prospect-accounts stream allows for full-refresh only due to the lack of an `updatedAt` filter in this endpoint's [query params](https://developer.salesforce.com/docs/marketing/pardot/guide/prospect-account-v5.html#filtering-results), for accounts with >100k records in the table this poses an issue due to Pardot's [100k record limit](https://developer.salesforce.com/docs/marketing/pardot/guide/version5overview.html#restrictions-and-assumptions), resulting in the prospect-accounts stream syncing the same 100k records on every run.

## How
<!--
* Describe how code changes achieve the solution.
-->
Default to using `nextPageUrl`.

Once there's no `nextPageUrl` (e.g. after hitting the 100k record limit), construct a new request filtering for `"?idGreaterThan=" ~ last_record.id` to avoid returning records already seen.

The stop condition is `{{ not last_record.id }}`, meaning the stream will continue to construct requests until one of them returns an empty page, at which point it will stop.

Ideally I would like this to the [Pardot-Warning header](https://developer.salesforce.com/docs/marketing/pardot/guide/version5overview.html#account-engagement-warning-header-values) `203;Record count for nextPageToken sequence has been exceeded.` so that it's more explicit about what it's doing, we attempted this a few different ways but were unable to get it working.

## Review guide
<!--
1. `x.py`
2. `y.py`
-->
1. `manifest.yml`

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->
Users will be able to sync >100k records on the `prospect-accounts` endpoint.

I plan to refactor the rest of the v5 endpoints to use this same pagination method so that they can also query >100k records, as their paginators currently stop once they hit the limit meaning it takes multiple consecutive runs to backfill a large amount of data, but for now I just wanted to get the simpler PR in.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌

## Credit
Thanks @justbeez for the discussion and help in slack, and thanks @jkrclaro for figuring out the final working solution.