### PR TITLE
fix(source-google-analytics) - adds fallback start date value if not provided in config

### DIFF
--- a/airbyte-integrations/connectors/source-google-analytics-data-api/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-analytics-data-api/metadata.yaml
@@ -27,6 +27,7 @@ data:
   registryOverrides:
     cloud:
       enabled: true
+      dockerImageTag: 2.7.7
     oss:
       enabled: true
   releaseStage: generally_available

--- a/airbyte-integrations/connectors/source-google-analytics-data-api/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-analytics-data-api/metadata.yaml
@@ -12,7 +12,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 3cc2eafd-84aa-4dca-93af-322d9dfeec1a
-  dockerImageTag: 2.8.0
+  dockerImageTag: 2.8.1
   dockerRepository: airbyte/source-google-analytics-data-api
   documentationUrl: https://docs.airbyte.com/integrations/sources/google-analytics-data-api
   githubIssueLabel: source-google-analytics-data-api
@@ -27,7 +27,6 @@ data:
   registryOverrides:
     cloud:
       enabled: true
-      dockerImageTag: 2.7.7
     oss:
       enabled: true
   releaseStage: generally_available

--- a/airbyte-integrations/connectors/source-google-analytics-data-api/pyproject.toml
+++ b/airbyte-integrations/connectors/source-google-analytics-data-api/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "2.8.0"
+version = "2.8.1"
 name = "source-google-analytics-data-api"
 description = "Source implementation for Google Analytics Data Api."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-google-analytics-data-api/source_google_analytics_data_api/manifest.yaml
+++ b/airbyte-integrations/connectors/source-google-analytics-data-api/source_google_analytics_data_api/manifest.yaml
@@ -944,7 +944,7 @@ dynamic_streams:
               - type: AddFields
                 fields:
                   - path: [ "startDate" ]
-                    value: "{% raw %}{{ stream_slice.start_time or config['date_ranges_start_date'] }}{% endraw %}"
+                    value: "{% raw %}{{ stream_slice.start_time or config.get('date_ranges_start_date', day_delta(-730, '%Y-%m-%d')) }}{% endraw %}"
               - type: AddFields
                 fields:
                   - path: [ "endDate" ]
@@ -984,7 +984,7 @@ dynamic_streams:
             {% endfor %}
 
             {% if not ns.cursor %}
-              - startDate: "{{ config['date_ranges_start_date'] }}"
+              - startDate: "{{ config.get('date_ranges_start_date', day_delta(-730, '%Y-%m-%d')) }}"
                 endDate: "{{ format_datetime(config['date_ranges_end_date'] if config.get('date_ranges_end_date') else now_utc(), '%Y-%m-%d') }}"
             {% else %}
               - startDate: "{{ '{{ stream_slice.start_time }}' }}"
@@ -1022,7 +1022,7 @@ dynamic_streams:
               datetime_format: "%Y-%m-%d"
               start_datetime:
                 type: MinMaxDatetime
-                datetime: "{% raw %}{{ config['date_ranges_start_date'] }}{% endraw %}"
+                datetime: "{% raw %}{{ config.get('date_ranges_start_date', day_delta(-730, '%Y-%m-%d')) }}{% endraw %}"
                 datetime_format: "%Y-%m-%d"
               end_datetime:
                 type: MinMaxDatetime

--- a/airbyte-integrations/connectors/source-google-analytics-data-api/source_google_analytics_data_api/manifest.yaml
+++ b/airbyte-integrations/connectors/source-google-analytics-data-api/source_google_analytics_data_api/manifest.yaml
@@ -928,6 +928,7 @@ dynamic_streams:
         # This mapping add transformation that add property_id and date slice value to record.
         # Note: We need {% raw %} as we don't want to attempt interpolation on stream_slice since
         # it doesn't exist in this context yet as we populate the template
+        # If the `date_ranges_start_date`` is not set in the config, the startDate value will default to 2 years ago.
         - type: ComponentMappingDefinition
           field_path: ["transformations"]
           create_or_update: True
@@ -969,6 +970,7 @@ dynamic_streams:
               {% endfor %}]
         # Since the Google Analytics API requires defining dateRanges for requests,
         # we need to set up a single slice of query parameters here for full-refresh streams only
