### PR TITLE
docs: update managing connector secrets section for clarity and detail

### DIFF
--- a/docs/platform/connector-development/local-connector-development.md
+++ b/docs/platform/connector-development/local-connector-development.md
@@ -177,10 +177,10 @@ To understand which secrets are required for a connector, consult the `metadata.
 To view a list of secrets, or to fetch them locally, you can use the [Airbyte CDK CLI](#the-airbyte-cdk-cli):
 
 - `airbyte-cdk secrets --help` - Gives general usage instructions for the `secrets` CLI functions.
-- `airbyte-cdk secrets list` - Lists the secrets available for the give connector, along with a GSM deep link to each available secret.
+- `airbyte-cdk secrets list` - Lists the secrets available for the given connector, along with a GSM deep link to each available secret.
   - Note: The `secrets list` command is purely a metadata operation; no secrets are downloaded to your machine locally when running this step.
 - `airbyte-cdk secrets fetch`
-  - Fetching the secrets saves them to local `.json` files within in the connector's `secrets`, making them secrets available for local connector testing.
+  - Fetching the secrets saves them to local `.json` files within in the connector's `secrets`, making them available for local connector testing.
 
 :::caution
 The `secrets` directory should be automatically excluded from git based upon repo-level `.gitignore` rules. It is always a good idea to confirm that his is true for your case, and please always use caution whenever handling sensitive credentials.

--- a/docs/platform/connector-development/local-connector-development.md
+++ b/docs/platform/connector-development/local-connector-development.md
@@ -159,7 +159,7 @@ Airbyte tools and CI workflows will expect secrets to be stored in Google Secret
    1. `connector: <connector-name>`: indicates the name of the connector that the secret pertains to.
       - For example, `connector: source-s3` will be used when testing the S3 source connector.
    2. `filename: <use-case-name>`: The use case name or scenario name that is being declared.
-      - Common `filename` values are: `config` (default), `invalid_config`, `oath_config`, etc.
+      - Common `filename` values are: `config` (default), `invalid_config`, `oauth_config`, etc.
       - When fetching secrets locally, the label `filename: oath_config` value will result in a config file being fetched with the name `secrets/oauth_config.json`.
       - Note: Google Secrets Manager does not support including the "`.`" character in label text, which is why the label should always be stored without the `.json` suffix.
 3. Airbyte tooling will authenticate to your GSM instance using the following two env vars:

--- a/docs/platform/connector-development/local-connector-development.md
+++ b/docs/platform/connector-development/local-connector-development.md
@@ -163,7 +163,7 @@ Airbyte tools and CI workflows will expect secrets to be stored in Google Secret
       - When fetching secrets locally, the label `filename: oath_config` value will result in a config file being fetched with the name `secrets/oauth_config.json`.
       - Note: Google Secrets Manager does not support including the "`.`" character in label text, which is why the label should always be stored without the `.json` suffix.
 3. Airbyte tooling will authenticate to your GSM instance using the following two env vars:
-   1. `GCP_PROJECT_ID` - This is a alphanumeric project name, which tells Airbyte which project ID to authenticate against when fetching secrets.
+   1. `GCP_PROJECT_ID` - This is your alphanumeric project name, which tells Airbyte which project ID to authenticate against when fetching secrets.
       - Airbyte CI workflows will look for this value as a **repo-level variable** with the same name.
    1. `GCP_GSM_CREDENTIALS` - A variable containing the GCP credentials JSON text for your service account.
       - Airbyte CI workflows will look for this value as a **repo-level secret** with the same name.

--- a/docs/platform/connector-development/local-connector-development.md
+++ b/docs/platform/connector-development/local-connector-development.md
@@ -164,9 +164,9 @@ Airbyte tools and CI workflows will expect secrets to be stored in Google Secret
       - Note: Google Secrets Manager does not support including the "`.`" character in label text, which is why the label should always be stored without the `.json` suffix.
 3. Airbyte tooling will authenticate to your GSM instance using the following two env vars:
    1. `GCP_PROJECT_ID` - This is a alphanumeric project name, which tells Airbyte which project ID to authenticate against when fetching secrets.
-      - Airbyte CI workflows will look for this value as a repo-level variable with the same name.
-   1. `GCP_GSM_CREDENTIALS` - Unlike `GCP_PROJECT_ID`
-      - Airbyte CI workflows will look for this value as a repo-level secret with the same name.
+      - Airbyte CI workflows will look for this value as a **repo-level variable** with the same name.
+   1. `GCP_GSM_CREDENTIALS`
+      - Airbyte CI workflows will look for this value as a **repo-level secret** with the same name.
 
 ### Understanding the required secrets for testing
 

--- a/docs/platform/connector-development/local-connector-development.md
+++ b/docs/platform/connector-development/local-connector-development.md
@@ -165,7 +165,7 @@ Airbyte tools and CI workflows will expect secrets to be stored in Google Secret
 3. Airbyte tooling will authenticate to your GSM instance using the following two env vars:
    1. `GCP_PROJECT_ID` - This is a alphanumeric project name, which tells Airbyte which project ID to authenticate against when fetching secrets.
       - Airbyte CI workflows will look for this value as a **repo-level variable** with the same name.
-   1. `GCP_GSM_CREDENTIALS`
+   1. `GCP_GSM_CREDENTIALS` - A variable containing the GCP credentials JSON text for your service account.
       - Airbyte CI workflows will look for this value as a **repo-level secret** with the same name.
 
 ### Understanding the required secrets for testing

--- a/docs/platform/connector-development/local-connector-development.md
+++ b/docs/platform/connector-development/local-connector-development.md
@@ -183,7 +183,7 @@ To view a list of secrets, or to fetch them locally, you can use the [Airbyte CD
   - Fetching the secrets saves them to local `.json` files within in the connector's `secrets`, making them available for local connector testing.
 
 :::caution
-The `secrets` directory should be automatically excluded from git based upon repo-level `.gitignore` rules. It is always a good idea to confirm that his is true for your case, and please always use caution whenever handling sensitive credentials.
+The `secrets` directory should be automatically excluded from git based upon repo-level `.gitignore` rules. It is always a good idea to confirm that this is true for your case, and please always use caution whenever handling sensitive credentials.
 :::
 
 ## PR Slash Commands

--- a/docs/platform/connector-development/local-connector-development.md
+++ b/docs/platform/connector-development/local-connector-development.md
@@ -164,9 +164,9 @@ Airbyte tools and CI workflows will expect secrets to be stored in Google Secret
       - Note: Google Secrets Manager does not support including the "`.`" character in label text, which is why the label should always be stored without the `.json` suffix.
 3. Airbyte tooling will authenticate to your GSM instance using the following two env vars:
    1. `GCP_PROJECT_ID` - This is your alphanumeric project name, which tells Airbyte which project ID to authenticate against when fetching secrets.
-      - Airbyte CI workflows will look for this value as a **repo-level variable** with the same name.
+      - Airbyte CI workflows will look for this value as a [**repo-level variable**](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#creating-configuration-variables-for-a-repository) with the same name.
    1. `GCP_GSM_CREDENTIALS` - A variable containing the GCP credentials JSON text for your service account.
-      - Airbyte CI workflows will look for this value as a **repo-level secret** with the same name.
+      - Airbyte CI workflows will look for this value as a [**repo-level secret**](https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions) with the same name.
 
 ### Understanding the required secrets for testing
 
@@ -174,7 +174,7 @@ To understand which secrets are required for a connector, consult the `metadata.
 
 ### Fetching and Listing Connector Secrets Locally
 
