### PR TITLE
fix(live-tests): use first 8 symbols of connection id instead of hashing

### DIFF
--- a/airbyte-ci/connectors/live-tests/README.md
+++ b/airbyte-ci/connectors/live-tests/README.md
@@ -181,6 +181,9 @@ The traffic recorded on the control connector is passed to the target connector 
 ## Changelog
 
 
+### 0.21.4
+Update connection id to use first 8 chars in the report
+
 ### 0.21.3
 Update dependencies to avoid genson issue
 

--- a/airbyte-ci/connectors/live-tests/pyproject.toml
+++ b/airbyte-ci/connectors/live-tests/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "live-tests"
-version = "0.21.3"
+version = "0.21.4"
 description = "Contains utilities for testing connectors against live data."
 authors = ["Airbyte <contact@airbyte.io>"]
 license = "MIT"

--- a/airbyte-ci/connectors/live-tests/src/live_tests/commons/models.py
+++ b/airbyte-ci/connectors/live-tests/src/live_tests/commons/models.py
@@ -540,4 +540,4 @@ class ConnectionObjects:
     def hashed_connection_id(self) -> Optional[str]:
         if not self.connection_id:
             return None
-        return self.connection_id[:4]
+        return self.connection_id[:8]

--- a/airbyte-ci/connectors/live-tests/src/live_tests/commons/models.py
+++ b/airbyte-ci/connectors/live-tests/src/live_tests/commons/models.py
@@ -540,4 +540,4 @@ class ConnectionObjects:
     def hashed_connection_id(self) -> Optional[str]:
         if not self.connection_id:
             return None
-        return hashlib.sha256(self.connection_id.encode("utf-8")).hexdigest()[:7]
+        return self.connection_id[:4]

--- a/airbyte-ci/connectors/live-tests/src/live_tests/conftest.py
+++ b/airbyte-ci/connectors/live-tests/src/live_tests/conftest.py
@@ -642,5 +642,5 @@ def pytest_generate_tests(metafunc):
         requested_fixtures,
         [[c] * len(requested_fixtures) for c in all_connection_objects],
         indirect=requested_fixtures,
-        ids=[f"CONNECTION {c.connection_id[:4]}" for c in all_connection_objects],
+        ids=[f"CONNECTION {c.connection_id[:8]}" for c in all_connection_objects],
     )

--- a/airbyte-ci/connectors/live-tests/src/live_tests/conftest.py
+++ b/airbyte-ci/connectors/live-tests/src/live_tests/conftest.py
@@ -642,5 +642,5 @@ def pytest_generate_tests(metafunc):
         requested_fixtures,
         [[c] * len(requested_fixtures) for c in all_connection_objects],
         indirect=requested_fixtures,
-        ids=[f"CONNECTION {hashlib.sha256(c.connection_id.encode()).hexdigest()[:7]}" for c in all_connection_objects],
+        ids=[f"CONNECTION {c.connection_id[:4]}" for c in all_connection_objects],
     )


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->

## How
Use first 8 symbols of connection id in regression tests instead of hashing

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
