### PR TITLE
fix(airbyte-ci): fixes to unit test step for manifest-only connectors

### DIFF
--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -821,6 +821,7 @@ airbyte-ci connectors --language=low-code migrate-to-manifest-only
 ## Changelog
 
 | Version | PR                                                          | Description                                                                                                                  |
+| 5.2.4   | [#59724](https://github.com/airbytehq/airbyte/pull/59724)  | Fix components mounting and test dependencies for manifest-only unit tests |
 | 5.1.0   | [#53238](https://github.com/airbytehq/airbyte/pull/53238)  | Add ability to opt out of version increment checks via metadata flag                                                         |
 | 5.0.1   | [#52664](https://github.com/airbytehq/airbyte/pull/52664)  | Update Python version requirement from 3.10 to 3.11.                                                                         |
 | ------- | ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/manifest_only_connectors.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/test/steps/manifest_only_connectors.py
@@ -1,9 +1,3 @@
-#
-# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
-#
-
-"""This module groups steps made to run tests for a specific manifest only connector given a test context."""
-
 from typing import List, Sequence, Tuple
 
 from dagger import Container, File
@@ -15,6 +9,7 @@ from pipelines.airbyte_ci.connectors.test.steps.common import AcceptanceTests, I
 from pipelines.airbyte_ci.connectors.test.steps.python_connectors import PytestStep
 from pipelines.consts import LOCAL_BUILD_PLATFORM
 from pipelines.helpers.execution.run_steps import STEP_TREE, StepToRun
+from pipelines.dagger.actions import secrets
 
 
 def get_test_steps(context: ConnectorTestContext) -> STEP_TREE:
@@ -76,28 +71,127 @@ class ManifestOnlyConnectorUnitTests(PytestStep):
         """Install the testing environment for manifest-only connectors."""
 
         connector_name = self.context.connector.technical_name
-        connector_path = f"/airbyte-integrations/connectors/{connector_name}"
+        # Use a simpler path structure to match what the CDK expects
+        test_dir = "/tmp/test_environment"
+        connector_base_path = f"{test_dir}/airbyte-integrations/connectors"
+        connector_path = f"{connector_base_path}/{connector_name}"
 
-        # Create a symlink between the local connector's directory and the built container
-        test_environment = built_connector_container.with_workdir(f"{connector_path}/unit_tests").with_exec(
+        # Get the proper user from the container
+        user = await built_connector_container.user()
+        if not user:
+            user = "root"
+
+        self.logger.info(f"Using user {user} for test environment")
+
+        # Set up base test environment with reset entrypoint
+        test_environment = built_connector_container.with_entrypoint([])
+
+        # Create test directories with proper permissions
+        test_environment = (
+            test_environment
+            .with_user("root")  # Temporarily switch to root to create directories
+            .with_exec(["mkdir", "-p", test_dir, connector_base_path, connector_path, f"{connector_path}/{self.test_directory_name}"])
+            .with_workdir(test_dir)
+        )
+
+        # Mount the connector directory and files
+        connector_dir = await self.context.get_connector_dir()
+
+        # Check what files are in the connector directory to identify components.py
+        connector_entries = await connector_dir.entries()
+        self.logger.info(f"Files in connector directory: {connector_entries}")
+
+        # Mount the entire connector directory to ensure all files (especially components.py) are available
+        test_environment = (
+            test_environment
+            .with_mounted_directory(connector_path, connector_dir)
+        )
+
+        # Get and mount the unit_tests directory specifically
+        unit_tests_dir = connector_dir.directory(self.test_directory_name)
+        unit_tests_path = f"{connector_path}/{self.test_directory_name}"
+
+        # Mount secrets 
+        secret_mounting_function = await secrets.mounted_connector_secrets(
+            self.context, f"{test_dir}/secrets", self.secrets, owner=user
+        )
+
+        # Apply secrets and set up Python path
+        test_environment = (
+            test_environment
+            .with_(secret_mounting_function)
+            .with_env_variable("PYTHONPATH", f"{connector_base_path}:{connector_path}:{unit_tests_path}:{test_dir}")
+        )
+
+        # Create symlink to source-declarative-manifest
+        test_environment = test_environment.with_exec(
             ["ln", "-s", "/source-declarative-manifest", connector_path]
         )
 
-        return await super().install_testing_environment(
-            test_environment,
-            test_config_file_name,
-            test_config_file,
-            extra_dependencies_names,
+        # Debug: Check the connector structure
+        test_environment = test_environment.with_exec(
+            ["echo", "=== CHECKING IF COMPONENTS.PY EXISTS ==="]
+        ).with_exec(
+            ["ls", "-la", connector_path]
         )
+
+        # Set working directory to unit tests path
+        test_environment = test_environment.with_workdir(unit_tests_path)
+
+        # Install Poetry
+        test_environment = test_environment.with_exec(
+            ["echo", "=== INSTALLING POETRY ==="]
+        ).with_exec(
+            ["pip", "install", "poetry==1.8.4"]  # Install specific Poetry version for stability
+        )
+
+        # Install dependencies directly with Poetry
+        test_environment = test_environment.with_exec(
+            ["poetry", "config", "virtualenvs.create", "false"]  # Disable virtualenv creation
+        ).with_exec(
+            ["poetry", "install", "--no-root"]  # Install dependencies without the root package
+        )
+
+        # Install common test dependencies
+        if self.common_test_dependencies:
+            test_environment = test_environment.with_exec(
+                ["echo", "=== INSTALLING COMMON TEST DEPENDENCIES ==="]
+            ).with_exec(
+                ["pip", "install"] + self.common_test_dependencies
+            )
+
+        # Add CDK tests utilities diagnostics
+        test_environment = test_environment.with_exec(
+            ["echo", "=== CHECKING CDK TEST UTILS ==="]
+        ).with_exec(
+            ["python", "-c", "try:\n    import airbyte_cdk.test.utils.manifest_only_fixtures\n    print(f'CDK manifest fixtures found at: {airbyte_cdk.test.utils.manifest_only_fixtures.__file__}')\nexcept ImportError as e:\n    print(f'Error importing CDK test utils: {e}')"]
+        )
+
+        # Set ownership of all files to the proper user and switch to that user
+        test_environment = (
+            test_environment
+            .with_exec(["chown", "-R", f"{user}:{user}", test_dir])
+            .with_user(user)
+        )
+
+        # Add final environment check
+        test_environment = test_environment.with_exec(
+            ["echo", "=== FINAL PYTHON ENVIRONMENT ==="]
+        ).with_exec(
+            ["pip", "list"]
+        )
+
+        return test_environment
 
     async def get_config_file_name_and_file(self) -> Tuple[str, File]:
         """
         Get the config file name and file to use for pytest.
-        For manifest-only connectors, we expect the poetry config to be found in the unit_tests directory.
+        For manifest-only connectors, we expect the poetry config to be found 
+        in the unit_tests directory.
         """
         connector_name = self.context.connector.technical_name
         connector_dir = await self.context.get_connector_dir()
-        unit_tests_dir = connector_dir.directory("unit_tests")
+        unit_tests_dir = connector_dir.directory(self.test_directory_name)
         unit_tests_entries = await unit_tests_dir.entries()
         if self.PYPROJECT_FILE_NAME in unit_tests_entries:
             config_file_name = self.PYPROJECT_FILE_NAME
@@ -109,5 +203,5 @@ class ManifestOnlyConnectorUnitTests(PytestStep):
 
     def get_pytest_command(self, test_config_file_name: str) -> List[str]:
         """Get the pytest command to run."""
-        cmd = ["pytest", "-s", self.test_directory_name, "-c", test_config_file_name] + self.params_as_cli_options
-        return ["poetry", "run"] + cmd
+        cmd = ["pytest", "-v", ".", "-c", test_config_file_name] + self.params_as_cli_options
+        return ["python", "-m"] + cmd

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "5.2.3"
+version = "5.2.4"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 


### PR DESCRIPTION
## What

Couple of fixes to the unit test step in airbyte-ci for manifest only connectors. The core issues are that the current test environment:

1. Doesn't mount the components file
2. Has path structure issues
3. Doesn't install dependencies declared in the connector's test pyproject 🤡 

## How

- We now mount the entire connector directory, including components.py
- Uses Poetry directly to install the dependencies specified in pyproject.toml
- Uses the `--no-root` flag to avoid trying to install the non-existent package
- Sets Poetry to not create virtualenvs since we just need to install the deps directly for the tests
- We now use root temporarily to create directories, then switch to the correct user for running tests. I'm not particularly sure why this was necessary, but I was running into multiple permission issues when trying to refactor this code.
- PYTHONPATH wasn't set correctly to find the connector components. We now include connector base path, unit_tests path and test directory

## Note

Airbyte-ci is on its way out in favour of the much-improved FAST test implementation, so this is not meant to be a robust, long-term solution. Just trying to unblock our existing manifest-only connectors that are facing unit test issues in CI.

