### PR TITLE
🐛 Source MongoDB: fix hardcoded read preferences

### DIFF
--- a/airbyte-integrations/connectors/source-mongodb-v2/src/main/java/io/airbyte/integrations/source/mongodb/MongoConnectionUtils.java
+++ b/airbyte-integrations/connectors/source-mongodb-v2/src/main/java/io/airbyte/integrations/source/mongodb/MongoConnectionUtils.java
@@ -10,6 +10,7 @@ import com.mongodb.ConnectionString;
 import com.mongodb.MongoClientSettings;
 import com.mongodb.MongoCredential;
 import com.mongodb.MongoDriverInformation;
+import com.mongodb.ReadPreference;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
 import io.airbyte.integrations.source.mongodb.cdc.MongoDbDebeziumPropertiesManager;
@@ -36,6 +37,10 @@ public class MongoConnectionUtils {
 
     final MongoClientSettings.Builder mongoClientSettingsBuilder = MongoClientSettings.builder()
         .applyConnectionString(mongoConnectionString);
+
+    if (mongoConnectionString.getReadPreference() == null) {
+      mongoClientSettingsBuilder.readPreference(ReadPreference.secondaryPreferred());
+    }
 
     if (config.hasAuthCredentials()) {
       final String authSource = config.getAuthSource();

--- a/airbyte-integrations/connectors/source-mongodb-v2/src/main/java/io/airbyte/integrations/source/mongodb/MongoConnectionUtils.java
+++ b/airbyte-integrations/connectors/source-mongodb-v2/src/main/java/io/airbyte/integrations/source/mongodb/MongoConnectionUtils.java
@@ -10,7 +10,6 @@ import com.mongodb.ConnectionString;
 import com.mongodb.MongoClientSettings;
 import com.mongodb.MongoCredential;
 import com.mongodb.MongoDriverInformation;
-import com.mongodb.ReadPreference;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
 import io.airbyte.integrations.source.mongodb.cdc.MongoDbDebeziumPropertiesManager;

--- a/airbyte-integrations/connectors/source-mongodb-v2/src/main/java/io/airbyte/integrations/source/mongodb/MongoConnectionUtils.java
+++ b/airbyte-integrations/connectors/source-mongodb-v2/src/main/java/io/airbyte/integrations/source/mongodb/MongoConnectionUtils.java
@@ -36,8 +36,7 @@ public class MongoConnectionUtils {
         .build();
 
     final MongoClientSettings.Builder mongoClientSettingsBuilder = MongoClientSettings.builder()
-        .applyConnectionString(mongoConnectionString)
-        .readPreference(ReadPreference.secondaryPreferred());
+        .applyConnectionString(mongoConnectionString);
 
     if (config.hasAuthCredentials()) {
       final String authSource = config.getAuthSource();

--- a/airbyte-integrations/connectors/source-mongodb-v2/src/test/java/io/airbyte/integrations/source/mongodb/MongoConnectionUtilsTest.java
+++ b/airbyte-integrations/connectors/source-mongodb-v2/src/test/java/io/airbyte/integrations/source/mongodb/MongoConnectionUtilsTest.java
@@ -43,6 +43,36 @@ class MongoConnectionUtilsTest {
     assertEquals(username, ((MongoClientImpl) mongoClient).getSettings().getCredential().getUserName());
     assertEquals(password, new String(((MongoClientImpl) mongoClient).getSettings().getCredential().getPassword()));
     assertEquals(authSource, ((MongoClientImpl) mongoClient).getSettings().getCredential().getSource());
+    // read prefernce defaults to primary
+    // https://mongodb.github.io/mongo-java-driver/3.9/javadoc/com/mongodb/MongoClientSettings.html#getReadPreference--
+    assertEquals(ReadPreference.primary(), ((MongoClientImpl) mongoClient).getSettings().getReadPreference()); 
+  }
+
+  @Test
+  void testCreateMongoClientWithReadPreference() {
+    final String authSource = "admin";
+    final String host = "host";
+    final int port = 1234;
+    final String username = "user";
+    final String password = "password";
+    final String readPreference = "readPreference=secondary";
+    final MongoDbSourceConfig config = new MongoDbSourceConfig(Jsons.jsonNode(
+        Map.of(DATABASE_CONFIG_CONFIGURATION_KEY,
+            Map.of(
+                MongoConstants.CONNECTION_STRING_CONFIGURATION_KEY, "mongodb://" + host + ":" + port + "/" + readPreference,
+                MongoConstants.USERNAME_CONFIGURATION_KEY, username,
+                MongoConstants.PASSWORD_CONFIGURATION_KEY, password,
+                MongoConstants.AUTH_SOURCE_CONFIGURATION_KEY, authSource))));
+
+    final MongoClient mongoClient = MongoConnectionUtils.createMongoClient(config);
+
+    assertNotNull(mongoClient);
+    assertEquals(List.of(new ServerAddress(host, port)), ((MongoClientImpl) mongoClient).getSettings().getClusterSettings().getHosts());
+    assertEquals(List.of("sync", MongoConstants.DRIVER_NAME), ((MongoClientImpl) mongoClient).getMongoDriverInformation().getDriverNames());
+    assertEquals(username, ((MongoClientImpl) mongoClient).getSettings().getCredential().getUserName());
+    assertEquals(password, new String(((MongoClientImpl) mongoClient).getSettings().getCredential().getPassword()));
+    assertEquals(authSource, ((MongoClientImpl) mongoClient).getSettings().getCredential().getSource());
+    assertEquals(ReadPreference.secondary(), ((MongoClientImpl) mongoClient).getSettings().getReadPreference());
   }
 
   @Test

--- a/airbyte-integrations/connectors/source-mongodb-v2/src/test/java/io/airbyte/integrations/source/mongodb/MongoConnectionUtilsTest.java
+++ b/airbyte-integrations/connectors/source-mongodb-v2/src/test/java/io/airbyte/integrations/source/mongodb/MongoConnectionUtilsTest.java
@@ -44,9 +44,7 @@ class MongoConnectionUtilsTest {
     assertEquals(username, ((MongoClientImpl) mongoClient).getSettings().getCredential().getUserName());
     assertEquals(password, new String(((MongoClientImpl) mongoClient).getSettings().getCredential().getPassword()));
     assertEquals(authSource, ((MongoClientImpl) mongoClient).getSettings().getCredential().getSource());
-    // read prefernce defaults to primary
-    // https://mongodb.github.io/mongo-java-driver/3.9/javadoc/com/mongodb/MongoClientSettings.html#getReadPreference--
-    assertEquals(ReadPreference.primary(), ((MongoClientImpl) mongoClient).getSettings().getReadPreference());
+    assertEquals(ReadPreference.secondaryPreferred(), ((MongoClientImpl) mongoClient).getSettings().getReadPreference());
   }
 
   @Test

--- a/airbyte-integrations/connectors/source-mongodb-v2/src/test/java/io/airbyte/integrations/source/mongodb/MongoConnectionUtilsTest.java
+++ b/airbyte-integrations/connectors/source-mongodb-v2/src/test/java/io/airbyte/integrations/source/mongodb/MongoConnectionUtilsTest.java
@@ -60,7 +60,7 @@ class MongoConnectionUtilsTest {
     final MongoDbSourceConfig config = new MongoDbSourceConfig(Jsons.jsonNode(
         Map.of(DATABASE_CONFIG_CONFIGURATION_KEY,
             Map.of(
-                MongoConstants.CONNECTION_STRING_CONFIGURATION_KEY, "mongodb://" + host + ":" + port + "/" + readPreference,
+                MongoConstants.CONNECTION_STRING_CONFIGURATION_KEY, "mongodb://" + host + ":" + port + "/?" + readPreference,
                 MongoConstants.USERNAME_CONFIGURATION_KEY, username,
                 MongoConstants.PASSWORD_CONFIGURATION_KEY, password,
                 MongoConstants.AUTH_SOURCE_CONFIGURATION_KEY, authSource))));

--- a/airbyte-integrations/connectors/source-mongodb-v2/src/test/java/io/airbyte/integrations/source/mongodb/MongoConnectionUtilsTest.java
+++ b/airbyte-integrations/connectors/source-mongodb-v2/src/test/java/io/airbyte/integrations/source/mongodb/MongoConnectionUtilsTest.java
@@ -10,6 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+import com.mongodb.ReadPreference;
 import com.mongodb.ServerAddress;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.internal.MongoClientImpl;

--- a/airbyte-integrations/connectors/source-mongodb-v2/src/test/java/io/airbyte/integrations/source/mongodb/MongoConnectionUtilsTest.java
+++ b/airbyte-integrations/connectors/source-mongodb-v2/src/test/java/io/airbyte/integrations/source/mongodb/MongoConnectionUtilsTest.java
@@ -45,7 +45,7 @@ class MongoConnectionUtilsTest {
     assertEquals(authSource, ((MongoClientImpl) mongoClient).getSettings().getCredential().getSource());
     // read prefernce defaults to primary
     // https://mongodb.github.io/mongo-java-driver/3.9/javadoc/com/mongodb/MongoClientSettings.html#getReadPreference--
-    assertEquals(ReadPreference.primary(), ((MongoClientImpl) mongoClient).getSettings().getReadPreference()); 
+    assertEquals(ReadPreference.primary(), ((MongoClientImpl) mongoClient).getSettings().getReadPreference());
   }
 
   @Test


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->

https://github.com/airbytehq/airbyte/pull/35673

Currently the connector sets read preference to secondaryPreferred with no option of overriding it.

This https://github.com/airbytehq/airbyte/pull/35673 is not quite complete as its intention was to remove default connection string options but did not remove a hardcoded read preference. The (unnecessary?) removal of read preference test in the PR unfortunately allowed this bug to go through.

## How
<!--
* Describe how code changes achieve the solution.
-->

- remove hard coded read preference
- add test for read preference when building connection strings

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->
EDIT: decided to default to `secondaryPreferred` as per previous behaviour to avoid gotcha. It's also a sensible default

As the default behaviour for mongo java driver is to read from primary, this might could be a gotcha for existing users who does not set read preference in the existing connection string. I am not sure what we might want to do, a few possibilities exists:

1. set read preference to secondary preferred if the connection string does not specify i.e. we change the default behaviour
1. make no changes to the code but warn users of a change in default read preference


## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
