### PR TITLE
Bigquery: add check tests for failure cases

### DIFF
--- a/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigQueryCheckTest.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigQueryCheckTest.kt
@@ -6,8 +6,8 @@ package io.airbyte.integrations.destination.bigquery
 
 import io.airbyte.cdk.load.check.CheckIntegrationTest
 import io.airbyte.cdk.load.check.CheckTestConfig
-import io.airbyte.cdk.load.util.serializeToString
 import io.airbyte.integrations.destination.bigquery.spec.BigquerySpecification
+import java.util.regex.Pattern
 import org.junit.jupiter.api.Test
 
 class BigQueryCheckTest :
@@ -16,11 +16,44 @@ class BigQueryCheckTest :
             listOf(
                 CheckTestConfig(BigQueryDestinationTestUtils.standardInsertConfig),
             ),
-        failConfigFilenamesAndFailureReasons = mapOf(),
+        failConfigFilenamesAndFailureReasons =
+            mapOf(
+                CheckTestConfig(
+                    BigQueryDestinationTestUtils.createConfig("secrets/credentials-badproject.json")
+                ) to
+                    Pattern.compile(
+                        "Access Denied: Project fake: User does not have bigquery.datasets.create permission in project fake"
+                    ),
+                CheckTestConfig(
+                    BigQueryDestinationTestUtils.createConfig(
+                        "secrets/credentials-no-edit-public-schema-role.json"
+                    )
+                ) to Pattern.compile("Permission bigquery.tables.create denied"),
+                CheckTestConfig(
+                    BigQueryDestinationTestUtils.createConfig(
+                        "secrets/credentials-standard-no-dataset-creation.json"
+                    )
+                ) to Pattern.compile("Permission bigquery.tables.create denied"),
+                CheckTestConfig(
+                    BigQueryDestinationTestUtils.createConfig(
+                        "secrets/credentials-standard-non-billable-project.json"
+                    )
+                ) to Pattern.compile("Billing has not been enabled for this project"),
+                CheckTestConfig(
+                    BigQueryDestinationTestUtils.createConfig(
+                        "secrets/credentials-1s1t-gcs-bad-copy-permission.json"
+                    )
+                ) to Pattern.compile("Permission bigquery.tables.updateData denied on table"),
+            ),
         additionalMicronautEnvs = additionalMicronautEnvs,
     ) {
     @Test
     override fun testSuccessConfigs() {
         super.testSuccessConfigs()
+    }
+
+    @Test
+    override fun testFailConfigs() {
+        super.testFailConfigs()
     }
 }

--- a/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigQueryCheckTest.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigQueryCheckTest.kt
@@ -14,9 +14,7 @@ class BigQueryCheckTest :
     CheckIntegrationTest<BigquerySpecification>(
         successConfigFilenames =
             listOf(
-                CheckTestConfig(
-                    BigQueryDestinationTestUtils.standardInsertConfig.serializeToString()
-                ),
+                CheckTestConfig(BigQueryDestinationTestUtils.standardInsertConfig),
             ),
         failConfigFilenamesAndFailureReasons = mapOf(),
         additionalMicronautEnvs = additionalMicronautEnvs,

--- a/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigQueryDestinationTestUtils.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigQueryDestinationTestUtils.kt
@@ -3,7 +3,6 @@
  */
 package io.airbyte.integrations.destination.bigquery
 
-import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.node.ObjectNode
 import io.airbyte.cdk.load.util.Jsons
 import io.airbyte.cdk.load.util.deserializeToNode

--- a/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryDestinationCleaner.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryDestinationCleaner.kt
@@ -4,7 +4,6 @@
 
 package io.airbyte.integrations.destination.bigquery
 
-import com.fasterxml.jackson.databind.JsonNode
 import com.google.cloud.bigquery.BigQuery
 import com.google.cloud.bigquery.BigQueryException
 import io.airbyte.cdk.load.test.util.DestinationCleaner

--- a/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryDestinationCleaner.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryDestinationCleaner.kt
@@ -34,9 +34,9 @@ object BigqueryDestinationCleaner : DestinationCleaner {
     }
 }
 
