### PR TITLE
fix(source-bing-ads): fix accounts stream filtering and partitioning

### DIFF
--- a/airbyte-integrations/connectors/source-bing-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-bing-ads/metadata.yaml
@@ -16,7 +16,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 47f25999-dd5e-4636-8c39-e7cea2453331
-  dockerImageTag: 2.9.1
+  dockerImageTag: 2.9.2
   dockerRepository: airbyte/source-bing-ads
   documentationUrl: https://docs.airbyte.com/integrations/sources/bing-ads
   erdUrl: https://dbdocs.io/airbyteio/source-bing-ads?view=relationships

--- a/airbyte-integrations/connectors/source-bing-ads/pyproject.toml
+++ b/airbyte-integrations/connectors/source-bing-ads/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "2.9.1"
+version = "2.9.2"
 name = "source-bing-ads"
 description = "Source implementation for Bing Ads."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-bing-ads/source_bing_ads/manifest.yaml
+++ b/airbyte-integrations/connectors/source-bing-ads/source_bing_ads/manifest.yaml
@@ -96,6 +96,7 @@ definitions:
             ]
             {% endif %}
           ReturnAdditionalFields: "TaxCertificate,AccountMode"
+        authenticator: "#/definitions/authenticator"
       paginator:
         type: DefaultPaginator
         pagination_strategy:
@@ -111,7 +112,7 @@ definitions:
               stream:
                 $ref: "#/definitions/users_stream"
         - type: ListPartitionRouter
-          values: "{{ config['account_names'] if 'account_names' in config and config['account_names'] | length else ['invalid'] }}"
+          values: "{{ config['account_names'] if 'account_names' in config and config['account_names'] | length else [''] }}"
           cursor_field: account_name
       record_selector:
         type: RecordSelector

--- a/airbyte-integrations/connectors/source-bing-ads/source_bing_ads/manifest.yaml
+++ b/airbyte-integrations/connectors/source-bing-ads/source_bing_ads/manifest.yaml
@@ -72,12 +72,30 @@ definitions:
           PageInfo:
             Index: "{{ next_page_token.next_page_token }}"
             Size: 1000
-          Predicates:
-            - Field: UserId
-              Operator: Equals
-              Value: "'{{ stream_partition['user_id'] }}'"
-          ReturnAdditionalFields: TaxCertificate,AccountMode
-        authenticator: "#/definitions/authenticator"
+            Predicates: |
+              {% if "account_names" in config and config["account_names"] | length %}
+              [
+                {
+                  "Field": "UserId",
+                  "Operator": "Equals",
+                  "Value": "{{ stream_partition['user_id'] }}"
+                },
+                {
+                  "Field": "AccountName",
+                  "Operator": "{{ stream_slice.account_name['operator'] }}",
+                  "Value": "{{ stream_slice.account_name['name'] }}"
+                }
+              ]
+              {% else %}
+              [
+                {
+                  "Field": "UserId",
+                  "Operator": "Equals",
+                  "Value": "{{ stream_partition['user_id'] }}"
+                }
+              ]
+              {% endif %}
+          ReturnAdditionalFields: "TaxCertificate,AccountMode"
       paginator:
         type: DefaultPaginator
         pagination_strategy:
@@ -85,13 +103,16 @@ definitions:
           inject_on_first_request: true
           page_size: 1000
       partition_router:
-        type: SubstreamPartitionRouter
-        parent_stream_configs:
-          - type: ParentStreamConfig
-            parent_key: Id
-            partition_field: user_id
-            stream:
-              $ref: "#/definitions/users_stream"
+        - type: SubstreamPartitionRouter
+          parent_stream_configs:
+            - type: ParentStreamConfig
+              parent_key: Id
+              partition_field: user_id
+              stream:
+                $ref: "#/definitions/users_stream"
+        - type: ListPartitionRouter
+          values: "{{ config['account_names'] if 'account_names' in config and config['account_names'] | length else [] }}"
+          cursor_field: account_name
       record_selector:
         type: RecordSelector
         extractor:

