### PR TITLE
bigquery: more tests and fixes

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/IntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/IntegrationTest.kt
@@ -90,7 +90,6 @@ abstract class IntegrationTest(
     fun getTestInfo(testInfo: TestInfo) {
         this.testInfo = testInfo
         testPrettyName = "${testInfo.testClass.get().simpleName}.${testInfo.displayName}"
-        destinationProcessFactory.testName = testPrettyName
     }
 
     @AfterEach
@@ -177,13 +176,15 @@ abstract class IntegrationTest(
         messages: List<InputMessage>,
         streamStatus: AirbyteStreamStatus? = AirbyteStreamStatus.COMPLETE,
         useFileTransfer: Boolean = false,
+        destinationProcessFactory: DestinationProcessFactory = this.destinationProcessFactory,
     ): List<AirbyteMessage> =
         runSync(
             configContents,
             DestinationCatalog(listOf(stream)),
             messages,
             streamStatus,
-            useFileTransfer,
+            useFileTransfer = useFileTransfer,
+            destinationProcessFactory,
         )
 
     /**
@@ -218,7 +219,9 @@ abstract class IntegrationTest(
          */
         streamStatus: AirbyteStreamStatus? = AirbyteStreamStatus.COMPLETE,
         useFileTransfer: Boolean = false,
+        destinationProcessFactory: DestinationProcessFactory = this.destinationProcessFactory,
     ): List<AirbyteMessage> {
+        destinationProcessFactory.testName = testPrettyName
         val fileTransferProperty =
             if (useFileTransfer) {
                 mapOf(EnvVarConstants.FILE_TRANSFER_ENABLED to "true")

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/typing_deduping/BigQuerySqlGenerator.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/typing_deduping/BigQuerySqlGenerator.kt
@@ -482,7 +482,7 @@ class BigQuerySqlGenerator(private val projectId: String?, private val datasetLo
                     ""
                 } else if (importType.cursor.size == 1) {
                     val columnName = importType.cursor.first()
-                    "`$columnName` DESC NULLS LAST"
+                    "`$columnName` DESC NULLS LAST,"
                 } else {
                     throw UnsupportedOperationException(
                         "Only top-level cursors are supported, got ${importType.cursor}"
@@ -521,7 +521,7 @@ class BigQuerySqlGenerator(private val projectId: String?, private val datasetLo
                      FROM intermediate_data
                    ), numbered_rows AS (
                      SELECT *, row_number() OVER (
-                       PARTITION BY $pkList ORDER BY $cursorOrderClause, `_airbyte_extracted_at` DESC
+                       PARTITION BY $pkList ORDER BY $cursorOrderClause `_airbyte_extracted_at` DESC
                      ) AS row_number
                      FROM new_records
                    )

--- a/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryWriteTest.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryWriteTest.kt
@@ -4,9 +4,16 @@
 
 package io.airbyte.integrations.destination.bigquery
 
+import io.airbyte.cdk.load.command.Append
+import io.airbyte.cdk.load.command.Dedupe
+import io.airbyte.cdk.load.command.DestinationStream
+import io.airbyte.cdk.load.data.ObjectType
+import io.airbyte.cdk.load.message.InputRecord
 import io.airbyte.cdk.load.test.util.DestinationDataDumper
 import io.airbyte.cdk.load.test.util.ExpectedRecordMapper
+import io.airbyte.cdk.load.test.util.OutputRecord
 import io.airbyte.cdk.load.test.util.UncoercedExpectedRecordMapper
+import io.airbyte.cdk.load.test.util.destination_process.DockerizedDestinationFactory
 import io.airbyte.cdk.load.toolkits.load.db.orchestration.ColumnNameModifyingMapper
 import io.airbyte.cdk.load.toolkits.load.db.orchestration.RootLevelTimestampsToUtcMapper
 import io.airbyte.cdk.load.toolkits.load.db.orchestration.TypingDedupingMetaChangeMapper
@@ -23,7 +30,10 @@ import io.airbyte.integrations.destination.bigquery.BigQueryDestinationTestUtils
 import io.airbyte.integrations.destination.bigquery.BigQueryDestinationTestUtils.STANDARD_INSERT_CONFIG
 import io.airbyte.integrations.destination.bigquery.spec.BigquerySpecification
 import io.airbyte.integrations.destination.bigquery.typing_deduping.BigqueryColumnNameGenerator
+import kotlin.test.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertAll
 
 abstract class BigqueryWriteTest(
     configContents: String,
@@ -70,9 +80,7 @@ abstract class BigqueryRawTablesWriteTest(
         Untyped,
     )
 
-abstract class BigqueryTDWriteTest(
-    configContents: String,
-) :
+abstract class BigqueryTDWriteTest(configContents: String) :
     BigqueryWriteTest(
         configContents = configContents,
         BigqueryFinalTableDataDumper,
@@ -92,7 +100,174 @@ abstract class BigqueryTDWriteTest(
             numberCanBeLarge = false,
             timeWithTimezoneBehavior = SimpleValueBehavior.PASS_THROUGH,
         ),
-    )
+    ) {
+    private val oldCdkDestinationFactory =
+        DockerizedDestinationFactory("airbyte/destination-bigquery", "2.10.2")
+
+    @Test
+    open fun testAppendCdkMigration() {
+        val stream =
+            DestinationStream(
+                DestinationStream.Descriptor(randomizedNamespace, "test_stream"),
+                Append,
+                ObjectType(linkedMapOf("id" to intType)),
+                generationId = 0,
+                minimumGenerationId = 0,
+                syncId = 42,
+            )
+        // Run a sync on the old CDK
+        runSync(
+            updatedConfig,
+            stream,
+            listOf(
+                InputRecord(
+                    namespace = randomizedNamespace,
+                    name = "test_stream",
+                    data = """{"id": 1234}""",
+                    emittedAtMs = 1234,
+                ),
+            ),
+            destinationProcessFactory = oldCdkDestinationFactory,
+        )
+        // Grab the loaded_at value from this sync
+        val firstSyncLoadedAt =
+            BigqueryRawTableDataDumper.dumpRecords(parsedConfig, stream).first().loadedAt!!
+
+        // Run a sync with the current destination
+        runSync(
+            updatedConfig,
+            stream,
+            listOf(
+                InputRecord(
+                    namespace = randomizedNamespace,
+                    name = "test_stream",
+                    data = """{"id": 1234}""",
+                    emittedAtMs = 5678,
+                ),
+            ),
+        )
+        val secondSyncLoadedAt =
+            BigqueryRawTableDataDumper.dumpRecords(parsedConfig, stream)
+                .map { it.loadedAt!! }
+                .toSet()
+        // verify that we didn't execute a soft reset
+        assertAll(
+            {
+                assertEquals(
+                    2,
+                    secondSyncLoadedAt.size,
+                    "Expected two unique values for loaded_at after two syncs. If there is only 1 value, then we likely executed a soft reset.",
+                )
+            },
+            {
+                assertTrue(
+                    secondSyncLoadedAt.contains(firstSyncLoadedAt),
+                    "Expected the first sync's loaded_at value to exist after the second sync. If this is not true, then we likely executed a soft reset.",
+                )
+            },
+        )
+
+        dumpAndDiffRecords(
+            parsedConfig,
+            listOf(
+                OutputRecord(
+                    extractedAt = 1234,
+                    generationId = 0,
+                    data = mapOf("id" to 1234),
+                    airbyteMeta = OutputRecord.Meta(syncId = 42, changes = emptyList()),
+                ),
+                OutputRecord(
+                    extractedAt = 5678,
+                    generationId = 0,
+                    data = mapOf("id" to 1234),
+                    airbyteMeta = OutputRecord.Meta(syncId = 42, changes = emptyList()),
+                ),
+            ),
+            stream,
+            listOf(listOf("id")),
+            cursor = null,
+        )
+    }
+
+    @Test
+    open fun testDedupCdkMigration() {
+        val stream =
+            DestinationStream(
+                DestinationStream.Descriptor(randomizedNamespace, "test_stream"),
+                Dedupe(primaryKey = listOf(listOf("id")), cursor = emptyList()),
+                ObjectType(linkedMapOf("id" to intType)),
+                generationId = 0,
+                minimumGenerationId = 0,
+                syncId = 42,
+            )
+        // Run a sync on the old CDK
+        runSync(
+            updatedConfig,
+            stream,
+            listOf(
+                InputRecord(
+                    namespace = randomizedNamespace,
+                    name = "test_stream",
+                    data = """{"id": 1234}""",
+                    emittedAtMs = 1234,
+                ),
+            ),
+            destinationProcessFactory = oldCdkDestinationFactory,
+        )
+        // Grab the loaded_at value from this sync
+        val firstSyncLoadedAt =
+            BigqueryRawTableDataDumper.dumpRecords(parsedConfig, stream).first().loadedAt!!
+
+        // Run a sync with the current destination
+        runSync(
+            updatedConfig,
+            stream,
+            listOf(
+                InputRecord(
+                    namespace = randomizedNamespace,
+                    name = "test_stream",
+                    data = """{"id": 1234}""",
+                    emittedAtMs = 5678,
+                ),
+            ),
+        )
+        val secondSyncLoadedAt =
+            BigqueryRawTableDataDumper.dumpRecords(parsedConfig, stream)
+                .map { it.loadedAt!! }
+                .toSet()
+        // verify that we didn't execute a soft reset
+        assertAll(
+            {
+                assertEquals(
+                    2,
+                    secondSyncLoadedAt.size,
+                    "Expected two unique values for loaded_at after two syncs. If there is only 1 value, then we likely executed a soft reset.",
+                )
+            },
+            {
+                assertTrue(
+                    secondSyncLoadedAt.contains(firstSyncLoadedAt),
+                    "Expected the first sync's loaded_at value to exist after the second sync. If this is not true, then we likely executed a soft reset.",
+                )
+            },
+        )
+
+        dumpAndDiffRecords(
+            parsedConfig,
+            listOf(
+                OutputRecord(
+                    extractedAt = 5678,
+                    generationId = 0,
+                    data = mapOf("id" to 1234),
+                    airbyteMeta = OutputRecord.Meta(syncId = 42, changes = emptyList()),
+                ),
+            ),
+            stream,
+            listOf(listOf("id")),
+            cursor = null,
+        )
+    }
+}
 
 class StandardInsertRawOverrideDisableTd :
     BigqueryRawTablesWriteTest(
@@ -131,8 +306,8 @@ class StandardInsertRawOverride :
 class StandardInsert :
     BigqueryTDWriteTest(BigQueryDestinationTestUtils.standardInsertConfig.serializeToString()) {
     @Test
-    override fun testBasicWrite() {
-        super.testBasicWrite()
+    override fun testDedup() {
+        super.testDedup()
     }
 }
 


### PR DESCRIPTION
* add two tests that runs a sync on the old CDK, runs a sync on the current version, and verifies that we don't trigger a soft reset
* add a test to run dedup with no cursor, and fix bigquery dedup when there's no cursor