### PR TITLE
Bulk load CDK: improve UUID handling more

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/IntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/IntegrationTest.kt
@@ -37,6 +37,7 @@ import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
+import kotlin.test.assertEquals
 import kotlin.test.fail
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -162,6 +163,12 @@ abstract class IntegrationTest(
                 }
                 fail(message)
             }
+
+        assertEquals(
+            actualRecords.size,
+            actualRecords.map { it.rawId }.toSet().size,
+            "Expected each record to have a unique UUID",
+        )
     }
 
     /**

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/test/kotlin/io/airbyte/cdk/load/write/object_storage/ObjectStorageFormattingWriterTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/test/kotlin/io/airbyte/cdk/load/write/object_storage/ObjectStorageFormattingWriterTest.kt
@@ -4,13 +4,28 @@
 
 package io.airbyte.cdk.load.write.object_storage
 
+import io.airbyte.cdk.load.command.Append
+import io.airbyte.cdk.load.command.DestinationStream
+import io.airbyte.cdk.load.command.NamespaceMapper
+import io.airbyte.cdk.load.config.NamespaceDefinitionType
+import io.airbyte.cdk.load.data.FieldType
+import io.airbyte.cdk.load.data.ObjectType
+import io.airbyte.cdk.load.data.StringType
 import io.airbyte.cdk.load.file.NoopProcessor
 import io.airbyte.cdk.load.file.object_storage.BufferedFormattingWriter
+import io.airbyte.cdk.load.file.object_storage.JsonFormattingWriter
 import io.airbyte.cdk.load.file.object_storage.ObjectStorageFormattingWriter
+import io.airbyte.cdk.load.message.DestinationRecordJsonSource
+import io.airbyte.cdk.load.message.DestinationRecordRaw
+import io.airbyte.protocol.models.Jsons
+import io.airbyte.protocol.models.v0.AirbyteMessage
+import io.airbyte.protocol.models.v0.AirbyteRecordMessage
 import io.mockk.coEvery
 import io.mockk.impl.annotations.MockK
 import io.mockk.mockk
 import java.io.ByteArrayOutputStream
+import java.util.UUID
+import kotlin.test.assertEquals
 import org.junit.jupiter.api.Test
 
 class ObjectStorageFormattingWriterTest {
@@ -53,5 +68,65 @@ class ObjectStorageFormattingWriterTest {
         assert(bytes.contentEquals("i am a header!".toByteArray())) {
             "buffer yields all data written to it"
         }
+    }
+}
+
+private val stream =
+    DestinationStream(
+        unmappedNamespace = "test_ns",
+        unmappedName = "test_name",
+        Append,
+        ObjectType(linkedMapOf("foo" to FieldType(StringType, nullable = true))),
+        generationId = 42,
+        minimumGenerationId = 0,
+        syncId = 123,
+        namespaceMapper = NamespaceMapper(namespaceDefinitionType = NamespaceDefinitionType.SOURCE),
+    )
+
+private val record =
+    DestinationRecordRaw(
+        stream,
+        DestinationRecordJsonSource(
+            AirbyteMessage()
+                .withType(AirbyteMessage.Type.RECORD)
+                .withRecord(
+                    AirbyteRecordMessage()
+                        .withStream("test_name")
+                        .withNamespace("test_ns")
+                        .withEmittedAt(1234)
+                        .withData(Jsons.deserialize("""{"foo": "bar"}"""))
+                )
+        ),
+        serializedSizeBytes = 42,
+        airbyteRawId = UUID.fromString("0197604b-ca2e-7e7c-9126-dacc18b68e8e"),
+    )
+
+class JsonFormattingWriterTest {
+    @Test
+    fun testAcceptNoFlattening() {
+        val os = ByteArrayOutputStream()
+        val writer = JsonFormattingWriter(stream, os, rootLevelFlattening = false)
+        writer.accept(record)
+        assertEquals(
+            """
+            {"_airbyte_raw_id":"0197604b-ca2e-7e7c-9126-dacc18b68e8e","_airbyte_extracted_at":1234,"_airbyte_meta":{"sync_id":123,"changes":[]},"_airbyte_generation_id":42,"_airbyte_data":{"foo":"bar"}}
+            
+            """.trimIndent(),
+            os.toByteArray().decodeToString(),
+        )
+    }
+
+    @Test
+    fun testAcceptWithFlattening() {
+        val os = ByteArrayOutputStream()
+        val writer = JsonFormattingWriter(stream, os, rootLevelFlattening = true)
+        writer.accept(record)
+        assertEquals(
+            """
+            {"_airbyte_raw_id":"0197604b-ca2e-7e7c-9126-dacc18b68e8e","_airbyte_extracted_at":1234,"_airbyte_meta":{"sync_id":123,"changes":[]},"_airbyte_generation_id":42,"foo":"bar"}
+            
+            """.trimIndent(),
+            os.toByteArray().decodeToString(),
+        )
     }
 }


### PR DESCRIPTION
followup to https://github.com/airbytehq/airbyte/pull/61530

* ObjectStorageFormattingWriter uses the uuid from the record instead of generating a new one
* add a basic unit test for JsonFormattingWriter
* integration tests also assert that UUID are unique