### PR TITLE
chore: implement missing interface for the mock object storage client

### DIFF
--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/testFixtures/kotlin/io/airbyte/cdk/load/MockObjectStorageClient.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/testFixtures/kotlin/io/airbyte/cdk/load/MockObjectStorageClient.kt
@@ -15,7 +15,7 @@ import java.io.InputStream
 import java.util.concurrent.ConcurrentHashMap
 import kotlinx.coroutines.flow.flow
 
-private val logger = KotlinLogging.logger {  }
+private val logger = KotlinLogging.logger {}
 
 class MockRemoteObject(
     override val key: String,
@@ -77,7 +77,8 @@ class MockObjectStorageClient : ObjectStorageClient<MockRemoteObject> {
         return block(remoteObject.data.inputStream())
     }
 
-    fun get(key: String): MockRemoteObject = objects[key] ?: throw IllegalArgumentException("Object $key not found")
+    fun get(key: String): MockRemoteObject =
+        objects[key] ?: throw IllegalArgumentException("Object $key not found")
 
     override suspend fun getMetadata(key: String): Map<String, String> {
         return objects[key]?.metadata ?: emptyMap()

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/testFixtures/kotlin/io/airbyte/cdk/load/MockObjectStorageClient.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/testFixtures/kotlin/io/airbyte/cdk/load/MockObjectStorageClient.kt
@@ -8,11 +8,14 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 import io.airbyte.cdk.load.file.object_storage.ObjectStorageClient
 import io.airbyte.cdk.load.file.object_storage.RemoteObject
 import io.airbyte.cdk.load.file.object_storage.StreamingUpload
+import io.github.oshai.kotlinlogging.KotlinLogging
 import io.micronaut.context.annotation.Requires
 import jakarta.inject.Singleton
 import java.io.InputStream
 import java.util.concurrent.ConcurrentHashMap
 import kotlinx.coroutines.flow.flow
+
+private val logger = KotlinLogging.logger {  }
 
 class MockRemoteObject(
     override val key: String,
@@ -20,6 +23,31 @@ class MockRemoteObject(
     val data: ByteArray,
     val metadata: Map<String, String> = emptyMap()
 ) : RemoteObject<Int>
+
+class MockObjectStreamingUpload(
+    private val client: MockObjectStorageClient,
+    private val key: String,
+    private val metadata: Map<String, String>,
+) : StreamingUpload<MockRemoteObject> {
+    private val parts: MutableList<Pair<Int, ByteArray>> = mutableListOf()
+    override suspend fun uploadPart(part: ByteArray, index: Int) {
+        parts.add(index to part)
+        updateRemoteStorage()
+    }
+
+    override suspend fun complete(): MockRemoteObject {
+        updateRemoteStorage()
+        return client.get(key).also {
+            logger.info { "Writing $key to MockObjectStorage\n${it.data.decodeToString()}" }
+        }
+    }
+
+    private suspend fun updateRemoteStorage() {
+        parts.sortBy { it.first }
+        val data = parts.map { it.second }.reduce { acc, bytes -> acc + bytes }
+        client.put(key, data)
+    }
+}
 
 @SuppressFBWarnings("NP_NONNULL_PARAM_VIOLATION", justification = "Kotlin async continuation")
 @Singleton
@@ -49,6 +77,8 @@ class MockObjectStorageClient : ObjectStorageClient<MockRemoteObject> {
         return block(remoteObject.data.inputStream())
     }
 
+    fun get(key: String): MockRemoteObject = objects[key] ?: throw IllegalArgumentException("Object $key not found")
+
     override suspend fun getMetadata(key: String): Map<String, String> {
         return objects[key]?.metadata ?: emptyMap()
     }
@@ -70,7 +100,5 @@ class MockObjectStorageClient : ObjectStorageClient<MockRemoteObject> {
     override suspend fun startStreamingUpload(
         key: String,
         metadata: Map<String, String>
-    ): StreamingUpload<MockRemoteObject> {
-        TODO("Not yet implemented")
-    }
+    ): StreamingUpload<MockRemoteObject> = MockObjectStreamingUpload(this, key, metadata)
 }


### PR DESCRIPTION
## What

Implement the missing interfaces of the `MockObjectStorageClient` in order to be able to use it in tests.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [X] YES 💚
- [ ] NO ❌
