### PR TITLE
chore(source-s3): bump base image to `4.0.1`

### DIFF
--- a/airbyte-integrations/connectors/source-s3/metadata.yaml
+++ b/airbyte-integrations/connectors/source-s3/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: file
   connectorType: source
   definitionId: 69589781-7828-43c5-9f63-8925b1c1ccc2
-  dockerImageTag: 4.14.1
+  dockerImageTag: 4.14.2
   dockerRepository: airbyte/source-s3
   documentationUrl: https://docs.airbyte.com/integrations/sources/s3
   githubIssueLabel: source-s3

--- a/airbyte-integrations/connectors/source-s3/metadata.yaml
+++ b/airbyte-integrations/connectors/source-s3/metadata.yaml
@@ -6,7 +6,7 @@ data:
     hosts:
       - "*.s3.amazonaws.com"
   connectorBuildOptions:
-    baseImage: docker.io/airbyte/python-connector-base:4.0.0@sha256:d9894b6895923b379f3006fa251147806919c62b7d9021b5cd125bb67d7bbe22
+    baseImage: ghcr.io/airbytehq/python-connector-base:draft-pr-60820@sha256:8deec9986b9502e1d93e4b88a20fab5c2e525e9658e16d222d7a7a329d1dafd4
   connectorSubtype: file
   connectorType: source
   definitionId: 69589781-7828-43c5-9f63-8925b1c1ccc2

--- a/airbyte-integrations/connectors/source-s3/metadata.yaml
+++ b/airbyte-integrations/connectors/source-s3/metadata.yaml
@@ -6,7 +6,7 @@ data:
     hosts:
       - "*.s3.amazonaws.com"
   connectorBuildOptions:
-    baseImage: ghcr.io/airbytehq/python-connector-base:draft-pr-60820@sha256:8deec9986b9502e1d93e4b88a20fab5c2e525e9658e16d222d7a7a329d1dafd4
+    baseImage: airbyte/python-connector-base:4.0.1@sha256:111cbcb26795adcd42b03c3f29c8b6b7adbbfcb5c5192a520d9b8d399a976b22
   connectorSubtype: file
   connectorType: source
   definitionId: 69589781-7828-43c5-9f63-8925b1c1ccc2

--- a/airbyte-integrations/connectors/source-s3/metadata.yaml
+++ b/airbyte-integrations/connectors/source-s3/metadata.yaml
@@ -6,7 +6,7 @@ data:
     hosts:
       - "*.s3.amazonaws.com"
   connectorBuildOptions:
-    baseImage: airbyte/python-connector-base:4.0.1@sha256:111cbcb26795adcd42b03c3f29c8b6b7adbbfcb5c5192a520d9b8d399a976b22
+    baseImage: docker.io/airbyte/python-connector-base:4.0.1@sha256:111cbcb26795adcd42b03c3f29c8b6b7adbbfcb5c5192a520d9b8d399a976b22
   connectorSubtype: file
   connectorType: source
   definitionId: 69589781-7828-43c5-9f63-8925b1c1ccc2

--- a/airbyte-integrations/connectors/source-s3/pyproject.toml
+++ b/airbyte-integrations/connectors/source-s3/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "4.14.1"
+version = "4.14.2"
 name = "source-s3"
 description = "Source implementation for S3."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/docs/integrations/sources/s3.md
+++ b/docs/integrations/sources/s3.md
@@ -356,6 +356,7 @@ This connector utilizes the open source [Unstructured](https://unstructured-io.g
 
 | Version     | Date       | Pull Request                                                                                                    | Subject                                                                                                              |
 |:------------|:-----------|:----------------------------------------------------------------------------------------------------------------|:---------------------------------------------------------------------------------------------------------------------|
+| 4.14.2 | 2025-05-22 | [60863](https://github.com/airbytehq/airbyte/pull/60863) | chore(source-s3): bump base image to  |
 | 4.14.1 | 2025-05-10 | [58988](https://github.com/airbytehq/airbyte/pull/58988) | Update dependencies |
 | 4.14.0 | 2025-05-06 | [59685](https://github.com/airbytehq/airbyte/pull/59685) | Promoting release candidate 4.14.0-rc.1 to a main version. |
 | 4.14.0-rc.1 | 2025-05-05 | [57498](https://github.com/airbytehq/airbyte/pull/57498) | Adapt file-transfer records to latest protocol, requires platform >= 1.7.0, destination-s3 >= 1.8.0 |

--- a/docs/integrations/sources/s3.md
+++ b/docs/integrations/sources/s3.md
@@ -356,7 +356,7 @@ This connector utilizes the open source [Unstructured](https://unstructured-io.g
 
 | Version     | Date       | Pull Request                                                                                                    | Subject                                                                                                              |
 |:------------|:-----------|:----------------------------------------------------------------------------------------------------------------|:---------------------------------------------------------------------------------------------------------------------|
-| 4.14.2 | 2025-05-22 | [60863](https://github.com/airbytehq/airbyte/pull/60863) | chore(source-s3): bump base image to  |
+| 4.14.2 | 2025-05-22 | [60863](https://github.com/airbytehq/airbyte/pull/60863) | chore(source-s3): bump base image to `4.0.1` |
 | 4.14.1 | 2025-05-10 | [58988](https://github.com/airbytehq/airbyte/pull/58988) | Update dependencies |
 | 4.14.0 | 2025-05-06 | [59685](https://github.com/airbytehq/airbyte/pull/59685) | Promoting release candidate 4.14.0-rc.1 to a main version. |
 | 4.14.0-rc.1 | 2025-05-05 | [57498](https://github.com/airbytehq/airbyte/pull/57498) | Adapt file-transfer records to latest protocol, requires platform >= 1.7.0, destination-s3 >= 1.8.0 |


### PR DESCRIPTION
## What

This PR will bump the `source-s3` connector to the new `4.0.1` Python base image.

Pre-publish of the base image, this PR bumps to the GHCR image tag. If that works correctly, we have higher confidence that the connector will run properly and be built properly, using the new base image.


Builds on:

- #60820 