### PR TITLE
ci: fix image tags for new image build slash command

### DIFF
--- a/.github/workflows/build-connector-images-command.yml
+++ b/.github/workflows/build-connector-images-command.yml
@@ -3,9 +3,9 @@ name: Connector Image Builds
 # It can be triggered manually via slash command or workflow dispatch.
 
 on:
-  # # For testing (TODO: comment out the below before merging):
-  # pull_request:
-  #  types: [opened, synchronize, reopened]
+  # For testing (TODO: comment out the below before merging):
+  pull_request:
+   types: [opened, synchronize, reopened]
 
   workflow_dispatch:
     inputs:

--- a/.github/workflows/build-connector-images-command.yml
+++ b/.github/workflows/build-connector-images-command.yml
@@ -3,9 +3,9 @@ name: Connector Image Builds
 # It can be triggered manually via slash command or workflow dispatch.
 
 on:
-  # For testing (TODO: comment out the below before merging):
-  pull_request:
-   types: [opened, synchronize, reopened]
+  # # For testing (TODO: comment out the below before merging):
+  # pull_request:
+  #   types: [opened, synchronize, reopened]
 
   workflow_dispatch:
     inputs:

--- a/.github/workflows/connector-image-build.yml
+++ b/.github/workflows/connector-image-build.yml
@@ -67,6 +67,8 @@ jobs:
           # Read connector language and base image:
           echo "connector-language=$(poe -qq get-language)" | tee -a $GITHUB_OUTPUT
           echo "connector-base-image=$(poe -qq get-base-image)" | tee -a $GITHUB_OUTPUT
+          echo "image-pr-tag=draft-pr-${{ inputs.pr }}-build${{ github.run_number }}" | tee -a $GITHUB_OUTPUT
+          echo "image-build-num-tag=ghcr.io/airbytehq/${{ inputs.connector }}:draft-pr-${{ inputs.pr }}-build${{ github.run_number }}" | tee -a $GITHUB_OUTPUT
 
       # Java deps
       - uses: actions/setup-java@v4
@@ -106,8 +108,8 @@ jobs:
           file: docker-images/Dockerfile.${{ steps.vars.outputs.connector-language }}-connector
           platforms: linux/amd64,linux/arm64
           tags: |
-            ghcr.io/airbytehq/${{ inputs.connector }}:draft-pr-${{ github.event.pull_request.number }}
-            ghcr.io/airbytehq/${{ inputs.connector }}:draft-pr-${{ github.event.pull_request.number }}-build${{ github.run_number }}
+            ${{ steps.vars.outputs.image-pr-tag }}
+            ${{ steps.vars.outputs.image-build-num-tag }}
           build-args: |
             BASE_IMAGE=${{ steps.vars.outputs.connector-base-image }}
             CONNECTOR_NAME=${{ inputs.connector }}
@@ -117,13 +119,13 @@ jobs:
         run: |
           docker run \
             --rm \
-            ghcr.io/airbytehq/${{ inputs.connector }}:draft-pr-${{ github.event.pull_request.number }} \
+            ${{ steps.vars.outputs.image-build-num-tag }} \
             spec
 
       - name: Run ${{ inputs.connector }} Image Vulnerability Scan
         uses: anchore/scan-action@v6
         with:
-          image: "ghcr.io/airbytehq/${{ inputs.connector }}:draft-pr-${{ github.event.pull_request.number }}"
+          image: "${{ steps.vars.outputs.image-build-num-tag }}"
           output-format: "table"
           severity-cutoff: high
           fail-build: false

--- a/.github/workflows/connector-image-build.yml
+++ b/.github/workflows/connector-image-build.yml
@@ -67,8 +67,10 @@ jobs:
           # Read connector language and base image:
           echo "connector-language=$(poe -qq get-language)" | tee -a $GITHUB_OUTPUT
           echo "connector-base-image=$(poe -qq get-base-image)" | tee -a $GITHUB_OUTPUT
-          echo "image-pr-tag=draft-pr-${{ inputs.pr }}-build${{ github.run_number }}" | tee -a $GITHUB_OUTPUT
-          echo "image-build-num-tag=ghcr.io/airbytehq/${{ inputs.connector }}:draft-pr-${{ inputs.pr }}-build${{ github.run_number }}" | tee -a $GITHUB_OUTPUT
+          PR_NUMBER=${{ github.event_name == 'pull_request' && github.event.pull_request.number || inputs.pr }}
+          echo "pr-number=$PR_NUMBER" | tee -a $GITHUB_OUTPUT
+          echo "image-pr-tag=draft-pr-${PR_NUMBER}-build${{ github.run_number }}" | tee -a $GITHUB_OUTPUT
+          echo "image-build-num-tag=ghcr.io/airbytehq/${{ inputs.connector }}:draft-pr-${PR_NUMBER}-build${{ github.run_number }}" | tee -a $GITHUB_OUTPUT
 
       # Java deps
       - uses: actions/setup-java@v4

--- a/.github/workflows/connector-image-build.yml
+++ b/.github/workflows/connector-image-build.yml
@@ -67,7 +67,7 @@ jobs:
           # Read connector language and base image:
           echo "connector-language=$(poe -qq get-language)" | tee -a $GITHUB_OUTPUT
           echo "connector-base-image=$(poe -qq get-base-image)" | tee -a $GITHUB_OUTPUT
-          PR_NUMBER=${{ github.event_name == 'pull_request' && github.event.pull_request.number || inputs.pr }}
+          PR_NUMBER=${{ inputs.pr || github.event.pull_request.number }}
           IMAGE_PR_NUM_TAG="ghcr.io/airbytehq/${{ inputs.connector }}:draft-pr-${PR_NUMBER}"
           echo "pr-number=$PR_NUMBER" | tee -a $GITHUB_OUTPUT
           echo "image-pr-num-tag=${IMAGE_PR_NUM_TAG}" | tee -a $GITHUB_OUTPUT

--- a/.github/workflows/connector-image-build.yml
+++ b/.github/workflows/connector-image-build.yml
@@ -68,9 +68,10 @@ jobs:
           echo "connector-language=$(poe -qq get-language)" | tee -a $GITHUB_OUTPUT
           echo "connector-base-image=$(poe -qq get-base-image)" | tee -a $GITHUB_OUTPUT
           PR_NUMBER=${{ github.event_name == 'pull_request' && github.event.pull_request.number || inputs.pr }}
+          IMAGE_PR_NUM_TAG="ghcr.io/airbytehq/${{ inputs.connector }}:draft-pr-${PR_NUMBER}"
           echo "pr-number=$PR_NUMBER" | tee -a $GITHUB_OUTPUT
-          echo "image-pr-tag=draft-pr-${PR_NUMBER}-build${{ github.run_number }}" | tee -a $GITHUB_OUTPUT
-          echo "image-build-num-tag=ghcr.io/airbytehq/${{ inputs.connector }}:draft-pr-${PR_NUMBER}-build${{ github.run_number }}" | tee -a $GITHUB_OUTPUT
+          echo "image-pr-num-tag=${IMAGE_PR_NUM_TAG}" | tee -a $GITHUB_OUTPUT
+          echo "image-build-num-tag=${IMAGE_PR_NUM_TAG}-build${{ github.run_number }}" | tee -a $GITHUB_OUTPUT
 
       # Java deps
       - uses: actions/setup-java@v4
@@ -110,7 +111,7 @@ jobs:
           file: docker-images/Dockerfile.${{ steps.vars.outputs.connector-language }}-connector
           platforms: linux/amd64,linux/arm64
           tags: |
-            ${{ steps.vars.outputs.image-pr-tag }}
+            ${{ steps.vars.outputs.image-pr-num-tag }}
             ${{ steps.vars.outputs.image-build-num-tag }}
           build-args: |
             BASE_IMAGE=${{ steps.vars.outputs.connector-base-image }}

--- a/airbyte-integrations/connectors/source-klaviyo/metadata.yaml
+++ b/airbyte-integrations/connectors/source-klaviyo/metadata.yaml
@@ -62,4 +62,3 @@ data:
             type: GSM
             alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"
-# Dummy change (revert-me)

--- a/airbyte-integrations/connectors/source-klaviyo/metadata.yaml
+++ b/airbyte-integrations/connectors/source-klaviyo/metadata.yaml
@@ -62,3 +62,4 @@ data:
             type: GSM
             alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"
+# Dummy change (revert-me)


### PR DESCRIPTION
Fixes dynamic tagging for connector images in draft pull requests to streamline the build process and improve versioning clarity.

Previously the PR number wasn't captured correctly from inputs.

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._