### PR TITLE
ci: add comment annotation with job run link

### DIFF
--- a/.github/workflows/run-connector-tests-command.yml
+++ b/.github/workflows/run-connector-tests-command.yml
@@ -25,9 +25,39 @@ on:
   push:
 
 jobs:
+  post-start-comment:
+    name: "Post Start Comment"
+    runs-on: ubuntu-24.04
+    if: >
+      inputs.comment-id &&
+      (
+        github.event_name == 'workflow_dispatch' ||
+        (
+          github.event_name == 'push' &&
+          github.repository != 'airbytehq/airbyte' &&
+          vars.GCP_PROJECT_ID != ''
+        )
+      )
+    steps:
+      - name: Get job variables
+        id: job-vars
+        run: |
+          echo "run-url=https://github.com/${{ inputs.repo || github.repository }}/actions/runs/$GITHUB_RUN_ID" >> $GITHUB_OUTPUT
+
+      - name: Append start comment
+        uses: peter-evans/create-or-update-comment@v4
+        if: success()
+        with:
+          comment-id: ${{ inputs.comment-id }}
+          issue-number: ${{ inputs.pr }}
+          reactions: "+1"
+          body: |
+            > Connector CI Tests job started... [Check job output.](${{ steps.job-vars.outputs.run-url }})
+
   call-connector-ci-tests:
     # Run always for 'workflow_dispatch' events.
     # Run for 'push' events on forks, but only if the fork defines "BYO Secrets".
+    name: "Call Connector CI Tests"
     if: >
       github.event_name == 'workflow_dispatch' ||
       (
@@ -42,3 +72,26 @@ jobs:
       comment-id: "${{ github.event_name == 'workflow_dispatch' && inputs['comment-id'] || '' }}"
       pr: "${{ github.event_name == 'workflow_dispatch' && inputs.pr || '' }}"
     secrets: inherit
+
+  post-end-comment:
+    name: "Post End Comment"
+    needs: call-connector-ci-tests
+    runs-on: ubuntu-24.04
+    if: >
+      inputs.comment-id &&
+      (
+        github.event_name == 'workflow_dispatch' ||
+        (
+          github.event_name == 'push' &&
+          github.repository != 'airbytehq/airbyte' &&
+          vars.GCP_PROJECT_ID != ''
+        )
+      )
+    steps:
+      - name: Append end comment
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          comment-id: ${{ inputs.comment-id }}
+          issue-number: ${{ inputs.pr }}
+          body: |
+            > Connector CI Tests job completed. See logs for details.

--- a/.github/workflows/run-connector-tests-command.yml
+++ b/.github/workflows/run-connector-tests-command.yml
@@ -78,6 +78,7 @@ jobs:
     needs: call-connector-ci-tests
     runs-on: ubuntu-24.04
     if: >
+      always() &&
       inputs.comment-id &&
       (
         github.event_name == 'workflow_dispatch' ||

--- a/.github/workflows/run-connector-tests-command.yml
+++ b/.github/workflows/run-connector-tests-command.yml
@@ -29,7 +29,7 @@ jobs:
     name: "Post Start Comment"
     runs-on: ubuntu-24.04
     if: >
-      inputs.comment-id &&
+      inputs.comment-id != '' &&
       (
         github.event_name == 'workflow_dispatch' ||
         (

--- a/.github/workflows/run-connector-tests-command.yml
+++ b/.github/workflows/run-connector-tests-command.yml
@@ -74,7 +74,7 @@ jobs:
     secrets: inherit
 
   post-end-comment:
-    name: "Post End Comment"
+    name: "Post Completion Comment"
     needs: call-connector-ci-tests
     runs-on: ubuntu-24.04
     if: >


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->

Add comment annotations to the `/run-connector-tests` slash command.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
