### PR TITLE
chore: enable appsflyer, open exchange rates and elastic search in cloud

### DIFF
--- a/airbyte-integrations/connectors/source-appsflyer/metadata.yaml
+++ b/airbyte-integrations/connectors/source-appsflyer/metadata.yaml
@@ -14,7 +14,7 @@ data:
       packageName: airbyte-source-appsflyer
   registryOverrides:
     cloud:
-      enabled: false
+      enabled: true
     oss:
       enabled: true
   releaseStage: alpha

--- a/airbyte-integrations/connectors/source-elasticsearch/metadata.yaml
+++ b/airbyte-integrations/connectors/source-elasticsearch/metadata.yaml
@@ -19,7 +19,7 @@ data:
   name: Elasticsearch
   registryOverrides:
     cloud:
-      enabled: false
+      enabled: true
     oss:
       enabled: true
   releaseStage: alpha

--- a/airbyte-integrations/connectors/source-open-exchange-rates/metadata.yaml
+++ b/airbyte-integrations/connectors/source-open-exchange-rates/metadata.yaml
@@ -1,4 +1,7 @@
 data:
+  ab_internal:
+    sl: 100
+    ql: 100
   allowedHosts:
     hosts:
       - openexchangerates.org

--- a/airbyte-integrations/connectors/source-open-exchange-rates/metadata.yaml
+++ b/airbyte-integrations/connectors/source-open-exchange-rates/metadata.yaml
@@ -16,7 +16,7 @@ data:
   name: Open Exchange Rates
   registryOverrides:
     cloud:
-      enabled: false
+      enabled: true
     oss:
       enabled: true
   releaseDate: 2023-10-02


### PR DESCRIPTION
## What
- enable three connectors in cloud:
  - appsflyer
  - OpenExchangeRates
  - ElasticSearch
  

## Can This PR Be Reverted and Rolled Back
- Yes, the changes can be reverted if access control is found to be ineffective.