### PR TITLE
Fix lifecycle_stages - `format` was erroneously top-level instead of a property of column `createdAt`

### DIFF
--- a/airbyte-integrations/connectors/source-pardot/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/source-pardot/acceptance-test-config.yml
@@ -1,7 +1,7 @@
 # See [Connector Acceptance Tests](https://docs.airbyte.com/connector-development/testing-connectors/connector-acceptance-tests-reference)
 # for more information about how to configure these tests
 connector_image: airbyte/source-pardot:dev
-tests:
+acceptance_tests:
   spec:
     - spec_path: "manifest.yaml"
   connection:

--- a/airbyte-integrations/connectors/source-pardot/manifest.yaml
+++ b/airbyte-integrations/connectors/source-pardot/manifest.yaml
@@ -4760,7 +4760,7 @@ schemas:
         type:
           - string
           - "null"
-      format: date-time
+        format: date-time
       id:
         type: integer
       isDeleted:

--- a/airbyte-integrations/connectors/source-pardot/metadata.yaml
+++ b/airbyte-integrations/connectors/source-pardot/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: ad15c7ba-72a7-440b-af15-b9a963dc1a8a
-  dockerImageTag: 1.0.14
+  dockerImageTag: 1.0.15
   dockerRepository: airbyte/source-pardot
   githubIssueLabel: source-pardot
   icon: salesforcepardot.svg

--- a/docs/integrations/sources/pardot.md
+++ b/docs/integrations/sources/pardot.md
@@ -93,6 +93,7 @@ If there are more endpoints you'd like Airbyte to support, please [create an iss
 
 | Version | Date       | Pull Request                                             | Subject               |
 | :------ | :--------- | :------------------------------------------------------- | :-------------------- |
+| 1.0.15 | 2025-06-20 | [61736](https://github.com/airbytehq/airbyte/pull/61736) | Fix lifecycle_stages -  was erroneously top-level instead of a property of column  |
 | 1.0.14 | 2025-05-24 | [60515](https://github.com/airbytehq/airbyte/pull/60515) | Update dependencies |
 | 1.0.13 | 2025-05-10 | [60108](https://github.com/airbytehq/airbyte/pull/60108) | Update dependencies |
 | 1.0.12 | 2025-05-04 | [59521](https://github.com/airbytehq/airbyte/pull/59521) | Update dependencies |


### PR DESCRIPTION
## What
lifecycle_stages had a malformed column that caused parsing errors downstream

## How
properly indent

## Questions
How could we have caught this sooner?

What team am I supposed to tag for this? I pulled @dbgold17 and @ChristoGrab out of a hat. Sorry in advance if yall are not the right people 🙇 
