### PR TITLE
fix(Amazon Seller Partner): fix record extraction for GET_XML_ALL_ORDERS_DATA_BY_ORDER_DATE_GENERAL stream

### DIFF
--- a/airbyte-integrations/connectors/source-amazon-seller-partner/source_amazon_seller_partner/components/decoder.py
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/source_amazon_seller_partner/components/decoder.py
@@ -63,7 +63,7 @@ class GzipXmlDecoder(Decoder):
 
         reports = parsed.get("AmazonEnvelope", {}).get("Message", {})
         for report in reports:
-            yield report.get("OrderReport", {})
+            yield report.get("Order", {})
 
 
 @dataclass


### PR DESCRIPTION
## What
`GET_XML_ALL_ORDERS_DATA_BY_ORDER_DATE_GENERAL` stream currently returns no records due to incorrect tag name used in `GzipXmlDecoder`

## How
Fix the tag name

## Review guide
0. Fill appropriate values to `secrets/config.json`
1. On `main`, run `poetry run source-amazon-seller-partner read --config secrets/config.json --catalog integration_tests/configured_catalog_get_xml_all_orders_data_by_order_date_general.json`, see that no records are emitted
2. Check out this branch, run `poetry run source-amazon-seller-partner read --config secrets/config.json --catalog integration_tests/configured_catalog_get_xml_all_orders_data_by_order_date_general.json`, see that some records are emitted (as long as the seller has eligible orders for the report)

## User Impact
Records will now be emitted after running the stream

## Can this PR be safely reverted and rolled back?
- [ ] YES 💚
- [ ] NO ❌
