### PR TITLE
[source-mongodb-v2] upgrade debezium to fix unable to acquire buffer lock

### DIFF
--- a/airbyte-integrations/connectors/source-mongodb-v2/build.gradle
+++ b/airbyte-integrations/connectors/source-mongodb-v2/build.gradle
@@ -40,8 +40,8 @@ java {
 }
 
 dependencies {
-    implementation 'io.debezium:debezium-embedded:2.6.2.Final'
-    implementation 'io.debezium:debezium-connector-mongodb:2.6.2.Final'
+    implementation 'io.debezium:debezium-embedded:2.7.1.Final'
+    implementation 'io.debezium:debezium-connector-mongodb:2.7.1.Final'
 
     testImplementation 'org.testcontainers:mongodb:1.19.0'
 
@@ -55,8 +55,8 @@ dependencies {
     dataGeneratorImplementation 'org.jetbrains.kotlinx:kotlinx-cli-jvm:0.3.5'
     dataGeneratorImplementation 'org.mongodb:mongodb-driver-sync:4.10.2'
 
-    debeziumTestImplementation 'io.debezium:debezium-embedded:2.6.0.Final'
-    debeziumTestImplementation 'io.debezium:debezium-connector-mongodb:2.6.0.Final'
+    debeziumTestImplementation 'io.debezium:debezium-embedded:2.7.1.Final'
+    debeziumTestImplementation 'io.debezium:debezium-connector-mongodb:2.7.1.Final'
     debeziumTestImplementation 'org.jetbrains.kotlinx:kotlinx-cli-jvm:0.3.5'
     debeziumTestImplementation 'com.github.spotbugs:spotbugs-annotations:4.7.3'
 }


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->
Facing an issue with the following logs errors
```
2025-06-04 22:12:34 source INFO main i.a.c.i.d.i.DebeziumRecordIterator(computeNext):184 CDC events queue poll(): returned a change event with "source": {"version":"2.6.2.Final","connector":"mongodb","name":"captur","ts_ms":1749028389000,"snapshot":null,"db":"captur","sequence":null,"ts_us":1749028389000000,"ts_ns":1749028389000000000,"collection":"records","ord":4,"lsid":null,"txnNumber":null,"wallTime":1749028389069}.
2025-06-04 22:12:34 source WARN debezium-mongodbconnector-captur-replicator-fetcher-0 i.d.c.m.e.BufferingChangeStreamCursor$EventFetcher(enqueue):285 Unable to acquire buffer lock, buffer queue is likely full
2025-06-04 22:12:34 source WARN debezium-mongodbconnector-captur-replicator-fetcher-0 i.d.c.m.e.BufferingChangeStreamCursor$EventFetcher(enqueue):285 Unable to acquire buffer lock, buffer queue is likely full
2025-06-04 22:12:34 source WARN debezium-mongodbconnector-captur-replicator-fetcher-0 i.d.c.m.e.BufferingChangeStreamCursor$EventFetcher(enqueue):285 Unable to acquire buffer lock, buffer queue is likely full
2025-06-04 22:12:34 source WARN debezium-mongodbconnector-captur-replicator-fetcher-0 i.d.c.m.e.BufferingChangeStreamCursor$EventFetcher(enqueue):285 Unable to acquire buffer lock, buffer queue is likely full
2025-06-04 22:12:34 source INFO main i.a.c.i.d.i.DebeziumRecordIterator(computeNext):87 CDC events queue poll(): blocked for PT0.00001766S after 999 previous call(s) which were not logged.
2025-06-04 22:12:34 source INFO main i.a.c.i.d.i.DebeziumRecordIterator(computeNext):184 CDC events queue poll(): returned a change event with "source": {"version":"2.6.2.Final","connector":"mongodb","name":"captur","ts_ms":1749028450000,"snapshot":null,"db":"captur","sequence":null,"ts_us":1749028450000000,"ts_ns":1749028450000000000,"collection":"media","ord":13,"lsid":null,"txnNumber":null,"wallTime":1749028450464}.
2025-06-04 22:12:34 source WARN debezium-mongodbconnector-captur-replicator-fetcher-0 i.d.c.m.e.BufferingChangeStreamCursor$EventFetcher(enqueue):285 Unable to acquire buffer lock, buffer queue is likely full
```

[Debezium release 2.7.1 Final has backported the fix to 2.7 branch](https://debezium.io/blog/2024/08/08/debezium-2-7-1-final-released/#:~:text=Unable%20to%20acquire%20buffer%20lock%2C%20buffer%20queue%20is%20likely%20full) 

This has been making my syncs throw OOM errors with out-of-memory, java heap space and source exists, after successfully running for 24 hours

Selfhosted deployment
## How
<!--
* Describe how code changes achieve the solution.
-->
Upgraded debezium to the version that fixes it, i've seen there's a 3.1.0.Final debezium PR, but that probably involves breaking changes that im not comfortable with

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->
I think there should be 0 impact, unless there's problems with debezium
i'm opening this PR to use the existing test suite

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
