### PR TITLE
ci: add on-demand CAT tests

### DIFF
--- a/.github/community-pr-welcome.md
+++ b/.github/community-pr-welcome.md
@@ -15,6 +15,7 @@ As needed or by request, Airbyte Maintainers can execute the following slash com
 - `/format-fix` - Fixes most formatting issues.
 - `/bump-version` - Bumps connector versions.
 - `/run-connector-tests` - Runs connector tests.
+- `/run-cat-tests` - Runs CAT tests.
 
 If you have any questions, feel free to ask in the PR comments or join our [Slack community](https://airbytehq.slack.com/).
 

--- a/.github/workflows/run-cat-tests-command.yml
+++ b/.github/workflows/run-cat-tests-command.yml
@@ -100,4 +100,4 @@ jobs:
           comment-id: ${{ steps.first-comment-action.outputs.comment-id }}
           reactions: confused
           body: |
-            > 🔴 Tests failed.
+            > 🔴 CAT Tests failed.

--- a/.github/workflows/run-cat-tests-command.yml
+++ b/.github/workflows/run-cat-tests-command.yml
@@ -83,8 +83,6 @@ jobs:
           s3_build_cache_secret_key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
           git_branch: ${{ steps.job-vars.outputs.branch }}
           git_revision: ${{ steps.job-vars.outputs.commit_id }}
-          # Unit and integration tests are moved to the new connector-ci workflows,
-          # along with pre-release checks (qa_checks, version_inc_check)
           subcommand: "connectors --modified test --only-step=acceptance"
 
       - name: Append success comment

--- a/.github/workflows/run-cat-tests-command.yml
+++ b/.github/workflows/run-cat-tests-command.yml
@@ -1,0 +1,104 @@
+name: On-Demand CAT Tests (Legacy)
+# This workflow is used to run the legacy CAT tests for modified connectors.
+# It can be triggered manually via slash command or workflow dispatch.
+
+on:
+  workflow_dispatch:
+    inputs:
+      repo:
+        description: "The repository name"
+        required: false
+        type: string
+      gitref:
+        description: "The git reference (branch or tag)"
+        required: false
+        type: string
+      comment-id:
+        description: "The ID of the comment triggering the workflow"
+        required: false
+        type: number
+      pr:
+        description: "The pull request number, if applicable"
+        required: false
+        type: number
+
+run-name: "Run connector CAT tests in PR: #${{ github.event.inputs.pr }}"
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.inputs.pr }}
+  # Cancel any previous runs on the same branch if they are still in progress
+  cancel-in-progress: true
+
+jobs:
+  post-start-comment:
+    name: "Post Start Comment"
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Get job variables
+        id: job-vars
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          PR_JSON=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.inputs.pr }})
+          echo "repo=$(echo "$PR_JSON" | jq -r .head.repo.full_name)" >> $GITHUB_OUTPUT
+          echo "branch=$(echo "$PR_JSON" | jq -r .head.ref)" >> $GITHUB_OUTPUT
+          echo "pr_title=$(echo "$PR_JSON" | jq -r .title)" >> $GITHUB_OUTPUT
+          echo "run-url=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" >> $GITHUB_OUTPUT
+
+      - name: Checkout Airbyte
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ steps.job-vars.outputs.repo }}
+          ref: ${{ steps.job-vars.outputs.branch }}
+          fetch-depth: 0
+
+      - name: Append comment with job run link
+        # If comment-id is not provided, this will create a new
+        # comment with the job run link.
+        id: first-comment-action
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          comment-id: ${{ github.event.inputs.comment-id }}
+          issue-number: ${{ github.event.inputs.pr }}
+          body: |
+            > Connector CAT tests started... [Check job output.](${{ steps.job-vars.outputs.run-url }})
+
+      - name: Run CAT tests with `airbyte-ci`
+        if: github.event_name == 'workflow_dispatch'
+        uses: ./.github/actions/run-airbyte-ci
+        with:
+          context: "manual"
+          dagger_cloud_token: ${{ secrets.DAGGER_CLOUD_TOKEN_CACHE_3 }}
+          docker_hub_password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+          docker_hub_username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          gcp_gsm_credentials: ${{ secrets.GCP_GSM_CREDENTIALS }}
+          sentry_dsn: ${{ secrets.SENTRY_AIRBYTE_CI_DSN }}
+          github_token: ${{ secrets.GH_PAT_APPROVINGTON_OCTAVIA }}
+          s3_build_cache_access_key_id: ${{ secrets.SELF_RUNNER_AWS_ACCESS_KEY_ID }}
+          s3_build_cache_secret_key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
+          git_branch: ${{ steps.job-vars.outputs.branch }}
+          git_revision: ${{ steps.job-vars.outputs.commit_id }}
+          # Unit and integration tests are moved to the new connector-ci workflows,
+          # along with pre-release checks (qa_checks, version_inc_check)
+          subcommand: "connectors --modified test --only-step=acceptance"
+
+      - name: Append success comment
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          comment-id: ${{ steps.first-comment-action.outputs.comment-id }}
+          reactions: hooray
+          body: |
+            > ✅ CAT Tests ran successfully.
+            >
+            > If the connector supports live tests or regression tests, you may want to run them now also:
+            > - [Run Live Tests](https://github.com/airbytehq/airbyte/actions/workflows/live_tests.yml)
+            > - [Run Regression Tests](https://github.com/airbytehq/airbyte/actions/workflows/regression_tests.yml)
+
+      - name: Append failure comment
+        uses: peter-evans/create-or-update-comment@v4
+        if: failure()
+        with:
+          comment-id: ${{ steps.first-comment-action.outputs.comment-id }}
+          reactions: confused
+          body: |
+            > 🔴 Tests failed.

--- a/.github/workflows/run-cat-tests-command.yml
+++ b/.github/workflows/run-cat-tests-command.yml
@@ -62,6 +62,11 @@ jobs:
           issue-number: ${{ github.event.inputs.pr }}
           body: |
             > Connector CAT tests started... [Check job output.](${{ steps.job-vars.outputs.run-url }})
+            >
+            > If the connector supports live tests or regression tests, you may want to run those now also:
+            > - [Run Live Tests](https://github.com/airbytehq/airbyte/actions/workflows/live_tests.yml)
+            > - [Run Regression Tests](https://github.com/airbytehq/airbyte/actions/workflows/regression_tests.yml)
+            >
 
       - name: Run CAT tests with `airbyte-ci`
         if: github.event_name == 'workflow_dispatch'
@@ -89,10 +94,6 @@ jobs:
           reactions: hooray
           body: |
             > ✅ CAT Tests ran successfully.
-            >
-            > If the connector supports live tests or regression tests, you may want to run them now also:
-            > - [Run Live Tests](https://github.com/airbytehq/airbyte/actions/workflows/live_tests.yml)
-            > - [Run Regression Tests](https://github.com/airbytehq/airbyte/actions/workflows/regression_tests.yml)
 
       - name: Append failure comment
         uses: peter-evans/create-or-update-comment@v4

--- a/docs/platform/connector-development/local-connector-development.md
+++ b/docs/platform/connector-development/local-connector-development.md
@@ -193,6 +193,7 @@ Maintainers can execute any of the following connector admin commands upon reque
 - `/bump-version` - Run the bump version command, which advances the connector version(s) and adds a changelog entry for any modified connector(s).
 - `/format-fix` - Fixes any formatting issues.
 - `/run-connector-tests` - Run the connector tests for any modified connectors.
+- `/run-cat-tests` - Run the legacy connector acceptance tests (CAT) for any modified connectors. This is helpful if the connector has poor test coverage overall.
 - `/poe` - Run a Poe task.
 
 When working on PRs from forks, maintainers can apply `/format-fix` to help expedite formatting fixes, and `/run-connector-tests` if the fork does not have sufficient secrets bootstrapping or other permissions needed to fully test the connector changes.

--- a/docusaurus/platform_versioned_docs/version-1.6/connector-development/local-connector-development.md
+++ b/docusaurus/platform_versioned_docs/version-1.6/connector-development/local-connector-development.md
@@ -193,6 +193,7 @@ Maintainers can execute any of the following connector admin commands upon reque
 - `/bump-version` - Run the bump version command, which advances the connector version(s) and adds a changelog entry for any modified connector(s).
 - `/format-fix` - Fixes any formatting issues.
 - `/run-connector-tests` - Run the connector tests for any modified connectors.
+- `/run-cat-tests` - Run the legacy connector acceptance tests (CAT) for any modified connectors. This is helpful if the connector has poor test coverage overall.
 - `/poe` - Run a Poe task.
 
 When working on PRs from forks, maintainers can apply `/format-fix` to help expedite formatting fixes, and `/run-connector-tests` if the fork does not have sufficient secrets bootstrapping or other permissions needed to fully test the connector changes.

--- a/poe-tasks/gradle-connector-tasks.toml
+++ b/poe-tasks/gradle-connector-tasks.toml
@@ -28,6 +28,7 @@
 [tasks]
 
 get-language = "echo 'java'" # Use with -qq to get just the language name
+get-connector-name = 'basename "$PWD"' # Use with -qq to get just the connector name
 fetch-secrets = "airbyte-cdk secrets fetch"
 
 install = [
@@ -69,3 +70,7 @@ ${POE_ROOT}/gradlew :airbyte-integrations:connectors:${connector_name}:${task_an
 args = [
   { name = "task_and_args", positional = true, multiple = true, help = "Gradle task name and its arguments" }
 ]
+
+[tasks.run-cat-tests]
+shell = "airbyte-ci connectors --name=`poe -qq get-connector-name` test --only-step=acceptance"
+help = "Run the legacy Airbyte-CI acceptance tests (CAT tests)."

--- a/poe-tasks/manifest-only-connector-tasks.toml
+++ b/poe-tasks/manifest-only-connector-tasks.toml
@@ -11,6 +11,7 @@
 [tasks]
 
 get-language = "echo 'manifest-only'" # Use with -qq to get just the language name
+get-connector-name = 'basename "$PWD"' # Use with -qq to get just the connector name
 fetch-secrets = "airbyte-cdk secrets fetch ${POE_PWD}"
 
 install = [
@@ -57,3 +58,7 @@ else
   echo "No unit tests defined; skipping unit tests locking."
 fi
 '''
+
+[tasks.run-cat-tests]
+shell = "airbyte-ci connectors --name=`poe -qq get-connector-name` test --only-step=acceptance"
+help = "Run the legacy Airbyte-CI acceptance tests (CAT tests)."

--- a/poe-tasks/poetry-connector-tasks.toml
+++ b/poe-tasks/poetry-connector-tasks.toml
@@ -129,7 +129,3 @@ help = "Pin to a specific branch of the CDK."
 [tool.poe.tasks.run-cat-tests]
 shell = "airbyte-ci connectors --name=`poe -qq get-connector-name` test --only-step=acceptance"
 help = "Run the legacy Airbyte-CI acceptance tests (CAT tests)."
-
-[tasks.run-cat-tests]
-shell = "airbyte-ci connectors --name=`poe -qq get-connector-name` test --only-step=acceptance"
-help = "Run the legacy Airbyte-CI acceptance tests (CAT tests)."

--- a/poe-tasks/poetry-connector-tasks.toml
+++ b/poe-tasks/poetry-connector-tasks.toml
@@ -17,6 +17,7 @@
 [tool.poe.tasks]
 
 get-language = "echo 'python'" # Use with -qq to get just the language name
+get-connector-name = 'basename "$PWD"' # Use with -qq to get just the connector name
 fetch-secrets = "airbyte-cdk secrets fetch"
 
 install = ["install-project", "install-cdk-cli"]
@@ -124,3 +125,11 @@ args = [
   { name = "BRANCH", positional = true, default = "main" },
 ]
 help = "Pin to a specific branch of the CDK."
+
+[tool.poe.tasks.run-cat-tests]
+shell = "airbyte-ci connectors --name=`poe -qq get-connector-name` test --only-step=acceptance"
+help = "Run the legacy Airbyte-CI acceptance tests (CAT tests)."
+
+[tasks.run-cat-tests]
+shell = "airbyte-ci connectors --name=`poe -qq get-connector-name` test --only-step=acceptance"
+help = "Run the legacy Airbyte-CI acceptance tests (CAT tests)."


### PR DESCRIPTION
## What

- Add a `run-cat-tests` Poe command so that `poe run-cat-tests` locally will kick off CAT for the working directory context.
- Add a `/run-cat-tests` slash command for PRs, so that we can run CAT when needed.
- As soon as the CAT tests are kicked off via slash command, the workflow will provide direct links (for convenience) to Regression Tests and Live Tests. This streamlines the ability to run them manually when appropriate.
- Documents the new `/run-cat-tests` slash command in the places where we document these.
- `airbyte-ci` wants _tons_ of secrets. I didn't question them - I just pasted in what is being provided from another instantiation of `airbyte-ci`.
  - Aka: this will _never_ be able to run from forks using user creds. But it should be able to run on-demand on PRs from forks.

The above sets the stage to remove `airbyte-ci` and CAT tests from the main critical-path test flow.

Note: I will have to merge in order to test the new slash command. So, please expect some hotfixes over a few iterations after the merge.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
