### PR TITLE
fix(ci): declare missing dependency

### DIFF
--- a/airbyte-ci/connectors/pipelines/poetry.lock
+++ b/airbyte-ci/connectors/pipelines/poetry.lock
@@ -2941,7 +2941,7 @@ version = "80.1.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "setuptools-80.1.0-py3-none-any.whl", hash = "sha256:ea0e7655c05b74819f82e76e11a85b31779fee7c4969e82f72bab0664e8317e4"},
     {file = "setuptools-80.1.0.tar.gz", hash = "sha256:2e308396e1d83de287ada2c2fd6e64286008fe6aca5008e0b6a8cb0e2c86eedd"},
@@ -3474,4 +3474,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "~3.11"
-content-hash = "c3351bcd394c5b4cf367cb2f397439e7b8266c7596d8aa5ddac717ab1b8a529f"
+content-hash = "c1c6ef79f440d927fbc161dbba53ce544cacda1401ccd315f8679ef1e8c22ca7"

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -43,6 +43,7 @@ pydash = "6.0.2"
 python-slugify = ">=8.0.4"
 deepdiff = "^7.0.1"
 auto-merge = { path = "../auto_merge", develop = true }
+setuptools = "^80.1.0"  # Needed due to pkg_resources refs
 
 [tool.poetry.group.dev.dependencies]
 freezegun = "^1.2.2"


### PR DESCRIPTION
## What

Follow-on to resolve this error:

<img width="650" alt="image" src="https://github.com/user-attachments/assets/ff506b00-6f05-4449-b465-79dbd6924d34" />

airbyte-ci should declare its dependency on `setuptools` because it imports `pkg_resources` in production code.

## How
<!--
* Describe how code changes achieve the solution.
-->

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
