### PR TITLE
[Docs][1.7] Low resource mode disables the Connector Builder

### DIFF
--- a/docs/platform/connector-development/connector-builder-ui/overview.md
+++ b/docs/platform/connector-development/connector-builder-ui/overview.md
@@ -38,3 +38,7 @@ If you'd like to share your connector with other Airbyte users, you can contribu
 Reviews typically take under a week.
 
 You can also export the YAML manifest file for your connector and share it with others. The manifest file contains all the information about the connector, including the global configuration, streams, and user inputs.
+
+## Disabled in low-resource mode
+
+If you install Airbyte with abctl using low-resource mode, you are unable to access the Connector Builder. To access the Connector Builder, allocate Airbyte's [suggested resources](/platform/using-airbyte/getting-started/oss-quickstart#suggested-resources) and re-deploy Airbyte without setting the `--low-resource-mode` flag.

--- a/docs/platform/using-airbyte/getting-started/oss-quickstart.md
+++ b/docs/platform/using-airbyte/getting-started/oss-quickstart.md
@@ -186,7 +186,7 @@ Use [Homebrew](https://brew.sh/) to install abctl.
     ``` 
     -->
 
-    To run Airbyte in a low-resource environment (fewer than 4 CPUs), specify the `--low-resource-mode` flag to the local install command.
+    To run Airbyte in a low-resource environment (fewer than 4 CPUs), specify the `--low-resource-mode` flag to the local install command. In low-resource mode, you are unable to access the Connector Builder.
 
     ```bash
     abctl local install --low-resource-mode


### PR DESCRIPTION
## What

Closes https://github.com/airbytehq/airbyte-internal-issues/issues/13172. Updates end user documentation to specify the Connector Builder is off in low resource mode.

## How

- Update Quickstart
- Add a note to the Connector Builder docs

## Review guide

Just a short Markdown change.

## User Impact


## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌
