### PR TITLE
fix: avoid race condition when marking end of stream in socket mode

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/state/PipelineEventBookkeepingRouter.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/state/PipelineEventBookkeepingRouter.kt
@@ -216,7 +216,7 @@ class PipelineEventBookkeepingRouter(
                 catalog.streams.forEach {
                     val sawComplete = sawEndOfStreamComplete.contains(it.descriptor)
                     val manager = syncManager.getStreamManager(it.descriptor)
-                    if(sawComplete) {
+                    if (sawComplete) {
                         manager.markEndOfStream(sawComplete)
                     }
                     batchStateUpdateQueue.publish(

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/state/PipelineEventBookkeepingRouter.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/state/PipelineEventBookkeepingRouter.kt
@@ -216,7 +216,9 @@ class PipelineEventBookkeepingRouter(
                 catalog.streams.forEach {
                     val sawComplete = sawEndOfStreamComplete.contains(it.descriptor)
                     val manager = syncManager.getStreamManager(it.descriptor)
-                    manager.markEndOfStream(sawComplete)
+                    if(sawComplete) {
+                        manager.markEndOfStream(sawComplete)
+                    }
                     batchStateUpdateQueue.publish(
                         BatchEndOfStream(it.descriptor, "bookkeepingRouter", 0, manager.readCount())
                     )

--- a/airbyte-integrations/connectors/destination-s3/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2WriteTest.kt
+++ b/airbyte-integrations/connectors/destination-s3/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_v2/S3V2WriteTest.kt
@@ -536,7 +536,6 @@ class S3V2WriteTestJsonUncompressedSockets :
     }
 
     @Test
-    @Disabled("known bug - https://github.com/airbytehq/airbyte-internal-issues/issues/13354")
     override fun testTruncateRefresh() {
         super.testTruncateRefresh()
     }
@@ -565,7 +564,6 @@ class S3V2WriteTestJsonUncompressedSocketsProtobuf :
     }
 
     @Test
-    @Disabled("known bug - https://github.com/airbytehq/airbyte-internal-issues/issues/13354")
     override fun testTruncateRefresh() {
         super.testTruncateRefresh()
     }


### PR DESCRIPTION
## What
* Fix race condition when closing streams in socket mode that causes truncate refresh tests to fail

## How
* Only mark end of stream on close when true
* Enable truncate refresh tests for socket mode

## Review guide
1. `PipelineEventBookkeepingRouter.kt`

## Can this PR be safely reverted and rolled back?
- [X] YES 💚
- [ ] NO ❌
