### PR TITLE
fix(source-microsoft-sharepoint): add size limit to check_connection

### DIFF
--- a/airbyte-integrations/connectors/source-microsoft-sharepoint/source_microsoft_sharepoint/source.py
+++ b/airbyte-integrations/connectors/source-microsoft-sharepoint/source_microsoft_sharepoint/source.py
@@ -3,8 +3,8 @@
 #
 
 
-from typing import Any, Mapping, Optional, Tuple
 import logging
+from typing import Any, Mapping, Optional, Tuple
 
 from airbyte_cdk import AdvancedAuth, ConfiguredAirbyteCatalog, ConnectorSpecification, OAuthConfigSpecification, TState
 from airbyte_cdk.models import AuthFlowType, OauthConnectorInputSpecification
@@ -37,12 +37,12 @@ class SourceMicrosoftSharePoint(FileBasedSource):
             # Mark the stream reader as being used in a check operation
             if hasattr(self.stream_reader, "mark_as_check"):
                 self.stream_reader.mark_as_check()
-            
+
             # Call the parent check_connection method
             return super().check_connection(logger, config)
         except Exception as e:
             return False, str(e)
-            
+
     def spec(self, *args: Any, **kwargs: Any) -> ConnectorSpecification:
         """
         Returns the specification describing what fields can be configured by a user when setting up a file-based source.

--- a/airbyte-integrations/connectors/source-microsoft-sharepoint/source_microsoft_sharepoint/stream_reader.py
+++ b/airbyte-integrations/connectors/source-microsoft-sharepoint/source_microsoft_sharepoint/stream_reader.py
@@ -503,7 +503,7 @@ class SourceMicrosoftSharePointStreamReader(AbstractFileBasedStreamReader):
                         if chunk:
                             local_file.write(chunk)
                 logger.info(f"Finished uploading file {file.uri} to {local_file_path}")
-            
+
             # Get the file size
             file_size = getsize(local_file_path) if not (is_check_operation and file_size > self.CHECK_SIZE_LIMIT) else file_size
 

--- a/airbyte-integrations/connectors/source-microsoft-sharepoint/unit_tests/test_source.py
+++ b/airbyte-integrations/connectors/source-microsoft-sharepoint/unit_tests/test_source.py
@@ -27,19 +27,12 @@ def mock_config():
             "auth_type": "Client",
             "client_id": "test_client_id",
             "client_secret": "test_client_secret",
-            "tenant_id": "test_tenant_id"
+            "tenant_id": "test_tenant_id",
         },
         "site_url": "https://example.sharepoint.com/sites/test",
-        "streams": [
-            {
-                "name": "test_stream",
-                "globs": ["*.csv"],
-                "validation_policy": "Emit Record",
-                "format": {"filetype": "csv"}
-            }
-        ],
+        "streams": [{"name": "test_stream", "globs": ["*.csv"], "validation_policy": "Emit Record", "format": {"filetype": "csv"}}],
         "start_date": "2021-01-01T00:00:00Z",
-        "folder_path": "Shared Documents"
+        "folder_path": "Shared Documents",
     }
 
 
@@ -49,63 +42,54 @@ def test_check_connection_marks_stream_reader(mock_logger, mock_config):
     """
     # Create mock stream reader
     mock_stream_reader = MagicMock(spec=SourceMicrosoftSharePointStreamReader)
-    
+
     # Create a source instance with the mock stream reader
     source = SourceMicrosoftSharePoint(None, None, None)
     source.stream_reader = mock_stream_reader
-    
+
     # Patch parent check_connection method
-    with patch(
-        'source_microsoft_sharepoint.source.FileBasedSource.check_connection',
-        return_value=(True, None)
-    ):
+    with patch("source_microsoft_sharepoint.source.FileBasedSource.check_connection", return_value=(True, None)):
         # Call check_connection directly
         source.check_connection(mock_logger, mock_config)
-    
+
     # Verify mark_as_check was called
     mock_stream_reader.mark_as_check.assert_called_once()
 
 
-@patch('source_microsoft_sharepoint.source.FileBasedSource.check_connection')
-def test_check_connection_forwards_to_parent(
-    mock_parent_check, mock_logger, mock_config
-):
+@patch("source_microsoft_sharepoint.source.FileBasedSource.check_connection")
+def test_check_connection_forwards_to_parent(mock_parent_check, mock_logger, mock_config):
     """
-    Test that check_connection forwards the call to the parent class after 
+    Test that check_connection forwards the call to the parent class after
     marking the reader.
     """
     # Create a source instance
     source = SourceMicrosoftSharePoint(None, None, None)
