### PR TITLE
source-mysql: Update default ssl mode to required

### DIFF
--- a/airbyte-integrations/connectors/source-mysql/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mysql/metadata.yaml
@@ -9,7 +9,7 @@ data:
   connectorSubtype: database
   connectorType: source
   definitionId: 435bb9a5-7887-4809-aa58-28c27df0d7ad
-  dockerImageTag: 3.11.13
+  dockerImageTag: 3.11.14
   dockerRepository: airbyte/source-mysql
   documentationUrl: https://docs.airbyte.com/integrations/sources/mysql
   githubIssueLabel: source-mysql

--- a/airbyte-integrations/connectors/source-mysql/src/main/kotlin/io/airbyte/integrations/source/mysql/MySqlSourceConfiguration.kt
+++ b/airbyte-integrations/connectors/source-mysql/src/main/kotlin/io/airbyte/integrations/source/mysql/MySqlSourceConfiguration.kt
@@ -124,6 +124,7 @@ class MySqlSourceConfigurationFactory @Inject constructor(val featureFlags: Set<
         }
         val sslJdbcProperties: Map<String, String> = fromEncryptionSpec(pojo.getEncryptionValue()!!)
         jdbcProperties.putAll(sslJdbcProperties)
+        log.info { "SSL mode: ${sslJdbcProperties["sslMode"]}" }
 
         // Configure cursor.
         val incremental: IncrementalConfiguration = fromIncrementalSpec(pojo.getIncrementalValue())

