### PR TITLE
Add redirect from old getting-started page

### DIFF
--- a/docusaurus/vercel.json
+++ b/docusaurus/vercel.json
@@ -297,6 +297,11 @@
       "statusCode": 301
     },
     {
+      "source": "/using-airbyte/getting-started",
+      "destination": "/platform",
+      "statusCode": 301
+    },
+    {
       "source": "/project-overview/licenses/:path*",
       "destination": "/platform/developer-guides/licenses/:path*",
       "statusCode": 301


### PR DESCRIPTION
## What

While testing the AI chat https://github.com/airbytehq/airbyte/pull/60789, I noticed its response to a question referenced an unhandled page that was deleted a while ago (this is separate issue with the vendor). This change adds a redirect for any cases where someone might still link to this page.

## How

Updated vercel.json.

## Review guide

- `/using-airbyte/getting-started` redirects to `/platform`.
- `/using-airbyte/getting-started/` redirects to `/platform`.

## User Impact


## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌
