### PR TITLE
feat(connectors): Add `buildImage` Gradle task to run `airbyte-cdk image build`

### DIFF
--- a/airbyte-integrations/connectors/build.gradle
+++ b/airbyte-integrations/connectors/build.gradle
@@ -108,32 +108,17 @@ allprojects {
             logger.lifecycle("Building connector image using airbyte-cdk")
             logger.lifecycle("If this fails with 'command not found', please install with 'pip install airbyte-cdk[dev]'")
             
-            // Create a shell script to run the command with proper syntax
-            def scriptFile = new File(temporaryDir, "build_image.sh")
-            scriptFile.text = """#!/bin/bash
-cd "${projectDir.absolutePath}"
-# Check if airbyte-cdk command is available
-command -v airbyte-cdk >/dev/null 2>&1 || { 
-  echo "airbyte-cdk command not found. Please install with 'pip install airbyte-cdk[dev]'"; 
-  echo "If pip is not available, install uv with 'brew install uv' first";
-  exit 127; 
-}
-# Run the image build command
-airbyte-cdk image build
-exit \$?
-"""
-            scriptFile.setExecutable(true)
-            
+            // Run the command directly
             def result = exec {
                 workingDir = projectDir
-                executable '/bin/bash'
-                args scriptFile.absolutePath
+                executable 'sh'
+                args '-c', 'airbyte-cdk image build'
                 ignoreExitValue = true
             }
             
             if (result.exitValue != 0) {
                 if (result.exitValue == 127) { // Command not found exit code
-                    throw new GradleException("Error: 'uvx' command not found. Please install uv with 'brew install uv'")
+                    throw new GradleException("Error: 'airbyte-cdk' command not found. Please install with 'pip install airbyte-cdk[dev]'")
                 } else {
                     throw new GradleException("Error: Image build failed with exit code ${result.exitValue}. Check the logs for details.")
                 }

--- a/airbyte-integrations/connectors/build.gradle
+++ b/airbyte-integrations/connectors/build.gradle
@@ -98,7 +98,7 @@ allprojects {
     // Convenience tasks for local airbyte-ci execution.
     airbyteCIConnectorsTask('airbyteCIConnectorBuild', 'build')
     airbyteCIConnectorsTask('airbyteCIConnectorTest', 'test')
-    
+
     // Task to build connector image using the CDK CLI
     tasks.register('buildImage', Exec) {
         description = 'Build connector Docker image using the CDK CLI'
@@ -106,7 +106,7 @@ allprojects {
         workingDir projectDir
         commandLine pythonBin
         args "-m", "uvx", "airbyte-cdk[dev]", "image", "build"
-        
+
         // Always re-run this task
         outputs.upToDateWhen { false }
     }

--- a/airbyte-integrations/connectors/build.gradle
+++ b/airbyte-integrations/connectors/build.gradle
@@ -103,11 +103,11 @@ allprojects {
     tasks.register('buildImage') {
         description = 'Build connector Docker image using the CDK CLI'
         group = 'build'
-        
+
         doLast {
             logger.lifecycle("Building connector image using airbyte-cdk")
             logger.lifecycle("If this fails with 'command not found', please install with 'pip install airbyte-cdk[dev]'")
-            
+
             // Run the command directly
             def result = exec {
                 workingDir = projectDir
@@ -115,7 +115,7 @@ allprojects {
                 args '-c', 'airbyte-cdk image build'
                 ignoreExitValue = true
             }
-            
+
             if (result.exitValue != 0) {
                 if (result.exitValue == 127) { // Command not found exit code
                     throw new GradleException("Error: 'airbyte-cdk' command not found. Please install with 'pip install airbyte-cdk[dev]'")
@@ -124,7 +124,7 @@ allprojects {
                 }
             }
         }
-        
+
         // Always re-run this task
         outputs.upToDateWhen { false }
     }

--- a/airbyte-integrations/connectors/build.gradle
+++ b/airbyte-integrations/connectors/build.gradle
@@ -100,13 +100,46 @@ allprojects {
     airbyteCIConnectorsTask('airbyteCIConnectorTest', 'test')
 
     // Task to build connector image using the CDK CLI
-    tasks.register('buildImage', Exec) {
+    tasks.register('buildImage') {
         description = 'Build connector Docker image using the CDK CLI'
         group = 'build'
-        workingDir projectDir
-        commandLine pythonBin
-        args "-m", "uvx", "airbyte-cdk[dev]", "image", "build"
-
+        
+        doLast {
+            logger.lifecycle("Building connector image using airbyte-cdk")
+            logger.lifecycle("If this fails with 'command not found', please install with 'pip install airbyte-cdk[dev]'")
+            
+            // Create a shell script to run the command with proper syntax
+            def scriptFile = new File(temporaryDir, "build_image.sh")
+            scriptFile.text = """#!/bin/bash
+cd "${projectDir.absolutePath}"
+# Check if airbyte-cdk command is available
+command -v airbyte-cdk >/dev/null 2>&1 || { 
+  echo "airbyte-cdk command not found. Please install with 'pip install airbyte-cdk[dev]'"; 
+  echo "If pip is not available, install uv with 'brew install uv' first";
+  exit 127; 
+}
+# Run the image build command
+airbyte-cdk image build
+exit \$?
+"""
+            scriptFile.setExecutable(true)
+            
+            def result = exec {
+                workingDir = projectDir
+                executable '/bin/bash'
+                args scriptFile.absolutePath
+                ignoreExitValue = true
+            }
+            
+            if (result.exitValue != 0) {
+                if (result.exitValue == 127) { // Command not found exit code
+                    throw new GradleException("Error: 'uvx' command not found. Please install uv with 'brew install uv'")
+                } else {
+                    throw new GradleException("Error: Image build failed with exit code ${result.exitValue}. Check the logs for details.")
+                }
+            }
+        }
+        
         // Always re-run this task
         outputs.upToDateWhen { false }
     }

--- a/airbyte-integrations/connectors/build.gradle
+++ b/airbyte-integrations/connectors/build.gradle
@@ -106,7 +106,6 @@ allprojects {
 
         doLast {
             logger.lifecycle("Building connector image using airbyte-cdk")
-            logger.lifecycle("If this fails with 'command not found', please install with 'pip install airbyte-cdk[dev]'")
 
             // Run the command directly
             def result = exec {

--- a/airbyte-integrations/connectors/build.gradle
+++ b/airbyte-integrations/connectors/build.gradle
@@ -98,4 +98,16 @@ allprojects {
     // Convenience tasks for local airbyte-ci execution.
     airbyteCIConnectorsTask('airbyteCIConnectorBuild', 'build')
     airbyteCIConnectorsTask('airbyteCIConnectorTest', 'test')
+    
+    // Task to build connector image using the CDK CLI
+    tasks.register('buildImage', Exec) {
+        description = 'Build connector Docker image using the CDK CLI'
+        group = 'build'
+        workingDir projectDir
+        commandLine pythonBin
+        args "-m", "uvx", "airbyte-cdk[dev]", "image", "build"
+        
+        // Always re-run this task
+        outputs.upToDateWhen { false }
+    }
 }

--- a/airbyte-integrations/connectors/build.gradle
+++ b/airbyte-integrations/connectors/build.gradle
@@ -105,22 +105,15 @@ allprojects {
         group = 'build'
 
         doLast {
-            logger.lifecycle("Building connector image using airbyte-cdk")
+            logger.lifecycle("Building connector image using airbyte-cdk...")
+            logger.lifecycle("If this fails, make sure `uv` is installed (`brew install uv`).")
 
             // Run the command directly
             def result = exec {
                 workingDir = projectDir
-                executable 'sh'
-                args '-c', 'airbyte-cdk image build'
-                ignoreExitValue = true
-            }
-
-            if (result.exitValue != 0) {
-                if (result.exitValue == 127) { // Command not found exit code
-                    throw new GradleException("Error: 'airbyte-cdk' command not found. Please install with 'pip install airbyte-cdk[dev]'")
-                } else {
-                    throw new GradleException("Error: Image build failed with exit code ${result.exitValue}. Check the logs for details.")
-                }
+                executable 'uvx'
+                args 'airbyte-cdk[dev]@latest', 'image', 'build'
+                ignoreExitValue = false
             }
         }
 


### PR DESCRIPTION
# Add `buildImage` Gradle task to run `airbyte-cdk image build` via `uv`

This PR adds a new Gradle task called `buildImage` that runs `uvx airbyte-cdk[dev] image build` from the connector directory. The task is added to the central build.gradle file for all connectors, making it available to all connector types.

## Implementation Details

The task is implemented as an Exec task that:
- Uses the Python binary from the project's virtualenv
- Runs `uvx airbyte-cdk[dev] image build` command
- Uses the connector directory as the working directory
- Is configured to always run (not cached)

## How to Use

Connectors can now run this task with:
```
./gradlew :airbyte-integrations:connectors:{connector-name}:buildImage
```

For example:
```
./gradlew :airbyte-integrations:connectors:source-mysql:buildImage
```

The `airbyte-cdk` CLI does not need to be preinstalled, but `uv` does. The task output clearly suggests to install `uv` with `brew install uv` if it is not already installed.

https://www.loom.com/share/6473fb70d9ba427a9d75b98579d04743

## Link to Devin run
https://app.devin.ai/sessions/47c1b7b74c484cb0acf356050df99aa5
