### PR TITLE
Rbroughan/add date and timestamp coercion validation to ch

### DIFF
--- a/airbyte-integrations/connectors/destination-clickhouse-v2/src/main/kotlin/io/airbyte/integrations/destination/clickhouse_v2/client/ClickhouseSqlGenerator.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse-v2/src/main/kotlin/io/airbyte/integrations/destination/clickhouse_v2/client/ClickhouseSqlGenerator.kt
@@ -370,7 +370,7 @@ class ClickhouseSqlGenerator {
 fun AirbyteType.toDialectType(): String =
     when (this) {
         BooleanType -> ClickHouseDataType.Bool.name
-        DateType -> ClickHouseDataType.Date.name
+        DateType -> ClickHouseDataType.Date32.name
         IntegerType -> ClickHouseDataType.Int64.name
         NumberType -> DECIMAL_WITH_PRECISION_AND_SCALE
         StringType -> ClickHouseDataType.String.name

--- a/airbyte-integrations/connectors/destination-clickhouse-v2/src/main/kotlin/io/airbyte/integrations/destination/clickhouse_v2/write/transform/ClickhouseCoercingValidator.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse-v2/src/main/kotlin/io/airbyte/integrations/destination/clickhouse_v2/write/transform/ClickhouseCoercingValidator.kt
@@ -8,8 +8,6 @@ import io.airbyte.cdk.load.data.DateValue
 import io.airbyte.cdk.load.data.EnrichedAirbyteValue
 import io.airbyte.cdk.load.data.IntegerValue
 import io.airbyte.cdk.load.data.NumberValue
-import io.airbyte.cdk.load.data.TimestampTypeWithTimezone
-import io.airbyte.cdk.load.data.TimestampTypeWithoutTimezone
 import io.airbyte.cdk.load.data.TimestampWithTimezoneValue
 import io.airbyte.cdk.load.data.TimestampWithoutTimezoneValue
 import io.airbyte.integrations.destination.clickhouse_v2.write.transform.ClickhouseCoercingValidator.Constants.DATE32_MAX
@@ -97,9 +95,9 @@ class ClickhouseCoercingValidator {
         val DATE32_MAX = DATE32_MAX_RAW.toEpochDay()
         val DATE32_MIN = DATE32_MIN_RAW.toEpochDay()
 
-        val DATETIME64_MAX = LocalDateTime.of(DATE32_MAX_RAW, LocalTime.MAX)
-            .toEpochSecond(ZoneOffset.UTC)
-        val DATETIME64_MIN = LocalDateTime.of(DATE32_MIN_RAW, LocalTime.MIN)
-            .toEpochSecond(ZoneOffset.UTC)
+        val DATETIME64_MAX =
+            LocalDateTime.of(DATE32_MAX_RAW, LocalTime.MAX).toEpochSecond(ZoneOffset.UTC)
+        val DATETIME64_MIN =
+            LocalDateTime.of(DATE32_MIN_RAW, LocalTime.MIN).toEpochSecond(ZoneOffset.UTC)
     }
 }

--- a/airbyte-integrations/connectors/destination-clickhouse-v2/src/main/kotlin/io/airbyte/integrations/destination/clickhouse_v2/write/transform/ClickhouseCoercingValidator.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse-v2/src/main/kotlin/io/airbyte/integrations/destination/clickhouse_v2/write/transform/ClickhouseCoercingValidator.kt
@@ -90,12 +90,16 @@ class ClickhouseCoercingValidator {
         val DECIMAL128_MAX = BigDecimal("100000000000000000000000000000000000000")
         val DECIMAL128_MIN = BigDecimal("-100000000000000000000000000000000000000")
 
-        val DATE32_MAX = LocalDate.of(2299, 12, 31).toEpochDay()
-        val DATE32_MIN = LocalDate.of(1900, 1, 1).toEpochDay()
+        // used by both date 32 and date time 64
+        val DATE32_MAX_RAW = LocalDate.of(2299, 12, 31)
+        val DATE32_MIN_RAW = LocalDate.of(1900, 1, 1)
 
-        val DATETIME64_MAX = LocalDateTime.of(LocalDate.of(2299, 12, 31), LocalTime.MAX)
+        val DATE32_MAX = DATE32_MAX_RAW.toEpochDay()
+        val DATE32_MIN = DATE32_MIN_RAW.toEpochDay()
+
+        val DATETIME64_MAX = LocalDateTime.of(DATE32_MAX_RAW, LocalTime.MAX)
             .toEpochSecond(ZoneOffset.UTC)
-        val DATETIME64_MIN = LocalDateTime.of(LocalDate.of(1900, 1, 1), LocalTime.MIN)
+        val DATETIME64_MIN = LocalDateTime.of(DATE32_MIN_RAW, LocalTime.MIN)
             .toEpochSecond(ZoneOffset.UTC)
     }
 }

