### PR TITLE
bigquery: drop broken test

### DIFF
--- a/airbyte-integrations/connectors/destination-bigquery/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-bigquery/metadata.yaml
@@ -67,11 +67,6 @@ data:
           secretStore:
             type: GSM
             alias: airbyte-connector-testing-secret-store
-        - name: SECRET_DESTINATION-BIGQUERY_STANDARD_NON_BILLABLE_PROJECT__CREDS
-          fileName: credentials-standard-non-billable-project.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
         - name: SECRET_DESTINATION-BIGQUERY_CREDENTIALS_1S1T_GCS_BAD_COPY
           fileName: credentials-1s1t-gcs-bad-copy-permission.json
           secretStore:

--- a/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigQueryCheckTest.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigQueryCheckTest.kt
@@ -36,11 +36,6 @@ class BigQueryCheckTest :
                 ) to Pattern.compile("Permission bigquery.tables.create denied"),
                 CheckTestConfig(
                     BigQueryDestinationTestUtils.createConfig(
-                        "secrets/credentials-standard-non-billable-project.json"
-                    )
-                ) to Pattern.compile("Billing has not been enabled for this project"),
-                CheckTestConfig(
-                    BigQueryDestinationTestUtils.createConfig(
                         "secrets/credentials-1s1t-gcs-bad-copy-permission.json"
                     )
                 ) to Pattern.compile("Permission bigquery.tables.updateData denied on table"),


### PR DESCRIPTION
this test config is broken after some recent GCP project cleanup. We know it works, and it's going to continue working (b/c `check` is literally just running a sync). So no reason to keep the testcase.

derp. I forgot to grep for FAILED. but we should merge this anyway