### PR TITLE
Bulk load CDK: fix typo

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/ReservingDeserializingInputFlow.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/ReservingDeserializingInputFlow.kt
@@ -48,7 +48,7 @@ class ReservingDeserializingInputFlow(
 
             bytes += lineSize
             if (++index % logPerNRecords == 0L) {
-                log.info { "Processed $index lines (${bytes/1024/1024}Mb" }
+                log.info { "Processed $index lines (${bytes/1024/1024}Mb)" }
             }
         }
 


### PR DESCRIPTION
currently we're writing logs like `Processed 32800000 lines (8539Mb`, fix that to have a closing paren :shrug: