### PR TITLE
Fix(Source-Intercom): Add Required Custom Component For `companies` stream. & Other fixes

### DIFF
--- a/airbyte-integrations/connectors/source-intercom/components.py
+++ b/airbyte-integrations/connectors/source-intercom/components.py
@@ -5,17 +5,16 @@
 from dataclasses import dataclass
 from functools import wraps
 from time import sleep
-from typing import Any, Callable, Iterable, Mapping, Optional, Union
+from typing import Any, Callable, Iterable, Mapping, Optional, Union, Dict
 
 import requests
 
 from airbyte_cdk.sources.declarative.migrations.state_migration import StateMigration
-from airbyte_cdk.sources.declarative.partition_routers.single_partition_router import SinglePartitionRouter
 from airbyte_cdk.sources.declarative.requesters.error_handlers import DefaultErrorHandler
 from airbyte_cdk.sources.declarative.retrievers.simple_retriever import SimpleRetriever
 from airbyte_cdk.sources.streams.http.error_handlers.response_models import ErrorResolution, FailureType, ResponseAction
 from airbyte_cdk.sources.types import Record, StreamSlice
-
+from airbyte_cdk.sources.declarative.requesters.paginators.strategies import CursorPaginationStrategy
 
 RequestInput = Union[str, Mapping[str, str]]
 
@@ -333,3 +332,50 @@ class IntercomScrollRetriever(SimpleRetriever):
                     pagination_complete = True
 
         yield from []
+
+class IntercomScrollPagination(CursorPaginationStrategy):
+    '''
+    Custom pagination strategy for Intercom's companies stream. Only compatible with streams that sync using
+    a single date time window instead of multiple windows when the step is defined. This is okay for the companies stream
+    since it only allows for single-threaded processing.
+    
+    The only change is the stop condtion logic, which is done by comparing the
+    token value with the last page token value. If they are equal, we stop the pagination. This is needed since the Intercom API does not
+    have any clear stop condition for pagination, and we need to rely on the token value to determine when to stop.
+
+    As of 5/12/25 - they have some fields used for pagination stop conditons but they always result in null values, so we cannot rely on them.
+    Ex: 
+    {
+        "type": "list",
+        "data": [
+            {...}
+        ],
+        "pages": null,
+        "total_count": null,
+        "scroll_param": "6287df44-6323-4dfa-8d19-eae43fdc4ab2" <- The scroll param also remains even if there are no more pages; leading to infinite pagination.
+    }
+    '''
+    def next_page_token(
+        self,
+        response: requests.Response,
+        last_page_size: int,
+        last_record: Optional[Record],
+        last_page_token_value: Optional[Any] = None,
+    ) -> Optional[Any]:
+        decoded_response = next(self.decoder.decode(response))
+        # The default way that link is presented in requests.Response is a string of various links (last, next, etc). This
+        # is not indexable or useful for parsing the cursor, so we replace it with the link dictionary from response.links
+        headers: Dict[str, Any] = dict(response.headers)
+        headers["link"] = response.links
+        token = self._cursor_value.eval(
+            config=self.config,
+            response=decoded_response,
+            headers=headers,
+            last_record=last_record,
+            last_page_size=last_page_size,
+        )
+
+        if token == last_page_token_value:
+            return None #stop pagination
+        
+        return token if token else None

--- a/airbyte-integrations/connectors/source-intercom/manifest.yaml
+++ b/airbyte-integrations/connectors/source-intercom/manifest.yaml
@@ -704,7 +704,7 @@ definitions:
           pagination_strategy:
             type: CursorPagination
             page_size: 150
-            cursor_value: "{{ response.get('pages', {}).get('next') }}"
+            cursor_value: "{{ response.get('pages', {}).get('next', {}).get('starting_after') }}"
             stop_condition: "{{ not response.get('pages', {}).get('next', {}).get('starting_after') }}"
           page_size_option:
             type: RequestOption

