### PR TITLE
Split DebeziumOperations interface

### DIFF
--- a/airbyte-cdk/bulk/toolkits/extract-cdc/src/main/kotlin/io/airbyte/cdk/read/cdc/CdcPartitionReaderDebeziumOperations.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-cdc/src/main/kotlin/io/airbyte/cdk/read/cdc/CdcPartitionReaderDebeziumOperations.kt
@@ -1,0 +1,43 @@
+package io.airbyte.cdk.read.cdc
+
+import io.airbyte.cdk.command.OpaqueStateValue
+import io.airbyte.cdk.read.Stream
+import org.apache.kafka.connect.source.SourceRecord
+
+interface CdcPartitionReaderDebeziumOperations<T : Comparable<T>> {
+
+    /**
+     * Transforms a [DebeziumRecordKey] and a [DebeziumRecordValue] into a [DeserializedRecord].
+     *
+     * Returning null means that the event should be treated like a heartbeat.
+     */
+    fun deserializeRecord(
+        key: DebeziumRecordKey,
+        value: DebeziumRecordValue,
+        stream: Stream,
+    ): DeserializedRecord?
+
+    /** Identifies the namespace of the stream that this event belongs to, if applicable. */
+    fun findStreamNamespace(
+        key: DebeziumRecordKey,
+        value: DebeziumRecordValue,
+    ): String?
+
+    /** Identifies the null of the stream that this event belongs to, if applicable. */
+    fun findStreamName(
+        key: DebeziumRecordKey,
+        value: DebeziumRecordValue,
+    ): String?
+
+    /** Maps a Debezium state to an [OpaqueStateValue]. */
+    fun serializeState(
+        offset: DebeziumOffset,
+        schemaHistory: DebeziumSchemaHistory?
+    ): OpaqueStateValue
+
+    /** Tries to extract the WAL position from a [DebeziumRecordValue]. */
+    fun position(recordValue: DebeziumRecordValue): T?
+
+    /** Tries to extract the WAL position from a [SourceRecord]. */
+    fun position(sourceRecord: SourceRecord): T?
+}

--- a/airbyte-cdk/bulk/toolkits/extract-cdc/src/main/kotlin/io/airbyte/cdk/read/cdc/CdcPartitionReaderDebeziumOperations.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-cdc/src/main/kotlin/io/airbyte/cdk/read/cdc/CdcPartitionReaderDebeziumOperations.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+ */
+
 package io.airbyte.cdk.read.cdc
 
 import io.airbyte.cdk.command.OpaqueStateValue

--- a/airbyte-cdk/bulk/toolkits/extract-cdc/src/main/kotlin/io/airbyte/cdk/read/cdc/CdcPartitionsCreatorDebeziumOperations.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-cdc/src/main/kotlin/io/airbyte/cdk/read/cdc/CdcPartitionsCreatorDebeziumOperations.kt
@@ -1,0 +1,24 @@
+package io.airbyte.cdk.read.cdc
+
+import io.airbyte.cdk.command.OpaqueStateValue
+import io.airbyte.cdk.read.Stream
+
+interface CdcPartitionsCreatorDebeziumOperations<T : Comparable<T>> {
+
+    /** Extracts the WAL position from a [DebeziumOffset]. */
+    fun position(offset: DebeziumOffset): T
+
+    /**
+     * Synthesizes a [DebeziumColdStartingState] when no incumbent [OpaqueStateValue] is available.
+     */
+    fun generateColdStartOffset(): DebeziumOffset
+
+    /** Generates Debezium properties for use with a [DebeziumColdStartingState]. */
+    fun generateColdStartProperties(streams: List<Stream>): Map<String, String>
+
+    /** Maps an incumbent [OpaqueStateValue] into a [DebeziumWarmStartState]. */
+    fun deserializeState(opaqueStateValue: OpaqueStateValue): DebeziumWarmStartState
+
+    /** Generates Debezium properties for use with a [ValidDebeziumWarmStartState]. */
+    fun generateWarmStartProperties(streams: List<Stream>): Map<String, String>
+}

