### PR TITLE
rollback(source-hubspot): revert to prior version (p0 resolution)

### DIFF
--- a/airbyte-integrations/connectors/source-hubspot/metadata.yaml
+++ b/airbyte-integrations/connectors/source-hubspot/metadata.yaml
@@ -32,8 +32,10 @@ data:
   registryOverrides:
     cloud:
       enabled: true
+      dockerImageTag: 5.8.4
     oss:
       enabled: true
+      dockerImageTag: 5.8.4
   releaseStage: generally_available
   releases:
     rolloutConfiguration:


### PR DESCRIPTION
Resolves https://github.com/airbytehq/oncall/issues/7985

## What

Rolls back 2 versions to resolve this issue:

- https://github.com/airbytehq/oncall/issues/7985

TODO:

- [x] Need to confirm if rollback to 5.8.4 (2 versions back) or 5.8.5 (1 version back).
  - Confirmed the first cause was in 5.8.5, so we are rolling back 2 versions: to 5.8.4.
- [x] Need to confirm it is safe to rollback.
  - Confirmed with @darynaishchenko that no state changes are in these PRs, so it is safe to rollback.