### PR TITLE
Ignore Vale in prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,6 +4,9 @@ airbyte-integrations/bases/connector-acceptance-test/unit_tests/data/docs
 airbyte-integrations/connectors/destination-*/src/test-integration/resources/expected-spec*.json
 airbyte-cdk/bulk/*/*/src/test-integration/resources/expected-spec-*.json
 
+# Ignore documentation linter configuration files
+docs/vale-styles/**
+
 # Ignore manifest files in manifest-only connectors
 # This is done due to prettier being overly opinionated on the formatting of quotes
 # Ref: https://github.com/prettier/prettier/issues/973


### PR DESCRIPTION
## What

Update .prettierignore to ignore documentation linter configuration files. The two are set up in a way that they have some incompatibilities because they're strongly opinionated on the formatting of quotes. There's no need to lint these files anyway.

## How

Ignore everything in /docs/vale-styles/**

## Review guide

This PR should pass.

## User Impact

The master branch in airbyte isn't broken.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌
