### PR TITLE
chore: fix mssql build

### DIFF
--- a/airbyte-integrations/connectors/destination-mssql/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-mssql/metadata.yaml
@@ -16,7 +16,7 @@ data:
             type: GSM
   connectorType: destination
   definitionId: d4353156-9217-4cad-8dd7-c108fd4f74cf
-  dockerImageTag: 2.2.10
+  dockerImageTag: 2.2.11
   dockerRepository: airbyte/destination-mssql
   documentationUrl: https://docs.airbyte.com/integrations/destinations/mssql
   githubIssueLabel: destination-mssql

--- a/airbyte-integrations/connectors/destination-mssql/src/test-integration/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLContainerHelper.kt
+++ b/airbyte-integrations/connectors/destination-mssql/src/test-integration/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLContainerHelper.kt
@@ -11,7 +11,6 @@ import io.airbyte.integrations.destination.mssql.v2.MSSQLContainerHelper.getPort
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.testcontainers.containers.MSSQLServerContainer
 import org.testcontainers.containers.MSSQLServerContainer.MS_SQL_SERVER_PORT
-import org.testcontainers.containers.Network
 
 val logger = KotlinLogging.logger {}
 /**
@@ -19,7 +18,7 @@ val logger = KotlinLogging.logger {}
  * configuration to match test container configuration.
  */
 object MSSQLContainerHelper {
-    
+
     private val testContainer =
         MSSQLServerContainer("mcr.microsoft.com/mssql/server:2022-latest")
             .acceptLicense()

--- a/airbyte-integrations/connectors/destination-mssql/src/test-integration/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLContainerHelper.kt
+++ b/airbyte-integrations/connectors/destination-mssql/src/test-integration/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLContainerHelper.kt
@@ -19,9 +19,7 @@ val logger = KotlinLogging.logger {}
  * configuration to match test container configuration.
  */
 object MSSQLContainerHelper {
-
-    private val network = Network.newNetwork()
-
+    
     private val testContainer =
         MSSQLServerContainer("mcr.microsoft.com/mssql/server:2022-latest")
             .acceptLicense()

--- a/airbyte-integrations/connectors/destination-mssql/src/test-integration/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLContainerHelper.kt
+++ b/airbyte-integrations/connectors/destination-mssql/src/test-integration/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLContainerHelper.kt
@@ -25,7 +25,6 @@ object MSSQLContainerHelper {
     private val testContainer =
         MSSQLServerContainer("mcr.microsoft.com/mssql/server:2022-latest")
             .acceptLicense()
-            .withNetwork(network)
             .withLogConsumer { e -> logger.debug { e.utf8String } }
 
     fun start() {
@@ -37,8 +36,6 @@ object MSSQLContainerHelper {
     }
 
     fun getHost(): String = testContainer.host
-
-    fun getNetwork(): Network = network
 
     fun getPassword(): String = testContainer.password
 

--- a/buildSrc/src/main/groovy/airbyte-bulk-connector.gradle
+++ b/buildSrc/src/main/groovy/airbyte-bulk-connector.gradle
@@ -205,11 +205,7 @@ class AirbyteBulkConnectorPlugin implements Plugin<Project> {
                 environment "AIRBYTE_CONNECTOR_INTEGRATION_TEST_RUNNER", "docker"
 
                 jvmArgs = project.test.jvmArgs
-                systemProperties = project.test.systemProperties + [
-                        'junit.jupiter.execution.parallel.enabled': 'true',
-                        'junit.jupiter.execution.parallel.config.strategy': 'fixed',
-                        'junit.jupiter.execution.parallel.config.fixed.parallelism': Math.max((Runtime.runtime.availableProcessors() / 2).toInteger(), 1).toString()
-                ]
+                systemProperties = project.test.systemProperties
                 maxParallelForks = project.test.maxParallelForks
                 maxHeapSize = project.test.maxHeapSize
 

--- a/docs/integrations/destinations/mssql.md
+++ b/docs/integrations/destinations/mssql.md
@@ -158,6 +158,7 @@ See the [Getting Started: Configuration section](#configuration) of this guide f
 
 | Version    | Date       | Pull Request                                               | Subject                                                                                             |
 |:-----------|:-----------|:-----------------------------------------------------------|:----------------------------------------------------------------------------------------------------|
+| 2.2.11     | 2025-05-30 | [61017](https://github.com/airbytehq/airbyte/pull/61017)   | Integration test fixes                                                                              |
 | 2.2.10     | 2025-05-29 | [60897](https://github.com/airbytehq/airbyte/pull/60897)   | Internal fixes                                                                                      |
 | 2.2.9      | 2025-05-19 | [60791](https://github.com/airbytehq/airbyte/pull/60791)   | Fix bug in detecting schema change when stream has no columns                                       |
 | 2.2.8      | 2025-05-08 | [59735](https://github.com/airbytehq/airbyte/pull/59735)   | Cleanup: Remove unused code                                                                         |


### PR DESCRIPTION
## What
We found several bugs:
- the bulk connector plugin hardcodes integration tests set up today instead of inheriting the same properties from the general test set up. Remove this.
- the Dest MSSQL uses a custom network to spin up test containers that is no longer required since we are no longer in Dagger. Remove this. This also simplifies things.

## How
As description.

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._