### PR TITLE
source-stripe: Invoice Line Items and subscription items 

### DIFF
--- a/airbyte-integrations/connectors/source-stripe/metadata.yaml
+++ b/airbyte-integrations/connectors/source-stripe/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: e094cb9a-26de-4645-8761-65c0c425d1de
-  dockerImageTag: 5.13.0
+  dockerImageTag: 5.13.1
   dockerRepository: airbyte/source-stripe
   documentationUrl: https://docs.airbyte.com/integrations/sources/stripe
   erdUrl: https://dbdocs.io/airbyteio/source-stripe?view=relationships

--- a/airbyte-integrations/connectors/source-stripe/pyproject.toml
+++ b/airbyte-integrations/connectors/source-stripe/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "5.13.0"
+version = "5.13.1"
 name = "source-stripe"
 description = "Source implementation for Stripe."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-stripe/source_stripe/manifest.yaml
+++ b/airbyte-integrations/connectors/source-stripe/source_stripe/manifest.yaml
@@ -1065,100 +1065,46 @@ definitions:
               types[]: '{{["person.created", "person.updated", "person.deleted"]}}'
 
     invoice_line_items:
-      type: StateDelegatingStream
+      $ref: "#/definitions/entity_stream"
       $parameters:
         name: invoice_line_items
-      full_refresh_stream:
-        type: DeclarativeStream
-        primary_key:
-          - id
-        schema_loader:
-          type: JsonFileSchemaLoader
-          file_path: "./source_stripe/schemas/{{ parameters['name'] }}.json"
-        retriever:
-          type: SimpleRetriever
-          requester:
-            $ref: "#/definitions/base_requester"
-            path: invoices/{{stream_partition.invoice_id}}/lines
-          record_selector:
-            type: RecordSelector
-            extractor:
-              type: DpathExtractor
-              field_path:
-                - data
-            transform_before_filtering: true
-            schema_normalization: Default
-          paginator:
-            $ref: "#/definitions/base_paginator"
-          partition_router:
-            type: SubstreamPartitionRouter
-            parent_stream_configs:
-              - type: ParentStreamConfig
-                parent_key: id
-                partition_field: invoice_id
-                extra_fields:
-                  - ["id"]
-                  - ["created"]
-                  - ["updated"]
-                lazy_read_pointer: ["lines"]
-                stream:
-                  $ref: "#/definitions/streams/invoices"
-        incremental_sync:
-          $ref: "#/definitions/entity_single_slice_cursor"
-          cursor_field: invoice_updated
-          global_substream_cursor: true
-        transformations:
-          - type: AddFields
-            fields:
-              - path:
-                  - invoice_id
-                value: "{{ stream_slice.extra_fields['id']}}"
-                value_type: integer
-          - type: AddFields
-            fields:
-              - path:
-                  - invoice_created
-                value: "{{ stream_slice.extra_fields['created'] | int}}"
-                value_type: integer
-          - type: AddFields
-            fields:
-              - path:
-                  - invoice_updated
-                value: "{{ stream_slice.extra_fields['updated'] | int}}"
-                value_type: integer
-      incremental_stream:
-        $ref: "#/definitions/events_based_stream"
-        incremental_sync:
-          $ref: "#/definitions/entity_single_slice_cursor"
-          cursor_field: invoice_updated
-        retriever:
-          $ref: "#/definitions/events_objects_retriever"
-          $parameters:
-            request_parameters:
-              types[]: '{{["invoice.created", "invoice.deleted", "invoice.updated"]}}'
-        transformations:
-          - type: AddFields
-            fields:
-              - path:
-                  - data
-                  - object
-                  - is_deleted
-                value: "{{ True }}"
-            condition: "{{ record.get('data', {}).get('object', False) and record.get('type', '').endswith('.deleted') }}"
-          - type: AddFields
-            fields:
-              - path:
-                  - data
-                  - object
-                  - invoice_updated
-                value: "{{ record.get('updated', record.get('created', now_utc().timestamp())) | int }}"
-                value_type: integer
-            condition: "{{ record.get('data', {}).get('object', False) }}"
-          - type: DpathFlattenFields
-            field_path:
-              - data
-              - object
-            replace_record: true
+      retriever:
+        $ref: "#/definitions/base_retriever"
+        partition_router:
+          type: SubstreamPartitionRouter
+          parent_stream_configs:
+            - type: ParentStreamConfig
+              parent_key: id
+              partition_field: partition_id
+              stream:
+                $ref: "#/definitions/streams/invoices"
+              incremental_dependency: true
+              extra_fields:
+                - ["created"]
+                - ["updated"]
+        $parameters:
+          path: invoices/{{ stream_partition.partition_id }}/lines
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path: ["data"]
+      incremental_sync:
+        $ref: "#/definitions/entity_single_slice_cursor"
+        cursor_field: invoice_created
+        global_substream_cursor: true
+      transformations:
+        - type: AddFields
+          fields:
+            - path: ["invoice_id"]
+              value: "{{ stream_partition.partition_id }}"
+              value_type: string
+            - path: ["invoice_created"]
+              value: "{{ stream_slice.extra_fields['created'] | int }}"
+              value_type: integer
+            - path: ["invoice_updated"]
+              value: "{{ stream_slice.extra_fields['updated'] | int }}"
+              value_type: integer
 
     application_fees_refunds:
       type: StateDelegatingStream
