### PR TITLE
✨ Source HubSpot: add new stream `properties`

### DIFF
--- a/airbyte-integrations/connectors/source-hubspot/erd/source.dbml
+++ b/airbyte-integrations/connectors/source-hubspot/erd/source.dbml
@@ -3421,3 +3421,41 @@ Ref {
 Ref {
     "workflows"."originalAuthorUserId" <> "owners"."userId"
 }
+
+Table "properties" {
+    "type" string
+    "description" string
+    "archived" boolean
+    "calculated" boolean
+    "calculationFormula" string
+    "createdAt" string
+    "createdUserId" string
+    "dataSensitivity" string
+    "dateDisplayHint" string
+    "displayOrder" number
+    "externalOptions" boolean
+    "fieldType" string
+    "formField" boolean
+    "groupName" string
+    "hasUniqueValue" boolean
+    "hubspotDefined" boolean
+    "label" string
+    "modificationMetadata" object
+    "name" string
+    "numberDisplayHint" string
+    "options" array
+    "optionSortStrategy" string
+    "referencedObjectType" string
+    "readOnlyDefinition" boolean
+    "readOnlyOptions" boolean
+    "readOnlyValue" boolean
+    "referencedObjectType" string
+    "searchableInGlobalSearch" boolean
+    "searchableInKnowledgeBase" boolean
+    "showCurrencySymbol" boolean
+    "sortable" boolean
+    "updatedAt" string
+    "updatedUserId" string
+    "displayMode" string
+    "objectType" string
+}

--- a/airbyte-integrations/connectors/source-hubspot/erd/source.dbml
+++ b/airbyte-integrations/connectors/source-hubspot/erd/source.dbml
@@ -3098,6 +3098,44 @@ Table "workflows" {
     "portalId" integer
 }
 
+Table "properties" {
+    "type" string
+    "description" string
+    "archived" boolean
+    "calculated" boolean
+    "calculationFormula" string
+    "createdAt" string
+    "createdUserId" string
+    "dataSensitivity" string
+    "dateDisplayHint" string
+    "displayOrder" number
+    "externalOptions" boolean
+    "fieldType" string
+    "formField" boolean
+    "groupName" string
+    "hasUniqueValue" boolean
+    "hubspotDefined" boolean
+    "label" string
+    "modificationMetadata" object
+    "name" string
+    "numberDisplayHint" string
+    "options" array
+    "optionSortStrategy" string
+    "referencedObjectType" string
+    "readOnlyDefinition" boolean
+    "readOnlyOptions" boolean
+    "readOnlyValue" boolean
+    "referencedObjectType" string
+    "searchableInGlobalSearch" boolean
+    "searchableInKnowledgeBase" boolean
+    "showCurrencySymbol" boolean
+    "sortable" boolean
+    "updatedAt" string
+    "updatedUserId" string
+    "displayMode" string
+    "objectType" string
+}
+
 Ref {
     "companies"."properties_hs_created_by_user_id" <> "owners"."userId"
 }
@@ -3420,42 +3458,4 @@ Ref {
 
 Ref {
     "workflows"."originalAuthorUserId" <> "owners"."userId"
-}
-
-Table "properties" {
-    "type" string
-    "description" string
-    "archived" boolean
-    "calculated" boolean
-    "calculationFormula" string
-    "createdAt" string
-    "createdUserId" string
-    "dataSensitivity" string
-    "dateDisplayHint" string
-    "displayOrder" number
-    "externalOptions" boolean
-    "fieldType" string
-    "formField" boolean
-    "groupName" string
-    "hasUniqueValue" boolean
-    "hubspotDefined" boolean
-    "label" string
-    "modificationMetadata" object
-    "name" string
-    "numberDisplayHint" string
-    "options" array
-    "optionSortStrategy" string
-    "referencedObjectType" string
-    "readOnlyDefinition" boolean
-    "readOnlyOptions" boolean
-    "readOnlyValue" boolean
-    "referencedObjectType" string
-    "searchableInGlobalSearch" boolean
-    "searchableInKnowledgeBase" boolean
-    "showCurrencySymbol" boolean
-    "sortable" boolean
-    "updatedAt" string
-    "updatedUserId" string
-    "displayMode" string
-    "objectType" string
 }

--- a/airbyte-integrations/connectors/source-hubspot/integration_tests/basic_read_catalog.json
+++ b/airbyte-integrations/connectors/source-hubspot/integration_tests/basic_read_catalog.json
@@ -359,6 +359,15 @@
       },
       "sync_mode": "full_refresh",
       "destination_sync_mode": "overwrite"
+    },
+    {
+      "stream": {
+        "name": "properties",
+        "json_schema": {},
+        "supported_sync_modes": ["full_refresh"]
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     }
   ]
 }

