### PR TITLE
fix: only build and push connectors if versions have changed.

### DIFF
--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -62,7 +62,7 @@ jobs:
         id: build-and-publish-JVM-connectors-images-master
         if: github.event_name == 'push'
         shell: bash
-        run: ./poe-tasks/get-modified-connectors.sh --prev-commit --json  --java | ./poe-tasks/build-and-publish-java-connectors-with-tag.sh --main-release
+        run: ./poe-tasks/get-modified-connectors.sh --prev-commit --json  --java | ./poe-tasks/build-and-publish-java-connectors-with-tag.sh --main-release --publish
 
       - name: Publish modified connectors [On merge to master]
         # JVM docker images are published beforehand so Airbyte-CI only does registry publishing.
@@ -92,7 +92,7 @@ jobs:
         id: build-and-publish-JVM-connectors-images-manual
         if: github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call'
         shell: bash
-        run: ./poe-tasks/build-and-publish-java-connectors-with-tag.sh  ${{ inputs.publish-options }} ${{ inputs.connectors-options }}
+        run: ./poe-tasks/build-and-publish-java-connectors-with-tag.sh  ${{ inputs.publish-options }} ${{ inputs.connectors-options }} --publish
 
       - name: Publish connectors [manual]
         id: publish-connectors

--- a/airbyte-integrations/connectors/destination-dev-null/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-dev-null/metadata.yaml
@@ -16,7 +16,7 @@ data:
     - suite: integrationTests
   connectorType: destination
   definitionId: a7bcc9d8-13b3-4e49-b80d-d020b90045e3
-  dockerImageTag: 0.7.26
+  dockerImageTag: 0.7.27
   dockerRepository: airbyte/destination-dev-null
   documentationUrl: https://docs.airbyte.com/integrations/destinations/dev-null
   githubIssueLabel: destination-dev-null

--- a/airbyte-integrations/connectors/destination-dev-null/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-dev-null/metadata.yaml
@@ -16,7 +16,7 @@ data:
     - suite: integrationTests
   connectorType: destination
   definitionId: a7bcc9d8-13b3-4e49-b80d-d020b90045e3
-  dockerImageTag: 0.7.27
+  dockerImageTag: 0.7.26
   dockerRepository: airbyte/destination-dev-null
   documentationUrl: https://docs.airbyte.com/integrations/destinations/dev-null
   githubIssueLabel: destination-dev-null

--- a/poe-tasks/build-and-publish-java-connectors-with-tag.sh
+++ b/poe-tasks/build-and-publish-java-connectors-with-tag.sh
@@ -1,4 +1,18 @@
 #!/usr/bin/env bash
+# This script builds and optionally publishes Java connector Docker images.
+#
+# Flag descriptions:
+#   --main-release: Publishes images with the exact version from metadata.yaml.
+#                   Only publishes if the version has increased compared to the previous commit.
+#                   Used for production releases on merge to master.
+#
+#   --pre-release:  Publishes images with a dev tag (version-dev.githash).
+#                   Always publishes regardless of version changes.
+#                   Used for development/testing purposes.
+#
+#   --publish:      Actually publishes the images. Without this flag, the script runs in dry-run mode
+#                   and only shows what would be published without actually publishing.
+#
 # Usage examples:
 #   ./get-modified-connectors.sh --prev-commit --json | ./build-and-publish-java-connectors-with-tag.sh
 #
@@ -76,7 +90,7 @@ connectors=()
 while [[ $# -gt 0 ]]; do
   case "$1" in
     -h|--help)
-      sed -n '1,20p' "$0"
+      sed -n '1,34p' "$0"
       exit 0
       ;;
     --main-release)

--- a/poe-tasks/build-and-publish-java-connectors-with-tag.sh
+++ b/poe-tasks/build-and-publish-java-connectors-with-tag.sh
@@ -169,8 +169,9 @@ dockerhub_tag_exists() {
     fi
   done
 
-  echo "❌ Failed to contact Docker Hub after $max_attempts attempts. Assuming tag does not exist." >&2
-  return 1
+  # Blow up to be safe.
+  echo "❌ Failed to contact Docker Hub after $max_attempts attempts. Exiting to be safe." >&2
+  exit 1
 }
 
 generate_dev_tag() {

--- a/poe-tasks/build-and-publish-java-connectors-with-tag.sh
+++ b/poe-tasks/build-and-publish-java-connectors-with-tag.sh
@@ -148,17 +148,17 @@ version_gt() {
     return 1
   fi
 
-  # Extract components (assuming semantic versioning)
+  # Extract components (assuming semantic versioning) on the . separator.
   local IFS=.
   local i v1_array=($v1) v2_array=($v2)
 
   # Compare each component
   for ((i=0; i<${#v1_array[@]} || i<${#v2_array[@]}; i++)); do
-    # Default to 0 if component doesn't exist
+    # Default to 0 if component doesn't exist. 1.2 -> 1.2.0
     local v1_comp=${v1_array[i]:-0}
     local v2_comp=${v2_array[i]:-0}
 
-    # Remove any non-numeric suffix (like -alpha, -beta, etc.)
+    # Remove any non-numeric suffix (like -alpha, -beta, etc.) for simplicity.
     v1_comp=$(echo "$v1_comp" | sed -E 's/([0-9]+).*/\1/')
     v2_comp=$(echo "$v2_comp" | sed -E 's/([0-9]+).*/\1/')
 
@@ -227,10 +227,6 @@ while read -r connector; do
               ":${CONNECTORS_DIR//\//:}:${connector}:assemble"
   else
     echo "DRY RUN: Would build & publish ${connector} with tag ${docker_tag}"
-    ./gradlew -DciMode=true \
-              -Psbom=false \
-              -Pdocker.tag="${docker_tag}" \
-              ":${CONNECTORS_DIR//\//:}:${connector}:assemble"
   fi
 done < <(get_connectors)
 if $do_publish; then

--- a/poe-tasks/build-and-publish-java-connectors-with-tag.sh
+++ b/poe-tasks/build-and-publish-java-connectors-with-tag.sh
@@ -23,41 +23,50 @@ set -euo pipefail
 CONNECTORS_DIR="airbyte-integrations/connectors"
 
 # ── Rollout whitelist: only connectors listed here will be built/published
-declare -A rollout_map=(
-  [destination-azure-blob-storage]=1
-  [destination-bigquery]=1
-  [destination-clickhouse-strict-encrypt]=1
-  [destination-clickhouse]=1
-  [destination-csv]=1
-  [destination-databricks]=1
-  [destination-dev-null]=1
-  [destination-dynamodb]=1
-  [destination-elasticsearch-strict-encrypt]=1
-  [destination-elasticsearch]=1
-  [destination-gcs]=1
-  [destination-kafka]=1
-  [destination-local-json]=1
-  [destination-mongodb-strict-encrypt]=1
-  [destination-mongodb]=1
-  [destination-mysql-strict-encrypt]=1
-  [destination-mysql]=1
-  [destination-oracle-strict-encrypt]=1
-  [destination-oracle]=1
-  [destination-postgres-strict-encrypt]=1
-  [destination-postgres]=1
-  [destination-redis]=1
-  [destination-redshift]=1
-  [destination-s3-data-lake]=1
-  [destination-s3]=1
-  [destination-singlestore]=1
-  [destination-snowflake]=1
-  [destination-starburst-galaxy]=1
-  [destination-teradata]=1
-  [destination-yellowbrick]=1
-  [source-e2e-test]=1
-  [source-postgres]=1
-  [source-mysql]=1
-)
+# Function to check if a connector is in the whitelist
+is_in_whitelist() {
+  local connector="$1"
+  case "$connector" in
+    destination-azure-blob-storage|\
+    destination-bigquery|\
+    destination-clickhouse-strict-encrypt|\
+    destination-clickhouse|\
+    destination-csv|\
+    destination-databricks|\
+    destination-dev-null|\
+    destination-dynamodb|\
+    destination-elasticsearch-strict-encrypt|\
+    destination-elasticsearch|\
+    destination-gcs|\
+    destination-kafka|\
+    destination-local-json|\
+    destination-mongodb-strict-encrypt|\
+    destination-mongodb|\
+    destination-mysql-strict-encrypt|\
+    destination-mysql|\
+    destination-oracle-strict-encrypt|\
+    destination-oracle|\
+    destination-postgres-strict-encrypt|\
+    destination-postgres|\
+    destination-redis|\
+    destination-redshift|\
+    destination-s3-data-lake|\
+    destination-s3|\
+    destination-singlestore|\
+    destination-snowflake|\
+    destination-starburst-galaxy|\
+    destination-teradata|\
+    destination-yellowbrick|\
+    source-e2e-test|\
+    source-postgres|\
+    source-mysql)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
 
 # ------ Defaults & arg parsing -------
 publish_mode="pre-release"
@@ -168,8 +177,8 @@ version_gt() {
 
 # ---------- main loop ----------
 while read -r connector; do
-  # only publish if connector is in rollout_map
-  if [[ -z ${rollout_map[$connector]:-} ]]; then
+  # only publish if connector is in whitelist
+  if ! is_in_whitelist "$connector"; then
     echo "ℹ️  Skipping '$connector'; not in rollout whitelist"
     continue
   fi


### PR DESCRIPTION
## What
A bug currently exists in the publishing flow for JVM connectors - we always build and publish connectors on changes.

This is fine if the connector's version actually changed. Some destinations use `requireVersionIncrementsInPullRequests` to false to allow for rapid iteration without publishing versions. 

Because of this, we want to add logic here to only publish images if the image does not exists.

## How
Curl dockerhub to see if the image exists. If it does, do not publish.

I also added a `--publish` flag and defaulted the script to dry-run for better testing. This was previously requested, and I though I'd do so since I was here.

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
