### PR TITLE
ci: add no-op lint-check for manifest-only connectors

### DIFF
--- a/poe-tasks/manifest-only-connector-tasks.toml
+++ b/poe-tasks/manifest-only-connector-tasks.toml
@@ -45,6 +45,7 @@ fi
 '''
 test-integration-tests = "airbyte-cdk connector test ${POE_PWD}"
 format-check = "echo 'No format check step for this connector.'"
+lint-check = "echo 'No lint check step for this connector."
 
 lock.shell = '''
 set -eu # Ensure we return non-zero exit code upon failure


### PR DESCRIPTION
Adds a no-op lint check for manifest-only connectors. This is preferable to a hard-failure in the CI workflow - even though the failures are ignored (for now) for lint-check action.

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._