### PR TITLE
Minor fixes to new CI workflow.

### DIFF
--- a/.github/workflows/connector-test-command.yml
+++ b/.github/workflows/connector-test-command.yml
@@ -115,7 +115,8 @@ jobs:
 
   connectors-test-matrix:
     needs: [generate-matrix]
-    runs-on: ubuntu-24.04
+    runs-on: linux-24.04-large # Custom runner, defined in GitHub org settings
+    timeout-minutes: 60 # 1 hour
     env:
       GCP_GSM_CREDENTIALS: ${{ secrets.GCP_GSM_CREDENTIALS }}
     if: ${{ needs.generate-matrix.outputs.connector-matrix != '' }}

--- a/airbyte-integrations/connectors/destination-s3-data-lake/poe_tasks.toml
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/poe_tasks.toml
@@ -1,0 +1,3 @@
+include = [
+    "${POE_GIT_DIR}/poe-tasks/gradle-connector-tasks.toml",
+]

--- a/airbyte-integrations/connectors/destination-s3/poe_tasks.toml
+++ b/airbyte-integrations/connectors/destination-s3/poe_tasks.toml
@@ -1,0 +1,3 @@
+include = [
+    "${POE_GIT_DIR}/poe-tasks/gradle-connector-tasks.toml",
+]


### PR DESCRIPTION
## What
As title.

## How
* Dest S3 & Dest S3-data-lake were missing a poe file.
* Set the test workflow to match the current GHA instance type. Otherwise we aren't able to parallelise effectively, and tests take too long to run. See [here](https://github.com/airbytehq/airbyte/blob/master/.github/workflows/connectors_tests.yml#L81-L82) for current settings. Instead of 5 hours, I'm using 1 hour to start.

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
