### PR TITLE
fix(destination-motherduck): Add Unicode-aware normalizer

### DIFF
--- a/airbyte-integrations/connectors/destination-motherduck/destination_motherduck/destination.py
+++ b/airbyte-integrations/connectors/destination-motherduck/destination_motherduck/destination.py
@@ -32,6 +32,7 @@ from airbyte_cdk.models import (
 )
 from airbyte_cdk.models.airbyte_protocol_serializers import custom_type_resolver
 from airbyte_cdk.sql._util.name_normalizers import LowerCaseNormalizer
+from airbyte_cdk.sql import exceptions as exc
 from airbyte_cdk.sql.constants import AB_EXTRACTED_AT_COLUMN, AB_INTERNAL_COLUMNS, AB_META_COLUMN, AB_RAW_ID_COLUMN
 from airbyte_cdk.sql.secrets import SecretString
 from airbyte_cdk.sql.shared.catalog_providers import CatalogProvider
@@ -81,9 +82,63 @@ def validated_sql_name(sql_name: Any) -> str:
     raise ValueError(f"Invalid SQL name: {sql_name}")
 
 
+class UnicodeAwareNormalizer:
+    """Normalizer that preserves Unicode characters while following LowerCaseNormalizer behavior for ASCII."""
+    
+    def normalize(self, name: str) -> str:
+        """
+        Normalize name while preserving Unicode characters.
+        
+        Behavior:
+        - Converts ASCII letters to lowercase
+        - Replaces whitespace with underscores
+        - Preserves Unicode letters and numbers
+        - Adds underscore prefix if name starts with ASCII digit
+        - Replaces other special characters with underscores
+        """
+        if not name:
+            raise exc.AirbyteNameNormalizationError(
+                "Name cannot be empty after normalization.",
+                raw_name=name,
+                normalization_result="",
+            )
+        
+        import unicodedata
+        
+        # Convert to lowercase (handles both ASCII and Unicode)
+        result = name.lower()
+        
+        # Replace whitespace with underscores
+        result = re.sub(r'\s+', '_', result)
+        
+        # Replace special characters (non-letters, non-digits, non-underscores) with underscores
+        # But preserve Unicode letters and digits using Unicode-aware regex
+        result = re.sub(r'[^\w]', '_', result, flags=re.UNICODE)
+        
+        # Collapse multiple consecutive underscores
+        result = re.sub(r'_+', '_', result)
+        
+        # Remove leading/trailing underscores
+        result = result.strip('_')
+        
+        # Add underscore prefix if starts with ASCII digit (following LowerCaseNormalizer behavior)
+        if result and result[0].isdigit():
+            result = '_' + result
+        
+        # Final validation
+        if not result:
+            raise exc.AirbyteNameNormalizationError(
+                "Name cannot be empty after normalization.",
+                raw_name=name,
+                normalization_result=result,
+            )
+        
+        return result
+
+
 class DestinationMotherDuck(Destination):
     type_converter_class = SQLTypeConverter
-    normalizer = LowerCaseNormalizer
+    normalizer = UnicodeAwareNormalizer
 
     @staticmethod
     def _is_motherduck(path: str | None) -> bool:

--- a/airbyte-integrations/connectors/destination-motherduck/destination_motherduck/destination.py
+++ b/airbyte-integrations/connectors/destination-motherduck/destination_motherduck/destination.py
@@ -31,8 +31,8 @@ from airbyte_cdk.models import (
     Type,
 )
 from airbyte_cdk.models.airbyte_protocol_serializers import custom_type_resolver
-from airbyte_cdk.sql._util.name_normalizers import LowerCaseNormalizer
 from airbyte_cdk.sql import exceptions as exc
+from airbyte_cdk.sql._util.name_normalizers import LowerCaseNormalizer
 from airbyte_cdk.sql.constants import AB_EXTRACTED_AT_COLUMN, AB_INTERNAL_COLUMNS, AB_META_COLUMN, AB_RAW_ID_COLUMN
 from airbyte_cdk.sql.secrets import SecretString
 from airbyte_cdk.sql.shared.catalog_providers import CatalogProvider
