### PR TITLE
Fix documentation about enabling Custom Components for Connector Builder

### DIFF
--- a/docs/connector-development/connector-builder-ui/custom-components.md
+++ b/docs/connector-development/connector-builder-ui/custom-components.md
@@ -59,10 +59,12 @@ If you deploy Airbyte with abctl, follow the steps below to update your values a
    ```yaml title="values.yaml"
    workload-launcher:
      extraEnv:
-       AIRBYTE_ENABLE_UNSAFE_CODE: true
+       - name: AIRBYTE_ENABLE_UNSAFE_CODE
+         value: "true"
    connector-builder-server:
      extraEnv:
-       AIRBYTE_ENABLE_UNSAFE_CODE: true
+       - name: AIRBYTE_ENABLE_UNSAFE_CODE
+         value: "true"
    ```
 
 2. Use this file during deployment with the abctl command:
@@ -80,10 +82,12 @@ If you're deploying Airbyte using public Helm charts without abctl, follow the s
    ```yaml title="values.yaml"
    workload-launcher:
      extraEnv:
-       AIRBYTE_ENABLE_UNSAFE_CODE: true
+       - name: AIRBYTE_ENABLE_UNSAFE_CODE
+         value: "true"
    connector-builder-server:
      extraEnv:
-       AIRBYTE_ENABLE_UNSAFE_CODE: true
+       - name: AIRBYTE_ENABLE_UNSAFE_CODE
+         value: "true"
    ```
 
 2. Apply the configuration during Helm installation or upgrade:


### PR DESCRIPTION
## What
Fix documentation about enabling Custom Components for Connector Builder

## How
extraEnv is supplied by the documentation as a dict, but it should be a list of dicts instead

## Review guide
1. Install Airbyte with `abctl`
2. Apply `values.yaml` as instructed by the `master` documentation. See that it does not work, Custom Components menu item does not appear as shown in the screenshot in the documentation. The log says something about `extraEnv` is expected to be a "table".
3. Apply `values.yaml` as instructed by this PR. Now Custom Components menu item appears as shown in the screenshot.

## User Impact
- They can actually enable Custom Components

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌
