### PR TITLE
ci: working Python Connector Image build outside Airbyte CI

### DIFF
--- a/.github/workflows/docker-connector-base-image-tests.yml
+++ b/.github/workflows/docker-connector-base-image-tests.yml
@@ -243,7 +243,6 @@ jobs:
       matrix:
         connector:
           - source-google-drive
-          - source-hubspot
           - source-s3
           - source-salesforce
           - source-shopify

--- a/docker-images/Dockerfile.python-connector
+++ b/docker-images/Dockerfile.python-connector
@@ -39,5 +39,8 @@ set -e
 ${CONNECTOR_NAME} "\$\@"
 EOT
 
+# Set the non-root user
+USER airbyte
+
 ENV AIRBYTE_ENTRYPOINT="/entrypoint.sh"
 ENTRYPOINT ["/entrypoint.sh"]

--- a/docker-images/Dockerfile.python-connector-base
+++ b/docker-images/Dockerfile.python-connector-base
@@ -19,9 +19,6 @@ RUN mkdir --mode 755 /airbyte && \
     chown -R airbyte:airbyte /custom_cache && \
     chown -R airbyte:airbyte /secrets && \
     chown -R airbyte:airbyte /config && \
-    chown -R airbyte:airbyte /usr/share/pki/ca-trust-source && \
-    chown -R airbyte:airbyte /usr/share/pki/nltk_data && \
-    chown -R airbyte:airbyte /etc/pki/ca-trust && \
     chown -R airbyte:airbyte /tmp
 
 

--- a/docker-images/Dockerfile.python-connector-base
+++ b/docker-images/Dockerfile.python-connector-base
@@ -6,28 +6,37 @@ FROM ${BASE_IMAGE}
 
 RUN ln -snf /usr/share/zoneinfo/Etc/UTC /etc/localtime
 
+# Install dependencies needed for OCR and PDF processing in certain file-based connectors
+# TODO: move these out of the base image
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get dist-upgrade -y && \
+    apt-get install -y --no-install-recommends \
+      socat=1.7.4.4-2 \
+      tesseract-ocr=5.3.0-2 \
+      poppler-utils=22.12.0-2+deb12u1 && \
+    apt-get clean
+    
+RUN pip install --upgrade \
+      pip==24.0 \
+      setuptools==78.1.1 && \
+    pip install --no-cache-dir \
+      poetry==1.8.4
+
 # Set-up groups, users, and directories
 RUN adduser --uid 1000 --system --group --no-create-home airbyte && \
-    mkdir --mode 755 /custom_cache && \
     mkdir --mode 755 /airbyte && \
-    chown airbyte:airbyte /airbyte
-
-ENV PIP_CACHE_DIR=/custom_cache/pip
-RUN pip install --upgrade pip==24.0 setuptools==78.1.1
+    mkdir --mode 755 /custom_cache && \
+    mkdir -p 755 /usr/share/nltk_data && \
+    chown -R airbyte:airbyte /airbyte && \
+    chown -R airbyte:airbyte /custom_cache && \
+    chown -R airbyte:airbyte /secrets && \
+    chown -R airbyte:airbyte /config && \
+    chown -R airbyte:airbyte /usr/share/pki/ca-trust-source && \
+    chown -R airbyte:airbyte /usr/share/pki/nltk_data && \
+    chown -R airbyte:airbyte /etc/pki/ca-trust && \
+    chown -R airbyte:airbyte /tmp
 
 ENV POETRY_VIRTUALENVS_CREATE=false
 ENV POETRY_VIRTUALENVS_IN_PROJECT=false
 ENV POETRY_NO_INTERACTION=1
-
-RUN pip install poetry==1.8.4
-RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt-get dist-upgrade -y && \
-    apt-get clean
-RUN apt-get install -y socat=1.7.4.4-2
-RUN apt-get update && \
-    apt-get install -y \
-        tesseract-ocr=5.3.0-2 \
-        poppler-utils=22.12.0-2+deb12u1
-
-RUN mkdir -p 755 /usr/share/nltk_data

