### PR TITLE
[BigQuery] Refactor Value validation and extract common code

### DIFF
--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/formatter/BigQueryRecordFormatter.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/formatter/BigQueryRecordFormatter.kt
@@ -145,10 +145,6 @@ class BigQueryRecordFormatter(
         // see https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types
         private val INT64_MIN_VALUE: BigInteger = BigInteger.valueOf(Long.MIN_VALUE)
         private val INT64_MAX_VALUE: BigInteger = BigInteger.valueOf(Long.MAX_VALUE)
-        private val NUMERIC_SCALE = BigDecimal("1e9")
-        val MAX_NUMERIC: BigDecimal = BigDecimal("1e38").minus(BigDecimal.ONE).divide(NUMERIC_SCALE)
-        val MIN_NUMERIC: BigDecimal = BigDecimal("-1e38").plus(BigDecimal.ONE).divide(NUMERIC_SCALE)
-
         private const val NUMERIC_MAX_PRECISION = 38
         private val DATE_MIN_VALUE = LocalDate.parse("0001-01-01")
         private val DATE_MAX_VALUE = LocalDate.parse("9999-12-31")

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/formatter/BigQueryRecordFormatter.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/formatter/BigQueryRecordFormatter.kt
@@ -243,7 +243,8 @@ class BigQueryRecordFormatter(
                     }
                 }
                 // Noting that we do not need to validate date / datetime with and without timezone
-                // ranges here since any issue would be caught earlier and would result in a nullification
+                // ranges here since any issue would be caught earlier and would result in a
+                // nullification
                 // with a DESTINATION_SERIALIZATION_ERROR reason. So checking again here does not
                 // add any value
                 else -> {}

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/formatter/BigQueryRecordFormatter.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/formatter/BigQueryRecordFormatter.kt
@@ -9,8 +9,6 @@ import com.google.cloud.bigquery.QueryParameterValue
 import com.google.cloud.bigquery.Schema
 import com.google.cloud.bigquery.StandardSQLTypeName
 import io.airbyte.cdk.load.command.DestinationStream
-import io.airbyte.cdk.load.data.DateType
-import io.airbyte.cdk.load.data.DateValue
 import io.airbyte.cdk.load.data.EnrichedAirbyteValue
 import io.airbyte.cdk.load.data.IntegerType
 import io.airbyte.cdk.load.data.IntegerValue
@@ -35,9 +33,6 @@ import io.airbyte.cdk.load.util.serializeToString
 import io.airbyte.integrations.destination.bigquery.write.typing_deduping.direct_load_tables.BigqueryDirectLoadSqlGenerator
 import io.airbyte.protocol.models.v0.AirbyteRecordMessageMetaChange.Reason
 import java.math.BigInteger
-import java.time.LocalDate
-import java.time.LocalDateTime
-import java.time.OffsetDateTime
 import java.time.format.DateTimeFormatter
 import java.util.concurrent.TimeUnit
 
@@ -145,12 +140,6 @@ class BigQueryRecordFormatter(
         private val INT64_MIN_VALUE: BigInteger = BigInteger.valueOf(Long.MIN_VALUE)
         private val INT64_MAX_VALUE: BigInteger = BigInteger.valueOf(Long.MAX_VALUE)
         private const val NUMERIC_MAX_PRECISION = 38
-        private val DATE_MIN_VALUE = LocalDate.parse("0001-01-01")
-        private val DATE_MAX_VALUE = LocalDate.parse("9999-12-31")
-        private val TIMESTAMP_MIN_VALUE = OffsetDateTime.parse("0001-01-01T00:00:00Z")
-        private val TIMESTAMP_MAX_VALUE = OffsetDateTime.parse("9999-12-31T23:59:59.999999Z")
-        private val DATETIME_MIN_VALUE = LocalDateTime.parse("0001-01-01T00:00:00")
-        private val DATETIME_MAX_VALUE = LocalDateTime.parse("9999-12-31T23:59:59.999999")
 
         private val DATETIME_WITH_TIMEZONE_FORMATTER: DateTimeFormatter =
             DateTimeFormatter.ISO_OFFSET_DATE_TIME
@@ -253,27 +242,10 @@ class BigQueryRecordFormatter(
                         }
                     }
                 }
