### PR TITLE
Bulk load CDK: stop requiring global state's stream states to exist in the catalog

### DIFF
--- a/airbyte-cdk/bulk/core/base/src/main/kotlin/io/airbyte/cdk/output/OutputConsumer.kt
+++ b/airbyte-cdk/bulk/core/base/src/main/kotlin/io/airbyte/cdk/output/OutputConsumer.kt
@@ -35,10 +35,6 @@ import java.util.function.Consumer
 /** Emits the [AirbyteMessage] instances produced by the connector. */
 @DefaultImplementation(StdoutOutputConsumer::class)
 abstract class OutputConsumer(private val clock: Clock) : Consumer<AirbyteMessage>, AutoCloseable {
-    companion object {
-        const val IS_DUMMY_STATS_MESSAGE = "isDummyStatsMessage"
-    }
-
     /**
      * The constant emittedAt timestamp we use for record timestamps.
      *
@@ -164,10 +160,7 @@ private class StdoutOutputConsumer(
         // Using println is not particularly efficient, however.
         // To improve performance, this method accumulates RECORD messages into a buffer
         // before writing them to standard output in a batch.
-        if (
-            airbyteMessage.type == AirbyteMessage.Type.RECORD &&
-                airbyteMessage.record.additionalProperties[IS_DUMMY_STATS_MESSAGE] != true
-        ) {
+        if (airbyteMessage.type == AirbyteMessage.Type.RECORD) {
             // RECORD messages undergo a different serialization scheme.
             accept(airbyteMessage.record)
         } else {

--- a/airbyte-cdk/bulk/core/load/src/integrationTest/kotlin/io/airbyte/cdk/load/mock_integration_test/MockBasicFunctionalityIntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/integrationTest/kotlin/io/airbyte/cdk/load/mock_integration_test/MockBasicFunctionalityIntegrationTest.kt
@@ -7,6 +7,8 @@ package io.airbyte.cdk.load.mock_integration_test
 import io.airbyte.cdk.load.command.Append
 import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.data.ObjectType
+import io.airbyte.cdk.load.message.CheckpointMessage.Checkpoint
+import io.airbyte.cdk.load.message.InputGlobalCheckpoint
 import io.airbyte.cdk.load.message.InputStreamCheckpoint
 import io.airbyte.cdk.load.test.mock.MockDestinationBackend.MOCK_TEST_MICRONAUT_ENVIRONMENT
 import io.airbyte.cdk.load.test.mock.MockDestinationDataDumper
@@ -15,6 +17,7 @@ import io.airbyte.cdk.load.test.util.NoopDestinationCleaner
 import io.airbyte.cdk.load.test.util.NoopNameMapper
 import io.airbyte.cdk.load.test.util.UncoercedExpectedRecordMapper
 import io.airbyte.cdk.load.test.util.destination_process.DestinationUncleanExitException
+import io.airbyte.cdk.load.util.Jsons
 import io.airbyte.cdk.load.write.BasicFunctionalityIntegrationTest
 import io.airbyte.cdk.load.write.DedupBehavior
 import io.airbyte.cdk.load.write.SchematizedNestedValueBehavior
@@ -22,6 +25,7 @@ import io.airbyte.cdk.load.write.UnionBehavior
 import io.airbyte.cdk.load.write.Untyped
 import kotlin.test.assertEquals
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 
 class MockBasicFunctionalityIntegrationTest :
@@ -149,5 +153,40 @@ class MockBasicFunctionalityIntegrationTest :
             listOf("Stream not found: Descriptor(namespace=potato, name=tomato)"),
             e.traceMessages.map { it.message },
         )
+    }
+
+    @Test
+    fun testGlobalStateWithUnknownStreamState() {
+        val stream =
+            DestinationStream(
+                randomizedNamespace,
+                "test_stream",
+                Append,
+                ObjectType(linkedMapOf("id" to intType)),
+                generationId = 0,
+                minimumGenerationId = 0,
+                syncId = 42,
+                namespaceMapper = namespaceMapperForMedium(),
+            )
+        assertDoesNotThrow {
+            runSync(
+                updatedConfig,
+                stream,
+                listOf(
+                    // send a state message for a stream that isn't in the catalog.
+                    // this should cause the sync to crash.
+                    InputGlobalCheckpoint(
+                        Jsons.readTree("""{"foo": "bar"}"""),
+                        checkpointKeyForMedium(),
+                        listOf(
+                            Checkpoint(
+                                DestinationStream.Descriptor("potato", "tomato"),
+                                Jsons.readTree("""{"foo": "bar"}""")
+                            )
+                        )
+                    )
+                ),
+            )
+        }
     }
 }

--- a/airbyte-cdk/bulk/core/load/src/integrationTest/kotlin/io/airbyte/cdk/load/mock_integration_test/MockBasicFunctionalityIntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/integrationTest/kotlin/io/airbyte/cdk/load/mock_integration_test/MockBasicFunctionalityIntegrationTest.kt
@@ -136,16 +136,8 @@ class MockBasicFunctionalityIntegrationTest :
                         // send a state message for a stream that isn't in the catalog.
                         // this should cause the sync to crash.
                         InputStreamCheckpoint(
-                            DestinationStream(
-                                "potato",
-                                "tomato",
-                                Append,
-                                ObjectType(linkedMapOf("id" to intType)),
-                                generationId = 0,
-                                minimumGenerationId = 0,
-                                syncId = 42,
-                                namespaceMapper = namespaceMapperForMedium(),
-                            ),
+                            "potato",
+                            "tomato",
                             blob = """{"foo": "bar"}""",
                             sourceRecordCount = 1,
                             checkpointKey = checkpointKeyForMedium(),

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/config/SyncBeanFactory.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/config/SyncBeanFactory.kt
@@ -57,7 +57,7 @@ class SyncBeanFactory {
     fun checkpointManager(
         catalog: DestinationCatalog,
         syncManager: SyncManager,
-        outputConsumer: suspend (Reserved<CheckpointMessage>, Long, Long) -> Unit,
+        outputConsumer: suspend (Reserved<CheckpointMessage>) -> Unit,
         timeProvider: TimeProvider,
     ): CheckpointManager<Reserved<CheckpointMessage>> =
         CheckpointManager(

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/DestinationMessage.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/DestinationMessage.kt
@@ -473,21 +473,15 @@ sealed interface CheckpointMessage : DestinationMessage {
     }
     data class Stats(val recordCount: Long)
     data class Checkpoint(
-        val stream: DestinationStream,
+        val stream: DestinationStream.Descriptor,
         val state: JsonNode?,
     ) {
         fun asProtocolObject(): AirbyteStreamState =
-            AirbyteStreamState()
-                .withStreamDescriptor(
-                    StreamDescriptor()
-                        .withNamespace(stream.unmappedNamespace)
-                        .withName(stream.unmappedName)
-                )
-                .also {
-                    if (state != null) {
-                        it.streamState = state
-                    }
+            AirbyteStreamState().withStreamDescriptor(stream.asProtocolObject()).also {
+                if (state != null) {
+                    it.streamState = state
                 }
+            }
     }
 
     val checkpointKey: CheckpointKey?
@@ -539,7 +533,8 @@ data class StreamCheckpoint(
 ) : CheckpointMessage {
     /** Convenience constructor, intended for use in tests. */
     constructor(
-        stream: DestinationStream,
+        streamNamespace: String?,
+        streamName: String,
         blob: String,
         sourceRecordCount: Long,
         destinationRecordCount: Long? = null,
@@ -548,7 +543,7 @@ data class StreamCheckpoint(
         totalBytes: Long? = null
     ) : this(
         Checkpoint(
-            stream,
+            DestinationStream.Descriptor(streamNamespace, streamName),
             state = blob.deserializeToNode(),
         ),
         Stats(sourceRecordCount),

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/DestinationMessageFactory.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/DestinationMessageFactory.kt
@@ -6,6 +6,7 @@ package io.airbyte.cdk.load.message
 
 import io.airbyte.cdk.ConfigErrorException
 import io.airbyte.cdk.load.command.DestinationCatalog
+import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.command.NamespaceMapper
 import io.airbyte.cdk.load.state.CheckpointId
 import io.airbyte.cdk.load.state.CheckpointIndex
@@ -208,9 +209,8 @@ class DestinationMessageFactory(
                 namespace = streamState.streamDescriptor.namespace,
                 name = streamState.streamDescriptor.name
             )
-        val stream = catalog.getStream(descriptor)
         return CheckpointMessage.Checkpoint(
-            stream = stream,
+            stream = DestinationStream.Descriptor(descriptor.namespace, descriptor.name),
             state = runCatching { streamState.streamState }.getOrNull(),
         )
     }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/InputMessage.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/InputMessage.kt
@@ -188,14 +188,18 @@ sealed interface InputCheckpoint : InputMessage
 
 data class InputStreamCheckpoint(val checkpoint: StreamCheckpoint) : InputCheckpoint {
     constructor(
-        stream: DestinationStream,
+        streamNamespace: String?,
+        streamName: String,
         blob: String,
         sourceRecordCount: Long,
         destinationRecordCount: Long? = null,
         checkpointKey: CheckpointKey? = null,
     ) : this(
         StreamCheckpoint(
-            Checkpoint(stream, state = blob.deserializeToNode()),
+            Checkpoint(
+                DestinationStream.Descriptor(streamNamespace, streamName),
+                state = blob.deserializeToNode()
+            ),
             Stats(sourceRecordCount),
             destinationRecordCount?.let { Stats(it) },
             emptyMap(),

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/InputMessage.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/InputMessage.kt
@@ -212,7 +212,8 @@ data class InputStreamCheckpoint(val checkpoint: StreamCheckpoint) : InputCheckp
 
 data class InputGlobalCheckpoint(
     val sharedState: JsonNode?,
-    val checkpointKey: CheckpointKey? = null
+    val checkpointKey: CheckpointKey? = null,
+    val streamStates: List<Checkpoint> = emptyList(),
 ) : InputCheckpoint {
     override fun asProtocolMessage(): AirbyteMessage =
         AirbyteMessage()
@@ -220,7 +221,11 @@ data class InputGlobalCheckpoint(
             .withState(
                 AirbyteStateMessage()
                     .withType(AirbyteStateMessage.AirbyteStateType.GLOBAL)
-                    .withGlobal(AirbyteGlobalState().withSharedState(sharedState))
+                    .withGlobal(
+                        AirbyteGlobalState()
+                            .withSharedState(sharedState)
+                            .withStreamStates(streamStates.map { it.asProtocolObject() })
+                    )
                     .also {
                         if (checkpointKey != null) {
                             it.additionalProperties["partition_id"] =

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/state/PipelineEventBookkeepingRouter.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/state/PipelineEventBookkeepingRouter.kt
@@ -135,13 +135,13 @@ class PipelineEventBookkeepingRouter(
         when (val checkpoint = reservation.value) {
             is StreamCheckpoint -> {
                 val stream = checkpoint.checkpoint.stream
-                val manager = syncManager.getStreamManager(stream.descriptor)
+                val manager = syncManager.getStreamManager(stream)
                 val (checkpointKey, checkpointRecordCount) = getKeyAndCounts(checkpoint, manager)
                 val messageWithCount =
                     checkpoint.withDestinationStats(CheckpointMessage.Stats(checkpointRecordCount))
                 checkpointQueue.publish(
                     reservation.replace(
-                        StreamCheckpointWrapped(stream.descriptor, checkpointKey, messageWithCount)
+                        StreamCheckpointWrapped(stream, checkpointKey, messageWithCount)
                     )
                 )
             }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/StatsEmitter.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/StatsEmitter.kt
@@ -14,7 +14,6 @@ import io.airbyte.cdk.output.OutputConsumer
 import io.airbyte.protocol.models.Jsons
 import io.airbyte.protocol.models.v0.AirbyteMessage
 import io.airbyte.protocol.models.v0.AirbyteRecordMessage
-import io.github.oshai.kotlinlogging.KotlinLogging
 import io.micronaut.context.annotation.Factory
 import io.micronaut.context.annotation.Requires
 import io.micronaut.context.annotation.Value
@@ -60,10 +59,9 @@ class StatsEmitter(
                         .withType(AirbyteMessage.Type.RECORD)
                         .withRecord(
                             AirbyteRecordMessage()
-                                .withNamespace(stream.unmappedNamespace)
-                                .withStream(stream.unmappedName)
+                                .withNamespace(stream.descriptor.namespace)
+                                .withStream(stream.descriptor.name)
                                 .withData(EMPTY_JSON)
-                                .withAdditionalProperty(OutputConsumer.IS_DUMMY_STATS_MESSAGE, true)
                                 .withAdditionalProperty(DEST_EMITTED_RECORDS_COUNT, recordsRead)
                                 .withAdditionalProperty(DEST_EMITTED_BYTES_COUNT, bytesRead),
                         )
@@ -92,7 +90,6 @@ class FrequencyFactory {
 @Requires(property = "airbyte.destination.core.data-channel.medium", value = "SOCKET")
 class DummyStatsMessageConsumer(private val consumer: OutputConsumer) :
     suspend (AirbyteMessage) -> Unit {
-    private val log = KotlinLogging.logger {}
     override suspend fun invoke(message: AirbyteMessage) {
         consumer.accept(message)
     }

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/message/DestinationMessageTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/message/DestinationMessageTest.kt
@@ -33,6 +33,7 @@ import io.airbyte.protocol.models.v0.AirbyteStateStats
 import io.airbyte.protocol.models.v0.AirbyteStreamState
 import io.airbyte.protocol.models.v0.AirbyteStreamStatusTraceMessage
 import io.airbyte.protocol.models.v0.AirbyteTraceMessage
+import io.airbyte.protocol.models.v0.StreamDescriptor
 import io.airbyte.protocol.protobuf.AirbyteMessage.AirbyteMessageProtobuf
 import io.airbyte.protocol.protobuf.AirbyteMessage.AirbyteProbeMessageProtobuf
 import io.airbyte.protocol.protobuf.AirbyteRecordMessage.AirbyteRecordMessageProtobuf
@@ -730,5 +731,46 @@ class DestinationMessageTest {
                 .build()
         val message = factory.fromAirbyteProtobufMessage(heartbeatMessage, 0L)
         Assertions.assertTrue(message is ProbeMessage)
+    }
+
+    @Test
+    fun `message factory does not throw on global state message with stream state belonging to unrecognized stream`() {
+        val inputMessage =
+            AirbyteMessage()
+                .withType(AirbyteMessage.Type.STATE)
+                .withState(
+                    AirbyteStateMessage()
+                        .withType(AirbyteStateMessage.AirbyteStateType.GLOBAL)
+                        .withGlobal(
+                            AirbyteGlobalState()
+                                .withSharedState(blob1)
+                                .withStreamStates(
+                                    listOf(
+                                        AirbyteStreamState()
+                                            .withStreamDescriptor(
+                                                StreamDescriptor()
+                                                    .withNamespace("potato")
+                                                    .withName("tomato")
+                                            )
+                                            .withStreamState(blob2),
+                                    ),
+                                ),
+                        )
+                        // Note: only source stats, no destination stats
+                        .withSourceStats(AirbyteStateStats().withRecordCount(2.0))
+                        .withAdditionalProperty("id", 1234)
+                )
+
+        val parsedMessage = convert(factory(false), inputMessage) as GlobalCheckpoint
+
+        assertEquals(
+            inputMessage
+                .also { it.state.destinationStats = AirbyteStateStats().withRecordCount(3.0) }
+                .serializeToString(),
+            parsedMessage
+                .withDestinationStats(CheckpointMessage.Stats(3))
+                .asProtocolMessage()
+                .serializeToString()
+        )
     }
 }

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/message/PipelineEventBookkeepingRouterTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/message/PipelineEventBookkeepingRouterTest.kt
@@ -129,7 +129,7 @@ class PipelineEventBookkeepingRouterTest {
         val reservationManager = ReservationManager(2)
         val checkpointMessage: CheckpointMessage.Checkpoint = mockk(relaxed = true)
 
-        every { checkpointMessage.stream } returns stream1
+        every { checkpointMessage.stream } returns stream1.descriptor
 
         every { streamManager.inferNextCheckpointKey() } returns
             CheckpointKey(CheckpointIndex(1), CheckpointId("foo"))
@@ -155,7 +155,7 @@ class PipelineEventBookkeepingRouterTest {
         val reservationManager = ReservationManager(2)
         val checkpointMessage: CheckpointMessage.Checkpoint = mockk(relaxed = true)
 
-        every { checkpointMessage.stream } returns stream1
+        every { checkpointMessage.stream } returns stream1.descriptor
 
         every { streamManager.inferNextCheckpointKey() } returns
             CheckpointKey(CheckpointIndex(1), CheckpointId("foo"))

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/state/CheckpointManagerUTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/state/CheckpointManagerUTest.kt
@@ -22,8 +22,8 @@ import org.junit.jupiter.api.Test
 class CheckpointManagerUTest {
     @MockK(relaxed = true) lateinit var catalog: DestinationCatalog
     @MockK(relaxed = true) lateinit var syncManager: SyncManager
-    private val outputConsumer: suspend (Reserved<CheckpointMessage>, Long, Long) -> Unit =
-        mockk<suspend (Reserved<CheckpointMessage>, Long, Long) -> Unit>(relaxed = true)
+    private val outputConsumer: suspend (Reserved<CheckpointMessage>) -> Unit =
+        mockk<suspend (Reserved<CheckpointMessage>) -> Unit>(relaxed = true)
     @MockK(relaxed = true) lateinit var timeProvider: TimeProvider
     @MockK(relaxed = true) lateinit var streamManager1: StreamManager
     @MockK(relaxed = true) lateinit var streamManager2: StreamManager
@@ -55,7 +55,7 @@ class CheckpointManagerUTest {
     @BeforeEach
     fun setup() {
         coEvery { catalog.streams } returns listOf(stream1, stream2)
-        coEvery { outputConsumer.invoke(any(), any(), any()) } returns Unit
+        coEvery { outputConsumer.invoke(any()) } returns Unit
         coEvery { syncManager.getStreamManager(stream1.descriptor) } returns streamManager1
         coEvery { syncManager.getStreamManager(stream2.descriptor) } returns streamManager2
     }
@@ -85,8 +85,8 @@ class CheckpointManagerUTest {
 
         // Only stream2 should be flushed.
         checkpointManager.flushReadyCheckpointMessages()
-        coVerify(exactly = 0) { outputConsumer.invoke(message1, any(), any()) }
-        coVerify(exactly = 1) { outputConsumer.invoke(message2, any(), any()) }
+        coVerify(exactly = 0) { outputConsumer.invoke(message1) }
+        coVerify(exactly = 1) { outputConsumer.invoke(message2) }
     }
 
     @Test
@@ -111,7 +111,7 @@ class CheckpointManagerUTest {
 
         checkpointManager.flushReadyCheckpointMessages()
 
-        coVerify(exactly = 0) { outputConsumer.invoke(any(), any(), any()) }
+        coVerify(exactly = 0) { outputConsumer.invoke(any()) }
     }
 
     @Test
@@ -136,7 +136,7 @@ class CheckpointManagerUTest {
 
         checkpointManager.flushReadyCheckpointMessages()
 
-        coVerify(exactly = 2) { outputConsumer.invoke(any(), any(), any()) }
+        coVerify(exactly = 2) { outputConsumer.invoke(any()) }
     }
 
     @Test
@@ -161,6 +161,6 @@ class CheckpointManagerUTest {
 
         checkpointManager.flushReadyCheckpointMessages()
 
-        coVerify(exactly = 1) { outputConsumer.invoke(any(), any(), any()) }
+        coVerify(exactly = 1) { outputConsumer.invoke(any()) }
     }
 }

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/internal/StatsEmitterTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/internal/StatsEmitterTest.kt
@@ -64,10 +64,8 @@ class StatsEmitterTest {
             }
         syncManager = mockk { every { getStreamManager(testDescriptor) } returns streamManager }
 
-        val dstStream = mockk<DestinationStream>()
-        every { dstStream.unmappedNamespace } returns "foo"
-        every { dstStream.unmappedName } returns "bar"
-        every { dstStream.descriptor } returns testDescriptor
+        val dstStream =
+            mockk<DestinationStream> { every { this@mockk.descriptor } returns testDescriptor }
         catalog = mockk { every { streams } returns listOf(dstStream) }
 
         recordingConsumer = RecordingOutputConsumer()

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/test/util/StubDestinationMessageFactory.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/test/util/StubDestinationMessageFactory.kt
@@ -57,7 +57,10 @@ object StubDestinationMessageFactory {
     fun makeStreamState(stream: DestinationStream, recordCount: Long): CheckpointMessage {
         return StreamCheckpoint(
             checkpoint =
-                CheckpointMessage.Checkpoint(stream, JsonNodeFactory.instance.objectNode()),
+                CheckpointMessage.Checkpoint(
+                    stream.descriptor,
+                    JsonNodeFactory.instance.objectNode()
+                ),
             sourceStats = CheckpointMessage.Stats(recordCount),
             serializedSizeBytes = 0L
         )

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/IntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/IntegrationTest.kt
@@ -336,7 +336,6 @@ abstract class IntegrationTest(
                 micronautProperties = micronautProperties + micronautPropertyEnableMicrobatching,
                 dataChannelMedium = dataChannelMedium,
                 dataChannelFormat = dataChannelFormat,
-                namespaceMappingConfig = NamespaceMappingConfig(NamespaceDefinitionType.SOURCE),
             )
         var outputStateMessage: AirbyteStateMessage? = null
         fun doRun() =

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/write/BasicFunctionalityIntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/write/BasicFunctionalityIntegrationTest.kt
@@ -943,7 +943,8 @@ abstract class BasicFunctionalityIntegrationTest(
                 )
             ),
             StreamCheckpoint(
-                finalStream,
+                randomizedNamespace,
+                "test_stream",
                 """{}""",
                 sourceRecordCount = 1,
                 checkpointKey = checkpointKeyForMedium(),

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/write/BasicFunctionalityIntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/write/BasicFunctionalityIntegrationTest.kt
@@ -358,7 +358,8 @@ abstract class BasicFunctionalityIntegrationTest(
                         checkpointId = checkpointKeyForMedium()?.checkpointId
                     ),
                     InputStreamCheckpoint(
-                        stream = stream,
+                        streamName = "test_stream",
+                        streamNamespace = randomizedNamespace,
                         blob = """{"foo": "bar"}""",
                         sourceRecordCount = 1,
                         checkpointKey = checkpointKeyForMedium(),
@@ -377,13 +378,14 @@ abstract class BasicFunctionalityIntegrationTest(
 
                 val asProtocolMessage =
                     StreamCheckpoint(
-                            stream = stream,
+                            streamName = "test_stream",
+                            streamNamespace = randomizedNamespace,
                             blob = """{"foo": "bar"}""",
                             sourceRecordCount = 1,
                             destinationRecordCount = 1,
                             checkpointKey = checkpointKeyForMedium(),
                             totalRecords = 1L,
-                            totalBytes = expectedBytesForMediumAndFormat(234L, 254L, 59L)
+                            totalBytes = expectedBytesForMediumAndFormat(234L, 253L, 59L)
                         )
                         .asProtocolMessage()
                 assertEquals(
@@ -481,7 +483,8 @@ abstract class BasicFunctionalityIntegrationTest(
                 listOf(
                     input,
                     InputStreamCheckpoint(
-                        stream = stream,
+                        streamName = stream.descriptor.name,
+                        streamNamespace = stream.descriptor.namespace,
                         blob = """{"foo": "bar"}""",
                         sourceRecordCount = 1,
                         checkpointKey = checkpointKeyForMedium(),
@@ -499,7 +502,8 @@ abstract class BasicFunctionalityIntegrationTest(
             )
             assertEquals(
                 StreamCheckpoint(
-                        stream = stream,
+                        streamName = stream.descriptor.name,
+                        streamNamespace = stream.descriptor.namespace,
                         blob = """{"foo": "bar"}""",
                         sourceRecordCount = 1,
                         destinationRecordCount = 1,
@@ -548,7 +552,8 @@ abstract class BasicFunctionalityIntegrationTest(
                         )
                     ),
                     StreamCheckpoint(
-                        stream = stream,
+                        streamNamespace = randomizedNamespace,
+                        streamName = "test_stream",
                         blob = """{"foo": "bar1"}""",
                         sourceRecordCount = 1,
                         checkpointKey = checkpointKeyForMedium()
@@ -1108,7 +1113,8 @@ abstract class BasicFunctionalityIntegrationTest(
             stream2,
             listOf(makeInputRecord(1, "2024-01-23T02:00:00Z", 200)),
             StreamCheckpoint(
-                stream2,
+                randomizedNamespace,
+                stream2.descriptor.name,
                 """{}""",
                 sourceRecordCount = 1,
                 checkpointKey = checkpointKeyForMedium(),
@@ -1240,7 +1246,8 @@ abstract class BasicFunctionalityIntegrationTest(
             stream,
             listOf(makeInputRecord(1, "2024-01-23T02:00:00Z", 200)),
             StreamCheckpoint(
-                stream,
+                randomizedNamespace,
+                stream.descriptor.name,
                 """{}""",
                 sourceRecordCount = 1,
                 checkpointKey = checkpointKeyForMedium(),
@@ -1404,7 +1411,8 @@ abstract class BasicFunctionalityIntegrationTest(
             stream2,
             listOf(makeInputRecord(1, "2024-01-23T02:00:00Z", 200)),
             StreamCheckpoint(
-                stream2,
+                randomizedNamespace,
+                stream2.descriptor.name,
                 """{}""",
                 sourceRecordCount = 1,
                 checkpointKey = checkpointKeyForMedium(),


### PR DESCRIPTION
## What
Stop crashing on syncs with global state messages and mapped namespace. Platform doesn't map those objects, and probably shouldn't map those objects.

## How
Revert https://github.com/airbytehq/airbyte/pull/61406/, then add tests

## Review guide
review commits in order. First commit is just `git revert 17d9874` + fixing conflict.

## User Impact
none

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._