### PR TITLE
hotfix(ci): fix fork check in gradle dependency-diff

### DIFF
--- a/.github/workflows/gradle-dependency-diff.yml
+++ b/.github/workflows/gradle-dependency-diff.yml
@@ -4,6 +4,7 @@ on:
 
 jobs:
   dependencies-diff:
+    name: Gradle Dependency Diff
     runs-on: ubuntu-latest
     # As of now, the diff analysis does not work for forks.
     if: ${{ ! github.event.pull_request.head.repo.fork }}

--- a/.github/workflows/gradle-dependency-diff.yml
+++ b/.github/workflows/gradle-dependency-diff.yml
@@ -7,7 +7,7 @@ jobs:
     name: Gradle Dependency Diff
     runs-on: ubuntu-latest
     # As of now, the diff analysis does not work for forks.
-    if: ${{ github.event.pull_request.head.repo.fork == false }}
+    if: github.event.pull_request.head.repo.fork == false
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4

--- a/.github/workflows/gradle-dependency-diff.yml
+++ b/.github/workflows/gradle-dependency-diff.yml
@@ -7,7 +7,7 @@ jobs:
     name: Gradle Dependency Diff
     runs-on: ubuntu-latest
     # As of now, the diff analysis does not work for forks.
-    if: ${{ ! github.event.pull_request.head.repo.fork }}
+    if: ${{ github.event.pull_request.head.repo.fork == false }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4

--- a/.github/workflows/gradle-dependency-diff.yml
+++ b/.github/workflows/gradle-dependency-diff.yml
@@ -6,7 +6,7 @@ jobs:
   dependencies-diff:
     runs-on: ubuntu-latest
     # As of now, the diff analysis does not work for forks.
-    if: github.repository == 'airbytehq/airbyte'
+    if: ${{ ! github.event.pull_request.head.repo.fork }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4


### PR DESCRIPTION
Fixes the check condition for the Gradle dependency-diff logic to skip running on forks.
