### PR TITLE
ci: add named environments for docker image builds, tests, and publish actions

### DIFF
--- a/.github/workflows/docker-connector-base-image-tests.yml
+++ b/.github/workflows/docker-connector-base-image-tests.yml
@@ -3,7 +3,7 @@
 
 # NOTE: This workflow does not publish the images to Docker Hub. It only builds them and tests them.
 
-name: Dockerimage Tests for Connector and Base Images
+name: Docker Tests for Connector and Base Images
 on:
   pull_request:
     paths:
@@ -51,6 +51,7 @@ jobs:
     name: Build Java Base Image
     runs-on: ubuntu-latest
     needs: detect-changes
+    environment: ghcr.io/airbytehq/java-connector-base
     if: needs.detect-changes.outputs.java-base == 'true'
     steps:
       - name: Checkout code
@@ -97,6 +98,7 @@ jobs:
     name: Build Python Base Image
     runs-on: ubuntu-latest
     needs: detect-changes
+    environment: ghcr.io/airbytehq/python-connector-base
     if: needs.detect-changes.outputs.python-base == 'true'
     steps:
       - name: Checkout code
@@ -146,6 +148,7 @@ jobs:
   test-java-connector-image-matrix:
     runs-on: ubuntu-latest
     needs: [detect-changes, build-java-base-image]
+    environment: ghcr.io/airbytehq
     if: >
       needs.detect-changes.outputs.java-connector
     strategy:

--- a/.github/workflows/docker-connector-base-image-tests.yml
+++ b/.github/workflows/docker-connector-base-image-tests.yml
@@ -3,7 +3,7 @@
 
 # NOTE: This workflow does not publish the images to Docker Hub. It only builds them and tests them.
 
-name: Docker Tests for Connector and Base Images
+name: Docker Image Tests
 on:
   pull_request:
     paths:

--- a/.github/workflows/docker-connector-base-image-tests.yml
+++ b/.github/workflows/docker-connector-base-image-tests.yml
@@ -51,7 +51,9 @@ jobs:
     name: Build Java Base Image
     runs-on: ubuntu-latest
     needs: detect-changes
-    environment: ghcr.io/airbytehq/java-connector-base
+    environment:
+      name: ghcr.io/airbytehq/java-connector-base
+      url: https://ghcr.io/airbytehq/java-connector-base
     if: needs.detect-changes.outputs.java-base == 'true'
     steps:
       - name: Checkout code
@@ -98,7 +100,9 @@ jobs:
     name: Build Python Base Image
     runs-on: ubuntu-latest
     needs: detect-changes
-    environment: ghcr.io/airbytehq/python-connector-base
+    environment:
+      name: ghcr.io/airbytehq/python-connector-base
+      url: https://ghcr.io/airbytehq/python-connector-base
     if: needs.detect-changes.outputs.python-base == 'true'
     steps:
       - name: Checkout code
@@ -148,7 +152,6 @@ jobs:
   test-java-connector-image-matrix:
     runs-on: ubuntu-latest
     needs: [detect-changes, build-java-base-image]
-    environment: ghcr.io/airbytehq
     if: >
       needs.detect-changes.outputs.java-connector
     strategy:
@@ -159,6 +162,9 @@ jobs:
           - destination-postgres
           - destination-snowflake
     name: Build ${{ matrix.connector }} Java Test Image
+    environment:
+      name: ghcr.io/airbytehq
+      url: https://ghcr.io/airbytehq/${{ matrix.connector }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -239,6 +245,9 @@ jobs:
           - source-shopify
           - destination-motherduck
     name: Build ${{ matrix.connector }} Python Test Image
+    environment:
+      name: ghcr.io/airbytehq
+      url: https://ghcr.io/airbytehq/${{ matrix.connector }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/docker-connector-image-publishing.yml
+++ b/.github/workflows/docker-connector-image-publishing.yml
@@ -1,4 +1,4 @@
-name: Docker Connector Image Publishing (On-Demand)
+name: Docker Image Publishing (On-Demand)
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/docker-connector-image-publishing.yml
+++ b/.github/workflows/docker-connector-image-publishing.yml
@@ -45,6 +45,9 @@ jobs:
     name: Build and Publish ${{ github.event.inputs.connector-type }} Base Image
     runs-on: ubuntu-latest
     if: ${{ github.event.inputs.image-type == 'base' }}
