### PR TITLE
bigquery: standard inserts lazy init tablewritechannel

### DIFF
--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/spec/BigqueryConfiguration.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/spec/BigqueryConfiguration.kt
@@ -19,7 +19,9 @@ data class BigqueryConfiguration(
     val transformationPriority: TransformationPriority,
     val rawTableDataset: String,
     val disableTypingDeduping: Boolean,
-) : DestinationConfiguration()
+) : DestinationConfiguration() {
+    override val numOpenStreamWorkers: Int = 10
+}
 
 sealed interface LoadingMethodConfiguration
 

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/spec/BigqueryConfiguration.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/spec/BigqueryConfiguration.kt
@@ -19,9 +19,8 @@ data class BigqueryConfiguration(
     val transformationPriority: TransformationPriority,
     val rawTableDataset: String,
     val disableTypingDeduping: Boolean,
-) : DestinationConfiguration() {
-    override val numOpenStreamWorkers: Int = 10
-}
+    override val numOpenStreamWorkers: Int,
+) : DestinationConfiguration()
 
 sealed interface LoadingMethodConfiguration
 
@@ -62,6 +61,7 @@ class BigqueryConfigurationFactory :
                     pojo.rawTableDataset!!
                 },
             disableTypingDeduping = pojo.disableTypingDeduping ?: false,
