### PR TITLE
Bulk load CDK: run cleaner once per class

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/IntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/IntegrationTest.kt
@@ -67,6 +67,13 @@ abstract class IntegrationTest(
     // multiple times.
     val destinationProcessFactory = DestinationProcessFactory.get(additionalMicronautEnvs)
 
+    // we want to run the cleaner exactly once per test class.
+    // technically this is a little inefficient - e.g. multiple test classes could reuse the same
+    // cleaner, so we'd prefer to only them once.
+    // but this is simpler to implement than tracking hasRunCleaner across test classes,
+    // and then also requiring cleaners to be able to recognize themselves as identical.
+    private val hasRunCleaner = AtomicBoolean(false)
+
     @Suppress("DEPRECATION") private val randomSuffix = RandomStringUtils.randomAlphabetic(4)
     private val timestampString =
         LocalDateTime.ofInstant(Instant.now(), ZoneOffset.UTC)
@@ -328,8 +335,6 @@ abstract class IntegrationTest(
                 LocalDate.parse(matchResult.groupValues[1], randomizedNamespaceDateFormatter)
             return namespaceCreationDate.isBefore(cleanupCutoffDate)
         }
-
-        private val hasRunCleaner = AtomicBoolean(false)
 
         // Connectors are calling System.getenv rather than using micronaut-y properties,
         // so we have to mock it out, instead of just setting more properties

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/IntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/IntegrationTest.kt
@@ -72,6 +72,8 @@ abstract class IntegrationTest(
     // cleaner, so we'd prefer to only them once.
     // but this is simpler to implement than tracking hasRunCleaner across test classes,
     // and then also requiring cleaners to be able to recognize themselves as identical.
+    // (you would think this is just an AfterAll method, but junit requires those to be static,
+    // so we wouldn't have access to the cleaner instance >.>)
     private val hasRunCleaner = AtomicBoolean(false)
 
     @Suppress("DEPRECATION") private val randomSuffix = RandomStringUtils.randomAlphabetic(4)

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/IntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/IntegrationTest.kt
@@ -69,7 +69,7 @@ abstract class IntegrationTest(
 
     // we want to run the cleaner exactly once per test class.
     // technically this is a little inefficient - e.g. multiple test classes could reuse the same
-    // cleaner, so we'd prefer to only them once.
+    // cleaner, so we'd prefer to only call each of them once.
     // but this is simpler to implement than tracking hasRunCleaner across test classes,
     // and then also requiring cleaners to be able to recognize themselves as identical.
     // (you would think this is just an AfterAll method, but junit requires those to be static,


### PR DESCRIPTION
closes https://github.com/airbytehq/airbyte-internal-issues/issues/12566

just move the hasRunCleaner from the companion object into an instance val

this is probably why s3-data-lake wasn't correctly deleting stuff from glue, even though we have nightlies

(this will also be useful for bigquery, where different cleaners will point at different rawTableDataset)