### PR TITLE
remediate bugged v1.5.18

### DIFF
--- a/airbyte-integrations/connectors/source-mongodb-v2/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mongodb-v2/metadata.yaml
@@ -47,8 +47,10 @@ data:
   registryOverrides:
     cloud:
       enabled: true
+      dockerImageTag: 1.5.17
     oss:
       enabled: true
+      dockerImageTag: 1.5.17
   releaseStage: generally_available
   releases:
     breakingChanges:

--- a/airbyte-integrations/connectors/source-mongodb-v2/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mongodb-v2/metadata.yaml
@@ -47,9 +47,11 @@ data:
   registryOverrides:
     cloud:
       enabled: true
+      # avoid 1.5.18 which introduced an issue while upgrading dependencies
       dockerImageTag: 1.5.17
     oss:
       enabled: true
+      # avoid 1.5.18 which introduced an issue while upgrading dependencies
       dockerImageTag: 1.5.17
   releaseStage: generally_available
   releases:


### PR DESCRIPTION
Instruct cloud and oss to use version 1.5.17, rather than the bugged 1.5.18

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
