### PR TITLE
Destination bigquery: limit test parallelism

### DIFF
--- a/airbyte-integrations/connectors/destination-bigquery/gradle.properties
+++ b/airbyte-integrations/connectors/destination-bigquery/gradle.properties
@@ -1,2 +1,2 @@
-testExecutionConcurrency=4
+testExecutionConcurrency=2
 JunitMethodExecutionTimeout=10 m

--- a/airbyte-integrations/connectors/destination-bigquery/gradle.properties
+++ b/airbyte-integrations/connectors/destination-bigquery/gradle.properties
@@ -1,2 +1,2 @@
-testExecutionConcurrency=-1
+testExecutionConcurrency=4
 JunitMethodExecutionTimeout=10 m


### PR DESCRIPTION
we're seeing a lot of transient failures right now. see if this helps