### PR TITLE
Don't filter if files stream.

### DIFF
--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/state/object_storage/ObjectStorageDestinationStateManager.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/state/object_storage/ObjectStorageDestinationStateManager.kt
@@ -58,7 +58,7 @@ class ObjectStorageDestinationState(
 
         return client
             .list(prefix)
-            .filter { matcher.match(it.key) != null }
+            .filter { stream.includeFiles || matcher.match(it.key) != null }
             .toList() // Force the list call to complete before initiating metadata calls
             .mapNotNull { obj ->
                 val generationId =

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/test/kotlin/io/airbyte/cdk/load/state/object_storage/ObjectStorageDestinationStateUTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/test/kotlin/io/airbyte/cdk/load/state/object_storage/ObjectStorageDestinationStateUTest.kt
@@ -124,7 +124,12 @@ class ObjectStorageDestinationStateUTest {
                     MockObj("cat/2"),
                     MockObj("cat/3"),
                     MockObj("turtle-1/1"),
-                    MockObj("turtle-1/2")
+                    MockObj("turtle-1/2"),
+                    MockObj("file-1/2025_05_12_1747072042466/1"),
+                    MockObj("file-1/2025_05_12_1747072175452/2"),
+                    MockObj("file-1/2025_05_12_1747072196432/3"),
+                    MockObj("file-2/2025_05_12_1747072196432/3"),
+                    MockObj("file-1/2025_05_12_1747072200811/4"),
                 )
             )
         coEvery { client.list(any()) } answers
@@ -176,5 +181,21 @@ class ObjectStorageDestinationStateUTest {
         every { turtleStream.shouldBeTruncatedAtEndOfSync() } returns false
         val turtleState = persister.load(turtleStream)
         assertEquals(0, turtleState.getObjectsToDelete().size)
+
+        every { pathFactory.getLongestStreamConstantPrefix(any()) } returns "file"
+        val fileStream = mockk<DestinationStream>(relaxed = true)
+        every { fileStream.descriptor } returns DestinationStream.Descriptor("test", "file-1")
+        every { fileStream.minimumGenerationId } returns 4L
+        every { fileStream.shouldBeTruncatedAtEndOfSync() } returns true
+
+        // when the stream is not configured to include files, we filter out subdirs
+        every { fileStream.includeFiles } returns false
+        val fileState1 = persister.load(fileStream)
+        assertEquals(0, fileState1.getObjectsToDelete().size)
+
+        // when the stream _is_ configured to include files, we match against subdirs
+        every { fileStream.includeFiles } returns true
+        val fileState2 = persister.load(fileStream)
+        assertEquals(4, fileState2.getObjectsToDelete().size)
     }
 }


### PR DESCRIPTION
## What
Don't filter the state bucket as much for files refreshes, so we delete files from previous syncs during refresh overwrite for files.

Does not cut a release for s3 yet.

## User Impact
This will delete old files once released on subsequent runs.

