### PR TITLE
:sparkles: [source-apple-search-ads] External token refresh endpoint configuration

### DIFF
--- a/airbyte-integrations/connectors/source-apple-search-ads/integration_tests/invalid_config.json
+++ b/airbyte-integrations/connectors/source-apple-search-ads/integration_tests/invalid_config.json
@@ -2,6 +2,7 @@
   "org_id": "wrongid",
   "client_id": "aaaaaaaaaa",
   "client_secret": "eyvbvubevxUIBVUYEUYB",
+  "token_refresh_endpoint": "httpx://baba.baba",
   "start_date": "9999-99-99",
   "backoff_factor": 9999,
   "lookback_window": 9999

--- a/airbyte-integrations/connectors/source-apple-search-ads/integration_tests/sample_config.json
+++ b/airbyte-integrations/connectors/source-apple-search-ads/integration_tests/sample_config.json
@@ -2,6 +2,7 @@
   "org_id": "REPLACEME",
   "client_id": "REPLACEME",
   "client_secret": "REPLACEME",
+  "token_refresh_endpoint": "https://apple.oauth.com/token",
   "start_date": "2022-11-11",
   "backoff_factor": 10,
   "lookback_window": 3

--- a/airbyte-integrations/connectors/source-apple-search-ads/manifest.yaml
+++ b/airbyte-integrations/connectors/source-apple-search-ads/manifest.yaml
@@ -555,8 +555,7 @@ definitions:
       client_id: "{{ config.client_id }}"
       grant_type: client_credentials
       client_secret: "{{ config.client_secret }}"
-      token_refresh_endpoint: >-
-        https://appleid.apple.com/auth/oauth2/token?grant_type=client_credentials&scope=searchadsorg
+      token_refresh_endpoint: "{{ config.token_refresh_endpoint }}"
       refresh_request_body: {}
 
 streams:
@@ -578,6 +577,7 @@ spec:
       - start_date
       - client_secret
       - timezone
+      - token_refresh_endpoint
     properties:
       org_id:
         type: integer
@@ -652,6 +652,15 @@ spec:
           - UTC
         order: 7
         title: Time Zone
+      token_refresh_endpoint:
+        type: string
+        description: >-
+          Token Refresh Endpoint. You should override the default value in scenarios 
+          where it's required to proxy requests to Apple's token endpoint
+        title: Token Refresh Endpoint
+        default: >-
+          https://appleid.apple.com/auth/oauth2/token?grant_type=client_credentials&scope=searchadsorg
+        order: 8
     additionalProperties: true
 
 metadata:

--- a/airbyte-integrations/connectors/source-apple-search-ads/manifest.yaml
+++ b/airbyte-integrations/connectors/source-apple-search-ads/manifest.yaml
@@ -555,7 +555,7 @@ definitions:
       client_id: "{{ config.client_id }}"
       grant_type: client_credentials
       client_secret: "{{ config.client_secret }}"
-      token_refresh_endpoint: "{{ config.token_refresh_endpoint }}"
+      token_refresh_endpoint: "{{ config.get('token_refresh_endpoint', 'https://appleid.apple.com/auth/oauth2/token?grant_type=client_credentials&scope=searchadsorg') }}"
       refresh_request_body: {}
 
 streams:

--- a/airbyte-integrations/connectors/source-apple-search-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-apple-search-ads/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: e59c8416-c2fa-4bd3-9e95-52677ea281c1
-  dockerImageTag: 0.7.9
+  dockerImageTag: 0.8.0
   dockerRepository: airbyte/source-apple-search-ads
   githubIssueLabel: source-apple-search-ads
   icon: icon.svg

--- a/docs/integrations/sources/apple-search-ads.md
+++ b/docs/integrations/sources/apple-search-ads.md
@@ -71,57 +71,58 @@ However, at this moment and as indicated in the stream names, the connector only
 
 | Version | Date       | Pull Request                                             | Subject                                                                              |
 |:--------|:-----------|:---------------------------------------------------------|:-------------------------------------------------------------------------------------|
