### PR TITLE
fix(source-hubspot): Catch OverflowError since the dependency might still raise it

### DIFF
--- a/airbyte-integrations/connectors/source-hubspot/components.py
+++ b/airbyte-integrations/connectors/source-hubspot/components.py
@@ -425,12 +425,12 @@ class EntitySchemaNormalization(TypeTransformer):
 
         try:
             return ab_datetime_parse(datetime_str)
-        except (ValueError, TypeError) as ex:
+        except (ValueError, TypeError, OverflowError) as ex:
             logger.warning(f"Couldn't parse date/datetime string field. Timestamp field value: {datetime_str}. Ex: {ex}")
 
         try:
             return ab_datetime_parse(int(datetime_str) // 1000)
-        except (ValueError, TypeError) as ex:
+        except (ValueError, TypeError, OverflowError) as ex:
             logger.warning(f"Couldn't parse date/datetime string field. Timestamp field value: {datetime_str}. Ex: {ex}")
 
         return None

--- a/airbyte-integrations/connectors/source-hubspot/metadata.yaml
+++ b/airbyte-integrations/connectors/source-hubspot/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 36c891d9-4bd9-43ac-bad2-10e12756272c
-  dockerImageTag: 5.8.4
+  dockerImageTag: 5.8.5
   dockerRepository: airbyte/source-hubspot
   documentationUrl: https://docs.airbyte.com/integrations/sources/hubspot
   resourceRequirements:

--- a/docs/integrations/sources/hubspot.md
+++ b/docs/integrations/sources/hubspot.md
@@ -333,6 +333,7 @@ The connector is restricted by normal HubSpot [rate limitations](https://legacyd
 
 | Version    | Date       | Pull Request                                             | Subject                                                                                                                                                                          |
 |:-----------|:-----------|:---------------------------------------------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 5.8.5      | 2025-06-02 | [61326](https://github.com/airbytehq/airbyte/pull/61326) | Additional change for millisecond float timestamps |
 | 5.8.4      | 2025-05-30 | [61013](https://github.com/airbytehq/airbyte/pull/61013) | Fix Typo|
 | 5.8.3      | 2025-05-30 | [61007](https://github.com/airbytehq/airbyte/pull/61007) | Bump memory on Check to 1600mi|
 | 5.8.2      | 2025-05-29 | [60962](https://github.com/airbytehq/airbyte/pull/60962) | Fix bug to allow millisecond timestamps coming in as a float string to be parsed into a datetime.                                                                                                                                                                    |


### PR DESCRIPTION
## What

This was sort of fixed in: https://github.com/airbytehq/airbyte/pull/60962

But after looking at a few specific customers, for some reason it can either raise as a `ValueError` (Which currently works and what happens locally), but for some reason may also come as an `OverflowError`. This modifies the check to account for either one and perform the necessary conversion if needed

## How

I have no idea what triggers raising the `OverflowError` using some test data that causes the error on Cloud, when I run it locally with that exact value, it comes back as a `ValueError`. That's why I didn't add a test case. So unfortunately gonna just have to yolo this fix out

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌
