### PR TITLE
chore: enable cdk toolkit version pinning

### DIFF
--- a/buildSrc/src/main/groovy/airbyte-bulk-connector.gradle
+++ b/buildSrc/src/main/groovy/airbyte-bulk-connector.gradle
@@ -52,7 +52,11 @@ class AirbyteBulkConnectorExtension {
                     project.project(":airbyte-cdk:bulk:core:bulk-cdk-core-$core"),
             ]
             for (toolkit in toolkits) {
-                fromSource << project.project(":airbyte-cdk:bulk:toolkits:bulk-cdk-toolkit-$toolkit")
+                if (toolkit.contains(':')) {
+                    fromJar << "io.airbyte.bulk-cdk:bulk-cdk-toolkit-$toolkit"
+                } else {
+                    fromSource << project.project(":airbyte-cdk:bulk:toolkits:bulk-cdk-toolkit-$toolkit")
+                }
             }
         } else {
             fromJar = [
@@ -60,7 +64,11 @@ class AirbyteBulkConnectorExtension {
                     "io.airbyte.bulk-cdk:bulk-cdk-core-$core:$cdk",
             ]
             for (toolkit in toolkits) {
-                fromJar << "io.airbyte.bulk-cdk:bulk-cdk-toolkit-$toolkit:$cdk"
+                if (toolkit.contains(':')) {
+                    fromJar << "io.airbyte.bulk-cdk:bulk-cdk-toolkit-$toolkit"
+                } else {
+                    fromJar << "io.airbyte.bulk-cdk:bulk-cdk-toolkit-$toolkit:$cdk"
+                }
             }
         }
 


### PR DESCRIPTION
## What

The toolkit versions are currently tightly coupled to the CDK version.
This can create some situation where in order to upgrade a specific toolkit, we are forced to upgrade the entire CDK version which means that we might need to pull in other breaking changes.

This PR extends the `AirbyteBulkConnectorExtension` to enable specific versions to be applied to the toolkits independently from the version of the CDK.


Examples:

In order to only pin the `load-aws` toolkit to `0.400` while the rest is using local.
```
airbyteBulkConnector {
    core = 'load'
    toolkits = ['load-s3', 'load-avro', 'load-aws:0.400']
    cdk = 'local'
}
```

It also works with different versions. In the following examples, the CDK and the toolkits will be on `0.404` by default while `load-aws` will be on `0.409`
```
airbyteBulkConnector {
    core = 'load'
    toolkits = ['load-s3', 'load-avro', 'load-aws:0.409']
    cdk = '0.404'
}
```

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
