### PR TITLE
Cache the cdc initial state once constructed to prevent race conditio…

### DIFF
--- a/airbyte-integrations/connectors/source-postgres/build.gradle
+++ b/airbyte-integrations/connectors/source-postgres/build.gradle
@@ -14,7 +14,7 @@ java {
 }
 
 airbyteJavaConnector {
-    cdkVersionRequired = '0.48.9'
+    cdkVersionRequired = '0.48.13'
     features = ['db-sources', 'datastore-postgres']
     useLocalCdk = false
 }

--- a/airbyte-integrations/connectors/source-postgres/metadata.yaml
+++ b/airbyte-integrations/connectors/source-postgres/metadata.yaml
@@ -9,7 +9,7 @@ data:
   connectorSubtype: database
   connectorType: source
   definitionId: decd338e-5647-4c0b-adf4-da0e75f5a750
-  dockerImageTag: 3.6.33
+  dockerImageTag: 3.6.34
   dockerRepository: airbyte/source-postgres
   documentationUrl: https://docs.airbyte.com/integrations/sources/postgres
   githubIssueLabel: source-postgres

--- a/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/cdc/PostgresDebeziumStateUtil.java
+++ b/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/cdc/PostgresDebeziumStateUtil.java
@@ -214,16 +214,21 @@ public class PostgresDebeziumStateUtil implements DebeziumStateUtil {
 
   }
 
+  private static ThreadLocal<JsonNode> initialState = new ThreadLocal<>();
   /**
    * Method to construct initial Debezium state which can be passed onto Debezium engine to make it
    * process WAL from a specific LSN and skip snapshot phase
    */
   public JsonNode constructInitialDebeziumState(final JdbcDatabase database, final String dbName) {
-    try {
-      return format(currentXLogLocation(database), currentTransactionId(database), dbName, Instant.now());
-    } catch (SQLException e) {
-      throw new RuntimeException(e);
+    if (initialState.get() == null) {
+      try {
+        final JsonNode asJson = format(currentXLogLocation(database), currentTransactionId(database), dbName, Instant.now());
+        initialState.set(asJson);
+      } catch (SQLException e) {
+        throw new RuntimeException(e);
+      }
     }
+    return initialState.get();
   }
 
   @VisibleForTesting
@@ -255,4 +260,8 @@ public class PostgresDebeziumStateUtil implements DebeziumStateUtil {
     return transactionId.get(0);
   }
 
+  public static void disposeInitialState() {
+    LOGGER.debug("Dispose initial state cached for {}", Thread.currentThread());
+    initialState.remove();
+  }
 }

--- a/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/cdc/PostgresDebeziumStateUtil.java
+++ b/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/cdc/PostgresDebeziumStateUtil.java
@@ -215,6 +215,7 @@ public class PostgresDebeziumStateUtil implements DebeziumStateUtil {
   }
 
   private static ThreadLocal<JsonNode> initialState = new ThreadLocal<>();
