### PR TITLE
(Fix: Source-Shopify): AttributeError with Null `measurement_weight` fields for  `product_variants` stream

### DIFF
--- a/airbyte-integrations/connectors/source-shopify/metadata.yaml
+++ b/airbyte-integrations/connectors/source-shopify/metadata.yaml
@@ -11,7 +11,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 9da77001-af33-4bcd-be46-6252bf9342b9
-  dockerImageTag: 3.0.4
+  dockerImageTag: 3.0.5
   dockerRepository: airbyte/source-shopify
   documentationUrl: https://docs.airbyte.com/integrations/sources/shopify
   erdUrl: https://dbdocs.io/airbyteio/source-shopify?view=relationships

--- a/airbyte-integrations/connectors/source-shopify/pyproject.toml
+++ b/airbyte-integrations/connectors/source-shopify/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "3.0.4"
+version = "3.0.5"
 name = "source-shopify"
 description = "Source CDK implementation for Shopify."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-shopify/source_shopify/shopify_graphql/bulk/query.py
+++ b/airbyte-integrations/connectors/source-shopify/source_shopify/shopify_graphql/bulk/query.py
@@ -2749,6 +2749,8 @@ class ProductVariant(ShopifyBulkQuery):
         measurement_weight = record.get("inventoryItem", {}).get("measurement", {}).get("weight")
         record["weight"] = measurement_weight.get("value", 0.0) if measurement_weight is not None else 0.0
         record["weight_unit"] = measurement_weight.get("unit") if measurement_weight else None
+        record["tracked"] = inventory_item.get("tracked") if inventory_item else None
+        record["requires_shipping"] = inventory_item.get("requires_shipping") if inventory_item else None
         record["image_id"] = self._unnest_and_resolve_id(record, "image", "image_id")
         image = record.get("image", {})
         record["image_src"] = image.get("image_src") if image else None

--- a/airbyte-integrations/connectors/source-shopify/source_shopify/shopify_graphql/bulk/query.py
+++ b/airbyte-integrations/connectors/source-shopify/source_shopify/shopify_graphql/bulk/query.py
@@ -2747,10 +2747,8 @@ class ProductVariant(ShopifyBulkQuery):
         record["inventory_item_id"] = self._unnest_and_resolve_id(record, "inventoryItem", "inventory_item_id")
         inventory_item = record.get("inventoryItem")
         measurement_weight = record.get("inventoryItem", {}).get("measurement", {}).get("weight")
-        record["weight"] = measurement_weight.get("value") if measurement_weight.get("value") else 0.0
+        record["weight"] = measurement_weight.get("value", 0.0) if measurement_weight is not None else 0.0
         record["weight_unit"] = measurement_weight.get("unit") if measurement_weight else None
-        record["tracked"] = inventory_item.get("tracked") if inventory_item else None
-        record["requires_shipping"] = inventory_item.get("requires_shipping") if inventory_item else None
         record["image_id"] = self._unnest_and_resolve_id(record, "image", "image_id")
         image = record.get("image", {})
         record["image_src"] = image.get("image_src") if image else None

--- a/docs/integrations/sources/shopify.md
+++ b/docs/integrations/sources/shopify.md
@@ -220,7 +220,7 @@ Expand to see details about Shopify connector limitations and troubleshooting
 
 #### Rate limiting
 
