### PR TITLE
bigquery: allow unlimited concurrency, remove spec option

### DIFF
--- a/airbyte-integrations/connectors/destination-bigquery/gradle.properties
+++ b/airbyte-integrations/connectors/destination-bigquery/gradle.properties
@@ -1,2 +1,2 @@
-testExecutionConcurrency=2
+testExecutionConcurrency=-1
 JunitMethodExecutionTimeout=10 m

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/spec/BigqueryConfiguration.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/spec/BigqueryConfiguration.kt
@@ -19,7 +19,6 @@ data class BigqueryConfiguration(
     val transformationPriority: TransformationPriority,
     val rawTableDataset: String,
     val disableTypingDeduping: Boolean,
-    override val numOpenStreamWorkers: Int,
 ) : DestinationConfiguration()
 
 sealed interface LoadingMethodConfiguration
@@ -61,7 +60,6 @@ class BigqueryConfigurationFactory :
                     pojo.rawTableDataset!!
                 },
             disableTypingDeduping = pojo.disableTypingDeduping ?: false,
-            numOpenStreamWorkers = pojo.numOpenStreamWorkers ?: 10,
         )
     }
 }

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/spec/BigqueryConfiguration.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/spec/BigqueryConfiguration.kt
@@ -19,7 +19,9 @@ data class BigqueryConfiguration(
     val transformationPriority: TransformationPriority,
     val rawTableDataset: String,
     val disableTypingDeduping: Boolean,
-) : DestinationConfiguration()
+) : DestinationConfiguration() {
+    override val numOpenStreamWorkers = 3
+}
 
 sealed interface LoadingMethodConfiguration
 

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/spec/BigquerySpecification.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/spec/BigquerySpecification.kt
@@ -31,8 +31,6 @@ import java.io.IOException
 
 @Singleton
 class BigquerySpecification : ConfigurationSpecification() {
-    val numOpenStreamWorkers: Int? = null
-
     @get:JsonSchemaTitle("Project ID")
     @get:JsonPropertyDescription(
         """The GCP project ID for the project containing the target BigQuery dataset. Read more <a href="https://cloud.google.com/resource-manager/docs/creating-managing-projects#identifying_projects">here</a>.""",


### PR DESCRIPTION
some final fixes before we ship the first RC