### PR TITLE
Destination MSSQL: Improve numeric handling

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/data/EnrichedDestinationRecordAirbyteValueTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/data/EnrichedDestinationRecordAirbyteValueTest.kt
@@ -32,8 +32,8 @@ class EnrichedDestinationRecordAirbyteValueTest {
         val record =
             EnrichedDestinationRecordAirbyteValue(
                 stream = destinationStream,
-                declaredFields = emptyMap(),
-                undeclaredFields = emptyMap(),
+                declaredFields = linkedMapOf(),
+                undeclaredFields = linkedMapOf(),
                 emittedAtMs = emittedAtMs,
                 meta = null
             )
@@ -79,7 +79,7 @@ class EnrichedDestinationRecordAirbyteValueTest {
     @Test
     fun `test allTypedFields property`() {
         val declaredFields =
-            mapOf(
+            linkedMapOf(
                 "field1" to
                     EnrichedAirbyteValue(
                         StringValue("value1"),
@@ -100,7 +100,7 @@ class EnrichedDestinationRecordAirbyteValueTest {
             EnrichedDestinationRecordAirbyteValue(
                 stream = destinationStream,
                 declaredFields = declaredFields,
-                undeclaredFields = emptyMap(),
+                undeclaredFields = linkedMapOf(),
                 emittedAtMs = emittedAtMs,
                 meta = null
             )
@@ -144,7 +144,7 @@ class EnrichedDestinationRecordAirbyteValueTest {
             )
         field2.nullify(Reason.DESTINATION_FIELD_SIZE_LIMITATION)
 
-        val declaredFields = mapOf("field1" to field1, "field2" to field2)
+        val declaredFields = linkedMapOf("field1" to field1, "field2" to field2)
 
         // Create meta with its own changes
         val meta =
@@ -163,7 +163,7 @@ class EnrichedDestinationRecordAirbyteValueTest {
             EnrichedDestinationRecordAirbyteValue(
                 stream = destinationStream,
                 declaredFields = declaredFields,
-                undeclaredFields = emptyMap(),
+                undeclaredFields = linkedMapOf(),
                 emittedAtMs = emittedAtMs,
                 meta = meta
             )
@@ -215,8 +215,8 @@ class EnrichedDestinationRecordAirbyteValueTest {
         val record1 =
             EnrichedDestinationRecordAirbyteValue(
                 stream = destinationStream,
-                declaredFields = emptyMap(),
-                undeclaredFields = emptyMap(),
+                declaredFields = linkedMapOf(),
+                undeclaredFields = linkedMapOf(),
                 emittedAtMs = emittedAtMs,
                 meta = null
             )
@@ -224,8 +224,8 @@ class EnrichedDestinationRecordAirbyteValueTest {
         val record2 =
             EnrichedDestinationRecordAirbyteValue(
                 stream = destinationStream,
-                declaredFields = emptyMap(),
-                undeclaredFields = emptyMap(),
+                declaredFields = linkedMapOf(),
+                undeclaredFields = linkedMapOf(),
                 emittedAtMs = emittedAtMs,
                 meta = null
             )

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/write/BasicFunctionalityIntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/write/BasicFunctionalityIntegrationTest.kt
@@ -1966,6 +1966,7 @@ abstract class BasicFunctionalityIntegrationTest(
                 // 50000.0000000000000001 can't be represented as a standard float64,
                 // and gets rounded off.
                 // 1e39 is greater than the typical max 1e39-1 for database/warehouse destinations
+                // (decimal points are to force jackson to recognize it as a decimal)
                 makeRecord(
                     """
                         {
@@ -1973,7 +1974,7 @@ abstract class BasicFunctionalityIntegrationTest(
                           "struct": {"foo": 50000.0000000000000001},
                           "number": 50000.0000000000000001,
                           "integer": 99999999999999999999999999999999,
-                          "number": 1e39
+                          "number": 1.0000000000000000000000000000000000000000e39
                         }
                     """.trimIndent(),
                 ),
@@ -2002,7 +2003,7 @@ abstract class BasicFunctionalityIntegrationTest(
                     """
                         {
                           "id": 6,
-                          "number": -2e39,
+                          "number": -2.0000000000000000000000000000000000000000e39,
                           "integer": -99999999999999999999999999999999
                         }
                     """.trimIndent(),

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/write/BasicFunctionalityIntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/write/BasicFunctionalityIntegrationTest.kt
@@ -89,6 +89,8 @@ data class StronglyTyped(
     val nestedFloatLosesPrecision: Boolean = true,
     /** Whether the destination supports integers larger than int64 */
     val integerCanBeLarge: Boolean = true,
+    /** Whether the destination supports numbers larger than 1e39-1 */
+    val numberCanBeLarge: Boolean = true,
 ) : AllTypesBehavior
 
 data object Untyped : AllTypesBehavior
@@ -1963,13 +1965,15 @@ abstract class BasicFunctionalityIntegrationTest(
                 // 99999999999999999999999999999999 is out of range for int64.
                 // 50000.0000000000000001 can't be represented as a standard float64,
                 // and gets rounded off.
+                // 1e39 is greater than the typical max 1e39-1 for database/warehouse destinations
                 makeRecord(
                     """
                         {
                           "id": 4,
                           "struct": {"foo": 50000.0000000000000001},
                           "number": 50000.0000000000000001,
-                          "integer": 99999999999999999999999999999999
+                          "integer": 99999999999999999999999999999999,
+                          "number": 1e39
                         }
                     """.trimIndent(),
                 ),
@@ -1992,10 +1996,13 @@ abstract class BasicFunctionalityIntegrationTest(
                 ),
                 // Another record that verifies numeric behavior.
                 // -99999999999999999999999999999999 is out of range for int64.
+                // -1e39 is out of range for many database/warehouse destinations,
+                // where the maximum precision of a numeric type is 38.
                 makeRecord(
                     """
                         {
                           "id": 6,
+                          "number": -2e39,
                           "integer": -99999999999999999999999999999999
                         }
                     """.trimIndent(),
@@ -2044,6 +2051,9 @@ abstract class BasicFunctionalityIntegrationTest(
         val positiveBigInt: BigInteger?
         val bigIntChanges: List<Change>
         val negativeBigInt: BigInteger?
+        val positiveBigNumber: BigDecimal?
+        val bigNumberChanges: List<Change>
+        val negativeBigNumber: BigDecimal?
         val badValuesData: Map<String, Any?>
         val badValuesChanges: MutableList<Change>
         when (allTypesBehavior) {
@@ -2074,6 +2084,26 @@ abstract class BasicFunctionalityIntegrationTest(
                         listOf(
                             Change(
                                 "integer",
+                                AirbyteRecordMessageMetaChange.Change.NULLED,
+                                AirbyteRecordMessageMetaChange.Reason
+                                    .DESTINATION_FIELD_SIZE_LIMITATION,
+                            )
+                        )
+                    }
+                if (allTypesBehavior.numberCanBeLarge) {
+                    positiveBigNumber = BigDecimal("1e39")
+                    negativeBigNumber = BigDecimal("-2e39")
+                } else {
+                    positiveBigNumber = null
+                    negativeBigNumber = null
+                }
+                bigNumberChanges =
+                    if (allTypesBehavior.numberCanBeLarge) {
+                        emptyList()
+                    } else {
+                        listOf(
+                            Change(
+                                "number",
                                 AirbyteRecordMessageMetaChange.Change.NULLED,
                                 AirbyteRecordMessageMetaChange.Reason
                                     .DESTINATION_FIELD_SIZE_LIMITATION,
@@ -2124,6 +2154,9 @@ abstract class BasicFunctionalityIntegrationTest(
                 positiveBigInt = BigInteger("99999999999999999999999999999999")
                 negativeBigInt = BigInteger("-99999999999999999999999999999999")
                 bigIntChanges = emptyList()
+                positiveBigNumber = BigDecimal("1e39")
+                negativeBigNumber = BigDecimal("-2e39")
+                bigNumberChanges = emptyList()
                 badValuesData =
                     // note that the values have different types than what's declared in the schema
                     mapOf(
@@ -2197,8 +2230,10 @@ abstract class BasicFunctionalityIntegrationTest(
                             "struct" to schematizedObject(linkedMapOf("foo" to nestedFloat)),
                             "number" to topLevelFloat,
                             "integer" to positiveBigInt,
+                            "number" to positiveBigNumber,
                         ),
-                    airbyteMeta = OutputRecord.Meta(syncId = 42, changes = bigIntChanges),
+                    airbyteMeta =
+                        OutputRecord.Meta(syncId = 42, changes = bigNumberChanges + bigIntChanges),
                 ),
                 OutputRecord(
                     extractedAt = 100,
@@ -2213,8 +2248,10 @@ abstract class BasicFunctionalityIntegrationTest(
                         mapOf(
                             "id" to 6,
                             "integer" to negativeBigInt,
+                            "number" to negativeBigNumber,
                         ),
-                    airbyteMeta = OutputRecord.Meta(syncId = 42, changes = bigIntChanges),
+                    airbyteMeta =
+                        OutputRecord.Meta(syncId = 42, changes = bigNumberChanges + bigIntChanges),
                 ),
                 OutputRecord(
                     extractedAt = 100,

--- a/airbyte-integrations/connectors/destination-mssql/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-mssql/metadata.yaml
@@ -16,7 +16,7 @@ data:
             type: GSM
   connectorType: destination
   definitionId: d4353156-9217-4cad-8dd7-c108fd4f74cf
-  dockerImageTag: 2.2.5
+  dockerImageTag: 2.2.6
   dockerRepository: airbyte/destination-mssql
   documentationUrl: https://docs.airbyte.com/integrations/destinations/mssql
   githubIssueLabel: destination-mssql

--- a/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLCsvRowGenerator.kt
+++ b/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLCsvRowGenerator.kt
@@ -7,6 +7,7 @@ package io.airbyte.integrations.destination.mssql.v2
 import io.airbyte.cdk.load.data.ArrayType
 import io.airbyte.cdk.load.data.BooleanType
 import io.airbyte.cdk.load.data.BooleanValue
+import io.airbyte.cdk.load.data.EnrichedAirbyteValue
 import io.airbyte.cdk.load.data.IntegerType
 import io.airbyte.cdk.load.data.IntegerValue
 import io.airbyte.cdk.load.data.NullValue
@@ -24,6 +25,7 @@ import io.airbyte.cdk.load.data.csv.toCsvValue
 import io.airbyte.cdk.load.message.DestinationRecordRaw
 import io.airbyte.cdk.load.util.serializeToString
 import io.airbyte.protocol.models.v0.AirbyteRecordMessageMetaChange.Reason
+import java.math.BigDecimal
 import java.math.BigInteger
 import java.time.format.DateTimeFormatter
 
@@ -31,9 +33,31 @@ object LIMITS {
     // Maximum value for BIGINT in SQL Server
     val MAX_BIGINT = BigInteger("9223372036854775807")
     val MIN_BIGINT = BigInteger("-9223372036854775808")
+    val MAX_NUMERIC: BigDecimal = BigDecimal("1e38").minus(BigDecimal.ONE).divide(BigDecimal("1e8"))
+    val MIN_NUMERIC: BigDecimal = BigDecimal("-1e39").divide(BigDecimal("1e8"))
 
     val TRUE = IntegerValue(1)
     val FALSE = IntegerValue(0)
+
+    fun validateNumber(value: EnrichedAirbyteValue): BigDecimal? {
+        val numValue = (value.abValue as NumberValue).value
+        return if (numValue < MIN_NUMERIC || MAX_NUMERIC < numValue) {
+            value.nullify(Reason.DESTINATION_FIELD_SIZE_LIMITATION)
+            null
+        } else {
+            return numValue
+        }
+    }
+
+    fun validateInteger(value: EnrichedAirbyteValue): BigInteger? {
+        val intValue = (value.abValue as IntegerValue).value
+        return if (intValue < MIN_BIGINT || MAX_BIGINT < intValue) {
+            value.nullify(Reason.DESTINATION_FIELD_SIZE_LIMITATION)
+            null
+        } else {
+            intValue
+        }
+    }
 }
 
 /**
@@ -60,21 +84,8 @@ class MSSQLCsvRowGenerator(private val validateValuesPreLoad: Boolean) {
                 val actualValue = value.abValue
                 when (value.type) {
                     // Enforce numeric range
-                    is IntegerType -> {
-                        if (
-                            (actualValue as IntegerValue).value < LIMITS.MIN_BIGINT ||
-                                LIMITS.MAX_BIGINT < actualValue.value
-                        ) {
-                            value.nullify(Reason.DESTINATION_FIELD_SIZE_LIMITATION)
-                        }
-                    }
-                    is NumberType -> {
-                        // Force to BigDecimal -> re-box as NumberValue
-                        value.abValue =
-                            NumberValue(
-                                (actualValue as NumberValue).value.toDouble().toBigDecimal()
-                            )
-                    }
+                    is IntegerType -> LIMITS.validateInteger(value)
+                    is NumberType -> LIMITS.validateNumber(value)
 
                     // SQL server expects booleans as 0 or 1
                     is BooleanType ->

--- a/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLCsvRowGenerator.kt
+++ b/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLCsvRowGenerator.kt
@@ -33,8 +33,11 @@ object LIMITS {
     // Maximum value for BIGINT in SQL Server
     val MAX_BIGINT = BigInteger("9223372036854775807")
     val MIN_BIGINT = BigInteger("-9223372036854775808")
-    val MAX_NUMERIC: BigDecimal = BigDecimal("1e38").minus(BigDecimal.ONE).divide(BigDecimal("1e8"))
-    val MIN_NUMERIC: BigDecimal = BigDecimal("-1e39").divide(BigDecimal("1e8"))
+
+    // see MssqlType. We currently use precision=38, scale=8.
+    private val NUMERIC_SCALE = BigDecimal("1e8")
+    val MAX_NUMERIC: BigDecimal = BigDecimal("1e38").minus(BigDecimal.ONE).divide(NUMERIC_SCALE)
+    val MIN_NUMERIC: BigDecimal = BigDecimal("-1e38").plus(BigDecimal.ONE).divide(NUMERIC_SCALE)
 
     val TRUE = IntegerValue(1)
     val FALSE = IntegerValue(0)

--- a/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/convert/AirbyteTypeToMssqlType.kt
+++ b/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/convert/AirbyteTypeToMssqlType.kt
@@ -21,6 +21,7 @@ import io.airbyte.cdk.load.data.TimestampTypeWithTimezone
 import io.airbyte.cdk.load.data.TimestampTypeWithoutTimezone
 import io.airbyte.cdk.load.data.UnionType
 import io.airbyte.cdk.load.data.UnknownType
+import io.airbyte.integrations.destination.mssql.v2.LIMITS
 import java.sql.Types
 
 enum class MssqlType(val sqlType: Int, val sqlStringOverride: String? = null) {
@@ -28,6 +29,10 @@ enum class MssqlType(val sqlType: Int, val sqlStringOverride: String? = null) {
     BIT(Types.BOOLEAN),
     DATE(Types.DATE),
     BIGINT(Types.BIGINT),
+    /**
+     * if you change the numeric precision/scale, remember to also update [LIMITS.MAX_NUMERIC] /
+     * [LIMITS.MIN_NUMERIC]
+     */
     DECIMAL(Types.DECIMAL, sqlStringOverride = "DECIMAL(38, 8)"),
     VARCHAR(Types.VARCHAR, sqlStringOverride = "VARCHAR(MAX)"),
     VARCHAR_INDEX(Types.VARCHAR, sqlStringOverride = "VARCHAR(200)"),

--- a/airbyte-integrations/connectors/destination-mssql/src/test-integration/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLWriterTest.kt
+++ b/airbyte-integrations/connectors/destination-mssql/src/test-integration/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLWriterTest.kt
@@ -66,7 +66,11 @@ abstract class MSSQLWriterTest(
         supportFileTransfer = false,
         commitDataIncrementally = true,
         allTypesBehavior =
-            StronglyTyped(integerCanBeLarge = false, nestedFloatLosesPrecision = false),
+            StronglyTyped(
+                integerCanBeLarge = false,
+                numberCanBeLarge = false,
+                nestedFloatLosesPrecision = false,
+            ),
         unknownTypesBehavior = UnknownTypesBehavior.SERIALIZE,
         nullEqualsUnset = true,
         configUpdater = configUpdater,
@@ -264,8 +268,8 @@ internal class StandardInsert :
     ) {
 
     @Test
-    override fun testUnknownTypes() {
-        super.testUnknownTypes()
+    override fun testBasicTypes() {
+        super.testBasicTypes()
     }
 
     companion object {
@@ -302,6 +306,11 @@ internal class BulkInsert :
                     )
             ) { spec -> MSSQLConfigurationFactory().makeWithOverrides(spec, emptyMap()) },
     ) {
+    @Test
+    override fun testBasicTypes() {
+        super.testBasicTypes()
+    }
+
     companion object {
         const val CONFIG_FILE = "secrets/bulk_upload_config.json"
     }

--- a/airbyte-integrations/connectors/destination-s3-data-lake/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/metadata.yaml
@@ -26,7 +26,7 @@ data:
             alias: airbyte-connector-testing-secret-store
   connectorType: destination
   definitionId: 716ca874-520b-4902-9f80-9fad66754b89
-  dockerImageTag: 0.3.26
+  dockerImageTag: 0.3.27
   dockerRepository: airbyte/destination-s3-data-lake
   documentationUrl: https://docs.airbyte.com/integrations/destinations/s3-data-lake
   githubIssueLabel: destination-s3-data-lake

--- a/airbyte-integrations/connectors/destination-s3-data-lake/src/test/kotlin/io/airbyte/integrations/destination/s3_data_lake/io/S3DataLakeUtilTest.kt
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/src/test/kotlin/io/airbyte/integrations/destination/s3_data_lake/io/S3DataLakeUtilTest.kt
@@ -209,7 +209,7 @@ internal class S3DataLakeUtilTest {
             EnrichedDestinationRecordAirbyteValue(
                 stream = airbyteStream,
                 declaredFields =
-                    mapOf(
+                    linkedMapOf(
                         "id" to
                             EnrichedAirbyteValue(
                                 IntegerValue(42L),
@@ -225,7 +225,7 @@ internal class S3DataLakeUtilTest {
                                 airbyteMetaField = null
                             )
                     ),
-                undeclaredFields = emptyMap(),
+                undeclaredFields = linkedMapOf(),
                 emittedAtMs = System.currentTimeMillis(),
                 meta = Meta(),
             )
@@ -270,7 +270,7 @@ internal class S3DataLakeUtilTest {
             EnrichedDestinationRecordAirbyteValue(
                 stream = airbyteStream,
                 declaredFields =
-                    mapOf(
+                    linkedMapOf(
                         "id" to
                             EnrichedAirbyteValue(
                                 IntegerValue(42L),
@@ -293,7 +293,7 @@ internal class S3DataLakeUtilTest {
                                 airbyteMetaField = null,
                             ),
                     ),
-                undeclaredFields = emptyMap(),
+                undeclaredFields = linkedMapOf(),
                 emittedAtMs = System.currentTimeMillis(),
                 meta = Meta(),
             )
@@ -336,7 +336,7 @@ internal class S3DataLakeUtilTest {
             EnrichedDestinationRecordAirbyteValue(
                 stream = airbyteStream,
                 declaredFields =
-                    mapOf(
+                    linkedMapOf(
                         "id" to
                             EnrichedAirbyteValue(
                                 IntegerValue(42L),
@@ -352,7 +352,7 @@ internal class S3DataLakeUtilTest {
                                 airbyteMetaField = null
                             ),
                     ),
-                undeclaredFields = emptyMap(),
+                undeclaredFields = linkedMapOf(),
                 emittedAtMs = System.currentTimeMillis(),
                 meta = Meta(),
             )

--- a/airbyte-integrations/connectors/destination-s3/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-s3/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: file
   connectorType: destination
   definitionId: 4816b78f-1489-44c1-9060-4b19d5fa9362
-  dockerImageTag: 1.7.3
+  dockerImageTag: 1.7.4
   dockerRepository: airbyte/destination-s3
   githubIssueLabel: destination-s3
   icon: s3.svg

--- a/airbyte-integrations/connectors/destination-s3/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2WriteTest.kt
+++ b/airbyte-integrations/connectors/destination-s3/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2WriteTest.kt
@@ -393,6 +393,10 @@ class S3V2WriteTestAvroUncompressed :
         schematizedObjectBehavior = SchematizedNestedValueBehavior.STRONGLY_TYPE,
         schematizedArrayBehavior = SchematizedNestedValueBehavior.STRONGLY_TYPE,
         preserveUndeclaredFields = false,
+        // this is technically false. Avro + parquet do have limits on numbers.
+        // But float64 is weird, in that the actual _limits_ are unreasonably large -
+        // but at that size, you have very little precision.
+        // This is actually covered by the nested/topLevelFloatLosesPrecision test cases.
         allTypesBehavior = StronglyTyped(integerCanBeLarge = false),
         nullEqualsUnset = true,
         unknownTypesBehavior = UnknownTypesBehavior.FAIL,

--- a/docs/integrations/destinations/mssql.md
+++ b/docs/integrations/destinations/mssql.md
@@ -158,6 +158,7 @@ See the [Getting Started: Configuration section](#configuration) of this guide f
 
 | Version    | Date       | Pull Request                                               | Subject                                                                                             |
 |:-----------|:-----------|:-----------------------------------------------------------|:----------------------------------------------------------------------------------------------------|
+| 2.2.6      | 2025-04-21 | [58146](https://github.com/airbytehq/airbyte/pull/58146)   | Fix numeric bounds-handling                                                                         |
 | 2.2.5      | 2025-04-18 | [58140](https://github.com/airbytehq/airbyte/pull/58140)   | Upgrade to latest CDK                                                                               |
 | 2.2.4      | 2025-04-11 | [57563](https://github.com/airbytehq/airbyte/pull/57563)   | Improve BULK INSERT documentation.                                                                  |
 | 2.2.3      | 2025-04-16 | [58085](https://github.com/airbytehq/airbyte/pull/58085)   | Internal refactoring                                                                                |

--- a/docs/integrations/destinations/s3-data-lake.md
+++ b/docs/integrations/destinations/s3-data-lake.md
@@ -307,6 +307,7 @@ Now, you can identify the latest version of the 'Alice' record by querying wheth
 
 | Version | Date       | Pull Request                                               | Subject                                                                        |
 |:--------|:-----------|:-----------------------------------------------------------|:-------------------------------------------------------------------------------|
+| 0.3.27  | 2025-04-21 | [58146](https://github.com/airbytehq/airbyte/pull/58146)   | Upgrade to latest CDK                                                          |
 | 0.3.26  | 2025-04-17 | [58104](https://github.com/airbytehq/airbyte/pull/58104)   | Chore: Now passing a string around for the region                              |
 | 0.3.25  | 2025-04-16 | [58085](https://github.com/airbytehq/airbyte/pull/58085)   | Internal refactoring                                                           |
 | 0.3.24  | 2025-03-27 | [56435](https://github.com/airbytehq/airbyte/pull/56435)   | Bug fix: Correctly handle non-positive numbers.                                |

--- a/docs/integrations/destinations/s3.md
+++ b/docs/integrations/destinations/s3.md
@@ -544,6 +544,7 @@ To see connector limitations, or troubleshoot your S3 connector, see more [in ou
 
 | Version     | Date       | Pull Request                                               | Subject                                                                                                                                              |
 |:------------|:-----------|:-----------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| 1.7.4       | 2025-04-21 | [58146](https://github.com/airbytehq/airbyte/pull/58146)   | Upgrade to latest CDK                                                                                                                                |
 | 1.7.3       | 2025-04-18 | [58140](https://github.com/airbytehq/airbyte/pull/58140)   | Upgrade to latest CDK                                                                                                                                |
 | 1.7.2       | 2025-04-07 | [56391](https://github.com/airbytehq/airbyte/pull/56391)   | Internal code refactor                                                                                                                               |
 | 1.7.1       | 2025-04-02 | [56974](https://github.com/airbytehq/airbyte/pull/56974)   | Nonfunctional change: pin cdk version                                                                                                                |


### PR DESCRIPTION
from https://github.com/airbytehq/airbyte/issues/58061 - our current numeric handling doesn't actually enforce size limitations. Fix that.

Also:
* add test case to catch this
* make EnrichedAirbyteValue actually guarantee field ordering (intellij decided to add commas everywhere, sorry :( )
* bump s3+s3datalake metadata just to trigger their CI - I ran basicTypes locally, but want to rerun everything just in case