-| 0.7.9 | 2025-05-10 | [59888](https://github.com/airbytehq/airbyte/pull/59888) | Update dependencies |
-| 0.7.8 | 2025-05-03 | [59308](https://github.com/airbytehq/airbyte/pull/59308) | Update dependencies |
-| 0.7.7 | 2025-04-26 | [58712](https://github.com/airbytehq/airbyte/pull/58712) | Update dependencies |
-| 0.7.6 | 2025-04-19 | [58275](https://github.com/airbytehq/airbyte/pull/58275) | Update dependencies |
-| 0.7.5 | 2025-04-12 | [57658](https://github.com/airbytehq/airbyte/pull/57658) | Update dependencies |
-| 0.7.4 | 2025-04-05 | [57158](https://github.com/airbytehq/airbyte/pull/57158) | Update dependencies |
-| 0.7.3 | 2025-03-29 | [56573](https://github.com/airbytehq/airbyte/pull/56573) | Update dependencies |
-| 0.7.2 | 2025-03-25 | [56383](https://github.com/airbytehq/airbyte/pull/56383) | add countryorregion to report schemas |
-| 0.7.1 | 2025-03-22 | [56109](https://github.com/airbytehq/airbyte/pull/56109) | Update dependencies |
-| 0.7.0 | 2025-03-20 | [55839](https://github.com/airbytehq/airbyte/pull/55839) | countryOrRegion metadata info included |
-| 0.6.0 | 2025-03-20 | [55785](https://github.com/airbytehq/airbyte/pull/55785) | Add timezone config parameter |
-| 0.5.1 | 2025-03-08 | [55366](https://github.com/airbytehq/airbyte/pull/55366) | Update dependencies |
-| 0.5.0 | 2025-03-05 | [55210](https://github.com/airbytehq/airbyte/pull/55210) | Remove primary keys |
-| 0.4.3 | 2025-03-01 | [54873](https://github.com/airbytehq/airbyte/pull/54873) | Update dependencies |
-| 0.4.2 | 2025-02-24 | [54646](https://github.com/airbytehq/airbyte/pull/54646) | Fix paginator settings for incremental report streams |
-| 0.4.1 | 2025-02-22 | [54284](https://github.com/airbytehq/airbyte/pull/54284) | Update dependencies |
-| 0.4.0 | 2025-02-20 | [54170](https://github.com/airbytehq/airbyte/pull/54170) | Externalize backoff factor and lookback window configurations |
-| 0.3.3 | 2025-02-15 | [53920](https://github.com/airbytehq/airbyte/pull/53920) | Update dependencies |
-| 0.3.2 | 2025-02-14 | [53685](https://github.com/airbytehq/airbyte/pull/53685) | Fix granularity to daily |
-| 0.3.1 | 2025-02-08 | [53422](https://github.com/airbytehq/airbyte/pull/53422) | Update dependencies |
-| 0.3.0 | 2025-02-03 | [53136](https://github.com/airbytehq/airbyte/pull/53136) | Update API version to V5 |
-| 0.2.9 | 2025-02-01 | [52899](https://github.com/airbytehq/airbyte/pull/52899) | Update dependencies |
-| 0.2.8 | 2025-01-25 | [52197](https://github.com/airbytehq/airbyte/pull/52197) | Update dependencies |
-| 0.2.7 | 2025-01-18 | [51745](https://github.com/airbytehq/airbyte/pull/51745) | Update dependencies |
-| 0.2.6 | 2025-01-11 | [51249](https://github.com/airbytehq/airbyte/pull/51249) | Update dependencies |
-| 0.2.5 | 2024-12-28 | [50469](https://github.com/airbytehq/airbyte/pull/50469) | Update dependencies |
-| 0.2.4 | 2024-12-21 | [50155](https://github.com/airbytehq/airbyte/pull/50155) | Update dependencies |
-| 0.2.3 | 2024-12-14 | [49561](https://github.com/airbytehq/airbyte/pull/49561) | Update dependencies |
-| 0.2.2 | 2024-12-12 | [47751](https://github.com/airbytehq/airbyte/pull/47751) | Update dependencies |
-| 0.2.1 | 2024-11-08 | [48440](https://github.com/airbytehq/airbyte/pull/48440) | Set authentication grant_type to client_credentials |
-| 0.2.0 | 2024-10-01 | [46288](https://github.com/airbytehq/airbyte/pull/46288) | Migrate to Manifest-only |
-| 0.1.20 | 2024-09-28 | [46153](https://github.com/airbytehq/airbyte/pull/46153) | Update dependencies |
-| 0.1.19 | 2024-09-21 | [45803](https://github.com/airbytehq/airbyte/pull/45803) | Update dependencies |
-| 0.1.18 | 2024-09-14 | [45474](https://github.com/airbytehq/airbyte/pull/45474) | Update dependencies |
-| 0.1.17 | 2024-09-07 | [45326](https://github.com/airbytehq/airbyte/pull/45326) | Update dependencies |
-| 0.1.16 | 2024-08-31 | [45013](https://github.com/airbytehq/airbyte/pull/45013) | Update dependencies |
-| 0.1.15 | 2024-08-24 | [44654](https://github.com/airbytehq/airbyte/pull/44654) | Update dependencies |
-| 0.1.14 | 2024-08-17 | [44322](https://github.com/airbytehq/airbyte/pull/44322) | Update dependencies |
-| 0.1.13 | 2024-08-12 | [43912](https://github.com/airbytehq/airbyte/pull/43912) | Update dependencies |
-| 0.1.12 | 2024-08-10 | [43514](https://github.com/airbytehq/airbyte/pull/43514) | Update dependencies |
-| 0.1.11 | 2024-08-03 | [43195](https://github.com/airbytehq/airbyte/pull/43195) | Update dependencies |
-| 0.1.10 | 2024-07-27 | [42660](https://github.com/airbytehq/airbyte/pull/42660) | Update dependencies |
-| 0.1.9 | 2024-07-20 | [42225](https://github.com/airbytehq/airbyte/pull/42225) | Update dependencies |
-| 0.1.8 | 2024-07-13 | [41722](https://github.com/airbytehq/airbyte/pull/41722) | Update dependencies |
-| 0.1.7 | 2024-07-10 | [41546](https://github.com/airbytehq/airbyte/pull/41546) | Update dependencies |
-| 0.1.6 | 2024-07-09 | [40832](https://github.com/airbytehq/airbyte/pull/40832) | Update dependencies |
-| 0.1.5 | 2024-06-25 | [40364](https://github.com/airbytehq/airbyte/pull/40364) | Update dependencies |
-| 0.1.4 | 2024-06-22 | [40186](https://github.com/airbytehq/airbyte/pull/40186) | Update dependencies |
-| 0.1.3 | 2024-06-04 | [38967](https://github.com/airbytehq/airbyte/pull/38967) | [autopull] Upgrade base image to v1.2.1 |
-| 0.1.2 | 2024-05-21 | [38502](https://github.com/airbytehq/airbyte/pull/38502) | [autopull] base image + poetry + up_to_date |
-| 0.1.1 | 2023-07-11 | [28153](https://github.com/airbytehq/airbyte/pull/28153) | Fix manifest duplicate key (no change in behavior for the syncs) |
-| 0.1.0 | 2022-11-17 | [19557](https://github.com/airbytehq/airbyte/pull/19557) | Initial release with campaigns, adgroups & keywords streams (base and daily reports) |
+| 0.8.0   | 2025-05-13 | ...                                                      | Add token refresh endpoint override configuration override                                  |
+| 0.7.9   | 2025-05-10 | [59888](https://github.com/airbytehq/airbyte/pull/59888) | Update dependencies                                                                  |
+| 0.7.8   | 2025-05-03 | [59308](https://github.com/airbytehq/airbyte/pull/59308) | Update dependencies                                                                  |
+| 0.7.7   | 2025-04-26 | [58712](https://github.com/airbytehq/airbyte/pull/58712) | Update dependencies                                                                  |
+| 0.7.6   | 2025-04-19 | [58275](https://github.com/airbytehq/airbyte/pull/58275) | Update dependencies                                                                  |
+| 0.7.5   | 2025-04-12 | [57658](https://github.com/airbytehq/airbyte/pull/57658) | Update dependencies                                                                  |
+| 0.7.4   | 2025-04-05 | [57158](https://github.com/airbytehq/airbyte/pull/57158) | Update dependencies                                                                  |
+| 0.7.3   | 2025-03-29 | [56573](https://github.com/airbytehq/airbyte/pull/56573) | Update dependencies                                                                  |
+| 0.7.2   | 2025-03-25 | [56383](https://github.com/airbytehq/airbyte/pull/56383) | add countryorregion to report schemas                                                |
+| 0.7.1   | 2025-03-22 | [56109](https://github.com/airbytehq/airbyte/pull/56109) | Update dependencies                                                                  |
+| 0.7.0   | 2025-03-20 | [55839](https://github.com/airbytehq/airbyte/pull/55839) | countryOrRegion metadata info included                                               |
+| 0.6.0   | 2025-03-20 | [55785](https://github.com/airbytehq/airbyte/pull/55785) | Add timezone config parameter                                                        |
+| 0.5.1   | 2025-03-08 | [55366](https://github.com/airbytehq/airbyte/pull/55366) | Update dependencies                                                                  |
+| 0.5.0   | 2025-03-05 | [55210](https://github.com/airbytehq/airbyte/pull/55210) | Remove primary keys                                                                  |
+| 0.4.3   | 2025-03-01 | [54873](https://github.com/airbytehq/airbyte/pull/54873) | Update dependencies                                                                  |
+| 0.4.2   | 2025-02-24 | [54646](https://github.com/airbytehq/airbyte/pull/54646) | Fix paginator settings for incremental report streams                                |
+| 0.4.1   | 2025-02-22 | [54284](https://github.com/airbytehq/airbyte/pull/54284) | Update dependencies                                                                  |
+| 0.4.0   | 2025-02-20 | [54170](https://github.com/airbytehq/airbyte/pull/54170) | Externalize backoff factor and lookback window configurations                        |
+| 0.3.3   | 2025-02-15 | [53920](https://github.com/airbytehq/airbyte/pull/53920) | Update dependencies                                                                  |
+| 0.3.2   | 2025-02-14 | [53685](https://github.com/airbytehq/airbyte/pull/53685) | Fix granularity to daily                                                             |
+| 0.3.1   | 2025-02-08 | [53422](https://github.com/airbytehq/airbyte/pull/53422) | Update dependencies                                                                  |
+| 0.3.0   | 2025-02-03 | [53136](https://github.com/airbytehq/airbyte/pull/53136) | Update API version to V5                                                             |
+| 0.2.9   | 2025-02-01 | [52899](https://github.com/airbytehq/airbyte/pull/52899) | Update dependencies                                                                  |
+| 0.2.8   | 2025-01-25 | [52197](https://github.com/airbytehq/airbyte/pull/52197) | Update dependencies                                                                  |
+| 0.2.7   | 2025-01-18 | [51745](https://github.com/airbytehq/airbyte/pull/51745) | Update dependencies                                                                  |
+| 0.2.6   | 2025-01-11 | [51249](https://github.com/airbytehq/airbyte/pull/51249) | Update dependencies                                                                  |
+| 0.2.5   | 2024-12-28 | [50469](https://github.com/airbytehq/airbyte/pull/50469) | Update dependencies                                                                  |
+| 0.2.4   | 2024-12-21 | [50155](https://github.com/airbytehq/airbyte/pull/50155) | Update dependencies                                                                  |
+| 0.2.3   | 2024-12-14 | [49561](https://github.com/airbytehq/airbyte/pull/49561) | Update dependencies                                                                  |
+| 0.2.2   | 2024-12-12 | [47751](https://github.com/airbytehq/airbyte/pull/47751) | Update dependencies                                                                  |
+| 0.2.1   | 2024-11-08 | [48440](https://github.com/airbytehq/airbyte/pull/48440) | Set authentication grant_type to client_credentials                                  |
+| 0.2.0   | 2024-10-01 | [46288](https://github.com/airbytehq/airbyte/pull/46288) | Migrate to Manifest-only                                                             |
+| 0.1.20  | 2024-09-28 | [46153](https://github.com/airbytehq/airbyte/pull/46153) | Update dependencies                                                                  |
+| 0.1.19  | 2024-09-21 | [45803](https://github.com/airbytehq/airbyte/pull/45803) | Update dependencies                                                                  |
+| 0.1.18  | 2024-09-14 | [45474](https://github.com/airbytehq/airbyte/pull/45474) | Update dependencies                                                                  |
+| 0.1.17  | 2024-09-07 | [45326](https://github.com/airbytehq/airbyte/pull/45326) | Update dependencies                                                                  |
+| 0.1.16  | 2024-08-31 | [45013](https://github.com/airbytehq/airbyte/pull/45013) | Update dependencies                                                                  |
+| 0.1.15  | 2024-08-24 | [44654](https://github.com/airbytehq/airbyte/pull/44654) | Update dependencies                                                                  |
+| 0.1.14  | 2024-08-17 | [44322](https://github.com/airbytehq/airbyte/pull/44322) | Update dependencies                                                                  |
+| 0.1.13  | 2024-08-12 | [43912](https://github.com/airbytehq/airbyte/pull/43912) | Update dependencies                                                                  |
+| 0.1.12  | 2024-08-10 | [43514](https://github.com/airbytehq/airbyte/pull/43514) | Update dependencies                                                                  |
+| 0.1.11  | 2024-08-03 | [43195](https://github.com/airbytehq/airbyte/pull/43195) | Update dependencies                                                                  |
+| 0.1.10  | 2024-07-27 | [42660](https://github.com/airbytehq/airbyte/pull/42660) | Update dependencies                                                                  |
+| 0.1.9   | 2024-07-20 | [42225](https://github.com/airbytehq/airbyte/pull/42225) | Update dependencies                                                                  |
+| 0.1.8   | 2024-07-13 | [41722](https://github.com/airbytehq/airbyte/pull/41722) | Update dependencies                                                                  |
+| 0.1.7   | 2024-07-10 | [41546](https://github.com/airbytehq/airbyte/pull/41546) | Update dependencies                                                                  |
+| 0.1.6   | 2024-07-09 | [40832](https://github.com/airbytehq/airbyte/pull/40832) | Update dependencies                                                                  |
+| 0.1.5   | 2024-06-25 | [40364](https://github.com/airbytehq/airbyte/pull/40364) | Update dependencies                                                                  |
+| 0.1.4   | 2024-06-22 | [40186](https://github.com/airbytehq/airbyte/pull/40186) | Update dependencies                                                                  |
+| 0.1.3   | 2024-06-04 | [38967](https://github.com/airbytehq/airbyte/pull/38967) | [autopull] Upgrade base image to v1.2.1                                              |
+| 0.1.2   | 2024-05-21 | [38502](https://github.com/airbytehq/airbyte/pull/38502) | [autopull] base image + poetry + up_to_date                                          |
+| 0.1.1   | 2023-07-11 | [28153](https://github.com/airbytehq/airbyte/pull/28153) | Fix manifest duplicate key (no change in behavior for the syncs)                     |
+| 0.1.0   | 2022-11-17 | [19557](https://github.com/airbytehq/airbyte/pull/19557) | Initial release with campaigns, adgroups & keywords streams (base and daily reports) |
 
 </details>

--- a/docs/integrations/sources/apple-search-ads.md
+++ b/docs/integrations/sources/apple-search-ads.md
@@ -6,8 +6,12 @@ This page contains the setup guide and reference information for the Apple Ads s
 
 ### Step 1: Set up Apple Ads
 
-1. With an administrator account, [create an API user role](https://developer.apple.com/documentation/apple_search_ads/implementing_oauth_for_the_apple_search_ads_api) from the Apple Ads UI.
-2. Then [implement OAuth for your API user](https://developer.apple.com/documentation/apple_search_ads/implementing_oauth_for_the_apple_search_ads_api) in order to the required Client Secret and Client Id.
+1. With an administrator
+   account, [create an API user role](https://developer.apple.com/documentation/apple_search_ads/implementing_oauth_for_the_apple_search_ads_api)
+   from the Apple Ads UI.
+2.
+Then [implement OAuth for your API user](https://developer.apple.com/documentation/apple_search_ads/implementing_oauth_for_the_apple_search_ads_api)
+in order to the required Client Secret and Client Id.
 
 ### Step 2: Set up the source connector in Airbyte
 
@@ -29,7 +33,8 @@ This page contains the setup guide and reference information for the Apple Ads s
 
 ## Supported sync modes
 
-The Apple Ads source connector supports the following [sync modes](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/):
+The Apple Ads source connector supports the
+following [sync modes](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/):
 
 - [Full Refresh - Overwrite](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite)
 - [Full Refresh - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-append)
@@ -38,7 +43,8 @@ The Apple Ads source connector supports the following [sync modes](https://docs.
 
 ## Supported Streams
 
-The Apple Ads source connector supports the following streams. For more information, see the [Apple Ads API](https://developer.apple.com/documentation/apple_search_ads).
+The Apple Ads source connector supports the following streams. For more information, see
+the [Apple Ads API](https://developer.apple.com/documentation/apple_search_ads).
 
 ### Base streams
 
@@ -60,7 +66,9 @@ One example is `countryOrRegion`.
 
 ### Report aggregation
 
-The Apple Ads currently offers [aggregation](https://developer.apple.com/documentation/apple_search_ads/reportingrequest) at hourly, daily, weekly, or monthly level.
+The Apple Ads currently
+offers [aggregation](https://developer.apple.com/documentation/apple_search_ads/reportingrequest) at hourly, daily,
+weekly, or monthly level.
 
 However, at this moment and as indicated in the stream names, the connector only offers data with daily aggregation.
 
@@ -71,7 +79,7 @@ However, at this moment and as indicated in the stream names, the connector only
 
 | Version | Date       | Pull Request                                             | Subject                                                                              |
 |:--------|:-----------|:---------------------------------------------------------|:-------------------------------------------------------------------------------------|
-| 0.8.0   | 2025-05-13 | ...                                                      | Add token refresh endpoint override configuration override                                  |
+| 0.8.0   | 2025-05-13 | [60241](https://github.com/airbytehq/airbyte/pull/59888) | Add token refresh endpoint override configuration override                           |
 | 0.7.9   | 2025-05-10 | [59888](https://github.com/airbytehq/airbyte/pull/59888) | Update dependencies                                                                  |
 | 0.7.8   | 2025-05-03 | [59308](https://github.com/airbytehq/airbyte/pull/59308) | Update dependencies                                                                  |
 | 0.7.7   | 2025-04-26 | [58712](https://github.com/airbytehq/airbyte/pull/58712) | Update dependencies                                                                  |

--- a/docs/integrations/sources/apple-search-ads.md
+++ b/docs/integrations/sources/apple-search-ads.md
@@ -76,7 +76,7 @@ However, at this moment and as indicated in the stream names, the connector only
 
 | Version | Date       | Pull Request                                             | Subject                                                                              |
 |:--------|:-----------|:---------------------------------------------------------|:-------------------------------------------------------------------------------------|
-| 0.8.0   | 2025-05-13 | [60241](https://github.com/airbytehq/airbyte/pull/59888) | Add token refresh endpoint override configuration override                           |
+| 0.8.0   | 2025-05-13 | [60241](https://github.com/airbytehq/airbyte/pull/60241) | Add token refresh endpoint override configuration override                           |
 | 0.7.9   | 2025-05-10 | [59888](https://github.com/airbytehq/airbyte/pull/59888) | Update dependencies                                                                  |
 | 0.7.8   | 2025-05-03 | [59308](https://github.com/airbytehq/airbyte/pull/59308) | Update dependencies                                                                  |
 | 0.7.7   | 2025-04-26 | [58712](https://github.com/airbytehq/airbyte/pull/58712) | Update dependencies                                                                  |

--- a/docs/integrations/sources/apple-search-ads.md
+++ b/docs/integrations/sources/apple-search-ads.md
@@ -6,11 +6,8 @@ This page contains the setup guide and reference information for the Apple Ads s
 
 ### Step 1: Set up Apple Ads
 
-1. With an administrator
-   account, [create an API user role](https://developer.apple.com/documentation/apple_search_ads/implementing_oauth_for_the_apple_search_ads_api)
-   from the Apple Ads UI.
-2.
-Then [implement OAuth for your API user](https://developer.apple.com/documentation/apple_search_ads/implementing_oauth_for_the_apple_search_ads_api)
+1. With an administrator account, [create an API user role](https://developer.apple.com/documentation/apple_search_ads/implementing_oauth_for_the_apple_search_ads_api) from the Apple Ads UI.
+2. Then [implement OAuth for your API user](https://developer.apple.com/documentation/apple_search_ads/implementing_oauth_for_the_apple_search_ads_api)
 in order to the required Client Secret and Client Id.
 
 ### Step 2: Set up the source connector in Airbyte

--- a/docs/integrations/sources/apple-search-ads.md
+++ b/docs/integrations/sources/apple-search-ads.md
@@ -7,8 +7,7 @@ This page contains the setup guide and reference information for the Apple Ads s
 ### Step 1: Set up Apple Ads
 
 1. With an administrator account, [create an API user role](https://developer.apple.com/documentation/apple_search_ads/implementing_oauth_for_the_apple_search_ads_api) from the Apple Ads UI.
-2. Then [implement OAuth for your API user](https://developer.apple.com/documentation/apple_search_ads/implementing_oauth_for_the_apple_search_ads_api)
-in order to the required Client Secret and Client Id.
+2. Then [implement OAuth for your API user](https://developer.apple.com/documentation/apple_search_ads/implementing_oauth_for_the_apple_search_ads_api) in order to the required Client Secret and Client Id.
 
 ### Step 2: Set up the source connector in Airbyte
 
@@ -30,8 +29,7 @@ in order to the required Client Secret and Client Id.
 
 ## Supported sync modes
 
-The Apple Ads source connector supports the
-following [sync modes](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/):
+The Apple Ads source connector supports the following [sync modes](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/):
 
 - [Full Refresh - Overwrite](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-overwrite)
 - [Full Refresh - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/full-refresh-append)
@@ -40,8 +38,7 @@ following [sync modes](https://docs.airbyte.com/platform/using-airbyte/core-conc
 
 ## Supported Streams
 
-The Apple Ads source connector supports the following streams. For more information, see
-the [Apple Ads API](https://developer.apple.com/documentation/apple_search_ads).
+The Apple Ads source connector supports the following streams. For more information, see the [Apple Ads API](https://developer.apple.com/documentation/apple_search_ads).
 
 ### Base streams
 
@@ -63,9 +60,7 @@ One example is `countryOrRegion`.
 
 ### Report aggregation
 
-The Apple Ads currently
-offers [aggregation](https://developer.apple.com/documentation/apple_search_ads/reportingrequest) at hourly, daily,
-weekly, or monthly level.
+The Apple Ads currently offers [aggregation](https://developer.apple.com/documentation/apple_search_ads/reportingrequest) at hourly, daily, weekly, or monthly level.
 
 However, at this moment and as indicated in the stream names, the connector only offers data with daily aggregation.
 


### PR DESCRIPTION
## What
Allow overriding the external token endpoint, in scenarios where it is required to proxy token refresh request

## How
Make the `token_refresh_endpoint` configurable

## Review guide
Have a look at the configuration keys in `manifest.yaml`

## User Impact
None, If not set, the default value is used

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌
