### PR TITLE
ci: add GitHub App authentication and status reporting to connector CI workflow

### DIFF
--- a/.github/workflows/connector-ci-checks.yml
+++ b/.github/workflows/connector-ci-checks.yml
@@ -186,6 +186,30 @@ jobs:
     needs: [jvm-connectors-test-matrix]
     runs-on: ubuntu-24.04
     steps:
+      - name: Authenticate as GitHub App
+        uses: actions/create-github-app-token@v1
+        id: get-app-token
+        if: github.event_name == 'workflow_call' && inputs.gitref != ''
+        with:
+          owner: "airbytehq"
+          repositories: "airbyte"
+          app-id: ${{ secrets.OCTAVIA_BOT_APP_ID }}
+          private-key: ${{ secrets.OCTAVIA_BOT_PRIVATE_KEY }}
+
+      # Post completion status to the PR.
+      # This is required because otherwise slash commands won't automatically
+      # update the PR checks status.
+      - name: Create Check Status
+        if: github.event_name == 'workflow_call' && inputs.gitref != ''
+        uses: LouisBrunner/checks-action@v2.0.0
+        with:
+          name: ${{ job.name }}
+          repo: "airbytehq/airbyte"  # Post to the main repo, not the fork
+          sha: ${{ inputs.gitref }}
+          status: completed
+          conclusion: ${{ job.status }}
+          token: ${{ steps.get-app-token.outputs.token }}
+
       - name: Report Test Summary
         run: echo "✅ All JVM connector tests completed successfully (or nothing to test)."
 
@@ -291,6 +315,31 @@ jobs:
     needs: [non-jvm-connectors-test-matrix]
     runs-on: ubuntu-24.04
     steps:
+      - name: Authenticate as GitHub App
+        uses: actions/create-github-app-token@v1
+        id: get-app-token
+        if: github.event_name == 'workflow_call' && inputs.gitref != ''
+
+        with:
+          owner: "airbytehq"
+          repositories: "airbyte"
+          app-id: ${{ secrets.OCTAVIA_BOT_APP_ID }}
+          private-key: ${{ secrets.OCTAVIA_BOT_PRIVATE_KEY }}
+
+      # Post completion status to the PR.
+      # This is required because otherwise slash commands won't automatically
+      # update the PR checks status.
+      - name: Create Check Status
+        if: github.event_name == 'workflow_call' && inputs.gitref != ''
+        uses: LouisBrunner/checks-action@v2.0.0
+        with:
+          name: ${{ job.name }}
+          repo: "airbytehq/airbyte"  # Post to the main repo, not the fork
+          sha: ${{ inputs.gitref }}
+          status: completed
+          conclusion: ${{ job.status }}
+          token: ${{ steps.get-app-token.outputs.token }}
+
       - name: Report Test Summary
         run: echo "✅ All non-JVM connector tests completed successfully (or nothing to test)."
 

--- a/.github/workflows/connector-ci-checks.yml
+++ b/.github/workflows/connector-ci-checks.yml
@@ -204,7 +204,7 @@ jobs:
         uses: LouisBrunner/checks-action@v2.0.0
         with:
           name: ${{ job.name }}
-          repo: "airbytehq/airbyte"  # Post to the main repo, not the fork
+          repo: "airbytehq/airbyte" # Post to the main repo, not the fork
           sha: ${{ inputs.gitref }}
           status: completed
           conclusion: ${{ job.status }}
@@ -333,7 +333,7 @@ jobs:
         uses: LouisBrunner/checks-action@v2.0.0
         with:
           name: ${{ job.name }}
-          repo: "airbytehq/airbyte"  # Post to the main repo, not the fork
+          repo: "airbytehq/airbyte" # Post to the main repo, not the fork
           sha: ${{ inputs.gitref }}
           status: completed
           conclusion: ${{ job.status }}

--- a/.github/workflows/connector-ci-checks.yml
+++ b/.github/workflows/connector-ci-checks.yml
@@ -319,7 +319,6 @@ jobs:
         uses: actions/create-github-app-token@v1
         id: get-app-token
         if: github.event_name == 'workflow_call' && inputs.gitref != ''
-
         with:
           owner: "airbytehq"
           repositories: "airbyte"


### PR DESCRIPTION
## What

When the `connector-ci-checks.yml` workflow is run via Slash command, this update ensures that the check results are also posted to the PR.

Otherwise, the workflow results would not be directly associated with any PR.

This also pilots how we can use the github app "Octavia-Bot" in place of a PAT and in place of the built-in `github.token`.


## Caveat / Disclaimer

I did the best I could to pre-test this on the PyAirbyte repo. Here: https://github.com/airbytehq/PyAirbyte/pull/684

That said, Slash commands can only be _truly_ tested after they are merged. If any issues are found, I'll follow up with the needed fixes.