--- a/airbyte-integrations/connectors/source-hubspot/integration_tests/full_refresh_oauth_catalog.json
+++ b/airbyte-integrations/connectors/source-hubspot/integration_tests/full_refresh_oauth_catalog.json
@@ -206,6 +206,15 @@
       },
       "sync_mode": "full_refresh",
       "destination_sync_mode": "overwrite"
+    },
+    {
+      "stream": {
+        "name": "properties",
+        "json_schema": {},
+        "supported_sync_modes": ["full_refresh"]
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
     }
   ]
 }

--- a/airbyte-integrations/connectors/source-hubspot/manifest.yaml
+++ b/airbyte-integrations/connectors/source-hubspot/manifest.yaml
@@ -1979,6 +1979,65 @@ definitions:
             $ref: "#/schemas/tickets"
         - $ref: "#/definitions/base_dynamic_schema_loader"
 
+  properties_stream:
+    type: DeclarativeStream
+    name: properties
+    retriever:
+      type: SimpleRetriever
+      requester:
+        $ref: "#/definitions/base_requester"
+        path: /crm/v3/properties/{{ stream_partition['objectType'] }}
+        http_method: GET
+        error_handler:
+          type: CompositeErrorHandler
+          error_handlers:
+            - type: DefaultErrorHandler
+              response_filters:
+                - type: HttpResponseFilter
+                  action: IGNORE
+                  http_codes:
+                    - 403
+    record_selector:
+      type: RecordSelector
+      extractor:
+        type: DpathExtractor
+        field_path:
+          - results
+    partition_router:
+      type: ListPartitionRouter
+      values:
+        - company
+        - contact
+        - deal
+        - ticket
+        - call
+        - communication
+        - email
+        - lead
+        - meeting
+        - note
+        - order
+        - product
+        - quote
+        - service
+        - subscription
+        - task
+        - user
+      cursor_field: objectType
+    decoder:
+      type: JsonDecoder
+    transformations:
+      - type: AddFields
+        fields:
+          - type: AddedFieldDefinition
+            path:
+              - objectType
+            value: "{{ stream_partition['objectType'] }}"
+  schema_loader:
+    type: InlineSchemaLoader
+    schema:
+      $ref: "#/schemas/properties"
+
 streams:
   - "#/definitions/campaigns_stream"
   - "#/definitions/companies_stream"
@@ -2012,6 +2071,7 @@ streams:
   - "#/definitions/ticket_pipelines_stream"
   - "#/definitions/tickets_stream"
   - "#/definitions/workflows_stream"
+  - "#/definitions/properties_stream"
 
 dynamic_streams:
   - type: DynamicDeclarativeStream
@@ -8284,3 +8344,155 @@ schemas:
         type:
           - "null"
           - boolean
