### PR TITLE
feat: convert protobuf record to airbyte value

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/AirbyteValueProtobufProxy.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/AirbyteValueProtobufProxy.kt
@@ -20,8 +20,10 @@ import java.math.BigInteger
  * the same schema. Eventually this order needs to be set by the source with a header message.
  */
 class AirbyteValueProtobufProxy(private val data: List<AirbyteValueProtobuf>) : AirbyteValueProxy {
-    private inline fun <T> getNullable(field: FieldAccessor, getter: (FieldAccessor) -> T): T? =
-        if (data[field.index].isNull) null else getter(field)
+    private inline fun <T> getNullable(field: FieldAccessor, getter: (FieldAccessor) -> T): T? {
+        return if (data.isEmpty() || data.size < field.index || data[field.index].isNull) null
+        else getter(field)
+    }
 
     override fun getBoolean(field: FieldAccessor): Boolean? =
         getNullable(field) { data[it.index].boolean }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/protobuf/ProtobufToAirbyteValue.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/protobuf/ProtobufToAirbyteValue.kt
@@ -32,6 +32,7 @@ import io.airbyte.cdk.load.data.TimestampTypeWithoutTimezone
 import io.airbyte.cdk.load.data.TimestampWithTimezoneValue
 import io.airbyte.cdk.load.data.TimestampWithoutTimezoneValue
 import io.airbyte.cdk.load.data.UnionType
+import io.airbyte.cdk.load.data.UnknownType
 import io.airbyte.cdk.load.data.json.JsonToAirbyteValue
 import io.airbyte.cdk.load.message.DestinationRecordProtobufSource
 
@@ -42,62 +43,67 @@ import io.airbyte.cdk.load.message.DestinationRecordProtobufSource
 class ProtobufToAirbyteValue(
     private val fields: Array<AirbyteValueProxy.FieldAccessor>,
 ) {
-
     private val jsonToAirbyteValue = JsonToAirbyteValue()
 
     fun convert(record: DestinationRecordProtobufSource): AirbyteValue {
         val proxy = record.asAirbyteValueProxy()
-        val values: LinkedHashMap<String, AirbyteValue> =
-            LinkedHashMap(
-                fields.associate { field ->
-                    field.name to
-                        when (field.type) {
-                            is BooleanType ->
-                                if (proxy.getBoolean(field) == null) NullValue
-                                else BooleanValue(proxy.getBoolean(field)!!)
-                            is IntegerType ->
-                                if (proxy.getInteger(field) == null) NullValue
-                                else IntegerValue(proxy.getInteger(field)!!)
-                            is NumberType ->
-                                if (proxy.getNumber(field) == null) NullValue
-                                else NumberValue(proxy.getNumber(field)!!)
-                            is DateType ->
-                                if (proxy.getDate(field) == null) NullValue
-                                else DateValue(proxy.getDate(field)!!)
-                            is ArrayType,
-                            is ArrayTypeWithoutSchema,
-                            is UnionType,
-                            is ObjectType,
-                            is ObjectTypeWithEmptySchema,
-                            is ObjectTypeWithoutSchema ->
-                                if (proxy.getJsonNode(field) == null) NullValue
-                                else jsonToAirbyteValue.convert(proxy.getJsonNode(field)!!)
-                            is StringType ->
-                                if (proxy.getString(field) == null) NullValue
-                                else StringValue(proxy.getString(field)!!)
-                            is TimeTypeWithTimezone ->
-                                if (proxy.getTimeWithTimezone(field) == null) NullValue
-                                else TimeWithTimezoneValue(proxy.getTimeWithTimezone(field)!!)
-                            is TimeTypeWithoutTimezone ->
-                                if (proxy.getTimeWithoutTimezone(field) == null) NullValue
-                                else TimeWithoutTimezoneValue(proxy.getTimeWithoutTimezone(field)!!)
-                            is TimestampTypeWithTimezone ->
-                                if (proxy.getTimestampWithTimezone(field) == null) NullValue
-                                else
-                                    TimestampWithTimezoneValue(
-                                        proxy.getTimestampWithTimezone(field)!!
-                                    )
-                            is TimestampTypeWithoutTimezone ->
-                                if (proxy.getTimestampWithoutTimezone(field) == null) NullValue
-                                else
-                                    TimestampWithoutTimezoneValue(
-                                        proxy.getTimestampWithoutTimezone(field)!!
-                                    )
-                            else -> NullValue
-                        }
-                }
-            )
-        return ObjectValue(values)
+        val convertedFields = fields.associate { field -> field.name to convertField(proxy, field) }
+        return ObjectValue(LinkedHashMap(convertedFields))
+    }
+
+    private fun convertField(
+        proxy: AirbyteValueProxy,
+        field: AirbyteValueProxy.FieldAccessor
+    ): AirbyteValue {
+        return when (field.type) {
+            is BooleanType -> convertPrimitiveField { proxy.getBoolean(field) }?.let(::BooleanValue)
+                    ?: NullValue
+            is IntegerType -> convertPrimitiveField { proxy.getInteger(field) }?.let(::IntegerValue)
+                    ?: NullValue
+            is NumberType -> convertPrimitiveField { proxy.getNumber(field) }?.let(::NumberValue)
+                    ?: NullValue
+            is DateType -> convertPrimitiveField { proxy.getDate(field) }?.let(::DateValue)
+                    ?: NullValue
+            is StringType -> convertPrimitiveField { proxy.getString(field) }?.let(::StringValue)
+                    ?: NullValue
+            is TimeTypeWithTimezone ->
+                convertPrimitiveField { proxy.getTimeWithTimezone(field) }
+                    ?.let(::TimeWithTimezoneValue)
+                    ?: NullValue
+            is TimeTypeWithoutTimezone ->
+                convertPrimitiveField { proxy.getTimeWithoutTimezone(field) }
+                    ?.let(::TimeWithoutTimezoneValue)
+                    ?: NullValue
+            is TimestampTypeWithTimezone ->
+                convertPrimitiveField { proxy.getTimestampWithTimezone(field) }
+                    ?.let(::TimestampWithTimezoneValue)
+                    ?: NullValue
+            is TimestampTypeWithoutTimezone ->
+                convertPrimitiveField { proxy.getTimestampWithoutTimezone(field) }
+                    ?.let(::TimestampWithoutTimezoneValue)
+                    ?: NullValue
+            is ArrayType,
+            is ArrayTypeWithoutSchema,
+            is UnionType,
+            is ObjectType,
+            is ObjectTypeWithEmptySchema,
+            is ObjectTypeWithoutSchema -> convertComplexField(proxy, field)
+            is UnknownType -> NullValue
+        }
+    }
+
+    private inline fun <T> convertPrimitiveField(getter: () -> T?): T? = getter()
+
+    private fun convertComplexField(
+        proxy: AirbyteValueProxy,
+        field: AirbyteValueProxy.FieldAccessor
+    ): AirbyteValue {
+        val jsonNode = proxy.getJsonNode(field)
+        return if (jsonNode != null) {
+            jsonToAirbyteValue.convert(jsonNode)
+        } else {
+            NullValue
+        }
     }
 }
 

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/protobuf/ProtobufToAirbyteValue.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/protobuf/ProtobufToAirbyteValue.kt
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.load.data.protobuf
+
+import io.airbyte.cdk.load.data.AirbyteValue
+import io.airbyte.cdk.load.data.AirbyteValueProxy
+import io.airbyte.cdk.load.data.ArrayType
+import io.airbyte.cdk.load.data.ArrayTypeWithoutSchema
+import io.airbyte.cdk.load.data.BooleanType
+import io.airbyte.cdk.load.data.BooleanValue
+import io.airbyte.cdk.load.data.DateType
+import io.airbyte.cdk.load.data.DateValue
+import io.airbyte.cdk.load.data.IntegerType
+import io.airbyte.cdk.load.data.IntegerValue
+import io.airbyte.cdk.load.data.NullValue
+import io.airbyte.cdk.load.data.NumberType
+import io.airbyte.cdk.load.data.NumberValue
+import io.airbyte.cdk.load.data.ObjectType
+import io.airbyte.cdk.load.data.ObjectTypeWithEmptySchema
+import io.airbyte.cdk.load.data.ObjectTypeWithoutSchema
+import io.airbyte.cdk.load.data.ObjectValue
+import io.airbyte.cdk.load.data.StringType
+import io.airbyte.cdk.load.data.StringValue
+import io.airbyte.cdk.load.data.TimeTypeWithTimezone
+import io.airbyte.cdk.load.data.TimeTypeWithoutTimezone
+import io.airbyte.cdk.load.data.TimeWithTimezoneValue
+import io.airbyte.cdk.load.data.TimeWithoutTimezoneValue
+import io.airbyte.cdk.load.data.TimestampTypeWithTimezone
+import io.airbyte.cdk.load.data.TimestampTypeWithoutTimezone
+import io.airbyte.cdk.load.data.TimestampWithTimezoneValue
+import io.airbyte.cdk.load.data.TimestampWithoutTimezoneValue
+import io.airbyte.cdk.load.data.UnionType
+import io.airbyte.cdk.load.data.json.JsonToAirbyteValue
+import io.airbyte.cdk.load.message.DestinationRecordProtobufSource
+
+/**
+ * Naively convert a Protocol Buffers object to the equivalent [AirbyteValue]. Note that this does
+ * not match against a declared schema; it simply does the most obvious conversion.
+ */
+class ProtobufToAirbyteValue(
+    private val fields: Array<AirbyteValueProxy.FieldAccessor>,
+) {
+    
+    private val jsonToAirbyteValue = JsonToAirbyteValue()
+
+    fun convert(record: DestinationRecordProtobufSource): AirbyteValue {
+        val proxy = record.asAirbyteValueProxy()
+        val values: LinkedHashMap<String, AirbyteValue> =
+            LinkedHashMap(
+                fields.associate { field ->
+                    field.name to
+                        when (field.type) {
+                            is BooleanType ->
+                                if (proxy.getBoolean(field) == null) NullValue
+                                else BooleanValue(proxy.getBoolean(field)!!)
+                            is IntegerType ->
+                                if (proxy.getInteger(field) == null) NullValue
+                                else IntegerValue(proxy.getInteger(field)!!)
+                            is NumberType ->
+                                if (proxy.getNumber(field) == null) NullValue
+                                else NumberValue(proxy.getNumber(field)!!)
+                            is DateType ->
+                                if (proxy.getDate(field) == null) NullValue
+                                else DateValue(proxy.getDate(field)!!)
+                            is ArrayType,
+                            is ArrayTypeWithoutSchema,
+                            is UnionType,
+                            is ObjectType,
+                            is ObjectTypeWithEmptySchema,
+                            is ObjectTypeWithoutSchema ->
+                                if (proxy.getJsonNode(field) == null) NullValue
+                                else jsonToAirbyteValue.convert(proxy.getJsonNode(field)!!)
+                            is StringType ->
+                                if (proxy.getString(field) == null) NullValue
+                                else StringValue(proxy.getString(field)!!)
+                            is TimeTypeWithTimezone ->
+                                if (proxy.getTimeWithTimezone(field) == null) NullValue
+                                else TimeWithTimezoneValue(proxy.getTimeWithTimezone(field)!!)
+                            is TimeTypeWithoutTimezone ->
+                                if (proxy.getTimeWithoutTimezone(field) == null) NullValue
+                                else TimeWithoutTimezoneValue(proxy.getTimeWithoutTimezone(field)!!)
+                            is TimestampTypeWithTimezone ->
+                                if (proxy.getTimestampWithTimezone(field) == null) NullValue
+                                else
+                                    TimestampWithTimezoneValue(
+                                        proxy.getTimestampWithTimezone(field)!!
+                                    )
+                            is TimestampTypeWithoutTimezone ->
+                                if (proxy.getTimestampWithoutTimezone(field) == null) NullValue
+                                else
+                                    TimestampWithoutTimezoneValue(
+                                        proxy.getTimestampWithoutTimezone(field)!!
+                                    )
+                            else -> NullValue
+                        }
+                }
+            )
+        return ObjectValue(values)
+    }
+}
+
+fun DestinationRecordProtobufSource.toAirbyteValue(
+    fields: Array<AirbyteValueProxy.FieldAccessor>
+): AirbyteValue {
+    return ProtobufToAirbyteValue(fields = fields).convert(this)
+}

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/protobuf/ProtobufToAirbyteValue.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/protobuf/ProtobufToAirbyteValue.kt
@@ -42,7 +42,7 @@ import io.airbyte.cdk.load.message.DestinationRecordProtobufSource
 class ProtobufToAirbyteValue(
     private val fields: Array<AirbyteValueProxy.FieldAccessor>,
 ) {
-    
+
     private val jsonToAirbyteValue = JsonToAirbyteValue()
 
     fun convert(record: DestinationRecordProtobufSource): AirbyteValue {

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/DestinationRecordRaw.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/DestinationRecordRaw.kt
@@ -12,6 +12,7 @@ import io.airbyte.cdk.load.data.FieldType
 import io.airbyte.cdk.load.data.NullValue
 import io.airbyte.cdk.load.data.ObjectType
 import io.airbyte.cdk.load.data.json.toAirbyteValue
+import io.airbyte.cdk.load.data.protobuf.toAirbyteValue
 import io.airbyte.cdk.load.state.CheckpointId
 import io.airbyte.protocol.models.v0.AirbyteRecordMessageMetaChange
 import java.util.*
@@ -37,10 +38,13 @@ data class DestinationRecordRaw(
 
     fun asDestinationRecordAirbyteValue(): DestinationRecordAirbyteValue {
         return DestinationRecordAirbyteValue(
-            stream,
-            asJsonRecord().toAirbyteValue(),
-            rawData.emittedAtMs,
-            rawData.sourceMeta
+            stream = stream,
+            data =
+                if (rawData is DestinationRecordProtobufSource) {
+                    rawData.toAirbyteValue(stream.airbyteValueProxyFieldAccessors)
+                } else asJsonRecord().toAirbyteValue(),
+            emittedAtMs = rawData.emittedAtMs,
+            meta = rawData.sourceMeta,
         )
     }
 

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/data/protobuf/ProtobufToAirbyteValueTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/data/protobuf/ProtobufToAirbyteValueTest.kt
@@ -1,0 +1,651 @@
+/*
+ * Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.load.data.protobuf
+
+import com.google.protobuf.kotlin.toByteStringUtf8
+import io.airbyte.cdk.load.command.Append
+import io.airbyte.cdk.load.command.DestinationStream
+import io.airbyte.cdk.load.command.NamespaceMapper
+import io.airbyte.cdk.load.data.AirbyteType
+import io.airbyte.cdk.load.data.ArrayType
+import io.airbyte.cdk.load.data.ArrayTypeWithoutSchema
+import io.airbyte.cdk.load.data.BooleanType
+import io.airbyte.cdk.load.data.BooleanValue
+import io.airbyte.cdk.load.data.DateType
+import io.airbyte.cdk.load.data.DateValue
+import io.airbyte.cdk.load.data.FieldType
+import io.airbyte.cdk.load.data.IntegerType
+import io.airbyte.cdk.load.data.IntegerValue
+import io.airbyte.cdk.load.data.NullValue
+import io.airbyte.cdk.load.data.NumberType
+import io.airbyte.cdk.load.data.NumberValue
+import io.airbyte.cdk.load.data.ObjectType
+import io.airbyte.cdk.load.data.ObjectTypeWithEmptySchema
+import io.airbyte.cdk.load.data.ObjectTypeWithoutSchema
+import io.airbyte.cdk.load.data.ObjectValue
+import io.airbyte.cdk.load.data.StringType
+import io.airbyte.cdk.load.data.StringValue
+import io.airbyte.cdk.load.data.TimeTypeWithTimezone
+import io.airbyte.cdk.load.data.TimeTypeWithoutTimezone
+import io.airbyte.cdk.load.data.TimeWithTimezoneValue
+import io.airbyte.cdk.load.data.TimeWithoutTimezoneValue
+import io.airbyte.cdk.load.data.TimestampTypeWithTimezone
+import io.airbyte.cdk.load.data.TimestampTypeWithoutTimezone
+import io.airbyte.cdk.load.data.TimestampWithTimezoneValue
+import io.airbyte.cdk.load.data.TimestampWithoutTimezoneValue
+import io.airbyte.cdk.load.data.UnionType
+import io.airbyte.cdk.load.message.DestinationRecordProtobufSource
+import io.airbyte.protocol.protobuf.AirbyteMessage.AirbyteMessageProtobuf
+import io.airbyte.protocol.protobuf.AirbyteRecordMessage
+import io.mockk.mockk
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.OffsetDateTime
+import java.time.OffsetTime
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+internal class ProtobufToAirbyteValueTest {
+
+    @Test
+    fun testString() {
+        val fieldName = "testString"
+        val expectedValue = "testValue"
+        val stream = createStream(fieldName = fieldName, fieldType = StringType)
+        val protobuf =
+            AirbyteMessageProtobuf.newBuilder()
+                .setRecord(
+                    AirbyteRecordMessage.AirbyteRecordMessageProtobuf.newBuilder()
+                        .setStreamName("test")
+                        .setEmittedAtMs(1234)
+                        .addData(
+                            AirbyteRecordMessage.AirbyteValueProtobuf.newBuilder()
+                                .setString(expectedValue)
+                        )
+                        .setPartitionId("checkpoint_id")
+                        .build()
+                )
+                .build()
+        val rawData = DestinationRecordProtobufSource(source = protobuf)
+        val value =
+            ProtobufToAirbyteValue(fields = stream.airbyteValueProxyFieldAccessors).convert(rawData)
+
+        assertTrue(value is ObjectValue)
+        assertTrue((value as ObjectValue).values[fieldName] is StringValue)
+        assertEquals(expectedValue, (value.values[fieldName] as StringValue).value)
+    }
+
+    @Test
+    fun testBoolean() {
+        val fieldName = "testBoolean"
+        val expectedValue = true
+        val stream = createStream(fieldName = fieldName, fieldType = BooleanType)
+        val protobuf =
+            AirbyteMessageProtobuf.newBuilder()
+                .setRecord(
+                    AirbyteRecordMessage.AirbyteRecordMessageProtobuf.newBuilder()
+                        .setStreamName("test")
+                        .setEmittedAtMs(1234)
+                        .addData(
+                            AirbyteRecordMessage.AirbyteValueProtobuf.newBuilder()
+                                .setBoolean(expectedValue)
+                        )
+                        .setPartitionId("checkpoint_id")
+                        .build()
+                )
+                .build()
+        val rawData = DestinationRecordProtobufSource(source = protobuf)
+        val value =
+            ProtobufToAirbyteValue(fields = stream.airbyteValueProxyFieldAccessors).convert(rawData)
+
+        assertTrue(value is ObjectValue)
+        assertTrue((value as ObjectValue).values[fieldName] is BooleanValue)
+        assertEquals(expectedValue, (value.values[fieldName] as BooleanValue).value)
+    }
+
+    @Test
+    fun testInteger() {
+        val fieldName = "testInteger"
+        val expectedValue = 1L
+        val stream = createStream(fieldName = fieldName, fieldType = IntegerType)
+        val protobuf =
+            AirbyteMessageProtobuf.newBuilder()
+                .setRecord(
+                    AirbyteRecordMessage.AirbyteRecordMessageProtobuf.newBuilder()
+                        .setStreamName("test")
+                        .setEmittedAtMs(1234)
+                        .addData(
+                            AirbyteRecordMessage.AirbyteValueProtobuf.newBuilder()
+                                .setInteger(expectedValue)
+                        )
+                        .setPartitionId("checkpoint_id")
+                        .build()
+                )
+                .build()
+        val rawData = DestinationRecordProtobufSource(source = protobuf)
+        val value =
+            ProtobufToAirbyteValue(fields = stream.airbyteValueProxyFieldAccessors).convert(rawData)
+
+        assertTrue(value is ObjectValue)
+        assertTrue((value as ObjectValue).values[fieldName] is IntegerValue)
+        assertEquals(expectedValue.toBigInteger(), (value.values[fieldName] as IntegerValue).value)
+    }
+
+    @Test
+    fun testNumber() {
+        val fieldName = "testNumber"
+        val expectedValue = 1.0
+        val stream = createStream(fieldName = fieldName, fieldType = NumberType)
+        val protobuf =
+            AirbyteMessageProtobuf.newBuilder()
+                .setRecord(
+                    AirbyteRecordMessage.AirbyteRecordMessageProtobuf.newBuilder()
+                        .setStreamName("test")
+                        .setEmittedAtMs(1234)
+                        .addData(
+                            AirbyteRecordMessage.AirbyteValueProtobuf.newBuilder()
+                                .setNumber(expectedValue)
+                        )
+                        .setPartitionId("checkpoint_id")
+                        .build()
+                )
+                .build()
+        val rawData = DestinationRecordProtobufSource(source = protobuf)
+        val value =
+            ProtobufToAirbyteValue(fields = stream.airbyteValueProxyFieldAccessors).convert(rawData)
+
+        assertTrue(value is ObjectValue)
+        assertTrue((value as ObjectValue).values[fieldName] is NumberValue)
+        assertEquals(expectedValue.toBigDecimal(), (value.values[fieldName] as NumberValue).value)
+    }
+
+    @Test
+    fun testObject() {
+        val fieldName = "testObject"
+        val expectedValue = "{\"name\":\"testObject\"}"
+        val stream =
+            createStream(
+                fieldName = fieldName,
+                fieldType =
+                    ObjectType(properties = linkedMapOf("name" to FieldType(StringType, false)))
+            )
+        val protobuf =
+            AirbyteMessageProtobuf.newBuilder()
+                .setRecord(
+                    AirbyteRecordMessage.AirbyteRecordMessageProtobuf.newBuilder()
+                        .setStreamName("test")
+                        .setEmittedAtMs(1234)
+                        .addData(
+                            AirbyteRecordMessage.AirbyteValueProtobuf.newBuilder()
+                                .setJson(expectedValue.toByteStringUtf8())
+                        )
+                        .setPartitionId("checkpoint_id")
+                        .build()
+                )
+                .build()
+        val rawData = DestinationRecordProtobufSource(source = protobuf)
+        val value =
+            ProtobufToAirbyteValue(fields = stream.airbyteValueProxyFieldAccessors).convert(rawData)
+
+        assertTrue(value is ObjectValue)
+        assertTrue((value as ObjectValue).values[fieldName] is ObjectValue)
+        assertEquals(
+            "testObject",
+            ((value.values[fieldName] as ObjectValue).values["name"] as StringValue).value
+        )
+    }
+
+    @Test
+    fun testArray() {
+        val fieldName = "testArray"
+        val expectedValue = "{\"name\":\"testObject\"}"
+        val stream =
+            createStream(
+                fieldName = fieldName,
+                fieldType = ArrayType(FieldType(StringType, false)),
+            )
+        val protobuf =
+            AirbyteMessageProtobuf.newBuilder()
+                .setRecord(
+                    AirbyteRecordMessage.AirbyteRecordMessageProtobuf.newBuilder()
+                        .setStreamName("test")
+                        .setEmittedAtMs(1234)
+                        .addData(
+                            AirbyteRecordMessage.AirbyteValueProtobuf.newBuilder()
+                                .setJson(expectedValue.toByteStringUtf8())
+                        )
+                        .setPartitionId("checkpoint_id")
+                        .build()
+                )
+                .build()
+        val rawData = DestinationRecordProtobufSource(source = protobuf)
+        val value =
+            ProtobufToAirbyteValue(fields = stream.airbyteValueProxyFieldAccessors).convert(rawData)
+
+        assertTrue(value is ObjectValue)
+        assertTrue((value as ObjectValue).values[fieldName] is ObjectValue)
+        assertEquals(
+            "testObject",
+            ((value.values[fieldName] as ObjectValue).values["name"] as StringValue).value
+        )
+    }
+
+    @Test
+    fun testArrayWithoutSchema() {
+        val fieldName = "testArrayWithoutSchema"
+        val expectedValue = "{\"name\":\"testObject\"}"
+        val stream =
+            createStream(
+                fieldName = fieldName,
+                fieldType = ArrayTypeWithoutSchema,
+            )
+        val protobuf =
+            AirbyteMessageProtobuf.newBuilder()
+                .setRecord(
+                    AirbyteRecordMessage.AirbyteRecordMessageProtobuf.newBuilder()
+                        .setStreamName("test")
+                        .setEmittedAtMs(1234)
+                        .addData(
+                            AirbyteRecordMessage.AirbyteValueProtobuf.newBuilder()
+                                .setJson(expectedValue.toByteStringUtf8())
+                        )
+                        .setPartitionId("checkpoint_id")
+                        .build()
+                )
+                .build()
+        val rawData = DestinationRecordProtobufSource(source = protobuf)
+        val value =
+            ProtobufToAirbyteValue(fields = stream.airbyteValueProxyFieldAccessors).convert(rawData)
+
+        assertTrue(value is ObjectValue)
+        assertTrue((value as ObjectValue).values[fieldName] is ObjectValue)
+        assertEquals(
+            "testObject",
+            ((value.values[fieldName] as ObjectValue).values["name"] as StringValue).value
+        )
+    }
+
+    @Test
+    fun testUnion() {
+        val fieldName = "testUnion"
+        val expectedValue = "{\"name\":\"testObject\"}"
+        val stream =
+            createStream(
+                fieldName = fieldName,
+                fieldType = UnionType(setOf(StringType), false),
+            )
+        val protobuf =
+            AirbyteMessageProtobuf.newBuilder()
+                .setRecord(
+                    AirbyteRecordMessage.AirbyteRecordMessageProtobuf.newBuilder()
+                        .setStreamName("test")
+                        .setEmittedAtMs(1234)
+                        .addData(
+                            AirbyteRecordMessage.AirbyteValueProtobuf.newBuilder()
+                                .setJson(expectedValue.toByteStringUtf8())
+                        )
+                        .setPartitionId("checkpoint_id")
+                        .build()
+                )
+                .build()
+        val rawData = DestinationRecordProtobufSource(source = protobuf)
+        val value =
+            ProtobufToAirbyteValue(fields = stream.airbyteValueProxyFieldAccessors).convert(rawData)
+
+        assertTrue(value is ObjectValue)
+        assertTrue((value as ObjectValue).values[fieldName] is ObjectValue)
+        assertEquals(
+            "testObject",
+            ((value.values[fieldName] as ObjectValue).values["name"] as StringValue).value
+        )
+    }
+
+    @Test
+    fun testObjectWithEmptySchema() {
+        val fieldName = "testObjectWithEmptySchema"
+        val expectedValue = "{\"name\":\"testObject\"}"
+        val stream =
+            createStream(
+                fieldName = fieldName,
+                fieldType = ObjectTypeWithEmptySchema,
+            )
+        val protobuf =
+            AirbyteMessageProtobuf.newBuilder()
+                .setRecord(
+                    AirbyteRecordMessage.AirbyteRecordMessageProtobuf.newBuilder()
+                        .setStreamName("test")
+                        .setEmittedAtMs(1234)
+                        .addData(
+                            AirbyteRecordMessage.AirbyteValueProtobuf.newBuilder()
+                                .setJson(expectedValue.toByteStringUtf8())
+                        )
+                        .setPartitionId("checkpoint_id")
+                        .build()
+                )
+                .build()
+        val rawData = DestinationRecordProtobufSource(source = protobuf)
+        val value =
+            ProtobufToAirbyteValue(fields = stream.airbyteValueProxyFieldAccessors).convert(rawData)
+
+        assertTrue(value is ObjectValue)
+        assertTrue((value as ObjectValue).values[fieldName] is ObjectValue)
+        assertEquals(
+            "testObject",
+            ((value.values[fieldName] as ObjectValue).values["name"] as StringValue).value
+        )
+    }
+
+    @Test
+    fun testObjectWithoutSchema() {
+        val fieldName = "testObjectWithoutSchema"
+        val expectedValue = "{\"name\":\"testObject\"}"
+        val stream =
+            createStream(
+                fieldName = fieldName,
+                fieldType = ObjectTypeWithoutSchema,
+            )
+        val protobuf =
+            AirbyteMessageProtobuf.newBuilder()
+                .setRecord(
+                    AirbyteRecordMessage.AirbyteRecordMessageProtobuf.newBuilder()
+                        .setStreamName("test")
+                        .setEmittedAtMs(1234)
+                        .addData(
+                            AirbyteRecordMessage.AirbyteValueProtobuf.newBuilder()
+                                .setJson(expectedValue.toByteStringUtf8())
+                        )
+                        .setPartitionId("checkpoint_id")
+                        .build()
+                )
+                .build()
+        val rawData = DestinationRecordProtobufSource(source = protobuf)
+        val value =
+            ProtobufToAirbyteValue(fields = stream.airbyteValueProxyFieldAccessors).convert(rawData)
+
+        assertTrue(value is ObjectValue)
+        assertTrue((value as ObjectValue).values[fieldName] is ObjectValue)
+        assertEquals(
+            "testObject",
+            ((value.values[fieldName] as ObjectValue).values["name"] as StringValue).value
+        )
+    }
+
+    @Test
+    fun testDate() {
+        val fieldName = "testDate"
+        val expectedValue = "2025-01-01"
+        val stream = createStream(fieldName = fieldName, fieldType = DateType)
+        val protobuf =
+            AirbyteMessageProtobuf.newBuilder()
+                .setRecord(
+                    AirbyteRecordMessage.AirbyteRecordMessageProtobuf.newBuilder()
+                        .setStreamName("test")
+                        .setEmittedAtMs(1234)
+                        .addData(
+                            AirbyteRecordMessage.AirbyteValueProtobuf.newBuilder()
+                                .setDate(expectedValue)
+                        )
+                        .setPartitionId("checkpoint_id")
+                        .build()
+                )
+                .build()
+        val rawData = DestinationRecordProtobufSource(source = protobuf)
+        val value =
+            ProtobufToAirbyteValue(fields = stream.airbyteValueProxyFieldAccessors).convert(rawData)
+
+        assertTrue(value is ObjectValue)
+        assertTrue((value as ObjectValue).values[fieldName] is DateValue)
+        assertEquals(LocalDate.parse(expectedValue), (value.values[fieldName] as DateValue).value)
+    }
+
+    @Test
+    fun testTimeWithTimezone() {
+        val fieldName = "testTimeWithTimezone"
+        val expectedValue = "10:15:30+01:00"
+        val stream = createStream(fieldName = fieldName, fieldType = TimeTypeWithTimezone)
+        val protobuf =
+            AirbyteMessageProtobuf.newBuilder()
+                .setRecord(
+                    AirbyteRecordMessage.AirbyteRecordMessageProtobuf.newBuilder()
+                        .setStreamName("test")
+                        .setEmittedAtMs(1234)
+                        .addData(
+                            AirbyteRecordMessage.AirbyteValueProtobuf.newBuilder()
+                                .setTimeWithTimezone(expectedValue)
+                        )
+                        .setPartitionId("checkpoint_id")
+                        .build()
+                )
+                .build()
+        val rawData = DestinationRecordProtobufSource(source = protobuf)
+        val value =
+            ProtobufToAirbyteValue(fields = stream.airbyteValueProxyFieldAccessors).convert(rawData)
+
+        assertTrue(value is ObjectValue)
+        assertTrue((value as ObjectValue).values[fieldName] is TimeWithTimezoneValue)
+        assertEquals(
+            OffsetTime.parse(expectedValue),
+            (value.values[fieldName] as TimeWithTimezoneValue).value
+        )
+    }
+
+    @Test
+    fun testTimeWithoutTimezone() {
+        val fieldName = "testTimeWithoutTimezone"
+        val expectedValue = "10:15:30"
+        val stream = createStream(fieldName = fieldName, fieldType = TimeTypeWithoutTimezone)
+        val protobuf =
+            AirbyteMessageProtobuf.newBuilder()
+                .setRecord(
+                    AirbyteRecordMessage.AirbyteRecordMessageProtobuf.newBuilder()
+                        .setStreamName("test")
+                        .setEmittedAtMs(1234)
+                        .addData(
+                            AirbyteRecordMessage.AirbyteValueProtobuf.newBuilder()
+                                .setTimeWithoutTimezone(expectedValue)
+                        )
+                        .setPartitionId("checkpoint_id")
+                        .build()
+                )
+                .build()
+        val rawData = DestinationRecordProtobufSource(source = protobuf)
+        val value =
+            ProtobufToAirbyteValue(fields = stream.airbyteValueProxyFieldAccessors).convert(rawData)
+
+        assertTrue(value is ObjectValue)
+        assertTrue((value as ObjectValue).values[fieldName] is TimeWithoutTimezoneValue)
+        assertEquals(
+            LocalTime.parse(expectedValue),
+            (value.values[fieldName] as TimeWithoutTimezoneValue).value
+        )
+    }
+
+    @Test
+    fun testTimestampWithTimezone() {
+        val fieldName = "testTimestampWithTimezone"
+        val expectedValue = "2007-12-03T10:15:30+01:00"
+        val stream = createStream(fieldName = fieldName, fieldType = TimestampTypeWithTimezone)
+        val protobuf =
+            AirbyteMessageProtobuf.newBuilder()
+                .setRecord(
+                    AirbyteRecordMessage.AirbyteRecordMessageProtobuf.newBuilder()
+                        .setStreamName("test")
+                        .setEmittedAtMs(1234)
+                        .addData(
+                            AirbyteRecordMessage.AirbyteValueProtobuf.newBuilder()
+                                .setTimestampWithTimezone(expectedValue)
+                        )
+                        .setPartitionId("checkpoint_id")
+                        .build()
+                )
+                .build()
+        val rawData = DestinationRecordProtobufSource(source = protobuf)
+        val value =
+            ProtobufToAirbyteValue(fields = stream.airbyteValueProxyFieldAccessors).convert(rawData)
+
+        assertTrue(value is ObjectValue)
+        assertTrue((value as ObjectValue).values[fieldName] is TimestampWithTimezoneValue)
+        assertEquals(
+            OffsetDateTime.parse(expectedValue),
+            (value.values[fieldName] as TimestampWithTimezoneValue).value
+        )
+    }
+
+    @Test
+    fun testTimestampWithoutTimezone() {
+        val fieldName = "testTimestampWithoutTimezone"
+        val expectedValue = "2007-12-03T10:15:30"
+        val stream = createStream(fieldName = fieldName, fieldType = TimestampTypeWithoutTimezone)
+        val protobuf =
+            AirbyteMessageProtobuf.newBuilder()
+                .setRecord(
+                    AirbyteRecordMessage.AirbyteRecordMessageProtobuf.newBuilder()
+                        .setStreamName("test")
+                        .setEmittedAtMs(1234)
+                        .addData(
+                            AirbyteRecordMessage.AirbyteValueProtobuf.newBuilder()
+                                .setTimestampWithoutTimezone(expectedValue)
+                        )
+                        .setPartitionId("checkpoint_id")
+                        .build()
+                )
+                .build()
+        val rawData = DestinationRecordProtobufSource(source = protobuf)
+        val value =
+            ProtobufToAirbyteValue(fields = stream.airbyteValueProxyFieldAccessors).convert(rawData)
+
+        assertTrue(value is ObjectValue)
+        assertTrue((value as ObjectValue).values[fieldName] is TimestampWithoutTimezoneValue)
+        assertEquals(
+            LocalDateTime.parse(expectedValue),
+            (value.values[fieldName] as TimestampWithoutTimezoneValue).value
+        )
+    }
+
+    @Test
+    fun testNull() {
+        val fieldName = "testString"
+        val stream = createStream(fieldName = fieldName, fieldType = StringType)
+        val protobuf =
+            AirbyteMessageProtobuf.newBuilder()
+                .setRecord(
+                    AirbyteRecordMessage.AirbyteRecordMessageProtobuf.newBuilder()
+                        .setStreamName("test")
+                        .setEmittedAtMs(1234)
+                        .addData(
+                            AirbyteRecordMessage.AirbyteValueProtobuf.newBuilder().setIsNull(true)
+                        )
+                        .setPartitionId("checkpoint_id")
+                        .build()
+                )
+                .build()
+        val rawData = DestinationRecordProtobufSource(source = protobuf)
+        val value =
+            ProtobufToAirbyteValue(fields = stream.airbyteValueProxyFieldAccessors).convert(rawData)
+
+        assertTrue(value is ObjectValue)
+        assertTrue((value as ObjectValue).values[fieldName] is NullValue)
+    }
+
+    @Test
+    fun testNullValueForMissingValues() {
+        val stream =
+            DestinationStream(
+                unmappedNamespace = null,
+                unmappedName = "test",
+                importType = Append,
+                schema =
+                    ObjectType(
+                        properties =
+                            linkedMapOf(
+                                "field1" to FieldType(BooleanType, false),
+                                "field2" to FieldType(IntegerType, false),
+                                "field3" to FieldType(NumberType, false),
+                                "field4" to FieldType(DateType, false),
+                                "field5" to
+                                    FieldType(ObjectType(properties = linkedMapOf()), false),
+                                "field6" to FieldType(StringType, false),
+                                "field7" to FieldType(TimeTypeWithTimezone, false),
+                                "field8" to FieldType(TimeTypeWithoutTimezone, false),
+                                "field9" to FieldType(TimestampTypeWithTimezone, false),
+                                "field10" to FieldType(TimestampTypeWithoutTimezone, false),
+                            )
+                    ),
+                generationId = 1L,
+                minimumGenerationId = 1L,
+                syncId = 1L,
+                namespaceMapper = mockk<NamespaceMapper>(relaxed = true),
+                isFileBased = false,
+                includeFiles = false,
+                destinationObjectName = null,
+                matchingKey = null,
+            )
+        val protobuf =
+            AirbyteMessageProtobuf.newBuilder()
+                .setRecord(
+                    AirbyteRecordMessage.AirbyteRecordMessageProtobuf.newBuilder()
+                        .setStreamName("test")
+                        .setEmittedAtMs(1234)
+                        .setPartitionId("checkpoint_id")
+                        .build()
+                )
+                .build()
+        val rawData = DestinationRecordProtobufSource(source = protobuf)
+        val value =
+            ProtobufToAirbyteValue(fields = stream.airbyteValueProxyFieldAccessors).convert(rawData)
+
+        assertTrue(value is ObjectValue)
+        assertEquals(0, (value as ObjectValue).values.filter { it.value !is NullValue }.count())
+    }
+
+    @Test
+    fun testExtensionFunction() {
+        val fieldName = "testString"
+        val expectedValue = "testValue"
+        val stream = createStream(fieldName = fieldName, fieldType = StringType)
+        val protobuf =
+            AirbyteMessageProtobuf.newBuilder()
+                .setRecord(
+                    AirbyteRecordMessage.AirbyteRecordMessageProtobuf.newBuilder()
+                        .setStreamName("test")
+                        .setEmittedAtMs(1234)
+                        .addData(
+                            AirbyteRecordMessage.AirbyteValueProtobuf.newBuilder()
+                                .setString(expectedValue)
+                        )
+                        .setPartitionId("checkpoint_id")
+                        .build()
+                )
+                .build()
+        val value =
+            DestinationRecordProtobufSource(source = protobuf)
+                .toAirbyteValue(fields = stream.airbyteValueProxyFieldAccessors)
+
+        assertTrue(value is ObjectValue)
+        assertTrue((value as ObjectValue).values[fieldName] is StringValue)
+        assertEquals(expectedValue, (value.values[fieldName] as StringValue).value)
+    }
+
+    private fun createStream(fieldName: String, fieldType: AirbyteType): DestinationStream {
+        val properties = LinkedHashMap<String, FieldType>()
+        properties.put(fieldName, FieldType(fieldType, false))
+        return DestinationStream(
+            unmappedNamespace = null,
+            unmappedName = "test",
+            importType = Append,
+            schema = ObjectType(properties = properties),
+            generationId = 1L,
+            minimumGenerationId = 1L,
+            syncId = 1L,
+            namespaceMapper = mockk<NamespaceMapper>(relaxed = true),
+            isFileBased = false,
+            includeFiles = false,
+            destinationObjectName = null,
+            matchingKey = null,
+        )
+    }
+}


### PR DESCRIPTION
## What
* Avoid converting Prototbuf Airbyte records to JSON before converting to other formats

## How
* Implement direct Airbyte Protobuf records to `AirbyteValue` values
* Modify raw record to use correct raw data to airbyte value converter

## Review guide
1. `ProtobufToAirbyteValue.kt`
2. `DestinationRecordRow.kt`

## Can this PR be safely reverted and rolled back?
- [X] YES 💚
- [ ] NO ❌
