### PR TITLE
chore(source-hubspot): Set earlier auto_upgrade date in `metadata.yaml` customers do not end up pinned to old Hubspot version for too long

### DIFF
--- a/airbyte-integrations/connectors/source-hubspot/metadata.yaml
+++ b/airbyte-integrations/connectors/source-hubspot/metadata.yaml
@@ -40,7 +40,7 @@ data:
           Hubspot's V3 API and the V1 API is being deprecated on 2025-09-30. Updates the `contact_lists`
           stream to use V3 API, which contains changes to the schema due to old fields no longer exposed by
           the V3 API. Users will need to refresh the source schema and clear the stream.
-        upgradeDeadline: "2025-09-30"
+        upgradeDeadline: "2025-06-15"
         deadlineAction: "auto_upgrade"
         scopedImpact:
           - scopeType: stream


### PR DESCRIPTION
👮‍♂️ 🎫 

although we have 4 months, of access, pinning customers back for too long w/ the breaking change means they won't get new versions of the connectors if they take no action