### PR TITLE
Destination bigquery / direct-load: write docs

### DIFF
--- a/airbyte-integrations/connectors/destination-bigquery/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-bigquery/metadata.yaml
@@ -6,7 +6,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: 22f6c74f-5699-40ff-833c-4a879ea40133
-  dockerImageTag: 2.12.0
+  dockerImageTag: 3.0.0
   dockerRepository: airbyte/destination-bigquery
   documentationUrl: https://docs.airbyte.com/integrations/destinations/bigquery
   githubIssueLabel: destination-bigquery
@@ -29,6 +29,9 @@ data:
       2.0.0:
         message: "**Do not upgrade until you have run a test upgrade as outlined [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#testing-destinations-v2-for-a-single-connection)**.\nThis version introduces [Destinations V2](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#what-is-destinations-v2), which provides better error handling, incremental delivery of data for large syncs, and improved final table structures. To review the breaking changes, and how to upgrade, see [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#quick-start-to-upgrading). These changes will likely require updates to downstream dbt / SQL models, which we walk through [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#updating-downstream-transformations).\nSelecting `Upgrade` will upgrade **all** connections using this destination at their next sync. You can manually sync existing connections prior to the next scheduled sync to start the upgrade early.\n"
         upgradeDeadline: "2023-11-07"
+      3.0.0:
+        message: "If you never interact with the raw tables, you can upgrade without taking any action. Otherwise, make sure to read the migration guide for more details."
+        upgradeDeadline: "2026-07-31"
     rolloutConfiguration:
       enableProgressiveRollout: false
   resourceRequirements:

--- a/docs/integrations/destinations/bigquery-migrations.md
+++ b/docs/integrations/destinations/bigquery-migrations.md
@@ -2,7 +2,7 @@
 
 ## Upgrading to 3.0.0
 
-This version upgrades Destination BigQuery to the [Direct-Load](/platform/using-airbyte/direct-load-tables) paradigm, which improves performance and reduces warehouse spend. If you have unusual requirements around record visibility or schema evolution, read that document for more information about how direct-load differs from Typing and Deduping.
+This version upgrades Destination BigQuery to the [Direct-Load](/platform/using-airbyte/core-concepts/direct-load-tables) paradigm, which improves performance and reduces warehouse spend. If you have unusual requirements around record visibility or schema evolution, read that document for more information about how direct-load differs from Typing and Deduping.
 
 If you do not interact with the raw tables, you can safely upgrade. There is no breakage for this usecase.
 

--- a/docs/integrations/destinations/bigquery-migrations.md
+++ b/docs/integrations/destinations/bigquery-migrations.md
@@ -1,5 +1,15 @@
 # BigQuery Migration Guide
 
