### PR TITLE
feat: add load-dlq toolkit

### DIFF
--- a/airbyte-cdk/bulk/toolkits/load-dlq/build.gradle
+++ b/airbyte-cdk/bulk/toolkits/load-dlq/build.gradle
@@ -1,0 +1,8 @@
+dependencies {
+    implementation project(':airbyte-cdk:bulk:core:bulk-cdk-core-base')
+    implementation project(':airbyte-cdk:bulk:core:bulk-cdk-core-load')
+    api project(':airbyte-cdk:bulk:toolkits:bulk-cdk-toolkit-load-object-storage')
+    api project(':airbyte-cdk:bulk:toolkits:bulk-cdk-toolkit-load-s3')
+
+    testFixturesApi(testFixtures(project(":airbyte-cdk:bulk:toolkits:bulk-cdk-toolkit-load-object-storage")))
+}

--- a/airbyte-cdk/bulk/toolkits/load-dlq/src/main/kotlin/io/airbyte/cdk/load/pipeline/dlq/DlqLoaderPipelineStep.kt
+++ b/airbyte-cdk/bulk/toolkits/load-dlq/src/main/kotlin/io/airbyte/cdk/load/pipeline/dlq/DlqLoaderPipelineStep.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+ */
+
 package io.airbyte.cdk.load.pipeline.dlq
 
 import io.airbyte.cdk.load.message.BatchState
@@ -48,15 +52,11 @@ class DlqStepOutput(
     val rejectedRecords: List<DestinationRecordRaw>? = null,
 ) : WithBatchState
 
