### PR TITLE
feat(ci): add dockerimage files in new `docker-images` directory

### DIFF
--- a/docker-images/Dockerfile.java-connector
+++ b/docker-images/Dockerfile.java-connector
@@ -1,0 +1,30 @@
+# syntax=docker/dockerfile:1
+# check=skip=InvalidDefaultArgInFrom
+
+# Java connector Dockerfile for Airbyte
+
+# Build arguments
+ARG BASE_IMAGE
+
+# Base image - using Amazon Corretto (Amazon's distribution of OpenJDK)
+FROM ${BASE_IMAGE}
+ARG CONNECTOR_NAME
+
+# Set permissions for downloaded files
+RUN chmod +x /airbyte/base.sh /airbyte/javabase.sh && \
+    chown airbyte:airbyte /airbyte/base.sh /airbyte/javabase.sh /airbyte/dd-java-agent.jar
+
+ENV AIRBYTE_ENTRYPOINT="/airbyte/base.sh"
+ENV APPLICATION="${CONNECTOR_NAME}"
+
+# Add the connector TAR file and extract it
+COPY ./build/distributions/${CONNECTOR_NAME}.tar /tmp/${CONNECTOR_NAME}.tar
+RUN tar xf /tmp/${CONNECTOR_NAME}.tar --strip-components=1 -C /airbyte && \
+    rm -rf /tmp/${CONNECTOR_NAME}.tar && \
+    chown -R airbyte:airbyte /airbyte
+
+# Set the non-root user
+USER airbyte
+
+# Set entrypoint
+ENTRYPOINT ["/airbyte/base.sh"]

--- a/docker-images/Dockerfile.java-connector-base
+++ b/docker-images/Dockerfile.java-connector-base
@@ -1,0 +1,1 @@
+#TODO: Add base image definition

