### PR TITLE
ci: make JVM checkout work from forks

### DIFF
--- a/.github/workflows/connector-ci-tests.yml
+++ b/.github/workflows/connector-ci-tests.yml
@@ -80,9 +80,11 @@ jobs:
         if: matrix.connector
         uses: actions/checkout@v4
         with:
+          # In order to work correctly on forks, `repository` must be set if `ref` is set:
+          repository: ${{ github.repository }}
           # Java `integrationTestJava` Gradle task still calls Airbyte-CI, which fails on a detached head.
           # TODO: Remove the Airbyte-CI dependency for running java integration tests.
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.head_ref || github.ref_name }}
           fetch-depth: 1
 
       # Java deps


### PR DESCRIPTION
## What

Related to:

- https://github.com/airbytehq/airbyte/pull/56985

Update the JVM-tests checkout step to work with forks, based on the root cause analysis below.

## Root Cause

For legacy reasons, we have to provide `ref` so that `airybte-ci` (still used internally by some Java connectors) will not implode when running from a detached head. However, when providing `ref` we apparently also need to provide an explicit `repository` ref.

More context: Other `checkout` tasks ran successfully in the same PR (linked above). It is only in this case, where we are sending `ref` that we see the failure.

## How to test.

There's not any great way to test - except to merge this, then pull the change into a fork, and let CI re-run. That said, these changes should be safe (and easy enough to revert) if we see any issues.
