### PR TITLE
🐛 Destination Google Sheets: truncate cell values exceeding 50k chars

### DIFF
--- a/airbyte-integrations/connectors/destination-google-sheets/integration_tests/test_writer.py
+++ b/airbyte-integrations/connectors/destination-google-sheets/integration_tests/test_writer.py
@@ -143,6 +143,43 @@ def test_deduplicate_records(expected):
     records = test_wks.get_all_records()
     assert records == expected
 
+    # clean worksheet for future tests
+    test_wks.clear()
+
+
+long_input_records = [
+    {
+        "stream": TEST_STREAM,
+        "data": {"id": 1, "key1": "A" * 50_001},
+    },
+]
+
+
+@pytest.mark.parametrize(
+    "expected",
+    [
+        ([{"id": 1, "key1": f"{'A' * 49_986}...[TRUNCATED]", "list": ""}]),
+    ],
+    ids=["truncate_long_cell"],
+)
+def test_truncate_long_cell(expected):
+    # set `is_set` for headers to False
+    # because previously the headers have been set already
+    TEST_WRITER.stream_info[TEST_STREAM]["is_set"] = False
+
+    for record in long_input_records:
+        stream_name = record["stream"]
+        data = record["data"]
+        TEST_WRITER.add_to_buffer(stream_name, data)
+        TEST_WRITER.queue_write_operation(stream_name)
+
+    TEST_WRITER.write_whats_left()
+
+    # check expected records are written into target worksheet
+    test_wks = TEST_SPREADSHEET.open_worksheet(TEST_STREAM)
+    records = test_wks.get_all_records()
+    assert records == expected
+
     # remove the test worksheet after tests
     TEST_SPREADSHEET.spreadsheet.del_worksheet(test_wks)
 

--- a/airbyte-integrations/connectors/destination-google-sheets/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-google-sheets/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: api
   connectorType: destination
   definitionId: a4cbd2d1-8dbe-4818-b8bc-b90ad782d12a
-  dockerImageTag: 0.3.4
+  dockerImageTag: 0.3.5
   dockerRepository: airbyte/destination-google-sheets
   githubIssueLabel: destination-google-sheets
   icon: google-sheets.svg

--- a/airbyte-integrations/connectors/destination-google-sheets/pyproject.toml
+++ b/airbyte-integrations/connectors/destination-google-sheets/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "0.3.4"
+version = "0.3.5"
 name = "destination-google-sheets"
 description = "Destination implementation for Google Sheets."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/destination-google-sheets/unit_tests/test_writer.py
+++ b/airbyte-integrations/connectors/destination-google-sheets/unit_tests/test_writer.py
@@ -1,0 +1,21 @@
+#
+# Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+#
+
+
+import pytest
+from destination_google_sheets.writer import GoogleSheetsWriter
+
+
+@pytest.mark.parametrize(
+    "row, col, expected",
+    [
+        (0, 0, "A1"),
+        (0, 25, "Z1"),
+        (0, 26, "AA1"),
+        (99, 18277, "ZZZ100"),
+    ],
+)
+def test_a1_notation(row, col, expected):
+    writer = GoogleSheetsWriter(None)
+    assert writer._a1_notation(row, col) == expected

--- a/docs/integrations/destinations/google-sheets.md
+++ b/docs/integrations/destinations/google-sheets.md
@@ -102,7 +102,7 @@ The [Google API rate limit](https://developers.google.com/sheets/api/limits) is 
 
 ### <a name="limitations"></a>Limitations
 
-Google Sheets imposes hard limits on the amount of data that can be synced. If you attempt to sync more data than is allowed, the sync will fail.
+Google Sheets imposes hard limits on the amount of data that can be synced. If you attempt to sync more data than is allowed, the sync may fail or, in some cases, data will be truncated to comply with limits.
 
 **Maximum of 10 Million Cells**
 
@@ -111,7 +111,7 @@ If you already have reached the 10 million limit, it will not allow you to add m
 
 **Maximum of 50,000 characters per cell**
 
-There can be at most 50,000 characters per cell. Do not use Google Sheets if you have fields with long text in your source.
+There can be at most 50,000 characters in a single cell. Airbyte will automatically truncate any value exceeding this limit, appending `...[TRUNCATED]` to the end of the value. Do not use Google Sheets if you have fields with long text in your source.
 
 **Maximum of 18,278 Columns**
 
@@ -120,8 +120,6 @@ There can be at most 18,278 columns in Google Sheets in a worksheet.
 **Maximum of 200 Worksheets in a Spreadsheet**
 
 You cannot create more than 200 worksheets within single spreadsheet.
-
-Syncs will fail if any of these limits are reached.
 
 #### Note:
 
@@ -185,6 +183,7 @@ EXAMPLE:
 
 | Version | Date       | Pull Request                                             | Subject                                                    |
 |---------| ---------- | -------------------------------------------------------- | ---------------------------------------------------------- |
+| 0.3.5 | 2025-04-30 | [59647](https://github.com/airbytehq/airbyte/pull/59647) | Truncate cell values exceeding 50,000 characters with warning |
 | 0.3.4 | 2025-04-26 | [58280](https://github.com/airbytehq/airbyte/pull/58280) | Update dependencies |
 | 0.3.3 | 2025-04-12 | [57636](https://github.com/airbytehq/airbyte/pull/57636) | Update dependencies |
 | 0.3.2 | 2025-04-05 | [57166](https://github.com/airbytehq/airbyte/pull/57166) | Update dependencies |


### PR DESCRIPTION
## What
Fixes #15500 by truncating cell values in the Google Sheets destination connector when they exceed the 50,000 character limit imposed by Google Sheets.

## How
- Added `_truncate_cell` method that:
    - Truncates a cell value to fit within the 50,000 character limit.
    - Appends `...[TRUNCATED]` to indicate data loss.
    - Logs the truncated cell using A1 notation for clarity.
- Added `_a1_notation` utility method to convert (row, col) indexes to A1 notation.
- Updated `write_from_queue` method to apply truncation.
- Added an integration test to verify truncation and ensure sync succeeds with long cell values.
- Added a unit test for `_a1_notation` to verify correct A1 notation formatting.
- Updated documentation to reflect this new behavior.
- Bumped connector version.

## Review guide
- Main logic is in the `_truncate_cell` method.

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->
Before: Syncs fail a cell exceeded 50,000 characters.
After: Long values are truncated safely, syncs complete successfully, and truncated cells are clearly marked.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