--- a/docker-images/Dockerfile.java-connector.dockerignore
+++ b/docker-images/Dockerfile.java-connector.dockerignore
@@ -1,0 +1,18 @@
+# This file is auto-generated. Do not edit.
+*
+# Ignore everything not explicitly allowed below
+build/
+!build/distributions/*.tar
+.venv/
+secrets/
+!setup.py
+!pyproject.toml
+!poetry.lock
+!poetry.toml
+!components.py
+!requirements.txt
+!README.md
+!metadata.yaml
+!build_customization.py
+!source_*
+!destination_*

--- a/docker-images/Dockerfile.manifest-only-connector
+++ b/docker-images/Dockerfile.manifest-only-connector
@@ -1,0 +1,17 @@
+# syntax=docker/dockerfile:1
+# check=skip=InvalidDefaultArgInFrom
+
+# Manifest-Only connector Dockerfile for Airbyte
+
+ARG BASE_IMAGE
+
+FROM ${BASE_IMAGE}
+ARG CONNECTOR_SNAKE_NAME
+ARG CONNECTOR_NAME
+
+WORKDIR /airbyte/integration_code
+
+COPY . ./
+
+ENV AIRBYTE_ENTRYPOINT="python ./main.py"
+ENTRYPOINT ["python", "./main.py"]

--- a/docker-images/Dockerfile.manifest-only-connector-base
+++ b/docker-images/Dockerfile.manifest-only-connector-base
@@ -1,0 +1,1 @@
+#TODO: Add base image definition

--- a/docker-images/Dockerfile.manifest-only-connector.dockerignore
+++ b/docker-images/Dockerfile.manifest-only-connector.dockerignore
@@ -1,0 +1,18 @@
+# This file is auto-generated. Do not edit.
+*
+# Ignore everything not explicitly allowed below
+build/
+!build/distributions/*.tar
+.venv/
+secrets/
+!setup.py
+!pyproject.toml
+!poetry.lock
+!poetry.toml
+!components.py
+!requirements.txt
+!README.md
+!metadata.yaml
+!build_customization.py
+!source_*
+!destination_*

--- a/docker-images/Dockerfile.python-connector
+++ b/docker-images/Dockerfile.python-connector
@@ -1,0 +1,43 @@
+# syntax=docker/dockerfile:1
+# check=skip=InvalidDefaultArgInFrom
+
+# Python connector Dockerfile for Airbyte
+
+ARG BASE_IMAGE
+
+FROM ${BASE_IMAGE} AS builder
+ARG BASE_IMAGE
+ARG CONNECTOR_NAME
+ARG EXTRA_PREREQS_SCRIPT=""
+
+WORKDIR /airbyte/integration_code
+
+COPY . ./
+
+# Conditionally copy and execute the extra build script if provided
+RUN if [ -n "${EXTRA_PREREQS_SCRIPT}" ]; then \
+        cp ${EXTRA_PREREQS_SCRIPT} ./extra_prereqs_script && \
+        ./extra_prereqs_script; \
+    fi
+
+# TODO: Pre-install uv on the base image to speed up the build.
+#       (uv is still faster even with the extra step.)
+RUN pip install --no-cache-dir uv
+RUN python -m uv pip install --no-cache-dir .
+
+FROM ${BASE_IMAGE}
+ARG CONNECTOR_NAME
+ARG BASE_IMAGE
+
+WORKDIR /airbyte/integration_code
+
+COPY --from=builder /usr/local /usr/local
+COPY --chmod=755 <<EOT /entrypoint.sh
+#!/usr/bin/env bash
+set -e
+
+${CONNECTOR_NAME} "\$\@"
+EOT
+
+ENV AIRBYTE_ENTRYPOINT="/entrypoint.sh"
+ENTRYPOINT ["/entrypoint.sh"]

--- a/docker-images/Dockerfile.python-connector-base
+++ b/docker-images/Dockerfile.python-connector-base
@@ -1,0 +1,1 @@
+#TODO: Add base image definition

--- a/docker-images/Dockerfile.python-connector.dockerignore
+++ b/docker-images/Dockerfile.python-connector.dockerignore
@@ -1,0 +1,18 @@
+# This file is auto-generated. Do not edit.
+*
+# Ignore everything not explicitly allowed below
+build/
+!build/distributions/*.tar
+.venv/
+secrets/
+!setup.py
+!pyproject.toml
+!poetry.lock
+!poetry.toml
+!components.py
+!requirements.txt
+!README.md
+!metadata.yaml
+!build_customization.py
+!source_*
+!destination_*

--- a/docker-images/README.md
+++ b/docker-images/README.md
@@ -29,6 +29,8 @@ For example:
 ### Building a Connector Image
 
 ```bash
+cd airbyte-integrations/connectors/source-mysql
+
 DOCKER_BUILDKIT=1
 ARCH=amd64
 

--- a/docker-images/README.md
+++ b/docker-images/README.md
@@ -53,7 +53,7 @@ docker build \
 
 ### Why is `DOCKER_BUILDKIT=1` needed?
 
-This uses Buildkit in Docker, which allows us to use custom `.dockerignore` files, which is normally not allowed. Instead, docker will accept a `{Dockerfile-name}.dockerignore` in the same directory as the Dockerfile, saving us from needing to store `.dockerignore` files redundantly in each connector directory.
+This uses Buildkit in Docker, which allows us to use custom `.dockerignore` files, which is normally not allowed. With this env var set, docker will accept a `{Dockerfile-name}.dockerignore` in the same directory as the Dockerfile. This eliminates the need for us to store `.dockerignore` files redundantly in each connector directory.
 
 ### Why don't the base image definitions have a `.dockerignore` file
 

--- a/docker-images/README.md
+++ b/docker-images/README.md
@@ -1,0 +1,64 @@
+# Docker Images Definitions
+
+This directory contains the Dockerfile resources needed to build Docker connector images.
+
+## About these files
+
+For each connector type, there are three files. Taking Java as the example:
+
+- `Dockerfile.java-connector` - This file defines how to build a Java connector image.
+- `Dockerfile.java-connector-base` - This file defines how to build the _base image_ for a Java connector.
+- `Dockerfile.java-connector.dockerignore` - This file defines what local files from the context directory to ignore when building the connector image. The best practice is to ignore all files not needed, as this speeds up the build process and reduces the chance of busting layer caches from unrelated file changes.
+
+## How to build images
+
+### Prereqs (java only)
+
+Java connectors require the `.tar` archive to be built before building the Docker image.
+
+```bash
+./gradlew :airbyte-integrations:connectors:{connector_name}:distTar
+```
+
+For example:
+
+```bash
+./gradlew :airbyte-integrations:connectors:source-mysql:distTar
+```
+
+### Building a Connector Image
+
+```bash
+DOCKER_BUILDKIT=1
+ARCH=amd64
+
+docker build \
+    --platform linux/${ARCH} \
+    --label io.airbyte.version=3.11.15\
+    --label io.airbyte.name=airbyte/source-mysql \
+    --file ../../../docker-images/Dockerfile.java-connector \
+    --build-arg=BASE_IMAGE=docker.io/airbyte/java-connector-base:2.0.1@sha256:ec89bd1a89e825514dd2fc8730ba299a3ae1544580a078df0e35c5202c2085b3 \
+    --build-arg=CONNECTOR_NAME=source-mysql \
+    --build-arg=EXTRA_BUILD_SCRIPT= \
+    -t airbyte/source-mysql:dev-${ARCH} .'
+```
+
+## Common Build Args
+
+- `BASE_IMAGE` - The image tag to use when building the connector.
+- `CONNECTOR_NAME`: The connector name, in kebab format: `source-mysql`
+- `EXTRA_BUILD_SCRIPT`: Optional `build_customization.py` script. An additional prereq-installation script that is custom to this connector.
+
+## FAQ
+
+### Why is `DOCKER_BUILDKIT=1` needed?
+
+This uses Buildkit in Docker, which allows us to use custom `.dockerignore` files, which is normally not allowed. Instead, docker will accept a `{Dockerfile-name}.dockerignore` in the same directory as the Dockerfile, saving us from needing to store `.dockerignore` files redundantly in each connector directory.
+
+### Why don't the base image definitions have a `.dockerignore` file
+
+The base images don't need to copy in any files from the host computer. That is why they don't require a dockerfile, since nothing is copied in, nothing is needed to be ignored.
+
+### Where should I source the build args?
+
+The build args should be scraped from the connector's `metadata.yml` file.

--- a/docker-images/README.md
+++ b/docker-images/README.md
@@ -40,7 +40,7 @@ docker build \
     --build-arg=BASE_IMAGE=docker.io/airbyte/java-connector-base:2.0.1@sha256:ec89bd1a89e825514dd2fc8730ba299a3ae1544580a078df0e35c5202c2085b3 \
     --build-arg=CONNECTOR_NAME=source-mysql \
     --build-arg=EXTRA_BUILD_SCRIPT= \
-    -t airbyte/source-mysql:dev-${ARCH} .'
+    -t airbyte/source-mysql:dev-${ARCH} .
 ```
 
 ## Common Build Args


### PR DESCRIPTION
## What

These `Dockerfile` definitions can be safely merged without impacting other projects or tools. In the long run, this directory should become the authoritative source for image build definition files. Although I included a readme to explain methodology, I do not expect users to call these files directly. They should be wrapped in a tool, probably either `airbyte-cdk image build` or a native `gradle` task.

Migrated from here:

- https://github.com/airbytehq/airbyte-python-cdk/pull/504
- https://github.com/airbytehq/airbyte-python-cdk/pull/522

Related to:

- https://github.com/airbytehq/airbyte/pull/59174

I expect after this merges, I will probably refactor the CDK to use the definitions from this directory when building images.

## How
<!--
* Describe how code changes achieve the solution.
-->

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
