### PR TITLE
bigquery: fix schema change detection

### DIFF
--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/typing_deduping/BigqueryDatabaseInitialStatusGatherer.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/typing_deduping/BigqueryDatabaseInitialStatusGatherer.kt
@@ -177,7 +177,7 @@ class BigqueryDatabaseInitialStatusGatherer(private val bq: BigQuery) :
 
         val streamSchema: Map<String, StandardSQLTypeName> =
             (stream.schema as ObjectType).properties.entries.associate {
-                it.key to BigQuerySqlGenerator.toDialectType(it.value.type)
+                columnNameMapping[it.key]!! to BigQuerySqlGenerator.toDialectType(it.value.type)
             }
 
         val existingSchema =

--- a/airbyte-integrations/connectors/destination-bigquery/src/test/kotlin/io/airbyte/integrations/destination/bigquery/typing_deduping/BigqueryDestinationHandlerTest.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test/kotlin/io/airbyte/integrations/destination/bigquery/typing_deduping/BigqueryDestinationHandlerTest.kt
@@ -1,0 +1,217 @@
+/*
+ * Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+ */
+package io.airbyte.integrations.destination.bigquery.typing_deduping
+
+import com.google.cloud.bigquery.Clustering
+import com.google.cloud.bigquery.Field
+import com.google.cloud.bigquery.FieldList
+import com.google.cloud.bigquery.StandardSQLTypeName
+import com.google.cloud.bigquery.StandardTableDefinition
+import com.google.cloud.bigquery.TimePartitioning
+import io.airbyte.cdk.load.command.Append
+import io.airbyte.cdk.load.command.Dedupe
+import io.airbyte.cdk.load.command.DestinationStream
+import io.airbyte.cdk.load.data.ArrayType
+import io.airbyte.cdk.load.data.BooleanType
+import io.airbyte.cdk.load.data.FieldType
+import io.airbyte.cdk.load.data.IntegerType
+import io.airbyte.cdk.load.data.NumberType
+import io.airbyte.cdk.load.data.ObjectType
+import io.airbyte.cdk.load.data.ObjectTypeWithoutSchema
+import io.airbyte.cdk.load.data.UnionType
+import io.airbyte.cdk.load.orchestration.db.ColumnNameMapping
+import io.airbyte.integrations.destination.bigquery.typing_deduping.BigQuerySqlGenerator.Companion.toDialectType
+import io.airbyte.integrations.destination.bigquery.typing_deduping.BigqueryDatabaseInitialStatusGatherer.Companion.clusteringMatches
+import io.airbyte.integrations.destination.bigquery.typing_deduping.BigqueryDatabaseInitialStatusGatherer.Companion.partitioningMatches
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito
+import org.mockito.Mockito.RETURNS_DEEP_STUBS
+
+class BigqueryDestinationHandlerTest {
+    @Test
+    fun testToDialectType() {
+        val s = ObjectType(linkedMapOf())
+        val a = ArrayType(FieldType(BooleanType, nullable = true))
+
+        Assertions.assertEquals(StandardSQLTypeName.INT64, toDialectType(IntegerType))
+        Assertions.assertEquals(StandardSQLTypeName.JSON, toDialectType(s))
+        Assertions.assertEquals(StandardSQLTypeName.JSON, toDialectType(a))
+        Assertions.assertEquals(
+            StandardSQLTypeName.JSON,
+            toDialectType(UnionType(emptySet(), isLegacyUnion = false))
+        )
+
+        var u = UnionType(setOf(s), isLegacyUnion = true)
+        Assertions.assertEquals(StandardSQLTypeName.JSON, toDialectType(u))
+        u = UnionType(setOf(a), isLegacyUnion = true)
+        Assertions.assertEquals(StandardSQLTypeName.JSON, toDialectType(u))
+        u = UnionType(setOf(BooleanType, NumberType), isLegacyUnion = true)
+        Assertions.assertEquals(StandardSQLTypeName.NUMERIC, toDialectType(u))
+    }
+
+    @Test
+    fun testColumnsMatch() {
+        val stream =
+            DestinationStream(
+                Mockito.mock(),
+                Append,
+                ObjectType(linkedMapOf("a1" to FieldType(IntegerType, nullable = true))),
+                generationId = 0,
+                minimumGenerationId = 0,
+                syncId = 0,
+            )
+        val columnNameMapping = ColumnNameMapping(mapOf("a1" to "a2"))
+        val existingTable = Mockito.mock(StandardTableDefinition::class.java, RETURNS_DEEP_STUBS)
+        Mockito.`when`(existingTable.schema!!.fields)
+            .thenReturn(FieldList.of(Field.of("a2", StandardSQLTypeName.INT64)))
+        val alterTableReport =
+            BigqueryDatabaseInitialStatusGatherer(Mockito.mock())
+                .buildAlterTableReport(stream, columnNameMapping, existingTable)
+        Assertions.assertAll(
+            { Assertions.assertEquals(emptySet<String>(), alterTableReport.columnsToAdd) },
+            { Assertions.assertEquals(emptySet<String>(), alterTableReport.columnsToRemove) },
+            { Assertions.assertEquals(emptySet<String>(), alterTableReport.columnsToChangeType) },
+        )
+    }
+
+    @Test
+    fun testColumnsNotMatch() {
+        val stream =
+            DestinationStream(
+                Mockito.mock(),
+                Append,
+                ObjectType(
+                    linkedMapOf(
+                        "a1" to FieldType(IntegerType, nullable = true),
+                        "c1" to FieldType(IntegerType, nullable = true),
+                    )
+                ),
+                generationId = 0,
+                minimumGenerationId = 0,
+                syncId = 0,
+            )
+        val columnNameMapping = ColumnNameMapping(mapOf("a1" to "a2", "c1" to "c2"))
+        val existingTable = Mockito.mock(StandardTableDefinition::class.java, RETURNS_DEEP_STUBS)
+        Mockito.`when`(existingTable.schema!!.fields)
+            .thenReturn(
+                FieldList.of(
+                    listOf(
+                        Field.of("a2", StandardSQLTypeName.STRING),
+                        Field.of("b2", StandardSQLTypeName.INT64)
+                    )
+                )
+            )
+        val alterTableReport =
+            BigqueryDatabaseInitialStatusGatherer(Mockito.mock())
+                .buildAlterTableReport(stream, columnNameMapping, existingTable)
+        Assertions.assertAll(
+            { Assertions.assertEquals(setOf("c2"), alterTableReport.columnsToAdd) },
+            { Assertions.assertEquals(setOf("b2"), alterTableReport.columnsToRemove) },
+            { Assertions.assertEquals(setOf("a2"), alterTableReport.columnsToChangeType) },
+        )
+    }
+
+    @Test
+    fun testClusteringMatches() {
+        var stream =
+            DestinationStream(
+                Mockito.mock(),
+                Dedupe(
+                    listOf(listOf("bar")),
+                    emptyList(),
+                ),
+                ObjectTypeWithoutSchema,
+                generationId = 0,
+                minimumGenerationId = 0,
+                syncId = 0,
+            )
+        var columnNameMapping = ColumnNameMapping(mapOf("bar" to "foo"))
+
+        // Clustering is null
+        val existingTable = Mockito.mock(StandardTableDefinition::class.java)
+        Mockito.`when`(existingTable.clustering).thenReturn(null)
+        Assertions.assertFalse(clusteringMatches(stream, columnNameMapping, existingTable))
+
+        // Clustering does not contain all fields
+        Mockito.`when`(existingTable.clustering)
+            .thenReturn(Clustering.newBuilder().setFields(listOf("_airbyte_extracted_at")).build())
+        Assertions.assertFalse(clusteringMatches(stream, columnNameMapping, existingTable))
+
+        // Clustering matches
+        stream =
+            DestinationStream(
+                Mockito.mock(),
+                Append,
+                ObjectTypeWithoutSchema,
+                generationId = 0,
+                minimumGenerationId = 0,
+                syncId = 0,
+            )
+        Assertions.assertTrue(clusteringMatches(stream, columnNameMapping, existingTable))
+
+        // Clustering only the first 3 PK columns (See
+        // https://github.com/airbytehq/oncall/issues/2565)
+        Mockito.`when`(existingTable.clustering)
+            .thenReturn(
+                Clustering.newBuilder()
+                    .setFields(listOf("a2", "b2", "c2", "_airbyte_extracted_at"))
+                    .build()
+            )
+        stream =
+            DestinationStream(
+                Mockito.mock(),
+                Dedupe(
+                    listOf(listOf("a1"), listOf("b1"), listOf("c1"), listOf("d1"), listOf("e1")),
+                    emptyList()
+                ),
+                ObjectTypeWithoutSchema,
+                generationId = 0,
+                minimumGenerationId = 0,
+                syncId = 0
+            )
+        columnNameMapping =
+            ColumnNameMapping(
+                mapOf(
+                    "a1" to "a2",
+                    "b1" to "b2",
+                    "c1" to "c2",
+                    "d1" to "d2",
+                    "e1" to "e2",
+                )
+            )
+        Assertions.assertTrue(clusteringMatches(stream, columnNameMapping, existingTable))
+    }
+
+    @Test
+    fun testPartitioningMatches() {
+        val existingTable = Mockito.mock(StandardTableDefinition::class.java)
+        // Partitioning is null
+        Mockito.`when`(existingTable.timePartitioning).thenReturn(null)
+        Assertions.assertFalse(partitioningMatches(existingTable))
+        // incorrect field
+        Mockito.`when`(existingTable.timePartitioning)
+            .thenReturn(
+                TimePartitioning.newBuilder(TimePartitioning.Type.DAY).setField("_foo").build()
+            )
+        Assertions.assertFalse(partitioningMatches(existingTable))
+        // incorrect partitioning scheme
+        Mockito.`when`(existingTable.timePartitioning)
+            .thenReturn(
+                TimePartitioning.newBuilder(TimePartitioning.Type.YEAR)
+                    .setField("_airbyte_extracted_at")
+                    .build()
+            )
+        Assertions.assertFalse(partitioningMatches(existingTable))
+
+        // partitioning matches
+        Mockito.`when`(existingTable.timePartitioning)
+            .thenReturn(
+                TimePartitioning.newBuilder(TimePartitioning.Type.DAY)
+                    .setField("_airbyte_extracted_at")
+                    .build()
+            )
+        Assertions.assertTrue(partitioningMatches(existingTable))
+    }
+}


### PR DESCRIPTION
(incidentally closes https://github.com/airbytehq/airbyte-internal-issues/issues/12669 )

super insidious bug here.

old code: https://github.com/airbytehq/airbyte/blob/661e189bfa0658199c2c9517535c6e962fb45226/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/typing_deduping/BigQueryDestinationHandler.kt#L289-L292

`it.key.name` is `ColumnId.name`, which is the _post_ transform column name.

new code is `it.key`, which is the _original_ column name.

fix that, revive the old unit test.

I could be convinced to make simple wrapper classes `OriginalColumnName(val originalName: String)` / `TransformedColumnName(val transformedName: String)` to make this more obvious?