-To view a list of secrets, or to fetch them locally, you can use the Airbyte CDK CLI:
+To view a list of secrets, or to fetch them locally, you can use the [Airbyte CDK CLI](#the-airbyte-cdk-cli):
 
 - `airbyte-cdk secrets --help` - Gives general usage instructions for the `secrets` CLI functions.
 - `airbyte-cdk secrets list` - Lists the secrets available for the give connector, along with a GSM deep link to each available secret.

--- a/docs/platform/connector-development/local-connector-development.md
+++ b/docs/platform/connector-development/local-connector-development.md
@@ -160,7 +160,7 @@ Airbyte tools and CI workflows will expect secrets to be stored in Google Secret
       - For example, `connector: source-s3` will be used when testing the S3 source connector.
    2. `filename: <use-case-name>`: The use case name or scenario name that is being declared.
       - Common `filename` values are: `config` (default), `invalid_config`, `oauth_config`, etc.
-      - When fetching secrets locally, the label `filename: oath_config` value will result in a config file being fetched with the name `secrets/oauth_config.json`.
+      - When fetching secrets locally, the label `filename: oauth_config` value will result in a config file being fetched with the name `secrets/oauth_config.json`.
       - Note: Google Secrets Manager does not support including the "`.`" character in label text, which is why the label should always be stored without the `.json` suffix.
 3. Airbyte tooling will authenticate to your GSM instance using the following two env vars:
    1. `GCP_PROJECT_ID` - This is your alphanumeric project name, which tells Airbyte which project ID to authenticate against when fetching secrets.

--- a/docusaurus/platform_versioned_docs/version-1.6/connector-development/local-connector-development.md
+++ b/docusaurus/platform_versioned_docs/version-1.6/connector-development/local-connector-development.md
@@ -177,10 +177,10 @@ To understand which secrets are required for a connector, consult the `metadata.
 To view a list of secrets, or to fetch them locally, you can use the [Airbyte CDK CLI](#the-airbyte-cdk-cli):
 
 - `airbyte-cdk secrets --help` - Gives general usage instructions for the `secrets` CLI functions.
-- `airbyte-cdk secrets list` - Lists the secrets available for the give connector, along with a GSM deep link to each available secret.
+- `airbyte-cdk secrets list` - Lists the secrets available for the given connector, along with a GSM deep link to each available secret.
   - Note: The `secrets list` command is purely a metadata operation; no secrets are downloaded to your machine locally when running this step.
 - `airbyte-cdk secrets fetch`
-  - Fetching the secrets saves them to local `.json` files within in the connector's `secrets`, making them secrets available for local connector testing.
+  - Fetching the secrets saves them to local `.json` files within in the connector's `secrets`, making them available for local connector testing.
 
 :::caution
 The `secrets` directory should be automatically excluded from git based upon repo-level `.gitignore` rules. It is always a good idea to confirm that his is true for your case, and please always use caution whenever handling sensitive credentials.

--- a/docusaurus/platform_versioned_docs/version-1.6/connector-development/local-connector-development.md
+++ b/docusaurus/platform_versioned_docs/version-1.6/connector-development/local-connector-development.md
@@ -163,7 +163,7 @@ Airbyte tools and CI workflows will expect secrets to be stored in Google Secret
       - When fetching secrets locally, the label `filename: oath_config` value will result in a config file being fetched with the name `secrets/oauth_config.json`.
       - Note: Google Secrets Manager does not support including the "`.`" character in label text, which is why the label should always be stored without the `.json` suffix.
 3. Airbyte tooling will authenticate to your GSM instance using the following two env vars:
-   1. `GCP_PROJECT_ID` - This is a alphanumeric project name, which tells Airbyte which project ID to authenticate against when fetching secrets.
+   1. `GCP_PROJECT_ID` - This is your alphanumeric project name, which tells Airbyte which project ID to authenticate against when fetching secrets.
       - Airbyte CI workflows will look for this value as a **repo-level variable** with the same name.
    1. `GCP_GSM_CREDENTIALS` - A variable containing the GCP credentials JSON text for your service account.
       - Airbyte CI workflows will look for this value as a **repo-level secret** with the same name.

--- a/docusaurus/platform_versioned_docs/version-1.6/connector-development/local-connector-development.md
+++ b/docusaurus/platform_versioned_docs/version-1.6/connector-development/local-connector-development.md
@@ -164,9 +164,9 @@ Airbyte tools and CI workflows will expect secrets to be stored in Google Secret
       - Note: Google Secrets Manager does not support including the "`.`" character in label text, which is why the label should always be stored without the `.json` suffix.
 3. Airbyte tooling will authenticate to your GSM instance using the following two env vars:
    1. `GCP_PROJECT_ID` - This is a alphanumeric project name, which tells Airbyte which project ID to authenticate against when fetching secrets.
-      - Airbyte CI workflows will look for this value as a repo-level variable with the same name.
-   1. `GCP_GSM_CREDENTIALS` - Unlike `GCP_PROJECT_ID`
-      - Airbyte CI workflows will look for this value as a repo-level secret with the same name.
+      - Airbyte CI workflows will look for this value as a **repo-level variable** with the same name.
+   1. `GCP_GSM_CREDENTIALS`
+      - Airbyte CI workflows will look for this value as a **repo-level secret** with the same name.
 
 ### Understanding the required secrets for testing
 

--- a/docusaurus/platform_versioned_docs/version-1.6/connector-development/local-connector-development.md
+++ b/docusaurus/platform_versioned_docs/version-1.6/connector-development/local-connector-development.md
@@ -159,8 +159,8 @@ Airbyte tools and CI workflows will expect secrets to be stored in Google Secret
    1. `connector: <connector-name>`: indicates the name of the connector that the secret pertains to.
       - For example, `connector: source-s3` will be used when testing the S3 source connector.
    2. `filename: <use-case-name>`: The use case name or scenario name that is being declared.
-      - Common `filename` values are: `config` (default), `invalid_config`, `oath_config`, etc.
-      - When fetching secrets locally, the label `filename: oath_config` value will result in a config file being fetched with the name `secrets/oauth_config.json`.
+      - Common `filename` values are: `config` (default), `invalid_config`, `oauth_config`, etc.
+      - When fetching secrets locally, the label `filename: oauth_config` value will result in a config file being fetched with the name `secrets/oauth_config.json`.
       - Note: Google Secrets Manager does not support including the "`.`" character in label text, which is why the label should always be stored without the `.json` suffix.
 3. Airbyte tooling will authenticate to your GSM instance using the following two env vars:
    1. `GCP_PROJECT_ID` - This is your alphanumeric project name, which tells Airbyte which project ID to authenticate against when fetching secrets.

--- a/docusaurus/platform_versioned_docs/version-1.6/connector-development/local-connector-development.md
+++ b/docusaurus/platform_versioned_docs/version-1.6/connector-development/local-connector-development.md
@@ -165,7 +165,7 @@ Airbyte tools and CI workflows will expect secrets to be stored in Google Secret
 3. Airbyte tooling will authenticate to your GSM instance using the following two env vars:
    1. `GCP_PROJECT_ID` - This is a alphanumeric project name, which tells Airbyte which project ID to authenticate against when fetching secrets.
       - Airbyte CI workflows will look for this value as a **repo-level variable** with the same name.
-   1. `GCP_GSM_CREDENTIALS`
+   1. `GCP_GSM_CREDENTIALS` - A variable containing the GCP credentials JSON text for your service account.
       - Airbyte CI workflows will look for this value as a **repo-level secret** with the same name.
 
 ### Understanding the required secrets for testing

--- a/docusaurus/platform_versioned_docs/version-1.6/connector-development/local-connector-development.md
+++ b/docusaurus/platform_versioned_docs/version-1.6/connector-development/local-connector-development.md
@@ -183,7 +183,7 @@ To view a list of secrets, or to fetch them locally, you can use the [Airbyte CD
   - Fetching the secrets saves them to local `.json` files within in the connector's `secrets`, making them available for local connector testing.
 
 :::caution
-The `secrets` directory should be automatically excluded from git based upon repo-level `.gitignore` rules. It is always a good idea to confirm that his is true for your case, and please always use caution whenever handling sensitive credentials.
+The `secrets` directory should be automatically excluded from git based upon repo-level `.gitignore` rules. It is always a good idea to confirm that this is true for your case, and please always use caution whenever handling sensitive credentials.
 :::
 
 ## PR Slash Commands

--- a/docusaurus/platform_versioned_docs/version-1.6/connector-development/local-connector-development.md
+++ b/docusaurus/platform_versioned_docs/version-1.6/connector-development/local-connector-development.md
@@ -164,9 +164,9 @@ Airbyte tools and CI workflows will expect secrets to be stored in Google Secret
       - Note: Google Secrets Manager does not support including the "`.`" character in label text, which is why the label should always be stored without the `.json` suffix.
 3. Airbyte tooling will authenticate to your GSM instance using the following two env vars:
    1. `GCP_PROJECT_ID` - This is your alphanumeric project name, which tells Airbyte which project ID to authenticate against when fetching secrets.
-      - Airbyte CI workflows will look for this value as a **repo-level variable** with the same name.
+      - Airbyte CI workflows will look for this value as a [**repo-level variable**](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#creating-configuration-variables-for-a-repository) with the same name.
    1. `GCP_GSM_CREDENTIALS` - A variable containing the GCP credentials JSON text for your service account.
-      - Airbyte CI workflows will look for this value as a **repo-level secret** with the same name.
+      - Airbyte CI workflows will look for this value as a [**repo-level secret**](https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions) with the same name.
 
 ### Understanding the required secrets for testing
 
@@ -174,7 +174,7 @@ To understand which secrets are required for a connector, consult the `metadata.
 
 ### Fetching and Listing Connector Secrets Locally
 
-To view a list of secrets, or to fetch them locally, you can use the Airbyte CDK CLI:
+To view a list of secrets, or to fetch them locally, you can use the [Airbyte CDK CLI](#the-airbyte-cdk-cli):
 
 - `airbyte-cdk secrets --help` - Gives general usage instructions for the `secrets` CLI functions.
 - `airbyte-cdk secrets list` - Lists the secrets available for the give connector, along with a GSM deep link to each available secret.


### PR DESCRIPTION
Enhance the clarity and detail of the managing connector secrets section to better guide users on storing and handling secrets in Google Secrets Manager.

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._