+
+  properties:
+    type: object
+    $schema: http://json-schema.org/schema#
+    additionalProperties: true
+    properties:
+      type:
+        type:
+          - string
+          - "null"
+      description:
+        type:
+          - string
+          - "null"
+      archived:
+        type:
+          - boolean
+          - "null"
+      calculated:
+        type:
+          - boolean
+          - "null"
+      calculationFormula:
+        type:
+          - string
+          - "null"
+      createdAt:
+        type:
+          - string
+          - "null"
+      createdUserId:
+        type:
+          - string
+          - "null"
+      dataSensitivity:
+        type:
+          - string
+          - "null"
+      dateDisplayHint:
+        type:
+          - string
+          - "null"
+      displayOrder:
+        type:
+          - number
+          - "null"
+      externalOptions:
+        type:
+          - boolean
+          - "null"
+      fieldType:
+        type:
+          - string
+          - "null"
+      formField:
+        type:
+          - boolean
+          - "null"
+      groupName:
+        type:
+          - string
+          - "null"
+      hasUniqueValue:
+        type:
+          - boolean
+          - "null"
+      hidden:
+        type:
+          - boolean
+          - "null"
+      hubspotDefined:
+        type:
+          - boolean
+          - "null"
+      label:
+        type:
+          - string
+          - "null"
+      modificationMetadata:
+        type:
+          - object
+          - "null"
+        properties:
+          archivable:
+            type:
+              - boolean
+              - "null"
+          readOnlyDefinition:
+            type:
+              - boolean
+              - "null"
+          readOnlyOptions:
+            type:
+              - boolean
+              - "null"
+          readOnlyValue:
+            type:
+              - boolean
+              - "null"
+      name:
+        type:
+          - string
+          - "null"
+      objectType:
+        type:
+          - string
+          - "null"
+      options:
+        type:
+          - array
+          - "null"
+        items:
+          type:
+            - object
+            - "null"
+          properties:
+            description:
+              type:
+                - string
+                - "null"
+            displayOrder:
+              type:
+                - number
+                - "null"
+            hidden:
+              type:
+                - boolean
+                - "null"
+            label:
+              type:
+                - string
+                - "null"
+            value:
+              type:
+                - string
+                - "null"
+      referencedObjectType:
+        type:
+          - string
+          - "null"
+      showCurrencySymbol:
+        type:
+          - boolean
+          - "null"
+      updatedAt:
+        type:
+          - string
+          - "null"
+      updatedUserId:
+        type:
+          - string
+          - "null"

--- a/airbyte-integrations/connectors/source-hubspot/manifest.yaml
+++ b/airbyte-integrations/connectors/source-hubspot/manifest.yaml
@@ -88,6 +88,55 @@ definitions:
         error_message: >-
           Bad request (400). Please verify your credentials and try again.
 
+  error_handler_ignore_403:
+    # Same as the base error handler, but ignores 403 errors
+    # to avoid failing the sync when fetching dynamic streams.
+    type: DefaultErrorHandler
+    backoff_strategies:
+      - type: WaitTimeFromHeader
+        header: Retry-After
+      # HubSpot API does not always return Retry-After value for 429 HTTP error
+      - type: ExponentialBackoffStrategy
+    response_filters:
+      - type: HttpResponseFilter
+        action: RETRY
+        http_codes:
+          - 429
+        error_message: >-
+          HubSpot rate limit reached (429). Backoff based on 'Retry-After' header, then exponential backoff fallback.
+      - type: HttpResponseFilter
+        action: RETRY
+        http_codes:
+          - 502
+          - 503
+        error_message: >-
+          HubSpot server error (5xx). Retrying with exponential backoff...
+      - type: HttpResponseFilter
+        action: RETRY
+        http_codes:
+          - 401
+        error_message: >-
+          Authentication to HubSpot has expired. Authentication will be retried, but if this issue persists, re-authenticate to restore access to HubSpot."
+      # we get a 530 Cloudflare Origin DNS Error when the provided API Token has incorrect format
+      - type: HttpResponseFilter
+        action: FAIL
+        http_codes:
+          - 530
+        error_message: >-
+          The user cannot be authorized with provided credentials. Please verify that your credentials are valid and try again.
+      - type: HttpResponseFilter
+        action: IGNORE
+        http_codes:
+          - 403
+        error_message: >-
+          Access denied (403). The authenticated user does not have permissions to access the resource. Verify your permissions to access this endpoint.
+      - type: HttpResponseFilter
+        action: FAIL
+        http_codes:
+          - 400
+        error_message: >-
+          Bad request (400). Please verify your credentials and try again.
+
   offset_paginator:
     type: DefaultPaginator
     page_token_option:
@@ -1989,43 +2038,32 @@ definitions:
         path: /crm/v3/properties/{{ stream_partition['objectType'] }}
         http_method: GET
         error_handler:
