### PR TITLE
docs: add note that raw Dv2 raw JSON blobs are being phased out

### DIFF
--- a/docs/platform/using-airbyte/core-concepts/typing-deduping.md
+++ b/docs/platform/using-airbyte/core-concepts/typing-deduping.md
@@ -4,6 +4,13 @@ products: all
 
 # Typing and Deduping
 
+:::warning
+**Typing and Deduping is currently being phased out in favor of Direct Loads.**
+
+With Direct Loads, there is no intermediate table result containing the raw JSON blob. Instead, top-level fields are typed during time of insert, and there is only a single destination table maintained per stream.
+:::
+
+
 This page refers to new functionality added by
 [Destinations V2](/release_notes/upgrading_to_destinations_v2/). Typing and deduping is the default
 method of transforming datasets within data warehouse and database destinations after they've been


### PR DESCRIPTION
## What

- This PR adds a note that Dv2 (raw tables and the JSON blob, specifically) are being deprecated.

## How

For now, this adds a note to the top of the page.

Better would be (in future iterations if needed):

- [ ] Consider hiding or deleting this page (although other pages currently link to it).
- [ ] Alternatively, we can rework this page, since 'typing-deduping' is still accurate for the Direct Loads behavior.
- [ ] Link to other pages or blog posts if/when available.

