### PR TITLE
Feat:(Source-Google-Sheets) - Add Stream Name  Override Options

### DIFF
--- a/airbyte-integrations/connectors/source-google-sheets/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-sheets/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: file
   connectorType: source
   definitionId: 71607ba1-c0ac-4799-8049-7f4b90dd50f7
-  dockerImageTag: 0.10.0
+  dockerImageTag: 0.11.0
   dockerRepository: airbyte/source-google-sheets
   documentationUrl: https://docs.airbyte.com/integrations/sources/google-sheets
   githubIssueLabel: source-google-sheets

--- a/airbyte-integrations/connectors/source-google-sheets/pyproject.toml
+++ b/airbyte-integrations/connectors/source-google-sheets/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "0.10.0"
+version = "0.11.0"
 name = "source-google-sheets"
 description = "Source implementation for Google Sheets."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-google-sheets/source_google_sheets/components/extractors.py
+++ b/airbyte-integrations/connectors/source-google-sheets/source_google_sheets/components/extractors.py
@@ -13,7 +13,6 @@ from airbyte_cdk.sources.declarative.extractors.dpath_extractor import DpathExtr
 from airbyte_cdk.sources.declarative.interpolation.interpolated_string import InterpolatedString
 from airbyte_cdk.sources.types import Config
 from source_google_sheets.utils import (
-    name_conversion,
     safe_name_conversion,
     safe_sanitzation_conversion,
 )
@@ -80,14 +79,14 @@ class RawSchemaParser:
             "combine_letter_number_pairs": config.get("combine_letter_number_pairs", False),
             "allow_leading_numbers": config.get("allow_leading_numbers", False),
         }
-        use_granular = any(flags.values())
+        use_sanitzation = any(flags.values())
 
         for property_index, raw_schema_property in enumerate(raw_schema_properties):
             raw_schema_property_value = self._extract_data(raw_schema_property, key_pointer)
             if not raw_schema_property_value or raw_schema_property_value.isspace():
                 break
-            # Use granular if any flag is set, else legacy
-            if names_conversion and use_granular:
+            # Use sanitzation if any flag is set, else legacy
+            if names_conversion and use_sanitzation:
                 raw_schema_property_value = safe_sanitzation_conversion(raw_schema_property_value, **flags)
             elif names_conversion:
                 raw_schema_property_value = safe_name_conversion(raw_schema_property_value)

--- a/airbyte-integrations/connectors/source-google-sheets/source_google_sheets/manifest.yaml
+++ b/airbyte-integrations/connectors/source-google-sheets/source_google_sheets/manifest.yaml
@@ -107,21 +107,13 @@ dynamic_streams:
             - name
           type: ComponentMappingDefinition
           # Expression is structured as: <value_if_true> if <condition> else <value_if_false>
-          # This sets the stream name to the custom name from stream_name_overrides if a match is found, otherwise uses the original sheet/tab name.
+          # This sets the stream name to the custom name from stream_name_overrides if a match is found,
+          # otherwise uses the original sheet/tab name.
           value: >-
-            {{
-              (
-                config.get('stream_name_overrides', [])
+            {%- set overrides = config.get('stream_name_overrides', [])
                 | selectattr('source_stream_name', 'equalto', components_values['properties']['title'])
-                | list
-              )[0]['custom_stream_name']
-              if (
-                config.get('stream_name_overrides', [])
-                | selectattr('source_stream_name', 'equalto', components_values['properties']['title'])
-                | list
-              )
-              else components_values['properties']['title']
-            }}
+                | list -%}
+            {{ overrides[0]['custom_stream_name'] if overrides else components_values['properties']['title'] }}
           value_type: string
           description: name for dynamic stream (with optional override).
         - field_path:
@@ -173,30 +165,6 @@ dynamic_streams:
           type: ComponentMappingDefinition
           value: "{{config.get('batch_size', 1000000)}}"
           description: batch size count for dynamic stream partition router (slicer).
-        - field_path:
-            - $parameters
-            - primary_key
-          type: ComponentMappingDefinition
-          # This Jinja2 block sets the primary key for each stream.
-          # It first resolves the stream name, using the override from config if present, otherwise the original sheet/tab name.
-          # The PK is then set at the end: {{ [] }}
-
-          value: >-
-            {%- set resolved_stream_name = (
-              (
-                config.get('stream_name_overrides', [])
-                | selectattr('source_stream_name', 'equalto', components_values['properties']['title'])
-                | list
-              )[0]['custom_stream_name']
-              if (
-                config.get('stream_name_overrides', [])
-                | selectattr('source_stream_name', 'equalto', components_values['properties']['title'])
-                | list
-              )
-              else components_values['properties']['title']
-            ) -%}
-            {{ [] }}
-          description: Primary key for the stream.
 
 definitions:
   streams:

--- a/airbyte-integrations/connectors/source-google-sheets/source_google_sheets/manifest.yaml
+++ b/airbyte-integrations/connectors/source-google-sheets/source_google_sheets/manifest.yaml
@@ -14,7 +14,6 @@ dynamic_streams:
       name: ""
       $parameters:
         i: 123
-        primary_key: []
       primary_key: []
       retriever:
         type: SimpleRetriever

--- a/airbyte-integrations/connectors/source-google-sheets/source_google_sheets/manifest.yaml
+++ b/airbyte-integrations/connectors/source-google-sheets/source_google_sheets/manifest.yaml
@@ -105,9 +105,22 @@ dynamic_streams:
         - field_path:
             - name
           type: ComponentMappingDefinition
-          value: "{{components_values['properties']['title']}}"
+          value: >-
+            {{
+              (
+                config.get('stream_name_overrides', [])
+                | selectattr('source_stream_name', 'equalto', components_values['properties']['title'])
+                | list
+              )[0]['custom_stream_name']
+              if (
+                config.get('stream_name_overrides', [])
+                | selectattr('source_stream_name', 'equalto', components_values['properties']['title'])
+                | list
+              )
+              else components_values['properties']['title']
+            }}
           value_type: string
-          description: name for dynamic stream.
+          description: name for dynamic stream (with optional override).
         - field_path:
             - schema_loader
             - retriever

--- a/airbyte-integrations/connectors/source-google-sheets/source_google_sheets/manifest.yaml
+++ b/airbyte-integrations/connectors/source-google-sheets/source_google_sheets/manifest.yaml
@@ -14,7 +14,8 @@ dynamic_streams:
       name: ""
       $parameters:
         i: 123
-      primary_key: []
+        primary_key: []
+      primary_key: "{{parameters['primary_key']}}"
       retriever:
         type: SimpleRetriever
         $parameters:
@@ -172,6 +173,30 @@ dynamic_streams:
           type: ComponentMappingDefinition
           value: "{{config.get('batch_size', 1000000)}}"
           description: batch size count for dynamic stream partition router (slicer).
+        - field_path:
+            - $parameters
+            - primary_key
+          type: ComponentMappingDefinition
+          # This Jinja2 block sets the primary key for each stream.
+          # It first resolves the stream name, using the override from config if present, otherwise the original sheet/tab name.
+          # The PK is then set at the end: {{ [] }}
+
+          value: >-
+            {%- set resolved_stream_name = (
+              (
+                config.get('stream_name_overrides', [])
+                | selectattr('source_stream_name', 'equalto', components_values['properties']['title'])
+                | list
+              )[0]['custom_stream_name']
+              if (
+                config.get('stream_name_overrides', [])
+                | selectattr('source_stream_name', 'equalto', components_values['properties']['title'])
+                | list
+              )
+              else components_values['properties']['title']
+            ) -%}
+            {{ [] }}
+          description: Primary key for the stream.
 
 definitions:
   streams:

--- a/airbyte-integrations/connectors/source-google-sheets/source_google_sheets/manifest.yaml
+++ b/airbyte-integrations/connectors/source-google-sheets/source_google_sheets/manifest.yaml
@@ -105,6 +105,8 @@ dynamic_streams:
         - field_path:
             - name
           type: ComponentMappingDefinition
