### PR TITLE
Add flatten and external ID support for S3 source

### DIFF
--- a/airbyte-integrations/connectors/source-s3/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-s3/configured_catalog.json
@@ -1,0 +1,41 @@
+{
+  "streams": [
+    {
+      "stream": {
+        "name": "cloudtrail",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": ["null", "integer"]
+            },
+            "name": {
+              "type": ["null", "string"]
+            },
+            "valid": {
+              "type": ["null", "boolean"]
+            },
+            "value": {
+              "type": ["null", "number"]
+            },
+            "event_date": {
+              "type": ["null", "string"]
+            },
+            "_ab_source_file_last_modified": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "_ab_source_file_url": {
+              "type": "string"
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "source_defined_cursor": true,
+        "default_cursor_field": ["_ab_source_file_last_modified"]
+      },
+      "sync_mode": "incremental",
+      "destination_sync_mode": "append"
+    }
+  ]
+}

--- a/airbyte-integrations/connectors/source-s3/source_s3/v4/config.py
+++ b/airbyte-integrations/connectors/source-s3/source_s3/v4/config.py
@@ -40,6 +40,14 @@ class Config(AbstractFileBasedSpec):
         f"requested using this profile. Set the External ID to the Airbyte workspace ID, which can be found in the URL of this page.",
         order=6,
     )
+    
+    external_id: Optional[str] = Field(
+        title="External ID",
+        default=None,
+        description="External ID to use when assuming a role. This is used for cross-account access using the role_arn parameter.",
+        airbyte_secret=True,
+        order=7,
+    )
 
     aws_secret_access_key: Optional[str] = Field(
         title="AWS Secret Access Key",
@@ -73,6 +81,14 @@ class Config(AbstractFileBasedSpec):
         display_type="radio",
         group="advanced",
         default="use_records_transfer",
+    )
+
+    flatten_records_key: Optional[str] = Field(
+        title="Flatten Records Key",
+        default=None,
+        description="If your JSON/JSONL files contain an array of records under a specific key (e.g., 'Records' in CloudTrail logs), specify that key here. Each record in the array will be emitted as an individual record with all relevant metadata preserved.",
+        examples=["Records"],
+        order=8,
     )
 
     @root_validator

