### PR TITLE
bigquery / bulk CDK: direct-load: use internal namespace for temp tables

### DIFF
--- a/airbyte-cdk/bulk/toolkits/load-db/src/main/kotlin/io/airbyte/cdk/load/orchestration/db/DestinationNames.kt
+++ b/airbyte-cdk/bulk/toolkits/load-db/src/main/kotlin/io/airbyte/cdk/load/orchestration/db/DestinationNames.kt
@@ -6,7 +6,6 @@ package io.airbyte.cdk.load.orchestration.db
 
 import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.orchestration.db.TableNames.Companion.TMP_TABLE_SUFFIX
-import io.airbyte.cdk.load.orchestration.db.legacy_typing_deduping.DEFAULT_AIRBYTE_INTERNAL_NAMESPACE
 import io.airbyte.cdk.load.orchestration.db.legacy_typing_deduping.TypingDedupingUtil
 import org.apache.commons.codec.digest.DigestUtils
 
@@ -50,7 +49,7 @@ data class TableName(val namespace: String, val name: String) {
      * T+D destinations simply appended [TMP_TABLE_SUFFIX] to the table name, and should use
      * [asOldStyleTempTable] instead
      */
-    fun asTempTable(length: Int = 32) =
+    fun asTempTable(internalNamespace: String, length: Int = 32) =
         TableName(
             name =
                 // sha256 might start with a digit, so prefix with a letter
@@ -62,7 +61,7 @@ data class TableName(val namespace: String, val name: String) {
                             )
                         ))
                     .substring(length),
-            namespace = DEFAULT_AIRBYTE_INTERNAL_NAMESPACE,
+            namespace = internalNamespace,
         )
 
     fun asOldStyleTempTable() = copy(name = name + TMP_TABLE_SUFFIX)

