### PR TITLE
ci: fix community CI docs build step

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -37,6 +37,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.head_ref }}
 
       - name: Check For Skip Conditions


### PR DESCRIPTION
This resolves an error in the docs build step, where if the repo is a fork, it doesn't find the needed ref on the main repo. Passing the repo name explicitly should resolve this (atapted from other working checkout implementation in `connector-ci-checks.yml`).

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._