### PR TITLE
bigquery: fix one last thing about test config

### DIFF
--- a/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigQueryDestinationTestUtils.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigQueryDestinationTestUtils.kt
@@ -31,7 +31,6 @@ object BigQueryDestinationTestUtils {
             configFile = Path.of("secrets/credentials-1s1t-standard-raw-override.json"),
             datasetId = DEFAULT_NAMESPACE_PLACEHOLDER,
             stagingPath = "test_path/$DEFAULT_NAMESPACE_PLACEHOLDER",
-            rawDatasetId = "${DEFAULT_NAMESPACE_PLACEHOLDER}_raw_dataset",
         )
     val standardInsertConfig =
         createConfig(


### PR DESCRIPTION
forgot to update this reference to the raw table dataset in #59184

(it doesn't break anything, just means the data cleaner is cleaning the wrong thing)