### PR TITLE
Destinations S3, MSSQL: pick up latest CDK version

### DIFF
--- a/airbyte-integrations/connectors/destination-mssql/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-mssql/metadata.yaml
@@ -16,7 +16,7 @@ data:
             type: GSM
   connectorType: destination
   definitionId: d4353156-9217-4cad-8dd7-c108fd4f74cf
-  dockerImageTag: 2.2.4
+  dockerImageTag: 2.2.5
   dockerRepository: airbyte/destination-mssql
   documentationUrl: https://docs.airbyte.com/integrations/destinations/mssql
   githubIssueLabel: destination-mssql

--- a/airbyte-integrations/connectors/destination-s3/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-s3/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: file
   connectorType: destination
   definitionId: 4816b78f-1489-44c1-9060-4b19d5fa9362
-  dockerImageTag: 1.7.2
+  dockerImageTag: 1.7.3
   dockerRepository: airbyte/destination-s3
   githubIssueLabel: destination-s3
   icon: s3.svg

--- a/docs/integrations/destinations/mssql.md
+++ b/docs/integrations/destinations/mssql.md
@@ -158,6 +158,7 @@ See the [Getting Started: Configuration section](#configuration) of this guide f
 
 | Version    | Date       | Pull Request                                               | Subject                                                                                             |
 |:-----------|:-----------|:-----------------------------------------------------------|:----------------------------------------------------------------------------------------------------|
+| 2.2.5      | 2025-04-18 | [58140](https://github.com/airbytehq/airbyte/pull/58140)   | Upgrade to latest CDK                                                                               |
 | 2.2.4      | 2025-04-11 | [57563](https://github.com/airbytehq/airbyte/pull/57563)   | Improve BULK INSERT documentation.                                                                  |
 | 2.2.3      | 2025-04-16 | [58085](https://github.com/airbytehq/airbyte/pull/58085)   | Internal refactoring                                                                                |
 | 2.2.2      | 2025-04-07 | [56391](https://github.com/airbytehq/airbyte/pull/56391)   | Add support for Azure blob storage auth via storage account key.                                    |

--- a/docs/integrations/destinations/s3.md
+++ b/docs/integrations/destinations/s3.md
@@ -544,6 +544,7 @@ To see connector limitations, or troubleshoot your S3 connector, see more [in ou
 
 | Version     | Date       | Pull Request                                               | Subject                                                                                                                                              |
 |:------------|:-----------|:-----------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| 1.7.3       | 2025-04-18 | [58140](https://github.com/airbytehq/airbyte/pull/58140)   | Upgrade to latest CDK                                                                                                                                |
 | 1.7.2       | 2025-04-07 | [56391](https://github.com/airbytehq/airbyte/pull/56391)   | Internal code refactor                                                                                                                               |
 | 1.7.1       | 2025-04-02 | [56974](https://github.com/airbytehq/airbyte/pull/56974)   | Nonfunctional change: pin cdk version                                                                                                                |
 | 1.7.0       | 2025-04-02 | [56974](https://github.com/airbytehq/airbyte/pull/56974)   | Release 1.7.0 release candidate                                                                                                                      |


### PR DESCRIPTION
pull in the heartbeat fix from https://github.com/airbytehq/airbyte/pull/58104/files#diff-d3dbebf39d6cee2e09ce3d62cef86ccfa14ec27cb9e60cd0fde9ccb9467a7575. That PR already released to S3 Data Lake, so just release S3 + MSSQL here.