### PR TITLE
bigquery direct load: more fixes

### DIFF
--- a/airbyte-cdk/bulk/toolkits/load-db/src/main/kotlin/io/airbyte/cdk/load/orchestration/db/direct_load_table/DirectLoadTableOperations.kt
+++ b/airbyte-cdk/bulk/toolkits/load-db/src/main/kotlin/io/airbyte/cdk/load/orchestration/db/direct_load_table/DirectLoadTableOperations.kt
@@ -66,7 +66,7 @@ interface DirectLoadTableSqlOperations {
     fun dropTable(tableName: TableName)
 }
 
-class DefaultDirectLoadTableSqlOperations(
+open class DefaultDirectLoadTableSqlOperations(
     private val generator: DirectLoadSqlGenerator,
     private val handler: DatabaseHandler,
 ) : DirectLoadTableSqlOperations {

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryBeansFactory.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryBeansFactory.kt
@@ -32,6 +32,7 @@ import io.airbyte.integrations.destination.bigquery.write.typing_deduping.BigQue
 import io.airbyte.integrations.destination.bigquery.write.typing_deduping.direct_load_tables.BigqueryDirectLoadDatabaseInitialStatusGatherer
 import io.airbyte.integrations.destination.bigquery.write.typing_deduping.direct_load_tables.BigqueryDirectLoadNativeTableOperations
 import io.airbyte.integrations.destination.bigquery.write.typing_deduping.direct_load_tables.BigqueryDirectLoadSqlGenerator
+import io.airbyte.integrations.destination.bigquery.write.typing_deduping.direct_load_tables.BigqueryDirectLoadSqlTableOperations
 import io.airbyte.integrations.destination.bigquery.write.typing_deduping.direct_load_tables.BigqueryDirectLoadTableExistenceChecker
 import io.airbyte.integrations.destination.bigquery.write.typing_deduping.legacy_raw_tables.BigqueryRawTableOperations
 import io.airbyte.integrations.destination.bigquery.write.typing_deduping.legacy_raw_tables.BigqueryTypingDedupingDatabaseInitialStatusGatherer
@@ -96,11 +97,14 @@ class BigqueryBeansFactory {
             )
         } else {
             val sqlTableOperations =
-                DefaultDirectLoadTableSqlOperations(
-                    BigqueryDirectLoadSqlGenerator(
-                        config.projectId,
+                BigqueryDirectLoadSqlTableOperations(
+                    DefaultDirectLoadTableSqlOperations(
+                        BigqueryDirectLoadSqlGenerator(
+                            config.projectId,
+                        ),
+                        destinationHandler,
                     ),
-                    destinationHandler,
+                    bigquery,
                 )
             @Suppress("UNCHECKED_CAST")
             return DirectLoadTableWriter(

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/formatter/BigQueryRecordFormatter.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/formatter/BigQueryRecordFormatter.kt
@@ -23,7 +23,10 @@ import java.util.concurrent.TimeUnit
  * The class formats incoming JsonSchema and AirbyteRecord in order to be inline with a
  * corresponding uploader.
  */
-class BigQueryRecordFormatter(private val legacyRawTablesOnly: Boolean) {
+class BigQueryRecordFormatter(
+    private val columnNameMapping: ColumnNameMapping,
+    private val legacyRawTablesOnly: Boolean,
+) {
 
     fun formatRecord(record: DestinationRecordRaw): String {
         val enrichedRecord = record.asEnrichedDestinationRecordAirbyteValue()
@@ -68,7 +71,7 @@ class BigQueryRecordFormatter(private val legacyRawTablesOnly: Boolean) {
                     outputRecord[key] = (value.abValue as IntegerValue).value
                 else -> {
                     if (!legacyRawTablesOnly) {
-                        outputRecord[key] = value.abValue
+                        outputRecord[columnNameMapping[key]!!] = value.abValue
                     }
                 }
             }

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/formatter/BigQueryRecordFormatter.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/formatter/BigQueryRecordFormatter.kt
@@ -8,15 +8,28 @@ import com.google.cloud.bigquery.QueryParameterValue
 import com.google.cloud.bigquery.Schema
 import com.google.cloud.bigquery.StandardSQLTypeName
 import io.airbyte.cdk.load.command.DestinationStream
+import io.airbyte.cdk.load.data.DateValue
 import io.airbyte.cdk.load.data.IntegerValue
+import io.airbyte.cdk.load.data.NullValue
+import io.airbyte.cdk.load.data.NumberValue
 import io.airbyte.cdk.load.data.ObjectValue
 import io.airbyte.cdk.load.data.StringValue
+import io.airbyte.cdk.load.data.TimeWithoutTimezoneValue
+import io.airbyte.cdk.load.data.TimestampWithTimezoneValue
+import io.airbyte.cdk.load.data.TimestampWithoutTimezoneValue
 import io.airbyte.cdk.load.message.DestinationRecordRaw
 import io.airbyte.cdk.load.message.Meta
 import io.airbyte.cdk.load.orchestration.db.ColumnNameMapping
 import io.airbyte.cdk.load.util.serializeToString
 import io.airbyte.integrations.destination.bigquery.write.typing_deduping.direct_load_tables.BigqueryDirectLoadSqlGenerator
 import io.airbyte.protocol.models.v0.AirbyteRecordMessageMeta
+import io.airbyte.protocol.models.v0.AirbyteRecordMessageMetaChange.Reason
+import java.math.BigInteger
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.OffsetDateTime
+import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeFormatterBuilder
 import java.util.concurrent.TimeUnit
 
 /**
@@ -50,20 +63,9 @@ class BigQueryRecordFormatter(
                     outputRecord[key] = getExtractedAt(extractedAtMillis)
                 }
                 Meta.COLUMN_NAME_AB_META -> {
-                    if (legacyRawTablesOnly) {
-                        // this is a hack - in legacy mode, we don't do any in-connector validation
-                        // so we just need to pass through the original record's airbyte_meta.
-                        // so we completely ignore `value.abValue` here.
-                        if (record.rawData.record.meta == null) {
-                            record.rawData.record.meta = AirbyteRecordMessageMeta()
-                            record.rawData.record.meta.changes = emptyList()
-                        }
-                        record.rawData.record.meta.additionalProperties["sync_id"] =
-                            record.stream.syncId
-                        outputRecord[key] = record.rawData.record.meta.serializeToString()
-                    } else {
-                        outputRecord[key] = (value.abValue as ObjectValue).values
-                    }
+                    // do nothing for now - we'll be updating the meta field when we process
+                    // other fields in this record.
+                    // so we need to defer it until _after_ we process the entire record.
                 }
                 Meta.COLUMN_NAME_AB_RAW_ID ->
                     outputRecord[key] = (value.abValue as StringValue).value
@@ -71,11 +73,95 @@ class BigQueryRecordFormatter(
                     outputRecord[key] = (value.abValue as IntegerValue).value
                 else -> {
                     if (!legacyRawTablesOnly) {
-                        outputRecord[columnNameMapping[key]!!] = value.abValue
+                        val bigqueryType = BigqueryDirectLoadSqlGenerator.toDialectType(value.type)
+                        if (value.abValue == NullValue) {
+                            outputRecord[columnNameMapping[key]!!] = NullValue
+                        } else {
+                            when (bigqueryType) {
+                                StandardSQLTypeName.INT64 -> {
+                                    (value.abValue as IntegerValue).value.let {
+                                        if (it < INT64_MIN_VALUE || INT64_MAX_VALUE < it) {
+                                            value.nullify(Reason.DESTINATION_FIELD_SIZE_LIMITATION)
+                                        }
+                                    }
+                                }
+                                StandardSQLTypeName.NUMERIC -> {
+                                    (value.abValue as NumberValue).value.let {
+                                        if (it.precision() > NUMERIC_MAX_PRECISION) {
+                                            value.nullify(Reason.DESTINATION_FIELD_SIZE_LIMITATION)
+                                        }
+                                    }
+                                }
+                                StandardSQLTypeName.DATE -> {
+                                    (value.abValue as DateValue).value.let {
+                                        if (it < DATE_MIN_VALUE || DATE_MAX_VALUE < it) {
+                                            value.nullify(Reason.DESTINATION_FIELD_SIZE_LIMITATION)
+                                        }
+                                    }
+                                }
+                                StandardSQLTypeName.TIMESTAMP -> {
+                                    (value.abValue as TimestampWithTimezoneValue).value.let {
+                                        if (it < TIMESTAMP_MIN_VALUE || TIMESTAMP_MAX_VALUE < it) {
+                                            value.nullify(Reason.DESTINATION_FIELD_SIZE_LIMITATION)
+                                        }
+                                    }
+                                }
+                                StandardSQLTypeName.DATETIME -> {
+                                    (value.abValue as TimestampWithoutTimezoneValue).value.let {
+                                        if (it < DATETIME_MIN_VALUE || DATETIME_MAX_VALUE < it) {
+                                            value.nullify(Reason.DESTINATION_FIELD_SIZE_LIMITATION)
+                                        }
+                                    }
+                                }
+                                // these types don't require validation
+                                StandardSQLTypeName.BOOL,
+                                StandardSQLTypeName.JSON,
+                                StandardSQLTypeName.STRING,
+                                StandardSQLTypeName.TIME -> {}
+                                // we shouldn't be generating these types
+                                StandardSQLTypeName.ARRAY,
+                                StandardSQLTypeName.BIGNUMERIC,
+                                StandardSQLTypeName.BYTES,
+                                StandardSQLTypeName.FLOAT64,
+                                StandardSQLTypeName.STRUCT,
+                                StandardSQLTypeName.GEOGRAPHY,
+                                StandardSQLTypeName.INTERVAL,
+                                StandardSQLTypeName.RANGE -> throw NotImplementedError()
+                            }
+                            when (bigqueryType) {
+                                StandardSQLTypeName.DATETIME ->
+                                    outputRecord[columnNameMapping[key]!!] =
+                                        DATETIME_FORMATTER.format(
+                                            (value.abValue as TimestampWithoutTimezoneValue).value
+                                        )
+                                StandardSQLTypeName.TIME ->
+                                    outputRecord[columnNameMapping[key]!!] =
+                                        TIME_FORMATTER.format(
+                                            (value.abValue as TimeWithoutTimezoneValue).value
+                                        )
+                                else -> outputRecord[columnNameMapping[key]!!] = value.abValue
+                            }
+                        }
                     }
                 }
             }
         }
+
+        // Now that we've gone through the whole record, we can process the airbyte_meta field.
+        outputRecord[Meta.COLUMN_NAME_AB_META] =
+            if (legacyRawTablesOnly) {
+                // this is a hack - in legacy mode, we don't do any in-connector validation
+                // so we just need to pass through the original record's airbyte_meta.
+                // so we completely ignore `value.abValue` here.
+                if (record.rawData.record.meta == null) {
+                    record.rawData.record.meta = AirbyteRecordMessageMeta()
+                    record.rawData.record.meta.changes = emptyList()
+                }
+                record.rawData.record.meta.additionalProperties["sync_id"] = record.stream.syncId
+                record.rawData.record.meta.serializeToString()
+            } else {
+                (enrichedRecord.airbyteMeta.abValue as ObjectValue).values
+            }
 
         return outputRecord.serializeToString()
     }
@@ -89,6 +175,25 @@ class BigQueryRecordFormatter(
     }
 
     companion object {
+        // see https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types
+        private val INT64_MIN_VALUE = BigInteger.valueOf(Long.MIN_VALUE)
+        private val INT64_MAX_VALUE = BigInteger.valueOf(Long.MAX_VALUE)
+        private const val NUMERIC_MAX_PRECISION = 38
+        private val DATE_MIN_VALUE = LocalDate.parse("0001-01-01")
+        private val DATE_MAX_VALUE = LocalDate.parse("9999-12-31")
+        private val TIMESTAMP_MIN_VALUE = OffsetDateTime.parse("0001-01-01T00:00:00Z")
+        private val TIMESTAMP_MAX_VALUE = OffsetDateTime.parse("9999-12-31T23:59:59.999999Z")
+        private val DATETIME_MIN_VALUE = LocalDateTime.parse("0001-01-01T00:00:00")
+        private val DATETIME_MAX_VALUE = LocalDateTime.parse("9999-12-31T23:59:59.999999")
+
+        private val DATETIME_FORMATTER =
+            DateTimeFormatterBuilder()
+                .append(DateTimeFormatter.ISO_DATE)
+                .appendLiteral(' ')
+                .append(DateTimeFormatter.ISO_LOCAL_TIME)
+                .toFormatter()
+        private val TIME_FORMATTER = DateTimeFormatter.ISO_LOCAL_TIME
+
         // This is the schema used to represent the final raw table
         val SCHEMA_V2: Schema =
             Schema.of(

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/standard_insert/BigqueryBatchStandardInsertLoader.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/standard_insert/BigqueryBatchStandardInsertLoader.kt
@@ -142,7 +142,10 @@ class BigqueryBatchStandardInsertsLoaderFactory(
             bigquery,
             writeChannelConfiguration,
             jobId,
-            BigQueryRecordFormatter(legacyRawTablesOnly = config.legacyRawTablesOnly),
+            BigQueryRecordFormatter(
+                tableNameInfo.columnNameMapping,
+                legacyRawTablesOnly = config.legacyRawTablesOnly,
+            ),
         )
     }
 

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/typing_deduping/direct_load_tables/BigqueryDirectLoadSqlGenerator.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/typing_deduping/direct_load_tables/BigqueryDirectLoadSqlGenerator.kt
@@ -87,7 +87,7 @@ class BigqueryDirectLoadSqlGenerator(private val projectId: String?) : DirectLoa
         sourceTableName: TableName,
         targetTableName: TableName
     ): Sql {
-        val columnNames = columnNameMapping.map { (_, actualName) -> actualName }
+        val columnNames = columnNameMapping.map { (_, actualName) -> actualName }.joinToString(",")
         return Sql.of(
             // TODO can we use CDK builtin stuff instead of hardcoding the airbyte meta columns?
             """

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/typing_deduping/direct_load_tables/BigqueryDirectLoadSqlGenerator.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/typing_deduping/direct_load_tables/BigqueryDirectLoadSqlGenerator.kt
@@ -77,11 +77,8 @@ class BigqueryDirectLoadSqlGenerator(private val projectId: String?) : DirectLoa
     }
 
     override fun overwriteTable(sourceTableName: TableName, targetTableName: TableName): Sql {
-        val targetTableId = targetTableName.toPrettyString(QUOTE)
-        val sourceTableId = sourceTableName.toPrettyString(QUOTE)
-        return Sql.separately(
-            "DROP TABLE IF EXISTS `$projectId`.$targetTableId;",
-            "ALTER TABLE `$projectId`.$sourceTableId RENAME TO `${targetTableName.name}`;"
+        throw NotImplementedError(
+            "This method is implemented using a native bigquery API call in BigqueryDirectLoadSqlTableOperations"
         )
     }
 

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/typing_deduping/direct_load_tables/BigqueryDirectLoadSqlTableOperations.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/typing_deduping/direct_load_tables/BigqueryDirectLoadSqlTableOperations.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination.bigquery.write.typing_deduping.direct_load_tables
+
+import com.google.cloud.bigquery.BigQuery
+import com.google.cloud.bigquery.CopyJobConfiguration
+import com.google.cloud.bigquery.JobInfo
+import io.airbyte.cdk.load.orchestration.db.TableName
+import io.airbyte.cdk.load.orchestration.db.direct_load_table.DefaultDirectLoadTableSqlOperations
+import io.airbyte.cdk.load.orchestration.db.direct_load_table.DirectLoadTableSqlOperations
+import io.airbyte.integrations.destination.bigquery.BigQueryUtils
+import io.airbyte.integrations.destination.bigquery.write.typing_deduping.toTableId
+
+class BigqueryDirectLoadSqlTableOperations(
+    private val defaultOperations: DefaultDirectLoadTableSqlOperations,
+    private val bq: BigQuery,
+) : DirectLoadTableSqlOperations by defaultOperations {
+    override fun overwriteTable(sourceTableName: TableName, targetTableName: TableName) {
+        // Bigquery's SQL `ALTER TABLE RENAME TO` statement doesn't support moving tables
+        // across datasets.
+        // So we'll use a Copy job instead.
+        // TODO verify this works in e.g. schema change.
+        val sourceTableId = sourceTableName.toTableId()
+        val job =
+            bq.create(
+                JobInfo.of(
+                    CopyJobConfiguration.newBuilder(
+                            targetTableName.toTableId(),
+                            sourceTableId,
+                        )
+                        // create the table if it doesn't yet exist
+                        .setCreateDisposition(JobInfo.CreateDisposition.CREATE_IF_NEEDED)
+                        // overwrite the table if it already exists
+                        .setWriteDisposition(JobInfo.WriteDisposition.WRITE_TRUNCATE)
+                        .build()
+                )
+            )
+        BigQueryUtils.waitForJobFinish(job)
+        bq.getTable(sourceTableId).delete()
+    }
+}

--- a/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryWriteTest.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryWriteTest.kt
@@ -124,8 +124,8 @@ class StandardInsertRawOverride :
 
 class StandardInsert : BigqueryTDWriteTest(BigQueryDestinationTestUtils.standardInsertConfig) {
     @Test
-    override fun testTruncateRefresh() {
-        super.testTruncateRefresh()
+    override fun testFunkyCharacters() {
+        super.testFunkyCharacters()
     }
 }
 

--- a/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryWriteTest.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryWriteTest.kt
@@ -9,7 +9,6 @@ import io.airbyte.cdk.load.test.util.ExpectedRecordMapper
 import io.airbyte.cdk.load.test.util.UncoercedExpectedRecordMapper
 import io.airbyte.cdk.load.toolkits.load.db.orchestration.ColumnNameModifyingMapper
 import io.airbyte.cdk.load.toolkits.load.db.orchestration.RootLevelTimestampsToUtcMapper
-import io.airbyte.cdk.load.toolkits.load.db.orchestration.TypingDedupingMetaChangeMapper
 import io.airbyte.cdk.load.write.AllTypesBehavior
 import io.airbyte.cdk.load.write.BasicFunctionalityIntegrationTest
 import io.airbyte.cdk.load.write.DedupBehavior
@@ -75,8 +74,8 @@ abstract class BigqueryTDWriteTest(configContents: String) :
         configContents = configContents,
         BigqueryFinalTableDataDumper,
         ColumnNameModifyingMapper(BigqueryColumnNameGenerator())
+            .compose(TimeWithTimezoneMapper)
             .compose(RootLevelTimestampsToUtcMapper)
-            .compose(TypingDedupingMetaChangeMapper)
             .compose(IntegralNumberRecordMapper),
         isStreamSchemaRetroactive = true,
         preserveUndeclaredFields = false,
@@ -88,7 +87,7 @@ abstract class BigqueryTDWriteTest(configContents: String) :
             nestedFloatLosesPrecision = true,
             integerCanBeLarge = false,
             numberCanBeLarge = false,
-            timeWithTimezoneBehavior = SimpleValueBehavior.PASS_THROUGH,
+            timeWithTimezoneBehavior = SimpleValueBehavior.STRONGLY_TYPE,
         ),
     )
 
@@ -124,8 +123,8 @@ class StandardInsertRawOverride :
 
 class StandardInsert : BigqueryTDWriteTest(BigQueryDestinationTestUtils.standardInsertConfig) {
     @Test
-    override fun testFunkyCharacters() {
-        super.testFunkyCharacters()
+    override fun testBasicTypes() {
+        super.testBasicTypes()
     }
 }
 

--- a/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryWriteTest.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryWriteTest.kt
@@ -124,8 +124,8 @@ class StandardInsertRawOverride :
 
 class StandardInsert : BigqueryTDWriteTest(BigQueryDestinationTestUtils.standardInsertConfig) {
     @Test
-    override fun testDedup() {
-        super.testDedup()
+    override fun testTruncateRefresh() {
+        super.testTruncateRefresh()
     }
 }
 

--- a/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/ExpectedRecordMappers.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/ExpectedRecordMappers.kt
@@ -10,6 +10,8 @@ import io.airbyte.cdk.load.data.ArrayValue
 import io.airbyte.cdk.load.data.IntegerValue
 import io.airbyte.cdk.load.data.NumberValue
 import io.airbyte.cdk.load.data.ObjectValue
+import io.airbyte.cdk.load.data.StringValue
+import io.airbyte.cdk.load.data.TimeWithTimezoneValue
 import io.airbyte.cdk.load.test.util.ExpectedRecordMapper
 import io.airbyte.cdk.load.test.util.OutputRecord
 
@@ -55,4 +57,23 @@ object IntegralNumberRecordMapper : ExpectedRecordMapper {
                 )
             else -> value
         }
+}
+
+/**
+ * Bigquery doesn't have a timetz data type, so we use a STRING column. Which means that we need to
+ * map the expected values to string.
+ */
+object TimeWithTimezoneMapper : ExpectedRecordMapper {
+    override fun mapRecord(expectedRecord: OutputRecord, schema: AirbyteType): OutputRecord {
+        val mappedData =
+            ObjectValue(
+                expectedRecord.data.values.mapValuesTo(linkedMapOf()) { (_, value) ->
+                    when (value) {
+                        is TimeWithTimezoneValue -> StringValue(value.value.toString())
+                        else -> value
+                    }
+                }
+            )
+        return expectedRecord.copy(data = mappedData)
+    }
 }


### PR DESCRIPTION
* more informative log messages
* fix copyTable
* make overwriteTable use a CopyJob instead of ALTER TABLE RENAME TO - necessary b/c we're putting the temp table in airbyte_internal, and this is the best way to copy a table across datasets
* standard inserts:
    * respect the column name mapping
    * do type validation