### PR TITLE
fix: report failure from cat test slash command

### DIFF
--- a/.github/workflows/run-cat-tests-command.yml
+++ b/.github/workflows/run-cat-tests-command.yml
@@ -96,7 +96,7 @@ jobs:
 
       - name: Append failure comment
         uses: peter-evans/create-or-update-comment@v4
-        if: failure()
+        if: ${{ failure() }}
         with:
           comment-id: ${{ steps.first-comment-action.outputs.comment-id }}
           reactions: confused


### PR DESCRIPTION
## What
CAT tests run on-demand through the PR commend slash command `/run-cat-tests` rerport a successful status even if they ran and failed. see [this example](https://github.com/airbytehq/airbyte/pull/61355#issuecomment-2937872269)

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
