### PR TITLE
Bulk load CDK: streamloader.close() knows whether there was any data in the sync

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/integrationTest/kotlin/io/airbyte/cdk/load/mock_integration_test/MockDestinationWriter.kt
+++ b/airbyte-cdk/bulk/core/load/src/integrationTest/kotlin/io/airbyte/cdk/load/mock_integration_test/MockDestinationWriter.kt
@@ -46,7 +46,7 @@ class MockStreamLoader(override val stream: DestinationStream) : StreamLoader {
         override val state = BatchState.STAGED
     }
 
-    override suspend fun close(streamFailure: StreamProcessingFailed?) {
+    override suspend fun close(hadNonzeroRecords: Boolean, streamFailure: StreamProcessingFailed?) {
         if (streamFailure == null) {
             when (val importType = stream.importType) {
                 is Append -> {

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/state/StreamManager.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/state/StreamManager.kt
@@ -132,6 +132,13 @@ interface StreamManager {
      * marked as complete.
      */
     fun isBatchProcessingCompleteForCheckpoints(): Boolean
+
+    /**
+     * Some destinations need to perform expensive post-processing at the end of a sync, but can
+     * skip that post-processing if the sync had 0 records. So we should tell the destination
+     * whether any records were processed.
+     */
+    fun hadNonzeroRecords(): Boolean
 }
 
 class DefaultStreamManager(
@@ -495,6 +502,10 @@ class DefaultStreamManager(
                 .sumOf { it.records }
 
         return completedCount == readCount
+    }
+
+    override fun hadNonzeroRecords(): Boolean {
+        return recordCount.get() > 0
     }
 }
 

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/implementor/CloseStreamTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/implementor/CloseStreamTask.kt
@@ -30,7 +30,9 @@ class DefaultCloseStreamTask(
 
     override suspend fun execute() {
         val streamLoader = syncManager.getOrAwaitStreamLoader(streamDescriptor)
-        streamLoader.close()
+        streamLoader.close(
+            hadNonzeroRecords = syncManager.getStreamManager(streamDescriptor).hadNonzeroRecords(),
+        )
         syncManager.getStreamManager(streamDescriptor).markProcessingSucceeded()
         taskLauncher.handleStreamClosed(streamLoader.stream.descriptor)
     }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/implementor/FailStreamTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/implementor/FailStreamTask.kt
@@ -41,7 +41,9 @@ class DefaultFailStreamTask(
                 log.info { "Cannot fail stream $stream, which is already complete, doing nothing." }
             }
             is StreamProcessingFailed -> {
-                syncManager.getStreamLoaderOrNull(stream)?.close(streamResult)
+                syncManager
+                    .getStreamLoaderOrNull(stream)
+                    ?.close(hadNonzeroRecords = streamManager.hadNonzeroRecords(), streamResult)
                     ?: log.warn { "StreamLoader not found for stream $stream, cannot call close." }
             }
         }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/write/StreamLoader.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/write/StreamLoader.kt
@@ -57,7 +57,7 @@ interface StreamLoader : BatchAccumulator, FileBatchAccumulator {
     ): FileBatchAccumulator = this
 
     suspend fun processBatch(batch: Batch): Batch = SimpleBatch(BatchState.COMPLETE)
-    suspend fun close(streamFailure: StreamProcessingFailed? = null) {}
+    suspend fun close(hadNonzeroRecords: Boolean, streamFailure: StreamProcessingFailed? = null) {}
 }
 
 interface BatchAccumulator {

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/write/object_storage/ObjectStorageStreamLoaderFactory.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/write/object_storage/ObjectStorageStreamLoaderFactory.kt
@@ -103,7 +103,7 @@ class ObjectStorageStreamLoader<T : RemoteObject<*>, U : OutputStream>(
 
     override suspend fun processBatch(batch: Batch): Batch = objectAccumulator.processBatch(batch)
 
-    override suspend fun close(streamFailure: StreamProcessingFailed?) {
+    override suspend fun close(hadNonzeroRecords: Boolean, streamFailure: StreamProcessingFailed?) {
         if (streamFailure != null) {
             log.info { "Sync failed, persisting destination state for next run" }
         } else if (stream.shouldBeTruncatedAtEndOfSync()) {

--- a/airbyte-integrations/connectors/destination-mssql/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-mssql/metadata.yaml
@@ -16,7 +16,7 @@ data:
             type: GSM
   connectorType: destination
   definitionId: d4353156-9217-4cad-8dd7-c108fd4f74cf
-  dockerImageTag: 2.2.2
+  dockerImageTag: 2.2.3
   dockerRepository: airbyte/destination-mssql
   documentationUrl: https://docs.airbyte.com/integrations/destinations/mssql
   githubIssueLabel: destination-mssql

--- a/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/AbstractMSSQLStreamLoader.kt
+++ b/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/AbstractMSSQLStreamLoader.kt
@@ -33,11 +33,11 @@ abstract class AbstractMSSQLStreamLoader(
      * Called after processing completes or fails. By default, if there was no failure, attempts to
      * truncate previous data generations.
      */
-    override suspend fun close(streamFailure: StreamProcessingFailed?) {
+    override suspend fun close(hadNonzeroRecords: Boolean, streamFailure: StreamProcessingFailed?) {
         if (streamFailure == null) {
             truncatePreviousGenerations()
         }
-        super.close(streamFailure)
+        super.close(hadNonzeroRecords = hadNonzeroRecords, streamFailure)
     }
 
     /** Ensures the table exists, creating it if needed, and updates its schema if necessary. */

--- a/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLBulkLoadStreamLoader.kt
+++ b/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLBulkLoadStreamLoader.kt
@@ -77,9 +77,9 @@ class MSSQLBulkLoadStreamLoader(
      * If the stream finishes successfully, super.close() will handle truncating previous
      * generations. We also delete the format file from Blob.
      */
-    override suspend fun close(streamFailure: StreamProcessingFailed?) {
+    override suspend fun close(hadNonzeroRecords: Boolean, streamFailure: StreamProcessingFailed?) {
         deleteBlobSafe(formatFilePath)
-        super.close(streamFailure)
+        super.close(hadNonzeroRecords = hadNonzeroRecords, streamFailure)
     }
 
     /**

--- a/airbyte-integrations/connectors/destination-s3-data-lake/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/metadata.yaml
@@ -26,7 +26,7 @@ data:
             alias: airbyte-connector-testing-secret-store
   connectorType: destination
   definitionId: 716ca874-520b-4902-9f80-9fad66754b89
-  dockerImageTag: 0.3.24
+  dockerImageTag: 0.3.25
   dockerRepository: airbyte/destination-s3-data-lake
   documentationUrl: https://docs.airbyte.com/integrations/destinations/s3-data-lake
   githubIssueLabel: destination-s3-data-lake

--- a/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/S3DataLakeStreamLoader.kt
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/S3DataLakeStreamLoader.kt
@@ -90,7 +90,7 @@ class S3DataLakeStreamLoader(
         streamStateStore.put(stream.descriptor, state)
     }
 
-    override suspend fun close(streamFailure: StreamProcessingFailed?) {
+    override suspend fun close(hadNonzeroRecords: Boolean, streamFailure: StreamProcessingFailed?) {
         if (streamFailure == null) {
             // Doing it first to make sure that data coming in the current batch is written to the
             // main branch

--- a/airbyte-integrations/connectors/destination-s3-data-lake/src/test/kotlin/io/airbyte/integrations/destination/s3_data_lake/S3DataLakeStreamLoaderTest.kt
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/src/test/kotlin/io/airbyte/integrations/destination/s3_data_lake/S3DataLakeStreamLoaderTest.kt
@@ -276,7 +276,7 @@ internal class S3DataLakeStreamLoaderTest {
         verify { updateSchema.addColumn(null, "id", Types.LongType.get()) }
         verify(exactly = 0) { updateSchema.commit() }
 
-        runBlocking { streamLoader.close(streamFailure = null) }
+        runBlocking { streamLoader.close(hadNonzeroRecords = true, streamFailure = null) }
         verify { updateSchema.commit() }
     }
 
@@ -424,7 +424,7 @@ internal class S3DataLakeStreamLoaderTest {
         verify(exactly = 1) { updateSchema.setIdentifierFields(primaryKeys) }
         verify(exactly = 0) { updateSchema.commit() }
 
-        runBlocking { streamLoader.close(streamFailure = null) }
+        runBlocking { streamLoader.close(hadNonzeroRecords = true, streamFailure = null) }
         verify { updateSchema.commit() }
     }
 

--- a/docs/integrations/destinations/mssql.md
+++ b/docs/integrations/destinations/mssql.md
@@ -158,6 +158,7 @@ See the [Getting Started: Configuration section](#configuration) of this guide f
 
 | Version    | Date       | Pull Request                                               | Subject                                                                                             |
 |:-----------|:-----------|:-----------------------------------------------------------|:----------------------------------------------------------------------------------------------------|
+| 2.2.3      | 2025-04-16 | [58085](https://github.com/airbytehq/airbyte/pull/58085)   | Internal refactoring                                                                                |
 | 2.2.2      | 2025-04-07 | [56391](https://github.com/airbytehq/airbyte/pull/56391)   | Add support for Azure blob storage auth via storage account key.                                    |
 | 2.2.1      | 2025-03-27 | [56402](https://github.com/airbytehq/airbyte/pull/56402)   | Improve Azure blob storage load logic.                                                              |
 | 2.2.0      | 2025-03-23 | [56353](https://github.com/airbytehq/airbyte/pull/56353)   | Bulk Load performance improvements                                                                  |

--- a/docs/integrations/destinations/s3-data-lake.md
+++ b/docs/integrations/destinations/s3-data-lake.md
@@ -307,6 +307,7 @@ Now, you can identify the latest version of the 'Alice' record by querying wheth
 
 | Version | Date       | Pull Request                                               | Subject                                                                        |
 |:--------|:-----------| :--------------------------------------------------------- |:-------------------------------------------------------------------------------|
+| 0.3.25  | 2025-04-16 | [58085](https://github.com/airbytehq/airbyte/pull/58085) | Internal refactoring |
 | 0.3.24  | 2025-03-27 | [56435](https://github.com/airbytehq/airbyte/pull/56435) | Bug fix: Correctly handle non-positive numbers. |
 | 0.3.23  | 2025-03-25 | [56395](https://github.com/airbytehq/airbyte/pull/56395) | Bug fix: Correctly coerce values inside nested arrays. |
 | 0.3.22  | 2025-03-24 | [56355](https://github.com/airbytehq/airbyte/pull/56355) | Upgrade to airbyte/java-connector-base:2.0.1 to be M4 compatible. |


### PR DESCRIPTION
this will be useful for warehouses (i.e. skip deduping if there was no data during the sync)

I could be convinced to just pass the actual record count into the streamloader?

e.g. existing (old CDK) code https://github.com/airbytehq/airbyte/blob/0e0f2dc9f7f43a24b6afd0f0f68e6cf9d2ae43a8/airbyte-cdk/java/airbyte-cdk/typing-deduping/src/main/kotlin/io/airbyte/integrations/base/destination/operation/AbstractStreamOperation.kt#L375