### PR TITLE
[source-redshift] Support late-binding views and upgrade Redshift JDBC driver

### DIFF
--- a/airbyte-integrations/connectors/source-redshift/build.gradle
+++ b/airbyte-integrations/connectors/source-redshift/build.gradle
@@ -16,7 +16,10 @@ application {
 }
 
 dependencies {
-    implementation 'com.amazon.redshift:redshift-jdbc42:1.2.43.1067'
+    implementation 'com.amazon.redshift:redshift-jdbc42:2.1.0.32'
+    // TODO: remove this once the dependency v1 SDK dependency on StringUtils for the metadata is removed.
+    // https://github.com/aws/amazon-redshift-jdbc-driver/issues/132
+    implementation 'com.amazonaws:aws-java-sdk-core:1.12.775'
 
     testImplementation 'org.hamcrest:hamcrest-all:1.3'
     testImplementation "org.testcontainers:jdbc:1.19.4"

--- a/airbyte-integrations/connectors/source-redshift/metadata.yaml
+++ b/airbyte-integrations/connectors/source-redshift/metadata.yaml
@@ -14,9 +14,16 @@ data:
           secretStore:
             alias: airbyte-connector-testing-secret-store
             type: GSM
+    - suite: acceptanceTests
+      testSecrets:
+        - fileName: config.json
+          name: SECRET_SOURCE-REDSHIFT__CREDS
+          secretStore:
+            alias: airbyte-connector-testing-secret-store
+            type: GSM
   connectorType: source
   definitionId: e87ffa8e-a3b5-f69c-9076-6011339de1f6
-  dockerImageTag: 0.5.4
+  dockerImageTag: 0.5.5
   dockerRepository: airbyte/source-redshift
   documentationUrl: https://docs.airbyte.com/integrations/sources/redshift
   githubIssueLabel: source-redshift

--- a/airbyte-integrations/connectors/source-redshift/src/main/java/io/airbyte/integrations/source/redshift/RedshiftSource.java
+++ b/airbyte-integrations/connectors/source-redshift/src/main/java/io/airbyte/integrations/source/redshift/RedshiftSource.java
@@ -116,13 +116,13 @@ public class RedshiftSource extends AbstractJdbcSource<JDBCType> {
           connection.setAutoCommit(true);
           final PreparedStatement ps = connection.prepareStatement(
               "SELECT "
-                + "  v.schemaname as schemaname, "
-                + "  v.resourcename as tablename "
-                + "FROM "
-                + "  (SELECT schemaname, viewname as resourcename FROM pg_views "
-                + "  UNION ALL SELECT schemaname, tablename as resourcename from pg_tables) v "
-                + "WHERE "
-                + "    has_table_privilege(current_user, v.schemaname || '.' || quote_ident(v.resourcename), 'select') = true and v.schemaname = ?;");
+                  + "  v.schemaname as schemaname, "
+                  + "  v.resourcename as tablename "
+                  + "FROM "
+                  + "  (SELECT schemaname, viewname as resourcename FROM pg_views "
+                  + "  UNION ALL SELECT schemaname, tablename as resourcename from pg_tables) v "
+                  + "WHERE "
+                  + "    has_table_privilege(current_user, v.schemaname || '.' || quote_ident(v.resourcename), 'select') = true and v.schemaname = ?;");
           ps.setString(1, schema);
           return ps.executeQuery();
         },

--- a/docs/integrations/sources/redshift.md
+++ b/docs/integrations/sources/redshift.md
@@ -59,11 +59,12 @@ All Redshift connections are encrypted using SSL
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                                   |
 | :------ | :--------- | :------------------------------------------------------- | :---------------------------------------------------------------------------------------------------------------------------------------- |
-| 0.5.4 | 2025-07-10 | [62922](https://github.com/airbytehq/airbyte/pull/62922) | Convert to new gradle build flow |
-| 0.5.3 | 2024-12-18 | [49893](https://github.com/airbytehq/airbyte/pull/49893) | Use a base image: airbyte/java-connector-base:1.0.0 |
-| 0.5.2 | 2024-02-13 | [35223](https://github.com/airbytehq/airbyte/pull/35223) | Adopt CDK 0.20.4 |
-| 0.5.1 | 2024-01-24 | [34453](https://github.com/airbytehq/airbyte/pull/34453) | bump CDK version |
-| 0.5.0 | 2023-12-18 | [33484](https://github.com/airbytehq/airbyte/pull/33484) | Remove LEGACY state |
+| 0.5.5   | 2025-01-27 | [60892](https://github.com/airbytehq/airbyte/pull/TBD)   | Update Redshift JDBC dependency and enhance table selection query                                                                         |
+| 0.5.4   | 2025-07-10 | [62922](https://github.com/airbytehq/airbyte/pull/62922) | Convert to new gradle build flow                                                                                                          |
+| 0.5.3   | 2024-12-18 | [49893](https://github.com/airbytehq/airbyte/pull/49893) | Use a base image: airbyte/java-connector-base:1.0.0                                                                                       |
+| 0.5.2   | 2024-02-13 | [35223](https://github.com/airbytehq/airbyte/pull/35223) | Adopt CDK 0.20.4                                                                                                                          |
+| 0.5.1   | 2024-01-24 | [34453](https://github.com/airbytehq/airbyte/pull/34453) | bump CDK version                                                                                                                          |
+| 0.5.0   | 2023-12-18 | [33484](https://github.com/airbytehq/airbyte/pull/33484) | Remove LEGACY state                                                                                                                       |
 | (none)  | 2023-11-17 | [32616](https://github.com/airbytehq/airbyte/pull/32616) | Improve timestamptz handling                                                                                                              |
 | 0.4.0   | 2023-06-26 | [27737](https://github.com/airbytehq/airbyte/pull/27737) | License Update: Elv2                                                                                                                      |
 | 0.3.17  | 2023-06-20 | [27212](https://github.com/airbytehq/airbyte/pull/27212) | Fix silent exception swallowing in StreamingJdbcDatabase                                                                                  |


### PR DESCRIPTION
## What
This PR enhances the Redshift source connector by:

- Updating the Redshift JDBC driver to version 2.1.0.32
- Adding AWS SDK core as a dependency for future compatibility
- Updating the SQL query used for table discovery to include late-binding views

This enables the connector to support Redshift schemas that use views created without immediate table bindings.

## How

- The Redshift JDBC driver version was updated in the connector's build.gradle file.
- The AWS SDK core dependency was added explicitly to ensure compatibility with potential future AWS-related Redshift features.
- The query used to retrieve tables was updated in RedshiftSource.java to ensure late-binding views are included during the schema discovery process.
- The connector was tested against a Redshift instance with both standard tables and late-binding views.

## Review guide

1. `build.gradle` — to verify dependency updates
2. `RedshiftSource.java` — to review query changes

## User Impact

- Postive: Redshift users relying on late-binding views will see correct schema discovery.
- No known negative side effects. Existing users with standard tables should see no change in behavior.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌

The changes are isolated to connector discovery logic and dependency versions. They do not affect core sync functionality and can be reverted cleanly if needed.


## Additional Information

Links to open issue: 
1. https://github.com/airbytehq/airbyte/issues/48832
2. https://github.com/airbytehq/airbyte/issues/25825