### PR TITLE
Bulk load CDK: handle failure in StreamLoader.close()

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/state/StreamManager.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/state/StreamManager.kt
@@ -55,7 +55,7 @@ interface StreamManager {
     fun endOfStreamRead(): Boolean
 
     /** Whether we received a stream complete message for the managed stream. */
-    fun isComplete(): Boolean
+    fun receivedStreamComplete(): Boolean
 
     /**
      * Mark a checkpoint in the stream and return the current index and the number of records since
@@ -200,7 +200,7 @@ class DefaultStreamManager(
         return markedEndOfStream.get()
     }
 
-    override fun isComplete(): Boolean {
+    override fun receivedStreamComplete(): Boolean {
         return receivedComplete.get()
     }
 

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/state/SyncManager.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/state/SyncManager.kt
@@ -123,7 +123,7 @@ class DefaultSyncManager(
     }
 
     override suspend fun allStreamsComplete(): Boolean {
-        return streamManagers.all { it.value.isComplete() }
+        return streamManagers.all { it.value.receivedStreamComplete() }
     }
 
     override fun isActive(): Boolean {

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/DestinationTaskLauncher.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/DestinationTaskLauncher.kt
@@ -332,9 +332,15 @@ class DefaultDestinationTaskLauncher<K : WithStream>(
     override suspend fun handleStreamComplete(stream: DestinationStream.Descriptor) {
         log.info { "Processing complete for $stream" }
         if (closeStreamHasRun.getOrPut(stream) { AtomicBoolean(false) }.setOnce()) {
-            log.info { "Batch processing complete: Starting close stream task for $stream" }
-            val task = closeStreamTaskFactory.make(this, stream)
-            launch(task)
+            if (syncManager.getStreamManager(stream).setClosed()) {
+                log.info { "Batch processing complete: Starting close stream task for $stream" }
+                val task = closeStreamTaskFactory.make(this, stream)
+                launch(task)
+            } else {
+                log.warn {
+                    "Close stream task was already initiated for $stream. This is probably undesired; skipping it."
+                }
+            }
         } else {
             log.info { "Close stream task has already run, skipping." }
         }
@@ -352,7 +358,16 @@ class DefaultDestinationTaskLauncher<K : WithStream>(
     override suspend fun handleException(e: Exception) {
         openStreamQueue.close()
         catalog.streams
-            .map { failStreamTaskFactory.make(this, e, it.descriptor) }
+            .map {
+                val shouldRunStreamLoaderClose =
+                    syncManager.getStreamManager(it.descriptor).setClosed()
+                failStreamTaskFactory.make(
+                    this,
+                    e,
+                    it.descriptor,
+                    shouldRunStreamLoaderClose = shouldRunStreamLoaderClose,
+                )
+            }
             .forEach { launch(it, withExceptionHandling = false) }
     }
 

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/DestinationTaskLauncherTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/DestinationTaskLauncherTest.kt
@@ -309,7 +309,8 @@ class DestinationTaskLauncherTest {
         override fun make(
             taskLauncher: DestinationTaskLauncher,
             exception: Exception,
-            stream: DestinationStream.Descriptor
+            stream: DestinationStream.Descriptor,
+            shouldRunStreamLoaderClose: Boolean,
         ): FailStreamTask {
             return object : FailStreamTask {
                 override val terminalCondition: TerminalCondition = SelfTerminating


### PR DESCRIPTION
## What
closes https://github.com/airbytehq/airbyte-internal-issues/issues/12569

## How
the problem:
* `CloseStreamTask` calls `StreamLoader.close()`, which crashes
* this triggers exception handling, so call `FailStreamTask`
* `FailStreamTask` then calls `StreamLoader.close()` again... so it _also_ crashes
* This means we never reach the `taskLauncher.handleFailStreamComplete(stream, exception)` call [here](https://github.com/airbytehq/airbyte/blob/6800e43b6600db5ebf4edfc0d553163b00dc963c/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/implementor/FailStreamTask.kt#L50)
* which causes the sync to hang

the fix:
* when calling `CloseStreamTask`, set a flag on the `StreamManager` to track that we've initiated shutdown for this stream
* pass that flag to `FailStreamTask`, and use it to conditionally skip the `StreamLoader.close()` call

verified locally:
* when I make `MockStreamLoader.close()` just `throw RuntimeException()`, we no longer hang in `MockBasicFuncIntTest.testBasicWrite()`
* I briefly rebased onto the bigquery branch, and verified that `testDedup` no longer hangs (b/c currently dedup is failing in `close()`)

... I could be convinced to add a test somewhere, but not entirely sure where or how. Simplest thing might be to actually use the integration tests, which feels kind of heavyweight

## Review guide
First commit is a simple rename to clarify an unrelated method

second commit is the actual change

## User Impact
fewer hanging syncs :P

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
