### PR TITLE
[Load-CDK]: Speed state record count fix

### DIFF
--- a/airbyte-integrations/connectors/destination-s3/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2WriteTest.kt
+++ b/airbyte-integrations/connectors/destination-s3/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2WriteTest.kt
@@ -523,7 +523,8 @@ class S3V2WriteTestJsonUncompressedSockets :
         dataChannelMedium = DataChannelMedium.SOCKETS
     ) {
     @Test
-    override fun testBasicWrite() {
-        super.testBasicWrite()
+    @Disabled("Clear will never run in socket mode")
+    override fun testClear() {
+        super.testClear()
     }
 }


### PR DESCRIPTION
## What
This addresses a gap that @subodh1810 uncovered in the new state flow where we were failing to set the read counts for each CheckpointId on the socket path.

Read counts are compared to persisted counts in order to determine whether state should be flushed.

On the old path, these counts came from the literal count of records between state messages.

On the socket path, this is no longer possible, due to the asynchronous processing of records and state, so now we use the source counts.

The reason why this worked was because the stream manager would make this comparison:

```
    /**
     * True if persisted counts associated with the index [checkpointId] are equal to the number of
     * records read.
     */
    fun areRecordsPersistedForCheckpoint(checkpointId: CheckpointId): Boolean {
        val readCount =
            recordsReadPerCheckpoint[checkpointId] ?: 0L // <- bug: should not default

        val persistedCount = countByStateForCheckpoint(checkpointId, BatchState.PERSISTED)
        val completedCount = countByStateForCheckpoint(checkpointId, BatchState.COMPLETE)

        if (persistedCount == readCount) {
            return true
        }

        // Completed implies persisted.
        return completedCount == readCount
    }
```

Which would pass if no records had been completed yet, or if the sync only had a completed step but no persisted step.

The error was in defaulting to 0. Since this will always be called AFTER a checkpoint has been processed, and since processing => storing counts, the fix is to throw if there are no counts.

This manifest as a transient failure in the new socket tests (depending on how the race condition flopped). As soon as the exception was added, any socket test with state failed deterministically. The fix addressed those failures.

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._