### PR TITLE
[Load-CDK] Speed: prepare state handling for new protocol

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/DestinationMessageQueues.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/DestinationMessageQueues.kt
@@ -5,7 +5,7 @@
 package io.airbyte.cdk.load.message
 
 import io.airbyte.cdk.load.command.DestinationStream
-import io.airbyte.cdk.load.state.CheckpointId
+import io.airbyte.cdk.load.state.CheckpointKey
 import io.airbyte.cdk.load.state.Reserved
 import io.micronaut.context.annotation.Secondary
 import jakarta.inject.Singleton
@@ -15,13 +15,13 @@ sealed interface CheckpointMessageWrapped
 
 data class StreamCheckpointWrapped(
     val stream: DestinationStream.Descriptor,
-    val checkpointId: CheckpointId,
+    val checkpointKey: CheckpointKey,
     val checkpoint: CheckpointMessage
 ) : CheckpointMessageWrapped
 
 data class GlobalCheckpointWrapped(
-    val streamIndexes: List<Pair<DestinationStream.Descriptor, CheckpointId>>,
-    val checkpoint: CheckpointMessage
+    val checkpointKey: CheckpointKey,
+    val checkpoint: CheckpointMessage,
 ) : CheckpointMessageWrapped
 
 /**

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/state/CheckpointManager.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/state/CheckpointManager.kt
@@ -13,13 +13,45 @@ import io.airbyte.cdk.load.util.use
 import io.airbyte.cdk.output.OutputConsumer
 import io.github.oshai.kotlinlogging.KotlinLogging
 import jakarta.inject.Singleton
+import java.util.*
 import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.atomic.AtomicReference
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+
+/**
+ * Represents the checkpoint's order (stream-level for stream state, global for global state).
+ * Specifically, no state shall be released for CheckpointIndex N until all state for
+ * CheckpointIndexes 1..N-1 have been released.
+ *
+ * Begins at 1.
+ */
+@JvmInline value class CheckpointIndex(val value: Int)
+
+/**
+ * Uniquely identifies the checkpoint. This is used by the StreamManager to count persisted records
+ * against the checkpoint. Specifically, it should be passed to the StreamManager to determine data
+ * sufficiency.
+ *
+ * Unique, unordered.
+ */
+@JvmInline value class CheckpointId(val value: String)
+
+/**
+ * Used internally by the checkpoint manager to maintain ordered maps of checkpoints. Ordered by
+ * index only.
+ */
+data class CheckpointKey(
+    val checkpointIndex: CheckpointIndex,
+    val checkpointId: CheckpointId,
+) : Comparable<CheckpointKey> {
+    // order only by index
+    override fun compareTo(other: CheckpointKey): Int {
+        return this.checkpointIndex.value - other.checkpointIndex.value
+    }
+}
 
 /**
  * Message-type agnostic streams checkpoint manager.
@@ -41,88 +73,59 @@ class CheckpointManager<T>(
     val timeProvider: TimeProvider,
 ) {
     private val log = KotlinLogging.logger {}
-    private val flushLock = Mutex()
-    protected val lastFlushTimeMs = AtomicLong(0L)
+    private val storedCheckpointsLock = Mutex()
+    private val lastFlushTimeMs = AtomicLong(0L)
 
-    data class GlobalCheckpoint<T>(
-        val streamCheckpoints: List<Pair<DestinationStream.Descriptor, CheckpointId>>,
-        val checkpointMessage: T
-    )
+    data class GlobalCheckpoint<T>(val checkpointMessage: T)
 
     private val checkpointsAreGlobal: AtomicReference<Boolean?> = AtomicReference(null)
     private val streamCheckpoints:
-        ConcurrentHashMap<
-            DestinationStream.Descriptor, ConcurrentLinkedQueue<Pair<CheckpointId, T>>> =
+        ConcurrentHashMap<DestinationStream.Descriptor, TreeMap<CheckpointKey, T>> =
         ConcurrentHashMap()
-    private val globalCheckpoints: ConcurrentLinkedQueue<GlobalCheckpoint<T>> =
-        ConcurrentLinkedQueue()
-    private val lastCheckpointIdEmitted =
-        ConcurrentHashMap<DestinationStream.Descriptor, CheckpointId>()
+    private val globalCheckpoints: TreeMap<CheckpointKey, GlobalCheckpoint<T>> = TreeMap()
+    private val lastCheckpointKeyEmitted =
+        ConcurrentHashMap<DestinationStream.Descriptor, CheckpointKey>()
 
     init {
         lastFlushTimeMs.set(timeProvider.currentTimeMillis())
     }
 
     suspend fun addStreamCheckpoint(
-        key: DestinationStream.Descriptor,
-        checkpointId: CheckpointId,
+        streamDescriptor: DestinationStream.Descriptor,
+        checkpointKey: CheckpointKey,
         checkpointMessage: T
     ) {
-        flushLock.withLock {
+        storedCheckpointsLock.withLock {
             if (checkpointsAreGlobal.updateAndGet { it == true } != false) {
                 throw IllegalStateException(
                     "Global checkpoints cannot be mixed with non-global checkpoints"
                 )
             }
 
-            val indexedMessages: ConcurrentLinkedQueue<Pair<CheckpointId, T>> =
-                streamCheckpoints.getOrPut(key) { ConcurrentLinkedQueue() }
-            if (indexedMessages.isNotEmpty()) {
-                // Make sure the messages are coming in order
-                val (latestIndex, _) = indexedMessages.last()!!
-                if (latestIndex.id > checkpointId.id) {
-                    throw IllegalStateException(
-                        "Checkpoint message received out of order ($latestIndex before $checkpointId)"
-                    )
-                }
-            }
-            indexedMessages.add(checkpointId to checkpointMessage)
+            val indexedMessages: TreeMap<CheckpointKey, T> =
+                streamCheckpoints.getOrPut(streamDescriptor) { TreeMap() }
+            indexedMessages[checkpointKey] = checkpointMessage
 
-            log.info { "Added checkpoint for stream: $key at index: $checkpointId" }
+            log.info { "Added checkpoint for stream: $streamDescriptor at index: $checkpointKey" }
         }
     }
 
     // TODO: Is it an error if we don't get all the streams every time?
-    suspend fun addGlobalCheckpoint(
-        keyIndexes: List<Pair<DestinationStream.Descriptor, CheckpointId>>,
-        checkpointMessage: T
-    ) {
-        flushLock.withLock {
+    suspend fun addGlobalCheckpoint(checkpointKey: CheckpointKey, checkpointMessage: T) {
+        storedCheckpointsLock.withLock {
             if (checkpointsAreGlobal.updateAndGet { it != false } != true) {
                 throw IllegalStateException(
                     "Global checkpoint cannot be mixed with non-global checkpoints"
                 )
             }
 
-            val head = globalCheckpoints.peek()
-            if (head != null) {
-                val keyCheckpointsByStream = keyIndexes.associate { it.first to it.second }
-                head.streamCheckpoints.forEach {
-                    if (keyCheckpointsByStream[it.first]!!.id < it.second.id) {
-                        throw IllegalStateException(
-                            "Global checkpoint message received out of order"
-                        )
-                    }
-                }
-            }
-
-            globalCheckpoints.add(GlobalCheckpoint(keyIndexes, checkpointMessage))
-            log.info { "Added global checkpoint with stream indexes: $keyIndexes" }
+            globalCheckpoints[checkpointKey] = GlobalCheckpoint(checkpointMessage)
+            log.info { "Added global checkpoint with key $checkpointKey" }
         }
     }
 
     suspend fun flushReadyCheckpointMessages() {
-        flushLock.withLock {
+        storedCheckpointsLock.withLock {
             /*
                Iterate over the checkpoints in order, evicting each that passes
                the persistence check. If a checkpoint is not persisted, then
@@ -143,23 +146,26 @@ class CheckpointManager<T>(
             return
         }
         while (!globalCheckpoints.isEmpty()) {
-            val head = globalCheckpoints.peek()
+            val head = globalCheckpoints.firstEntry() ?: break
             val allStreamsPersisted =
-                head.streamCheckpoints.all { (stream, checkpointId) ->
-                    syncManager
-                        .getStreamManager(stream)
-                        .areRecordsPersistedUntilCheckpoint(checkpointId)
+                catalog.streams.all { stream ->
+                    wasPreviousStateEmitted(stream.descriptor, head.key.checkpointIndex) &&
+                        syncManager
+                            .getStreamManager(stream.descriptor)
+                            .areRecordsPersistedForCheckpoint(head.key.checkpointId)
                 }
             if (allStreamsPersisted) {
-                log.info {
-                    "Flushing global checkpoint with stream indexes: ${head.streamCheckpoints}"
-                }
-                validateAndSendMessage(head.checkpointMessage, head.streamCheckpoints)
-                globalCheckpoints.poll() // don't remove until after we've successfully sent
+                log.info { "Flushing global checkpoint with key ${head.key}" }
+                sendStateMessage(
+                    head.value.checkpointMessage,
+                    head.key,
+                    catalog.streams.map { it.descriptor }
+                )
+                globalCheckpoints.remove(
+                    head.key
+                ) // don't remove until after we've successfully sent
             } else {
-                log.info {
-                    "Not flushing global checkpoint with stream indexes: ${head.streamCheckpoints}"
-                }
+                log.info { "Not flushing global checkpoint with key: ${head.key}" }
                 break
             }
         }
@@ -177,20 +183,26 @@ class CheckpointManager<T>(
                 continue
             }
             while (true) {
-                val (nextCheckpointId, nextMessage) = streamCheckpoints.peek() ?: break
-                val persisted = manager.areRecordsPersistedUntilCheckpoint(nextCheckpointId)
+                val (nextCheckpointKey, nextMessage) = streamCheckpoints.firstEntry() ?: break
+
+                if (
+                    !wasPreviousStateEmitted(stream.descriptor, nextCheckpointKey.checkpointIndex)
+                ) {
+                    break
+                }
+
+                val persisted =
+                    manager.areRecordsPersistedForCheckpoint(nextCheckpointKey.checkpointId)
                 if (persisted) {
 
                     log.info {
-                        "Flushing checkpoint for stream: ${stream.descriptor} at index: $nextCheckpointId"
+                        "Flushing checkpoint for stream: ${stream.descriptor} at index: $nextCheckpointKey"
                     }
-                    validateAndSendMessage(
-                        nextMessage,
-                        listOf(stream.descriptor to nextCheckpointId)
-                    )
-                    streamCheckpoints.poll() // don't remove until after we've successfully sent
+                    sendStateMessage(nextMessage, nextCheckpointKey, listOf(stream.descriptor))
+                    // don't remove until after we've successfully sent
+                    streamCheckpoints.remove(nextCheckpointKey)
                 } else {
-                    log.info { "Not flushing next checkpoint for index $nextCheckpointId" }
+                    log.info { "Not flushing next checkpoint for index $nextCheckpointKey" }
                     break
                 }
             }
@@ -200,19 +212,30 @@ class CheckpointManager<T>(
         }
     }
 
-    private suspend fun validateAndSendMessage(
-        checkpointMessage: T,
-        streamCheckpoints: List<Pair<DestinationStream.Descriptor, CheckpointId>>
-    ) {
-        streamCheckpoints.forEach { (stream, checkpointId) ->
-            val lastCheckpoint = lastCheckpointIdEmitted[stream]
-            if (lastCheckpoint != null && checkpointId.id < lastCheckpoint.id) {
-                throw IllegalStateException(
-                    "Checkpoint message for $stream emitted out of order (emitting $checkpointId after $lastCheckpoint)"
-                )
+    private fun wasPreviousStateEmitted(
+        descriptor: DestinationStream.Descriptor,
+        nextCheckpointIndex: CheckpointIndex
+    ): Boolean {
+        val lastIndex = lastCheckpointKeyEmitted[descriptor]?.checkpointIndex?.value ?: 0
+        if (nextCheckpointIndex.value != lastIndex + 1) {
+            // This state cannot be emitted, because we have not emitted the previous.
+            // (This implies that we also have not received it yet, or else it would
+            // have been first in this table.)
+            log.info {
+                "Cannot flush checkpoint for index $nextCheckpointIndex because previous index has not been flushed."
             }
-            lastCheckpointIdEmitted[stream] = checkpointId
+            return false
         }
+
+        return true
+    }
+
+    private suspend fun sendStateMessage(
+        checkpointMessage: T,
+        checkpointKey: CheckpointKey,
+        streamCheckpoints: List<DestinationStream.Descriptor>
+    ) {
+        streamCheckpoints.forEach { stream -> lastCheckpointKeyEmitted[stream] = checkpointKey }
 
         lastFlushTimeMs.set(timeProvider.currentTimeMillis())
         outputConsumer.invoke(checkpointMessage)
@@ -221,7 +244,7 @@ class CheckpointManager<T>(
     suspend fun awaitAllCheckpointsFlushed() {
         while (true) {
             val allCheckpointsFlushed =
-                flushLock.withLock {
+                storedCheckpointsLock.withLock {
                     globalCheckpoints.isEmpty() && streamCheckpoints.all { it.value.isEmpty() }
                 }
             if (allCheckpointsFlushed) {

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/state/StreamManager.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/state/StreamManager.kt
@@ -9,9 +9,9 @@ import io.airbyte.cdk.load.message.BatchState
 import io.airbyte.cdk.load.task.implementor.CloseStreamTask
 import io.airbyte.cdk.load.task.implementor.FailStreamTask
 import io.airbyte.cdk.load.util.setOnce
-import io.github.oshai.kotlinlogging.KotlinLogging
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicLong
 import kotlinx.coroutines.CompletableDeferred
 
@@ -21,9 +21,12 @@ data class StreamProcessingFailed(val streamException: Exception) : StreamResult
 
 data object StreamProcessingSucceeded : StreamResult
 
-@JvmInline value class CheckpointId(val id: Int)
-
-data class CheckpointValue(
+/**
+ * For tracking counts against checkpoints of records read and persisted. Currently it only tracks
+ * row count, but could be extended to track bytes moved if needed.
+ */
+@JvmInline
+value class CheckpointValue(
     val records: Long,
 // TODO: File bytes moved
 ) {
@@ -38,8 +41,6 @@ class StreamManager(
 ) {
     private val streamResult = CompletableDeferred<StreamResult>()
 
-    private val log = KotlinLogging.logger {}
-
     private val recordCount = AtomicLong(0)
 
     private val markedEndOfStream = AtomicBoolean(false)
@@ -47,17 +48,13 @@ class StreamManager(
 
     private val isClosed = AtomicBoolean(false)
 
-    private val nextCheckpointId = AtomicLong(0L)
+    private val nextInferredCheckpointIndex = AtomicInteger(1)
     private val lastCheckpointRecordIndex = AtomicLong(0L)
     private val recordsReadPerCheckpoint: ConcurrentHashMap<CheckpointId, CheckpointValue> =
         ConcurrentHashMap()
-    data class TaskKey(val name: String, val part: Int)
-    private val namedCheckpointCounts:
-        ConcurrentHashMap<
-            Pair<TaskKey, BatchState>, ConcurrentHashMap<CheckpointId, CheckpointValue>> =
+    private val checkpointCountsByState:
+        ConcurrentHashMap<BatchState, ConcurrentHashMap<CheckpointId, CheckpointValue>> =
         ConcurrentHashMap()
-    private val taskInputCounts = ConcurrentHashMap<TaskKey, Long>()
-    private val taskCompletionCounts = ConcurrentHashMap<TaskKey, Long>()
 
     /**
      * Count incoming record and return the record's *index*. If [markEndOfStream] has been called,
@@ -121,12 +118,13 @@ class StreamManager(
         val recordIndex = recordCount.get()
         val count = recordIndex - lastCheckpointRecordIndex.getAndSet(recordIndex)
 
-        val checkpointId = CheckpointId(nextCheckpointId.getAndIncrement().toInt())
+        val checkpointIndex = nextInferredCheckpointIndex.getAndIncrement()
+        val checkpointId = CheckpointId(checkpointIndex.toString())
         recordsReadPerCheckpoint.merge(checkpointId, CheckpointValue(records = count)) { old, _ ->
             if (old.records > 0) {
                 throw IllegalStateException("Checkpoint $old already exists")
             }
-            old.copy(records = count)
+            CheckpointValue(records = count)
         }
 
         return Pair(recordIndex, count)
@@ -163,75 +161,52 @@ class StreamManager(
     }
 
     /**
-     * Return a monotonically increasing id of the checkpointed batch of records on which we're
+     * Return a monotonically increasing index of the checkpointed batch of records on which we're
      * working.
      *
-     * This will be incremented each time `markCheckpoint` is called.
+     * It is returned as a CheckpointKey, with the id as the string representation of the index.
+     * This is to make it compatible with state management for the socket path, where id and index
+     * are maintained separately by the source and delivered on state and record messages.
+     *
+     * The underlying value will be incremented each time `markCheckpoint` is called.
      */
-    fun getCurrentCheckpointId(): CheckpointId {
-        return CheckpointId(nextCheckpointId.get().toInt())
+    fun inferNextCheckpointKey(): CheckpointKey {
+        val indexValue = nextInferredCheckpointIndex.get()
+        return CheckpointKey(
+            checkpointIndex = CheckpointIndex(indexValue),
+            checkpointId = CheckpointId(indexValue.toString())
+        )
     }
 
     fun incrementCheckpointCounts(
-        taskName: String,
-        part: Int,
         state: BatchState,
         checkpointCounts: Map<CheckpointId, Long>,
-        inputCount: Long
     ) {
-        val taskKey = TaskKey(taskName, part)
-        check(!taskCompletionCounts.containsKey(taskKey)) {
-            """"$taskKey received input after seeing end-of-stream
-                    (checkpointCounts=$checkpointCounts, inputCount=$inputCount, sawEosAt=${taskCompletionCounts[taskKey]})
-                    This indicates data was processed out of order and future bookkeeping might be corrupt. Failing hard."""
-        }
-        val idToValue =
-            namedCheckpointCounts.getOrPut(TaskKey(taskName, part) to state) { ConcurrentHashMap() }
+        val idToValue = checkpointCountsByState.getOrPut(state) { ConcurrentHashMap() }
 
         checkpointCounts.forEach { (checkpointId, recordCount) ->
             idToValue.merge(checkpointId, CheckpointValue(recordCount)) { old, new -> old + new }
         }
-
-        taskInputCounts.merge(TaskKey(taskName, part), inputCount) { old, new -> old + new }
     }
 
-    fun markTaskEndOfStream(taskName: String, part: Int, finalInputCount: Long) {
-        taskCompletionCounts.putIfAbsent(TaskKey(taskName, part), finalInputCount)?.let {
-            throw IllegalStateException(
-                "End-of-stream reported at $finalInputCount already seen for $taskName[$part] at $it"
-            )
-        }
-    }
-
-    private fun countByStateUpToInclusive(
+    private fun countByStateForCheckpoint(
         checkpointId: CheckpointId,
         state: BatchState
     ): CheckpointValue {
-        return namedCheckpointCounts
-            .filter { (key, _) -> key.second == state }
-            .values
-            .fold(CheckpointValue(records = 0)) { totalValue, checkpointIdToValue ->
-                totalValue +
-                    checkpointIdToValue
-                        .filterKeys { it.id <= checkpointId.id }
-                        .values
-                        .fold(CheckpointValue(records = 0)) { z, x -> z + x }
-            }
+        val countsForState = checkpointCountsByState.filter { (it.key == state) }.values
+        val count = countsForState.sumOf { it[checkpointId]?.records ?: 0L }
+        return CheckpointValue(records = count)
     }
 
     /**
-     * True if persisted counts for each checkpoint up to and including [checkpointId] match the
-     * number of records read for that id.
+     * True if persisted counts associated with the index [checkpointId] are equal to the number of
+     * records read.
      */
-    fun areRecordsPersistedUntilCheckpoint(checkpointId: CheckpointId): Boolean {
-        val counts = recordsReadPerCheckpoint.filter { it.key.id <= checkpointId.id }
-        if (counts.size < checkpointId.id + 1) {
-            return false
-        }
+    fun areRecordsPersistedForCheckpoint(checkpointId: CheckpointId): Boolean {
+        val readCount = recordsReadPerCheckpoint[checkpointId] ?: CheckpointValue(records = 0)
 
-        val readCount = counts.map { it.value.records }.sum()
-        val persistedCount = countByStateUpToInclusive(checkpointId, BatchState.PERSISTED).records
-        val completedCount = countByStateUpToInclusive(checkpointId, BatchState.COMPLETE).records
+        val persistedCount = countByStateForCheckpoint(checkpointId, BatchState.PERSISTED)
+        val completedCount = countByStateForCheckpoint(checkpointId, BatchState.COMPLETE)
 
         if (persistedCount == readCount) {
             return true
@@ -255,60 +230,9 @@ class StreamManager(
             return true
         }
 
-        // Detailed debug logging for completeness checks. It's a little verbose but is only emitted
-        // per-batch (every 10-20mb in most cases).
-        // TODO: A more user-friendly aggregated version of this on a regular cadence?
-        log.debug {
-            val header =
-                "\nStream ${stream.descriptor.namespace}:${stream.descriptor.name}: Records Read: $readCount (done: ${markedEndOfStream.get()})"
-            val byPart =
-                namedCheckpointCounts.map { (key, value) ->
-                    val (taskKey, state) = key
-                    val recordCount = value.values.sumOf { it.records }
-                    val inputCount = taskInputCounts[taskKey] ?: 0L
-                    val isCompleteCount = taskCompletionCounts[taskKey]
-                    Triple(taskKey, state, Triple(recordCount, inputCount, isCompleteCount))
-                }
-            val byTask =
-                byPart
-                    .groupBy { TaskKey(it.first.name, 999) }
-                    .mapValues {
-                        it.value.fold(Triple(BatchState.PROCESSED, Pair(0L, 0L), null as Long?)) {
-                            z,
-                            x ->
-                            Triple(
-                                x.second,
-                                Pair(
-                                    z.second.first + x.third.first,
-                                    z.second.second + x.third.second
-                                ),
-                                (z.third?.plus(x.third.third ?: 0L)) ?: x.third.third
-                            )
-                        }
-                    }
-                    .map { (taskKey, stateAndCountsAndComplete) ->
-                        val (state, counts, isCompleteCount) = stateAndCountsAndComplete
-                        Triple(taskKey, state, Triple(counts.first, counts.second, isCompleteCount))
-                    }
-            val sortedAndFormatted =
-                (byPart + byTask)
-                    .sortedBy { (taskKey, state, _) -> state.ordinal * 1_000 + taskKey.part }
-                    .map { (taskKey, state, countsAndComplete) ->
-                        val (recordCount, inputCount, isCompleteCount) = countsAndComplete
-                        val partString = if (taskKey.part == 999) "[TOTAL]" else "[${taskKey.part}]"
-                        val inputString =
-                            if (recordCount == inputCount) "(" else " (inputs: $inputCount, "
-                        val completeString =
-                            if (isCompleteCount == null) "false"
-                            else "true, saw eos at input $isCompleteCount"
-                        "${taskKey.name}$partString($state): $recordCount records ${inputString}done: $completeString)"
-                    }
-            (listOf(header) + sortedAndFormatted).joinToString(separator = "\n")
-        }
-
         val completedCount =
-            namedCheckpointCounts
-                .filter { (key, _) -> key.second == BatchState.COMPLETE }
+            checkpointCountsByState
+                .filter { (state, _) -> state == BatchState.COMPLETE }
                 .values
                 .flatMap { it.values }
                 .sumOf { it.records }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/UpdateBatchStateTaskFactory.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/UpdateBatchStateTaskFactory.kt
@@ -39,11 +39,8 @@ class UpdateBatchStateTask(
                             "Batch update for ${message.stream}: ${message.taskName}[${message.part}](${message.state}) += ${message.checkpointCounts} (inputs += ${message.inputCount})"
                         }
                         manager.incrementCheckpointCounts(
-                            message.taskName,
-                            message.part,
                             message.state,
                             message.checkpointCounts,
-                            message.inputCount
                         )
                         message.state
                     }
@@ -51,11 +48,6 @@ class UpdateBatchStateTask(
                         log.info {
                             "End-of-stream checks for ${message.stream}: ${message.taskName}[${message.part}]"
                         }
-                        manager.markTaskEndOfStream(
-                            message.taskName,
-                            message.part,
-                            message.totalInputCount
-                        )
                         BatchState.COMPLETE
                     }
                 }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/UpdateCheckpointsTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/UpdateCheckpointsTask.kt
@@ -35,14 +35,18 @@ class UpdateCheckpointsTask(
         checkpointMessageQueue.consume().collect {
             when (it.value) {
                 is StreamCheckpointWrapped -> {
-                    val (stream, checkpointId, message) = it.value
-                    log.info { "Updating checkpoint for stream $stream with id $checkpointId" }
-                    checkpointManager.addStreamCheckpoint(stream, checkpointId, it.replace(message))
+                    val (stream, checkpointKey, message) = it.value
+                    log.info { "Updating checkpoint for stream $stream with id $checkpointKey" }
+                    checkpointManager.addStreamCheckpoint(
+                        stream,
+                        checkpointKey,
+                        it.replace(message)
+                    )
                 }
                 is GlobalCheckpointWrapped -> {
-                    val (streamCheckpointIds, message) = it.value
-                    log.info { "Updating global checkpoint for streams $streamCheckpointIds" }
-                    checkpointManager.addGlobalCheckpoint(streamCheckpointIds, it.replace(message))
+                    val (checkpointKey, message) = it.value
+                    log.info { "Updating global checkpoint with $checkpointKey" }
+                    checkpointManager.addGlobalCheckpoint(checkpointKey, it.replace(message))
                 }
             }
         }

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/state/StreamManagerTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/state/StreamManagerTest.kt
@@ -4,7 +4,6 @@
 
 package io.airbyte.cdk.load.state
 
-import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.command.MockDestinationCatalogFactory.Companion.stream1
 import io.airbyte.cdk.load.command.MockDestinationCatalogFactory.Companion.stream2
 import io.airbyte.cdk.load.message.BatchState
@@ -22,8 +21,8 @@ class StreamManagerTest {
         val manager1 = StreamManager(stream1)
         val manager2 = StreamManager(stream2)
 
-        Assertions.assertEquals(0, manager1.getCurrentCheckpointId().id)
-        Assertions.assertEquals(0, manager2.getCurrentCheckpointId().id)
+        Assertions.assertEquals(1, manager1.inferNextCheckpointKey().checkpointIndex.value)
+        Assertions.assertEquals(1, manager2.inferNextCheckpointKey().checkpointIndex.value)
 
         // Incrementing once yields (n, n)
         repeat(10) { manager1.incrementReadCount() }
@@ -32,8 +31,8 @@ class StreamManagerTest {
         Assertions.assertEquals(10, index)
         Assertions.assertEquals(10, count)
 
-        Assertions.assertEquals(1, manager1.getCurrentCheckpointId().id)
-        Assertions.assertEquals(0, manager2.getCurrentCheckpointId().id)
+        Assertions.assertEquals(2, manager1.inferNextCheckpointKey().checkpointIndex.value)
+        Assertions.assertEquals(1, manager2.inferNextCheckpointKey().checkpointIndex.value)
 
         // Incrementing a second time yields (n + m, m)
         repeat(5) { manager1.incrementReadCount() }
@@ -42,14 +41,14 @@ class StreamManagerTest {
         Assertions.assertEquals(15, index2)
         Assertions.assertEquals(5, count2)
 
-        Assertions.assertEquals(2, manager1.getCurrentCheckpointId().id)
-        Assertions.assertEquals(0, manager2.getCurrentCheckpointId().id)
+        Assertions.assertEquals(3, manager1.inferNextCheckpointKey().checkpointIndex.value)
+        Assertions.assertEquals(1, manager2.inferNextCheckpointKey().checkpointIndex.value)
 
         // Never incrementing yields (0, 0)
         val (index3, count3) = manager2.markCheckpoint()
 
-        Assertions.assertEquals(2, manager1.getCurrentCheckpointId().id)
-        Assertions.assertEquals(1, manager2.getCurrentCheckpointId().id)
+        Assertions.assertEquals(3, manager1.inferNextCheckpointKey().checkpointIndex.value)
+        Assertions.assertEquals(2, manager2.inferNextCheckpointKey().checkpointIndex.value)
 
         Assertions.assertEquals(0, index3)
         Assertions.assertEquals(0, count3)
@@ -57,8 +56,8 @@ class StreamManagerTest {
         // Incrementing twice in a row yields (n + m + 0, 0)
         val (index4, count4) = manager1.markCheckpoint()
 
-        Assertions.assertEquals(3, manager1.getCurrentCheckpointId().id)
-        Assertions.assertEquals(1, manager2.getCurrentCheckpointId().id)
+        Assertions.assertEquals(4, manager1.inferNextCheckpointKey().checkpointIndex.value)
+        Assertions.assertEquals(2, manager2.inferNextCheckpointKey().checkpointIndex.value)
 
         Assertions.assertEquals(15, index4)
         Assertions.assertEquals(0, count4)
@@ -99,21 +98,6 @@ class StreamManagerTest {
         Assertions.assertTrue(manager.awaitStreamResult() is StreamProcessingFailed)
     }
 
-    // TODO: break these out into non-parameterized tests, factor out mixing streams.
-    //  (It's irrelevant if testing at the single manager level.)
-    sealed class TestEvent
-    data class SetRecordCount(val count: Long) : TestEvent()
-    data object SetEndOfStream : TestEvent()
-    data class AddPersisted(val firstIndex: Long, val lastIndex: Long) : TestEvent()
-    data class AddComplete(val firstIndex: Long, val lastIndex: Long) : TestEvent()
-    data class ExpectPersistedUntil(val end: Long, val expectation: Boolean = true) : TestEvent()
-    data class ExpectComplete(val expectation: Boolean = true) : TestEvent()
-
-    data class TestCase(
-        val name: String,
-        val events: List<Pair<DestinationStream, TestEvent>>,
-    )
-
     @Test
     fun testCannotUpdateOrCloseReadClosedStream() {
         val manager = StreamManager(stream1)
@@ -137,146 +121,113 @@ class StreamManagerTest {
     @Test
     fun `test persisted counts`() {
         val manager = StreamManager(stream1)
-        val checkpointId = manager.getCurrentCheckpointId()
-        val taskName = "foo"
-        val part = 1
+        val checkpointId = manager.inferNextCheckpointKey().checkpointId
 
         repeat(10) { manager.incrementReadCount() }
         manager.markCheckpoint()
 
-        Assertions.assertFalse(manager.areRecordsPersistedUntilCheckpoint(checkpointId))
+        Assertions.assertFalse(manager.areRecordsPersistedForCheckpoint(checkpointId))
         manager.incrementCheckpointCounts(
-            taskName,
-            part,
             BatchState.PERSISTED,
             mapOf(checkpointId to 5),
-            1
         )
-        Assertions.assertFalse(manager.areRecordsPersistedUntilCheckpoint(checkpointId))
+        Assertions.assertFalse(manager.areRecordsPersistedForCheckpoint(checkpointId))
         manager.incrementCheckpointCounts(
-            taskName,
-            part,
             BatchState.PERSISTED,
             mapOf(checkpointId to 5),
-            1
         )
-        Assertions.assertTrue(manager.areRecordsPersistedUntilCheckpoint(checkpointId))
+        Assertions.assertTrue(manager.areRecordsPersistedForCheckpoint(checkpointId))
     }
 
     @Test
     fun `test persisted count for multiple checkpoints`() {
         val manager = StreamManager(stream1)
-        val taskName = "foo"
-        val part = 1
 
-        val checkpointId1 = manager.getCurrentCheckpointId()
+        val checkpointId1 = manager.inferNextCheckpointKey().checkpointId
         repeat(10) { manager.incrementReadCount() }
         manager.markCheckpoint()
 
-        val checkpointId2 = manager.getCurrentCheckpointId()
+        val checkpointId2 = manager.inferNextCheckpointKey().checkpointId
         repeat(15) { manager.incrementReadCount() }
         manager.markCheckpoint()
 
-        Assertions.assertFalse(manager.areRecordsPersistedUntilCheckpoint(checkpointId1))
-        Assertions.assertFalse(manager.areRecordsPersistedUntilCheckpoint(checkpointId2))
+        Assertions.assertFalse(manager.areRecordsPersistedForCheckpoint(checkpointId1))
+        Assertions.assertFalse(manager.areRecordsPersistedForCheckpoint(checkpointId2))
 
         manager.incrementCheckpointCounts(
-            taskName,
-            part,
             BatchState.PERSISTED,
             mapOf(checkpointId1 to 10),
-            1
         )
-        Assertions.assertTrue(manager.areRecordsPersistedUntilCheckpoint(checkpointId1))
-        Assertions.assertFalse(manager.areRecordsPersistedUntilCheckpoint(checkpointId2))
+        Assertions.assertTrue(manager.areRecordsPersistedForCheckpoint(checkpointId1))
+        Assertions.assertFalse(manager.areRecordsPersistedForCheckpoint(checkpointId2))
 
         manager.incrementCheckpointCounts(
-            taskName,
-            part,
             BatchState.PERSISTED,
             mapOf(checkpointId2 to 15),
-            1
         )
-        Assertions.assertTrue(manager.areRecordsPersistedUntilCheckpoint(checkpointId1))
-        Assertions.assertTrue(manager.areRecordsPersistedUntilCheckpoint(checkpointId2))
+        Assertions.assertTrue(manager.areRecordsPersistedForCheckpoint(checkpointId1))
+        Assertions.assertTrue(manager.areRecordsPersistedForCheckpoint(checkpointId2))
     }
 
     @Test
     fun `test persisted count for multiple checkpoints out of order`() {
         val manager = StreamManager(stream1)
-        val taskName = "foo"
-        val part = 1
 
-        val checkpointId1 = manager.getCurrentCheckpointId()
+        val checkpointId1 = manager.inferNextCheckpointKey().checkpointId
 
         repeat(10) { manager.incrementReadCount() }
         manager.markCheckpoint()
 
-        val checkpointId2 = manager.getCurrentCheckpointId()
+        val checkpointId2 = manager.inferNextCheckpointKey().checkpointId
         repeat(15) { manager.incrementReadCount() }
 
         manager.markCheckpoint()
 
-        Assertions.assertFalse(manager.areRecordsPersistedUntilCheckpoint(checkpointId1))
-        Assertions.assertFalse(manager.areRecordsPersistedUntilCheckpoint(checkpointId2))
+        Assertions.assertFalse(manager.areRecordsPersistedForCheckpoint(checkpointId1))
+        Assertions.assertFalse(manager.areRecordsPersistedForCheckpoint(checkpointId2))
 
         manager.incrementCheckpointCounts(
-            taskName,
-            part,
             BatchState.PERSISTED,
             mapOf(checkpointId2 to 15),
-            1
         )
-        Assertions.assertFalse(manager.areRecordsPersistedUntilCheckpoint(checkpointId1))
-        Assertions.assertFalse(manager.areRecordsPersistedUntilCheckpoint(checkpointId2))
+        Assertions.assertFalse(manager.areRecordsPersistedForCheckpoint(checkpointId1))
+        Assertions.assertTrue(manager.areRecordsPersistedForCheckpoint(checkpointId2))
 
         manager.incrementCheckpointCounts(
-            taskName,
-            part,
             BatchState.PERSISTED,
             mapOf(checkpointId1 to 10),
-            1
         )
-        Assertions.assertTrue(manager.areRecordsPersistedUntilCheckpoint(checkpointId1))
-        Assertions.assertTrue(manager.areRecordsPersistedUntilCheckpoint(checkpointId2))
+        Assertions.assertTrue(manager.areRecordsPersistedForCheckpoint(checkpointId1))
+        Assertions.assertTrue(manager.areRecordsPersistedForCheckpoint(checkpointId2))
     }
 
     @Test
     fun `test completion implies persistence`() {
         val manager = StreamManager(stream1)
 
-        val checkpointId1 = manager.getCurrentCheckpointId()
+        val checkpointId1 = manager.inferNextCheckpointKey().checkpointId
 
         repeat(10) { manager.incrementReadCount() }
         manager.markCheckpoint()
 
-        Assertions.assertFalse(manager.areRecordsPersistedUntilCheckpoint(checkpointId1))
+        Assertions.assertFalse(manager.areRecordsPersistedForCheckpoint(checkpointId1))
         manager.incrementCheckpointCounts(
-            "foo",
-            1,
             BatchState.COMPLETE,
             mapOf(checkpointId1 to 4),
-            1
         )
-        Assertions.assertFalse(manager.areRecordsPersistedUntilCheckpoint(checkpointId1))
+        Assertions.assertFalse(manager.areRecordsPersistedForCheckpoint(checkpointId1))
         manager.incrementCheckpointCounts(
-            "foo",
-            2,
             BatchState.COMPLETE,
             mapOf(checkpointId1 to 6),
-            1
         )
-        Assertions.assertTrue(manager.areRecordsPersistedUntilCheckpoint(checkpointId1))
+        Assertions.assertTrue(manager.areRecordsPersistedForCheckpoint(checkpointId1))
 
         // Can still count persisted (but without effect)
         manager.incrementCheckpointCounts(
-            "bar",
-            1,
             BatchState.PERSISTED,
             mapOf(checkpointId1 to 10),
-            1
         )
-        Assertions.assertTrue(manager.areRecordsPersistedUntilCheckpoint(checkpointId1))
+        Assertions.assertTrue(manager.areRecordsPersistedForCheckpoint(checkpointId1))
     }
 
     @Test
@@ -294,12 +245,12 @@ class StreamManagerTest {
 
         cases.forEach { steps ->
             val manager = StreamManager(stream1)
-            val checkpointId1 = manager.getCurrentCheckpointId()
+            val checkpointId1 = manager.inferNextCheckpointKey().checkpointId
 
             repeat(10) { manager.incrementReadCount() }
             manager.markCheckpoint()
 
-            val checkpointId2 = manager.getCurrentCheckpointId()
+            val checkpointId2 = manager.inferNextCheckpointKey().checkpointId
             repeat(20) { manager.incrementReadCount() }
             manager.markCheckpoint()
 
@@ -307,19 +258,13 @@ class StreamManagerTest {
                 when (step) {
                     "1" ->
                         manager.incrementCheckpointCounts(
-                            "foo",
-                            1,
                             BatchState.COMPLETE,
                             mapOf(checkpointId1 to 10),
-                            1
                         )
                     "2" ->
                         manager.incrementCheckpointCounts(
-                            "bar",
-                            1,
                             BatchState.COMPLETE,
                             mapOf(checkpointId2 to 20),
-                            1
                         )
                     "end" -> manager.markEndOfStream(true)
                 }
@@ -342,15 +287,12 @@ class StreamManagerTest {
     fun `do not throw when counting before marking`() {
         val manager1 = StreamManager(stream1)
 
-        Assertions.assertEquals(0, manager1.getCurrentCheckpointId().id)
+        Assertions.assertEquals(1, manager1.inferNextCheckpointKey().checkpointIndex.value)
 
         repeat(10) { manager1.incrementReadCount() }
         manager1.incrementCheckpointCounts(
-            "foo",
-            1,
             BatchState.PERSISTED,
-            mapOf(manager1.getCurrentCheckpointId() to 10),
-            1
+            mapOf(manager1.inferNextCheckpointKey().checkpointId to 10),
         )
         assertDoesNotThrow { manager1.markCheckpoint() }
     }

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/internal/InputConsumerTaskTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/internal/InputConsumerTaskTest.kt
@@ -17,6 +17,8 @@ import io.airbyte.cdk.load.message.PipelineEvent
 import io.airbyte.cdk.load.message.StreamCheckpointWrapped
 import io.airbyte.cdk.load.message.StreamKey
 import io.airbyte.cdk.load.state.CheckpointId
+import io.airbyte.cdk.load.state.CheckpointIndex
+import io.airbyte.cdk.load.state.CheckpointKey
 import io.airbyte.cdk.load.state.PipelineEventBookkeepingRouter
 import io.airbyte.cdk.load.state.ReservationManager
 import io.airbyte.cdk.load.state.Reserved
@@ -210,7 +212,7 @@ class InputConsumerTaskTest {
         coEvery { checkpointQueue.publish(any()) } coAnswers { published.add(firstArg()) }
         published.toList().zip(batches).forEach { (checkpoint, event) ->
             val wrapped = checkpoint.value
-            Assertions.assertEquals(event.expectedStateIndex, wrapped.checkpointId)
+            Assertions.assertEquals(event.expectedStateIndex, wrapped.checkpointKey.checkpointIndex)
             Assertions.assertEquals(event.stream.descriptor, wrapped.stream)
         }
     }
@@ -219,22 +221,19 @@ class InputConsumerTaskTest {
     fun testSendGlobalState() = runTest {
         open class TestEvent
         data class AddRecords(val stream: DestinationStream, val count: Int) : TestEvent()
-        data class SendState(
-            val expectedStream1CheckpointId: CheckpointId,
-            val expectedStream2CheckpointId: CheckpointId,
-            val expectedStats: Long = 0
-        ) : TestEvent()
+        data class SendState(val expectedCheckpointIndex: Int, val expectedStats: Long = 0) :
+            TestEvent()
 
         val batches =
             listOf(
                 AddRecords(MockDestinationCatalogFactory.stream1, 10),
-                SendState(CheckpointId(0), CheckpointId(0), 10),
+                SendState(0, 10),
                 AddRecords(MockDestinationCatalogFactory.stream2, 5),
                 AddRecords(MockDestinationCatalogFactory.stream1, 4),
-                SendState(CheckpointId(1), CheckpointId(1), 9),
+                SendState(1, 9),
                 AddRecords(MockDestinationCatalogFactory.stream2, 3),
-                SendState(CheckpointId(2), CheckpointId(2), 3),
-                SendState(CheckpointId(3), CheckpointId(3), 0),
+                SendState(2, 3),
+                SendState(3, 0),
             )
 
         val task =
@@ -275,10 +274,12 @@ class InputConsumerTaskTest {
         checkpoints.toList().zip(batches.filterIsInstance<SendState>()).forEach {
             (checkpoint, event) ->
             val wrapped = checkpoint.value
-            val stream1State = wrapped.streamIndexes.find { it.first == stream1.descriptor }!!
-            val stream2State = wrapped.streamIndexes.find { it.first == stream2.descriptor }!!
-            Assertions.assertEquals(event.expectedStream1CheckpointId, stream1State.second)
-            Assertions.assertEquals(event.expectedStream2CheckpointId, stream2State.second)
+            val expectedKey =
+                CheckpointKey(
+                    checkpointIndex = CheckpointIndex(event.expectedCheckpointIndex),
+                    checkpointId = CheckpointId(event.expectedCheckpointIndex.toString())
+                )
+            Assertions.assertEquals(expectedKey, wrapped.checkpointKey)
             Assertions.assertEquals(
                 event.expectedStats,
                 wrapped.checkpoint.destinationStats?.recordCount

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/internal/LoadPipelineStepTaskUTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/internal/LoadPipelineStepTaskUTest.kt
@@ -110,7 +110,7 @@ class LoadPipelineStepTaskUTest {
         value: String,
         counts: Map<Int, Long> = emptyMap()
     ): PipelineEvent<StreamKey, String> =
-        PipelineMessage(counts.mapKeys { CheckpointId(it.key) }, key, value)
+        PipelineMessage(counts.mapKeys { CheckpointId(it.key.toString()) }, key, value)
     private fun endOfStreamEvent(key: StreamKey): PipelineEvent<StreamKey, String> =
         PipelineEndOfStream(key.stream)
 
@@ -409,7 +409,7 @@ class LoadPipelineStepTaskUTest {
         val expectedBatchUpdateStream1 =
             BatchStateUpdate(
                 key1.stream,
-                mapOf(CheckpointId(0) to 15L, CheckpointId(1) to 51L),
+                mapOf(CheckpointId("0") to 15L, CheckpointId("1") to 51L),
                 BatchState.COMPLETE,
                 taskId,
                 part,
@@ -418,7 +418,7 @@ class LoadPipelineStepTaskUTest {
         val expectedBatchUpdateStream2 =
             BatchStateUpdate(
                 key2.stream,
-                mapOf(CheckpointId(1) to 6L, CheckpointId(2) to 22L, CheckpointId(3) to 38L),
+                mapOf(CheckpointId("1") to 6L, CheckpointId("2") to 22L, CheckpointId("3") to 38L),
                 BatchState.PERSISTED,
                 taskId,
                 part,

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/test/kotlin/io/airbyte/cdk/load/pipeline/object_storage/file/FileChunkTaskTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/test/kotlin/io/airbyte/cdk/load/pipeline/object_storage/file/FileChunkTaskTest.kt
@@ -155,13 +155,13 @@ class FileChunkTaskTest<T> {
 
         val input =
             PipelineMessage(
-                checkpointCounts = mapOf(CheckpointId(1) to 2),
+                checkpointCounts = mapOf(CheckpointId("1") to 2),
                 key = key,
                 value = record,
                 postProcessingCallback = {},
                 context =
                     PipelineContext(
-                        mapOf(CheckpointId(1) to 2),
+                        mapOf(CheckpointId("1") to 2),
                         record,
                     )
             )

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/test/kotlin/io/airbyte/cdk/load/pipeline/object_storage/file/ForwardFileRecordTaskTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/test/kotlin/io/airbyte/cdk/load/pipeline/object_storage/file/ForwardFileRecordTaskTest.kt
@@ -92,7 +92,7 @@ class ForwardFileRecordTaskTest {
             val key = StreamKey(stream.descriptor)
             val context =
                 PipelineContext(
-                    mapOf(CheckpointId(123) to 14L),
+                    mapOf(CheckpointId("123") to 14L),
                     Fixtures.record(),
                 )
             val result =
@@ -118,7 +118,7 @@ class ForwardFileRecordTaskTest {
         val key = StreamKey(stream.descriptor)
         val context =
             PipelineContext(
-                mapOf(CheckpointId(123) to 14L),
+                mapOf(CheckpointId("123") to 14L),
                 Fixtures.record(),
             )
         val result =

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/test/kotlin/io/airbyte/cdk/load/pipeline/object_storage/file/RouteEventTaskTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/test/kotlin/io/airbyte/cdk/load/pipeline/object_storage/file/RouteEventTaskTest.kt
@@ -76,7 +76,7 @@ class RouteEventTaskTest {
             val stream = Fixtures.stream(includeFiles = true)
             val key = StreamKey(stream.descriptor)
             val record = Fixtures.record()
-            val checkpoints = mapOf(CheckpointId(1) to 2L)
+            val checkpoints = mapOf(CheckpointId("1") to 2L)
             val releaseMemCallback: (suspend () -> Unit) = mockk(relaxed = true)
 
             val input =
@@ -92,7 +92,7 @@ class RouteEventTaskTest {
 
             val expectedContext =
                 PipelineContext(
-                    mapOf(CheckpointId(1) to 2),
+                    mapOf(CheckpointId("1") to 2),
                     record,
                 )
 
@@ -127,7 +127,7 @@ class RouteEventTaskTest {
         val stream = Fixtures.stream(includeFiles = false)
         val key = StreamKey(stream.descriptor)
         val record = Fixtures.record()
-        val checkpoints = mapOf(CheckpointId(1) to 2L)
+        val checkpoints = mapOf(CheckpointId("1") to 2L)
 
         val input =
             PipelineMessage(

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/test/kotlin/io/airbyte/cdk/load/write/object_storage/FilePartAccumulatorLegacyTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/test/kotlin/io/airbyte/cdk/load/write/object_storage/FilePartAccumulatorLegacyTest.kt
@@ -50,11 +50,13 @@ class FilePartAccumulatorLegacyTest {
         val index = 21L
         val fileMessage = createFileMessage(file)
 
-        filePartAccumulatorLegacy.handleFileMessage(fileMessage, index, CheckpointId(0))
+        filePartAccumulatorLegacy.handleFileMessage(fileMessage, index, CheckpointId("0"))
 
         coVerify(exactly = 1) {
             outputQueue.publish(
-                match { (it as PipelineMessage).checkpointCounts == mapOf(CheckpointId(0) to 1L) },
+                match {
+                    (it as PipelineMessage).checkpointCounts == mapOf(CheckpointId("0") to 1L)
+                },
                 0
             )
         }
@@ -68,7 +70,7 @@ class FilePartAccumulatorLegacyTest {
         val index = 21L
         val fileMessage = createFileMessage(file)
 
-        filePartAccumulatorLegacy.handleFileMessage(fileMessage, index, CheckpointId(0))
+        filePartAccumulatorLegacy.handleFileMessage(fileMessage, index, CheckpointId("0"))
 
         coVerify(exactly = 2) { outputQueue.publish(any(), 0) }
     }
@@ -82,7 +84,7 @@ class FilePartAccumulatorLegacyTest {
         val index = 21L
         val fileMessage = createFileMessage(file)
 
-        filePartAccumulatorLegacy.handleFileMessage(fileMessage, index, CheckpointId(0))
+        filePartAccumulatorLegacy.handleFileMessage(fileMessage, index, CheckpointId("0"))
 
         coVerify(exactly = 2) { outputQueue.publish(any(), 0) }
     }


### PR DESCRIPTION
## What
Implements the spec outlined [here](https://docs.google.com/document/d/1As-9SU5ooVbHSCvOWo2lDdJ1ggvBi9pMITZIM1IhcDk/edit?tab=t.0#heading=h.aaoycelopvqk).

Lays groundwork for the CDK to use the new Speed state protocol. TLDR:
* in sockets, state and messages arrive in parallel on multiple threads
* to maintain coherence, source will put a string `partition_id` on both the state message and its associated records (called internally CheckpointId)
* source will also mark the state message with a global index (`id` for bw-compatibility w/ the platform, called internally CheckpointIndex); the index specifies the order in which the state should be returned/persisted

Previous STDIO workflow:
* destination keeps a monotonic index (called CheckpointId currently), incremented as new state arrives
* records are marked with the index
* the index both identifies and orders the records
* CheckpointManager keeps state by CheckpointId and polls the StreamManager to find out if enough records have been persisted to flush
* CheckpointManager enforces that state arrive in order, which guarantees that it is released in order
* StreamManager counts persisted records by CheckpointId as they are processed

To prepare the STDIO workflow for Speed:
* CheckpointManager now keeps state by CheckpointKey which composes CheckpointId and CheckpointIndex; the index is used for ordering, the id is used to poll the StreamManager to determine whether all the associated records have been flushed
* StreamManager keeps persisted counts by CheckpointId only (it knows nothing about the Index)
* In STDIO mode, we still keep the monotonic index for CheckpointIndex, and we generate fake ids by `CheckpointIndex::value.toString()`

Some callouts:
The source will try to release states in order, but long-term we can't rely on that, and using multiple threads means we can't guarantee the destination will process the state in order. Implications:
* CheckpointManager now stores state in TreeMaps sorted by index instead of LinkedQueues
* We no longer require that state messages arrive in order
* Before releasing state message w/ index N, we must verify that all state with index 1..N-1 has been sent
* Because the CheckpointManager is now enforcing order, the StreamManager doesn't need to check persistence for every record up to now, just the checkpoint id in question (and it can't anyway, because it knows nothing about indexes)

Additional changes:
* There was some unnecessary complexity in the StreamManager for tracking metrics by task, and some elaborate debug logging that was not worth the maintenance cost (and which will be mooted by planned speed changes anyway), so I removed it to make the flow clearer.
* I also simplied Global state management a bit -- there's no need to maintain index/id by stream (that's an artifact of when we used to aggregate ranges), so I simplified it to one key per state message w/ checks on data sufficiency per record. (Now it's pretty close to being generalizeable if anyone ever wants to break the CheckpointManagers up into separate Global and Stream classes.)
