### PR TITLE
docs: add docs for how to create a working docker image

### DIFF
--- a/docs/integrations/custom-connectors.md
+++ b/docs/integrations/custom-connectors.md
@@ -36,7 +36,6 @@ See the following guides for more information on building custom Airbyte Docker 
 
 :::
 
-
 ## Upgrading a connector
 
 To upgrade your connector version, go to the Settings in the left hand side of the UI and navigate to either Sources or Destinations. Find your connector in the list, and input the latest connector version.

--- a/docs/integrations/custom-connectors.md
+++ b/docs/integrations/custom-connectors.md
@@ -25,11 +25,17 @@ It's easy to build your own connectors for Airbyte. You can learn how to build n
 While the guides in the link above are specific to the languages used most frequently to write integrations, **Airbyte connectors can be written in any language**. Please reach out to us if you'd like help developing connectors in other languages.
 
 :::caution
-If you don't use one of the official development options, remember to set the `AIRBYTE_ENTRYPOINT` environment variable to your Docker image's entrypoint!
-Otherwise, your connector will not run correctly.
+We strongly recommend creating new connectors using the [Connector Builder](https://docs.airbyte.com/connector-development/connector-builder-ui/overview) or one of the Airbyte CDKs.
+
+While it is not recommended to build Docker images from scratch, it can be useful to build a custom Docker image if you cannot use the Connector Builder, and if you need to use a language other than Python or CDK.
+
+See the following guides for more information on building custom Airbyte Docker images:
+
+- [Using Custom Connectors](../platform/operator-guides/using-custom-connectors)
+- [Airbyte Docker Protocol](../platform/understanding-airbyte/airbyte-protocol-docker.md)
+
 :::
 
-Learn how to upload Docker-based custom connectors [here](../../platform/operator-guides/using-custom-connectors/)
 
 ## Upgrading a connector
 

--- a/docs/integrations/custom-connectors.md
+++ b/docs/integrations/custom-connectors.md
@@ -32,7 +32,7 @@ While it is not recommended to build Docker images from scratch, it can be usefu
 See the following guides for more information on building custom Airbyte Docker images:
 
 - [Using Custom Connectors](../platform/operator-guides/using-custom-connectors)
-- [Airbyte Docker Protocol](../platform/understanding-airbyte/airbyte-protocol-docker.md)
+- [Airbyte Docker Protocol](../platform/understanding-airbyte/airbyte-protocol-docker)
 
 :::
 

--- a/docs/platform/operator-guides/using-custom-connectors.md
+++ b/docs/platform/operator-guides/using-custom-connectors.md
@@ -111,10 +111,10 @@ You can pull your connector image from your private registry to validate the pre
 
 5. `Add` the connector to save the configuration. You can now select your new connector when setting up a new connection!
 
-
 # Troubleshooting
 
 ## Loading connector docker containers into kind
+
 If you are running Airbyte in kind (kubernetes in docker -- this is the default method for abctl), you must load the docker image of that connector into the cluster. If you are seeing the following error, it likely means that the docker image has not been properly loaded into the cluster.
 
 ![Screenshot of UI error when custom connector container is not loaded in the cluster](./assets/custom-connector-error1.png)
@@ -122,10 +122,13 @@ If you are running Airbyte in kind (kubernetes in docker -- this is the default 
 ![Screenshot of K8s error when custom connector container is not loaded in the cluster](./assets/custom-connector-error2.png)
 
 A connector container can be loaded using the following command:
-```
+
+```bash
 kind load docker-image <image-name>:<image-tag> -n airbyte-abctl
 ```
+
 For the example above, the command would be:
-```
+
+```bash
 kind load docker-image airbyte/source-custom:1 -n airbyte-abctl
 ```

--- a/docs/platform/operator-guides/using-custom-connectors.md
+++ b/docs/platform/operator-guides/using-custom-connectors.md
@@ -36,6 +36,10 @@ To push and pull images to your private Docker registry, you need to authenticat
 - Your local or CI environment (where you build your connector image) must be able to **push** images to your registry.
 - Your Airbyte instance must be able to **pull** images from your registry.
 
+## 3. Adhere to Airbyte's Docker Image Requirements
+
+See the [Airbyte Protocol Docker Interface](../understanding-airbyte/airbyte-protocol-docker.md) page for specific Docker image requirements, such as required environment variables.
+
 ### For Docker-compose Airbyte deployments
 
 #### On GCP - Artifact Registry:

--- a/docs/platform/understanding-airbyte/airbyte-protocol-docker.md
+++ b/docs/platform/understanding-airbyte/airbyte-protocol-docker.md
@@ -70,7 +70,7 @@ This is the directory to which temporary files will be mounted, including the `c
 
 ## Only write file artifacts to directories permitted by the base image
 
-The connector code must only write only to directories permitted within the connector's base image.
+The connector code must only write to directories permitted within the connector's base image.
 
 For a list of permitted write directories, please consult the base image definitions in the [`airbytehq/airbyte` repo](https://github.com/airbytehq/airbyte), under the [`docker-images` directory](https://github.com/airbytehq/airbyte/tree/master/docker-images).
 

--- a/docs/platform/understanding-airbyte/airbyte-protocol-docker.md
+++ b/docs/platform/understanding-airbyte/airbyte-protocol-docker.md
@@ -73,3 +73,7 @@ This is the directory to which temporary files will be mounted, including the `c
 The connector code must only write only to directories permitted within the connector's base image.
 
 For a list of permitted write directories, please consult the base image definitions in the [`airbytehq/airbyte` repo](https://github.com/airbytehq/airbyte), under the [`docker-images` directory](https://github.com/airbytehq/airbyte/tree/master/docker-images).
+
+## Must be an `amd64` or multi-arch image
+
+To run on Airbyte Platform, the image bust be valid for `amd64`. Since most developers contribute from (ARM-based) Mac M-series laptops, we recommend creating a multi-arch image that covers both `arm64/amd64` so that the same image tags work on both ARM and AMD runtimes.

--- a/docs/platform/understanding-airbyte/airbyte-protocol-docker.md
+++ b/docs/platform/understanding-airbyte/airbyte-protocol-docker.md
@@ -51,3 +51,25 @@ The `write` command will consume `AirbyteMessage`s from STDIN.
 - Connectors receive arguments on the command line via JSON files. `e.g. --catalog catalog.json`
 - They read `AirbyteMessage`s from STDIN. The destination `write` action is the only command that consumes `AirbyteMessage`s.
 - They emit `AirbyteMessage`s on STDOUT.
+
+## Additional Docker Image Requirements
+
+### Environment variable: `AIRBYTE_ENTRYPOINT` 
+
+The Docker image should contain an environment variable called `AIRBYTE_ENTRYPOINT`. This must be the same as the `ENTRYPOINT` of the image.
+
+## User: `Airbyte`
+
+The Docker image should run under a user named `airbyte`.
+
+## Specified `/airbyte` directory
+
+The Docker image must have a directory called `/airbyte`, which the user `airbyte` owns and can write to.
+
+This is the directory to which temporary files will be mounted, including the `config.json` and `catalog.json` files.
+
+## Only write file artifacts to directories permitted by the base image
+
+The connector code must only write only to directories permitted within the connector's base image.
+
+For a list of permitted write directories, please consult the base image definitions in the [`airbytehq/airbyte` repo](https://github.com/airbytehq/airbyte), under the [`docker-images` directory](https://github.com/airbytehq/airbyte/tree/master/docker-images).

--- a/docs/platform/understanding-airbyte/airbyte-protocol-docker.md
+++ b/docs/platform/understanding-airbyte/airbyte-protocol-docker.md
@@ -56,9 +56,9 @@ The `write` command will consume `AirbyteMessage`s from STDIN.
 
 ### Environment variable: `AIRBYTE_ENTRYPOINT` 
 
-The Docker image should contain an environment variable called `AIRBYTE_ENTRYPOINT`. This must be the same as the `ENTRYPOINT` of the image.
+The Docker image must contain an environment variable called `AIRBYTE_ENTRYPOINT`. This must be the same as the `ENTRYPOINT` of the image.
 
-## User: `Airbyte`
+## Non-Root User: `airbyte`
 
 The Docker image should run under a user named `airbyte`.
 

--- a/docusaurus/platform_versioned_docs/version-1.6/operator-guides/using-custom-connectors.md
+++ b/docusaurus/platform_versioned_docs/version-1.6/operator-guides/using-custom-connectors.md
@@ -3,7 +3,7 @@ products: oss-*
 sidebar_label: Uploading custom connectors
 ---
 
-import ContainerProviders from '@site/static/\_docker_image_registries.md';
+import ContainerProviders from '@site/static/_docker_image_registries.md';
 
 # Uploading Docker-based custom connectors
 
@@ -110,9 +110,11 @@ You can pull your connector image from your private registry to validate the pre
    This documentation will be linked in your connector setting's page.
 
 5. `Add` the connector to save the configuration. You can now select your new connector when setting up a new connection!
+
 # Troubleshooting
 
 ## Loading connector docker containers into kind
+
 If you are running Airbyte in kind (kubernetes in docker -- this is the default method for abctl), you must load the docker image of that connector into the cluster. If you are seeing the following error, it likely means that the docker image has not been properly loaded into the cluster.
 
 ![Screenshot of UI error when custom connector container is not loaded in the cluster](./assets/custom-connector-error1.png)
@@ -120,10 +122,13 @@ If you are running Airbyte in kind (kubernetes in docker -- this is the default 
 ![Screenshot of K8s error when custom connector container is not loaded in the cluster](./assets/custom-connector-error2.png)
 
 A connector container can be loaded using the following command:
-```
+
+```bash
 kind load docker-image <image-name>:<image-tag> -n airbyte-abctl
 ```
+
 For the example above, the command would be:
-```
+
+```bash
 kind load docker-image airbyte/source-custom:1 -n airbyte-abctl
 ```

--- a/docusaurus/platform_versioned_docs/version-1.6/operator-guides/using-custom-connectors.md
+++ b/docusaurus/platform_versioned_docs/version-1.6/operator-guides/using-custom-connectors.md
@@ -3,7 +3,7 @@ products: oss-*
 sidebar_label: Uploading custom connectors
 ---
 
-import ContainerProviders from '@site/static/_docker_image_registries.md';
+import ContainerProviders from '@site/static/\_docker_image_registries.md';
 
 # Uploading Docker-based custom connectors
 

--- a/docusaurus/platform_versioned_docs/version-1.6/operator-guides/using-custom-connectors.md
+++ b/docusaurus/platform_versioned_docs/version-1.6/operator-guides/using-custom-connectors.md
@@ -3,7 +3,7 @@ products: oss-*
 sidebar_label: Uploading custom connectors
 ---
 
-import ContainerProviders from '@site/static/\_docker_image_registries.md';
+import ContainerProviders from '@site/static/_docker_image_registries.md';
 
 # Uploading Docker-based custom connectors
 
@@ -35,6 +35,10 @@ To push and pull images to your private Docker registry, you need to authenticat
 
 - Your local or CI environment (where you build your connector image) must be able to **push** images to your registry.
 - Your Airbyte instance must be able to **pull** images from your registry.
+
+## 3. Adhere to Airbyte's Docker Image Requirements
+
+See the [Airbyte Protocol Docker Interface](../understanding-airbyte/airbyte-protocol-docker.md) page for specific Docker image requirements, such as required environment variables.
 
 ### For Docker-compose Airbyte deployments
 
@@ -107,10 +111,10 @@ You can pull your connector image from your private registry to validate the pre
 
 5. `Add` the connector to save the configuration. You can now select your new connector when setting up a new connection!
 
+
 # Troubleshooting
 
 ## Loading connector docker containers into kind
-
 If you are running Airbyte in kind (kubernetes in docker -- this is the default method for abctl), you must load the docker image of that connector into the cluster. If you are seeing the following error, it likely means that the docker image has not been properly loaded into the cluster.
 
 ![Screenshot of UI error when custom connector container is not loaded in the cluster](./assets/custom-connector-error1.png)
@@ -118,13 +122,10 @@ If you are running Airbyte in kind (kubernetes in docker -- this is the default 
 ![Screenshot of K8s error when custom connector container is not loaded in the cluster](./assets/custom-connector-error2.png)
 
 A connector container can be loaded using the following command:
-
 ```
 kind load docker-image <image-name>:<image-tag> -n airbyte-abctl
 ```
-
 For the example above, the command would be:
-
 ```
 kind load docker-image airbyte/source-custom:1 -n airbyte-abctl
 ```

--- a/docusaurus/platform_versioned_docs/version-1.6/operator-guides/using-custom-connectors.md
+++ b/docusaurus/platform_versioned_docs/version-1.6/operator-guides/using-custom-connectors.md
@@ -110,8 +110,6 @@ You can pull your connector image from your private registry to validate the pre
    This documentation will be linked in your connector setting's page.
 
 5. `Add` the connector to save the configuration. You can now select your new connector when setting up a new connection!
-
-
 # Troubleshooting
 
 ## Loading connector docker containers into kind

--- a/docusaurus/platform_versioned_docs/version-1.6/understanding-airbyte/airbyte-protocol-docker.md
+++ b/docusaurus/platform_versioned_docs/version-1.6/understanding-airbyte/airbyte-protocol-docker.md
@@ -73,3 +73,7 @@ This is the directory to which temporary files will be mounted, including the `c
 The connector code must only write only to directories permitted within the connector's base image.
 
 For a list of permitted write directories, please consult the base image definitions in the [`airbytehq/airbyte` repo](https://github.com/airbytehq/airbyte), under the [`docker-images` directory](https://github.com/airbytehq/airbyte/tree/master/docker-images).
+
+## Must be an `amd64` or multi-arch image
+
+To run on Airbyte Platform, the image bust be valid for `amd64`. Since most developers contribute from (ARM-based) Mac M-series laptops, we recommend creating a multi-arch image that covers both `arm64/amd64` so that the same image tags work on both ARM and AMD runtimes.

--- a/docusaurus/platform_versioned_docs/version-1.6/understanding-airbyte/airbyte-protocol-docker.md
+++ b/docusaurus/platform_versioned_docs/version-1.6/understanding-airbyte/airbyte-protocol-docker.md
@@ -51,3 +51,25 @@ The `write` command will consume `AirbyteMessage`s from STDIN.
 - Connectors receive arguments on the command line via JSON files. `e.g. --catalog catalog.json`
 - They read `AirbyteMessage`s from STDIN. The destination `write` action is the only command that consumes `AirbyteMessage`s.
 - They emit `AirbyteMessage`s on STDOUT.
+
+## Additional Docker Image Requirements
+
+### Environment variable: `AIRBYTE_ENTRYPOINT` 
+
+The Docker image should contain an environment variable called `AIRBYTE_ENTRYPOINT`. This must be the same as the `ENTRYPOINT` of the image.
+
+## User: `Airbyte`
+
+The Docker image should run under a user named `airbyte`.
+
+## Specified `/airbyte` directory
+
+The Docker image must have a directory called `/airbyte`, which the user `airbyte` owns and can write to.
+
+This is the directory to which temporary files will be mounted, including the `config.json` and `catalog.json` files.
+
+## Only write file artifacts to directories permitted by the base image
+
+The connector code must only write only to directories permitted within the connector's base image.
+
+For a list of permitted write directories, please consult the base image definitions in the [`airbytehq/airbyte` repo](https://github.com/airbytehq/airbyte), under the [`docker-images` directory](https://github.com/airbytehq/airbyte/tree/master/docker-images).

--- a/docusaurus/platform_versioned_docs/version-1.6/understanding-airbyte/airbyte-protocol-docker.md
+++ b/docusaurus/platform_versioned_docs/version-1.6/understanding-airbyte/airbyte-protocol-docker.md
@@ -56,9 +56,9 @@ The `write` command will consume `AirbyteMessage`s from STDIN.
 
 ### Environment variable: `AIRBYTE_ENTRYPOINT` 
 
-The Docker image should contain an environment variable called `AIRBYTE_ENTRYPOINT`. This must be the same as the `ENTRYPOINT` of the image.
+The Docker image must contain an environment variable called `AIRBYTE_ENTRYPOINT`. This must be the same as the `ENTRYPOINT` of the image.
 
-## User: `Airbyte`
+## Non-Root User: `airbyte`
 
 The Docker image should run under a user named `airbyte`.
 


### PR DESCRIPTION
## What

This PR attempts to document all requirements for building Docker images that:
1. Work correctly in Airbyte Platform (Cloud, OSS, etc.)
2. Play nicely with base images and current status quo `airbyte-ci`-managed image builds.

## My Ask

If I've missed anything, lmk.
If anything is wrong, lmk.

## Philosophy

If something is _sometimes_ needed, lets document it. Better for the reader to jump through extra hoops than to create a docker image that won't run for any reason. 😇

## Preview Docs Link

[Rendered preview here](https://github.com/airbytehq/airbyte/blob/4d8180c111a94f38f356ef63102b5546505977f6/docusaurus/platform_versioned_docs/version-1.6/understanding-airbyte/airbyte-protocol-docker.md#additional-docker-image-requirements)

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._