### PR TITLE
[Do not merge] Set "required" as the default value for ssl_mode

### DIFF
--- a/airbyte-integrations/connectors/source-mysql/src/main/kotlin/io/airbyte/integrations/source/mysql/MySqlSourceConfigurationSpecification.kt
+++ b/airbyte-integrations/connectors/source-mysql/src/main/kotlin/io/airbyte/integrations/source/mysql/MySqlSourceConfigurationSpecification.kt
@@ -41,6 +41,7 @@ import jakarta.inject.Singleton
 @ConfigurationProperties(CONNECTOR_CONFIG_PREFIX)
 @SuppressFBWarnings(value = ["NP_NONNULL_RETURN_VIOLATION"], justification = "Micronaut DI")
 class MySqlSourceConfigurationSpecification : ConfigurationSpecification() {
+//class MySqlSourceConfigurationSpecification @Inject constructor(private val featureFlags: Set<FeatureFlag>) : ConfigurationSpecification() {
     @JsonProperty("host")
     @JsonSchemaTitle("Host")
     @JsonSchemaInject(json = """{"order":1}""")
@@ -98,10 +99,9 @@ class MySqlSourceConfigurationSpecification : ConfigurationSpecification() {
     @JsonGetter("ssl_mode")
     @JsonSchemaTitle("Encryption")
     @JsonPropertyDescription(
-        "The encryption method with is used when communicating with the database.",
+        "The encryption method which is used when communicating with the database.",
     )
-    @JsonSchemaInject(json = """{"order":8}""")
-    @JsonSchemaDefault("required")
+    @JsonSchemaInject(json = """{"order":8,"default":"required"}""")
     fun getEncryptionValue(): EncryptionSpecification? = encryptionJson ?: encryption.asEncryption()
 
     @JsonIgnore

--- a/airbyte-integrations/connectors/source-mysql/src/test/kotlin/io/airbyte/integrations/source/mysql/MySqlSourceConfigurationSpecificationTest.kt
+++ b/airbyte-integrations/connectors/source-mysql/src/test/kotlin/io/airbyte/integrations/source/mysql/MySqlSourceConfigurationSpecificationTest.kt
@@ -33,7 +33,7 @@ class MySqlSourceConfigurationSpecificationTest {
         Assertions.assertEquals("BAR", pojo.password)
         Assertions.assertEquals("SYSTEM", pojo.database)
         val encryption: EncryptionSpecification = pojo.getEncryptionValue()!!
-        Assertions.assertTrue(encryption is EncryptionPreferred, encryption::class.toString())
+        Assertions.assertTrue(encryption is EncryptionRequired, encryption::class.toString())
         val tunnelMethod: SshTunnelMethodConfiguration? = pojo.getTunnelMethodValue()
         Assertions.assertTrue(
             tunnelMethod is SshPasswordAuthTunnelMethod,
@@ -66,7 +66,7 @@ class MySqlSourceConfigurationSpecificationTest {
   "password": "BAR",
   "database": "SYSTEM",
   "ssl_mode": {
-    "mode": "preferred"
+    "mode": "required"
   },
   "tunnel_method": {
     "tunnel_method": "SSH_PASSWORD_AUTH",

--- a/airbyte-integrations/connectors/source-mysql/src/test/kotlin/io/airbyte/integrations/source/mysql/MySqlSourceConfigurationTest.kt
+++ b/airbyte-integrations/connectors/source-mysql/src/test/kotlin/io/airbyte/integrations/source/mysql/MySqlSourceConfigurationTest.kt
@@ -62,15 +62,8 @@ class MySqlSourceConfigurationTest {
     @Property(name = "airbyte.connector.config.username", value = "FOO")
     @Property(name = "airbyte.connector.config.password", value = "BAR")
     @Property(name = "airbyte.connector.config.database", value = "SYSTEM")
-    fun testAirbyteCloudDeployment() {
-        val pojo: MySqlSourceConfigurationSpecification = pojoSupplier.get()
-        Assertions.assertThrows(ConfigErrorException::class.java) {
-            factory.makeWithoutExceptionHandling(pojo)
-        }
-    }
-
-    @Test
     @Property(name = "airbyte.connector.config.json", value = CONFIG_V1)
+
     fun testParseConfigFromV1() {
         val pojo: MySqlSourceConfigurationSpecification = pojoSupplier.get()
 

--- a/airbyte-integrations/connectors/source-mysql/src/test/resources/expected-spec.json
+++ b/airbyte-integrations/connectors/source-mysql/src/test/resources/expected-spec.json
@@ -124,7 +124,7 @@
         "type": "object"
       },
       "ssl_mode": {
-        "description": "The encryption method with is used when communicating with the database.",
+        "description": "The encryption method which is used when communicating with the database.",
         "oneOf": [
           {
             "additionalProperties": true,


### PR DESCRIPTION
This PR is for visibility only and is not intended to be merged.

## What
Partially fix [7612](https://github.com/airbytehq/oncall/issues/7612)

- Set "required" as the default value for ssl_mode. 
- Missing: environment-specific defaults (`required` for Cloud, `disable` for OSS) and other items listed in #7612.

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