--- a/airbyte-integrations/connectors/destination-clickhouse-v2/src/test/kotlin/io/airbyte/integrations/destination/clickhouse_v2/write/transform/ClickhouseCoercingValidatorTest.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse-v2/src/test/kotlin/io/airbyte/integrations/destination/clickhouse_v2/write/transform/ClickhouseCoercingValidatorTest.kt
@@ -10,8 +10,8 @@ import io.airbyte.cdk.load.data.IntegerValue
 import io.airbyte.cdk.load.data.NullValue
 import io.airbyte.cdk.load.data.NumberValue
 import io.airbyte.cdk.load.data.StringType
-import io.airbyte.integrations.destination.clickhouse_v2.write.transform.ClickhouseCoercingValidator.Constants.DECIMAL64_MAX
-import io.airbyte.integrations.destination.clickhouse_v2.write.transform.ClickhouseCoercingValidator.Constants.DECIMAL64_MIN
+import io.airbyte.integrations.destination.clickhouse_v2.write.transform.ClickhouseCoercingValidator.Constants.DECIMAL128_MAX
+import io.airbyte.integrations.destination.clickhouse_v2.write.transform.ClickhouseCoercingValidator.Constants.DECIMAL128_MIN
 import io.airbyte.integrations.destination.clickhouse_v2.write.transform.ClickhouseCoercingValidator.Constants.INT64_MAX
 import io.airbyte.integrations.destination.clickhouse_v2.write.transform.ClickhouseCoercingValidator.Constants.INT64_MIN
 import io.airbyte.integrations.destination.clickhouse_v2.write.transform.ClickhouseCoercingValidatorTest.Fixtures.toAirbyteIntegerValue