--- a/airbyte-integrations/connectors/source-bing-ads/source_bing_ads/manifest.yaml
+++ b/airbyte-integrations/connectors/source-bing-ads/source_bing_ads/manifest.yaml
@@ -72,29 +72,29 @@ definitions:
           PageInfo:
             Index: "{{ next_page_token.next_page_token }}"
             Size: 1000
-            Predicates: |
-              {% if "account_names" in config and config["account_names"] | length %}
-              [
-                {
-                  "Field": "UserId",
-                  "Operator": "Equals",
-                  "Value": "{{ stream_partition['user_id'] }}"
-                },
-                {
-                  "Field": "AccountName",
-                  "Operator": "{{ stream_slice.account_name['operator'] }}",
-                  "Value": "{{ stream_slice.account_name['name'] }}"
-                }
-              ]
-              {% else %}
-              [
-                {
-                  "Field": "UserId",
-                  "Operator": "Equals",
-                  "Value": "{{ stream_partition['user_id'] }}"
-                }
-              ]
-              {% endif %}
+          Predicates: |
+            {% if "account_names" in config and config["account_names"] | length %}
+            [
+              {
+                "Field": "UserId",
+                "Operator": "Equals",
+                "Value": "{{ stream_partition['user_id'] }}"
+              },
+              {
+                "Field": "AccountName",
+                "Operator": "{{ stream_slice.account_name['operator'] }}",
+                "Value": "{{ stream_slice.account_name['name'] }}"
+              }
+            ]
+            {% else %}
+            [
+              {
+                "Field": "UserId",
+                "Operator": "Equals",
+                "Value": "{{ stream_partition['user_id'] }}"
+              }
+            ]
+            {% endif %}
           ReturnAdditionalFields: "TaxCertificate,AccountMode"
       paginator:
         type: DefaultPaginator
@@ -111,7 +111,7 @@ definitions:
               stream:
                 $ref: "#/definitions/users_stream"
         - type: ListPartitionRouter
-          values: "{{ config['account_names'] if 'account_names' in config and config['account_names'] | length else [] }}"
+          values: "{{ config['account_names'] if 'account_names' in config and config['account_names'] | length else ['invalid'] }}"
           cursor_field: account_name
       record_selector:
         type: RecordSelector

--- a/airbyte-integrations/connectors/source-bing-ads/unit_tests/integrations/test_accounts_stream.py
+++ b/airbyte-integrations/connectors/source-bing-ads/unit_tests/integrations/test_accounts_stream.py
@@ -95,7 +95,7 @@ class TestAccountsStream(BaseTest):
         # Use a config with account_names predicate
         config_with_account_names = {
             **self._config,
-            "account_names": [{"operator": "Equals", "name": "Airbyte"}, {"operator": "Contains", "name": "demo"}]
+            "account_names": [{"operator": "Equals", "name": "Airbyte"}, {"operator": "Contains", "name": "demo"}],
         }
 
         http_mocker = self.http_mocker

--- a/airbyte-integrations/connectors/source-bing-ads/unit_tests/integrations/test_accounts_stream.py
+++ b/airbyte-integrations/connectors/source-bing-ads/unit_tests/integrations/test_accounts_stream.py
@@ -86,3 +86,47 @@ class TestAccountsStream(BaseTest):
                 }
             ]
         }
