### PR TITLE
Salesforce doesn't use tabs.

### DIFF
--- a/docs/integrations/sources/salesforce.md
+++ b/docs/integrations/sources/salesforce.md
@@ -1,8 +1,5 @@
 # Salesforce
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
-
 <HideInUI>
 
 This page contains the setup guide and reference information for the [Salesforce](https://www.salesforce.com/) source connector.


### PR DESCRIPTION
## What

The in-app help rendered some React component imports because they were not declared at the top of the document. However, we don't even use Tabs in that article, so I've removed them.

## How
<!--
* Describe how code changes achieve the solution.
-->

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