+          # Expression is structured as: <value_if_true> if <condition> else <value_if_false>
+          # This sets the stream name to the custom name from stream_name_overrides if a match is found, otherwise uses the original sheet/tab name.
           value: >-
             {{
               (

--- a/airbyte-integrations/connectors/source-google-sheets/source_google_sheets/manifest.yaml
+++ b/airbyte-integrations/connectors/source-google-sheets/source_google_sheets/manifest.yaml
@@ -15,7 +15,7 @@ dynamic_streams:
       $parameters:
         i: 123
         primary_key: []
-      primary_key: "{{parameters['primary_key']}}"
+      primary_key: []
       retriever:
         type: SimpleRetriever
         $parameters:

--- a/airbyte-integrations/connectors/source-google-sheets/source_google_sheets/spec.yaml
+++ b/airbyte-integrations/connectors/source-google-sheets/source_google_sheets/spec.yaml
@@ -135,12 +135,18 @@ connectionSpecification:
       type: array
       title: Stream Name Overrides
       description: >-
+        **Overridden streams will default to Sync Mode: Full Refresh (Append), which does not support primary keys. If you want to use primary keys and deduplication, update the sync mode to "Full Refresh | Overwrite + Deduped" in your connection settings.**
+
         Allows you to rename streams (Google Sheet tab names) as they appear in Airbyte. 
+
         Each item should be an object with a `source_stream_name` (the exact name of the sheet/tab in your spreadsheet) 
         and a `custom_stream_name` (the name you want it to appear as in Airbyte and the destination).
+
         If a `source_stream_name` is not found in your spreadsheet, it will be ignored and the default name will be used.
         This feature only affects stream (sheet/tab) names, not field/column names.
+
         If you want to rename fields or column names, you can do so using the Airbyte Mappings feature after your connection is created. See the Airbyte documentation for more details on how to use Mappings.
+
         Examples:
           - To rename a sheet called "Sheet1" to "sales_data", and "2024 Q1" to "q1_2024":
             [

--- a/airbyte-integrations/connectors/source-google-sheets/source_google_sheets/spec.yaml
+++ b/airbyte-integrations/connectors/source-google-sheets/source_google_sheets/spec.yaml
@@ -21,6 +21,7 @@ connectionSpecification:
         otherwise the request returns a timeout error. In regards to this information, consider network speed and
         number of columns of the google sheet when deciding a batch_size value.
       default: 1000000
+      order: 1
     spreadsheet_id:
       type: string
       title: Spreadsheet Link
@@ -28,6 +29,7 @@ connectionSpecification:
         Enter the link to the Google spreadsheet you want to sync. To copy the link, click the 'Share' button in the top-right corner of the spreadsheet, then click 'Copy link'.
       examples:
         - https://docs.google.com/spreadsheets/d/1hLd9Qqti3UyLXZB2aFfUWDT7BG-arw2xy4HR3D-dwUb/edit
+      order: 0
     names_conversion:
       type: boolean
       title: Convert Column Names to SQL-Compliant Format
@@ -35,6 +37,7 @@ connectionSpecification:
         Converts column names to a SQL-compliant format (snake_case, lowercase, etc).
         If enabled, you can further customize the sanitization using the options below.
       default: false
+      order: 2
     remove_leading_trailing_underscores:
       type: boolean
       title: Remove Leading and Trailing Underscores
@@ -43,6 +46,7 @@ connectionSpecification:
         Example: "50th Percentile? "→ "_50_th_percentile"
         This option will only work if "Convert Column Names to SQL-Compliant Format (names_conversion)" is enabled.
       default: false
+      order: 3
     combine_number_word_pairs:
       type: boolean
       title: Combine Number-Word Pairs
@@ -51,6 +55,7 @@ connectionSpecification:
         Example: "50th Percentile?" → "_50th_percentile_"
         This option will only work if "Convert Column Names to SQL-Compliant Format (names_conversion)" is enabled.
       default: false
+      order: 4
     remove_special_characters:
       type: boolean
       title: Remove All Special Characters
@@ -59,6 +64,7 @@ connectionSpecification:
         Example: "Example ID*" → "example_id"
         This option will only work if "Convert Column Names to SQL-Compliant Format (names_conversion)" is enabled.
       default: false
+      order: 5
     combine_letter_number_pairs:
       type: boolean
       title: Combine Letter-Number Pairs
@@ -67,6 +73,7 @@ connectionSpecification:
         Example: "Q3 2023" → "q3_2023"
         This option will only work if "Convert Column Names to SQL-Compliant Format (names_conversion)" is enabled.
       default: false
+      order: 6
     allow_leading_numbers:
       type: boolean
       title: Allow Leading Numbers
@@ -75,6 +82,7 @@ connectionSpecification:
         Example: "50th Percentile" → "50_th_percentile"
         This option will only work if "Convert Column Names to SQL-Compliant Format (names_conversion)" is enabled.
       default: false
+      order: 7
     credentials:
       type: object
       title: Authentication
@@ -123,6 +131,40 @@ connectionSpecification:
               airbyte_secret: true
               examples:
                 - '{ "type": "service_account", "project_id": YOUR_PROJECT_ID, "private_key_id": YOUR_PRIVATE_KEY, ... }'
+    stream_name_overrides:
+      type: array
+      title: Stream Name Overrides
+      description: >-
+        Allows you to rename streams (Google Sheet tab names) as they appear in Airbyte. 
+        Each item should be an object with a `source_stream_name` (the exact name of the sheet/tab in your spreadsheet) 
+        and a `custom_stream_name` (the name you want it to appear as in Airbyte and the destination).
+        If a `source_stream_name` is not found in your spreadsheet, it will be ignored and the default name will be used.
+        This feature only affects stream (sheet/tab) names, not field/column names.
+        If you want to rename fields or column names, you can do so using the Airbyte Mappings feature after your connection is created. See the Airbyte documentation for more details on how to use Mappings.
+        Examples:
+          - To rename a sheet called "Sheet1" to "sales_data", and "2024 Q1" to "q1_2024":
+            [
+              { "source_stream_name": "Sheet1", "custom_stream_name": "sales_data" },
+              { "source_stream_name": "2024 Q1", "custom_stream_name": "q1_2024" }
+            ]
+          - If you do not wish to rename any streams, leave this blank.
+      items:
+        type: object
+        required:
+          - source_stream_name
+          - custom_stream_name
+        properties:
+          source_stream_name:
+            type: string
+            title: Source Stream Name
+            description: The exact name of the sheet/tab in your Google Spreadsheet.
+            order: 0
+          custom_stream_name:
+            type: string
+            title: Custom Stream Name
+            description: The name you want this stream to appear as in Airbyte and your destination.
+            order: 1
+        order: 8
 advanced_auth:
   auth_flow_type: oauth2.0
   predicate_key:

--- a/docs/integrations/sources/google-sheets.md
+++ b/docs/integrations/sources/google-sheets.md
@@ -131,6 +131,38 @@ If your spreadsheet is viewable by anyone with its link, no further action is ne
 
 ## Configuration Options
 
+### Stream Name Overrides (Rename Sheet/Stream Names)
+
+The Google Sheets connector allows you to optionally rename streams (sheet/tab names) as they appear in Airbyte and your destination. This is useful if your sheet names are not descriptive, contain special characters, or you want to standardize naming across sources.
+
+#### How it works
+
+- You can provide a list of overrides, each specifying a `source_stream_name` (the exact name of the sheet/tab in your spreadsheet) and a `custom_stream_name` (the name you want it to appear as in Airbyte and your destination).
+- If a `source_stream_name` is not found in your spreadsheet, it will be ignored and the default name will be used.
+- This feature only affects stream (sheet/tab) names, not field/column names.
+- If you want to rename fields or column names, you can do so using the Airbyte Mappings feature after your connection is created. See the Airbyte [documentation](https://docs.airbyte.com/platform/using-airbyte/mappings) for more details on how to use Mappings.
+- Renaming occurs before any other name conversion or sanitization options.
+
+#### Example
+
+Suppose your spreadsheet has sheets named `Sheet1`, `2024 Q1`, and `Summary`. You want to rename them to `sales_data`, `q1_2024`, and leave `Summary` unchanged. You would configure:
+
+```json
+[
+  { "source_stream_name": "Sheet1", "custom_stream_name": "sales_data" },
+  { "source_stream_name": "2024 Q1", "custom_stream_name": "q1_2024" }
+]
+```
+
+After discovery, your streams in Airbyte will be named `sales_data`, `q1_2024`, and `Summary`.
+
+#### How to configure
+
+- In the Airbyte UI, add your overrides in the **Stream Name Overrides** field as an array of objects.
+- If you do not wish to rename any streams, leave this field blank.
+
+---
+
 ### Google Sheets Connector Column Name Conversion
 
 The Google Sheets connector offers options to customize how column names from your spreadsheet are converted to be SQL-compliant. These settings can be configured in the Airbyte UI when setting up the connector.
@@ -179,8 +211,8 @@ The following options allow you to fine-tune the column name conversion process.
   - **Description**: Allows column names to start with numbers. If disabled, a leading underscore is added to column names that begin with a number.
   - **Example**:  
     - Input: `"50th Percentile"`  
-    - Output: `"50th_percentile"` (if enabled)  
-    - Output: `"_50th_percentile"` (if disabled)
+    - Output: `"50_th_percentile"` (if enabled)  
+    - Output: `"_50_th_percentile"` (if disabled)
   - **Default**: Off
 
 ---

--- a/docs/integrations/sources/google-sheets.md
+++ b/docs/integrations/sources/google-sheets.md
@@ -285,6 +285,7 @@ Airbyte batches requests to the API in order to efficiently pull data and respec
 
 | Version    | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |------------|------------|----------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 0.11.0 | 2025-06-09 | [61489](https://github.com/airbytehq/airbyte/pull/61489) | Feature: Added Streeam Name Override Options|
 | 0.10.0 | 2025-06-09 | [60836](https://github.com/airbytehq/airbyte/pull/60836) | Feature: Added additional sanitization flags when using Convert Column Names to SQL-Compliant Format (names_conversion)|
 | 0.9.6 | 2025-05-22 | [60874](https://github.com/airbytehq/airbyte/pull/60874) | Use custom backoff policy on 429 errors for single sheets |
 | 0.9.5 | 2025-05-13 | [60259](https://github.com/airbytehq/airbyte/pull/60259) | Fix whitespaces used for column names when enabling `names_conversion`|

--- a/docs/integrations/sources/google-sheets.md
+++ b/docs/integrations/sources/google-sheets.md
@@ -160,6 +160,8 @@ After discovery, your streams in Airbyte will be named `sales_data`, `q1_2024`, 
 
 - In the Airbyte UI, add your overrides in the **Stream Name Overrides** field as an array of objects.
 - If you do not wish to rename any streams, leave this field blank.
+- **After adding or changing a stream name override, refresh your schema in Airbyte to see the new stream names take effect.**
+- **Overridden streams will default to Sync Mode: Full Refresh (Append), which does not support primary keys. If you want to use primary keys and deduplication, update the sync mode to "Full Refresh | Overwrite + Deduped" in your connection settings.**
 
 ---
 
@@ -285,7 +287,7 @@ Airbyte batches requests to the API in order to efficiently pull data and respec
 
 | Version    | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |------------|------------|----------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 0.11.0 | 2025-06-10 | [61489](https://github.com/airbytehq/airbyte/pull/61489) | Feature: Added Streeam Name Override Options|
+| 0.11.0 | 2025-06-11 | [61489](https://github.com/airbytehq/airbyte/pull/61489) | Feature: Added Streeam Name Override Options|
 | 0.10.0 | 2025-06-09 | [60836](https://github.com/airbytehq/airbyte/pull/60836) | Feature: Added additional sanitization flags when using Convert Column Names to SQL-Compliant Format (names_conversion)|
 | 0.9.6 | 2025-05-22 | [60874](https://github.com/airbytehq/airbyte/pull/60874) | Use custom backoff policy on 429 errors for single sheets |
 | 0.9.5 | 2025-05-13 | [60259](https://github.com/airbytehq/airbyte/pull/60259) | Fix whitespaces used for column names when enabling `names_conversion`|

--- a/docs/integrations/sources/google-sheets.md
+++ b/docs/integrations/sources/google-sheets.md
@@ -285,7 +285,7 @@ Airbyte batches requests to the API in order to efficiently pull data and respec
 
 | Version    | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |------------|------------|----------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 0.11.0 | 2025-06-09 | [61489](https://github.com/airbytehq/airbyte/pull/61489) | Feature: Added Streeam Name Override Options|
+| 0.11.0 | 2025-06-10 | [61489](https://github.com/airbytehq/airbyte/pull/61489) | Feature: Added Streeam Name Override Options|
 | 0.10.0 | 2025-06-09 | [60836](https://github.com/airbytehq/airbyte/pull/60836) | Feature: Added additional sanitization flags when using Convert Column Names to SQL-Compliant Format (names_conversion)|
 | 0.9.6 | 2025-05-22 | [60874](https://github.com/airbytehq/airbyte/pull/60874) | Use custom backoff policy on 429 errors for single sheets |
 | 0.9.5 | 2025-05-13 | [60259](https://github.com/airbytehq/airbyte/pull/60259) | Fix whitespaces used for column names when enabling `names_conversion`|


### PR DESCRIPTION

## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->
Follow-up Feature Request to: https://github.com/airbytehq/oncall/issues/7901
Request the ability to rename the streams since they cannot control what users decide to name their sheets. 
## How
<!--
* Describe how code changes achieve the solution.
-->
Added `stream_name_overrides` as an optional config option when creating the source. An array of objects. Each object contains:
source_stream_name (string) - to search for the existing stream (sheet) name provided by GSheets
custom_stream_name (string) - allow the user to enter the desired stream name for this sheet.

The way we process Stream names is defined in the manifest inside of `components_resolver`, here we added a Jijna Expression to override the `source_stream_name` with the `custom_stream_name` if we get a match. Otherwise, we default to the existing stream name.

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