--- a/docker-images/Dockerfile.python-connector-base
+++ b/docker-images/Dockerfile.python-connector-base
@@ -13,6 +13,8 @@ RUN adduser --uid 1000 --system --group --no-create-home airbyte
 # Create the cache airbyte directories and set the right permissions
 RUN mkdir --mode 755 /airbyte && \
     mkdir --mode 755 /custom_cache && \
+    mkdir /secrets && \
+    mkdir /config && \
     chown airbyte:airbyte /airbyte && \
     chown -R airbyte:airbyte /custom_cache && \
     chown -R airbyte:airbyte /secrets && \

--- a/docker-images/Dockerfile.python-connector-base
+++ b/docker-images/Dockerfile.python-connector-base
@@ -13,7 +13,15 @@ RUN adduser --uid 1000 --system --group --no-create-home airbyte
 # Create the cache airbyte directories and set the right permissions
 RUN mkdir --mode 755 /airbyte && \
     mkdir --mode 755 /custom_cache && \
-    chown airbyte:airbyte /airbyte
+    chown airbyte:airbyte /airbyte && \
+    chown -R airbyte:airbyte /custom_cache && \
+    chown -R airbyte:airbyte /secrets && \
+    chown -R airbyte:airbyte /config && \
+    chown -R airbyte:airbyte /usr/share/pki/ca-trust-source && \
+    chown -R airbyte:airbyte /usr/share/pki/nltk_data && \
+    chown -R airbyte:airbyte /etc/pki/ca-trust && \
+    chown -R airbyte:airbyte /tmp
+
 
 ENV POETRY_VIRTUALENVS_CREATE=false
 ENV POETRY_VIRTUALENVS_IN_PROJECT=false

--- a/docker-images/Dockerfile.python-connector-base
+++ b/docker-images/Dockerfile.python-connector-base
@@ -19,7 +19,8 @@ ENV POETRY_VIRTUALENVS_CREATE=false
 ENV POETRY_VIRTUALENVS_IN_PROJECT=false
 ENV POETRY_NO_INTERACTION=1
 
-# Create and set up pip cache directory (maybe don't need this)
+# Create and set up pip cache directory
+# TODO: Remove this block if not needed.
 ENV PIP_CACHE_DIR=/pip_cache
 RUN mkdir -p ${PIP_CACHE_DIR} && chown -R airbyte:airbyte ${PIP_CACHE_DIR}
 

--- a/docker-images/Dockerfile.python-connector-base
+++ b/docker-images/Dockerfile.python-connector-base
@@ -15,10 +15,12 @@ RUN mkdir --mode 755 /airbyte && \
     mkdir --mode 755 /custom_cache && \
     mkdir /secrets && \
     mkdir /config && \
+    mkdir /nonexistent && \
     chown airbyte:airbyte /airbyte && \
     chown -R airbyte:airbyte /custom_cache && \
     chown -R airbyte:airbyte /secrets && \
     chown -R airbyte:airbyte /config && \
+    chown -R airbyte:airbyte /nonexistent && \
     chown -R airbyte:airbyte /tmp
 
 

--- a/docker-images/Dockerfile.python-connector-base
+++ b/docker-images/Dockerfile.python-connector-base
@@ -4,39 +4,59 @@
 ARG BASE_IMAGE=docker.io/python:3.11.11-slim-bookworm@sha256:081075da77b2b55c23c088251026fb69a7b2bf92471e491ff5fd75c192fd38e5
 FROM ${BASE_IMAGE}
 
+# Set the timezone to UTC
 RUN ln -snf /usr/share/zoneinfo/Etc/UTC /etc/localtime
 
-# Install dependencies needed for OCR and PDF processing in certain file-based connectors
-# TODO: move these out of the base image
-RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt-get dist-upgrade -y && \
-    apt-get install -y --no-install-recommends \
-      socat=1.7.4.4-2 \
-      tesseract-ocr=5.3.0-2 \
-      poppler-utils=22.12.0-2+deb12u1 && \
-    apt-get clean
-    
-RUN pip install --upgrade \
-      pip==24.0 \
-      setuptools==78.1.1 && \
-    pip install --no-cache-dir \
-      poetry==1.8.4
-
 # Set-up groups, users, and directories
