### PR TITLE
chore: release record res from files pipeline

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/state/StreamManager.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/state/StreamManager.kt
@@ -258,7 +258,7 @@ class StreamManager(
         // Detailed debug logging for completeness checks. It's a little verbose but is only emitted
         // per-batch (every 10-20mb in most cases).
         // TODO: A more user-friendly aggregated version of this on a regular cadence?
-        log.debug {
+        log.info {
             val header =
                 "\nStream ${stream.descriptor.namespace}:${stream.descriptor.name}: Records Read: $readCount (done: ${markedEndOfStream.get()})"
             val byPart =

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/HeartbeatTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/HeartbeatTask.kt
@@ -12,6 +12,7 @@ import io.airbyte.cdk.load.message.WithStream
 import io.airbyte.cdk.load.task.OnEndOfSync
 import io.airbyte.cdk.load.task.Task
 import io.airbyte.cdk.load.task.TerminalCondition
+import io.github.oshai.kotlinlogging.KotlinLogging
 import jakarta.inject.Named
 import jakarta.inject.Singleton
 import kotlinx.coroutines.channels.ClosedSendChannelException
@@ -22,12 +23,14 @@ class HeartbeatTask<K : WithStream, V>(
     private val config: DestinationConfiguration,
     @Named("pipelineInputQueue") private val inputQueue: PartitionedQueue<PipelineEvent<K, V>>
 ) : Task {
+    private val log = KotlinLogging.logger {}
     override val terminalCondition: TerminalCondition = OnEndOfSync
 
     override suspend fun execute() {
         while (true) {
             delay(config.heartbeatIntervalSeconds * 1000L)
             try {
+                log.info { "Broadcasting heartbeat..." }
                 inputQueue.broadcast(PipelineHeartbeat())
             } catch (e: ClosedSendChannelException) {
                 // Do nothing. We don't care. Move on

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/LoadPipelineStepTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/LoadPipelineStepTask.kt
@@ -242,6 +242,8 @@ class LoadPipelineStepTask<S : AutoCloseable, K1 : WithStream, T, K2 : WithStrea
                         stateStore
                     }
                     is PipelineHeartbeat -> {
+                        log.info { "Step: $stepId — Heartbeat received..." }
+
                         flushStrategy?.let { strategy ->
                             val now = System.currentTimeMillis()
                             val keysToRemove =

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/factory/object_storage/ObjectLoaderStepBeanFactory.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/factory/object_storage/ObjectLoaderStepBeanFactory.kt
@@ -11,6 +11,7 @@ import io.airbyte.cdk.load.message.PartitionedQueue
 import io.airbyte.cdk.load.message.PipelineEvent
 import io.airbyte.cdk.load.message.StreamKey
 import io.airbyte.cdk.load.message.WithStream
+import io.airbyte.cdk.load.pipeline.PipelineFlushStrategy
 import io.airbyte.cdk.load.pipline.object_storage.ObjectKey
 import io.airbyte.cdk.load.pipline.object_storage.ObjectLoaderCompletedUploadPartitioner
 import io.airbyte.cdk.load.pipline.object_storage.ObjectLoaderPartFormatter
@@ -48,6 +49,7 @@ class ObjectLoaderStepBeanFactory {
             outputQueue,
             taskFactory,
             "record-part-formatter-step",
+            null,
         )
 
     @Named("recordPartLoaderStep")
@@ -156,6 +158,7 @@ class ObjectLoaderStepBeanFactory {
         outputQueue:
             PartitionedQueue<PipelineEvent<ObjectKey, ObjectLoaderPartFormatter.FormattedPart>>,
         taskFactory: LoadPipelineStepTaskFactory,
+        flushStrategy: PipelineFlushStrategy,
     ) =
         ObjectLoaderPartFormatterStep(
             loader,
@@ -164,6 +167,7 @@ class ObjectLoaderStepBeanFactory {
             outputQueue,
             taskFactory,
             "file-record-part-formatter-step",
+            flushStrategy,
         )
 
     @Singleton

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/pipline/object_storage/file/ForwardFileRecordTask.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/pipline/object_storage/file/ForwardFileRecordTask.kt
@@ -46,6 +46,7 @@ class ForwardFileRecordTask<T>(
                             event.context!!.parentCheckpointCounts!!,
                             event.key,
                             event.context!!.parentRecord!!,
+                            event.postProcessingCallback,
                         )
                     }
                 }


### PR DESCRIPTION
## What
Ensures records release their reservations

Adds some logging for debugging stuck files connect

## How
Forwards callback through

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