--- a/airbyte-cdk/bulk/toolkits/extract-cdc/src/main/kotlin/io/airbyte/cdk/read/cdc/CdcPartitionsCreatorDebeziumOperations.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-cdc/src/main/kotlin/io/airbyte/cdk/read/cdc/CdcPartitionsCreatorDebeziumOperations.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+ */
+
 package io.airbyte.cdk.read.cdc
 
 import io.airbyte.cdk.command.OpaqueStateValue

--- a/airbyte-cdk/bulk/toolkits/extract-cdc/src/main/kotlin/io/airbyte/cdk/read/cdc/CdcPartitionsCreatorFactory.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-cdc/src/main/kotlin/io/airbyte/cdk/read/cdc/CdcPartitionsCreatorFactory.kt
@@ -18,7 +18,8 @@ import java.util.concurrent.atomic.AtomicReference
 /** [PartitionsCreatorFactory] implementation for CDC with Debezium. */
 class CdcPartitionsCreatorFactory<T : Comparable<T>>(
     val concurrencyResource: ConcurrencyResource,
-    val debeziumOps: DebeziumOperations<T>,
+    val cdcPartitionsCreatorDbzOps: CdcPartitionsCreatorDebeziumOperations<T>,
+    val cdcPartitionReaderDbzOps: CdcPartitionReaderDebeziumOperations<T>,
 ) : PartitionsCreatorFactory {
 
     /**
@@ -45,8 +46,8 @@ class CdcPartitionsCreatorFactory<T : Comparable<T>>(
         return CdcPartitionsCreator(
             concurrencyResource,
             feedBootstrap,
-            debeziumOps,
-            debeziumOps,
+            cdcPartitionsCreatorDbzOps,
+            cdcPartitionReaderDbzOps,
             lowerBoundReference,
             upperBoundReference,
             resetReason,

--- a/airbyte-cdk/bulk/toolkits/extract-cdc/src/main/kotlin/io/airbyte/cdk/read/cdc/DebeziumOperations.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-cdc/src/main/kotlin/io/airbyte/cdk/read/cdc/DebeziumOperations.kt
@@ -4,77 +4,7 @@
 
 package io.airbyte.cdk.read.cdc
 
-import com.fasterxml.jackson.databind.node.ObjectNode
-import io.airbyte.cdk.command.OpaqueStateValue
-import io.airbyte.cdk.discover.Field
-import io.airbyte.cdk.read.FieldValueChange
-import io.airbyte.cdk.read.Stream
-import org.apache.kafka.connect.source.SourceRecord
-
 /** Stateless connector-specific Debezium operations. */
+@Deprecated("Implement the two interfaces separately")
 interface DebeziumOperations<T : Comparable<T>> :
     CdcPartitionsCreatorDebeziumOperations<T>, CdcPartitionReaderDebeziumOperations<T>
-
-interface CdcPartitionsCreatorDebeziumOperations<T : Comparable<T>> {
-
-    /** Extracts the WAL position from a [DebeziumOffset]. */
-    fun position(offset: DebeziumOffset): T
-
-    /**
-     * Synthesizes a [DebeziumColdStartingState] when no incumbent [OpaqueStateValue] is available.
-     */
-    fun generateColdStartOffset(): DebeziumOffset
-
-    /** Generates Debezium properties for use with a [DebeziumColdStartingState]. */
-    fun generateColdStartProperties(streams: List<Stream>): Map<String, String>
-
-    /** Maps an incumbent [OpaqueStateValue] into a [DebeziumWarmStartState]. */
-    fun deserializeState(opaqueStateValue: OpaqueStateValue): DebeziumWarmStartState
-
-    /** Generates Debezium properties for use with a [ValidDebeziumWarmStartState]. */
-    fun generateWarmStartProperties(streams: List<Stream>): Map<String, String>
-}
-
-interface CdcPartitionReaderDebeziumOperations<T : Comparable<T>> {
-
-    /**
-     * Transforms a [DebeziumRecordKey] and a [DebeziumRecordValue] into a [DeserializedRecord].
-     *
-     * Returning null means that the event should be treated like a heartbeat.
-     */
-    fun deserializeRecord(
-        key: DebeziumRecordKey,
-        value: DebeziumRecordValue,
-        stream: Stream,
-    ): DeserializedRecord?
-
-    /** Identifies the namespace of the stream that this event belongs to, if applicable. */
-    fun findStreamNamespace(
-        key: DebeziumRecordKey,
-        value: DebeziumRecordValue,
-    ): String?
-
-    /** Identifies the null of the stream that this event belongs to, if applicable. */
-    fun findStreamName(
-        key: DebeziumRecordKey,
-        value: DebeziumRecordValue,
-    ): String?
-
-    /** Maps a Debezium state to an [OpaqueStateValue]. */
-    fun serializeState(
-        offset: DebeziumOffset,
-        schemaHistory: DebeziumSchemaHistory?
-    ): OpaqueStateValue
-
-    /** Tries to extract the WAL position from a [DebeziumRecordValue]. */
-    fun position(recordValue: DebeziumRecordValue): T?
-
-    /** Tries to extract the WAL position from a [SourceRecord]. */
-    fun position(sourceRecord: SourceRecord): T?
-}
-
-/** [DeserializedRecord]s are used to generate Airbyte RECORD messages. */
-data class DeserializedRecord(
-    val data: ObjectNode,
-    val changes: Map<Field, FieldValueChange>,
-)

--- a/airbyte-cdk/bulk/toolkits/extract-cdc/src/main/kotlin/io/airbyte/cdk/read/cdc/DeserializedRecord.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-cdc/src/main/kotlin/io/airbyte/cdk/read/cdc/DeserializedRecord.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+ */
+
 package io.airbyte.cdk.read.cdc
 
 import com.fasterxml.jackson.databind.node.ObjectNode

--- a/airbyte-cdk/bulk/toolkits/extract-cdc/src/main/kotlin/io/airbyte/cdk/read/cdc/DeserializedRecord.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-cdc/src/main/kotlin/io/airbyte/cdk/read/cdc/DeserializedRecord.kt
@@ -1,0 +1,11 @@
+package io.airbyte.cdk.read.cdc
+
+import com.fasterxml.jackson.databind.node.ObjectNode
+import io.airbyte.cdk.discover.Field
+import io.airbyte.cdk.read.FieldValueChange
+
+/** [DeserializedRecord]s are used to generate Airbyte RECORD messages. */
+data class DeserializedRecord(
+    val data: ObjectNode,
+    val changes: Map<Field, FieldValueChange>,
+)

--- a/airbyte-cdk/bulk/toolkits/extract-cdc/src/test/kotlin/io/airbyte/cdk/read/cdc/CdcPartitionReaderMongoTest.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-cdc/src/test/kotlin/io/airbyte/cdk/read/cdc/CdcPartitionReaderMongoTest.kt
@@ -80,26 +80,17 @@ class CdcPartitionReaderMongoTest :
             fn(it.getCollection(stream.name))
         }
 
