### PR TITLE
ci: add docs-skip logic

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -33,7 +33,6 @@ jobs:
     needs: detect-changes
     if: needs.detect-changes.outputs.changed == 'true'
     steps:
-
       - name: Checkout Current Branch
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -7,10 +7,33 @@ on:
     types: [opened, synchronize, reopened]
 
 jobs:
+  detect-changes:
+    name: Detect Changes
+    runs-on: ubuntu-24.04
+    steps:
+      # Checkout not required from `pull_request` event.
+      # The detection method uses the GitHub REST API.
+      - name: Detect Changes
+        id: detect-changes
+        uses: dorny/paths-filter@v3.0.2
+        with:
+          filters: |
+            docs:
+              - 'docs/**'
+              - 'docusaurus/**'
+              - '.markdownlint.jsonc'
+
+    outputs:
+      # 'true' if any of the docs files have changed, 'false' otherwise.
+      changed: ${{ steps.detect-changes.outputs.docs }}
+
   build-docs:
     name: Build Airbyte Docs
     runs-on: ubuntu-24.04
+    needs: detect-changes
+    if: needs.detect-changes.outputs.changed == 'true'
     steps:
+
       - name: Checkout Current Branch
         uses: actions/checkout@v4
         with:

--- a/docusaurus/README.md
+++ b/docusaurus/README.md
@@ -1,3 +1,5 @@
 # Documentation and Docusaurus
 
 For instructions, visit [Contribute to Documentation](https://docs.airbyte.com/contributing-to-airbyte/writing-docs).
+
+<!-- # dummy-change (revert-me) -->

--- a/docusaurus/README.md
+++ b/docusaurus/README.md
@@ -1,5 +1,3 @@
 # Documentation and Docusaurus
 
 For instructions, visit [Contribute to Documentation](https://docs.airbyte.com/contributing-to-airbyte/writing-docs).
-
-<!-- # dummy-change (revert-me) -->


### PR DESCRIPTION
## What

Skip the new Docs Build step if nothing relevant has changed.

## Other Notes

### Q: Why not use a workflow-level paths filter?

Since the job is required for PR merges, we need the job to be evaluated in order for it to allow PRs to merge.

- If the workflow is entirely skipped, it will not satisfy the merge requirement.
- If the workflow is evaluated but the _job_ is skipped, then it will satisfy the merge requirement.

### How does the diff work?

I just learned this today: The action we are using actually gets the diff using the GitHub API when responding to `pull_request` events - which is awesome because it doesn't need to spend the 45 seconds to checkout the repo with history.

We should _absolutely_ try to use this pattern in more places, where otherwise we're checking out the repo before we know if there are relevant changes. Action definition is [here](https://github.com/dorny/paths-filter/tree/v3.0.2) and their source code is [here](https://github.com/dorny/paths-filter/blob/v3.0.2/src/main.ts#L178).


## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._