### PR TITLE
Make CheckIntegrationTest abstract

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/check/CheckIntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/check/CheckIntegrationTest.kt
@@ -28,7 +28,7 @@ data class CheckTestConfig(
     val name: String? = null,
 )
 
-open class CheckIntegrationTest<T : ConfigurationSpecification>(
+abstract class CheckIntegrationTest<T : ConfigurationSpecification>(
     val successConfigFilenames: List<CheckTestConfig>,
     val failConfigFilenamesAndFailureReasons: Map<CheckTestConfig, Pattern>,
     additionalMicronautEnvs: List<String> = emptyList(),


### PR DESCRIPTION
## What

Make `CheckIntegrationTest` abstract. It should have always been abstract?