### PR TITLE
CI: remove old CLI arg from `secrets fetch` CLI syntax (fixes broken beta test matrix)

### DIFF
--- a/.github/workflows/connector-test-command.yml
+++ b/.github/workflows/connector-test-command.yml
@@ -120,7 +120,7 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install pipx
           uv tool run airbyte-cdk[dev] secrets fetch \
-            --connector-name=${{ matrix.connector }} \
+            ${{ matrix.connector }} \
             --print-ci-secrets-masks
 
       - name: Run Unit Tests
@@ -225,7 +225,7 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install pipx
           pipx run airbyte-cdk[dev] secrets fetch \
-            --connector-name=${{ matrix.connector }} \
+            ${{ matrix.connector }} \
             --print-ci-secrets-masks
 
       - name: Run Unit Tests


### PR DESCRIPTION
## What

Latest version of the CDK CLI has a change to the signature for all connector-related commands, which broke the 'secrets fetch' commands in the workflow.

A larger revamp is coming shortly but I wanted to fix this to unblock @davinchia. Larger PR is here:

- https://github.com/airbytehq/airbyte/pull/59714

## How
<!--
* Describe how code changes achieve the solution.
-->

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
