### PR TITLE
ci: add `docs-build` workflow (unprivileged)

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -1,0 +1,27 @@
+# This workflow builds the documentation for the project using `poe` and `uv`.
+# It is redundant with the Vercel Preview deployment, but is runs unprivileged and
+# can be used on forks to verify the documentation build without deploying it.
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  build-docs:
+    runs-on: ubuntu-24.04
+    steps:
+    - name: Checkout Current Branch
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 1
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v6
+
+    - name: Install Poe
+      run: |
+        # Install Poe so we can run the connector tasks:
+        uv tool install poethepoet
+
+    - name: Build Docs
+      run: |
+        poe docs-build

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -1,7 +1,7 @@
 # This workflow builds the documentation for the project using `poe` and `uv`.
 # It is redundant with the Vercel Preview deployment, but is runs unprivileged and
 # can be used on forks to verify the documentation build without deploying it.
-name: Docusaurus Build
+name: Docusaurus
 on:
   pull_request:
     types: [opened, synchronize, reopened]

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -11,25 +11,25 @@ jobs:
     name: Build Documentation
     runs-on: ubuntu-24.04
     steps:
-    - name: Checkout Current Branch
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 1
+      - name: Checkout Current Branch
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
 
-    - name: Set up pnpm
-      # pnpm is used to manage the dependencies of the documentation build.
-      uses: pnpm/action-setup@v4
-      with:
-        version: 10.12.1
+      - name: Set up pnpm
+        # pnpm is used to manage the dependencies of the documentation build.
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.12.1
 
-    - name: Install uv
-      uses: astral-sh/setup-uv@v6
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
 
-    - name: Install Poe
-      run: |
-        # Install Poe so we can run the connector tasks:
-        uv tool install poethepoet
+      - name: Install Poe
+        run: |
+          # Install Poe so we can run the connector tasks:
+          uv tool install poethepoet
 
-    - name: Build Docs
-      run: |
-        poe docs-build
+      - name: Build Docs
+        run: |
+          poe docs-build

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build-docs:
-    name: Build Airbyte Docs Site
+    name: Build Airbyte Docs
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout Current Branch

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build-docs:
-    name: Build Documentation
+    name: Build Airbyte Docs Site
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout Current Branch

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -19,6 +19,8 @@ jobs:
     - name: Set up pnpm
       # pnpm is used to manage the dependencies of the documentation build.
       uses: pnpm/action-setup@v4
+      with:
+        version: 10.12.1
 
     - name: Install uv
       uses: astral-sh/setup-uv@v6

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -1,18 +1,24 @@
 # This workflow builds the documentation for the project using `poe` and `uv`.
 # It is redundant with the Vercel Preview deployment, but is runs unprivileged and
 # can be used on forks to verify the documentation build without deploying it.
+name: Docusaurus Build
 on:
   pull_request:
     types: [opened, synchronize, reopened]
 
 jobs:
   build-docs:
+    name: Build Documentation
     runs-on: ubuntu-24.04
     steps:
     - name: Checkout Current Branch
       uses: actions/checkout@v4
       with:
         fetch-depth: 1
+
+    - name: Set up pnpm
+      # pnpm is used to manage the dependencies of the documentation build.
+      uses: pnpm/action-setup@v4
 
     - name: Install uv
       uses: astral-sh/setup-uv@v6


### PR DESCRIPTION
## What

Adds a new `docs-build` workflow that can run unprivileged on forks. It also completes faster than the `Vercel Preview` deployment, due to lack of queuing. (Approx 5 minutes, versus 10-12 minutes with the Vercel deployment.)

After merging this PR, the new `Build Airbyte Docs` Job will replace `Vercel` as a required check for PRs to merge.

> ⚠️ Important
>
> Auto-merge enabled.
>
> This PR is set to merge automatically when all requirements are met.

> [!NOTE]
> **Auto-merge may have been disabled. Please check the PR status to confirm.**