### PR TITLE
[Toolkit] Create a GCS s3 client wrapper

### DIFF
--- a/airbyte-cdk/bulk/toolkits/load-gcs/build.gradle
+++ b/airbyte-cdk/bulk/toolkits/load-gcs/build.gradle
@@ -3,6 +3,7 @@ dependencies {
     implementation project(':airbyte-cdk:bulk:core:bulk-cdk-core-load')
     api project(':airbyte-cdk:bulk:toolkits:bulk-cdk-toolkit-load-object-storage')
     api project(':airbyte-cdk:bulk:toolkits:bulk-cdk-toolkit-load-gcp')
+    api project(':airbyte-cdk:bulk:toolkits:bulk-cdk-toolkit-load-s3')
 
     api 'com.google.cloud:google-cloud-storage'
 

--- a/airbyte-cdk/bulk/toolkits/load-gcs/build.gradle
+++ b/airbyte-cdk/bulk/toolkits/load-gcs/build.gradle
@@ -3,6 +3,7 @@ dependencies {
     implementation project(':airbyte-cdk:bulk:core:bulk-cdk-core-load')
     api project(':airbyte-cdk:bulk:toolkits:bulk-cdk-toolkit-load-object-storage')
     api project(':airbyte-cdk:bulk:toolkits:bulk-cdk-toolkit-load-gcp')
+    // This is because we are building a client wrapper around S3.
     api project(':airbyte-cdk:bulk:toolkits:bulk-cdk-toolkit-load-s3')
 
     api 'com.google.cloud:google-cloud-storage'

--- a/airbyte-cdk/bulk/toolkits/load-gcs/src/main/kotlin/io/airbyte/cdk/load/command/gcs/GcsClientConfiguration.kt
+++ b/airbyte-cdk/bulk/toolkits/load-gcs/src/main/kotlin/io/airbyte/cdk/load/command/gcs/GcsClientConfiguration.kt
@@ -12,16 +12,11 @@ data class GcsClientConfiguration(
     val credential: GcsAuthConfiguration,
     val region: GcsRegion?,
 ) {
-    constructor(
-        commonSpecification: GcsCommonSpecification,
-        regionSpecification: GcsRegion,
-    ) : this(
-        commonSpecification.gcsBucketName,
-        commonSpecification.path,
-        commonSpecification.credential.toGcsAuthConfiguration(),
-        regionSpecification,
-    )
 
+    /**
+     * This is used when creating the S3Client wrapper. We need to be able to use the current config
+     * as if we were using an S3Client
+     */
     fun s3BucketConfiguration() =
         S3BucketConfiguration(
             gcsBucketName,

--- a/airbyte-cdk/bulk/toolkits/load-gcs/src/main/kotlin/io/airbyte/cdk/load/command/gcs/GcsClientConfiguration.kt
+++ b/airbyte-cdk/bulk/toolkits/load-gcs/src/main/kotlin/io/airbyte/cdk/load/command/gcs/GcsClientConfiguration.kt
@@ -26,7 +26,7 @@ data class GcsClientConfiguration(
         S3BucketConfiguration(
             gcsBucketName,
             region?.region,
-            "https://storage.googleapis.com",
+            GOOGLE_STORAGE_ENDPOINT,
         )
 }
 

--- a/airbyte-cdk/bulk/toolkits/load-gcs/src/main/kotlin/io/airbyte/cdk/load/command/gcs/GcsClientConfiguration.kt
+++ b/airbyte-cdk/bulk/toolkits/load-gcs/src/main/kotlin/io/airbyte/cdk/load/command/gcs/GcsClientConfiguration.kt
@@ -4,6 +4,8 @@
 
 package io.airbyte.cdk.load.command.gcs
 
+import io.airbyte.cdk.load.command.s3.S3BucketConfiguration
+
 data class GcsClientConfiguration(
     val gcsBucketName: String,
     val path: String,
@@ -19,6 +21,13 @@ data class GcsClientConfiguration(
         commonSpecification.credential.toGcsAuthConfiguration(),
         regionSpecification,
     )
+
+    fun s3BucketConfiguration() =
+        S3BucketConfiguration(
+            gcsBucketName,
+            region?.region,
+            "https://storage.googleapis.com",
+        )
 }
 
 interface GcsClientConfigurationProvider {

--- a/airbyte-cdk/bulk/toolkits/load-gcs/src/main/kotlin/io/airbyte/cdk/load/command/gcs/GcsConstants.kt
+++ b/airbyte-cdk/bulk/toolkits/load-gcs/src/main/kotlin/io/airbyte/cdk/load/command/gcs/GcsConstants.kt
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.load.command.gcs
+
+const val GOOGLE_STORAGE_ENDPOINT = "https://storage.googleapis.com"

--- a/airbyte-cdk/bulk/toolkits/load-gcs/src/main/kotlin/io/airbyte/cdk/load/file/gcs/GcsClient.kt
+++ b/airbyte-cdk/bulk/toolkits/load-gcs/src/main/kotlin/io/airbyte/cdk/load/file/gcs/GcsClient.kt
@@ -7,6 +7,7 @@ package io.airbyte.cdk.load.file.gcs
 import com.google.cloud.storage.BlobId
 import com.google.cloud.storage.BlobInfo
 import com.google.cloud.storage.Storage
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 import io.airbyte.cdk.load.command.gcs.GcsClientConfiguration
 import io.airbyte.cdk.load.file.object_storage.ObjectStorageClient
 import io.airbyte.cdk.load.file.object_storage.RemoteObject
@@ -36,6 +37,7 @@ fun GcsBlob.toS3Object() = S3Object(this.key, this.storageConfig.s3BucketConfigu
  * because we are forced into the HMAC auth for legacy reasons. At the end of the day, this is just
  * a bare-bone wrapper around the S3Client
  */
+@SuppressFBWarnings("NP_NONNULL_PARAM_VIOLATION", justification = "Kotlin async continuation")
 class GcsS3Client(
     private val s3Client: S3Client,
     private val config: GcsClientConfiguration,

--- a/airbyte-cdk/bulk/toolkits/load-gcs/src/main/kotlin/io/airbyte/cdk/load/file/gcs/GcsClient.kt
+++ b/airbyte-cdk/bulk/toolkits/load-gcs/src/main/kotlin/io/airbyte/cdk/load/file/gcs/GcsClient.kt
@@ -30,6 +30,12 @@ fun S3Object.toGcsBlob(config: GcsClientConfiguration) = GcsBlob(this.key, confi
 
 fun GcsBlob.toS3Object() = S3Object(this.key, this.storageConfig.s3BucketConfiguration())
 
+/**
+ * This client is currently the primary class. It is specifically built around the S3Client. It
+ * exists to allow us to no load the S3 toolkit and avoid client collision. We specifically need it
+ * because we are forced into the HMAC auth for legacy reasons. At the end of the day, this is just
+ * a bare-bone wrapper around the S3Client
+ */
 class GcsS3Client(
     private val s3Client: S3Client,
     private val config: GcsClientConfiguration,
@@ -69,6 +75,10 @@ class GcsS3Client(
     }
 }
 
+/**
+ * THis client should be used when we finally decide to support native GCP auth. We can then swap
+ * over to this client instead of the [GcsS3Client] which will require us to use HMAC auth.
+ */
 class GcsNativeClient(private val storage: Storage, private val config: GcsClientConfiguration) :
     GcsClient {
 

--- a/airbyte-cdk/bulk/toolkits/load-gcs/src/main/kotlin/io/airbyte/cdk/load/file/gcs/GcsClientFactory.kt
+++ b/airbyte-cdk/bulk/toolkits/load-gcs/src/main/kotlin/io/airbyte/cdk/load/file/gcs/GcsClientFactory.kt
@@ -27,6 +27,8 @@ class GcsClientFactory(
 
     @Singleton
     @Secondary
+    // We do this because we want to allow someone to supersede this client if their heart desire
+    // But that at the same time we want to ensure that we always supersede the S3Client ourselves.
     @Replaces(S3Client::class)
     fun make(): GcsClient {
         val config = gcsClientConfigurationProvider.gcsClientConfiguration

--- a/airbyte-cdk/bulk/toolkits/load-gcs/src/main/kotlin/io/airbyte/cdk/load/file/gcs/GcsClientFactory.kt
+++ b/airbyte-cdk/bulk/toolkits/load-gcs/src/main/kotlin/io/airbyte/cdk/load/file/gcs/GcsClientFactory.kt
@@ -8,6 +8,7 @@ import io.airbyte.cdk.load.command.aws.AWSAccessKeyConfiguration
 import io.airbyte.cdk.load.command.aws.AWSAccessKeyConfigurationProvider
 import io.airbyte.cdk.load.command.aws.AWSArnRoleConfiguration
 import io.airbyte.cdk.load.command.aws.AWSArnRoleConfigurationProvider
+import io.airbyte.cdk.load.command.gcs.GOOGLE_STORAGE_ENDPOINT
 import io.airbyte.cdk.load.command.gcs.GcsClientConfigurationProvider
 import io.airbyte.cdk.load.command.gcs.GcsHmacKeyConfiguration
 import io.airbyte.cdk.load.command.s3.S3BucketConfiguration
@@ -51,7 +52,7 @@ class GcsClientFactory(
                                         S3BucketConfiguration(
                                             s3BucketName = config.gcsBucketName,
                                             s3BucketRegion = config.region?.region,
-                                            s3Endpoint = "https://storage.googleapis.com"
+                                            s3Endpoint = GOOGLE_STORAGE_ENDPOINT
                                         )
                                 },
                                 assumeRoleCredentials = null,

--- a/airbyte-cdk/bulk/toolkits/load-gcs/src/main/kotlin/io/airbyte/cdk/load/file/gcs/GcsClientFactory.kt
+++ b/airbyte-cdk/bulk/toolkits/load-gcs/src/main/kotlin/io/airbyte/cdk/load/file/gcs/GcsClientFactory.kt
@@ -4,11 +4,18 @@
 
 package io.airbyte.cdk.load.file.gcs
 
-import com.google.auth.oauth2.AwsCredentials
-import com.google.cloud.storage.StorageOptions
+import io.airbyte.cdk.load.command.aws.AWSAccessKeyConfiguration
+import io.airbyte.cdk.load.command.aws.AWSAccessKeyConfigurationProvider
+import io.airbyte.cdk.load.command.aws.AWSArnRoleConfiguration
+import io.airbyte.cdk.load.command.aws.AWSArnRoleConfigurationProvider
 import io.airbyte.cdk.load.command.gcs.GcsClientConfigurationProvider
 import io.airbyte.cdk.load.command.gcs.GcsHmacKeyConfiguration
+import io.airbyte.cdk.load.command.s3.S3BucketConfiguration
+import io.airbyte.cdk.load.command.s3.S3BucketConfigurationProvider
+import io.airbyte.cdk.load.file.s3.S3Client
+import io.airbyte.cdk.load.file.s3.S3ClientFactory
 import io.micronaut.context.annotation.Factory
+import io.micronaut.context.annotation.Replaces
 import io.micronaut.context.annotation.Secondary
 import jakarta.inject.Singleton
 
@@ -19,19 +26,49 @@ class GcsClientFactory(
 
     @Singleton
     @Secondary
+    @Replaces(S3Client::class)
     fun make(): GcsClient {
         val config = gcsClientConfigurationProvider.gcsClientConfiguration
-        val credentials = config.credential as GcsHmacKeyConfiguration
 
-        val awsCredentials =
-            AwsCredentials.newBuilder()
-                .setClientId(credentials.accessKeyId)
-                .setClientSecret(credentials.secretAccessKey)
-                .build()
-
-        // For HMAC authentication, we use StorageOptions with AwsCredentials
-        val storage = StorageOptions.newBuilder().setCredentials(awsCredentials).build().service
-
-        return GcsClient(storage, config)
+        return when (config.credential) {
+            is GcsHmacKeyConfiguration -> {
+                GcsS3Client(
+                    s3Client =
+                        S3ClientFactory(
+                                object : AWSArnRoleConfigurationProvider {
+                                    override val awsArnRoleConfiguration =
+                                        AWSArnRoleConfiguration(null)
+                                },
+                                object : AWSAccessKeyConfigurationProvider {
+                                    override val awsAccessKeyConfiguration =
+                                        AWSAccessKeyConfiguration(
+                                            config.credential.accessKeyId,
+                                            config.credential.secretAccessKey,
+                                        )
+                                },
+                                object : S3BucketConfigurationProvider {
+                                    override val s3BucketConfiguration: S3BucketConfiguration =
+                                        S3BucketConfiguration(
+                                            s3BucketName = config.gcsBucketName,
+                                            s3BucketRegion = config.region?.region,
+                                            s3Endpoint = "https://storage.googleapis.com"
+                                        )
+                                },
+                                assumeRoleCredentials = null,
+                                null
+                            )
+                            .make(),
+                    config = config,
+                )
+            }
+        //            else -> {
+        //                // This branch is never executed, because there's no alternative to HMAC
+        // auth.
+        //                // But this is approximately what we would do.
+        //                val storage =
+        // StorageOptions.newBuilder().setCredentials(TODO()).build().service
+        //                return GcsNativeClient(storage, config)
+        //            }
+        }
     }
 }

--- a/airbyte-cdk/bulk/toolkits/load-gcs/src/test/kotlin/io/airbyte/cdk/load/file/gcs/GcsClientTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-gcs/src/test/kotlin/io/airbyte/cdk/load/file/gcs/GcsClientTest.kt
@@ -36,7 +36,7 @@ class GcsClientTest {
             GcsHmacKeyConfiguration("test-access-key", "test-secret-key"),
             region
         )
-    private val gcsClient = GcsClient(storage, config)
+    private val gcsClient = GcsNativeClient(storage, config)
 
     @Test
     fun `test list with empty prefix`() = runBlocking {
@@ -247,7 +247,7 @@ class GcsClientTest {
                 GcsHmacKeyConfiguration("test-access-key", "test-secret-key"),
                 region
             )
-        val gcsClient = GcsClient(storage, config)
+        val gcsClient = GcsNativeClient(storage, config)
         val key = "test-file"
         val blobId = BlobId.of(bucketName, key)
 
@@ -267,7 +267,7 @@ class GcsClientTest {
                 GcsHmacKeyConfiguration("test-access-key", "test-secret-key"),
                 region
             )
-        val gcsClient = GcsClient(storage, config)
+        val gcsClient = GcsNativeClient(storage, config)
         val key = "/test-file"
 
         val expectedPath = "path/test-file"

--- a/airbyte-cdk/bulk/toolkits/load-s3/src/main/kotlin/io/airbyte/cdk/load/file/s3/S3Client.kt
+++ b/airbyte-cdk/bulk/toolkits/load-s3/src/main/kotlin/io/airbyte/cdk/load/file/s3/S3Client.kt
@@ -156,14 +156,13 @@ class S3KotlinClient(
 
 /**
  * [assumeRoleCredentials] is required if [keyConfig] does not have an access key, _and_ [arnRole]
- * includes a nonnull role ARN. Otherwise it is ignored.
+ * includes a nonnull role ARN. Otherwise, it is ignored.
  */
 @Factory
 class S3ClientFactory(
     private val arnRole: AWSArnRoleConfigurationProvider,
     private val keyConfig: AWSAccessKeyConfigurationProvider,
     private val bucketConfig: S3BucketConfigurationProvider,
-    private val uploadConfig: ObjectStorageUploadConfigurationProvider? = null,
     private val assumeRoleCredentials: AwsAssumeRoleCredentials?,
     private val s3ClientConfig: S3ClientConfigurationProvider? = null,
 ) {
@@ -177,7 +176,7 @@ class S3ClientFactory(
         T : AWSAccessKeyConfigurationProvider,
         T : AWSArnRoleConfigurationProvider,
         T : ObjectStorageUploadConfigurationProvider =
-            S3ClientFactory(config, config, config, config, assumeRoleCredentials).make()
+            S3ClientFactory(config, config, config, assumeRoleCredentials).make()
     }
 
     @Singleton


### PR DESCRIPTION
## What

In this PR we create a wrapper around the S3Client within the GCS load toolkit.
This will allow us to only load one toolkit which will, in turn, allow us to avoid conflicts between the two client within Micronaut

## Can this PR be safely reverted and rolled back?
- [X] YES 💚
- [ ] NO ❌
