### PR TITLE
put bigquery back on the new build flow

### DIFF
--- a/poe-tasks/build-and-publish-java-connectors-with-tag.sh
+++ b/poe-tasks/build-and-publish-java-connectors-with-tag.sh
@@ -42,6 +42,7 @@ is_in_whitelist() {
   local connector="$1"
   case "$connector" in
     destination-azure-blob-storage|\
+    destination-bigquery|\
     destination-csv|\
     destination-clickhouse|\
     destination-clickhouse-strict-encrypt|\


### PR DESCRIPTION
I think we removed this when we were trying to publish 2.12.3, and then didn't re-add it in the RC publish PR