### PR TITLE
feat(#60965): get instagram_business_account in a single request

### DIFF
--- a/airbyte-integrations/connectors/source-instagram/integration_tests/test_streams.py
+++ b/airbyte-integrations/connectors/source-instagram/integration_tests/test_streams.py
@@ -46,6 +46,7 @@ class TestInstagramSource:
 
     def test_incremental_streams(self, config, state):
         records, states = self._read_records(config, "user_insights")
+        # TODO: Remove this magic number and somehow read the number of days from the config.jsonj
         assert len(records) == 30, "UserInsights for two accounts over last 30 day should return 30 records when empty STATE provided"
 
         records, states = self._read_records(config, "user_insights", state)
@@ -60,9 +61,9 @@ class TestInstagramSource:
             )
 
             assert stream_name == "user_insights", f"each state message should reference 'user_insights' stream, got {stream_name} instead"
-            assert isinstance(
-                stream_state, AirbyteStateBlob
-            ), f"Stream state should be type AirbyteStateBlob, got {type(stream_state)} instead"
+            assert isinstance(stream_state, AirbyteStateBlob), (
+                f"Stream state should be type AirbyteStateBlob, got {type(stream_state)} instead"
+            )
             assert state_keys_count == 2, f"Stream state should contain 2 partition keys, got {state_keys_count} instead"
 
     @staticmethod

--- a/airbyte-integrations/connectors/source-instagram/integration_tests/test_streams.py
+++ b/airbyte-integrations/connectors/source-instagram/integration_tests/test_streams.py
@@ -61,9 +61,9 @@ class TestInstagramSource:
             )
 
             assert stream_name == "user_insights", f"each state message should reference 'user_insights' stream, got {stream_name} instead"
-            assert isinstance(stream_state, AirbyteStateBlob), (
-                f"Stream state should be type AirbyteStateBlob, got {type(stream_state)} instead"
-            )
+            assert isinstance(
+                stream_state, AirbyteStateBlob
+            ), f"Stream state should be type AirbyteStateBlob, got {type(stream_state)} instead"
             assert state_keys_count == 2, f"Stream state should contain 2 partition keys, got {state_keys_count} instead"
 
     @staticmethod

--- a/airbyte-integrations/connectors/source-instagram/metadata.yaml
+++ b/airbyte-integrations/connectors/source-instagram/metadata.yaml
@@ -7,7 +7,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 6acf6b55-4f1e-4fca-944e-1a3caef8aba8
-  dockerImageTag: 4.1.0-rc.1
+  dockerImageTag: 4.1.1
   dockerRepository: airbyte/source-instagram
   githubIssueLabel: source-instagram
   icon: instagram.svg

--- a/airbyte-integrations/connectors/source-instagram/metadata.yaml
+++ b/airbyte-integrations/connectors/source-instagram/metadata.yaml
@@ -7,7 +7,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 6acf6b55-4f1e-4fca-944e-1a3caef8aba8
-  dockerImageTag: 4.1.1
+  dockerImageTag: 4.1.0-rc.2
   dockerRepository: airbyte/source-instagram
   githubIssueLabel: source-instagram
   icon: instagram.svg

--- a/airbyte-integrations/connectors/source-instagram/pyproject.toml
+++ b/airbyte-integrations/connectors/source-instagram/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "4.1.0-rc.1"
+version = "4.1.1"
 name = "source-instagram"
 description = "Source implementation for Instagram."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-instagram/pyproject.toml
+++ b/airbyte-integrations/connectors/source-instagram/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "4.1.1"
+version = "4.1.0-rc.2"
 name = "source-instagram"
 description = "Source implementation for Instagram."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-instagram/source_instagram/api.py
+++ b/airbyte-integrations/connectors/source-instagram/source_instagram/api.py
@@ -78,14 +78,13 @@ class InstagramAPI:
     def _find_accounts(self) -> List[Mapping[str, Any]]:
         try:
             instagram_business_accounts = []
-            accounts = fb_user.User(fbid="me").get_accounts()
+            accounts = fb_user.User(fbid="me").get_accounts(params={"fields": "id,name,instagram_business_account{id}"})
             for account in accounts:
-                page = Page(account.get_id()).api_get(fields=["instagram_business_account"])
-                if page.get("instagram_business_account"):
+                if account.get("instagram_business_account"):
                     instagram_business_accounts.append(
                         {
                             "page_id": account.get_id(),
-                            "instagram_business_account": IGUser(page.get("instagram_business_account").get("id")),
+                            "instagram_business_account": IGUser(account.get("instagram_business_account").get("id")),
                         }
                     )
         except FacebookRequestError as exc:

--- a/airbyte-integrations/connectors/source-instagram/unit_tests/conftest.py
+++ b/airbyte-integrations/connectors/source-instagram/unit_tests/conftest.py
@@ -44,36 +44,18 @@ def some_config_future_date_fixture(account_id):
 
 @fixture(name="fb_account_response")
 def fb_account_response_fixture(account_id, some_config, requests_mock):
