### PR TITLE
fix(source-google-search-console): fix serialization bug -> add transformation to cast query values as string

### DIFF
--- a/airbyte-integrations/connectors/source-google-search-console/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-search-console/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: eb4c9e00-db83-4d63-a386-39cfa91012a8
-  dockerImageTag: 1.9.2
+  dockerImageTag: 1.9.3
   dockerRepository: airbyte/source-google-search-console
   documentationUrl: https://docs.airbyte.com/integrations/sources/google-search-console
   erdUrl: https://dbdocs.io/airbyteio/source-google-search-console?view=relationships

--- a/airbyte-integrations/connectors/source-google-search-console/pyproject.toml
+++ b/airbyte-integrations/connectors/source-google-search-console/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "1.9.2"
+version = "1.9.3"
 name = "source-google-search-console"
 description = "Source implementation for Google Search Console."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-google-search-console/source_google_search_console/manifest.yaml
+++ b/airbyte-integrations/connectors/source-google-search-console/source_google_search_console/manifest.yaml
@@ -158,6 +158,11 @@ definitions:
       - type: RemoveFields
         field_pointers:
           - - keys
+      # The purpose of the following transformation is to
+      # cast the query value as a string. The GSC API allows
+      # users to make queries with a wide array of datatypes resulting
+      # in occasional non-string values. This transformation ensures
+      # the Airbyte Entrypoint can serialize these non-string values.
       - type: AddFields
         fields:
           - type: AddedFieldDefinition
@@ -394,6 +399,11 @@ definitions:
       - type: RemoveFields
         field_pointers:
           - - keys
+      # The purpose of the following transformation is to
+      # cast the query value as a string. The GSC API allows
+      # users to make queries with a wide array of datatypes resulting
+      # in occasional non-string values. This transformation ensures
+      # the Airbyte Entrypoint can serialize these non-string values.
       - type: AddFields
         fields:
           - type: AddedFieldDefinition

--- a/airbyte-integrations/connectors/source-google-search-console/source_google_search_console/manifest.yaml
+++ b/airbyte-integrations/connectors/source-google-search-console/source_google_search_console/manifest.yaml
@@ -158,6 +158,14 @@ definitions:
       - type: RemoveFields
         field_pointers:
           - - keys
+      - type: AddFields
+        fields:
+          - type: AddedFieldDefinition
+            path:
+              - query
+            value: "{{ record['query'] }}"
+            value_type: string
+        condition: "{{ record.get('query', False) }}"
     schema_loader:
       type: InlineSchemaLoader
       schema:
@@ -386,6 +394,14 @@ definitions:
       - type: RemoveFields
         field_pointers:
           - - keys
+      - type: AddFields
+        fields:
+          - type: AddedFieldDefinition
+            path:
+              - query
+            value: "{{ record['query'] }}"
+            value_type: string
+        condition: "{{ record.get('query', False) }}"
     schema_loader:
       type: InlineSchemaLoader
       schema:

--- a/docs/integrations/sources/google-search-console.md
+++ b/docs/integrations/sources/google-search-console.md
@@ -230,7 +230,7 @@ Google Search Console only retains data for websites from the last 16 months. An
 
 | Version     | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |:------------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 1.9.3 | 2025-06-18 | [XXXXX](https://github.com/airbytehq/airbyte/pull/XXXXX) | Fix record serialization bug |
+| 1.9.3 | 2025-06-18 | [61706](https://github.com/airbytehq/airbyte/pull/61706) | Fix record serialization bug |
 | 1.9.2 | 2025-06-14 | [60663](https://github.com/airbytehq/airbyte/pull/60663) | Update dependencies |
 | 1.9.1 | 2025-06-10 | [61514](https://github.com/airbytehq/airbyte/pull/61514) | Promoting release candidate 1.9.1-rc.1 to a main version. |
 | 1.9.1-rc.1  | 2025-06-10 | [61508](https://github.com/airbytehq/airbyte/pull/61508) | Add API budget, reduce concurrency levels, and catch 403 rate limiting errors                                                                                          |

--- a/docs/integrations/sources/google-search-console.md
+++ b/docs/integrations/sources/google-search-console.md
@@ -230,6 +230,7 @@ Google Search Console only retains data for websites from the last 16 months. An
 
 | Version     | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |:------------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 1.9.3 | 2025-06-18 | [XXXXX](https://github.com/airbytehq/airbyte/pull/XXXXX) | Fix record serialization bug |
 | 1.9.2 | 2025-06-14 | [60663](https://github.com/airbytehq/airbyte/pull/60663) | Update dependencies |
 | 1.9.1 | 2025-06-10 | [61514](https://github.com/airbytehq/airbyte/pull/61514) | Promoting release candidate 1.9.1-rc.1 to a main version. |
 | 1.9.1-rc.1  | 2025-06-10 | [61508](https://github.com/airbytehq/airbyte/pull/61508) | Add API budget, reduce concurrency levels, and catch 403 rate limiting errors                                                                                          |


### PR DESCRIPTION
## What
- Adds transformation to `search_analytics_by_query` and `search_analytics_all_fields` which casts the `query` value to a string, resolving an issue surfaced when resolving rate limiting for google search console

## Review guide
1. manifest

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._