### PR TITLE
[Load-CDK] Speed: Sockets are multi-threaded

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/file/ClientSocket.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/file/ClientSocket.kt
@@ -14,7 +14,7 @@ import java.nio.channels.SocketChannel
 import kotlinx.coroutines.delay
 
 class ClientSocket(
-    private val socketPath: String,
+    val socketPath: String,
     private val bufferSizeBytes: Int,
     private val connectWaitDelayMs: Long = 1000L,
     private val connectTimeoutMs: Long = 15 * 60 * 1000L,
@@ -35,10 +35,11 @@ class ClientSocket(
                 )
             }
         }
+        log.info { "Socket file $socketPath created" }
 
         val address = UnixDomainSocketAddress.of(socketFile.toPath())
         SocketChannel.open(StandardProtocolFamily.UNIX).use { channel ->
-            log.info { "Socket $socketPath opened" }
+            log.info { "Socket file $socketPath opened" }
 
             if (!channel.connect(address)) {
                 throw IllegalStateException("Failed to connect to socket $socketPath")
@@ -48,7 +49,7 @@ class ClientSocket(
             // as a signal that it's safe to create the TCP connection to the
             // socat sidecar that feeds data into the socket. Removing it
             // will break tests. TODO: Anything else.
-            log.info { "Socket $socketPath connected for reading" }
+            log.info { "Socket file $socketPath connected for reading" }
 
             Channels.newInputStream(channel).buffered(bufferSizeBytes).use { inputStream ->
                 block(inputStream)

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/file/JSONLDataChannelReader.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/file/JSONLDataChannelReader.kt
@@ -4,17 +4,15 @@
 
 package io.airbyte.cdk.load.file
 
-import io.airbyte.cdk.load.command.DestinationCatalog
 import io.airbyte.cdk.load.message.DestinationMessage
 import io.airbyte.cdk.load.message.DestinationMessageFactory
 import io.airbyte.cdk.load.util.Jsons
 import io.airbyte.protocol.models.v0.AirbyteMessage
 import java.io.InputStream
 
-class JSONLDataChannelReader(catalog: DestinationCatalog) : DataChannelReader {
+class JSONLDataChannelReader(private val destinationMessageFactory: DestinationMessageFactory) :
+    DataChannelReader {
     // NOTE: Presumes that legacy file transfer is not compatible with sockets.
-    private val destinationMessageFactory: DestinationMessageFactory =
-        DestinationMessageFactory(catalog, fileTransferEnabled = false)
     private var bytesRead: Long = 0
 
     override fun read(inputStream: InputStream): Sequence<DestinationMessage> {

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/state/PipelineEventBookkeepingRouter.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/state/PipelineEventBookkeepingRouter.kt
@@ -31,7 +31,10 @@ import io.airbyte.cdk.load.message.StreamCheckpointWrapped
 import io.airbyte.cdk.load.message.StreamKey
 import io.airbyte.cdk.load.util.CloseableCoroutine
 import io.github.oshai.kotlinlogging.KotlinLogging
+import jakarta.inject.Named
 import jakarta.inject.Singleton
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicInteger
 
 /**
  * The stdio and socket input channel differ in subtle and critical ways
@@ -56,8 +59,24 @@ class PipelineEventBookkeepingRouter(
     private val checkpointQueue: QueueWriter<Reserved<CheckpointMessageWrapped>>,
     private val openStreamQueue: QueueWriter<DestinationStream>,
     private val fileTransferQueue: MessageQueue<FileTransferQueueMessage>,
+    @Named("numDataChannels") numDataChannels: Int,
 ) : CloseableCoroutine {
     private val log = KotlinLogging.logger {}
+
+    private val clientCount = AtomicInteger(numDataChannels)
+
+    // With sockets, multiple reader threads run in parallel. Source will send end-of-stream to all
+    // threads. This ensures that only the last one to recieve end-of-stream actually closes the
+    // stream. (However all will forward end-of-stream to cause their thread to flush and finish
+    // work.)
+    private val streamCompletionCountdownLatches =
+        ConcurrentHashMap(
+            catalog.streams.associate { it.descriptor to AtomicInteger(numDataChannels) }
+        )
+
+    init {
+        log.info { "Creating bookkeeping router for $numDataChannels data channels" }
+    }
 
     suspend fun handleStreamMessage(
         message: DestinationStreamAffinedMessage,
@@ -79,21 +98,29 @@ class PipelineEventBookkeepingRouter(
             is DestinationRecord -> {
                 val record = message.asDestinationRecordRaw()
                 manager.incrementReadCount()
+                // Fallback to the manager if the record doesn't have a checkpointId
+                // This should only happen in STDIO mode.
+                val checkpointId =
+                    record.checkpointId ?: manager.inferNextCheckpointKey().checkpointId
                 PipelineMessage(
-                    mapOf(manager.inferNextCheckpointKey().checkpointId to 1),
+                    mapOf(checkpointId to 1),
                     StreamKey(stream.descriptor),
                     record,
                     postProcessingCallback
                 )
             }
             is DestinationRecordStreamComplete -> {
-                manager.markEndOfStream(true)
                 log.info { "Read COMPLETE for stream ${stream.descriptor}" }
+                if (streamCompletionCountdownLatches[stream.descriptor]!!.decrementAndGet() == 0) {
+                    manager.markEndOfStream(true)
+                }
                 PipelineEndOfStream(stream.descriptor)
             }
             is DestinationRecordStreamIncomplete -> {
-                manager.markEndOfStream(false)
                 log.info { "Read INCOMPLETE for stream ${stream.descriptor}" }
+                if (streamCompletionCountdownLatches[stream.descriptor]!!.decrementAndGet() == 0) {
+                    manager.markEndOfStream(false)
+                }
                 PipelineEndOfStream(stream.descriptor)
             }
 
@@ -123,10 +150,9 @@ class PipelineEventBookkeepingRouter(
             is StreamCheckpoint -> {
                 val stream = checkpoint.checkpoint.stream
                 val manager = syncManager.getStreamManager(stream)
-                val checkpointKey = manager.inferNextCheckpointKey()
-                val (_, countSinceLast) = manager.markCheckpoint()
+                val (checkpointKey, checkpointRecordCount) = getKeyAndCounts(checkpoint, manager)
                 val messageWithCount =
-                    checkpoint.withDestinationStats(CheckpointMessage.Stats(countSinceLast))
+                    checkpoint.withDestinationStats(CheckpointMessage.Stats(checkpointRecordCount))
                 checkpointQueue.publish(
                     reservation.replace(
                         StreamCheckpointWrapped(stream, checkpointKey, messageWithCount)
@@ -134,44 +160,59 @@ class PipelineEventBookkeepingRouter(
                 )
             }
 
-            /**
-             * For a global state message, collect the index per stream, but add the total count to
-             * the destination stats.
-             */
+            /** For a global state message, gather the */
             is GlobalCheckpoint -> {
-                val streamWithKeyAndCount =
-                    catalog.streams.map { stream ->
-                        val manager = syncManager.getStreamManager(stream.descriptor)
-                        val checkpointKey = manager.inferNextCheckpointKey()
-                        val (_, countSinceLast) = manager.markCheckpoint()
-                        Pair(checkpointKey, countSinceLast)
-                    }
-                val singleKey =
-                    streamWithKeyAndCount
-                        .map { (key, _) -> key }
-                        .toSet()
-                        .let {
-                            if (it.size != 1) {
-                                throw IllegalStateException(
-                                    "For global state, all streams should have the same inferred key: $it"
-                                )
+                val (checkpointKey, checkpointRecordCount) =
+                    if (checkpoint.checkpointKey == null) {
+                        val streamWithKeyAndCount =
+                            catalog.streams.map { stream ->
+                                val manager = syncManager.getStreamManager(stream.descriptor)
+                                getKeyAndCounts(checkpoint, manager)
                             }
-                            it.first()
+                        val singleKey =
+                            streamWithKeyAndCount.map { (key, _) -> key }.toSet().singleOrNull()
+                        check(singleKey != null) {
+                            "For global state, all streams should have the same key: $streamWithKeyAndCount"
                         }
-                val totalCount = streamWithKeyAndCount.sumOf { (_, count) -> count }
+                        val totalCounts = streamWithKeyAndCount.sumOf { (_, count) -> count }
+                        Pair(singleKey, totalCounts)
+                    } else {
+                        Pair(checkpoint.checkpointKey!!, checkpoint.sourceStats?.recordCount ?: 0L)
+                    }
+
                 val messageWithCount =
-                    checkpoint.withDestinationStats(CheckpointMessage.Stats(totalCount))
+                    checkpoint.withDestinationStats(CheckpointMessage.Stats(checkpointRecordCount))
                 checkpointQueue.publish(
-                    reservation.replace(GlobalCheckpointWrapped(singleKey, messageWithCount))
+                    reservation.replace(GlobalCheckpointWrapped(checkpointKey, messageWithCount))
                 )
             }
         }
     }
 
+    // If the key is not on the record, assume we're expected to generate it.
+    private fun getKeyAndCounts(
+        checkpoint: CheckpointMessage,
+        manager: StreamManager
+    ): Pair<CheckpointKey, Long> {
+        // If the key is not on the record, assume we're expected to generate it.
+        // (Assume its presence will be appropriately enforced.)
+        return if (checkpoint.checkpointKey == null) {
+            val key = manager.inferNextCheckpointKey()
+            val (_, countSinceLast) = manager.markCheckpoint()
+            Pair(key, countSinceLast)
+        } else {
+            Pair(checkpoint.checkpointKey!!, checkpoint.sourceStats?.recordCount ?: 0L)
+        }
+    }
+
     override suspend fun close() {
-        fileTransferQueue.close()
-        checkpointQueue.close()
-        openStreamQueue.close()
-        syncManager.markInputConsumed()
+        log.info { "Maybe closing bookkeeping router ${clientCount.get()}" }
+        if (clientCount.decrementAndGet() == 0) {
+            log.info { "Closing internal control channels" }
+            fileTransferQueue.close()
+            checkpointQueue.close()
+            openStreamQueue.close()
+            syncManager.markInputConsumed()
+        }
     }
 }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/state/StreamManager.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/state/StreamManager.kt
@@ -38,6 +38,7 @@ value class CheckpointValue(
 /** Manages the state of a single stream. */
 class StreamManager(
     val stream: DestinationStream,
+    private val requireCheckpointKeyOnState: Boolean = false,
 ) {
     private val streamResult = CompletableDeferred<StreamResult>()
 
@@ -115,6 +116,10 @@ class StreamManager(
      * synchronized.
      */
     fun markCheckpoint(): Pair<Long, Long> {
+        check(!requireCheckpointKeyOnState) {
+            "Cannot force mark a checkpoint when requireCheckpointKeyOnState is true"
+        }
+
         val recordIndex = recordCount.get()
         val count = recordIndex - lastCheckpointRecordIndex.getAndSet(recordIndex)
 
@@ -171,6 +176,9 @@ class StreamManager(
      * The underlying value will be incremented each time `markCheckpoint` is called.
      */
     fun inferNextCheckpointKey(): CheckpointKey {
+        check(!requireCheckpointKeyOnState) {
+            "Cannot infer CheckpointKey when requireCheckpointKeyOnState is true"
+        }
         val indexValue = nextInferredCheckpointIndex.get()
         return CheckpointKey(
             checkpointIndex = CheckpointIndex(indexValue),

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/config/DataChannelBeanFactoryTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/config/DataChannelBeanFactoryTest.kt
@@ -8,6 +8,7 @@ import io.airbyte.cdk.load.write.LoadStrategy
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 class DataChannelBeanFactoryTest {
@@ -32,6 +33,7 @@ class DataChannelBeanFactoryTest {
                     loadStrategy = loadStrategy,
                     isFileTransfer = false,
                     dataChannelMedium = DataChannelMedium.STDIO,
+                    dataChannelSocketPaths = mockk(relaxed = true)
                 )
 
         assertEquals(2, numInputPartitions)
@@ -47,13 +49,14 @@ class DataChannelBeanFactoryTest {
                     loadStrategy = loadStrategy,
                     isFileTransfer = true,
                     dataChannelMedium = DataChannelMedium.STDIO,
+                    dataChannelSocketPaths = mockk(relaxed = true)
                 )
 
         assertEquals(1, numInputPartitions)
     }
 
     @Test
-    fun `num input partitions is 1 if sockets enabled`() {
+    fun `num input partitions is equal to the number of sockets if sockets enabled`() {
         val loadStrategy: LoadStrategy = mockk(relaxed = true)
         every { loadStrategy.inputPartitions } returns 2
         val numInputPartitions =
@@ -62,7 +65,36 @@ class DataChannelBeanFactoryTest {
                     loadStrategy = loadStrategy,
                     isFileTransfer = false,
                     dataChannelMedium = DataChannelMedium.SOCKETS,
+                    dataChannelSocketPaths = (0 until 3).map { "socket.$it" }
                 )
-        assertEquals(1, numInputPartitions)
+        assertEquals(3, numInputPartitions)
+    }
+
+    @Test
+    fun `num data channels is num_input_partitions if sockets enabled`() {
+        val loadStrategy: LoadStrategy = mockk(relaxed = true)
+        every { loadStrategy.inputPartitions } returns 2
+        val numDataChannels =
+            DataChannelBeanFactory()
+                .numDataChannels(dataChannelMedium = DataChannelMedium.SOCKETS, 3)
+        assertEquals(3, numDataChannels)
+    }
+
+    @Test
+    fun `num data channels always 1 for stdio`() {
+        val numDataChannels =
+            DataChannelBeanFactory()
+                .numDataChannels(
+                    dataChannelMedium = DataChannelMedium.STDIO,
+                    numInputPartitions = 3
+                )
+        assertEquals(1, numDataChannels)
+    }
+
+    @Test
+    fun `require checkpoint key for sockets`() {
+        val checkpointKeyRequired =
+            DataChannelBeanFactory().requireCheckpointIdOnRecord(DataChannelMedium.SOCKETS)
+        assertTrue(checkpointKeyRequired)
     }
 }

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/message/PipelineEventBookkeepingRouterTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/message/PipelineEventBookkeepingRouterTest.kt
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.load.message
+
+import io.airbyte.cdk.load.command.DestinationCatalog
+import io.airbyte.cdk.load.command.DestinationStream
+import io.airbyte.cdk.load.state.CheckpointId
+import io.airbyte.cdk.load.state.CheckpointIndex
+import io.airbyte.cdk.load.state.CheckpointKey
+import io.airbyte.cdk.load.state.PipelineEventBookkeepingRouter
+import io.airbyte.cdk.load.state.ReservationManager
+import io.airbyte.cdk.load.state.Reserved
+import io.airbyte.cdk.load.state.StreamManager
+import io.airbyte.cdk.load.state.SyncManager
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.mockk
+import io.mockk.verify
+import kotlin.test.assertEquals
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class PipelineEventBookkeepingRouterTest {
+    @MockK(relaxed = true) lateinit var catalog: DestinationCatalog
+    @MockK(relaxed = true) lateinit var syncManager: SyncManager
+    @MockK(relaxed = true) lateinit var streamManager: StreamManager
+    @MockK(relaxed = true)
+    lateinit var checkpointQueue: QueueWriter<Reserved<CheckpointMessageWrapped>>
+    @MockK(relaxed = true) lateinit var openStreamQueue: QueueWriter<DestinationStream>
+    @MockK(relaxed = true) lateinit var fileTransferQueue: MessageQueue<FileTransferQueueMessage>
+
+    private val stream1 =
+        DestinationStream(DestinationStream.Descriptor("test", "stream"), mockk(), mockk(), 1, 1, 1)
+
+    private fun makeBookkeepingRouter(numDataChannels: Int) =
+        PipelineEventBookkeepingRouter(
+            catalog,
+            syncManager,
+            checkpointQueue,
+            openStreamQueue,
+            fileTransferQueue,
+            numDataChannels
+        )
+
+    @BeforeEach
+    fun setup() {
+        every { catalog.streams } returns listOf(stream1)
+        every { syncManager.getStreamManager(stream1.descriptor) } returns streamManager
+        every { streamManager.incrementReadCount() } returns 1L
+    }
+
+    @Test
+    fun `router uses inferred checkpoint when checkpoint id not available on record`() = runTest {
+        val router = makeBookkeepingRouter(1)
+
+        every { streamManager.inferNextCheckpointKey() } returns
+            CheckpointKey(CheckpointIndex(1), CheckpointId("foo"))
+
+        val event =
+            router.handleStreamMessage(
+                DestinationRecord(stream1, mockk(relaxed = true), mockk(relaxed = true), 0L, null),
+                unopenedStreams = mutableSetOf(),
+            ) as PipelineMessage
+
+        verify { streamManager.inferNextCheckpointKey() }
+        assertEquals(mapOf(CheckpointId("foo") to 1L), event.checkpointCounts)
+    }
+
+    @Test
+    fun `router does not use inferred checkpoint when checkpoint id is available on record`() =
+        runTest {
+            val router = makeBookkeepingRouter(1)
+
+            every { streamManager.inferNextCheckpointKey() } returns
+                CheckpointKey(CheckpointIndex(1), CheckpointId("foo"))
+
+            val event =
+                router.handleStreamMessage(
+                    DestinationRecord(
+                        stream1,
+                        mockk(relaxed = true),
+                        mockk(relaxed = true),
+                        0L,
+                        CheckpointId("bar")
+                    ),
+                    unopenedStreams = mutableSetOf(),
+                ) as PipelineMessage
+
+            verify(exactly = 0) { streamManager.inferNextCheckpointKey() }
+            assertEquals(mapOf(CheckpointId("bar") to 1L), event.checkpointCounts)
+        }
+
+    @Test
+    fun `router infers and marks when checkpoint key is not available on state`() = runTest {
+        val router = makeBookkeepingRouter(1)
+        val reservationManager = ReservationManager(2)
+        val checkpointMessage: CheckpointMessage.Checkpoint = mockk(relaxed = true)
+
+        every { checkpointMessage.stream } returns stream1.descriptor
+
+        every { streamManager.inferNextCheckpointKey() } returns
+            CheckpointKey(CheckpointIndex(1), CheckpointId("foo"))
+        every { streamManager.markCheckpoint() } returns Pair(0L, 1L)
+
+        router.handleCheckpoint(
+            reservationManager.reserve(
+                1,
+                StreamCheckpoint(checkpointMessage, null, null, emptyMap(), 0, null)
+            )
+        )
+        router.handleCheckpoint(
+            reservationManager.reserve(1, GlobalCheckpoint("""{"foo": 1}""", 1L))
+        )
+
+        verify(exactly = 2) { streamManager.inferNextCheckpointKey() }
+        verify(exactly = 2) { streamManager.markCheckpoint() }
+    }
+
+    @Test
+    fun `router does not infer or mark when checkpoint key is available on state`() = runTest {
+        val router = makeBookkeepingRouter(1)
+        val reservationManager = ReservationManager(2)
+        val checkpointMessage: CheckpointMessage.Checkpoint = mockk(relaxed = true)
+
+        every { checkpointMessage.stream } returns stream1.descriptor
+
+        every { streamManager.inferNextCheckpointKey() } returns
+            CheckpointKey(CheckpointIndex(1), CheckpointId("foo"))
+        every { streamManager.markCheckpoint() } returns Pair(0L, 1L)
+
+        router.handleCheckpoint(
+            reservationManager.reserve(
+                1,
+                StreamCheckpoint(
+                    checkpointMessage,
+                    null,
+                    null,
+                    emptyMap(),
+                    0,
+                    CheckpointKey(CheckpointIndex(2), CheckpointId("bar"))
+                )
+            )
+        )
+        val global =
+            GlobalCheckpoint(
+                null,
+                null,
+                null,
+                emptyList(),
+                emptyMap(),
+                null,
+                0,
+                CheckpointKey(CheckpointIndex(2), CheckpointId("baz"))
+            )
+        router.handleCheckpoint(reservationManager.reserve(1, global))
+
+        verify(exactly = 0) { streamManager.inferNextCheckpointKey() }
+        verify(exactly = 0) { streamManager.markCheckpoint() }
+    }
+
+    @Test
+    fun `router does not close the stream until all channels set end-of-stream`() = runTest {
+        val router = makeBookkeepingRouter(2)
+
+        // Send a record to the first channel
+        val eos = DestinationRecordStreamComplete(stream1, 0L)
+        router.handleStreamMessage(eos, unopenedStreams = mutableSetOf())
+
+        coVerify(exactly = 0) { streamManager.markEndOfStream(any()) }
+
+        router.handleStreamMessage(eos, unopenedStreams = mutableSetOf())
+
+        coVerify(exactly = 1) { streamManager.markEndOfStream(any()) }
+    }
+}

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/state/StreamManagerTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/state/StreamManagerTest.kt
@@ -296,4 +296,18 @@ class StreamManagerTest {
         )
         assertDoesNotThrow { manager1.markCheckpoint() }
     }
+
+    @Test
+    fun `throw if inferNextCheckpointKey called when disabled`() {
+        val manager1 = StreamManager(stream1, requireCheckpointKeyOnState = true)
+        Assertions.assertThrows(IllegalStateException::class.java) {
+            manager1.inferNextCheckpointKey()
+        }
+    }
+
+    @Test
+    fun `throw if force marking a checkpoint when disabled`() {
+        val manager1 = StreamManager(stream1, requireCheckpointKeyOnState = true)
+        Assertions.assertThrows(IllegalStateException::class.java) { manager1.markCheckpoint() }
+    }
 }

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/internal/InputConsumerTaskTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/internal/InputConsumerTaskTest.kt
@@ -100,6 +100,7 @@ class InputConsumerTaskTest {
                 checkpointQueue = checkpointQueue,
                 openStreamQueue = mockk(relaxed = true),
                 fileTransferQueue = mockk(relaxed = true),
+                1
             )
         val task =
             InputConsumerTask(
@@ -148,6 +149,7 @@ class InputConsumerTaskTest {
                 checkpointQueue = checkpointQueue,
                 openStreamQueue = mockk(relaxed = true),
                 fileTransferQueue = mockk(relaxed = true),
+                1
             )
         val task =
             InputConsumerTask(
@@ -313,6 +315,7 @@ class InputConsumerTaskTest {
                 checkpointQueue = checkpointQueue,
                 openStreamQueue = mockk(relaxed = true),
                 fileTransferQueue = mockk(relaxed = true),
+                1
             )
         val task =
             InputConsumerTask(

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/file/ServerSocketWriter.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/file/ServerSocketWriter.kt
@@ -14,7 +14,7 @@ import java.nio.channels.ServerSocketChannel
 
 /** Used by the non-dockerized destination to write to a local unix domain socket for testing. */
 class ServerSocketWriterOutputStream(
-    private val socketPath: String,
+    val socketPath: String,
 ) : OutputStream() {
     private val log = KotlinLogging.logger {}
 

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/AtomicUtils.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/AtomicUtils.kt
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.load.test.util
+
+import java.util.concurrent.atomic.AtomicInteger
+
+fun AtomicInteger.rotate(limit: Int) =
+    this.getAndUpdate {
+        if (it + 1 == limit) {
+            0
+        } else {
+            it + 1
+        }
+    }

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/IntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/IntegrationTest.kt
@@ -31,6 +31,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
 import kotlin.test.fail
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
@@ -196,6 +197,7 @@ abstract class IntegrationTest(
      * [AirbyteStreamStatus] messages unless [streamStatus] is set to `null` (unless you actually
      * want to send multiple stream status messages).
      */
+    @OptIn(ExperimentalCoroutinesApi::class)
     fun runSync(
         configContents: String,
         catalog: DestinationCatalog,
@@ -242,7 +244,8 @@ abstract class IntegrationTest(
                 catalog.streams.forEach {
                     destination.sendMessage(
                         DestinationRecordStreamComplete(it, System.currentTimeMillis())
-                            .asProtocolMessage()
+                            .asProtocolMessage(),
+                        broadcast = true
                     )
                 }
             }
@@ -266,6 +269,7 @@ abstract class IntegrationTest(
      * using this method would take significantly longer, because they would need to push 100MB
      * (ish) to the destination before it would ack a state message.
      */
+    @OptIn(ExperimentalCoroutinesApi::class)
     fun runSyncUntilStateAck(
         configContents: String,
         stream: DestinationStream,
@@ -328,6 +332,8 @@ abstract class IntegrationTest(
     fun updateConfig(config: String): String = configUpdater.update(config)
 
     companion object {
+        const val NUM_SOCKETS = 2
+
         val randomizedNamespaceRegex = Regex("test(\\d{8})[A-Za-z]{4}.*")
         val randomizedNamespaceDateFormatter: DateTimeFormatter =
             DateTimeFormatter.ofPattern("yyyyMMdd")

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/destination_process/DestinationProcess.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/destination_process/DestinationProcess.kt
@@ -25,6 +25,8 @@ import java.nio.file.Path
  * 5. [shutdown] once you have no more messages to send to the destination
  */
 interface DestinationProcess {
+    val dataChannelMedium: DataChannelMedium
+
     /**
      * Run the destination process. Callers who want to interact with the destination should
      * `launch` this method.
@@ -32,7 +34,7 @@ interface DestinationProcess {
     suspend fun run()
 
     suspend fun sendMessage(string: String)
-    suspend fun sendMessage(message: AirbyteMessage)
+    suspend fun sendMessage(message: AirbyteMessage, broadcast: Boolean = false)
     suspend fun sendMessages(vararg messages: AirbyteMessage) {
         messages.forEach { sendMessage(it) }
     }

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/write/BasicFunctionalityIntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/write/BasicFunctionalityIntegrationTest.kt
@@ -41,6 +41,9 @@ import io.airbyte.cdk.load.message.InputRecord
 import io.airbyte.cdk.load.message.InputStreamCheckpoint
 import io.airbyte.cdk.load.message.Meta.Change
 import io.airbyte.cdk.load.message.StreamCheckpoint
+import io.airbyte.cdk.load.state.CheckpointId
+import io.airbyte.cdk.load.state.CheckpointIndex
+import io.airbyte.cdk.load.state.CheckpointKey
 import io.airbyte.cdk.load.test.util.ConfigurationUpdater
 import io.airbyte.cdk.load.test.util.DestinationCleaner
 import io.airbyte.cdk.load.test.util.DestinationDataDumper
@@ -302,13 +305,15 @@ abstract class BasicFunctionalityIntegrationTest(
                                         AirbyteRecordMessageMetaChange.Reason
                                             .SOURCE_FIELD_SIZE_LIMITATION
                                 )
-                            )
+                            ),
+                        checkpointId = checkpointKeyForMedium()?.checkpointId
                     ),
                     InputStreamCheckpoint(
                         streamName = "test_stream",
                         streamNamespace = randomizedNamespace,
                         blob = """{"foo": "bar"}""",
                         sourceRecordCount = 1,
+                        checkpointKey = checkpointKeyForMedium(),
                     )
                 ),
             )
@@ -328,9 +333,10 @@ abstract class BasicFunctionalityIntegrationTest(
                             blob = """{"foo": "bar"}""",
                             sourceRecordCount = 1,
                             destinationRecordCount = 1,
+                            checkpointKey = checkpointKeyForMedium(),
                         )
                         .asProtocolMessage(),
-                    stateMessages.first()
+                    stateMessages.first(),
                 )
             },
             {
@@ -409,6 +415,7 @@ abstract class BasicFunctionalityIntegrationTest(
                 emittedAtMs = 1234,
                 changes = mutableListOf(),
                 fileReference = fileReference,
+                checkpointId = checkpointKeyForMedium()?.checkpointId
             )
 
         val messages =
@@ -422,6 +429,7 @@ abstract class BasicFunctionalityIntegrationTest(
                         streamNamespace = stream.descriptor.namespace,
                         blob = """{"foo": "bar"}""",
                         sourceRecordCount = 1,
+                        checkpointKey = checkpointKeyForMedium(),
                     )
                 ),
                 useFileTransfer = true,
@@ -441,6 +449,7 @@ abstract class BasicFunctionalityIntegrationTest(
                         blob = """{"foo": "bar"}""",
                         sourceRecordCount = 1,
                         destinationRecordCount = 1,
+                        checkpointKey = checkpointKeyForMedium(),
                     )
                     .asProtocolMessage(),
                 stateMessages.first()
@@ -477,13 +486,15 @@ abstract class BasicFunctionalityIntegrationTest(
                             name = "test_stream",
                             data = """{"id": 12}""",
                             emittedAtMs = 1234,
+                            checkpointId = checkpointKeyForMedium()?.checkpointId
                         )
                     ),
                     StreamCheckpoint(
                         streamNamespace = randomizedNamespace,
                         streamName = "test_stream",
                         blob = """{"foo": "bar1"}""",
-                        sourceRecordCount = 1
+                        sourceRecordCount = 1,
+                        checkpointKey = checkpointKeyForMedium()
                     ),
                     allowGracefulShutdown = false,
                 )
@@ -571,18 +582,21 @@ abstract class BasicFunctionalityIntegrationTest(
                     name = stream1.descriptor.name,
                     data = """{"id": 1234}""",
                     emittedAtMs = 1234,
+                    checkpointId = checkpointKeyForMedium()?.checkpointId
                 ),
                 InputRecord(
                     namespace = stream2.descriptor.namespace,
                     name = stream2.descriptor.name,
                     data = """{"id": 5678}""",
                     emittedAtMs = 1234,
+                    checkpointId = checkpointKeyForMedium()?.checkpointId
                 ),
                 InputRecord(
                     namespace = streamWithDefaultNamespace.descriptor.namespace,
                     name = streamWithDefaultNamespace.descriptor.name,
                     data = """{"id": 91011}""",
                     emittedAtMs = 1234,
+                    checkpointId = checkpointKeyForMedium()?.checkpointId
                 ),
             )
         )
@@ -719,6 +733,7 @@ abstract class BasicFunctionalityIntegrationTest(
                     emittedAtMs = 1234,
                     meta = null,
                     serialized = "",
+                    checkpointId = checkpointKeyForMedium()?.checkpointId
                 )
             }
         runSync(updatedConfig, catalog, messages)
@@ -799,6 +814,7 @@ abstract class BasicFunctionalityIntegrationTest(
                       "name~!@#${'$'}%^&*()`[]{}|;':\",./<>?": "Alice1"
                     }""".trimIndent(),
                     emittedAtMs = 1000,
+                    checkpointId = checkpointKeyForMedium()?.checkpointId
                 )
             )
         )
@@ -846,6 +862,7 @@ abstract class BasicFunctionalityIntegrationTest(
                     "test_stream",
                     """{"id": 42, "name": "first_value"}""",
                     emittedAtMs = 1234L,
+                    checkpointId = checkpointKeyForMedium()?.checkpointId
                 )
             )
         )
@@ -859,6 +876,7 @@ abstract class BasicFunctionalityIntegrationTest(
                     "test_stream",
                     """{"id": 42, "name": "second_value"}""",
                     emittedAtMs = 1234,
+                    checkpointId = checkpointKeyForMedium()?.checkpointId
                 )
             )
         )
@@ -897,6 +915,7 @@ abstract class BasicFunctionalityIntegrationTest(
                 "test_stream",
                 """{"id": $id, "updated_at": "$updatedAt", "name": "foo_${id}_$extractedAt"}""",
                 emittedAtMs = extractedAt,
+                checkpointId = checkpointKeyForMedium()?.checkpointId
             )
         fun makeOutputRecord(
             id: Int,
@@ -980,6 +999,7 @@ abstract class BasicFunctionalityIntegrationTest(
                 stream2.descriptor.name,
                 """{}""",
                 sourceRecordCount = 1,
+                checkpointKey = checkpointKeyForMedium(),
             ),
             allowGracefulShutdown = false,
         )
@@ -1066,6 +1086,7 @@ abstract class BasicFunctionalityIntegrationTest(
                 "test_stream",
                 """{"id": $id, "updated_at": "$updatedAt", "name": "foo_${id}_$extractedAt"}""",
                 emittedAtMs = extractedAt,
+                checkpointId = checkpointKeyForMedium()?.checkpointId
             )
         fun makeOutputRecord(
             id: Int,
@@ -1110,6 +1131,7 @@ abstract class BasicFunctionalityIntegrationTest(
                 stream.descriptor.name,
                 """{}""",
                 sourceRecordCount = 1,
+                checkpointKey = checkpointKeyForMedium(),
             ),
             allowGracefulShutdown = false,
         )
@@ -1187,6 +1209,7 @@ abstract class BasicFunctionalityIntegrationTest(
                 "test_stream",
                 """{"id": $id, "updated_at": "$updatedAt", "name": "foo_${id}_$extractedAt"}""",
                 emittedAtMs = extractedAt,
+                checkpointId = checkpointKeyForMedium()?.checkpointId
             )
         fun makeOutputRecord(
             id: Int,
@@ -1271,6 +1294,7 @@ abstract class BasicFunctionalityIntegrationTest(
                 stream2.descriptor.name,
                 """{}""",
                 sourceRecordCount = 1,
+                checkpointKey = checkpointKeyForMedium(),
             ),
             allowGracefulShutdown = false,
         )
@@ -1386,6 +1410,7 @@ abstract class BasicFunctionalityIntegrationTest(
                     "test_stream",
                     """{"id": 42, "name": "first_value"}""",
                     emittedAtMs = 1234L,
+                    checkpointId = checkpointKeyForMedium()?.checkpointId
                 )
             )
         )
@@ -1399,6 +1424,7 @@ abstract class BasicFunctionalityIntegrationTest(
                     "test_stream",
                     """{"id": 42, "name": "second_value"}""",
                     emittedAtMs = 5678L,
+                    checkpointId = checkpointKeyForMedium()?.checkpointId
                 )
             )
         )
@@ -1455,6 +1481,7 @@ abstract class BasicFunctionalityIntegrationTest(
                     "test_stream",
                     """{"id": 42, "to_drop": "val1", "to_change": 42}""",
                     emittedAtMs = 1234L,
+                    checkpointId = checkpointKeyForMedium()?.checkpointId
                 )
             )
         )
@@ -1472,6 +1499,7 @@ abstract class BasicFunctionalityIntegrationTest(
                     "test_stream",
                     """{"id": 42, "to_change": "val2", "to_add": "val3"}""",
                     emittedAtMs = 2345,
+                    checkpointId = checkpointKeyForMedium()?.checkpointId
                 )
             )
         )
@@ -1539,6 +1567,7 @@ abstract class BasicFunctionalityIntegrationTest(
                     "test_stream",
                     """{"id": 42, "to_drop": "val1", "to_change": 42}""",
                     emittedAtMs = 1234L,
+                    checkpointId = checkpointKeyForMedium()?.checkpointId
                 )
             )
         )
@@ -1558,6 +1587,7 @@ abstract class BasicFunctionalityIntegrationTest(
                     "test_stream",
                     """{"id": 42, "to_change": "val2", "to_add": "val3"}""",
                     emittedAtMs = 1234L,
+                    checkpointId = checkpointKeyForMedium()?.checkpointId
                 )
             )
         )
@@ -1590,6 +1620,7 @@ abstract class BasicFunctionalityIntegrationTest(
                     "test_stream",
                     """{"id": 42, "to_change": "val4", "to_add": "val5"}""",
                     emittedAtMs = 5678L,
+                    checkpointId = checkpointKeyForMedium()?.checkpointId
                 )
             )
         )
@@ -1649,6 +1680,7 @@ abstract class BasicFunctionalityIntegrationTest(
                 "test_stream",
                 data,
                 emittedAtMs = extractedAt,
+                checkpointId = checkpointKeyForMedium()?.checkpointId
             )
 
         val sync1Stream = makeStream(syncId = 42)
@@ -1792,6 +1824,7 @@ abstract class BasicFunctionalityIntegrationTest(
                 "test_stream",
                 data,
                 emittedAtMs = extractedAt,
+                checkpointId = checkpointKeyForMedium()?.checkpointId
             )
 
         val sync1Stream = makeStream(syncId = 42)
@@ -1923,6 +1956,7 @@ abstract class BasicFunctionalityIntegrationTest(
                     name = "test_stream",
                     data = """{"id": 1234, "name": "a"}""",
                     emittedAtMs = 1234,
+                    checkpointId = checkpointKeyForMedium()?.checkpointId
                 ),
             ),
         )
@@ -1935,6 +1969,7 @@ abstract class BasicFunctionalityIntegrationTest(
                     name = "test_stream",
                     data = """{"id": 1234, "name": "b"}""",
                     emittedAtMs = 5678,
+                    checkpointId = checkpointKeyForMedium()?.checkpointId
                 ),
             ),
         )
@@ -1993,6 +2028,7 @@ abstract class BasicFunctionalityIntegrationTest(
                 // but it lets us force the dedupe behavior to rely solely on the cursor column,
                 // instead of being able to fallback onto extractedAt.
                 emittedAtMs = emittedAtMs,
+                checkpointId = checkpointKeyForMedium()?.checkpointId
             )
         runSync(
             updatedConfig,
@@ -2054,6 +2090,7 @@ abstract class BasicFunctionalityIntegrationTest(
                     "test_stream_$i",
                     """{"id": 1, "name": "foo_$i"}""",
                     emittedAtMs = 100,
+                    checkpointId = checkpointKeyForMedium()?.checkpointId
                 )
             }
         // Just verify that we don't crash.
@@ -2108,6 +2145,7 @@ abstract class BasicFunctionalityIntegrationTest(
                 "test_stream",
                 data,
                 emittedAtMs = 100,
+                checkpointId = checkpointKeyForMedium()?.checkpointId
             )
         runSync(
             updatedConfig,
@@ -2564,6 +2602,7 @@ abstract class BasicFunctionalityIntegrationTest(
                           "schemaless_array": [ 10, "foo", null, { "bar": "qua" } ]
                         }""".trimIndent(),
                     emittedAtMs = 1602637589100,
+                    checkpointId = checkpointKeyForMedium()?.checkpointId
                 ),
                 InputRecord(
                     randomizedNamespace,
@@ -2578,6 +2617,7 @@ abstract class BasicFunctionalityIntegrationTest(
                           "schemaless_array": []
                         }""".trimIndent(),
                     emittedAtMs = 1602637589200,
+                    checkpointId = checkpointKeyForMedium()?.checkpointId
                 ),
                 InputRecord(
                     randomizedNamespace,
@@ -2592,6 +2632,7 @@ abstract class BasicFunctionalityIntegrationTest(
                           "schemaless_array": null
                         }""".trimIndent(),
                     emittedAtMs = 1602637589300,
+                    checkpointId = checkpointKeyForMedium()?.checkpointId
                 ),
             )
         )
@@ -2741,6 +2782,7 @@ abstract class BasicFunctionalityIntegrationTest(
                           "name": "ex falso quodlibet"
                         }""".trimIndent(),
                         emittedAtMs = 1602637589100,
+                        checkpointId = checkpointKeyForMedium()?.checkpointId
                     )
                 )
             )
@@ -2927,6 +2969,7 @@ abstract class BasicFunctionalityIntegrationTest(
                           "union_of_objects_with_properties_nonoverlapping": { "id": 30, "name": "Phil", "flagged": false, "description":"Very Phil" }
                         }""".trimIndent(),
                     emittedAtMs = 1602637589100,
+                    checkpointId = checkpointKeyForMedium()?.checkpointId
                 ),
                 InputRecord(
                     randomizedNamespace,
@@ -2941,6 +2984,7 @@ abstract class BasicFunctionalityIntegrationTest(
                           "union_of_objects_with_properties_contradicting": { "id": "seal-one-hippity", "name": "James" }
                         }""".trimIndent(),
                     emittedAtMs = 1602637589200,
+                    checkpointId = checkpointKeyForMedium()?.checkpointId
                 ),
                 InputRecord(
                     randomizedNamespace,
@@ -2955,6 +2999,7 @@ abstract class BasicFunctionalityIntegrationTest(
                           "union_of_objects_with_properties_contradicting": null
                         }""".trimIndent(),
                     emittedAtMs = 1602637589300,
+                    checkpointId = checkpointKeyForMedium()?.checkpointId
                 ),
             )
         )
@@ -3112,6 +3157,7 @@ abstract class BasicFunctionalityIntegrationTest(
                     "test_stream",
                     """{"foo": "bar"}""",
                     emittedAtMs = 1000L,
+                    checkpointId = checkpointKeyForMedium()?.checkpointId
                 )
             )
         )
@@ -3144,6 +3190,7 @@ abstract class BasicFunctionalityIntegrationTest(
                     "test_stream",
                     """{}""",
                     emittedAtMs = 2000L,
+                    checkpointId = checkpointKeyForMedium()?.checkpointId
                 )
             )
         )
@@ -3207,6 +3254,7 @@ abstract class BasicFunctionalityIntegrationTest(
                     "test_stream",
                     """{"id": 42, "name": "first_value"}""",
                     emittedAtMs = 1234L,
+                    checkpointId = checkpointKeyForMedium()?.checkpointId
                 )
             )
         )
@@ -3234,7 +3282,11 @@ abstract class BasicFunctionalityIntegrationTest(
                 syncId = 42,
             )
         assertDoesNotThrow {
-            runSync(updatedConfig, stream, messages = listOf(InputGlobalCheckpoint(null)))
+            runSync(
+                updatedConfig,
+                stream,
+                messages = listOf(InputGlobalCheckpoint(null, checkpointKeyForMedium()))
+            )
         }
     }
 
@@ -3297,5 +3349,12 @@ abstract class BasicFunctionalityIntegrationTest(
         private val numberType = FieldType(NumberType, nullable = true)
         val stringType = FieldType(StringType, nullable = true)
         private val timestamptzType = FieldType(TimestampTypeWithTimezone, nullable = true)
+    }
+
+    private fun checkpointKeyForMedium(): CheckpointKey? {
+        return when (dataChannelMedium) {
+            DataChannelMedium.STDIO -> null
+            DataChannelMedium.SOCKETS -> CheckpointKey(CheckpointIndex(1), CheckpointId("1"))
+        }
     }
 }


### PR DESCRIPTION
## What
Makes sockets multi-threaded.

* b/c end-of-stream will be sent to every socket
  * we need to count down until we've seen EOS N times before actually closing
  * integration tests need to send EOS to every socket
* state needs to use CheckpointId and CheckpointIndex to remain coherent
  * added code to use it when present, fallback to old behavior when not
  * added guards to make sure it's always present when expected / never present when not
  * added the values to records and state in Integration Tests and Performance tests, conditionally present when sockets enabled
* multiple sockets added to integration tests and performance tests
  * writing records rotates over sockets
  * broadcast option for sending messages to all sockets (ie, EOS)
(Performance tests are still disabled, but socket tests all run successfully.)

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._

> [!NOTE]
> **Auto-merge may have been disabled. Please check the PR status to confirm.**