### PR TITLE
Destination bigquery: fix build; really roll back

### DIFF
--- a/airbyte-cdk/bulk/toolkits/load-db/src/main/kotlin/io/airbyte/cdk/load/orchestration/db/legacy_typing_deduping/AlterTableReport.kt
+++ b/airbyte-cdk/bulk/toolkits/load-db/src/main/kotlin/io/airbyte/cdk/load/orchestration/db/legacy_typing_deduping/AlterTableReport.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.load.orchestration.db.legacy_typing_deduping
+
+data class AlterTableReport(
+    val columnsToAdd: Set<String>,
+    val columnsToRemove: Set<String>,
+    val columnsToChangeType: Set<String>,
+) {
+    /**
+     * A no-op for an AlterTableReport is when the existing table matches the expected schema
+     *
+     * @return whether the schema matches
+     */
+    val isNoOp =
+        columnsToAdd.isEmpty() && columnsToRemove.isEmpty() && columnsToChangeType.isEmpty()
+}

--- a/airbyte-integrations/connectors/destination-bigquery/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-bigquery/metadata.yaml
@@ -17,6 +17,7 @@ data:
     baseImage: docker.io/airbyte/java-connector-base:2.0.1@sha256:ec89bd1a89e825514dd2fc8730ba299a3ae1544580a078df0e35c5202c2085b3
   registryOverrides:
     cloud:
+      # rolling back b/c of spurious "no stream status" error
       dockerImageTag: 2.10.2
       enabled: true
     oss:

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/typing_deduping/BigqueryDatabaseInitialStatusGatherer.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/typing_deduping/BigqueryDatabaseInitialStatusGatherer.kt
@@ -13,10 +13,13 @@ import com.google.cloud.bigquery.TableDefinition
 import com.google.cloud.bigquery.TableId
 import com.google.cloud.bigquery.TimePartitioning
 import com.google.common.annotations.VisibleForTesting
+import io.airbyte.cdk.ConfigErrorException
 import io.airbyte.cdk.load.command.Append
 import io.airbyte.cdk.load.command.Dedupe
 import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.command.Overwrite
+import io.airbyte.cdk.load.command.SoftDelete
+import io.airbyte.cdk.load.command.Update
 import io.airbyte.cdk.load.message.Meta
 import io.airbyte.cdk.load.orchestration.db.ColumnNameMapping
 import io.airbyte.cdk.load.orchestration.db.DatabaseInitialStatusGatherer
@@ -270,6 +273,8 @@ class BigqueryDatabaseInitialStatusGatherer(private val bq: BigQuery) :
                         .primaryKey
                         .map { pk -> columnNameMapping[pk.first()]!! }
                         .toSet()
+                SoftDelete,
+                Update -> throw ConfigErrorException("Unsupported sync mode: ${stream.importType}")
             }
         }
     }


### PR DESCRIPTION
first commit just undeletes a file, second commit is just forcing CI to run against dest-bigquery

third commit is to satisfy the compiler, since we added some new sync modes for DA

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._