### PR TITLE
bigquery: fix GCS

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/DestinationRecordToAirbyteValueWithMeta.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/DestinationRecordToAirbyteValueWithMeta.kt
@@ -12,15 +12,21 @@ import java.time.OffsetDateTime
 import java.time.ZoneOffset
 import java.util.*
 
+/**
+ * @param flatten whether to promote user-defined fields to the root level. If this is set to
+ * `false`, fields defined in `stream.schema` will be left inside an `_airbyte_data` field.
+ * @param extractedAtAsTimestampWithTimezone whether to return the `_airbyte_extracted_at` field as
+ * an [IntegerValue] or as a [TimestampWithTimezoneValue].
+ */
 class DestinationRecordToAirbyteValueWithMeta(
     val stream: DestinationStream,
-    private val flatten: Boolean
+    private val flatten: Boolean,
+    private val extractedAtAsTimestampWithTimezone: Boolean,
 ) {
     fun convert(
         data: AirbyteValue,
         emittedAtMs: Long,
         meta: Meta?,
-        extractedAtAsTimestampWithTimezone: Boolean
     ): ObjectValue {
         val properties =
             linkedMapOf(
@@ -75,12 +81,15 @@ fun Pair<AirbyteValue, List<Meta.Change>>.withAirbyteMeta(
     flatten: Boolean = false,
     extractedAtAsTimestampWithTimezone: Boolean = false,
 ) =
-    DestinationRecordToAirbyteValueWithMeta(stream, flatten)
+    DestinationRecordToAirbyteValueWithMeta(
+            stream,
+            flatten = flatten,
+            extractedAtAsTimestampWithTimezone = extractedAtAsTimestampWithTimezone,
+        )
         .convert(
             first,
             emittedAtMs,
             Meta(second),
-            extractedAtAsTimestampWithTimezone = extractedAtAsTimestampWithTimezone
         )
 
 fun DestinationRecordAirbyteValue.dataWithAirbyteMeta(
@@ -88,12 +97,15 @@ fun DestinationRecordAirbyteValue.dataWithAirbyteMeta(
     flatten: Boolean = false,
     extractedAtAsTimestampWithTimezone: Boolean = false,
 ) =
-    DestinationRecordToAirbyteValueWithMeta(stream, flatten)
+    DestinationRecordToAirbyteValueWithMeta(
+            stream,
+            flatten = flatten,
+            extractedAtAsTimestampWithTimezone = extractedAtAsTimestampWithTimezone,
+        )
         .convert(
             data,
             emittedAtMs,
             meta,
-            extractedAtAsTimestampWithTimezone = extractedAtAsTimestampWithTimezone
         )
 
 fun Meta.Change.toAirbyteValue(): ObjectValue =

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/file/object_storage/ObjectStorageFormattingWriter.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/file/object_storage/ObjectStorageFormattingWriter.kt
@@ -73,7 +73,13 @@ class DefaultObjectStorageFormattingWriterFactory(
                         as ParquetFormatConfiguration,
                     flatten
                 )
-            is CSVFormatConfiguration -> CSVFormattingWriter(stream, outputStream, flatten)
+            is CSVFormatConfiguration ->
+                CSVFormattingWriter(
+                    stream,
+                    outputStream,
+                    flatten,
+                    extractedAtAsTimestampWithTimezone = false
+                )
         }
     }
 }
@@ -107,7 +113,8 @@ class JsonFormattingWriter(
 class CSVFormattingWriter(
     private val stream: DestinationStream,
     outputStream: OutputStream,
-    private val rootLevelFlattening: Boolean
+    private val rootLevelFlattening: Boolean,
+    private val extractedAtAsTimestampWithTimezone: Boolean,
 ) : ObjectStorageFormattingWriter {
 
     private val finalSchema = stream.schema.withAirbyteMeta(rootLevelFlattening)
@@ -116,7 +123,11 @@ class CSVFormattingWriter(
         printer.printRecord(
             record
                 .asDestinationRecordAirbyteValue()
-                .dataWithAirbyteMeta(stream, rootLevelFlattening)
+                .dataWithAirbyteMeta(
+                    stream,
+                    rootLevelFlattening,
+                    extractedAtAsTimestampWithTimezone = extractedAtAsTimestampWithTimezone
+                )
                 .toCsvRecord(finalSchema)
         )
     }

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/bulk_loader/BigQueryObjectStorageFormattingWriter.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/bulk_loader/BigQueryObjectStorageFormattingWriter.kt
@@ -14,20 +14,10 @@ import jakarta.inject.Singleton
 import java.io.OutputStream
 
 class BigQueryObjectStorageFormattingWriter(
-    stream: DestinationStream,
-    outputStream: OutputStream,
-    rootLevelFlattening: Boolean = true,
-) :
-    ObjectStorageFormattingWriter by CSVFormattingWriter(
-        stream,
-        outputStream,
-        rootLevelFlattening
-    ) {
-
-    private val csvFormattingWriter = CSVFormattingWriter(stream, outputStream, rootLevelFlattening)
+    private val csvFormattingWriter: CSVFormattingWriter,
+) : ObjectStorageFormattingWriter by csvFormattingWriter {
 
     override fun accept(record: DestinationRecordRaw) {
-        record.rawData.record.emittedAt *= 1000
         csvFormattingWriter.accept(record)
     }
 }
@@ -41,6 +31,13 @@ class BigQueryObjectStorageFormattingWriterFactory(
         outputStream: OutputStream
     ): ObjectStorageFormattingWriter {
         val flatten = formatConfigProvider.objectStorageFormatConfiguration.rootLevelFlattening
-        return BigQueryObjectStorageFormattingWriter(stream, outputStream, flatten)
+        return BigQueryObjectStorageFormattingWriter(
+            CSVFormattingWriter(
+                stream,
+                outputStream,
+                rootLevelFlattening = flatten,
+                extractedAtAsTimestampWithTimezone = true,
+            ),
+        )
     }
 }


### PR DESCRIPTION
* fix - use a single CSVFormattingWriter instance in BigQueryObjectStorageFormattingWriter, instead of making two instances
* write extracted_at as a timestamp instead of epoch millis (bigquery requires epoch seconds w/ millis decimals, which is painful - easier for us to just write it as an actual timestamp string)