### PR TITLE
Cut release.

### DIFF
--- a/airbyte-integrations/connectors/destination-s3/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-s3/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: file
   connectorType: destination
   definitionId: 4816b78f-1489-44c1-9060-4b19d5fa9362
-  dockerImageTag: 1.8.5
+  dockerImageTag: 1.8.6
   dockerRepository: airbyte/destination-s3
   githubIssueLabel: destination-s3
   icon: s3.svg

--- a/docs/integrations/destinations/s3.md
+++ b/docs/integrations/destinations/s3.md
@@ -544,7 +544,7 @@ To see connector limitations, or troubleshoot your S3 connector, see more [in ou
 
 | Version     | Date       | Pull Request                                               | Subject                                                                                                                                              |
 |:------------|:-----------|:-----------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------|
-| 1.8.6       | 2025-05-23 | [123](https://github.com/airbytehq/airbyte/pull/123)       | Improves refresh overwrite behavior for file streams with differing paths per sync.                                                                  |
+| 1.8.6       | 2025-05-23 | [60893](https://github.com/airbytehq/airbyte/pull/60893)   | Improves refresh overwrite behavior for file streams with differing paths per sync.                                                                  |
 | 1.8.5       | 2025-05-16 | [60327](https://github.com/airbytehq/airbyte/pull/60327)   | Fixes file partitioning out of bounds error.                                                                                                         |
 | 1.8.4       | 2025-05-14 | [60313](https://github.com/airbytehq/airbyte/pull/60313)   | Re-wires up time window trigger. Files path releases memory properly.                                                                                |
 | 1.8.3       | 2025-05-14 | [60287](https://github.com/airbytehq/airbyte/pull/60287)   | Update spec.                                                                                                                                         |

--- a/docs/integrations/destinations/s3.md
+++ b/docs/integrations/destinations/s3.md
@@ -544,6 +544,7 @@ To see connector limitations, or troubleshoot your S3 connector, see more [in ou
 
 | Version     | Date       | Pull Request                                               | Subject                                                                                                                                              |
 |:------------|:-----------|:-----------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| 1.8.6       | 2025-05-23 | [123](https://github.com/airbytehq/airbyte/pull/123)       | Improves refresh overwrite behavior for file streams with differing paths per sync.                                                                  |
 | 1.8.5       | 2025-05-16 | [60327](https://github.com/airbytehq/airbyte/pull/60327)   | Fixes file partitioning out of bounds error.                                                                                                         |
 | 1.8.4       | 2025-05-14 | [60313](https://github.com/airbytehq/airbyte/pull/60313)   | Re-wires up time window trigger. Files path releases memory properly.                                                                                |
 | 1.8.3       | 2025-05-14 | [60287](https://github.com/airbytehq/airbyte/pull/60287)   | Update spec.                                                                                                                                         |


### PR DESCRIPTION
## What
Cuts new s3 release with the fix to not filter aggressively for file streams [link](https://github.com/airbytehq/airbyte/pull/60799)

## User Impact
We will now delete older files that exist in separate subdirs per sync when in full refresh overwrite mode.

