### PR TITLE
fix(source-recharge): improve 429, 5XX retry strategy

### DIFF
--- a/airbyte-integrations/connectors/source-recharge/metadata.yaml
+++ b/airbyte-integrations/connectors/source-recharge/metadata.yaml
@@ -7,7 +7,7 @@ data:
   connectorBuildOptions:
     baseImage: docker.io/airbyte/python-connector-base:4.0.0@sha256:d9894b6895923b379f3006fa251147806919c62b7d9021b5cd125bb67d7bbe22
   definitionId: 45d2e135-2ede-49e1-939f-3e3ec357a65e
-  dockerImageTag: 2.7.0
+  dockerImageTag: 2.7.1
   dockerRepository: airbyte/source-recharge
   githubIssueLabel: source-recharge
   icon: recharge.svg

--- a/airbyte-integrations/connectors/source-recharge/pyproject.toml
+++ b/airbyte-integrations/connectors/source-recharge/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "2.7.0"
+version = "2.7.1"
 name = "source-recharge"
 description = "Source implementation for Recharge."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-recharge/source_recharge/manifest.yaml
+++ b/airbyte-integrations/connectors/source-recharge/source_recharge/manifest.yaml
@@ -66,8 +66,13 @@ definitions:
       $ref: "#/definitions/authenticator"
     error_handler:
       type: DefaultErrorHandler
-      description: >-
-        The default error handler
+      max_retries: 10
+      response_filters:
+        - http_codes: [429]
+          action: RETRY
+          backoff_strategies:
+            - type: ConstantBackoffStrategy
+              backoff_time_in_seconds: 2
   requester_deprecated_api:
     $ref: "#/definitions/requester_base"
     # for deprecated retriever we should use `2021-01` api version

--- a/docs/integrations/sources/recharge.md
+++ b/docs/integrations/sources/recharge.md
@@ -80,6 +80,7 @@ The Recharge connector should gracefully handle Recharge API limitations under n
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                        |
 |:--------|:-----------| :------------------------------------------------------- |:-------------------------------------------------------------------------------------------------------------------------------|
+| 2.7.1 | 2025-05-16 | [60317](https://github.com/airbytehq/airbyte/pull/60317) | improve 429 error handler |
 | 2.7.0 | 2025-05-08 | [59734](https://github.com/airbytehq/airbyte/pull/59734) | Added lookback window to connector manifest configuration |
 | 2.6.14 | 2025-05-04 | [59512](https://github.com/airbytehq/airbyte/pull/59512) | Update dependencies |
 | 2.6.13 | 2025-04-27 | [59114](https://github.com/airbytehq/airbyte/pull/59114) | Update dependencies |


### PR DESCRIPTION
Since there’s already an open PR (https://github.com/airbytehq/airbyte/pull/60265), I’ll update the connector version and documentation based on whichever PR is approved first, and notify once it’s ready to merge 😄 

## What
[Recharge](https://docs.getrecharge.com/docs/api-rate-limits) recommends:

> Handle your 429s gracefully. Where possible, if you get a 429 error, sleep for at least 2 seconds and then retry your request.

They utilise the “leaky bucket” algorithm:

> If the “leaky bucket'' becomes full, no additional requests will be processed, and a 429 error code will be returned.

The default leak rate is 2 requests per second.

To better handle transient 5XX errors (e.g., Gateway Timeout), I have increased the maximum retries to 10.


## How
- Changed `max_retries` from the default of `5` to `10`
- Added an entry in `response_filters` to handle 429s with a `backoff_time_in_seconds` of `2 seconds`


## Review guide
1. `manifest.yaml`

## User Impact
- Better handling of 429s and Gateway Timeout errors instead of hard-failing the sync.
- Backward compatible config change.


## Can this PR be safely reverted and rolled back?

- [x] YES 💚
