### PR TITLE
Rbroughan/productionalize check

### DIFF
--- a/airbyte-integrations/connectors/destination-clickhouse-v2/build.gradle
+++ b/airbyte-integrations/connectors/destination-clickhouse-v2/build.gradle
@@ -37,7 +37,13 @@ dependencies {
 
     implementation 'com.clickhouse:client-v2:0.8.6'
 
+    testImplementation("io.mockk:mockk:1.14.2")
+
     // https://mvnrepository.com/artifact/org.testcontainers/clickhouse
     integrationTestImplementation 'org.testcontainers:clickhouse:1.21.1'
     integrationTestImplementation 'com.clickhouse:client-v2:0.8.6'
+}
+
+test {
+    systemProperties(["mockk.junit.extension.requireParallelTesting":"true"])
 }

--- a/airbyte-integrations/connectors/destination-clickhouse-v2/src/main/kotlin/io/airbyte/integrations/destination/clickhouse_v2/write/direct/ClickhouseDirectLoader.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse-v2/src/main/kotlin/io/airbyte/integrations/destination/clickhouse_v2/write/direct/ClickhouseDirectLoader.kt
@@ -61,7 +61,7 @@ class ClickhouseDirectLoader(
             log.info { "Beginning insert of $recordCount rows into ${descriptor.name}" }
 
             val insertResult = clickhouseClient.insert(
-                "`${descriptor.namespace}`.`${descriptor.name}`",
+                "`${descriptor.namespace ?: "default"}`.`${descriptor.name}`",
                 jsonBytes,
                 ClickHouseFormat.JSONEachRow
             ).await()

--- a/airbyte-integrations/connectors/destination-clickhouse-v2/src/test/kotlin/io/airbyte/integrations/destination/clickhouse_v2/check/ClickhouseCheckerTest.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse-v2/src/test/kotlin/io/airbyte/integrations/destination/clickhouse_v2/check/ClickhouseCheckerTest.kt
@@ -1,0 +1,118 @@
+package io.airbyte.integrations.destination.clickhouse_v2.check
+import com.clickhouse.client.api.Client
+import com.clickhouse.client.api.insert.InsertResponse
+import com.clickhouse.data.ClickHouseFormat
+import io.airbyte.integrations.destination.clickhouse_v2.spec.ClickhouseConfiguration
+import io.mockk.impl.annotations.MockK
+import io.mockk.every
+import io.mockk.junit5.MockKExtension
+import io.mockk.mockk
+import io.mockk.verify
+import java.io.InputStream
+import java.time.Clock
+import java.util.concurrent.CompletableFuture
+import kotlin.test.assertNotEquals
+import kotlin.test.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(MockKExtension::class)
+class ClickhouseCheckerTest {
+    @MockK
+    lateinit var clock: Clock
+
+    @MockK
+    lateinit var client: Client
+
+    @MockK
+    lateinit var clientFactory: RawClickHouseClientFactory
+
+    @MockK
+    lateinit var insertResponse: InsertResponse
+
+    private lateinit var checker: ClickhouseChecker
+
+    @BeforeEach
+    fun setup() {
+        every { clientFactory.make(any()) } returns client
+        every { client.execute(any()) } returns mockk(relaxed = true)
+        every { insertResponse.writtenRows } returns 1
+        every { client.insert(any(), any<InputStream>(), any()) } returns CompletableFuture.completedFuture(insertResponse)
+        every { clock.millis() } returns Fixtures.MILLIS
+        checker = ClickhouseChecker(clock, clientFactory)
+    }
+
+    @Test
+    fun `check happy path - creates check table and inserts data`() {
+        checker.check(Fixtures.config)
+
+        verify { client.execute("CREATE TABLE IF NOT EXISTS ${Fixtures.config.database}.${checker.tableName} (test UInt8) ENGINE = MergeTree ORDER BY ()") }
+        verify { client.insert(checker.tableName, any<InputStream>(), ClickHouseFormat.JSONEachRow) }
+    }
+
+    @Test
+    fun `check happy path - table name differs between instantiations to prevent collision`() {
+        val time1 = 123L
+        every { clock.millis() } returns time1
+        val checker1 = ClickhouseChecker(clock, clientFactory)
+        val time2 = 3416L
+        every { clock.millis() } returns time2
+        val checker2 = ClickhouseChecker(clock, clientFactory)
+        val time3 = 1236L
+        every { clock.millis() } returns time3
+        val checker3 = ClickhouseChecker(clock, clientFactory)
+
+        assertNotEquals(checker1.tableName, checker2.tableName)
+        assertNotEquals(checker1.tableName, checker3.tableName)
+        assertNotEquals(checker2.tableName, checker3.tableName)
+    }
+
+    @Test
+    fun `check table creation failure`() {
+        val exception = Exception("blam")
+        every { client.execute(any()) } throws exception
+
+        val caught = assertThrows<Exception> { checker.check(Fixtures.config) }
+        assertEquals(exception, caught)
+    }
+
+    @Test
+    fun `check insert data failure`() {
+        val exception = Exception("blam")
+        every { client.insert(any(), any<InputStream>(), any()) } throws exception
+
+        val caught = assertThrows<Exception> { checker.check(Fixtures.config) }
+        assertEquals(exception, caught)
+    }
+
+    @Test
+    fun `cleanup happy path - drops the check table`() {
+        checker.cleanup(Fixtures.config)
+
+        verify { client.execute("DROP TABLE IF EXISTS ${Fixtures.config.database}.${checker.tableName}") }
+    }
+
+    @Test
+    fun `cleanup drop table failure`() {
+        val exception = Exception("blam")
+        every { client.execute(any()) } throws exception
+
+        val caught = assertThrows<Exception> { checker.cleanup(Fixtures.config) }
+        assertEquals(exception, caught)
+    }
+
+    object Fixtures {
+        const val MILLIS = 1234L
+
+        val config = ClickhouseConfiguration(
+            "hostname",
+            "port",
+            "protocol",
+            "database",
+            "username",
+            "password",
+        )
+    }
+}


### PR DESCRIPTION
## What
Adds some unit tests and makes the client mockable

## Other
I spent a lot of time looking for ways to simply inject the higher level airbyte client and leverage that, but it's create table methods are also complicated (they require bespoke objects that need creation that drown out the actual check logic) 

Long term, I think we will want to decompose some of the table interfaces so the basic commands are simpler (e.g. they mostly take primitives and standard collections, etc.)
