### PR TITLE
Fix partition creation to avoid a loop when primary key is a string

### DIFF
--- a/airbyte-integrations/connectors/source-mysql/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mysql/metadata.yaml
@@ -9,7 +9,7 @@ data:
   connectorSubtype: database
   connectorType: source
   definitionId: 435bb9a5-7887-4809-aa58-28c27df0d7ad
-  dockerImageTag: 3.11.17
+  dockerImageTag: 3.11.18
   dockerRepository: airbyte/source-mysql
   documentationUrl: https://docs.airbyte.com/integrations/sources/mysql
   githubIssueLabel: source-mysql

--- a/airbyte-integrations/connectors/source-mysql/src/main/kotlin/io/airbyte/integrations/source/mysql/MySqlSourceJdbcPartitionFactory.kt
+++ b/airbyte-integrations/connectors/source-mysql/src/main/kotlin/io/airbyte/integrations/source/mysql/MySqlSourceJdbcPartitionFactory.kt
@@ -206,7 +206,7 @@ class MySqlSourceJdbcPartitionFactory(
 
             if (stream.configuredSyncMode == ConfiguredSyncMode.FULL_REFRESH) {
                 val upperBound = findPkUpperBound(stream, pkChosenFromCatalog)
-                if (sv.pkVal == Jsons.writeValueAsString(upperBound)) {
+                if (sv.pkVal == upperBound.asText()) {
                     return null
                 }
                 val pkLowerBound: JsonNode = stateValueToJsonNode(pkChosenFromCatalog[0], sv.pkVal)
@@ -233,7 +233,7 @@ class MySqlSourceJdbcPartitionFactory(
 
                 if (stream.configuredSyncMode == ConfiguredSyncMode.FULL_REFRESH) {
                     val upperBound = findPkUpperBound(stream, pkChosenFromCatalog)
-                    if (sv.pkVal == Jsons.writeValueAsString(upperBound)) {
+                    if (sv.pkVal == upperBound.asText()) {
                         return null
                     }
                     return MySqlSourceJdbcCdcRfrSnapshotPartition(
@@ -257,7 +257,7 @@ class MySqlSourceJdbcPartitionFactory(
 
             if (stream.configuredSyncMode == ConfiguredSyncMode.FULL_REFRESH) {
                 val upperBound = findPkUpperBound(stream, pkChosenFromCatalog)
-                if (sv.pkValue == Jsons.writeValueAsString(upperBound)) {
+                if (sv.pkValue == upperBound.asText()) {
                     return null
                 }
                 val pkLowerBound: JsonNode =

--- a/docs/integrations/sources/mysql.md
+++ b/docs/integrations/sources/mysql.md
@@ -226,6 +226,7 @@ Any database or table encoding combination of charset and collation is supported
 
 | Version     | Date       | Pull Request                                               | Subject                                                                                                                                         |
 |:------------|:-----------|:-----------------------------------------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------|
+| 3.11.18     | 2025-05-02 | [59732](https://github.com/airbytehq/airbyte/pull/59732)   | Fix a bug that caused the sync to go into a loop in some cases.                                                                                 |
 | 3.11.17     | 2025-05-02 | [59683](https://github.com/airbytehq/airbyte/pull/59683)   | CDK version bump.                                                                                                                               |
 | 3.11.16     | 2025-05-02 | [59223](https://github.com/airbytehq/airbyte/pull/59223)   | Improve handling of big int and decimal values preventing it from represented with scientific notation                                          |
 | 3.11.15     | 2025-04-29 | [59150](https://github.com/airbytehq/airbyte/pull/59150)   | Mitigate issue where cursor state was serialized with scientific notation                                                                       |


### PR DESCRIPTION
## What
The json to string change we made in 3.11.17 was adding another quotes to strings so the exit condition would fail when primary key was a string value (comparing `abc == "abc"` is false.
## How
Revert back to the previous `.asText` string output to prevent tables with string primary key from going into infinite loop.
## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