--- a/airbyte-cdk/bulk/toolkits/load-db/src/main/kotlin/io/airbyte/cdk/load/orchestration/db/direct_load_table/DirectLoadTableStreamLoader.kt
+++ b/airbyte-cdk/bulk/toolkits/load-db/src/main/kotlin/io/airbyte/cdk/load/orchestration/db/direct_load_table/DirectLoadTableStreamLoader.kt
@@ -234,6 +234,7 @@ class DirectLoadTableAppendTruncateStreamLoader(
 class DirectLoadTableDedupTruncateStreamLoader(
     override val stream: DestinationStream,
     private val initialStatus: DirectLoadInitialStatus,
+    private val internalNamespace: String,
     private val realTableName: TableName,
     private val tempTableName: TableName,
     private val columnNameMapping: ColumnNameMapping,
@@ -342,7 +343,7 @@ class DirectLoadTableDedupTruncateStreamLoader(
 
     /** Performs upsert using an additional temporary table for safer operation */
     private fun performUpsertWithTemporaryTable() {
-        val tempTempTable = tempTableName.asTempTable()
+        val tempTempTable = tempTableName.asTempTable(internalNamespace = internalNamespace)
 
         // Create temporary table for intermediate operations
         sqlTableOperations.createTable(stream, tempTempTable, columnNameMapping, replace = true)

--- a/airbyte-cdk/bulk/toolkits/load-db/src/main/kotlin/io/airbyte/cdk/load/orchestration/db/direct_load_table/DirectLoadTableWriter.kt
+++ b/airbyte-cdk/bulk/toolkits/load-db/src/main/kotlin/io/airbyte/cdk/load/orchestration/db/direct_load_table/DirectLoadTableWriter.kt
@@ -23,6 +23,7 @@ import io.airbyte.cdk.load.write.StreamStateStore
  * with `_airbyte_tmp`), you MUST provide this object.
  */
 class DirectLoadTableWriter(
+    private val internalNamespace: String,
     private val names: TableCatalog,
     private val stateGatherer: DatabaseInitialStatusGatherer<DirectLoadInitialStatus>,
     private val destinationHandler: DatabaseHandler,
@@ -33,10 +34,9 @@ class DirectLoadTableWriter(
 ) : DestinationWriter {
     private lateinit var initialStatuses: Map<DestinationStream, DirectLoadInitialStatus>
     override suspend fun setup() {
-        // TODO also create airbyte_internal namespace
         val namespaces =
             names.values.map { (tableNames, _) -> tableNames.finalTableName!!.namespace }.toSet()
-        destinationHandler.createNamespaces(namespaces)
+        destinationHandler.createNamespaces(namespaces + listOf(internalNamespace))
 
         directLoadTableTempTableNameMigration?.execute(names)
 
@@ -47,7 +47,7 @@ class DirectLoadTableWriter(
         val initialStatus = initialStatuses[stream]!!
         val tableNameInfo = names[stream]!!
         val realTableName = tableNameInfo.tableNames.finalTableName!!
-        val tempTableName = realTableName.asTempTable()
+        val tempTableName = realTableName.asTempTable(internalNamespace = internalNamespace)
         val columnNameMapping = tableNameInfo.columnNameMapping
         return when (stream.minimumGenerationId) {
             0L ->
@@ -94,6 +94,7 @@ class DirectLoadTableWriter(
                         DirectLoadTableDedupTruncateStreamLoader(
                             stream,
                             initialStatus,
+                            internalNamespace = internalNamespace,
                             realTableName = realTableName,
                             tempTableName = tempTableName,
                             columnNameMapping,

--- a/airbyte-cdk/bulk/toolkits/load-db/src/main/kotlin/io/airbyte/cdk/load/orchestration/db/direct_load_table/migrations/DirectLoadTableTempTableNameMigration.kt
+++ b/airbyte-cdk/bulk/toolkits/load-db/src/main/kotlin/io/airbyte/cdk/load/orchestration/db/direct_load_table/migrations/DirectLoadTableTempTableNameMigration.kt
@@ -23,6 +23,7 @@ interface DirectLoadTableTempTableNameMigration {
 }
 
 class DefaultDirectLoadTableTempTableNameMigration(
+    private val internalNamespace: String,
     private val tableExistenceChecker: DirectLoadTableExistenceChecker,
     private val sqlTableOperations: DirectLoadTableSqlOperations,
 ) : DirectLoadTableTempTableNameMigration {
@@ -32,7 +33,8 @@ class DefaultDirectLoadTableTempTableNameMigration(
                 .map { (_, tableNameInfo) ->
                     val realTableName = tableNameInfo.tableNames.finalTableName!!
                     val oldTempTableName = realTableName.asOldStyleTempTable()
-                    val newTempTableName = realTableName.asTempTable()
+                    val newTempTableName =
+                        realTableName.asTempTable(internalNamespace = internalNamespace)
                     oldTempTableName to newTempTableName
                 }
                 .toMap()
@@ -42,7 +44,8 @@ class DefaultDirectLoadTableTempTableNameMigration(
             for (oldTempTableName in existingOldTempTables) {
                 launch {
                     val realTableName = oldTempNameToNewTempName[oldTempTableName]!!
-                    val tempTableName = realTableName.asTempTable()
+                    val tempTableName =
+                        realTableName.asTempTable(internalNamespace = internalNamespace)
                     sqlTableOperations.overwriteTable(oldTempTableName, tempTableName)
                 }
             }

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryBeansFactory.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryBeansFactory.kt
@@ -113,8 +113,13 @@ class BigqueryBeansFactory {
             @Suppress("UNCHECKED_CAST")
             streamStateStore as StreamStateStore<DirectLoadTableExecutionConfig>
             return DirectLoadTableWriter(
+                internalNamespace = config.internalTableDataset,
                 names = names,
-                stateGatherer = BigqueryDirectLoadDatabaseInitialStatusGatherer(bigquery),
+                stateGatherer =
+                    BigqueryDirectLoadDatabaseInitialStatusGatherer(
+                        bigquery,
+                        internalTableDataset = config.internalTableDataset,
+                    ),
                 destinationHandler = destinationHandler,
                 nativeTableOperations =
                     BigqueryDirectLoadNativeTableOperations(
@@ -122,11 +127,13 @@ class BigqueryBeansFactory {
                         sqlTableOperations,
                         destinationHandler,
                         projectId = config.projectId,
+                        internalTableDataset = config.internalTableDataset,
                     ),
                 sqlTableOperations = sqlTableOperations,
                 streamStateStore = streamStateStore,
                 directLoadTableTempTableNameMigration =
                     DefaultDirectLoadTableTempTableNameMigration(
+                        internalNamespace = config.internalTableDataset,
                         BigqueryDirectLoadTableExistenceChecker(bigquery),
                         sqlTableOperations,
                     ),

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/spec/BigqueryConfiguration.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/spec/BigqueryConfiguration.kt
@@ -18,7 +18,7 @@ data class BigqueryConfiguration(
     val credentialsJson: String?,
     val cdcDeletionMode: CdcDeletionMode,
     val transformationPriority: TransformationPriority,
-    val rawTableDataset: String,
+    val internalTableDataset: String,
     val legacyRawTablesOnly: Boolean,
 ) : DestinationConfiguration() {
     override val numOpenStreamWorkers = 3
@@ -58,11 +58,11 @@ class BigqueryConfigurationFactory :
             // default to hard delete for backwards compatibility.
             cdcDeletionMode = pojo.cdcDeletionMode ?: CdcDeletionMode.HARD_DELETE,
             pojo.transformationPriority ?: TransformationPriority.INTERACTIVE,
-            rawTableDataset =
-                if (pojo.rawTableDataset.isNullOrBlank()) {
+            internalTableDataset =
+                if (pojo.internalTableDataset.isNullOrBlank()) {
                     DbConstants.DEFAULT_RAW_TABLE_NAMESPACE
                 } else {
-                    pojo.rawTableDataset!!
+                    pojo.internalTableDataset!!
                 },
             legacyRawTablesOnly = pojo.legacyRawTablesOnly ?: false,
         )

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/spec/BigquerySpecification.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/spec/BigquerySpecification.kt
@@ -105,13 +105,13 @@ class BigquerySpecification : ConfigurationSpecification() {
     @get:JsonSchemaInject(json = """{"group": "advanced", "order": 7, "default": false}""")
     val legacyRawTablesOnly: Boolean? = null
 
-    @get:JsonSchemaTitle("Legacy Raw Table Dataset Name")
+    @get:JsonSchemaTitle("Airbyte Internal Table Dataset Name")
     @get:JsonPropertyDescription(
-        """The dataset to write raw tables into (default: airbyte_internal). Only relevant if you enable legacy raw tables.""",
+        """Airbyte will use this dataset for various internal tables (default: airbyte_internal). In legacy raw tables mode, the raw tables will be stored in this dataset.""",
     )
     @get:JsonProperty("raw_data_dataset")
     @get:JsonSchemaInject(json = """{"group": "advanced", "order": 8}""")
-    val rawTableDataset: String? = null
+    val internalTableDataset: String? = null
 }
 
 @JsonTypeInfo(

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/spec/BigquerySpecification.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/spec/BigquerySpecification.kt
@@ -109,6 +109,7 @@ class BigquerySpecification : ConfigurationSpecification() {
     @get:JsonPropertyDescription(
         """Airbyte will use this dataset for various internal tables (default: airbyte_internal). In legacy raw tables mode, the raw tables will be stored in this dataset.""",
     )
+    // for backwards compatibility, the JSON property is still called raw_data_dataset.
     @get:JsonProperty("raw_data_dataset")
     @get:JsonSchemaInject(json = """{"group": "advanced", "order": 8}""")
     val internalTableDataset: String? = null

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/typing_deduping/BigqueryNameGenerators.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/typing_deduping/BigqueryNameGenerators.kt
@@ -22,7 +22,7 @@ private val nameTransformer = BigQuerySQLNameTransformer()
 class BigqueryRawTableNameGenerator(val config: BigqueryConfiguration) : RawTableNameGenerator {
     override fun getTableName(streamDescriptor: DestinationStream.Descriptor) =
         TableName(
-            nameTransformer.getNamespace(config.rawTableDataset),
+            nameTransformer.getNamespace(config.internalTableDataset),
             nameTransformer.convertStreamName(
                 TypingDedupingUtil.concatenateRawTableName(
                     streamDescriptor.namespace ?: config.datasetId,

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/typing_deduping/direct_load_tables/BigqueryDirectLoadNativeTableOperations.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/typing_deduping/direct_load_tables/BigqueryDirectLoadNativeTableOperations.kt
@@ -37,6 +37,7 @@ class BigqueryDirectLoadNativeTableOperations(
     private val sqlOperations: BigqueryDirectLoadSqlTableOperations,
     private val databaseHandler: BigQueryDatabaseHandler,
     private val projectId: String,
+    private val internalTableDataset: String,
 ) : DirectLoadTableNativeOperations {
     override fun ensureSchemaMatches(
         stream: DestinationStream,
@@ -231,7 +232,9 @@ class BigqueryDirectLoadNativeTableOperations(
         // a truncate-refresh temp table.
         // so add an explicit suffix that this is for schema change.
         val tempTableName =
-            tableName.asTempTable().let { it.copy(name = it.name + "_airbyte_tmp_schema_change") }
+            tableName.asTempTable(internalNamespace = internalTableDataset).let {
+                it.copy(name = it.name + "_airbyte_tmp_schema_change")
+            }
 
         val originalTableId = "`$projectId`.`${tableName.namespace}`.`${tableName.name}`"
         val tempTableId = "`$projectId`.`${tempTableName.namespace}`.`${tempTableName.name}`"

--- a/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryDataDumper.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryDataDumper.kt
@@ -51,7 +51,8 @@ object BigqueryRawTableDataDumper : DestinationDataDumper {
         val (_, rawTableName) =
             BigqueryRawTableNameGenerator(config).getTableName(stream.descriptor)
 
-        return bigquery.getTable(TableId.of(config.rawTableDataset, rawTableName))?.let { table ->
+        return bigquery.getTable(TableId.of(config.internalTableDataset, rawTableName))?.let { table
+            ->
             val bigquerySchema = table.getDefinition<StandardTableDefinition>().schema!!
             table.list(bigquerySchema).iterateAll().map { row ->
                 OutputRecord(
@@ -72,7 +73,7 @@ object BigqueryRawTableDataDumper : DestinationDataDumper {
         }
             ?: run {
                 logger.warn {
-                    "Raw table does not exist: ${config.rawTableDataset}.$rawTableName. Returning empty list."
+                    "Raw table does not exist: ${config.internalTableDataset}.$rawTableName. Returning empty list."
                 }
                 emptyList()
             }

--- a/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryDestinationCleaner.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryDestinationCleaner.kt
@@ -44,9 +44,9 @@ class BigqueryDestinationCleanerInstance(private val configString: String) : Des
         val bigquery = BigqueryBeansFactory().getBigqueryClient(config)
 
         runBlocking(Dispatchers.IO) {
-            logger.info { "Cleaning up old raw tables in ${config.rawTableDataset}" }
+            logger.info { "Cleaning up old raw tables in ${config.internalTableDataset}" }
 
-            var rawTables = bigquery.listTables(config.rawTableDataset)
+            var rawTables = bigquery.listTables(config.internalTableDataset)
             // Page.iterateAll is _really_ slow, even if the interior function is `launch`-ed.
             // Manually page through, and launch all the deletion work, so that we're always
             // fetching new pages.

--- a/airbyte-integrations/connectors/destination-bigquery/src/test-integration/resources/expected-spec-cloud.json
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test-integration/resources/expected-spec-cloud.json
@@ -158,8 +158,8 @@
       },
       "raw_data_dataset" : {
         "type" : "string",
-        "description" : "The dataset to write raw tables into (default: airbyte_internal). Only relevant if you enable legacy raw tables.",
-        "title" : "Legacy Raw Table Dataset Name",
+        "description" : "Airbyte will use this dataset for various internal tables (default: airbyte_internal). In legacy raw tables mode, the raw tables will be stored in this dataset.",
+        "title" : "Airbyte Internal Table Dataset Name",
         "group" : "advanced",
         "order" : 8
       }

--- a/airbyte-integrations/connectors/destination-bigquery/src/test-integration/resources/expected-spec-oss.json
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test-integration/resources/expected-spec-oss.json
@@ -158,8 +158,8 @@
       },
       "raw_data_dataset" : {
         "type" : "string",
-        "description" : "The dataset to write raw tables into (default: airbyte_internal). Only relevant if you enable legacy raw tables.",
-        "title" : "Legacy Raw Table Dataset Name",
+        "description" : "Airbyte will use this dataset for various internal tables (default: airbyte_internal). In legacy raw tables mode, the raw tables will be stored in this dataset.",
+        "title" : "Airbyte Internal Table Dataset Name",
         "group" : "advanced",
         "order" : 8
       }

--- a/airbyte-integrations/connectors/destination-bigquery/src/test/kotlin/io/airbyte/integrations/destination/bigquery/typing_deduping/direct_load_tables/BigqueryDirectLoadNativeTableOperationsTest.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test/kotlin/io/airbyte/integrations/destination/bigquery/typing_deduping/direct_load_tables/BigqueryDirectLoadNativeTableOperationsTest.kt
@@ -74,7 +74,8 @@ class BigqueryDirectLoadNativeTableOperationsTest {
                     Mockito.mock(),
                     Mockito.mock(),
                     Mockito.mock(),
-                    projectId = "unused"
+                    projectId = "unused",
+                    internalTableDataset = "unused",
                 )
                 .buildAlterTableReport(stream, columnNameMapping, existingTable)
         Assertions.assertAll(
@@ -128,7 +129,8 @@ class BigqueryDirectLoadNativeTableOperationsTest {
                     Mockito.mock(),
                     Mockito.mock(),
                     Mockito.mock(),
-                    projectId = "unused"
+                    projectId = "unused",
+                    internalTableDataset = "unused",
                 )
                 .buildAlterTableReport(stream, columnNameMapping, existingTable)
         // NB: column names in AlterTableReport are all _after_ destination name transform


### PR DESCRIPTION
two related changes:
1. CDK accepts the internal table namespace in `asTempTable`, so that we actually respect this user config
2. bigquery renames the spec/config option rawTableDataset -> internalTableDataset, and update the spec appropriately