### PR TITLE
[Load-CDK]: Speed namespace mapping in destination

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/check/DestinationChecker.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/check/DestinationChecker.kt
@@ -8,6 +8,7 @@ import io.airbyte.cdk.load.command.Append
 import io.airbyte.cdk.load.command.DestinationCatalog
 import io.airbyte.cdk.load.command.DestinationConfiguration
 import io.airbyte.cdk.load.command.DestinationStream
+import io.airbyte.cdk.load.command.NamespaceMapper
 import io.airbyte.cdk.load.data.ObjectTypeWithoutSchema
 import io.airbyte.cdk.load.message.DestinationRecordStreamComplete
 import io.airbyte.cdk.load.message.InputRecord
@@ -38,12 +39,14 @@ private val logger = KotlinLogging.logger {}
 interface DestinationChecker<C : DestinationConfiguration> {
     fun mockStream() =
         DestinationStream(
-            descriptor = DestinationStream.Descriptor("testing", "test"),
+            unmappedNamespace = "testing",
+            unmappedName = "test",
             importType = Append,
             schema = ObjectTypeWithoutSchema,
             generationId = 1,
             minimumGenerationId = 0,
             syncId = 1,
+            namespaceMapper = NamespaceMapper()
         )
 
     fun check(config: C)

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/command/DestinationCatalog.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/command/DestinationCatalog.kt
@@ -67,6 +67,7 @@ class DefaultDestinationCatalogFactory {
         streamFactory: DestinationStreamFactory,
         @Value("\${${Operation.PROPERTY}}") operation: String,
         @Named("checkNamespace") checkNamespace: String?,
+        namespaceMapper: NamespaceMapper
     ): DestinationCatalog {
         if (operation == "check") {
             // generate a string like "20240523"
@@ -77,7 +78,8 @@ class DefaultDestinationCatalogFactory {
             return DestinationCatalog(
                 listOf(
                     DestinationStream(
-                        descriptor = DestinationStream.Descriptor(namespace, "test$date$random"),
+                        unmappedNamespace = namespace,
+                        unmappedName = "test$date$random",
                         importType = Append,
                         schema =
                             ObjectType(
@@ -86,6 +88,7 @@ class DefaultDestinationCatalogFactory {
                         generationId = 1,
                         minimumGenerationId = 0,
                         syncId = 1,
+                        namespaceMapper = namespaceMapper
                     )
                 )
             )

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/command/EnvVarConstants.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/command/EnvVarConstants.kt
@@ -46,4 +46,9 @@ object EnvVarConstants {
             "airbyte.destination.core.data-channel.socket-paths",
             "DATA_CHANNEL_SOCKET_PATHS",
         )
+    val NAMESPACE_MAPPER_CONFIG_PATH =
+        Property(
+            "airbyte.destination.core.mappers.namespace-mapping-config-path",
+            "NAMESPACE_MAPPING_CONFIG_PATH",
+        )
 }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/command/NamespaceMapper.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/command/NamespaceMapper.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.load.command
+
+import io.airbyte.cdk.load.config.NamespaceDefinitionType
+
+data class NamespaceMapper(
+    private val namespaceDefinitionType: NamespaceDefinitionType =
+        NamespaceDefinitionType.SOURCE, // ie, identity
+    private val namespaceFormat: String? = null,
+    private val streamPrefix: String? = null,
+) {
+    fun map(namespace: String?, name: String): DestinationStream.Descriptor {
+        val newNamespace =
+            when (namespaceDefinitionType) {
+                NamespaceDefinitionType.SOURCE -> namespace
+                NamespaceDefinitionType.DESTINATION -> null
+                NamespaceDefinitionType.CUSTOM_FORMAT ->
+                    formatNamespace(
+                        sourceNamespace = namespace,
+                        namespaceFormat = namespaceFormat,
+                    )
+            } // null implies namespace default
+        val newName = transformStreamName(streamName = name, streamPrefix = streamPrefix)
+        return DestinationStream.Descriptor(
+            namespace = newNamespace,
+            name = newName,
+        )
+    }
+
+    // Copied from platform code.
+    private fun formatNamespace(
+        sourceNamespace: String?,
+        namespaceFormat: String?,
+    ): String? {
+        var result: String? = ""
+        namespaceFormat
+            ?.takeIf { it.isNotBlank() }
+            ?.let { format ->
+                val replaceWith = sourceNamespace?.takeIf { it.isNotBlank() } ?: ""
+                result = format.replace("\${SOURCE_NAMESPACE}", replaceWith)
+            }
+
+        return if (result.isNullOrBlank()) {
+            null
+        } else {
+            result
+        }
+    }
+
+    // Copied from platform code
+    private fun transformStreamName(
+        streamName: String,
+        streamPrefix: String?,
+    ): String =
+        if (streamPrefix.isNullOrBlank()) {
+            streamName
+        } else {
+            streamPrefix + streamName
+        }
+
+    fun unmap(descriptor: DestinationStream.Descriptor): Pair<String?, String> {
+        return Pair(descriptor.namespace, descriptor.name)
+    }
+}

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/config/NamespaceMappingConfig.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/config/NamespaceMappingConfig.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.load.config
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonValue
+
+enum class NamespaceDefinitionType(@JsonValue val value: String) {
+    SOURCE("source"),
+    DESTINATION("destination"),
+    CUSTOM_FORMAT("customformat");
+
+    companion object {
+        @JvmStatic
+        @JsonCreator
+        fun fromValue(value: String): NamespaceDefinitionType =
+            entries.find { it.value == value }
+                ?: throw IllegalArgumentException("Unknown value: $value")
+    }
+}
+
+data class NamespaceMappingConfig(
+    val namespaceDefinitionType: NamespaceDefinitionType,
+    val namespaceFormat: String? = null,
+    val streamPrefix: String? = null
+)

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/DestinationMessage.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/DestinationMessage.kt
@@ -43,6 +43,7 @@ import io.airbyte.protocol.models.v0.AirbyteStreamState
 import io.airbyte.protocol.models.v0.AirbyteStreamStatusTraceMessage
 import io.airbyte.protocol.models.v0.AirbyteStreamStatusTraceMessage.AirbyteStreamStatus
 import io.airbyte.protocol.models.v0.AirbyteTraceMessage
+import io.airbyte.protocol.models.v0.StreamDescriptor
 import java.math.BigInteger
 import java.time.OffsetDateTime
 import java.util.*
@@ -199,8 +200,8 @@ data class DestinationRecord(
             .withType(AirbyteMessage.Type.RECORD)
             .withRecord(
                 AirbyteRecordMessage()
-                    .withNamespace(stream.descriptor.namespace)
-                    .withStream(stream.descriptor.name)
+                    .withNamespace(stream.unmappedNamespace)
+                    .withStream(stream.unmappedName)
                     .withEmittedAt(message.emittedAtMs)
                     .withData(message.asJsonRecord(stream.airbyteValueProxyFieldAccessors))
                     .also {
@@ -393,8 +394,8 @@ data class DestinationFile(
             .withType(AirbyteMessage.Type.RECORD)
             .withRecord(
                 AirbyteRecordMessage()
-                    .withStream(stream.descriptor.name)
-                    .withNamespace(stream.descriptor.namespace)
+                    .withStream(stream.unmappedName)
+                    .withNamespace(stream.unmappedNamespace)
                     .withEmittedAt(emittedAtMs)
                     .withAdditionalProperty("file", file),
             )
@@ -402,7 +403,7 @@ data class DestinationFile(
 }
 
 private fun statusToProtocolMessage(
-    stream: DestinationStream.Descriptor,
+    destinationStream: DestinationStream,
     emittedAtMs: Long,
     status: AirbyteStreamStatus,
 ): AirbyteMessage =
@@ -414,7 +415,11 @@ private fun statusToProtocolMessage(
                 .withEmittedAt(emittedAtMs.toDouble())
                 .withStreamStatus(
                     AirbyteStreamStatusTraceMessage()
-                        .withStreamDescriptor(stream.asProtocolObject())
+                        .withStreamDescriptor(
+                            StreamDescriptor()
+                                .withNamespace(destinationStream.unmappedNamespace)
+                                .withName(destinationStream.unmappedName)
+                        )
                         .withStatus(status),
                 ),
         )
@@ -424,7 +429,7 @@ data class DestinationRecordStreamComplete(
     val emittedAtMs: Long,
 ) : DestinationRecordDomainMessage {
     override fun asProtocolMessage(): AirbyteMessage =
-        statusToProtocolMessage(stream.descriptor, emittedAtMs, AirbyteStreamStatus.COMPLETE)
+        statusToProtocolMessage(stream, emittedAtMs, AirbyteStreamStatus.COMPLETE)
 }
 
 data class DestinationRecordStreamIncomplete(
@@ -432,7 +437,7 @@ data class DestinationRecordStreamIncomplete(
     val emittedAtMs: Long,
 ) : DestinationRecordDomainMessage {
     override fun asProtocolMessage(): AirbyteMessage =
-        statusToProtocolMessage(stream.descriptor, emittedAtMs, AirbyteStreamStatus.INCOMPLETE)
+        statusToProtocolMessage(stream, emittedAtMs, AirbyteStreamStatus.INCOMPLETE)
 }
 
 data class DestinationFileStreamComplete(
@@ -440,7 +445,7 @@ data class DestinationFileStreamComplete(
     val emittedAtMs: Long,
 ) : DestinationFileDomainMessage {
     override fun asProtocolMessage(): AirbyteMessage =
-        statusToProtocolMessage(stream.descriptor, emittedAtMs, AirbyteStreamStatus.COMPLETE)
+        statusToProtocolMessage(stream, emittedAtMs, AirbyteStreamStatus.COMPLETE)
 }
 
 data class DestinationFileStreamIncomplete(
@@ -448,7 +453,7 @@ data class DestinationFileStreamIncomplete(
     val emittedAtMs: Long,
 ) : DestinationFileDomainMessage {
     override fun asProtocolMessage(): AirbyteMessage =
-        statusToProtocolMessage(stream.descriptor, emittedAtMs, AirbyteStreamStatus.INCOMPLETE)
+        statusToProtocolMessage(stream, emittedAtMs, AirbyteStreamStatus.INCOMPLETE)
 }
 
 /** State. */

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/DestinationMessageFactory.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/DestinationMessageFactory.kt
@@ -6,6 +6,7 @@ package io.airbyte.cdk.load.message
 
 import io.airbyte.cdk.load.command.DestinationCatalog
 import io.airbyte.cdk.load.command.DestinationStream
+import io.airbyte.cdk.load.command.NamespaceMapper
 import io.airbyte.cdk.load.state.CheckpointId
 import io.airbyte.cdk.load.state.CheckpointIndex
 import io.airbyte.cdk.load.state.CheckpointKey
@@ -22,7 +23,8 @@ class DestinationMessageFactory(
     @Value("\${airbyte.destination.core.file-transfer.enabled}")
     private val fileTransferEnabled: Boolean,
     @Named("requireCheckpointIdOnRecordAndKeyOnState")
-    private val requireCheckpointIdOnRecordAndKeyOnState: Boolean = false
+    private val requireCheckpointIdOnRecordAndKeyOnState: Boolean = false,
+    private val namespaceMapper: NamespaceMapper
 ) {
 
     fun fromAirbyteProtocolMessage(
@@ -46,11 +48,12 @@ class DestinationMessageFactory(
 
         return when (message.type) {
             AirbyteMessage.Type.RECORD -> {
-                val stream =
-                    catalog.getStream(
+                val descriptor =
+                    namespaceMapper.map(
                         namespace = message.record.namespace,
-                        name = message.record.stream,
+                        name = message.record.stream
                     )
+                val stream = catalog.getStream(descriptor)
                 if (fileTransferEnabled) {
                     try {
                         @Suppress("UNCHECKED_CAST")
@@ -104,11 +107,12 @@ class DestinationMessageFactory(
                     message.trace.type == null ||
                         message.trace.type == AirbyteTraceMessage.Type.STREAM_STATUS
                 ) {
-                    val stream =
-                        catalog.getStream(
+                    val descriptor =
+                        namespaceMapper.map(
                             namespace = status.streamDescriptor.namespace,
                             name = status.streamDescriptor.name,
                         )
+                    val stream = catalog.getStream(descriptor)
                     when (status.status) {
                         AirbyteStreamStatusTraceMessage.AirbyteStreamStatus.COMPLETE ->
                             if (fileTransferEnabled) {
@@ -204,7 +208,11 @@ class DestinationMessageFactory(
     private fun fromAirbyteStreamState(
         streamState: AirbyteStreamState
     ): CheckpointMessage.Checkpoint {
-        val descriptor = streamState.streamDescriptor
+        val descriptor =
+            namespaceMapper.map(
+                namespace = streamState.streamDescriptor.namespace,
+                name = streamState.streamDescriptor.name
+            )
         return CheckpointMessage.Checkpoint(
             stream = DestinationStream.Descriptor(descriptor.namespace, descriptor.name),
             state = runCatching { streamState.streamState }.getOrNull(),
@@ -221,15 +229,17 @@ class DestinationMessageFactory(
                 Jsons.readValue(message.airbyteProtocolMessage, AirbyteMessage::class.java)
             fromAirbyteProtocolMessage(airbyteMessage, serializedSizeBytes)
         } else if (message.hasRecord()) {
-            val stream =
-                catalog.getStream(
-                    message.record.streamName,
-                    if (message.record.hasStreamNamespace()) {
-                        message.record.streamNamespace // defaults to "", not null
-                    } else {
-                        null
-                    }
+            val descriptor =
+                namespaceMapper.map(
+                    namespace =
+                        if (message.record.hasStreamNamespace()) {
+                            message.record.streamNamespace // defaults to "", not null
+                        } else {
+                            null
+                        },
+                    name = message.record.streamName
                 )
+            val stream = catalog.getStream(descriptor)
             DestinationRecord(
                 stream,
                 DestinationRecordProtobufSource(message),

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/InputMessage.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/InputMessage.kt
@@ -96,10 +96,10 @@ data class InputRecord(
     override fun asProtobuf(): AirbyteMessageProtobuf {
         val recordBuilder =
             AirbyteRecordMessageProtobuf.newBuilder()
-                .setStreamName(stream.descriptor.name)
+                .setStreamName(stream.unmappedName)
                 .setEmittedAtMs(emittedAtMs)
         checkpointId?.let { recordBuilder.setPartitionId(it.value) }
-        stream.descriptor.namespace?.let { recordBuilder.setStreamNamespace(it) }
+        stream.unmappedNamespace?.let { recordBuilder.setStreamNamespace(it) }
         meta?.let { meta ->
             recordBuilder.setMeta(
                 AirbyteRecordMessageMetaOuterClass.AirbyteRecordMessageMeta.newBuilder()
@@ -149,8 +149,8 @@ data class InputRecord(
             .withType(AirbyteMessage.Type.RECORD)
             .withRecord(
                 AirbyteRecordMessage()
-                    .withStream(stream.descriptor.name)
-                    .withNamespace(stream.descriptor.namespace)
+                    .withStream(stream.unmappedName)
+                    .withNamespace(stream.unmappedNamespace)
                     .withEmittedAt(emittedAtMs)
                     .withData(data.toJson())
                     .also {

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/state/CheckpointManager.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/state/CheckpointManager.kt
@@ -235,12 +235,12 @@ class CheckpointManager<T>(
                     manager.areRecordsPersistedForCheckpoint(nextCheckpointKey.checkpointId)
                 if (persisted) {
 
-                    log.info {
-                        "Flushing checkpoint for stream: ${stream.descriptor} at index: $nextCheckpointKey"
-                    }
-
                     val delta = manager.committedCount(nextCheckpointKey.checkpointId)
                     val aggregate = committedCount.increment(stream.descriptor, delta)
+
+                    log.info {
+                        "Flushing checkpoint for stream: ${stream.descriptor} at index: $nextCheckpointKey:${aggregate.records} records, ${aggregate.serializedBytes} bytes"
+                    }
 
                     sendStateMessage(
                         nextMessage,

--- a/airbyte-cdk/bulk/core/load/src/main/resources/application.yaml
+++ b/airbyte-cdk/bulk/core/load/src/main/resources/application.yaml
@@ -8,6 +8,8 @@ airbyte:
         socket-buffer-size-bytes: 16384
         socket-connection-timeout-ms: 900000 # 15 minutes
         log-per-n-records: 100000 # How often the input consumer(s) should log their progress
+      mappers:
+        namespace-mapping-config-path: ${NAMESPACE_MAPPING_CONFIG_PATH:/dest/namespace-mapping.json}
       record-batch-size-override: ${AIRBYTE_DESTINATION_RECORD_BATCH_SIZE_OVERRIDE:null}
       file-transfer:
         enabled: ${USE_FILE_TRANSFER:false}

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/command/DestinationCatalogTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/command/DestinationCatalogTest.kt
@@ -87,7 +87,8 @@ class DestinationCatalogTest {
     fun roundTrip() {
         val streamFactory =
             DestinationStreamFactory(
-                JsonSchemaToAirbyteType(JsonSchemaToAirbyteType.UnionBehavior.DEFAULT)
+                JsonSchemaToAirbyteType(JsonSchemaToAirbyteType.UnionBehavior.DEFAULT),
+                namespaceMapper = NamespaceMapper()
             )
         val catalogFactory = DefaultDestinationCatalogFactory()
         val destinationCatalog =
@@ -96,6 +97,7 @@ class DestinationCatalogTest {
                 streamFactory,
                 operation = "write",
                 checkNamespace = null,
+                namespaceMapper = NamespaceMapper()
             )
         assertEquals(originalCatalog, destinationCatalog.asProtocolObject())
     }
@@ -104,7 +106,8 @@ class DestinationCatalogTest {
     fun proxyOrderedSchema() {
         val stream =
             DestinationStream(
-                descriptor = DestinationStream.Descriptor("namespace", "name"),
+                unmappedNamespace = "namespace",
+                unmappedName = "name",
                 importType = Append,
                 generationId = 1,
                 minimumGenerationId = 0,
@@ -118,7 +121,8 @@ class DestinationCatalogTest {
                                 "y" to FieldType(BooleanType, nullable = true),
                                 "x" to FieldType(IntegerType, nullable = true),
                             )
-                    )
+                    ),
+                namespaceMapper = NamespaceMapper()
             )
         val expectedOrderedSchema =
             arrayOf(

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/command/NamespaceMapperTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/command/NamespaceMapperTest.kt
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.load.command
+
+import io.airbyte.cdk.load.config.NamespaceDefinitionType
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+class NamespaceMapperTest {
+    private fun makeStream(
+        unmappedNamespace: String,
+        unmappedName: String,
+        namespaceMapper: NamespaceMapper
+    ): DestinationStream {
+        return DestinationStream(
+            unmappedNamespace = unmappedNamespace,
+            unmappedName = unmappedName,
+            importType = Append,
+            generationId = 1,
+            minimumGenerationId = 0,
+            syncId = 1,
+            schema = mockk(relaxed = true),
+            namespaceMapper = namespaceMapper
+        )
+    }
+
+    @Test
+    fun `default mapper does not map`() {
+        val mapper = NamespaceMapper()
+        val stream =
+            makeStream(
+                unmappedNamespace = "namespace",
+                unmappedName = "name",
+                namespaceMapper = mapper,
+            )
+        Assertions.assertEquals(
+            DestinationStream.Descriptor("namespace", "name"),
+            stream.descriptor
+        )
+    }
+
+    @Test
+    fun `prefixes are applied unconditionally`() {
+        val mapper = NamespaceMapper(streamPrefix = "prefix_")
+        val stream =
+            makeStream(
+                unmappedNamespace = "namespace",
+                unmappedName = "name",
+                namespaceMapper = mapper,
+            )
+        Assertions.assertEquals(
+            DestinationStream.Descriptor("namespace", "prefix_name"),
+            stream.descriptor
+        )
+    }
+
+    @Test
+    fun `custom format is not applied not in custom mode`() {
+        val mapper =
+            NamespaceMapper(
+                namespaceDefinitionType = NamespaceDefinitionType.SOURCE,
+                namespaceFormat = "custom_format_\${SOURCE_NAMESPACE}",
+            )
+        val stream =
+            makeStream(
+                unmappedNamespace = "namespace",
+                unmappedName = "name",
+                namespaceMapper = mapper
+            )
+        Assertions.assertEquals(
+            DestinationStream.Descriptor("namespace", "name"),
+            stream.descriptor
+        )
+    }
+
+    @Test
+    fun `custom format is applied in custom mode`() {
+        val mapper =
+            NamespaceMapper(
+                namespaceDefinitionType = NamespaceDefinitionType.CUSTOM_FORMAT,
+                namespaceFormat = "custom_format_\${SOURCE_NAMESPACE}",
+            )
+        val stream =
+            makeStream(
+                unmappedNamespace = "namespace",
+                unmappedName = "name",
+                namespaceMapper = mapper,
+            )
+        Assertions.assertEquals(
+            DestinationStream.Descriptor("custom_format_namespace", "name"),
+            stream.descriptor
+        )
+    }
+
+    @Test
+    fun `namespace is always null in destination mode`() {
+        val mapper =
+            NamespaceMapper(
+                namespaceDefinitionType = NamespaceDefinitionType.DESTINATION,
+            )
+        val stream =
+            makeStream(
+                unmappedNamespace = "namespace",
+                unmappedName = "name",
+                namespaceMapper = mapper,
+            )
+        Assertions.assertEquals(DestinationStream.Descriptor(null, "name"), stream.descriptor)
+    }
+
+    @Test
+    fun `names are still prefixed in destination mode`() {
+        val mapper =
+            NamespaceMapper(
+                namespaceDefinitionType = NamespaceDefinitionType.DESTINATION,
+                streamPrefix = "prefix_",
+            )
+        val stream =
+            makeStream(
+                unmappedNamespace = "namespace",
+                unmappedName = "name",
+                namespaceMapper = mapper,
+            )
+        Assertions.assertEquals(
+            DestinationStream.Descriptor(null, "prefix_name"),
+            stream.descriptor
+        )
+    }
+}

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/data/AirbyteValueProxyTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/data/AirbyteValueProxyTest.kt
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.node.ObjectNode
 import io.airbyte.cdk.load.command.Append
 import io.airbyte.cdk.load.command.DestinationStream
+import io.airbyte.cdk.load.command.NamespaceMapper
 import io.airbyte.cdk.load.data.json.toAirbyteValue
 import io.airbyte.cdk.load.util.deserializeToNode
 import io.airbyte.cdk.load.util.serializeToString
@@ -84,13 +85,15 @@ class AirbyteValueProxyTest {
 
     val stream: DestinationStream =
         DestinationStream(
-            descriptor = DestinationStream.Descriptor("namespace", "name"),
+            unmappedNamespace = "namespace",
+            unmappedName = "name",
             importType = Append,
             generationId = 1,
             minimumGenerationId = 0,
             syncId = 1,
             includeFiles = false,
-            schema = ALL_TYPES_SCHEMA
+            schema = ALL_TYPES_SCHEMA,
+            namespaceMapper = NamespaceMapper()
         )
 
     private fun ifNull(value: JsonNode?): JsonNode? {

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/data/EnrichedDestinationRecordAirbyteValueTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/data/EnrichedDestinationRecordAirbyteValueTest.kt
@@ -6,6 +6,7 @@ package io.airbyte.cdk.load.data
 
 import io.airbyte.cdk.load.command.Append
 import io.airbyte.cdk.load.command.DestinationStream
+import io.airbyte.cdk.load.command.NamespaceMapper
 import io.airbyte.cdk.load.message.EnrichedDestinationRecordAirbyteValue
 import io.airbyte.cdk.load.message.Meta
 import io.airbyte.protocol.models.v0.AirbyteRecordMessageMetaChange.Change
@@ -17,12 +18,14 @@ class EnrichedDestinationRecordAirbyteValueTest {
 
     private val destinationStream =
         DestinationStream(
-            descriptor = DestinationStream.Descriptor("test_namespace", "test_stream"),
+            unmappedNamespace = "test_namespace",
+            unmappedName = "test_stream",
             importType = Append,
             schema = ObjectTypeWithoutSchema,
             generationId = 42L,
             minimumGenerationId = 10L,
-            syncId = 100L
+            syncId = 100L,
+            namespaceMapper = NamespaceMapper()
         )
 
     private val emittedAtMs = 1234567890L

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/message/DestinationRecordRawTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/message/DestinationRecordRawTest.kt
@@ -5,6 +5,7 @@
 package io.airbyte.cdk.load.message
 
 import io.airbyte.cdk.load.command.DestinationStream
+import io.airbyte.cdk.load.command.NamespaceMapper
 import io.airbyte.cdk.load.data.*
 import io.airbyte.cdk.load.util.deserializeToNode
 import io.airbyte.cdk.load.util.serializeToString
@@ -37,12 +38,14 @@ class DestinationRecordRawTest {
 
     private val stream =
         DestinationStream(
-            DestinationStream.Descriptor("test_namespace", "test_stream"),
+            unmappedNamespace = "test_namespace",
+            unmappedName = "test_stream",
             io.airbyte.cdk.load.command.Append,
             recordSchema,
             generationId = 42L,
             minimumGenerationId = 0L,
             syncId = 123L,
+            namespaceMapper = NamespaceMapper()
         )
 
     @Test
@@ -262,12 +265,14 @@ class DestinationRecordRawTest {
 
         val streamWithEmptySchema =
             DestinationStream(
-                DestinationStream.Descriptor("test_namespace", "test_stream"),
+                unmappedNamespace = "test_namespace",
+                unmappedName = "test_stream",
                 io.airbyte.cdk.load.command.Append,
                 emptySchema,
                 generationId = 42L,
                 minimumGenerationId = 0L,
                 syncId = 123L,
+                namespaceMapper = NamespaceMapper()
             )
 
         val jsonData = """{"field1": "value1", "field2": 123}"""
@@ -339,12 +344,14 @@ class DestinationRecordRawTest {
 
         val streamWithComplexSchema =
             DestinationStream(
-                DestinationStream.Descriptor("test_namespace", "test_stream"),
+                unmappedNamespace = "test_namespace",
+                unmappedName = "test_stream",
                 io.airbyte.cdk.load.command.Append,
                 complexSchema,
                 generationId = 42L,
                 minimumGenerationId = 0L,
                 syncId = 123L,
+                namespaceMapper = NamespaceMapper()
             )
 
         val jsonData =

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/message/PipelineEventBookkeepingRouterTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/message/PipelineEventBookkeepingRouterTest.kt
@@ -6,6 +6,7 @@ package io.airbyte.cdk.load.message
 
 import io.airbyte.cdk.load.command.DestinationCatalog
 import io.airbyte.cdk.load.command.DestinationStream
+import io.airbyte.cdk.load.command.NamespaceMapper
 import io.airbyte.cdk.load.state.CheckpointId
 import io.airbyte.cdk.load.state.CheckpointIndex
 import io.airbyte.cdk.load.state.CheckpointKey
@@ -36,7 +37,16 @@ class PipelineEventBookkeepingRouterTest {
     @MockK(relaxed = true) lateinit var fileTransferQueue: MessageQueue<FileTransferQueueMessage>
 
     private val stream1 =
-        DestinationStream(DestinationStream.Descriptor("test", "stream"), mockk(), mockk(), 1, 1, 1)
+        DestinationStream(
+            unmappedNamespace = "test",
+            unmappedName = "stream",
+            mockk(),
+            mockk(),
+            1,
+            1,
+            1,
+            namespaceMapper = NamespaceMapper()
+        )
 
     private fun makeBookkeepingRouter(numDataChannels: Int, markEndOfStreamAtEnd: Boolean = false) =
         PipelineEventBookkeepingRouter(

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/state/CheckpointManagerUTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/state/CheckpointManagerUTest.kt
@@ -7,6 +7,7 @@ package io.airbyte.cdk.load.state
 import io.airbyte.cdk.load.command.Append
 import io.airbyte.cdk.load.command.DestinationCatalog
 import io.airbyte.cdk.load.command.DestinationStream
+import io.airbyte.cdk.load.command.NamespaceMapper
 import io.airbyte.cdk.load.data.ObjectTypeWithEmptySchema
 import io.airbyte.cdk.load.file.TimeProvider
 import io.airbyte.cdk.load.message.CheckpointMessage
@@ -29,22 +30,26 @@ class CheckpointManagerUTest {
 
     private val stream1 =
         DestinationStream(
-            DestinationStream.Descriptor("test", "stream1"),
+            unmappedNamespace = "test",
+            unmappedName = "stream1",
             importType = Append,
             schema = ObjectTypeWithEmptySchema,
             generationId = 10L,
             minimumGenerationId = 10L,
-            syncId = 101L
+            syncId = 101L,
+            namespaceMapper = NamespaceMapper()
         )
 
     private val stream2 =
         DestinationStream(
-            DestinationStream.Descriptor("test", "stream2"),
+            unmappedNamespace = "test",
+            unmappedName = "stream2",
             importType = Append,
             schema = ObjectTypeWithEmptySchema,
             generationId = 10L,
             minimumGenerationId = 10L,
-            syncId = 101L
+            syncId = 101L,
+            namespaceMapper = NamespaceMapper()
         )
 
     @BeforeEach

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/command/MockDestinationCatalogFactory.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/command/MockDestinationCatalogFactory.kt
@@ -22,7 +22,8 @@ class MockDestinationCatalogFactory : DestinationCatalogFactory {
     companion object {
         val stream1 =
             DestinationStream(
-                DestinationStream.Descriptor("test", "stream1"),
+                unmappedNamespace = "test",
+                unmappedName = "stream1",
                 importType = Append,
                 schema =
                     ObjectType(
@@ -35,10 +36,12 @@ class MockDestinationCatalogFactory : DestinationCatalogFactory {
                 generationId = 42,
                 minimumGenerationId = 0,
                 syncId = 42,
+                namespaceMapper = NamespaceMapper()
             )
         val stream2 =
             DestinationStream(
-                DestinationStream.Descriptor("test", "stream2"),
+                unmappedNamespace = "test",
+                unmappedName = "stream2",
                 importType = Append,
                 schema =
                     ObjectType(
@@ -51,6 +54,7 @@ class MockDestinationCatalogFactory : DestinationCatalogFactory {
                 generationId = 42,
                 minimumGenerationId = 0,
                 syncId = 42,
+                namespaceMapper = NamespaceMapper()
             )
     }
 

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/IntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/IntegrationTest.kt
@@ -12,6 +12,8 @@ import io.airbyte.cdk.load.command.EnvVarConstants
 import io.airbyte.cdk.load.command.Property
 import io.airbyte.cdk.load.config.DataChannelFormat
 import io.airbyte.cdk.load.config.DataChannelMedium
+import io.airbyte.cdk.load.config.NamespaceDefinitionType
+import io.airbyte.cdk.load.config.NamespaceMappingConfig
 import io.airbyte.cdk.load.message.DestinationRecordStreamComplete
 import io.airbyte.cdk.load.message.InputMessage
 import io.airbyte.cdk.load.message.InputMessageOther
@@ -232,6 +234,7 @@ abstract class IntegrationTest(
         streamStatus: AirbyteStreamStatus? = AirbyteStreamStatus.COMPLETE,
         useFileTransfer: Boolean = false,
         destinationProcessFactory: DestinationProcessFactory = this.destinationProcessFactory,
+        namespaceMappingConfig: NamespaceMappingConfig? = null,
     ): List<AirbyteMessage> {
         destinationProcessFactory.testName = testPrettyName
 
@@ -244,6 +247,10 @@ abstract class IntegrationTest(
                 micronautProperties = micronautProperties,
                 dataChannelMedium = dataChannelMedium,
                 dataChannelFormat = dataChannelFormat,
+                namespaceMappingConfig = namespaceMappingConfig
+                        ?: NamespaceMappingConfig(
+                            NamespaceDefinitionType.SOURCE,
+                        ),
             )
         return runBlocking(Dispatchers.IO) {
             launch { destination.run() }

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/destination_process/DestinationProcess.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/destination_process/DestinationProcess.kt
@@ -9,6 +9,8 @@ import io.airbyte.cdk.command.FeatureFlag
 import io.airbyte.cdk.load.command.Property
 import io.airbyte.cdk.load.config.DataChannelFormat
 import io.airbyte.cdk.load.config.DataChannelMedium
+import io.airbyte.cdk.load.config.NamespaceDefinitionType
+import io.airbyte.cdk.load.config.NamespaceMappingConfig
 import io.airbyte.cdk.load.message.InputMessage
 import io.airbyte.cdk.load.test.util.IntegrationTest
 import io.airbyte.protocol.models.v0.AirbyteMessage
@@ -80,6 +82,8 @@ abstract class DestinationProcessFactory {
         micronautProperties: Map<Property, String> = emptyMap(),
         dataChannelMedium: DataChannelMedium = DataChannelMedium.STDIO,
         dataChannelFormat: DataChannelFormat = DataChannelFormat.JSONL,
+        namespaceMappingConfig: NamespaceMappingConfig =
+            NamespaceMappingConfig(NamespaceDefinitionType.SOURCE),
         vararg featureFlags: FeatureFlag,
     ): DestinationProcess
 

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/destination_process/NonDockerizedDestination.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/destination_process/NonDockerizedDestination.kt
@@ -12,10 +12,12 @@ import io.airbyte.cdk.load.command.EnvVarConstants
 import io.airbyte.cdk.load.command.Property
 import io.airbyte.cdk.load.config.DataChannelFormat
 import io.airbyte.cdk.load.config.DataChannelMedium
+import io.airbyte.cdk.load.config.NamespaceMappingConfig
 import io.airbyte.cdk.load.file.ServerSocketWriterOutputStream
 import io.airbyte.cdk.load.message.InputMessage
 import io.airbyte.cdk.load.test.util.IntegrationTest.Companion.NUM_SOCKETS
 import io.airbyte.cdk.load.test.util.rotate
+import io.airbyte.cdk.load.util.serializeToJsonBytes
 import io.airbyte.protocol.models.v0.AirbyteMessage
 import io.airbyte.protocol.models.v0.ConfiguredAirbyteCatalog
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -24,8 +26,10 @@ import java.io.InputStream
 import java.io.OutputStream
 import java.io.PipedInputStream
 import java.io.PipedOutputStream
+import java.nio.file.Files
 import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicInteger
+import kotlin.io.path.outputStream
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.launch
@@ -46,6 +50,7 @@ class NonDockerizedDestination(
     injectInputStream: Boolean,
     override val dataChannelMedium: DataChannelMedium,
     val dataChannelFormat: DataChannelFormat,
+    val namespaceMappingConfig: NamespaceMappingConfig,
     vararg featureFlags: FeatureFlag,
 ) : DestinationProcess {
     private val destinationDataChannels: Array<OutputStream>
@@ -59,6 +64,8 @@ class NonDockerizedDestination(
     private val coroutineDispatcher = executor.asCoroutineDispatcher()
     private val file = File("/tmp/test_file")
     private val writeLock = Mutex()
+    private val namespaceMappingConfigPath =
+        Files.createTempFile("namespace_mapping_config", ".json")
 
     init {
         if (useFileTransfer) {
@@ -90,11 +97,16 @@ class NonDockerizedDestination(
                             ServerSocketWriterOutputStream(socketFile.path.toString())
                         }
                     destinationDataChannels = socketWriters.toTypedArray()
+                    namespaceMappingConfigPath.outputStream().use { outputStream ->
+                        outputStream.write(namespaceMappingConfig.serializeToJsonBytes())
+                    }
                     mapOf(
                         EnvVarConstants.DATA_CHANNEL_MEDIUM to DataChannelMedium.SOCKET.toString(),
                         EnvVarConstants.DATA_CHANNEL_FORMAT to dataChannelFormat.toString(),
                         EnvVarConstants.DATA_CHANNEL_SOCKET_PATHS to
-                            socketWriters.joinToString(",") { it.socketPath }
+                            socketWriters.joinToString(",") { it.socketPath },
+                        EnvVarConstants.NAMESPACE_MAPPER_CONFIG_PATH to
+                            namespaceMappingConfigPath.toString()
                     )
                 }
             }
@@ -194,6 +206,7 @@ class NonDockerizedDestinationFactory(
         micronautProperties: Map<Property, String>,
         dataChannelMedium: DataChannelMedium,
         dataChannelFormat: DataChannelFormat,
+        namespaceMappingConfig: NamespaceMappingConfig,
         vararg featureFlags: FeatureFlag,
     ): DestinationProcess {
         // TODO pass test name into the destination process
@@ -207,6 +220,7 @@ class NonDockerizedDestinationFactory(
             injectInputStream = injectInputStream,
             dataChannelMedium = dataChannelMedium,
             dataChannelFormat = dataChannelFormat,
+            namespaceMappingConfig = namespaceMappingConfig,
             *featureFlags
         )
     }

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/write/PerformanceTestScenarios.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/write/PerformanceTestScenarios.kt
@@ -8,6 +8,7 @@ import io.airbyte.cdk.load.command.Append
 import io.airbyte.cdk.load.command.Dedupe
 import io.airbyte.cdk.load.command.DestinationCatalog
 import io.airbyte.cdk.load.command.DestinationStream
+import io.airbyte.cdk.load.command.NamespaceMapper
 import io.airbyte.cdk.load.data.FieldType
 import io.airbyte.cdk.load.data.ObjectType
 import io.airbyte.cdk.load.data.ObjectTypeWithoutSchema
@@ -65,12 +66,14 @@ class SingleStreamInsert(
             }
 
         DestinationStream(
-            descriptor = DestinationStream.Descriptor(randomizedNamespace, streamName),
+            unmappedNamespace = randomizedNamespace,
+            unmappedName = streamName,
             importType = importType,
             schema = ObjectType(linkedMapOf(*schema.toTypedArray())),
             generationId = generationId,
             minimumGenerationId = minGenerationId,
             syncId = 1,
+            namespaceMapper = NamespaceMapper()
         )
     }
 
@@ -174,27 +177,30 @@ class SingleStreamFileTransfer(
 ) : PerformanceTestScenario {
     private val log = KotlinLogging.logger {}
 
-    private val descriptor = DestinationStream.Descriptor(randomizedNamespace, streamName)
     private val stream =
         DestinationStream(
-            descriptor = DestinationStream.Descriptor(randomizedNamespace, streamName),
+            unmappedNamespace = randomizedNamespace,
+            unmappedName = streamName,
             importType = Append,
             schema = ObjectType(linkedMapOf()),
             generationId = 1,
             minimumGenerationId = 0,
             syncId = 1,
+            namespaceMapper = NamespaceMapper()
         )
 
     override val catalog: DestinationCatalog =
         DestinationCatalog(
             listOf(
                 DestinationStream(
-                    descriptor = descriptor,
+                    unmappedNamespace = randomizedNamespace,
+                    unmappedName = streamName,
                     importType = Append,
                     schema = ObjectTypeWithoutSchema,
                     generationId = 1,
                     minimumGenerationId = 1,
-                    syncId = 101
+                    syncId = 101,
+                    namespaceMapper = NamespaceMapper(),
                 )
             )
         )
@@ -252,29 +258,32 @@ class SingleStreamFileAndMetadataTransfer(
 ) : PerformanceTestScenario {
     private val log = KotlinLogging.logger {}
 
-    private val descriptor = DestinationStream.Descriptor(randomizedNamespace, streamName)
     private val stream =
         DestinationStream(
-            descriptor = DestinationStream.Descriptor(randomizedNamespace, streamName),
+            unmappedNamespace = randomizedNamespace,
+            unmappedName = streamName,
             importType = Append,
             schema = ObjectType(linkedMapOf()),
             generationId = 1,
             minimumGenerationId = 0,
             syncId = 1,
             includeFiles = true,
+            namespaceMapper = NamespaceMapper()
         )
 
     override val catalog: DestinationCatalog =
         DestinationCatalog(
             listOf(
                 DestinationStream(
-                    descriptor = descriptor,
+                    unmappedNamespace = randomizedNamespace,
+                    unmappedName = streamName,
                     importType = Append,
                     schema = ObjectTypeWithoutSchema,
                     generationId = 1,
                     minimumGenerationId = 1,
                     syncId = 101,
                     includeFiles = true,
+                    namespaceMapper = NamespaceMapper()
                 )
             )
         )
@@ -372,13 +381,14 @@ class MultiStreamInsert(
 
         (0 until numStreams).map {
             DestinationStream(
-                descriptor =
-                    DestinationStream.Descriptor(randomizedNamespace, "${streamNamePrefix}__$it"),
+                unmappedNamespace = randomizedNamespace,
+                unmappedName = "${streamNamePrefix}__$it",
                 importType = importType,
                 schema = ObjectType(linkedMapOf(*schema.toTypedArray())),
                 generationId = generationId,
                 minimumGenerationId = minGenerationId,
                 syncId = 1,
+                namespaceMapper = NamespaceMapper()
             )
         }
     }

--- a/airbyte-cdk/bulk/toolkits/load-db/src/test/kotlin/io/airbyte/cdk/load/toolkits/load/db/orchestration/TableCatalogFactoryTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-db/src/test/kotlin/io/airbyte/cdk/load/toolkits/load/db/orchestration/TableCatalogFactoryTest.kt
@@ -7,6 +7,7 @@ package io.airbyte.cdk.load.toolkits.load.db.orchestration
 import io.airbyte.cdk.load.command.Append
 import io.airbyte.cdk.load.command.DestinationCatalog
 import io.airbyte.cdk.load.command.DestinationStream
+import io.airbyte.cdk.load.command.NamespaceMapper
 import io.airbyte.cdk.load.data.AirbyteType
 import io.airbyte.cdk.load.data.FieldType
 import io.airbyte.cdk.load.data.ObjectType
@@ -241,12 +242,14 @@ class TableCatalogFactoryTest {
         schema: AirbyteType = ObjectType(linkedMapOf())
     ): DestinationStream {
         return DestinationStream(
-            descriptor = DestinationStream.Descriptor(namespace, name),
+            unmappedNamespace = namespace,
+            unmappedName = name,
             importType = Append,
             schema = schema,
             generationId = 1L,
             minimumGenerationId = 0L,
-            syncId = 0L
+            syncId = 0L,
+            namespaceMapper = NamespaceMapper()
         )
     }
 }

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/testFixtures/kotlin/io/airbyte/cdk/load/data/icerberg/parquet/IcebergWriteTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/testFixtures/kotlin/io/airbyte/cdk/load/data/icerberg/parquet/IcebergWriteTest.kt
@@ -8,6 +8,7 @@ import io.airbyte.cdk.command.ConfigurationSpecification
 import io.airbyte.cdk.load.command.Append
 import io.airbyte.cdk.load.command.Dedupe
 import io.airbyte.cdk.load.command.DestinationStream
+import io.airbyte.cdk.load.command.NamespaceMapper
 import io.airbyte.cdk.load.command.Property
 import io.airbyte.cdk.load.data.FieldType
 import io.airbyte.cdk.load.data.IntegerType
@@ -84,12 +85,14 @@ abstract class IcebergWriteTest(
         Assumptions.assumeTrue(verifyDataWriting)
         fun makeStream(syncId: Long, schema: LinkedHashMap<String, FieldType>) =
             DestinationStream(
-                DestinationStream.Descriptor(randomizedNamespace, "test_stream"),
+                unmappedNamespace = randomizedNamespace,
+                unmappedName = "test_stream",
                 Append,
                 ObjectType(schema),
                 generationId = 0,
                 minimumGenerationId = 0,
                 syncId,
+                namespaceMapper = NamespaceMapper()
             )
         val firstStream =
             makeStream(
@@ -154,12 +157,14 @@ abstract class IcebergWriteTest(
     open fun testDedupNullPk() {
         val stream =
             DestinationStream(
-                DestinationStream.Descriptor(randomizedNamespace, "test_stream"),
+                unmappedNamespace = randomizedNamespace,
+                unmappedName = "test_stream",
                 Dedupe(primaryKey = listOf(listOf("id")), cursor = emptyList()),
                 ObjectType(linkedMapOf("id" to FieldType(IntegerType, nullable = true))),
                 generationId = 42,
                 minimumGenerationId = 0,
                 syncId = 12,
+                namespaceMapper = NamespaceMapper()
             )
         val failure = expectFailure {
             runSync(

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/test/kotlin/io/airbyte/cdk/load/pipeline/object_storage/file/ForwardFileRecordTaskTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/test/kotlin/io/airbyte/cdk/load/pipeline/object_storage/file/ForwardFileRecordTaskTest.kt
@@ -7,6 +7,7 @@ package io.airbyte.cdk.load.pipeline.object_storage.file
 import io.airbyte.cdk.load.command.Append
 import io.airbyte.cdk.load.command.DestinationCatalog
 import io.airbyte.cdk.load.command.DestinationStream
+import io.airbyte.cdk.load.command.NamespaceMapper
 import io.airbyte.cdk.load.data.FieldType
 import io.airbyte.cdk.load.data.ObjectType
 import io.airbyte.cdk.load.data.StringType
@@ -72,7 +73,7 @@ class ForwardFileRecordTaskTest {
     fun `forwards end of stream`() = runTest {
         val input =
             PipelineEndOfStream<StreamKey, ObjectLoaderUploadCompleter.UploadResult<String>>(
-                Fixtures.descriptor
+                Fixtures.unmappedDescriptor
             )
         task.handleEvent(input)
 
@@ -148,7 +149,7 @@ class ForwardFileRecordTaskTest {
     }
 
     object Fixtures {
-        val descriptor = DestinationStream.Descriptor("namespace-1", "name-1")
+        val unmappedDescriptor = DestinationStream.Descriptor("namespace-1", "name-1")
 
         private fun message() =
             AirbyteMessage()
@@ -165,13 +166,15 @@ class ForwardFileRecordTaskTest {
 
         fun stream(includeFiles: Boolean = true, schema: ObjectType = schema()) =
             DestinationStream(
-                descriptor = descriptor,
+                unmappedNamespace = unmappedDescriptor.namespace,
+                unmappedName = unmappedDescriptor.name,
                 importType = Append,
                 generationId = 1,
                 minimumGenerationId = 0,
                 syncId = 3,
                 schema = schema,
                 includeFiles = includeFiles,
+                namespaceMapper = NamespaceMapper()
             )
 
         fun record(message: AirbyteMessage = message(), stream: DestinationStream = stream()) =

--- a/airbyte-integrations/connectors/destination-s3-data-lake/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_data_lake/S3DataLakeWriteTest.kt
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_data_lake/S3DataLakeWriteTest.kt
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import io.airbyte.cdk.load.command.Append
 import io.airbyte.cdk.load.command.DestinationCatalog
 import io.airbyte.cdk.load.command.DestinationStream
+import io.airbyte.cdk.load.command.NamespaceMapper
 import io.airbyte.cdk.load.command.aws.asMicronautProperties
 import io.airbyte.cdk.load.data.ArrayType
 import io.airbyte.cdk.load.data.FieldType
@@ -68,12 +69,14 @@ class GlueWriteTest :
             namespaceSuffix: String,
         ) =
             DestinationStream(
-                DestinationStream.Descriptor(randomizedNamespace + namespaceSuffix, name),
+                unmappedNamespace = randomizedNamespace + namespaceSuffix,
+                unmappedName = name,
                 Append,
                 ObjectType(linkedMapOf("id" to intType)),
                 generationId = 0,
                 minimumGenerationId = 0,
                 syncId = 42,
+                namespaceMapper = NamespaceMapper()
             )
         // Glue downcases stream IDs, and also coerces to alphanumeric+underscore.
         // So these two streams will collide.
@@ -102,7 +105,8 @@ class GlueWriteTest :
     fun testNestedArrayCoercion() {
         val stream =
             DestinationStream(
-                DestinationStream.Descriptor(randomizedNamespace, "test_stream"),
+                unmappedNamespace = randomizedNamespace,
+                unmappedName = "test_stream",
                 Append,
                 ObjectType(
                     linkedMapOf(
@@ -117,6 +121,7 @@ class GlueWriteTest :
                 generationId = 42,
                 minimumGenerationId = 0,
                 syncId = 42,
+                namespaceMapper = NamespaceMapper()
             )
 
         runSync(

--- a/airbyte-integrations/connectors/destination-s3/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-s3/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: file
   connectorType: destination
   definitionId: 4816b78f-1489-44c1-9060-4b19d5fa9362
-  dockerImageTag: 1.8.5
+  dockerImageTag: 1.8.6
   dockerRepository: airbyte/destination-s3
   githubIssueLabel: destination-s3
   icon: s3.svg

--- a/airbyte-integrations/connectors/destination-s3/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2WriteTest.kt
+++ b/airbyte-integrations/connectors/destination-s3/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2WriteTest.kt
@@ -93,7 +93,9 @@ abstract class S3V2WriteTest(
         val streamName = "stream"
         val stream =
             DestinationStream(
-                descriptor = DestinationStream.Descriptor(randomizedNamespace, streamName),
+                unmappedNamespace = randomizedNamespace,
+                unmappedName = streamName,
+                namespaceMapper = namespaceMapperForMedium(),
                 importType = Append,
                 generationId = 1L,
                 minimumGenerationId = 0L,
@@ -199,7 +201,8 @@ abstract class S3V2WriteTest(
         Assumptions.assumeTrue(unionBehavior == UnionBehavior.PROMOTE_TO_OBJECT)
         val stream =
             DestinationStream(
-                descriptor = DestinationStream.Descriptor(randomizedNamespace, "stream"),
+                unmappedNamespace = randomizedNamespace,
+                unmappedName = "stream",
                 importType = Append,
                 generationId = 1L,
                 minimumGenerationId = 0L,
@@ -222,7 +225,8 @@ abstract class S3V2WriteTest(
                                     nullable = true
                                 )
                         )
-                    )
+                    ),
+                namespaceMapper = namespaceMapperForMedium()
             )
 
         assertThrows<DestinationUncleanExitException> {
@@ -245,7 +249,8 @@ abstract class S3V2WriteTest(
         Assumptions.assumeTrue(mergesUnions)
         val stream =
             DestinationStream(
-                descriptor = DestinationStream.Descriptor(randomizedNamespace, "stream"),
+                unmappedNamespace = randomizedNamespace,
+                unmappedName = "stream",
                 importType = Append,
                 generationId = 1L,
                 minimumGenerationId = 0L,
@@ -289,7 +294,8 @@ abstract class S3V2WriteTest(
                                     nullable = true
                                 ),
                         )
-                    )
+                    ),
+                namespaceMapper = namespaceMapperForMedium()
             )
 
         val expectedRecords =

--- a/docs/integrations/destinations/s3.md
+++ b/docs/integrations/destinations/s3.md
@@ -544,6 +544,7 @@ To see connector limitations, or troubleshoot your S3 connector, see more [in ou
 
 | Version     | Date       | Pull Request                                               | Subject                                                                                                                                              |
 |:------------|:-----------|:-----------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| 1.8.6       | 2025-05-30 | [60327](https://github.com/airbytehq/airbyte/pull/60327)   | IPC Metadata, internal refactors.                                                                                                                    |
 | 1.8.5       | 2025-05-16 | [60327](https://github.com/airbytehq/airbyte/pull/60327)   | Fixes file partitioning out of bounds error.                                                                                                         |
 | 1.8.4       | 2025-05-14 | [60313](https://github.com/airbytehq/airbyte/pull/60313)   | Re-wires up time window trigger. Files path releases memory properly.                                                                                |
 | 1.8.3       | 2025-05-14 | [60287](https://github.com/airbytehq/airbyte/pull/60287)   | Update spec.                                                                                                                                         |


### PR DESCRIPTION
## What
Destination namespace mapping for speed

### Destination Behavior
* in SOCKET mode only, loads a file at `/dest/namespace-mapping.json` (or whatever path is defined in the NAMESPACE_MAPPING_CONFIG_PATH env var)
* uses that file to configure namespace mapping
  * if type is SOURCE, passes through namespace from source, maybe adding prefixes to the stream names
  * if type is DESTINATION, nulls out the namespace, maybe adding prefixes to the stream names (existing destination code will sub in default namespaces as/a)
  * if type is CUSTOM_FORMAT, uses the format string, substituting the variable ${SOURCE_NAMESPACE} with the namespace from the source (also optionally prefixing the stream names)
* mapping is performed as soon as messages from outside the destination are consumed, including the catalog, so the mapped records/control messages/catalog schema etc are all exactly the same as they would have been before from the POV of the connector
* unmapping is performed as control messages are emitted
* to keep all this sane(ish), streams must be constructed with their unmapped names and namespaces AND a namespace mapper, and the `.descriptor` field will always produce the mapped namespace

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._