-/**
- * Wraps a [DlqLoader] into a [BatchAccumulator] so that it fits into a [LoadPipeline].
- */
+/** Wraps a [DlqLoader] into a [BatchAccumulator] so that it fits into a [LoadPipeline]. */
 class DlqLoaderAccumulator<S>(
     private val loader: DlqLoader<S>,
 ) : BatchAccumulator<S, StreamKey, DestinationRecordRaw, DlqStepOutput> {
-    /**
-     * Propagates the call to the [DlqLoader] in order to create a new state for a stream.
-     */
+    /** Propagates the call to the [DlqLoader] in order to create a new state for a stream. */
     override suspend fun start(key: StreamKey, part: Int): S = loader.start(key, part)
 
     /**
@@ -65,9 +65,9 @@ class DlqLoaderAccumulator<S>(
      * If the [DlqLoader] returns:
      * - [DlqLoader.Incomplete]: it assumes that no data was persisted, and continue with the
      * current state.
-     * - [DlqLoader.Complete]: it assumes that data was at least partially persisted. If no
-     * records are returned, it means that the upload was successful, the batch is complete since
-     * there are no data to write to the dead letter queue. The CDK should be able to persist the
+     * - [DlqLoader.Complete]: it assumes that data was at least partially persisted. If no records
+     * are returned, it means that the upload was successful, the batch is complete since there are
+     * no data to write to the dead letter queue. The CDK should be able to persist the
      * AirbyteState. On the other hand, if records are returned, they are sent to the
      * DeadLetterQueue and the BatchState is PERSISTED in order to let the CDK know that it
      * shouldn't ack the AirbyteState until those records are persisted in the DeadLetterQueue.
@@ -87,8 +87,9 @@ class DlqLoaderAccumulator<S>(
         return FinalOutput(getOutput(result.rejectedRecords))
     }
 
-    private fun getOutput(rejectedRecords: List<DestinationRecordRaw>?) = when (rejectedRecords) {
-        null -> DlqStepOutput(BatchState.COMPLETE, null)
-        else -> DlqStepOutput(BatchState.PERSISTED, rejectedRecords)
-    }
+    private fun getOutput(rejectedRecords: List<DestinationRecordRaw>?) =
+        when (rejectedRecords) {
+            null -> DlqStepOutput(BatchState.COMPLETE, null)
+            else -> DlqStepOutput(BatchState.PERSISTED, rejectedRecords)
+        }
 }

--- a/airbyte-cdk/bulk/toolkits/load-dlq/src/main/kotlin/io/airbyte/cdk/load/pipeline/dlq/DlqLoaderPipelineStep.kt
+++ b/airbyte-cdk/bulk/toolkits/load-dlq/src/main/kotlin/io/airbyte/cdk/load/pipeline/dlq/DlqLoaderPipelineStep.kt
@@ -1,0 +1,94 @@
+package io.airbyte.cdk.load.pipeline.dlq
+
+import io.airbyte.cdk.load.message.BatchState
+import io.airbyte.cdk.load.message.DestinationRecordRaw
+import io.airbyte.cdk.load.message.PartitionedQueue
+import io.airbyte.cdk.load.message.PipelineEvent
+import io.airbyte.cdk.load.message.StreamKey
+import io.airbyte.cdk.load.message.WithBatchState
+import io.airbyte.cdk.load.pipeline.BatchAccumulator
+import io.airbyte.cdk.load.pipeline.BatchAccumulatorResult
+import io.airbyte.cdk.load.pipeline.FinalOutput
+import io.airbyte.cdk.load.pipeline.LoadPipelineStep
+import io.airbyte.cdk.load.pipeline.NoOutput
+import io.airbyte.cdk.load.task.Task
+import io.airbyte.cdk.load.task.internal.LoadPipelineStepTaskFactory
+import io.airbyte.cdk.load.write.dlq.DlqLoader
+
+/**
+ * DeadLetterQueue Loader Pipeline Step.
+ *
+ * This is the first step of the dead letter queue pipeline that will wrap the destination
+ * implementer code.
+ */
+class DlqLoaderPipelineStep<S : AutoCloseable>(
+    override val numWorkers: Int,
+    private val taskFactory: LoadPipelineStepTaskFactory,
+    private val dlqLoader: DlqLoader<S>,
+    private val outputQueue: PartitionedQueue<PipelineEvent<StreamKey, DestinationRecordRaw>>,
+) : LoadPipelineStep {
+    override fun taskForPartition(partition: Int): Task {
+        return taskFactory.createFirstStep(
+            batchAccumulator = DlqLoaderAccumulator(dlqLoader),
+            outputPartitioner = PassThroughPartitioner(),
+            outputQueue = FlattenQueueAdapter(outputQueue),
+            part = partition,
+            numWorkers = numWorkers,
+        )
+    }
+}
+
+/**
+ * Part of the BatchAccumulator interface.
+ * - This implements [WithBatchState] in order to control checkpointing.
+ * - [rejectedRecords] are records meant for the DeadLetterQueue.
+ */
+class DlqStepOutput(
+    override val state: BatchState,
+    val rejectedRecords: List<DestinationRecordRaw>? = null,
+) : WithBatchState
+
+/**
+ * Wraps a [DlqLoader] into a [BatchAccumulator] so that it fits into a [LoadPipeline].
+ */
+class DlqLoaderAccumulator<S>(
+    private val loader: DlqLoader<S>,
+) : BatchAccumulator<S, StreamKey, DestinationRecordRaw, DlqStepOutput> {
+    /**
+     * Propagates the call to the [DlqLoader] in order to create a new state for a stream.
+     */
+    override suspend fun start(key: StreamKey, part: Int): S = loader.start(key, part)
+
+    /**
+     * Propagates the accept call to the [DlqLoader].
+     *
+     * If the [DlqLoader] returns:
+     * - [DlqLoader.Incomplete]: it assumes that no data was persisted, and continue with the
+     * current state.
+     * - [DlqLoader.Complete]: it assumes that data was at least partially persisted. If no
+     * records are returned, it means that the upload was successful, the batch is complete since
+     * there are no data to write to the dead letter queue. The CDK should be able to persist the
+     * AirbyteState. On the other hand, if records are returned, they are sent to the
+     * DeadLetterQueue and the BatchState is PERSISTED in order to let the CDK know that it
+     * shouldn't ack the AirbyteState until those records are persisted in the DeadLetterQueue.
+     */
+    override suspend fun accept(
+        input: DestinationRecordRaw,
+        state: S,
+    ): BatchAccumulatorResult<S, DlqStepOutput> {
+        return when (val result = loader.accept(input, state)) {
+            is DlqLoader.Incomplete -> NoOutput(state)
+            is DlqLoader.Complete -> FinalOutput(getOutput(result.rejectedRecords))
+        }
+    }
+
+    override suspend fun finish(state: S): FinalOutput<S, DlqStepOutput> {
+        val result = loader.finish(state)
+        return FinalOutput(getOutput(result.rejectedRecords))
+    }
+
+    private fun getOutput(rejectedRecords: List<DestinationRecordRaw>?) = when (rejectedRecords) {
+        null -> DlqStepOutput(BatchState.COMPLETE, null)
+        else -> DlqStepOutput(BatchState.PERSISTED, rejectedRecords)
+    }
+}

--- a/airbyte-cdk/bulk/toolkits/load-dlq/src/main/kotlin/io/airbyte/cdk/load/pipeline/dlq/FlattenQueueAdapter.kt
+++ b/airbyte-cdk/bulk/toolkits/load-dlq/src/main/kotlin/io/airbyte/cdk/load/pipeline/dlq/FlattenQueueAdapter.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+ */
+
 package io.airbyte.cdk.load.pipeline.dlq
 
 import io.airbyte.cdk.load.message.DestinationRecordRaw
@@ -18,7 +22,7 @@ import kotlinx.coroutines.flow.Flow
  */
 class FlattenQueueAdapter<K : WithStream>(
     private val queue: PartitionedQueue<PipelineEvent<K, DestinationRecordRaw>>,
-): PartitionedQueue<PipelineEvent<K, DlqStepOutput>> {
+) : PartitionedQueue<PipelineEvent<K, DlqStepOutput>> {
     override val partitions = queue.partitions
 
     override fun consume(partition: Int): Flow<PipelineEvent<K, DlqStepOutput>> {
@@ -47,8 +51,8 @@ class FlattenQueueAdapter<K : WithStream>(
         }
     }
 
-    private fun PipelineMessage<K, DlqStepOutput>.flatten()
-    : Iterable<PipelineMessage<K, DestinationRecordRaw>> =
+    private fun PipelineMessage<K, DlqStepOutput>.flatten():
+        Iterable<PipelineMessage<K, DestinationRecordRaw>> =
         value.rejectedRecords?.let { failedRecords ->
             val lastIndex = failedRecords.size - 1
             return failedRecords.mapIndexed { index, destinationRecordRaw ->
@@ -70,6 +74,6 @@ class FlattenQueueAdapter<K : WithStream>(
                     )
                 }
             }
-        } ?: emptyList()
-
+        }
+            ?: emptyList()
 }

