### PR TITLE
feat: add '/build-connector-images' command and related workflows for pre-release docker image builds

### DIFF
--- a/.github/pr-welcome-community.md
+++ b/.github/pr-welcome-community.md
@@ -12,10 +12,12 @@ Thank you for your contribution from **{{ .repo_name }}**! We're excited to have
 ### PR Slash Commands
 
 As needed or by request, Airbyte Maintainers can execute the following slash commands on your PR:
+
 - `/format-fix` - Fixes most formatting issues.
 - `/bump-version` - Bumps connector versions.
 - `/run-connector-tests` - Runs connector tests.
 - `/run-cat-tests` - Runs CAT tests.
+- `/build-connector-images` - Builds and publishes a pre-release docker image for the modified connector(s).
 
 If you have any questions, feel free to ask in the PR comments or join our [Slack community](https://airbytehq.slack.com/).
 

--- a/.github/pr-welcome-internal.md
+++ b/.github/pr-welcome-internal.md
@@ -19,5 +19,6 @@ Airbyte Maintainers (that's you!) can execute the following slash commands on yo
 - `/format-fix` - Fixes most formatting issues.
 - `/bump-version` - Bumps connector versions.
 - `/run-cat-tests` - Runs legacy CAT tests (Connector Acceptance Tests)
+- `/build-connector-images` - Builds and publishes a pre-release docker image for the modified connector(s).
 
 [📝 _Edit this welcome message._](https://github.com/airbytehq/airbyte/blob/master/.github/pr-welcome-internal.md)

--- a/.github/workflows/build-connector-images-command.yml
+++ b/.github/workflows/build-connector-images-command.yml
@@ -3,6 +3,12 @@ name: Connector Image Builds
 # It can be triggered manually via slash command or workflow dispatch.
 
 on:
+  # For testing:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches:
+      - '**/ci/*-build-connector-images*'
+
   workflow_dispatch:
     inputs:
       repo:
@@ -21,12 +27,6 @@ on:
         description: "The pull request number, if applicable"
         required: false
         type: number
-
-  # For testing:
-  pull_request:
-    types: [opened, synchronize, reopened]
-    branches:
-      - "*/ci/*-build-connector-images*"
 
 jobs:
   init-workflow:

--- a/.github/workflows/build-connector-images-command.yml
+++ b/.github/workflows/build-connector-images-command.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           echo "run-url=https://github.com/${{ github.repository }}/actions/runs/$GITHUB_RUN_ID" >> $GITHUB_OUTPUT
           echo "image-name=ghcr.io/airbytehq/${{ inputs.repo || github.repository }}:${{ inputs.gitref || github.ref_name }}" >> $GITHUB_OUTPUT
-          echo "pr-number=${{ inputs.pr || github.event.pull_request.number || '' }}" >> $GITHUB_OUTPUT
+          echo "pr-number=${{ github.event_name == 'pull_request' && github.event.pull_request.number || inputs.pr }}" >> $GITHUB_OUTPUT
 
       - name: Generate Connector Matrix from Changes
         id: generate-matrix

--- a/.github/workflows/build-connector-images-command.yml
+++ b/.github/workflows/build-connector-images-command.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
     branches:
-      - '*/ci/*-build-connector-images*'
+      - '**/ci/**'
 
   workflow_dispatch:
     inputs:

--- a/.github/workflows/build-connector-images-command.yml
+++ b/.github/workflows/build-connector-images-command.yml
@@ -1,7 +1,6 @@
 name: Airbyte CI for Connector Contributions
-# This workflow is used to run connector tests for contributors.
+# This workflow is used to run connector image builds.
 # It can be triggered manually via slash command or workflow dispatch.
-# It also will run on push events to forks, if the fork has "BYO Secrets" defined.
 
 on:
   workflow_dispatch:

--- a/.github/workflows/build-connector-images-command.yml
+++ b/.github/workflows/build-connector-images-command.yml
@@ -1,0 +1,93 @@
+name: Airbyte CI for Connector Contributions
+# This workflow is used to run connector tests for contributors.
+# It can be triggered manually via slash command or workflow dispatch.
+# It also will run on push events to forks, if the fork has "BYO Secrets" defined.
+
+on:
+  workflow_dispatch:
+    inputs:
+      repo:
+        description: "The repository name"
+        required: false
+        type: string
+      gitref:
+        description: "The git reference (branch or tag)"
+        required: false
+        type: string
+      comment-id:
+        description: "The ID of the comment triggering the workflow"
+        required: false
+        type: number
+      pr:
+        description: "The pull request number, if applicable"
+        required: false
+        type: number
+  push:
+
+jobs:
+  post-start-comment:
+    name: "Post Start Comment"
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Get job variables
+        id: job-vars
+        # Create the job run variables.
+        # We intentionally ignore `inputs.repo` because the check run will be run on the
+        # current repository, not the one with the commit being tested.
+        run: |
+          echo "run-url=https://github.com/${{ github.repository }}/actions/runs/$GITHUB_RUN_ID" >> $GITHUB_OUTPUT
+
+      - name: Append start comment
+        uses: peter-evans/create-or-update-comment@v4
+        if: success()
+        with:
+          comment-id: ${{ inputs.comment-id }}
+          issue-number: ${{ inputs.pr }}
+          reactions: "+1"
+          body: |
+            > **Connector Image Build Started**
+            >
+            > [Check job output.](${{ steps.job-vars.outputs.run-url }})
+
+  call-connector-ci-tests:
+    # Run always for 'workflow_dispatch' events.
+    # Run for 'push' events on forks, but only if the fork defines "BYO Secrets".
+    name: "Call Connector CI Tests"
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event_name == 'push' &&
+        github.repository != 'airbytehq/airbyte' &&
+        vars.GCP_PROJECT_ID != ''
+      )
+    uses: ./.github/workflows/connector-ci-checks.yml
+    with:
+      repo: "${{ inputs.repo || github.repository }}"
+      gitref: "${{ inputs.gitref || github.ref_name }}"
+      comment-id: "${{ github.event_name == 'workflow_dispatch' && inputs['comment-id'] || '' }}"
+      pr: "${{ github.event_name == 'workflow_dispatch' && inputs.pr || '' }}"
+    secrets: inherit
+
+  post-end-comment:
+    name: "Post Completion Comment"
+    needs: call-connector-ci-tests
+    runs-on: ubuntu-24.04
+    if: >
+      always() &&
+      inputs.comment-id &&
+      (
+        github.event_name == 'workflow_dispatch' ||
+        (
+          github.event_name == 'push' &&
+          github.repository != 'airbytehq/airbyte' &&
+          vars.GCP_PROJECT_ID != ''
+        )
+      )
+    steps:
+      - name: Append end comment
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          comment-id: ${{ inputs.comment-id }}
+          issue-number: ${{ inputs.pr }}
+          body: |
+            > Connector CI Tests job completed. See logs for details.

--- a/.github/workflows/build-connector-images-command.yml
+++ b/.github/workflows/build-connector-images-command.yml
@@ -61,7 +61,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: ${{ inputs.repo || github.repository }}
-          ref: ${{ inputs.gitref || github.ref_name }}
+          ref: ${{ inputs.gitref || '' }}
           # Use fetch-depth: 0 to ensure we can access the full commit history
           fetch-depth: 0
 

--- a/.github/workflows/build-connector-images-command.yml
+++ b/.github/workflows/build-connector-images-command.yml
@@ -86,7 +86,7 @@ jobs:
       fail-fast: false # Don't stop on first failure
     with:
       repo: "${{ inputs.repo || github.repository }}"
-      gitref: "${{ inputs.gitref || github.ref_name }}"
+      gitref: "${{ inputs.gitref || '' }}"
       comment-id: "${{ github.event_name == 'workflow_dispatch' && inputs['comment-id'] || '' }}"
       pr: "${{ github.event_name == 'workflow_dispatch' && inputs.pr || '' }}"
       connector: ${{ matrix.connector }}

--- a/.github/workflows/build-connector-images-command.yml
+++ b/.github/workflows/build-connector-images-command.yml
@@ -43,6 +43,14 @@ jobs:
           echo "image-name=ghcr.io/airbytehq/${{ inputs.repo || github.repository }}:${{ inputs.gitref || github.ref_name }}" >> $GITHUB_OUTPUT
           echo "pr-number=${{ github.event_name == 'pull_request' && github.event.pull_request.number || inputs.pr }}" >> $GITHUB_OUTPUT
 
+      - name: Repo Checkout
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ inputs.repo || github.repository }}
+          ref: ${{ inputs.gitref || github.ref_name }}
+          # Use fetch-depth: 0 to ensure we can access the full commit history
+          fetch-depth: 0
+
       - name: Generate Connector Matrix from Changes
         id: generate-matrix
         run: |

