### PR TITLE
source-the-guardian-api contribution from ChristoGrab

### DIFF
--- a/airbyte-integrations/connectors/source-the-guardian-api/manifest.yaml
+++ b/airbyte-integrations/connectors/source-the-guardian-api/manifest.yaml
@@ -2,11 +2,10 @@ version: 6.44.0
 
 type: DeclarativeSource
 
-description: >-
+description: |-
   Website: https://open-platform.theguardian.com/
 
-  API Reference:
-  https://open-platform.theguardian.com/documentation/
+  API Reference: https://open-platform.theguardian.com/documentation/
 
 check:
   type: CheckStream


### PR DESCRIPTION
## What

This PR updates source The Guardian API (source-the-guardian-api).

#### The contributor provided the following description of the change:

> Test workflow
## Reviewer checklist
- [ ] Resolve any merge conflicts and validate file diffs (make sure the PR only includes changes intended by the contributor)
- [ ] After reviewing the changes, run the [`bump-version` Airbyte-CI command](https://github.com/airbytehq/airbyte/blob/master/airbyte-ci/connectors/pipelines/README.md#connectors-bump-version-command) locally to update the version of the connector according to the [versioning guidelines](https://docs.airbyte.io/contributor-guide/versioning-guidelines). Add `breakingChanges` to metadata if necessary.
- [ ] Ensure connector docs are up to date with any changes
- [ ] Run `/format-fix` to resolve any formatting errors
- [ ] Click into the CI workflows that wait for a maintainer to run them, which should trigger CI runs

<!-- DO NOT REMOVE: connector-builder-edit-connector-contribution -->