@@ -1251,6 +1197,7 @@ definitions:
           fields:
             - path: ["subscription_id"]
               value: "{{ stream_partition.subscription_id }}"
+              value_type: string
             - path: ["subscription_updated"]
               value: "{{ stream_slice.extra_fields['updated'] | int }}"
               value_type: integer
@@ -1432,6 +1379,7 @@ streams:
   - $ref: "#/definitions/streams/setup_attempts"
   - $ref: "#/definitions/streams/transfer_reversals"
   - $ref: "#/definitions/streams/subscription_items"
+  - $ref: "#/definitions/streams/invoice_line_items"
 
   ## These streams are state condition streams with partition behavior:
   # - No State: Runs the partition stream that shares the same parent state condition stream.
@@ -1444,7 +1392,6 @@ streams:
   # - State: Uses the event stream to call events related to streams (event types provided by params).
   - $ref: "#/definitions/streams/application_fees_refunds"
   - $ref: "#/definitions/streams/bank_accounts"
-  #  - $ref: "#/definitions/streams/invoice_line_items" - Rollback to the Python version due to memory leak issue: https://github.com/airbytehq/oncall/issues/7876
   # These streams are base incremental partition streams with state condition streams as parents using lazy read logic:
   #  - $ref: "#/definitions/streams/usage_records"
 

--- a/airbyte-integrations/connectors/source-stripe/source_stripe/manifest.yaml
+++ b/airbyte-integrations/connectors/source-stripe/source_stripe/manifest.yaml
@@ -67,8 +67,8 @@ definitions:
               http_codes:
                 - 404
               error_message: >-
-                Data was not found. Error message: {{ response['error']['message'] }} If this is a path for getting 
-                child attributes like /v1/checkout/sessions/<session_id>/line_items when running the incremental sync, 
+                Data was not found. Error message: {{ response['error']['message'] }} If this is a path for getting
+                child attributes like /v1/checkout/sessions/<session_id>/line_items when running the incremental sync,
                 you may safely ignore this warning.
   bearer_authenticator:
     type: BearerAuthenticator
@@ -1216,88 +1216,44 @@ definitions:
             request_parameters: "{{ {'type': 'application_fee.refund.updated'} }}"
 
     subscription_items:
-      type: StateDelegatingStream
+      $ref: "#/definitions/entity_stream"
       $parameters:
         name: subscription_items
-      full_refresh_stream:
-        type: DeclarativeStream
-        primary_key:
-          - id
-        schema_loader:
-          type: JsonFileSchemaLoader
-          file_path: "./source_stripe/schemas/{{ parameters['name'] }}.json"
-        retriever:
-          type: SimpleRetriever
-          requester:
-            $ref: "#/definitions/base_requester"
-            path: subscription_items
-            request_parameters:
-              subscription: "{{stream_partition.subscription_id}}"
-          record_selector:
-            type: RecordSelector
-            extractor:
-              type: DpathExtractor
-              field_path:
-                - data
-            transform_before_filtering: true
-            schema_normalization: Default
-          paginator:
-            $ref: "#/definitions/base_paginator"
-          partition_router:
-            type: SubstreamPartitionRouter
-            parent_stream_configs:
-              - type: ParentStreamConfig
-                parent_key: id
-                partition_field: subscription_id
-                lazy_read_pointer: ["items"]
-                extra_fields:
-                  - ["updated"]
-                stream:
-                  $ref: "#/definitions/streams/subscriptions"
-        incremental_sync:
-          $ref: "#/definitions/entity_single_slice_cursor"
-          cursor_field: subscription_updated
-          global_substream_cursor: true
-        transformations:
-          - type: AddFields
-            fields:
-              - path:
-                  - subscription_updated
-                value: "{{ stream_slice.extra_fields['updated'] | int}}"
-                value_type: integer
-      incremental_stream:
-        $ref: "#/definitions/events_based_stream"
-        incremental_sync:
-          $ref: "#/definitions/events_read_slice_cursor"
-          cursor_field: subscription_updated
-        retriever:
-          $ref: "#/definitions/events_objects_retriever"
-          $parameters:
-            request_parameters:
-              types[]: '{{["customer.subscription.created", "customer.subscription.updated"]}}'
-        transformations:
-          - type: AddFields
-            fields:
-              - path:
-                  - data
-                  - object
-                  - is_deleted
-                value: "{{ True }}"
-            condition: "{{ record.get('data', {}).get('object', False) and record.get('type', '').endswith('.deleted') }}"
-          - type: AddFields
-            fields:
-              - path:
-                  - data
-                  - object
-                  - subscription_updated
-                value: "{{ record.get('updated', record.get('created', now_utc().timestamp())) | int }}"
-                value_type: integer
-            condition: "{{ record.get('data', {}).get('object', False) }}"
-          - type: DpathFlattenFields
-            field_path:
-              - data
-              - object
-            replace_record: true
+      retriever:
+        $ref: "#/definitions/base_retriever"
+        partition_router:
+          type: SubstreamPartitionRouter
+          parent_stream_configs:
+            - type: ParentStreamConfig
+              parent_key: id
+              partition_field: partition_id
+              stream:
+                $ref: "#/definitions/streams/subscriptions"
+              incremental_dependency: true
+              extra_fields:
+                - ["updated"]
+        $parameters:
+          path: subscription_items?subscription={{ stream_partition.partition_id }}
+        record_selector:
+          type: RecordSelector
+          extractor:
+            type: DpathExtractor
+            field_path: ["data"]
+      # This stream is not truly incremental on the child level.
+      # We're configuring it this way to support incremental syncs on the parent only,
+      # which helps reduce the size of the state.
+      incremental_sync:
+        $ref: "#/definitions/entity_single_slice_cursor"
+        cursor_field: subscription_updated
+        global_substream_cursor: true
+      transformations:
+        - type: AddFields
+          fields:
+            - path: ["subscription_id"]
+              value: "{{ stream_partition.subscription_id }}"
+            - path: ["subscription_updated"]
+              value: "{{ stream_slice.extra_fields['updated'] | int }}"
+              value_type: integer
 
     bank_accounts:
       type: StateDelegatingStream

--- a/airbyte-integrations/connectors/source-stripe/source_stripe/manifest.yaml
+++ b/airbyte-integrations/connectors/source-stripe/source_stripe/manifest.yaml
@@ -1431,6 +1431,7 @@ streams:
   - $ref: "#/definitions/streams/payout_balance_transactions"
   - $ref: "#/definitions/streams/setup_attempts"
   - $ref: "#/definitions/streams/transfer_reversals"
+  - $ref: "#/definitions/streams/subscription_items"
 
   ## These streams are state condition streams with partition behavior:
   # - No State: Runs the partition stream that shares the same parent state condition stream.
@@ -1444,8 +1445,6 @@ streams:
   - $ref: "#/definitions/streams/application_fees_refunds"
   - $ref: "#/definitions/streams/bank_accounts"
   #  - $ref: "#/definitions/streams/invoice_line_items" - Rollback to the Python version due to memory leak issue: https://github.com/airbytehq/oncall/issues/7876
-  #  - $ref: "#/definitions/streams/subscription_items" - Rollback to the Python version due to memory leak issue: https://github.com/airbytehq/oncall/issues/7876
-
   # These streams are base incremental partition streams with state condition streams as parents using lazy read logic:
   #  - $ref: "#/definitions/streams/usage_records"
 

