### PR TITLE
ci: add a script for vercel to determine if builds are necessary

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Checkout Current Branch
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          fetch-depth: 0
           ref: ${{ github.head_ref }}
 
       - name: Check For Skip Conditions

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -37,6 +37,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
+          ref: ${{ github.head_ref }}
 
       - name: Check For Skip Conditions
         id: check-skip

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -56,7 +56,7 @@ jobs:
             echo skip-build=false | tee -a $GITHUB_OUTPUT
           fi
 
-      - name: Set up pnpm
+      - name: Set Up pnpm
         if: steps.check-skip.outputs.skip-build != 'true'
         # pnpm is used to manage the dependencies of the documentation build.
         uses: pnpm/action-setup@v4

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -41,9 +41,12 @@ jobs:
       - name: Check For Skip Conditions
         id: check-skip
         run: |
-          # Run the script and capture both output and exit code
-          output=$(./docs/check-docs-git-diff.sh 2>&1)
+          # temporarily disable -e so we can capture a non-zero exit
+          set +e
+          # Run the script and capture the exit code.
+          ./docs/check-docs-git-diff.sh
           exit_code=$?
+          set -e
 
           if [ $exit_code -eq 0 ]; then
             echo "✅ Documentation already up-to-date. No build required."

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -38,20 +38,39 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Check For Skip Conditions
+        id: check-skip
+        run: |
+          # Run the script and capture both output and exit code
+          output=$(./docs/check-docs-git-diff.sh 2>&1)
+          exit_code=$?
+
+          if [ $exit_code -eq 0 ]; then
+            echo "✅ Documentation already up-to-date. No build required."
+            echo skip-build=true | tee -a $GITHUB_OUTPUT
+          else
+            echo "❌ Documentation needs to be built."
+            echo skip-build=false | tee -a $GITHUB_OUTPUT
+          fi
+
       - name: Set up pnpm
+        if: steps.check-skip.outputs.skip-build != 'true'
         # pnpm is used to manage the dependencies of the documentation build.
         uses: pnpm/action-setup@v4
         with:
           version: 10.12.1
 
       - name: Install uv
+        if: steps.check-skip.outputs.skip-build != 'true'
         uses: astral-sh/setup-uv@v6
 
       - name: Install Poe
+        if: steps.check-skip.outputs.skip-build != 'true'
         run: |
           # Install Poe so we can run the connector tasks:
           uv tool install poethepoet
 
       - name: Build Docs
+        if: steps.check-skip.outputs.skip-build != 'true'
         run: |
           poe docs-build

--- a/.github/workflows/slash-commands.yml
+++ b/.github/workflows/slash-commands.yml
@@ -6,13 +6,13 @@ jobs:
   slashCommandDispatch:
     runs-on: ubuntu-24.04
     steps:
-      # Use pre-made action (handles private repo auth):
-      - name: Get PR Info
+      - name: Get PR repo and ref
         if: ${{ github.event.issue.pull_request }}
-        id: pr-info
-        uses: cloudposse-github-actions/get-pr@v2.0.0
-        with:
-          id: ${{ github.event.issue.number }}
+        id: getref
+        run: |
+          pr_info="$(curl ${{ github.event.issue.pull_request.url }})"
+          echo ref="$(echo $pr_info | jq -r '.head.ref')" >> $GITHUB_OUTPUT
+          echo repo="$(echo $pr_info | jq -r '.head.repo.full_name')" >> $GITHUB_OUTPUT
 
       - name: Slash Command Dispatch (Workflow)
         id: scd
@@ -42,8 +42,8 @@ jobs:
           # - If the slash command is invoked from an issue, we intentionally pass 'null' as the PR number.
           # - Comment ID will always be sent, and this is sufficient to post back status updates to the originating comment.
           static-args: |
-            repo=${{ fromJSON(steps.pr-info.outputs.json).head.repo.full_name || github.repository }}
-            gitref=${{ fromJSON(steps.pr-info.outputs.json).head.ref }}
+            repo=${{ steps.getref.outputs.repo }}
+            gitref=${{ steps.getref.outputs.ref }}
             comment-id=${{ github.event.comment.id }}
             pr=${{ github.event.issue.pull_request != null && github.event.issue.number || '' }}
 

--- a/.github/workflows/slash-commands.yml
+++ b/.github/workflows/slash-commands.yml
@@ -6,13 +6,13 @@ jobs:
   slashCommandDispatch:
     runs-on: ubuntu-24.04
     steps:
-      - name: Get PR repo and ref
+      # Use pre-made action (handles private repo auth):
+      - name: Get PR Info
         if: ${{ github.event.issue.pull_request }}
-        id: getref
-        run: |
-          pr_info="$(curl ${{ github.event.issue.pull_request.url }})"
-          echo ref="$(echo $pr_info | jq -r '.head.ref')" >> $GITHUB_OUTPUT
-          echo repo="$(echo $pr_info | jq -r '.head.repo.full_name')" >> $GITHUB_OUTPUT
+        id: pr-info
+        uses: cloudposse-github-actions/get-pr@v2.0.0
+        with:
+          id: ${{ github.event.issue.number }}
 
       - name: Slash Command Dispatch (Workflow)
         id: scd
