### PR TITLE
Docs 12686 update contributor docs with multi-instance and versioning info

### DIFF
--- a/docs/platform/contributing-to-airbyte/writing-docs.md
+++ b/docs/platform/contributing-to-airbyte/writing-docs.md
@@ -5,7 +5,7 @@ import TabItem from "@theme/TabItem";
 
 Everyone is welcome to contribute to Airbyte's documentation.
 
-Airbyte's documentation is in the [Airbyte repository](https://github.com/airbytehq/airbyte/tree/master/docs) on GitHub. It's published at [docs.airbyte.com](https://docs.airbyte.com/) using [Vercel](https://vercel.com). Connector docs are also rendered within Airbyte itself when setting up new connectors. The docs are built on [Docusaurus](https://docusaurus.io/). Content is written in [Markdown](https://guides.github.com/features/mastering-markdown/) and all topics are in the `/docs` folder. Configuration files and historical platform docs versions are in the `/docusaurus` folder.
+Airbyte's documentation is in the [Airbyte repository](https://github.com/airbytehq/airbyte/tree/master/docs) on GitHub. It's published at [docs.airbyte.com](https://docs.airbyte.com/) using [Vercel](https://vercel.com). Connector docs are also rendered within Airbyte itself when setting up new connectors. The docs are built on [Docusaurus](https://docusaurus.io/). Content is written in [Markdown](https://guides.github.com/features/mastering-markdown/) and all topics are in the `/docs` folder. Configuration files and previously-released versions of platform docs versions are in the `/docusaurus` folder.
 
 ## Open source contributions welcome
 
@@ -164,11 +164,9 @@ Currently, the site has four instances, but Airbyte could add more instances lat
 - Connectors (not versioned)
 - Release notes (not versioned)
 
-For most contributors, this reality is transparent and not particularly relevant. However, there is one important concept to keep in mind.
+For most contributors, this reality isn't particularly relevant to producing docs. However, there is one important concept to keep in mind.
 
-When you update content for a versioned set of docs, your changes go into what Docusaurus calls the Next version: the version of Airbyte that isn't released yet, and which users can access by selecting "Next" using the version picker in the navigation. Docs for previously released versions of Airbyte aren't updated with these changes.
-
-If you find yourself looking at a local build but unable to see your changes, you're probably looking at docs for a version that was already released. Switch to the Next version to see your changes immediately.
+When you update content for a versioned set of docs, your changes go into what Docusaurus calls the Next version: the version of Airbyte that isn't released yet, and which users can access by selecting "Next" using the version picker in the navigation. Docs for previously released versions of Airbyte aren't updated. If you are unable to see your changes reflected on the site, you're probably looking at docs for a version that was already released. Switch to the Next version to see your changes.
 
 You can still update documentation for released versions, but you need to make these changes to the released files. Docusaurus stores these in `/docusaurus/<instance>_versioned_docs`.
 
@@ -483,29 +481,38 @@ When someone merges documentation changes into the `master` branch, Vercel deplo
 This information is only relevant to Airbyte employees who release new versions of Airbyte.
 :::
 
+When you release a new version of Airbyte, make a new docs version of the docs to match it.
+
 ### Create a new major version
 
 When you release a new major version of Airbyte (for example, 2.0, 2.1, etc.), generate a documentation version for it. This process generates a "frozen" set of the docs based on their state at that point in time. Once the version exists, you _can_ still update those docs, but changes you make don't carry forward to future versions.
 
-Open a terminal, change to the docusaurus folder, and run the command to generate a version.
+1. In GitHub, create a new branch off `master`.
 
-```bash
-cd docusaurus
-pnpm run docusaurus docs:version:platform <version>
-```
+2. Open a terminal, change to the docusaurus folder, and run the command to generate a version. `<version>` can be a number like `2.0` or anything else you like. Be consistent with Airbyte and other versions on the docs site. Whatever string you enter here later appears in the docs UI.
 
-Where `<version>` can be `1.7`, `1.8`, etc.
+      ```bash
+      cd docusaurus
+      pnpm run docusaurus docs:version:platform <version>
+      ```
+
+      Docusaurus automatically does three things at this point. It:
+
+      - Defines the existence of that version in the `/docusaurus/platform_versions.json` file
+      - Creates a physical copy of the versioned platform docs in `/docusaurus/platform_versioned_docs`
+      - Creates a physical copy of the versioned platform sidebar in `/docusaurus/platform_versioned_sidebars`
+
+3. Test your build locally to make sure everything looks as expected. Verify:
+
+   - The docs site builds locally
+   - Your local Docusaurus build doesn't report new broken links
+   - The version selector in the navigation contains your new version
+
+4. Create a pull request, get an approval, wait for CI checks to pass, and merge your changes into `master`.
 
 ### Create a new minor version
 
-Typically, you don't generate a docs version for patch releases (2.1.1). The only exception is if there is an actual substantive change in that patch and it needs separate documentation. If you actually need to do this, the process is the same as a major version.
-
-```bash
-cd docusaurus
-pnpm run docusaurus docs:version:platform <version>
-```
-
-Where `<version>` can be `1.7.1`, `1.8.2`, etc.
+Typically, you don't generate a docs version for patch releases (2.1.1). The only exception is if there is an actual substantive change in that patch and it needs separate documentation. If you actually need to do this, the process is the same as a major version, described in the preceding section.
 
 ### Delete a version
 
@@ -519,15 +526,15 @@ Delete old documentation versions when they're no longer useful, like when all u
 
 In almost all cases, you work on docs for the Next version. Sometimes, though, you need to update something you've already released.
 
-Though released documentation versions are "frozen," they're made of normal files, and you can still edit them like you would anything else. When you do, those changes only apply to the version you are editing. You can't automatically carry them forward. For this reason, it's best not to make major changes to released docs versions. Focus on making future versions better and only updated released versions because you have to.
+Though released documentation versions are "frozen," they're made of normal files, and you can still edit them like you would anything else. When you do, those changes only apply to the version you are editing. You can't automatically carry them forward to future versions. For this reason, it's best not to make major changes to released docs versions. Focus on making the next version better and only updated released versions when it's unavoidable.
 
 Find content files in `/docusaurus/<instance>_versioned_docs` and sidebars in `/docusaurus/<instance>_versioned_sidebars`.
 
 ### Regenerate an existing version
 
-From time to time, you may need to regenerate an existing version. For example, imagine you follow a major version release with a patch, and that patch requires updating all docs for that version. Rather than trying to update both the next and current docs versions, you could potentially just regenerate them using the current state of the docs.
+From time to time, you may need to regenerate an existing version of the docs from the next version. For example, you follow a major version release with a critical patch, and that patch requires updating all docs for that version. Rather than trying to update both the next and current docs versions, you could potentially just regenerate the versioned docs using the current state of the docs.
 
 1. Follow the preceding steps to delete that version.
 2. Follow the preceding steps to create that version.
 
-When you do this, you run the risk of an unintended change leaking into this version of the docs. For example, a documented feature from a future, unreleased version of Airbyte. Pay attention to the diff in GitHub and, if necessary, expunge anything from the versioned docs that shouldn't be there.
+When you do this, you run the risk of an unintended change leaking into this version of the docs. For example, a documented feature from a future, unreleased version of Airbyte. Pay attention to the diff in GitHub and, if necessary, expunge anything from the versioned docs files that shouldn't be there.

--- a/docs/platform/contributing-to-airbyte/writing-docs.md
+++ b/docs/platform/contributing-to-airbyte/writing-docs.md
@@ -5,7 +5,7 @@ import TabItem from "@theme/TabItem";
 
 Everyone is welcome to contribute to Airbyte's documentation.
 
-Airbyte's documentation is in the [Airbyte repository](https://github.com/airbytehq/airbyte/tree/master/docs) on GitHub. It's published at [docs.airbyte.com](https://docs.airbyte.com/) using [Vercel](https://vercel.com). Connector docs are also rendered within Airbyte itself when setting up new connectors. The docs are built on [Docusaurus](https://docusaurus.io/). Content is written in [Markdown](https://guides.github.com/features/mastering-markdown/) and all topics are in the `/docs` folder. Configuration files and previously-released versions of platform docs versions are in the `/docusaurus` folder.
+Airbyte's documentation is in the [Airbyte repository](https://github.com/airbytehq/airbyte/tree/master/docs) on GitHub. It's published at [docs.airbyte.com](https://docs.airbyte.com/) using [Vercel](https://vercel.com). Connector docs are also rendered within Airbyte itself when setting up new connectors. The docs are built on [Docusaurus](https://docusaurus.io/). Content is written in [Markdown](https://guides.github.com/features/mastering-markdown/) and all topics are in the `/docs` folder. Configuration files and previously-released versions of platform docs are in the `/docusaurus` folder.
 
 ## Open source contributions welcome
 

--- a/docs/platform/contributing-to-airbyte/writing-docs.md
+++ b/docs/platform/contributing-to-airbyte/writing-docs.md
@@ -5,7 +5,7 @@ import TabItem from "@theme/TabItem";
 
 Everyone is welcome to contribute to Airbyte's documentation.
 
-Airbyte's documentation is in the [Airbyte repository](https://github.com/airbytehq/airbyte/tree/master/docs) on GitHub. It's published at [docs.airbyte.com](https://docs.airbyte.com/) using [Vercel](https://vercel.com). Connector docs are also rendered within Airbyte itself when setting up new connectors. The docs are built on [Docusaurus](https://docusaurus.io/). Content is written in [Markdown](https://guides.github.com/features/mastering-markdown/) and all topics are in the `/docs` folder. Configuration files are in the `/docusaurus` folder.
+Airbyte's documentation is in the [Airbyte repository](https://github.com/airbytehq/airbyte/tree/master/docs) on GitHub. It's published at [docs.airbyte.com](https://docs.airbyte.com/) using [Vercel](https://vercel.com). Connector docs are also rendered within Airbyte itself when setting up new connectors. The docs are built on [Docusaurus](https://docusaurus.io/). Content is written in [Markdown](https://guides.github.com/features/mastering-markdown/) and all topics are in the `/docs` folder. Configuration files and historical platform docs versions are in the `/docusaurus` folder.
 
 ## Open source contributions welcome
 
@@ -153,6 +153,27 @@ These templates can only be used for platform docs. Docs for connectors have the
 
 If you're writing docs for a data source or destination, there are special rules you must follow. See the [Connector Documentation Guide](../connector-development/writing-connector-docs.md). Platform documentation is less formulaic.
 
+## Multiple instances and versions
+
+The docs site uses [multiple instances](https://docusaurus.io/docs/docs-multi-instance). Some of these instances [use versioning](https://docusaurus.io/docs/versioning) and some do not. This pattern allows us to maintain multiple smaller doc sets that each have their own properties and configurations, and which are aggregated into a single site at build time. The rationale behind this is that some content benefits from allowing users to view different versions of the docs while other content does not.
+
+Currently, the site has four instances, but Airbyte could add more instances later.
+
+- Home (not versioned - this is our home page)
+- Platform (versioned)
+- Connectors (not versioned)
+- Release notes (not versioned)
+
+For most contributors, this reality is transparent and not particularly relevant. However, there is one important concept to keep in mind.
+
+When you update content for a versioned set of docs, your changes go into what Docusaurus calls the Next version: the version of Airbyte that isn't released yet, and which users can access by selecting "Next" using the version picker in the navigation. Docs for previously released versions of Airbyte aren't updated with these changes.
+
+If you find yourself looking at a local build but unable to see your changes, you're probably looking at docs for a version that was already released. Switch to the Next version to see your changes immediately.
+
+You can still update documentation for released versions, but you need to make these changes to the released files. Docusaurus stores these in `/docusaurus/<instance>_versioned_docs`.
+
+For help creating and managing versions, see [Release and manage documentation versions](#doc-versions).
+
 ## Common patterns and components
 
 Since the docs site is based on Docusaurus, it inherits all of Docusaurus' capabilities. You should be aware of some Airbyte-specific elements. Most of these customizations can be combined together.
@@ -162,7 +183,7 @@ Since the docs site is based on Docusaurus, it inherits all of Docusaurus' capab
 Use tabs to display mutually exclusive concepts in a concise way. See [Tabs](https://docusaurus.io/docs/markdown-features/tabs).
 
 :::note
-We maintain a separate `Tabs` implementation to support rendering tabs in Airbyte's in-app documentation. Our in-app renderer creates some additional rules that aren't necessarily true in other Docusaurus implementations:
+We maintain a separate `Tabs` implementation to support rendering tabs in Airbyte's in-app documentation. Airbyte's in-app renderer creates some additional rules that aren't necessarily true in other Docusaurus implementations:
 
 - Always use empty lines to separate different Markup elements (tags, paragraphs, lists, etc.)
 - Do not indent `TabItem` tags and their content according to normal HTML conventions. Different Markdown rendering tools handle indented tags inconsistently.
@@ -260,13 +281,25 @@ The [Mermaid documentation](https://mermaid.js.org/intro) goes into more depth.
 
 ### Update the sidebar
 
-If you're adding a new file, removing a file, or moving things around, update [`docusaurus/sidebars.js`](https://github.com/airbytehq/airbyte/blob/master/docusaurus/sidebars.js) to reflect the new structure.
+If you're adding a new file, removing a file, or moving things around, update the appropriate sidebar.
+
+Each instance in the docs has its own sidebar. Make sure you add topics to the sidebar appropriate to your change.
+
+- Add platform docs in `/docs/platform` and add an entry for them to [`docusaurus/sidebar-platform.js`](https://github.com/airbytehq/airbyte/blob/master/docusaurus/sidebar-platform.js).
+- Add connector docs in `/docs/integrations`. Docusaurus automatically adds files in this directory to [`docusaurus/sidebar-connectors.js`](https://github.com/airbytehq/airbyte/blob/master/docusaurus/sidebar-connectors.js), so you don't need to do anything else.
+- Add release notes in `/docs/release_notes` and add an entry for them to [`docusaurus/sidebar-release_notes.js`](https://github.com/airbytehq/airbyte/blob/master/docusaurus/sidebar-release_notes.js).
 
 ### Add a redirect
 
 If you're moving or renaming a page, you should add a redirect to its new location. If you're deleting a page, you should add a redirect to the most relevant new file, like a replacement topic or a parent page.
 
-To add a redirect, open the [`docusaurus/vercel.json`](https://github.com/airbytehq/airbyte/blob/master/docusaurus/vercel.json) file and add an entry from the old path to the new path. Vercel.json supports complex redirects using wildcards and regular expressions, if necessary. For help, see [Configuring projects with vercel.json](https://vercel.com/docs/project-configuration#redirects).
+Redirects are managed by Vercel. To add or change a redirect, open the [`docusaurus/vercel.json`](https://github.com/airbytehq/airbyte/blob/master/docusaurus/vercel.json) file and add an entry from the old path to the new path. Vercel.json supports complex redirects using wildcards and regular expressions, if necessary. For help, see [Configuring projects with vercel.json](https://vercel.com/docs/project-configuration#redirects).
+
+You can test redirects on the test build Vercel generates after you submit a pull request.
+
+:::note
+Redirect rules with trailing slashes in them may not function correctly. Vercel.json automatically redirects trailing slashes to the same URL without a trailing slash. You don't need to handle trailing slashes and can assume they never exist.
+:::
 
 ### Document a code module
 
@@ -443,3 +476,58 @@ Before Airbyte accepts your contribution, you need to sign the Contributor Licen
 ## Deploy the documentation site
 
 When someone merges documentation changes into the `master` branch, Vercel deploys updated docs automatically. This takes 5-10 minutes and needs no human intervention.
+
+## Release and manage documentation versions {#doc-versions}
+
+:::info Airbyte employees only
+This information is only relevant to Airbyte employees who release new versions of Airbyte.
+:::
+
+### Create a new major version
+
+When you release a new major version of Airbyte (for example, 2.0, 2.1, etc.), generate a documentation version for it. This process generates a "frozen" set of the docs based on their state at that point in time. Once the version exists, you _can_ still update those docs, but changes you make don't carry forward to future versions.
+
+Open a terminal, change to the docusaurus folder, and run the command to generate a version.
+
+```bash
+cd docusaurus
+pnpm run docusaurus docs:version:platform <version>
+```
+
+Where `<version>` can be `1.7`, `1.8`, etc.
+
+### Create a new minor version
+
+Typically, you don't generate a docs version for patch releases (2.1.1). The only exception is if there is an actual substantive change in that patch and it needs separate documentation. If you actually need to do this, the process is the same as a major version.
+
+```bash
+cd docusaurus
+pnpm run docusaurus docs:version:platform <version>
+```
+
+Where `<version>` can be `1.7.1`, `1.8.2`, etc.
+
+### Delete a version
+
+Delete old documentation versions when they're no longer useful, like when all users have upgraded past that version. Deleting old versions speeds up docs builds and removes irrelevant information from the internet so it doesn't confuse people.
+
+1. Remove the version from the array in the `/docusaurus/<instance>_versions.json` file.
+2. Delete the versioned docs directory from `/docusaurus/<instance>_versioned_docs`.
+3. Delete the versioned sidebar file from `/docusaurus/<instance>_versioned_sidebars`.
+
+### Update an existing version
+
+In almost all cases, you work on docs for the Next version. Sometimes, though, you need to update something you've already released.
+
+Though released documentation versions are "frozen," they're made of normal files, and you can still edit them like you would anything else. When you do, those changes only apply to the version you are editing. You can't automatically carry them forward. For this reason, it's best not to make major changes to released docs versions. Focus on making future versions better and only updated released versions because you have to.
+
+Find content files in `/docusaurus/<instance>_versioned_docs` and sidebars in `/docusaurus/<instance>_versioned_sidebars`.
+
+### Regenerate an existing version
+
+From time to time, you may need to regenerate an existing version. For example, imagine you follow a major version release with a patch, and that patch requires updating all docs for that version. Rather than trying to update both the next and current docs versions, you could potentially just regenerate them using the current state of the docs.
+
+1. Follow the preceding steps to delete that version.
+2. Follow the preceding steps to create that version.
+
+When you do this, you run the risk of an unintended change leaking into this version of the docs. For example, a documented feature from a future, unreleased version of Airbyte. Pay attention to the diff in GitHub and, if necessary, expunge anything from the versioned docs that shouldn't be there.


### PR DESCRIPTION
## What

Updates the docs contributor guide on how to work with multiple instances and versions of the docs.

## How

Added new sections describing our implementation of multi-instance docs and how create new platform versions.

## Review guide

Just read the docs and let me know if they make sense.

## User Impact

Only really affects Airbyte employees.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌
