### PR TITLE
ci: add github auto-merge support, disable 'skip-ci' marker, use specific tags in commit messages

### DIFF
--- a/airbyte-ci/connectors/auto_merge/src/auto_merge/main.py
+++ b/airbyte-ci/connectors/auto_merge/src/auto_merge/main.py
@@ -23,7 +23,6 @@ from .env import GITHUB_TOKEN, PRODUCTION
 from .helpers import generate_job_summary_as_markdown
 from .pr_validators import VALIDATOR_MAPPING
 
-
 if TYPE_CHECKING:
     from github.Commit import Commit as GithubCommit
     from github.PullRequest import PullRequest
@@ -157,17 +156,12 @@ def auto_merge() -> None:
         logger.info(f"Fetching required passing contexts for {BASE_BRANCH}")
         required_passing_contexts = set(main_branch.get_required_status_checks().contexts)
         candidate_issues = gh_client.search_issues(
-            f"repo:{AIRBYTE_REPO} is:pr "
-            + "base:{BASE_BRANCH} state:open "
-            + "label:{AUTO_MERGE_BYPASS_CI_CHECKS_LABEL} "
+            f"repo:{AIRBYTE_REPO} is:pr " + "base:{BASE_BRANCH} state:open " + "label:{AUTO_MERGE_BYPASS_CI_CHECKS_LABEL} "
             # We no longer use this tool for auto-merging PRs that do not need to bypass CI checks
             # + "label:{AUTO_MERGE_LABEL},{AUTO_MERGE_BYPASS_CI_CHECKS_LABEL} "
         )
         prs = [issue.as_pull_request() for issue in candidate_issues]
-        logger.info(
-            f"Found {len(prs)} open PRs targeting {BASE_BRANCH} with "
-            f"the '{AUTO_MERGE_BYPASS_CI_CHECKS_LABEL}' label"
-        )
+        logger.info(f"Found {len(prs)} open PRs targeting {BASE_BRANCH} with " f"the '{AUTO_MERGE_BYPASS_CI_CHECKS_LABEL}' label")
         merged_prs = []
         for pr in prs:
             back_off_if_rate_limited(gh_client)

--- a/airbyte-ci/connectors/auto_merge/src/auto_merge/main.py
+++ b/airbyte-ci/connectors/auto_merge/src/auto_merge/main.py
@@ -15,7 +15,7 @@ from github import Auth, Github
 from .consts import (
     AIRBYTE_REPO,
     AUTO_MERGE_BYPASS_CI_CHECKS_LABEL,
-    # AUTO_MERGE_LABEL,  # << This is taken care of by native GitHub auto-merge.
+    AUTO_MERGE_LABEL,
     BASE_BRANCH,
     MERGE_METHOD,
 )
@@ -172,12 +172,11 @@ def auto_merge() -> None:
         logger.info(f"Fetching required passing contexts for {BASE_BRANCH}")
         required_passing_contexts = set(main_branch.get_required_status_checks().contexts)
         candidate_issues = gh_client.search_issues(
-            f"repo:{AIRBYTE_REPO} is:pr base:{BASE_BRANCH} state:open label:{AUTO_MERGE_BYPASS_CI_CHECKS_LABEL}"
-            # We no longer use this tool for auto-merging PRs that do not need to bypass CI checks
+            f"repo:{AIRBYTE_REPO} is:pr label:{AUTO_MERGE_LABEL},{AUTO_MERGE_BYPASS_CI_CHECKS_LABEL} base:{BASE_BRANCH} state:open"
         )
         prs = [issue.as_pull_request() for issue in candidate_issues]
         logger.info(
-            f"Found {len(prs)} open PRs targeting {BASE_BRANCH} with the '{AUTO_MERGE_BYPASS_CI_CHECKS_LABEL}' label",
+            f"Found {len(prs)} open PRs targeting {BASE_BRANCH} with the '{AUTO_MERGE_LABEL}' or '{AUTO_MERGE_BYPASS_CI_CHECKS_LABEL}' label"
         )
         merged_prs = []
         for pr in prs:

--- a/airbyte-ci/connectors/auto_merge/src/auto_merge/main.py
+++ b/airbyte-ci/connectors/auto_merge/src/auto_merge/main.py
@@ -89,7 +89,7 @@ def get_pr_validators(pr: PullRequest) -> set[Callable]:
         raise ValueError(
             f"PR #{pr.number} does not have a valid auto-merge label. "
             f"Expected one of [{', '.join(VALIDATOR_MAPPING.keys())}], but got: "
-            f"[{', '.join(label.name for label in pr.labels)}]",
+            f"[{'; '.join(label.name for label in pr.labels)}]",
         )
 
     return validators

--- a/airbyte-ci/connectors/auto_merge/src/auto_merge/main.py
+++ b/airbyte-ci/connectors/auto_merge/src/auto_merge/main.py
@@ -86,8 +86,7 @@ def get_pr_validators(pr: PullRequest) -> set[Callable]:
     # TODO: We could consider returning a dummy callable which always returns False,
     # but for now, we raise an error to ensure we catch any misconfigurations.
     raise ValueError(
-        f"PR #{pr.number} does not have a valid auto-merge label. "
-        f"Currently only '{AUTO_MERGE_BYPASS_CI_CHECKS_LABEL}' is supported",
+        f"PR #{pr.number} does not have a valid auto-merge label. Currently only '{AUTO_MERGE_BYPASS_CI_CHECKS_LABEL}' is supported",
     )
 
 

--- a/airbyte-ci/connectors/auto_merge/src/auto_merge/main.py
+++ b/airbyte-ci/connectors/auto_merge/src/auto_merge/main.py
@@ -23,7 +23,6 @@ from .env import GITHUB_TOKEN, PRODUCTION
 from .helpers import generate_job_summary_as_markdown
 from .pr_validators import VALIDATOR_MAPPING
 
-
 if TYPE_CHECKING:
     from github.Commit import Commit as GithubCommit
     from github.PullRequest import PullRequest

--- a/airbyte-ci/connectors/auto_merge/src/auto_merge/main.py
+++ b/airbyte-ci/connectors/auto_merge/src/auto_merge/main.py
@@ -23,6 +23,7 @@ from .env import GITHUB_TOKEN, PRODUCTION
 from .helpers import generate_job_summary_as_markdown
 from .pr_validators import VALIDATOR_MAPPING
 
+
 if TYPE_CHECKING:
     from github.Commit import Commit as GithubCommit
     from github.PullRequest import PullRequest
@@ -161,7 +162,10 @@ def auto_merge() -> None:
             # + "label:{AUTO_MERGE_LABEL},{AUTO_MERGE_BYPASS_CI_CHECKS_LABEL} "
         )
         prs = [issue.as_pull_request() for issue in candidate_issues]
-        logger.info(f"Found {len(prs)} open PRs targeting {BASE_BRANCH} with " f"the '{AUTO_MERGE_BYPASS_CI_CHECKS_LABEL}' label")
+        logger.info(
+            f"Found {len(prs)} open PRs targeting {BASE_BRANCH} with "
+            + f"the '{AUTO_MERGE_BYPASS_CI_CHECKS_LABEL}' label"
+        )
         merged_prs = []
         for pr in prs:
             back_off_if_rate_limited(gh_client)

--- a/airbyte-ci/connectors/auto_merge/src/auto_merge/main.py
+++ b/airbyte-ci/connectors/auto_merge/src/auto_merge/main.py
@@ -12,10 +12,17 @@ from typing import TYPE_CHECKING, Callable, Optional
 
 from github import Auth, Github
 
-from .consts import AIRBYTE_REPO, AUTO_MERGE_BYPASS_CI_CHECKS_LABEL, AUTO_MERGE_LABEL, BASE_BRANCH, MERGE_METHOD
+from .consts import (
+    AIRBYTE_REPO,
+    AUTO_MERGE_BYPASS_CI_CHECKS_LABEL,
+    # AUTO_MERGE_LABEL,  # << This is taken care of by native GitHub auto-merge.
+    BASE_BRANCH,
+    MERGE_METHOD,
+)
 from .env import GITHUB_TOKEN, PRODUCTION
 from .helpers import generate_job_summary_as_markdown
 from .pr_validators import VALIDATOR_MAPPING
+
 
 if TYPE_CHECKING:
     from github.Commit import Commit as GithubCommit
@@ -70,11 +77,7 @@ def get_pr_validators(pr: PullRequest) -> set[Callable]:
     Returns:
         list[callable]: The validators
     """
-
-    for label in pr.labels:
-        if label.name in VALIDATOR_MAPPING:
-            return VALIDATOR_MAPPING[label.name]
-    return VALIDATOR_MAPPING[AUTO_MERGE_LABEL]
+    return VALIDATOR_MAPPING[AUTO_MERGE_BYPASS_CI_CHECKS_LABEL]
 
 
 def merge_with_retries(pr: PullRequest, max_retries: int = 3, wait_time: int = 60) -> Optional[PullRequest]:
@@ -154,10 +157,17 @@ def auto_merge() -> None:
         logger.info(f"Fetching required passing contexts for {BASE_BRANCH}")
         required_passing_contexts = set(main_branch.get_required_status_checks().contexts)
         candidate_issues = gh_client.search_issues(
-            f"repo:{AIRBYTE_REPO} is:pr label:{AUTO_MERGE_LABEL},{AUTO_MERGE_BYPASS_CI_CHECKS_LABEL} base:{BASE_BRANCH} state:open"
+            f"repo:{AIRBYTE_REPO} is:pr "
+            + "base:{BASE_BRANCH} state:open "
+            + "label:{AUTO_MERGE_BYPASS_CI_CHECKS_LABEL} "
+            # We no longer use this tool for auto-merging PRs that do not need to bypass CI checks
+            # + "label:{AUTO_MERGE_LABEL},{AUTO_MERGE_BYPASS_CI_CHECKS_LABEL} "
         )
         prs = [issue.as_pull_request() for issue in candidate_issues]
-        logger.info(f"Found {len(prs)} open PRs targeting {BASE_BRANCH} with the {AUTO_MERGE_LABEL} label")
+        logger.info(
+            f"Found {len(prs)} open PRs targeting {BASE_BRANCH} with "
+            f"the '{AUTO_MERGE_BYPASS_CI_CHECKS_LABEL}' label"
+        )
         merged_prs = []
         for pr in prs:
             back_off_if_rate_limited(gh_client)

--- a/airbyte-ci/connectors/auto_merge/src/auto_merge/main.py
+++ b/airbyte-ci/connectors/auto_merge/src/auto_merge/main.py
@@ -76,7 +76,19 @@ def get_pr_validators(pr: PullRequest) -> set[Callable]:
     Returns:
         list[callable]: The validators
     """
-    return VALIDATOR_MAPPING[AUTO_MERGE_BYPASS_CI_CHECKS_LABEL]
+    for label in pr.labels:
+        if label.name == AUTO_MERGE_BYPASS_CI_CHECKS_LABEL:
+            logger.info(f"Using validator for label: {label.name}")
+            return VALIDATOR_MAPPING[label.name]
+
+    # We no longer use the 'AUTO_MERGE_LABEL' for auto-merging.
+    # We shouldn't reach this point, but if we do, we raise an error.
+    # TODO: We could consider returning a dummy callable which always returns False,
+    # but for now, we raise an error to ensure we catch any misconfigurations.
+    raise ValueError(
+        f"PR #{pr.number} does not have a valid auto-merge label. "
+        f"Currently only '{AUTO_MERGE_BYPASS_CI_CHECKS_LABEL}' is supported",
+    )
 
 
 def merge_with_retries(pr: PullRequest, max_retries: int = 3, wait_time: int = 60) -> Optional[PullRequest]:

--- a/airbyte-ci/connectors/auto_merge/src/auto_merge/main.py
+++ b/airbyte-ci/connectors/auto_merge/src/auto_merge/main.py
@@ -157,14 +157,12 @@ def auto_merge() -> None:
         logger.info(f"Fetching required passing contexts for {BASE_BRANCH}")
         required_passing_contexts = set(main_branch.get_required_status_checks().contexts)
         candidate_issues = gh_client.search_issues(
-            f"repo:{AIRBYTE_REPO} is:pr " + "base:{BASE_BRANCH} state:open " + "label:{AUTO_MERGE_BYPASS_CI_CHECKS_LABEL} "
+            f"repo:{AIRBYTE_REPO} is:pr base:{BASE_BRANCH} state:open label:{AUTO_MERGE_BYPASS_CI_CHECKS_LABEL}"
             # We no longer use this tool for auto-merging PRs that do not need to bypass CI checks
-            # + "label:{AUTO_MERGE_LABEL},{AUTO_MERGE_BYPASS_CI_CHECKS_LABEL} "
         )
         prs = [issue.as_pull_request() for issue in candidate_issues]
         logger.info(
-            f"Found {len(prs)} open PRs targeting {BASE_BRANCH} with "
-            + f"the '{AUTO_MERGE_BYPASS_CI_CHECKS_LABEL}' label"
+            f"Found {len(prs)} open PRs targeting {BASE_BRANCH} with the '{AUTO_MERGE_BYPASS_CI_CHECKS_LABEL}' label",
         )
         merged_prs = []
         for pr in prs:

--- a/airbyte-ci/connectors/auto_merge/src/auto_merge/pr_validators.py
+++ b/airbyte-ci/connectors/auto_merge/src/auto_merge/pr_validators.py
@@ -79,7 +79,7 @@ VALIDATOR_MAPPING: dict[str, set[Callable]] = {
     # Until we have an auto-approve mechanism, we use this pipeline to force-merge,
     # as long as all required checks pass. This doesn't bypass checks but it bypasses the
     # approval requirement:
-    AUTO_MERGE_LABEL: COMMON_VALIDATORS
+    AUTO_MERGE_LABEL: COMMON_VALIDATORS | {has_auto_merge_label, head_commit_passes_all_required_checks},
     | {has_auto_merge_label, head_commit_passes_all_required_checks},
     # These are pure registry updates, and can be auto-merged without any CI checks:
     AUTO_MERGE_BYPASS_CI_CHECKS_LABEL: COMMON_VALIDATORS | {has_auto_merge_bypass_ci_checks_label},

--- a/airbyte-ci/connectors/auto_merge/src/auto_merge/pr_validators.py
+++ b/airbyte-ci/connectors/auto_merge/src/auto_merge/pr_validators.py
@@ -76,7 +76,10 @@ COMMON_VALIDATORS = {
 }
 # Let's declare faster checks first as the check_if_pr_is_auto_mergeable function fails fast.
 VALIDATOR_MAPPING: dict[str, set[Callable]] = {
-    # Normal auto-merge is now handled by native GitHub auto-merge.
-    # AUTO_MERGE_LABEL: COMMON_VALIDATORS | {has_auto_merge_label, head_commit_passes_all_required_checks},
+    # These are pure registry updates, and can be auto-merged without any CI checks:
     AUTO_MERGE_BYPASS_CI_CHECKS_LABEL: COMMON_VALIDATORS | {has_auto_merge_bypass_ci_checks_label},
+    # Until we have an auto-approve mechanism, we use this pipeline to force-merge,
+    # as long as all required checks pass. This doesn't bypass checks but it bypasses the
+    # approval requirement:
+    AUTO_MERGE_LABEL: COMMON_VALIDATORS | {has_auto_merge_label, head_commit_passes_all_required_checks},
 }

--- a/airbyte-ci/connectors/auto_merge/src/auto_merge/pr_validators.py
+++ b/airbyte-ci/connectors/auto_merge/src/auto_merge/pr_validators.py
@@ -4,7 +4,13 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Callable, Optional, Tuple
 
-from .consts import AUTO_MERGE_BYPASS_CI_CHECKS_LABEL, AUTO_MERGE_LABEL, BASE_BRANCH, CONNECTOR_PATH_PREFIXES
+from .consts import (
+    AUTO_MERGE_BYPASS_CI_CHECKS_LABEL,
+    AUTO_MERGE_LABEL,
+    BASE_BRANCH,
+    CONNECTOR_PATH_PREFIXES,
+)
+
 
 if TYPE_CHECKING:
     from github.Commit import Commit as GithubCommit
@@ -71,6 +77,7 @@ COMMON_VALIDATORS = {
 }
 # Let's declare faster checks first as the check_if_pr_is_auto_mergeable function fails fast.
 VALIDATOR_MAPPING: dict[str, set[Callable]] = {
-    AUTO_MERGE_LABEL: COMMON_VALIDATORS | {has_auto_merge_label, head_commit_passes_all_required_checks},
+    # Normal auto-merge is now handled by native GitHub auto-merge.
+    # AUTO_MERGE_LABEL: COMMON_VALIDATORS | {has_auto_merge_label, head_commit_passes_all_required_checks},
     AUTO_MERGE_BYPASS_CI_CHECKS_LABEL: COMMON_VALIDATORS | {has_auto_merge_bypass_ci_checks_label},
 }

--- a/airbyte-ci/connectors/auto_merge/src/auto_merge/pr_validators.py
+++ b/airbyte-ci/connectors/auto_merge/src/auto_merge/pr_validators.py
@@ -11,7 +11,6 @@ from .consts import (
     CONNECTOR_PATH_PREFIXES,
 )
 
-
 if TYPE_CHECKING:
     from github.Commit import Commit as GithubCommit
     from github.PullRequest import PullRequest

--- a/airbyte-ci/connectors/auto_merge/src/auto_merge/pr_validators.py
+++ b/airbyte-ci/connectors/auto_merge/src/auto_merge/pr_validators.py
@@ -11,6 +11,7 @@ from .consts import (
     CONNECTOR_PATH_PREFIXES,
 )
 
+
 if TYPE_CHECKING:
     from github.Commit import Commit as GithubCommit
     from github.PullRequest import PullRequest
@@ -80,7 +81,6 @@ VALIDATOR_MAPPING: dict[str, set[Callable]] = {
     # as long as all required checks pass. This doesn't bypass checks but it bypasses the
     # approval requirement:
     AUTO_MERGE_LABEL: COMMON_VALIDATORS | {has_auto_merge_label, head_commit_passes_all_required_checks},
-    | {has_auto_merge_label, head_commit_passes_all_required_checks},
     # These are pure registry updates, and can be auto-merged without any CI checks:
     AUTO_MERGE_BYPASS_CI_CHECKS_LABEL: COMMON_VALIDATORS | {has_auto_merge_bypass_ci_checks_label},
 }

--- a/airbyte-ci/connectors/auto_merge/src/auto_merge/pr_validators.py
+++ b/airbyte-ci/connectors/auto_merge/src/auto_merge/pr_validators.py
@@ -76,10 +76,11 @@ COMMON_VALIDATORS = {
 }
 # Let's declare faster checks first as the check_if_pr_is_auto_mergeable function fails fast.
 VALIDATOR_MAPPING: dict[str, set[Callable]] = {
-    # These are pure registry updates, and can be auto-merged without any CI checks:
-    AUTO_MERGE_BYPASS_CI_CHECKS_LABEL: COMMON_VALIDATORS | {has_auto_merge_bypass_ci_checks_label},
     # Until we have an auto-approve mechanism, we use this pipeline to force-merge,
     # as long as all required checks pass. This doesn't bypass checks but it bypasses the
     # approval requirement:
-    AUTO_MERGE_LABEL: COMMON_VALIDATORS | {has_auto_merge_label, head_commit_passes_all_required_checks},
+    AUTO_MERGE_LABEL: COMMON_VALIDATORS
+    | {has_auto_merge_label, head_commit_passes_all_required_checks},
+    # These are pure registry updates, and can be auto-merged without any CI checks:
+    AUTO_MERGE_BYPASS_CI_CHECKS_LABEL: COMMON_VALIDATORS | {has_auto_merge_bypass_ci_checks_label},
 }

--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -822,6 +822,7 @@ airbyte-ci connectors --language=low-code migrate-to-manifest-only
 
 | Version | PR                                                          | Description                                                                                                                  |
 | ------- | ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| 5.3.0   | [#61598](https://github.com/airbytehq/airbyte/pull/61598)  | Add trackable commit text and github-native auto-merge in up-to-date, auto-merge, rc-promote, and rc-rollback |
 | 5.2.5   | [#60325](https://github.com/airbytehq/airbyte/pull/60325)  | Update slack team to oc-extensibility-critical-systems |
 | 5.2.4   | [#59724](https://github.com/airbytehq/airbyte/pull/59724)  | Fix components mounting and test dependencies for manifest-only unit tests |
 | 5.1.0   | [#53238](https://github.com/airbytehq/airbyte/pull/53238)  | Add ability to opt out of version increment checks via metadata flag                                                         |

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/publish/pipeline.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/publish/pipeline.py
@@ -13,6 +13,7 @@ from typing import Dict, Iterable, List, Tuple
 import anyio
 import semver
 import yaml
+from airbyte_protocol.models.airbyte_protocol import ConnectorSpecification  # type: ignore
 from auto_merge.consts import AUTO_MERGE_BYPASS_CI_CHECKS_LABEL  # type: ignore
 from connector_ops.utils import METADATA_FILE_NAME, ConnectorLanguage  # type: ignore
 from dagger import (
@@ -26,7 +27,6 @@ from dagger import (
 )
 from pydantic import BaseModel, ValidationError
 
-from airbyte_protocol.models.airbyte_protocol import ConnectorSpecification  # type: ignore
 from pipelines import consts
 from pipelines.airbyte_ci.connectors.build_image import steps
 from pipelines.airbyte_ci.connectors.publish.context import PublishConnectorContext, RolloutMode

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/publish/pipeline.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/publish/pipeline.py
@@ -688,10 +688,13 @@ async def run_connector_rollback_pipeline(context: PublishConnectorContext, sema
             # Open PR when all previous steps are successful
             initial_pr_creation = CreateOrUpdatePullRequest(
                 context,
-                skip_ci=False,  # Don't skip CI, as it prevents the PR from auto-merging naturally.
-                # We will merge even if the CI checks fail, due to the "bypass-ci-checks" label:
+                # We will merge even if the CI checks fail, due to this label:
                 labels=[AUTO_MERGE_BYPASS_CI_CHECKS_LABEL, "rollback-rc"],
+                # Let GitHub auto-merge this if all checks pass before the next run
+                # of our auto-merge workflow:
                 github_auto_merge=True,
+                # Don't skip CI, as it prevents the PR from auto-merging naturally:
+                skip_ci=False,
             )
             pr_creation_args, pr_creation_kwargs = get_rollback_pr_creation_arguments(all_modified_files, context, results, current_version)
             initial_pr_creation_result = await initial_pr_creation.run(*pr_creation_args, **pr_creation_kwargs)

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/publish/pipeline.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/publish/pipeline.py
@@ -652,7 +652,7 @@ def get_rollback_pr_creation_arguments(
         {
             "branch_id": f"{context.connector.technical_name}/rollback-{release_candidate_version}",
             "commit_message": "[auto-publish] "  # << We can skip Vercel builds if this is in the commit message
-            + ", ".join(step_result.step.title for step_result in step_results if step_result.success),
+            + "; ".join(step_result.step.title for step_result in step_results if step_result.success),
             "pr_title": f"🐙 {context.connector.technical_name}: Stop progressive rollout for {release_candidate_version}",
             "pr_body": f"The release candidate version {release_candidate_version} has been deemed unstable. This PR stops its progressive rollout. This PR will be automatically merged as part of the `auto-merge` workflow. This workflow runs every 2 hours.",
         },
@@ -720,7 +720,7 @@ def get_promotion_pr_creation_arguments(
         {
             "branch_id": f"{context.connector.technical_name}/{promoted_version}",
             "commit_message": "[auto-publish] "  # << We can skip Vercel builds if this is in the commit message
-            + "\n".join(step_result.step.title for step_result in step_results if step_result.success),
+            + "; ".join(step_result.step.title for step_result in step_results if step_result.success),
             "pr_title": f"🐙 {context.connector.technical_name}: release {promoted_version}",
             "pr_body": f"The release candidate version {release_candidate_version} has been deemed stable and is now ready to be promoted to an official release ({promoted_version}). This PR will be automatically merged as part of the `auto-merge` workflow. This workflow runs every 2 hours.",
         },

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/publish/pipeline.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/publish/pipeline.py
@@ -647,12 +647,16 @@ def get_rollback_pr_creation_arguments(
     step_results: Iterable[StepResult],
     release_candidate_version: str,
 ) -> Tuple[Tuple, Dict]:
-    return (modified_files,), {
-        "branch_id": f"{context.connector.technical_name}/rollback-{release_candidate_version}",
-        "commit_message": "\n".join(step_result.step.title for step_result in step_results if step_result.success),
-        "pr_title": f"🐙 {context.connector.technical_name}: Stop progressive rollout for {release_candidate_version}",
-        "pr_body": f"The release candidate version {release_candidate_version} has been deemed unstable. This PR stops its progressive rollout. This PR will be automatically merged as part of the `auto-merge` workflow. This workflow runs every 2 hours.",
-    }
+    return (
+        (modified_files,),
+        {
+            "branch_id": f"{context.connector.technical_name}/rollback-{release_candidate_version}",
+            "commit_message": "[auto-publish] "  # << We can skip Vercel builds if this is in the commit message
+            + ", ".join(step_result.step.title for step_result in step_results if step_result.success),
+            "pr_title": f"🐙 {context.connector.technical_name}: Stop progressive rollout for {release_candidate_version}",
+            "pr_body": f"The release candidate version {release_candidate_version} has been deemed unstable. This PR stops its progressive rollout. This PR will be automatically merged as part of the `auto-merge` workflow. This workflow runs every 2 hours.",
+        },
+    )
 
 
 async def run_connector_rollback_pipeline(context: PublishConnectorContext, semaphore: anyio.Semaphore) -> ConnectorReport:
@@ -711,12 +715,16 @@ def get_promotion_pr_creation_arguments(
     release_candidate_version: str,
     promoted_version: str,
 ) -> Tuple[Tuple, Dict]:
-    return (modified_files,), {
-        "branch_id": f"{context.connector.technical_name}/{promoted_version}",
-        "commit_message": "\n".join(step_result.step.title for step_result in step_results if step_result.success),
-        "pr_title": f"🐙 {context.connector.technical_name}: release {promoted_version}",
-        "pr_body": f"The release candidate version {release_candidate_version} has been deemed stable and is now ready to be promoted to an official release ({promoted_version}). This PR will be automatically merged as part of the `auto-merge` workflow. This workflow runs every 2 hours.",
-    }
+    return (
+        (modified_files,),
+        {
+            "branch_id": f"{context.connector.technical_name}/{promoted_version}",
+            "commit_message": "[auto-publish] "  # << We can skip Vercel builds if this is in the commit message
+            + "\n".join(step_result.step.title for step_result in step_results if step_result.success),
+            "pr_title": f"🐙 {context.connector.technical_name}: release {promoted_version}",
+            "pr_body": f"The release candidate version {release_candidate_version} has been deemed stable and is now ready to be promoted to an official release ({promoted_version}). This PR will be automatically merged as part of the `auto-merge` workflow. This workflow runs every 2 hours.",
+        },
+    )
 
 
 async def run_connector_promote_pipeline(context: PublishConnectorContext, semaphore: anyio.Semaphore) -> ConnectorReport:

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/up_to_date/pipeline.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/up_to_date/pipeline.py
@@ -67,7 +67,7 @@ def get_pr_creation_arguments(
         {
             "branch_id": f"up-to-date/{context.connector.technical_name}",
             "commit_message": "[up-to-date]"  # << We can skip Vercel builds if this is in the commit message
-            + "\n".join(step_result.step.title for step_result in step_results if step_result.success),
+            + ", ".join(step_result.step.title for step_result in step_results if step_result.success),
             "pr_title": f"🐙 {context.connector.technical_name}: run up-to-date pipeline [{datetime.now(timezone.utc).strftime('%Y-%m-%d')}]",
             "pr_body": get_pr_body(context, step_results, dependency_updates),
         },

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/up_to_date/pipeline.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/up_to_date/pipeline.py
@@ -67,7 +67,7 @@ def get_pr_creation_arguments(
         {
             "branch_id": f"up-to-date/{context.connector.technical_name}",
             "commit_message": "[up-to-date]"  # << We can skip Vercel builds if this is in the commit message
-            + ", ".join(step_result.step.title for step_result in step_results if step_result.success),
+            + "; ".join(step_result.step.title for step_result in step_results if step_result.success),
             "pr_title": f"🐙 {context.connector.technical_name}: run up-to-date pipeline [{datetime.now(timezone.utc).strftime('%Y-%m-%d')}]",
             "pr_body": get_pr_body(context, step_results, dependency_updates),
         },

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/up_to_date/pipeline.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/up_to_date/pipeline.py
@@ -21,7 +21,6 @@ from pipelines.consts import LOCAL_BUILD_PLATFORM
 
 from .steps import DependencyUpdate, GetDependencyUpdates, PoetryUpdate
 
-
 if TYPE_CHECKING:
     from typing import Dict, Iterable, List, Set, Tuple
 

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/up_to_date/pipeline.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/up_to_date/pipeline.py
@@ -62,12 +62,16 @@ def get_pr_creation_arguments(
     step_results: Iterable[StepResult],
     dependency_updates: Iterable[DependencyUpdate],
 ) -> Tuple[Tuple, Dict]:
-    return (modified_files,), {
-        "branch_id": f"up-to-date/{context.connector.technical_name}",
-        "commit_message": "\n".join(step_result.step.title for step_result in step_results if step_result.success),
-        "pr_title": f"🐙 {context.connector.technical_name}: run up-to-date pipeline [{datetime.now(timezone.utc).strftime('%Y-%m-%d')}]",
-        "pr_body": get_pr_body(context, step_results, dependency_updates),
-    }
+    return (
+        (modified_files,),
+        {
+            "branch_id": f"up-to-date/{context.connector.technical_name}",
+            "commit_message": "[up-to-date]"  # << We can skip Vercel builds if this is in the commit message
+            + "\n".join(step_result.step.title for step_result in step_results if step_result.success),
+            "pr_title": f"🐙 {context.connector.technical_name}: run up-to-date pipeline [{datetime.now(timezone.utc).strftime('%Y-%m-%d')}]",
+            "pr_body": get_pr_body(context, step_results, dependency_updates),
+        },
+    )
 
 
 ## MAIN FUNCTION

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/up_to_date/pipeline.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/up_to_date/pipeline.py
@@ -21,6 +21,7 @@ from pipelines.consts import LOCAL_BUILD_PLATFORM
 
 from .steps import DependencyUpdate, GetDependencyUpdates, PoetryUpdate
 
+
 if TYPE_CHECKING:
     from typing import Dict, Iterable, List, Set, Tuple
 
@@ -143,10 +144,11 @@ async def run_connector_up_to_date_pipeline(
 
                 # We open a PR even if build is failing.
                 # This might allow a developer to fix the build in the PR.
-                # ---
-                # We are skipping CI on this first PR creation attempt to avoid useless runs:
-                # the new changelog entry is missing, it will fail QA checks
-                initial_pr_creation = CreateOrUpdatePullRequest(context, skip_ci=True, labels=DEFAULT_PR_LABELS)
+                initial_pr_creation = CreateOrUpdatePullRequest(
+                    context,
+                    skip_ci=False,
+                    labels=DEFAULT_PR_LABELS,
+                )
                 pr_creation_args, pr_creation_kwargs = get_pr_creation_arguments(
                     all_modified_files, context, step_results, dependency_updates
                 )
@@ -176,7 +178,12 @@ async def run_connector_up_to_date_pipeline(
                     context.logger.info(f"Exported files following the changelog entry: {exported_modified_files}")
                     all_modified_files.update(exported_modified_files)
                     final_labels = DEFAULT_PR_LABELS + [AUTO_MERGE_PR_LABEL] if auto_merge else DEFAULT_PR_LABELS
-                    post_changelog_pr_update = CreateOrUpdatePullRequest(context, skip_ci=False, labels=final_labels)
+                    post_changelog_pr_update = CreateOrUpdatePullRequest(
+                        context,
+                        skip_ci=False,
+                        labels=final_labels,
+                        github_auto_merge=auto_merge,
+                    )
                     pr_creation_args, pr_creation_kwargs = get_pr_creation_arguments(
                         all_modified_files, context, step_results, dependency_updates
                     )

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/up_to_date/steps.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/up_to_date/steps.py
@@ -27,7 +27,7 @@ class PoetryUpdate(StepModifyingFiles):
     context: ConnectorContext
     dev: bool
     specified_versions: dict[str, str]
-    title = "Update versions of libraries in poetry."
+    title = "Update versions of libraries in poetry"
 
     def __init__(
         self,

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/steps/pull_request.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/steps/pull_request.py
@@ -8,6 +8,7 @@ from pipelines.airbyte_ci.connectors.context import ConnectorContext, PipelineCo
 from pipelines.helpers import github
 from pipelines.models.steps import Step, StepResult, StepStatus
 
+
 if TYPE_CHECKING:
     from pathlib import Path
     from typing import Iterable, Optional
@@ -24,10 +25,12 @@ class CreateOrUpdatePullRequest(Step):
         context: PipelineContext,
         skip_ci: bool,
         labels: Optional[Iterable[str]] = None,
+        github_auto_merge: bool = False,
     ) -> None:
         super().__init__(context)
         self.skip_ci = skip_ci
         self.labels = labels or []
+        self.github_auto_merge = github_auto_merge
 
     async def _run(
         self,
@@ -51,6 +54,7 @@ class CreateOrUpdatePullRequest(Step):
                 logger=self.logger,
                 skip_ci=self.skip_ci,
                 labels=self.labels,
+                github_auto_merge=self.github_auto_merge,
             )
         except Exception as e:
             return StepResult(step=self, status=StepStatus.FAILURE, stderr=str(e), exc_info=e)

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/steps/pull_request.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/steps/pull_request.py
@@ -8,7 +8,6 @@ from pipelines.airbyte_ci.connectors.context import ConnectorContext, PipelineCo
 from pipelines.helpers import github
 from pipelines.models.steps import Step, StepResult, StepStatus
 
-
 if TYPE_CHECKING:
     from pathlib import Path
     from typing import Iterable, Optional

--- a/airbyte-ci/connectors/pipelines/pipelines/helpers/github.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/helpers/github.py
@@ -137,6 +137,7 @@ def create_or_update_github_pull_request(
     skip_ci: bool = False,
     labels: Optional[Iterable[str]] = None,
     force_push: bool = True,
+    github_auto_merge: bool = False,
 ) -> github_sdk.PullRequest.PullRequest:
     logger = logger or main_logger
     g = github_sdk.Github(auth=github_sdk.Auth.Token(github_token))
@@ -221,6 +222,10 @@ def create_or_update_github_pull_request(
     for label in labels:
         pull_request.add_to_labels(label)
         logger.info(f"Added label {label} to pull request")
+
+    if github_auto_merge:
+        logger.info("Enabling (native) GitHub auto-merge for the pull request")
+        pull_request.enable_auto_merge("SQUASH")
 
     return pull_request
 

--- a/airbyte-ci/connectors/pipelines/pipelines/helpers/github.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/helpers/github.py
@@ -19,6 +19,7 @@ from pipelines import main_logger
 from pipelines.consts import CIContext
 from pipelines.models.secrets import Secret
 
+
 if TYPE_CHECKING:
     from logging import Logger
     from typing import Iterable, List, Optional
@@ -225,7 +226,7 @@ def create_or_update_github_pull_request(
 
     if github_auto_merge:
         logger.info("Enabling (native) GitHub auto-merge for the pull request")
-        pull_request.enable_auto_merge("SQUASH")
+        pull_request.enable_automerge("SQUASH")
 
     return pull_request
 

--- a/airbyte-ci/connectors/pipelines/pipelines/helpers/github.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/helpers/github.py
@@ -19,7 +19,6 @@ from pipelines import main_logger
 from pipelines.consts import CIContext
 from pipelines.models.secrets import Secret
 
-
 if TYPE_CHECKING:
     from logging import Logger
     from typing import Iterable, List, Optional

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "5.2.5"
+version = "5.3.0"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 


### PR DESCRIPTION
## What

1. ~~Modify the auto-merge pipeline to only handle the promote/rollback PRs that use "bypass ci".~~
   - Update: I realized on looking at existing PRs that we don't have an "auto-approve" pipeline, and that the lack of approval will still block PRs from merging, even with GitHub-native auto-merge enabled. So, I've reverted to still allow the auto-merge pipeline to force-merge them, and I've confirmed that the auto-merge behavior _does_ still wait for all required checks to pass. So, for now at least, we can keep mostly as-is, with the addition of the auto-merge status being set explicitly on the PR. If someone approves manually, they can merge without the `auto-merge` force-merging them.
2. Turn off `[skip ci]` marker in cases where we want CI to at least try to run.
3. Add native GitHub auto-merge for all cases where we want CI to merge naturally - specifically for the up-to-date pipeline.
4. NEW: I've added explicit commit message prefixes for `[up-to-date]` and `[auto-publish]`. This allows Vercel to skip builds. Otherwise these builds overwhelm the Vercel build queue.
   - Vercel's old logic was checking for a static commit message string, which is apparently no longer used.
   - Vercel prev skip logic: `git log -n 1 --oneline | grep -q "run up-to-date pipeline"`
   - Vercel new skip logic: `git log -n 1 --oneline | grep -Eq "\[(up-to-date|auto-publish)\]"`
   - Vercel Settings URL: https://vercel.com/airbyte-growth/airbyte-docs/settings/git


Note:

While fixing the Vercel skip condition, I also found that the way step names are concatenated is incorrect. According to git commit conventions, the first line should always contain a summary of all steps, and subsequent lines should expand in detail. Whereas presently it is showing just the first step name. We want GitHub to render that it can't display the full description (with "..."), and not that the first step is all that was performed.

Without the change it renders like this:

<img width="796" alt="image" src="https://github.com/user-attachments/assets/c28f17c6-f950-4f09-890e-0f2f8d352453" />

And there's not visual cue that more things are actually changed:

<img width="823" alt="image" src="https://github.com/user-attachments/assets/c1277f8e-1731-4bf3-81f3-d73db8ec8c47" />


After the change, it will render as many steps as will fit and then show '..." to indicate there are more details not shown.