### PR TITLE
[skip ci] Promote release candidate dest-s3

### DIFF
--- a/airbyte-integrations/connectors/destination-s3/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-s3/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: file
   connectorType: destination
   definitionId: 4816b78f-1489-44c1-9060-4b19d5fa9362
-  dockerImageTag: 1.8.0-rc.1
+  dockerImageTag: 1.8.0
   dockerRepository: airbyte/destination-s3
   githubIssueLabel: destination-s3
   icon: s3.svg
@@ -23,7 +23,7 @@ data:
           **This release includes breaking changes, including major revisions to the schema of stored data. Do not upgrade without reviewing the migration guide.**
         upgradeDeadline: "2024-10-08"
     rolloutConfiguration:
-      enableProgressiveRollout: true
+      enableProgressiveRollout: false
   resourceRequirements:
     jobSpecific:
       - jobType: sync

--- a/docs/integrations/destinations/s3.md
+++ b/docs/integrations/destinations/s3.md
@@ -544,6 +544,7 @@ To see connector limitations, or troubleshoot your S3 connector, see more [in ou
 
 | Version     | Date       | Pull Request                                               | Subject                                                                                                                                              |
 |:------------|:-----------|:-----------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| 1.8.0 | 2025-04-30 | [59168](https://github.com/airbytehq/airbyte/pull/59168) | Promoting release candidate 1.8.0-rc.1 to a main version. |
 | 1.8.0-rc.1  | 2025-04-29 | [59148](https://github.com/airbytehq/airbyte/pull/59148)   | Upgrade to latest CDK with files+records support                                                                                                     |
 | 1.7.4       | 2025-04-21 | [58146](https://github.com/airbytehq/airbyte/pull/58146)   | Upgrade to latest CDK                                                                                                                                |
 | 1.7.3       | 2025-04-18 | [58140](https://github.com/airbytehq/airbyte/pull/58140)   | Upgrade to latest CDK                                                                                                                                |


### PR DESCRIPTION
The release candidate version 1.8.0-rc.1 has been deemed stable and is now ready to be promoted to an official release (1.8.0).