### PR TITLE
bigquery direct load: fix dedup?

### DIFF
--- a/airbyte-cdk/bulk/toolkits/load-db/src/main/kotlin/io/airbyte/cdk/load/orchestration/db/direct_load_table/DirectLoadTableStreamLoader.kt
+++ b/airbyte-cdk/bulk/toolkits/load-db/src/main/kotlin/io/airbyte/cdk/load/orchestration/db/direct_load_table/DirectLoadTableStreamLoader.kt
@@ -266,7 +266,7 @@ class DirectLoadTableDedupTruncateStreamLoader(
             return
         }
 
-        if (shouldCheckRealTableGeneration && shouldUpsertUnconditionally()) {
+        if (shouldCheckRealTableGeneration && shouldUpsertDirectly()) {
             // Direct upsert path for simpler cases
             performDirectUpsert()
             return
@@ -277,7 +277,7 @@ class DirectLoadTableDedupTruncateStreamLoader(
     }
 
     /** Determines if we can directly upsert without additional processing */
-    private fun shouldUpsertUnconditionally(): Boolean {
+    private fun shouldUpsertDirectly(): Boolean {
         return when {
             // Case 1: Real table doesn't exist yet
             initialStatus.realTable == null -> true

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/typing_deduping/direct_load_tables/BigqueryDirectLoadSqlGenerator.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/typing_deduping/direct_load_tables/BigqueryDirectLoadSqlGenerator.kt
@@ -248,7 +248,7 @@ class BigqueryDirectLoadSqlGenerator(private val projectId: String?) : DirectLoa
                 ""
             } else if (importType.cursor.size == 1) {
                 val columnName = columnNameMapping[importType.cursor.first()]!!
-                "`$columnName` DESC NULLS LAST"
+                "`$columnName` DESC NULLS LAST,"
             } else {
                 throw UnsupportedOperationException(
                     "Only top-level cursors are supported, got ${importType.cursor}"

--- a/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryWriteTest.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryWriteTest.kt
@@ -124,8 +124,8 @@ class StandardInsertRawOverride :
 
 class StandardInsert : BigqueryTDWriteTest(BigQueryDestinationTestUtils.standardInsertConfig) {
     @Test
-    override fun testBasicWrite() {
-        super.testBasicWrite()
+    override fun testDedup() {
+        super.testDedup()
     }
 }
 


### PR DESCRIPTION
* fix the orchestration code (create table / enforce schema when we need to; minor tweak to extract common code from two branches of an if/else)
* fix a typo in the sqlgenerator