### PR TITLE
[Load-CDK] Speed: Dummy Stats additionalProperties fix, namespace mapping bug fix, broken test fixes

### DIFF
--- a/airbyte-cdk/bulk/core/base/src/main/kotlin/io/airbyte/cdk/output/OutputConsumer.kt
+++ b/airbyte-cdk/bulk/core/base/src/main/kotlin/io/airbyte/cdk/output/OutputConsumer.kt
@@ -155,7 +155,10 @@ private class StdoutOutputConsumer(
         // Using println is not particularly efficient, however.
         // To improve performance, this method accumulates RECORD messages into a buffer
         // before writing them to standard output in a batch.
-        if (airbyteMessage.type == AirbyteMessage.Type.RECORD && airbyteMessage.record.additionalProperties[IS_DUMMY_STATS_MESSAGE] != true) {
+        if (
+            airbyteMessage.type == AirbyteMessage.Type.RECORD &&
+                airbyteMessage.record.additionalProperties[IS_DUMMY_STATS_MESSAGE] != true
+        ) {
             // RECORD messages undergo a different serialization scheme.
             accept(airbyteMessage.record)
         } else {

--- a/airbyte-cdk/bulk/core/base/src/main/kotlin/io/airbyte/cdk/output/OutputConsumer.kt
+++ b/airbyte-cdk/bulk/core/base/src/main/kotlin/io/airbyte/cdk/output/OutputConsumer.kt
@@ -34,6 +34,10 @@ import java.util.function.Consumer
 /** Emits the [AirbyteMessage] instances produced by the connector. */
 @DefaultImplementation(StdoutOutputConsumer::class)
 abstract class OutputConsumer(private val clock: Clock) : Consumer<AirbyteMessage>, AutoCloseable {
+    companion object {
+        const val IS_DUMMY_STATS_MESSAGE = "is_dummy_stats_message"
+    }
+
     /**
      * The constant emittedAt timestamp we use for record timestamps.
      *
@@ -151,7 +155,7 @@ private class StdoutOutputConsumer(
         // Using println is not particularly efficient, however.
         // To improve performance, this method accumulates RECORD messages into a buffer
         // before writing them to standard output in a batch.
-        if (airbyteMessage.type == AirbyteMessage.Type.RECORD) {
+        if (airbyteMessage.type == AirbyteMessage.Type.RECORD && airbyteMessage.record.additionalProperties[IS_DUMMY_STATS_MESSAGE] != true) {
             // RECORD messages undergo a different serialization scheme.
             accept(airbyteMessage.record)
         } else {

--- a/airbyte-cdk/bulk/core/base/src/main/kotlin/io/airbyte/cdk/output/OutputConsumer.kt
+++ b/airbyte-cdk/bulk/core/base/src/main/kotlin/io/airbyte/cdk/output/OutputConsumer.kt
@@ -35,7 +35,7 @@ import java.util.function.Consumer
 @DefaultImplementation(StdoutOutputConsumer::class)
 abstract class OutputConsumer(private val clock: Clock) : Consumer<AirbyteMessage>, AutoCloseable {
     companion object {
-        const val IS_DUMMY_STATS_MESSAGE = "is_dummy_stats_message"
+        const val IS_DUMMY_STATS_MESSAGE = "isDummyStatsMessage"
     }
 
     /**

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/config/SyncBeanFactory.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/config/SyncBeanFactory.kt
@@ -57,7 +57,7 @@ class SyncBeanFactory {
     fun checkpointManager(
         catalog: DestinationCatalog,
         syncManager: SyncManager,
-        outputConsumer: suspend (Reserved<CheckpointMessage>) -> Unit,
+        outputConsumer: suspend (Reserved<CheckpointMessage>, Long, Long) -> Unit,
         timeProvider: TimeProvider,
     ): CheckpointManager<Reserved<CheckpointMessage>> =
         CheckpointManager(

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/DestinationMessage.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/DestinationMessage.kt
@@ -468,15 +468,17 @@ sealed interface CheckpointMessage : DestinationMessage {
         val state: JsonNode?,
     ) {
         fun asProtocolObject(): AirbyteStreamState =
-            AirbyteStreamState().withStreamDescriptor(
-                StreamDescriptor()
-                    .withNamespace(stream.unmappedNamespace)
-                    .withName(stream.unmappedName)
-            ).also {
-                if (state != null) {
-                    it.streamState = state
+            AirbyteStreamState()
+                .withStreamDescriptor(
+                    StreamDescriptor()
+                        .withNamespace(stream.unmappedNamespace)
+                        .withName(stream.unmappedName)
+                )
+                .also {
+                    if (state != null) {
+                        it.streamState = state
+                    }
                 }
-            }
     }
 
     val checkpointKey: CheckpointKey?

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/DestinationMessage.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/DestinationMessage.kt
@@ -464,11 +464,15 @@ sealed interface CheckpointMessage : DestinationMessage {
     }
     data class Stats(val recordCount: Long)
     data class Checkpoint(
-        val stream: DestinationStream.Descriptor,
+        val stream: DestinationStream,
         val state: JsonNode?,
     ) {
         fun asProtocolObject(): AirbyteStreamState =
-            AirbyteStreamState().withStreamDescriptor(stream.asProtocolObject()).also {
+            AirbyteStreamState().withStreamDescriptor(
+                StreamDescriptor()
+                    .withNamespace(stream.unmappedNamespace)
+                    .withName(stream.unmappedName)
+            ).also {
                 if (state != null) {
                     it.streamState = state
                 }
@@ -524,8 +528,7 @@ data class StreamCheckpoint(
 ) : CheckpointMessage {
     /** Convenience constructor, intended for use in tests. */
     constructor(
-        streamNamespace: String?,
-        streamName: String,
+        stream: DestinationStream,
         blob: String,
         sourceRecordCount: Long,
         destinationRecordCount: Long? = null,
@@ -534,7 +537,7 @@ data class StreamCheckpoint(
         totalBytes: Long? = null
     ) : this(
         Checkpoint(
-            DestinationStream.Descriptor(streamNamespace, streamName),
+            stream,
             state = blob.deserializeToNode(),
         ),
         Stats(sourceRecordCount),

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/DestinationMessageFactory.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/DestinationMessageFactory.kt
@@ -213,8 +213,9 @@ class DestinationMessageFactory(
                 namespace = streamState.streamDescriptor.namespace,
                 name = streamState.streamDescriptor.name
             )
+        val stream = catalog.getStream(descriptor)
         return CheckpointMessage.Checkpoint(
-            stream = DestinationStream.Descriptor(descriptor.namespace, descriptor.name),
+            stream = stream,
             state = runCatching { streamState.streamState }.getOrNull(),
         )
     }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/DestinationMessageFactory.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/DestinationMessageFactory.kt
@@ -5,7 +5,6 @@
 package io.airbyte.cdk.load.message
 
 import io.airbyte.cdk.load.command.DestinationCatalog
-import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.command.NamespaceMapper
 import io.airbyte.cdk.load.state.CheckpointId
 import io.airbyte.cdk.load.state.CheckpointIndex

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/InputMessage.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/InputMessage.kt
@@ -195,10 +195,7 @@ data class InputStreamCheckpoint(val checkpoint: StreamCheckpoint) : InputCheckp
         checkpointKey: CheckpointKey? = null,
     ) : this(
         StreamCheckpoint(
-            Checkpoint(
-                stream,
-                state = blob.deserializeToNode()
-            ),
+            Checkpoint(stream, state = blob.deserializeToNode()),
             Stats(sourceRecordCount),
             destinationRecordCount?.let { Stats(it) },
             emptyMap(),

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/InputMessage.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/InputMessage.kt
@@ -188,8 +188,7 @@ sealed interface InputCheckpoint : InputMessage
 
 data class InputStreamCheckpoint(val checkpoint: StreamCheckpoint) : InputCheckpoint {
     constructor(
-        streamNamespace: String?,
-        streamName: String,
+        stream: DestinationStream,
         blob: String,
         sourceRecordCount: Long,
         destinationRecordCount: Long? = null,
@@ -197,7 +196,7 @@ data class InputStreamCheckpoint(val checkpoint: StreamCheckpoint) : InputCheckp
     ) : this(
         StreamCheckpoint(
             Checkpoint(
-                DestinationStream.Descriptor(streamNamespace, streamName),
+                stream,
                 state = blob.deserializeToNode()
             ),
             Stats(sourceRecordCount),

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/state/CheckpointManager.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/state/CheckpointManager.kt
@@ -68,7 +68,7 @@ data class CheckpointKey(
 class CheckpointManager<T>(
     val catalog: DestinationCatalog,
     val syncManager: SyncManager,
-    val outputConsumer: suspend (T) -> Unit,
+    val outputConsumer: suspend (T, Long, Long) -> Unit,
     val timeProvider: TimeProvider,
 ) {
     private val log = KotlinLogging.logger {}
@@ -249,6 +249,11 @@ class CheckpointManager<T>(
                         aggregate.records,
                         aggregate.serializedBytes,
                     )
+
+                    log.info {
+                        "Flushed checkpoint for stream: ${stream.descriptor} at index: $nextCheckpointKey (records=${aggregate.records}, bytes=${aggregate.serializedBytes})"
+                    }
+
                     // don't remove until after we've successfully sent
                     streamCheckpoints.remove(nextCheckpointKey)
                 } else {
@@ -288,7 +293,6 @@ class CheckpointManager<T>(
         return true
     }
 
-    @Suppress("UNCHECKED_CAST")
     private suspend fun sendStateMessage(
         checkpointMessage: T,
         checkpointKey: CheckpointKey,
@@ -298,13 +302,7 @@ class CheckpointManager<T>(
     ) {
         streamCheckpoints.forEach { stream -> lastCheckpointKeyEmitted[stream] = checkpointKey }
         lastFlushTimeMs.set(timeProvider.currentTimeMillis())
-        if (checkpointMessage is Reserved<*> && checkpointMessage.value is CheckpointMessage) {
-            val updated =
-                checkpointMessage.value.withTotalRecords(totalRecords).withTotalBytes(totalBytes)
-            outputConsumer.invoke(checkpointMessage.replace(updated) as T)
-        } else {
-            outputConsumer.invoke(checkpointMessage)
-        }
+        outputConsumer.invoke(checkpointMessage, totalRecords, totalBytes)
     }
 
     suspend fun awaitAllCheckpointsFlushed() {
@@ -332,10 +330,15 @@ class CheckpointManager<T>(
 )
 @Singleton
 class FreeingAnnotatingCheckpointConsumer(private val consumer: OutputConsumer) :
-    suspend (Reserved<CheckpointMessage>) -> Unit {
-    override suspend fun invoke(message: Reserved<CheckpointMessage>) {
+    suspend (Reserved<CheckpointMessage>, Long, Long) -> Unit {
+    private val log = KotlinLogging.logger {}
+    override suspend fun invoke(message: Reserved<CheckpointMessage>, totalRecords: Long, totalBytes: Long) {
         message.use {
-            val outMessage = it.value.asProtocolMessage()
+            val outMessage = it.value
+                .withTotalRecords(totalRecords = totalRecords)
+                .withTotalBytes(totalBytes = totalBytes)
+                .asProtocolMessage()
+            log.info { "TMP: Writing state message to STDOUT: $outMessage" }
             consumer.accept(outMessage)
         }
     }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/state/CheckpointManager.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/state/CheckpointManager.kt
@@ -332,12 +332,17 @@ class CheckpointManager<T>(
 class FreeingAnnotatingCheckpointConsumer(private val consumer: OutputConsumer) :
     suspend (Reserved<CheckpointMessage>, Long, Long) -> Unit {
     private val log = KotlinLogging.logger {}
-    override suspend fun invoke(message: Reserved<CheckpointMessage>, totalRecords: Long, totalBytes: Long) {
+    override suspend fun invoke(
+        message: Reserved<CheckpointMessage>,
+        totalRecords: Long,
+        totalBytes: Long
+    ) {
         message.use {
-            val outMessage = it.value
-                .withTotalRecords(totalRecords = totalRecords)
-                .withTotalBytes(totalBytes = totalBytes)
-                .asProtocolMessage()
+            val outMessage =
+                it.value
+                    .withTotalRecords(totalRecords = totalRecords)
+                    .withTotalBytes(totalBytes = totalBytes)
+                    .asProtocolMessage()
             log.info { "TMP: Writing state message to STDOUT: $outMessage" }
             consumer.accept(outMessage)
         }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/state/CheckpointManager.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/state/CheckpointManager.kt
@@ -343,7 +343,6 @@ class FreeingAnnotatingCheckpointConsumer(private val consumer: OutputConsumer) 
                     .withTotalRecords(totalRecords = totalRecords)
                     .withTotalBytes(totalBytes = totalBytes)
                     .asProtocolMessage()
-            log.info { "TMP: Writing state message to STDOUT: $outMessage" }
             consumer.accept(outMessage)
         }
     }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/state/PipelineEventBookkeepingRouter.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/state/PipelineEventBookkeepingRouter.kt
@@ -143,13 +143,13 @@ class PipelineEventBookkeepingRouter(
         when (val checkpoint = reservation.value) {
             is StreamCheckpoint -> {
                 val stream = checkpoint.checkpoint.stream
-                val manager = syncManager.getStreamManager(stream)
+                val manager = syncManager.getStreamManager(stream.descriptor)
                 val (checkpointKey, checkpointRecordCount) = getKeyAndCounts(checkpoint, manager)
                 val messageWithCount =
                     checkpoint.withDestinationStats(CheckpointMessage.Stats(checkpointRecordCount))
                 checkpointQueue.publish(
                     reservation.replace(
-                        StreamCheckpointWrapped(stream, checkpointKey, messageWithCount)
+                        StreamCheckpointWrapped(stream.descriptor, checkpointKey, messageWithCount)
                     )
                 )
             }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/StatsEmitter.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/StatsEmitter.kt
@@ -60,8 +60,8 @@ class StatsEmitter(
                         .withType(AirbyteMessage.Type.RECORD)
                         .withRecord(
                             AirbyteRecordMessage()
-                                .withNamespace(stream.descriptor.namespace)
-                                .withStream(stream.descriptor.name)
+                                .withNamespace(stream.unmappedNamespace)
+                                .withStream(stream.unmappedName)
                                 .withData(EMPTY_JSON)
                                 .withAdditionalProperty(DEST_EMITTED_RECORDS_COUNT, recordsRead)
                                 .withAdditionalProperty(DEST_EMITTED_BYTES_COUNT, bytesRead),

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/StatsEmitter.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/StatsEmitter.kt
@@ -94,7 +94,6 @@ class DummyStatsMessageConsumer(private val consumer: OutputConsumer) :
     suspend (AirbyteMessage) -> Unit {
     private val log = KotlinLogging.logger {}
     override suspend fun invoke(message: AirbyteMessage) {
-        log.info { "TMP: Writing dummy stats message: $message" }
         consumer.accept(message)
     }
 }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/StatsEmitter.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/StatsEmitter.kt
@@ -63,6 +63,7 @@ class StatsEmitter(
                                 .withNamespace(stream.unmappedNamespace)
                                 .withStream(stream.unmappedName)
                                 .withData(EMPTY_JSON)
+                                .withAdditionalProperty(OutputConsumer.IS_DUMMY_STATS_MESSAGE, true)
                                 .withAdditionalProperty(DEST_EMITTED_RECORDS_COUNT, recordsRead)
                                 .withAdditionalProperty(DEST_EMITTED_BYTES_COUNT, bytesRead),
                         )

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/StatsEmitter.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/StatsEmitter.kt
@@ -14,6 +14,7 @@ import io.airbyte.cdk.output.OutputConsumer
 import io.airbyte.protocol.models.Jsons
 import io.airbyte.protocol.models.v0.AirbyteMessage
 import io.airbyte.protocol.models.v0.AirbyteRecordMessage
+import io.github.oshai.kotlinlogging.KotlinLogging
 import io.micronaut.context.annotation.Factory
 import io.micronaut.context.annotation.Requires
 import io.micronaut.context.annotation.Value
@@ -90,7 +91,9 @@ class FrequencyFactory {
 @Requires(property = "airbyte.destination.core.data-channel.medium", value = "SOCKET")
 class DummyStatsMessageConsumer(private val consumer: OutputConsumer) :
     suspend (AirbyteMessage) -> Unit {
+    private val log = KotlinLogging.logger {}
     override suspend fun invoke(message: AirbyteMessage) {
+        log.info { "TMP: Writing dummy stats message: $message" }
         consumer.accept(message)
     }
 }

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/message/PipelineEventBookkeepingRouterTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/message/PipelineEventBookkeepingRouterTest.kt
@@ -113,7 +113,7 @@ class PipelineEventBookkeepingRouterTest {
         val reservationManager = ReservationManager(2)
         val checkpointMessage: CheckpointMessage.Checkpoint = mockk(relaxed = true)
 
-        every { checkpointMessage.stream } returns stream1.descriptor
+        every { checkpointMessage.stream } returns stream1
 
         every { streamManager.inferNextCheckpointKey() } returns
             CheckpointKey(CheckpointIndex(1), CheckpointId("foo"))
@@ -139,7 +139,7 @@ class PipelineEventBookkeepingRouterTest {
         val reservationManager = ReservationManager(2)
         val checkpointMessage: CheckpointMessage.Checkpoint = mockk(relaxed = true)
 
-        every { checkpointMessage.stream } returns stream1.descriptor
+        every { checkpointMessage.stream } returns stream1
 
         every { streamManager.inferNextCheckpointKey() } returns
             CheckpointKey(CheckpointIndex(1), CheckpointId("foo"))

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/state/CheckpointManagerUTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/state/CheckpointManagerUTest.kt
@@ -22,8 +22,8 @@ import org.junit.jupiter.api.Test
 class CheckpointManagerUTest {
     @MockK(relaxed = true) lateinit var catalog: DestinationCatalog
     @MockK(relaxed = true) lateinit var syncManager: SyncManager
-    private val outputConsumer: suspend (Reserved<CheckpointMessage>) -> Unit =
-        mockk<suspend (Reserved<CheckpointMessage>) -> Unit>(relaxed = true)
+    private val outputConsumer: suspend (Reserved<CheckpointMessage>, Long, Long) -> Unit =
+        mockk<suspend (Reserved<CheckpointMessage>, Long, Long) -> Unit>(relaxed = true)
     @MockK(relaxed = true) lateinit var timeProvider: TimeProvider
     @MockK(relaxed = true) lateinit var streamManager1: StreamManager
     @MockK(relaxed = true) lateinit var streamManager2: StreamManager
@@ -55,7 +55,7 @@ class CheckpointManagerUTest {
     @BeforeEach
     fun setup() {
         coEvery { catalog.streams } returns listOf(stream1, stream2)
-        coEvery { outputConsumer.invoke(any()) } returns Unit
+        coEvery { outputConsumer.invoke(any(), any(), any()) } returns Unit
         coEvery { syncManager.getStreamManager(stream1.descriptor) } returns streamManager1
         coEvery { syncManager.getStreamManager(stream2.descriptor) } returns streamManager2
     }
@@ -85,8 +85,8 @@ class CheckpointManagerUTest {
 
         // Only stream2 should be flushed.
         checkpointManager.flushReadyCheckpointMessages()
-        coVerify(exactly = 0) { outputConsumer.invoke(message1) }
-        coVerify(exactly = 1) { outputConsumer.invoke(message2) }
+        coVerify(exactly = 0) { outputConsumer.invoke(message1, any(), any()) }
+        coVerify(exactly = 1) { outputConsumer.invoke(message2, any(), any()) }
     }
 
     @Test
@@ -111,7 +111,7 @@ class CheckpointManagerUTest {
 
         checkpointManager.flushReadyCheckpointMessages()
 
-        coVerify(exactly = 0) { outputConsumer.invoke(any()) }
+        coVerify(exactly = 0) { outputConsumer.invoke(any(), any(), any()) }
     }
 
     @Test
@@ -136,7 +136,7 @@ class CheckpointManagerUTest {
 
         checkpointManager.flushReadyCheckpointMessages()
 
-        coVerify(exactly = 2) { outputConsumer.invoke(any()) }
+        coVerify(exactly = 2) { outputConsumer.invoke(any(), any(), any()) }
     }
 
     @Test
@@ -161,6 +161,6 @@ class CheckpointManagerUTest {
 
         checkpointManager.flushReadyCheckpointMessages()
 
-        coVerify(exactly = 1) { outputConsumer.invoke(any()) }
+        coVerify(exactly = 1) { outputConsumer.invoke(any(), any(), any()) }
     }
 }

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/internal/StatsEmitterTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/internal/StatsEmitterTest.kt
@@ -64,8 +64,10 @@ class StatsEmitterTest {
             }
         syncManager = mockk { every { getStreamManager(testDescriptor) } returns streamManager }
 
-        val dstStream =
-            mockk<DestinationStream> { every { this@mockk.descriptor } returns testDescriptor }
+        val dstStream = mockk<DestinationStream>()
+        every { dstStream.unmappedNamespace } returns "foo"
+        every { dstStream.unmappedName } returns "bar"
+        every { dstStream.descriptor } returns testDescriptor
         catalog = mockk { every { streams } returns listOf(dstStream) }
 
         recordingConsumer = RecordingOutputConsumer()

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/test/util/StubDestinationMessageFactory.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/test/util/StubDestinationMessageFactory.kt
@@ -65,10 +65,7 @@ object StubDestinationMessageFactory {
     fun makeStreamState(stream: DestinationStream, recordCount: Long): CheckpointMessage {
         return StreamCheckpoint(
             checkpoint =
-                CheckpointMessage.Checkpoint(
-                    stream.descriptor,
-                    JsonNodeFactory.instance.objectNode()
-                ),
+                CheckpointMessage.Checkpoint(stream, JsonNodeFactory.instance.objectNode()),
             sourceStats = CheckpointMessage.Stats(recordCount),
             serializedSizeBytes = 0L
         )

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/IntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/IntegrationTest.kt
@@ -303,6 +303,7 @@ abstract class IntegrationTest(
                 micronautProperties = micronautProperties + micronautPropertyEnableMicrobatching,
                 dataChannelMedium = dataChannelMedium,
                 dataChannelFormat = dataChannelFormat,
+                namespaceMappingConfig = NamespaceMappingConfig(NamespaceDefinitionType.SOURCE),
             )
         return runBlocking(Dispatchers.IO) {
             launch {

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/write/BasicFunctionalityIntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/write/BasicFunctionalityIntegrationTest.kt
@@ -320,8 +320,7 @@ abstract class BasicFunctionalityIntegrationTest(
                         checkpointId = checkpointKeyForMedium()?.checkpointId
                     ),
                     InputStreamCheckpoint(
-                        streamName = "test_stream",
-                        streamNamespace = randomizedNamespace,
+                        stream = stream,
                         blob = """{"foo": "bar"}""",
                         sourceRecordCount = 1,
                         checkpointKey = checkpointKeyForMedium(),
@@ -340,14 +339,13 @@ abstract class BasicFunctionalityIntegrationTest(
 
                 val asProtocolMessage =
                     StreamCheckpoint(
-                            streamName = "test_stream",
-                            streamNamespace = randomizedNamespace,
+                            stream = stream,
                             blob = """{"foo": "bar"}""",
                             sourceRecordCount = 1,
                             destinationRecordCount = 1,
                             checkpointKey = checkpointKeyForMedium(),
                             totalRecords = 1L,
-                            totalBytes = expectedBytesForMediumAndFormat(234L, 253L, 59L)
+                            totalBytes = expectedBytesForMediumAndFormat(234L, 254L, 59L)
                         )
                         .asProtocolMessage()
                 assertEquals(
@@ -445,8 +443,7 @@ abstract class BasicFunctionalityIntegrationTest(
                 listOf(
                     input,
                     InputStreamCheckpoint(
-                        streamName = stream.descriptor.name,
-                        streamNamespace = stream.descriptor.namespace,
+                        stream = stream,
                         blob = """{"foo": "bar"}""",
                         sourceRecordCount = 1,
                         checkpointKey = checkpointKeyForMedium(),
@@ -464,8 +461,7 @@ abstract class BasicFunctionalityIntegrationTest(
             )
             assertEquals(
                 StreamCheckpoint(
-                        streamName = stream.descriptor.name,
-                        streamNamespace = stream.descriptor.namespace,
+                        stream = stream,
                         blob = """{"foo": "bar"}""",
                         sourceRecordCount = 1,
                         destinationRecordCount = 1,
@@ -514,8 +510,7 @@ abstract class BasicFunctionalityIntegrationTest(
                         )
                     ),
                     StreamCheckpoint(
-                        streamNamespace = randomizedNamespace,
-                        streamName = "test_stream",
+                        stream = stream,
                         blob = """{"foo": "bar1"}""",
                         sourceRecordCount = 1,
                         checkpointKey = checkpointKeyForMedium()
@@ -1018,8 +1013,7 @@ abstract class BasicFunctionalityIntegrationTest(
             stream2,
             listOf(makeInputRecord(1, "2024-01-23T02:00:00Z", 200)),
             StreamCheckpoint(
-                randomizedNamespace,
-                stream2.descriptor.name,
+                stream2,
                 """{}""",
                 sourceRecordCount = 1,
                 checkpointKey = checkpointKeyForMedium(),
@@ -1151,8 +1145,7 @@ abstract class BasicFunctionalityIntegrationTest(
             stream,
             listOf(makeInputRecord(1, "2024-01-23T02:00:00Z", 200)),
             StreamCheckpoint(
-                randomizedNamespace,
-                stream.descriptor.name,
+                stream,
                 """{}""",
                 sourceRecordCount = 1,
                 checkpointKey = checkpointKeyForMedium(),
@@ -1316,8 +1309,7 @@ abstract class BasicFunctionalityIntegrationTest(
             stream2,
             listOf(makeInputRecord(1, "2024-01-23T02:00:00Z", 200)),
             StreamCheckpoint(
-                randomizedNamespace,
-                stream2.descriptor.name,
+                stream2,
                 """{}""",
                 sourceRecordCount = 1,
                 checkpointKey = checkpointKeyForMedium(),


### PR DESCRIPTION
****DO NOT MERGE WITHOUT REMOVING THE DEBUG LOG LINES (MARKED "TMP")**

## What
* Fixes a bug in the namespace mapping that was causing us to send the mapped namespace on Dummy Stats and State
* Fixes the outputconsumer issue that was dropping additionalProperties ([this fix did not work](https://github.com/airbytehq/airbyte/pull/61403/commits/5a91a2b460455459067256ad552c1929e05db389))
* Fixes a failing test caused by not setting the namespace mapper for socket tests using runUntilStateAck
* Fixes a test that was broken by the fix for the counting error on the Json path
* Cleans up the state record annotation by moving adding committed bytes/records to a scope with visibility into the message type (avoids casting in the wrong scope)

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._