+## Upgrading to 3.0.0
+
+This version upgrades Destination BigQuery to the [Direct-Load](/platform/using-airbyte/direct-load-tables) paradigm, which improves performance and reduces warehouse spend. If you have unusual requirements around record visibility or schema evolution, read that document for more information about how direct-load differs from Typing and Deduping.
+
+If you do not interact with the raw tables, you can safely upgrade. There is no breakage for this usecase.
+
+If you _only_ interact with the raw tables, make sure that you have the `Disable Final Tables` option enabled before upgrading. This will automatically enable the `Legacy raw tables` option after upgrading.
+
+If you interact with both the raw _and_ final tables, this usecase will no longer be directly supported. You must create two connectors (one with `Disable Final Tables` enabled, and one with it disabled) and run two connections in parallel.
+
 ## Upgrading to 2.0.0
 
 This version introduces [Destinations V2](/release_notes/upgrading_to_destinations_v2/#what-is-destinations-v2), which provides better error handling, incremental delivery of data for large syncs, and improved final table structures. To review the breaking changes, and how to upgrade, see [here](/release_notes/upgrading_to_destinations_v2/#quick-start-to-upgrading). These changes will likely require updates to downstream dbt / SQL models, which we walk through [here](/release_notes/upgrading_to_destinations_v2/#updating-downstream-transformations). Selecting `Upgrade` will upgrade **all** connections using this destination at their next sync. You can manually sync existing connections prior to the next scheduled sync to start the upgrade early.

--- a/docs/integrations/destinations/bigquery-migrations.md
+++ b/docs/integrations/destinations/bigquery-migrations.md
@@ -4,6 +4,8 @@
 
 This version upgrades Destination BigQuery to the [Direct-Load](/platform/using-airbyte/core-concepts/direct-load-tables) paradigm, which improves performance and reduces warehouse spend. If you have unusual requirements around record visibility or schema evolution, read that document for more information about how direct-load differs from Typing and Deduping.
 
+This version also adds an option to enable CDC deletions as soft-deletes.
+
 If you do not interact with the raw tables, you can safely upgrade. There is no breakage for this usecase.
 
 If you _only_ interact with the raw tables, make sure that you have the `Disable Final Tables` option enabled before upgrading. This will automatically enable the `Legacy raw tables` option after upgrading.

--- a/docs/integrations/destinations/bigquery.md
+++ b/docs/integrations/destinations/bigquery.md
@@ -115,28 +115,6 @@ The BigQuery destination connector supports the following
 
 ## Output schema
 
-Airbyte outputs each stream into its own raw table in `airbyte_internal` dataset by default (can be
-overriden by user) and a final table with Typed columns. Contents in raw table are _NOT_
-deduplicated.
-
-### Raw Table schema
-
-The raw table contains these fields:
-- `_airbyte_raw_id`
-- `_airbyte_generation_id`
-- `_airbyte_extracted_at`
-- `_airbyte_loaded_at`
-- `_airbyte_meta`
-- `_airbyte_data`
-
-`_airbyte_data` is a JSON blob with the event data. See [here](/platform/understanding-airbyte/airbyte-metadata-fields)
-for more information about the other fields.
-
-**Note:** Although the contents of the `_airbyte_data` are fairly stable, schema of the raw table
-could be subject to change in future versions.
-
-### Final Table schema
-
 The final table contains these fields, in addition to the columns declared in your stream schema:
 - `airbyte_raw_id`
 - `_airbyte_generation_id`
@@ -152,6 +130,25 @@ querying these partitioned tables, by using a predicate filter (a `WHERE` clause
 partitioning column are used to prune the partitions and reduce the query cost. (The parameter
 **Require partition filter** is not enabled by Airbyte, but you may toggle it by updating the
 produced tables.)
+
+### Legacy Raw Tables schema
+
+If you enable the `Legacy raw tables` option, the connector will write tables in this format.
+
+Airbyte outputs each stream into its own raw table in `airbyte_internal` dataset by default (can be
+overriden by user) and a final table with Typed columns. Contents in raw table are _NOT_
+deduplicated.
+
+The raw table contains these fields:
+- `_airbyte_raw_id`
+- `_airbyte_generation_id`
+- `_airbyte_extracted_at`
+- `_airbyte_loaded_at`
+- `_airbyte_meta`
+- `_airbyte_data`
+
+`_airbyte_data` is a JSON blob with the record's data. See [here](/platform/understanding-airbyte/airbyte-metadata-fields)
+for more information about the other fields.
 
 ## BigQuery Naming Conventions
 

--- a/docs/integrations/destinations/bigquery.md
+++ b/docs/integrations/destinations/bigquery.md
@@ -135,9 +135,9 @@ produced tables.)
 
 If you enable the `Legacy raw tables` option, the connector will write tables in this format.
 
-Airbyte outputs each stream into its own raw table in `airbyte_internal` dataset by default (can be
-overriden by user) and a final table with Typed columns. Contents in raw table are _NOT_
-deduplicated.
+Airbyte outputs each stream into its own raw table in `airbyte_internal` dataset by default (you can
+override this via the `Airbyte Internal Table Dataset Name` option). Contents in the raw table are
+_NOT_ deduplicated.
 
 The raw table contains these fields:
 - `_airbyte_raw_id`

--- a/docs/integrations/destinations/bigquery.md
+++ b/docs/integrations/destinations/bigquery.md
@@ -210,6 +210,7 @@ tutorials:
 
 | Version     | Date       | Pull Request                                               | Subject                                                                                                                                                                           |
 |:------------|:-----------|:-----------------------------------------------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 3.0.0  | 2025-06-25 | [59752](https://github.com/airbytehq/airbyte/pull/59752) | Upgrade to direct-load tables; add option for soft CDC deletes. |
 | 2.12.0 | 2025-06-06 | [61432](https://github.com/airbytehq/airbyte/pull/61432) | Improve performance in GCS staging mode by writing GZIP-compressed files. |
 | 2.11.4 | 2025-05-30 | [61018](https://github.com/airbytehq/airbyte/pull/61018) | Always emit a useful error message when erroring during sync startup. |
 | 2.11.3 | 2025-06-02 | [61321](https://github.com/airbytehq/airbyte/pull/61321) | CHECK operation doesn't need to drop the dataset anymore. |

--- a/docs/platform/using-airbyte/core-concepts/direct-load-tables.md
+++ b/docs/platform/using-airbyte/core-concepts/direct-load-tables.md
@@ -1,0 +1,45 @@
+# Direct-Load Tables
+
+Direct-load is an improvement to [Typing and Deduping](typing-deduping). Under direct-load, the final tables in your destination are identical to their T+D version, but without the need to store the raw tables in your destination. Direct-load tables are also significantly faster and less expensive in terms of warehouse compute/storage cost, because some of the processing is handled by the destination connector itself, rather than executed within your warehouse.
+
+## Why is this happening?
+
+Under Typing and Deduping, during a sync, a destination connector only writes JSON data into a "raw table." At the end of each sync, the connector then executes a SQL query (the "T+D" query) to load new records from that raw table into the true (fully-typed) "final table."
+
+This has two main downsides:
+
+* Unbounded growth in the raw tables (because they're never deduped)
+* High warehouse compute spend (because the T+D query does some nontrivial `cast` operations)
+
+Direct-load addresses both of those problems, by offloading the type-casting to the destination connector itself. This allows the connector to load typed data directly into the warehouse (hence the name "direct-load"), and avoids the need to store persistent, non-deduped raw tables in the warehouse.
+
+## What will change?
+
+If you never query the raw tables, you will notice very little difference, other than a reduced warehouse bill. The format and structure of your tables will remain the same. If you query _only_ the raw tables, see the [compatibility support](#raw-tables-compatibility-support) section.
+
+Connectors will continue to populate the `_airbyte_meta` column with any type validation errors. Note that the `reason` field in each change will change (under T+D it was `DESTINATION_TYPECAST_ERROR`; under direct-load it is `DESTINATION_SERIALIZATION_ERROR`). However, if you are using our recommended query style (e.g. `WHERE json_array_length(_airbyte_meta ->> changes) = 0`), this will not impact you.
+
+### Schema evolution
+
+Direct-load connectors may require user intervention in certain schema evolution situations. This is a change from T+D destinations, where schema evolution was handled by triggering a soft reset (which always succeeds, but requires a slow/expensive table rebuild). Direct-load connectors instead execute `alter table` statements (or some equivalent), which may not succeed in all cases.
+
+Specifically, if a column's type is changed, and any historical records contain a value which cannot be cast to the new type, the schema change will fail in direct-load destinations.
+
+If you see such a failure, you have two options:
+
+* Run a refresh, and choose to remove existing records
+* Manually update historical records to be valid under the new type
+
+### Record visibility
+
+`Append` syncs will now insert records directly to the target table. This is different from T+D, where new records are first written to the raw table, and not populated to the final table until the end of the sync.
+
+Depending on the destination, `dedup` syncs may periodically upsert records to the target table. `Dedup` syncs will (for most destinations) still write to a separate table during the sync. However, that table only exists for the duration of the sync; after a successful sync, it will be deleted.
+
+`Overwrite` syncs (including any "refresh and remove records" operation) will also continue to use a temporary table, to support Airbyte's no-data-downtime feature.
+
+### Raw tables compatibility support
+
+If you were previously querying the raw tables directly, you may choose to enable the `Legacy raw tables` option on the connector. This is equivalent to the T+D `Disable Final Tables` option: the connector will _only_ write the raw tables, and will _not_ create the final tables at all. Connectors with the `Disable Final Tables` option enabled will automatically have the `Legacy raw tables` option enabled.
+
+The connector no longer supports writing both the raw and final tables in a single connection. If you need to do this, you should configure two destinations, and run connections to them in parallel.

--- a/docs/platform/using-airbyte/core-concepts/direct-load-tables.md
+++ b/docs/platform/using-airbyte/core-concepts/direct-load-tables.md
@@ -2,7 +2,7 @@
 
 Direct-load is an improvement to [Typing and Deduping](typing-deduping). Airbyte intends to eventually replace typing and deduping with direct-load. Under direct-load, the final tables in your destination are identical to their typed and deduped version, but without the need to store the raw tables in your destination.
 
-## Why is this happening?
+## Why direct-loading is superior to typing and deduping
 
 Under Typing and Deduping, during a sync, a destination connector only writes JSON data into a "raw table." At the end of each sync, the connector then executes a SQL query (the "T+D" query) to load new records from that raw table into the true (fully-typed) "final table."
 

--- a/docs/platform/using-airbyte/core-concepts/direct-load-tables.md
+++ b/docs/platform/using-airbyte/core-concepts/direct-load-tables.md
@@ -1,6 +1,6 @@
 # Direct-Load Tables
 
-Direct-load is an improvement to [Typing and Deduping](typing-deduping). Under direct-load, the final tables in your destination are identical to their T+D version, but without the need to store the raw tables in your destination. Direct-load tables are also significantly faster and less expensive in terms of warehouse compute/storage cost, because some of the processing is handled by the destination connector itself, rather than executed within your warehouse.
+Direct-load is an improvement to [Typing and Deduping](typing-deduping). Airbyte intends to eventually replace typing and deduping with direct-load. Under direct-load, the final tables in your destination are identical to their typed and deduped version, but without the need to store the raw tables in your destination.
 
 ## Why is this happening?
 

--- a/docs/platform/using-airbyte/core-concepts/typing-deduping.md
+++ b/docs/platform/using-airbyte/core-concepts/typing-deduping.md
@@ -5,7 +5,7 @@ products: all
 # Typing and Deduping
 
 :::warning
-**Typing and Deduping is currently being phased out in favor of Direct Loads.**
+**Typing and Deduping is currently being phased out in favor of [Direct-Load](direct-load-tables).**
 
 With Direct Loads, there is no intermediate table result containing the raw JSON blob. Instead, top-level fields are typed during time of insert, and there is only a single destination table maintained per stream.
 :::
@@ -61,7 +61,7 @@ The types of changes which will be stored in `_airbyte_meta.changes` include:
   Destinations V2 will allow us to trim records which cannot fit into destinations, but retain the
   primary key(s) and cursors and include "too big" changes messages.
 
-Also, sources can make use of the same tooling to denote that there was a problem emitting the Airbyte record to begin with, 
+Also, sources can make use of the same tooling to denote that there was a problem emitting the Airbyte record to begin with,
 possibly also creating an entry in `_airbyte_meta.changes`.
 
 Depending on your use-case, it may still be valuable to consider rows with changes, especially for

--- a/docusaurus/platform_versioned_docs/version-1.6/using-airbyte/core-concepts/direct-load-tables.md
+++ b/docusaurus/platform_versioned_docs/version-1.6/using-airbyte/core-concepts/direct-load-tables.md
@@ -1,0 +1,45 @@
+# Direct-Load Tables
+
+Direct-load is an improvement to [Typing and Deduping](typing-deduping). Airbyte intends to eventually replace typing and deduping with direct-load. Under direct-load, the final tables in your destination are identical to their typed and deduped version, but without the need to store the raw tables in your destination.
+
+## Why direct-loading is superior to typing and deduping
+
+Under Typing and Deduping, during a sync, a destination connector only writes JSON data into a "raw table." At the end of each sync, the connector then executes a SQL query (the "T+D" query) to load new records from that raw table into the true (fully-typed) "final table."
+
+This has two main downsides:
+
+* Unbounded growth in the raw tables (because they're never deduped)
+* High warehouse compute spend (because the T+D query does some nontrivial `cast` operations)
+
+Direct-load addresses both of those problems, by offloading the type-casting to the destination connector itself. This allows the connector to load typed data directly into the warehouse (hence the name "direct-load"), and avoids the need to store persistent, non-deduped raw tables in the warehouse.
+
+## What will change?
+
+If you never query the raw tables, you will notice very little difference, other than a reduced warehouse bill. The format and structure of your tables will remain the same. If you query _only_ the raw tables, see the [compatibility support](#raw-tables-compatibility-support) section.
+
+Connectors will continue to populate the `_airbyte_meta` column with any type validation errors. Note that the `reason` field in each change will change (under T+D it was `DESTINATION_TYPECAST_ERROR`; under direct-load it is `DESTINATION_SERIALIZATION_ERROR`). However, if you are using our recommended query style (e.g. `WHERE json_array_length(_airbyte_meta ->> changes) = 0`), this will not impact you.
+
+### Schema evolution
+
+Direct-load connectors may require user intervention in certain schema evolution situations. This is a change from T+D destinations, where schema evolution was handled by triggering a soft reset (which always succeeds, but requires a slow/expensive table rebuild). Direct-load connectors instead execute `alter table` statements (or some equivalent), which may not succeed in all cases.
+
+Specifically, if a column's type is changed, and any historical records contain a value which cannot be cast to the new type, the schema change will fail in direct-load destinations.
+
+If you see such a failure, you have two options:
+
+* Run a refresh, and choose to remove existing records
+* Manually update historical records to be valid under the new type
+
+### Record visibility
+
+`Append` syncs will now insert records directly to the target table. This is different from T+D, where new records are first written to the raw table, and not populated to the final table until the end of the sync.
+
+Depending on the destination, `dedup` syncs may periodically upsert records to the target table. `Dedup` syncs will (for most destinations) still write to a separate table during the sync. However, that table only exists for the duration of the sync; after a successful sync, it will be deleted.
+
+`Overwrite` syncs (including any "refresh and remove records" operation) will also continue to use a temporary table, to support Airbyte's no-data-downtime feature.
+
+### Raw tables compatibility support
+
+If you were previously querying the raw tables directly, you may choose to enable the `Legacy raw tables` option on the connector. This is equivalent to the T+D `Disable Final Tables` option: the connector will _only_ write the raw tables, and will _not_ create the final tables at all. Connectors with the `Disable Final Tables` option enabled will automatically have the `Legacy raw tables` option enabled.
+
+The connector no longer supports writing both the raw and final tables in a single connection. If you need to do this, you should configure two destinations, and run connections to them in parallel.

--- a/docusaurus/sidebar-platform.js
+++ b/docusaurus/sidebar-platform.js
@@ -324,6 +324,10 @@ module.exports = {
         connectionConfigurations,
         {
           type: "doc",
+          id: "using-airbyte/core-concepts/direct-load-tables",
+        },
+        {
+          type: "doc",
           id: "using-airbyte/core-concepts/typing-deduping",
         },
         {


### PR DESCRIPTION
closes https://github.com/airbytehq/airbyte-internal-issues/issues/13020

* add a top-level description of direct-load, next to the T+D doc (`platform/using-airbyte/core-concepts/typing-deduping.md`)
* add a migration guide + metadata.yaml entry
* update the bigquery connector guide