-    override fun createDebeziumOperations(): DebeziumOperations<BsonTimestamp> =
-        MongoTestDebeziumOperations()
+    override fun createCdcPartitionsCreatorDbzOps():
+        CdcPartitionsCreatorDebeziumOperations<BsonTimestamp> = TestCdcPartitionsCreatorDbzOps()
 
-    inner class MongoTestDebeziumOperations : AbstractDebeziumOperationsForTest<BsonTimestamp>() {
+    override fun createCdcPartitionReaderDbzOps():
+        CdcPartitionReaderDebeziumOperations<BsonTimestamp> = TestCdcPartitionReaderDbzOps()
 
+    inner class TestCdcPartitionsCreatorDbzOps :
+        AbstractCdcPartitionsCreatorDbzOps<BsonTimestamp>() {
         override fun position(offset: DebeziumOffset): BsonTimestamp {
             val offsetValue: ObjectNode = offset.wrapped.values.first() as ObjectNode
             return BsonTimestamp(offsetValue["sec"].asInt(), offsetValue["ord"].asInt())
-        }
-
-        override fun position(recordValue: DebeziumRecordValue): BsonTimestamp? {
-            val resumeToken: String =
-                recordValue.source["resume_token"]?.takeIf { it.isTextual }?.asText() ?: return null
-            return ResumeTokens.getTimestamp(ResumeTokens.fromData(resumeToken))
-        }
-
-        override fun position(sourceRecord: SourceRecord): BsonTimestamp? {
-            val offset: Map<String, *> = sourceRecord.sourceOffset()
-            val resumeTokenBase64: String = offset["resume_token"] as? String ?: return null
-            return ResumeTokens.getTimestamp(ResumeTokens.fromBase64(resumeTokenBase64))
         }
 
         override fun generateColdStartOffset(): DebeziumOffset {
@@ -143,7 +134,7 @@ class CdcPartitionReaderMongoTest :
         override fun generateWarmStartProperties(streams: List<Stream>): Map<String, String> =
             generateColdStartProperties(streams)
 
-        fun currentResumeToken(): BsonDocument =
+        private fun currentResumeToken(): BsonDocument =
             container.withMongoDatabase { mongoDatabase: MongoDatabase ->
                 val pipeline = listOf<Bson>(Aggregates.match(Filters.`in`("ns.coll", stream.name)))
                 mongoDatabase.watch(pipeline, BsonDocument::class.java).cursor().use {
@@ -151,6 +142,20 @@ class CdcPartitionReaderMongoTest :
                     it.resumeToken!!
                 }
             }
+    }
+
+    inner class TestCdcPartitionReaderDbzOps : AbstractCdcPartitionReaderDbzOps<BsonTimestamp>() {
+        override fun position(recordValue: DebeziumRecordValue): BsonTimestamp? {
+            val resumeToken: String =
+                recordValue.source["resume_token"]?.takeIf { it.isTextual }?.asText() ?: return null
+            return ResumeTokens.getTimestamp(ResumeTokens.fromData(resumeToken))
+        }
+
+        override fun position(sourceRecord: SourceRecord): BsonTimestamp? {
+            val offset: Map<String, *> = sourceRecord.sourceOffset()
+            val resumeTokenBase64: String = offset["resume_token"] as? String ?: return null
+            return ResumeTokens.getTimestamp(ResumeTokens.fromBase64(resumeTokenBase64))
+        }
 
         override fun deserializeRecord(
             key: DebeziumRecordKey,

--- a/airbyte-cdk/java/airbyte-cdk/db-sources/src/testFixtures/kotlin/io/airbyte/cdk/integrations/debezium/CdcSourceTest.kt
+++ b/airbyte-cdk/java/airbyte-cdk/db-sources/src/testFixtures/kotlin/io/airbyte/cdk/integrations/debezium/CdcSourceTest.kt
@@ -220,11 +220,11 @@ abstract class CdcSourceTest<S : Source, T : TestDatabase<*, T, *>> {
 
     @AfterEach
     protected open fun tearDown() {
-        // try {
-        testdb.close()
-        // } catch (e: Throwable) {
-        //    LOGGER.error("exception during teardown", e)
-        // }
+        try {
+            testdb.close()
+        } catch (e: Throwable) {
+            LOGGER.error("exception during teardown", e)
+        }
     }
 
     protected open fun columnClause(

--- a/airbyte-cdk/java/airbyte-cdk/db-sources/src/testFixtures/kotlin/io/airbyte/cdk/integrations/debezium/CdcSourceTest.kt
+++ b/airbyte-cdk/java/airbyte-cdk/db-sources/src/testFixtures/kotlin/io/airbyte/cdk/integrations/debezium/CdcSourceTest.kt
@@ -220,11 +220,11 @@ abstract class CdcSourceTest<S : Source, T : TestDatabase<*, T, *>> {
 
     @AfterEach
     protected open fun tearDown() {
-        try {
-            testdb.close()
-        } catch (e: Throwable) {
-            LOGGER.error("exception during teardown", e)
-        }
+        // try {
+        testdb.close()
+        // } catch (e: Throwable) {
+        //    LOGGER.error("exception during teardown", e)
+        // }
     }
 
     protected open fun columnClause(


### PR DESCRIPTION
The DebeziumOperations interface:
- creates unnecessary coupling between startup and per-record behavior
- impedes testability
- adds unnecessary complexity to the class hierarchy

Here we break it down into its two constituent interfaces. It is now possible to implement a CDC connector by implementing the `CdcPartitionsCreatorDebeziumOperations` and `CdcPartitionReaderDebeziumOperations` separately. We leave the `DebeziumOperations` interface in place and mark it `@Deprecated` in order to allow existing connectors to take up newer CDK versions without additional maintenance hurdles.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
