### PR TITLE
[BigQuery] Update the emittedAt value to be 1000 * its own value in BulkLoad

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/DestinationMessage.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/DestinationMessage.kt
@@ -301,6 +301,10 @@ data class DestinationRecordRaw(
         return rawData.record.data
     }
 
+    fun dangerousMutateData(f: (AirbyteMessage) -> Unit) {
+        f(rawData)
+    }
+
     fun asDestinationRecordAirbyteValue(): DestinationRecordAirbyteValue {
         return DestinationRecordAirbyteValue(
             stream,

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/bulk_loader/BigQueryObjectStorageFormattingWriter.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/bulk_loader/BigQueryObjectStorageFormattingWriter.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination.bigquery.write.bulk_loader
+
+import io.airbyte.cdk.load.command.DestinationStream
+import io.airbyte.cdk.load.command.object_storage.ObjectStorageFormatConfigurationProvider
+import io.airbyte.cdk.load.file.object_storage.CSVFormattingWriter
+import io.airbyte.cdk.load.file.object_storage.ObjectStorageFormattingWriter
+import io.airbyte.cdk.load.file.object_storage.ObjectStorageFormattingWriterFactory
+import io.airbyte.cdk.load.message.DestinationRecordRaw
+import jakarta.inject.Singleton
+import java.io.OutputStream
+
+class BigQueryObjectStorageFormattingWriter(
+    stream: DestinationStream,
+    outputStream: OutputStream,
+    rootLevelFlattening: Boolean = true,
+) :
+    ObjectStorageFormattingWriter by CSVFormattingWriter(
+        stream,
+        outputStream,
+        rootLevelFlattening
+    ) {
+
+    private val csvFormattingWriter = CSVFormattingWriter(stream, outputStream, rootLevelFlattening)
+
+    override fun accept(record: DestinationRecordRaw) {
+        record.dangerousMutateData { it.record.emittedAt *= 1000 }
+        csvFormattingWriter.accept(record)
+    }
+}
+
+@Singleton
+class BigQueryObjectStorageFormattingWriterFactory(
+    private val formatConfigProvider: ObjectStorageFormatConfigurationProvider,
+) : ObjectStorageFormattingWriterFactory {
+    override fun create(
+        stream: DestinationStream,
+        outputStream: OutputStream
+    ): ObjectStorageFormattingWriter {
+        val flatten = formatConfigProvider.objectStorageFormatConfiguration.rootLevelFlattening
+        return BigQueryObjectStorageFormattingWriter(stream, outputStream, flatten)
+    }
+}


### PR DESCRIPTION
## What

BQ uses microseconds for it's timestamps, so we need to update the `emittedAt` value to be 1000 times itself.

## Can this PR be safely reverted and rolled back?
- [X] YES 💚
- [ ] NO ❌