### PR TITLE
[source-quickbooks] Add missing VendorRef to source-qbo time_activities

### DIFF
--- a/airbyte-integrations/connectors/source-quickbooks/manifest.yaml
+++ b/airbyte-integrations/connectors/source-quickbooks/manifest.yaml
@@ -6810,6 +6810,19 @@ definitions:
                   type:
                   - "null"
                   - string
+            VendorRef:
+              type:
+              - "null"
+              - object
+              properties:
+                name:
+                  type:
+                  - "null"
+                  - string
+                value:
+                  type:
+                  - "null"
+                  - string
             HourlyRate:
               type:
               - "null"
@@ -14400,6 +14413,19 @@ streams:
               type:
               - "null"
               - string
+        VendorRef:
+          type:
+          - "null"
+          - object
+          properties:
+            name:
+              type:
+              - "null"
+              - string
+            value:
+              type:
+              - "null"
+              - string
         HourlyRate:
           type:
           - "null"
@@ -20378,6 +20404,19 @@ schemas:
         - "null"
         - string
       EmployeeRef:
+        type:
+        - "null"
+        - object
+        properties:
+          name:
+            type:
+            - "null"
+            - string
+          value:
+            type:
+            - "null"
+            - string
+      VendorRef:
         type:
         - "null"
         - object


### PR DESCRIPTION
## What
Fixes https://github.com/airbytehq/airbyte/issues/58150

## How
Adds `VendorRef` to the QBO `time_activities` stream schema

## Review guide
See schema changes

## User Impac
Additional field should be added to the schema. No negative side effects should be observed.

## Can this PR be safely reverted and rolled back?
- [X] YES 💚
- [ ] NO ❌
