### PR TITLE
fix(destination-teradata) removes duplicate property in metadata

### DIFF
--- a/airbyte-integrations/connectors/destination-teradata/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-teradata/metadata.yaml
@@ -10,8 +10,6 @@ data:
   icon: teradata.svg
   license: MIT
   name: Teradata Vantage
-  connectorBuildOptions:
-    baseImage: docker.io/airbyte/java-connector-base:2.0.1@sha256:ec89bd1a89e825514dd2fc8730ba299a3ae1544580a078df0e35c5202c2085b3
   registryOverrides:
     cloud:
       enabled: true


### PR DESCRIPTION
## What
- `connectorBuilderOptions` was listed twice in metadata file, this removes the "older" one w/ base image 2.0.1

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._

> [!NOTE]
> **Auto-merge may have been disabled. Please check the PR status to confirm.**