### PR TITLE
fix: progressive rollout rollback PR label

### DIFF
--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/publish/pipeline.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/publish/pipeline.py
@@ -675,7 +675,7 @@ async def run_connector_rollback_pipeline(context: PublishConnectorContext, sema
 
             # Open PR when all previous steps are successful
             initial_pr_creation = CreateOrUpdatePullRequest(
-                context, skip_ci=False, labels=[AUTO_MERGE_BYPASS_CI_CHECKS_LABEL, "rollback-rc"]
+                context, skip_ci=True, labels=[AUTO_MERGE_BYPASS_CI_CHECKS_LABEL, "rollback-rc"]
             )
             pr_creation_args, pr_creation_kwargs = get_rollback_pr_creation_arguments(all_modified_files, context, results, current_version)
             initial_pr_creation_result = await initial_pr_creation.run(*pr_creation_args, **pr_creation_kwargs)

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/publish/pipeline.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/publish/pipeline.py
@@ -674,7 +674,9 @@ async def run_connector_rollback_pipeline(context: PublishConnectorContext, sema
                 return connector_report
 
             # Open PR when all previous steps are successful
-            initial_pr_creation = CreateOrUpdatePullRequest(context, skip_ci=False, labels=[AUTO_MERGE_BYPASS_CI_CHECKS_LABEL, "rollback-rc"])
+            initial_pr_creation = CreateOrUpdatePullRequest(
+                context, skip_ci=False, labels=[AUTO_MERGE_BYPASS_CI_CHECKS_LABEL, "rollback-rc"]
+            )
             pr_creation_args, pr_creation_kwargs = get_rollback_pr_creation_arguments(all_modified_files, context, results, current_version)
             initial_pr_creation_result = await initial_pr_creation.run(*pr_creation_args, **pr_creation_kwargs)
             results.append(initial_pr_creation_result)

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/publish/pipeline.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/publish/pipeline.py
@@ -674,7 +674,7 @@ async def run_connector_rollback_pipeline(context: PublishConnectorContext, sema
                 return connector_report
 
             # Open PR when all previous steps are successful
-            initial_pr_creation = CreateOrUpdatePullRequest(context, skip_ci=False, labels=["auto-merge"])
+            initial_pr_creation = CreateOrUpdatePullRequest(context, skip_ci=False, labels=[AUTO_MERGE_BYPASS_CI_CHECKS_LABEL, "rollback-rc"])
             pr_creation_args, pr_creation_kwargs = get_rollback_pr_creation_arguments(all_modified_files, context, results, current_version)
             initial_pr_creation_result = await initial_pr_creation.run(*pr_creation_args, **pr_creation_kwargs)
             results.append(initial_pr_creation_result)


### PR DESCRIPTION
## What
- Fixed rollback PRs to include the PR label that would enables automerge while bypassing PR checks.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
