### PR TITLE
Chore: replace Dockerfile.java-connector contents with similarly-named file

### DIFF
--- a/docker-images/Dockerfile.java-connector
+++ b/docker-images/Dockerfile.java-connector
@@ -18,7 +18,7 @@ ENV AIRBYTE_ENTRYPOINT="/airbyte/base.sh"
 ENV APPLICATION="${CONNECTOR_NAME}"
 
 # Add the connector TAR file and extract it
-COPY ./build/distributions/${CONNECTOR_NAME}.tar /tmp/${CONNECTOR_NAME}.tar
+COPY airbyte-app.tar /tmp/${CONNECTOR_NAME}.tar
 RUN tar xf /tmp/${CONNECTOR_NAME}.tar --strip-components=1 -C /airbyte && \
     rm -rf /tmp/${CONNECTOR_NAME}.tar && \
     chown -R airbyte:airbyte /airbyte


### PR DESCRIPTION
This PR attempts to remove the duplicate file created. Also we should come up with a test workflow that tests Platform compatibility.