### PR TITLE
fix(docker-images): Update Python and Java connector image definitions

### DIFF
--- a/docker-images/Dockerfile.java-connector
+++ b/docker-images/Dockerfile.java-connector
@@ -17,10 +17,15 @@ RUN chmod +x /airbyte/base.sh /airbyte/javabase.sh && \
 ENV AIRBYTE_ENTRYPOINT="/airbyte/base.sh"
 ENV APPLICATION="${CONNECTOR_NAME}"
 
-# Add the connector TAR file and extract it
-COPY ./build/distributions/${CONNECTOR_NAME}.tar /tmp/${CONNECTOR_NAME}.tar
-RUN tar xf /tmp/${CONNECTOR_NAME}.tar --strip-components=1 -C /airbyte && \
-    rm -rf /tmp/${CONNECTOR_NAME}.tar && \
+# Add the connector TAR file and extract it (try connector-specific name first, fallback to airbyte-app.tar)
+COPY ./build/distributions/ /tmp/distributions/
+RUN if [ -f /tmp/distributions/${CONNECTOR_NAME}.tar ]; then \
+        cp /tmp/distributions/${CONNECTOR_NAME}.tar /tmp/${CONNECTOR_NAME}.tar; \
+    else \
+        cp /tmp/distributions/airbyte-app.tar /tmp/${CONNECTOR_NAME}.tar; \
+    fi && \
+    tar xf /tmp/${CONNECTOR_NAME}.tar --strip-components=1 -C /airbyte && \
+    rm -rf /tmp/${CONNECTOR_NAME}.tar /tmp/distributions && \
     chown -R airbyte:airbyte /airbyte
 
 # Set the non-root user

--- a/docker-images/Dockerfile.java-connector
+++ b/docker-images/Dockerfile.java-connector
@@ -17,7 +17,8 @@ RUN chmod +x /airbyte/base.sh /airbyte/javabase.sh && \
 ENV AIRBYTE_ENTRYPOINT="/airbyte/base.sh"
 ENV APPLICATION="${CONNECTOR_NAME}"
 
-# Add the connector TAR file and extract it (try connector-specific name first, fallback to airbyte-app.tar)
+# Add the connector TAR file and extract it.
+# For compatibility reasons, first try connector-specific name, then `airbyte-app.tar`
 COPY ./build/distributions/ /tmp/distributions/
 RUN if [ -f /tmp/distributions/${CONNECTOR_NAME}.tar ]; then \
         cp /tmp/distributions/${CONNECTOR_NAME}.tar /tmp/${CONNECTOR_NAME}.tar; \

--- a/docker-images/Dockerfile.python-connector
+++ b/docker-images/Dockerfile.python-connector
@@ -10,6 +10,11 @@ ARG BASE_IMAGE
 ARG CONNECTOR_NAME
 ARG EXTRA_PREREQS_SCRIPT=""
 
+# Install git and openssh-client for cloning repositories when needed
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git openssh-client \
+    && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /airbyte/integration_code
 
 COPY . ./

--- a/docker-images/Dockerfile.python-connector
+++ b/docker-images/Dockerfile.python-connector
@@ -10,7 +10,7 @@ ARG BASE_IMAGE
 ARG CONNECTOR_NAME
 ARG EXTRA_PREREQS_SCRIPT=""
 
-# Install git and openssh-client for cloning repositories when needed
+# Install git and openssh-client are needed to clone repositories for testing connectors on pre-release versions of the CDK
 RUN apt-get update \
     && apt-get install -y --no-install-recommends git openssh-client \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
1. Enhance the Java container definition to support both old and new .jar file naming.
2. Ensure Git and SSH client installation in the Python connector image for repository cloning capabilities. (This is needed for testing connectors on pre-release versions of the CDK.)

Tested successfully in:

- #61443 

Carved out from that PR because that PR also depends on the CDK PR:

- https://github.com/airbytehq/airbyte-python-cdk/pull/586