### PR TITLE
docs: add documentation of CDKs and the new CDK CLI

### DIFF
--- a/docs/platform/connector-development/local-connector-development.md
+++ b/docs/platform/connector-development/local-connector-development.md
@@ -16,7 +16,7 @@ When developing connectors locally, you'll want to ensure the following tools ar
 1. [`uv`](#uv) - Used for installing Python-based CLI apps, such as `Poe`.
 1. [`docker`](#docker) - Used when building and running connector container images.
 1. [`gradle`](#gradle) - Required when working with Java and Kotlin connectors.
-1. [Airbyte CDK](#airbyte-cdk) - The Airbyte Connector Development Kit.
+1. [Airbyte CDKs](#airbyte-connector-development-kits-cdks) - The Airbyte Connector Development Kit (CDK) tools, including the [`airbyte-cdk` CLI](#the-airbyte-cdk-cli).
 1. [`airbyte-ci` (deprecated)](#airbyte-ci-deprecated) - Used for a large number of tasks such as building and publishing.
 
 ### Poe the Poet
@@ -78,20 +78,22 @@ What we loosely refer to as the "Airbyte CDK" is actually a combination of sever
 
 1. [**Python CDK**](https://airbytehq.github.io/airbyte-python-cdk/airbyte_cdk.html) - A developer kit that includes the foundation for low-code and no-code connectors, as well as several other Python-based implementations.
 1. **File CDK** - A CDK for building file-based source connectors, built on the Python CDK.
-1. **Airbyte CDK CLI** - A command line interface (CLI) for performing common connector-related tasks, built into the Python CDK. (See below for installation instructions.)
+1. **Airbyte CDK CLI** - A command line interface (CLI) for performing common connector-related tasks, built into the Python CDK. (See [below](#the-airbyte-cdk-cli) for installation instructions.)
 
 For high-throughput connectors, we also use:
 
 1. **Bulk Load CDK** - A set of libraries and resources for building destinations using the Kotlin language.
 1. **Bulk Extract CDK** - A set of libraries and resources for building sources using the Kotlin language.
 
-#### Installing the `airbyte-cdk` CLI
+#### The `airbyte-cdk` CLI
 
-First install `uv` using the instructions above. Then, you can install or upgrade the `airbyte-cdk` CLI using:
+To install the `airbyte-cdk` CLI, first install `uv` using the instructions above. Then you can install or upgrade the `airbyte-cdk` CLI using:
 
 ```bash
 uv install --upgrade 'airbyte-cdk[dev]'
 ```
+
+For a list of available commands in the `airbyte-cdk` CLI, run `airbyte-cdk --help`.
 
 ### airbyte-ci (deprecated)
 

--- a/docs/platform/connector-development/local-connector-development.md
+++ b/docs/platform/connector-development/local-connector-development.md
@@ -2,6 +2,12 @@
 
 This document outlines the tools needed to develop connectors locally, and how to use each tool.
 
+:::tip
+**Using Connector Builder**
+
+For most cases, when building new source connectors, and especially when building API sources, we recommend starting with our Connector Builder instead of starting from the development tools described here. The Connector Builder provides the most streamlined experience for building new connectors, with little or no code, and directly within the web interface.
+:::
+
 ## Tooling
 
 When developing connectors locally, you'll want to ensure the following tools are installed:
@@ -10,6 +16,7 @@ When developing connectors locally, you'll want to ensure the following tools ar
 1. [`uv`](#uv) - Used for installing Python-based CLI apps, such as `Poe`.
 1. [`docker`](#docker) - Used when building and running connector container images.
 1. [`gradle`](#gradle) - Required when working with Java and Kotlin connectors.
+1. [Airbyte CDK](#airbyte-cdk) - The Airbyte Connector Development Kit.
 1. [`airbyte-ci` (deprecated)](#airbyte-ci-deprecated) - Used for a large number of tasks such as building and publishing.
 
 ### Poe the Poet
@@ -64,6 +71,27 @@ You can also use `poe` to execute Gradle tasks, often with less typing. From wit
 Using this syntax you can avoid the long task prefixes such as typing `gradle :integration-tests:connectors:source-mysource:unitTest` and instead run `poe gradle unitTest` within the connector directory.
 
 :::
+
+### Airbyte Connector Development Kits (CDKs)
+
+What we loosely refer to as the "Airbyte CDK" is actually a combination of several CDKs and tools:
+
+1. [**Python CDK**](https://airbytehq.github.io/airbyte-python-cdk/airbyte_cdk.html) - A developer kit that includes the foundation for low-code and no-code connectors, as well as several other Python-based implementations.
+1. "File CDK" - A CDK for building file-based source connectors, built on the Python CDK.
+1. Airbyte CDK CLI - A command line interface (CLI) for performing common connector-related tasks.
+
+For high-throughput connectors, we also use:
+
+1. "Bulk Load CDK" - A CDK for building destinations using the Kotlin language.
+1. "Bulk Extract CDK" - A CDK for build sources using the Kotlin language.
+
+#### Installing the `airbyte-cdk` CLI
+
+First install `uv` using the instructions above. Then, you can install or upgrade the `airbyte-cdk` CLI using:
+
+```bash
+uv install --upgrade 'airbyte-cdk[dev]'
+```
 
 ### airbyte-ci (deprecated)
 

--- a/docs/platform/connector-development/local-connector-development.md
+++ b/docs/platform/connector-development/local-connector-development.md
@@ -5,7 +5,7 @@ This document outlines the tools needed to develop connectors locally, and how t
 :::tip
 **Using Connector Builder**
 
-For most cases, when building new source connectors, and especially when building API sources, we recommend starting with our Connector Builder instead of starting from the development tools described here. The Connector Builder provides the most streamlined experience for building new connectors, with little or no code, and directly within the web interface.
+For most cases, when building new source connectors, we recommend starting with our [**Low-Code Connector Builder**](./connector-builder-ui/overview) instead of starting from the development tools described here. The Connector Builder provides the most streamlined experience for building new connectors, with little or no code, and directly within the Airbyte web interface.
 :::
 
 ## Tooling
@@ -77,13 +77,13 @@ Using this syntax you can avoid the long task prefixes such as typing `gradle :i
 What we loosely refer to as the "Airbyte CDK" is actually a combination of several CDKs and tools:
 
 1. [**Python CDK**](https://airbytehq.github.io/airbyte-python-cdk/airbyte_cdk.html) - A developer kit that includes the foundation for low-code and no-code connectors, as well as several other Python-based implementations.
-1. "File CDK" - A CDK for building file-based source connectors, built on the Python CDK.
-1. Airbyte CDK CLI - A command line interface (CLI) for performing common connector-related tasks.
+1. **File CDK** - A CDK for building file-based source connectors, built on the Python CDK.
+1. **Airbyte CDK CLI** - A command line interface (CLI) for performing common connector-related tasks, built into the Python CDK. (See below for installation instructions.)
 
 For high-throughput connectors, we also use:
 
-1. "Bulk Load CDK" - A CDK for building destinations using the Kotlin language.
-1. "Bulk Extract CDK" - A CDK for build sources using the Kotlin language.
+1. **Bulk Load CDK** - A set of libraries and resources for building destinations using the Kotlin language.
+1. **Bulk Extract CDK** - A set of libraries and resources for building sources using the Kotlin language.
 
 #### Installing the `airbyte-cdk` CLI
 

--- a/docusaurus/platform_versioned_docs/version-1.6/connector-development/local-connector-development.md
+++ b/docusaurus/platform_versioned_docs/version-1.6/connector-development/local-connector-development.md
@@ -16,7 +16,7 @@ When developing connectors locally, you'll want to ensure the following tools ar
 1. [`uv`](#uv) - Used for installing Python-based CLI apps, such as `Poe`.
 1. [`docker`](#docker) - Used when building and running connector container images.
 1. [`gradle`](#gradle) - Required when working with Java and Kotlin connectors.
-1. [Airbyte CDK](#airbyte-cdk) - The Airbyte Connector Development Kit.
+1. [Airbyte CDKs](#airbyte-connector-development-kits-cdks) - The Airbyte Connector Development Kit (CDK) tools, including the [`airbyte-cdk` CLI](#the-airbyte-cdk-cli).
 1. [`airbyte-ci` (deprecated)](#airbyte-ci-deprecated) - Used for a large number of tasks such as building and publishing.
 
 ### Poe the Poet
@@ -78,20 +78,22 @@ What we loosely refer to as the "Airbyte CDK" is actually a combination of sever
 
 1. [**Python CDK**](https://airbytehq.github.io/airbyte-python-cdk/airbyte_cdk.html) - A developer kit that includes the foundation for low-code and no-code connectors, as well as several other Python-based implementations.
 1. **File CDK** - A CDK for building file-based source connectors, built on the Python CDK.
-1. **Airbyte CDK CLI** - A command line interface (CLI) for performing common connector-related tasks, built into the Python CDK. (See below for installation instructions.)
+1. **Airbyte CDK CLI** - A command line interface (CLI) for performing common connector-related tasks, built into the Python CDK. (See [below](#the-airbyte-cdk-cli) for installation instructions.)
 
 For high-throughput connectors, we also use:
 
 1. **Bulk Load CDK** - A set of libraries and resources for building destinations using the Kotlin language.
 1. **Bulk Extract CDK** - A set of libraries and resources for building sources using the Kotlin language.
 
-#### Installing the `airbyte-cdk` CLI
+#### The `airbyte-cdk` CLI
 
-First install `uv` using the instructions above. Then, you can install or upgrade the `airbyte-cdk` CLI using:
+To install the `airbyte-cdk` CLI, first install `uv` using the instructions above. Then you can install or upgrade the `airbyte-cdk` CLI using:
 
 ```bash
 uv install --upgrade 'airbyte-cdk[dev]'
 ```
+
+For a list of available commands in the `airbyte-cdk` CLI, run `airbyte-cdk --help`.
 
 ### airbyte-ci (deprecated)
 

--- a/docusaurus/platform_versioned_docs/version-1.6/connector-development/local-connector-development.md
+++ b/docusaurus/platform_versioned_docs/version-1.6/connector-development/local-connector-development.md
@@ -2,6 +2,12 @@
 
 This document outlines the tools needed to develop connectors locally, and how to use each tool.
 
+:::tip
+**Using Connector Builder**
+
+For most cases, when building new source connectors, and especially when building API sources, we recommend starting with our Connector Builder instead of starting from the development tools described here. The Connector Builder provides the most streamlined experience for building new connectors, with little or no code, and directly within the web interface.
+:::
+
 ## Tooling
 
 When developing connectors locally, you'll want to ensure the following tools are installed:
@@ -10,6 +16,7 @@ When developing connectors locally, you'll want to ensure the following tools ar
 1. [`uv`](#uv) - Used for installing Python-based CLI apps, such as `Poe`.
 1. [`docker`](#docker) - Used when building and running connector container images.
 1. [`gradle`](#gradle) - Required when working with Java and Kotlin connectors.
+1. [Airbyte CDK](#airbyte-cdk) - The Airbyte Connector Development Kit.
 1. [`airbyte-ci` (deprecated)](#airbyte-ci-deprecated) - Used for a large number of tasks such as building and publishing.
 
 ### Poe the Poet
@@ -64,6 +71,27 @@ You can also use `poe` to execute Gradle tasks, often with less typing. From wit
 Using this syntax you can avoid the long task prefixes such as typing `gradle :integration-tests:connectors:source-mysource:unitTest` and instead run `poe gradle unitTest` within the connector directory.
 
 :::
+
+### Airbyte Connector Development Kits (CDKs)
+
+What we loosely refer to as the "Airbyte CDK" is actually a combination of several CDKs and tools:
+
+1. [**Python CDK**](https://airbytehq.github.io/airbyte-python-cdk/airbyte_cdk.html) - A developer kit that includes the foundation for low-code and no-code connectors, as well as several other Python-based implementations.
+1. "File CDK" - A CDK for building file-based source connectors, built on the Python CDK.
+1. Airbyte CDK CLI - A command line interface (CLI) for performing common connector-related tasks.
+
+For high-throughput connectors, we also use:
+
+1. "Bulk Load CDK" - A CDK for building destinations using the Kotlin language.
+1. "Bulk Extract CDK" - A CDK for build sources using the Kotlin language.
+
+#### Installing the `airbyte-cdk` CLI
+
+First install `uv` using the instructions above. Then, you can install or upgrade the `airbyte-cdk` CLI using:
+
+```bash
+uv install --upgrade 'airbyte-cdk[dev]'
+```
 
 ### airbyte-ci (deprecated)
 

--- a/docusaurus/platform_versioned_docs/version-1.6/connector-development/local-connector-development.md
+++ b/docusaurus/platform_versioned_docs/version-1.6/connector-development/local-connector-development.md
@@ -5,7 +5,7 @@ This document outlines the tools needed to develop connectors locally, and how t
 :::tip
 **Using Connector Builder**
 
-For most cases, when building new source connectors, and especially when building API sources, we recommend starting with our Connector Builder instead of starting from the development tools described here. The Connector Builder provides the most streamlined experience for building new connectors, with little or no code, and directly within the web interface.
+For most cases, when building new source connectors, we recommend starting with our [**Low-Code Connector Builder**](./connector-builder-ui/overview) instead of starting from the development tools described here. The Connector Builder provides the most streamlined experience for building new connectors, with little or no code, and directly within the Airbyte web interface.
 :::
 
 ## Tooling
@@ -77,13 +77,13 @@ Using this syntax you can avoid the long task prefixes such as typing `gradle :i
 What we loosely refer to as the "Airbyte CDK" is actually a combination of several CDKs and tools:
 
 1. [**Python CDK**](https://airbytehq.github.io/airbyte-python-cdk/airbyte_cdk.html) - A developer kit that includes the foundation for low-code and no-code connectors, as well as several other Python-based implementations.
-1. "File CDK" - A CDK for building file-based source connectors, built on the Python CDK.
-1. Airbyte CDK CLI - A command line interface (CLI) for performing common connector-related tasks.
+1. **File CDK** - A CDK for building file-based source connectors, built on the Python CDK.
+1. **Airbyte CDK CLI** - A command line interface (CLI) for performing common connector-related tasks, built into the Python CDK. (See below for installation instructions.)
 
 For high-throughput connectors, we also use:
 
-1. "Bulk Load CDK" - A CDK for building destinations using the Kotlin language.
-1. "Bulk Extract CDK" - A CDK for build sources using the Kotlin language.
+1. **Bulk Load CDK** - A set of libraries and resources for building destinations using the Kotlin language.
+1. **Bulk Extract CDK** - A set of libraries and resources for building sources using the Kotlin language.
 
 #### Installing the `airbyte-cdk` CLI
 


### PR DESCRIPTION
Adds a basic introduction to the various Airbyte Connector Development Kits (CDKs) and the new CDK CLI, highlighting their usage and adding installation instructions for the CDK CLI.

Emphasize the benefits of using the Connector Builder for developing new source connectors.

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._