### PR TITLE
bulk CDK: stop validating configs

### DIFF
--- a/airbyte-cdk/bulk/core/base/src/main/kotlin/io/airbyte/cdk/command/ConfigurationSpecificationSupplier.kt
+++ b/airbyte-cdk/bulk/core/base/src/main/kotlin/io/airbyte/cdk/command/ConfigurationSpecificationSupplier.kt
@@ -21,8 +21,6 @@ import java.util.function.Supplier
  * ability to set values via the nested properties. This current design caters to both use cases.
  * Furthermore, by deferring the parsing and validation of the configuration, we don't need to worry
  * about exception handling edge cases when implementing the CHECK operation.
- *
- * The object is also validated against its [jsonSchema] JSON schema, derived from [javaClass].
  */
 @Singleton
 class ConfigurationSpecificationSupplier<T : ConfigurationSpecification>(
@@ -43,7 +41,7 @@ class ConfigurationSpecificationSupplier<T : ConfigurationSpecification>(
             }
         }
         val json: String = jsonPropertyValue ?: jsonMicronautFallback
-        return ValidatedJsonUtils.parseOne(javaClass, json)
+        return ValidatedJsonUtils.parseUnvalidated(json, javaClass)
     }
 }
 

--- a/airbyte-cdk/bulk/core/base/src/main/kotlin/io/airbyte/cdk/command/ValidatedJsonUtils.kt
+++ b/airbyte-cdk/bulk/core/base/src/main/kotlin/io/airbyte/cdk/command/ValidatedJsonUtils.kt
@@ -69,6 +69,19 @@ object ValidatedJsonUtils {
     }
 
     fun <T> parseUnvalidated(
+        json: String,
+        klazz: Class<T>,
+    ): T {
+        val tree: JsonNode =
+            try {
+                Jsons.readTree(json)
+            } catch (e: Exception) {
+                throw ConfigErrorException("malformed json value while parsing for $klazz", e)
+            }
+        return parseUnvalidated(tree, klazz)
+    }
+
+    fun <T> parseUnvalidated(
         jsonNode: JsonNode,
         klazz: Class<T>,
     ): T =

--- a/airbyte-cdk/bulk/core/extract/src/test/kotlin/io/airbyte/cdk/check/CheckTest.kt
+++ b/airbyte-cdk/bulk/core/extract/src/test/kotlin/io/airbyte/cdk/check/CheckTest.kt
@@ -24,7 +24,11 @@ class CheckTest {
     @Property(name = "airbyte.connector.config.database", value = "testdb")
     @Property(name = "metadata.resource", value = "discover/metadata-valid.json")
     fun testConfigBadPort() {
-        assertFailed("port: Minimum is '0', found '-1'. \\(code: 1015\\)".toRegex())
+        // we don't validate the config against the jsonschema, so even though -1
+        // isn't within the declared bounds (0<=it<=65536),
+        // we should still succeed.
+        // (the connector is responsible for catching this sort of thing)
+        assertSucceeded()
     }
 
     @Test


### PR DESCRIPTION
on occasion we have/will change the schema of our configs. For example, bigquery (very long ago) had a `credentialsJson` field as a full JSON object, and at some point changed it to be a string - so the current connector (not yet on the bulk CDK) has a shim to handle both cases: https://github.com/airbytehq/airbyte/blob/60b0aeda8c37a55b86832fcc32f18c34119a9d63/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/BigQueryDestination.kt#L552-L554

the bulk CDK's validation prevents us from parsing those configs, even though they should continue to be supported.

---
~configs were never meant to be validated~

~hundreds of years of programming yet no real world use found for~