-          type: CompositeErrorHandler
-          error_handlers:
-            - type: DefaultErrorHandler
-              response_filters:
-                - type: HttpResponseFilter
-                  action: IGNORE
-                  http_codes:
-                    - 403
-    record_selector:
-      type: RecordSelector
-      extractor:
-        type: DpathExtractor
-        field_path:
-          - results
-    partition_router:
-      type: ListPartitionRouter
-      values:
-        - company
-        - contact
-        - deal
-        - ticket
-        - call
-        - communication
-        - email
-        - lead
-        - meeting
-        - note
-        - order
-        - product
-        - quote
-        - service
-        - subscription
-        - task
-        - user
-      cursor_field: objectType
-    decoder:
-      type: JsonDecoder
+          $ref: "#/definitions/error_handler_ignore_403"
+      record_selector:
+        $ref: "#/definitions/base_selector"
+      partition_router:
+        type: ListPartitionRouter
+        values:
+          - company
+          - contact
+          - deal
+          - ticket
+          - call
+          - communication
+          - email
+          - lead
+          - meeting
+          - note
+          - order
+          - product
+          - quote
+          - service
+          - subscription
+          - task
+          - user
+        cursor_field: objectType
+      decoder:
+        type: JsonDecoder
     transformations:
       - type: AddFields
         fields:
@@ -2033,10 +2071,10 @@ definitions:
             path:
               - objectType
             value: "{{ stream_partition['objectType'] }}"
-  schema_loader:
-    type: InlineSchemaLoader
-    schema:
-      $ref: "#/schemas/properties"
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        $ref: "#/schemas/properties"
 
 streams:
   - "#/definitions/campaigns_stream"
@@ -2192,53 +2230,7 @@ dynamic_streams:
           path: /crm/v3/schemas
           http_method: GET
           error_handler:
-            # Same as the base error handler, but ignores 403 errors
-            # to avoid failing the sync when fetching dynamic streams.
-            type: DefaultErrorHandler
-            backoff_strategies:
-              - type: WaitTimeFromHeader
-                header: Retry-After
-              # HubSpot API does not always return Retry-After value for 429 HTTP error
-              - type: ExponentialBackoffStrategy
-            response_filters:
-              - type: HttpResponseFilter
-                action: RETRY
-                http_codes:
-                  - 429
-                error_message: >-
-                  HubSpot rate limit reached (429). Backoff based on 'Retry-After' header, then exponential backoff fallback.
-              - type: HttpResponseFilter
-                action: RETRY
-                http_codes:
-                  - 502
-                  - 503
-                error_message: >-
-                  HubSpot server error (5xx). Retrying with exponential backoff...
-              - type: HttpResponseFilter
-                action: RETRY
-                http_codes:
-                  - 401
-                error_message: >-
-                  Authentication to HubSpot has expired. Authentication will be retried, but if this issue persists, re-authenticate to restore access to HubSpot."
-              # we get a 530 Cloudflare Origin DNS Error when the provided API Token has incorrect format
-              - type: HttpResponseFilter
-                action: FAIL
-                http_codes:
-                  - 530
-                error_message: >-
-                  The user cannot be authorized with provided credentials. Please verify that your credentials are valid and try again.
-              - type: HttpResponseFilter
-                action: IGNORE
-                http_codes:
-                  - 403
-                error_message: >-
-                  Access denied (403). The authenticated user does not have permissions to access the resource. Verify your permissions to access this endpoint.
-              - type: HttpResponseFilter
-                action: FAIL
-                http_codes:
-                  - 400
-                error_message: >-
-                  Bad request (400). Please verify your credentials and try again.
+            $ref: "#/definitions/error_handler_ignore_403"
         record_selector:
           type: RecordSelector
           extractor:


### PR DESCRIPTION
## What
There is currently no way to retrieve the list of all properties, adding a new stream to handle this.
The streams `companies_property_history`, `contacts_property_history`, `deals_property_history` retrieve the list of properties for each object. However, these streams don't include the property type, and the available options (in case of type `enumeration`).

## How
This new stream pulls data from endpoint [/crm/v3/properties/{objectType}](https://developers.hubspot.com/docs/reference/api/crm/properties#get-%2Fcrm%2Fv3%2Fproperties%2F%7Bobjecttype%7D), for the following object types:
- company
- contact
- deal
- ticket
- call
- communication
- email
- lead
- meeting
- note
- order
- product
- quote
- service
- subscription
- task
- user

If properties cannot be pulled for a given object type because of missing scopes, the error is ignored (the sync doesn't fail).
I struggled to find an exhaustive list of default object types, the only thing I could find is [this](https://developers.hubspot.com/docs/guides/api/crm/using-object-apis#properties). The custom object types properties are not pulled, as the dedicated endpoint is [different](https://developers.hubspot.com/docs/reference/api/crm/objects/schemas#get-%2Fcrm-object-schemas%2Fv3%2Fschemas).
The stream adds the additional field `objectType` to identify the object type of a property.

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
