### PR TITLE
fix(workflow): update Docker image tags to also create a tag with build number for more efficient bumping in Cloud

### DIFF
--- a/.github/workflows/docker-connector-base-image-tests.yml
+++ b/.github/workflows/docker-connector-base-image-tests.yml
@@ -210,7 +210,9 @@ jobs:
           context: airbyte-integrations/connectors/${{ matrix.connector }}
           file: docker-images/Dockerfile.java-connector
           platforms: linux/amd64,linux/arm64
-          tags: ghcr.io/airbytehq/${{ matrix.connector }}:draft-pr-${{ github.event.pull_request.number }}
+          tags: |
+            ghcr.io/airbytehq/${{ matrix.connector }}:draft-pr-${{ github.event.pull_request.number }}
+            ghcr.io/airbytehq/${{ matrix.connector }}:draft-pr-${{ github.event.pull_request.number }}-build${{ github.run_number }}
           build-args: |
             BASE_IMAGE=ghcr.io/airbytehq/java-connector-base:draft-pr-${{ github.event.pull_request.number }}
             CONNECTOR_NAME=${{ matrix.connector }}
@@ -274,7 +276,9 @@ jobs:
           context: airbyte-integrations/connectors/${{ matrix.connector }}
           file: docker-images/Dockerfile.python-connector
           platforms: linux/amd64,linux/arm64
-          tags: ghcr.io/airbytehq/${{ matrix.connector }}:draft-pr-${{ github.event.pull_request.number }}
+          tags: |
+            ghcr.io/airbytehq/${{ matrix.connector }}:draft-pr-${{ github.event.pull_request.number }}
+            ghcr.io/airbytehq/${{ matrix.connector }}:draft-pr-${{ github.event.pull_request.number }}-build${{ github.run_number }}
           build-args: |
             BASE_IMAGE=ghcr.io/airbytehq/python-connector-base:draft-pr-${{ github.event.pull_request.number }}
             CONNECTOR_NAME=${{ matrix.connector }}


### PR DESCRIPTION
## What

Pushes a second image tag for each connector test image. This is because Cloud can't otherwise pick up the new version of an already-published image. (Possible, but requires overriding Pod settings.)

So, now we'll generate images like this:

```
ghcr.io/airbytehq/source-s3:draft-pr-1234-build1034
```

As well as:

```
ghcr.io/airbytehq/source-s3:draft-pr-1234
```

More context: https://airbytehq-team.slack.com/archives/C03AS1GAQV6/p1747930609675539?thread_ts=1747928917.788129&cid=C03AS1GAQV6


## How
<!--
* Describe how code changes achieve the solution.
-->

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._