### PR TITLE
Update dependencies for security.

### DIFF
--- a/airbyte-cdk/java/airbyte-cdk/core/src/main/resources/version.properties
+++ b/airbyte-cdk/java/airbyte-cdk/core/src/main/resources/version.properties
@@ -1,1 +1,1 @@
-version=0.48.10
+version=0.48.11

--- a/airbyte-cdk/java/airbyte-cdk/s3-destinations/build.gradle
+++ b/airbyte-cdk/java/airbyte-cdk/s3-destinations/build.gradle
@@ -29,10 +29,15 @@ dependencies {
     api 'org.apache.commons:commons-text:1.12.0'
     api ('org.apache.hadoop:hadoop-aws:3.4.0') { exclude group: 'com.amazonaws', module: 'aws-java-sdk-bundle' }
     api ('org.apache.hadoop:hadoop-common:3.4.0') {
+        exclude group: 'com.google.protobuf'
+        exclude group: 'dnsjava'
+        exclude group: 'io.netty'
         exclude group: 'org.apache.zookeeper'
         exclude group: 'org.apache.hadoop', module: 'hadoop-yarn-common'
     }
     api ('org.apache.hadoop:hadoop-mapreduce-client-core:3.4.0') {
+        exclude group: 'com.google.protobuf'
+        exclude group: 'io.netty'
         exclude group: 'org.apache.zookeeper'
         exclude group: 'org.apache.hadoop', module: 'hadoop-yarn-common'
     }

--- a/airbyte-cdk/java/airbyte-cdk/s3-destinations/build.gradle
+++ b/airbyte-cdk/java/airbyte-cdk/s3-destinations/build.gradle
@@ -29,17 +29,19 @@ dependencies {
     api 'org.apache.commons:commons-text:1.12.0'
     api ('org.apache.hadoop:hadoop-aws:3.4.0') { exclude group: 'com.amazonaws', module: 'aws-java-sdk-bundle' }
     api ('org.apache.hadoop:hadoop-common:3.4.0') {
+        exclude group: 'org.apache.zookeeper'
+        exclude group: 'org.apache.hadoop', module: 'hadoop-yarn-common'
+        // The below dependencies contain security vulnerabilities and are unused.
         exclude group: 'com.google.protobuf'
         exclude group: 'dnsjava'
         exclude group: 'io.netty'
-        exclude group: 'org.apache.zookeeper'
-        exclude group: 'org.apache.hadoop', module: 'hadoop-yarn-common'
     }
     api ('org.apache.hadoop:hadoop-mapreduce-client-core:3.4.0') {
-        exclude group: 'com.google.protobuf'
-        exclude group: 'io.netty'
         exclude group: 'org.apache.zookeeper'
         exclude group: 'org.apache.hadoop', module: 'hadoop-yarn-common'
+        // The below dependencies contain security vulnerabilities and are unused.
+        exclude group: 'com.google.protobuf'
+        exclude group: 'io.netty'
     }
     api 'org.apache.parquet:parquet-avro:1.15.1'
     runtimeOnly 'com.hadoop.gplcompression:hadoop-lzo:0.4.20'

--- a/airbyte-integrations/connectors/destination-snowflake/build.gradle
+++ b/airbyte-integrations/connectors/destination-snowflake/build.gradle
@@ -5,7 +5,7 @@ plugins {
 airbyteJavaConnector {
     cdkVersionRequired = '0.48.10'
     features = ['db-destinations', 's3-destinations', 'typing-deduping']
-    useLocalCdk = false
+    useLocalCdk = true
 }
 
 java {

--- a/airbyte-integrations/connectors/destination-snowflake/build.gradle
+++ b/airbyte-integrations/connectors/destination-snowflake/build.gradle
@@ -5,7 +5,7 @@ plugins {
 airbyteJavaConnector {
     cdkVersionRequired = '0.48.10'
     features = ['db-destinations', 's3-destinations', 'typing-deduping']
-    useLocalCdk = true
+    useLocalCdk = false
 }
 
 java {


### PR DESCRIPTION
## What
All of these dependencies have vulnerabilities. It also looks like we aren't using them - we are primarily using the hadoop libraries parquet right now.

The goal of this is to remove all the high vulnerabilities in the base CDK now, and update Snowflake to take advantage of this.

## How
Stop including them.

The Hadoop Commons dependency is the main culprit, and 3.4.0 is the latest, which contains the protobuf, netty and dnsjava vulnerabilities. No later versions exists, so we have to exclude these for now.

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
