### PR TITLE
ci: fix detect-changes from slash command

### DIFF
--- a/.github/workflows/connector-ci-tests.yml
+++ b/.github/workflows/connector-ci-tests.yml
@@ -98,6 +98,7 @@ jobs:
     steps:
       - name: Checkout Airbyte
         if: matrix.connector
+        id: checkout
         uses: actions/checkout@v4
         with:
           repository: ${{ inputs.repo || github.event.pull_request.head.repo.full_name }}
@@ -165,6 +166,7 @@ jobs:
         if: always() && !cancelled() && matrix.connector && github.repository == 'airbytehq/airbyte'
         with:
           check_name: "`${{ matrix.connector }}` Connector Test Results"
+          commit: ${{ steps.checkout.outputs.commit }}
           large_files: true
           files: |
             airbyte-integrations/connectors/${{ matrix.connector }}/build/test-results/**/*.xml
@@ -192,6 +194,7 @@ jobs:
     steps:
       - name: Checkout Airbyte
         if: matrix.connector
+        id: checkout
         uses: actions/checkout@v4
         with:
           repository: ${{ inputs.repo || github.event.pull_request.head.repo.full_name }}
@@ -268,6 +271,7 @@ jobs:
         if: always() && !cancelled() && matrix.connector && github.repository == 'airbytehq/airbyte'
         with:
           check_name: "`${{ matrix.connector }}` Connector Test Results"
+          commit: ${{ steps.checkout.outputs.commit }}
           large_files: true
           files: |
             airbyte-integrations/connectors/${{ matrix.connector }}/build/test-results/**/*.xml

--- a/.github/workflows/connector-ci-tests.yml
+++ b/.github/workflows/connector-ci-tests.yml
@@ -34,6 +34,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          # In order to work correctly on forks, `repository` must be set if `ref` is set:
+          repository: ${{ inputs.repo || github.event.pull_request.head.repo.full_name }}
+          ref: ${{ inputs.gitref || github.head_ref || github.ref_name }}
 
       - name: Add upstream remote (forks only)
         # This step only runs from forks.
@@ -92,8 +95,6 @@ jobs:
         with:
           # In order to work correctly on forks, `repository` must be set if `ref` is set:
           repository: ${{ inputs.repo || github.event.pull_request.head.repo.full_name }}
-          # Java `integrationTestJava` Gradle task still calls Airbyte-CI, which fails on a detached head.
-          # TODO: Remove the Airbyte-CI dependency for running java integration tests.
           ref: ${{ inputs.gitref || github.head_ref || github.ref_name }}
           fetch-depth: 1
 

--- a/.github/workflows/connector-ci-tests.yml
+++ b/.github/workflows/connector-ci-tests.yml
@@ -33,10 +33,10 @@ jobs:
       - name: Checkout Current Branch
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
-          # In order to work correctly on forks, `repository` must be set if `ref` is set:
           repository: ${{ inputs.repo || github.event.pull_request.head.repo.full_name }}
           ref: ${{ inputs.gitref || github.head_ref || github.ref_name }}
+          # Use fetch-depth: 0 to ensure we can access the full commit history
+          fetch-depth: 0
 
       - name: Add upstream remote (forks only)
         # This step only runs from forks.
@@ -93,7 +93,6 @@ jobs:
         if: matrix.connector
         uses: actions/checkout@v4
         with:
-          # In order to work correctly on forks, `repository` must be set if `ref` is set:
           repository: ${{ inputs.repo || github.event.pull_request.head.repo.full_name }}
           ref: ${{ inputs.gitref || github.head_ref || github.ref_name }}
           fetch-depth: 1
@@ -188,6 +187,8 @@ jobs:
         if: matrix.connector
         uses: actions/checkout@v4
         with:
+          repository: ${{ inputs.repo || github.event.pull_request.head.repo.full_name }}
+          ref: ${{ inputs.gitref || github.head_ref || github.ref_name }}
           fetch-depth: 1
 
       # Python deps
@@ -287,6 +288,8 @@ jobs:
         if: matrix.connector
         uses: actions/checkout@v4
         with:
+          repository: ${{ inputs.repo || github.event.pull_request.head.repo.full_name }}
+          ref: ${{ inputs.gitref || github.head_ref || github.ref_name }}
           fetch-depth: 1
 
       # Java deps

--- a/.github/workflows/connector-ci-tests.yml
+++ b/.github/workflows/connector-ci-tests.yml
@@ -25,6 +25,13 @@ on:
         required: false
         description: "The pull request number, if applicable. Unused as of now."
 
+permissions:
+  # Allow the workflow to read contents
+  # and to read/write checks and PR comments.
+  contents: read
+  checks: write
+  pull-requests: write
+
 jobs:
   generate-matrix:
     name: Generate Connector Matrix


### PR DESCRIPTION
## What

Resolves an issue in within the `connector-ci` workflows - specifically, when called using slash commands, we need to explicitly sent `repository` and `ref` inputs to the `checkout` commands. Otherwise, when invoked from a slash command, they simply check out `master`, which is not helpful in tests or when detecting changes.

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._

> [!NOTE]
> **Auto-merge may have been disabled. Please check the PR status to confirm.**