### PR TITLE
Dependency Change Github Workflow

### DIFF
--- a/.github/workflows/dependency-diff.yml
+++ b/.github/workflows/dependency-diff.yml
@@ -1,4 +1,4 @@
-name: Dependency Changes
+name: Gradle Dependency Changes
 on:
   pull_request:
 

--- a/.github/workflows/dependency-diff.yml
+++ b/.github/workflows/dependency-diff.yml
@@ -1,0 +1,14 @@
+name: Dependency Changes
+on:
+  pull_request:
+
+jobs:
+  dependencies-diff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+      - uses: be-hase/gradle-dependency-diff-action@v2

--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ allprojects {
     apply plugin: 'org.jetbrains.kotlin.jvm'
     apply plugin: 'com.google.devtools.ksp'
     apply plugin: 'idea'
+    apply plugin: 'project-report'
 
 
     // By default gradle uses directory as the project name. That works very well in a single project environment but


### PR DESCRIPTION
Add a github workflow which highlights changes in gradle dependencies for every PR. This includes transitive dependencies and subprojects. If dependencies change, the action will post a comment linking to a report on the differences.

For example workflow usage, see this PR: https://github.com/airbytehq/airbyte/pull/60274

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