### PR TITLE
fix: fixes from testing new base image build and publish workflow

### DIFF
--- a/.github/workflows/docker-connector-image-publishing.yml
+++ b/.github/workflows/docker-connector-image-publishing.yml
@@ -75,7 +75,7 @@ jobs:
         run: |
           DOCKERFILE=docker-images/Dockerfile.${{ github.event.inputs.connector-type }}-connector-base
           IMAGE_NAME=${{ github.event.inputs.connector-type }}-connector-base
-          FULL_IMAGE_REF=${{ github.event.inputs.repository-root }}${IMAGE_NAME}:${{ github.event.inputs.tag-or-version-number }}
+          FULL_IMAGE_REF=${{ github.event.inputs.repository-root }}/${IMAGE_NAME}:${{ github.event.inputs.tag-or-version-number }}
           echo "DOCKERFILE=${DOCKERFILE}" | tee -a "$GITHUB_OUTPUT"
           echo "IMAGE_NAME=${IMAGE_NAME}" | tee -a "$GITHUB_OUTPUT"
           echo "FULL_IMAGE_REF=${FULL_IMAGE_REF}" | tee -a "$GITHUB_OUTPUT"

--- a/.github/workflows/docker-connector-image-publishing.yml
+++ b/.github/workflows/docker-connector-image-publishing.yml
@@ -105,7 +105,7 @@ jobs:
         # rebuilding the image.
         # https://docs.docker.com/build/ci/github-actions/test-before-push/
         id: docker-image-publish
-        if: ${{ github.event.inputs.dry-run == false }}
+        if: ${{ github.event.inputs.dry-run == 'false' }}
         uses: docker/build-push-action@v6
         with:
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/docker-connector-image-publishing.yml
+++ b/.github/workflows/docker-connector-image-publishing.yml
@@ -55,7 +55,6 @@ jobs:
         uses: docker/login-action@v3
         if: ${{ github.event.inputs.repository-root == 'docker.io/airbyte' }}
         with:
-          registry: ${{ github.event.inputs.repository-root }}
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}
 

--- a/.github/workflows/docker-connector-image-publishing.yml
+++ b/.github/workflows/docker-connector-image-publishing.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Set image build variables
+      - name: Set and debug variables
         id: vars
         run: |
           DOCKERFILE=docker-images/Dockerfile.${{ github.event.inputs.connector-type }}-connector-base
@@ -79,6 +79,9 @@ jobs:
           echo "DOCKERFILE=${DOCKERFILE}" | tee -a "$GITHUB_OUTPUT"
           echo "IMAGE_NAME=${IMAGE_NAME}" | tee -a "$GITHUB_OUTPUT"
           echo "FULL_IMAGE_REF=${FULL_IMAGE_REF}" | tee -a "$GITHUB_OUTPUT"
+          # Echo other input variables for debugging and logging purposes
+          echo "dry-run=${{ github.event.inputs.dry-run }}"
+          echo "require-security-check=${{ github.event.inputs.require-security-check }}"
 
       - name: Build Base Image
         id: docker-build-base


### PR DESCRIPTION
## What

This PR follows from:

- https://github.com/airbytehq/airbyte/pull/60308

GitHub requires us to merge at least one copy of a workflow before we can invoke it's workflow with manual workflow dispatch.

This PR addresses issues found in testing that first merge.

URL to kick off tests:

- https://github.com/airbytehq/airbyte/actions/workflows/docker-connector-image-publishing.yml

Branch name to use when testing: `ci/docker-images/fixes-on-new-workflow`