### PR TITLE
bug(source-microsoft-sharepoint): edge case, when unable to match a uri

### DIFF
--- a/airbyte-integrations/connectors/source-microsoft-sharepoint/metadata.yaml
+++ b/airbyte-integrations/connectors/source-microsoft-sharepoint/metadata.yaml
@@ -20,7 +20,7 @@ data:
   connectorSubtype: file
   connectorType: source
   definitionId: 59353119-f0f2-4e5a-a8ba-15d887bc34f6
-  dockerImageTag: 0.10.0
+  dockerImageTag: 0.10.1
   dockerRepository: airbyte/source-microsoft-sharepoint
   githubIssueLabel: source-microsoft-sharepoint
   icon: microsoft-sharepoint.svg

--- a/airbyte-integrations/connectors/source-microsoft-sharepoint/pyproject.toml
+++ b/airbyte-integrations/connectors/source-microsoft-sharepoint/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "0.10.0"
+version = "0.10.1"
 name = "source-microsoft-sharepoint"
 description = "Source implementation for Microsoft SharePoint."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-microsoft-sharepoint/source_microsoft_sharepoint/stream_reader.py
+++ b/airbyte-integrations/connectors/source-microsoft-sharepoint/source_microsoft_sharepoint/stream_reader.py
@@ -425,8 +425,10 @@ class SourceMicrosoftSharePointStreamReader(AbstractFileBasedStreamReader):
 
     @staticmethod
     def _parse_file_path_from_uri(file_uri: str) -> str:
+        file_path = file_uri
         match = re.search(r"sharepoint\.com(?:/sites/[^/]+)?/Shared%20Documents(.*)", file_uri)
-        file_path = match.group(1)
+        if match:
+            file_path = match.group(1)
         return file_path
 
     def _get_headers(self) -> Dict[str, str]:

--- a/airbyte-integrations/connectors/source-microsoft-sharepoint/source_microsoft_sharepoint/stream_reader.py
+++ b/airbyte-integrations/connectors/source-microsoft-sharepoint/source_microsoft_sharepoint/stream_reader.py
@@ -425,11 +425,8 @@ class SourceMicrosoftSharePointStreamReader(AbstractFileBasedStreamReader):
 
     @staticmethod
     def _parse_file_path_from_uri(file_uri: str) -> str:
-        file_path = file_uri
         match = re.search(r"sharepoint\.com(?:/sites/[^/]+)?/Shared%20Documents(.*)", file_uri)
-        if match:
-            file_path = match.group(1)
-        return file_path
+        return match.group(1) if match else file_uri
 
     def _get_headers(self) -> Dict[str, str]:
         access_token = self.get_access_token()

--- a/docs/integrations/sources/microsoft-sharepoint.md
+++ b/docs/integrations/sources/microsoft-sharepoint.md
@@ -306,6 +306,7 @@ The connector is restricted by normal Microsoft Graph [requests limitation](http
 
 | Version | Date       | Pull Request                                             | Subject                                                                   |
 |:--------|:-----------|:---------------------------------------------------------|:--------------------------------------------------------------------------|
+| 0.10.1 | 2025-05-07 | [59700](https://github.com/airbytehq/airbyte/pull/59711) | Fix edege case for unexcpeted uris. |
 | 0.10.0 | 2025-05-07 | [59700](https://github.com/airbytehq/airbyte/pull/59700) | Promoting release candidate 0.10.0-rc.1 to a main version. |
 | 0.10.0-rc.1 | 2025-05-05 | [57507](https://github.com/airbytehq/airbyte/pull/57507) | Adapt file-transfer records to latest protocol, requires platform >= 1.7.0, destination-s3 >= 1.8.0 |
 | 0.9.3 | 2025-04-19 | [58471](https://github.com/airbytehq/airbyte/pull/58471) | Update dependencies |


### PR DESCRIPTION
## What
This was a miss when migration to the latest protocol occurred. We used to check if a match existed, and there seems to be some URIs that don't follow this pattern (like 'https://client_name.sharepoint.com/Pages/some_page.aspx'). I will investigate further but this should mitigate the case.

## How
<!--
* Describe how code changes achieve the solution.
-->

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