--- a/airbyte-integrations/connectors/source-stripe/source_stripe/source.py
+++ b/airbyte-integrations/connectors/source-stripe/source_stripe/source.py
@@ -285,41 +285,41 @@ class SourceStripe(YamlDeclarativeSource):
         # TODO: Remove all Python connector-related implementations once this issue is resolved –
         #  https://github.com/airbytehq/oncall/issues/7876
 
-        streams = [
-            UpdatedCursorIncrementalStripeLazySubStream(
-                name="invoice_line_items",
-                path=lambda self, stream_slice, *args, **kwargs: f"invoices/{stream_slice['parent']['id']}/lines",
-                parent=invoices,
-                cursor_field="invoice_updated",
-                event_types=[
-                    "invoice.created",
-                    "invoice.deleted",
-                    "invoice.updated",
-                    # the event type = "invoice.upcoming" doesn't contain the `primary_key = `id` field,
-                    # thus isn't used, see the doc: https://docs.stripe.com/api/invoices/object#invoice_object-id
-                    # reference issue: https://github.com/airbytehq/oncall/issues/5560
-                ],
-                sub_items_attr="lines",
-                slice_data_retriever=lambda record, stream_slice: {
-                    "invoice_id": stream_slice["parent"]["id"],
-                    "invoice_created": stream_slice["parent"]["created"],
-                    "invoice_updated": stream_slice["parent"]["updated"],
-                    **record,
-                },
-                **args,
-            ),
-            subscription_items,
-            StripeSubStream(
-                name="usage_records",
-                path=lambda self,
-                stream_slice,
-                *args,
-                **kwargs: f"subscription_items/{stream_slice['parent']['id']}/usage_record_summaries",
-                parent=subscription_items,
-                primary_key=None,
-                **args,
-            ),
-        ]
+        streams = []
+#            UpdatedCursorIncrementalStripeLazySubStream(
+#                name="invoice_line_items",
+#                path=lambda self, stream_slice, *args, **kwargs: f"invoices/{stream_slice['parent']['id']}/lines",
+#                parent=invoices,
+#                cursor_field="invoice_updated",
+#                event_types=[
+#                    "invoice.created",
+#                    "invoice.deleted",
+#                    "invoice.updated",
+#                    # the event type = "invoice.upcoming" doesn't contain the `primary_key = `id` field,
+#                    # thus isn't used, see the doc: https://docs.stripe.com/api/invoices/object#invoice_object-id
+#                    # reference issue: https://github.com/airbytehq/oncall/issues/5560
+#                ],
+#                sub_items_attr="lines",
+#                slice_data_retriever=lambda record, stream_slice: {
+#                    "invoice_id": stream_slice["parent"]["id"],
+#                    "invoice_created": stream_slice["parent"]["created"],
+#                    "invoice_updated": stream_slice["parent"]["updated"],
+#                    **record,
+#                },
+#                **args,
+#            ),
+#            subscription_items,
+#            StripeSubStream(
+#                name="usage_records",
+#                path=lambda self,
+#                stream_slice,
+#                *args,
+#                **kwargs: f"subscription_items/{stream_slice['parent']['id']}/usage_record_summaries",
+#                parent=subscription_items,
+#                primary_key=None,
+#                **args,
+#            ),
+#        ]
 
         state_manager = ConnectorStateManager(state=self._state)
         return super().streams(config=config) + [


### PR DESCRIPTION
## What
Original PR before move to Low Code CDK - https://github.com/airbytehq/airbyte/pull/49976/files
```
Unrelated, there was an issue with the invoice line items and subscription items lazy loading with the updated cursor. The events were the parent events, and the logic was exposed to use the sub_attrib element to drill into lines and items respectively to pull out the correct nested object. For now, I've fixed it by just changing the stream to pull those non-lazy from the API when the parent is updated.
```

This will still not solve the issue noted in https://github.com/airbytehq/airbyte/issues/59154

```
2025-04-25 01:30:08 warn The maximum number of partitions has been reached. Dropping the oldest finished partition: <airbyte_cdk.sources.streams.concurrent.cursor.ConcurrentCursor object at 0x7c4b35b5c290>. Over limit: 10163.
```





## How
<!--
* Describe how code changes achieve the solution.
-->

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