+
   /**
    * Method to construct initial Debezium state which can be passed onto Debezium engine to make it
    * process WAL from a specific LSN and skip snapshot phase
@@ -264,4 +265,5 @@ public class PostgresDebeziumStateUtil implements DebeziumStateUtil {
     LOGGER.debug("Dispose initial state cached for {}", Thread.currentThread());
     initialState.remove();
   }
+
 }

--- a/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/CdcPostgresSourceTest.java
+++ b/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/CdcPostgresSourceTest.java
@@ -43,6 +43,7 @@ import io.airbyte.commons.util.AutoCloseableIterators;
 import io.airbyte.integrations.source.postgres.PostgresTestDatabase.BaseImage;
 import io.airbyte.integrations.source.postgres.PostgresTestDatabase.ContainerModifier;
 import io.airbyte.integrations.source.postgres.cdc.PostgresCdcTargetPosition;
+import io.airbyte.integrations.source.postgres.cdc.PostgresDebeziumStateUtil;
 import io.airbyte.integrations.source.postgres.cdc.PostgresReplicationConnection;
 import io.airbyte.protocol.models.Field;
 import io.airbyte.protocol.models.JsonSchemaType;
@@ -701,6 +702,7 @@ public class CdcPostgresSourceTest extends CdcSourceTest<PostgresSource, Postgre
     // second batch of records again 20 being created
     bulkInsertRecords(recordsToCreate);
 
+    PostgresDebeziumStateUtil.disposeInitialState();
     // Extract the last state message
     final JsonNode state = Jsons.jsonNode(Collections.singletonList(stateAfterFirstBatch.get(stateAfterFirstBatch.size() - 1)));
     final AutoCloseableIterator<AirbyteMessage> secondBatchIterator = source()
@@ -718,6 +720,7 @@ public class CdcPostgresSourceTest extends CdcSourceTest<PostgresSource, Postgre
       writeModelRecord(record);
     }
 
+    PostgresDebeziumStateUtil.disposeInitialState();
     // Triggering sync with the first sync's state only which would mimic a scenario that the second
     // sync failed on destination end, and we didn't save state
     final AutoCloseableIterator<AirbyteMessage> thirdBatchIterator = source()

--- a/airbyte-integrations/connectors/source-postgres/src/testFixtures/java/io/airbyte/integrations/source/postgres/PostgresTestDatabase.java
+++ b/airbyte-integrations/connectors/source-postgres/src/testFixtures/java/io/airbyte/integrations/source/postgres/PostgresTestDatabase.java
@@ -16,6 +16,8 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.List;
 import java.util.stream.Stream;
+
+import io.airbyte.integrations.source.postgres.cdc.PostgresDebeziumStateUtil;
 import org.jooq.SQLDialect;
 import org.testcontainers.containers.PostgreSQLContainer;
 
@@ -200,4 +202,9 @@ public class PostgresTestDatabase extends
 
   }
 
+  @Override
+  public void close() {
+    PostgresDebeziumStateUtil.disposeInitialState();
+    super.close();
+  }
 }

--- a/airbyte-integrations/connectors/source-postgres/src/testFixtures/java/io/airbyte/integrations/source/postgres/PostgresTestDatabase.java
+++ b/airbyte-integrations/connectors/source-postgres/src/testFixtures/java/io/airbyte/integrations/source/postgres/PostgresTestDatabase.java
@@ -12,12 +12,11 @@ import io.airbyte.cdk.db.factory.DatabaseDriver;
 import io.airbyte.cdk.db.jdbc.JdbcUtils;
 import io.airbyte.cdk.testutils.TestDatabase;
 import io.airbyte.commons.json.Jsons;
+import io.airbyte.integrations.source.postgres.cdc.PostgresDebeziumStateUtil;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.List;
 import java.util.stream.Stream;
-
-import io.airbyte.integrations.source.postgres.cdc.PostgresDebeziumStateUtil;
 import org.jooq.SQLDialect;
 import org.testcontainers.containers.PostgreSQLContainer;
 
@@ -207,4 +206,5 @@ public class PostgresTestDatabase extends
     PostgresDebeziumStateUtil.disposeInitialState();
     super.close();
   }
+
 }

--- a/docs/integrations/sources/postgres.md
+++ b/docs/integrations/sources/postgres.md
@@ -344,6 +344,7 @@ According to Postgres [documentation](https://www.postgresql.org/docs/14/datatyp
 
 | Version | Date       | Pull Request                                               | Subject                                                                                                                                                                    |
 |---------|------------|------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 3.6.34  | 2025-05-11 | [60876](https://github.com/airbytehq/airbyte/pull/60876)   | Cache CDC initial state once constructed.
 | 3.6.33  | 2025-05-11 | [60214](https://github.com/airbytehq/airbyte/pull/60214)   | Migrate to new Gradle flow.
 | 3.6.32  | 2025-05-8  | [59722](https://github.com/airbytehq/airbyte/pull/59722)   | Consolidate gradle set up.                                                                                                                                                 |
 | 3.6.31  | 2025-04-18 | [58132](https://github.com/airbytehq/airbyte/pull/58132)   | Fix vulnerabilities in dependencies.                                                                                                                                       |


### PR DESCRIPTION
## What
During the connector initialization we construct the current CDC state for various uses.
Our code was unnecessarily generating this state multiple time in a very short sequence - sometimes in less than a second.
This was seen on GCP AlloyDB and AWS Aurora postgres:
CDC log keeps moving constantly so constructing a CDC state one after the other generates slightly incrementing values.
The problem we see is that values that are close but not identical were used for various things
One was saved in state, another was used to acknowledge to the server our location.
The issue here was that we ended up releasing the log at a later point than we needed for the next read, which resulted in an invalid offset.

## How
The solution is to only construct an initial CDC state once per session and reuse the cached value so activity on the server CDC will not cause this infraction.
The same pattern is already implemented on mssql successfully.

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
