### PR TITLE
ci: skip qa checks for nightly build

### DIFF
--- a/.github/workflows/connectors_nightly_build.yml
+++ b/.github/workflows/connectors_nightly_build.yml
@@ -61,4 +61,4 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           s3_build_cache_access_key_id: ${{ secrets.SELF_RUNNER_AWS_ACCESS_KEY_ID }}
           s3_build_cache_secret_key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
-          subcommand: "connectors ${{ matrix.connector_names}} test"
+          subcommand: "connectors ${{ matrix.connector_names}} test --skip-step qa_checks" #qa_checks should only be run pre-release of new connectors


### PR DESCRIPTION
## What
Since the introduction of the version increment check into the QA check bundle [[PR](https://github.com/airbytehq/airbyte/pull/60225)], nightly runs of airbyte CI test have been failing because, of course, the version on master has not been incremented relative to the version on master. 

Rather than skip just the version increment check on nightlies, @aaronsteers and I believe it doesn't make sense to run any QA checks since they are really only useful to be run prior to the release of a new version of a connector. [[slack thread](https://airbytehq-team.slack.com/archives/C02U9R3AF37/p1748538780203569)]

I verified the qa_checks step is skipped by running airbyte ci locally.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
