### PR TITLE
feat: add Data Activation fields to stream

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/command/DestinationStream.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/command/DestinationStream.kt
@@ -59,6 +59,8 @@ data class DestinationStream(
     val isFileBased: Boolean = false,
     // whether we will move the file (in addition to the metadata)
     val includeFiles: Boolean = false,
+    val destinationObjectName: String? = null,
+    val matchingKey: List<String> = emptyList<String>(),
     private val namespaceMapper: NamespaceMapper
 ) {
     val descriptor = namespaceMapper.map(namespace = unmappedNamespace, name = unmappedName)
@@ -184,9 +186,23 @@ class DestinationStreamFactory(
             schema = jsonSchemaToAirbyteType.convert(stream.stream.jsonSchema),
             isFileBased = stream.stream.isFileBased ?: false,
             includeFiles = stream.includeFiles ?: false,
+            destinationObjectName = stream.destinationObjectName,
+            matchingKey = stream.destinationObjectName?.let { fromCompositeNestedKeyToCompositeKey(stream.primaryKey) }.orEmpty()
         )
     }
 }
+
+private fun fromCompositeNestedKeyToCompositeKey(compositeNestedKey: List<List<String>>) : List<String> {
+    if (compositeNestedKey.any { it.size > 1 }) {
+        throw IllegalArgumentException("Nested keys are not supported for matching keys. Key was $compositeNestedKey")
+    }
+    if (compositeNestedKey.any { it.isEmpty() }) {
+        throw IllegalArgumentException("Parts of the composite key need to have at least one element. Key was $compositeNestedKey")
+    }
+
+    return compositeNestedKey.map { it[0] }.toList()
+}
+
 
 sealed interface ImportType
 

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/command/DestinationStream.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/command/DestinationStream.kt
@@ -188,7 +188,9 @@ class DestinationStreamFactory(
             includeFiles = stream.includeFiles ?: false,
             destinationObjectName = stream.destinationObjectName,
             matchingKey =
-                stream.destinationObjectName?.let { fromCompositeNestedKeyToCompositeKey(stream.primaryKey) }
+                stream.destinationObjectName?.let {
+                    fromCompositeNestedKeyToCompositeKey(stream.primaryKey)
+                }
         )
     }
 }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/command/DestinationStream.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/command/DestinationStream.kt
@@ -187,22 +187,30 @@ class DestinationStreamFactory(
             isFileBased = stream.stream.isFileBased ?: false,
             includeFiles = stream.includeFiles ?: false,
             destinationObjectName = stream.destinationObjectName,
-            matchingKey = stream.destinationObjectName?.let { fromCompositeNestedKeyToCompositeKey(stream.primaryKey) }.orEmpty()
+            matchingKey =
+                stream.destinationObjectName
+                    ?.let { fromCompositeNestedKeyToCompositeKey(stream.primaryKey) }
+                    .orEmpty()
         )
     }
 }
 
-private fun fromCompositeNestedKeyToCompositeKey(compositeNestedKey: List<List<String>>) : List<String> {
+private fun fromCompositeNestedKeyToCompositeKey(
+    compositeNestedKey: List<List<String>>
+): List<String> {
     if (compositeNestedKey.any { it.size > 1 }) {
-        throw IllegalArgumentException("Nested keys are not supported for matching keys. Key was $compositeNestedKey")
+        throw IllegalArgumentException(
+            "Nested keys are not supported for matching keys. Key was $compositeNestedKey"
+        )
     }
     if (compositeNestedKey.any { it.isEmpty() }) {
-        throw IllegalArgumentException("Parts of the composite key need to have at least one element. Key was $compositeNestedKey")
+        throw IllegalArgumentException(
+            "Parts of the composite key need to have at least one element. Key was $compositeNestedKey"
+        )
     }
 
     return compositeNestedKey.map { it[0] }.toList()
 }
-
 
 sealed interface ImportType
 

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/command/DestinationStream.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/command/DestinationStream.kt
@@ -60,7 +60,7 @@ data class DestinationStream(
     // whether we will move the file (in addition to the metadata)
     val includeFiles: Boolean = false,
     val destinationObjectName: String? = null,
-    val matchingKey: List<String> = emptyList<String>(),
+    val matchingKey: List<String>? = null,
     private val namespaceMapper: NamespaceMapper
 ) {
     val descriptor = namespaceMapper.map(namespace = unmappedNamespace, name = unmappedName)
@@ -188,9 +188,7 @@ class DestinationStreamFactory(
             includeFiles = stream.includeFiles ?: false,
             destinationObjectName = stream.destinationObjectName,
             matchingKey =
-                stream.destinationObjectName
-                    ?.let { fromCompositeNestedKeyToCompositeKey(stream.primaryKey) }
-                    .orEmpty()
+                stream.destinationObjectName?.let { fromCompositeNestedKeyToCompositeKey(stream.primaryKey) }
         )
     }
 }

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/command/DestinationStreamUTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/command/DestinationStreamUTest.kt
@@ -4,10 +4,22 @@
 
 package io.airbyte.cdk.load.command
 
