### PR TITLE
ci: fix condition where `${{ }}` is not correctly evaluated as falsey within the community CI `if:` clause

### DIFF
--- a/.github/workflows/run-connector-tests-command.yml
+++ b/.github/workflows/run-connector-tests-command.yml
@@ -25,7 +25,6 @@ on:
   push:
 
 jobs:
-
   call-connector-ci-tests:
     # Run always for 'workflow_dipatch' events.
     # Run for 'push' events on forks, but only if the fork defines "BYO Secrets".

--- a/.github/workflows/run-connector-tests-command.yml
+++ b/.github/workflows/run-connector-tests-command.yml
@@ -39,6 +39,15 @@ jobs:
           echo "github.repository   = |${{ github.repository }}|"
           echo "vars.GCP_PROJECT_ID = |${{ vars.GCP_PROJECT_ID }}|"
 
+      - name: Skip-me
+        if: >
+          ${{ github.event_name == 'workflow_dispatch' ||
+           (github.event_name == 'push' &&
+           github.repository != 'airbytehq/airbyte' &&
+           vars.GCP_PROJECT_ID != '') }}
+        run: |
+          echo "This should not run."
+
   call-connector-ci-tests:
     # Run always for 'workflow_dipatch' events.
     # Run for 'push' events on forks, but only if the fork defines "BYO Secrets".

--- a/.github/workflows/run-connector-tests-command.yml
+++ b/.github/workflows/run-connector-tests-command.yml
@@ -48,9 +48,17 @@ jobs:
         if: >
           github.event_name == 'workflow_dispatch' ||
           (github.event_name == 'push' &&
-            github.repository != 'airbytehq/airbyte' &&
-            vars.GCP_PROJECT_ID != ''
-          )
+          github.repository != 'airbytehq/airbyte' &&
+          vars.GCP_PROJECT_ID != '')
+        run: |
+          echo "This should not run."
+
+      - name: Skip-me (2)
+        if: >
+          ${{ github.event_name == 'workflow_dispatch' ||
+          (github.event_name == 'push' &&
+           github.repository != 'airbytehq/airbyte' &&
+           vars.GCP_PROJECT_ID != '') }}
         run: |
           echo "This should not run."
 

--- a/.github/workflows/run-connector-tests-command.yml
+++ b/.github/workflows/run-connector-tests-command.yml
@@ -26,42 +26,6 @@ on:
 
 jobs:
 
-
-  debug-connector-ci-outputs:
-    name: "🛠️ Debug Connector-CI Outputs"
-    runs-on: ubuntu-latest
-    # if: >
-    #   github.event_name == 'workflow_dispatch' ||
-    #   (github.event_name == 'push' &&
-    #     github.repository != 'airbytehq/airbyte' &&
-    #     vars.GCP_PROJECT_ID != ''
-    #    )
-    steps:
-      - name: Dump all reusable-workflow outputs
-        run: |
-          echo "github.event_name   = |${{ github.event_name }}|"
-          echo "github.repository   = |${{ github.repository }}|"
-          echo "vars.GCP_PROJECT_ID = |${{ vars.GCP_PROJECT_ID }}|"
-          echo "condition = |${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.repository != 'airbytehq/airbyte' && vars.GCP_PROJECT_ID != '') }}|"
-
-      - name: Skip-me
-        if: >
-          github.event_name == 'workflow_dispatch' ||
-          (github.event_name == 'push' &&
-          github.repository != 'airbytehq/airbyte' &&
-          vars.GCP_PROJECT_ID != '')
-        run: |
-          echo "This should not run."
-
-      - name: Skip-me (2)
-        if: >
-          github.event_name == 'workflow_dispatch' ||
-          (github.event_name == 'push' &&
-           github.repository != 'airbytehq/airbyte' &&
-           vars.GCP_PROJECT_ID != '')
-        run: |
-          echo "This should not run."
-
   call-connector-ci-tests:
     # Run always for 'workflow_dipatch' events.
     # Run for 'push' events on forks, but only if the fork defines "BYO Secrets".

--- a/.github/workflows/run-connector-tests-command.yml
+++ b/.github/workflows/run-connector-tests-command.yml
@@ -31,9 +31,11 @@ jobs:
     # Run for 'push' events on forks, but only if the fork defines "BYO Secrets".
     if: >
       github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'push' &&
-       github.repository != 'airbytehq/airbyte' &&
-       vars.GCP_PROJECT_ID != '')
+      (
+        github.event_name == 'push' &&
+        github.repository != 'airbytehq/airbyte' &&
+        vars.GCP_PROJECT_ID != ''
+      )
     uses: ./.github/workflows/connector-ci-tests.yml
     with:
       repo: "${{ inputs.repo || github.repository }}"

--- a/.github/workflows/run-connector-tests-command.yml
+++ b/.github/workflows/run-connector-tests-command.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     if: >
       github.event_name == 'workflow_dispatch' ||
-       (github.event_name == 'push' &&
+      (github.event_name == 'push' &&
         github.repository != 'airbytehq/airbyte' &&
         vars.GCP_PROJECT_ID != ''
        )

--- a/.github/workflows/run-connector-tests-command.yml
+++ b/.github/workflows/run-connector-tests-command.yml
@@ -55,10 +55,10 @@ jobs:
 
       - name: Skip-me (2)
         if: >
-          ${{ github.event_name == 'workflow_dispatch' ||
+          github.event_name == 'workflow_dispatch' ||
           (github.event_name == 'push' &&
            github.repository != 'airbytehq/airbyte' &&
-           vars.GCP_PROJECT_ID != '') }}
+           vars.GCP_PROJECT_ID != '')
         run: |
           echo "This should not run."
 

--- a/.github/workflows/run-connector-tests-command.yml
+++ b/.github/workflows/run-connector-tests-command.yml
@@ -62,18 +62,18 @@ jobs:
         run: |
           echo "This should not run."
 
-  # call-connector-ci-tests:
-  #   # Run always for 'workflow_dipatch' events.
-  #   # Run for 'push' events on forks, but only if the fork defines "BYO Secrets".
-  #   if: >
-  #     ${{ github.event_name == 'workflow_dispatch' ||
-  #     (github.event_name == 'push' &&
-  #      github.repository != 'airbytehq/airbyte' &&
-  #      vars.GCP_PROJECT_ID != '') }}
-  #   uses: ./.github/workflows/connector-ci-tests.yml
-  #   with:
-  #     repo: "${{ inputs.repo || github.repository }}"
-  #     gitref: "${{ inputs.gitref || github.ref_name }}"
-  #     comment-id: "${{ github.event_name == 'workflow_dispatch' && inputs['comment-id'] || '' }}"
-  #     pr: "${{ github.event_name == 'workflow_dispatch' && inputs.pr || '' }}"
-  #   secrets: inherit
+  call-connector-ci-tests:
+    # Run always for 'workflow_dipatch' events.
+    # Run for 'push' events on forks, but only if the fork defines "BYO Secrets".
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'push' &&
+       github.repository != 'airbytehq/airbyte' &&
+       vars.GCP_PROJECT_ID != '')
+    uses: ./.github/workflows/connector-ci-tests.yml
+    with:
+      repo: "${{ inputs.repo || github.repository }}"
+      gitref: "${{ inputs.gitref || github.ref_name }}"
+      comment-id: "${{ github.event_name == 'workflow_dispatch' && inputs['comment-id'] || '' }}"
+      pr: "${{ github.event_name == 'workflow_dispatch' && inputs.pr || '' }}"
+    secrets: inherit

--- a/.github/workflows/run-connector-tests-command.yml
+++ b/.github/workflows/run-connector-tests-command.yml
@@ -25,6 +25,20 @@ on:
   push:
 
 jobs:
+
+
+  debug-connector-ci-outputs:
+    name: "🛠️ Debug Connector-CI Outputs"
+    needs: call-connector-ci-tests
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Dump all reusable-workflow outputs
+        run: |
+          echo "github.event_name   = |${{ github.event_name }}|"
+          echo "github.repository   = |${{ github.repository }}|"
+          echo "vars.GCP_PROJECT_ID = |${{ vars.GCP_PROJECT_ID }}|"
+
   call-connector-ci-tests:
     # Run always for 'workflow_dipatch' events.
     # Run for 'push' events on forks, but only if the fork defines "BYO Secrets".

--- a/.github/workflows/run-connector-tests-command.yml
+++ b/.github/workflows/run-connector-tests-command.yml
@@ -30,8 +30,9 @@ jobs:
     # Run for 'push' events on forks, but only if the fork defines "BYO Secrets".
     if: >
       ${{ github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'push' && github.repository != 'airbytehq/airbyte' &&
-      (vars.GCP_PROJECT_ID != '')) }}
+      (github.event_name == 'push' &&
+       github.repository != 'airbytehq/airbyte' &&
+       vars.GCP_PROJECT_ID != '') }}
     uses: ./.github/workflows/connector-ci-tests.yml
     with:
       repo: "${{ inputs.repo || github.repository }}"

--- a/.github/workflows/run-connector-tests-command.yml
+++ b/.github/workflows/run-connector-tests-command.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   call-connector-ci-tests:
-    # Run always for 'workflow_dipatch' events.
+    # Run always for 'workflow_dispatch' events.
     # Run for 'push' events on forks, but only if the fork defines "BYO Secrets".
     if: >
       github.event_name == 'workflow_dispatch' ||

--- a/.github/workflows/run-connector-tests-command.yml
+++ b/.github/workflows/run-connector-tests-command.yml
@@ -30,12 +30,12 @@ jobs:
   debug-connector-ci-outputs:
     name: "🛠️ Debug Connector-CI Outputs"
     runs-on: ubuntu-latest
-    if: >
-      github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'push' &&
-        github.repository != 'airbytehq/airbyte' &&
-        vars.GCP_PROJECT_ID != ''
-       )
+    # if: >
+    #   github.event_name == 'workflow_dispatch' ||
+    #   (github.event_name == 'push' &&
+    #     github.repository != 'airbytehq/airbyte' &&
+    #     vars.GCP_PROJECT_ID != ''
+    #    )
     steps:
       - name: Dump all reusable-workflow outputs
         run: |
@@ -46,10 +46,11 @@ jobs:
 
       - name: Skip-me
         if: >
-          ${{ github.event_name == 'workflow_dispatch' ||
-           (github.event_name == 'push' &&
-           github.repository != 'airbytehq/airbyte' &&
-           vars.GCP_PROJECT_ID != '') }}
+          github.event_name == 'workflow_dispatch' ||
+          (github.event_name == 'push' &&
+            github.repository != 'airbytehq/airbyte' &&
+            vars.GCP_PROJECT_ID != ''
+          )
         run: |
           echo "This should not run."
 

--- a/.github/workflows/run-connector-tests-command.yml
+++ b/.github/workflows/run-connector-tests-command.yml
@@ -30,7 +30,12 @@ jobs:
   debug-connector-ci-outputs:
     name: "🛠️ Debug Connector-CI Outputs"
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.repository != 'airbytehq/airbyte' && vars.GCP_PROJECT_ID != '') }}
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+       (github.event_name == 'push' &&
+        github.repository != 'airbytehq/airbyte' &&
+        vars.GCP_PROJECT_ID != ''
+       )
     steps:
       - name: Dump all reusable-workflow outputs
         run: |

--- a/.github/workflows/run-connector-tests-command.yml
+++ b/.github/workflows/run-connector-tests-command.yml
@@ -29,15 +29,15 @@ jobs:
 
   debug-connector-ci-outputs:
     name: "🛠️ Debug Connector-CI Outputs"
-    needs: call-connector-ci-tests
     runs-on: ubuntu-latest
-    if: always()
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.repository != 'airbytehq/airbyte' && vars.GCP_PROJECT_ID != '') }}
     steps:
       - name: Dump all reusable-workflow outputs
         run: |
           echo "github.event_name   = |${{ github.event_name }}|"
           echo "github.repository   = |${{ github.repository }}|"
           echo "vars.GCP_PROJECT_ID = |${{ vars.GCP_PROJECT_ID }}|"
+          echo "condition = |${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.repository != 'airbytehq/airbyte' && vars.GCP_PROJECT_ID != '') }}|"
 
       - name: Skip-me
         if: >
@@ -48,18 +48,18 @@ jobs:
         run: |
           echo "This should not run."
 
-  call-connector-ci-tests:
-    # Run always for 'workflow_dipatch' events.
-    # Run for 'push' events on forks, but only if the fork defines "BYO Secrets".
-    if: >
-      ${{ github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'push' &&
-       github.repository != 'airbytehq/airbyte' &&
-       vars.GCP_PROJECT_ID != '') }}
-    uses: ./.github/workflows/connector-ci-tests.yml
-    with:
-      repo: "${{ inputs.repo || github.repository }}"
-      gitref: "${{ inputs.gitref || github.ref_name }}"
-      comment-id: "${{ github.event_name == 'workflow_dispatch' && inputs['comment-id'] || '' }}"
-      pr: "${{ github.event_name == 'workflow_dispatch' && inputs.pr || '' }}"
-    secrets: inherit
+  # call-connector-ci-tests:
+  #   # Run always for 'workflow_dipatch' events.
+  #   # Run for 'push' events on forks, but only if the fork defines "BYO Secrets".
+  #   if: >
+  #     ${{ github.event_name == 'workflow_dispatch' ||
+  #     (github.event_name == 'push' &&
+  #      github.repository != 'airbytehq/airbyte' &&
+  #      vars.GCP_PROJECT_ID != '') }}
+  #   uses: ./.github/workflows/connector-ci-tests.yml
+  #   with:
+  #     repo: "${{ inputs.repo || github.repository }}"
+  #     gitref: "${{ inputs.gitref || github.ref_name }}"
+  #     comment-id: "${{ github.event_name == 'workflow_dispatch' && inputs['comment-id'] || '' }}"
+  #     pr: "${{ github.event_name == 'workflow_dispatch' && inputs.pr || '' }}"
+  #   secrets: inherit


### PR DESCRIPTION
## What

Resolved a hard-to-diagnose formatting bug in GitHub `if` condition syntax.

For future reference: Multi-line `if` statements that use wrapped space-delimited folding (`if: >`) or newline-delimited folding (`if: |`) apparently can't also have the `${{ }}` wrapper around conditions. If so, they'll evaluate to truthy strings and the condition won't be evaluated as expected.

This PR resolves the issue. Thanks to @davinchia for reporting.

> [!NOTE]
> **Auto-merge may have been disabled. Please check the PR status to confirm.**