### PR TITLE
clarify Clear documentation

### DIFF
--- a/docs/operator-guides/clear.md
+++ b/docs/operator-guides/clear.md
@@ -42,7 +42,7 @@ A single stream clear will sync all enabled streams on the next sync.
 
 ## Clear behavior
 
-When clearing data is successfully completed, all the records are deleted from your destination tables (and files, if using local JSON or local CSV as the destination). The tables are not removed, they will only be emptied. However, files will be deleted, and new (empty) files will be created.
+When clearing data is successfully completed, all the records are deleted from your destination tables (and files, if using local JSON or local CSV as the destination). The tables are not removed, they will only be emptied. However, files will be deleted.
 
 Clearing your data causes data downtime, meaning that your final tables will be empty once the Clear is complete. Clearing your data also blocks the running of regularly-scheduled syncs until they are complete. If you choose to clear your data while another sync is running, it will enqueue, and start at the end of the currently running sync.
 

--- a/docs/operator-guides/clear.md
+++ b/docs/operator-guides/clear.md
@@ -42,7 +42,7 @@ A single stream clear will sync all enabled streams on the next sync.
 
 ## Clear behavior
 
-When clearing data is successfully completed, all the records are deleted from your destination tables (and files, if using local JSON or local CSV as the destination). The tables or files are not removed, they will only be emptied.
+When clearing data is successfully completed, all the records are deleted from your destination tables (and files, if using local JSON or local CSV as the destination). The tables are not removed, they will only be emptied. However, files will be deleted, and new (empty) files will be created.
 
 Clearing your data causes data downtime, meaning that your final tables will be empty once the Clear is complete. Clearing your data also blocks the running of regularly-scheduled syncs until they are complete. If you choose to clear your data while another sync is running, it will enqueue, and start at the end of the currently running sync.
 


### PR DESCRIPTION
from https://github.com/airbytehq/airbyte/issues/56926 - the wording is a bit misleading, and I think the user misunderstood what we're doing.

@johnny-schmidt tagging you just to doublecheck - during a clear (i.e truncate refresh with 0 records), destination-s3 will (a) delete all existing files, and then (b) create an empty file? Or does it just not create a file at all