### PR TITLE
Make edit URL for platform docs more robust

### DIFF
--- a/docusaurus/docusaurus.config.js
+++ b/docusaurus/docusaurus.config.js
@@ -102,7 +102,14 @@ const config = {
         path: "../docs/platform",
         routeBasePath: "/platform",
         sidebarPath: "./sidebar-platform.js",
-        editUrl: "https://github.com/airbytehq/airbyte/blob/master/docs",
+        editUrl: ({version, docPath}) => {
+          if (version === 'current') { // For the "next" (unreleased) version
+            return `https://github.com/airbytehq/airbyte/edit/master/docs/platform/${docPath}`;
+          } 
+          else { // For released versions
+            return `https://github.com/airbytehq/airbyte/edit/master/docusaurus/platform_versioned_docs/version-${version}/${docPath}`;
+          }
+        },
         remarkPlugins: [
           docsHeaderDecoration,
           enterpriseDocsHeaderInformation,


### PR DESCRIPTION
## What

@jim-kutz-ab noticed the "Edit this page" link at the bottom of released platform docs was broken, but the one in the Next platform version still worked.

This fixes that, so the link works for all versions.

## How

The bug is a consequence of switching to multi-instance, multi-version platform docs. It's due to the fact that released docs versions are stored in the `/docusaurus/` folder while unreleased/Next docs are stored in the `/docs/` folder. That's an old architecture decision we're stuck with.

Fixed by updating the `editURL` for the platform instance. It's now a function that sets this value differently depending on which versioned is being viewed: Next or one of the released versions.

Note that the logic in the function uses 'current' to mean 'next'. Normally, in Docusaurus the word 'current' is used  specifically to mean the latest released version of the platform docs. In this case, that would be 1.6. However, for whatever reason, 'current' is needed here to represent 'next'. It's an unusual departure from their standard terminology and it makes the code a bit confusing. But, yeah, 'current' does indeed mean 'next' in this function. I tried to use 'next' anyway and it did not work.

## Review guide

1. Open platform docs to the 'Next' version. Click the "edit this page" link. You are taken to the equivalent page in GitHub.
2. Open platform docs to the '1.6' version. Click the "edit this page" link. You are taken to the equivalent page in GitHub.

## User Impact

Fixes a broken link.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌
