### PR TITLE
[Toolkit] Pass around a String for the region instead of a GcsRegion

### DIFF
--- a/airbyte-cdk/bulk/toolkits/load-gcs/src/main/kotlin/io/airbyte/cdk/load/command/gcs/GcsClientConfiguration.kt
+++ b/airbyte-cdk/bulk/toolkits/load-gcs/src/main/kotlin/io/airbyte/cdk/load/command/gcs/GcsClientConfiguration.kt
@@ -29,7 +29,7 @@ data class GcsClientConfiguration(
     fun s3BucketConfiguration() =
         S3BucketConfiguration(
             gcsBucketName,
-            region?.region,
+            region,
             GOOGLE_STORAGE_ENDPOINT,
         )
 }

--- a/airbyte-cdk/bulk/toolkits/load-gcs/src/main/kotlin/io/airbyte/cdk/load/command/gcs/GcsClientConfiguration.kt
+++ b/airbyte-cdk/bulk/toolkits/load-gcs/src/main/kotlin/io/airbyte/cdk/load/command/gcs/GcsClientConfiguration.kt
@@ -10,8 +10,17 @@ data class GcsClientConfiguration(
     val gcsBucketName: String,
     val path: String,
     val credential: GcsAuthConfiguration,
-    val region: GcsRegion?,
+    val region: String?,
 ) {
+    constructor(
+        commonSpecification: GcsCommonSpecification,
+        regionSpecification: GcsRegion,
+    ) : this(
+        commonSpecification.gcsBucketName,
+        commonSpecification.path,
+        commonSpecification.credential.toGcsAuthConfiguration(),
+        regionSpecification.region,
+    )
 
     /**
      * This is used when creating the S3Client wrapper. We need to be able to use the current config

--- a/airbyte-cdk/bulk/toolkits/load-gcs/src/main/kotlin/io/airbyte/cdk/load/file/gcs/GcsClientFactory.kt
+++ b/airbyte-cdk/bulk/toolkits/load-gcs/src/main/kotlin/io/airbyte/cdk/load/file/gcs/GcsClientFactory.kt
@@ -53,7 +53,7 @@ class GcsClientFactory(
                                     override val s3BucketConfiguration: S3BucketConfiguration =
                                         S3BucketConfiguration(
                                             s3BucketName = config.gcsBucketName,
-                                            s3BucketRegion = config.region?.region,
+                                            s3BucketRegion = config.region,
                                             s3Endpoint = GOOGLE_STORAGE_ENDPOINT
                                         )
                                 },

--- a/airbyte-cdk/bulk/toolkits/load-gcs/src/test/kotlin/io/airbyte/cdk/load/file/gcs/GcsClientTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-gcs/src/test/kotlin/io/airbyte/cdk/load/file/gcs/GcsClientTest.kt
@@ -34,7 +34,7 @@ class GcsClientTest {
             bucketName,
             bucketPath,
             GcsHmacKeyConfiguration("test-access-key", "test-secret-key"),
-            region
+            region.region
         )
     private val gcsClient = GcsNativeClient(storage, config)
 
@@ -245,7 +245,7 @@ class GcsClientTest {
                 bucketName,
                 "",
                 GcsHmacKeyConfiguration("test-access-key", "test-secret-key"),
-                region
+                region.region
             )
         val gcsClient = GcsNativeClient(storage, config)
         val key = "test-file"
@@ -265,7 +265,7 @@ class GcsClientTest {
                 bucketName,
                 "path",
                 GcsHmacKeyConfiguration("test-access-key", "test-secret-key"),
-                region
+                region.region
             )
         val gcsClient = GcsNativeClient(storage, config)
         val key = "/test-file"

--- a/airbyte-cdk/bulk/toolkits/load-gcs/src/test/kotlin/io/airbyte/cdk/load/file/gcs/GcsStreamingUploadTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-gcs/src/test/kotlin/io/airbyte/cdk/load/file/gcs/GcsStreamingUploadTest.kt
@@ -39,7 +39,7 @@ class GcsStreamingUploadTest {
                 gcsBucketName = "test-bucket",
                 path = "test-path",
                 credential = GcsHmacKeyConfiguration("dummy-access-key", "dummy-secret-key"),
-                region = GcsRegion.US_WEST1
+                region = GcsRegion.US_WEST1.region
             )
         metadata = mapOf("env" to "test", "author" to "testUser")
         streamingUpload = GcsStreamingUpload(storage, key, config, metadata)
@@ -184,7 +184,7 @@ class GcsStreamingUploadTest {
                 gcsBucketName = "bucket",
                 path = "prefix",
                 credential = GcsHmacKeyConfiguration("dummy-access-key", "dummy-secret-key"),
-                region = GcsRegion.US_WEST1
+                region = GcsRegion.US_WEST1.region
             )
         val upload1 = GcsStreamingUpload(storage, "key", config1, emptyMap())
 
@@ -194,7 +194,7 @@ class GcsStreamingUploadTest {
                 gcsBucketName = "bucket",
                 path = "",
                 credential = GcsHmacKeyConfiguration("dummy-access-key", "dummy-secret-key"),
-                region = GcsRegion.US_WEST1
+                region = GcsRegion.US_WEST1.region
             )
         val upload2 = GcsStreamingUpload(storage, "key", config2, emptyMap())
 


### PR DESCRIPTION
## What

Let's do the same thing we are doing for S3 and start passing a string around for the region instead of a GcsRegion enum

## Can this PR be safely reverted and rolled back?
- [X] YES 💚
- [ ] NO ❌