-RUN adduser --uid 1000 --system --group --no-create-home airbyte && \
-    mkdir --mode 755 /airbyte && \
+RUN adduser --uid 1000 --system --group --no-create-home airbyte
+
+# Create the cache airbyte directories and set the right permissions
+RUN mkdir --mode 755 /airbyte && \
     mkdir --mode 755 /custom_cache && \
-    mkdir -p 755 /usr/share/nltk_data && \
-    chown -R airbyte:airbyte /airbyte && \
-    chown -R airbyte:airbyte /custom_cache && \
-    chown -R airbyte:airbyte /secrets && \
-    chown -R airbyte:airbyte /config && \
-    chown -R airbyte:airbyte /usr/share/pki/ca-trust-source && \
-    chown -R airbyte:airbyte /usr/share/pki/nltk_data && \
-    chown -R airbyte:airbyte /etc/pki/ca-trust && \
-    chown -R airbyte:airbyte /tmp
+    chown airbyte:airbyte /airbyte
 
 ENV POETRY_VIRTUALENVS_CREATE=false
 ENV POETRY_VIRTUALENVS_IN_PROJECT=false
 ENV POETRY_NO_INTERACTION=1
+
+# Create and set up pip cache directory (maybe don't need this)
+ENV PIP_CACHE_DIR=/pip_cache
+RUN mkdir -p ${PIP_CACHE_DIR} && chown -R airbyte:airbyte ${PIP_CACHE_DIR}
+
+# Install pip and poetry
+RUN pip install --upgrade \
+      pip==24.0 \
+      setuptools==78.1.1 \
+      poetry==1.8.4
+
+# Install system dependencies 
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get dist-upgrade -y && \
+    apt-get clean
+RUN apt-get install -y socat=1.7.4.4-2
+
+# Install system dependencies related to OCR and PDF processing
+# TODO: move these out of the base image since they are only needed for a few connectors
+RUN apt-get update && \
+    apt-get install -y \
+      tesseract-ocr=5.3.0-2 \
+      poppler-utils=22.12.0-2+deb12u1
+
+# NLTK data directory (this may not be needed)
+# ENV NLTK_DATA_DIR="/usr/share/nltk_data"
+# RUN mkdir -p 755 ${NLTK_DATA_DIR}
+# TODO: add nltk data to the base image s
+
+# RUN mkdir --mode 755 /airbyte && \
+#     mkdir --mode 755 /custom_cache && \
+#     mkdir -p 755 /usr/share/nltk_data && \
+#     chown -R airbyte:airbyte /airbyte && \
+#     chown -R airbyte:airbyte /custom_cache && \
+#     chown -R airbyte:airbyte /secrets && \
+#     chown -R airbyte:airbyte /config && \
+#     chown -R airbyte:airbyte /usr/share/pki/ca-trust-source && \
+#     chown -R airbyte:airbyte /usr/share/pki/nltk_data && \
+#     chown -R airbyte:airbyte /etc/pki/ca-trust && \
+#     chown -R airbyte:airbyte /tmp
+

--- a/docker-images/Dockerfile.python-connector-base
+++ b/docker-images/Dockerfile.python-connector-base
@@ -48,15 +48,14 @@ RUN apt-get update && \
 # RUN mkdir -p 755 ${NLTK_DATA_DIR}
 # TODO: add nltk data to the base image s
 