-class BigqueryDestinationCleanerInstance(private val configJson: JsonNode) : DestinationCleaner {
+class BigqueryDestinationCleanerInstance(private val configString: String) : DestinationCleaner {
     override fun cleanup() {
-        val config = BigQueryDestinationTestUtils.parseConfig(configJson)
+        val config = BigQueryDestinationTestUtils.parseConfig(configString)
         val bigquery = BigqueryClientFactory(config).make()
 
         val oldThreshold = System.currentTimeMillis() - Duration.ofDays(RETENTION_DAYS).toMillis()

--- a/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryWriteTest.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryWriteTest.kt
@@ -271,10 +271,10 @@ abstract class BigqueryTDWriteTest(configContents: String) :
 class StandardInsertRawOverrideDisableTd :
     BigqueryRawTablesWriteTest(
         BigQueryDestinationTestUtils.createConfig(
-                configFile = STANDARD_INSERT_CONFIG,
-                rawDatasetId = RAW_DATASET_OVERRIDE,
-                disableTypingDeduping = true,
-            ),
+            configFile = STANDARD_INSERT_CONFIG,
+            rawDatasetId = RAW_DATASET_OVERRIDE,
+            disableTypingDeduping = true,
+        ),
     ) {
     @Test
     override fun testBasicWrite() {
@@ -298,8 +298,7 @@ class StandardInsertRawOverride :
     }
 }
 
-class StandardInsert :
-    BigqueryTDWriteTest(BigQueryDestinationTestUtils.standardInsertConfig) {
+class StandardInsert : BigqueryTDWriteTest(BigQueryDestinationTestUtils.standardInsertConfig) {
     @Test
     override fun testDedup() {
         super.testDedup()
@@ -309,10 +308,10 @@ class StandardInsert :
 class GcsRawOverrideDisableTd :
     BigqueryRawTablesWriteTest(
         BigQueryDestinationTestUtils.createConfig(
-                configFile = GCS_STAGING_CONFIG,
-                rawDatasetId = RAW_DATASET_OVERRIDE,
-                disableTypingDeduping = true,
-            ),
+            configFile = GCS_STAGING_CONFIG,
+            rawDatasetId = RAW_DATASET_OVERRIDE,
+            disableTypingDeduping = true,
+        ),
     ) {
     @Test
     override fun testBasicWrite() {
@@ -323,9 +322,9 @@ class GcsRawOverrideDisableTd :
 class GcsRawOverride :
     BigqueryTDWriteTest(
         BigQueryDestinationTestUtils.createConfig(
-                configFile = GCS_STAGING_CONFIG,
-                rawDatasetId = RAW_DATASET_OVERRIDE,
-            ),
+            configFile = GCS_STAGING_CONFIG,
+            rawDatasetId = RAW_DATASET_OVERRIDE,
+        ),
     ) {
     @Test
     override fun testBasicWrite() {
@@ -334,7 +333,9 @@ class GcsRawOverride :
 }
 
 class Gcs :
-    BigqueryTDWriteTest(BigQueryDestinationTestUtils.createConfig(configFile = GCS_STAGING_CONFIG)) {
+    BigqueryTDWriteTest(
+        BigQueryDestinationTestUtils.createConfig(configFile = GCS_STAGING_CONFIG)
+    ) {
     @Test
     override fun testBasicWrite() {
         super.testBasicWrite()

--- a/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryWriteTest.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryWriteTest.kt
@@ -17,7 +17,6 @@ import io.airbyte.cdk.load.test.util.destination_process.DockerizedDestinationFa
 import io.airbyte.cdk.load.toolkits.load.db.orchestration.ColumnNameModifyingMapper
 import io.airbyte.cdk.load.toolkits.load.db.orchestration.RootLevelTimestampsToUtcMapper
 import io.airbyte.cdk.load.toolkits.load.db.orchestration.TypingDedupingMetaChangeMapper
-import io.airbyte.cdk.load.util.serializeToString
 import io.airbyte.cdk.load.write.AllTypesBehavior
 import io.airbyte.cdk.load.write.BasicFunctionalityIntegrationTest
 import io.airbyte.cdk.load.write.SchematizedNestedValueBehavior
@@ -273,11 +272,9 @@ class StandardInsertRawOverrideDisableTd :
     BigqueryRawTablesWriteTest(
         BigQueryDestinationTestUtils.createConfig(
                 configFile = STANDARD_INSERT_CONFIG,
-                datasetId = DEFAULT_NAMESPACE_PLACEHOLDER,
                 rawDatasetId = RAW_DATASET_OVERRIDE,
                 disableTypingDeduping = true,
-            )
-            .serializeToString(),
+            ),
     ) {
     @Test
     override fun testBasicWrite() {
@@ -290,9 +287,7 @@ class StandardInsertRawOverrideDisableTd :
 }
 
 class StandardInsertRawOverride :
-    BigqueryTDWriteTest(
-        BigQueryDestinationTestUtils.standardInsertRawOverrideConfig.serializeToString()
-    ) {
+    BigqueryTDWriteTest(BigQueryDestinationTestUtils.standardInsertRawOverrideConfig) {
     @Test
     override fun testBasicWrite() {
         super.testBasicWrite()
@@ -304,7 +299,7 @@ class StandardInsertRawOverride :
 }
 
 class StandardInsert :
-    BigqueryTDWriteTest(BigQueryDestinationTestUtils.standardInsertConfig.serializeToString()) {
+    BigqueryTDWriteTest(BigQueryDestinationTestUtils.standardInsertConfig) {
     @Test
     override fun testDedup() {
         super.testDedup()
@@ -315,11 +310,9 @@ class GcsRawOverrideDisableTd :
     BigqueryRawTablesWriteTest(
         BigQueryDestinationTestUtils.createConfig(
                 configFile = GCS_STAGING_CONFIG,
-                datasetId = DEFAULT_NAMESPACE_PLACEHOLDER,
                 rawDatasetId = RAW_DATASET_OVERRIDE,
                 disableTypingDeduping = true,
-            )
-            .serializeToString(),
+            ),
     ) {
     @Test
     override fun testBasicWrite() {
@@ -331,10 +324,8 @@ class GcsRawOverride :
     BigqueryTDWriteTest(
         BigQueryDestinationTestUtils.createConfig(
                 configFile = GCS_STAGING_CONFIG,
-                datasetId = DEFAULT_NAMESPACE_PLACEHOLDER,
                 rawDatasetId = RAW_DATASET_OVERRIDE,
-            )
-            .serializeToString(),
+            ),
     ) {
     @Test
     override fun testBasicWrite() {
@@ -343,13 +334,7 @@ class GcsRawOverride :
 }
 
 class Gcs :
-    BigqueryTDWriteTest(
-        BigQueryDestinationTestUtils.createConfig(
-                configFile = GCS_STAGING_CONFIG,
-                datasetId = DEFAULT_NAMESPACE_PLACEHOLDER,
-            )
-            .serializeToString(),
-    ) {
+    BigqueryTDWriteTest(BigQueryDestinationTestUtils.createConfig(configFile = GCS_STAGING_CONFIG)) {
     @Test
     override fun testBasicWrite() {
         super.testBasicWrite()


### PR DESCRIPTION
by commit:
* tweak the createConfig interface to be nicer (returns a string; hardcodes the default namespace placeholder)
* add all the configs with different failure modes
* add custom deserializer for legacy configs >.>

this depends on https://github.com/airbytehq/airbyte/pull/59709 being merged + me rebasing the entire PR stack. And that PR is blocked on me checking with sources whether they depend on this behavior. Tested locally that these work though.