### PR TITLE
Fix(Source-Google-Analytics-Data-Api): Bump memory on CHECK to 1600Mi

### DIFF
--- a/airbyte-integrations/connectors/source-google-analytics-data-api/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-analytics-data-api/metadata.yaml
@@ -12,9 +12,15 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 3cc2eafd-84aa-4dca-93af-322d9dfeec1a
-  dockerImageTag: 2.8.1
+  dockerImageTag: 2.8.2
   dockerRepository: airbyte/source-google-analytics-data-api
   documentationUrl: https://docs.airbyte.com/integrations/sources/google-analytics-data-api
+  resourceRequirements:
+    jobSpecific:
+      - jobType: check_connection
+        resourceRequirements:
+          memory_limit: 1600Mi
+          memory_request: 1600Mi
   githubIssueLabel: source-google-analytics-data-api
   icon: google-analytics.svg
   license: Elv2

--- a/airbyte-integrations/connectors/source-google-analytics-data-api/pyproject.toml
+++ b/airbyte-integrations/connectors/source-google-analytics-data-api/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "2.8.1"
+version = "2.8.2"
 name = "source-google-analytics-data-api"
 description = "Source implementation for Google Analytics Data Api."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/docs/integrations/sources/google-analytics-data-api.md
+++ b/docs/integrations/sources/google-analytics-data-api.md
@@ -272,7 +272,7 @@ The Google Analytics connector is subject to Google Analytics Data API quotas. P
 
 | Version    | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |:-----------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 2.8.2 | 2025-06-17 | [XXXXX](https://github.com/airbytehq/airbyte/pull/XXXXX) | Bump Memory on CHECK to 1600Mi |
+| 2.8.2 | 2025-06-17 | [61678](https://github.com/airbytehq/airbyte/pull/61678) | Bump Memory on CHECK to 1600Mi |
 | 2.8.1 | 2025-06-12 | [61555](https://github.com/airbytehq/airbyte/pull/61555) | Fixes time data parsing issue |
 | 2.8.0 | 2025-06-11 | [61533](https://github.com/airbytehq/airbyte/pull/61533) | Promoting release candidate 2.8.0-rc.2 to a main version. |
 | 2.8.0-rc.2 | 2025-06-11 | [61491](https://github.com/airbytehq/airbyte/pull/61491) | Fixed cohort check, record extractor and discovery                                                                                                                     |

--- a/docs/integrations/sources/google-analytics-data-api.md
+++ b/docs/integrations/sources/google-analytics-data-api.md
@@ -272,6 +272,7 @@ The Google Analytics connector is subject to Google Analytics Data API quotas. P
 
 | Version    | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |:-----------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 2.8.2 | 2025-06-17 | [XXXXX](https://github.com/airbytehq/airbyte/pull/XXXXX) | Bump Memory on CHECK to 1600Mi |
 | 2.8.1 | 2025-06-12 | [61555](https://github.com/airbytehq/airbyte/pull/61555) | Fixes time data parsing issue |
 | 2.8.0 | 2025-06-11 | [61533](https://github.com/airbytehq/airbyte/pull/61533) | Promoting release candidate 2.8.0-rc.2 to a main version. |
 | 2.8.0-rc.2 | 2025-06-11 | [61491](https://github.com/airbytehq/airbyte/pull/61491) | Fixed cohort check, record extractor and discovery                                                                                                                     |


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->
Users getting OOM errors on check for GA4 source. OC: https://github.com/airbytehq/oncall/issues/8061
## How
<!--
* Describe how code changes achieve the solution.
-->
Default is 800mi for check. Update this on the metadata.yml for check_connection datatype. 
## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [X ] YES 💚
- [ ] NO ❌
