### PR TITLE
chore: correct Gradle caching behaviour for JVM connector builds.

### DIFF
--- a/.github/workflows/connector-ci-tests.yml
+++ b/.github/workflows/connector-ci-tests.yml
@@ -105,11 +105,10 @@ jobs:
           java-version: 21
           cache: gradle
 
+      # The default behaviour is read-only on PR branches and read/write on master.
+      # See https://github.com/gradle/actions/blob/main/docs/setup-gradle.md#using-the-cache-read-only.
       - uses: gradle/actions/setup-gradle@v4
         if: matrix.connector
-        with:
-          cache-read-only: false
-          cache-write-only: false
 
       # TODO: We can delete this step once Airbyte-CI is removed from Java integration tests.
       - name: Set up Python (For Airbyte-CI)


### PR DESCRIPTION
## What
The current configuration writes on all branches. This can lead to confusing behaviour since we don't kill previous test runs, so the scenario where an earlier build writes the cache that a later build uses is possible. We've also run into some hard-to-debug caching weirdness we believe is related, so let's simplify the configuration to only write on master and read on PR builds.

## How
Use the default behaviour.

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
