### PR TITLE
ci: fix missing slash command in dispatch

### DIFF
--- a/.github/workflows/slash-commands.yml
+++ b/.github/workflows/slash-commands.yml
@@ -29,6 +29,7 @@ jobs:
             bump-cdk-version-and-merge
             format-fix
             test
+            run-cat-tests
             run-connector-tests
             test-performance
             publish-java-cdk


### PR DESCRIPTION
## What

Fix missing slash command entry in slash command dispatch.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