+import io.airbyte.cdk.load.data.json.JsonSchemaToAirbyteType
+import io.airbyte.protocol.models.JsonSchemaType
+import io.airbyte.protocol.models.v0.CatalogHelpers
+import io.airbyte.protocol.models.v0.ConfiguredAirbyteStream
+import io.airbyte.protocol.models.v0.DestinationSyncMode
+import io.airbyte.protocol.models.v0.Field
+import io.airbyte.protocol.models.v0.SyncMode
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Test
+
+private const val A_DESTINATION_OBJECT_NAME = "a_destination_object_name"
 
 class DestinationStreamUTest {
     @MockK(relaxed = true) private lateinit var stream: DestinationStream
@@ -35,4 +47,62 @@ class DestinationStreamUTest {
         every { stream.generationId } returns 1
         assertFalse(stream.shouldBeTruncatedAtEndOfSync())
     }
+
+    @Test
+    fun `test given no destination object name when make then no matching keys`() {
+        val configuredStream = a_configured_stream()
+
+        val stream = a_stream_factory().make(configuredStream)
+
+        assertEquals(stream.matchingKey, emptyList())
+        assertNull(stream.destinationObjectName)
+    }
+
+    @Test
+    fun `test given destination object name when make then assemble matching keys`() {
+        val configuredStream = a_configured_stream()
+            .withDestinationObjectName(A_DESTINATION_OBJECT_NAME)
+            .withPrimaryKey(listOf<List<String>>(listOf<String>("composite_key_1"), listOf<String>("composite_key_2")))
+
+        val stream = a_stream_factory().make(configuredStream)
+
+        assertEquals(stream.matchingKey, listOf("composite_key_1", "composite_key_2"))
+        assertEquals(stream.destinationObjectName, A_DESTINATION_OBJECT_NAME)
+    }
+
+    @Test
+    fun `test given primary key is nested when make then throw error`() {
+        val configuredStream = a_configured_stream()
+            .withDestinationObjectName(A_DESTINATION_OBJECT_NAME)
+            .withPrimaryKey(listOf<List<String>>(listOf<String>("nested_key_root", "nested_key_leaf")))
+
+        assertFailsWith<IllegalArgumentException>(block = { a_stream_factory().make(configuredStream) })
+    }
+
+    @Test
+    fun `test given primary key has empty key when make then throw error`() {
+        val configuredStream = a_configured_stream()
+            .withDestinationObjectName(A_DESTINATION_OBJECT_NAME)
+            .withPrimaryKey(listOf<List<String>>(listOf<String>("composite_key_1"), listOf<String>()))
+
+        assertFailsWith<IllegalArgumentException>(block = { a_stream_factory().make(configuredStream) })
+    }
+
+    private fun a_stream_factory(): DestinationStreamFactory = DestinationStreamFactory(
+        JsonSchemaToAirbyteType(JsonSchemaToAirbyteType.UnionBehavior.DEFAULT),
+        namespaceMapper = NamespaceMapper(),
+    )
+
+    private fun a_configured_stream(): ConfiguredAirbyteStream = ConfiguredAirbyteStream()
+        .withStream(
+            CatalogHelpers.createAirbyteStream(
+                "a_stream_name",
+                "namespace",
+                Field.of("field_name", JsonSchemaType.STRING),
+            ),
+        )
+        .withDestinationSyncMode(DestinationSyncMode.APPEND)
+        .withMinimumGenerationId(0L)
+        .withGenerationId(1L)
+        .withSyncId(2L)
 }

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/command/DestinationStreamUTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/command/DestinationStreamUTest.kt
@@ -53,8 +53,8 @@ class DestinationStreamUTest {
 
         val stream = a_stream_factory().make(configuredStream)
 
-        assertEquals(stream.matchingKey, emptyList())
         assertNull(stream.destinationObjectName)
+        assertNull(stream.matchingKey)
     }
 
     @Test

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/command/DestinationStreamUTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/command/DestinationStreamUTest.kt
@@ -10,7 +10,6 @@ import io.airbyte.protocol.models.v0.CatalogHelpers
 import io.airbyte.protocol.models.v0.ConfiguredAirbyteStream
 import io.airbyte.protocol.models.v0.DestinationSyncMode
 import io.airbyte.protocol.models.v0.Field
-import io.airbyte.protocol.models.v0.SyncMode
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import kotlin.test.assertEquals
@@ -60,9 +59,15 @@ class DestinationStreamUTest {
 
     @Test
     fun `test given destination object name when make then assemble matching keys`() {
-        val configuredStream = a_configured_stream()
-            .withDestinationObjectName(A_DESTINATION_OBJECT_NAME)
-            .withPrimaryKey(listOf<List<String>>(listOf<String>("composite_key_1"), listOf<String>("composite_key_2")))
+        val configuredStream =
+            a_configured_stream()
+                .withDestinationObjectName(A_DESTINATION_OBJECT_NAME)
+                .withPrimaryKey(
+                    listOf<List<String>>(
+                        listOf<String>("composite_key_1"),
+                        listOf<String>("composite_key_2")
+                    )
+                )
 
         val stream = a_stream_factory().make(configuredStream)
 
@@ -72,37 +77,49 @@ class DestinationStreamUTest {
 
     @Test
     fun `test given primary key is nested when make then throw error`() {
-        val configuredStream = a_configured_stream()
-            .withDestinationObjectName(A_DESTINATION_OBJECT_NAME)
-            .withPrimaryKey(listOf<List<String>>(listOf<String>("nested_key_root", "nested_key_leaf")))
+        val configuredStream =
+            a_configured_stream()
+                .withDestinationObjectName(A_DESTINATION_OBJECT_NAME)
+                .withPrimaryKey(
+                    listOf<List<String>>(listOf<String>("nested_key_root", "nested_key_leaf"))
+                )
 
-        assertFailsWith<IllegalArgumentException>(block = { a_stream_factory().make(configuredStream) })
+        assertFailsWith<IllegalArgumentException>(
+            block = { a_stream_factory().make(configuredStream) }
+        )
     }
 
     @Test
     fun `test given primary key has empty key when make then throw error`() {
-        val configuredStream = a_configured_stream()
-            .withDestinationObjectName(A_DESTINATION_OBJECT_NAME)
-            .withPrimaryKey(listOf<List<String>>(listOf<String>("composite_key_1"), listOf<String>()))
+        val configuredStream =
+            a_configured_stream()
+                .withDestinationObjectName(A_DESTINATION_OBJECT_NAME)
+                .withPrimaryKey(
+                    listOf<List<String>>(listOf<String>("composite_key_1"), listOf<String>())
+                )
 
-        assertFailsWith<IllegalArgumentException>(block = { a_stream_factory().make(configuredStream) })
+        assertFailsWith<IllegalArgumentException>(
+            block = { a_stream_factory().make(configuredStream) }
+        )
     }
 
-    private fun a_stream_factory(): DestinationStreamFactory = DestinationStreamFactory(
-        JsonSchemaToAirbyteType(JsonSchemaToAirbyteType.UnionBehavior.DEFAULT),
-        namespaceMapper = NamespaceMapper(),
-    )
-
-    private fun a_configured_stream(): ConfiguredAirbyteStream = ConfiguredAirbyteStream()
-        .withStream(
-            CatalogHelpers.createAirbyteStream(
-                "a_stream_name",
-                "namespace",
-                Field.of("field_name", JsonSchemaType.STRING),
-            ),
+    private fun a_stream_factory(): DestinationStreamFactory =
+        DestinationStreamFactory(
+            JsonSchemaToAirbyteType(JsonSchemaToAirbyteType.UnionBehavior.DEFAULT),
+            namespaceMapper = NamespaceMapper(),
         )
-        .withDestinationSyncMode(DestinationSyncMode.APPEND)
-        .withMinimumGenerationId(0L)
-        .withGenerationId(1L)
-        .withSyncId(2L)
+
+    private fun a_configured_stream(): ConfiguredAirbyteStream =
+        ConfiguredAirbyteStream()
+            .withStream(
+                CatalogHelpers.createAirbyteStream(
+                    "a_stream_name",
+                    "namespace",
+                    Field.of("field_name", JsonSchemaType.STRING),
+                ),
+            )
+            .withDestinationSyncMode(DestinationSyncMode.APPEND)
+            .withMinimumGenerationId(0L)
+            .withGenerationId(1L)
+            .withSyncId(2L)
 }


### PR DESCRIPTION
## What
In order for Data Activation destinations to work, they need to have access to the fields that were added to the protocol [here](https://github.com/airbytehq/airbyte-protocol/pull/130). The logic is that if there is a destination object, then we should provide both `destinationObjectName` and `matchingKeys`.

## How
Improving the factory to consider those two fields..

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
This will unblock further work on Data Activation destinations

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
