### PR TITLE
fix(ci): use `set -euo pipefail` for shell tasks in poe

### DIFF
--- a/poe-tasks/manifest-only-connector-tasks.toml
+++ b/poe-tasks/manifest-only-connector-tasks.toml
@@ -32,6 +32,8 @@ test-all = [
   "test-integration-tests",
 ]
 test-unit-tests.shell = '''
+set -euo pipefail
+
 if [ -f ${POE_PWD}/unit_tests/pyproject.toml ]; then
   echo "Found 'unit_tests/pyproject.toml' file, running unit tests..."
   cd ${POE_PWD}/unit_tests
@@ -45,6 +47,8 @@ test-integration-tests = "airbyte-cdk connector test ${POE_PWD}"
 format-check = "echo 'No format check step for this connector.'"
 
 lock.shell = '''
+set -euo pipefail
+
 if [ -f ${POE_PWD}/unit_tests/pyproject.toml ]; then
   echo "Found 'unit_tests/pyproject.toml' file, locking unit tests project..."
   cd ${POE_PWD}/unit_tests

--- a/poe-tasks/poetry-connector-tasks.toml
+++ b/poe-tasks/poetry-connector-tasks.toml
@@ -38,6 +38,8 @@ lock = "poetry lock"
 # Pytest
 pytest-fast = "poetry run pytest --ff -m 'not slow and not requires_creds' --junitxml=build/test-results/pytest-fast-junit.xml unit_tests"
 pytest-unit-tests.shell = '''
+set -euo pipefail
+
 if [ -d unit_tests ]; then
   poetry run pytest --junitxml=build/test-results/pytest-unit-tests-junit.xml unit_tests
 else
@@ -46,6 +48,8 @@ fi
 '''
 
 pytest-integration-tests.shell = '''
+set -euo pipefail
+
 if ls integration_tests/test_*.py >/dev/null 2>&1; then
   poetry run pytest --junitxml=build/test-results/pytest-integration-tests-junit.xml integration_tests
 else


### PR DESCRIPTION
"[Unofficial Bash Strict Mode](https://gist.github.com/robin-a-meade/58d60124b88b60816e8349d1e3938615)" is apparently needed to prevent Poe shell scripts from sometimes swallowing failures.

