### PR TITLE
Bulk load CDK: fix legacy union detection

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/json/JsonSchemaToAirbyteType.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/json/JsonSchemaToAirbyteType.kt
@@ -81,7 +81,12 @@ class JsonSchemaToAirbyteType(
             // {"oneOf": [...], ...} or {"anyOf": [...], ...} or {"allOf": [...], ...}
             val options = schema.get("oneOf") ?: schema.get("anyOf") ?: schema.get("allOf")
             return if (options != null) {
-                unionOf(options.mapNotNull { convertInner(it as ObjectNode) })
+                // intentionally don't use the `unionOf()` utility method.
+                // We know this is a non-legacy union.
+                UnionType.of(
+                    options.mapNotNull { convertInner(it as ObjectNode) },
+                    isLegacyUnion = false,
+                )
             } else {
                 // Default to object if no type and not a union type
                 convertInner((schema as ObjectNode).put("type", "object"))

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/data/json/JsonSchemaToAirbyteSchemaTypeTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/data/json/JsonSchemaToAirbyteSchemaTypeTest.kt
@@ -178,6 +178,7 @@ class JsonSchemaToAirbyteSchemaTypeTest {
             val airbyteType = defaultJsonSchemaToAirbyteType.convert(schemaNode)
             Assertions.assertTrue(airbyteType is UnionType)
             val unionType = airbyteType as UnionType
+            Assertions.assertFalse(unionType.isLegacyUnion)
             Assertions.assertEquals(2, unionType.options.size)
             Assertions.assertTrue(unionType.options.contains(StringType))
             Assertions.assertTrue(unionType.options.contains(IntegerType))
@@ -193,7 +194,7 @@ class JsonSchemaToAirbyteSchemaTypeTest {
             val airbyteType = legacyJsonSchemaToAirbyteType.convert(schemaNode)
             Assertions.assertTrue(airbyteType is UnionType)
             val unionType = airbyteType as UnionType
-            Assertions.assertTrue(unionType.isLegacyUnion)
+            Assertions.assertFalse(unionType.isLegacyUnion)
             Assertions.assertEquals(2, unionType.options.size)
             Assertions.assertTrue(unionType.options.contains(StringType))
             Assertions.assertTrue(unionType.options.contains(IntegerType))
@@ -207,6 +208,7 @@ class JsonSchemaToAirbyteSchemaTypeTest {
         val airbyteType = defaultJsonSchemaToAirbyteType.convert(schemaNode)
         Assertions.assertTrue(airbyteType is UnionType)
         val unionType = airbyteType as UnionType
+        Assertions.assertFalse(unionType.isLegacyUnion)
         Assertions.assertEquals(3, unionType.options.size)
         Assertions.assertTrue(unionType.options.contains(StringType))
     }
@@ -238,6 +240,7 @@ class JsonSchemaToAirbyteSchemaTypeTest {
         val field1 = objectType.properties["field1"]!!
         Assertions.assertTrue(field1.type is UnionType)
         val unionType = field1.type as UnionType
+        Assertions.assertFalse(unionType.isLegacyUnion)
         Assertions.assertEquals(2, unionType.options.size)
         Assertions.assertTrue(unionType.options.contains(StringType))
         Assertions.assertTrue(unionType.options.contains(IntegerType))
@@ -275,6 +278,7 @@ class JsonSchemaToAirbyteSchemaTypeTest {
         val airbyteType = defaultJsonSchemaToAirbyteType.convert(schemaNode)
         Assertions.assertTrue(airbyteType is UnionType)
         val unionType = airbyteType as UnionType
+        Assertions.assertFalse(unionType.isLegacyUnion)
         Assertions.assertEquals(2, unionType.options.size)
         val objectOption = unionType.options.find { it is ObjectType }!!
         val arrayOption = unionType.options.find { it is ArrayType }!!


### PR DESCRIPTION
https://github.com/airbytehq/airbyte/pull/58102/ wasn't implemented correctly (not a problem for now, since nobody uses the LEGACY mode yet).

it was _always_ setting isLegacy = true in LEGACY mode; this is incorrect. `{oneOf: [...]}` should have `isLegacy = false`.