### PR TITLE
chore: return gitlab to certified

### DIFF
--- a/airbyte-integrations/connectors/source-gitlab/metadata.yaml
+++ b/airbyte-integrations/connectors/source-gitlab/metadata.yaml
@@ -1,7 +1,7 @@
 data:
   ab_internal:
     ql: 400
-    sl: 100
+    sl: 200
   allowedHosts:
     hosts:
       - ${api_url}
@@ -62,7 +62,7 @@ data:
       - issues
       - projects
       - commits
-  supportLevel: community
+  supportLevel: certified
   tags:
     - language:python
     - cdk:low-code


### PR DESCRIPTION
## What
Mistakenly moved gitlab to community. This reverts that change