### PR TITLE
bigquery: increase memory overhead ratio

### DIFF
--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/spec/BigqueryConfiguration.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/spec/BigqueryConfiguration.kt
@@ -20,7 +20,9 @@ data class BigqueryConfiguration(
     val transformationPriority: TransformationPriority,
     val rawTableDataset: String,
     val disableTypingDeduping: Boolean,
-) : DestinationConfiguration()
+) : DestinationConfiguration() {
+    override val estimatedRecordMemoryOverheadRatio = 2.0
+}
 
 sealed interface LoadingMethodConfiguration
 


### PR DESCRIPTION
tested on two connections ([1](https://cloud.airbyte.com/workspaces/b61bc266-ef3c-460c-af2f-f70da4a2993c/connections/585802fb-8908-4385-92a3-f8a25d91013f/timeline), [2](https://cloud.airbyte.com/workspaces/a0cc325a-d358-4df4-bdd4-c09d753b6afb/connections/adb9dbc4-b2cf-4f94-a7ce-69ee693296dc/timeline)) with overheadRatio=2, and they both succeeded where they previously failed.

there's probably some tuning we could do here, but I ran with 1.8 / 1.6 / 1.4 and they all behaved about the same. 2 feels like a safe ratio, and it's clearly not causing any performance loss. We can always revisit later.