### PR TITLE
docs: add the gcp-central1 ip CIDR block to the allow ip documentation

### DIFF
--- a/docs/platform/operating-airbyte/ip-allowlist.md
+++ b/docs/platform/operating-airbyte/ip-allowlist.md
@@ -10,16 +10,17 @@ Airbyte defaults to running syncs in the United States. To change this, or to ch
 
 ## Google Cloud Platform
 
-| Geography     | Region    | IP address (CIDR) | IP addresses   |
-| ------------- | --------- | ----------------- | -------------- |
-| United States | us-west-3 | N/A               | 34.106.109.131 |
-| United States | us-west-3 | N/A               | 34.106.196.165 |
-| United States | us-west-3 | N/A               | 34.106.60.246  |
-| United States | us-west-3 | N/A               | 34.106.229.69  |
-| United States | us-west-3 | N/A               | 34.106.127.139 |
-| United States | us-west-3 | N/A               | 34.106.218.58  |
-| United States | us-west-3 | N/A               | 34.106.115.240 |
-| United States | us-west-3 | N/A               | 34.106.225.141 |
+| Geography     | Region       | IP address (CIDR) | IP addresses   |
+| ------------- |--------------|-------------------|----------------|
+| United States | us-west-3    | N/A               | 34.106.109.131 |
+| United States | us-west-3    | N/A               | 34.106.196.165 |
+| United States | us-west-3    | N/A               | 34.106.60.246  |
+| United States | us-west-3    | N/A               | 34.106.229.69  |
+| United States | us-west-3    | N/A               | 34.106.127.139 |
+| United States | us-west-3    | N/A               | 34.106.218.58  |
+| United States | us-west-3    | N/A               | 34.106.115.240 |
+| United States | us-west-3    | N/A               | 34.106.225.141 |
+| United States | us-central-1 | 34.33.7.0/29      | 34.33.7.[0,8]  |
 
 ## AWS
 


### PR DESCRIPTION
## What
add the gcp-central1 ip CIDR block to the allow ip documentation

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
