### PR TITLE
Bulk load CDK: better exception handling in input loop

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/state/SyncManager.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/state/SyncManager.kt
@@ -123,7 +123,7 @@ class SyncManager(
         if (incompleteStreams.isNotEmpty()) {
             val prettyStreams = incompleteStreams.map { it.toPrettyString() }
             throw TransientErrorException(
-                "Input was fully read, but some streams did not receive a terminal stream status message. This likely indicates an error in the source or platform. Streams without a status message: $prettyStreams"
+                "Input was fully read, but some streams did not receive a terminal stream status message. If the destination did not encounter other errors, this likely indicates an error in the source or platform. Streams without a status message: $prettyStreams"
             )
         }
         inputConsumed.complete(true)

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/InputConsumerTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/InputConsumerTask.kt
@@ -138,14 +138,13 @@ class InputConsumerTask(
                 // because that would cause the sync to hang.
                 pipelineEventBookkeepingRouter.close()
             } catch (t: Throwable) {
-                if (processingThrowable == null) {
-                    throw t
-                } else {
+                processingThrowable?.let {
                     log.warn(t) {
                         "Encountered exception when closing PipelineEventBookkeepingRouter, but we're already handling another exception ($processingThrowable). Swallowing this exception."
                     }
                     throw processingThrowable
                 }
+                    ?: throw t
             }
             // if the `pipelineEventBookkeepingRouter.close()` ran successfully,
             // we should rethrow the original exception.

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/util/CoroutineUtils.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/util/CoroutineUtils.kt
@@ -10,11 +10,29 @@ interface CloseableCoroutine {
     suspend fun close()
 }
 
-suspend fun <T : CloseableCoroutine, R> T.use(block: suspend (T) -> R) =
+// this is taken almost verbatim from kotlin's AutoCloseable?.use implementation,
+// but with `suspend` modifiers added.
+suspend inline fun <T : CloseableCoroutine, R> T.use(block: (T) -> R): R {
+    var exception: Throwable? = null
     try {
-        block(this)
+        return block(this)
+    } catch (e: Throwable) {
+        exception = e
+        throw e
     } finally {
-        close()
+        this.closeFinally(exception)
+    }
+}
+
+suspend inline fun CloseableCoroutine.closeFinally(cause: Throwable?): Unit =
+    when {
+        cause == null -> close()
+        else ->
+            try {
+                close()
+            } catch (closeException: Throwable) {
+                cause.addSuppressed(closeException)
+            }
     }
 
 /** Set the latch exactly once. Return true iff this is the first time we've set it. */

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/state/SyncManagerTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/state/SyncManagerTest.kt
@@ -137,7 +137,7 @@ class SyncManagerTest {
         val e = assertThrows<TransientErrorException> { syncManager.markInputConsumed() }
         assertEquals(
             // stream1 is fine, so the message only includes stream2
-            "Input was fully read, but some streams did not receive a terminal stream status message. This likely indicates an error in the source or platform. Streams without a status message: [test.stream2]",
+            "Input was fully read, but some streams did not receive a terminal stream status message. If the destination did not encounter other errors, this likely indicates an error in the source or platform. Streams without a status message: [test.stream2]",
             e.message
         )
     }

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/internal/InputConsumerTaskTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/internal/InputConsumerTaskTest.kt
@@ -32,13 +32,11 @@ import io.mockk.coVerifySequence
 import io.mockk.impl.annotations.MockK
 import io.mockk.mockk
 import java.util.concurrent.ConcurrentLinkedQueue
-import kotlin.test.assertEquals
 import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 
 class InputConsumerTaskTest {
     companion object {

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/internal/InputConsumerTaskTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/internal/InputConsumerTaskTest.kt
@@ -336,20 +336,4 @@ class InputConsumerTaskTest {
 
         assertThrows(IllegalStateException::class) { task.execute() }
     }
-
-    @Test
-    fun testInputErrorThrowsOriginalError() = runTest {
-        val bookkeeper =
-            mockk<PipelineEventBookkeepingRouter> {
-                coEvery { close() } throws RuntimeException("blah blah no stream status")
-            }
-        val e =
-            assertThrows<RuntimeException> {
-                InputConsumerTask.closePipelineEventBookkeepingRouter(
-                    bookkeeper,
-                    RuntimeException("original exception"),
-                )
-            }
-        assertEquals("original exception", e.message)
-    }
 }

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/internal/InputConsumerTaskUTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/internal/InputConsumerTaskUTest.kt
@@ -31,6 +31,9 @@ import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
+// TODO merge this class into InputConsumerTaskTest.
+//   There are historical reasons that these are separate classes, but those
+//   reasons are no longer true.
 class InputConsumerTaskUTest {
     @MockK lateinit var catalog: DestinationCatalog
     @MockK lateinit var inputFlow: ReservingDeserializingInputFlow

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/util/CoroutineUtilsKtTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/util/CoroutineUtilsKtTest.kt
@@ -31,7 +31,13 @@ class CloseableCoroutineTest {
                     throw RuntimeException("exception in close")
                 }
             }
-        val e = assertThrows<RuntimeException> { closeable.use { 42 } }
+        val e =
+            assertThrows<RuntimeException> {
+                closeable.use {
+                    // `close` will throw an exception, so we never actually use this value.
+                    @Suppress("UNUSED_EXPRESSION") 42
+                }
+            }
         assertEquals("exception in close", e.message)
     }
 

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/util/CoroutineUtilsKtTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/util/CoroutineUtilsKtTest.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.load.util
+
+import io.mockk.Runs
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.just
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class CloseableCoroutineTest {
+    @Test
+    fun testCloseCleanly() = runTest {
+        val closeable = mockk<CloseableCoroutine> { coEvery { close() } just Runs }
+        val ret = closeable.use { 42 }
+        assertEquals(42, ret)
+        coVerify { closeable.close() }
+    }
+
+    @Test
+    fun testCloseThrows() = runTest {
+        val closeable =
+            object : CloseableCoroutine {
+                override suspend fun close() {
+                    throw RuntimeException("exception in close")
+                }
+            }
+        val e = assertThrows<RuntimeException> { closeable.use { 42 } }
+        assertEquals("exception in close", e.message)
+    }
+
+    @Test
+    fun testCloseableThrowsAndCloseThrows() = runTest {
+        val closeable =
+            object : CloseableCoroutine {
+                override suspend fun close() {
+                    throw RuntimeException("exception in close")
+                }
+            }
+        val e =
+            assertThrows<RuntimeException> {
+                closeable.use { throw RuntimeException("exception in block") }
+            }
+        assertEquals("exception in block", e.message)
+        assertEquals(listOf("exception in close"), e.suppressedExceptions.map { it.message })
+    }
+}

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/write/BasicFunctionalityIntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/write/BasicFunctionalityIntegrationTest.kt
@@ -3639,7 +3639,7 @@ abstract class BasicFunctionalityIntegrationTest(
         private val timestamptzType = FieldType(TimestampTypeWithTimezone, nullable = true)
     }
 
-    private fun checkpointKeyForMedium(): CheckpointKey? {
+    fun checkpointKeyForMedium(): CheckpointKey? {
         return when (dataChannelMedium) {
             DataChannelMedium.STDIO -> null
             DataChannelMedium.SOCKET -> CheckpointKey(CheckpointIndex(1), CheckpointId("1"))


### PR DESCRIPTION
not sure this is the right approach - maybe better to refactor stuff so that `pipelineEventBookkeepingRouter.close()` doesn't itself throw? but I'm not sure how hard that would be.

just copy the stdlib's `AutoCloseable.use` implementation.

previous behavior: if you had any exception in the input loop, this sequence would happen:
1. the `pipelineEventBookkeepingRouter.use` call would bail out, and you'd go to the `finally` block (i.e. call `pipelineEventBookkeepingRouter.close()`)
2. `pipelineEventBookkeepingRouter.close()` would then _also_ throw an exception, because we probably didn't read all the input (and therefore didn't read the stream success message, so we'd crash with `no stream status message blah blah blah`)
3. the JVM then actually _drops_ the original exception, and we _only_ throw the `no stream status` exception

new behavior: we'll emit a trace message like this: (note the `suppressed` `no stream status` exception at the bottom)
```
io.airbyte.protocol.models.v0.AirbyteErrorTraceMessage@48d2603b[message=Stream not found: Descriptor(namespace=potato, name=tomato),internalMessage=java.lang.IllegalArgumentException: Stream not found: Descriptor(namespace=potato, name=tomato),stackTrace=java.lang.IllegalArgumentException: Stream not found: Descriptor(namespace=potato, name=tomato)
	at io.airbyte.cdk.load.command.DestinationCatalog.getStream(DestinationCatalog.kt:49)
	at io.airbyte.cdk.load.message.DestinationMessageFactory.fromAirbyteStreamState(DestinationMessageFactory.kt:215)
	at io.airbyte.cdk.load.message.DestinationMessageFactory.fromAirbyteProtocolMessage(DestinationMessageFactory.kt:152)
	at io.airbyte.cdk.load.message.ProtocolMessageDeserializer.deserialize(DestinationMessageDeserializer.kt:50)
	at io.airbyte.cdk.load.task.internal.ReservingDeserializingInputFlow.collect(ReservingDeserializingInputFlow.kt:46)
	at io.airbyte.cdk.load.task.internal.InputConsumerTask.execute(InputConsumerTask.kt:120)
	at io.airbyte.cdk.load.task.DestinationTaskLauncher$WrappedTask.execute(DestinationTaskLauncher.kt:124)
	at io.airbyte.cdk.load.task.TaskScopeProvider$launch$job$1.invokeSuspend(TaskScopeProvider.kt:35)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith$$$capture(ContinuationImpl.kt:33)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:104)
	at kotlinx.coroutines.internal.LimitedDispatcher$Worker.run(LimitedDispatcher.kt:111)
	at kotlinx.coroutines.scheduling.TaskImpl.run(Tasks.kt:99)
	at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:584)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:811)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:715)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:702)
	Suppressed: io.airbyte.cdk.TransientErrorException: Input was fully read, but some streams did not receive a terminal stream status message. If the destination did not encounter other errors, this likely indicates an error in the source or platform. Streams without a status message: [test20250610eVzm.test_stream]
		at io.airbyte.cdk.load.state.SyncManager.markInputConsumed(SyncManager.kt:125)
		at io.airbyte.cdk.load.state.PipelineEventBookkeepingRouter.close(PipelineEventBookkeepingRouter.kt:242)
		at io.airbyte.cdk.load.task.internal.InputConsumerTask.execute(InputConsumerTask.kt:133)
		... 11 more
,failureType=system_error,streamDescriptor=<null>,additionalProperties={}]
```