-    account = {"id": "test_id", "instagram_business_account": {"id": "test_id"}}
-    requests_mock.register_uri(
-        "GET",
-        FacebookSession.GRAPH + f"/{FB_API_VERSION}/act_{account_id}/"
-        f"?access_token={some_config['access_token']}&fields=instagram_business_account",
-        json=account,
-    )
-    return {
-        "json": {
-            "data": [
-                {
-                    "access_token": "access_token",
-                    "category": "Software company",
-                    "id": f"act_{account_id}",
-                    "paging": {"cursors": {"before": "cursor", "after": "cursor"}},
-                    "summary": {"total_count": 1},
-                    "status_code": 200,
-                }
-            ]
-        }
-    }
+    return {"json": {"data": [{"id": "test_id", "name": "Test Page", "instagram_business_account": {"id": "test_id"}}]}}
 
 
 @fixture(name="api")
 def api_fixture(some_config, requests_mock, fb_account_response):
     api = API(access_token=some_config["access_token"])
 
+    # Mock the new API call pattern that includes fields parameter
     requests_mock.register_uri(
         "GET",
-        FacebookSession.GRAPH + f"/{FB_API_VERSION}/me/accounts?" f"access_token={some_config['access_token']}&summary=true",
+        FacebookSession.GRAPH + f"/{FB_API_VERSION}/me/accounts?"
+        f"access_token={some_config['access_token']}&fields=id%2Cname%2Cinstagram_business_account%7Bid%7D",
         [fb_account_response],
     )
 

--- a/airbyte-integrations/connectors/source-instagram/unit_tests/test_source.py
+++ b/airbyte-integrations/connectors/source-instagram/unit_tests/test_source.py
@@ -24,7 +24,7 @@ GRAPH_URL = resolve_manifest(source=SourceInstagram(config={}, catalog=None, sta
     "base_requester"
 ]["url_base"]
 
-account_url = f"{GRAPH_URL}/me/accounts?fields=id%2Cinstagram_business_account"
+account_url = f"{GRAPH_URL}/me/accounts?fields=id%2Cname%2Cinstagram_business_account%7Bid%7D"
 
 
 account_url_response = {

--- a/airbyte-integrations/connectors/source-instagram/unit_tests/test_streams.py
+++ b/airbyte-integrations/connectors/source-instagram/unit_tests/test_streams.py
@@ -152,7 +152,7 @@ def test_exit_gracefully(api, config, requests_mock, caplog):
     requests_mock.register_uri("GET", FacebookSession.GRAPH + f"/{FB_API_VERSION}/{test_id}/insights", json={"data": []})
     records = read_incremental(stream, {})
     assert not records
-    assert requests_mock.call_count == 6  # 4 * 1 per `metric_to_period` map + 1 `summary` request + 1 `business_account_id` request
+    assert requests_mock.call_count == 5  # 4 * 1 per `metric_to_period` map + 1 combined accounts request
     assert "Stopping syncing stream 'user_insights'" in caplog.text
 
 

--- a/docs/integrations/sources/instagram.md
+++ b/docs/integrations/sources/instagram.md
@@ -146,6 +146,7 @@ for more information.
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                   |
 |:--------|:-----------|:---------------------------------------------------------|:--------------------------------------------------------------------------------------------------------------------------|
+| 4.1.1   | 2025-06-02 | [60976](https://github.com/airbytehq/airbyte/pull/60976) | Optimize requests made to Instagram Graph API |
 | 4.1.0-rc.1   | 2025-05-27 | [60848](https://github.com/airbytehq/airbyte/pull/60848) | Add `views` metric to `StoryInsights` and `MediaInsights` streams. |
 | 4.0.5 | 2025-05-10 | [59798](https://github.com/airbytehq/airbyte/pull/59798) | Update dependencies |
 | 4.0.4 | 2025-05-03 | [59243](https://github.com/airbytehq/airbyte/pull/59243) | Update dependencies |

--- a/docs/integrations/sources/instagram.md
+++ b/docs/integrations/sources/instagram.md
@@ -146,7 +146,7 @@ for more information.
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                   |
 |:--------|:-----------|:---------------------------------------------------------|:--------------------------------------------------------------------------------------------------------------------------|
-| 4.1.1   | 2025-06-02 | [60976](https://github.com/airbytehq/airbyte/pull/60976) | Optimize requests made to Instagram Graph API |
+| 4.1.0-rc.2   | 2025-06-02 | [60976](https://github.com/airbytehq/airbyte/pull/60976) | Optimize requests made to Instagram Graph API |
 | 4.1.0-rc.1   | 2025-05-27 | [60848](https://github.com/airbytehq/airbyte/pull/60848) | Add `views` metric to `StoryInsights` and `MediaInsights` streams. |
 | 4.0.5 | 2025-05-10 | [59798](https://github.com/airbytehq/airbyte/pull/59798) | Update dependencies |
 | 4.0.4 | 2025-05-03 | [59243](https://github.com/airbytehq/airbyte/pull/59243) | Update dependencies |


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change
-->
As described in #60965, currently the connector makes two separate requests to get the instagram_business_account id, which is needed to get insights. For (facebook developer) apps in development  this isnt an issue, because you dont need to ask advanced access for the permission `pages_read_engagement`, that is needed to run the request to get `page` information (`/[page id]`).
For apps that are approved and live, this doesnt work without the permission. To fix this, we can leverage the graph api and request the needed fields in the first request, to '/accounts`. 
This doesnt change anything for apps in development, but makes it easier for apps that are live. 

## How
Just request te field instagram_business_account{id} in the first request and remove the second one.

## Review guide
I've run both unit and integration tests, everything is passing.

## User Impact
No negative impacts expected here. The connector should work without any changes.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌

closes ##60965