### PR TITLE
[source-apple-search-ads] update naming to `Apple Ads` in documentation and metadata

### DIFF
--- a/airbyte-integrations/connectors/source-apple-search-ads/README.md
+++ b/airbyte-integrations/connectors/source-apple-search-ads/README.md
@@ -1,4 +1,4 @@
-# Apple search ads source connector
+# Apple Ads (Apple Search Ads) source connector
 
 This directory contains the manifest-only connector for `source-apple-search-ads`.
 This _manifest-only_ connector is not a Python package on its own, as it runs inside of the base `source-declarative-manifest` image.

--- a/airbyte-integrations/connectors/source-apple-search-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-apple-search-ads/metadata.yaml
@@ -7,7 +7,7 @@ data:
   githubIssueLabel: source-apple-search-ads
   icon: icon.svg
   license: MIT
-  name: Apple Search Ads
+  name: Apple
   remoteRegistries:
     pypi:
       enabled: false

--- a/airbyte-integrations/connectors/source-apple-search-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-apple-search-ads/metadata.yaml
@@ -7,7 +7,7 @@ data:
   githubIssueLabel: source-apple-search-ads
   icon: icon.svg
   license: MIT
-  name: Apple
+  name: Apple Ads
   remoteRegistries:
     pypi:
       enabled: false

--- a/docs/integrations/sources/apple-search-ads.md
+++ b/docs/integrations/sources/apple-search-ads.md
@@ -1,12 +1,12 @@
-# Apple Search Ads
+# Apple Ads (FKA Apple Search Ads)
 
-This page contains the setup guide and reference information for the Apple Search Ads source connector.
+This page contains the setup guide and reference information for the Apple Ads source connector.
 
 ## Setup guide
 
-### Step 1: Set up Apple Search Ads
+### Step 1: Set up Apple Ads
 
-1. With an administrator account, [create an API user role](https://developer.apple.com/documentation/apple_search_ads/implementing_oauth_for_the_apple_search_ads_api) from the Apple Search Ads UI.
+1. With an administrator account, [create an API user role](https://developer.apple.com/documentation/apple_search_ads/implementing_oauth_for_the_apple_search_ads_api) from the Apple Ads UI.
 2. Then [implement OAuth for your API user](https://developer.apple.com/documentation/apple_search_ads/implementing_oauth_for_the_apple_search_ads_api) in order to the required Client Secret and Client Id.
 
 ### Step 2: Set up the source connector in Airbyte
@@ -15,9 +15,9 @@ This page contains the setup guide and reference information for the Apple Searc
 
 1. Log in to your Airbyte Open Source account.
 2. Click **Sources** and then click **+ New source**.
-3. On the Set up the source page, select **Apple Search Ads** from the **Source type** dropdown.
+3. On the Set up the source page, select **Apple Ads** from the **Source type** dropdown.
 4. Enter a name for your source.
-5. For **Org Id**, enter the Id of your organization (found in the Apple Search Ads UI).
+5. For **Org Id**, enter the Id of your organization (found in the Apple Ads UI).
 6. Enter the **Client ID** and the **Client Secret** from [Step 1](#step-1-set-up-apple-search-ads).
 7. For **Start Date** and **End Date**, enter the date in YYYY-MM-DD format. For DAILY reports, the Start Date can't be
    earlier than 90 days from today. If the End Date field is left blank, Airbyte will replicate data to today.
@@ -29,7 +29,7 @@ This page contains the setup guide and reference information for the Apple Searc
 
 ## Supported sync modes
 
-The Apple Search Ads source connector supports the following [sync modes](https://docs.airbyte.com/cloud/core-concepts#connection-sync-modes):
+The Apple Ads source connector supports the following [sync modes](https://docs.airbyte.com/cloud/core-concepts#connection-sync-modes):
 
 - [Full Refresh - Overwrite](https://docs.airbyte.com/understanding-airbyte/glossary#full-refresh-sync)
 - [Full Refresh - Append](https://docs.airbyte.com/understanding-airbyte/connections/full-refresh-append)
@@ -38,7 +38,7 @@ The Apple Search Ads source connector supports the following [sync modes](https:
 
 ## Supported Streams
 
-The Apple Ads source connector supports the following streams. For more information, see the [Apple Search Ads API](https://developer.apple.com/documentation/apple_search_ads).
+The Apple Ads source connector supports the following streams. For more information, see the [Apple Ads API](https://developer.apple.com/documentation/apple_search_ads).
 
 ### Base streams
 
@@ -60,7 +60,7 @@ One example is `countryOrRegion`.
 
 ### Report aggregation
 
-The Apple Search Ads currently offers [aggregation](https://developer.apple.com/documentation/apple_search_ads/reportingrequest) at hourly, daily, weekly, or monthly level.
+The Apple Ads currently offers [aggregation](https://developer.apple.com/documentation/apple_search_ads/reportingrequest) at hourly, daily, weekly, or monthly level.
 
 However, at this moment and as indicated in the stream names, the connector only offers data with daily aggregation.
 

--- a/docs/integrations/sources/apple-search-ads.md
+++ b/docs/integrations/sources/apple-search-ads.md
@@ -1,4 +1,4 @@
-# Apple Ads (FKA Apple Search Ads)
+# Apple Ads (Apple Search Ads)
 
 This page contains the setup guide and reference information for the Apple Ads source connector.
 


### PR DESCRIPTION
## What
- [Apple Search Ads is now Apple Ads](https://ads.apple.com/app-store/news#:~:text=Apple%20Search%20Ads%20is%20now,below%20to%20access%20your%20account.)
- This PR updates the `name` property in the metadata to reflect
- This PR updates references to `Apple Search Ads` in the documentation to `Apple Ads`

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [X] YES 💚
- [ ] NO ❌