--- a/.github/workflows/build-connector-images-command.yml
+++ b/.github/workflows/build-connector-images-command.yml
@@ -1,4 +1,4 @@
-name: Airbyte CI for Connector Contributions
+name: Connector Image Builds
 # This workflow is used to run connector image builds.
 # It can be triggered manually via slash command or workflow dispatch.
 

--- a/.github/workflows/build-connector-images-command.yml
+++ b/.github/workflows/build-connector-images-command.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
     branches:
-      - 'aj/ci/**'
+      - '**'
 
   workflow_dispatch:
     inputs:

--- a/.github/workflows/build-connector-images-command.yml
+++ b/.github/workflows/build-connector-images-command.yml
@@ -25,8 +25,8 @@ on:
   push:
 
 jobs:
-  post-start-comment:
-    name: "Post Start Comment"
+  init-workflow:
+    name: "Initialize Workflow"
     runs-on: ubuntu-24.04
     steps:
       - name: Get job variables
@@ -36,6 +36,13 @@ jobs:
         # current repository, not the one with the commit being tested.
         run: |
           echo "run-url=https://github.com/${{ github.repository }}/actions/runs/$GITHUB_RUN_ID" >> $GITHUB_OUTPUT
+          echo "image-name=ghcr.io/airbytehq/${{ inputs.repo || github.repository }}:${{ inputs.gitref || github.ref_name }}" >> $GITHUB_OUTPUT
+
+      - name: Generate Connector Matrix from Changes
+        id: generate-matrix
+        run: |
+          # Get the list of modified connectors
+          echo "connectors_matrix=$(./poe-tasks/get-modified-connectors.sh --json)" | tee -a $GITHUB_OUTPUT
 
       - name: Append start comment
         uses: peter-evans/create-or-update-comment@v4
@@ -47,42 +54,36 @@ jobs:
           body: |
             > **Connector Image Build Started**
             >
+            > - This workflow will build the connector image and run basic tests.
+            > - The connector image(s) will be pushed to the GitHub Container Registry.
+            >
             > [Check job output.](${{ steps.job-vars.outputs.run-url }})
 
-  call-connector-ci-tests:
+    outputs:
+      connectors-matrix: ${{ steps.generate-matrix.outputs.connectors_matrix }}
+
+  call-connector-ci-build:
     # Run always for 'workflow_dispatch' events.
     # Run for 'push' events on forks, but only if the fork defines "BYO Secrets".
-    name: "Call Connector CI Tests"
-    if: >
-      github.event_name == 'workflow_dispatch' ||
-      (
-        github.event_name == 'push' &&
-        github.repository != 'airbytehq/airbyte' &&
-        vars.GCP_PROJECT_ID != ''
-      )
-    uses: ./.github/workflows/connector-ci-checks.yml
+    name: "Call Connector CI Build"
+    uses: ./.github/workflows/connector-image-build.yml
+    needs: [init-workflow]
+    strategy:
+      matrix: ${{ fromJson(needs.init-workflow.outputs.connectors-matrix) }}
+      max-parallel: 5 # Limit number of parallel jobs
+      fail-fast: false # Don't stop on first failure
     with:
       repo: "${{ inputs.repo || github.repository }}"
       gitref: "${{ inputs.gitref || github.ref_name }}"
       comment-id: "${{ github.event_name == 'workflow_dispatch' && inputs['comment-id'] || '' }}"
       pr: "${{ github.event_name == 'workflow_dispatch' && inputs.pr || '' }}"
+      connector: ${{ matrix.connector }}
     secrets: inherit
 
   post-end-comment:
     name: "Post Completion Comment"
-    needs: call-connector-ci-tests
+    needs: call-connector-ci-build
     runs-on: ubuntu-24.04
-    if: >
-      always() &&
-      inputs.comment-id &&
-      (
-        github.event_name == 'workflow_dispatch' ||
-        (
-          github.event_name == 'push' &&
-          github.repository != 'airbytehq/airbyte' &&
-          vars.GCP_PROJECT_ID != ''
-        )
-      )
     steps:
       - name: Append end comment
         uses: peter-evans/create-or-update-comment@v4
@@ -90,4 +91,4 @@ jobs:
           comment-id: ${{ inputs.comment-id }}
           issue-number: ${{ inputs.pr }}
           body: |
-            > Connector CI Tests job completed. See logs for details.
+            > Connector Image Builds job completed. See logs for details.

--- a/.github/workflows/build-connector-images-command.yml
+++ b/.github/workflows/build-connector-images-command.yml
@@ -53,7 +53,7 @@ jobs:
             > **Connector Image Build Started**
             >
             > - This workflow will build the connector image and run basic tests.
-            > - The connector image(s) will be pushed to the GitHub Container Registry.
+            > - The connector image(s) will be pushed to the [GitHub Container Registry](https://github.com/orgs/airbytehq/packages).
             >
             > [Check job output.](${{ steps.job-vars.outputs.run-url }})
 

--- a/.github/workflows/build-connector-images-command.yml
+++ b/.github/workflows/build-connector-images-command.yml
@@ -3,11 +3,9 @@ name: Connector Image Builds
 # It can be triggered manually via slash command or workflow dispatch.
 
 on:
-  # For testing:
+  # For testing (TODO: comment out the below before merging):
   pull_request:
     types: [opened, synchronize, reopened]
-    branches:
-      - '**/ci/**'
 
   workflow_dispatch:
     inputs:

--- a/.github/workflows/build-connector-images-command.yml
+++ b/.github/workflows/build-connector-images-command.yml
@@ -26,7 +26,7 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
     branches:
-      - */ci/*-build-connector-images*
+      - "*/ci/*-build-connector-images*"
 
 jobs:
   init-workflow:

--- a/.github/workflows/build-connector-images-command.yml
+++ b/.github/workflows/build-connector-images-command.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
     branches:
-      - '**/ci/*-build-connector-images*'
+      - '*/ci/*-build-connector-images*'
 
   workflow_dispatch:
     inputs:

--- a/.github/workflows/build-connector-images-command.yml
+++ b/.github/workflows/build-connector-images-command.yml
@@ -21,7 +21,12 @@ on:
         description: "The pull request number, if applicable"
         required: false
         type: number
-  push:
+
+  # For testing:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches:
+      - */ci/*-build-connector-images*
 
 jobs:
   init-workflow:
@@ -36,6 +41,7 @@ jobs:
         run: |
           echo "run-url=https://github.com/${{ github.repository }}/actions/runs/$GITHUB_RUN_ID" >> $GITHUB_OUTPUT
           echo "image-name=ghcr.io/airbytehq/${{ inputs.repo || github.repository }}:${{ inputs.gitref || github.ref_name }}" >> $GITHUB_OUTPUT
+          echo "pr-number=${{ inputs.pr || github.event.pull_request.number || '' }}" >> $GITHUB_OUTPUT
 
       - name: Generate Connector Matrix from Changes
         id: generate-matrix
@@ -44,11 +50,12 @@ jobs:
           echo "connectors_matrix=$(./poe-tasks/get-modified-connectors.sh --json)" | tee -a $GITHUB_OUTPUT
 
       - name: Append start comment
+        id: append-start-comment
         uses: peter-evans/create-or-update-comment@v4
         if: success()
         with:
           comment-id: ${{ inputs.comment-id }}
-          issue-number: ${{ inputs.pr }}
+          issue-number: ${{ steps.job-vars.outputs.pr-number }}
           reactions: "+1"
           body: |
             > **Connector Image Build Started**
@@ -60,6 +67,8 @@ jobs:
 
     outputs:
       connectors-matrix: ${{ steps.generate-matrix.outputs.connectors_matrix }}
+      pr-number: ${{ steps.job-vars.outputs.pr-number }}
+      comment-id: ${{ steps.append-start-comment.outputs.comment-id }}
 
   call-connector-ci-build:
     name: "Call Connector CI Build"
@@ -79,13 +88,13 @@ jobs:
 
   post-end-comment:
     name: "Post Completion Comment"
-    needs: call-connector-ci-build
+    needs: [init-workflow, call-connector-ci-build]
     runs-on: ubuntu-24.04
     steps:
       - name: Append end comment
         uses: peter-evans/create-or-update-comment@v4
         with:
-          comment-id: ${{ inputs.comment-id }}
-          issue-number: ${{ inputs.pr }}
+          comment-id: ${{ needs.init-workflow.outputs.comment-id }}
+          issue-number: ${{ needs.init-workflow.outputs.pr-number }}
           body: |
             > Connector Image Builds job completed. See logs for details.

--- a/.github/workflows/build-connector-images-command.yml
+++ b/.github/workflows/build-connector-images-command.yml
@@ -3,9 +3,9 @@ name: Connector Image Builds
 # It can be triggered manually via slash command or workflow dispatch.
 
 on:
-  # For testing (TODO: comment out the below before merging):
-  pull_request:
-    types: [opened, synchronize, reopened]
+  # # For testing (TODO: comment out the below before merging):
+  # pull_request:
+  #  types: [opened, synchronize, reopened]
 
   workflow_dispatch:
     inputs:

--- a/.github/workflows/build-connector-images-command.yml
+++ b/.github/workflows/build-connector-images-command.yml
@@ -63,8 +63,6 @@ jobs:
       connectors-matrix: ${{ steps.generate-matrix.outputs.connectors_matrix }}
 
   call-connector-ci-build:
-    # Run always for 'workflow_dispatch' events.
-    # Run for 'push' events on forks, but only if the fork defines "BYO Secrets".
     name: "Call Connector CI Build"
     uses: ./.github/workflows/connector-image-build.yml
     needs: [init-workflow]

--- a/.github/workflows/build-connector-images-command.yml
+++ b/.github/workflows/build-connector-images-command.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
     branches:
-      - '**/ci/**'
+      - 'aj/ci/**'
 
   workflow_dispatch:
     inputs:

--- a/.github/workflows/build-connector-images-command.yml
+++ b/.github/workflows/build-connector-images-command.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
     branches:
-      - '**'
+      - '**/ci/**'
 
   workflow_dispatch:
     inputs:
@@ -43,20 +43,6 @@ jobs:
           echo "image-name=ghcr.io/airbytehq/${{ inputs.repo || github.repository }}:${{ inputs.gitref || github.ref_name }}" >> $GITHUB_OUTPUT
           echo "pr-number=${{ github.event_name == 'pull_request' && github.event.pull_request.number || inputs.pr }}" >> $GITHUB_OUTPUT
 
-      - name: Repo Checkout
-        uses: actions/checkout@v4
-        with:
-          repository: ${{ inputs.repo || github.repository }}
-          ref: ${{ inputs.gitref || github.ref_name }}
-          # Use fetch-depth: 0 to ensure we can access the full commit history
-          fetch-depth: 0
-
-      - name: Generate Connector Matrix from Changes
-        id: generate-matrix
-        run: |
-          # Get the list of modified connectors
-          echo "connectors_matrix=$(./poe-tasks/get-modified-connectors.sh --json)" | tee -a $GITHUB_OUTPUT
-
       - name: Append start comment
         id: append-start-comment
         uses: peter-evans/create-or-update-comment@v4
@@ -72,6 +58,20 @@ jobs:
             > - The connector image(s) will be pushed to the GitHub Container Registry.
             >
             > [Check job output.](${{ steps.job-vars.outputs.run-url }})
+
+      - name: Repo Checkout
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ inputs.repo || github.repository }}
+          ref: ${{ inputs.gitref || github.ref_name }}
+          # Use fetch-depth: 0 to ensure we can access the full commit history
+          fetch-depth: 0
+
+      - name: Generate Connector Matrix from Changes
+        id: generate-matrix
+        run: |
+          # Get the list of modified connectors
+          echo "connectors_matrix=$(./poe-tasks/get-modified-connectors.sh --json)" | tee -a $GITHUB_OUTPUT
 
     outputs:
       connectors-matrix: ${{ steps.generate-matrix.outputs.connectors_matrix }}

--- a/.github/workflows/connector-image-build.yml
+++ b/.github/workflows/connector-image-build.yml
@@ -46,7 +46,6 @@ jobs:
         with:
           repository: ${{ inputs.repo || github.event.pull_request.head.repo.full_name }}
           ref: ${{ inputs.gitref || github.head_ref }}
-          # Use fetch-depth: 0 to ensure we can access the full commit history
           fetch-depth: 1
 
       - name: Install the latest version of uv

--- a/.github/workflows/connector-image-build.yml
+++ b/.github/workflows/connector-image-build.yml
@@ -1,7 +1,6 @@
 name: Connector Image Build
 
 on:
-
   # Available as a reusable workflow
   # (https://docs.github.com/en/actions/sharing-automations/reusing-workflows)
   workflow_call:

--- a/.github/workflows/connector-image-build.yml
+++ b/.github/workflows/connector-image-build.yml
@@ -65,8 +65,8 @@ jobs:
           echo "connector-root=$CONNECTOR_ROOT" | tee -a $GITHUB_OUTPUT
           cd $CONNECTOR_ROOT
           # Read connector language and base image:
-          echo "connector-language=$(poe get-language)" | tee -a $GITHUB_OUTPUT
-          echo "connector-base-image=$(poe get-base-image)" | tee -a $GITHUB_OUTPUT
+          echo "connector-language=$(poe -qq get-language)" | tee -a $GITHUB_OUTPUT
+          echo "connector-base-image=$(poe -qq get-base-image)" | tee -a $GITHUB_OUTPUT
 
       # Java deps
       - uses: actions/setup-java@v4

--- a/.github/workflows/connector-image-build.yml
+++ b/.github/workflows/connector-image-build.yml
@@ -60,6 +60,7 @@ jobs:
       - name: Resolve Vars
         id: vars
         run: |
+          set -eu
           # Detect connector root directory:
           CONNECTOR_ROOT="airbyte-integrations/connectors/${{ inputs.connector }}"
           echo "connector-root=$CONNECTOR_ROOT" | tee -a $GITHUB_OUTPUT

--- a/.github/workflows/connector-image-build.yml
+++ b/.github/workflows/connector-image-build.yml
@@ -45,7 +45,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: ${{ inputs.repo || github.event.pull_request.head.repo.full_name }}
-          ref: ${{ inputs.gitref || github.head_ref || github.ref_name }}
+          ref: ${{ inputs.gitref || github.head_ref }}
           # Use fetch-depth: 0 to ensure we can access the full commit history
           fetch-depth: 1
 

--- a/.github/workflows/connector-image-build.yml
+++ b/.github/workflows/connector-image-build.yml
@@ -1,0 +1,121 @@
+name: Connector Image Build
+
+on:
+
+  # Available as a reusable workflow
+  # (https://docs.github.com/en/actions/sharing-automations/reusing-workflows)
+  workflow_call:
+    inputs:
+      repo:
+        type: string
+        required: false
+        description: "The repository name"
+      gitref:
+        type: string
+        required: false
+        description: "The git reference (branch or tag)"
+      comment-id:
+        type: string
+        required: false
+        description: "The ID of the comment triggering the workflow. Unused as of now."
+      pr:
+        type: string
+        required: false
+        description: "The pull request number, if applicable. Unused as of now."
+      connector:
+        type: string
+        required: true
+        description: "The name of the connector to build and test."
+
+permissions:
+  contents: read
+  pull-requests: write
+  actions: write
+  checks: write
+  packages: write
+
+jobs:
+  build-connector-image:
+    runs-on: ubuntu-24.04
+    environment:
+      name: ghcr.io/airbytehq
+      url: https://ghcr.io/airbytehq/${{ inputs.connector }}
+    steps:
+      - name: Checkout Current Branch
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ inputs.repo || github.event.pull_request.head.repo.full_name }}
+          ref: ${{ inputs.gitref || github.head_ref || github.ref_name }}
+          # Use fetch-depth: 0 to ensure we can access the full commit history
+          fetch-depth: 1
+
+      - name: Resolve Vars
+        id: vars
+        run: |
+          # Detect connector root directory:
+          CONNECTOR_ROOT="airbyte-integrations/connectors/${{ inputs.connector }}"
+          echo "connector-root=$CONNECTOR_ROOT" | tee -a $GITHUB_OUTPUT
+          cd $CONNECTOR_ROOT
+          # Read connector language and base image:
+          echo "connector-language=$(poe get-language)" | tee -a $GITHUB_OUTPUT
+          echo "connector-base-image=$(poe get-base-image)" | tee -a $GITHUB_OUTPUT
+
+      # Java deps
+      - uses: actions/setup-java@v4
+        if: ${{ steps.vars.outputs.connector-language == 'java' }}
+        with:
+          distribution: zulu
+          java-version: 21
+          cache: gradle
+
+      - uses: gradle/actions/setup-gradle@v4
+        if: ${{ steps.vars.outputs.connector-language == 'java' }}
+        with:
+          cache-read-only: false
+          cache-write-only: false
+          add-job-summary: "on-failure"
+
+      - name: Build Connector Tarball
+        if: ${{ steps.vars.outputs.connector-language == 'java' }}
+        run: |
+          ./gradlew :airbyte-integrations:connectors:${{ inputs.connector }}:distTar
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Connector Image
+        id: build-connector-image
+        uses: docker/build-push-action@v5
+        with:
+          context: airbyte-integrations/connectors/${{ inputs.connector }}
+          file: docker-images/Dockerfile.${{ steps.vars.outputs.connector-language }}-connector
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            ghcr.io/airbytehq/${{ inputs.connector }}:draft-pr-${{ github.event.pull_request.number }}
+            ghcr.io/airbytehq/${{ inputs.connector }}:draft-pr-${{ github.event.pull_request.number }}-build${{ github.run_number }}
+          build-args: |
+            BASE_IMAGE=${{ steps.vars.outputs.connector-base-image }}
+            CONNECTOR_NAME=${{ inputs.connector }}
+          push: true
+
+      - name: Run `spec` Image Test
+        run: |
+          docker run \
+            --rm \
+            ghcr.io/airbytehq/${{ inputs.connector }}:draft-pr-${{ github.event.pull_request.number }} \
+            spec
+
+      - name: Run ${{ inputs.connector }} Image Vulnerability Scan
+        uses: anchore/scan-action@v6
+        with:
+          image: "ghcr.io/airbytehq/${{ inputs.connector }}:draft-pr-${{ github.event.pull_request.number }}"
+          output-format: "table"
+          severity-cutoff: high
+          fail-build: false

--- a/.github/workflows/connector-image-build.yml
+++ b/.github/workflows/connector-image-build.yml
@@ -24,7 +24,7 @@ on:
       connector:
         type: string
         required: true
-        description: "The name of the connector to build and test."
+        description: "The name of the connector to build and test. If empty, this is a no-op."
 
 permissions:
   contents: read
@@ -36,6 +36,7 @@ permissions:
 jobs:
   build-connector-image:
     runs-on: ubuntu-24.04
+    if: inputs.connector
     environment:
       name: ghcr.io/airbytehq
       url: https://ghcr.io/airbytehq/${{ inputs.connector }}

--- a/.github/workflows/connector-image-build.yml
+++ b/.github/workflows/connector-image-build.yml
@@ -49,6 +49,14 @@ jobs:
           # Use fetch-depth: 0 to ensure we can access the full commit history
           fetch-depth: 1
 
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Install Poe
+        run: |
+          # Install Poe so we can run the connector tasks:
+          uv tool install poethepoet
+
       - name: Resolve Vars
         id: vars
         run: |

--- a/.github/workflows/slash-commands.yml
+++ b/.github/workflows/slash-commands.yml
@@ -28,6 +28,7 @@ jobs:
             bump-bulk-cdk-and-release-connectors
             bump-cdk-version-and-merge
             bump-version
+            build-connector-images
             connector-performance
             format-fix
             poe

--- a/airbyte-integrations/connectors/source-klaviyo/metadata.yaml
+++ b/airbyte-integrations/connectors/source-klaviyo/metadata.yaml
@@ -62,4 +62,3 @@ data:
             type: GSM
             alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"
-# Dummy change (revert-me)

--- a/airbyte-integrations/connectors/source-klaviyo/metadata.yaml
+++ b/airbyte-integrations/connectors/source-klaviyo/metadata.yaml
@@ -62,3 +62,4 @@ data:
             type: GSM
             alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"
+# Dummy change (revert-me)

--- a/docs/platform/connector-development/local-connector-development.md
+++ b/docs/platform/connector-development/local-connector-development.md
@@ -194,6 +194,7 @@ Maintainers can execute any of the following connector admin commands upon reque
 - `/format-fix` - Fixes any formatting issues.
 - `/run-connector-tests` - Run the connector tests for any modified connectors.
 - `/run-cat-tests` - Run the legacy connector acceptance tests (CAT) for any modified connectors. This is helpful if the connector has poor test coverage overall.
+- `/build-connector-images` - Builds and publishes a pre-release docker image for the modified connector(s).
 - `/poe` - Run a Poe task.
 
 When working on PRs from forks, maintainers can apply `/format-fix` to help expedite formatting fixes, and `/run-connector-tests` if the fork does not have sufficient secrets bootstrapping or other permissions needed to fully test the connector changes.

--- a/docusaurus/platform_versioned_docs/version-1.6/connector-development/local-connector-development.md
+++ b/docusaurus/platform_versioned_docs/version-1.6/connector-development/local-connector-development.md
@@ -194,6 +194,7 @@ Maintainers can execute any of the following connector admin commands upon reque
 - `/format-fix` - Fixes any formatting issues.
 - `/run-connector-tests` - Run the connector tests for any modified connectors.
 - `/run-cat-tests` - Run the legacy connector acceptance tests (CAT) for any modified connectors. This is helpful if the connector has poor test coverage overall.
+- `/build-connector-images` - Builds and publishes a pre-release docker image for the modified connector(s).
 - `/poe` - Run a Poe task.
 
 When working on PRs from forks, maintainers can apply `/format-fix` to help expedite formatting fixes, and `/run-connector-tests` if the fork does not have sufficient secrets bootstrapping or other permissions needed to fully test the connector changes.

--- a/poe-tasks/gradle-connector-tasks.toml
+++ b/poe-tasks/gradle-connector-tasks.toml
@@ -27,7 +27,6 @@
 
 [tasks]
 
-get-language = "echo 'java'" # Use with -qq to get just the language name
 get-connector-name = 'basename "$PWD"' # Use with -qq to get just the connector name
 fetch-secrets = "airbyte-cdk secrets fetch"
 
@@ -70,6 +69,16 @@ ${POE_ROOT}/gradlew :airbyte-integrations:connectors:${connector_name}:${task_an
 args = [
   { name = "task_and_args", positional = true, multiple = true, help = "Gradle task name and its arguments" }
 ]
+
+# Generic tasks (same across all connector types)
+
+[tasks.get-language]
+cmd = """yq eval '.data.tags[] | select(test("^language:")) | sub("language:","")' $PWD/metadata.yaml"""
+help = "Get the language of the connector from its metadata.yaml file. Use with -qq to get just the language name."
+
+[tasks.get-base-image]
+cmd = """yq eval '.data.connectorBuildOptions.baseImage' $PWD/metadata.yaml"""
+help = "Get the base image of the connector from its metadata.yaml file."
 
 [tasks.run-cat-tests]
 shell = "airbyte-ci connectors --name=`poe -qq get-connector-name` test --only-step=acceptance"

--- a/poe-tasks/manifest-only-connector-tasks.toml
+++ b/poe-tasks/manifest-only-connector-tasks.toml
@@ -10,7 +10,6 @@
 
 [tasks]
 
-get-language = "echo 'manifest-only'" # Use with -qq to get just the language name
 get-connector-name = 'basename "$PWD"' # Use with -qq to get just the connector name
 fetch-secrets = "airbyte-cdk secrets fetch ${POE_PWD}"
 
@@ -58,6 +57,16 @@ else
   echo "No unit tests defined; skipping unit tests locking."
 fi
 '''
+
+# Generic tasks (same across all connector types)
+
+[tasks.get-language]
+cmd = """yq eval '.data.tags[] | select(test("^language:")) | sub("language:","")' $PWD/metadata.yaml"""
+help = "Get the language of the connector from its metadata.yaml file. Use with -qq to get just the language name."
+
+[tasks.get-base-image]
+cmd = """yq eval '.data.connectorBuildOptions.baseImage' $PWD/metadata.yaml"""
+help = "Get the base image of the connector from its metadata.yaml file."
 
 [tasks.run-cat-tests]
 shell = "airbyte-ci connectors --name=`poe -qq get-connector-name` test --only-step=acceptance"

--- a/poe-tasks/poetry-connector-tasks.toml
+++ b/poe-tasks/poetry-connector-tasks.toml
@@ -16,7 +16,6 @@
 
 [tool.poe.tasks]
 
-get-language = "echo 'python'" # Use with -qq to get just the language name
 get-connector-name = 'basename "$PWD"' # Use with -qq to get just the connector name
 fetch-secrets = "airbyte-cdk secrets fetch"
 
@@ -125,6 +124,16 @@ args = [
   { name = "BRANCH", positional = true, default = "main" },
 ]
 help = "Pin to a specific branch of the CDK."
+
+# Generic tasks (same across all connector types)
+
+[tool.poe.tasks.get-language]
+cmd = """yq eval '.data.tags[] | select(test("^language:")) | sub("language:","")' $PWD/metadata.yaml"""
+help = "Get the language of the connector from its metadata.yaml file. Use with -qq to get just the language name."
+
+[tool.poe.tasks.get-base-image]
+cmd = """yq eval '.data.connectorBuildOptions.baseImage' $PWD/metadata.yaml"""
+help = "Get the base image of the connector from its metadata.yaml file."
 
 [tool.poe.tasks.run-cat-tests]
 shell = "airbyte-ci connectors --name=`poe -qq get-connector-name` test --only-step=acceptance"

--- a/poe_tasks.toml
+++ b/poe_tasks.toml
@@ -66,3 +66,10 @@ args = [
   { name = "destination", positional = true, help = "Name of the destination (e.g., 'motherduck')" },
   { name = "task_and_args", positional = true, multiple = true, help = "Task name and its arguments" }
 ]
+
+[tasks.dummy-change]
+help = "A task to add a dummy change to the specified connector."
+shell = "echo '# Dummy change (revert-me)' >> ${POE_ROOT}/airbyte-integrations/connectors/${connector}/metadata.yaml"
+args = [
+  { name = "connector", positional = true, help = "Name of the connector to add a dummy change to (e.g., 'source-hardcoded-records')" },
+]


### PR DESCRIPTION
## What

~~Initial draft, ready for early feedback.~~ Tested and working well. Still room for improvement but this is a good first pass.

This does a couple of enabling Poe things:

1. Update `poe get-language` task to actually look up the language from the `manifest.yaml` file.
2. Add a new `poe get-base-image` using the same methodology, to quickly find the base image name from the `manifest.yaml` file.
3. Adds a root-level `poe dummy-change source-foo` command to streamline adding connectors to a PR for testing. Ideally, someone will revert this before merging, but it is harmless, regardless.

And those two Poe tasks can then feed our new `/build-connector-images` pipeline:

1. The workflow doesn't need to know if it is running for java or python or manifest-only, because it will get that from Poe after it begins running.
2. Any steps specific to Java can be skipped when language is != Java.
4. Otherwise, the build process is the same across all connector types.


Note about common Poe tasks across the three Poe tasks files.

1. The long-term plan is that we'll have a `global-poe-connector-tasks.toml` file that contains all the commands that are common (exactly the same) across all connectors. However:
2. Poe doesn't let included files include other files. So, when we get around to it:
3. We can later do a global change so that whereever we import the language-specific Poe task, we _also_ import the global Poe tasks file. This will make common tasks DRY, but it requires a global search and replace across all imports.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._