### PR TITLE
Use the AirbyteValueCoercer date and time formatter everywhere

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/AirbyteValueCoercer.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/AirbyteValueCoercer.kt
@@ -157,11 +157,9 @@ object AirbyteValueCoercer {
     private fun offsetDateTime(it: StringValue): OffsetDateTime {
         val odt =
             try {
-                ZonedDateTime.parse(it.value, DATE_TIME_FORMATTER)
-                    .toOffsetDateTime()
+                ZonedDateTime.parse(it.value, DATE_TIME_FORMATTER).toOffsetDateTime()
             } catch (e: Exception) {
-                LocalDateTime.parse(it.value, DATE_TIME_FORMATTER)
-                    .atOffset(ZoneOffset.UTC)
+                LocalDateTime.parse(it.value, DATE_TIME_FORMATTER).atOffset(ZoneOffset.UTC)
             }
         return odt
     }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/AirbyteValueCoercer.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/AirbyteValueCoercer.kt
@@ -157,10 +157,10 @@ object AirbyteValueCoercer {
     private fun offsetDateTime(it: StringValue): OffsetDateTime {
         val odt =
             try {
-                ZonedDateTime.parse(it.value, AirbyteValueDeepCoercingMapper.DATE_TIME_FORMATTER)
+                ZonedDateTime.parse(it.value, DATE_TIME_FORMATTER)
                     .toOffsetDateTime()
             } catch (e: Exception) {
-                LocalDateTime.parse(it.value, AirbyteValueDeepCoercingMapper.DATE_TIME_FORMATTER)
+                LocalDateTime.parse(it.value, DATE_TIME_FORMATTER)
                     .atOffset(ZoneOffset.UTC)
             }
         return odt

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/AirbyteValueDeepCoercingMapper.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/AirbyteValueDeepCoercingMapper.kt
@@ -7,7 +7,6 @@ package io.airbyte.cdk.load.data
 import io.airbyte.cdk.load.message.Meta
 import io.airbyte.protocol.models.v0.AirbyteRecordMessageMetaChange.Change
 import io.airbyte.protocol.models.v0.AirbyteRecordMessageMetaChange.Reason
-import java.time.format.DateTimeFormatter
 
 /**
  * A mapper which coerces ALL values against the schema. This mapper MUST NOT be called after any

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/AirbyteValueDeepCoercingMapper.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/AirbyteValueDeepCoercingMapper.kt
@@ -178,15 +178,4 @@ class AirbyteValueDeepCoercingMapper(
             )
             NullValue to context
         }
-
-    companion object {
-        val DATE_TIME_FORMATTER: DateTimeFormatter =
-            DateTimeFormatter.ofPattern(
-                "[yyyy][yy]['-']['/']['.'][' '][MMM][MM][M]['-']['/']['.'][' '][dd][d][[' '][G]][[' ']['T']HH:mm[':'ss[.][SSSSSS][SSSSS][SSSS][SSS][' '][z][zzz][Z][O][x][XXX][XX][X][[' '][G]]]]"
-            )
-        val TIME_FORMATTER: DateTimeFormatter =
-            DateTimeFormatter.ofPattern(
-                "HH:mm[':'ss[.][SSSSSS][SSSSS][SSSS][SSS][' '][z][zzz][Z][O][x][XXX][XX][X]]"
-            )
-    }
 }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/DestinationMessage.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/DestinationMessage.kt
@@ -9,7 +9,7 @@ import com.fasterxml.jackson.databind.JsonNode
 import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.data.AirbyteType
 import io.airbyte.cdk.load.data.AirbyteValue
-import io.airbyte.cdk.load.data.AirbyteValueDeepCoercingMapper
+import io.airbyte.cdk.load.data.AirbyteValueCoercer.DATE_TIME_FORMATTER
 import io.airbyte.cdk.load.data.ArrayType
 import io.airbyte.cdk.load.data.ArrayValue
 import io.airbyte.cdk.load.data.EnrichedAirbyteValue
@@ -161,7 +161,7 @@ data class Meta(
                         TimestampWithTimezoneValue(
                             OffsetDateTime.parse(
                                 value,
-                                AirbyteValueDeepCoercingMapper.DATE_TIME_FORMATTER,
+                                DATE_TIME_FORMATTER,
                             ),
                         )
                     }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/util/TimeStringUtility.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/util/TimeStringUtility.kt
@@ -4,7 +4,8 @@
 
 package io.airbyte.cdk.load.util
 
-import io.airbyte.cdk.load.data.AirbyteValueDeepCoercingMapper
+import io.airbyte.cdk.load.data.AirbyteValueCoercer.DATE_TIME_FORMATTER
+import io.airbyte.cdk.load.data.AirbyteValueCoercer.TIME_FORMATTER
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
@@ -17,11 +18,11 @@ import java.time.ZonedDateTime
 object TimeStringUtility {
 
     fun toLocalDate(dateString: String): LocalDate {
-        return LocalDate.parse(dateString, AirbyteValueDeepCoercingMapper.DATE_TIME_FORMATTER)
+        return LocalDate.parse(dateString, DATE_TIME_FORMATTER)
     }
 
     fun toLocalDateTime(dateString: String): LocalDateTime {
-        return LocalDateTime.parse(dateString, AirbyteValueDeepCoercingMapper.DATE_TIME_FORMATTER)
+        return LocalDateTime.parse(dateString, DATE_TIME_FORMATTER)
     }
 
     fun toOffset(timeString: String): LocalTime {
@@ -33,12 +34,12 @@ object TimeStringUtility {
     }
 
     private fun toMicrosOfDayWithTimezone(timeString: String): LocalTime {
-        return OffsetTime.parse(timeString, AirbyteValueDeepCoercingMapper.TIME_FORMATTER)
+        return OffsetTime.parse(timeString, TIME_FORMATTER)
             .toLocalTime()
     }
 
     private fun toMicrosOfDayWithoutTimezone(timeString: String): LocalTime {
-        return LocalTime.parse(timeString, AirbyteValueDeepCoercingMapper.TIME_FORMATTER)
+        return LocalTime.parse(timeString, TIME_FORMATTER)
     }
 
     fun toOffsetDateTime(timestampString: String): OffsetDateTime {
@@ -52,7 +53,7 @@ object TimeStringUtility {
     private fun toOffsetDateTimeWithTimezone(timestampString: String): OffsetDateTime {
         return ZonedDateTime.parse(
                 timestampString,
-                AirbyteValueDeepCoercingMapper.DATE_TIME_FORMATTER
+                DATE_TIME_FORMATTER
             )
             .toOffsetDateTime()
     }
@@ -60,7 +61,7 @@ object TimeStringUtility {
     private fun toOffsetDateTimeWithoutTimezone(timestampString: String): OffsetDateTime {
         return LocalDateTime.parse(
                 timestampString,
-                AirbyteValueDeepCoercingMapper.DATE_TIME_FORMATTER
+                DATE_TIME_FORMATTER
             )
             .atOffset(ZoneOffset.UTC)
     }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/util/TimeStringUtility.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/util/TimeStringUtility.kt
@@ -34,8 +34,7 @@ object TimeStringUtility {
     }
 
     private fun toMicrosOfDayWithTimezone(timeString: String): LocalTime {
-        return OffsetTime.parse(timeString, TIME_FORMATTER)
-            .toLocalTime()
+        return OffsetTime.parse(timeString, TIME_FORMATTER).toLocalTime()
     }
 
     private fun toMicrosOfDayWithoutTimezone(timeString: String): LocalTime {
@@ -51,18 +50,10 @@ object TimeStringUtility {
     }
 
     private fun toOffsetDateTimeWithTimezone(timestampString: String): OffsetDateTime {
-        return ZonedDateTime.parse(
-                timestampString,
-                DATE_TIME_FORMATTER
-            )
-            .toOffsetDateTime()
+        return ZonedDateTime.parse(timestampString, DATE_TIME_FORMATTER).toOffsetDateTime()
     }
 
     private fun toOffsetDateTimeWithoutTimezone(timestampString: String): OffsetDateTime {
-        return LocalDateTime.parse(
-                timestampString,
-                DATE_TIME_FORMATTER
-            )
-            .atOffset(ZoneOffset.UTC)
+        return LocalDateTime.parse(timestampString, DATE_TIME_FORMATTER).atOffset(ZoneOffset.UTC)
     }
 }

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/data/AirbyteValueDeepCoercingMapperTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/data/AirbyteValueDeepCoercingMapperTest.kt
@@ -4,7 +4,7 @@
 
 package io.airbyte.cdk.load.data
 
-import io.airbyte.cdk.load.data.AirbyteValueDeepCoercingMapper.Companion.DATE_TIME_FORMATTER
+import io.airbyte.cdk.load.data.AirbyteValueCoercer.DATE_TIME_FORMATTER
 import io.airbyte.cdk.load.data.json.toAirbyteValue
 import io.airbyte.cdk.load.message.Meta
 import io.airbyte.cdk.load.util.Jsons

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/util/TimeStringUtilityTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/util/TimeStringUtilityTest.kt
@@ -4,6 +4,7 @@
 
 package io.airbyte.cdk.load.util
 
+import io.airbyte.cdk.load.data.AirbyteValueCoercer
 import io.airbyte.cdk.load.data.AirbyteValueDeepCoercingMapper
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -22,7 +23,7 @@ internal class TimeStringUtilityTest {
         val localDateString = "2024-11-18"
         val localDate = TimeStringUtility.toLocalDate(localDateString)
         assertEquals(
-            LocalDate.parse(localDateString, AirbyteValueDeepCoercingMapper.DATE_TIME_FORMATTER),
+            LocalDate.parse(localDateString, AirbyteValueCoercer.DATE_TIME_FORMATTER),
             localDate
         )
     }
@@ -42,7 +43,7 @@ internal class TimeStringUtilityTest {
         assertEquals(
             LocalDateTime.parse(
                 localDateTimeString,
-                AirbyteValueDeepCoercingMapper.DATE_TIME_FORMATTER
+                AirbyteValueCoercer.DATE_TIME_FORMATTER
             ),
             localDateTime
         )
@@ -55,7 +56,7 @@ internal class TimeStringUtilityTest {
         assertEquals(
             OffsetTime.parse(
                     offsetWithTimezoneString,
-                    AirbyteValueDeepCoercingMapper.TIME_FORMATTER
+                AirbyteValueCoercer.TIME_FORMATTER
                 )
                 .toLocalTime(),
             offsetWithTimezone
@@ -69,7 +70,7 @@ internal class TimeStringUtilityTest {
         assertEquals(
             LocalTime.parse(
                 offsetWithoutTimezoneString,
-                AirbyteValueDeepCoercingMapper.TIME_FORMATTER
+                AirbyteValueCoercer.TIME_FORMATTER
             ),
             offsetWithoutTimezone
         )
@@ -82,7 +83,7 @@ internal class TimeStringUtilityTest {
         assertEquals(
             ZonedDateTime.parse(
                     offsetWithTimezoneString,
-                    AirbyteValueDeepCoercingMapper.DATE_TIME_FORMATTER
+                AirbyteValueCoercer.DATE_TIME_FORMATTER
                 )
                 .toOffsetDateTime(),
             offsetWithTimezone
@@ -96,7 +97,7 @@ internal class TimeStringUtilityTest {
         assertEquals(
             LocalDateTime.parse(
                     offsetWithoutTimezoneString,
-                    AirbyteValueDeepCoercingMapper.DATE_TIME_FORMATTER
+                AirbyteValueCoercer.DATE_TIME_FORMATTER
                 )
                 .atOffset(ZoneOffset.UTC),
             offsetWithoutTimezone

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/util/TimeStringUtilityTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/util/TimeStringUtilityTest.kt
@@ -5,7 +5,6 @@
 package io.airbyte.cdk.load.util
 
 import io.airbyte.cdk.load.data.AirbyteValueCoercer
-import io.airbyte.cdk.load.data.AirbyteValueDeepCoercingMapper
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
@@ -41,10 +40,7 @@ internal class TimeStringUtilityTest {
         val localDateTimeString = "2024-11-18T12:34:56Z"
         val localDateTime = TimeStringUtility.toLocalDateTime(localDateTimeString)
         assertEquals(
-            LocalDateTime.parse(
-                localDateTimeString,
-                AirbyteValueCoercer.DATE_TIME_FORMATTER
-            ),
+            LocalDateTime.parse(localDateTimeString, AirbyteValueCoercer.DATE_TIME_FORMATTER),
             localDateTime
         )
     }
@@ -54,10 +50,7 @@ internal class TimeStringUtilityTest {
         val offsetWithTimezoneString = "12:34:56Z"
         val offsetWithTimezone = TimeStringUtility.toOffset(offsetWithTimezoneString)
         assertEquals(
-            OffsetTime.parse(
-                    offsetWithTimezoneString,
-                AirbyteValueCoercer.TIME_FORMATTER
-                )
+            OffsetTime.parse(offsetWithTimezoneString, AirbyteValueCoercer.TIME_FORMATTER)
                 .toLocalTime(),
             offsetWithTimezone
         )
@@ -68,10 +61,7 @@ internal class TimeStringUtilityTest {
         val offsetWithoutTimezoneString = "12:34:56"
         val offsetWithoutTimezone = TimeStringUtility.toOffset(offsetWithoutTimezoneString)
         assertEquals(
-            LocalTime.parse(
-                offsetWithoutTimezoneString,
-                AirbyteValueCoercer.TIME_FORMATTER
-            ),
+            LocalTime.parse(offsetWithoutTimezoneString, AirbyteValueCoercer.TIME_FORMATTER),
             offsetWithoutTimezone
         )
     }
@@ -81,10 +71,7 @@ internal class TimeStringUtilityTest {
         val offsetWithTimezoneString = "2024-11-18T12:34:56Z"
         val offsetWithTimezone = TimeStringUtility.toOffsetDateTime(offsetWithTimezoneString)
         assertEquals(
-            ZonedDateTime.parse(
-                    offsetWithTimezoneString,
-                AirbyteValueCoercer.DATE_TIME_FORMATTER
-                )
+            ZonedDateTime.parse(offsetWithTimezoneString, AirbyteValueCoercer.DATE_TIME_FORMATTER)
                 .toOffsetDateTime(),
             offsetWithTimezone
         )
@@ -97,7 +84,7 @@ internal class TimeStringUtilityTest {
         assertEquals(
             LocalDateTime.parse(
                     offsetWithoutTimezoneString,
-                AirbyteValueCoercer.DATE_TIME_FORMATTER
+                    AirbyteValueCoercer.DATE_TIME_FORMATTER
                 )
                 .atOffset(ZoneOffset.UTC),
             offsetWithoutTimezone


### PR DESCRIPTION
## What

We had 2 DATE_TIME_FORMATTER and TIME_FORMATTER that were identical.
Just merging the use and removing one of them

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [X] YES 💚
- [ ] NO ❌
