### PR TITLE
Rbroughan/fix timed flush for files

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/LoadPipelineStepTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/LoadPipelineStepTask.kt
@@ -243,6 +243,8 @@ class LoadPipelineStepTask<S : AutoCloseable, K1 : WithStream, T, K2 : WithStrea
                         stateStore
                     }
                     is PipelineHeartbeat -> {
+                        log.info { "Step: $stepId — Heartbeat received..." }
+
                         flushStrategy?.let { strategy ->
                             val now = System.currentTimeMillis()
                             val keysToRemove =

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/LoadPipelineStepTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/LoadPipelineStepTask.kt
@@ -243,8 +243,6 @@ class LoadPipelineStepTask<S : AutoCloseable, K1 : WithStream, T, K2 : WithStrea
                         stateStore
                     }
                     is PipelineHeartbeat -> {
-                        log.info { "Step: $stepId — Heartbeat received..." }
-
                         flushStrategy?.let { strategy ->
                             val now = System.currentTimeMillis()
                             val keysToRemove =

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/factory/object_storage/ObjectLoaderStepBeanFactory.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/factory/object_storage/ObjectLoaderStepBeanFactory.kt
@@ -11,6 +11,7 @@ import io.airbyte.cdk.load.message.PartitionedQueue
 import io.airbyte.cdk.load.message.PipelineEvent
 import io.airbyte.cdk.load.message.StreamKey
 import io.airbyte.cdk.load.message.WithStream
+import io.airbyte.cdk.load.pipeline.PipelineFlushStrategy
 import io.airbyte.cdk.load.pipline.object_storage.ObjectKey
 import io.airbyte.cdk.load.pipline.object_storage.ObjectLoaderCompletedUploadPartitioner
 import io.airbyte.cdk.load.pipline.object_storage.ObjectLoaderPartFormatter
@@ -41,6 +42,7 @@ class ObjectLoaderStepBeanFactory {
         outputQueue:
             PartitionedQueue<PipelineEvent<ObjectKey, ObjectLoaderPartFormatter.FormattedPart>>,
         taskFactory: LoadPipelineStepTaskFactory,
+        flushStrategy: PipelineFlushStrategy,
     ) =
         ObjectLoaderPartFormatterStep(
             loader,
@@ -49,6 +51,7 @@ class ObjectLoaderStepBeanFactory {
             outputQueue,
             taskFactory,
             "record-part-formatter-step",
+            flushStrategy,
         )
 
     @Named("recordPartLoaderStep")
@@ -157,6 +160,7 @@ class ObjectLoaderStepBeanFactory {
         outputQueue:
             PartitionedQueue<PipelineEvent<ObjectKey, ObjectLoaderPartFormatter.FormattedPart>>,
         taskFactory: LoadPipelineStepTaskFactory,
+        flushStrategy: PipelineFlushStrategy,
     ) =
         ObjectLoaderPartFormatterStep(
             loader,
@@ -165,6 +169,7 @@ class ObjectLoaderStepBeanFactory {
             outputQueue,
             taskFactory,
             "file-record-part-formatter-step",
+            flushStrategy,
         )
 
     @Singleton

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/pipline/object_storage/ObjectLoaderPartFormatterStep.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/pipline/object_storage/ObjectLoaderPartFormatterStep.kt
@@ -9,6 +9,7 @@ import io.airbyte.cdk.load.message.PartitionedQueue
 import io.airbyte.cdk.load.message.PipelineEvent
 import io.airbyte.cdk.load.message.StreamKey
 import io.airbyte.cdk.load.pipeline.LoadPipelineStep
+import io.airbyte.cdk.load.pipeline.PipelineFlushStrategy
 import io.airbyte.cdk.load.task.internal.LoadPipelineStepTask
 import io.airbyte.cdk.load.task.internal.LoadPipelineStepTaskFactory
 import io.airbyte.cdk.load.write.object_storage.ObjectLoader
@@ -22,15 +23,17 @@ class ObjectLoaderPartFormatterStep(
         PartitionedQueue<PipelineEvent<ObjectKey, ObjectLoaderPartFormatter.FormattedPart>>,
     private val taskFactory: LoadPipelineStepTaskFactory,
     private val stepId: String,
+    private val flushStrategy: PipelineFlushStrategy?,
 ) : LoadPipelineStep {
     override val numWorkers: Int = objectLoader.numPartWorkers
 
     override fun taskForPartition(partition: Int): LoadPipelineStepTask<*, *, *, *, *> {
-        return taskFactory.createIntermediateStep(
+        return taskFactory.create(
             partFormatter,
             inputFlows[partition],
             ObjectLoaderFormattedPartPartitioner(),
             outputQueue,
+            flushStrategy,
             partition,
             numWorkers,
             stepId = stepId,

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/pipline/object_storage/file/RouteEventTask.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/pipline/object_storage/file/RouteEventTask.kt
@@ -37,7 +37,6 @@ class RouteEventTask(
             is PipelineHeartbeat -> {
                 recordQueue.broadcast(event)
             }
-
             is PipelineMessage -> {
                 val streamDesc = event.key.stream
                 val stream = catalog.getStream(streamDesc)
@@ -62,7 +61,6 @@ class RouteEventTask(
                 // "releases" memory on the input queue.
                 event.postProcessingCallback?.let { it() }
             }
-
             is PipelineEndOfStream -> {
                 val streamDesc = event.stream
                 val stream = catalog.getStream(streamDesc)
@@ -74,4 +72,4 @@ class RouteEventTask(
                 }
             }
         }
-    }
+}

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/pipline/object_storage/file/RouteEventTask.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/pipline/object_storage/file/RouteEventTask.kt
@@ -53,6 +53,14 @@ class RouteEventTask(
                 } else {
                     recordQueue.publish(event, partition)
                 }
+
+                // TODO: Forward this all the way through to the record stage or change memory
+                // "release" mechanism on the input queue.
+                // Forwarding all the way through is not currently possible because the first
+                // PipelineStep in the file pipe (the formatter) will immediately call this.
+                // NOTE: though generically named, the post-processing callback is specifically what
+                // "releases" memory on the input queue.
+                event.postProcessingCallback?.let { it() }
             }
 
             is PipelineEndOfStream -> {

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/test/kotlin/io/airbyte/cdk/load/pipeline/object_storage/file/RouteEventTaskTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/test/kotlin/io/airbyte/cdk/load/pipeline/object_storage/file/RouteEventTaskTest.kt
@@ -29,6 +29,7 @@ import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
 import kotlinx.coroutines.flow.Flow
+import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -76,12 +77,14 @@ class RouteEventTaskTest {
             val key = StreamKey(stream.descriptor)
             val record = Fixtures.record()
             val checkpoints = mapOf(CheckpointId(1) to 2L)
+            val releaseMemCallback: (suspend () -> Unit) = mockk(relaxed = true)
 
             val input =
                 PipelineMessage(
                     checkpointCounts = checkpoints,
                     key = key,
                     value = record,
+                    postProcessingCallback = releaseMemCallback,
                 )
             every { catalog.getStream(key.stream) } returns stream
 
@@ -98,10 +101,12 @@ class RouteEventTaskTest {
                     checkpointCounts = checkpoints,
                     key = key,
                     value = Fixtures.record(),
+                    postProcessingCallback = releaseMemCallback,
                     context = expectedContext
                 )
 
             coVerify { fileQueue.publish(expected, partition) }
+            coVerify { releaseMemCallback() }
         }
 
     @Test
@@ -151,12 +156,12 @@ class RouteEventTaskTest {
     }
 
     @Test
-    fun `routes heartbeats to record queue`() = runTest {
+    fun `broadcasts heartbeats to record queue`() = runTest {
         val input = PipelineHeartbeat<StreamKey, DestinationRecordRaw>()
 
         task.handleEvent(input)
 
-        coVerify { recordQueue.publish(input, partition) }
+        coVerify { recordQueue.broadcast(input) }
     }
 
     object Fixtures {

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/test/kotlin/io/airbyte/cdk/load/pipeline/object_storage/file/RouteEventTaskTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/test/kotlin/io/airbyte/cdk/load/pipeline/object_storage/file/RouteEventTaskTest.kt
@@ -28,8 +28,8 @@ import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
-import kotlinx.coroutines.flow.Flow
 import io.mockk.mockk
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test

--- a/airbyte-integrations/connectors/destination-s3/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-s3/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: file
   connectorType: destination
   definitionId: 4816b78f-1489-44c1-9060-4b19d5fa9362
-  dockerImageTag: 1.8.3
+  dockerImageTag: 1.8.4
   dockerRepository: airbyte/destination-s3
   githubIssueLabel: destination-s3
   icon: s3.svg

--- a/airbyte-integrations/connectors/destination-s3/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2WriteTest.kt
+++ b/airbyte-integrations/connectors/destination-s3/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2WriteTest.kt
@@ -65,6 +65,13 @@ abstract class S3V2WriteTest(
         supportFileTransfer = true,
         unknownTypesBehavior = unknownTypesBehavior,
     ) {
+    @Disabled(
+        "tests are broken in avro/parquet; https://github.com/airbytehq/airbyte/pull/60322 will fix + reenable"
+    )
+    @Test
+    override fun testFunkyCharacters() {
+        super.testFunkyCharacters()
+    }
     @Disabled("Irrelevant for file destinations")
     @Test
     override fun testAppendSchemaEvolution() {

--- a/docs/integrations/destinations/s3.md
+++ b/docs/integrations/destinations/s3.md
@@ -544,6 +544,7 @@ To see connector limitations, or troubleshoot your S3 connector, see more [in ou
 
 | Version     | Date       | Pull Request                                               | Subject                                                                                                                                              |
 |:------------|:-----------|:-----------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| 1.8.4       | 2025-05-14 | [60313](https://github.com/airbytehq/airbyte/pull/60313)   | Re-wires up time window trigger. Files path releases memory properly.                                                                                |
 | 1.8.3       | 2025-05-14 | [60287](https://github.com/airbytehq/airbyte/pull/60287)   | Update spec.                                                                                                                                         |
 | 1.8.2       | 2025-05-07 | [59721](https://github.com/airbytehq/airbyte/pull/59721)   | Legacy File Transfer Uses New CDK Interface                                                                                                          |
 | 1.8.1       | 2025-05-07 | [59710](https://github.com/airbytehq/airbyte/pull/59710)   | CDK backpressure bugfix                                                                                                                              |


### PR DESCRIPTION
## What
Fixes timed flush behavior for object loader pipeline

Releases memory for incoming records in file path

## How
Wiring

## User Impact
Fixes high cardinality file syncs 

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
