### PR TITLE
mock integration test: reenable CDC test cases

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/integrationTest/kotlin/io/airbyte/cdk/load/mock_integration_test/MockBasicFunctionalityIntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/integrationTest/kotlin/io/airbyte/cdk/load/mock_integration_test/MockBasicFunctionalityIntegrationTest.kt
@@ -11,7 +11,6 @@ import io.airbyte.cdk.load.write.BasicFunctionalityIntegrationTest
 import io.airbyte.cdk.load.write.SchematizedNestedValueBehavior
 import io.airbyte.cdk.load.write.UnionBehavior
 import io.airbyte.cdk.load.write.Untyped
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 
 class MockBasicFunctionalityIntegrationTest :
@@ -78,13 +77,11 @@ class MockBasicFunctionalityIntegrationTest :
         super.testAppendSchemaEvolution()
     }
 
-    @Disabled("flaky")
     @Test
     override fun testDedup() {
         super.testDedup()
     }
 
-    @Disabled("flaky")
     @Test
     override fun testDedupWithStringKey() {
         super.testDedupWithStringKey()

--- a/airbyte-cdk/bulk/core/load/src/integrationTest/kotlin/io/airbyte/cdk/load/mock_integration_test/MockDestinationDirectLoader.kt
+++ b/airbyte-cdk/bulk/core/load/src/integrationTest/kotlin/io/airbyte/cdk/load/mock_integration_test/MockDestinationDirectLoader.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.load.mock_integration_test
+
+import io.airbyte.cdk.load.command.DestinationCatalog
+import io.airbyte.cdk.load.command.DestinationStream
+import io.airbyte.cdk.load.data.ObjectValue
+import io.airbyte.cdk.load.message.DestinationRecordRaw
+import io.airbyte.cdk.load.mock_integration_test.MockStreamLoader.Companion.getFilename
+import io.airbyte.cdk.load.test.util.OutputRecord
+import io.airbyte.cdk.load.write.DirectLoader
+import io.airbyte.cdk.load.write.DirectLoaderFactory
+import jakarta.inject.Singleton
+import java.time.Instant
+import java.util.UUID
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+
+@Singleton
+class MockDestinationDirectLoaderFactory(
+    private val catalog: DestinationCatalog,
+) : DirectLoaderFactory<MockDestinationDirectLoader> {
+    override fun create(streamDescriptor: DestinationStream.Descriptor, part: Int) =
+        MockDestinationDirectLoader(catalog.getStream(streamDescriptor))
+}
+
+class MockDestinationDirectLoader(
+    private val stream: DestinationStream,
+) : DirectLoader {
+    override fun accept(record: DestinationRecordRaw): DirectLoader.DirectLoadResult {
+        val recordAirbyteValue = record.asDestinationRecordAirbyteValue()
+        val filename = getFilename(record.stream.descriptor, staging = true)
+        val outputRecord =
+            OutputRecord(
+                UUID.randomUUID(),
+                Instant.ofEpochMilli(recordAirbyteValue.emittedAtMs),
+                Instant.ofEpochMilli(System.currentTimeMillis()),
+                stream.generationId,
+                recordAirbyteValue.data as ObjectValue,
+                OutputRecord.Meta(
+                    changes = recordAirbyteValue.meta?.changes ?: listOf(),
+                    syncId = stream.syncId
+                ),
+            )
+        // blind insert into the staging area. We'll dedupe on commit.
+        MockDestinationBackend.insert(filename, outputRecord)
+
+        // HACK: This destination is too fast and causes a race
+        // condition between consuming and flushing state messages
+        // that causes the test to fail. This would not be an issue
+        // in a real sync, because we would always either get more
+        // data or an end-of-stream that would force a final flush.
+        runBlocking { delay(100L) }
+
+        // records are immediately committed, so we can return Complete on every record
+        return DirectLoader.Complete
+    }
+
+    override fun finish() {
+        // do nothing
+    }
+
+    override fun close() {
+        // do nothing
+    }
+}

--- a/airbyte-cdk/bulk/core/load/src/integrationTest/kotlin/io/airbyte/cdk/load/mock_integration_test/MockDestinationWriter.kt
+++ b/airbyte-cdk/bulk/core/load/src/integrationTest/kotlin/io/airbyte/cdk/load/mock_integration_test/MockDestinationWriter.kt
@@ -8,21 +8,10 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 import io.airbyte.cdk.load.command.Append
 import io.airbyte.cdk.load.command.Dedupe
 import io.airbyte.cdk.load.command.DestinationStream
-import io.airbyte.cdk.load.data.ObjectValue
-import io.airbyte.cdk.load.message.Batch
-import io.airbyte.cdk.load.message.BatchState
-import io.airbyte.cdk.load.message.DestinationFile
-import io.airbyte.cdk.load.message.DestinationRecordRaw
-import io.airbyte.cdk.load.message.SimpleBatch
 import io.airbyte.cdk.load.state.StreamProcessingFailed
-import io.airbyte.cdk.load.test.util.OutputRecord
 import io.airbyte.cdk.load.write.DestinationWriter
 import io.airbyte.cdk.load.write.StreamLoader
-import io.github.oshai.kotlinlogging.KotlinLogging
-import java.time.Instant
-import java.util.UUID
 import javax.inject.Singleton
-import kotlinx.coroutines.delay
 
 @Singleton
 class MockDestinationWriter : DestinationWriter {
@@ -33,19 +22,6 @@ class MockDestinationWriter : DestinationWriter {
 
 @SuppressFBWarnings("NP_NONNULL_PARAM_VIOLATION", justification = "Kotlin async continuation")
 class MockStreamLoader(override val stream: DestinationStream) : StreamLoader {
-    private val log = KotlinLogging.logger {}
-
-    abstract class MockBatch : Batch {
-        override val groupId: String? = null
-    }
-
-    data class LocalBatch(val records: List<DestinationRecordRaw>) : MockBatch() {
-        override val state = BatchState.STAGED
-    }
-    data class LocalFileBatch(val file: DestinationFile) : MockBatch() {
-        override val state = BatchState.STAGED
-    }
-
     override suspend fun close(hadNonzeroRecords: Boolean, streamFailure: StreamProcessingFailed?) {
         if (streamFailure == null) {
             when (val importType = stream.importType) {
@@ -69,48 +45,6 @@ class MockStreamLoader(override val stream: DestinationStream) : StreamLoader {
                 getFilename(stream.descriptor),
                 stream.minimumGenerationId
             )
-        }
-    }
-
-    override suspend fun processRecords(
-        records: Iterator<DestinationRecordRaw>,
-        totalSizeBytes: Long,
-        endOfStream: Boolean
-    ): Batch {
-        return LocalBatch(records.asSequence().toList())
-    }
-
-    override suspend fun processBatch(batch: Batch): Batch {
-        return when (batch) {
-            is LocalBatch -> {
-                log.info { "Persisting ${batch.records.size} records for ${stream.descriptor}" }
-                batch.records.forEach {
-                    val recordAirbyteValue = it.asDestinationRecordAirbyteValue()
-                    val filename = getFilename(it.stream.descriptor, staging = true)
-                    val record =
-                        OutputRecord(
-                            UUID.randomUUID(),
-                            Instant.ofEpochMilli(recordAirbyteValue.emittedAtMs),
-                            Instant.ofEpochMilli(System.currentTimeMillis()),
-                            stream.generationId,
-                            recordAirbyteValue.data as ObjectValue,
-                            OutputRecord.Meta(
-                                changes = recordAirbyteValue.meta?.changes ?: listOf(),
-                                syncId = stream.syncId
-                            ),
-                        )
-                    // blind insert into the staging area. We'll dedupe on commit.
-                    MockDestinationBackend.insert(filename, record)
-                }
-                // HACK: This destination is too fast and causes a race
-                // condition between consuming and flushing state messages
-                // that causes the test to fail. This would not be an issue
-                // in a real sync, because we would always either get more
-                // data or an end-of-stream that would force a final flush.
-                delay(100L)
-                SimpleBatch(state = BatchState.COMPLETE)
-            }
-            else -> throw IllegalStateException("Unexpected batch type: $batch")
         }
     }
 

--- a/airbyte-cdk/bulk/core/load/src/integrationTest/kotlin/io/airbyte/cdk/load/mock_integration_test/MockDestinationWriter.kt
+++ b/airbyte-cdk/bulk/core/load/src/integrationTest/kotlin/io/airbyte/cdk/load/mock_integration_test/MockDestinationWriter.kt
@@ -8,10 +8,12 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 import io.airbyte.cdk.load.command.Append
 import io.airbyte.cdk.load.command.Dedupe
 import io.airbyte.cdk.load.command.DestinationStream
+import io.airbyte.cdk.load.pipeline.ByPrimaryKeyInputPartitioner
 import io.airbyte.cdk.load.state.StreamProcessingFailed
 import io.airbyte.cdk.load.write.DestinationWriter
 import io.airbyte.cdk.load.write.StreamLoader
-import javax.inject.Singleton
+import io.micronaut.context.annotation.Factory
+import jakarta.inject.Singleton
 
 @Singleton
 class MockDestinationWriter : DestinationWriter {
@@ -58,4 +60,9 @@ class MockStreamLoader(override val stream: DestinationStream) : StreamLoader {
                 "(${namespace},${name})"
             }
     }
+}
+
+@Factory
+class MockDestinationPartitionerFactory {
+    @Singleton fun get() = ByPrimaryKeyInputPartitioner()
 }


### PR DESCRIPTION
closes https://github.com/airbytehq/airbyte-internal-issues/issues/12571

* switch to the new interface (i.e. use a DirectLoader)
* this allows us to use the ByPKPartitioner
* which fixes our CDC deletions implementation