### PR TITLE
chore: cancel in progress connector tests except for master.

### DIFF
--- a/.github/workflows/connector-ci-tests.yml
+++ b/.github/workflows/connector-ci-tests.yml
@@ -1,5 +1,9 @@
 name: Connector CI Tests
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
 on:
   pull_request:
     types: [opened, synchronize, reopened]


### PR DESCRIPTION
## What
Let's save some money by cancelling in progress CI builds from previous commits except master.

We do not do so on master since we don't want red builds.

## How
Set cancel-in-progress to true on PR branches.

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
