### PR TITLE
Revert "ci: use 'push' event to leverage secrets from host repo/fork (#60339)"

### DIFF
--- a/.github/workflows/connector-ci-tests.yml
+++ b/.github/workflows/connector-ci-tests.yml
@@ -1,7 +1,8 @@
 name: Connector CI Tests
 
 on:
-  push:  # Push events use secrets from the host repo/fork
+  pull_request:
+    types: [opened, synchronize, reopened]
 
   # Available as a reusable workflow
   # (https://docs.github.com/en/actions/sharing-automations/reusing-workflows)
@@ -66,10 +67,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           # In order to work correctly on forks, `repository` must be set if `ref` is set:
-          repository: ${{ inputs.repo || github.repository }}
+          repository: ${{ inputs.repo || github.event.pull_request.head.repo.full_name }}
           # Java `integrationTestJava` Gradle task still calls Airbyte-CI, which fails on a detached head.
           # TODO: Remove the Airbyte-CI dependency for running java integration tests.
-          ref: ${{ inputs.gitref || github.ref_name }}
+          ref: ${{ inputs.gitref || github.head_ref || github.ref_name }}
           fetch-depth: 1
 
       # Java deps


### PR DESCRIPTION
This reverts commit 4231003086696a6e56bab4475365440fcb05c2e6.

## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->

## How
<!--
* Describe how code changes achieve the solution.
-->

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
