### PR TITLE
fix(ga4) - pin back to 2.7.7 on cloud

### DIFF
--- a/airbyte-integrations/connectors/source-google-analytics-data-api/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-analytics-data-api/metadata.yaml
@@ -27,6 +27,7 @@ data:
   registryOverrides:
     cloud:
       enabled: true
+      dockerImageTag: 2.7.7
     oss:
       enabled: true
   releaseStage: generally_available


### PR DESCRIPTION
## What
- Pins back to v2.7.7 on cloud