--- a/airbyte-integrations/connectors/source-s3/source_s3/v4/flattenable_stream.py
+++ b/airbyte-integrations/connectors/source-s3/source_s3/v4/flattenable_stream.py
@@ -1,0 +1,138 @@
+#
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+#
+
+from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Optional, Union
+import copy
+import logging
+import traceback
+
+from airbyte_cdk.models import AirbyteMessage, AirbyteRecordMessage, Type
+from airbyte_cdk.sources.file_based.stream.default_file_based_stream import DefaultFileBasedStream
+from airbyte_cdk.sources.streams.core import Stream
+from airbyte_cdk.sources.file_based.types import StreamSlice
+from airbyte_cdk.sources.utils.record_helper import stream_data_to_airbyte_message
+from airbyte_cdk.sources.streams import IncrementalMixin
+from airbyte_cdk.sources.streams.core import StreamData
+from airbyte_cdk.models import SyncMode, ConfiguredAirbyteStream
+from airbyte_cdk.sources.file_based.exceptions import (
+    DuplicatedFilesError,
+    FileBasedSourceError,
+    InvalidSchemaError,
+    MissingSchemaError,
+    RecordParseError,
+    SchemaInferenceError,
+    StopSyncPerValidationPolicy,
+)
+from airbyte_cdk.sources.file_based.file_types import FileTransfer
+from airbyte_cdk.sources.file_based.remote_file import RemoteFile
+from airbyte_cdk.sources.file_based.schema_helpers import (
+    SchemaType,
+    file_transfer_schema,
+    merge_schemas,
+    schemaless_schema,
+)
+from airbyte_cdk.models import AirbyteLogMessage, AirbyteMessage, FailureType, Level
+from airbyte_cdk.models import Type as MessageType
+from airbyte_cdk.utils.traced_exception import AirbyteTracedException
+
+
+
+class FlattenableFileBasedStream(DefaultFileBasedStream):
+    """
+    Extended implementation of DefaultFileBasedStream that supports flattening nested records.
+    Specifically used for JSON and JSONL files where records are nested under a specific key.
+    """
+    
+    def __init__(
+        self,
+        *args,
+        flatten_records_key=None,
+        **kwargs
+    ):
+        super().__init__(*args, **kwargs)
+        self.flatten_records_key = flatten_records_key
+        # Log that we're using a custom stream with flatten_records_key
+        if self.flatten_records_key:
+            self.logger.info(f"Stream {self.name}: Using flatten_records_key={self.flatten_records_key}")
+
+    def read_records_from_slice(self, stream_slice: StreamSlice) -> Iterable[Mapping[str, Any] | AirbyteMessage]:
+        """
+        Override read_records_from_slice to handle flattening of nested records based on the flatten_records_key parameter.
+        This method is called by the read_records method and processes records from each slice.
+        """
+        # If flatten_records_key is not set, use the default implementation
+        if not self.flatten_records_key:
+            yield from super().read_records_from_slice(stream_slice)
+            return
+        
+        schema = self.catalog_schema
+        if schema is None:
+            # On read requests we should always have the catalog available
+            raise MissingSchemaError(FileBasedSourceError.MISSING_SCHEMA, stream=self.name)
+        # The stream only supports a single file type, so we can use the same parser for all files
+        parser = self.get_parser()
+        for file in stream_slice["files"]:
+            # only serialize the datetime once
+            file_datetime_string = file.last_modified.strftime(self.DATE_TIME_FORMAT)
+            n_skipped = line_no = 0
+
+            try:
+                for record in parser.parse_records(
+                    self.config, file, self.stream_reader, self.logger, schema
+                ):
+                    flattened_records = record.get(self.flatten_records_key)
+                    for r in flattened_records:
+                        line_no += 1
+                        data = {"data": r}
+                        record = self.transform_record(data, file, file_datetime_string)
+                        yield stream_data_to_airbyte_message(self.name, record)
+                self._cursor.add_file(file)
+
+            except StopSyncPerValidationPolicy:
+                yield AirbyteMessage(
+                    type=MessageType.LOG,
+                    log=AirbyteLogMessage(
+                        level=Level.WARN,
+                        message=f"Stopping sync in accordance with the configured validation policy. Records in file did not conform to the schema. stream={self.name} file={file.uri} validation_policy={self.config.validation_policy.value} n_skipped={n_skipped}",
+                    ),
+                )
+                break
+
+            except RecordParseError:
+                # Increment line_no because the exception was raised before we could increment it
+                line_no += 1
+                self.errors_collector.collect(
+                    AirbyteMessage(
+                        type=MessageType.LOG,
+                        log=AirbyteLogMessage(
+                            level=Level.ERROR,
+                            message=f"{FileBasedSourceError.ERROR_PARSING_RECORD.value} stream={self.name} file={file.uri} line_no={line_no} n_skipped={n_skipped}",
+                            stack_trace=traceback.format_exc(),
+                        ),
+                    ),
+                )
+
+            except AirbyteTracedException as exc:
+                # Re-raise the exception to stop the whole sync immediately as this is a fatal error
+                raise exc
+
+            except Exception:
+                yield AirbyteMessage(
+                    type=MessageType.LOG,
+                    log=AirbyteLogMessage(
+                        level=Level.ERROR,
+                        message=f"{FileBasedSourceError.ERROR_PARSING_RECORD.value} stream={self.name} file={file.uri} line_no={line_no} n_skipped={n_skipped}",
+                        stack_trace=traceback.format_exc(),
+                    ),
+                )
+
+            finally:
+                if n_skipped:
+                    yield AirbyteMessage(
+                        type=MessageType.LOG,
+                        log=AirbyteLogMessage(
+                            level=Level.WARN,
+                            message=f"Records in file did not pass validation policy. stream={self.name} file={file.uri} n_skipped={n_skipped} validation_policy={self.validation_policy.name}",
+                        ),
+                    )

