### PR TITLE
ci: remove ai-language-model team from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,10 +1,10 @@
 # Vector db connectors
-/airbyte-integrations/connectors/destination-pinecone @airbytehq/ai-language-models
-/airbyte-integrations/connectors/destination-weaviate @airbytehq/ai-language-models
-/airbyte-integrations/connectors/destination-milvus @airbytehq/ai-language-models
-/airbyte-integrations/connectors/destination-qdrant @airbytehq/ai-language-models
-/airbyte-integrations/connectors/destination-chroma @airbytehq/ai-language-models
-/airbyte-integrations/connectors/destination-snowflake-cortex @airbytehq/ai-language-models
+/airbyte-integrations/connectors/destination-pinecone @airbytehq/dev-extensibility
+/airbyte-integrations/connectors/destination-weaviate @airbytehq/dev-extensibility
+/airbyte-integrations/connectors/destination-milvus @airbytehq/dev-extensibility
+/airbyte-integrations/connectors/destination-qdrant @airbytehq/dev-extensibility
+/airbyte-integrations/connectors/destination-chroma @airbytehq/dev-extensibility
+/airbyte-integrations/connectors/destination-snowflake-cortex @airbytehq/dev-extensibility
 
 # CI/CD
 /.github/ @airbytehq/dev-extensibility


### PR DESCRIPTION
## What
This team no longer exists (rolled up into extensibility). After this we will delete the team from Github

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
