### PR TITLE
destination bigquery: tune parameters

### DIFF
--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/spec/BigqueryConfiguration.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/spec/BigqueryConfiguration.kt
@@ -19,7 +19,9 @@ data class BigqueryConfiguration(
     val transformationPriority: TransformationPriority,
     val rawTableDataset: String,
     val disableTypingDeduping: Boolean,
-) : DestinationConfiguration()
+) : DestinationConfiguration() {
+    override val estimatedRecordMemoryOverheadRatio: Double = 16.0
+}
 
 sealed interface LoadingMethodConfiguration
 

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/spec/BigqueryConfiguration.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/spec/BigqueryConfiguration.kt
@@ -21,6 +21,7 @@ data class BigqueryConfiguration(
     val disableTypingDeduping: Boolean,
 ) : DestinationConfiguration() {
     override val estimatedRecordMemoryOverheadRatio: Double = 16.0
+    override val numOpenStreamWorkers: Int = 10
 }
 
 sealed interface LoadingMethodConfiguration


### PR DESCRIPTION
https://cloud.airbyte.com/workspaces/bed3b473-1518-4461-a37f-730ea3d3a848/connections/6dfa5871-b70e-4c1f-a8d5-6ec298242639/timeline - `Destination process exited with non-zero exit code 3`

last time, this was caused by memory pressure, and resolved by bumping overhead ratio 1.1 -> 2.0. Try further increasing it? :shrug:

also, increase open stream workers default (1) -> 10. This matches [old behavior](https://github.com/airbytehq/airbyte/blob/25c0e9a453de145226906104bd6aa8616d40e7ee/airbyte-cdk/java/airbyte-cdk/typing-deduping/src/main/kotlin/io/airbyte/integrations/base/destination/operation/DefaultSyncOperation.kt#L35C17-L39).