### PR TITLE
Required plugin for gradle deps diff workflow

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ allprojects {
     apply plugin: 'org.jetbrains.kotlin.jvm'
     apply plugin: 'com.google.devtools.ksp'
     apply plugin: 'idea'
+    apply plugin: 'project-report'
 
 
     // By default gradle uses directory as the project name. That works very well in a single project environment but


### PR DESCRIPTION
Introduce the plugin required by the gradle dependency change github action which is up for review here: https://github.com/airbytehq/airbyte/pull/60284

The other PR won't pass CI until this plugin is present in the base branch (master).

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
