### PR TITLE
ci: allow CI to run on progressive rollouts and rollbacks

### DIFF
--- a/.github/workflows/finalize_rollout.yml
+++ b/.github/workflows/finalize_rollout.yml
@@ -28,6 +28,18 @@ jobs:
         shell: bash
       - name: Checkout Airbyte
         uses: actions/checkout@v4
+
+      # Authenticate as the GitHub App to ensure CI can run.  This is necessary because
+      # commits created with the built-in GitHub token will not trigger workflows.
+      - name: Authenticate as GitHub App
+        uses: actions/create-github-app-token@v1
+        id: get-app-token
+        with:
+          owner: "airbytehq"
+          repositories: "airbyte"
+          app-id: ${{ secrets.OCTAVIA_BOT_APP_ID }}
+          private-key: ${{ secrets.OCTAVIA_BOT_PRIVATE_KEY }}
+
       - name: Promote ${{ github.event.inputs.connector_name }} release candidate
         id: promote-release-candidate
         if: ${{ env.ACTION == 'promote' }}
@@ -39,7 +51,7 @@ jobs:
           docker_hub_username: ${{ secrets.DOCKER_HUB_USERNAME }}
           gcp_gsm_credentials: ${{ secrets.GCP_GSM_CREDENTIALS }}
           gcs_credentials: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ steps.get-app-token.outputs.token }}
           metadata_service_gcs_credentials: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
           sentry_dsn: ${{ secrets.SENTRY_AIRBYTE_CI_DSN }}
           slack_webhook_url: ${{ secrets.PUBLISH_ON_MERGE_SLACK_WEBHOOK }}
@@ -56,7 +68,7 @@ jobs:
           docker_hub_username: ${{ secrets.DOCKER_HUB_USERNAME }}
           gcp_gsm_credentials: ${{ secrets.GCP_GSM_CREDENTIALS }}
           gcs_credentials: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ steps.get-app-token.outputs.token }}
           metadata_service_gcs_credentials: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
           sentry_dsn: ${{ secrets.SENTRY_AIRBYTE_CI_DSN }}
           slack_webhook_url: ${{ secrets.PUBLISH_ON_MERGE_SLACK_WEBHOOK }}


### PR DESCRIPTION
## What

Allow progressive rollouts and rollbacks to have CI run. Uses authentication as a GitHub App, which allows workflows to trigger as usual. This doesn't stop someone (including a bot) from force-merging, but it allows humans to merge after tests pass without needing admin permissions.

TODO:

- [x] Consider other ramifications and reasons _not_ to let CI run.
- [ ] Consider adding conditions to specific checks we don't want to wait for: such as chacking for `[skip ci]` in the commit message or `auto-merge/bypass-ci-checks` in the labels.
- [ ] Consider using the Native GitHub auto-merge behavior instead of the custom `auto_merge` workflow.