-Shopify has some [rate limit restrictions](https://shopify.dev/concepts/about-apis/rate-limits). Typically, there should not be issues with throttling or exceeding the rate limits but, in some edge cases, you may encounter the following warning message:
+Shopify has some [rate limit restrictions](https://shopify.dev/docs/api/usage/rate-limits). Typically, there should not be issues with throttling or exceeding the rate limits but, in some edge cases, you may encounter the following warning message:
 
 ```text
 "Caught retryable error '<some_error> or null' after <some_number> tries.
@@ -246,7 +246,7 @@ For all `Shopify GraphQL BULK` api requests these limitations are applied: https
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                                                                                                                                                                                                                                                                                   |
 |:--------|:-----------|:---------------------------------------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 3.0.5 | 2025-04-22 | [58598](https://github.com/airbytehq/airbyte/pull/58598) | Fix AttributeError with Null `measurement_weight` fields for `product_variants` streams |
+| 3.0.5 | 2025-04-23 | [58598](https://github.com/airbytehq/airbyte/pull/58598) | Fix AttributeError with Null `measurement_weight` fields for `product_variants` streams |
 | 3.0.4 | 2025-04-19 | [58431](https://github.com/airbytehq/airbyte/pull/58431) | Update dependencies |
 | 3.0.3 | 2025-04-12 | [57984](https://github.com/airbytehq/airbyte/pull/57984) | Update dependencies |
 | 3.0.2 | 2025-04-05 | [57449](https://github.com/airbytehq/airbyte/pull/57449) | Update dependencies |

--- a/docs/integrations/sources/shopify.md
+++ b/docs/integrations/sources/shopify.md
@@ -246,7 +246,7 @@ For all `Shopify GraphQL BULK` api requests these limitations are applied: https
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                                                                                                                                                                                                                                                                                   |
 |:--------|:-----------|:---------------------------------------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 3.0.5 | 2025-04-22 | [XXXXX](https://github.com/airbytehq/airbyte/pull/XXXXX) | Fix AttributeError with Null `measurement_weight` fields for `product_variants` streams |
+| 3.0.5 | 2025-04-22 | [58598](https://github.com/airbytehq/airbyte/pull/58598) | Fix AttributeError with Null `measurement_weight` fields for `product_variants` streams |
 | 3.0.4 | 2025-04-19 | [58431](https://github.com/airbytehq/airbyte/pull/58431) | Update dependencies |
 | 3.0.3 | 2025-04-12 | [57984](https://github.com/airbytehq/airbyte/pull/57984) | Update dependencies |
 | 3.0.2 | 2025-04-05 | [57449](https://github.com/airbytehq/airbyte/pull/57449) | Update dependencies |

--- a/docs/integrations/sources/shopify.md
+++ b/docs/integrations/sources/shopify.md
@@ -246,6 +246,7 @@ For all `Shopify GraphQL BULK` api requests these limitations are applied: https
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                                                                                                                                                                                                                                                                                   |
 |:--------|:-----------|:---------------------------------------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 3.0.5 | 2025-04-22 | [XXXXX](https://github.com/airbytehq/airbyte/pull/XXXXX) | Fix AttributeError with Null `measurement_weight` fields for `product_variants` streams |
 | 3.0.4 | 2025-04-19 | [58431](https://github.com/airbytehq/airbyte/pull/58431) | Update dependencies |
 | 3.0.3 | 2025-04-12 | [57984](https://github.com/airbytehq/airbyte/pull/57984) | Update dependencies |
 | 3.0.2 | 2025-04-05 | [57449](https://github.com/airbytehq/airbyte/pull/57449) | Update dependencies |


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->
Solves: https://github.com/airbytehq/oncall/issues/7786

Error while syncing `product_variants` stream. 
```
Traceback (most recent call last):
  File "/airbyte/integration_code/source_shopify/shopify_graphql/bulk/record.py", line 370, in read_file
    yield from self.produce_records(filename)
  File "/airbyte/integration_code/source_shopify/shopify_graphql/bulk/record.py", line 340, in produce_records
    for record in self.process_line(jsonl_file):
  File "/airbyte/integration_code/source_shopify/shopify_graphql/bulk/record.py", line 291, in process_line
    yield from self.record_compose(loads(line))
  File "/airbyte/integration_code/source_shopify/shopify_graphql/bulk/record.py", line 265, in record_compose
    yield from self.buffer_flush()
  File "/airbyte/integration_code/source_shopify/shopify_graphql/bulk/record.py", line 238, in buffer_flush
    yield from self.record_process_components(record)
  File "/airbyte/integration_code/source_shopify/shopify_graphql/bulk/query.py", line 2750, in record_process_components
    record["weight"] = measurement_weight.get("value") if measurement_weight.get("value") else 0.0
                                                          ^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'get'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/airbyte_cdk/sources/abstract_source.py", line 152, in read
    yield from self._read_stream(
  File "/usr/local/lib/python3.11/site-packages/airbyte_cdk/sources/abstract_source.py", line 276, in _read_stream
    for record_data_or_message in record_iterator:
  File "/usr/local/lib/python3.11/site-packages/airbyte_cdk/sources/streams/core.py", line 196, in read
    for record_data_or_message in records:
  File "/airbyte/integration_code/source_shopify/streams/base_streams.py", line 855, in read_records
    yield from self.filter_records_newer_than_state(stream_state, self.sort_output_asc(records))
  File "/airbyte/integration_code/source_shopify/streams/base_streams.py", line 242, in filter_records_newer_than_state
    for index, record in enumerate(records_slice, 1):
  File "/airbyte/integration_code/source_shopify/streams/base_streams.py", line 832, in sort_output_asc
    yield from sorted(
               ^^^^^^^
  File "/airbyte/integration_code/source_shopify/streams/base_streams.py", line 706, in add_shop_url_field
    for record in records:
  File "/airbyte/integration_code/source_shopify/shopify_graphql/bulk/job.py", line 588, in job_get_results
    yield from self._process_bulk_results()
  File "/airbyte/integration_code/source_shopify/shopify_graphql/bulk/job.py", line 573, in _process_bulk_results
    yield from self.record_producer.read_file(self._job_result_filename)
  File "/airbyte/integration_code/source_shopify/shopify_graphql/bulk/record.py", line 372, in read_file
    raise ShopifyBulkExceptions.BulkRecordProduceError(
source_shopify.shopify_graphql.bulk.exceptions.ShopifyBulkExceptions.BulkRecordProduceError: An error occured while producing records from BULK Job result. Trace: AttributeError("'NoneType' object has no attribute 'get'").
```
## How
<!--
* Describe how code changes achieve the solution.
-->
Add some checks for None values before using `get()`, and add defaults to the get method. 

Example:
`.get("value", 0.0)`

Tested locally and confirmed the error is no longer raised when we get a None value for `measurement_weight` field in the 
`product_variants` stream.


## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [X ] YES 💚
- [ ] NO ❌
