### PR TITLE
bug(source-s3): Pass AWS access credentials to session on role-based authentication

### DIFF
--- a/airbyte-integrations/connectors/source-s3/metadata.yaml
+++ b/airbyte-integrations/connectors/source-s3/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: file
   connectorType: source
   definitionId: 69589781-7828-43c5-9f63-8925b1c1ccc2
-  dockerImageTag: 4.13.5
+  dockerImageTag: 4.13.6
   dockerRepository: airbyte/source-s3
   documentationUrl: https://docs.airbyte.com/integrations/sources/s3
   githubIssueLabel: source-s3

--- a/airbyte-integrations/connectors/source-s3/pyproject.toml
+++ b/airbyte-integrations/connectors/source-s3/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "4.13.5"
+version = "4.13.6"
 name = "source-s3"
 description = "Source implementation for S3."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-s3/source_s3/v4/stream_reader.py
+++ b/airbyte-integrations/connectors/source-s3/source_s3/v4/stream_reader.py
@@ -99,8 +99,7 @@ class SourceS3StreamReader(AbstractFileBasedStreamReader):
         def refresh():
             if self.config.aws_access_key_id and self.config.aws_secret_access_key:
                 boto_session = boto3.Session(
-                    aws_access_key_id=self.config.aws_access_key_id,
-                    aws_secret_access_key=self.config.aws_secret_access_key
+                    aws_access_key_id=self.config.aws_access_key_id, aws_secret_access_key=self.config.aws_secret_access_key
                 )
             else:
                 boto_session = boto3.setup_default_session()

--- a/airbyte-integrations/connectors/source-s3/source_s3/v4/stream_reader.py
+++ b/airbyte-integrations/connectors/source-s3/source_s3/v4/stream_reader.py
@@ -97,7 +97,14 @@ class SourceS3StreamReader(AbstractFileBasedStreamReader):
         """
 
         def refresh():
-            client = boto3.client("sts")
+            if self.config.aws_access_key_id and self.config.aws_secret_access_key:
+                boto_session = boto3.Session(
+                    aws_access_key_id=self.config.aws_access_key_id,
+                    aws_secret_access_key=self.config.aws_secret_access_key
+                )
+            else:
+                boto_session = boto3.setup_default_session()
+            client = boto_session.client("sts")
             if AWS_EXTERNAL_ID:
                 role = client.assume_role(
                     RoleArn=self.config.role_arn,

--- a/docs/integrations/sources/s3.md
+++ b/docs/integrations/sources/s3.md
@@ -356,6 +356,7 @@ This connector utilizes the open source [Unstructured](https://unstructured-io.g
 
 | Version     | Date       | Pull Request                                                                                                    | Subject                                                                                                              |
 |:------------|:-----------|:----------------------------------------------------------------------------------------------------------------|:---------------------------------------------------------------------------------------------------------------------|
+| 4.13.6 | 2025-04-22 | [58590](https://github.com/airbytehq/airbyte/pull/58590) | Pass AWS access credentials to session on role-based authentication |
 | 4.13.5 | 2025-04-19 | [57994](https://github.com/airbytehq/airbyte/pull/57994) | Update dependencies |
 | 4.13.4 | 2025-04-05 | [57485](https://github.com/airbytehq/airbyte/pull/57485) | Update dependencies |
 | 4.13.3 | 2025-03-29 | [56791](https://github.com/airbytehq/airbyte/pull/56791) | Update dependencies |


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->
Fixes https://github.com/airbytehq/airbyte/issues/57577

This PR modifies the `refresh` function that refreshes the auth token for s3 IAM role-based authentication, to use the configured `aws_access_key_id` and `aws_secret_access_key`.

## How
<!--
* Describe how code changes achieve the solution.
-->
This is done by passing the `aws_access_key_id` and `aws_secret_access_key` to the boto3 session when both are provided in the config along with the `role_arn`. When `role_arn` is provided in the config but `aws_access_key_id` or `aws_secret_access_key` are not, it will default to the previous/default boto3 library behaviour.

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->
This now passes the check command when all `aws_access_key_id`, `aws_secret_access_key` and `role_arn` are configured:
![image](https://github.com/user-attachments/assets/ba80c312-c682-41d5-a483-0cf8cbc565cf)

**THIS CHANGE COULD CAUSE ISSUES FOR SOME PEOPLE ALREADY USING THIS CONNECTOR** 
This could happen for sources using IAM role based authentication where the `aws_access_key_id` and `aws_secret_access_key` are incorrect in the source configuration, but boto3 is getting them from somewhere else (env vars, for ex.), as now the values passed in the source config will take priority.
## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
