### PR TITLE
bigquery: hacky direct-load

### DIFF
--- a/airbyte-cdk/bulk/toolkits/load-db/src/main/kotlin/io/airbyte/cdk/load/orchestration/db/direct_load_table/DirectLoadTableStreamLoader.kt
+++ b/airbyte-cdk/bulk/toolkits/load-db/src/main/kotlin/io/airbyte/cdk/load/orchestration/db/direct_load_table/DirectLoadTableStreamLoader.kt
@@ -33,9 +33,11 @@ class DirectLoadTableAppendStreamLoader(
 ) : StreamLoader {
     override suspend fun start() {
         logger.info { "AppendStreamLoader starting for stream: ${stream.descriptor}" }
-
-        nativeTableOperations.ensureSchemaMatches(stream, realTableName, columnNameMapping)
-
+        if (initialStatus.realTable == null) {
+            sqlTableOperations.createTable(stream, realTableName, columnNameMapping, replace = true)
+        } else {
+            nativeTableOperations.ensureSchemaMatches(stream, realTableName, columnNameMapping)
+        }
         if (initialStatus.tempTable != null) {
             logger.info { "Processing temp table data: $tempTableName -> $realTableName" }
             nativeTableOperations.ensureSchemaMatches(stream, tempTableName, columnNameMapping)

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/formatter/BigQueryRecordFormatter.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/formatter/BigQueryRecordFormatter.kt
@@ -9,6 +9,7 @@ import com.google.cloud.bigquery.Schema
 import com.google.cloud.bigquery.StandardSQLTypeName
 import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.data.IntegerValue
+import io.airbyte.cdk.load.data.ObjectValue
 import io.airbyte.cdk.load.data.StringValue
 import io.airbyte.cdk.load.message.DestinationRecordRaw
 import io.airbyte.cdk.load.message.Meta
@@ -22,43 +23,56 @@ import java.util.concurrent.TimeUnit
  * The class formats incoming JsonSchema and AirbyteRecord in order to be inline with a
  * corresponding uploader.
  */
-class BigQueryRecordFormatter {
+class BigQueryRecordFormatter(private val legacyRawTablesOnly: Boolean) {
 
     fun formatRecord(record: DestinationRecordRaw): String {
         val enrichedRecord = record.asEnrichedDestinationRecordAirbyteValue()
 
         val outputRecord = mutableMapOf<String, Any?>()
-        enrichedRecord.airbyteMetaFields.forEach { (key, value) ->
+        val enrichedFieldsToIterate =
+            if (legacyRawTablesOnly) {
+                // in legacy raw tables mode, we only need to look at the airbyte fields.
+                // and we just dump the actual data fields into the output record
+                // as a JSON blob.
+                outputRecord[Meta.COLUMN_NAME_DATA] = record.asRawJson().serializeToString()
+                enrichedRecord.airbyteMetaFields
+            } else {
+                // but in direct-load mode, we do actually need to look at all the fields.
+                enrichedRecord.allTypedFields
+            }
+        enrichedFieldsToIterate.forEach { (key, value) ->
             when (key) {
                 Meta.COLUMN_NAME_AB_EXTRACTED_AT -> {
                     val extractedAtMillis = (value.abValue as IntegerValue).value.longValueExact()
                     outputRecord[key] = getExtractedAt(extractedAtMillis)
                 }
                 Meta.COLUMN_NAME_AB_META -> {
-                    // TODO this is a hack for T+D, we should remove it for direct-load tables
-                    //   we're completely ignoring the enrichedRecord's meta value, because that
-                    //   includes changes in-connector type coercion
-                    //   and for raw tables, we only want changes that originated from the source
-                    if (record.rawData.record.meta == null) {
-                        record.rawData.record.meta = AirbyteRecordMessageMeta()
-                        record.rawData.record.meta.changes = emptyList()
+                    if (legacyRawTablesOnly) {
+                        // this is a hack - in legacy mode, we don't do any in-connector validation
+                        // so we just need to pass through the original record's airbyte_meta.
+                        // so we completely ignore `value.abValue` here.
+                        if (record.rawData.record.meta == null) {
+                            record.rawData.record.meta = AirbyteRecordMessageMeta()
+                            record.rawData.record.meta.changes = emptyList()
+                        }
+                        record.rawData.record.meta.additionalProperties["sync_id"] =
+                            record.stream.syncId
+                        outputRecord[key] = record.rawData.record.meta.serializeToString()
+                    } else {
+                        outputRecord[key] = (value.abValue as ObjectValue).values
                     }
-                    record.rawData.record.meta.additionalProperties["sync_id"] =
-                        record.stream.syncId
-                    outputRecord[key] = record.rawData.record.meta.serializeToString()
-                    // TODO we should do this for direct-load tables
-                    // val serializedAirbyteMeta = (value.abValue as
-                    // ObjectValue).serializeToString()
-                    // outputRecord[key] = serializedAirbyteMeta
                 }
                 Meta.COLUMN_NAME_AB_RAW_ID ->
                     outputRecord[key] = (value.abValue as StringValue).value
                 Meta.COLUMN_NAME_AB_GENERATION_ID ->
                     outputRecord[key] = (value.abValue as IntegerValue).value
+                else -> {
+                    if (!legacyRawTablesOnly) {
+                        outputRecord[key] = value.abValue
+                    }
+                }
             }
         }
-
-        outputRecord[Meta.COLUMN_NAME_DATA] = record.asRawJson().serializeToString()
 
         return outputRecord.serializeToString()
     }

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/bulk_loader/BigQueryBulkLoader.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/bulk_loader/BigQueryBulkLoader.kt
@@ -92,8 +92,7 @@ class BigQueryBulkLoaderFactory(
     private val storageClient: GcsClient,
     private val bigQueryClient: BigQuery,
     private val bigQueryConfiguration: BigqueryConfiguration,
-    private val typingDedupingExecutionConfigStreamStateStore:
-        StreamStateStore<TypingDedupingExecutionConfig>?,
+    private val typingDedupingStreamStateStore: StreamStateStore<TypingDedupingExecutionConfig>?,
     private val directLoadStreamStateStore: StreamStateStore<DirectLoadTableExecutionConfig>?,
 ) : BulkLoaderFactory<StreamKey, GcsBlob> {
     override val numPartWorkers: Int = 2
@@ -110,8 +109,7 @@ class BigQueryBulkLoaderFactory(
         val tableNameInfo = names[key.stream]!!
         if (bigQueryConfiguration.legacyRawTablesOnly) {
             val rawTableName = tableNameInfo.tableNames.rawTableName!!
-            val rawTableSuffix =
-                typingDedupingExecutionConfigStreamStateStore!!.get(key.stream)!!.rawTableSuffix
+            val rawTableSuffix = typingDedupingStreamStateStore!!.get(key.stream)!!.rawTableSuffix
             tableId = TableId.of(rawTableName.namespace, rawTableName.name + rawTableSuffix)
             schema = BigQueryRecordFormatter.CSV_SCHEMA
         } else {

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/bulk_loader/BigQueryBulkLoaderConfiguration.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/bulk_loader/BigQueryBulkLoaderConfiguration.kt
@@ -41,8 +41,7 @@ data class BigqueryBulkLoadConfiguration(
     ObjectStorageCompressionConfigurationProvider<ByteArrayOutputStream> {
     override val objectStoragePathConfiguration: ObjectStoragePathConfiguration
     override val objectStorageFormatConfiguration: ObjectStorageFormatConfiguration =
-    // TODO format to raw or direct-load format as needed
-    CSVFormatConfiguration()
+        CSVFormatConfiguration(rootLevelFlattening = !bigQueryConfiguration.legacyRawTablesOnly)
     override val objectStorageUploadConfiguration: ObjectStorageUploadConfiguration =
         ObjectStorageUploadConfiguration()
     override val s3BucketConfiguration: S3BucketConfiguration

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/standard_insert/BigqueryBatchStandardInsertLoader.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/standard_insert/BigqueryBatchStandardInsertLoader.kt
@@ -9,12 +9,15 @@ import com.google.cloud.bigquery.BigQueryException
 import com.google.cloud.bigquery.FormatOptions
 import com.google.cloud.bigquery.JobId
 import com.google.cloud.bigquery.JobInfo
+import com.google.cloud.bigquery.Schema
 import com.google.cloud.bigquery.TableDataWriteChannel
 import com.google.cloud.bigquery.TableId
 import com.google.cloud.bigquery.WriteChannelConfiguration
 import io.airbyte.cdk.ConfigErrorException
+import io.airbyte.cdk.load.command.DestinationCatalog
 import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.message.DestinationRecordRaw
+import io.airbyte.cdk.load.orchestration.db.direct_load_table.DirectLoadTableExecutionConfig
 import io.airbyte.cdk.load.orchestration.db.legacy_typing_deduping.TableCatalogByDescriptor
 import io.airbyte.cdk.load.orchestration.db.legacy_typing_deduping.TypingDedupingExecutionConfig
 import io.airbyte.cdk.load.write.DirectLoader
@@ -27,6 +30,7 @@ import io.airbyte.integrations.destination.bigquery.spec.BigqueryConfiguration
 import io.airbyte.integrations.destination.bigquery.write.standard_insert.BigqueryBatchStandardInsertsLoaderFactory.Companion.CONFIG_ERROR_MSG
 import io.airbyte.integrations.destination.bigquery.write.standard_insert.BigqueryBatchStandardInsertsLoaderFactory.Companion.HTTP_STATUS_CODE_FORBIDDEN
 import io.airbyte.integrations.destination.bigquery.write.standard_insert.BigqueryBatchStandardInsertsLoaderFactory.Companion.HTTP_STATUS_CODE_NOT_FOUND
+import io.airbyte.integrations.destination.bigquery.write.typing_deduping.toTableId
 import io.micronaut.context.annotation.Requires
 import io.micronaut.context.condition.Condition
 import io.micronaut.context.condition.ConditionContext
@@ -39,13 +43,12 @@ class BigqueryBatchStandardInsertsLoader(
     private val bigquery: BigQuery,
     private val writeChannelConfiguration: WriteChannelConfiguration,
     private val job: JobId,
+    private val recordFormatter: BigQueryRecordFormatter,
 ) : DirectLoader {
-    private val recordFormatter = BigQueryRecordFormatter()
     private val buffer = ByteArrayOutputStream()
 
     override fun accept(record: DestinationRecordRaw): DirectLoader.DirectLoadResult {
         // TODO there was a RateLimiter here for some reason...?
-        // TODO format to raw or direct-load format as needed
         val formattedRecord = recordFormatter.formatRecord(record)
         val byteArray =
             "$formattedRecord${System.lineSeparator()}".toByteArray(StandardCharsets.UTF_8)
@@ -92,25 +95,38 @@ class BigqueryConfiguredForBatchStandardInserts : Condition {
 @Requires(condition = BigqueryConfiguredForBatchStandardInserts::class)
 @Singleton
 class BigqueryBatchStandardInsertsLoaderFactory(
+    private val catalog: DestinationCatalog,
     private val bigquery: BigQuery,
     private val config: BigqueryConfiguration,
     private val tableCatalog: TableCatalogByDescriptor,
-    private val streamStateStore: StreamStateStore<TypingDedupingExecutionConfig>,
+    private val typingDedupingStreamStateStore: StreamStateStore<TypingDedupingExecutionConfig>?,
+    private val directLoadStreamStateStore: StreamStateStore<DirectLoadTableExecutionConfig>?,
 ) : DirectLoaderFactory<BigqueryBatchStandardInsertsLoader> {
     override fun create(
         streamDescriptor: DestinationStream.Descriptor,
         part: Int,
     ): BigqueryBatchStandardInsertsLoader {
-        val rawTableName = tableCatalog[streamDescriptor]!!.tableNames.rawTableName!!
-        // TODO use the T+D raw table vs direct-load table as needed
-        val rawTableNameSuffix = streamStateStore.get(streamDescriptor)!!.rawTableSuffix
-
-        val writeChannelConfiguration =
-            WriteChannelConfiguration.newBuilder(
-                    TableId.of(rawTableName.namespace, rawTableName.name + rawTableNameSuffix)
+        val tableId: TableId
+        val schema: Schema
+        val tableNameInfo = tableCatalog[streamDescriptor]!!
+        if (config.legacyRawTablesOnly) {
+            val rawTableName = tableNameInfo.tableNames.rawTableName!!
+            val rawTableSuffix =
+                typingDedupingStreamStateStore!!.get(streamDescriptor)!!.rawTableSuffix
+            tableId = TableId.of(rawTableName.namespace, rawTableName.name + rawTableSuffix)
+            schema = BigQueryRecordFormatter.SCHEMA_V2
+        } else {
+            tableId = directLoadStreamStateStore!!.get(streamDescriptor)!!.tableName.toTableId()
+            schema =
+                BigQueryRecordFormatter.getDirectLoadSchema(
+                    catalog.getStream(streamDescriptor),
+                    tableNameInfo.columnNameMapping,
                 )
+        }
+        val writeChannelConfiguration =
+            WriteChannelConfiguration.newBuilder(tableId)
                 .setCreateDisposition(JobInfo.CreateDisposition.CREATE_IF_NEEDED)
-                .setSchema(BigQueryRecordFormatter.SCHEMA_V2)
+                .setSchema(schema)
                 // new-line delimited json.
                 .setFormatOptions(FormatOptions.json())
                 .build()
@@ -126,6 +142,7 @@ class BigqueryBatchStandardInsertsLoaderFactory(
             bigquery,
             writeChannelConfiguration,
             jobId,
+            BigQueryRecordFormatter(legacyRawTablesOnly = config.legacyRawTablesOnly),
         )
     }
 

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/typing_deduping/direct_load_tables/BigqueryDirectLoadNativeTableOperations.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/typing_deduping/direct_load_tables/BigqueryDirectLoadNativeTableOperations.kt
@@ -38,7 +38,7 @@ class BigqueryDirectLoadNativeTableOperations(private val bigquery: BigQuery) :
         tableName: TableName,
         columnNameMapping: ColumnNameMapping
     ) {
-        TODO("Not yet implemented")
+        //        TODO("Not yet implemented")
     }
 
     override fun getGenerationId(tableName: TableName): Long {

--- a/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryWriteTest.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryWriteTest.kt
@@ -4,16 +4,9 @@
 
 package io.airbyte.integrations.destination.bigquery
 
-import io.airbyte.cdk.load.command.Append
-import io.airbyte.cdk.load.command.Dedupe
-import io.airbyte.cdk.load.command.DestinationStream
-import io.airbyte.cdk.load.data.ObjectType
-import io.airbyte.cdk.load.message.InputRecord
 import io.airbyte.cdk.load.test.util.DestinationDataDumper
 import io.airbyte.cdk.load.test.util.ExpectedRecordMapper
-import io.airbyte.cdk.load.test.util.OutputRecord
 import io.airbyte.cdk.load.test.util.UncoercedExpectedRecordMapper
-import io.airbyte.cdk.load.test.util.destination_process.DockerizedDestinationFactory
 import io.airbyte.cdk.load.toolkits.load.db.orchestration.ColumnNameModifyingMapper
 import io.airbyte.cdk.load.toolkits.load.db.orchestration.RootLevelTimestampsToUtcMapper
 import io.airbyte.cdk.load.toolkits.load.db.orchestration.TypingDedupingMetaChangeMapper
@@ -30,10 +23,7 @@ import io.airbyte.integrations.destination.bigquery.BigQueryDestinationTestUtils
 import io.airbyte.integrations.destination.bigquery.BigQueryDestinationTestUtils.STANDARD_INSERT_CONFIG
 import io.airbyte.integrations.destination.bigquery.spec.BigquerySpecification
 import io.airbyte.integrations.destination.bigquery.write.typing_deduping.BigqueryColumnNameGenerator
-import kotlin.test.assertEquals
-import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertAll
 
 abstract class BigqueryWriteTest(
     configContents: String,
@@ -100,174 +90,7 @@ abstract class BigqueryTDWriteTest(configContents: String) :
             numberCanBeLarge = false,
             timeWithTimezoneBehavior = SimpleValueBehavior.PASS_THROUGH,
         ),
-    ) {
-    private val oldCdkDestinationFactory =
-        DockerizedDestinationFactory("airbyte/destination-bigquery", "2.10.2")
-
-    @Test
-    open fun testAppendCdkMigration() {
-        val stream =
-            DestinationStream(
-                DestinationStream.Descriptor(randomizedNamespace, "test_stream"),
-                Append,
-                ObjectType(linkedMapOf("id" to intType)),
-                generationId = 0,
-                minimumGenerationId = 0,
-                syncId = 42,
-            )
-        // Run a sync on the old CDK
-        runSync(
-            updatedConfig,
-            stream,
-            listOf(
-                InputRecord(
-                    namespace = randomizedNamespace,
-                    name = "test_stream",
-                    data = """{"id": 1234}""",
-                    emittedAtMs = 1234,
-                ),
-            ),
-            destinationProcessFactory = oldCdkDestinationFactory,
-        )
-        // Grab the loaded_at value from this sync
-        val firstSyncLoadedAt =
-            BigqueryRawTableDataDumper.dumpRecords(parsedConfig, stream).first().loadedAt!!
-
-        // Run a sync with the current destination
-        runSync(
-            updatedConfig,
-            stream,
-            listOf(
-                InputRecord(
-                    namespace = randomizedNamespace,
-                    name = "test_stream",
-                    data = """{"id": 1234}""",
-                    emittedAtMs = 5678,
-                ),
-            ),
-        )
-        val secondSyncLoadedAt =
-            BigqueryRawTableDataDumper.dumpRecords(parsedConfig, stream)
-                .map { it.loadedAt!! }
-                .toSet()
-        // verify that we didn't execute a soft reset
-        assertAll(
-            {
-                assertEquals(
-                    2,
-                    secondSyncLoadedAt.size,
-                    "Expected two unique values for loaded_at after two syncs. If there is only 1 value, then we likely executed a soft reset.",
-                )
-            },
-            {
-                assertTrue(
-                    secondSyncLoadedAt.contains(firstSyncLoadedAt),
-                    "Expected the first sync's loaded_at value to exist after the second sync. If this is not true, then we likely executed a soft reset.",
-                )
-            },
-        )
-
-        dumpAndDiffRecords(
-            parsedConfig,
-            listOf(
-                OutputRecord(
-                    extractedAt = 1234,
-                    generationId = 0,
-                    data = mapOf("id" to 1234),
-                    airbyteMeta = OutputRecord.Meta(syncId = 42, changes = emptyList()),
-                ),
-                OutputRecord(
-                    extractedAt = 5678,
-                    generationId = 0,
-                    data = mapOf("id" to 1234),
-                    airbyteMeta = OutputRecord.Meta(syncId = 42, changes = emptyList()),
-                ),
-            ),
-            stream,
-            listOf(listOf("id")),
-            cursor = null,
-        )
-    }
-
-    @Test
-    open fun testDedupCdkMigration() {
-        val stream =
-            DestinationStream(
-                DestinationStream.Descriptor(randomizedNamespace, "test_stream"),
-                Dedupe(primaryKey = listOf(listOf("id")), cursor = emptyList()),
-                ObjectType(linkedMapOf("id" to intType)),
-                generationId = 0,
-                minimumGenerationId = 0,
-                syncId = 42,
-            )
-        // Run a sync on the old CDK
-        runSync(
-            updatedConfig,
-            stream,
-            listOf(
-                InputRecord(
-                    namespace = randomizedNamespace,
-                    name = "test_stream",
-                    data = """{"id": 1234}""",
-                    emittedAtMs = 1234,
-                ),
-            ),
-            destinationProcessFactory = oldCdkDestinationFactory,
-        )
-        // Grab the loaded_at value from this sync
-        val firstSyncLoadedAt =
-            BigqueryRawTableDataDumper.dumpRecords(parsedConfig, stream).first().loadedAt!!
-
-        // Run a sync with the current destination
-        runSync(
-            updatedConfig,
-            stream,
-            listOf(
-                InputRecord(
-                    namespace = randomizedNamespace,
-                    name = "test_stream",
-                    data = """{"id": 1234}""",
-                    emittedAtMs = 5678,
-                ),
-            ),
-        )
-        val secondSyncLoadedAt =
-            BigqueryRawTableDataDumper.dumpRecords(parsedConfig, stream)
-                .map { it.loadedAt!! }
-                .toSet()
-        // verify that we didn't execute a soft reset
-        assertAll(
-            {
-                assertEquals(
-                    2,
-                    secondSyncLoadedAt.size,
-                    "Expected two unique values for loaded_at after two syncs. If there is only 1 value, then we likely executed a soft reset.",
-                )
-            },
-            {
-                assertTrue(
-                    secondSyncLoadedAt.contains(firstSyncLoadedAt),
-                    "Expected the first sync's loaded_at value to exist after the second sync. If this is not true, then we likely executed a soft reset.",
-                )
-            },
-        )
-
-        dumpAndDiffRecords(
-            parsedConfig,
-            listOf(
-                OutputRecord(
-                    extractedAt = 5678,
-                    generationId = 0,
-                    data = mapOf("id" to 1234),
-                    airbyteMeta = OutputRecord.Meta(syncId = 42, changes = emptyList()),
-                ),
-            ),
-            stream,
-            listOf(listOf("id")),
-            cursor = null,
-        )
-    }
-}
+    )
 
 class StandardInsertRawOverrideDisableTd :
     BigqueryRawTablesWriteTest(

--- a/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryWriteTest.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryWriteTest.kt
@@ -301,8 +301,8 @@ class StandardInsertRawOverride :
 
 class StandardInsert : BigqueryTDWriteTest(BigQueryDestinationTestUtils.standardInsertConfig) {
     @Test
-    override fun testDedup() {
-        super.testDedup()
+    override fun testBasicWrite() {
+        super.testBasicWrite()
     }
 }
 


### PR DESCRIPTION
just getting the base pieces together
* fix a bug in the CDK orchestration code. There's probably similar stuff in the other branches, I didn't look at them
* add code for constructing the direct-load table schema. Bigquery was weirdly picky about the nullability, so I hardcoded the airbyte meta fields.
* enable root-level flattening in direct-load mode, and switch between the legacy raw tables / new direct-load tables as needed

need to implement full type safety (enforcing bounds on numbers, etc.). GCS will probably need a larger rewrite to either (a) do the mssql thing and override the csv generator, or (b) inject something to the cdk csv generator to do that record mutation.

also:
* fix a typo in a sql statement
* delete no-longer-relevant tests (we don't have soft resets anymore, so we don't need to validate the lack of a soft reset)