-    
+
     # Mock the parent check_connection to return a specific result
     mock_parent_check.return_value = (True, None)
-    
+
     # Call check_connection
     result = source.check_connection(mock_logger, mock_config)
-    
+
     # Verify parent method was called with correct arguments
     mock_parent_check.assert_called_once_with(mock_logger, mock_config)
-    
+
     # Verify result is forwarded from parent
     assert result == (True, None)
 
 
-@patch('source_microsoft_sharepoint.source.FileBasedSource.check_connection')
-def test_check_connection_handles_exceptions(
-    mock_parent_check, mock_logger, mock_config
-):
+@patch("source_microsoft_sharepoint.source.FileBasedSource.check_connection")
+def test_check_connection_handles_exceptions(mock_parent_check, mock_logger, mock_config):
     """Test that check_connection handles exceptions properly."""
     # Create a source instance
     source = SourceMicrosoftSharePoint(None, None, None)
-    
+
     # Mock parent method to raise an exception
-    mock_exception = AirbyteTracedException(
-        message=FileBasedSourceError.CONFIG_VALIDATION_ERROR.value
-    )
+    mock_exception = AirbyteTracedException(message=FileBasedSourceError.CONFIG_VALIDATION_ERROR.value)
     mock_parent_check.side_effect = mock_exception
-    
+
     # Call check_connection
     result = source.check_connection(mock_logger, mock_config)
-    
+
     # Verify error is handled and returned properly
-    assert result == (False, str(mock_exception)) 
+    assert result == (False, str(mock_exception))

--- a/airbyte-integrations/connectors/source-microsoft-sharepoint/unit_tests/test_source.py
+++ b/airbyte-integrations/connectors/source-microsoft-sharepoint/unit_tests/test_source.py
@@ -1,0 +1,111 @@
+#
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+#
+
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+from source_microsoft_sharepoint.source import SourceMicrosoftSharePoint
+from source_microsoft_sharepoint.stream_reader import (
+    SourceMicrosoftSharePointStreamReader,
+)
+
+from airbyte_cdk import AirbyteTracedException
+from airbyte_cdk.sources.file_based.exceptions import FileBasedSourceError
+
+
+@pytest.fixture
+def mock_logger():
+    return logging.getLogger("airbyte.test")
+
+
+@pytest.fixture
+def mock_config():
+    return {
+        "credentials": {
+            "auth_type": "Client",
+            "client_id": "test_client_id",
+            "client_secret": "test_client_secret",
+            "tenant_id": "test_tenant_id"
+        },
+        "site_url": "https://example.sharepoint.com/sites/test",
+        "streams": [
+            {
+                "name": "test_stream",
+                "globs": ["*.csv"],
+                "validation_policy": "Emit Record",
+                "format": {"filetype": "csv"}
+            }
+        ],
+        "start_date": "2021-01-01T00:00:00Z",
+        "folder_path": "Shared Documents"
+    }
+
+
+def test_check_connection_marks_stream_reader(mock_logger, mock_config):
+    """
+    Test that the mark_as_check method is called during check_connection.
+    """
+    # Create mock stream reader
+    mock_stream_reader = MagicMock(spec=SourceMicrosoftSharePointStreamReader)
+    
+    # Create a source instance with the mock stream reader
+    source = SourceMicrosoftSharePoint(None, None, None)
+    source.stream_reader = mock_stream_reader
+    
+    # Patch parent check_connection method
+    with patch(
+        'source_microsoft_sharepoint.source.FileBasedSource.check_connection',
+        return_value=(True, None)
+    ):
+        # Call check_connection directly
+        source.check_connection(mock_logger, mock_config)
+    
+    # Verify mark_as_check was called
+    mock_stream_reader.mark_as_check.assert_called_once()
+
+
+@patch('source_microsoft_sharepoint.source.FileBasedSource.check_connection')
+def test_check_connection_forwards_to_parent(
+    mock_parent_check, mock_logger, mock_config
+):
+    """
+    Test that check_connection forwards the call to the parent class after 
+    marking the reader.
+    """
+    # Create a source instance
+    source = SourceMicrosoftSharePoint(None, None, None)
+    
+    # Mock the parent check_connection to return a specific result
+    mock_parent_check.return_value = (True, None)
+    
+    # Call check_connection
+    result = source.check_connection(mock_logger, mock_config)
+    
+    # Verify parent method was called with correct arguments
+    mock_parent_check.assert_called_once_with(mock_logger, mock_config)
+    
+    # Verify result is forwarded from parent
+    assert result == (True, None)
+
+
+@patch('source_microsoft_sharepoint.source.FileBasedSource.check_connection')
+def test_check_connection_handles_exceptions(
+    mock_parent_check, mock_logger, mock_config
+):
+    """Test that check_connection handles exceptions properly."""
+    # Create a source instance
+    source = SourceMicrosoftSharePoint(None, None, None)
+    
+    # Mock parent method to raise an exception
+    mock_exception = AirbyteTracedException(
+        message=FileBasedSourceError.CONFIG_VALIDATION_ERROR.value
+    )
+    mock_parent_check.side_effect = mock_exception
+    
+    # Call check_connection
+    result = source.check_connection(mock_logger, mock_config)
+    
+    # Verify error is handled and returned properly
+    assert result == (False, str(mock_exception)) 

