### PR TITLE
[source-snowflake] Support more types of encryption in snowflake private key auth

### DIFF
--- a/airbyte-integrations/connectors/source-snowflake/build.gradle
+++ b/airbyte-integrations/connectors/source-snowflake/build.gradle
@@ -10,7 +10,7 @@ airbyteJavaConnector {
 
 application {
     mainClass = 'io.airbyte.integrations.source.snowflake.SnowflakeSourceRunner'
-    applicationDefaultJvmArgs = ['-XX:+ExitOnOutOfMemoryError', '-XX:MaxRAMPercentage=75.0']
+    applicationDefaultJvmArgs = ['-XX:+ExitOnOutOfMemoryError', '-XX:MaxRAMPercentage=75.0', '-Dnet.snowflake.jdbc.enableBouncyCastle=TRUE']
 }
 
 dependencies {

--- a/airbyte-integrations/connectors/source-snowflake/metadata.yaml
+++ b/airbyte-integrations/connectors/source-snowflake/metadata.yaml
@@ -36,7 +36,7 @@ data:
             type: GSM
   connectorType: source
   definitionId: e2d65910-8c8b-40a1-ae7d-ee2416b2bfa2
-  dockerImageTag: 0.3.6
+  dockerImageTag: 0.3.7
   dockerRepository: airbyte/source-snowflake
   documentationUrl: https://docs.airbyte.com/integrations/sources/snowflake
   githubIssueLabel: source-snowflake

--- a/docs/integrations/sources/snowflake.md
+++ b/docs/integrations/sources/snowflake.md
@@ -140,6 +140,7 @@ To read more please check official [Snowflake documentation](https://docs.snowfl
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                                   |
 |:--------|:-----------|:---------------------------------------------------------|:------------------------------------------------------------------------------------------------------------------------------------------|
+| 0.3.7 | 2025-06-24 | [62039](https://github.com/airbytehq/airbyte/pull/62039) | Support more types of encryption in snowflake private key auth |
 | 0.3.6 | 2025-01-10 | [51504](https://github.com/airbytehq/airbyte/pull/51504) | Use a non root base image |
 | 0.3.5 | 2024-12-18 | [49911](https://github.com/airbytehq/airbyte/pull/49911) | Use a base image: airbyte/java-connector-base:1.0.0 |
 | 0.3.4 | 2024-10-31 | [48073](https://github.com/airbytehq/airbyte/pull/48073) | Upgrade jdbc driver |


### PR DESCRIPTION


## What
Fixes #62037. The default built-in java decryption only supports a subset encryption algorithms. Enabling bouncy castle allows supporting more types of encryption with passphrase, including des3 which is used in the examples on https://docs.snowflake.com/en/user-guide/key-pair-auth

## How
This change enables bouncy castle by default, which enables support for such keys. This is the recommended solution from Snowflake docs at https://docs.snowflake.com/en/developer-guide/jdbc/jdbc-configure#using-key-pair-authentication-and-key-rotation (examples use bouncy castle, plus the decryption errors section indicate the JVM arg should be enabled).

## Review guide

## User Impact
This will allow more encrypted keys to be used with Snowflake. We tested it successfully both with an old key that used to work, as well as a new key that was failing. 

However, it is not feasible to test every possible encryption algorithm with it, so I cannot guarantee no regressions.

## Can this PR be safely reverted and rolled back?
- [X] YES 💚
- [ ] NO ❌