--- a/airbyte-integrations/connectors/source-mysql/src/main/kotlin/io/airbyte/integrations/source/mysql/MySqlSourceConfigurationSpecification.kt
+++ b/airbyte-integrations/connectors/source-mysql/src/main/kotlin/io/airbyte/integrations/source/mysql/MySqlSourceConfigurationSpecification.kt
@@ -98,10 +98,9 @@ class MySqlSourceConfigurationSpecification : ConfigurationSpecification() {
     @JsonGetter("ssl_mode")
     @JsonSchemaTitle("Encryption")
     @JsonPropertyDescription(
-        "The encryption method with is used when communicating with the database.",
+        "The encryption method which is used when communicating with the database.",
     )
-    @JsonSchemaInject(json = """{"order":8}""")
-    @JsonSchemaDefault("required")
+    @JsonSchemaInject(json = """{"order":8,"default":"required"}""")
     fun getEncryptionValue(): EncryptionSpecification? = encryptionJson ?: encryption.asEncryption()
 
     @JsonIgnore

--- a/airbyte-integrations/connectors/source-mysql/src/test/kotlin/io/airbyte/integrations/source/mysql/MySqlSourceConfigurationSpecificationTest.kt
+++ b/airbyte-integrations/connectors/source-mysql/src/test/kotlin/io/airbyte/integrations/source/mysql/MySqlSourceConfigurationSpecificationTest.kt
@@ -33,7 +33,7 @@ class MySqlSourceConfigurationSpecificationTest {
         Assertions.assertEquals("BAR", pojo.password)
         Assertions.assertEquals("SYSTEM", pojo.database)
         val encryption: EncryptionSpecification = pojo.getEncryptionValue()!!
-        Assertions.assertTrue(encryption is EncryptionPreferred, encryption::class.toString())
+        Assertions.assertTrue(encryption is EncryptionRequired, encryption::class.toString())
         val tunnelMethod: SshTunnelMethodConfiguration? = pojo.getTunnelMethodValue()
         Assertions.assertTrue(
             tunnelMethod is SshPasswordAuthTunnelMethod,
@@ -66,7 +66,7 @@ class MySqlSourceConfigurationSpecificationTest {
   "password": "BAR",
   "database": "SYSTEM",
   "ssl_mode": {
-    "mode": "preferred"
+    "mode": "required"
   },
   "tunnel_method": {
     "tunnel_method": "SSH_PASSWORD_AUTH",

--- a/airbyte-integrations/connectors/source-mysql/src/test/kotlin/io/airbyte/integrations/source/mysql/MySqlSourceConfigurationTest.kt
+++ b/airbyte-integrations/connectors/source-mysql/src/test/kotlin/io/airbyte/integrations/source/mysql/MySqlSourceConfigurationTest.kt
@@ -63,8 +63,6 @@ class MySqlSourceConfigurationTest {
     @Property(name = "airbyte.connector.config.username", value = "FOO")
     @Property(name = "airbyte.connector.config.password", value = "BAR")
     @Property(name = "airbyte.connector.config.database", value = "SYSTEM")
-
-
     @Property(name = "airbyte.connector.config.json", value = CONFIG_V1)
     fun testParseConfigFromV1() {
         val pojo: MySqlSourceConfigurationSpecification = pojoSupplier.get()
@@ -97,7 +95,6 @@ class MySqlSourceConfigurationTest {
     @Property(name = "airbyte.connector.config.username", value = "FOO")
     @Property(name = "airbyte.connector.config.password", value = "BAR")
     @Property(name = "airbyte.connector.config.database", value = "SYSTEM")
-
     @Property(name = "airbyte.connector.config.json", value = CONFIG_V2)
     fun testCloudRequirements() {
         val pojo: MySqlSourceConfigurationSpecification = pojoSupplier.get()
@@ -108,7 +105,10 @@ class MySqlSourceConfigurationTest {
             Assertions.fail("Expected ConfigErrorException, but no exception was thrown")
         } catch (e: ConfigErrorException) {
             // Here we verify that the caught exception has the expected message
-            Assertions.assertEquals("Connection from Airbyte Cloud requires SSL encryption or an SSH tunnel.", e.message)
+            Assertions.assertEquals(
+                "Connection from Airbyte Cloud requires SSL encryption or an SSH tunnel.",
+                e.message
+            )
         }
     }
     companion object {

--- a/airbyte-integrations/connectors/source-mysql/src/test/kotlin/io/airbyte/integrations/source/mysql/MySqlSourceConfigurationTest.kt
+++ b/airbyte-integrations/connectors/source-mysql/src/test/kotlin/io/airbyte/integrations/source/mysql/MySqlSourceConfigurationTest.kt
@@ -30,7 +30,6 @@ class MySqlSourceConfigurationTest {
     @Property(name = "airbyte.connector.config.username", value = "FOO")
     @Property(name = "airbyte.connector.config.password", value = "BAR")
     @Property(name = "airbyte.connector.config.database", value = "SYSTEM")
-    @Property(name = "airbyte.connector.config.ssl_mode.mode", value = "required")
     @Property(
         name = "airbyte.connector.config.jdbc_url_params",
         value = "theAnswerToLiveAndEverything=42&sessionVariables=max_execution_time=10000&foo=bar&"
@@ -54,6 +53,8 @@ class MySqlSourceConfigurationTest {
 
         Assertions.assertEquals(config.jdbcProperties["theAnswerToLiveAndEverything"], "42")
         Assertions.assertEquals(config.jdbcProperties["foo"], "bar")
+        // test default value
+        Assertions.assertEquals(config.jdbcProperties["sslMode"], "required")
     }
 
     @Test
@@ -62,14 +63,8 @@ class MySqlSourceConfigurationTest {
     @Property(name = "airbyte.connector.config.username", value = "FOO")
     @Property(name = "airbyte.connector.config.password", value = "BAR")
     @Property(name = "airbyte.connector.config.database", value = "SYSTEM")
-    fun testAirbyteCloudDeployment() {
-        val pojo: MySqlSourceConfigurationSpecification = pojoSupplier.get()
-        Assertions.assertThrows(ConfigErrorException::class.java) {
-            factory.makeWithoutExceptionHandling(pojo)
-        }
-    }
 
-    @Test
+
     @Property(name = "airbyte.connector.config.json", value = CONFIG_V1)
     fun testParseConfigFromV1() {
         val pojo: MySqlSourceConfigurationSpecification = pojoSupplier.get()
@@ -96,6 +91,26 @@ class MySqlSourceConfigurationTest {
         Assertions.assertTrue(config.sshTunnel is SshNoTunnelMethod)
     }
 
+    @Test
+    @Property(name = "airbyte.connector.config.host", value = "localhost")
+    @Property(name = "airbyte.connector.config.port", value = "12345")
+    @Property(name = "airbyte.connector.config.username", value = "FOO")
+    @Property(name = "airbyte.connector.config.password", value = "BAR")
+    @Property(name = "airbyte.connector.config.database", value = "SYSTEM")
+
+    @Property(name = "airbyte.connector.config.json", value = CONFIG_V2)
+    fun testCloudRequirements() {
+        val pojo: MySqlSourceConfigurationSpecification = pojoSupplier.get()
+
+        try {
+            factory.makeWithoutExceptionHandling(pojo)
+            // If we reach here, no exception was thrown - test should fail
+            Assertions.fail("Expected ConfigErrorException, but no exception was thrown")
+        } catch (e: ConfigErrorException) {
+            // Here we verify that the caught exception has the expected message
+            Assertions.assertEquals("Connection from Airbyte Cloud requires SSL encryption or an SSH tunnel.", e.message)
+        }
+    }
     companion object {
 
         const val CONFIG_V1: String =
@@ -107,6 +122,28 @@ class MySqlSourceConfigurationTest {
   "password": "BAR",
   "ssl_mode": {
     "mode": "required"
+  },
+  "username": "FOO",
+  "tunnel_method": {
+    "tunnel_method": "NO_TUNNEL"
+  },
+  "replication_method": {
+    "method": "CDC",
+    "initial_waiting_seconds": 301,
+    "initial_load_timeout_hours": 9,
+    "invalid_cdc_cursor_position_behavior": "Re-sync data"
+  }
+}
+"""
+        const val CONFIG_V2: String =
+            """
+{
+  "host": "localhost",
+  "port": 12345,
+  "database": "SYSTEM",
+  "password": "BAR",
+  "ssl_mode": {
+    "mode": "preferred"
   },
   "username": "FOO",
   "tunnel_method": {

--- a/airbyte-integrations/connectors/source-mysql/src/test/resources/expected-spec.json
+++ b/airbyte-integrations/connectors/source-mysql/src/test/resources/expected-spec.json
@@ -124,7 +124,8 @@
         "type": "object"
       },
       "ssl_mode": {
-        "description": "The encryption method with is used when communicating with the database.",
+        "default": "required",
+        "description": "The encryption method which is used when communicating with the database.",
         "oneOf": [
           {
             "additionalProperties": true,

--- a/docs/integrations/sources/mysql.md
+++ b/docs/integrations/sources/mysql.md
@@ -125,16 +125,16 @@ Airbyte offers incremental replication using a custom cursor available in your s
 
 ### SSL Modes
 
-Airbyte Cloud uses SSL by default. You are not permitted to `disable` SSL while using Airbyte Cloud.
+Airbyte Cloud uses `required` SSL mode by default. You are not permitted to `disable` SSL while using Airbyte Cloud.
 
 Here is a breakdown of available SSL connection modes:
 
-- `disable` to disable encrypted communication between Airbyte and the source
+- `required` to always require encryption. Note: The connection will fail if the source doesn't support encryption.
+- `preferred` to allow unencrypted communication only when the source doesn't support encryption
+- `verify_ca` to always require encryption and verify that the source has a valid SSL certificate
+- `verify_identity` to always require encryption and verify the identity of the source
+- `disabled` to disable encrypted communication between Airbyte and the source
 - `allow` to enable encrypted communication only when required by the source
-- `prefer` to allow unencrypted communication only when the source doesn't support encryption
-- `require` to always require encryption. Note: The connection will fail if the source doesn't support encryption.
-- `verify-ca` to always require encryption and verify that the source has a valid SSL certificate
-- `verify-full` to always require encryption and verify the identity of the source
 
 </FieldAnchor>
 
@@ -226,6 +226,7 @@ Any database or table encoding combination of charset and collation is supported
 
 | Version     | Date       | Pull Request                                               | Subject                                                                                                                                         |
 |:------------|:-----------|:-----------------------------------------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------|
+| 3.11.14     | 2025-04-29 | []()   | Update default SSL mode.                                                                                                                        |
 | 3.11.13     | 2025-04-24 | [58646](https://github.com/airbytehq/airbyte/pull/58646)   | Fix vulnerabilities in dependencies.                                                                                                            |
 | 3.11.12     | 2025-04-18 | [58132](https://github.com/airbytehq/airbyte/pull/58132)   | Fix vulnerabilities in dependencies.                                                                                                            |
 | 3.11.11     | 2025-04-23 | [58623](https://github.com/airbytehq/airbyte/pull/58623) | Bump CDK version to the latets published                                                                                                        |

--- a/docs/integrations/sources/mysql.md
+++ b/docs/integrations/sources/mysql.md
@@ -226,7 +226,7 @@ Any database or table encoding combination of charset and collation is supported
 
 | Version     | Date       | Pull Request                                               | Subject                                                                                                                                         |
 |:------------|:-----------|:-----------------------------------------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------|
-| 3.11.14     | 2025-04-29 | []()   | Update default SSL mode.                                                                                                                        |
+| 3.11.14     | 2025-04-29 | [59144](https://github.com/airbytehq/airbyte/pull/59144)   | Update default SSL mode.                                                                                                                        |
 | 3.11.13     | 2025-04-24 | [58646](https://github.com/airbytehq/airbyte/pull/58646)   | Fix vulnerabilities in dependencies.                                                                                                            |
 | 3.11.12     | 2025-04-18 | [58132](https://github.com/airbytehq/airbyte/pull/58132)   | Fix vulnerabilities in dependencies.                                                                                                            |
 | 3.11.11     | 2025-04-23 | [58623](https://github.com/airbytehq/airbyte/pull/58623) | Bump CDK version to the latets published                                                                                                        |


### PR DESCRIPTION
## What

Fixes [7612](https://github.com/airbytehq/oncall/issues/7612 )

## How
- Sets "required" as the default ssl_mode whenever the spec JSON is generated.
- Extends unit tests to verify that this default is automatically applied.

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
No known impact. 

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