@@ -42,8 +42,8 @@ jobs:
           # - If the slash command is invoked from an issue, we intentionally pass 'null' as the PR number.
           # - Comment ID will always be sent, and this is sufficient to post back status updates to the originating comment.
           static-args: |
-            repo=${{ steps.getref.outputs.repo }}
-            gitref=${{ steps.getref.outputs.ref }}
+            repo=${{ fromJSON(steps.pr-info.outputs.json).head.repo.full_name || github.repository }}
+            gitref=${{ fromJSON(steps.pr-info.outputs.json).head.ref }}
             comment-id=${{ github.event.comment.id }}
             pr=${{ github.event.issue.pull_request != null && github.event.issue.number || '' }}
 

--- a/docs/check-docs-git-diff.sh
+++ b/docs/check-docs-git-diff.sh
@@ -10,7 +10,6 @@ set -eu
 latest_commit_message=$(git log -n 1 --oneline)
 echo "⚙️ Checking for a skip directive in the commit message: ('$latest_commit_message')"
 if echo "$latest_commit_message" | grep -Eq "\[(up-to-date|auto-publish)\]"; then
-    # Both conditions met - no changes and commit has required tag
     echo "✅ Skipping. Commit marked as [up-to-date]/[auto-publish]. ('$latest_commit_message')"
     exit 0
 fi
@@ -23,7 +22,6 @@ COMPARE_TO_REF="${REMOTE}/${DEFAULT_BRANCH}"
 
 echo "⚙️ Checking for git changes within the docs paths..."
 if git diff "${COMPARE_TO_REF}"...HEAD --quiet ./docusaurus ./docs .markdownlint.jsonc; then
-    # If there are no changes, we're good to skip the build.
     echo "✅ No changes in docs paths. Skipping build."
     exit 0
 fi

--- a/docs/check-docs-git-diff.sh
+++ b/docs/check-docs-git-diff.sh
@@ -19,7 +19,7 @@ REMOTE=origin
 DEFAULT_BRANCH=master
 
 echo "⚙️ Checking for git changes within the docs paths..."
-if git diff --name-only "${REMOTE}/${DEFAULT_BRANCH}"...HEAD --quiet ./docusaurus ./docs .markdownlint.jsonc; then
+if git diff "${REMOTE}/${DEFAULT_BRANCH}"...HEAD --quiet ./docusaurus ./docs .markdownlint.jsonc; then
     # If there are no changes, we're good to skip the build.
     echo "✅ No changes in docs paths. Skipping build."
     exit 0

--- a/docs/check-docs-git-diff.sh
+++ b/docs/check-docs-git-diff.sh
@@ -7,16 +7,15 @@ set -eux
 # This script will be called by Vercel here:
 # - https://vercel.com/airbyte-growth/airbyte-docs/settings/git#ignored-build-step
 
-git diff HEAD^ HEAD --quiet . ../docs && git log -n 1 --oneline | grep -Eq "\[(up-to-date|auto-publish)\]" || exit 1
-
 latest_commit_message=$(git log -n 1 --oneline)
+echo "⚙️ Checking for a skip directive in the commit message: ('$latest_commit_message')"
 if echo "$latest_commit_message" | grep -Eq "\[(up-to-date|auto-publish)\]"; then
     # Both conditions met - no changes and commit has required tag
     echo "✅ Skipping. Commit marked as [up-to-date]/[auto-publish]. ('$latest_commit_message')"
     exit 0
 fi
 
-# Check if the docs directories have changed in the latest commit
+echo "⚙️ Checking for git changes within the docs paths..."
 if git diff HEAD^ HEAD --quiet ./docusaurus ./docs; then
     # If there are no changes, we're good to skip the build.
     echo "✅ No changes in docs paths. Skipping build."

--- a/docs/check-docs-git-diff.sh
+++ b/docs/check-docs-git-diff.sh
@@ -1,4 +1,5 @@
 #!bin/bash
+set -eux
 
 # This script checks the status of the documentation files in the docs directory.
 # It should return '1' if a build is needed, and '0' if everything is up to date.

--- a/docs/check-docs-git-diff.sh
+++ b/docs/check-docs-git-diff.sh
@@ -15,8 +15,11 @@ if echo "$latest_commit_message" | grep -Eq "\[(up-to-date|auto-publish)\]"; the
     exit 0
 fi
 
+REMOTE=origin
+DEFAULT_BRANCH=master
+
 echo "⚙️ Checking for git changes within the docs paths..."
-if git diff HEAD^ HEAD --quiet ./docusaurus ./docs; then
+if git diff --name-only "${REMOTE}/${DEFAULT_BRANCH}"...HEAD --quiet ./docusaurus ./docs .markdownlint.jsonc; then
     # If there are no changes, we're good to skip the build.
     echo "✅ No changes in docs paths. Skipping build."
     exit 0

--- a/docs/check-docs-git-diff.sh
+++ b/docs/check-docs-git-diff.sh
@@ -1,4 +1,4 @@
-#!bin/bash
+#!/usr/bin/env bash
 set -eux
 
 # This script checks the status of the documentation files in the docs directory.

--- a/docs/check-docs-git-diff.sh
+++ b/docs/check-docs-git-diff.sh
@@ -7,6 +7,23 @@ set -eu
 # This script will be called by Vercel here:
 # - https://vercel.com/airbyte-growth/airbyte-docs/settings/git#ignored-build-step
 
+# parse flags
+LATEST_COMMIT_ONLY=false
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --latest-commit-only)
+      LATEST_COMMIT_ONLY=true
+      echo "⚙️ Running in '--latest-commit-only' mode."
+      echo "Only the most recent commit will be checked for changes."
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2;
+      exit 1
+      ;;
+  esac
+  shift
+done
+
 latest_commit_message=$(git log -n 1 --oneline)
 echo "⚙️ Checking for a skip directive in the commit message: ('$latest_commit_message')"
 if echo "$latest_commit_message" | grep -Eq "\[(up-to-date|auto-publish)\]"; then
@@ -17,8 +34,10 @@ fi
 REMOTE=origin
 DEFAULT_BRANCH=master
 COMPARE_TO_REF="${REMOTE}/${DEFAULT_BRANCH}"
-# If we only wanted to compare against the previous commit:
-# COMPARE_TO_REF="HEAD^"
+if [ "$LATEST_COMMIT_ONLY" == 'true' ]; then
+    # We only want to compare the latest commit against the previous one:
+    COMPARE_TO_REF="HEAD^"
+fi
 
 echo "⚙️ Checking for git changes within the docs paths..."
 if git diff "${COMPARE_TO_REF}"...HEAD --quiet ./docusaurus ./docs .markdownlint.jsonc; then

--- a/docs/check-docs-git-diff.sh
+++ b/docs/check-docs-git-diff.sh
@@ -6,6 +6,12 @@ set -eu
 #
 # This script will be called by Vercel here:
 # - https://vercel.com/airbyte-growth/airbyte-docs/settings/git#ignored-build-step
+#
+# This script is intended to be run from the root of the Airbyte repository.
+#
+# Usage:
+#   ./docs/check-docs-git-diff.sh                       # Check for any changes in the branch.
+#   ./docs/check-docs-git-diff.sh --latest-commit-only  # Only check the latest commit for changes.
 
 # parse flags
 LATEST_COMMIT_ONLY=false

--- a/docs/check-docs-git-diff.sh
+++ b/docs/check-docs-git-diff.sh
@@ -1,0 +1,29 @@
+#!bin/bash
+
+# This script checks the status of the documentation files in the docs directory.
+# It should return '1' if a build is needed, and '0' if everything is up to date.
+#
+# This script will be called by Vercel here:
+# - https://vercel.com/airbyte-growth/airbyte-docs/settings/git#ignored-build-step
+
+git diff HEAD^ HEAD --quiet . ../docs && git log -n 1 --oneline | grep -Eq "\[(up-to-date|auto-publish)\]" || exit 1
+
+latest_commit_message=$(git log -n 1 --oneline)
+if echo "$latest_commit_message" | grep -Eq "\[(up-to-date|auto-publish)\]"; then
+    # Both conditions met - no changes and commit has required tag
+    echo "✅ Skipping. Commit marked as [up-to-date]/[auto-publish]. ('$latest_commit_message')"
+    exit 0
+fi
+
+# Check if the docs directories have changed in the latest commit
+if git diff HEAD^ HEAD --quiet ./docusaurus ./docs; then
+    # If there are no changes, we're good to skip the build.
+    echo "✅ No changes in docs paths. Skipping build."
+    exit 0
+fi
+
+# If we got here, then both of these conditions are true:
+# 1. There were changes in the docs or current directory, and
+# 2. The commit didn't have one of the tags [up-to-date] or [auto-publish].
+echo "❌ Documentation changes detected. Build is requested."
+exit 1

--- a/docs/check-docs-git-diff.sh
+++ b/docs/check-docs-git-diff.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -eux
+set -eu
 
 # This script checks the status of the documentation files in the docs directory.
 # It should return '1' if a build is needed, and '0' if everything is up to date.
@@ -17,9 +17,12 @@ fi
 
 REMOTE=origin
 DEFAULT_BRANCH=master
+COMPARE_TO_REF="${REMOTE}/${DEFAULT_BRANCH}"
+# If we only wanted to compare against the previous commit:
+# COMPARE_TO_REF="HEAD^"
 
 echo "⚙️ Checking for git changes within the docs paths..."
-if git diff "${REMOTE}/${DEFAULT_BRANCH}"...HEAD --quiet ./docusaurus ./docs .markdownlint.jsonc; then
+if git diff "${COMPARE_TO_REF}"...HEAD --quiet ./docusaurus ./docs .markdownlint.jsonc; then
     # If there are no changes, we're good to skip the build.
     echo "✅ No changes in docs paths. Skipping build."
     exit 0


### PR DESCRIPTION
## What

Adds a script to determine if a docs build should be performed.

This appears to be working correctly now. We can should see the logic reflected in the docs build step. After we merge, we can use the same script call in Vercel.

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._