### PR TITLE
ci: cancel in progress tests when using large-sized runners

### DIFF
--- a/.github/workflows/connector-ci-tests.yml
+++ b/.github/workflows/connector-ci-tests.yml
@@ -68,6 +68,10 @@ jobs:
   jvm-connectors-test-matrix:
     needs: [generate-matrix]
     runs-on: linux-24.04-large # Custom runner, defined in GitHub org settings
+    concurrency:
+      # Large runners aren't free, so cancel in-progress jobs when a new commit is pushed to the PR.
+      cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+      group: ${{ github.workflow }}-jvm-tests-${{ github.head_ref || github.run_id }}
     env:
       GCP_GSM_CREDENTIALS: ${{ secrets.GCP_GSM_CREDENTIALS }}
     strategy:

--- a/.github/workflows/connector-ci-tests.yml
+++ b/.github/workflows/connector-ci-tests.yml
@@ -71,7 +71,7 @@ jobs:
     concurrency:
       # Large runners aren't free, so cancel in-progress jobs when a new commit is pushed to the PR.
       cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
-      group: ${{ github.workflow }}-jvm-tests-${{ github.head_ref || github.run_id }}
+      group: ${{ github.workflow }}-jvm-tests-${{ matrix.connector }}-${{ github.head_ref }}
     env:
       GCP_GSM_CREDENTIALS: ${{ secrets.GCP_GSM_CREDENTIALS }}
     strategy:


### PR DESCRIPTION
## What

Follows from:

- https://github.com/airbytehq/airbyte/pull/60264

but with a more narrow scope. Free (4-core) runners still get to finish but the larger runners are killed to save 💰💰💰.

## How
<!--
* Describe how code changes achieve the solution.
-->

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
