### PR TITLE
bigquery: fix log message

### DIFF
--- a/airbyte-cdk/bulk/toolkits/load-db/src/main/kotlin/io/airbyte/cdk/load/orchestration/db/legacy_typing_deduping/TypingDedupingStreamLoader.kt
+++ b/airbyte-cdk/bulk/toolkits/load-db/src/main/kotlin/io/airbyte/cdk/load/orchestration/db/legacy_typing_deduping/TypingDedupingStreamLoader.kt
@@ -207,10 +207,11 @@ class TypingDedupingStreamLoader(
             }
             return updatedStatus
         } else {
+            val initialRawTableStatus = initialStatus.rawTableStatus.reify()
             logger.info {
                 "${stream.descriptor.toPrettyString()}: non-truncate sync and no temp raw table. Initial raw table status is $initialRawTableStatus."
             }
-            return initialStatus.rawTableStatus.reify()
+            return initialRawTableStatus
         }
     }
 


### PR DESCRIPTION
the `initialRawTableStatus` field is initialized outside of this method 🤦 so just grab the new object in a temp variable so we can log.