### PR TITLE
Destination bigquery direct-load: improve numeric handling

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/AirbyteValue.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/AirbyteValue.kt
@@ -191,8 +191,8 @@ class EnrichedAirbyteValue(
      * @param newValue The new (truncated) value to use
      */
     fun truncate(
-        reason: Reason = Reason.DESTINATION_RECORD_SIZE_LIMITATION,
-        newValue: AirbyteValue
+        newValue: AirbyteValue,
+        reason: Reason = Reason.DESTINATION_RECORD_SIZE_LIMITATION
     ) {
         val truncateChange = Meta.Change(field = name, change = Change.TRUNCATED, reason = reason)
 

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/data/EnrichedAirbyteValueTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/data/EnrichedAirbyteValueTest.kt
@@ -73,7 +73,7 @@ class EnrichedAirbyteValueTest {
         val truncatedValue = StringValue("This is a very...")
 
         val enriched = EnrichedAirbyteValue(initialValue, type, name, airbyteMetaField = null)
-        enriched.truncate(Reason.DESTINATION_RECORD_SIZE_LIMITATION, truncatedValue)
+        enriched.truncate(truncatedValue, Reason.DESTINATION_RECORD_SIZE_LIMITATION)
 
         assertEquals(truncatedValue, enriched.abValue)
         assertEquals(1, enriched.changes.size)
@@ -111,7 +111,7 @@ class EnrichedAirbyteValueTest {
         val truncatedValue = StringValue("This is a very...")
 
         val enriched = EnrichedAirbyteValue(initialValue, type, name, airbyteMetaField = null)
-        enriched.truncate(Reason.DESTINATION_SERIALIZATION_ERROR, truncatedValue)
+        enriched.truncate(truncatedValue, Reason.DESTINATION_SERIALIZATION_ERROR)
 
         assertEquals(truncatedValue, enriched.abValue)
         assertEquals(1, enriched.changes.size)
@@ -132,7 +132,7 @@ class EnrichedAirbyteValueTest {
 
         // First change - truncate
         val truncatedValue = StringValue("Init...")
-        enriched.truncate(Reason.DESTINATION_RECORD_SIZE_LIMITATION, truncatedValue)
+        enriched.truncate(truncatedValue, Reason.DESTINATION_RECORD_SIZE_LIMITATION)
 
         // Second change - nullify
         enriched.nullify(Reason.DESTINATION_SERIALIZATION_ERROR)

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/data/EnrichedDestinationRecordAirbyteValueTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/data/EnrichedDestinationRecordAirbyteValueTest.kt
@@ -140,7 +140,7 @@ class EnrichedDestinationRecordAirbyteValueTest {
                 "field1",
                 airbyteMetaField = null
             )
-        field1.truncate(Reason.DESTINATION_RECORD_SIZE_LIMITATION, StringValue("val"))
+        field1.truncate(StringValue("val"), Reason.DESTINATION_RECORD_SIZE_LIMITATION)
 
         val field2 =
             EnrichedAirbyteValue(

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/write/BasicFunctionalityIntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/write/BasicFunctionalityIntegrationTest.kt
@@ -43,6 +43,7 @@ import io.airbyte.cdk.load.data.json.toAirbyteValue
 import io.airbyte.cdk.load.message.InputGlobalCheckpoint
 import io.airbyte.cdk.load.message.InputRecord
 import io.airbyte.cdk.load.message.InputStreamCheckpoint
+import io.airbyte.cdk.load.message.Meta
 import io.airbyte.cdk.load.message.Meta.Change
 import io.airbyte.cdk.load.message.StreamCheckpoint
 import io.airbyte.cdk.load.state.CheckpointId
@@ -67,6 +68,7 @@ import io.airbyte.protocol.models.v0.AirbyteRecordMessageFileReference
 import io.airbyte.protocol.models.v0.AirbyteRecordMessageMetaChange
 import java.math.BigDecimal
 import java.math.BigInteger
+import java.math.RoundingMode
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
@@ -104,6 +106,25 @@ data class StronglyTyped(
     val integerCanBeLarge: Boolean = true,
     /** Whether the destination supports numbers larger than 1e39-1 */
     val numberCanBeLarge: Boolean = true,
+    /**
+     * Clearly redundant with other fields on this struct. We should do some sort of refactor here.
+     * Many warehouse destinations use a NUMERIC(38, 9) type for number columns. This flag enables a
+     * test case to validate some specific rounding/truncation behavior for fixed-point numbers.
+     */
+    val numberIsFixedPointPrecision38Scale9: Boolean = false,
+    /**
+     * No effect unless [numberIsFixedPointPrecision38Scale9] is set.
+     *
+     * If your connector relies on the warehouse to truncate/round off numbers with too many decimal
+     * places, and therefore does not populate an `airbyte_meta.changes` entry, you should enable
+     * this flag.
+     *
+     * This is not best practice, but is compatible with historical behavior, and we don't have a
+     * strong preference to enforce populating the `changes` list in this case.
+     */
+    val truncatedNumbersPopulateAirbyteMeta: Boolean = true,
+    /** No effect unless [numberIsFixedPointPrecision38Scale9] is set. */
+    val truncatedNumberRoundingMode: RoundingMode = RoundingMode.HALF_UP,
     /**
      * In some strongly-typed destinations, timetz columns are actually weakly typed. For example,
      * Bigquery writes timetz values into STRING columns, and doesn't actually validate that they
@@ -2417,7 +2438,6 @@ abstract class BasicFunctionalityIntegrationTest(
                 makeRecord("""{"id": 3}"""),
                 // A record that verifies numeric behavior.
                 // 99999999999999999999999999999999 is out of range for int64.
-                // 50000.0000000000000001 can't be represented as a standard float64,
                 // and gets rounded off.
                 // 1e39 is greater than the typical max 1e39-1 for database/warehouse destinations
                 // (decimal points are to force jackson to recognize it as a decimal)
@@ -2426,7 +2446,6 @@ abstract class BasicFunctionalityIntegrationTest(
                         {
                           "id": 4,
                           "struct": {"foo": 50000.0000000000000001},
-                          "number": 50000.0000000000000001,
                           "integer": 99999999999999999999999999999999,
                           "number": 1.0000000000000000000000000000000000000000e39
                         }
@@ -2770,6 +2789,160 @@ abstract class BasicFunctionalityIntegrationTest(
                             "number" to -1.0,
                         ),
                     airbyteMeta = OutputRecord.Meta(syncId = 42),
+                ),
+            ),
+            stream,
+            primaryKey = listOf(listOf("id")),
+            cursor = null,
+        )
+    }
+
+    /**
+     * Further tests for number/int types. For historical reasons, some of the records in
+     * [testBasicTypes] also cover numerics.
+     */
+    @Test
+    open fun testNumericTypes() {
+        assumeTrue(verifyDataWriting)
+        assumeTrue(allTypesBehavior is StronglyTyped)
+        // TODO ideally we would have some more flexibility here, but it's kind of painful to
+        //   configure our tests already.
+        assumeTrue((allTypesBehavior as StronglyTyped).numberIsFixedPointPrecision38Scale9)
+        val stream =
+            DestinationStream(
+                unmappedNamespace = randomizedNamespace,
+                unmappedName = "test_stream",
+                Append,
+                ObjectType(
+                    linkedMapOf(
+                        "id" to intType,
+                        "number" to FieldType(NumberType, nullable = true),
+                        "integer" to FieldType(IntegerType, nullable = true),
+                    )
+                ),
+                generationId = 42,
+                minimumGenerationId = 0,
+                syncId = 42,
+                namespaceMapper = namespaceMapperForMedium()
+            )
+        fun makeRecord(data: String) =
+            InputRecord(
+                stream,
+                data,
+                emittedAtMs = 100,
+                checkpointId = checkpointKeyForMedium()?.checkpointId
+            )
+        // large numbers, 0, and -1 are already tested in testBasicTypes, but add them here also.
+        // Eventually we should remove them from testBasicTypes, but that would require a less dumb
+        // test config system.
+        val roundingModeTest = "5e-10"
+        val highPrecisionTest = "12345678912345678912345678912.3456789123"
+        runSync(
+            updatedConfig,
+            stream,
+            listOf(
+                // Test that we can handle numbers which require scale=10.
+                // Depending on destination behavior, these should either be
+                // truncated to 0, or rounded to +/-1e9
+                makeRecord(
+                    """
+                        {
+                          "id": 1,
+                          "number": $roundingModeTest
+                        }
+                    """.trimIndent(),
+                ),
+                makeRecord(
+                    """
+                        {
+                          "id": 2,
+                          "number": -$roundingModeTest
+                        }
+                    """.trimIndent(),
+                ),
+                // Similarly, test that we can handle numbers with precision=39,
+                // but that still fit within a (38, 9) field's min/max values.
+                makeRecord(
+                    """
+                        {
+                          "id": 3,
+                          "number": $highPrecisionTest
+                        }
+                    """.trimIndent(),
+                ),
+                makeRecord(
+                    """
+                        {
+                          "id": 4,
+                          "number": -$highPrecisionTest
+                        }
+                    """.trimIndent(),
+                ),
+            ),
+        )
+        val roundingModeExpectedValue =
+            BigDecimal(roundingModeTest).setScale(9, allTypesBehavior.truncatedNumberRoundingMode)
+        val highPrecisionExpectedValue =
+            BigDecimal(highPrecisionTest).setScale(9, allTypesBehavior.truncatedNumberRoundingMode)
+        val meta =
+            OutputRecord.Meta(
+                syncId = 42,
+                changes =
+                    listOfNotNull(
+                        if (allTypesBehavior.truncatedNumbersPopulateAirbyteMeta) {
+                            Change(
+                                "number",
+                                AirbyteRecordMessageMetaChange.Change.TRUNCATED,
+                                AirbyteRecordMessageMetaChange.Reason
+                                    .DESTINATION_FIELD_SIZE_LIMITATION,
+                            )
+                        } else {
+                            null
+                        }
+                    ),
+            )
+        dumpAndDiffRecords(
+            parsedConfig,
+            listOf(
+                OutputRecord(
+                    extractedAt = 100,
+                    generationId = 42,
+                    data =
+                        mapOf(
+                            "id" to 1,
+                            "number" to roundingModeExpectedValue,
+                        ),
+                    airbyteMeta = meta,
+                ),
+                OutputRecord(
+                    extractedAt = 100,
+                    generationId = 42,
+                    data =
+                        mapOf(
+                            "id" to 2,
+                            "number" to roundingModeExpectedValue.negate(),
+                        ),
+                    airbyteMeta = meta,
+                ),
+                OutputRecord(
+                    extractedAt = 100,
+                    generationId = 42,
+                    data =
+                        mapOf(
+                            "id" to 3,
+                            "number" to highPrecisionExpectedValue,
+                        ),
+                    airbyteMeta = meta,
+                ),
+                OutputRecord(
+                    extractedAt = 100,
+                    generationId = 42,
+                    data =
+                        mapOf(
+                            "id" to 4,
+                            "number" to highPrecisionExpectedValue.negate(),
+                        ),
+                    airbyteMeta = meta,
                 ),
             ),
             stream,

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/formatter/BigDecimalUtil.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/formatter/BigDecimalUtil.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination.bigquery.formatter
+
+import java.math.BigDecimal
+import java.math.BigInteger
+
+object BigDecimalUtil {
+    /** Returns the largest representable BigDecimal for a given (precision, scale) pair. */
+    fun maxForRange(precision: Int, scale: Int) =
+        BigDecimal(BigInteger("9".repeat(precision)), scale)
+}
+
+/**
+ * Calculate the precision (i.e. number of digits) in this BigDecimal, according to how Bigquery
+ * represents it.
+ *
+ * For BigDecimal instances with nonzero decimal points and 0 trailing 0-digits (e.g. `123.456`,
+ * `123`), this is equivalent to [BigDecimal.precision()].
+ *
+ * For BigDecimal instances with zero decimal points and some trailing 0-digits (e.g. `10`, `100`),
+ * this function calculates the total number of digits in the number.
+ */
+fun BigDecimal.normalizedPrecision(): Int =
+    if (this.scale() >= 0) {
+        this.precision()
+    } else {
+        this.precision() - this.scale()
+    }
+
+/**
+ * Calculate the scale (i.e. number of decimal points) in this BigDecimal, according to how Bigquery
+ * represents it.
+ *
+ * For BigDecimal instances with nonzero decimal points and 0 trailing 0-digits (e.g. `123.456`,
+ * `123`), this is equivalent to [BigDecimal.scale()].
+ *
+ * For BigDecimal instances with zero decimal points and some trailing 0-digits (e.g. `10`, `100`),
+ * this function returns zero.
+ */
+fun BigDecimal.normalizedScale(): Int =
+    if (this.scale() >= 0) {
+        this.scale()
+    } else {
+        0
+    }

--- a/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryWriteTest.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryWriteTest.kt
@@ -109,6 +109,7 @@ abstract class BigqueryDirectLoadWriteTest(
             nestedFloatLosesPrecision = true,
             integerCanBeLarge = false,
             numberCanBeLarge = false,
+            numberIsFixedPointPrecision38Scale9 = true,
             timeWithTimezoneBehavior = SimpleValueBehavior.STRONGLY_TYPE,
         ),
     )

--- a/airbyte-integrations/connectors/destination-bigquery/src/test/kotlin/io/airbyte/integrations/destination/bigquery/typing_deduping/direct_load_tables/BigDecimalUtilTest.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test/kotlin/io/airbyte/integrations/destination/bigquery/typing_deduping/direct_load_tables/BigDecimalUtilTest.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination.bigquery.typing_deduping.direct_load_tables
+
+import io.airbyte.integrations.destination.bigquery.formatter.BigDecimalUtil
+import io.airbyte.integrations.destination.bigquery.formatter.normalizedPrecision
+import io.airbyte.integrations.destination.bigquery.formatter.normalizedScale
+import java.math.BigDecimal
+import kotlin.test.assertEquals
+import org.junit.jupiter.api.Test
+
+class BigDecimalUtilTest {
+    @Test
+    fun testMaxForRange() {
+        assertEquals(
+            BigDecimal("999.99"),
+            // 5 significant figures; 2 decimal points
+            BigDecimalUtil.maxForRange(precision = 5, scale = 2),
+        )
+    }
+
+    @Test
+    fun testNormalizedPrecision() {
+        assertEquals(6, BigDecimal("123.456").normalizedPrecision())
+        assertEquals(3, BigDecimal("123").normalizedPrecision())
+        // precision() = 3 (b/c BigDecimal represents this as 123 * 1000)
+        assertEquals(6, BigDecimal("1.23E5").normalizedPrecision())
+    }
+
+    @Test
+    fun testNormalizedScale() {
+        assertEquals(3, BigDecimal("123.456").normalizedScale())
+        assertEquals(0, BigDecimal("123").normalizedScale())
+        // scale = -3 (b/c BigDecimal represents this as 123 * 1000)
+        assertEquals(0, BigDecimal("1.23E5").normalizedScale())
+    }
+}


### PR DESCRIPTION
bigquery had incorrect logic for validating numeric values. Fix it. Also add a test case.

probably best to review commits one by one.

Clickhouse folks - as usual, I'll copy over the CDK changes to master after merging this into the bigquery branch.

I didn't add an equivalent test case for int, since we're using int64. IMO we should make our test framework better before trying to add a ton more tests, even this one was already annoying enough. But we should do that fairly soon - e.g. Snowflake uses NUMERIC for integers, so we'll want coverage on that branch too.