### PR TITLE
[source-declarative-manifest] - update sdm to inject `config_path` into Source instantiation

### DIFF
--- a/airbyte-integrations/connectors/source-declarative-manifest/metadata.yaml
+++ b/airbyte-integrations/connectors/source-declarative-manifest/metadata.yaml
@@ -8,7 +8,7 @@ data:
   connectorType: source
   definitionId: 64a2f99c-542f-4af8-9a6f-355f1217b436
   # This version should not be updated manually - it is updated by the CDK release workflow.
-  dockerImageTag: 6.5.2
+  dockerImageTag: 6.6.0
   dockerRepository: airbyte/source-declarative-manifest
   # This page is hidden from the docs for now, since the connector is not in any Airbyte registries.
   documentationUrl: https://docs.airbyte.com/integrations/sources/low-code

--- a/airbyte-integrations/connectors/source-declarative-manifest/pyproject.toml
+++ b/airbyte-integrations/connectors/source-declarative-manifest/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "6.5.2"
+version = "6.6.0"
 name = "source-declarative-manifest"
 description = "Base source implementation for low-code sources."
 authors = ["Airbyte <contact@airbyte.io>"]


### PR DESCRIPTION
## What
- Follow-up to https://github.com/airbytehq/airbyte-python-cdk/pull/561
- Passes `config_path` to source instantiation, enabling config migrations

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [X] YES 💚
- [ ] NO ❌
