### PR TITLE
ci: use default `ubuntu-24.04` runner type for publish workflow

### DIFF
--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -34,7 +34,7 @@ on:
 jobs:
   publish_connectors:
     name: Publish connectors
-    runs-on: ubuntu-24.04-4core
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout Airbyte
         uses: actions/checkout@v4


### PR DESCRIPTION
## What

Replaces the custom runner `ubuntu-24.04-4core` with the generic runner `ubuntu-24.04`. I confirmed this is the only place it is used in the `airbyte` repo. This solves a queueing problem as discussed in slack here: https://airbytehq-team.slack.com/archives/C046KQF5GBT/p1750104097503029?thread_ts=1750103108.516729&cid=C046KQF5GBT

The link with info on the old runner is here (requires github admin permission):

https://github.com/organizations/airbytehq/settings/actions/github-hosted-runners/44?viewing_from_runner_group=false

Screenshot:

> <img width="599" alt="image" src="https://github.com/user-attachments/assets/7f1f32fc-3094-4e9f-ab19-be8946fe6af5" />

## About the default runners:

Default runners are the same size as what we were using as custom:

https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories

> <img width="765" alt="image" src="https://github.com/user-attachments/assets/d8e36e11-f3ad-45a9-9007-56e5944b3f0e" />


## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._