+            numOpenStreamWorkers = pojo.numOpenStreamWorkers ?: 10,
         )
     }
 }

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/spec/BigquerySpecification.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/spec/BigquerySpecification.kt
@@ -31,6 +31,8 @@ import java.io.IOException
 
 @Singleton
 class BigquerySpecification : ConfigurationSpecification() {
+    val numOpenStreamWorkers: Int? = null
+
     @get:JsonSchemaTitle("Project ID")
     @get:JsonPropertyDescription(
         """The GCP project ID for the project containing the target BigQuery dataset. Read more <a href="https://cloud.google.com/resource-manager/docs/creating-managing-projects#identifying_projects">here</a>.""",

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/standard_insert/BigqueryBatchStandardInsertLoader.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/standard_insert/BigqueryBatchStandardInsertLoader.kt
@@ -17,14 +17,16 @@ import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.message.DestinationRecordRaw
 import io.airbyte.cdk.load.orchestration.db.legacy_typing_deduping.TableCatalogByDescriptor
 import io.airbyte.cdk.load.orchestration.db.legacy_typing_deduping.TypingDedupingExecutionConfig
+import io.airbyte.cdk.load.write.DirectLoader
+import io.airbyte.cdk.load.write.DirectLoaderFactory
 import io.airbyte.cdk.load.write.StreamStateStore
-import io.airbyte.cdk.load.write.db.InsertLoader
-import io.airbyte.cdk.load.write.db.InsertLoaderRequest
-import io.airbyte.cdk.load.write.db.InsertLoaderRequestBuilder
 import io.airbyte.integrations.destination.bigquery.BigQueryUtils
 import io.airbyte.integrations.destination.bigquery.formatter.BigQueryRecordFormatter
 import io.airbyte.integrations.destination.bigquery.spec.BatchedStandardInsertConfiguration
 import io.airbyte.integrations.destination.bigquery.spec.BigqueryConfiguration
+import io.airbyte.integrations.destination.bigquery.write.standard_insert.BigqueryBatchStandardInsertsLoaderFactory.Companion.CONFIG_ERROR_MSG
+import io.airbyte.integrations.destination.bigquery.write.standard_insert.BigqueryBatchStandardInsertsLoaderFactory.Companion.HTTP_STATUS_CODE_FORBIDDEN
+import io.airbyte.integrations.destination.bigquery.write.standard_insert.BigqueryBatchStandardInsertsLoaderFactory.Companion.HTTP_STATUS_CODE_NOT_FOUND
 import io.micronaut.context.annotation.Requires
 import io.micronaut.context.condition.Condition
 import io.micronaut.context.condition.ConditionContext
@@ -33,82 +35,49 @@ import java.io.ByteArrayOutputStream
 import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets
 
-// the default chunk size on the TableDataWriteChannel is 15MB.
-private const val DEFAULT_CHUNK_SIZE: Long = 15 * 1024 * 1024
-
-class BigqueryStandardInsertsRequest(
-    private val baos: ByteArrayOutputStream,
-    // TableDataWriteChannel holds a 15MB buffer in memory,
-    // so we try to avoid instantiating it for as long as possible.
-    // so accept it as a supplier here, and don't invoke the supplier
-    // until the CDK tells us we're ready to actually submit the request.
-    private val tableWriteChannelSupplier: () -> TableDataWriteChannel,
-) : InsertLoaderRequest {
-    override suspend fun submit() {
-        val writer = tableWriteChannelSupplier()
-        writer.use { writer.write(ByteBuffer.wrap(baos.toByteArray())) }
-        BigQueryUtils.waitForJobFinish(writer.job)
-    }
-}
-
-class BigqueryStandardInsertsRequestBuilder(
+class BigqueryBatchStandardInsertsLoader(
     private val bigquery: BigQuery,
     private val writeChannelConfiguration: WriteChannelConfiguration,
     private val job: JobId,
-) : InsertLoaderRequestBuilder<BigqueryStandardInsertsRequest> {
+) : DirectLoader {
     private val recordFormatter = BigQueryRecordFormatter()
     private val baos = ByteArrayOutputStream()
 
-    override fun accept(
-        record: DestinationRecordRaw,
-        maxRequestSizeBytes: Long
-    ): InsertLoaderRequestBuilder.InsertAcceptResult<BigqueryStandardInsertsRequest> {
+    override fun accept(record: DestinationRecordRaw): DirectLoader.DirectLoadResult {
         val formattedRecord = recordFormatter.formatRecord(record)
         val byteArray =
             "$formattedRecord${System.lineSeparator()}".toByteArray(StandardCharsets.UTF_8)
         baos.write(byteArray)
-        return if (baos.size() > maxRequestSizeBytes) {
+        // the default chunk size on the TableDataWriteChannel is 15MB,
+        // so just terminate when we get there.
+        if (baos.size() > 15 * 1024 * 1024) {
             finish()
+            return DirectLoader.Complete
         } else {
-            InsertLoaderRequestBuilder.NoOutput()
+            return DirectLoader.Incomplete
         }
     }
 
-    override fun finish(): InsertLoaderRequestBuilder.Request<BigqueryStandardInsertsRequest> {
-        return InsertLoaderRequestBuilder.Request(
-            BigqueryStandardInsertsRequest(baos) {
-                try {
-                    bigquery.writer(job, writeChannelConfiguration)
-                } catch (e: BigQueryException) {
-                    if (
-                        e.code == HTTP_STATUS_CODE_FORBIDDEN || e.code == HTTP_STATUS_CODE_NOT_FOUND
-                    ) {
-                        throw ConfigErrorException(CONFIG_ERROR_MSG + e)
-                    } else {
-                        throw BigQueryException(e.code, e.message)
-                    }
+    override fun finish() {
+        // this object holds a 15MB buffer in memory.
+        // we shouldn't initialize that until we actually need it,
+        // so just do it in finish.
+        // this minimizes the time we're occupying that chunk of memory.
+        val writer: TableDataWriteChannel =
+            try {
+                bigquery.writer(job, writeChannelConfiguration)
+            } catch (e: BigQueryException) {
+                if (e.code == HTTP_STATUS_CODE_FORBIDDEN || e.code == HTTP_STATUS_CODE_NOT_FOUND) {
+                    throw ConfigErrorException(CONFIG_ERROR_MSG + e)
+                } else {
+                    throw BigQueryException(e.code, e.message)
                 }
             }
-        )
+        writer.use { writer.write(ByteBuffer.wrap(baos.toByteArray())) }
+        BigQueryUtils.waitForJobFinish(writer.job)
     }
 
-    override fun close() {
-        // do nothing
-    }
-
-    companion object {
-        const val HTTP_STATUS_CODE_FORBIDDEN = 403
-        const val HTTP_STATUS_CODE_NOT_FOUND = 404
-
-        val CONFIG_ERROR_MSG =
-            """
-            |Failed to write to destination schema.
-            |   1. Make sure you have all required permissions for writing to the schema.
-            |   2. Make sure that the actual destination schema's location corresponds to location provided in connector's config.
-            |   3. Try to change the "Destination schema" from "Mirror Source Structure" (if it's set) tp the "Destination Default" option.
-            |More details:
-            |""".trimMargin()
-    }
+    override fun close() {}
 }
 
 class BigqueryConfiguredForBatchStandardInserts : Condition {
@@ -120,18 +89,16 @@ class BigqueryConfiguredForBatchStandardInserts : Condition {
 
 @Requires(condition = BigqueryConfiguredForBatchStandardInserts::class)
 @Singleton
-class BigqueryBatchStandardInsertsLoader(
+class BigqueryBatchStandardInsertsLoaderFactory(
     private val bigquery: BigQuery,
     private val config: BigqueryConfiguration,
     private val names: TableCatalogByDescriptor,
     private val streamStateStore: StreamStateStore<TypingDedupingExecutionConfig>,
-) : InsertLoader<BigqueryStandardInsertsRequest> {
-    override val estimatedByteSizePerRequest: Long = DEFAULT_CHUNK_SIZE
-
-    override fun createAccumulator(
+) : DirectLoaderFactory<BigqueryBatchStandardInsertsLoader> {
+    override fun create(
         streamDescriptor: DestinationStream.Descriptor,
-        partition: Int,
-    ): InsertLoaderRequestBuilder<BigqueryStandardInsertsRequest> {
+        part: Int,
+    ): BigqueryBatchStandardInsertsLoader {
         val rawTableName = names[streamDescriptor]!!.tableNames.rawTableName!!
         val rawTableNameSuffix = streamStateStore.get(streamDescriptor)!!.rawTableSuffix
 
@@ -152,10 +119,24 @@ class BigqueryBatchStandardInsertsLoader(
                 .setProject(bigquery.options.projectId)
                 .build()
 
-        return BigqueryStandardInsertsRequestBuilder(
+        return BigqueryBatchStandardInsertsLoader(
             bigquery,
             writeChannelConfiguration,
             jobId,
         )
+    }
+
+    companion object {
+        const val HTTP_STATUS_CODE_FORBIDDEN = 403
+        const val HTTP_STATUS_CODE_NOT_FOUND = 404
+
+        val CONFIG_ERROR_MSG =
+            """
+            |Failed to write to destination schema.
+            |   1. Make sure you have all required permissions for writing to the schema.
+            |   2. Make sure that the actual destination schema's location corresponds to location provided in connector's config.
+            |   3. Try to change the "Destination schema" from "Mirror Source Structure" (if it's set) tp the "Destination Default" option.
+            |More details:
+            |""".trimMargin()
     }
 }


### PR DESCRIPTION
supersedes https://github.com/airbytehq/airbyte/pull/60222. Move the actual writechannel instantiation into the `finish` method, and just write to a BAOS in `accept`.

(also, cherrypick the thing about numOpenStreamWorkers, since that seems useful still)