### PR TITLE
Load-CDK: Allow source to send probe messages in socket mode

### DIFF
--- a/airbyte-cdk/bulk/core/base/src/main/proto/airbyte_message.proto
+++ b/airbyte-cdk/bulk/core/base/src/main/proto/airbyte_message.proto
@@ -15,5 +15,11 @@ message AirbyteMessageProtobuf {
   oneof type {
     AirbyteRecordMessageProtobuf record = 1;
     string airbyte_protocol_message = 2;
+    AirbyteProbeMessageProtobuf probe = 3;
   }
+};
+
+// An empty payload the source might send to check whether the socket is still alive.
+// The destination will treat is as a heartbeat internally but won't rely on it.
+message AirbyteProbeMessageProtobuf {
 };

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/file/SocketInputFlow.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/file/SocketInputFlow.kt
@@ -9,6 +9,8 @@ import io.airbyte.cdk.load.config.PipelineInputEvent
 import io.airbyte.cdk.load.message.CheckpointMessage
 import io.airbyte.cdk.load.message.DestinationStreamAffinedMessage
 import io.airbyte.cdk.load.message.Ignored
+import io.airbyte.cdk.load.message.PipelineHeartbeat
+import io.airbyte.cdk.load.message.ProbeMessage
 import io.airbyte.cdk.load.message.Undefined
 import io.airbyte.cdk.load.state.PipelineEventBookkeepingRouter
 import io.airbyte.cdk.load.state.ReservationManager
@@ -44,6 +46,7 @@ class SocketInputFlow(
                             pipelineEventBookkeepingRouter.handleCheckpoint(
                                 memoryManager.reserve(message.serializedSizeBytes, message)
                             )
+                        is ProbeMessage -> collector.emit(PipelineHeartbeat())
                         Undefined -> log.warn { "Unhandled message: $message" }
                         Ignored -> {
                             /* do nothing */

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/DestinationMessageFactory.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/DestinationMessageFactory.kt
@@ -236,10 +236,19 @@ class DestinationMessageFactory(
                 serializedSizeBytes,
                 CheckpointId(message.record.partitionId)
             )
+        } else if (message.hasProbe()) {
+            ProbeMessage
         } else {
-            throw IllegalArgumentException(
-                "AirbyteMessage must contain either a record or a serialized control message"
-            )
+            throw IllegalArgumentException("AirbyteMessage must contain a payload.")
         }
+    }
+}
+
+data object ProbeMessage : DestinationMessage {
+    override fun asProtocolMessage(): AirbyteMessage {
+        throw UnsupportedOperationException(
+            "ProbeMessage cannot be converted to AirbyteMessage. " +
+                "It is only used by the source to verify that the data channel is open."
+        )
     }
 }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/InputConsumerTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/InputConsumerTask.kt
@@ -15,6 +15,7 @@ import io.airbyte.cdk.load.message.PartitionedQueue
 import io.airbyte.cdk.load.message.PipelineEndOfStream
 import io.airbyte.cdk.load.message.PipelineEvent
 import io.airbyte.cdk.load.message.PipelineMessage
+import io.airbyte.cdk.load.message.ProbeMessage
 import io.airbyte.cdk.load.message.StreamKey
 import io.airbyte.cdk.load.message.Undefined
 import io.airbyte.cdk.load.pipeline.InputPartitioner
@@ -92,6 +93,7 @@ class InputConsumerTask(
                                 reserved.replace(message)
                             )
                         Undefined -> log.warn { "Unhandled message: $message" }
+                        ProbeMessage,
                         Ignored -> {
                             /* do nothing */
                         }

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/message/DestinationMessageTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/message/DestinationMessageTest.kt
@@ -31,6 +31,7 @@ import io.airbyte.protocol.models.v0.AirbyteStreamState
 import io.airbyte.protocol.models.v0.AirbyteStreamStatusTraceMessage
 import io.airbyte.protocol.models.v0.AirbyteTraceMessage
 import io.airbyte.protocol.protobuf.AirbyteMessage.AirbyteMessageProtobuf
+import io.airbyte.protocol.protobuf.AirbyteMessage.AirbyteProbeMessageProtobuf
 import io.airbyte.protocol.protobuf.AirbyteRecordMessage.AirbyteRecordMessageProtobuf
 import io.airbyte.protocol.protobuf.AirbyteRecordMessage.AirbyteValueProtobuf
 import io.mockk.mockk
@@ -687,5 +688,16 @@ class DestinationMessageTest {
         assertEquals(100L, streamCheckpoint.serializedSizeBytes)
         assertEquals(2L, streamCheckpoint.sourceStats?.recordCount)
         assertEquals(blob1, streamCheckpoint.asProtocolMessage().state.stream.streamState)
+    }
+
+    @Test
+    fun `message factory creates heartbeat from protobuf heartbeat`() {
+        val factory = factory(isFileTransferEnabled = false, requireCheckpointKey = true)
+        val heartbeatMessage =
+            AirbyteMessageProtobuf.newBuilder()
+                .setProbe(AirbyteProbeMessageProtobuf.newBuilder().build())
+                .build()
+        val message = factory.fromAirbyteProtobufMessage(heartbeatMessage, 0L)
+        Assertions.assertTrue(message is ProbeMessage)
     }
 }


### PR DESCRIPTION
## What
Source needs to send a periodic probe messages on the socket channels to make sure we're there. We might as well use that to trigger the timed flushes downstream

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._