### PR TITLE
Bulk load CDK: fix testTruncateRefresh; fix direct-load generation_id fetch logic

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/IntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/IntegrationTest.kt
@@ -334,7 +334,7 @@ abstract class IntegrationTest(
             launch {
                 if (
                     destination is DockerizedDestination &&
-                        syncEndBehavior != UncleanSyncEndBehavior.KILL
+                        syncEndBehavior == UncleanSyncEndBehavior.KILL
                 ) {
                     // when you kill a docker process, it doesn't exit uncleanly apparently
                     destination.run()

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/destination_process/NonDockerizedDestination.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/destination_process/NonDockerizedDestination.kt
@@ -60,7 +60,7 @@ class NonDockerizedDestination(
     // The destination has a runBlocking inside WriteOperation.
     // This means that normal coroutine cancellation doesn't work.
     // So we start our own thread pool, which we can forcibly kill if needed.
-    private val executor = Executors.newSingleThreadExecutor()
+    private val executor = Executors.newFixedThreadPool(4)
     private val coroutineDispatcher = executor.asCoroutineDispatcher()
     private val file = File("/tmp/test_file")
     private val writeLock = Mutex()
@@ -142,8 +142,9 @@ class NonDockerizedDestination(
                             destination.results.traces(),
                             destination.results.states(),
                         )
+                    } finally {
+                        destinationComplete.complete(Unit)
                     }
-                    destinationComplete.complete(Unit)
                 }
             }
             .invokeOnCompletion { executor.shutdownNow() }

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/write/BasicFunctionalityIntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/write/BasicFunctionalityIntegrationTest.kt
@@ -533,7 +533,7 @@ abstract class BasicFunctionalityIntegrationTest(
                     namespaceMapper = namespaceMapperForMedium()
                 )
             val stateMessage =
-                runSyncUntilStateAck(
+                runSyncUntilStateAckAndExpectFailure(
                     this@BasicFunctionalityIntegrationTest.updatedConfig,
                     stream,
                     listOf(
@@ -550,7 +550,7 @@ abstract class BasicFunctionalityIntegrationTest(
                         sourceRecordCount = 1,
                         checkpointKey = checkpointKeyForMedium()
                     ),
-                    allowGracefulShutdown = false,
+                    syncEndBehavior = UncleanSyncEndBehavior.KILL,
                 )
             runSync(this@BasicFunctionalityIntegrationTest.updatedConfig, stream, emptyList())
 
@@ -923,21 +923,25 @@ abstract class BasicFunctionalityIntegrationTest(
         val finalStream = makeStream(generationId = 13, minimumGenerationId = 13, syncId = 43)
         // start a truncate refresh, but emit INCOMPLETE.
         // This should retain the existing data, and maybe insert the new record.
-        assertThrows<DestinationUncleanExitException> {
-            runSync(
-                updatedConfig,
+        runSyncUntilStateAckAndExpectFailure(
+            updatedConfig,
+            finalStream,
+            listOf(
+                InputRecord(
+                    stream = stream,
+                    """{"id": 42, "name": "second_value"}""",
+                    emittedAtMs = 2345,
+                    checkpointId = checkpointKeyForMedium()?.checkpointId
+                )
+            ),
+            StreamCheckpoint(
                 finalStream,
-                listOf(
-                    InputRecord(
-                        stream = stream,
-                        """{"id": 42, "name": "second_value"}""",
-                        emittedAtMs = 2345,
-                        checkpointId = checkpointKeyForMedium()?.checkpointId
-                    )
-                ),
-                streamStatus = null,
-            )
-        }
+                """{}""",
+                sourceRecordCount = 1,
+                checkpointKey = checkpointKeyForMedium(),
+            ),
+            syncEndBehavior = UncleanSyncEndBehavior.TERMINATE_WITH_NO_STREAM_STATUS,
+        )
         dumpAndDiffRecords(
             parsedConfig,
             listOfNotNull(
@@ -1096,7 +1100,7 @@ abstract class BasicFunctionalityIntegrationTest(
                 syncId = 42,
             )
         // Run a sync, but emit a status incomplete. This should not delete any existing data.
-        runSyncUntilStateAck(
+        runSyncUntilStateAckAndExpectFailure(
             updatedConfig,
             stream2,
             listOf(makeInputRecord(1, "2024-01-23T02:00:00Z", 200)),
@@ -1106,7 +1110,7 @@ abstract class BasicFunctionalityIntegrationTest(
                 sourceRecordCount = 1,
                 checkpointKey = checkpointKeyForMedium(),
             ),
-            allowGracefulShutdown = false,
+            syncEndBehavior = UncleanSyncEndBehavior.KILL,
         )
         dumpAndDiffRecords(
             parsedConfig,
@@ -1228,7 +1232,7 @@ abstract class BasicFunctionalityIntegrationTest(
                 airbyteMeta = OutputRecord.Meta(syncId = syncId),
             )
         // Run a sync, but emit a stream status incomplete.
-        runSyncUntilStateAck(
+        runSyncUntilStateAckAndExpectFailure(
             updatedConfig,
             stream,
             listOf(makeInputRecord(1, "2024-01-23T02:00:00Z", 200)),
@@ -1238,7 +1242,7 @@ abstract class BasicFunctionalityIntegrationTest(
                 sourceRecordCount = 1,
                 checkpointKey = checkpointKeyForMedium(),
             ),
-            allowGracefulShutdown = false,
+            syncEndBehavior = UncleanSyncEndBehavior.KILL,
         )
         dumpAndDiffRecords(
             parsedConfig,
@@ -1392,7 +1396,7 @@ abstract class BasicFunctionalityIntegrationTest(
             )
         // Run a sync, but emit a stream status incomplete. This should not delete any existing
         // data.
-        runSyncUntilStateAck(
+        runSyncUntilStateAckAndExpectFailure(
             updatedConfig,
             stream2,
             listOf(makeInputRecord(1, "2024-01-23T02:00:00Z", 200)),
@@ -1402,7 +1406,7 @@ abstract class BasicFunctionalityIntegrationTest(
                 sourceRecordCount = 1,
                 checkpointKey = checkpointKeyForMedium(),
             ),
-            allowGracefulShutdown = false,
+            syncEndBehavior = UncleanSyncEndBehavior.KILL,
         )
         dumpAndDiffRecords(
             parsedConfig,

--- a/airbyte-cdk/bulk/toolkits/load-db/src/main/kotlin/io/airbyte/cdk/load/orchestration/db/direct_load_table/DirectLoadTableStreamLoader.kt
+++ b/airbyte-cdk/bulk/toolkits/load-db/src/main/kotlin/io/airbyte/cdk/load/orchestration/db/direct_load_table/DirectLoadTableStreamLoader.kt
@@ -146,20 +146,27 @@ class DirectLoadTableAppendTruncateStreamLoader(
         }
 
         if (initialStatus.tempTable != null) {
-            val generationId = nativeTableOperations.getGenerationId(tempTableName)
-
-            if (initialStatus.tempTable.isEmpty || generationId >= stream.minimumGenerationId) {
+            if (initialStatus.tempTable.isEmpty) {
                 nativeTableOperations.ensureSchemaMatches(stream, tempTableName, columnNameMapping)
             } else {
-                logger.info {
-                    "Recreating temp table (old generation ID: $generationId) for stream ${stream.descriptor.toPrettyString()}"
+                val generationId = nativeTableOperations.getGenerationId(tempTableName)
+                if (generationId >= stream.minimumGenerationId) {
+                    nativeTableOperations.ensureSchemaMatches(
+                        stream,
+                        tempTableName,
+                        columnNameMapping
+                    )
+                } else {
+                    logger.info {
+                        "Recreating temp table (old generation ID: $generationId) for stream ${stream.descriptor.toPrettyString()}"
+                    }
+                    sqlTableOperations.createTable(
+                        stream,
+                        tempTableName,
+                        columnNameMapping,
+                        replace = true
+                    )
                 }
-                sqlTableOperations.createTable(
-                    stream,
-                    tempTableName,
-                    columnNameMapping,
-                    replace = true
-                )
             }
             isWritingToTemporaryTable = true
             streamStateStore.put(stream.descriptor, DirectLoadTableExecutionConfig(tempTableName))
@@ -259,20 +266,27 @@ class DirectLoadTableDedupTruncateStreamLoader(
         }
 
         if (initialStatus.tempTable != null) {
-            val generationId = nativeTableOperations.getGenerationId(tempTableName)
-
-            if (initialStatus.tempTable.isEmpty || generationId >= stream.minimumGenerationId) {
+            if (initialStatus.tempTable.isEmpty) {
                 nativeTableOperations.ensureSchemaMatches(stream, tempTableName, columnNameMapping)
             } else {
-                logger.info {
-                    "Recreating temp table (old generation ID: $generationId) for stream ${stream.descriptor.toPrettyString()}"
+                val generationId = nativeTableOperations.getGenerationId(tempTableName)
+                if (generationId >= stream.minimumGenerationId) {
+                    nativeTableOperations.ensureSchemaMatches(
+                        stream,
+                        tempTableName,
+                        columnNameMapping
+                    )
+                } else {
+                    logger.info {
+                        "Recreating temp table (old generation ID: $generationId) for stream ${stream.descriptor.toPrettyString()}"
+                    }
+                    sqlTableOperations.createTable(
+                        stream,
+                        tempTableName,
+                        columnNameMapping,
+                        replace = true
+                    )
                 }
-                sqlTableOperations.createTable(
-                    stream,
-                    tempTableName,
-                    columnNameMapping,
-                    replace = true
-                )
             }
             shouldCheckRealTableGeneration = false
         } else {


### PR DESCRIPTION
I think I broke this when I added more log messages? We should only call getGenerationId if we know the table is empty

... also fix the test case I broke in https://github.com/airbytehq/airbyte/pull/61382

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._