@@ -92,8 +92,8 @@ class ClickhouseCoercingValidatorTest {
                 Arguments.of("42"),
                 Arguments.of("-10000000000000000.33"),
                 Arguments.of("100000000000000000.3"),
-                Arguments.of(DECIMAL64_MIN.add(BigDecimal.valueOf(1)).toString()),
-                Arguments.of(DECIMAL64_MAX.subtract(BigDecimal.valueOf(1)).toString()),
+                Arguments.of(DECIMAL128_MIN.add(BigDecimal.valueOf(1)).toString()),
+                Arguments.of(DECIMAL128_MAX.subtract(BigDecimal.valueOf(1)).toString()),
                 Arguments.of("1"),
                 Arguments.of("80327031.865312"),
                 Arguments.of("-80327031.8954"),
@@ -102,13 +102,13 @@ class ClickhouseCoercingValidatorTest {
         @JvmStatic
         fun invalidFloats() =
             listOf(
-                Arguments.of(DECIMAL64_MIN.toString()),
-                Arguments.of(DECIMAL64_MAX.toString()),
-                Arguments.of(DECIMAL64_MIN.subtract(BigDecimal.valueOf(124)).toString()),
-                Arguments.of(DECIMAL64_MAX.add(BigDecimal.valueOf(81)).toString()),
-                Arguments.of("10000000000000000000"),
-                Arguments.of("999999999999999999999999"),
-                Arguments.of("-999999999999999999999999.12"),
+                Arguments.of(DECIMAL128_MIN.toString()),
+                Arguments.of(DECIMAL128_MAX.toString()),
+                Arguments.of(DECIMAL128_MIN.subtract(BigDecimal.valueOf(124)).toString()),
+                Arguments.of(DECIMAL128_MAX.add(BigDecimal.valueOf(81)).toString()),
+                Arguments.of("100000000000000000000000000000000000001"),
+                Arguments.of("999999999999999999999999999999999999999.9"),
+                Arguments.of("-999999999999999999999999999999999999999.12"),
             )
 
         @JvmStatic

--- a/airbyte-integrations/connectors/destination-clickhouse-v2/src/test/kotlin/io/airbyte/integrations/destination/clickhouse_v2/write/transform/ClickhouseCoercingValidatorTest.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse-v2/src/test/kotlin/io/airbyte/integrations/destination/clickhouse_v2/write/transform/ClickhouseCoercingValidatorTest.kt
@@ -26,15 +26,15 @@ import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.junit5.MockKExtension
 import java.math.BigDecimal
 import java.math.BigInteger
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.ZoneOffset
 import kotlin.test.assertEquals
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
-import java.time.LocalDate
-import java.time.LocalDateTime
-import java.time.LocalTime
-import java.time.ZoneOffset
 
 @ExtendWith(MockKExtension::class)
 class ClickhouseCoercingValidatorTest {
@@ -123,9 +123,11 @@ class ClickhouseCoercingValidatorTest {
 
     @ParameterizedTest
     @MethodSource("validDates")
-    fun `validate and coerces timestamps with timezones - valid values are left unchanged`(value: Long) {
-        val timestamp = LocalDateTime.of(LocalDate.ofEpochDay(value), LocalTime.MAX)
-            .atOffset(ZoneOffset.UTC)
+    fun `validate and coerces timestamps with timezones - valid values are left unchanged`(
+        value: Long
+    ) {
+        val timestamp =
+            LocalDateTime.of(LocalDate.ofEpochDay(value), LocalTime.MAX).atOffset(ZoneOffset.UTC)
         val input = Fixtures.mockCoercedValue(TimestampWithTimezoneValue(timestamp))
 
         val result = validator.validateAndCoerce(input)
@@ -138,8 +140,8 @@ class ClickhouseCoercingValidatorTest {
     @ParameterizedTest
     @MethodSource("invalidDates")
     fun `validate and coerces timestamps with timezones - invalid values are nulled`(value: Long) {
-        val timestamp = LocalDateTime.of(LocalDate.ofEpochDay(value), LocalTime.MAX)
-            .atOffset(ZoneOffset.UTC)
+        val timestamp =
+            LocalDateTime.of(LocalDate.ofEpochDay(value), LocalTime.MAX).atOffset(ZoneOffset.UTC)
         val input = Fixtures.mockCoercedValue(TimestampWithTimezoneValue(timestamp))
 
         val result = validator.validateAndCoerce(input)
@@ -153,7 +155,9 @@ class ClickhouseCoercingValidatorTest {
 
     @ParameterizedTest
     @MethodSource("validDates")
-    fun `validate and coerces timestamps without timezones - valid values are left unchanged`(value: Long) {
+    fun `validate and coerces timestamps without timezones - valid values are left unchanged`(
+        value: Long
+    ) {
         val timestamp = LocalDateTime.of(LocalDate.ofEpochDay(value), LocalTime.MAX)
         val input = Fixtures.mockCoercedValue(TimestampWithoutTimezoneValue(timestamp))
 
@@ -166,7 +170,9 @@ class ClickhouseCoercingValidatorTest {
 
     @ParameterizedTest
     @MethodSource("invalidDates")
-    fun `validate and coerces timestamps without timezones - invalid values are nulled`(value: Long) {
+    fun `validate and coerces timestamps without timezones - invalid values are nulled`(
+        value: Long
+    ) {
         val timestamp = LocalDateTime.of(LocalDate.ofEpochDay(value), LocalTime.MAX)
         val input = Fixtures.mockCoercedValue(TimestampWithoutTimezoneValue(timestamp))
 


### PR DESCRIPTION
## What
Adds validation and coercion for dates and timestamps
Uses correct 128 bounds for decimals
