### PR TITLE
bigquery nondocker tests

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/DestinationMessage.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/DestinationMessage.kt
@@ -127,8 +127,11 @@ data class Meta(
                 COLUMN_NAME_AB_GENERATION_ID,
             )
 
-        /** A legacy column name. Used in "DV2" destinations' raw tables. */
-        const val COLUMN_NAME_AB_LOADED_AT = "_airbyte_loaded_at"
+        /**
+         * A legacy column name. Destinations with "typing and deduping" used this in the raw tables
+         * to indicate when a record went through T+D.
+         */
+        const val COLUMN_NAME_AB_LOADED_AT: String = "_airbyte_loaded_at"
 
         fun getMetaValue(metaColumnName: String, value: String): AirbyteValue {
             if (!COLUMN_NAMES.contains(metaColumnName)) {

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/DestinationMessage.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/DestinationMessage.kt
@@ -297,16 +297,12 @@ data class EnrichedDestinationRecordAirbyteValue(
 
 data class DestinationRecordRaw(
     val stream: DestinationStream,
-    private val rawData: AirbyteMessage,
-    private val serialized: String,
-    private val schema: AirbyteType
+    val rawData: AirbyteMessage,
+    val serialized: String,
+    val schema: AirbyteType
 ) {
     fun asRawJson(): JsonNode {
         return rawData.record.data
-    }
-
-    fun dangerousMutateData(f: (AirbyteMessage) -> Unit) {
-        f(rawData)
     }
 
     fun asDestinationRecordAirbyteValue(): DestinationRecordAirbyteValue {

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/ExpectedRecordMapper.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/ExpectedRecordMapper.kt
@@ -20,6 +20,14 @@ import java.time.format.DateTimeFormatter
 fun interface ExpectedRecordMapper {
     fun mapRecord(expectedRecord: OutputRecord, schema: AirbyteType): OutputRecord
     fun mapStreamDescriptor(descriptor: DestinationStream.Descriptor) = descriptor
+
+    fun compose(mapper: ExpectedRecordMapper) =
+        object : ExpectedRecordMapper {
+            override fun mapRecord(
+                expectedRecord: OutputRecord,
+                schema: AirbyteType
+            ): OutputRecord = mapper.mapRecord(this.mapRecord(expectedRecord, schema), schema)
+        }
 }
 
 object NoopExpectedRecordMapper : ExpectedRecordMapper {

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/OutputRecord.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/OutputRecord.kt
@@ -43,9 +43,9 @@ data class OutputRecord(
         data: Map<String, Any?>,
         airbyteMeta: Meta?,
     ) : this(
-        UUID.fromString(rawId),
-        Instant.ofEpochMilli(extractedAt),
-        loadedAt?.let { Instant.ofEpochMilli(it) },
+        rawId,
+        extractedAt,
+        loadedAt,
         generationId,
         ObjectValue.from(data),
         airbyteMeta,

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/OutputRecord.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/OutputRecord.kt
@@ -4,6 +4,7 @@
 
 package io.airbyte.cdk.load.test.util
 
+import io.airbyte.cdk.load.data.AirbyteValue
 import io.airbyte.cdk.load.data.ObjectValue
 import io.airbyte.cdk.load.message.Meta.Change
 import java.time.Instant
@@ -47,6 +48,22 @@ data class OutputRecord(
         loadedAt?.let { Instant.ofEpochMilli(it) },
         generationId,
         ObjectValue.from(data),
+        airbyteMeta,
+    )
+
+    constructor(
+        rawId: String,
+        extractedAt: Long,
+        loadedAt: Long?,
+        generationId: Long?,
+        data: AirbyteValue,
+        airbyteMeta: Meta?,
+    ) : this(
+        UUID.fromString(rawId),
+        Instant.ofEpochMilli(extractedAt),
+        loadedAt?.let { Instant.ofEpochMilli(it) },
+        generationId,
+        data as ObjectValue,
         airbyteMeta,
     )
 

--- a/airbyte-cdk/bulk/toolkits/load-db/build.gradle
+++ b/airbyte-cdk/bulk/toolkits/load-db/build.gradle
@@ -2,5 +2,7 @@ dependencies {
     implementation project(':airbyte-cdk:bulk:core:bulk-cdk-core-base')
     implementation project(':airbyte-cdk:bulk:core:bulk-cdk-core-load')
 
+    testFixturesImplementation testFixtures(project(':airbyte-cdk:bulk:core:bulk-cdk-core-load'))
+
     api project(':airbyte-cdk:bulk:toolkits:bulk-cdk-toolkit-load-object-storage')
 }

--- a/airbyte-cdk/bulk/toolkits/load-db/src/testFixtures/kotlin/io/airbyte/cdk/load/toolkits/load/db/orchestration/ColumnNameModifyingMapper.kt
+++ b/airbyte-cdk/bulk/toolkits/load-db/src/testFixtures/kotlin/io/airbyte/cdk/load/toolkits/load/db/orchestration/ColumnNameModifyingMapper.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.load.toolkits.load.db.orchestration
+
+import io.airbyte.cdk.load.data.AirbyteType
+import io.airbyte.cdk.load.data.ObjectValue
+import io.airbyte.cdk.load.orchestration.db.ColumnNameGenerator
+import io.airbyte.cdk.load.test.util.ExpectedRecordMapper
+import io.airbyte.cdk.load.test.util.OutputRecord
+
+class ColumnNameModifyingMapper(private val columnNameGenerator: ColumnNameGenerator) :
+    ExpectedRecordMapper {
+    override fun mapRecord(expectedRecord: OutputRecord, schema: AirbyteType): OutputRecord {
+        val mappedProperties =
+            expectedRecord.data.values.mapKeysTo(linkedMapOf()) { (k, _) ->
+                columnNameGenerator.getColumnName(k).displayName
+            }
+        return expectedRecord.copy(data = ObjectValue(mappedProperties))
+    }
+}

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/formatter/BigQueryRecordFormatter.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/formatter/BigQueryRecordFormatter.kt
@@ -34,7 +34,7 @@ class BigQueryRecordFormatter {
                 Meta.COLUMN_NAME_AB_META -> {
                     // TODO this is a hack for T+D, we should remove it for direct-load tables
                     //   we're completely ignoring the enrichedRecord's meta value, because that
-                    //   includes changes ein-connector type coercion
+                    //   includes changes in-connector type coercion
                     //   and for raw tables, we only want changes that originated from the source
                     if (record.rawData.record.meta == null) {
                         record.rawData.record.meta = AirbyteRecordMessageMeta()

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/formatter/BigQueryRecordFormatter.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/formatter/BigQueryRecordFormatter.kt
@@ -8,11 +8,11 @@ import com.google.cloud.bigquery.QueryParameterValue
 import com.google.cloud.bigquery.Schema
 import com.google.cloud.bigquery.StandardSQLTypeName
 import io.airbyte.cdk.load.data.IntegerValue
-import io.airbyte.cdk.load.data.ObjectValue
 import io.airbyte.cdk.load.data.StringValue
 import io.airbyte.cdk.load.message.DestinationRecordRaw
 import io.airbyte.cdk.load.message.Meta
 import io.airbyte.cdk.load.util.serializeToString
+import io.airbyte.protocol.models.v0.AirbyteRecordMessageMeta
 import java.util.concurrent.TimeUnit
 
 /**
@@ -32,8 +32,21 @@ class BigQueryRecordFormatter {
                     outputRecord[key] = getExtractedAt(extractedAtMillis)
                 }
                 Meta.COLUMN_NAME_AB_META -> {
-                    val serializedAirbyteMeta = (value.abValue as ObjectValue).serializeToString()
-                    outputRecord[key] = serializedAirbyteMeta
+                    // TODO this is a hack for T+D, we should remove it for direct-load tables
+                    //   we're completely ignoring the enrichedRecord's meta value, because that
+                    //   includes changes ein-connector type coercion
+                    //   and for raw tables, we only want changes that originated from the source
+                    if (record.rawData.record.meta == null) {
+                        record.rawData.record.meta = AirbyteRecordMessageMeta()
+                        record.rawData.record.meta.changes = emptyList()
+                    }
+                    record.rawData.record.meta.additionalProperties["sync_id"] =
+                        record.stream.syncId
+                    outputRecord[key] = record.rawData.record.meta.serializeToString()
+                    // TODO we should do this for direct-load tables
+                    // val serializedAirbyteMeta = (value.abValue as
+                    // ObjectValue).serializeToString()
+                    // outputRecord[key] = serializedAirbyteMeta
                 }
                 Meta.COLUMN_NAME_AB_RAW_ID ->
                     outputRecord[key] = (value.abValue as StringValue).value

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/spec/BigqueryConfiguration.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/spec/BigqueryConfiguration.kt
@@ -54,7 +54,12 @@ class BigqueryConfigurationFactory :
             loadingMethodConfig,
             credentialsJson = pojo.credentialsJson,
             pojo.transformationPriority ?: TransformationPriority.INTERACTIVE,
-            rawTableDataset = pojo.rawTableDataset ?: DbConstants.DEFAULT_RAW_TABLE_NAMESPACE,
+            rawTableDataset =
+                if (pojo.rawTableDataset.isNullOrBlank()) {
+                    DbConstants.DEFAULT_RAW_TABLE_NAMESPACE
+                } else {
+                    pojo.rawTableDataset!!
+                },
             disableTypingDeduping = pojo.disableTypingDeduping ?: false,
         )
     }

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/typing_deduping/BigQuerySqlGenerator.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/typing_deduping/BigQuerySqlGenerator.kt
@@ -407,7 +407,7 @@ class BigQuerySqlGenerator(private val projectId: String?, private val datasetLo
                 .asColumns()
                 .map { (fieldName, type) ->
                     val columnName = columnNameMapping[fieldName]!!
-                    val extractAndCast = extractAndCast(columnName, type.type, forceSafeCasting)
+                    val extractAndCast = extractAndCast(fieldName, type.type, forceSafeCasting)
                     "$extractAndCast as `$columnName`,"
                 }
                 .joinToString("\n")
@@ -417,9 +417,8 @@ class BigQuerySqlGenerator(private val projectId: String?, private val datasetLo
                     stream.schema
                         .asColumns()
                         .map { (fieldName, type) ->
-                            val columnName = columnNameMapping[fieldName]!!
                             val rawColName = escapeColumnNameForJsonPath(fieldName)
-                            val jsonExtract = extractAndCast(columnName, type.type, true)
+                            val jsonExtract = extractAndCast(fieldName, type.type, true)
                             // Explicitly parse json here. This is safe because
                             // we're not using the actual value anywhere,
                             // and necessary because json_query

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/bulk_loader/BigQueryObjectStorageFormattingWriter.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/bulk_loader/BigQueryObjectStorageFormattingWriter.kt
@@ -27,7 +27,7 @@ class BigQueryObjectStorageFormattingWriter(
     private val csvFormattingWriter = CSVFormattingWriter(stream, outputStream, rootLevelFlattening)
 
     override fun accept(record: DestinationRecordRaw) {
-        record.dangerousMutateData { it.record.emittedAt *= 1000 }
+        record.rawData.record.emittedAt *= 1000
         csvFormattingWriter.accept(record)
     }
 }

--- a/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigQueryDestinationTestUtils.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigQueryDestinationTestUtils.kt
@@ -39,11 +39,17 @@ object BigQueryDestinationTestUtils {
      * standard inserts mode. Should be randomized per test case.
      */
     @Throws(IOException::class)
-    fun createConfig(configFile: Path?, datasetId: String?, stagingPath: String?): ObjectNode {
+    fun createConfig(
+        configFile: Path?,
+        datasetId: String?,
+        stagingPath: String?,
+        rawDatasetId: String? = null,
+    ): ObjectNode {
         LOGGER.info("Setting default dataset to {}", datasetId)
         val tmpConfigAsString = Files.readString(configFile)
         val config = Jsons.readTree(tmpConfigAsString) as ObjectNode
         config.put(BigQueryConsts.CONFIG_DATASET_ID, datasetId)
+        rawDatasetId?.let { config.put(BigQueryConsts.RAW_DATA_DATASET, rawDatasetId) }
 
         // This is sort of a hack. Ideally tests shouldn't interfere with each other even when using
         // the

--- a/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigQueryDestinationTestUtils.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigQueryDestinationTestUtils.kt
@@ -12,6 +12,7 @@ import com.google.cloud.bigquery.Dataset
 import com.google.cloud.bigquery.DatasetInfo
 import io.airbyte.cdk.load.util.Jsons
 import io.airbyte.integrations.destination.bigquery.BigQueryUtils.getLoadingMethod
+import io.airbyte.integrations.destination.bigquery.spec.BigqueryConfiguration
 import io.airbyte.integrations.destination.bigquery.spec.BigqueryConfigurationFactory
 import io.airbyte.integrations.destination.bigquery.spec.BigquerySpecification
 import io.airbyte.integrations.destination.bigquery.util.BigqueryClientFactory
@@ -83,6 +84,11 @@ object BigQueryDestinationTestUtils {
         return null
     }
 
+    fun parseConfig(config: JsonNode): BigqueryConfiguration {
+        val spec = Jsons.treeToValue(config, BigquerySpecification::class.java)
+        return BigqueryConfigurationFactory().make(spec)
+    }
+
     /**
      * Initialized bigQuery instance that will be used for verifying results of test operations and
      * for cleaning up BigQuery dataset after the test
@@ -93,8 +99,7 @@ object BigQueryDestinationTestUtils {
      */
     @Throws(IOException::class)
     fun initBigQuery(config: JsonNode): BigQuery {
-        val spec = Jsons.treeToValue(config, BigquerySpecification::class.java)
-        val parsedConfig = BigqueryConfigurationFactory().make(spec)
+        val parsedConfig = parseConfig(config)
         return BigqueryClientFactory(parsedConfig).make()
     }
 

--- a/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryDataDumper.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryDataDumper.kt
@@ -25,7 +25,7 @@ import io.airbyte.cdk.load.data.TimestampWithTimezoneValue
 import io.airbyte.cdk.load.data.TimestampWithoutTimezoneValue
 import io.airbyte.cdk.load.data.json.toAirbyteValue
 import io.airbyte.cdk.load.message.Meta
-import io.airbyte.cdk.load.orchestration.legacy_typing_deduping.TypingDedupingUtil
+import io.airbyte.cdk.load.orchestration.db.legacy_typing_deduping.TypingDedupingUtil
 import io.airbyte.cdk.load.test.util.DestinationDataDumper
 import io.airbyte.cdk.load.test.util.OutputRecord
 import io.airbyte.cdk.load.util.Jsons

--- a/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryDataDumper.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryDataDumper.kt
@@ -4,20 +4,27 @@
 
 package io.airbyte.integrations.destination.bigquery
 
+import com.fasterxml.jackson.databind.node.ArrayNode
 import com.google.cloud.bigquery.FieldValueList
 import com.google.cloud.bigquery.QueryJobConfiguration
 import com.google.cloud.bigquery.TableResult
 import io.airbyte.cdk.command.ConfigurationSpecification
 import io.airbyte.cdk.load.command.DestinationStream
+import io.airbyte.cdk.load.data.AirbyteValue
+import io.airbyte.cdk.load.data.json.toAirbyteValue
 import io.airbyte.cdk.load.message.Meta
 import io.airbyte.cdk.load.orchestration.legacy_typing_deduping.TypingDedupingUtil
 import io.airbyte.cdk.load.test.util.DestinationDataDumper
 import io.airbyte.cdk.load.test.util.OutputRecord
+import io.airbyte.cdk.load.util.Jsons
+import io.airbyte.cdk.load.util.deserializeToNode
 import io.airbyte.integrations.destination.bigquery.spec.BigqueryConfigurationFactory
 import io.airbyte.integrations.destination.bigquery.spec.BigquerySpecification
 import io.airbyte.integrations.destination.bigquery.util.BigqueryClientFactory
+import io.airbyte.protocol.models.v0.AirbyteRecordMessageMetaChange
+import io.airbyte.protocol.models.v0.AirbyteRecordMessageMetaChange.Reason
 
-class BigqueryRawTableDataDumper : DestinationDataDumper {
+object BigqueryRawTableDataDumper : DestinationDataDumper {
     override fun dumpRecords(
         spec: ConfigurationSpecification,
         stream: DestinationStream
@@ -32,15 +39,9 @@ class BigqueryRawTableDataDumper : DestinationDataDumper {
                 QueryJobConfiguration.of("SELECT * FROM ${config.rawTableDataset}.$rawTableName")
             )
         return result.iterateAll().map { row: FieldValueList ->
-            OutputRecord(
-                rawId = row.get(Meta.COLUMN_NAME_AB_RAW_ID).stringValue,
-                extractedAt = row.get(Meta.COLUMN_NAME_AB_EXTRACTED_AT).longValue,
-                loadedAt = row.get(Meta.COLUMN_NAME_AB_LOADED_AT).longValue,
-                generationId = row.get(Meta.COLUMN_NAME_AB_GENERATION_ID).longValue,
-                // TODO
-                data = emptyMap(),
-                // TODO
-                airbyteMeta = null,
+            rowToOutputRecord(
+                row,
+                row.get(Meta.COLUMN_NAME_DATA).stringValue.deserializeToNode().toAirbyteValue(),
             )
         }
     }
@@ -54,3 +55,43 @@ class BigqueryRawTableDataDumper : DestinationDataDumper {
 }
 
 // TODO final table dumper
+
+fun rowToOutputRecord(
+    row: FieldValueList,
+    data: AirbyteValue,
+) =
+    OutputRecord(
+        rawId = row.get(Meta.COLUMN_NAME_AB_RAW_ID).stringValue,
+        extractedAt = row.get(Meta.COLUMN_NAME_AB_EXTRACTED_AT).timestampInstant.toEpochMilli(),
+        // loadedAt is nullable (e.g. if we disabled T+D, then it will always be null)
+        loadedAt =
+            row.get(Meta.COLUMN_NAME_AB_LOADED_AT).let {
+                if (it.isNull) {
+                    null
+                } else {
+                    it.timestampInstant.toEpochMilli()
+                }
+            },
+        generationId = row.get(Meta.COLUMN_NAME_AB_GENERATION_ID).longValue,
+        data = data,
+        airbyteMeta = stringToMeta(row.get(Meta.COLUMN_NAME_AB_META).stringValue),
+    )
+
+fun stringToMeta(metaAsString: String): OutputRecord.Meta {
+    val metaJson = Jsons.readTree(metaAsString)
+
+    val changes =
+        (metaJson["changes"] as ArrayNode).map { change ->
+            Meta.Change(
+                field = change["field"].textValue(),
+                change =
+                    AirbyteRecordMessageMetaChange.Change.fromValue(change["change"].textValue()),
+                reason = Reason.fromValue(change["reason"].textValue()),
+            )
+        }
+
+    return OutputRecord.Meta(
+        changes = changes,
+        syncId = metaJson["sync_id"].longValue(),
+    )
+}

--- a/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryDataDumper.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryDataDumper.kt
@@ -5,12 +5,23 @@
 package io.airbyte.integrations.destination.bigquery
 
 import com.fasterxml.jackson.databind.node.ArrayNode
+import com.google.cloud.bigquery.FieldValue
 import com.google.cloud.bigquery.FieldValueList
+import com.google.cloud.bigquery.LegacySQLTypeName
 import com.google.cloud.bigquery.QueryJobConfiguration
 import com.google.cloud.bigquery.TableResult
 import io.airbyte.cdk.command.ConfigurationSpecification
 import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.data.AirbyteValue
+import io.airbyte.cdk.load.data.BooleanValue
+import io.airbyte.cdk.load.data.DateValue
+import io.airbyte.cdk.load.data.IntegerValue
+import io.airbyte.cdk.load.data.NumberValue
+import io.airbyte.cdk.load.data.ObjectValue
+import io.airbyte.cdk.load.data.StringValue
+import io.airbyte.cdk.load.data.TimeWithoutTimezoneValue
+import io.airbyte.cdk.load.data.TimestampWithTimezoneValue
+import io.airbyte.cdk.load.data.TimestampWithoutTimezoneValue
 import io.airbyte.cdk.load.data.json.toAirbyteValue
 import io.airbyte.cdk.load.message.Meta
 import io.airbyte.cdk.load.orchestration.legacy_typing_deduping.TypingDedupingUtil
@@ -23,6 +34,9 @@ import io.airbyte.integrations.destination.bigquery.spec.BigquerySpecification
 import io.airbyte.integrations.destination.bigquery.util.BigqueryClientFactory
 import io.airbyte.protocol.models.v0.AirbyteRecordMessageMetaChange
 import io.airbyte.protocol.models.v0.AirbyteRecordMessageMetaChange.Reason
+import java.math.BigDecimal
+import java.time.ZoneOffset
+import java.util.LinkedHashMap
 
 object BigqueryRawTableDataDumper : DestinationDataDumper {
     override fun dumpRecords(
@@ -31,6 +45,7 @@ object BigqueryRawTableDataDumper : DestinationDataDumper {
     ): List<OutputRecord> {
         val config = BigqueryConfigurationFactory().make(spec as BigquerySpecification)
         val bigquery = BigqueryClientFactory(config).make()
+        // TODO handle special characters
         val namespace = stream.descriptor.namespace ?: config.datasetId
         val rawTableName =
             TypingDedupingUtil.concatenateRawTableName(namespace, stream.descriptor.name)
@@ -39,9 +54,23 @@ object BigqueryRawTableDataDumper : DestinationDataDumper {
                 QueryJobConfiguration.of("SELECT * FROM ${config.rawTableDataset}.$rawTableName")
             )
         return result.iterateAll().map { row: FieldValueList ->
-            rowToOutputRecord(
-                row,
-                row.get(Meta.COLUMN_NAME_DATA).stringValue.deserializeToNode().toAirbyteValue(),
+            OutputRecord(
+                rawId = row.get(Meta.COLUMN_NAME_AB_RAW_ID).stringValue,
+                extractedAt =
+                    row.get(Meta.COLUMN_NAME_AB_EXTRACTED_AT).timestampInstant.toEpochMilli(),
+                // loadedAt is nullable (e.g. if we disabled T+D, then it will always be null)
+                loadedAt =
+                    row.get(Meta.COLUMN_NAME_AB_LOADED_AT).let {
+                        if (it.isNull) {
+                            null
+                        } else {
+                            it.timestampInstant.toEpochMilli()
+                        }
+                    },
+                generationId = row.get(Meta.COLUMN_NAME_AB_GENERATION_ID).longValue,
+                data =
+                    row.get(Meta.COLUMN_NAME_DATA).stringValue.deserializeToNode().toAirbyteValue(),
+                airbyteMeta = stringToMeta(row.get(Meta.COLUMN_NAME_AB_META).stringValue),
             )
         }
     }
@@ -54,28 +83,72 @@ object BigqueryRawTableDataDumper : DestinationDataDumper {
     }
 }
 
-// TODO final table dumper
+object BigqueryFinalTableDataDumper : DestinationDataDumper {
+    override fun dumpRecords(
+        spec: ConfigurationSpecification,
+        stream: DestinationStream
+    ): List<OutputRecord> {
+        val config = BigqueryConfigurationFactory().make(spec as BigquerySpecification)
+        val bigquery = BigqueryClientFactory(config).make()
+        // TODO handle special characters
+        val namespace = stream.descriptor.namespace ?: config.datasetId
+        val name = stream.descriptor.name
+        val result: TableResult =
+            bigquery.query(QueryJobConfiguration.of("SELECT * FROM $namespace.$name"))
+        return result.iterateAll().map { row: FieldValueList ->
+            val valuesMap: LinkedHashMap<String, AirbyteValue> =
+                result.schema!!
+                    .fields
+                    .filter { field -> !Meta.COLUMN_NAMES.contains(field.name) }
+                    .associateTo(linkedMapOf()) { field ->
+                        val value: FieldValue = row.get(field.name)
+                        val airbyteValue =
+                            when (field.type) {
+                                LegacySQLTypeName.BOOLEAN -> BooleanValue(value.booleanValue)
+                                LegacySQLTypeName.BIGNUMERIC -> NumberValue(value.numericValue)
+                                LegacySQLTypeName.FLOAT ->
+                                    NumberValue(BigDecimal(value.doubleValue))
+                                LegacySQLTypeName.NUMERIC -> NumberValue(value.numericValue)
+                                LegacySQLTypeName.INTEGER -> IntegerValue(value.longValue)
+                                LegacySQLTypeName.STRING -> StringValue(value.stringValue)
+                                // TODO check these
+                                LegacySQLTypeName.DATE -> DateValue(value.stringValue)
+                                LegacySQLTypeName.DATETIME ->
+                                    TimestampWithoutTimezoneValue(value.stringValue)
+                                LegacySQLTypeName.TIME ->
+                                    TimeWithoutTimezoneValue(value.stringValue)
+                                LegacySQLTypeName.TIMESTAMP ->
+                                    TimestampWithTimezoneValue(
+                                        value.timestampInstant.atOffset(ZoneOffset.UTC)
+                                    )
+                                LegacySQLTypeName.JSON ->
+                                    value.stringValue.deserializeToNode().toAirbyteValue()
+                                else ->
+                                    throw UnsupportedOperationException(
+                                        "Bigquery data dumper doesn't know how to dump type ${field.type} with value $value"
+                                    )
+                            }
+                        field.name to airbyteValue
+                    }
+            OutputRecord(
+                rawId = row.get(Meta.COLUMN_NAME_AB_RAW_ID).stringValue,
+                extractedAt =
+                    row.get(Meta.COLUMN_NAME_AB_EXTRACTED_AT).timestampInstant.toEpochMilli(),
+                loadedAt = null,
+                generationId = row.get(Meta.COLUMN_NAME_AB_GENERATION_ID).longValue,
+                data = ObjectValue(valuesMap),
+                airbyteMeta = stringToMeta(row.get(Meta.COLUMN_NAME_AB_META).stringValue),
+            )
+        }
+    }
 
-fun rowToOutputRecord(
-    row: FieldValueList,
-    data: AirbyteValue,
-) =
-    OutputRecord(
-        rawId = row.get(Meta.COLUMN_NAME_AB_RAW_ID).stringValue,
-        extractedAt = row.get(Meta.COLUMN_NAME_AB_EXTRACTED_AT).timestampInstant.toEpochMilli(),
-        // loadedAt is nullable (e.g. if we disabled T+D, then it will always be null)
-        loadedAt =
-            row.get(Meta.COLUMN_NAME_AB_LOADED_AT).let {
-                if (it.isNull) {
-                    null
-                } else {
-                    it.timestampInstant.toEpochMilli()
-                }
-            },
-        generationId = row.get(Meta.COLUMN_NAME_AB_GENERATION_ID).longValue,
-        data = data,
-        airbyteMeta = stringToMeta(row.get(Meta.COLUMN_NAME_AB_META).stringValue),
-    )
+    override fun dumpFile(
+        spec: ConfigurationSpecification,
+        stream: DestinationStream
+    ): Map<String, String> {
+        throw NotImplementedError("Bigquery doesn't support file transfer")
+    }
+}
 
 fun stringToMeta(metaAsString: String): OutputRecord.Meta {
     val metaJson = Jsons.readTree(metaAsString)

--- a/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryDataDumper.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryDataDumper.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination.bigquery
+
+import com.google.cloud.bigquery.FieldValueList
+import com.google.cloud.bigquery.QueryJobConfiguration
+import com.google.cloud.bigquery.TableResult
+import io.airbyte.cdk.command.ConfigurationSpecification
+import io.airbyte.cdk.load.command.DestinationStream
+import io.airbyte.cdk.load.message.Meta
+import io.airbyte.cdk.load.orchestration.legacy_typing_deduping.TypingDedupingUtil
+import io.airbyte.cdk.load.test.util.DestinationDataDumper
+import io.airbyte.cdk.load.test.util.OutputRecord
+import io.airbyte.integrations.destination.bigquery.spec.BigqueryConfigurationFactory
+import io.airbyte.integrations.destination.bigquery.spec.BigquerySpecification
+import io.airbyte.integrations.destination.bigquery.util.BigqueryClientFactory
+
+class BigqueryRawTableDataDumper : DestinationDataDumper {
+    override fun dumpRecords(
+        spec: ConfigurationSpecification,
+        stream: DestinationStream
+    ): List<OutputRecord> {
+        val config = BigqueryConfigurationFactory().make(spec as BigquerySpecification)
+        val bigquery = BigqueryClientFactory(config).make()
+        val namespace = stream.descriptor.namespace ?: config.datasetId
+        val rawTableName =
+            TypingDedupingUtil.concatenateRawTableName(namespace, stream.descriptor.name)
+        val result: TableResult =
+            bigquery.query(
+                QueryJobConfiguration.of("SELECT * FROM ${config.rawTableDataset}.$rawTableName")
+            )
+        return result.iterateAll().map { row: FieldValueList ->
+            OutputRecord(
+                rawId = row.get(Meta.COLUMN_NAME_AB_RAW_ID).stringValue,
+                extractedAt = row.get(Meta.COLUMN_NAME_AB_EXTRACTED_AT).longValue,
+                loadedAt = row.get(Meta.COLUMN_NAME_AB_LOADED_AT).longValue,
+                generationId = row.get(Meta.COLUMN_NAME_AB_GENERATION_ID).longValue,
+                // TODO
+                data = emptyMap(),
+                // TODO
+                airbyteMeta = null,
+            )
+        }
+    }
+
+    override fun dumpFile(
+        spec: ConfigurationSpecification,
+        stream: DestinationStream
+    ): Map<String, String> {
+        throw NotImplementedError("Bigquery doesn't support file transfer")
+    }
+}
+
+// TODO final table dumper

--- a/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryDestinationCleaner.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryDestinationCleaner.kt
@@ -11,12 +11,10 @@ import io.airbyte.cdk.load.test.util.DestinationCleaner
 import io.airbyte.cdk.load.test.util.IntegrationTest
 import io.airbyte.integrations.destination.bigquery.util.BigqueryClientFactory
 import io.github.oshai.kotlinlogging.KotlinLogging
-import java.nio.file.Path
 import java.time.Duration
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
-import org.junit.jupiter.api.Test
 
 private val logger = KotlinLogging.logger {}
 
@@ -141,19 +139,5 @@ class BigqueryDestinationCleaner(private val configJson: JsonNode) : Destination
                 "tdtest_",
                 "test_deleteme_",
             )
-    }
-}
-
-class Foo {
-    @Test
-    fun foo() {
-        val config =
-            BigQueryDestinationTestUtils.createConfig(
-                configFile = Path.of("secrets/credentials-1s1t-standard-raw-override.json"),
-                datasetId = DEFAULT_NAMESPACE_PLACEHOLDER,
-                stagingPath = "test_path/$DEFAULT_NAMESPACE_PLACEHOLDER",
-            )
-        val cleaner = BigqueryDestinationCleaner(config)
-        cleaner.cleanup()
     }
 }

--- a/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryDestinationCleaner.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryDestinationCleaner.kt
@@ -117,13 +117,6 @@ class BigqueryDestinationCleaner(private val configJson: JsonNode) : Destination
 
         // some older tests used these table/dataset name prefixes.
         // might as well clean them up while we're here.
-        private val tableNamePrefixesToDelete =
-            listOf(
-                "_99namespace",
-                "_airbyte_tmp",
-                "tdtest_",
-                "typing_deduping_test",
-            )
         private val datasetNamePrefixesToDelete =
             listOf(
                 "99namespace",
@@ -139,5 +132,11 @@ class BigqueryDestinationCleaner(private val configJson: JsonNode) : Destination
                 "tdtest_",
                 "test_deleteme_",
             )
+        private val tableNamePrefixesToDelete =
+            listOf(
+                "_99namespace",
+                "_airbyte_tmp",
+                "typing_deduping_test",
+            ) + datasetNamePrefixesToDelete
     }
 }

--- a/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryDestinationCleaner.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryDestinationCleaner.kt
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination.bigquery
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.google.cloud.bigquery.BigQuery
+import com.google.cloud.bigquery.BigQueryException
+import io.airbyte.cdk.load.test.util.DestinationCleaner
+import io.airbyte.cdk.load.test.util.IntegrationTest
+import io.airbyte.integrations.destination.bigquery.util.BigqueryClientFactory
+import io.github.oshai.kotlinlogging.KotlinLogging
+import java.nio.file.Path
+import java.time.Duration
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+
+private val logger = KotlinLogging.logger {}
+
+class BigqueryDestinationCleaner(private val configJson: JsonNode) : DestinationCleaner {
+    override fun cleanup() {
+        val config = BigQueryDestinationTestUtils.parseConfig(configJson)
+        val bigquery = BigqueryClientFactory(config).make()
+
+        val oldThreshold = System.currentTimeMillis() - Duration.ofDays(RETENTION_DAYS).toMillis()
+
+        runBlocking(Dispatchers.IO) {
+            logger.info { "Cleaning up old raw tables in ${config.rawTableDataset}" }
+
+            var rawTables = bigquery.listTables(config.rawTableDataset)
+            // Page.iterateAll is _really_ slow, even if the interior function is `launch`-ed.
+            // Manually page through, and launch all the deletion work, so that we're always
+            // fetching new pages.
+            while (true) {
+                launch {
+                    rawTables.values.forEach { table ->
+                        val tableName = table.tableId.table
+                        // in raw tables, we embed the namespace into the table name.
+                        // so we have to call isNamespaceOld on the table name.
+                        if (
+                            IntegrationTest.isNamespaceOld(
+                                tableName,
+                                retentionDays = RETENTION_DAYS
+                            ) ||
+                                (tableNamePrefixesToDelete.any { tableName.startsWith(it) } &&
+                                    table.creationTime < oldThreshold)
+                        ) {
+                            launch {
+                                logger.info { "Deleting table ${table.tableId}" }
+                                try {
+                                    table.delete()
+                                } catch (e: BigQueryException) {
+                                    // ignore exception
+                                    // e.g. someone else might be running tests at the same time,
+                                    // and deleted this table before we got to it
+                                }
+                            }
+                        }
+                    }
+                }
+                if (rawTables.hasNextPage()) {
+                    rawTables = rawTables.nextPage
+                } else {
+                    break
+                }
+            }
+
+            logger.info { "Cleaning up old datasets in ${config.projectId}" }
+            var datasets = bigquery.listDatasets(config.projectId)
+            while (true) {
+                launch {
+                    datasets.values.forEach { plainDataset ->
+                        val datasetName = plainDataset.datasetId.dataset
+                        // listDatasets doesn't fetch all the dataset information.
+                        // we have to manually load the creationTime field.
+                        val dataset =
+                            plainDataset.reload(
+                                BigQuery.DatasetOption.fields(BigQuery.DatasetField.CREATION_TIME)
+                            )
+                        if (
+                            IntegrationTest.isNamespaceOld(
+                                datasetName,
+                                retentionDays = RETENTION_DAYS
+                            ) ||
+                                (datasetNamePrefixesToDelete.any { datasetName.startsWith(it) } &&
+                                    dataset.creationTime < oldThreshold)
+                        ) {
+                            launch {
+                                logger.info { "Deleting dataset ${dataset.datasetId}" }
+                                try {
+                                    dataset.delete(BigQuery.DatasetDeleteOption.deleteContents())
+                                } catch (e: BigQueryException) {
+                                    // ignore exception.
+                                    // there are some test-generated datasets that our test user
+                                    // doesn't have permissions on, for... some reason
+                                    // or maybe someone else is running tests at the same time as
+                                    // us, and we're racing to delete these datasets.
+                                }
+                            }
+                        }
+                    }
+                }
+                if (datasets.hasNextPage()) {
+                    datasets = datasets.nextPage
+                } else {
+                    break
+                }
+            }
+        }
+    }
+
+    companion object {
+        // set a more aggressive retention policy.
+        // bigquery is _really_ slow at listing datasets/tables.
+        const val RETENTION_DAYS = 7L
+
+        // some older tests used these table/dataset name prefixes.
+        // might as well clean them up while we're here.
+        private val tableNamePrefixesToDelete =
+            listOf(
+                "_99namespace",
+                "_airbyte_tmp",
+                "tdtest_",
+                "typing_deduping_test",
+            )
+        private val datasetNamePrefixesToDelete =
+            listOf(
+                "99namespace",
+                "airbyte_source_namespace_",
+                "airbyte_tests_",
+                "bq_dest_integration_test_",
+                "dest_1001_namespace_",
+                "diff_sourcenamespace_",
+                "namespace_with_special_character",
+                "raw_namespace_",
+                "sourcenamespace_",
+                "sql_generator_test_",
+                "tdtest_",
+                "test_deleteme_",
+            )
+    }
+}
+
+class Foo {
+    @Test
+    fun foo() {
+        val config =
+            BigQueryDestinationTestUtils.createConfig(
+                configFile = Path.of("secrets/credentials-1s1t-standard-raw-override.json"),
+                datasetId = DEFAULT_NAMESPACE_PLACEHOLDER,
+                stagingPath = "test_path/$DEFAULT_NAMESPACE_PLACEHOLDER",
+            )
+        val cleaner = BigqueryDestinationCleaner(config)
+        cleaner.cleanup()
+    }
+}

--- a/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryWriteTest.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryWriteTest.kt
@@ -5,7 +5,6 @@
 package io.airbyte.integrations.destination.bigquery
 
 import io.airbyte.cdk.load.test.util.DestinationDataDumper
-import io.airbyte.cdk.load.test.util.FakeDataDumper
 import io.airbyte.cdk.load.test.util.NoopDestinationCleaner
 import io.airbyte.cdk.load.util.serializeToString
 import io.airbyte.cdk.load.write.BasicFunctionalityIntegrationTest
@@ -74,7 +73,7 @@ class StandardInsertRawOverride :
                 stagingPath = "test_path/$DEFAULT_NAMESPACE_PLACEHOLDER",
             )
             .serializeToString(),
-        FakeDataDumper,
+        BigqueryFinalTableDataDumper,
         preserveUndeclaredFields = false,
     ) {
     @Test
@@ -108,7 +107,7 @@ class GcsRawOverride :
                 stagingPath = "test_path/$DEFAULT_NAMESPACE_PLACEHOLDER",
             )
             .serializeToString(),
-        FakeDataDumper,
+        BigqueryFinalTableDataDumper,
         preserveUndeclaredFields = false,
     ) {
     @Test

--- a/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryWriteTest.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryWriteTest.kt
@@ -5,7 +5,10 @@
 package io.airbyte.integrations.destination.bigquery
 
 import io.airbyte.cdk.load.test.util.DestinationDataDumper
+import io.airbyte.cdk.load.test.util.ExpectedRecordMapper
 import io.airbyte.cdk.load.test.util.NoopDestinationCleaner
+import io.airbyte.cdk.load.test.util.NoopExpectedRecordMapper
+import io.airbyte.cdk.load.test.util.UncoercedExpectedRecordMapper
 import io.airbyte.cdk.load.util.serializeToString
 import io.airbyte.cdk.load.write.BasicFunctionalityIntegrationTest
 import io.airbyte.cdk.load.write.SchematizedNestedValueBehavior
@@ -18,15 +21,18 @@ import org.junit.jupiter.api.Test
 abstract class BigqueryWriteTest(
     configContents: String,
     dataDumper: DestinationDataDumper,
+    expectedRecordMapper: ExpectedRecordMapper,
     preserveUndeclaredFields: Boolean,
+    supportsDedup: Boolean,
 ) :
     BasicFunctionalityIntegrationTest(
         configContents = configContents,
         BigquerySpecification::class.java,
-        dataDumper = dataDumper,
+        dataDumper,
         NoopDestinationCleaner,
+        recordMangler = expectedRecordMapper,
         isStreamSchemaRetroactive = true,
-        supportsDedup = true,
+        supportsDedup = supportsDedup,
         stringifySchemalessObjects = false,
         schematizedObjectBehavior = SchematizedNestedValueBehavior.PASS_THROUGH,
         schematizedArrayBehavior = SchematizedNestedValueBehavior.PASS_THROUGH,
@@ -57,7 +63,9 @@ class StandardInsertRawOverrideDisableTd :
             )
             .serializeToString(),
         BigqueryRawTableDataDumper,
+        UncoercedExpectedRecordMapper,
         preserveUndeclaredFields = true,
+        supportsDedup = false,
     ) {
     @Test
     override fun testBasicWrite() {
@@ -74,7 +82,9 @@ class StandardInsertRawOverride :
             )
             .serializeToString(),
         BigqueryFinalTableDataDumper,
+        NoopExpectedRecordMapper,
         preserveUndeclaredFields = false,
+        supportsDedup = true,
     ) {
     @Test
     override fun testBasicWrite() {
@@ -91,7 +101,9 @@ class GcsRawOverrideDisableTd :
             )
             .serializeToString(),
         BigqueryRawTableDataDumper,
+        UncoercedExpectedRecordMapper,
         preserveUndeclaredFields = true,
+        supportsDedup = false,
     ) {
     @Test
     override fun testBasicWrite() {
@@ -108,7 +120,9 @@ class GcsRawOverride :
             )
             .serializeToString(),
         BigqueryFinalTableDataDumper,
+        NoopExpectedRecordMapper,
         preserveUndeclaredFields = false,
+        supportsDedup = true,
     ) {
     @Test
     override fun testBasicWrite() {

--- a/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryWriteTest.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryWriteTest.kt
@@ -71,6 +71,10 @@ class StandardInsertRawOverrideDisableTd :
     override fun testBasicWrite() {
         super.testBasicWrite()
     }
+    @Test
+    override fun testTruncateRefresh() {
+        super.testTruncateRefresh()
+    }
 }
 
 class StandardInsertRawOverride :
@@ -89,6 +93,10 @@ class StandardInsertRawOverride :
     @Test
     override fun testBasicWrite() {
         super.testBasicWrite()
+    }
+    @Test
+    override fun testTruncateRefresh() {
+        super.testTruncateRefresh()
     }
 }
 

--- a/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryWriteTest.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryWriteTest.kt
@@ -72,8 +72,8 @@ class StandardInsertRawOverrideDisableTd :
         super.testBasicWrite()
     }
     @Test
-    override fun resumeAfterCancelledTruncate() {
-        super.resumeAfterCancelledTruncate()
+    override fun testInterruptedTruncateWithoutPriorData() {
+        super.testInterruptedTruncateWithoutPriorData()
     }
 }
 

--- a/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryWriteTest.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryWriteTest.kt
@@ -39,7 +39,7 @@ abstract class BigqueryWriteTest(
         unionBehavior = UnionBehavior.PASS_THROUGH,
         preserveUndeclaredFields = preserveUndeclaredFields,
         supportFileTransfer = false,
-        commitDataIncrementally = true,
+        commitDataIncrementally = false,
         allTypesBehavior =
             StronglyTyped(
                 convertAllValuesToString = false,
@@ -72,8 +72,8 @@ class StandardInsertRawOverrideDisableTd :
         super.testBasicWrite()
     }
     @Test
-    override fun testTruncateRefresh() {
-        super.testTruncateRefresh()
+    override fun resumeAfterCancelledTruncate() {
+        super.resumeAfterCancelledTruncate()
     }
 }
 

--- a/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryWriteTest.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryWriteTest.kt
@@ -4,6 +4,7 @@
 
 package io.airbyte.integrations.destination.bigquery
 
+import io.airbyte.cdk.load.test.util.DestinationDataDumper
 import io.airbyte.cdk.load.test.util.FakeDataDumper
 import io.airbyte.cdk.load.test.util.NoopDestinationCleaner
 import io.airbyte.cdk.load.util.serializeToString
@@ -15,11 +16,15 @@ import io.airbyte.integrations.destination.bigquery.spec.BigquerySpecification
 import java.nio.file.Path
 import org.junit.jupiter.api.Test
 
-abstract class BigqueryWriteTest(configContents: String) :
+abstract class BigqueryWriteTest(
+    configContents: String,
+    dataDumper: DestinationDataDumper,
+    preserveUndeclaredFields: Boolean,
+) :
     BasicFunctionalityIntegrationTest(
         configContents = configContents,
         BigquerySpecification::class.java,
-        FakeDataDumper,
+        dataDumper = dataDumper,
         NoopDestinationCleaner,
         isStreamSchemaRetroactive = true,
         supportsDedup = true,
@@ -27,7 +32,7 @@ abstract class BigqueryWriteTest(configContents: String) :
         schematizedObjectBehavior = SchematizedNestedValueBehavior.PASS_THROUGH,
         schematizedArrayBehavior = SchematizedNestedValueBehavior.PASS_THROUGH,
         unionBehavior = UnionBehavior.PASS_THROUGH,
-        preserveUndeclaredFields = false,
+        preserveUndeclaredFields = preserveUndeclaredFields,
         supportFileTransfer = false,
         commitDataIncrementally = true,
         allTypesBehavior =
@@ -52,6 +57,8 @@ class StandardInsertRawOverrideDisableTd :
                 stagingPath = "test_path/$DEFAULT_NAMESPACE_PLACEHOLDER",
             )
             .serializeToString(),
+        BigqueryRawTableDataDumper,
+        preserveUndeclaredFields = true,
     ) {
     @Test
     override fun testBasicWrite() {
@@ -67,6 +74,8 @@ class StandardInsertRawOverride :
                 stagingPath = "test_path/$DEFAULT_NAMESPACE_PLACEHOLDER",
             )
             .serializeToString(),
+        FakeDataDumper,
+        preserveUndeclaredFields = false,
     ) {
     @Test
     override fun testBasicWrite() {
@@ -82,6 +91,25 @@ class GcsRawOverrideDisableTd :
                 stagingPath = "test_path/$DEFAULT_NAMESPACE_PLACEHOLDER",
             )
             .serializeToString(),
+        BigqueryRawTableDataDumper,
+        preserveUndeclaredFields = true,
+    ) {
+    @Test
+    override fun testBasicWrite() {
+        super.testBasicWrite()
+    }
+}
+
+class GcsRawOverride :
+    BigqueryWriteTest(
+        BigQueryDestinationTestUtils.createConfig(
+                configFile = Path.of("secrets/credentials-1s1t-gcs-raw-override.json"),
+                datasetId = DEFAULT_NAMESPACE_PLACEHOLDER,
+                stagingPath = "test_path/$DEFAULT_NAMESPACE_PLACEHOLDER",
+            )
+            .serializeToString(),
+        FakeDataDumper,
+        preserveUndeclaredFields = false,
     ) {
     @Test
     override fun testBasicWrite() {

--- a/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryWriteTest.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryWriteTest.kt
@@ -6,9 +6,9 @@ package io.airbyte.integrations.destination.bigquery
 
 import io.airbyte.cdk.load.test.util.DestinationDataDumper
 import io.airbyte.cdk.load.test.util.ExpectedRecordMapper
-import io.airbyte.cdk.load.test.util.NoopDestinationCleaner
 import io.airbyte.cdk.load.test.util.UncoercedExpectedRecordMapper
 import io.airbyte.cdk.load.toolkits.load.db.orchestration.ColumnNameModifyingMapper
+import io.airbyte.cdk.load.util.deserializeToNode
 import io.airbyte.cdk.load.util.serializeToString
 import io.airbyte.cdk.load.write.AllTypesBehavior
 import io.airbyte.cdk.load.write.BasicFunctionalityIntegrationTest
@@ -35,7 +35,7 @@ abstract class BigqueryWriteTest(
         configContents = configContents,
         BigquerySpecification::class.java,
         dataDumper,
-        NoopDestinationCleaner,
+        BigqueryDestinationCleaner(configContents.deserializeToNode()),
         recordMangler = expectedRecordMapper,
         isStreamSchemaRetroactive = isStreamSchemaRetroactive,
         supportsDedup = supportsDedup,

--- a/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryWriteTest.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryWriteTest.kt
@@ -10,10 +10,12 @@ import io.airbyte.cdk.load.test.util.NoopDestinationCleaner
 import io.airbyte.cdk.load.test.util.NoopExpectedRecordMapper
 import io.airbyte.cdk.load.test.util.UncoercedExpectedRecordMapper
 import io.airbyte.cdk.load.util.serializeToString
+import io.airbyte.cdk.load.write.AllTypesBehavior
 import io.airbyte.cdk.load.write.BasicFunctionalityIntegrationTest
 import io.airbyte.cdk.load.write.SchematizedNestedValueBehavior
 import io.airbyte.cdk.load.write.StronglyTyped
 import io.airbyte.cdk.load.write.UnionBehavior
+import io.airbyte.cdk.load.write.Untyped
 import io.airbyte.integrations.destination.bigquery.spec.BigquerySpecification
 import java.nio.file.Path
 import org.junit.jupiter.api.Test
@@ -24,6 +26,7 @@ abstract class BigqueryWriteTest(
     expectedRecordMapper: ExpectedRecordMapper,
     preserveUndeclaredFields: Boolean,
     supportsDedup: Boolean,
+    allTypesBehavior: AllTypesBehavior,
 ) :
     BasicFunctionalityIntegrationTest(
         configContents = configContents,
@@ -40,21 +43,44 @@ abstract class BigqueryWriteTest(
         preserveUndeclaredFields = preserveUndeclaredFields,
         supportFileTransfer = false,
         commitDataIncrementally = false,
-        allTypesBehavior =
-            StronglyTyped(
-                convertAllValuesToString = false,
-                topLevelFloatLosesPrecision = true,
-                nestedFloatLosesPrecision = false,
-                integerCanBeLarge = false,
-            ),
+        allTypesBehavior = allTypesBehavior,
         configUpdater = BigqueryConfigUpdater,
         additionalMicronautEnvs = additionalMicronautEnvs,
+    )
+
+abstract class BigqueryRawTablesWriteTest(
+    configContents: String,
+) :
+    BigqueryWriteTest(
+        configContents = configContents,
+        BigqueryRawTableDataDumper,
+        UncoercedExpectedRecordMapper,
+        preserveUndeclaredFields = true,
+        supportsDedup = false,
+        Untyped,
+    )
+
+abstract class BigqueryTDWriteTest(
+    configContents: String,
+) :
+    BigqueryWriteTest(
+        configContents = configContents,
+        BigqueryFinalTableDataDumper,
+        NoopExpectedRecordMapper,
+        preserveUndeclaredFields = false,
+        supportsDedup = true,
+        StronglyTyped(
+            convertAllValuesToString = false,
+            topLevelFloatLosesPrecision = true,
+            nestedFloatLosesPrecision = false,
+            integerCanBeLarge = false,
+        ),
     )
 
 // TODO we should make the config stuff less dumb, this is just the minimal wiring to get something
 // that works
 class StandardInsertRawOverrideDisableTd :
-    BigqueryWriteTest(
+    BigqueryRawTablesWriteTest(
         BigQueryDestinationTestUtils.createConfig(
                 configFile =
                     Path.of("secrets/credentials-1s1t-disabletd-standard-raw-override.json"),
@@ -62,33 +88,25 @@ class StandardInsertRawOverrideDisableTd :
                 stagingPath = "test_path/$DEFAULT_NAMESPACE_PLACEHOLDER",
             )
             .serializeToString(),
-        BigqueryRawTableDataDumper,
-        UncoercedExpectedRecordMapper,
-        preserveUndeclaredFields = true,
-        supportsDedup = false,
     ) {
     @Test
     override fun testBasicWrite() {
         super.testBasicWrite()
     }
     @Test
-    override fun testInterruptedTruncateWithoutPriorData() {
-        super.testInterruptedTruncateWithoutPriorData()
+    override fun testBasicTypes() {
+        super.testBasicTypes()
     }
 }
 
 class StandardInsertRawOverride :
-    BigqueryWriteTest(
+    BigqueryTDWriteTest(
         BigQueryDestinationTestUtils.createConfig(
                 configFile = Path.of("secrets/credentials-1s1t-standard-raw-override.json"),
                 datasetId = DEFAULT_NAMESPACE_PLACEHOLDER,
                 stagingPath = "test_path/$DEFAULT_NAMESPACE_PLACEHOLDER",
             )
             .serializeToString(),
-        BigqueryFinalTableDataDumper,
-        NoopExpectedRecordMapper,
-        preserveUndeclaredFields = false,
-        supportsDedup = true,
     ) {
     @Test
     override fun testBasicWrite() {
@@ -101,17 +119,13 @@ class StandardInsertRawOverride :
 }
 
 class GcsRawOverrideDisableTd :
-    BigqueryWriteTest(
+    BigqueryRawTablesWriteTest(
         BigQueryDestinationTestUtils.createConfig(
                 configFile = Path.of("secrets/credentials-1s1t-disabletd-gcs-raw-override.json"),
                 datasetId = DEFAULT_NAMESPACE_PLACEHOLDER,
                 stagingPath = "test_path/$DEFAULT_NAMESPACE_PLACEHOLDER",
             )
             .serializeToString(),
-        BigqueryRawTableDataDumper,
-        UncoercedExpectedRecordMapper,
-        preserveUndeclaredFields = true,
-        supportsDedup = false,
     ) {
     @Test
     override fun testBasicWrite() {
@@ -120,17 +134,13 @@ class GcsRawOverrideDisableTd :
 }
 
 class GcsRawOverride :
-    BigqueryWriteTest(
+    BigqueryTDWriteTest(
         BigQueryDestinationTestUtils.createConfig(
                 configFile = Path.of("secrets/credentials-1s1t-gcs-raw-override.json"),
                 datasetId = DEFAULT_NAMESPACE_PLACEHOLDER,
                 stagingPath = "test_path/$DEFAULT_NAMESPACE_PLACEHOLDER",
             )
             .serializeToString(),
-        BigqueryFinalTableDataDumper,
-        NoopExpectedRecordMapper,
-        preserveUndeclaredFields = false,
-        supportsDedup = true,
     ) {
     @Test
     override fun testBasicWrite() {

--- a/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryWriteTest.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryWriteTest.kt
@@ -28,6 +28,7 @@ abstract class BigqueryWriteTest(
     isStreamSchemaRetroactive: Boolean,
     preserveUndeclaredFields: Boolean,
     supportsDedup: Boolean,
+    nullEqualsUnset: Boolean,
     allTypesBehavior: AllTypesBehavior,
 ) :
     BasicFunctionalityIntegrationTest(
@@ -46,6 +47,7 @@ abstract class BigqueryWriteTest(
         supportFileTransfer = false,
         commitDataIncrementally = false,
         allTypesBehavior = allTypesBehavior,
+        nullEqualsUnset = nullEqualsUnset,
         configUpdater = BigqueryConfigUpdater,
         additionalMicronautEnvs = additionalMicronautEnvs,
     )
@@ -60,6 +62,7 @@ abstract class BigqueryRawTablesWriteTest(
         isStreamSchemaRetroactive = false,
         preserveUndeclaredFields = true,
         supportsDedup = false,
+        nullEqualsUnset = false,
         Untyped,
     )
 
@@ -73,6 +76,7 @@ abstract class BigqueryTDWriteTest(
         isStreamSchemaRetroactive = true,
         preserveUndeclaredFields = false,
         supportsDedup = true,
+        nullEqualsUnset = true,
         StronglyTyped(
             convertAllValuesToString = false,
             topLevelFloatLosesPrecision = true,

--- a/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryWriteTest.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryWriteTest.kt
@@ -94,6 +94,7 @@ class StandardInsertRawOverrideDisableTd :
                     Path.of("secrets/credentials-1s1t-disabletd-standard-raw-override.json"),
                 datasetId = DEFAULT_NAMESPACE_PLACEHOLDER,
                 stagingPath = "test_path/$DEFAULT_NAMESPACE_PLACEHOLDER",
+                rawDatasetId = "${DEFAULT_NAMESPACE_PLACEHOLDER}_raw_dataset",
             )
             .serializeToString(),
     ) {
@@ -113,6 +114,7 @@ class StandardInsertRawOverride :
                 configFile = Path.of("secrets/credentials-1s1t-standard-raw-override.json"),
                 datasetId = DEFAULT_NAMESPACE_PLACEHOLDER,
                 stagingPath = "test_path/$DEFAULT_NAMESPACE_PLACEHOLDER",
+                rawDatasetId = "${DEFAULT_NAMESPACE_PLACEHOLDER}_raw_dataset",
             )
             .serializeToString(),
     ) {
@@ -126,12 +128,28 @@ class StandardInsertRawOverride :
     }
 }
 
+class StandardInsert :
+    BigqueryTDWriteTest(
+        BigQueryDestinationTestUtils.createConfig(
+                configFile = Path.of("secrets/credentials-1s1t-standard.json"),
+                datasetId = DEFAULT_NAMESPACE_PLACEHOLDER,
+                stagingPath = "test_path/$DEFAULT_NAMESPACE_PLACEHOLDER",
+            )
+            .serializeToString(),
+    ) {
+    @Test
+    override fun testBasicWrite() {
+        super.testBasicWrite()
+    }
+}
+
 class GcsRawOverrideDisableTd :
     BigqueryRawTablesWriteTest(
         BigQueryDestinationTestUtils.createConfig(
                 configFile = Path.of("secrets/credentials-1s1t-disabletd-gcs-raw-override.json"),
                 datasetId = DEFAULT_NAMESPACE_PLACEHOLDER,
                 stagingPath = "test_path/$DEFAULT_NAMESPACE_PLACEHOLDER",
+                rawDatasetId = "${DEFAULT_NAMESPACE_PLACEHOLDER}_raw_dataset",
             )
             .serializeToString(),
     ) {
@@ -145,6 +163,22 @@ class GcsRawOverride :
     BigqueryTDWriteTest(
         BigQueryDestinationTestUtils.createConfig(
                 configFile = Path.of("secrets/credentials-1s1t-gcs-raw-override.json"),
+                datasetId = DEFAULT_NAMESPACE_PLACEHOLDER,
+                stagingPath = "test_path/$DEFAULT_NAMESPACE_PLACEHOLDER",
+                rawDatasetId = "${DEFAULT_NAMESPACE_PLACEHOLDER}_raw_dataset",
+            )
+            .serializeToString(),
+    ) {
+    @Test
+    override fun testBasicWrite() {
+        super.testBasicWrite()
+    }
+}
+
+class Gcs :
+    BigqueryTDWriteTest(
+        BigQueryDestinationTestUtils.createConfig(
+                configFile = Path.of("secrets/credentials-1s1t-gcs.json"),
                 datasetId = DEFAULT_NAMESPACE_PLACEHOLDER,
                 stagingPath = "test_path/$DEFAULT_NAMESPACE_PLACEHOLDER",
             )

--- a/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryWriteTest.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryWriteTest.kt
@@ -25,6 +25,7 @@ abstract class BigqueryWriteTest(
     configContents: String,
     dataDumper: DestinationDataDumper,
     expectedRecordMapper: ExpectedRecordMapper,
+    isStreamSchemaRetroactive: Boolean,
     preserveUndeclaredFields: Boolean,
     supportsDedup: Boolean,
     allTypesBehavior: AllTypesBehavior,
@@ -35,7 +36,7 @@ abstract class BigqueryWriteTest(
         dataDumper,
         NoopDestinationCleaner,
         recordMangler = expectedRecordMapper,
-        isStreamSchemaRetroactive = true,
+        isStreamSchemaRetroactive = isStreamSchemaRetroactive,
         supportsDedup = supportsDedup,
         stringifySchemalessObjects = false,
         schematizedObjectBehavior = SchematizedNestedValueBehavior.PASS_THROUGH,
@@ -56,6 +57,7 @@ abstract class BigqueryRawTablesWriteTest(
         configContents = configContents,
         BigqueryRawTableDataDumper,
         UncoercedExpectedRecordMapper,
+        isStreamSchemaRetroactive = false,
         preserveUndeclaredFields = true,
         supportsDedup = false,
         Untyped,
@@ -68,6 +70,7 @@ abstract class BigqueryTDWriteTest(
         configContents = configContents,
         BigqueryFinalTableDataDumper,
         ColumnNameModifyingMapper(BigqueryColumnNameGenerator()),
+        isStreamSchemaRetroactive = true,
         preserveUndeclaredFields = false,
         supportsDedup = true,
         StronglyTyped(
@@ -95,8 +98,8 @@ class StandardInsertRawOverrideDisableTd :
         super.testBasicWrite()
     }
     @Test
-    override fun testFunkyCharacters() {
-        super.testFunkyCharacters()
+    override fun testAppendSchemaEvolution() {
+        super.testAppendSchemaEvolution()
     }
 }
 

--- a/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryWriteTest.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryWriteTest.kt
@@ -7,8 +7,8 @@ package io.airbyte.integrations.destination.bigquery
 import io.airbyte.cdk.load.test.util.DestinationDataDumper
 import io.airbyte.cdk.load.test.util.ExpectedRecordMapper
 import io.airbyte.cdk.load.test.util.NoopDestinationCleaner
-import io.airbyte.cdk.load.test.util.NoopExpectedRecordMapper
 import io.airbyte.cdk.load.test.util.UncoercedExpectedRecordMapper
+import io.airbyte.cdk.load.toolkits.load.db.orchestration.ColumnNameModifyingMapper
 import io.airbyte.cdk.load.util.serializeToString
 import io.airbyte.cdk.load.write.AllTypesBehavior
 import io.airbyte.cdk.load.write.BasicFunctionalityIntegrationTest
@@ -17,6 +17,7 @@ import io.airbyte.cdk.load.write.StronglyTyped
 import io.airbyte.cdk.load.write.UnionBehavior
 import io.airbyte.cdk.load.write.Untyped
 import io.airbyte.integrations.destination.bigquery.spec.BigquerySpecification
+import io.airbyte.integrations.destination.bigquery.typing_deduping.BigqueryColumnNameGenerator
 import java.nio.file.Path
 import org.junit.jupiter.api.Test
 
@@ -66,7 +67,7 @@ abstract class BigqueryTDWriteTest(
     BigqueryWriteTest(
         configContents = configContents,
         BigqueryFinalTableDataDumper,
-        NoopExpectedRecordMapper,
+        ColumnNameModifyingMapper(BigqueryColumnNameGenerator()),
         preserveUndeclaredFields = false,
         supportsDedup = true,
         StronglyTyped(
@@ -94,8 +95,8 @@ class StandardInsertRawOverrideDisableTd :
         super.testBasicWrite()
     }
     @Test
-    override fun testBasicTypes() {
-        super.testBasicTypes()
+    override fun testFunkyCharacters() {
+        super.testFunkyCharacters()
     }
 }
 
@@ -113,8 +114,8 @@ class StandardInsertRawOverride :
         super.testBasicWrite()
     }
     @Test
-    override fun testTruncateRefresh() {
-        super.testTruncateRefresh()
+    override fun testFunkyCharacters() {
+        super.testFunkyCharacters()
     }
 }
 


### PR DESCRIPTION
closes https://github.com/airbytehq/airbyte-internal-issues/issues/12455

there's still some failing tests, but I got a few of the low-hanging fruit here.

I submitted https://github.com/airbytehq/airbyte-internal-issues/issues/12636 to clean up the TestUtils class - I've decided I'm actually mostly OK with how the config stuff works, but we can definitely do some code cleanup once we believe the new tests have coverage over the old tests.

in this PR:
* add data dumpers (two implementations, for raw / final tables)
* add the destination cleaner
* add an ExpectedRecordMapper to handle column renaming
* fix a few bugs:
  * standard inserts - don't use the EnrichedRecord airbyte_meta yet, since we're still doing typing in-connector
    * this is why I needed direct access to DestinationRecordRaw.rawData
  * BIgquerySqlGenerator - extract from the JSON using the original column name, not the mangled name
* update test configuration
  * add intermediate base test classes for raw / T+D tests, with different settings.
* add tests using the default raw dataset