+
+    def test_read_accounts_with_account_names_predicate(self):
+        """
+        Test reading accounts data with account_names predicate in the config.
+        This tests the ListPartitionRouter that processes the account_names configuration.
+        """
+        # Use a config with account_names predicate
+        config_with_account_names = {
+            **self._config,
+            "account_names": [{"operator": "Equals", "name": "Airbyte"}, {"operator": "Contains", "name": "demo"}]
+        }
+
+        http_mocker = self.http_mocker
+        http_mocker.post(
+            RequestBuilder(resource="User/Query").with_body('{"UserId": null}').build(),
+            HttpResponse(json.dumps(find_template("user_query", __file__)), 200),
+        )
+
+        # Mock the first Accounts/Search request with Equals operator for "Airbyte"
+        http_mocker.post(
+            RequestBuilder(resource="Accounts/Search")
+            .with_body(
+                b'{"PageInfo": {"Index": 0, "Size": 1000}, "Predicates": [{"Field": "UserId", "Operator": "Equals", "Value": "123456789"}, {"Field": "AccountName", "Operator": "Equals", "Value": "Airbyte"}], "ReturnAdditionalFields": "TaxCertificate,AccountMode"}'
+            )
+            .build(),
+            HttpResponse(json.dumps(find_template("accounts_search_equals_airbyte", __file__)), 200),
+        )
+
+        # Mock the second Accounts/Search request with Contains operator for "demo"
+        http_mocker.post(
+            RequestBuilder(resource="Accounts/Search")
+            .with_body(
+                b'{"PageInfo": {"Index": 0, "Size": 1000}, "Predicates": [{"Field": "UserId", "Operator": "Equals", "Value": "123456789"}, {"Field": "AccountName", "Operator": "Contains", "Value": "demo"}], "ReturnAdditionalFields": "TaxCertificate,AccountMode"}'
+            )
+            .build(),
+            HttpResponse(json.dumps(find_template("accounts_search_contains_demo", __file__)), 200),
+        )
+
+        # Read the accounts stream with account_names predicate
+        output = self.read_stream(self.stream_name, SyncMode.full_refresh, config_with_account_names)
+        assert len(output.records) == 2
+        account_names = [record.record.data["Name"] for record in output.records]
+        assert "Airbyte" in account_names
+        assert any("demo" in name.lower() for name in account_names)

--- a/airbyte-integrations/connectors/source-bing-ads/unit_tests/resource/http/response/accounts_search_contains_demo.json
+++ b/airbyte-integrations/connectors/source-bing-ads/unit_tests/resource/http/response/accounts_search_contains_demo.json
@@ -47,4 +47,4 @@
       "AccountMode": "Expert"
     }
   ]
-} 
+}

--- a/airbyte-integrations/connectors/source-bing-ads/unit_tests/resource/http/response/accounts_search_contains_demo.json
+++ b/airbyte-integrations/connectors/source-bing-ads/unit_tests/resource/http/response/accounts_search_contains_demo.json
@@ -1,0 +1,50 @@
+{
+  "Accounts": [
+    {
+      "TaxCertificate": {
+        "Status": "Active",
+        "TaxCertificateBlobContainerName": "Test Container Name",
+        "TaxCertificates": [{ "key": "test_key", "value": "test_value" }]
+      },
+      "BillToCustomerId": "987654321",
+      "CurrencyCode": "USD",
+      "AccountFinancialStatus": "ClearFinancialStatus",
+      "Id": "180535609",
+      "Language": "English",
+      "LastModifiedByUserId": "0",
+      "LastModifiedTime": "2023-08-11T08:24:26.603",
+      "Name": "DEMO-ACCOUNT",
+      "Number": "F149W3B6",
+      "ParentCustomerId": "987654321",
+      "PaymentMethodId": null,
+      "PaymentMethodType": null,
+      "PrimaryUserId": "123456789",
+      "AccountLifeCycleStatus": "Pause",
+      "TimeStamp": "AAAAAH10c1A=",
+      "TimeZone": "Santiago",
+      "PauseReason": 2,
+      "ForwardCompatibilityMap": null,
+      "LinkedAgencies": [],
+      "SalesHouseCustomerId": null,
+      "TaxInformation": [],
+      "BackUpPaymentInstrumentId": null,
+      "BillingThresholdAmount": null,
+      "BusinessAddress": {
+        "City": "San Pancho",
+        "CountryCode": "US",
+        "Id": "149694999",
+        "Line1": "789 Test Blvd",
+        "Line2": null,
+        "Line3": null,
+        "Line4": null,
+        "PostalCode": "54321",
+        "StateOrProvince": "CA",
+        "TimeStamp": null,
+        "BusinessName": "Demo Inc."
+      },
+      "AutoTagType": "Inactive",
+      "SoldToPaymentInstrumentId": null,
+      "AccountMode": "Expert"
+    }
+  ]
+} 

--- a/airbyte-integrations/connectors/source-bing-ads/unit_tests/resource/http/response/accounts_search_equals_airbyte.json
+++ b/airbyte-integrations/connectors/source-bing-ads/unit_tests/resource/http/response/accounts_search_equals_airbyte.json
@@ -47,4 +47,4 @@
       "AccountMode": "Expert"
     }
   ]
