### PR TITLE
Update the name of the source connector in the tutorial

### DIFF
--- a/docs/platform/connector-development/tutorials/custom-python-connector/1-environment-setup.md
+++ b/docs/platform/connector-development/tutorials/custom-python-connector/1-environment-setup.md
@@ -16,15 +16,13 @@ git clone git@github.com:airbytehq/airbyte.git
 cd airbyte
 
 # Make a directory for a new connector and navigate to it
-mkdir airbyte-integrations/connectors/source-exchange-rates-tutorial
-cd airbyte-integrations/connectors/source-exchange-rates-tutorial
+mkdir airbyte-integrations/connectors/source-survey-monkey-demo
+cd airbyte-integrations/connectors/source-survey-monkey-demo
 
 # Initialize a project, follow Poetry prompts, and then add airbyte-cdk as a dependency.
 poetry init
 poetry add airbyte-cdk
 ```
-
-For this walkthrough, we'll refer to our source as `exchange-rates-tutorial`.
 
 ## Add Connector Metadata file
 

--- a/docusaurus/platform_versioned_docs/version-1.6/connector-development/tutorials/custom-python-connector/1-environment-setup.md
+++ b/docusaurus/platform_versioned_docs/version-1.6/connector-development/tutorials/custom-python-connector/1-environment-setup.md
@@ -16,15 +16,13 @@ git clone git@github.com:airbytehq/airbyte.git
 cd airbyte
 
 # Make a directory for a new connector and navigate to it
-mkdir airbyte-integrations/connectors/source-exchange-rates-tutorial
-cd airbyte-integrations/connectors/source-exchange-rates-tutorial
+mkdir airbyte-integrations/connectors/source-survey-monkey-demo
+cd airbyte-integrations/connectors/source-survey-monkey-demo
 
 # Initialize a project, follow Poetry prompts, and then add airbyte-cdk as a dependency.
 poetry init
 poetry add airbyte-cdk
 ```
-
-For this walkthrough, we'll refer to our source as `exchange-rates-tutorial`.
 
 ## Add Connector Metadata file
 


### PR DESCRIPTION
## What

This small change fixes a complaint that the CDK tutorial is for Survey Monkey, but asks them to create an exchange rates folder. It also removes a line about referring to the source as such, because it's never referred to again this way.

## How

## Review guide

## User Impact

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌
