### PR TITLE
fix: set default markprompt project key

### DIFF
--- a/docusaurus/docusaurus.config.js
+++ b/docusaurus/docusaurus.config.js
@@ -186,7 +186,9 @@ const config = {
   ],
   customFields: {
     requestErdApiUrl: process.env.REQUEST_ERD_API_URL,
-    markpromptProjectKey: process.env.MARKPROMPT_PROJECT_KEY,
+    markpromptProjectKey:
+      process.env.MARKPROMPT_PROJECT_KEY ||
+      "sk_test_cbPFAzAxUvafRj6l1yjzrESu0bRpzQGK",
   },
   clientModules: [
     require.resolve("./src/scripts/cloudStatus.js"),


### PR DESCRIPTION
## What
If users didn't have the local development `MARKPROMPT_PROJECT_KEY` they were not able to start docs locally. This PR fixes that

## How
Set default test  `MARKPROMPT_PROJECT_KEY` allow local development to start even if the env var is not set.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
