### PR TITLE
fix(docs): update cloud status badge on navigation

### DIFF
--- a/docusaurus/src/components/HeaderDecoration.jsx
+++ b/docusaurus/src/components/HeaderDecoration.jsx
@@ -358,7 +358,6 @@ export const HeaderDecoration = ({
   lastUpdated,
   definitionId,
 }) => {
-  console.log("definitionId", definitionId);
   const isOss = boolStringToBool(isOssString);
   const isCloud = boolStringToBool(isCloudString);
   const isEnterprise = boolStringToBool(isEnterpriseString);

--- a/docusaurus/src/scripts/cloudStatus.js
+++ b/docusaurus/src/scripts/cloudStatus.js
@@ -1,33 +1,46 @@
 import ExecutionEnvironment from "@docusaurus/ExecutionEnvironment";
-
-if (ExecutionEnvironment.canUseDOM) {
-  function updateCloudStatus() {
-    // Load status from instatus and attach page status as CSS class
-    // https://instatus.com/help/widgets/custom
-    fetch("https://status.airbyte.com/summary.json")
-      .then((resp) => resp.json())
-      .then((summary) => {
-        const status = summary.page.status;
-        const el = document.querySelector(".cloudStatusLink");
-        el?.classList.forEach((className) => {
-          if (className.startsWith("status-")) {
-            el.classList.remove(className);
-          }
-        });
-        el?.classList.add(`status-${status.toLowerCase()}`);
+function fetchAndUpdateCloudStatus(el) {
+  // Load status from instatus and attach page status as CSS class
+  // https://instatus.com/help/widgets/custom
+  fetch("https://status.airbyte.com/summary.json")
+    .then((resp) => resp.json())
+    .then((summary) => {
+      const status = summary.page.status;
+      el?.classList.forEach((className) => {
+        if (className.startsWith("status-")) {
+          el.classList.remove(className);
+        }
       });
-  }
+      el?.classList.add(`status-${status.toLowerCase()}`);
+    });
+}
 
+function pollForCloudStatusLinkAndUpdate() {
+  let attempts = 0;
+  const maxAttempts = 10;
+  const interval = setInterval(() => {
+    const el = document.querySelector(".cloudStatusLink");
+    if (el) {
+      clearInterval(interval);
+      fetchAndUpdateCloudStatus(el);
+    } else if (++attempts >= maxAttempts) {
+      clearInterval(interval);
+    }
+  }, 800);
+}
+if (ExecutionEnvironment.canUseDOM) {
   setInterval(
     () => {
       // Check Cloud status every 10 minutes
-      updateCloudStatus();
+      pollForCloudStatusLinkAndUpdate();
     },
     10 * 60 * 1000,
   );
-
-  setTimeout(() => {
-    // Wait 1 execution slot for first status load, since the navigation bar might not have rendered yet
-    updateCloudStatus();
-  });
+  pollForCloudStatusLinkAndUpdate();
 }
+
+export const onRouteDidUpdate = ({ location, previousLocation }) => {
+  if (!location.pathname.includes(previousLocation?.pathname)) {
+    pollForCloudStatusLinkAndUpdate();
+  }
+};

--- a/docusaurus/src/scripts/cloudStatus.js
+++ b/docusaurus/src/scripts/cloudStatus.js
@@ -40,7 +40,10 @@ if (ExecutionEnvironment.canUseDOM) {
 }
 
 export const onRouteDidUpdate = ({ location, previousLocation }) => {
-  if (!location.pathname.includes(previousLocation?.pathname)) {
+  if (
+    !location.pathname.includes(previousLocation?.pathname) ||
+    previousLocation?.pathname === "/"
+  ) {
     pollForCloudStatusLinkAndUpdate();
   }
 };


### PR DESCRIPTION
Closes https://github.com/airbytehq/airbyte-internal-issues/issues/13050
## What
The Cloud status indicator wasn't updating (or even keeping its status) on route changes, now it will.

## How
- Make sure .cloudStatusLink element is present before updating its status class.
- Added export of `onRouteDidUpdate` to re-run the polling logic on Docusaurus client-side navigation, as explained on docusarus [docs](https://docusaurus.io/docs/advanced/client#client-module-lifecycles)


## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->
User will see status indicator up to date.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
