### PR TITLE
[Load-CDK] Speed: Unbreak what speed broke

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/command/DestinationStream.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/command/DestinationStream.kt
@@ -20,9 +20,32 @@ import jakarta.inject.Singleton
  * Internal representation of destination streams. This is intended to be a case class specialized
  * for usability.
  *
- * TODO: Add missing info like sync type, generation_id, etc.
+ * NOTE ON NAMESPACE MAPPING:
  *
- * TODO: Add dedicated schema type, converted from json-schema.
+ * When run in speed mode ([io.airbyte.cdk.load.config.DataChannelMedium] = [SOCKET]), namespace
+ * mapping will be applied in the destination instead of in the orchestrator. The entails
+ * - the platform will give the destination a catalog with an unmapped namespace and stream names
+ * - the source will send the destination records and control messages with unmapped namespace and
+ * stream names
+ * - the destination will apply the namespace mapping as soon as it receives these messages (all of
+ * its written data/table names/object paths will use the mapped namespace and names, same as in a
+ * non-speed sync)
+ * - when the destination emits control messages (state, stats), it must use the *unmapped*
+ * namespace and names More generally: all inter-application communication will be unmapped, all
+ * communication between the connector and the destination, or between the CDK and the connector
+ * code, will be mapped.
+ *
+ * TO MAKE THIS AS ERROR-PROOF AS POSSIBLE:
+ * - every DestinationStream must be instantiated with an [unmappedName], [unmappedNamespace], AND a
+ * [NamespaceMapper]
+ * - the default namespace mapper will be identity, and will work as expected for standard syncs
+ * - [DestinationStream.Descriptor] will ALWAYS be MAPPED. (All code and tests should follow this
+ * pattern.)
+ * - [NamespaceMapper] is treated as data for the purpose of equality checks (ie, same unmapped
+ * names + and same mapping rules => same stream)
+ * - currently this won't impact the ordering of stream names for [AirbyteValueProxy.FieldAccessor]
+ * s, but only because the only stream name mapping currently supported is prepending a uniform
+ * prefix. IF THAT CHANGES, PROXY FIELD ORDERING WILL BREAK.
  */
 data class DestinationStream(
     val unmappedNamespace: String?,

--- a/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryWriteTest.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryWriteTest.kt
@@ -7,6 +7,7 @@ package io.airbyte.integrations.destination.bigquery
 import io.airbyte.cdk.load.command.Append
 import io.airbyte.cdk.load.command.Dedupe
 import io.airbyte.cdk.load.command.DestinationStream
+import io.airbyte.cdk.load.command.NamespaceMapper
 import io.airbyte.cdk.load.data.ObjectType
 import io.airbyte.cdk.load.message.InputRecord
 import io.airbyte.cdk.load.test.util.DestinationDataDumper
@@ -108,12 +109,14 @@ abstract class BigqueryTDWriteTest(configContents: String) :
     open fun testAppendCdkMigration() {
         val stream =
             DestinationStream(
-                DestinationStream.Descriptor(randomizedNamespace, "test_stream"),
+                unmappedNamespace = randomizedNamespace,
+                unmappedName = "test_stream",
                 Append,
                 ObjectType(linkedMapOf("id" to intType)),
                 generationId = 0,
                 minimumGenerationId = 0,
                 syncId = 42,
+                namespaceMapper = NamespaceMapper()
             )
         // Run a sync on the old CDK
         runSync(
@@ -191,12 +194,14 @@ abstract class BigqueryTDWriteTest(configContents: String) :
     open fun testDedupCdkMigration() {
         val stream =
             DestinationStream(
-                DestinationStream.Descriptor(randomizedNamespace, "test_stream"),
+                unmappedNamespace = randomizedNamespace,
+                unmappedName = "test_stream",
                 Dedupe(primaryKey = listOf(listOf("id")), cursor = emptyList()),
                 ObjectType(linkedMapOf("id" to intType)),
                 generationId = 0,
                 minimumGenerationId = 0,
                 syncId = 42,
+                namespaceMapper = NamespaceMapper(),
             )
         // Run a sync on the old CDK
         runSync(

--- a/airbyte-integrations/connectors/destination-bigquery/src/test/kotlin/io/airbyte/integrations/destination/bigquery/typing_deduping/BigqueryDestinationHandlerTest.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test/kotlin/io/airbyte/integrations/destination/bigquery/typing_deduping/BigqueryDestinationHandlerTest.kt
@@ -12,6 +12,7 @@ import com.google.cloud.bigquery.TimePartitioning
 import io.airbyte.cdk.load.command.Append
 import io.airbyte.cdk.load.command.Dedupe
 import io.airbyte.cdk.load.command.DestinationStream
+import io.airbyte.cdk.load.command.NamespaceMapper
 import io.airbyte.cdk.load.data.ArrayType
 import io.airbyte.cdk.load.data.BooleanType
 import io.airbyte.cdk.load.data.FieldType
@@ -55,12 +56,14 @@ class BigqueryDestinationHandlerTest {
     fun testColumnsMatch() {
         val stream =
             DestinationStream(
-                Mockito.mock(),
+                "foo",
+                "bar",
                 Append,
                 ObjectType(linkedMapOf("a1" to FieldType(IntegerType, nullable = true))),
                 generationId = 0,
                 minimumGenerationId = 0,
                 syncId = 0,
+                namespaceMapper = NamespaceMapper()
             )
         val columnNameMapping = ColumnNameMapping(mapOf("a1" to "a2"))
         val existingTable = Mockito.mock(StandardTableDefinition::class.java, RETURNS_DEEP_STUBS)
@@ -80,7 +83,8 @@ class BigqueryDestinationHandlerTest {
     fun testColumnsNotMatch() {
         val stream =
             DestinationStream(
-                Mockito.mock(),
+                "foo",
+                "bar",
                 Append,
                 ObjectType(
                     linkedMapOf(
@@ -91,6 +95,7 @@ class BigqueryDestinationHandlerTest {
                 generationId = 0,
                 minimumGenerationId = 0,
                 syncId = 0,
+                namespaceMapper = NamespaceMapper()
             )
         val columnNameMapping = ColumnNameMapping(mapOf("a1" to "a2", "c1" to "c2"))
         val existingTable = Mockito.mock(StandardTableDefinition::class.java, RETURNS_DEEP_STUBS)
@@ -117,7 +122,8 @@ class BigqueryDestinationHandlerTest {
     fun testClusteringMatches() {
         var stream =
             DestinationStream(
-                Mockito.mock(),
+                "foo",
+                "bar",
                 Dedupe(
                     listOf(listOf("bar")),
                     emptyList(),
@@ -126,6 +132,7 @@ class BigqueryDestinationHandlerTest {
                 generationId = 0,
                 minimumGenerationId = 0,
                 syncId = 0,
+                namespaceMapper = NamespaceMapper()
             )
         var columnNameMapping = ColumnNameMapping(mapOf("bar" to "foo"))
 
@@ -142,12 +149,14 @@ class BigqueryDestinationHandlerTest {
         // Clustering matches
         stream =
             DestinationStream(
-                Mockito.mock(),
+                "foo",
+                "bar",
                 Append,
                 ObjectTypeWithoutSchema,
                 generationId = 0,
                 minimumGenerationId = 0,
                 syncId = 0,
+                namespaceMapper = NamespaceMapper()
             )
         Assertions.assertTrue(clusteringMatches(stream, columnNameMapping, existingTable))
 
@@ -161,7 +170,8 @@ class BigqueryDestinationHandlerTest {
             )
         stream =
             DestinationStream(
-                Mockito.mock(),
+                "foo",
+                "bar",
                 Dedupe(
                     listOf(listOf("a1"), listOf("b1"), listOf("c1"), listOf("d1"), listOf("e1")),
                     emptyList()
@@ -169,7 +179,8 @@ class BigqueryDestinationHandlerTest {
                 ObjectTypeWithoutSchema,
                 generationId = 0,
                 minimumGenerationId = 0,
-                syncId = 0
+                syncId = 0,
+                namespaceMapper = NamespaceMapper()
             )
         columnNameMapping =
             ColumnNameMapping(

--- a/airbyte-integrations/connectors/destination-mssql/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-mssql/metadata.yaml
@@ -2,6 +2,7 @@ data:
   ab_internal:
     ql: 100
     sl: 100
+    requireVersionIncrementsInPullRequests: false
   connectorBuildOptions:
     baseImage: docker.io/airbyte/java-connector-base:2.0.1@sha256:ec89bd1a89e825514dd2fc8730ba299a3ae1544580a078df0e35c5202c2085b3
   connectorSubtype: database

--- a/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLChecker.kt
+++ b/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLChecker.kt
@@ -7,9 +7,11 @@ package io.airbyte.integrations.destination.mssql.v2
 import io.airbyte.cdk.load.check.DestinationChecker
 import io.airbyte.cdk.load.command.Append
 import io.airbyte.cdk.load.command.DestinationStream
+import io.airbyte.cdk.load.command.NamespaceMapper
 import io.airbyte.cdk.load.data.FieldType
 import io.airbyte.cdk.load.data.IntegerType
 import io.airbyte.cdk.load.data.ObjectType
+import io.airbyte.cdk.load.message.DestinationRecordJsonSource
 import io.airbyte.cdk.load.message.DestinationRecordRaw
 import io.airbyte.cdk.load.util.Jsons
 import io.airbyte.integrations.destination.mssql.v2.config.AzureBlobStorageClientCreator
@@ -37,17 +39,15 @@ class MSSQLChecker(private val dataSourceFactory: MSSQLDataSourceFactory) :
 
     private val testStream =
         DestinationStream(
-            descriptor =
-                DestinationStream.Descriptor(
-                    namespace = null,
-                    name = "check_test_${UUID.randomUUID()}",
-                ),
+            unmappedNamespace = null,
+            unmappedName = "check_test_${UUID.randomUUID()}",
             importType = Append,
             schema =
                 ObjectType(linkedMapOf(COLUMN_NAME to FieldType(IntegerType, nullable = true))),
             generationId = 0L,
             minimumGenerationId = 0L,
             syncId = 0L,
+            namespaceMapper = NamespaceMapper()
         )
 
     override fun check(config: MSSQLConfiguration) {
@@ -143,8 +143,7 @@ class MSSQLChecker(private val dataSourceFactory: MSSQLDataSourceFactory) :
                         .let { message ->
                             DestinationRecordRaw(
                                 stream,
-                                message,
-                                stream.schema,
+                                DestinationRecordJsonSource(message),
                                 Jsons.writeValueAsString(message).length.toLong(),
                             )
                         }


### PR DESCRIPTION
## What
Namespace mapping changes changed the DestinationStream interface.

I missed a couple of tests this broke. Everything should be fixed now.

I also added comments to better explain the rationale behind the new interface.

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._