--- a/airbyte-cdk/bulk/toolkits/load-dlq/src/main/kotlin/io/airbyte/cdk/load/pipeline/dlq/FlattenQueueAdapter.kt
+++ b/airbyte-cdk/bulk/toolkits/load-dlq/src/main/kotlin/io/airbyte/cdk/load/pipeline/dlq/FlattenQueueAdapter.kt
@@ -38,11 +38,7 @@ class FlattenQueueAdapter<K : WithStream>(
 
     override suspend fun broadcast(value: PipelineEvent<K, DlqStepOutput>) {
         when (value) {
-            is PipelineMessage -> value.flatten().forEach {
-                runBlocking {
-                    queue.broadcast(it)
-                }
-            }
+            is PipelineMessage -> value.flatten().forEach { runBlocking { queue.broadcast(it) } }
             is PipelineHeartbeat -> queue.broadcast(PipelineHeartbeat())
             is PipelineEndOfStream -> queue.broadcast(PipelineEndOfStream(value.stream))
         }
@@ -50,11 +46,8 @@ class FlattenQueueAdapter<K : WithStream>(
 
     override suspend fun publish(value: PipelineEvent<K, DlqStepOutput>, partition: Int) {
         when (value) {
-            is PipelineMessage -> value.flatten().forEach {
-                runBlocking {
-                    queue.publish(it, partition)
-                }
-            }
+            is PipelineMessage ->
+                value.flatten().forEach { runBlocking { queue.publish(it, partition) } }
             is PipelineHeartbeat -> queue.publish(PipelineHeartbeat(), partition)
             is PipelineEndOfStream -> queue.publish(PipelineEndOfStream(value.stream), partition)
         }

--- a/airbyte-cdk/bulk/toolkits/load-dlq/src/main/kotlin/io/airbyte/cdk/load/pipeline/dlq/FlattenQueueAdapter.kt
+++ b/airbyte-cdk/bulk/toolkits/load-dlq/src/main/kotlin/io/airbyte/cdk/load/pipeline/dlq/FlattenQueueAdapter.kt
@@ -57,6 +57,10 @@ class FlattenQueueAdapter<K : WithStream>(
         Iterable<PipelineMessage<K, DestinationRecordRaw>> =
         value.rejectedRecords?.let { failedRecords ->
             val lastIndex = failedRecords.size - 1
+            // In order to avoid duplicated counts, we push the checkpoint counts to the last
+            // record of the list.
+            // Same idea regarding the postProcessingCallback, to avoid having the callback called
+            // prematurely, we push it to the last record.
             return failedRecords.mapIndexed { index, destinationRecordRaw ->
                 if (index < lastIndex) {
                     PipelineMessage(

--- a/airbyte-cdk/bulk/toolkits/load-dlq/src/main/kotlin/io/airbyte/cdk/load/pipeline/dlq/FlattenQueueAdapter.kt
+++ b/airbyte-cdk/bulk/toolkits/load-dlq/src/main/kotlin/io/airbyte/cdk/load/pipeline/dlq/FlattenQueueAdapter.kt
@@ -1,0 +1,75 @@
+package io.airbyte.cdk.load.pipeline.dlq
+
+import io.airbyte.cdk.load.message.DestinationRecordRaw
+import io.airbyte.cdk.load.message.PartitionedQueue
+import io.airbyte.cdk.load.message.PipelineEndOfStream
+import io.airbyte.cdk.load.message.PipelineEvent
+import io.airbyte.cdk.load.message.PipelineHeartbeat
+import io.airbyte.cdk.load.message.PipelineMessage
+import io.airbyte.cdk.load.message.WithStream
+import io.airbyte.cdk.load.pipline.object_storage.ObjectLoaderPartFormatterStep
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Queue Adapter in order to be able to reuse existing ObjectStorage steps for the DeadLetterQueue.
+ *
+ * Because the [DlqLoader] may batch multiple records and the [ObjectLoaderPartFormatterStep]
+ * consumes record one by one, this Adapter flattens a list of [DestinationRecordRaw].
+ */
+class FlattenQueueAdapter<K : WithStream>(
+    private val queue: PartitionedQueue<PipelineEvent<K, DestinationRecordRaw>>,
+): PartitionedQueue<PipelineEvent<K, DlqStepOutput>> {
+    override val partitions = queue.partitions
+
+    override fun consume(partition: Int): Flow<PipelineEvent<K, DlqStepOutput>> {
+        throw IllegalStateException(
+            "Trying to consume from the adapter instead of the underlying queue"
+        )
+    }
+
+    override suspend fun close() {
+        queue.close()
+    }
+
+    override suspend fun broadcast(value: PipelineEvent<K, DlqStepOutput>) {
+        when (value) {
+            is PipelineMessage -> value.flatten().forEach { queue.broadcast(it) }
+            is PipelineHeartbeat -> queue.broadcast(PipelineHeartbeat())
+            is PipelineEndOfStream -> queue.broadcast(PipelineEndOfStream(value.stream))
+        }
+    }
+
+    override suspend fun publish(value: PipelineEvent<K, DlqStepOutput>, partition: Int) {
+        when (value) {
+            is PipelineMessage -> value.flatten().forEach { queue.publish(it, partition) }
+            is PipelineHeartbeat -> queue.publish(PipelineHeartbeat(), partition)
+            is PipelineEndOfStream -> queue.publish(PipelineEndOfStream(value.stream), partition)
+        }
+    }
+
+    private fun PipelineMessage<K, DlqStepOutput>.flatten()
+    : Iterable<PipelineMessage<K, DestinationRecordRaw>> =
+        value.rejectedRecords?.let { failedRecords ->
+            val lastIndex = failedRecords.size - 1
+            return failedRecords.mapIndexed { index, destinationRecordRaw ->
+                if (index < lastIndex) {
+                    PipelineMessage(
+                        checkpointCounts = emptyMap(),
+                        key = key,
+                        value = destinationRecordRaw,
+                        postProcessingCallback = null, // Should this be filled
+                        context = context,
+                    )
+                } else {
+                    PipelineMessage(
+                        checkpointCounts = checkpointCounts,
+                        key = key,
+                        value = destinationRecordRaw,
+                        postProcessingCallback = postProcessingCallback,
+                        context = context,
+                    )
+                }
+            }
+        } ?: emptyList()
+
+}

--- a/airbyte-cdk/bulk/toolkits/load-dlq/src/main/kotlin/io/airbyte/cdk/load/pipeline/dlq/PassThroughPartitioner.kt
+++ b/airbyte-cdk/bulk/toolkits/load-dlq/src/main/kotlin/io/airbyte/cdk/load/pipeline/dlq/PassThroughPartitioner.kt
@@ -1,0 +1,15 @@
+package io.airbyte.cdk.load.pipeline.dlq
+
+import io.airbyte.cdk.load.message.DestinationRecordRaw
+import io.airbyte.cdk.load.message.StreamKey
+import io.airbyte.cdk.load.pipeline.OutputPartitioner
+
+/**
+ * A partitioner that echoes the same partition as provided on the input.
+ */
+class PassThroughPartitioner
+    : OutputPartitioner<StreamKey, DestinationRecordRaw, StreamKey, DlqStepOutput> {
+    override fun getOutputKey(inputKey: StreamKey, output: DlqStepOutput): StreamKey = inputKey
+
+    override fun getPart(outputKey: StreamKey, inputPart: Int, numParts: Int): Int = inputPart
+}

--- a/airbyte-cdk/bulk/toolkits/load-dlq/src/main/kotlin/io/airbyte/cdk/load/pipeline/dlq/PassThroughPartitioner.kt
+++ b/airbyte-cdk/bulk/toolkits/load-dlq/src/main/kotlin/io/airbyte/cdk/load/pipeline/dlq/PassThroughPartitioner.kt
@@ -1,14 +1,16 @@
+/*
+ * Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+ */
+
 package io.airbyte.cdk.load.pipeline.dlq
 
 import io.airbyte.cdk.load.message.DestinationRecordRaw
 import io.airbyte.cdk.load.message.StreamKey
 import io.airbyte.cdk.load.pipeline.OutputPartitioner
 
-/**
- * A partitioner that echoes the same partition as provided on the input.
- */
-class PassThroughPartitioner
-    : OutputPartitioner<StreamKey, DestinationRecordRaw, StreamKey, DlqStepOutput> {
+/** A partitioner that echoes the same partition as provided on the input. */
+class PassThroughPartitioner :
+    OutputPartitioner<StreamKey, DestinationRecordRaw, StreamKey, DlqStepOutput> {
     override fun getOutputKey(inputKey: StreamKey, output: DlqStepOutput): StreamKey = inputKey
 
     override fun getPart(outputKey: StreamKey, inputPart: Int, numParts: Int): Int = inputPart

--- a/airbyte-cdk/bulk/toolkits/load-dlq/src/main/kotlin/io/airbyte/cdk/load/write/dlq/DlqLoader.kt
+++ b/airbyte-cdk/bulk/toolkits/load-dlq/src/main/kotlin/io/airbyte/cdk/load/write/dlq/DlqLoader.kt
@@ -1,0 +1,47 @@
+package io.airbyte.cdk.load.write.dlq
+
+import io.airbyte.cdk.load.message.DestinationRecordRaw
+import io.airbyte.cdk.load.message.StreamKey
+
+
+/**
+ * DeadLetterQueueLoader interface.
+ *
+ * A DeadLetterQueueLoader is a Loader that can return records for a dead letter queue.
+ *
+ * The Loader is expected to write the record into a destination. The batching strategy remains
+ * entirely up to the Loader implementation. To support batching, the Loader can declare its own
+ * state [S].
+ */
+interface DlqLoader<S> : AutoCloseable {
+
+    sealed interface DlqLoadResult
+    data object Incomplete: DlqLoadResult
+    data class Complete(val rejectedRecords: List<DestinationRecordRaw>? = null) : DlqLoadResult
+
+    /**
+     * Called when starting a batch.
+     */
+    fun start(key: StreamKey, part: Int): S
+
+    /**
+     * Accept is the main method called for every [record] to process.
+     * [state] is the current state associated with the record. Note that in this context,
+     * [state] refers to the output from the most recent [start] call. This is not an
+     * [AirbyteState].
+     *
+     * Returns
+     * - [Complete] if data was loaded completely. [accept] may return rejected records for the
+     * dead letter queue. Note that the CDK will only checkpoint when the all the records for a
+     * given AirbyteState are either loaded in the destination or written to the dead letter queue.
+     * - [Incomplete] if the record was staged.
+     */
+    fun accept(record: DestinationRecordRaw, state: S): DlqLoadResult
+
+    /**
+     * Called when the data needs to be persisted. The CDK will call this if data hasn't been
+     * persisted for a given amount of time or when under memory pressure in an attempt to
+     * reclaim some memory to continue processing.
+     */
+    fun finish(state: S): Complete
+}

--- a/airbyte-cdk/bulk/toolkits/load-dlq/src/main/kotlin/io/airbyte/cdk/load/write/dlq/DlqLoader.kt
+++ b/airbyte-cdk/bulk/toolkits/load-dlq/src/main/kotlin/io/airbyte/cdk/load/write/dlq/DlqLoader.kt
@@ -1,8 +1,11 @@
+/*
+ * Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+ */
+
 package io.airbyte.cdk.load.write.dlq
 
 import io.airbyte.cdk.load.message.DestinationRecordRaw
 import io.airbyte.cdk.load.message.StreamKey
-
 
 /**
  * DeadLetterQueueLoader interface.
@@ -16,32 +19,29 @@ import io.airbyte.cdk.load.message.StreamKey
 interface DlqLoader<S> : AutoCloseable {
 
     sealed interface DlqLoadResult
-    data object Incomplete: DlqLoadResult
+    data object Incomplete : DlqLoadResult
     data class Complete(val rejectedRecords: List<DestinationRecordRaw>? = null) : DlqLoadResult
 
-    /**
-     * Called when starting a batch.
-     */
+    /** Called when starting a batch. */
     fun start(key: StreamKey, part: Int): S
 
     /**
-     * Accept is the main method called for every [record] to process.
-     * [state] is the current state associated with the record. Note that in this context,
-     * [state] refers to the output from the most recent [start] call. This is not an
-     * [AirbyteState].
+     * Accept is the main method called for every [record] to process. [state] is the current state
+     * associated with the record. Note that in this context, [state] refers to the output from the
+     * most recent [start] call. This is not an [AirbyteState].
      *
      * Returns
-     * - [Complete] if data was loaded completely. [accept] may return rejected records for the
-     * dead letter queue. Note that the CDK will only checkpoint when the all the records for a
-     * given AirbyteState are either loaded in the destination or written to the dead letter queue.
+     * - [Complete] if data was loaded completely. [accept] may return rejected records for the dead
+     * letter queue. Note that the CDK will only checkpoint when the all the records for a given
+     * AirbyteState are either loaded in the destination or written to the dead letter queue.
      * - [Incomplete] if the record was staged.
      */
     fun accept(record: DestinationRecordRaw, state: S): DlqLoadResult
 
     /**
      * Called when the data needs to be persisted. The CDK will call this if data hasn't been
-     * persisted for a given amount of time or when under memory pressure in an attempt to
-     * reclaim some memory to continue processing.
+     * persisted for a given amount of time or when under memory pressure in an attempt to reclaim
+     * some memory to continue processing.
      */
     fun finish(state: S): Complete
 }

--- a/airbyte-cdk/bulk/toolkits/load-dlq/src/main/kotlin/io/airbyte/cdk/load/write/dlq/DlqPipelineFactory.kt
+++ b/airbyte-cdk/bulk/toolkits/load-dlq/src/main/kotlin/io/airbyte/cdk/load/write/dlq/DlqPipelineFactory.kt
@@ -78,11 +78,11 @@ class DlqPipelineFactoryFactory {
         @Named("globalMemoryManager") globalMemoryManager: ReservationManager
     ): PartitionedQueue<PipelineEvent<StreamKey, DestinationRecordRaw>> =
         ResourceReservingPartitionedQueue(
-            globalMemoryManager,
-            0.2,
-            1,
-            1,
-            100000,
+            reservationManager = globalMemoryManager,
+            ratioOfTotalMemoryToReserve = 0.2,
+            numConsumers = 1,
+            numProducers = 1,
+            expectedResourceUsagePerUnit = 100000,
         )
 
     /**
@@ -105,13 +105,13 @@ class DlqPipelineFactoryFactory {
         flushStrategy: PipelineFlushStrategy,
     ): ObjectLoaderPartFormatterStep =
         ObjectLoaderPartFormatterStep(
-            numInputPartitions,
-            partFormatter,
-            inputQueue.asOrderedFlows(),
-            outputQueue,
-            taskFactory,
-            "record-part-formatter-step",
-            flushStrategy,
+            numWorkers = numInputPartitions,
+            partFormatter = partFormatter,
+            inputFlows = inputQueue.asOrderedFlows(),
+            outputQueue = outputQueue,
+            taskFactory = taskFactory,
+            stepId = "record-part-formatter-step",
+            flushStrategy = flushStrategy,
         )
 
     /** References the traditional ObjectStorage pipeline steps. */

--- a/airbyte-cdk/bulk/toolkits/load-dlq/src/main/kotlin/io/airbyte/cdk/load/write/dlq/DlqPipelineFactory.kt
+++ b/airbyte-cdk/bulk/toolkits/load-dlq/src/main/kotlin/io/airbyte/cdk/load/write/dlq/DlqPipelineFactory.kt
@@ -1,0 +1,130 @@
+package io.airbyte.cdk.load.write.dlq
+
+import io.airbyte.cdk.load.file.object_storage.RemoteObject
+import io.airbyte.cdk.load.message.DestinationRecordRaw
+import io.airbyte.cdk.load.message.PartitionedQueue
+import io.airbyte.cdk.load.message.PipelineEvent
+import io.airbyte.cdk.load.message.ResourceReservingPartitionedQueue
+import io.airbyte.cdk.load.message.StreamKey
+import io.airbyte.cdk.load.message.WithStream
+import io.airbyte.cdk.load.pipeline.LoadPipeline
+import io.airbyte.cdk.load.pipeline.LoadPipelineStep
+import io.airbyte.cdk.load.pipeline.PipelineFlushStrategy
+import io.airbyte.cdk.load.pipeline.dlq.DlqLoaderPipelineStep
+import io.airbyte.cdk.load.pipline.object_storage.ObjectKey
+import io.airbyte.cdk.load.pipline.object_storage.ObjectLoaderPartFormatter
+import io.airbyte.cdk.load.pipline.object_storage.ObjectLoaderPartFormatterStep
+import io.airbyte.cdk.load.pipline.object_storage.ObjectLoaderPartLoaderStep
+import io.airbyte.cdk.load.pipline.object_storage.ObjectLoaderUploadCompleterStep
+import io.airbyte.cdk.load.state.ReservationManager
+import io.airbyte.cdk.load.task.internal.LoadPipelineStepTaskFactory
+import io.airbyte.cdk.load.write.object_storage.ObjectLoader
+import io.micronaut.context.annotation.Factory
+import jakarta.inject.Named
+import jakarta.inject.Singleton
+import java.io.OutputStream
+
+/**
+ * Factory to build a DeadLetterQueueLoadPipeline.
+ */
+class DlqPipelineFactory(
+    private val dlqInputQueue: PartitionedQueue<PipelineEvent<StreamKey, DestinationRecordRaw>>,
+    private val dlqPipelineSteps: List<LoadPipelineStep>,
+    private val pipelineStepTaskFactory: LoadPipelineStepTaskFactory,
+    private val objectLoader: ObjectLoader,
+) {
+    fun <S : AutoCloseable> createPipeline(dlqLoader: DlqLoader<S>): LoadPipeline =
+        object : LoadPipeline(
+            listOf(
+                DlqLoaderPipelineStep(
+                    numWorkers = objectLoader.numPartWorkers,
+                    outputQueue = dlqInputQueue,
+                    taskFactory = pipelineStepTaskFactory,
+                    dlqLoader = dlqLoader,
+                ),
+                *dlqPipelineSteps.toTypedArray(),
+            )
+        ) {}
+}
+
+/**
+ * A Micronaut Factory to help initialize the component required for a DeadLetterQueuePipeline
+ */
+@Factory
+class DlqPipelineFactoryFactory {
+    /**
+     * The end goal of this file.
+     */
+    @Singleton
+    fun dlqPipelineFactory(
+        @Named("dlqInputQueue") dlqInputQueue: PartitionedQueue<PipelineEvent<StreamKey,
+            DestinationRecordRaw>>,
+        @Named("dlqPipelineSteps") dlqPipelineSteps: List<LoadPipelineStep>,
+        pipelineStepTaskFactory: LoadPipelineStepTaskFactory,
+        objectLoader: ObjectLoader,
+    ) = DlqPipelineFactory(dlqInputQueue, dlqPipelineSteps, pipelineStepTaskFactory, objectLoader)
+
+    /**
+     * This queue is the input queue of a "traditional" ObjectStorageLoadPipeline
+     *
+     * Effectively, a DLQ LoadPipeline is a custom pipeline step that may pass down records
+     * meant for the DLQ. The DLQ LoadPipeline upload to ObjectStorage leverages the usual object
+     * storage pipeline steps with the exception of the input.
+     *
+     * This Queue is the shim between the DlqLoaderStep and the ObjectStorage input.
+     */
+    @Named("dlqInputQueue")
+    @Singleton
+    fun dlqInputQueue(
+        @Named("globalMemoryManager") globalMemoryManager: ReservationManager
+    ): PartitionedQueue<PipelineEvent<StreamKey, DestinationRecordRaw>> =
+        ResourceReservingPartitionedQueue(
+            globalMemoryManager,
+            0.2,
+            1,
+            1,
+            100000,
+        )
+
+    /**
+     * This is the start of the "traditional" object storage pipeline. However, in order for the
+     * updated pipeline to work, this recreates the ObjectLoaderPartFormatterStep but with the
+     * dlqInputQueue as in input instead of the actual input of the destination which is used by
+     * the DlqLoader in this case.
+     */
+    @Named("dlqRecordFormatterStep")
+    @Singleton
+    fun <T : OutputStream> partFormatterStep(
+        @Named("numInputPartitions") numInputPartitions: Int,
+        partFormatter: ObjectLoaderPartFormatter<T>,
+        @Named("dlqInputQueue") inputQueue: PartitionedQueue<PipelineEvent<StreamKey, DestinationRecordRaw>>,
+        @Named("objectLoaderPartQueue")
+        outputQueue: PartitionedQueue<PipelineEvent<ObjectKey, ObjectLoaderPartFormatter.FormattedPart>>,
+        taskFactory: LoadPipelineStepTaskFactory,
+        flushStrategy: PipelineFlushStrategy,
+    ): ObjectLoaderPartFormatterStep =
+        ObjectLoaderPartFormatterStep(
+            numInputPartitions,
+            partFormatter,
+            inputQueue.asOrderedFlows(),
+            outputQueue,
+            taskFactory,
+            "record-part-formatter-step",
+            flushStrategy,
+        )
+
+    /**
+     * References the traditional ObjectStorage pipeline steps.
+     */
+    @Named("dlqPipelineSteps")
+    @Singleton
+    fun <K : WithStream, T : RemoteObject<*>> dlqPipelineSteps(
+        @Named("dlqRecordFormatterStep") formatterStep: ObjectLoaderPartFormatterStep,
+        @Named("recordPartLoaderStep") loaderStep: ObjectLoaderPartLoaderStep<T>,
+        @Named("recordUploadCompleterStep") completerStep: ObjectLoaderUploadCompleterStep<K, T>,
+    ): List<LoadPipelineStep> = listOf(
+            formatterStep,
+            loaderStep,
+            completerStep,
+        )
+}

--- a/airbyte-cdk/bulk/toolkits/load-dlq/src/main/kotlin/io/airbyte/cdk/load/write/dlq/DlqPipelineFactory.kt
+++ b/airbyte-cdk/bulk/toolkits/load-dlq/src/main/kotlin/io/airbyte/cdk/load/write/dlq/DlqPipelineFactory.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+ */
+
 package io.airbyte.cdk.load.write.dlq
 
 import io.airbyte.cdk.load.file.object_storage.RemoteObject
@@ -24,9 +28,7 @@ import jakarta.inject.Named
 import jakarta.inject.Singleton
 import java.io.OutputStream
 
-/**
- * Factory to build a DeadLetterQueueLoadPipeline.
- */
+/** Factory to build a DeadLetterQueueLoadPipeline. */
 class DlqPipelineFactory(
     private val dlqInputQueue: PartitionedQueue<PipelineEvent<StreamKey, DestinationRecordRaw>>,
     private val dlqPipelineSteps: List<LoadPipelineStep>,
@@ -34,31 +36,28 @@ class DlqPipelineFactory(
     private val objectLoader: ObjectLoader,
 ) {
     fun <S : AutoCloseable> createPipeline(dlqLoader: DlqLoader<S>): LoadPipeline =
-        object : LoadPipeline(
-            listOf(
-                DlqLoaderPipelineStep(
-                    numWorkers = objectLoader.numPartWorkers,
-                    outputQueue = dlqInputQueue,
-                    taskFactory = pipelineStepTaskFactory,
-                    dlqLoader = dlqLoader,
-                ),
-                *dlqPipelineSteps.toTypedArray(),
-            )
-        ) {}
+        object :
+            LoadPipeline(
+                listOf(
+                    DlqLoaderPipelineStep(
+                        numWorkers = objectLoader.numPartWorkers,
+                        outputQueue = dlqInputQueue,
+                        taskFactory = pipelineStepTaskFactory,
+                        dlqLoader = dlqLoader,
+                    ),
+                    *dlqPipelineSteps.toTypedArray(),
+                )
+            ) {}
 }
 
-/**
- * A Micronaut Factory to help initialize the component required for a DeadLetterQueuePipeline
- */
+/** A Micronaut Factory to help initialize the component required for a DeadLetterQueuePipeline */
 @Factory
 class DlqPipelineFactoryFactory {
-    /**
-     * The end goal of this file.
-     */
+    /** The end goal of this file. */
     @Singleton
     fun dlqPipelineFactory(
-        @Named("dlqInputQueue") dlqInputQueue: PartitionedQueue<PipelineEvent<StreamKey,
-            DestinationRecordRaw>>,
+        @Named("dlqInputQueue")
+        dlqInputQueue: PartitionedQueue<PipelineEvent<StreamKey, DestinationRecordRaw>>,
         @Named("dlqPipelineSteps") dlqPipelineSteps: List<LoadPipelineStep>,
         pipelineStepTaskFactory: LoadPipelineStepTaskFactory,
         objectLoader: ObjectLoader,
@@ -67,9 +66,9 @@ class DlqPipelineFactoryFactory {
     /**
      * This queue is the input queue of a "traditional" ObjectStorageLoadPipeline
      *
-     * Effectively, a DLQ LoadPipeline is a custom pipeline step that may pass down records
-     * meant for the DLQ. The DLQ LoadPipeline upload to ObjectStorage leverages the usual object
-     * storage pipeline steps with the exception of the input.
+     * Effectively, a DLQ LoadPipeline is a custom pipeline step that may pass down records meant
+     * for the DLQ. The DLQ LoadPipeline upload to ObjectStorage leverages the usual object storage
+     * pipeline steps with the exception of the input.
      *
      * This Queue is the shim between the DlqLoaderStep and the ObjectStorage input.
      */
@@ -89,17 +88,19 @@ class DlqPipelineFactoryFactory {
     /**
      * This is the start of the "traditional" object storage pipeline. However, in order for the
      * updated pipeline to work, this recreates the ObjectLoaderPartFormatterStep but with the
-     * dlqInputQueue as in input instead of the actual input of the destination which is used by
-     * the DlqLoader in this case.
+     * dlqInputQueue as in input instead of the actual input of the destination which is used by the
+     * DlqLoader in this case.
      */
     @Named("dlqRecordFormatterStep")
     @Singleton
     fun <T : OutputStream> partFormatterStep(
         @Named("numInputPartitions") numInputPartitions: Int,
         partFormatter: ObjectLoaderPartFormatter<T>,
-        @Named("dlqInputQueue") inputQueue: PartitionedQueue<PipelineEvent<StreamKey, DestinationRecordRaw>>,
+        @Named("dlqInputQueue")
+        inputQueue: PartitionedQueue<PipelineEvent<StreamKey, DestinationRecordRaw>>,
         @Named("objectLoaderPartQueue")
-        outputQueue: PartitionedQueue<PipelineEvent<ObjectKey, ObjectLoaderPartFormatter.FormattedPart>>,
+        outputQueue:
+            PartitionedQueue<PipelineEvent<ObjectKey, ObjectLoaderPartFormatter.FormattedPart>>,
         taskFactory: LoadPipelineStepTaskFactory,
         flushStrategy: PipelineFlushStrategy,
     ): ObjectLoaderPartFormatterStep =
@@ -113,16 +114,15 @@ class DlqPipelineFactoryFactory {
             flushStrategy,
         )
 
-    /**
-     * References the traditional ObjectStorage pipeline steps.
-     */
+    /** References the traditional ObjectStorage pipeline steps. */
     @Named("dlqPipelineSteps")
     @Singleton
     fun <K : WithStream, T : RemoteObject<*>> dlqPipelineSteps(
         @Named("dlqRecordFormatterStep") formatterStep: ObjectLoaderPartFormatterStep,
         @Named("recordPartLoaderStep") loaderStep: ObjectLoaderPartLoaderStep<T>,
         @Named("recordUploadCompleterStep") completerStep: ObjectLoaderUploadCompleterStep<K, T>,
-    ): List<LoadPipelineStep> = listOf(
+    ): List<LoadPipelineStep> =
+        listOf(
             formatterStep,
             loaderStep,
             completerStep,


### PR DESCRIPTION
## What

Add `load-dlq`: the Dead Letter Queue Toolkit.

The `dlq` toolkit is a `Loader` that supports:
* loading into any destination, typically intended for an API destination where the implementer can decide to batch if it makes sense,
* return rejected records to be written into an object storage destination by leveraging the `load-object-storage` toolkit.

## How

This PR adds:
* `DlqLoader`, the abstraction for the implementer
* `DlqPipelineFactory`, a helper factory to build a complete DeadLetterQueue Pipeline from a `DlqLoader`
* some shims in order to be able to re-use the `load-object-storage` toolkit.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