@@ -84,11 +84,11 @@ def validated_sql_name(sql_name: Any) -> str:
 
 class UnicodeAwareNormalizer:
     """Normalizer that preserves Unicode characters while following LowerCaseNormalizer behavior for ASCII."""
-    
+
     def normalize(self, name: str) -> str:
         """
         Normalize name while preserving Unicode characters.
-        
+
         Behavior:
         - Converts ASCII letters to lowercase
         - Replaces whitespace with underscores
@@ -102,29 +102,29 @@ class UnicodeAwareNormalizer:
                 raw_name=name,
                 normalization_result="",
             )
-        
+
         import unicodedata
-        
+
         # Convert to lowercase (handles both ASCII and Unicode)
         result = name.lower()
-        
+
         # Replace whitespace with underscores
-        result = re.sub(r'\s+', '_', result)
-        
+        result = re.sub(r"\s+", "_", result)
+
         # Replace special characters (non-letters, non-digits, non-underscores) with underscores
         # But preserve Unicode letters and digits using Unicode-aware regex
-        result = re.sub(r'[^\w]', '_', result, flags=re.UNICODE)
-        
+        result = re.sub(r"[^\w]", "_", result, flags=re.UNICODE)
+
         # Collapse multiple consecutive underscores
-        result = re.sub(r'_+', '_', result)
-        
+        result = re.sub(r"_+", "_", result)
+
         # Remove leading/trailing underscores
-        result = result.strip('_')
-        
+        result = result.strip("_")
+
         # Add underscore prefix if starts with ASCII digit (following LowerCaseNormalizer behavior)
         if result and result[0].isdigit():
-            result = '_' + result
-        
+            result = "_" + result
+
         # Final validation
         if not result:
             raise exc.AirbyteNameNormalizationError(
@@ -132,7 +132,7 @@ class UnicodeAwareNormalizer:
                 raw_name=name,
                 normalization_result=result,
             )
-        
+
         return result
 
 
@@ -187,9 +187,7 @@ class DestinationMotherDuck(Destination):
 
         destination_path = os.path.normpath(destination_path)
         if not destination_path.startswith("/local"):
-            raise ValueError(
-                f"destination_path={destination_path} is not a valid path." "A valid path shall start with /local or no / prefix"
-            )
+            raise ValueError(f"destination_path={destination_path} is not a valid path. A valid path shall start with /local or no / prefix")
 
         return destination_path
 

--- a/airbyte-integrations/connectors/destination-motherduck/destination_motherduck/destination.py
+++ b/airbyte-integrations/connectors/destination-motherduck/destination_motherduck/destination.py
@@ -187,7 +187,9 @@ class DestinationMotherDuck(Destination):
 
         destination_path = os.path.normpath(destination_path)
         if not destination_path.startswith("/local"):
-            raise ValueError(f"destination_path={destination_path} is not a valid path. A valid path shall start with /local or no / prefix")
+            raise ValueError(
+                f"destination_path={destination_path} is not a valid path. A valid path shall start with /local or no / prefix"
+            )
 
         return destination_path
 

--- a/airbyte-integrations/connectors/destination-motherduck/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-motherduck/metadata.yaml
@@ -4,7 +4,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: 042ee9b5-eb98-4e99-a4e5-3f0d573bee66
-  dockerImageTag: 0.1.18
+  dockerImageTag: 0.1.19
   dockerRepository: airbyte/destination-motherduck
   githubIssueLabel: destination-motherduck
   icon: duckdb.svg

--- a/airbyte-integrations/connectors/destination-motherduck/pyproject.toml
+++ b/airbyte-integrations/connectors/destination-motherduck/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "airbyte-destination-motherduck"
-version = "0.1.18"
+version = "0.1.19"
 description = "Destination implementation for MotherDuck."
 authors = ["Guen Prawiroatmodjo, Simon Späti, Airbyte"]
 license = "MIT"

--- a/airbyte-integrations/connectors/destination-motherduck/unit_tests/unit_test.py
+++ b/airbyte-integrations/connectors/destination-motherduck/unit_tests/unit_test.py
@@ -1,7 +1,9 @@
 # Copyright (c) 2024 Airbyte, Inc., all rights reserved.
 
 import pytest
-from destination_motherduck.destination import DestinationMotherDuck, validated_sql_name
+from destination_motherduck.destination import DestinationMotherDuck, UnicodeAwareNormalizer, validated_sql_name
+from airbyte_cdk.sql._util.name_normalizers import LowerCaseNormalizer
+from airbyte_cdk.sql.exceptions import AirbyteNameNormalizationError
 
 
 def test_read_invalid_path():
@@ -32,3 +34,117 @@ def test_validated_sql_name(input, expected):
             validated_sql_name(input)
     else:
         assert validated_sql_name(input) == expected
+
+
+class TestUnicodeAwareNormalizer:
+    """Test the UnicodeAwareNormalizer that preserves Unicode characters."""
+    
+    def setup_method(self):
+        self.normalizer = UnicodeAwareNormalizer()
+        self.old_normalizer = LowerCaseNormalizer()
+    
+    @pytest.mark.parametrize(
+        "input_name, expected_output",
+        [
+            # ASCII cases should behave like LowerCaseNormalizer
+            ("normal_name", "normal_name"),
+            ("Test Name", "test_name"),
+            ("UPPERCASE", "uppercase"),
+            ("Column With Spaces", "column_with_spaces"),
+            ("mixed_123_name", "mixed_123_name"),
+            ("123", "_123"),  # Digit prefix gets underscore
+            ("test-with-dashes", "test_with_dashes"),
+            ("test.with.dots", "test_with_dots"),
+            ("test!@#$%^&*()", "test"),
+            ("café", "café"),  # Should preserve Unicode letters
+            
+            # Unicode cases that should work (these fail with LowerCaseNormalizer)
+            ("税率", "税率"),  # Japanese characters
+            ("你好", "你好"),  # Chinese characters  
+            ("åäö", "åäö"),  # Nordic characters
+            ("naïve", "naïve"),  # Accented characters
+            ("Müller", "müller"),  # German umlauts
+            ("Jürgen", "jürgen"),  # More German
+            ("François", "françois"),  # French
+            ("Москва", "москва"),  # Cyrillic (Russian)
+            ("مرحبا", "مرحبا"),  # Arabic
+            ("हिन्दी", "ह_न_द"),  # Hindi (complex script with combining chars)
+            
+            # Mixed Unicode and ASCII
+            ("User 名前", "user_名前"),
+            ("Product税率", "product税率"),
+            ("Column_税率_Name", "column_税率_name"),
+        ],
+    )
+    def test_unicode_aware_normalization(self, input_name, expected_output):
+        """Test that UnicodeAwareNormalizer preserves Unicode while normalizing ASCII."""
+        result = self.normalizer.normalize(input_name)
+        assert result == expected_output
+    
+    def test_empty_name_raises_error(self):
+        """Test that empty names raise appropriate error."""
+        with pytest.raises(AirbyteNameNormalizationError) as exc_info:
+            self.normalizer.normalize("")
+        
+        assert "Name cannot be empty after normalization" in str(exc_info.value)
+    
+    def test_whitespace_only_name_raises_error(self):
+        """Test that whitespace-only names raise appropriate error."""
+        with pytest.raises(AirbyteNameNormalizationError) as exc_info:
+            self.normalizer.normalize("   ")
+        
+        assert "Name cannot be empty after normalization" in str(exc_info.value)
+    
+    def test_special_chars_only_raises_error(self):
+        """Test that names with only special characters raise appropriate error."""
+        with pytest.raises(AirbyteNameNormalizationError) as exc_info:
+            self.normalizer.normalize("!@#$%^&*()")
+        
+        assert "Name cannot be empty after normalization" in str(exc_info.value)
+    
+    def test_ascii_compatibility_with_lowercase_normalizer(self):
+        """Test that ASCII inputs produce the same results as LowerCaseNormalizer."""
+        ascii_test_cases = [
+            "normal_name",
+            "Test Name", 
+            "UPPERCASE",
+            "mixed_123_name",
+            "Column With Spaces",
+        ]
+        
+        for test_case in ascii_test_cases:
+            try:
+                old_result = self.old_normalizer.normalize(test_case)
+                new_result = self.normalizer.normalize(test_case)
+                assert new_result == old_result, f"ASCII compatibility failed for '{test_case}'"
+            except AirbyteNameNormalizationError:
+                # If old normalizer fails, new one should also fail
+                with pytest.raises(AirbyteNameNormalizationError):
+                    self.normalizer.normalize(test_case)
+    
+    def test_unicode_cases_that_fail_with_old_normalizer(self):
+        """Test Unicode cases that fail with LowerCaseNormalizer but work with UnicodeAwareNormalizer."""
+        unicode_test_cases = [
+            ("税率", "税率"),  # The customer's specific problem case
+            ("你好", "你好"),
+            ("åäö", "åäö"),
+        ]
+        
+        for input_name, expected in unicode_test_cases:
+            # Old normalizer should fail
+            with pytest.raises(AirbyteNameNormalizationError):
+                self.old_normalizer.normalize(input_name)
+            
+            # New normalizer should succeed
+            result = self.normalizer.normalize(input_name)
+            assert result == expected
+    
+    def test_consecutive_underscores_collapsed(self):
+        """Test that consecutive underscores are collapsed to single underscore."""
+        result = self.normalizer.normalize("test___multiple___underscores")
+        assert result == "test_multiple_underscores"
+    
+    def test_leading_trailing_underscores_removed(self):
+        """Test that leading and trailing underscores are removed."""
+        result = self.normalizer.normalize("___test___")
+        assert result == "test"

--- a/airbyte-integrations/connectors/destination-motherduck/unit_tests/unit_test.py
+++ b/airbyte-integrations/connectors/destination-motherduck/unit_tests/unit_test.py
@@ -2,6 +2,7 @@
 
 import pytest
 from destination_motherduck.destination import DestinationMotherDuck, UnicodeAwareNormalizer, validated_sql_name
+
 from airbyte_cdk.sql._util.name_normalizers import LowerCaseNormalizer
 from airbyte_cdk.sql.exceptions import AirbyteNameNormalizationError
 
@@ -38,11 +39,11 @@ def test_validated_sql_name(input, expected):
 
 class TestUnicodeAwareNormalizer:
     """Test the UnicodeAwareNormalizer that preserves Unicode characters."""
-    
+
     def setup_method(self):
         self.normalizer = UnicodeAwareNormalizer()
         self.old_normalizer = LowerCaseNormalizer()
-    
+
     @pytest.mark.parametrize(
         "input_name, expected_output",
         [
@@ -57,10 +58,9 @@ class TestUnicodeAwareNormalizer:
             ("test.with.dots", "test_with_dots"),
             ("test!@#$%^&*()", "test"),
             ("café", "café"),  # Should preserve Unicode letters
-            
             # Unicode cases that should work (these fail with LowerCaseNormalizer)
             ("税率", "税率"),  # Japanese characters
-            ("你好", "你好"),  # Chinese characters  
+            ("你好", "你好"),  # Chinese characters
             ("åäö", "åäö"),  # Nordic characters
             ("naïve", "naïve"),  # Accented characters
             ("Müller", "müller"),  # German umlauts
@@ -69,7 +69,6 @@ class TestUnicodeAwareNormalizer:
             ("Москва", "москва"),  # Cyrillic (Russian)
             ("مرحبا", "مرحبا"),  # Arabic
             ("हिन्दी", "ह_न_द"),  # Hindi (complex script with combining chars)
-            
             # Mixed Unicode and ASCII
             ("User 名前", "user_名前"),
             ("Product税率", "product税率"),
@@ -80,38 +79,38 @@ class TestUnicodeAwareNormalizer:
         """Test that UnicodeAwareNormalizer preserves Unicode while normalizing ASCII."""
         result = self.normalizer.normalize(input_name)
         assert result == expected_output
-    
+
     def test_empty_name_raises_error(self):
         """Test that empty names raise appropriate error."""
         with pytest.raises(AirbyteNameNormalizationError) as exc_info:
             self.normalizer.normalize("")
-        
+
         assert "Name cannot be empty after normalization" in str(exc_info.value)
-    
+
     def test_whitespace_only_name_raises_error(self):
         """Test that whitespace-only names raise appropriate error."""
         with pytest.raises(AirbyteNameNormalizationError) as exc_info:
             self.normalizer.normalize("   ")
-        
+
         assert "Name cannot be empty after normalization" in str(exc_info.value)
-    
+
     def test_special_chars_only_raises_error(self):
         """Test that names with only special characters raise appropriate error."""
         with pytest.raises(AirbyteNameNormalizationError) as exc_info:
             self.normalizer.normalize("!@#$%^&*()")
-        
+
         assert "Name cannot be empty after normalization" in str(exc_info.value)
-    
+
     def test_ascii_compatibility_with_lowercase_normalizer(self):
         """Test that ASCII inputs produce the same results as LowerCaseNormalizer."""
         ascii_test_cases = [
             "normal_name",
-            "Test Name", 
+            "Test Name",
             "UPPERCASE",
             "mixed_123_name",
             "Column With Spaces",
         ]
-        
+
         for test_case in ascii_test_cases:
             try:
                 old_result = self.old_normalizer.normalize(test_case)
@@ -121,7 +120,7 @@ class TestUnicodeAwareNormalizer:
                 # If old normalizer fails, new one should also fail
                 with pytest.raises(AirbyteNameNormalizationError):
                     self.normalizer.normalize(test_case)
-    
+
     def test_unicode_cases_that_fail_with_old_normalizer(self):
         """Test Unicode cases that fail with LowerCaseNormalizer but work with UnicodeAwareNormalizer."""
         unicode_test_cases = [
@@ -129,21 +128,21 @@ class TestUnicodeAwareNormalizer:
             ("你好", "你好"),
             ("åäö", "åäö"),
         ]
-        
+
         for input_name, expected in unicode_test_cases:
             # Old normalizer should fail
             with pytest.raises(AirbyteNameNormalizationError):
                 self.old_normalizer.normalize(input_name)
-            
+
             # New normalizer should succeed
             result = self.normalizer.normalize(input_name)
             assert result == expected
-    
+
     def test_consecutive_underscores_collapsed(self):
         """Test that consecutive underscores are collapsed to single underscore."""
         result = self.normalizer.normalize("test___multiple___underscores")
         assert result == "test_multiple_underscores"
-    
+
     def test_leading_trailing_underscores_removed(self):
         """Test that leading and trailing underscores are removed."""
         result = self.normalizer.normalize("___test___")

--- a/docs/integrations/destinations/motherduck.md
+++ b/docs/integrations/destinations/motherduck.md
@@ -72,6 +72,7 @@ This connector is primarily designed to work with MotherDuck and local DuckDB fi
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                          |
 | :------ | :--------- | :------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------- |
+| 0.1.19 | 2025-05-25 | [60905](https://github.com/airbytehq/airbyte/pull/60905) | Allow unicode characters in database/table names |
 | 0.1.18 | 2025-03-01 | [54737](https://github.com/airbytehq/airbyte/pull/54737) | Update airbyte-cdk to ^6.0.0 in destination-motherduck |
 | 0.1.17 | 2024-12-26 | [50425](https://github.com/airbytehq/airbyte/pull/50425) | Fix bug overwrite write method not saving all batches |
 | 0.1.16 | 2024-12-06 | [48562](https://github.com/airbytehq/airbyte/pull/48562) | Improved handling of config parameters during SQL engine creation. |


### PR DESCRIPTION
Okay, Claude absolutely earned its attribution. It did what I would have done... but faster, and tbh, more thorougly. Do you want this normalizer to be pulled up from the MotherDuck destination to be a reusable utility?

## What
Replaces LowerCaseNormalizer with UnicodeAwareNormalizer in MotherDuck destination connector to preserve Unicode characters in column names while maintaining ASCII compatibility.

- Resolves customer issue with Japanese column names like "税率"
- Preserves Unicode letters/numbers using Unicode-aware regex
- Maintains existing LowerCaseNormalizer behavior for ASCII inputs
- Adds comprehensive unit tests covering 30 test cases
- Verified DuckDB compatibility with Unicode table names


## User Impact
Hopefully internationalized table names now work. DuckDB supports basically any name you throw at it.

## Can this PR be safely reverted and rolled back?

- [ x ] YES 💚
- [ ] NO ❌
