### PR TITLE
fix: align s3 key names with AWS names.

### DIFF
--- a/airbyte-cdk/bulk/toolkits/load-aws/src/main/kotlin/io/airbyte/cdk/load/command/aws/AWSAccessKeySpecification.kt
+++ b/airbyte-cdk/bulk/toolkits/load-aws/src/main/kotlin/io/airbyte/cdk/load/command/aws/AWSAccessKeySpecification.kt
@@ -16,7 +16,7 @@ import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaTitle
  * interface.
  */
 interface AWSAccessKeySpecification {
-    @get:JsonSchemaTitle("S3 Key ID")
+    @get:JsonSchemaTitle("Access Key ID")
     @get:JsonPropertyDescription(
         "The access key ID to access the S3 bucket. Airbyte requires Read and Write permissions to the given bucket. Read more <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys\">here</a>."
     )
@@ -27,7 +27,7 @@ interface AWSAccessKeySpecification {
     )
     val accessKeyId: String?
 
-    @get:JsonSchemaTitle("S3 Access Key")
+    @get:JsonSchemaTitle("Secret Access Key")
     @get:JsonPropertyDescription(
         "The corresponding secret to the access key ID. Read more <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys\">here</a>"
     )


### PR DESCRIPTION
## What
Aligns the s3 key names with what AWS calls them.

## Why
See discussion [here](https://airbytehq-team.slack.com/archives/C08H58XEZ3N/p1747071513617049)


## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