-} 
+}

--- a/airbyte-integrations/connectors/source-bing-ads/unit_tests/resource/http/response/accounts_search_equals_airbyte.json
+++ b/airbyte-integrations/connectors/source-bing-ads/unit_tests/resource/http/response/accounts_search_equals_airbyte.json
@@ -1,0 +1,50 @@
+{
+  "Accounts": [
+    {
+      "TaxCertificate": {
+        "Status": "Active",
+        "TaxCertificateBlobContainerName": "Test Container Name",
+        "TaxCertificates": [{ "key": "test_key", "value": "test_value" }]
+      },
+      "BillToCustomerId": "251186883",
+      "CurrencyCode": "USD",
+      "AccountFinancialStatus": "ClearFinancialStatus",
+      "Id": "180519267",
+      "Language": "English",
+      "LastModifiedByUserId": "138225488",
+      "LastModifiedTime": "2021-07-09T13:16:43.337000",
+      "Name": "Airbyte",
+      "Number": "F149MJ18",
+      "ParentCustomerId": "251186883",
+      "PaymentMethodId": null,
+      "PaymentMethodType": null,
+      "PrimaryUserId": "138225488",
+      "AccountLifeCycleStatus": "Pending",
+      "TimeStamp": "AAAAAEpme9E=",
+      "TimeZone": "CentralTimeUSCanada",
+      "PauseReason": null,
+      "ForwardCompatibilityMap": null,
+      "LinkedAgencies": null,
+      "SalesHouseCustomerId": null,
+      "TaxInformation": null,
+      "BackUpPaymentInstrumentId": null,
+      "BillingThresholdAmount": null,
+      "BusinessAddress": {
+        "City": "San Francisco",
+        "CountryCode": "US",
+        "Id": "149649761",
+        "Line1": "350 29th Ave",
+        "Line2": null,
+        "Line3": null,
+        "Line4": null,
+        "PostalCode": "94121-1703",
+        "StateOrProvince": "CA",
+        "TimeStamp": null,
+        "BusinessName": "Airbyte"
+      },
+      "AutoTagType": "Preserve",
+      "SoldToPaymentInstrumentId": null,
+      "AccountMode": "Expert"
+    }
+  ]
+} 

--- a/docs/integrations/sources/bing-ads.md
+++ b/docs/integrations/sources/bing-ads.md
@@ -261,6 +261,7 @@ The Bing Ads API limits the number of requests for all Microsoft Advertising cli
 
 | Version | Date       | Pull Request                                                                                                                     | Subject                                                                                                                                        |
 |:--------|:-----------|:---------------------------------------------------------------------------------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------|
+| 2.9.2 | 2025-05-22 | [60832](https://github.com/airbytehq/airbyte/pull/60832) | Fix handling of account_names predicate in declarative stream |
 | 2.9.1 | 2025-05-10 | [54233](https://github.com/airbytehq/airbyte/pull/54233) | Update dependencies |
 | 2.9.0 | 2025-05-07 | [59719](https://github.com/airbytehq/airbyte/pull/59719) | Promoting release candidate 2.9.0-rc.1 to a main version. |
 | 2.9.0-rc.1 | 2025-05-06 | [59136](https://github.com/airbytehq/airbyte/pull/59136) | Bump CDK v6 and migrate Accounts stream to low-code |


### PR DESCRIPTION
## What

Couple of fixes for the low-code accounts stream to better emulate the behavior of the previous Python implementation.

## How

- Request body json is conditionally set based on the existence of user-set `Predicate` filters in the config. When these filters are set by a user, we add these predicates as filters when reading accounts.
- Added a second partitionrouter for accounts that iterates through the list of account_names in config if provided by the user, on top of the existing partition router. 

## User Impact

- Should be two scenarios based on whether a customer has an existing config with specified predicate values:

1. No configured filter: reads should be unaffected
2. Configured filter: reads should return fewer accounts records based on the filtering. All other streams should be unaffected as they are still pointing to the original Python implementation. The drop in records is expected and matches the previous Python implementation before we migrated `accounts` to low-code

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌
