### PR TITLE
[Load-CDK] Tolerate source sending end-of-stream on only one socket

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/config/DataChannelBeanFactory.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/config/DataChannelBeanFactory.kt
@@ -125,6 +125,7 @@ class DataChannelBeanFactory {
         return dataChannelMedium == DataChannelMedium.SOCKET
     }
 
+    @Singleton
     @Named("logPerNRecords")
     fun logPerNRecords(
         @Value("\${airbyte.destination.core.data-channel.log-per-n-records:100000}")

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/config/DataChannelBeanFactory.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/config/DataChannelBeanFactory.kt
@@ -125,6 +125,15 @@ class DataChannelBeanFactory {
         return dataChannelMedium == DataChannelMedium.SOCKET
     }
 
+    @Named("logPerNRecords")
+    fun logPerNRecords(
+        @Value("\${airbyte.destination.core.data-channel.log-per-n-records:100000}")
+        logPerNRecords: Long
+    ): Long {
+        log.info { "Logging every $logPerNRecords records" }
+        return logPerNRecords
+    }
+
     /**
      * Because sockets uses multiple threads, state must be kept coherent by
      * - matching AirbyteRecords to AirbyteStateMessages by CheckpointId (from
@@ -208,6 +217,7 @@ class DataChannelBeanFactory {
         bufferSizeBytes: Int,
         @Value("\${airbyte.destination.core.data-channel.socket-connection-timeout-ms}")
         socketConnectionTimeoutMs: Long,
+        @Named("logPerNRecords") logPerNRecords: Long,
     ): Array<Flow<PipelineInputEvent>> {
         return when (dataChannelMedium) {
             DataChannelMedium.STDIO -> {
@@ -231,6 +241,7 @@ class DataChannelBeanFactory {
                             dataChannelReader,
                             pipelineEventBookkeepingRouter,
                             queueMemoryManager,
+                            logPerNRecords
                         )
                     }
                     .toTypedArray()

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/config/DataChannelBeanFactory.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/config/DataChannelBeanFactory.kt
@@ -112,6 +112,19 @@ class DataChannelBeanFactory {
         }
     }
 
+    @Singleton
+    @Named("markEndOfStreamAtEndOfSync")
+    fun markEndOfStreamAtEndOfSync(
+        @Named("dataChannelMedium") dataChannelMedium: DataChannelMedium
+    ): Boolean {
+        // For STDIO, we mark the end of stream when we get the message.
+        // For SOCKETs, source will only send end-of-stream on one socket (which is useless),
+        // so to avoid constantly syncing across threads we'll mark end of stream at the end of
+        // the sync. This means that the last checkpoint might not be flushed until end-of-sync,
+        // but it's possible that this happens already anyway.
+        return dataChannelMedium == DataChannelMedium.SOCKET
+    }
+
     /**
      * Because sockets uses multiple threads, state must be kept coherent by
      * - matching AirbyteRecords to AirbyteStateMessages by CheckpointId (from

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/file/SocketInputFlow.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/file/SocketInputFlow.kt
@@ -28,6 +28,7 @@ class SocketInputFlow(
     private val inputFormatReader: DataChannelReader,
     private val pipelineEventBookkeepingRouter: PipelineEventBookkeepingRouter,
     private val memoryManager: ReservationManager,
+    private val logPerNRecords: Long = 100_000L
 ) : Flow<PipelineInputEvent> {
     private val log = KotlinLogging.logger {}
 
@@ -40,7 +41,7 @@ class SocketInputFlow(
                 var messagesRead = 0L
                 inputFormatReader.read(inputStream).forEach { message ->
                     messagesRead++
-                    if (messagesRead % 100_000L == 0L) {
+                    if (messagesRead % logPerNRecords == 0L) {
                         log.info { "Read $messagesRead messages from ${socket.socketPath}" }
                     }
 

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/file/SocketInputFlow.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/file/SocketInputFlow.kt
@@ -5,10 +5,12 @@
 package io.airbyte.cdk.load.file
 
 import io.airbyte.cdk.load.command.DestinationCatalog
+import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.config.PipelineInputEvent
 import io.airbyte.cdk.load.message.CheckpointMessage
 import io.airbyte.cdk.load.message.DestinationStreamAffinedMessage
 import io.airbyte.cdk.load.message.Ignored
+import io.airbyte.cdk.load.message.PipelineEndOfStream
 import io.airbyte.cdk.load.message.PipelineHeartbeat
 import io.airbyte.cdk.load.message.ProbeMessage
 import io.airbyte.cdk.load.message.Undefined
@@ -18,6 +20,7 @@ import io.airbyte.cdk.load.util.use
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.FlowCollector
+import org.apache.mina.util.ConcurrentHashSet
 
 class SocketInputFlow(
     private val catalog: DestinationCatalog,
@@ -28,11 +31,19 @@ class SocketInputFlow(
 ) : Flow<PipelineInputEvent> {
     private val log = KotlinLogging.logger {}
 
+    private val sawEndOfStream = ConcurrentHashSet<DestinationStream.Descriptor>()
+
     override suspend fun collect(collector: FlowCollector<PipelineInputEvent>) {
         pipelineEventBookkeepingRouter.use {
             socket.connect { inputStream ->
                 val unopenedStreams = catalog.streams.map { it.descriptor }.toMutableSet()
+                var messagesRead = 0L
                 inputFormatReader.read(inputStream).forEach { message ->
+                    messagesRead++
+                    if (messagesRead % 100_000L == 0L) {
+                        log.info { "Read $messagesRead messages from ${socket.socketPath}" }
+                    }
+
                     when (message) {
                         is DestinationStreamAffinedMessage -> {
                             val event =
@@ -40,6 +51,9 @@ class SocketInputFlow(
                                     message,
                                     unopenedStreams = unopenedStreams
                                 )
+                            if (event is PipelineEndOfStream) {
+                                sawEndOfStream.add(event.stream)
+                            }
                             collector.emit(event)
                         }
                         is CheckpointMessage ->
@@ -52,6 +66,14 @@ class SocketInputFlow(
                             /* do nothing */
                         }
                     }
+                }
+            }
+            // Treat EOF as end-of-stream. (Source should send end-of-stream on every
+            // socket, but currently does not.)
+            catalog.streams.forEach {
+                if (!sawEndOfStream.contains(it.descriptor)) {
+                    log.info { "Emitting end-of-stream for ${it.descriptor}" }
+                    collector.emit(PipelineEndOfStream(it.descriptor))
                 }
             }
         }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/InputMessage.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/InputMessage.kt
@@ -87,7 +87,7 @@ data class InputRecord(
         data = JsonToAirbyteValue().convert(data.deserializeToNode()),
         emittedAtMs = emittedAtMs,
         meta = Meta(changes),
-        serialized = "",
+        serialized = data,
         fileReference,
         checkpointId,
         unknownFieldNames

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/state/CheckpointManager.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/state/CheckpointManager.kt
@@ -198,7 +198,7 @@ class CheckpointManager<T>(
                     head.key
                 ) // don't remove until after we've successfully sent
             } else {
-                log.info { "Not flushing global checkpoint with key: ${head.key}" }
+                log.info { "Not flushing global checkpoint ${head.key}:" }
                 break
             }
         }
@@ -253,7 +253,15 @@ class CheckpointManager<T>(
                     // don't remove until after we've successfully sent
                     streamCheckpoints.remove(nextCheckpointKey)
                 } else {
-                    log.info { "Not flushing next checkpoint for index $nextCheckpointKey" }
+                    log.info {
+                        val expectedCount =
+                            manager.readCountForCheckpoint(nextCheckpointKey.checkpointId)
+                        val committedCount =
+                            manager.persistedRecordCountForCheckpoint(
+                                nextCheckpointKey.checkpointId
+                            )
+                        "Not flushing next checkpoint for index $nextCheckpointKey (committed $committedCount records of expected $expectedCount)"
+                    }
                     break
                 }
             }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/state/CheckpointManager.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/state/CheckpointManager.kt
@@ -65,7 +65,6 @@ data class CheckpointKey(
  * TODO: Ensure that checkpoint is flushed at the end, and require that all checkpoints be flushed
  * before the destination can succeed.
  */
-@Singleton
 class CheckpointManager<T>(
     val catalog: DestinationCatalog,
     val syncManager: SyncManager,
@@ -332,7 +331,7 @@ class CheckpointManager<T>(
     justification = "message is guaranteed to be non-null by Kotlin's type system"
 )
 @Singleton
-class FreeingCheckpointConsumer(private val consumer: OutputConsumer) :
+class FreeingAnnotatingCheckpointConsumer(private val consumer: OutputConsumer) :
     suspend (Reserved<CheckpointMessage>) -> Unit {
     override suspend fun invoke(message: Reserved<CheckpointMessage>) {
         message.use {

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/state/PipelineEventBookkeepingRouter.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/state/PipelineEventBookkeepingRouter.kt
@@ -33,8 +33,8 @@ import io.airbyte.cdk.load.util.CloseableCoroutine
 import io.github.oshai.kotlinlogging.KotlinLogging
 import jakarta.inject.Named
 import jakarta.inject.Singleton
-import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicInteger
+import org.apache.mina.util.ConcurrentHashSet
 
 /**
  * The stdio and socket input channel differ in subtle and critical ways
@@ -59,20 +59,12 @@ class PipelineEventBookkeepingRouter(
     private val checkpointQueue: QueueWriter<Reserved<CheckpointMessageWrapped>>,
     private val openStreamQueue: QueueWriter<DestinationStream>,
     private val fileTransferQueue: MessageQueue<FileTransferQueueMessage>,
-    @Named("numDataChannels") numDataChannels: Int,
+    @Named("numDataChannels") private val numDataChannels: Int,
+    @Named("markEndOfStreamAtEndOfSync") private val markEndOfStreamAtEndOfSync: Boolean
 ) : CloseableCoroutine {
     private val log = KotlinLogging.logger {}
-
     private val clientCount = AtomicInteger(numDataChannels)
-
-    // With sockets, multiple reader threads run in parallel. Source will send end-of-stream to all
-    // threads. This ensures that only the last one to recieve end-of-stream actually closes the
-    // stream. (However all will forward end-of-stream to cause their thread to flush and finish
-    // work.)
-    private val streamCompletionCountdownLatches =
-        ConcurrentHashMap(
-            catalog.streams.associate { it.descriptor to AtomicInteger(numDataChannels) }
-        )
+    private val sawEndOfStreamComplete = ConcurrentHashSet<DestinationStream.Descriptor>()
 
     init {
         log.info { "Creating bookkeeping router for $numDataChannels data channels" }
@@ -112,14 +104,15 @@ class PipelineEventBookkeepingRouter(
             }
             is DestinationRecordStreamComplete -> {
                 log.info { "Read COMPLETE for stream ${stream.descriptor}" }
-                if (streamCompletionCountdownLatches[stream.descriptor]!!.decrementAndGet() == 0) {
+                sawEndOfStreamComplete.add(stream.descriptor)
+                if (!markEndOfStreamAtEndOfSync) {
                     manager.markEndOfStream(true)
                 }
                 PipelineEndOfStream(stream.descriptor)
             }
             is DestinationRecordStreamIncomplete -> {
                 log.info { "Read INCOMPLETE for stream ${stream.descriptor}" }
-                if (streamCompletionCountdownLatches[stream.descriptor]!!.decrementAndGet() == 0) {
+                if (!markEndOfStreamAtEndOfSync) {
                     manager.markEndOfStream(false)
                 }
                 PipelineEndOfStream(stream.descriptor)
@@ -227,6 +220,12 @@ class PipelineEventBookkeepingRouter(
     override suspend fun close() {
         log.info { "Maybe closing bookkeeping router ${clientCount.get()}" }
         if (clientCount.decrementAndGet() == 0) {
+            if (markEndOfStreamAtEndOfSync) {
+                catalog.streams.forEach {
+                    val sawComplete = sawEndOfStreamComplete.contains(it.descriptor)
+                    syncManager.getStreamManager(it.descriptor).markEndOfStream(sawComplete)
+                }
+            }
             log.info { "Closing internal control channels" }
             fileTransferQueue.close()
             checkpointQueue.close()

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/state/StreamManager.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/state/StreamManager.kt
@@ -307,6 +307,6 @@ class StreamManager(
     }
 
     fun readCountForCheckpoint(checkpointId: CheckpointId): Long? {
-        return recordsReadPerCheckpoint[checkpointId]?.records
+        return recordsReadPerCheckpoint[checkpointId]
     }
 }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/state/StreamManager.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/state/StreamManager.kt
@@ -305,4 +305,8 @@ class StreamManager(
             checkpointCountsByState[BatchState.COMPLETE]?.get(checkpointId)?.records ?: 0L
         return max(persistedCount, completeCount)
     }
+
+    fun readCountForCheckpoint(checkpointId: CheckpointId): Long? {
+        return recordsReadPerCheckpoint[checkpointId]?.records
+    }
 }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/ReservingDeserializingInputFlow.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/ReservingDeserializingInputFlow.kt
@@ -22,6 +22,7 @@ class ReservingDeserializingInputFlow(
     val deserializer: ProtocolMessageDeserializer,
     @Named("queueMemoryManager") val memoryManager: ReservationManager,
     @Named("inputStream") val inputStream: InputStream,
+    @Named("logPerNRecords") val logPerNRecords: Long = 100_000L,
 ) : Flow<Pair<Long, Reserved<DestinationMessage>>> {
     val log = KotlinLogging.logger {}
 
@@ -33,6 +34,7 @@ class ReservingDeserializingInputFlow(
         }
 
         var index = 0L
+        var bytes = 0L
         inputStream.bufferedReader().lineSequence().forEach { line ->
             if (line.isEmpty()) {
                 return@forEach
@@ -44,8 +46,9 @@ class ReservingDeserializingInputFlow(
             val message = deserializer.deserialize(line)
             collector.emit(Pair(lineSize, reserved.replace(message)))
 
-            if (++index % 10_000L == 0L) {
-                log.info { "Processed $index lines" }
+            bytes += lineSize
+            if (++index % logPerNRecords == 0L) {
+                log.info { "Processed $index lines (${bytes/1024/1024}Mb" }
             }
         }
 

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/UpdateCheckpointsTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/UpdateCheckpointsTask.kt
@@ -36,7 +36,9 @@ class UpdateCheckpointsTask(
             when (it.value) {
                 is StreamCheckpointWrapped -> {
                     val (stream, checkpointKey, message) = it.value
-                    log.info { "Updating checkpoint for stream $stream with id $checkpointKey" }
+                    log.info {
+                        "Updating stream checkpoint $stream:$checkpointKey:${it.value.checkpoint.sourceStats}"
+                    }
                     checkpointManager.addStreamCheckpoint(
                         stream,
                         checkpointKey,
@@ -45,7 +47,9 @@ class UpdateCheckpointsTask(
                 }
                 is GlobalCheckpointWrapped -> {
                     val (checkpointKey, message) = it.value
-                    log.info { "Updating global checkpoint with $checkpointKey" }
+                    log.info {
+                        "Updating global checkpoint with $checkpointKey:${it.value.checkpoint.sourceStats}"
+                    }
                     checkpointManager.addGlobalCheckpoint(checkpointKey, it.replace(message))
                 }
             }

--- a/airbyte-cdk/bulk/core/load/src/main/resources/application.yaml
+++ b/airbyte-cdk/bulk/core/load/src/main/resources/application.yaml
@@ -7,6 +7,7 @@ airbyte:
         socket-paths: ${DATA_CHANNEL_SOCKET_PATHS:}
         socket-buffer-size-bytes: 16384
         socket-connection-timeout-ms: 900000 # 15 minutes
+        log-per-n-records: 100000 # How often the input consumer(s) should log their progress
       record-batch-size-override: ${AIRBYTE_DESTINATION_RECORD_BATCH_SIZE_OVERRIDE:null}
       file-transfer:
         enabled: ${USE_FILE_TRANSFER:false}

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/internal/InputConsumerTaskTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/internal/InputConsumerTaskTest.kt
@@ -100,7 +100,8 @@ class InputConsumerTaskTest {
                 checkpointQueue = checkpointQueue,
                 openStreamQueue = mockk(relaxed = true),
                 fileTransferQueue = mockk(relaxed = true),
-                1
+                1,
+                false
             )
         val task =
             InputConsumerTask(
@@ -149,7 +150,8 @@ class InputConsumerTaskTest {
                 checkpointQueue = checkpointQueue,
                 openStreamQueue = mockk(relaxed = true),
                 fileTransferQueue = mockk(relaxed = true),
-                1
+                1,
+                false
             )
         val task =
             InputConsumerTask(
@@ -315,7 +317,8 @@ class InputConsumerTaskTest {
                 checkpointQueue = checkpointQueue,
                 openStreamQueue = mockk(relaxed = true),
                 fileTransferQueue = mockk(relaxed = true),
-                1
+                1,
+                false
             )
         val task =
             InputConsumerTask(


### PR DESCRIPTION
## What
Original spec was to send end-of-stream on every socket. Apparently that's no doable. This guards against that by sending end-of-stream on every socket that didn't get it at EOF, and by holding off on marking the end-of-stream in the stream manager until the router is closing. (In socket mode only)

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._