### PR TITLE
bigquery: some test fixes

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/ExpectedRecordMapper.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/ExpectedRecordMapper.kt
@@ -23,10 +23,11 @@ fun interface ExpectedRecordMapper {
 
     fun compose(mapper: ExpectedRecordMapper) =
         object : ExpectedRecordMapper {
-            override fun mapRecord(
-                expectedRecord: OutputRecord,
-                schema: AirbyteType
-            ): OutputRecord = mapper.mapRecord(this.mapRecord(expectedRecord, schema), schema)
+            override fun mapRecord(expectedRecord: OutputRecord, schema: AirbyteType) =
+                mapper.mapRecord(
+                    this@ExpectedRecordMapper.mapRecord(expectedRecord, schema),
+                    schema
+                )
         }
 }
 

--- a/airbyte-cdk/bulk/toolkits/load-db/src/testFixtures/kotlin/io/airbyte/cdk/load/toolkits/load/db/orchestration/RootLevelTimestampsToUtcMapper.kt
+++ b/airbyte-cdk/bulk/toolkits/load-db/src/testFixtures/kotlin/io/airbyte/cdk/load/toolkits/load/db/orchestration/RootLevelTimestampsToUtcMapper.kt
@@ -7,7 +7,6 @@ package io.airbyte.cdk.load.toolkits.load.db.orchestration
 import io.airbyte.cdk.load.data.AirbyteType
 import io.airbyte.cdk.load.data.ObjectValue
 import io.airbyte.cdk.load.data.TimeWithTimezoneValue
-import io.airbyte.cdk.load.data.TimeWithoutTimezoneValue
 import io.airbyte.cdk.load.data.TimestampWithTimezoneValue
 import io.airbyte.cdk.load.test.util.ExpectedRecordMapper
 import io.airbyte.cdk.load.test.util.OutputRecord
@@ -21,9 +20,7 @@ object RootLevelTimestampsToUtcMapper : ExpectedRecordMapper {
                 expectedRecord.data.values.mapValuesTo(linkedMapOf()) { (_, value) ->
                     when (value) {
                         is TimeWithTimezoneValue ->
-                            TimeWithoutTimezoneValue(
-                                value.value.withOffsetSameInstant(ZoneOffset.UTC).toLocalTime()
-                            )
+                            TimeWithTimezoneValue(value.value.withOffsetSameInstant(ZoneOffset.UTC))
                         is TimestampWithTimezoneValue ->
                             TimestampWithTimezoneValue(
                                 value.value.withOffsetSameInstant(ZoneOffset.UTC)

--- a/airbyte-cdk/bulk/toolkits/load-db/src/testFixtures/kotlin/io/airbyte/cdk/load/toolkits/load/db/orchestration/RootLevelTimestampsToUtcMapper.kt
+++ b/airbyte-cdk/bulk/toolkits/load-db/src/testFixtures/kotlin/io/airbyte/cdk/load/toolkits/load/db/orchestration/RootLevelTimestampsToUtcMapper.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.load.toolkits.load.db.orchestration
+
+import io.airbyte.cdk.load.data.AirbyteType
+import io.airbyte.cdk.load.data.ObjectValue
+import io.airbyte.cdk.load.data.TimeWithTimezoneValue
+import io.airbyte.cdk.load.data.TimeWithoutTimezoneValue
+import io.airbyte.cdk.load.data.TimestampWithTimezoneValue
+import io.airbyte.cdk.load.test.util.ExpectedRecordMapper
+import io.airbyte.cdk.load.test.util.OutputRecord
+import java.time.ZoneOffset
+
+/** Many warehouse destinations store timestamps in UTC. This mapper implements that conversion. */
+object RootLevelTimestampsToUtcMapper : ExpectedRecordMapper {
+    override fun mapRecord(expectedRecord: OutputRecord, schema: AirbyteType): OutputRecord {
+        val mappedData =
+            ObjectValue(
+                expectedRecord.data.values.mapValuesTo(linkedMapOf()) { (_, value) ->
+                    when (value) {
+                        is TimeWithTimezoneValue ->
+                            TimeWithoutTimezoneValue(
+                                value.value.withOffsetSameInstant(ZoneOffset.UTC).toLocalTime()
+                            )
+                        is TimestampWithTimezoneValue ->
+                            TimestampWithTimezoneValue(
+                                value.value.withOffsetSameInstant(ZoneOffset.UTC)
+                            )
+                        else -> value
+                    }
+                }
+            )
+        return expectedRecord.copy(data = mappedData)
+    }
+}

--- a/airbyte-cdk/bulk/toolkits/load-db/src/testFixtures/kotlin/io/airbyte/cdk/load/toolkits/load/db/orchestration/TypingDedupingMetaChangeMapper.kt
+++ b/airbyte-cdk/bulk/toolkits/load-db/src/testFixtures/kotlin/io/airbyte/cdk/load/toolkits/load/db/orchestration/TypingDedupingMetaChangeMapper.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.load.toolkits.load.db.orchestration
+
+import io.airbyte.cdk.load.data.AirbyteType
+import io.airbyte.cdk.load.test.util.ExpectedRecordMapper
+import io.airbyte.cdk.load.test.util.OutputRecord
+import io.airbyte.protocol.models.v0.AirbyteRecordMessageMetaChange.Reason
+
+/**
+ * T+D generated different _airbyte_meta changes than what we do now, because we didn't have any way
+ * to distinguish between e.g. size limitation vs invalid value. so we just map all the DESTINATION
+ * reasons to DESTINATION_TYPECAST_ERROR.
+ */
+object TypingDedupingMetaChangeMapper : ExpectedRecordMapper {
+    override fun mapRecord(expectedRecord: OutputRecord, schema: AirbyteType): OutputRecord {
+        val modifiedMeta =
+            expectedRecord.airbyteMeta?.let { meta ->
+                meta.copy(
+                    changes =
+                        meta.changes.map { change ->
+                            val newReason =
+                                when (change.reason) {
+                                    Reason.DESTINATION_RECORD_SIZE_LIMITATION,
+                                    Reason.DESTINATION_FIELD_SIZE_LIMITATION,
+                                    Reason.DESTINATION_SERIALIZATION_ERROR ->
+                                        Reason.DESTINATION_TYPECAST_ERROR
+                                    else -> change.reason
+                                }
+                            change.copy(reason = newReason)
+                        }
+                )
+            }
+        return expectedRecord.copy(airbyteMeta = modifiedMeta)
+    }
+}

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/typing_deduping/BigQuerySqlGenerator.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/typing_deduping/BigQuerySqlGenerator.kt
@@ -521,7 +521,7 @@ class BigQuerySqlGenerator(private val projectId: String?, private val datasetLo
                      FROM intermediate_data
                    ), numbered_rows AS (
                      SELECT *, row_number() OVER (
-                       PARTITION BY $pkList ORDER BY $cursorOrderClause `_airbyte_extracted_at` DESC
+                       PARTITION BY $pkList ORDER BY $cursorOrderClause, `_airbyte_extracted_at` DESC
                      ) AS row_number
                      FROM new_records
                    )

--- a/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryWriteTest.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryWriteTest.kt
@@ -81,10 +81,11 @@ abstract class BigqueryTDWriteTest(
         supportsDedup = true,
         nullEqualsUnset = true,
         StronglyTyped(
-            convertAllValuesToString = false,
+            convertAllValuesToString = true,
             topLevelFloatLosesPrecision = true,
-            nestedFloatLosesPrecision = false,
+            nestedFloatLosesPrecision = true,
             integerCanBeLarge = false,
+            numberCanBeLarge = false,
         ),
     )
 

--- a/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryWriteTest.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryWriteTest.kt
@@ -98,7 +98,6 @@ class StandardInsertRawOverrideDisableTd :
                     Path.of("secrets/credentials-1s1t-disabletd-standard-raw-override.json"),
                 datasetId = DEFAULT_NAMESPACE_PLACEHOLDER,
                 stagingPath = "test_path/$DEFAULT_NAMESPACE_PLACEHOLDER",
-                rawDatasetId = "${DEFAULT_NAMESPACE_PLACEHOLDER}_raw_dataset",
             )
             .serializeToString(),
     ) {
@@ -140,7 +139,6 @@ class GcsRawOverrideDisableTd :
                 configFile = Path.of("secrets/credentials-1s1t-disabletd-gcs-raw-override.json"),
                 datasetId = DEFAULT_NAMESPACE_PLACEHOLDER,
                 stagingPath = "test_path/$DEFAULT_NAMESPACE_PLACEHOLDER",
-                rawDatasetId = "${DEFAULT_NAMESPACE_PLACEHOLDER}_raw_dataset",
             )
             .serializeToString(),
     ) {
@@ -156,7 +154,6 @@ class GcsRawOverride :
                 configFile = Path.of("secrets/credentials-1s1t-gcs-raw-override.json"),
                 datasetId = DEFAULT_NAMESPACE_PLACEHOLDER,
                 stagingPath = "test_path/$DEFAULT_NAMESPACE_PLACEHOLDER",
-                rawDatasetId = "${DEFAULT_NAMESPACE_PLACEHOLDER}_raw_dataset",
             )
             .serializeToString(),
     ) {

--- a/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryWriteTest.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryWriteTest.kt
@@ -8,6 +8,8 @@ import io.airbyte.cdk.load.test.util.DestinationDataDumper
 import io.airbyte.cdk.load.test.util.ExpectedRecordMapper
 import io.airbyte.cdk.load.test.util.UncoercedExpectedRecordMapper
 import io.airbyte.cdk.load.toolkits.load.db.orchestration.ColumnNameModifyingMapper
+import io.airbyte.cdk.load.toolkits.load.db.orchestration.RootLevelTimestampsToUtcMapper
+import io.airbyte.cdk.load.toolkits.load.db.orchestration.TypingDedupingMetaChangeMapper
 import io.airbyte.cdk.load.util.serializeToString
 import io.airbyte.cdk.load.write.AllTypesBehavior
 import io.airbyte.cdk.load.write.BasicFunctionalityIntegrationTest
@@ -71,7 +73,9 @@ abstract class BigqueryTDWriteTest(
     BigqueryWriteTest(
         configContents = configContents,
         BigqueryFinalTableDataDumper,
-        ColumnNameModifyingMapper(BigqueryColumnNameGenerator()),
+        ColumnNameModifyingMapper(BigqueryColumnNameGenerator())
+            .compose(RootLevelTimestampsToUtcMapper)
+            .compose(TypingDedupingMetaChangeMapper),
         isStreamSchemaRetroactive = true,
         preserveUndeclaredFields = false,
         supportsDedup = true,


### PR DESCRIPTION
handle two more things:
* expect times/timestamps in UTC
* deal with T+D being bad at generating Meta.Change.Reason

and fix a few easy config problems, plus a sql syntax error

in particular: raw table dataset is no longer randomized. The entire point of that dataset is that it can be safely shared (and therefore testNamespaces should test our behavior when it's shared across tests).