### PR TITLE
Not displaying a literal null if the namespace is null

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/command/DestinationStream.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/command/DestinationStream.kt
@@ -42,7 +42,9 @@ data class DestinationStream(
                 }
             }
 
-        fun toPrettyString() = "$namespace.$name"
+        fun toPrettyString(): String {
+            return if (namespace == null) name else "$namespace.$name"
+        }
     }
 
     /**


### PR DESCRIPTION
## What

Instead of displaying something like "null.mystream" I think it would make more sense to only display the stream?
I feel like it is confusing right now when looking at the logs.

## Can this PR be safely reverted and rolled back?
- [X] YES 💚
- [ ] NO ❌
