### PR TITLE
fix: don't apply overrides for release candidate metadata.yaml

### DIFF
--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/registry_entry.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/registry_entry.py
@@ -127,9 +127,9 @@ def apply_overrides_from_registry(metadata_data: dict, override_registry_key: st
     Returns:
         dict: The metadata data field with the overrides applied.
     """
-    _rc_version = metadata_data["dockerImageTag"]
+    _rc_version = metadata_data.get("dockerImageTag", "")
     is_release_candidate = "-rc" in _rc_version
-    is_release_candidate_enabled = metadata_data["releases"].get("rolloutConfiguration", {}).get("enableProgressiveRollout", False)
+    is_release_candidate_enabled = metadata_data.get("releases", {}).get("rolloutConfiguration", {}).get("enableProgressiveRollout", False)
 
     override_registry = metadata_data["registryOverrides"][override_registry_key]
     del override_registry["enabled"]

--- a/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/registry_entry.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/orchestrator/assets/registry_entry.py
@@ -11,7 +11,6 @@ from typing import List, Optional, Tuple, Union
 
 import orchestrator.hacks as HACKS
 import pandas as pd
-import semver
 import sentry_sdk
 from dagster import AutoMaterializePolicy, DynamicPartitionsDefinition, MetadataValue, OpExecutionContext, Output, asset
 from dagster_gcp.gcs.file_manager import GCSFileHandle, GCSFileManager
@@ -128,6 +127,10 @@ def apply_overrides_from_registry(metadata_data: dict, override_registry_key: st
     Returns:
         dict: The metadata data field with the overrides applied.
     """
+    _rc_version = metadata_data["dockerImageTag"]
+    is_release_candidate = "-rc" in _rc_version
+    is_release_candidate_enabled = metadata_data["releases"].get("rolloutConfiguration", {}).get("enableProgressiveRollout", False)
+
     override_registry = metadata_data["registryOverrides"][override_registry_key]
     del override_registry["enabled"]
 
@@ -135,6 +138,8 @@ def apply_overrides_from_registry(metadata_data: dict, override_registry_key: st
     override_registry = {k: v for k, v in override_registry.items() if v is not None}
 
     metadata_data.update(override_registry)
+    if is_release_candidate and is_release_candidate_enabled:
+        metadata_data["dockerImageTag"] = _rc_version
 
     return metadata_data
 

--- a/airbyte-ci/connectors/metadata_service/orchestrator/tests/fixtures/metadata_airbyte_source-faker_non-release-candidate_metadata.yaml
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/tests/fixtures/metadata_airbyte_source-faker_non-release-candidate_metadata.yaml
@@ -1,0 +1,70 @@
+data:
+  ab_internal:
+    ql: 300
+    sl: 100
+  allowedHosts:
+    hosts: []
+  connectorBuildOptions:
+    baseImage: docker.io/airbyte/python-connector-base:4.0.0@sha256:d9894b6895923b379f3006fa251147806919c62b7d9021b5cd125bb67d7bbe22
+  connectorSubtype: api
+  connectorType: source
+  definitionId: dfd88b22-b603-4c3d-aad7-3701784586b1
+  dockerImageTag: 6.2.25
+  dockerRepository: airbyte/source-faker
+  documentationUrl: https://docs.airbyte.com/integrations/sources/faker
+  githubIssueLabel: source-faker
+  icon: faker.svg
+  license: MIT
+  name: Sample Data (Faker)
+  registryOverrides:
+    cloud:
+      enabled: true
+    oss:
+      enabled: true
+  releaseStage: beta
+  releases:
+    rolloutConfiguration:
+      enableProgressiveRollout: true
+    breakingChanges:
+      4.0.0:
+        message: This is a breaking change message
+        upgradeDeadline: "2023-07-19"
+      5.0.0:
+        message: ID and products.year fields are changing to be integers instead of floats.
+        upgradeDeadline: "2023-08-31"
+      6.0.0:
+        message: Declare 'id' columns as primary keys.
+        upgradeDeadline: "2024-04-01"
+  remoteRegistries:
+    pypi:
+      enabled: true
+      packageName: airbyte-source-faker
+  resourceRequirements:
+    jobSpecific:
+      - jobType: sync
+        resourceRequirements:
+          cpu_limit: "4.0"
+          cpu_request: "1.0"
+  suggestedStreams:
+    streams:
+      - users
+      - products
+      - purchases
+  supportLevel: community
+  tags:
+    - language:python
+    - cdk:python
+  connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: faker_config_dev_null
+          id: 73abc3a9-3fea-4e7c-b58d-2c8236464a95
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-FAKER_CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+metadataSpecVersion: "1.0"

--- a/airbyte-ci/connectors/metadata_service/orchestrator/tests/fixtures/metadata_airbyte_source-faker_non-release-candidate_with_overrides_metadata.yaml
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/tests/fixtures/metadata_airbyte_source-faker_non-release-candidate_with_overrides_metadata.yaml
@@ -1,0 +1,72 @@
+data:
+  ab_internal:
+    ql: 300
+    sl: 100
+  allowedHosts:
+    hosts: []
+  connectorBuildOptions:
+    baseImage: docker.io/airbyte/python-connector-base:4.0.0@sha256:d9894b6895923b379f3006fa251147806919c62b7d9021b5cd125bb67d7bbe22
+  connectorSubtype: api
+  connectorType: source
+  definitionId: dfd88b22-b603-4c3d-aad7-3701784586b1
+  dockerImageTag: 6.2.25
+  dockerRepository: airbyte/source-faker
+  documentationUrl: https://docs.airbyte.com/integrations/sources/faker
+  githubIssueLabel: source-faker
+  icon: faker.svg
+  license: MIT
+  name: Sample Data (Faker)
+  registryOverrides:
+    cloud:
+      dockerImageTag: 6.2.24
+      enabled: true
+    oss:
+      dockerImageTag: 6.2.24
+      enabled: true
+  releaseStage: beta
+  releases:
+    rolloutConfiguration:
+      enableProgressiveRollout: true
+    breakingChanges:
+      4.0.0:
+        message: This is a breaking change message
+        upgradeDeadline: "2023-07-19"
+      5.0.0:
+        message: ID and products.year fields are changing to be integers instead of floats.
+        upgradeDeadline: "2023-08-31"
+      6.0.0:
+        message: Declare 'id' columns as primary keys.
+        upgradeDeadline: "2024-04-01"
+  remoteRegistries:
+    pypi:
+      enabled: true
+      packageName: airbyte-source-faker
+  resourceRequirements:
+    jobSpecific:
+      - jobType: sync
+        resourceRequirements:
+          cpu_limit: "4.0"
+          cpu_request: "1.0"
+  suggestedStreams:
+    streams:
+      - users
+      - products
+      - purchases
+  supportLevel: community
+  tags:
+    - language:python
+    - cdk:python
+  connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: faker_config_dev_null
+          id: 73abc3a9-3fea-4e7c-b58d-2c8236464a95
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-FAKER_CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+metadataSpecVersion: "1.0"

--- a/airbyte-ci/connectors/metadata_service/orchestrator/tests/fixtures/metadata_airbyte_source-faker_release_candidate_metadata.yaml
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/tests/fixtures/metadata_airbyte_source-faker_release_candidate_metadata.yaml
@@ -1,0 +1,70 @@
+data:
+  ab_internal:
+    ql: 300
+    sl: 100
+  allowedHosts:
+    hosts: []
+  connectorBuildOptions:
+    baseImage: docker.io/airbyte/python-connector-base:4.0.0@sha256:d9894b6895923b379f3006fa251147806919c62b7d9021b5cd125bb67d7bbe22
+  connectorSubtype: api
+  connectorType: source
+  definitionId: dfd88b22-b603-4c3d-aad7-3701784586b1
+  dockerImageTag: 6.2.26-rc.1
+  dockerRepository: airbyte/source-faker
+  documentationUrl: https://docs.airbyte.com/integrations/sources/faker
+  githubIssueLabel: source-faker
+  icon: faker.svg
+  license: MIT
+  name: Sample Data (Faker)
+  registryOverrides:
+    cloud:
+      enabled: true
+    oss:
+      enabled: true
+  releaseStage: beta
+  releases:
+    rolloutConfiguration:
+      enableProgressiveRollout: true
+    breakingChanges:
+      4.0.0:
+        message: This is a breaking change message
+        upgradeDeadline: "2023-07-19"
+      5.0.0:
+        message: ID and products.year fields are changing to be integers instead of floats.
+        upgradeDeadline: "2023-08-31"
+      6.0.0:
+        message: Declare 'id' columns as primary keys.
+        upgradeDeadline: "2024-04-01"
+  remoteRegistries:
+    pypi:
+      enabled: true
+      packageName: airbyte-source-faker
+  resourceRequirements:
+    jobSpecific:
+      - jobType: sync
+        resourceRequirements:
+          cpu_limit: "4.0"
+          cpu_request: "1.0"
+  suggestedStreams:
+    streams:
+      - users
+      - products
+      - purchases
+  supportLevel: community
+  tags:
+    - language:python
+    - cdk:python
+  connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: faker_config_dev_null
+          id: 73abc3a9-3fea-4e7c-b58d-2c8236464a95
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-FAKER_CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+metadataSpecVersion: "1.0"

--- a/airbyte-ci/connectors/metadata_service/orchestrator/tests/fixtures/metadata_airbyte_source-faker_release_candidate_with_overrides_metadata.yaml
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/tests/fixtures/metadata_airbyte_source-faker_release_candidate_with_overrides_metadata.yaml
@@ -1,0 +1,72 @@
+data:
+  ab_internal:
+    ql: 300
+    sl: 100
+  allowedHosts:
+    hosts: []
+  connectorBuildOptions:
+    baseImage: docker.io/airbyte/python-connector-base:4.0.0@sha256:d9894b6895923b379f3006fa251147806919c62b7d9021b5cd125bb67d7bbe22
+  connectorSubtype: api
+  connectorType: source
+  definitionId: dfd88b22-b603-4c3d-aad7-3701784586b1
+  dockerImageTag: 6.2.26-rc.1
+  dockerRepository: airbyte/source-faker
+  documentationUrl: https://docs.airbyte.com/integrations/sources/faker
+  githubIssueLabel: source-faker
+  icon: faker.svg
+  license: MIT
+  name: Sample Data (Faker)
+  registryOverrides:
+    cloud:
+      dockerImageTag: 6.2.24
+      enabled: true
+    oss:
+      dockerImageTag: 6.2.24
+      enabled: true
+  releaseStage: beta
+  releases:
+    rolloutConfiguration:
+      enableProgressiveRollout: true
+    breakingChanges:
+      4.0.0:
+        message: This is a breaking change message
+        upgradeDeadline: "2023-07-19"
+      5.0.0:
+        message: ID and products.year fields are changing to be integers instead of floats.
+        upgradeDeadline: "2023-08-31"
+      6.0.0:
+        message: Declare 'id' columns as primary keys.
+        upgradeDeadline: "2024-04-01"
+  remoteRegistries:
+    pypi:
+      enabled: true
+      packageName: airbyte-source-faker
+  resourceRequirements:
+    jobSpecific:
+      - jobType: sync
+        resourceRequirements:
+          cpu_limit: "4.0"
+          cpu_request: "1.0"
+  suggestedStreams:
+    streams:
+      - users
+      - products
+      - purchases
+  supportLevel: community
+  tags:
+    - language:python
+    - cdk:python
+  connectorTestSuitesOptions:
+    - suite: liveTests
+      testConnections:
+        - name: faker_config_dev_null
+          id: 73abc3a9-3fea-4e7c-b58d-2c8236464a95
+    - suite: unitTests
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-FAKER_CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+metadataSpecVersion: "1.0"

--- a/airbyte-ci/connectors/metadata_service/orchestrator/tests/test_registry_entry.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/tests/test_registry_entry.py
@@ -1,3 +1,7 @@
+#
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+#
+
 import yaml
 import pytest
 from pathlib import Path

--- a/airbyte-ci/connectors/metadata_service/orchestrator/tests/test_registry_entry.py
+++ b/airbyte-ci/connectors/metadata_service/orchestrator/tests/test_registry_entry.py
@@ -1,0 +1,57 @@
+import yaml
+import pytest
+from pathlib import Path
+from orchestrator.assets.registry_entry import metadata_to_registry_entry
+from orchestrator.models.metadata import LatestMetadataEntry, MetadataDefinition
+
+
+@pytest.mark.parametrize(
+    ("input_metadata_filepath", "expected_docker_image_tag"),
+    [
+        # For release candidates we return the rc docker image tag, whether or not there are overrides.
+        # The override that was present on the registry entry for the latest connector will still be in effect as the default version.
+        ("fixtures/metadata_airbyte_source-faker_release_candidate_metadata.yaml", "6.2.26-rc.1"),
+        ("fixtures/metadata_airbyte_source-faker_release_candidate_with_overrides_metadata.yaml", "6.2.26-rc.1"),
+        # No override so we return the docker image tag that was set
+        ("fixtures/metadata_airbyte_source-faker_non-release-candidate_metadata.yaml", "6.2.25"),
+        # Not a release candidate so we use the override docker image tag
+        ("fixtures/metadata_airbyte_source-faker_non-release-candidate_with_overrides_metadata.yaml", "6.2.24"),
+    ]
+)
+def test_metadata_to_registry_entry_rc_keeps_rc_version(input_metadata_filepath, expected_docker_image_tag):
+    # Load the release candidate metadata
+    rc_metadata_path = Path(__file__).parent / input_metadata_filepath
+
+    with open(rc_metadata_path, "r") as f:
+        rc_metadata_dict = yaml.safe_load(f)
+
+    # The yaml file represents the metadata file, which has a top level "data" key
+    metadata_data = rc_metadata_dict["data"]
+
+    # Remove the invalid "registries" field
+    if "registries" in metadata_data:
+        del metadata_data["registries"]
+
+    # Create a MetadataDefinition object, which has a top level "data" key
+    # and a "metadataSpecVersion" key
+    metadata_definition = MetadataDefinition(
+        metadataSpecVersion="1.0",
+        data=metadata_data
+    )
+
+    # Create a LatestMetadataEntry object
+    latest_metadata_entry = LatestMetadataEntry(
+        metadata_definition=metadata_definition,
+        icon_blob=None, # Not needed for this test
+        icon_url="", # Not needed for this test
+        bucket_name="test_bucket",
+        file_path="test/path/release_candidate/metadata.yaml",
+        etag="test_etag",
+        last_modified="2024-01-01",
+    )
+
+    # Call the function under test
+    registry_entry_dict = metadata_to_registry_entry(latest_metadata_entry, "cloud")
+
+    # Assert that the dockerIm ageTag is the release candidate version
+    assert registry_entry_dict["dockerImageTag"] == expected_docker_image_tag


### PR DESCRIPTION
## What
Fixes a bug that was preventing us from doing a progressive rollout if the latest version of the connector had a `dockerImageTag` override (aka was not the latest version).

## How
When processing metadata.yaml, if the registry entry that we're creating is for a release candidate, doesn't use the docker image tag overrides.

**Note to reviewers**: this code change is removing the override for the [release candidate registry entry only](https://console.cloud.google.com/storage/browser/_details/prod-airbyte-cloud-connector-metadata-service/metadata/airbyte/destination-bigquery/release_candidate/metadata.yaml;tab=live_object?hl=en-AU&inv=1&invt=Ab0SyQ&project=prod-ab-cloud-proj&supportedpurview=project) only; the registry entry for the latest non-progressive-rollout connector version will still have the registry overrides - e.g. [latest from the registry as of 6/16](https://console.cloud.google.com/storage/browser/_details/prod-airbyte-cloud-connector-metadata-service/metadata/airbyte/destination-bigquery/latest/metadata.yaml;tab=live_object?hl=en-AU&inv=1&invt=Ab0SyQ&project=prod-ab-cloud-proj&supportedpurview=project):
```
data:
  ...
  connectorType: destination
  definitionId: 22f6c74f-5699-40ff-833c-4a879ea40133
  dockerImageTag: 2.12.1
  ...
  registryOverrides:
    cloud:
      dockerImageTag: 2.10.2
      enabled: true
    oss:
      dockerImageTag: 2.10.2
      enabled: true
  ...
```

## Can this PR be safely reverted and rolled back?
- [X] YES 💚
- [ ] NO ❌
