### PR TITLE
[Load-CDK] Reduce max flush interval; heartbeat flushes checkpoints

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/command/DestinationConfiguration.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/command/DestinationConfiguration.kt
@@ -87,7 +87,7 @@ abstract class DestinationConfiguration : Configuration {
     companion object {
         const val DEFAULT_RECORD_BATCH_SIZE_BYTES = 200L * 1024L * 1024L
         const val DEFAULT_HEARTBEAT_INTERVAL_SECONDS = 60L
-        const val DEFAULT_MAX_TIME_WITHOUT_FLUSHING_DATA_SECONDS = 15 * 60L
+        const val DEFAULT_MAX_TIME_WITHOUT_FLUSHING_DATA_SECONDS = 5 * 60L
         const val DEFAULT_GENERATION_ID_METADATA_KEY = "ab-generation-id"
     }
 

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/config/DataChannelBeanFactory.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/config/DataChannelBeanFactory.kt
@@ -19,6 +19,7 @@ import io.airbyte.cdk.load.message.QueueWriter
 import io.airbyte.cdk.load.message.StreamKey
 import io.airbyte.cdk.load.message.StrictPartitionedQueue
 import io.airbyte.cdk.load.pipeline.InputPartitioner
+import io.airbyte.cdk.load.state.CheckpointManager
 import io.airbyte.cdk.load.state.Reserved
 import io.airbyte.cdk.load.state.SyncManager
 import io.airbyte.cdk.load.task.internal.HeartbeatTask
@@ -161,11 +162,12 @@ class DataChannelBeanFactory {
     fun stdioHeartbeatTask(
         @Named("_pipelineInputQueue")
         pipelineInputQueue: PartitionedQueue<PipelineInputEvent>? = null,
-        config: DestinationConfiguration
+        config: DestinationConfiguration,
+        checkpointManager: CheckpointManager<*>,
     ): HeartbeatTask {
         check(pipelineInputQueue != null) {
             "Pipeline input queue is not initialized. This should never happen in STDIO mode."
         }
-        return HeartbeatTask(config, pipelineInputQueue)
+        return HeartbeatTask(config, pipelineInputQueue, checkpointManager)
     }
 }


### PR DESCRIPTION
Edge cases

1. Source sends a lot of state, memory queue gets blocked, heartbeat fires, data gets flushed, *data flush triggers checkpoint flush*, but then data and more too much state comes, we get blocked again: sync stalls for 15 minutes, takes forever to finish.

This addresses that by turning 15 minutes into 5 minutes.

2. Worse case: source sends ungodly amounts of state, so we flush data, flush state, then even more state checkpoints come in (for the data we just flushed), *but no data* and we get blocked before we even get to the next data, so there's no data to flush, and therefore no checkpoint flush gets trigger.

This addresses that by trying to flush any ready state every minute regardless.

3. Worst case: there's some bug in the state flushing logic that means if there's more than one state message for record range X, and we flush half of it on the first call, the second call won't work.

This doesn't try to address that. So if this doesn't fix the issue then #3 is the next likely culprit.