-                is DateType -> {
-                    (value.abValue as DateValue).value.let {
-                        if (it < DATE_MIN_VALUE || DATE_MAX_VALUE < it) {
-                            value.nullify(Reason.DESTINATION_FIELD_SIZE_LIMITATION)
-                        }
-                    }
-                }
-                is TimestampTypeWithTimezone -> {
-                    (value.abValue as TimestampWithTimezoneValue).value.let {
-                        if (it < TIMESTAMP_MIN_VALUE || TIMESTAMP_MAX_VALUE < it) {
-                            value.nullify(Reason.DESTINATION_FIELD_SIZE_LIMITATION)
-                        }
-                    }
-                }
-                is TimestampTypeWithoutTimezone -> {
-                    (value.abValue as TimestampWithoutTimezoneValue).value.let {
-                        if (it < DATETIME_MIN_VALUE || DATETIME_MAX_VALUE < it) {
-                            value.nullify(Reason.DESTINATION_FIELD_SIZE_LIMITATION)
-                        }
-                    }
-                }
+                // Noting that we do not need to validate date / datetime with and without timezone
+                // ranges here since any issue would be caught earlier and would result in a nullification
+                // with a DESTINATION_SERIALIZATION_ERROR reason. So checking again here does not
+                // add any value
                 else -> {}
             }
         }

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/formatter/BigQueryRecordFormatter.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/formatter/BigQueryRecordFormatter.kt
@@ -256,10 +256,13 @@ class BigQueryRecordFormatter(
                 // NOTE: This validation is currently unreachable because our coercion logic in
                 // AirbyteValueCoercer already rejects date/time values outside supported ranges
                 // via DATE_TIME_FORMATTER and TIME_FORMATTER, the Meta change reason will therefore
-                // always be DESTINATION_SERIALIZATION_ERROR instead of DESTINATION_FIELD_SIZE_LIMITATION.
+                // always be DESTINATION_SERIALIZATION_ERROR instead of
+                // DESTINATION_FIELD_SIZE_LIMITATION.
                 //
-                // However, we're planning to expand the supported date/time range in the coercion layer,
-                // which will make this validation relevant again. Keeping this code for that future change.
+                // However, we're planning to expand the supported date/time range in the coercion
+                // layer,
+                // which will make this validation relevant again. Keeping this code for that future
+                // change.
                 is DateType -> {
                     (value.abValue as DateValue).value.let {
                         if (it < DATE_MIN_VALUE || DATE_MAX_VALUE < it) {

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/formatter/BigQueryRecordFormatter.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/formatter/BigQueryRecordFormatter.kt
@@ -34,7 +34,6 @@ import io.airbyte.cdk.load.util.Jsons
 import io.airbyte.cdk.load.util.serializeToString
 import io.airbyte.integrations.destination.bigquery.write.typing_deduping.direct_load_tables.BigqueryDirectLoadSqlGenerator
 import io.airbyte.protocol.models.v0.AirbyteRecordMessageMetaChange.Reason
-import java.math.BigDecimal
 import java.math.BigInteger
 import java.time.LocalDate
 import java.time.LocalDateTime

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/formatter/BigQueryRecordFormatter.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/formatter/BigQueryRecordFormatter.kt
@@ -257,12 +257,11 @@ class BigQueryRecordFormatter(
                 // AirbyteValueCoercer already rejects date/time values outside supported ranges
                 // via DATE_TIME_FORMATTER and TIME_FORMATTER, the Meta change reason will therefore
                 // always be DESTINATION_SERIALIZATION_ERROR instead of
-                // DESTINATION_FIELD_SIZE_LIMITATION.
+                // DESTINATION_FIELD_SIZE_LIMITATION for now.
                 //
                 // However, we're planning to expand the supported date/time range in the coercion
-                // layer,
-                // which will make this validation relevant again. Keeping this code for that future
-                // change.
+                // layer, which will make this validation relevant again. Keeping this code for
+                // that future change.
                 is DateType -> {
                     (value.abValue as DateValue).value.let {
                         if (it < DATE_MIN_VALUE || DATE_MAX_VALUE < it) {

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/formatter/BigQueryRecordFormatter.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/formatter/BigQueryRecordFormatter.kt
@@ -143,8 +143,8 @@ class BigQueryRecordFormatter(
 
     companion object {
         // see https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types
-        val INT64_MIN_VALUE: BigInteger = BigInteger.valueOf(Long.MIN_VALUE)
-        val INT64_MAX_VALUE: BigInteger = BigInteger.valueOf(Long.MAX_VALUE)
+        private val INT64_MIN_VALUE: BigInteger = BigInteger.valueOf(Long.MIN_VALUE)
+        private val INT64_MAX_VALUE: BigInteger = BigInteger.valueOf(Long.MAX_VALUE)
         private val NUMERIC_SCALE = BigDecimal("1e9")
         val MAX_NUMERIC: BigDecimal = BigDecimal("1e38").minus(BigDecimal.ONE).divide(NUMERIC_SCALE)
         val MIN_NUMERIC: BigDecimal = BigDecimal("-1e38").plus(BigDecimal.ONE).divide(NUMERIC_SCALE)

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/bulk_loader/BigQueryCSVRowGenerator.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/bulk_loader/BigQueryCSVRowGenerator.kt
@@ -30,6 +30,7 @@ import io.airbyte.integrations.destination.bigquery.formatter.BigQueryRecordForm
 import io.airbyte.integrations.destination.bigquery.formatter.BigQueryRecordFormatter.Companion.formatTimeWithoutTimezone
 import io.airbyte.integrations.destination.bigquery.formatter.BigQueryRecordFormatter.Companion.formatTimestampWithTimezone
 import io.airbyte.integrations.destination.bigquery.formatter.BigQueryRecordFormatter.Companion.formatTimestampWithoutTimezone
+import io.airbyte.integrations.destination.bigquery.formatter.BigQueryRecordFormatter.Companion.validateAirbyteValue
 import io.airbyte.protocol.models.v0.AirbyteRecordMessageMetaChange.Reason
 import java.math.BigDecimal
 import java.math.BigInteger
@@ -76,6 +77,8 @@ class BigQueryCSVRowGenerator {
             if (value.abValue is NullValue) {
                 return@forEach
             }
+            validateAirbyteValue(value)
+
             val actualValue = value.abValue
             when (value.type) {
                 // Enforce numeric range

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/bulk_loader/BigQueryCSVRowGenerator.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/bulk_loader/BigQueryCSVRowGenerator.kt
@@ -47,9 +47,6 @@ class BigQueryCSVRowGenerator {
 
             val actualValue = value.abValue
             when (value.type) {
-                is BooleanType ->
-                    value.abValue =
-                        if ((actualValue as BooleanValue).value) LIMITS.TRUE else LIMITS.FALSE
                 is TimestampTypeWithTimezone ->
                     value.abValue = StringValue(formatTimestampWithTimezone(value))
                 is TimestampTypeWithoutTimezone ->

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/bulk_loader/BigQueryCSVRowGenerator.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/bulk_loader/BigQueryCSVRowGenerator.kt
@@ -7,12 +7,8 @@ package io.airbyte.integrations.destination.bigquery.write.bulk_loader
 import io.airbyte.cdk.load.data.ArrayType
 import io.airbyte.cdk.load.data.BooleanType
 import io.airbyte.cdk.load.data.BooleanValue
-import io.airbyte.cdk.load.data.EnrichedAirbyteValue
-import io.airbyte.cdk.load.data.IntegerType
 import io.airbyte.cdk.load.data.IntegerValue
 import io.airbyte.cdk.load.data.NullValue
-import io.airbyte.cdk.load.data.NumberType
-import io.airbyte.cdk.load.data.NumberValue
 import io.airbyte.cdk.load.data.ObjectType
 import io.airbyte.cdk.load.data.StringValue
 import io.airbyte.cdk.load.data.TimeTypeWithTimezone
@@ -25,45 +21,15 @@ import io.airbyte.cdk.load.data.csv.toCsvValue
 import io.airbyte.cdk.load.message.DestinationRecordRaw
 import io.airbyte.cdk.load.util.serializeToString
 import io.airbyte.integrations.destination.bigquery.BigQueryConsts
-import io.airbyte.integrations.destination.bigquery.formatter.BigQueryRecordFormatter
 import io.airbyte.integrations.destination.bigquery.formatter.BigQueryRecordFormatter.Companion.formatTimeWithTimezone
 import io.airbyte.integrations.destination.bigquery.formatter.BigQueryRecordFormatter.Companion.formatTimeWithoutTimezone
 import io.airbyte.integrations.destination.bigquery.formatter.BigQueryRecordFormatter.Companion.formatTimestampWithTimezone
 import io.airbyte.integrations.destination.bigquery.formatter.BigQueryRecordFormatter.Companion.formatTimestampWithoutTimezone
 import io.airbyte.integrations.destination.bigquery.formatter.BigQueryRecordFormatter.Companion.validateAirbyteValue
-import io.airbyte.protocol.models.v0.AirbyteRecordMessageMetaChange.Reason
-import java.math.BigDecimal
-import java.math.BigInteger
 
 object LIMITS {
     val TRUE = IntegerValue(1)
     val FALSE = IntegerValue(0)
-
-    fun validateNumber(value: EnrichedAirbyteValue): BigDecimal? {
-        val numValue = (value.abValue as NumberValue).value
-        return if (
-            numValue < BigQueryRecordFormatter.MIN_NUMERIC ||
-                BigQueryRecordFormatter.MAX_NUMERIC < numValue
-        ) {
-            value.nullify(Reason.DESTINATION_FIELD_SIZE_LIMITATION)
-            null
-        } else {
-            numValue
-        }
-    }
-
-    fun validateInteger(value: EnrichedAirbyteValue): BigInteger? {
-        val intValue = (value.abValue as IntegerValue).value
-        return if (
-            intValue < BigQueryRecordFormatter.INT64_MIN_VALUE ||
-                BigQueryRecordFormatter.INT64_MAX_VALUE < intValue
-        ) {
-            value.nullify(Reason.DESTINATION_FIELD_SIZE_LIMITATION)
-            null
-        } else {
-            intValue
-        }
-    }
 }
 
 class BigQueryCSVRowGenerator {
@@ -81,9 +47,6 @@ class BigQueryCSVRowGenerator {
 
             val actualValue = value.abValue
             when (value.type) {
-                // Enforce numeric range
-                is IntegerType -> LIMITS.validateInteger(value)
-                is NumberType -> LIMITS.validateNumber(value)
                 is BooleanType ->
                     value.abValue =
                         if ((actualValue as BooleanValue).value) LIMITS.TRUE else LIMITS.FALSE

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/bulk_loader/BigQueryCSVRowGenerator.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/bulk_loader/BigQueryCSVRowGenerator.kt
@@ -25,11 +25,6 @@ import io.airbyte.integrations.destination.bigquery.formatter.BigQueryRecordForm
 import io.airbyte.integrations.destination.bigquery.formatter.BigQueryRecordFormatter.Companion.formatTimestampWithoutTimezone
 import io.airbyte.integrations.destination.bigquery.formatter.BigQueryRecordFormatter.Companion.validateAirbyteValue
 
-object LIMITS {
-    val TRUE = IntegerValue(1)
-    val FALSE = IntegerValue(0)
-}
-
 class BigQueryCSVRowGenerator {
     fun generate(record: DestinationRecordRaw, schema: ObjectType): List<Any> {
         val enrichedRecord =

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/bulk_loader/BigQueryCSVRowGenerator.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/bulk_loader/BigQueryCSVRowGenerator.kt
@@ -5,7 +5,6 @@
 package io.airbyte.integrations.destination.bigquery.write.bulk_loader
 
 import io.airbyte.cdk.load.data.ArrayType
-import io.airbyte.cdk.load.data.IntegerValue
 import io.airbyte.cdk.load.data.NullValue
 import io.airbyte.cdk.load.data.ObjectType
 import io.airbyte.cdk.load.data.StringValue

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/bulk_loader/BigQueryCSVRowGenerator.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/bulk_loader/BigQueryCSVRowGenerator.kt
@@ -5,8 +5,6 @@
 package io.airbyte.integrations.destination.bigquery.write.bulk_loader
 
 import io.airbyte.cdk.load.data.ArrayType
-import io.airbyte.cdk.load.data.BooleanType
-import io.airbyte.cdk.load.data.BooleanValue
 import io.airbyte.cdk.load.data.IntegerValue
 import io.airbyte.cdk.load.data.NullValue
 import io.airbyte.cdk.load.data.ObjectType

--- a/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryWriteTest.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryWriteTest.kt
@@ -4,8 +4,24 @@
 
 package io.airbyte.integrations.destination.bigquery
 
+import io.airbyte.cdk.load.command.Append
+import io.airbyte.cdk.load.command.DestinationStream
+import io.airbyte.cdk.load.data.BooleanType
+import io.airbyte.cdk.load.data.DateType
+import io.airbyte.cdk.load.data.FieldType
+import io.airbyte.cdk.load.data.IntegerType
+import io.airbyte.cdk.load.data.NumberType
+import io.airbyte.cdk.load.data.ObjectType
+import io.airbyte.cdk.load.data.StringType
+import io.airbyte.cdk.load.data.TimeTypeWithTimezone
+import io.airbyte.cdk.load.data.TimeTypeWithoutTimezone
+import io.airbyte.cdk.load.data.TimestampTypeWithTimezone
+import io.airbyte.cdk.load.data.TimestampTypeWithoutTimezone
+import io.airbyte.cdk.load.message.InputRecord
+import io.airbyte.cdk.load.message.Meta
 import io.airbyte.cdk.load.test.util.DestinationDataDumper
 import io.airbyte.cdk.load.test.util.ExpectedRecordMapper
+import io.airbyte.cdk.load.test.util.OutputRecord
 import io.airbyte.cdk.load.test.util.UncoercedExpectedRecordMapper
 import io.airbyte.cdk.load.toolkits.load.db.orchestration.ColumnNameModifyingMapper
 import io.airbyte.cdk.load.toolkits.load.db.orchestration.RootLevelTimestampsToUtcMapper
@@ -23,6 +39,10 @@ import io.airbyte.integrations.destination.bigquery.BigQueryDestinationTestUtils
 import io.airbyte.integrations.destination.bigquery.spec.BigquerySpecification
 import io.airbyte.integrations.destination.bigquery.spec.CdcDeletionMode
 import io.airbyte.integrations.destination.bigquery.write.typing_deduping.BigqueryColumnNameGenerator
+import io.airbyte.protocol.models.v0.AirbyteRecordMessageMetaChange.Change
+import io.airbyte.protocol.models.v0.AirbyteRecordMessageMetaChange.Reason
+import java.time.LocalDate
+import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.Test
 
 abstract class BigqueryWriteTest(
@@ -56,7 +76,76 @@ abstract class BigqueryWriteTest(
         nullEqualsUnset = nullEqualsUnset,
         configUpdater = BigqueryConfigUpdater,
         additionalMicronautEnvs = additionalMicronautEnvs,
-    )
+    ) {
+        @Test
+        fun testValidDatetimeRanges() {
+            assumeTrue(verifyDataWriting)
+            val stream =
+                DestinationStream(
+                    unmappedNamespace = randomizedNamespace,
+                    unmappedName = "test_stream",
+                    Append,
+                    ObjectType(
+                        linkedMapOf(
+                            "timestamp_with_timezone" to
+                                FieldType(TimestampTypeWithTimezone, nullable = true),
+                            "timestamp_without_timezone" to
+                                FieldType(TimestampTypeWithoutTimezone, nullable = true),
+                            "time_with_timezone" to FieldType(TimeTypeWithTimezone, nullable = true),
+                            "time_without_timezone" to
+                                FieldType(TimeTypeWithoutTimezone, nullable = true),
+                            "date" to FieldType(DateType, nullable = true),
+                        )
+                    ),
+                    generationId = 42,
+                    minimumGenerationId = 0,
+                    syncId = 42,
+                    namespaceMapper = namespaceMapperForMedium()
+                )
+
+            runSync(
+                updatedConfig,
+                stream,
+                listOf(
+                    InputRecord(
+                        stream,
+                        """
+                        {
+                          "timestamp_without_timezone": ${LocalDate.parse("19999-12-31")}
+                        }
+                    """.trimIndent(),
+                        emittedAtMs = 100,
+                    )
+                )
+            )
+
+            dumpAndDiffRecords(
+                parsedConfig,
+                listOf(
+                    OutputRecord(
+                        extractedAt = 100,
+                        generationId = 42,
+                        data = mapOf("timestamp_without_timezone" to listOf(42.0, null)),
+                        airbyteMeta =
+                            OutputRecord.Meta(
+                                syncId = 42,
+                                changes =
+                                    listOf(
+                                        Meta.Change(
+                                            "array.1",
+                                            Change.NULLED,
+                                            Reason.DESTINATION_SERIALIZATION_ERROR
+                                        )
+                                    )
+                            ),
+                    ),
+                ),
+                stream,
+                primaryKey = listOf(listOf("id")),
+                cursor = null,
+            )
+        }
+    }
 
 abstract class BigqueryRawTablesWriteTest(
     configContents: String,


### PR DESCRIPTION
## What

Refactor the Airbyte value validation to be able to extract / reuse code between `BigQueryRecordFormatter` and `BigQueryCSVRowGenerator`

## Can this PR be safely reverted and rolled back?
- [X] YES 💚
- [ ] NO ❌
