### PR TITLE
bigquery direct load: update spec/config options

### DIFF
--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryBeansFactory.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryBeansFactory.kt
@@ -80,7 +80,7 @@ class BigqueryBeansFactory {
         streamStateStore: StreamStateStore<*>,
     ): DestinationWriter {
         val destinationHandler = BigQueryDatabaseHandler(bigquery, config.datasetLocation.region)
-        if (config.disableTypingDeduping) {
+        if (config.legacyRawTablesOnly) {
             @Suppress("UNCHECKED_CAST")
             return TypingDedupingWriter(
                 names,

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/spec/BigqueryConfiguration.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/spec/BigqueryConfiguration.kt
@@ -18,7 +18,7 @@ data class BigqueryConfiguration(
     val credentialsJson: String?,
     val transformationPriority: TransformationPriority,
     val rawTableDataset: String,
-    val disableTypingDeduping: Boolean,
+    val legacyRawTablesOnly: Boolean,
 ) : DestinationConfiguration() {
     override val numOpenStreamWorkers = 3
 }
@@ -61,7 +61,7 @@ class BigqueryConfigurationFactory :
                 } else {
                     pojo.rawTableDataset!!
                 },
-            disableTypingDeduping = pojo.disableTypingDeduping ?: false,
+            legacyRawTablesOnly = pojo.legacyRawTablesOnly ?: false,
         )
     }
 }

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/spec/BigquerySpecification.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/spec/BigquerySpecification.kt
@@ -83,23 +83,24 @@ class BigquerySpecification : ConfigurationSpecification() {
     @get:JsonSchemaInject(json = """{"group": "advanced", "order": 5}""")
     val transformationPriority: TransformationPriority? = null
 
-    @get:JsonSchemaTitle("Raw Table Dataset Name")
+    @get:JsonSchemaTitle(
+        """Legacy raw tables""",
+    )
     @get:JsonPropertyDescription(
-        """The dataset to write raw tables into (default: airbyte_internal)""",
+        """Write the legacy "raw tables" format, to enable backwards compatibility with older versions of this connector.""",
+    )
+    // for compatibility with existing actor configs, we keep the old property name.
+    @get:JsonProperty("disable_type_dedupe")
+    @get:JsonSchemaInject(json = """{"group": "advanced", "order": 7, "default": false}""")
+    val legacyRawTablesOnly: Boolean? = null
+
+    @get:JsonSchemaTitle("Legacy Raw Table Dataset Name")
+    @get:JsonPropertyDescription(
+        """The dataset to write raw tables into (default: airbyte_internal). Only relevant if you enable legacy raw tables.""",
     )
     @get:JsonProperty("raw_data_dataset")
-    @get:JsonSchemaInject(json = """{"group": "advanced", "order": 7}""")
+    @get:JsonSchemaInject(json = """{"group": "advanced", "order": 8}""")
     val rawTableDataset: String? = null
-
-    @get:JsonSchemaTitle(
-        "Disable Final Tables. (WARNING! Unstable option; Columns in raw table schema might change between versions)",
-    )
-    @get:JsonPropertyDescription(
-        """Disable Writing Final Tables. WARNING! The data format in _airbyte_data is likely stable but there are no guarantees that other metadata columns will remain the same in future versions""",
-    )
-    @get:JsonProperty("disable_type_dedupe")
-    @get:JsonSchemaInject(json = """{"group": "advanced", "order": 8, "default": false}""")
-    val disableTypingDeduping: Boolean? = null
 }
 
 @JsonTypeInfo(

--- a/airbyte-integrations/connectors/destination-bigquery/src/test-integration/resources/expected-spec-cloud.json
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test-integration/resources/expected-spec-cloud.json
@@ -140,17 +140,17 @@
       },
       "raw_data_dataset" : {
         "type" : "string",
-        "description" : "The dataset to write raw tables into (default: airbyte_internal)",
-        "title" : "Raw Table Dataset Name",
+        "description" : "The dataset to write raw tables into (default: airbyte_internal). Only relevant if you enable legacy raw tables.",
+        "title" : "Legacy Raw Table Dataset Name",
         "group" : "advanced",
-        "order" : 7
+        "order" : 8
       },
       "disable_type_dedupe" : {
         "type" : "boolean",
-        "description" : "Disable Writing Final Tables. WARNING! The data format in _airbyte_data is likely stable but there are no guarantees that other metadata columns will remain the same in future versions",
-        "title" : "Disable Final Tables. (WARNING! Unstable option; Columns in raw table schema might change between versions)",
+        "description" : "Write the legacy \"raw tables\" format, for backwards compatibility with older versions of this connector.",
+        "title" : "Legacy raw tables mode",
         "group" : "advanced",
-        "order" : 8,
+        "order" : 7,
         "default" : false
       }
     },

--- a/airbyte-integrations/connectors/destination-bigquery/src/test-integration/resources/expected-spec-oss.json
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test-integration/resources/expected-spec-oss.json
@@ -140,17 +140,17 @@
       },
       "raw_data_dataset" : {
         "type" : "string",
-        "description" : "The dataset to write raw tables into (default: airbyte_internal)",
-        "title" : "Raw Table Dataset Name",
+        "description" : "The dataset to write raw tables into (default: airbyte_internal). Only relevant if you enable legacy raw tables.",
+        "title" : "Legacy Raw Table Dataset Name",
         "group" : "advanced",
-        "order" : 7
+        "order" : 8
       },
       "disable_type_dedupe" : {
         "type" : "boolean",
-        "description" : "Disable Writing Final Tables. WARNING! The data format in _airbyte_data is likely stable but there are no guarantees that other metadata columns will remain the same in future versions",
-        "title" : "Disable Final Tables. (WARNING! Unstable option; Columns in raw table schema might change between versions)",
+        "description" : "Write the legacy \"raw tables\" format, for backwards compatibility with older versions of this connector.",
+        "title" : "Legacy raw tables mode",
         "group" : "advanced",
-        "order" : 8,
+        "order" : 7,
         "default" : false
       }
     },


### PR DESCRIPTION
diff is messy, but the changes are pretty simple:
* rename the spec field disableTypingDeduping -> legacyRawTablesOnly (but keep the JsonProperty unchanged, for compatibility). Also update the title/description.
* change the ordering in the spec (swap the rawTableDataset / legacyRawTablesOnly options); update the `order` jsonschema
* rename the config option disableTypingDeduping -> legacyRawTablesOnly