### PR TITLE
ci: disable dagger cloud telemetry for airbyte-ci runs

### DIFF
--- a/.github/actions/run-airbyte-ci/action.yml
+++ b/.github/actions/run-airbyte-ci/action.yml
@@ -149,9 +149,9 @@ runs:
         CI_REPORT_BUCKET_NAME: ${{ inputs.report_bucket_name }}
         # Disabling Dagger Cloud, as it is not used in the current workflow
         # and it is causing log spam in the GitHub Actions logs.
-        # If this is desired in the future, uncomment the following line and remove the line below setting AIRBYTE_CI_DISABLE_TELEMETRY
+        # If this is desired in the future, uncomment the following line and remove the line below setting DO_NOT_TRACK
         # DAGGER_CLOUD_TOKEN: "${{ inputs.dagger_cloud_token }}"
-        AIRBYTE_CI_DISABLE_TELEMETRY: "true"
+        DO_NOT_TRACK: "1" # Disable Dagger telemetry (noisy errors)
         DOCKER_HUB_PASSWORD: ${{ inputs.docker_hub_password }}
         DOCKER_HUB_USERNAME: ${{ inputs.docker_hub_username }}
         GCP_GSM_CREDENTIALS: ${{ inputs.gcp_gsm_credentials }}

--- a/.github/actions/run-airbyte-ci/action.yml
+++ b/.github/actions/run-airbyte-ci/action.yml
@@ -149,8 +149,9 @@ runs:
         CI_REPORT_BUCKET_NAME: ${{ inputs.report_bucket_name }}
         # Disabling Dagger Cloud, as it is not used in the current workflow
         # and it is causing log spam in the GitHub Actions logs.
-        # If this is desired in the future, uncomment the following line:
+        # If this is desired in the future, uncomment the following line and remove the line below setting AIRBYTE_CI_DISABLE_TELEMETRY
         # DAGGER_CLOUD_TOKEN: "${{ inputs.dagger_cloud_token }}"
+        AIRBYTE_CI_DISABLE_TELEMETRY: "true"
         DOCKER_HUB_PASSWORD: ${{ inputs.docker_hub_password }}
         DOCKER_HUB_USERNAME: ${{ inputs.docker_hub_username }}
         GCP_GSM_CREDENTIALS: ${{ inputs.gcp_gsm_credentials }}


### PR DESCRIPTION
## What
We continue to see noisy warnings along the lines of `failed to emit telemetry error="traces export: failed to send to https://api.dagger.cloud/v1/traces: 401 Unauthorized` when running airbyte-ci on github workflows. 

This [PR](https://github.com/airbytehq/airbyte/pull/61397) didn't seem to quite fix them problem, so I'm hopeful this environment variable does the trick. See reference [here](https://docs.dagger.io/faq/#can-dagger-telemetry-be-disabled) and relevant Slack thread [here](https://airbytehq-team.slack.com/archives/C05KSGM8MNC/p1749082645131559)



## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