+        # If the `date_ranges_start_date`` is not set in the config, the startDate value will default to 2 years ago.
         - type: ComponentMappingDefinition
           field_path:
             ["retriever", "requester", "request_body_json", "dateRanges"]
@@ -993,6 +995,7 @@ dynamic_streams:
         # This mapping adds the incremental_sync component for streams that support incremental loads.
         # It is enabled if any of the following fields are present in the dimensions list:
         # "date", "yearWeek", "yearMonth", or "year"
+        # If the `date_ranges_start_date`` is not set in the config, it will default to 2 years ago.
         - type: ComponentMappingDefinition
           field_path: ["incremental_sync"]
           create_or_update: True

--- a/docs/integrations/sources/google-analytics-data-api.md
+++ b/docs/integrations/sources/google-analytics-data-api.md
@@ -272,7 +272,7 @@ The Google Analytics connector is subject to Google Analytics Data API quotas. P
 
 | Version    | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |:-----------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 2.8.1 | 2025-06-2 | [XXXXX](https://github.com/airbytehq/airbyte/pull/XXXXX) | Fixes time data parsing issue |
+| 2.8.1 | 2025-06-2 | [61555](https://github.com/airbytehq/airbyte/pull/61555) | Fixes time data parsing issue |
 | 2.8.0 | 2025-06-11 | [61533](https://github.com/airbytehq/airbyte/pull/61533) | Promoting release candidate 2.8.0-rc.2 to a main version. |
 | 2.8.0-rc.2 | 2025-06-11 | [61491](https://github.com/airbytehq/airbyte/pull/61491) | Fixed cohort check, record extractor and discovery                                                                                                                     |
 | 2.8.0-rc.1 | 2025-05-20 | [60342](https://github.com/airbytehq/airbyte/pull/60342) | Migrate to low-code                                                                                                                                                    |

--- a/docs/integrations/sources/google-analytics-data-api.md
+++ b/docs/integrations/sources/google-analytics-data-api.md
@@ -272,6 +272,7 @@ The Google Analytics connector is subject to Google Analytics Data API quotas. P
 
 | Version    | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |:-----------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 2.8.1 | 2025-06-2 | [XXXXX](https://github.com/airbytehq/airbyte/pull/XXXXX) | Fixes time data parsing issue |
 | 2.8.0 | 2025-06-11 | [61533](https://github.com/airbytehq/airbyte/pull/61533) | Promoting release candidate 2.8.0-rc.2 to a main version. |
 | 2.8.0-rc.2 | 2025-06-11 | [61491](https://github.com/airbytehq/airbyte/pull/61491) | Fixed cohort check, record extractor and discovery                                                                                                                     |
 | 2.8.0-rc.1 | 2025-05-20 | [60342](https://github.com/airbytehq/airbyte/pull/60342) | Migrate to low-code                                                                                                                                                    |

--- a/docs/integrations/sources/google-analytics-data-api.md
+++ b/docs/integrations/sources/google-analytics-data-api.md
@@ -272,7 +272,7 @@ The Google Analytics connector is subject to Google Analytics Data API quotas. P
 
 | Version    | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |:-----------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 2.8.1 | 2025-06-2 | [61555](https://github.com/airbytehq/airbyte/pull/61555) | Fixes time data parsing issue |
+| 2.8.1 | 2025-06-12 | [61555](https://github.com/airbytehq/airbyte/pull/61555) | Fixes time data parsing issue |
 | 2.8.0 | 2025-06-11 | [61533](https://github.com/airbytehq/airbyte/pull/61533) | Promoting release candidate 2.8.0-rc.2 to a main version. |
 | 2.8.0-rc.2 | 2025-06-11 | [61491](https://github.com/airbytehq/airbyte/pull/61491) | Fixed cohort check, record extractor and discovery                                                                                                                     |
 | 2.8.0-rc.1 | 2025-05-20 | [60342](https://github.com/airbytehq/airbyte/pull/60342) | Migrate to low-code                                                                                                                                                    |


### PR DESCRIPTION
## What
- Adds a fallback start date value if not included in config
- Bumps patch version
- Removes version override for cloud

## How
```python
{{ config.get('date_ranges_start_date', day_delta(-730, '%Y-%m-%d')) }}
```

v2.7.7 of the connector defaulted to 2 years before now in the cases when `date_ranges_start_date` was not set in the config. This update mirrors that behavior.

## Review guide
1. manifest

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._