### PR TITLE
Destination bigquery: revert to 2.10.2

### DIFF
--- a/airbyte-integrations/connectors/destination-bigquery/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-bigquery/metadata.yaml
@@ -17,8 +17,10 @@ data:
     baseImage: docker.io/airbyte/java-connector-base:2.0.1@sha256:ec89bd1a89e825514dd2fc8730ba299a3ae1544580a078df0e35c5202c2085b3
   registryOverrides:
     cloud:
+      dockerImageTag: 2.10.2
       enabled: true
     oss:
+      dockerImageTag: 2.10.2
       enabled: true
   releaseStage: generally_available
   releases:


### PR DESCRIPTION
we're seeing some connections faililng spuriously with a `Input was fully read, but some streams did not receive a terminal stream status message` error.

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._

> [!NOTE]
> **Auto-merge may have been disabled. Please check the PR status to confirm.**