-# RUN mkdir --mode 755 /airbyte && \
-#     mkdir --mode 755 /custom_cache && \
-#     mkdir -p 755 /usr/share/nltk_data && \
-#     chown -R airbyte:airbyte /airbyte && \
-#     chown -R airbyte:airbyte /custom_cache && \
-#     chown -R airbyte:airbyte /secrets && \
-#     chown -R airbyte:airbyte /config && \
-#     chown -R airbyte:airbyte /usr/share/pki/ca-trust-source && \
-#     chown -R airbyte:airbyte /usr/share/pki/nltk_data && \
-#     chown -R airbyte:airbyte /etc/pki/ca-trust && \
-#     chown -R airbyte:airbyte /tmp
-
+RUN mkdir --mode 755 /airbyte && \
+    mkdir --mode 755 /custom_cache && \
+    mkdir -p 755 /usr/share/nltk_data && \
+    chown -R airbyte:airbyte /airbyte && \
+    chown -R airbyte:airbyte /custom_cache && \
+    chown -R airbyte:airbyte /secrets && \
+    chown -R airbyte:airbyte /config && \
+    chown -R airbyte:airbyte /usr/share/pki/ca-trust-source && \
+    chown -R airbyte:airbyte /usr/share/pki/nltk_data && \
+    chown -R airbyte:airbyte /etc/pki/ca-trust && \
+    chown -R airbyte:airbyte /tmp

--- a/docker-images/Dockerfile.python-connector-base
+++ b/docker-images/Dockerfile.python-connector-base
@@ -47,8 +47,9 @@ RUN apt-get update && \
 # NLTK data directory (this may not be needed)
 # ENV NLTK_DATA_DIR="/usr/share/nltk_data"
 # RUN mkdir -p 755 ${NLTK_DATA_DIR}
-# TODO: add nltk data to the base image s
+# TODO: remove this block if not needed. If it is needed, finish copying over from Airbyte CI.
 
+# Set a whole bunch of permissions for the non-root user (delete this block if not needed)
 # RUN mkdir --mode 755 /airbyte && \
 #     mkdir --mode 755 /custom_cache && \
 #     mkdir -p 755 /usr/share/nltk_data && \

--- a/docker-images/Dockerfile.python-connector-base
+++ b/docker-images/Dockerfile.python-connector-base
@@ -49,14 +49,14 @@ RUN apt-get update && \
 # RUN mkdir -p 755 ${NLTK_DATA_DIR}
 # TODO: add nltk data to the base image s
 
-RUN mkdir --mode 755 /airbyte && \
-    mkdir --mode 755 /custom_cache && \
-    mkdir -p 755 /usr/share/nltk_data && \
-    chown -R airbyte:airbyte /airbyte && \
-    chown -R airbyte:airbyte /custom_cache && \
-    chown -R airbyte:airbyte /secrets && \
-    chown -R airbyte:airbyte /config && \
-    chown -R airbyte:airbyte /usr/share/pki/ca-trust-source && \
-    chown -R airbyte:airbyte /usr/share/pki/nltk_data && \
-    chown -R airbyte:airbyte /etc/pki/ca-trust && \
-    chown -R airbyte:airbyte /tmp
+# RUN mkdir --mode 755 /airbyte && \
+#     mkdir --mode 755 /custom_cache && \
+#     mkdir -p 755 /usr/share/nltk_data && \
+#     chown -R airbyte:airbyte /airbyte && \
+#     chown -R airbyte:airbyte /custom_cache && \
+#     chown -R airbyte:airbyte /secrets && \
+#     chown -R airbyte:airbyte /config && \
+#     chown -R airbyte:airbyte /usr/share/pki/ca-trust-source && \
+#     chown -R airbyte:airbyte /usr/share/pki/nltk_data && \
+#     chown -R airbyte:airbyte /etc/pki/ca-trust && \
+#     chown -R airbyte:airbyte /tmp


### PR DESCRIPTION
## What
Modify the Dockerfiles defining the Python connector image to get them into a state where they can properly run syncs. This aims to replace a parallel build process currently managed by Airbyte CI. As of this PR, these Dockerfiles are not used to build any images pushed to production yet.

Also, this removes hubspot from the python build matrix since it has been migrated to manifest only.

## Testing
The current state of these files has only been manually tested on Cloud to run a Google Drive -> Google Sheet sync (with OCR text extraction from pdfs). This was chosen as it is a more complex sync and is known to need a couple extra dependencies (poppler-utils and tesseract).

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._