--- a/airbyte-integrations/connectors/source-s3/source_s3/v4/source.py
+++ b/airbyte-integrations/connectors/source-s3/source_s3/v4/source.py
@@ -28,12 +28,19 @@ from airbyte_cdk.models import (
     Type,
 )
 from airbyte_cdk.sources.file_based.file_based_source import DEFAULT_CONCURRENCY, FileBasedSource
+from airbyte_cdk.sources.file_based.config.file_based_stream_config import FileBasedStreamConfig
+from airbyte_cdk.sources.file_based.stream import AbstractFileBasedStream
+from airbyte_cdk.sources.file_based.stream.cursor import AbstractFileBasedCursor
+from airbyte_cdk.sources.file_based.config.abstract_file_based_spec import AbstractFileBasedSpec
+from airbyte_cdk.sources.file_based.config.validate_config_transfer_modes import use_file_transfer, preserve_directory_structure
+
 from source_s3.source import SourceS3Spec
 from source_s3.utils import airbyte_message_to_json
 from source_s3.v4.config import Config
 from source_s3.v4.cursor import Cursor
 from source_s3.v4.legacy_config_transformer import LegacyConfigTransformer
 from source_s3.v4.stream_reader import SourceS3StreamReader
+from source_s3.v4.flattenable_stream import FlattenableFileBasedStream
 
 
 _V3_DEPRECATION_FIELD_MAPPING = {
@@ -47,6 +54,34 @@ _V3_DEPRECATION_FIELD_MAPPING = {
 
 class SourceS3(FileBasedSource):
     _concurrency_level = DEFAULT_CONCURRENCY
+    
+    # Store the parsed main config for later use
+    def _get_parsed_config(self, config: Mapping[str, Any]) -> AbstractFileBasedSpec:
+        self.main_config = self.spec_class(**config)
+        return self.main_config
+
+    def _make_default_stream(
+        self,
+        stream_config: FileBasedStreamConfig,
+        cursor: Optional[AbstractFileBasedCursor],
+        parsed_config: AbstractFileBasedSpec,
+    ) -> AbstractFileBasedStream:
+        """Override to use our custom FlattenableFileBasedStream class that supports the flatten_records_key parameter"""
+        # Pass the flatten_records_key from the main config to the stream
+        return FlattenableFileBasedStream(
+            config=stream_config,
+            catalog_schema=self.stream_schemas.get(stream_config.name),
+            stream_reader=self.stream_reader,
+            availability_strategy=self.availability_strategy,
+            discovery_policy=self.discovery_policy,
+            parsers=self.parsers,
+            validation_policy=self._validate_and_get_validation_policy(stream_config),
+            errors_collector=self.errors_collector,
+            cursor=cursor,
+            use_file_transfer=use_file_transfer(parsed_config),
+            preserve_directory_structure=preserve_directory_structure(parsed_config),
+            flatten_records_key=getattr(parsed_config, 'flatten_records_key', None)
+        )
 
     @classmethod
     def read_config(cls, config_path: str) -> Mapping[str, Any]:

--- a/airbyte-integrations/connectors/source-s3/unit_tests/sample_files/v4_config.json
+++ b/airbyte-integrations/connectors/source-s3/unit_tests/sample_files/v4_config.json
@@ -1,10 +1,16 @@
 {
-  "bucket": "a-bucket",
+  "bucket": "aws-cloudtrail-logs-038462792154-50c30d32",
+  "region_name": "us-east-1",
+  "role_arn": "arn:aws:iam::038462792154:role/FabrixScannerReadOnly",
+  "external_id": "f713a95c39cdd5741dc67f6b",
+  "flatten_records_key":"Records",
   "streams": [
     {
-      "name": "output-stream-name",
-      "format": { "filetype": "csv" },
-      "file_type": "csv",
+      "name": "cloudtrail",
+      "globs": ["AWSLogs/038462792154/CloudTrail/us-west-1/2024/12/08/*.json.gz"],
+      "format": {
+        "filetype": "jsonl"
+      },
       "validation_policy": "Emit Record"
     }
   ]


### PR DESCRIPTION
Introduce support for flattening records from JSON/JSONL files and add an external ID parameter for cross-account access when assuming IAM roles. This enhances the configuration options for the S3 source.