### PR TITLE
chore: move dest-dev-null to new non-dagger flow.

### DIFF
--- a/airbyte-integrations/connectors/destination-dev-null/build.gradle
+++ b/airbyte-integrations/connectors/destination-dev-null/build.gradle
@@ -1,6 +1,8 @@
 plugins {
     id 'application'
     id 'airbyte-bulk-connector'
+    id "io.airbyte.gradle.docker"
+    id 'airbyte-connector-docker-convention'
 }
 
 airbyteBulkConnector {

--- a/airbyte-integrations/connectors/destination-dev-null/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-dev-null/metadata.yaml
@@ -11,7 +11,7 @@ data:
     - suite: integrationTests
   connectorType: destination
   definitionId: a7bcc9d8-13b3-4e49-b80d-d020b90045e3
-  dockerImageTag: 0.7.21
+  dockerImageTag: 0.7.22
   dockerRepository: airbyte/destination-dev-null
   documentationUrl: https://docs.airbyte.com/integrations/destinations/dev-null
   githubIssueLabel: destination-dev-null

--- a/buildSrc/src/main/groovy/airbyte-connector-docker-convention.gradle
+++ b/buildSrc/src/main/groovy/airbyte-connector-docker-convention.gradle
@@ -40,7 +40,8 @@ class AirbyteConnectorDockerConventionPlugin implements Plugin<Project> {
              *    The core plugin’s dockerCopyDockerfile task will copy
              *    it into build/airbyte/docker/Dockerfile automatically.
              * ------------------------------------------------------------ */
-            if (!dockerExt.dockerfile.present) {
+            def userFile = dockerExt.dockerfile.get().asFile
+            if (!userFile.exists()) {
                 dockerExt.dockerfile.set(project.rootProject.file(SHARED_DOCKERFILE))
             }
 

--- a/docs/integrations/destinations/dev-null.md
+++ b/docs/integrations/destinations/dev-null.md
@@ -49,6 +49,7 @@ The OSS and Cloud variants have the same version number starting from version `0
 
 | Version     | Date       | Pull Request                                             | Subject                                                                                      |
 |:------------|:-----------|:---------------------------------------------------------|:---------------------------------------------------------------------------------------------|
+| 0.7.22      | 2025-05-09 | [59759](https://github.com/airbytehq/airbyte/pull/59759) | Migrate to new flow.                                                                         |
 | 0.7.21      | 2025-05-07 | [59710](https://github.com/airbytehq/airbyte/pull/59710) | CDK: bugfixes                                                                                |
 | 0.7.20      | 2025-03-21 | [55906](https://github.com/airbytehq/airbyte/pull/55906) | CDK: Pass DestinationRecordRaw around instead of DestinationRecordAirbyteValue               |
 | 0.7.19      | 2025-03-13 | [55737](https://github.com/airbytehq/airbyte/pull/55737) | CDK: Pass DestinationRecordRaw around instead of DestinationRecordAirbyteValue               |


### PR DESCRIPTION
## What
As title.

Transition dev-null onto the new flow set up in #59716 and prep for #59740 .

## How
- Add the relevant plugins.
- Correct a bug I found.

## Review guide
Both files.

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
