### PR TITLE
[docs] Update Resumable Full Refresh Streams docs to use CheckpointMixin instead of StateMixin

### DIFF
--- a/docs/platform/connector-development/cdk-python/resumable-full-refresh-stream.md
+++ b/docs/platform/connector-development/cdk-python/resumable-full-refresh-stream.md
@@ -37,7 +37,7 @@ is retried.
 
 ## Implementing Resumable Full Refresh streams
 
-### `StateMixin`
+### `CheckpointMixin`
 
 This class mixin adds property `state` with abstract setter and getter.
 The `state` attribute helps the CDK figure out the current state of sync at any moment.
@@ -88,5 +88,5 @@ in between sync attempts, but deleted at the beginning of new sync jobs.
 
 In summary, a resumable full refresh stream requires:
 
-- to be inherited from `StateMixin` and state methods implemented
+- to be inherited from `CheckpointMixin` and state methods implemented
 - implementing `Stream.read_records()` to get the Stream's current state, request a single page of records, and update the Stream's state with the next page to fetch or `{}`.


### PR DESCRIPTION
## What

Fixes docs. In pull request https://github.com/airbytehq/airbyte/pull/37429 there were changes related to IncrementalMixin

`StateMixin` was added https://github.com/airbytehq/airbyte/pull/37429/commits/3aacffe6fc81a9d8b50b02e8a5fa5bdc1cabfeac and later it was renamed to `CheckpointMixin` https://github.com/airbytehq/airbyte/pull/37429/commits/0af07ebc713b72bb7c95cab12533b357ffdfe7be but docs still used `StateMixin` from the first change.

## How

I tracked down pull request https://github.com/airbytehq/airbyte/pull/37429 and use valid name.

## Review guide

1. `docs/platform/connector-development/cdk-python/resumable-full-refresh-stream.md`

## User Impact

Only connector developers that try to implement resumable full refresh streams are impacted.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌
