### PR TITLE
fix(source-linkedin-ads) - reduce default concurrency level

### DIFF
--- a/airbyte-integrations/connectors/source-linkedin-ads/README.md
+++ b/airbyte-integrations/connectors/source-linkedin-ads/README.md
@@ -1,48 +1,21 @@
-# Linkedin-Ads source connector
+# LinkedIn Ads source connector
 
-This is the repository for the Linkedin-Ads source connector, written in Python.
-For information about how to use this connector within Airbyte, see [the documentation](https://docs.airbyte.com/integrations/sources/linkedin-ads).
+This directory contains the manifest-only connector for `source-linkedin-ads`.
+This _manifest-only_ connector is not a Python package on its own, as it runs inside of the base `source-declarative-manifest` image.
+
+For information about how to configure and use this connector within Airbyte, see [the connector's full documentation](https://docs.airbyte.com/integrations/sources/linkedin-ads).
 
 ## Local development
 
-### Prerequisites
+We recommend using the Connector Builder to edit this connector.
+Using either Airbyte Cloud or your local Airbyte OSS instance, navigate to the **Builder** tab and select **Import a YAML**.
+Then select the connector's `manifest.yaml` file to load the connector into the Builder. You're now ready to make changes to the connector!
 
-- Python (~=3.9)
-- Poetry (~=1.7) - installation instructions [here](https://python-poetry.org/docs/#installation)
-
-### Installing the connector
-
-From this connector directory, run:
-
-```bash
-poetry install --with dev
-```
-
-### Create credentials
-
-**If you are a community contributor**, follow the instructions in the [documentation](https://docs.airbyte.com/integrations/sources/linkedin-ads)
-to generate the necessary credentials. Then create a file `secrets/config.json` conforming to the `source_linkedin_ads/spec.yaml` file.
-Note that any directory named `secrets` is gitignored across the entire Airbyte repo, so there is no danger of accidentally checking in sensitive information.
-See `integration_tests/sample_config.json` for a sample config file.
-
-### Locally running the connector
-
-```
-poetry run source-linkedin-ads spec
-poetry run source-linkedin-ads check --config secrets/config.json
-poetry run source-linkedin-ads discover --config secrets/config.json
-poetry run source-linkedin-ads read --config secrets/config.json --catalog integration_tests/configured_catalog.json
-```
-
-### Running unit tests
-
-To run unit tests locally, from the connector directory run:
-
-```
-poetry run pytest unit_tests
-```
+If you prefer to develop locally, you can follow the instructions below.
 
 ### Building the docker image
+
+You can build any manifest-only connector with `airbyte-ci`:
 
 1. Install [`airbyte-ci`](https://github.com/airbytehq/airbyte/blob/master/airbyte-ci/connectors/pipelines/README.md)
 2. Run the following command to build the docker image:
@@ -53,18 +26,24 @@ airbyte-ci connectors --name=source-linkedin-ads build
 
 An image will be available on your host with the tag `airbyte/source-linkedin-ads:dev`.
 
+### Creating credentials
+
+**If you are a community contributor**, follow the instructions in the [documentation](https://docs.airbyte.com/integrations/sources/linkedin-ads)
+to generate the necessary credentials. Then create a file `secrets/config.json` conforming to the `spec` object in the connector's `manifest.yaml` file.
+Note that any directory named `secrets` is gitignored across the entire Airbyte repo, so there is no danger of accidentally checking in sensitive information.
+
 ### Running as a docker container
 
-Then run any of the connector commands as follows:
+Then run any of the standard source connector commands:
 
-```
+```bash
 docker run --rm airbyte/source-linkedin-ads:dev spec
 docker run --rm -v $(pwd)/secrets:/secrets airbyte/source-linkedin-ads:dev check --config /secrets/config.json
 docker run --rm -v $(pwd)/secrets:/secrets airbyte/source-linkedin-ads:dev discover --config /secrets/config.json
 docker run --rm -v $(pwd)/secrets:/secrets -v $(pwd)/integration_tests:/integration_tests airbyte/source-linkedin-ads:dev read --config /secrets/config.json --catalog /integration_tests/configured_catalog.json
 ```
 
-### Running our CI test suite
+### Running the CI test suite
 
 You can run our full test suite locally using [`airbyte-ci`](https://github.com/airbytehq/airbyte/blob/master/airbyte-ci/connectors/pipelines/README.md):
 
@@ -72,31 +51,13 @@ You can run our full test suite locally using [`airbyte-ci`](https://github.com/
 airbyte-ci connectors --name=source-linkedin-ads test
 ```
 
-### Customizing acceptance Tests
-
-Customize `acceptance-test-config.yml` file to configure acceptance tests. See [Connector Acceptance Tests](https://docs.airbyte.com/connector-development/testing-connectors/connector-acceptance-tests-reference) for more information.
-If your connector requires to create or destroy resources for use during acceptance tests create fixtures for it and place them inside integration_tests/acceptance.py.
-
-### Dependency Management
-
-All of your dependencies should be managed via Poetry.
-To add a new dependency, run:
-
-```bash
-poetry add <package-name>
-```
-
-Please commit the changes to `pyproject.toml` and `poetry.lock` files.
-
 ## Publishing a new version of the connector
 
-You've checked out the repo, implemented a million dollar feature, and you're ready to share your changes with the world. Now what?
-
-1. Make sure your changes are passing our test suite: `airbyte-ci connectors --name=source-linkedin-ads test`
-2. Bump the connector version (please follow [semantic versioning for connectors](https://docs.airbyte.com/contributing-to-airbyte/resources/pull-requests-handbook/#semantic-versioning-for-connectors)):
-   - bump the `dockerImageTag` value in in `metadata.yaml`
-   - bump the `version` value in `pyproject.toml`
-3. Make sure the `metadata.yaml` content is up to date.
+If you want to contribute changes to `source-linkedin-ads`, here's how you can do that:
+1. Make your changes locally, or load the connector's manifest into Connector Builder and make changes there.
+2. Make sure your changes are passing our test suite with `airbyte-ci connectors --name=source-linkedin-ads test`
+3. Bump the connector version (please follow [semantic versioning for connectors](https://docs.airbyte.com/contributing-to-airbyte/resources/pull-requests-handbook/#semantic-versioning-for-connectors)):
+    - bump the `dockerImageTag` value in in `metadata.yaml`
 4. Make sure the connector documentation and its changelog is up to date (`docs/integrations/sources/linkedin-ads.md`).
 5. Create a Pull Request: use [our PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/resources/pull-requests-handbook/#pull-request-title-convention).
 6. Pat yourself on the back for being an awesome contributor.

--- a/airbyte-integrations/connectors/source-linkedin-ads/manifest.yaml
+++ b/airbyte-integrations/connectors/source-linkedin-ads/manifest.yaml
@@ -1676,7 +1676,7 @@ dynamic_streams:
 # limiting issues with v5.5.0 of the connector -- migration to manifest-only.
 concurrency_level:
   type: ConcurrencyLevel
-  default_concurrency: "{{ config.get('num_workers', 3) }}"
+  default_concurrency: "{{ config.get('num_workers', 2) }}"
   max_concurrency: 50
 
 spec:

--- a/airbyte-integrations/connectors/source-linkedin-ads/manifest.yaml
+++ b/airbyte-integrations/connectors/source-linkedin-ads/manifest.yaml
@@ -1670,9 +1670,13 @@ dynamic_streams:
 # could require some tuning.
 #
 # It is likely that certain customers may have a greater limit provisioned so allow for a max of 50.
+#
+# Update 2025-06-16: Added num_workers to the config to allow for more control over the number
+# of workers and set the default to 3. This is because some customers were experiencing rate
+# limiting issues with v5.5.0 of the connector -- migration to manifest-only.
 concurrency_level:
   type: ConcurrencyLevel
-  default_concurrency: "19"
+  default_concurrency: "{{ config.get('num_workers', 3) }}"
   max_concurrency: 50
 
 spec:
@@ -1803,6 +1807,12 @@ spec:
                 - MONTHLY
                 - YEARLY
         default: []
+      num_workers:
+        type: integer
+        title: Number of Workers
+        default: 3
+        minimum: 2
+        description: The number of workers to use for the connector. This is used to limit the number of concurrent requests to the LinkedIn Ads API. If not set, the default is 3 workers.
   advanced_auth:
     auth_flow_type: oauth2.0
     predicate_key:

--- a/airbyte-integrations/connectors/source-linkedin-ads/manifest.yaml
+++ b/airbyte-integrations/connectors/source-linkedin-ads/manifest.yaml
@@ -1808,11 +1808,12 @@ spec:
                 - YEARLY
         default: []
       num_workers:
-        type: integer
         title: Number of Workers
+        description: The number of workers to use for the connector. This is used to limit the number of concurrent requests to the LinkedIn Ads API. If not set, the default is 3 workers.
+        type: integer
         default: 3
         minimum: 2
-        description: The number of workers to use for the connector. This is used to limit the number of concurrent requests to the LinkedIn Ads API. If not set, the default is 3 workers.
+        maximum: 50
   advanced_auth:
     auth_flow_type: oauth2.0
     predicate_key:

--- a/airbyte-integrations/connectors/source-linkedin-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-linkedin-ads/metadata.yaml
@@ -11,7 +11,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 137ece28-5434-455c-8f34-69dc3782f451
-  dockerImageTag: 5.5.0
+  dockerImageTag: 5.5.1
   dockerRepository: airbyte/source-linkedin-ads
   documentationUrl: https://docs.airbyte.com/integrations/sources/linkedin-ads
   githubIssueLabel: source-linkedin-ads

--- a/docs/integrations/sources/linkedin-ads.md
+++ b/docs/integrations/sources/linkedin-ads.md
@@ -202,7 +202,7 @@ No workaround has been identified to manage this issue as of 2025, February.
 
 | Version    | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |:-----------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 5.5.1 | 2025-06-16 | [61639](https://github.com/airbytehq/airbyte/pull/61639) | Reduce default concurrency level to 3 and enable configurability via `num_workers` config property |
+| 5.5.1 | 2025-06-18 | [61639](https://github.com/airbytehq/airbyte/pull/61639) | Reduce default concurrency level to 3 and enable configurability via `num_workers` config property |
 | 5.5.0 | 2025-04-28 | [59116](https://github.com/airbytehq/airbyte/pull/59116) | Promoting release candidate 5.5.0-rc.1 to a main version. |
 | 5.5.0-rc.1 | 2025-04-25 | [58628](https://github.com/airbytehq/airbyte/pull/58628)     | Convert to manifest-only format                                                                                                                                        |
 | 5.4.1      | 2025-04-23 | [58134](https://github.com/airbytehq/airbyte/pull/58134) | Fix to properly retrieve `approximateMemberReach` for `adAnalytics` streams following `v5.3.3`.                                                                        |

--- a/docs/integrations/sources/linkedin-ads.md
+++ b/docs/integrations/sources/linkedin-ads.md
@@ -187,12 +187,12 @@ After 5 unsuccessful attempts - the connector will stop the sync operation. In s
 | `string`         | `string`     |                             |
 
 ## Limits & considerations regarding  `Lead forms` and `Lead form responses` streams
-1. LinkedIn API requires special query params characters (eg: `(`, `:` or `)`), and low-code automatically escapes them using `query params`.  
-As auto-escaping disabling does not look not manageable via low-code, the workaround was to hard-code them in the request `path` directly.  
+1. LinkedIn API requires special query params characters (eg: `(`, `:` or `)`), and low-code automatically escapes them using `query params`.
+As auto-escaping disabling does not look not manageable via low-code, the workaround was to hard-code them in the request `path` directly.
 2. `Incremental Sync` is not manageable via low-code due to LinkedIn API way to handle timerange via query param:
 ```
 submittedAtTimeRange=(start:1711407600000,end:1711494000000)
-```  
+```
 No workaround has been identified to manage this issue as of 2025, February.
 
 ## Changelog
@@ -202,6 +202,7 @@ No workaround has been identified to manage this issue as of 2025, February.
 
 | Version    | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |:-----------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 5.5.1 | 2025-06-16 | [61639](https://github.com/airbytehq/airbyte/pull/61639) | Reduce default concurrency level to 3 and enable configurability via `num_workers` config property |
 | 5.5.0 | 2025-04-28 | [59116](https://github.com/airbytehq/airbyte/pull/59116) | Promoting release candidate 5.5.0-rc.1 to a main version. |
 | 5.5.0-rc.1 | 2025-04-25 | [58628](https://github.com/airbytehq/airbyte/pull/58628)     | Convert to manifest-only format                                                                                                                                        |
 | 5.4.1      | 2025-04-23 | [58134](https://github.com/airbytehq/airbyte/pull/58134) | Fix to properly retrieve `approximateMemberReach` for `adAnalytics` streams following `v5.3.3`.                                                                        |


### PR DESCRIPTION
## What
- Customers began experiencing rate limiting issues with v5.5.0 (migrate to manifest-only)
- Reduces default concurrency level to 3 but enables configurability via the config (num_workers)
- Related to OC issue: https://github.com/airbytehq/oncall/issues/8022
- Update to README.md to reflect manifest-only connector
- Patch version bump

## Review guide
1.  manifest.yaml

## User Impact
- Reduce rate limiting failures

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
