### PR TITLE
chore: sort the secret mask spec

### DIFF
--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/specs_secrets_mask.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/specs_secrets_mask.py
@@ -73,7 +73,7 @@ def all_specs_secrets(
 @asset(required_resource_keys={"registry_directory_manager"}, group_name=GROUP_NAME)
 @sentry.instrument_asset_op
 def specs_secrets_mask_yaml(context: OpExecutionContext, all_specs_secrets: Set[str]) -> Output:
-    yaml_string = yaml.dump({"properties": list(all_specs_secrets)})
+    yaml_string = yaml.dump({"properties": sorted(list(all_specs_secrets))})
     registry_directory_manager = context.resources.registry_directory_manager
     file_handle = registry_directory_manager.write_data(yaml_string.encode(), ext="yaml", key="specs_secrets_mask")
     metadata = {


### PR DESCRIPTION
## What
Sort the `specs_secrets_mask.yaml` file.

The platform depends on this file. It downloads this file during builds. When the file changes, the platform build cache is significantly invalidated, leading to longer build times for everyone. 

I suspect that entries in this file don't change frequently, but the ETag changes frequently because the entries are not sorted (because they come from a Set).

## How
Call `sorted` before dumping to YAML.

## User Impact
None

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._