+    environment:
+      name: ${{ github.event.inputs.repository-root == 'docker.io/airbyte' && 'hub.docker.com/r/airbyte' || github.event.inputs.repository-root }}
+      url: https://${{ github.event.inputs.repository-root == 'docker.io/airbyte' && 'hub.docker.com/r/airbyte' || github.event.inputs.repository-root }}/${{ github.event.inputs.connector-type }}-connector-base
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/docker-images/Dockerfile.python-connector-base
+++ b/docker-images/Dockerfile.python-connector-base
@@ -1,5 +1,4 @@
 # Migrated from airbyte-ci/connectors/base_images/README.md
-# dummy-change
 # https://hub.docker.com/_/python/tags?name=3.11.11-slim-bookworm
 ARG BASE_IMAGE=docker.io/python:3.11.11-slim-bookworm@sha256:081075da77b2b55c23c088251026fb69a7b2bf92471e491ff5fd75c192fd38e5
 FROM ${BASE_IMAGE}

--- a/docker-images/Dockerfile.python-connector-base
+++ b/docker-images/Dockerfile.python-connector-base
@@ -27,6 +27,6 @@ RUN apt-get install -y socat=1.7.4.4-2
 RUN apt-get update && \
     apt-get install -y \
         tesseract-ocr=5.3.0-2 \
-        poppler-utils=22.12.0-2+deb12u1
+        poppler-utils=22.12.0-2+b1
 
 RUN mkdir -p 755 /usr/share/nltk_data

--- a/docker-images/Dockerfile.python-connector-base
+++ b/docker-images/Dockerfile.python-connector-base
@@ -1,5 +1,5 @@
 # Migrated from airbyte-ci/connectors/base_images/README.md
-
+# dummy-change
 # https://hub.docker.com/_/python/tags?name=3.11.11-slim-bookworm
 ARG BASE_IMAGE=docker.io/python:3.11.11-slim-bookworm@sha256:081075da77b2b55c23c088251026fb69a7b2bf92471e491ff5fd75c192fd38e5
 FROM ${BASE_IMAGE}
@@ -28,6 +28,6 @@ RUN apt-get install -y socat=1.7.4.4-2
 RUN apt-get update && \
     apt-get install -y \
         tesseract-ocr=5.3.0-2 \
-        poppler-utils=22.12.0-2+b1
+        poppler-utils=22.12.0-2+deb12u1
 
 RUN mkdir -p 755 /usr/share/nltk_data

--- a/docker-images/Dockerfile.python-connector-base
+++ b/docker-images/Dockerfile.python-connector-base
@@ -1,4 +1,5 @@
 # Migrated from airbyte-ci/connectors/base_images/README.md
+
 # https://hub.docker.com/_/python/tags?name=3.11.11-slim-bookworm
 ARG BASE_IMAGE=docker.io/python:3.11.11-slim-bookworm@sha256:081075da77b2b55c23c088251026fb69a7b2bf92471e491ff5fd75c192fd38e5
 FROM ${BASE_IMAGE}


### PR DESCRIPTION
This adds named environments to docker image build, test, and publish operations.

It also prints clickable URLs to the docker image in the "Summary" view of the workflow so you can quickly see what was built and published from the workflows.

https://github.com/airbytehq/airbyte/actions/runs/15173916391?pr=60845

> ![image](https://github.com/user-attachments/assets/01eba2ba-5fc6-4492-8a56-d22a18296af0)

> ![image](https://github.com/user-attachments/assets/698c998a-20c9-4f4b-818c-d68301758b00)

https://github.com/airbytehq/airbyte/actions/runs/15174109026

> ![image](https://github.com/user-attachments/assets/220c6ccf-16e6-4ebd-8f91-d32a6cc55798)

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._

> [!NOTE]
> **Auto-merge may have been disabled. Please check the PR status to confirm.**