--- a/airbyte-integrations/connectors/source-intercom/manifest.yaml
+++ b/airbyte-integrations/connectors/source-intercom/manifest.yaml
@@ -590,9 +590,9 @@ definitions:
         type: InlineSchemaLoader
         schema:
           $ref: "#/schemas/conversation_parts"
-        state_migrations:
-         - type: CustomStateMigration
-           class_name: source_declarative_manifest.components.SubstreamStateMigration
+      state_migrations:
+        - type: CustomStateMigration
+          class_name: source_declarative_manifest.components.SubstreamStateMigration
     company_segments:
       description: >-
         https://developers.intercom.com/docs/references/2.11/rest-api/api.intercom.io/companies/listattachedsegmentsforcompanies

--- a/airbyte-integrations/connectors/source-intercom/manifest.yaml
+++ b/airbyte-integrations/connectors/source-intercom/manifest.yaml
@@ -271,9 +271,9 @@ definitions:
             inject_into: "request_parameter"
             field_name: "scroll_param"
           pagination_strategy:
-            type: CursorPagination
+            type: CustomPaginationStrategy
+            class_name: "source_declarative_manifest.components.IntercomScrollPagination"
             cursor_value: "{{ response.get('scroll_param') }}"
-            stop_condition: "{{ not response.get('data') }}"
         record_selector:
           type: RecordSelector
           $parameters:

--- a/airbyte-integrations/connectors/source-intercom/metadata.yaml
+++ b/airbyte-integrations/connectors/source-intercom/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: d8313939-3782-41b0-be29-b3ca20d8dd3a
-  dockerImageTag: 0.13.0-rc.3
+  dockerImageTag: 0.13.0-rc.4
   dockerRepository: airbyte/source-intercom
   documentationUrl: https://docs.airbyte.com/integrations/sources/intercom
   githubIssueLabel: source-intercom

--- a/docs/integrations/sources/intercom.md
+++ b/docs/integrations/sources/intercom.md
@@ -97,7 +97,7 @@ The Intercom connector should not run into Intercom API limitations under normal
 
 | Version    | Date       | Pull Request                                             | Subject                                                                                                                          |
 |:-----------|:-----------|:---------------------------------------------------------|:---------------------------------------------------------------------------------------------------------------------------------|