--- a/airbyte-integrations/connectors/source-microsoft-sharepoint/unit_tests/test_stream_reader.py
+++ b/airbyte-integrations/connectors/source-microsoft-sharepoint/unit_tests/test_stream_reader.py
@@ -974,25 +974,27 @@ def test_get_all_sites_with_no_results(test_case, search_job_value, primary_quer
 @patch("source_microsoft_sharepoint.stream_reader.requests.head")
 @patch("source_microsoft_sharepoint.stream_reader.open")
 @patch("source_microsoft_sharepoint.stream_reader.getsize")
-def test_upload_check_operation_large_file(mock_getsize, mock_open, mock_requests_head, mock_requests_get, mock_get_access_token, setup_reader_class):
+def test_upload_check_operation_large_file(
+    mock_getsize, mock_open, mock_requests_head, mock_requests_get, mock_get_access_token, setup_reader_class
+):
     """
     Test that large files are not actually downloaded during check operations but placeholder files are created instead.
     """
     instance = setup_reader_class
-    
+
     # Mark as check operation
     instance.mark_as_check()
-    
+
     # Mock file size to be above CHECK_SIZE_LIMIT but below FILE_SIZE_LIMIT
     file_size = instance.CHECK_SIZE_LIMIT + 1000  # 8MB + 1KB
     mock_requests_head.return_value.headers = {"Content-Length": str(file_size)}
     mock_requests_head.return_value.status_code = 200
-    
+
     # Mock response
     mock_response = Mock()
     mock_response.status_code = 200
     mock_requests_get.return_value = mock_response
-    
+
     # Mock file
     file = MicrosoftSharePointRemoteFile(
         uri="large_file.xlsx",
@@ -1000,43 +1002,45 @@ def test_upload_check_operation_large_file(mock_getsize, mock_open, mock_request
         last_modified=datetime(2021, 1, 1),
         created_at=datetime(2021, 1, 1),
     )
-    
+
     # Mock file paths
-    instance._get_file_transfer_paths = Mock(return_value={
-        instance.LOCAL_FILE_PATH: "/tmp/large_file.xlsx",
-        instance.FILE_RELATIVE_PATH: "large_file.xlsx",
-        instance.FILE_NAME: "large_file.xlsx",
-        instance.FILE_FOLDER: "",
-    })
-    
+    instance._get_file_transfer_paths = Mock(
+        return_value={
+            instance.LOCAL_FILE_PATH: "/tmp/large_file.xlsx",
+            instance.FILE_RELATIVE_PATH: "large_file.xlsx",
+            instance.FILE_NAME: "large_file.xlsx",
+            instance.FILE_FOLDER: "",
+        }
+    )
+
     # Mock logger
     logger = Mock()
-    
+
     # Mock getsize to return the same file size
     mock_getsize.return_value = file_size
-    
+
     # Call the method
     file_record_data, file_reference = instance.upload(file, "/tmp", logger)
-    
+
     # Verify that head request was made to get file size
     mock_requests_head.assert_called_once()
-    
+
     # Verify that GET request was NOT made (we shouldn't download large files during check)
     mock_requests_get.assert_not_called()
-    
+
     # Verify that we created an empty file
     mock_open.assert_called_once_with("/tmp/large_file.xlsx", "wb")
     mock_open.return_value.__enter__.return_value.write.assert_called_once_with(b"")
-    
+
     # Verify the returned record data and file reference
     assert file_record_data.file_name == "large_file.xlsx"
     assert file_record_data.bytes == file_size  # Should still have the actual file size
     assert file_record_data.source_uri == "large_file.xlsx"
-    
+
     assert file_reference.staging_file_url == "/tmp/large_file.xlsx"
     assert file_reference.source_file_relative_path == "large_file.xlsx"
     assert file_reference.file_size_bytes == file_size
-    
+
     # Verify that appropriate log message was created
     logger.info.assert_called_once_with(f"Created placeholder for large file {file.uri} (size: {file_size} bytes) during check operation")
 
@@ -1046,26 +1050,28 @@ def test_upload_check_operation_large_file(mock_getsize, mock_open, mock_request
 @patch("source_microsoft_sharepoint.stream_reader.requests.head")
 @patch("source_microsoft_sharepoint.stream_reader.open")
 @patch("source_microsoft_sharepoint.stream_reader.getsize")
-def test_upload_check_operation_small_file(mock_getsize, mock_open, mock_requests_head, mock_requests_get, mock_get_access_token, setup_reader_class):
+def test_upload_check_operation_small_file(
+    mock_getsize, mock_open, mock_requests_head, mock_requests_get, mock_get_access_token, setup_reader_class
+):
     """
     Test that small files are actually downloaded during check operations.
     """
     instance = setup_reader_class
-    
+
     # Mark as check operation
     instance.mark_as_check()
-    
+
     # Mock file size to be below CHECK_SIZE_LIMIT
     file_size = instance.CHECK_SIZE_LIMIT - 1000  # 8MB - 1KB
     mock_requests_head.return_value.headers = {"Content-Length": str(file_size)}
     mock_requests_head.return_value.status_code = 200
-    
+
     # Mock response for the actual file download
     mock_response = Mock()
     mock_response.status_code = 200
     mock_response.iter_content.return_value = [b"test content"]
     mock_requests_get.return_value = mock_response
-    
+
     # Mock file
     file = MicrosoftSharePointRemoteFile(
         uri="small_file.csv",
@@ -1073,43 +1079,45 @@ def test_upload_check_operation_small_file(mock_getsize, mock_open, mock_request
         last_modified=datetime(2021, 1, 1),
         created_at=datetime(2021, 1, 1),
     )
-    
+
     # Mock file paths
-    instance._get_file_transfer_paths = Mock(return_value={
-        instance.LOCAL_FILE_PATH: "/tmp/small_file.csv",
-        instance.FILE_RELATIVE_PATH: "small_file.csv",
-        instance.FILE_NAME: "small_file.csv",
-        instance.FILE_FOLDER: "",
-    })
-    
+    instance._get_file_transfer_paths = Mock(
+        return_value={
+            instance.LOCAL_FILE_PATH: "/tmp/small_file.csv",
+            instance.FILE_RELATIVE_PATH: "small_file.csv",
+            instance.FILE_NAME: "small_file.csv",
+            instance.FILE_FOLDER: "",
+        }
+    )
+
     # Mock getsize to return the file size
     mock_getsize.return_value = file_size
-    
+
     # Mock logger
     logger = Mock()
-    
+
     # Call the method
     file_record_data, file_reference = instance.upload(file, "/tmp", logger)
-    
+
     # Verify that head request was made to get file size
     mock_requests_head.assert_called_once()
-    
+
     # Verify that GET request WAS made (we should download small files even during check)
     mock_requests_get.assert_called_once()
-    
+
     # Verify that we wrote the file contents
     file_handle = mock_open.return_value.__enter__.return_value
     file_handle.write.assert_called_once_with(b"test content")
-    
+
     # Verify the returned record data and file reference
     assert file_record_data.file_name == "small_file.csv"
     assert file_record_data.bytes == file_size
     assert file_record_data.source_uri == "small_file.csv"
-    
+
     assert file_reference.staging_file_url == "/tmp/small_file.csv"
     assert file_reference.source_file_relative_path == "small_file.csv"
     assert file_reference.file_size_bytes == file_size
-    
+
     # Verify that appropriate log message was created
     logger.info.assert_called_once_with(f"Finished uploading file {file.uri} to /tmp/small_file.csv")
 
@@ -1119,13 +1127,13 @@ def test_mark_as_check(setup_reader_class):
     Test that mark_as_check properly sets the flag.
     """
     instance = setup_reader_class
-    
+
     # Verify flag is not set initially
     assert not hasattr(instance, "_is_check_operation")
-    
+
     # Mark as check operation
     instance.mark_as_check()
-    
+
     # Verify flag is now set
     assert hasattr(instance, "_is_check_operation")
     assert instance._is_check_operation is True


### PR DESCRIPTION
## What

Updates Microsoft SharePoint connector's memory usage during check operations by preventing large file downloads.

## How

- Added a `CHECK_SIZE_LIMIT` (8MB) threshold to prevent downloading large files during connection check operations
- Implemented file size detection using `HEAD` requests before downloading content
- Created placeholder files with metadata for large files during check operations instead of downloading full content
- Added a `mark_as_check` method to flag when operations are part of a check connection process

## User Impact

- Users with large filesets should not run into OOM issues when running check

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