-| 0.13.0-rc.4 | 2025-05-13| [XXXXX](https://github.com/airbytehq/airbyte/pull/XXXXX) |  Add required custom paginator for 'companies' stream|
+| 0.13.0-rc.4 | 2025-05-13| [60235](https://github.com/airbytehq/airbyte/pull/60235) |  Add required custom paginator for 'companies' stream & Fix 500s on `Tickets` stream. |
 | 0.13.0-rc.3 | 2025-05-09| [55829](https://github.com/airbytehq/airbyte/pull/55829) |  Fix pagination for `conversations`, `tickets`, `companies` & `contacts` and cleanup manifest|
 | 0.13.0-rc.2 | 2025-04-08 | [57524](https://github.com/airbytehq/airbyte/pull/57524) | Use global state and pass state to parent streams for conversation_parts and company_segments                                    |
 | 0.13.0-rc.1 | 2025-02-22 | [53187](https://github.com/airbytehq/airbyte/pull/53187) | Update with latest CDK features, remove custom incremental sync components, update schema for conversation_parts  |

--- a/docs/integrations/sources/intercom.md
+++ b/docs/integrations/sources/intercom.md
@@ -97,6 +97,7 @@ The Intercom connector should not run into Intercom API limitations under normal
 
 | Version    | Date       | Pull Request                                             | Subject                                                                                                                          |
 |:-----------|:-----------|:---------------------------------------------------------|:---------------------------------------------------------------------------------------------------------------------------------|
+| 0.13.0-rc.4 | 2025-05-13| [XXXXX](https://github.com/airbytehq/airbyte/pull/XXXXX) |  Add required custom paginator for 'companies' stream|
 | 0.13.0-rc.3 | 2025-05-09| [55829](https://github.com/airbytehq/airbyte/pull/55829) |  Fix pagination for `conversations`, `tickets`, `companies` & `contacts` and cleanup manifest|
 | 0.13.0-rc.2 | 2025-04-08 | [57524](https://github.com/airbytehq/airbyte/pull/57524) | Use global state and pass state to parent streams for conversation_parts and company_segments                                    |
 | 0.13.0-rc.1 | 2025-02-22 | [53187](https://github.com/airbytehq/airbyte/pull/53187) | Update with latest CDK features, remove custom incremental sync components, update schema for conversation_parts  |

--- a/docs/integrations/sources/intercom.md
+++ b/docs/integrations/sources/intercom.md
@@ -97,7 +97,7 @@ The Intercom connector should not run into Intercom API limitations under normal
 
 | Version    | Date       | Pull Request                                             | Subject                                                                                                                          |
 |:-----------|:-----------|:---------------------------------------------------------|:---------------------------------------------------------------------------------------------------------------------------------|
-| 0.13.0-rc.4 | 2025-05-13| [60235](https://github.com/airbytehq/airbyte/pull/60235) |  Add required custom paginator for 'companies' stream & Fix 500s on `Tickets` stream. |
+| 0.13.0-rc.4 | 2025-05-15| [60235](https://github.com/airbytehq/airbyte/pull/60235) |  Add required custom paginator for 'companies' stream & Fix 500s on `Tickets` stream. |
 | 0.13.0-rc.3 | 2025-05-09| [55829](https://github.com/airbytehq/airbyte/pull/55829) |  Fix pagination for `conversations`, `tickets`, `companies` & `contacts` and cleanup manifest|
 | 0.13.0-rc.2 | 2025-04-08 | [57524](https://github.com/airbytehq/airbyte/pull/57524) | Use global state and pass state to parent streams for conversation_parts and company_segments                                    |
 | 0.13.0-rc.1 | 2025-02-22 | [53187](https://github.com/airbytehq/airbyte/pull/53187) | Update with latest CDK features, remove custom incremental sync components, update schema for conversation_parts  |


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->
Following [0.13.0-rc 3](https://github.com/airbytehq/airbyte/pull/55829), we see a handful of issues we'd like to fix in this version. 
1. `Companies` stream paginating endlessly, causing streams to stay stuck and emit duplicate records. 
2. `conversation_parts` [stream](https://cloud.airbyte.com/workspaces/07091d6a-c008-4031-a43a-958c76c12f57/connections/92abd2ef-fa6d-4f3e-9bb4-384163b7ddb0/timeline?eventId=07aea27e-7acd-4462-84e5-b7a4b6400064&openLogs=true) remains stuck and eventually fails with: `message='Airbyte could not track the sync progress. Sync process exited without reporting status.', type='io.airbyte.workers.exception.WorkloadMonitorException', nonRetryable=false`
3. `Tickets` stream fails with an HTTP 500 each time. (After investigating, I found the cursor for pagination was off, which would cause the HTTP 500 on the subsequent request.) - Note: We had to update our test credentials account to gain access to the `tickets` stream, but they just granted it today!

## How
<!--
* Describe how code changes achieve the solution.
-->
1. Implemented a custom paginator component for the `companies` stream: `IntercomScrollPagination` - this will determine the stop condition by comparing `last_page_token_value` and the current `token` value. If they are the same, we stop pagination. (See notes in this component for more context on why we need a custom component for this)
2. After debugging, we discovered the state wasn't being migrated at the start of the stream & the custom component wasn't running at all. Due to the state not migrating, sync would run from the config start date, skipping over already read records, which would lead to the heartbeat timeout. The exact cause for this one was an indentation issue. Now syncs should migrate the state correctly & start from the correct incremental start date rather than the config start date, which will prevent the heartbeat timeout error. 
3. Updated the cursor used in pagination to use `pages.next.starting_after`, instead of `pages.next`.
## Review guide
<!--
1. `x.py`
4. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
