### PR TITLE
chore: add helper extensions for dlq records

### DIFF
--- a/airbyte-cdk/bulk/toolkits/load-dlq/src/integrationTest/kotlin/DlqSpecTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-dlq/src/integrationTest/kotlin/DlqSpecTest.kt
@@ -2,6 +2,9 @@
  * Copyright (c) 2025 Airbyte, Inc., all rights reserved.
  */
 
+import io.airbyte.cdk.load.integrationTest.DLQ_INTEGRATION_TEST_ENV
 import io.airbyte.cdk.load.spec.SpecTest
 
-class DlqSpecTest : SpecTest() {}
+class DlqSpecTest : SpecTest(
+    additionalMicronautEnvs = listOf(DLQ_INTEGRATION_TEST_ENV)
+) {}

--- a/airbyte-cdk/bulk/toolkits/load-dlq/src/integrationTest/kotlin/DlqSpecTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-dlq/src/integrationTest/kotlin/DlqSpecTest.kt
@@ -5,6 +5,4 @@
 import io.airbyte.cdk.load.integrationTest.DLQ_INTEGRATION_TEST_ENV
 import io.airbyte.cdk.load.spec.SpecTest
 
-class DlqSpecTest : SpecTest(
-    additionalMicronautEnvs = listOf(DLQ_INTEGRATION_TEST_ENV)
-) {}
+class DlqSpecTest : SpecTest(additionalMicronautEnvs = listOf(DLQ_INTEGRATION_TEST_ENV)) {}

--- a/airbyte-cdk/bulk/toolkits/load-dlq/src/integrationTest/kotlin/DlqStateWithNewRecords.kt
+++ b/airbyte-cdk/bulk/toolkits/load-dlq/src/integrationTest/kotlin/DlqStateWithNewRecords.kt
@@ -1,0 +1,45 @@
+import io.airbyte.cdk.load.data.AirbyteValueProxy
+import io.airbyte.cdk.load.data.IntegerType
+import io.airbyte.cdk.load.integrationTest.DlqStateFactory
+import io.airbyte.cdk.load.integrationTest.DlqTestState
+import io.airbyte.cdk.load.message.DestinationRecordRaw
+import io.airbyte.cdk.load.message.StreamKey
+import io.airbyte.cdk.load.message.dlq.toDlqRecord
+import java.math.BigInteger
+import java.util.UUID
+
+class DlqStateWithNewRecords : DlqTestState {
+    private val records: MutableList<DestinationRecordRaw> = mutableListOf()
+
+    override fun accumulate(record: DestinationRecordRaw) {
+        records.add(record)
+    }
+
+    override fun isFull(): Boolean = records.size > 2
+
+    override fun flush(): List<DestinationRecordRaw>? = records
+        .filter { it.hasAnEvenId() }
+        .map {
+            it.toDlqRecord(mapOf(
+                "error" to UUID.randomUUID(),
+                "message" to "very custom error message",
+            ))
+        }
+        .ifEmpty { null }
+
+    override fun close() {}
+
+    // Just so that we do not write everything to the dead letter queue
+    // we only write even ids that are less than 10
+    private fun DestinationRecordRaw.hasAnEvenId(): Boolean {
+        val id =
+            this.rawData
+                .asAirbyteValueProxy()
+                .getInteger(AirbyteValueProxy.FieldAccessor(0, "id", IntegerType))
+        return id?.let { it < BigInteger.TEN && it.mod(BigInteger.TWO) == BigInteger.ZERO } ?: true
+    }
+
+    class Factory : DlqStateFactory {
+        override fun create(key: StreamKey, part: Int): DlqTestState = DlqStateWithNewRecords()
+    }
+}

--- a/airbyte-cdk/bulk/toolkits/load-dlq/src/integrationTest/kotlin/DlqStateWithNewRecords.kt
+++ b/airbyte-cdk/bulk/toolkits/load-dlq/src/integrationTest/kotlin/DlqStateWithNewRecords.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+ */
+
 import io.airbyte.cdk.load.data.AirbyteValueProxy
 import io.airbyte.cdk.load.data.IntegerType
 import io.airbyte.cdk.load.integrationTest.DlqStateFactory
@@ -17,15 +21,18 @@ class DlqStateWithNewRecords : DlqTestState {
 
     override fun isFull(): Boolean = records.size > 2
 
-    override fun flush(): List<DestinationRecordRaw>? = records
-        .filter { it.hasAnEvenId() }
-        .map {
-            it.toDlqRecord(mapOf(
-                "error" to UUID.randomUUID(),
-                "message" to "very custom error message",
-            ))
-        }
-        .ifEmpty { null }
+    override fun flush(): List<DestinationRecordRaw>? =
+        records
+            .filter { it.hasAnEvenId() }
+            .map {
+                it.toDlqRecord(
+                    mapOf(
+                        "error" to UUID.randomUUID(),
+                        "message" to "very custom error message",
+                    )
+                )
+            }
+            .ifEmpty { null }
 
     override fun close() {}
 

--- a/airbyte-cdk/bulk/toolkits/load-dlq/src/integrationTest/kotlin/DlqStateWithRecordSample.kt
+++ b/airbyte-cdk/bulk/toolkits/load-dlq/src/integrationTest/kotlin/DlqStateWithRecordSample.kt
@@ -1,0 +1,36 @@
+import io.airbyte.cdk.load.data.AirbyteValueProxy
+import io.airbyte.cdk.load.data.IntegerType
+import io.airbyte.cdk.load.integrationTest.DlqStateFactory
+import io.airbyte.cdk.load.integrationTest.DlqTestState
+import io.airbyte.cdk.load.message.DestinationRecordRaw
+import io.airbyte.cdk.load.message.StreamKey
+import java.math.BigInteger
+
+class DlqStateWithRecordSample : DlqTestState {
+    private val records: MutableList<DestinationRecordRaw> = mutableListOf()
+
+    override fun accumulate(record: DestinationRecordRaw) {
+        records.add(record)
+    }
+
+    override fun isFull(): Boolean = records.size > 2
+
+    override fun flush(): List<DestinationRecordRaw>? = records.filter { it.hasAnEvenId() }
+        .ifEmpty { null }
+
+    override fun close() {}
+
+    // Just so that we do not write everything to the dead letter queue
+    // we only write even ids that are less than 10
+    private fun DestinationRecordRaw.hasAnEvenId(): Boolean {
+        val id =
+            this.rawData
+                .asAirbyteValueProxy()
+                .getInteger(AirbyteValueProxy.FieldAccessor(0, "id", IntegerType))
+        return id?.let { it < BigInteger.TEN && it.mod(BigInteger.TWO) == BigInteger.ZERO } ?: true
+    }
+
+    class Factory : DlqStateFactory {
+        override fun create(key: StreamKey, part: Int): DlqTestState = DlqStateWithRecordSample()
+    }
+}

--- a/airbyte-cdk/bulk/toolkits/load-dlq/src/integrationTest/kotlin/DlqStateWithRecordSample.kt
+++ b/airbyte-cdk/bulk/toolkits/load-dlq/src/integrationTest/kotlin/DlqStateWithRecordSample.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+ */
+
 import io.airbyte.cdk.load.data.AirbyteValueProxy
 import io.airbyte.cdk.load.data.IntegerType
 import io.airbyte.cdk.load.integrationTest.DlqStateFactory
@@ -15,8 +19,8 @@ class DlqStateWithRecordSample : DlqTestState {
 
     override fun isFull(): Boolean = records.size > 2
 
-    override fun flush(): List<DestinationRecordRaw>? = records.filter { it.hasAnEvenId() }
-        .ifEmpty { null }
+    override fun flush(): List<DestinationRecordRaw>? =
+        records.filter { it.hasAnEvenId() }.ifEmpty { null }
 
     override fun close() {}
 

--- a/airbyte-cdk/bulk/toolkits/load-dlq/src/integrationTest/kotlin/DlqWriteTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-dlq/src/integrationTest/kotlin/DlqWriteTest.kt
@@ -157,7 +157,8 @@ class MockBucketDlqFromRecordSampleTest :
 class MockBucketDlqFromNewRecordsTest :
     AbstractDlqWriteTest(
         configContent = """{"objectStorageConfig":{"storage_type":"S3"}}""",
-        additionalMicronautEnvs = listOf("MockObjectStorage", DLQ_INTEGRATION_TEST_ENV, DLQ_SAMPLE_TEST),
+        additionalMicronautEnvs =
+            listOf("MockObjectStorage", DLQ_INTEGRATION_TEST_ENV, DLQ_SAMPLE_TEST),
     ) {
     @Test
     override fun testBasicWrite() {

--- a/airbyte-cdk/bulk/toolkits/load-dlq/src/integrationTest/kotlin/DlqWriteTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-dlq/src/integrationTest/kotlin/DlqWriteTest.kt
@@ -8,6 +8,8 @@ import io.airbyte.cdk.load.command.NamespaceMapper
 import io.airbyte.cdk.load.config.DataChannelFormat
 import io.airbyte.cdk.load.config.DataChannelMedium
 import io.airbyte.cdk.load.data.ObjectType
+import io.airbyte.cdk.load.integrationTest.DLQ_INTEGRATION_TEST_ENV
+import io.airbyte.cdk.load.integrationTest.DLQ_SAMPLE_TEST
 import io.airbyte.cdk.load.message.InputRecord
 import io.airbyte.cdk.load.message.InputStreamCheckpoint
 import io.airbyte.cdk.load.message.StreamCheckpoint
@@ -133,6 +135,7 @@ open class AbstractDlqWriteTest(
 class NoBucketDlqWriteTest :
     AbstractDlqWriteTest(
         configContent = """{"objectStorageConfig":{"storage_type":"None"}}""",
+        additionalMicronautEnvs = listOf(DLQ_INTEGRATION_TEST_ENV)
     ) {
     @Test
     override fun testBasicWrite() {
@@ -140,10 +143,21 @@ class NoBucketDlqWriteTest :
     }
 }
 
-class MockBucketDlqWriteTest :
+class MockBucketDlqFromRecordSampleTest :
     AbstractDlqWriteTest(
         configContent = """{"objectStorageConfig":{"storage_type":"S3"}}""",
-        additionalMicronautEnvs = listOf("MockObjectStorage"),
+        additionalMicronautEnvs = listOf("MockObjectStorage", DLQ_INTEGRATION_TEST_ENV),
+    ) {
+    @Test
+    override fun testBasicWrite() {
+        super.testBasicWrite()
+    }
+}
+
+class MockBucketDlqFromNewRecordsTest :
+    AbstractDlqWriteTest(
+        configContent = """{"objectStorageConfig":{"storage_type":"S3"}}""",
+        additionalMicronautEnvs = listOf("MockObjectStorage", DLQ_INTEGRATION_TEST_ENV, DLQ_SAMPLE_TEST),
     ) {
     @Test
     override fun testBasicWrite() {

--- a/airbyte-cdk/bulk/toolkits/load-dlq/src/main/kotlin/io/airbyte/cdk/load/message/dlq/DlqRecordBuilder.kt
+++ b/airbyte-cdk/bulk/toolkits/load-dlq/src/main/kotlin/io/airbyte/cdk/load/message/dlq/DlqRecordBuilder.kt
@@ -1,0 +1,50 @@
+package io.airbyte.cdk.load.message.dlq
+
+import com.fasterxml.jackson.databind.JsonNode
+import io.airbyte.cdk.load.command.DestinationStream
+import io.airbyte.cdk.load.message.DestinationRecordJsonSource
+import io.airbyte.cdk.load.message.DestinationRecordRaw
+import io.airbyte.cdk.util.Jsons
+import io.airbyte.protocol.models.v0.AirbyteMessage
+import io.airbyte.protocol.models.v0.AirbyteRecordMessage
+import java.util.UUID
+
+/**
+ * A helper method to modify a existing DestinationRecordRaw for a dead letter queue.
+ *
+ * This method ensures we still track the correct metadata against the original record when it comes
+ * to stats and checkpointing while allowing a different content to be persisted to the dead
+ * letter queue.
+ */
+fun DestinationRecordRaw.toDlqRecord(data: Map<String, Any>): DestinationRecordRaw =
+    // We want to preserve everything from the original record and only override the content.
+    // The rationale is that we should still be reporting original byte size and adhere to the
+    // original checkpoint.
+    copy(
+        rawData = DestinationRecordJsonSource(data.toAirbyteRecordMessage()),
+    )
+
+/**
+ * A helper method to generate a new DestinationRecordRaw for a dead letter queue.
+ *
+ * This method will generate the rawData from [data] and fill in reasonable defaults.
+ */
+fun DestinationStream.newDlqRecord(data : Map<String, Any>): DestinationRecordRaw =
+    DestinationRecordRaw(
+        stream = this,
+        rawData = DestinationRecordJsonSource(data.toAirbyteRecordMessage()),
+        // We should be reporting the original record so in this flow, do not fill in anything.
+        serializedSizeBytes = 0,
+        checkpointId = null,
+        airbyteRawId = UUID.randomUUID(),
+    )
+
+private fun Map<String, Any>.toAirbyteRecordMessage() = AirbyteMessage()
+    .withRecord(
+        AirbyteRecordMessage()
+            .withData(
+                Jsons.convertValue(this, JsonNode::class.java)
+            )
+            .withEmittedAt(System.currentTimeMillis())
+    )
+    .withType(AirbyteMessage.Type.RECORD)

--- a/airbyte-cdk/bulk/toolkits/load-dlq/src/main/kotlin/io/airbyte/cdk/load/message/dlq/DlqRecordBuilder.kt
+++ b/airbyte-cdk/bulk/toolkits/load-dlq/src/main/kotlin/io/airbyte/cdk/load/message/dlq/DlqRecordBuilder.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+ */
+
 package io.airbyte.cdk.load.message.dlq
 
 import com.fasterxml.jackson.databind.JsonNode
@@ -13,8 +17,8 @@ import java.util.UUID
  * A helper method to modify a existing DestinationRecordRaw for a dead letter queue.
  *
  * This method ensures we still track the correct metadata against the original record when it comes
- * to stats and checkpointing while allowing a different content to be persisted to the dead
- * letter queue.
+ * to stats and checkpointing while allowing a different content to be persisted to the dead letter
+ * queue.
  */
 fun DestinationRecordRaw.toDlqRecord(data: Map<String, Any>): DestinationRecordRaw =
     // We want to preserve everything from the original record and only override the content.
@@ -29,7 +33,7 @@ fun DestinationRecordRaw.toDlqRecord(data: Map<String, Any>): DestinationRecordR
  *
  * This method will generate the rawData from [data] and fill in reasonable defaults.
  */
-fun DestinationStream.newDlqRecord(data : Map<String, Any>): DestinationRecordRaw =
+fun DestinationStream.newDlqRecord(data: Map<String, Any>): DestinationRecordRaw =
     DestinationRecordRaw(
         stream = this,
         rawData = DestinationRecordJsonSource(data.toAirbyteRecordMessage()),
@@ -39,12 +43,11 @@ fun DestinationStream.newDlqRecord(data : Map<String, Any>): DestinationRecordRa
         airbyteRawId = UUID.randomUUID(),
     )
 
-private fun Map<String, Any>.toAirbyteRecordMessage() = AirbyteMessage()
-    .withRecord(
-        AirbyteRecordMessage()
-            .withData(
-                Jsons.convertValue(this, JsonNode::class.java)
-            )
-            .withEmittedAt(System.currentTimeMillis())
-    )
-    .withType(AirbyteMessage.Type.RECORD)
+private fun Map<String, Any>.toAirbyteRecordMessage() =
+    AirbyteMessage()
+        .withRecord(
+            AirbyteRecordMessage()
+                .withData(Jsons.convertValue(this, JsonNode::class.java))
+                .withEmittedAt(System.currentTimeMillis())
+        )
+        .withType(AirbyteMessage.Type.RECORD)

--- a/airbyte-cdk/bulk/toolkits/load-dlq/src/test/kotlin/io/airbyte/cdk/load/message/dlq/DlqRecordBuilderTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-dlq/src/test/kotlin/io/airbyte/cdk/load/message/dlq/DlqRecordBuilderTest.kt
@@ -1,0 +1,92 @@
+package io.airbyte.cdk.load.message.dlq
+
+import io.airbyte.cdk.load.command.Append
+import io.airbyte.cdk.load.command.DestinationStream
+import io.airbyte.cdk.load.command.NamespaceMapper
+import io.airbyte.cdk.load.data.AirbyteValueProxy
+import io.airbyte.cdk.load.data.ObjectTypeWithoutSchema
+import io.airbyte.cdk.load.data.StringType
+import io.airbyte.cdk.load.message.DestinationRecordJsonSource
+import io.airbyte.cdk.load.message.DestinationRecordRaw
+import io.airbyte.cdk.load.state.CheckpointId
+import io.airbyte.protocol.models.Jsons
+import io.airbyte.protocol.models.v0.AirbyteMessage
+import io.airbyte.protocol.models.v0.AirbyteRecordMessage
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import org.junit.jupiter.api.Test
+
+class DlqRecordBuilderTest {
+    @Test
+    fun `toDlqRecord should replace the data`() {
+        val initialRecord = DestinationRecordRaw(
+            stream = defaultStream,
+            rawData = DestinationRecordJsonSource(defaultRecordMessage),
+            serializedSizeBytes = 123L,
+            checkpointId = CheckpointId("myCheckPoint"),
+            airbyteRawId = UUID.randomUUID(),
+        )
+        val record = initialRecord.toDlqRecord(mapOf("new" to "content"))
+
+        val newFieldAccessor = AirbyteValueProxy.FieldAccessor(1, "new", StringType)
+
+        assertEquals(
+            """{"new":"content"}""",
+            record.rawData.asJsonRecord(arrayOf(newFieldAccessor)).toString(),
+        )
+    }
+
+    @Test
+    fun `toDlqRecord should preserve the source record metadata`() {
+        val initialRecord = DestinationRecordRaw(
+            stream = defaultStream,
+            rawData = DestinationRecordJsonSource(defaultRecordMessage),
+            serializedSizeBytes = 123L,
+            checkpointId = CheckpointId("myCheckPoint"),
+            airbyteRawId = UUID.randomUUID(),
+        )
+        val record = initialRecord.toDlqRecord(mapOf())
+
+        assertEquals(initialRecord.stream, record.stream)
+        assertEquals(initialRecord.serializedSizeBytes, record.serializedSizeBytes)
+        assertEquals(initialRecord.checkpointId, record.checkpointId)
+        assertEquals(initialRecord.airbyteRawId, record.airbyteRawId)
+    }
+
+    @Test
+    fun `newDlqRecord should fill in the blanks`() {
+        val record = defaultStream.newDlqRecord(mapOf("brand" to "new"))
+
+        val fieldAccessor = AirbyteValueProxy.FieldAccessor(1, "brand", StringType)
+        assertEquals(
+            """{"brand":"new"}""",
+            record.rawData.asJsonRecord(arrayOf(fieldAccessor)).toString(),
+        )
+
+        assertEquals(defaultStream, record.stream)
+        assertEquals(0, record.serializedSizeBytes)
+        assertNull(record.checkpointId)
+        assertNotNull(record.airbyteRawId)
+    }
+
+    private val defaultStream = DestinationStream(
+        unmappedName = "name",
+        unmappedNamespace = "namespace",
+        importType = Append,
+        schema = ObjectTypeWithoutSchema,
+        generationId = 2,
+        minimumGenerationId = 1,
+        syncId = 27,
+        namespaceMapper = NamespaceMapper(),
+    )
+
+    private val defaultRecordMessage = AirbyteMessage()
+        .withRecord(
+            AirbyteRecordMessage()
+                .withData(Jsons.deserialize("""{"test":"data"}""""))
+                .withEmittedAt(System.currentTimeMillis())
+        )
+        .withType(AirbyteMessage.Type.RECORD)
+}

--- a/airbyte-cdk/bulk/toolkits/load-dlq/src/test/kotlin/io/airbyte/cdk/load/message/dlq/DlqRecordBuilderTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-dlq/src/test/kotlin/io/airbyte/cdk/load/message/dlq/DlqRecordBuilderTest.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+ */
+
 package io.airbyte.cdk.load.message.dlq
 
 import io.airbyte.cdk.load.command.Append
@@ -21,13 +25,14 @@ import org.junit.jupiter.api.Test
 class DlqRecordBuilderTest {
     @Test
     fun `toDlqRecord should replace the data`() {
-        val initialRecord = DestinationRecordRaw(
-            stream = defaultStream,
-            rawData = DestinationRecordJsonSource(defaultRecordMessage),
-            serializedSizeBytes = 123L,
-            checkpointId = CheckpointId("myCheckPoint"),
-            airbyteRawId = UUID.randomUUID(),
-        )
+        val initialRecord =
+            DestinationRecordRaw(
+                stream = defaultStream,
+                rawData = DestinationRecordJsonSource(defaultRecordMessage),
+                serializedSizeBytes = 123L,
+                checkpointId = CheckpointId("myCheckPoint"),
+                airbyteRawId = UUID.randomUUID(),
+            )
         val record = initialRecord.toDlqRecord(mapOf("new" to "content"))
 
         val newFieldAccessor = AirbyteValueProxy.FieldAccessor(1, "new", StringType)
@@ -40,13 +45,14 @@ class DlqRecordBuilderTest {
 
     @Test
     fun `toDlqRecord should preserve the source record metadata`() {
-        val initialRecord = DestinationRecordRaw(
-            stream = defaultStream,
-            rawData = DestinationRecordJsonSource(defaultRecordMessage),
-            serializedSizeBytes = 123L,
-            checkpointId = CheckpointId("myCheckPoint"),
-            airbyteRawId = UUID.randomUUID(),
-        )
+        val initialRecord =
+            DestinationRecordRaw(
+                stream = defaultStream,
+                rawData = DestinationRecordJsonSource(defaultRecordMessage),
+                serializedSizeBytes = 123L,
+                checkpointId = CheckpointId("myCheckPoint"),
+                airbyteRawId = UUID.randomUUID(),
+            )
         val record = initialRecord.toDlqRecord(mapOf())
 
         assertEquals(initialRecord.stream, record.stream)
@@ -71,22 +77,24 @@ class DlqRecordBuilderTest {
         assertNotNull(record.airbyteRawId)
     }
 
-    private val defaultStream = DestinationStream(
-        unmappedName = "name",
-        unmappedNamespace = "namespace",
-        importType = Append,
-        schema = ObjectTypeWithoutSchema,
-        generationId = 2,
-        minimumGenerationId = 1,
-        syncId = 27,
-        namespaceMapper = NamespaceMapper(),
-    )
-
-    private val defaultRecordMessage = AirbyteMessage()
-        .withRecord(
-            AirbyteRecordMessage()
-                .withData(Jsons.deserialize("""{"test":"data"}""""))
-                .withEmittedAt(System.currentTimeMillis())
+    private val defaultStream =
+        DestinationStream(
+            unmappedName = "name",
+            unmappedNamespace = "namespace",
+            importType = Append,
+            schema = ObjectTypeWithoutSchema,
+            generationId = 2,
+            minimumGenerationId = 1,
+            syncId = 27,
+            namespaceMapper = NamespaceMapper(),
         )
-        .withType(AirbyteMessage.Type.RECORD)
+
+    private val defaultRecordMessage =
+        AirbyteMessage()
+            .withRecord(
+                AirbyteRecordMessage()
+                    .withData(Jsons.deserialize("""{"test":"data"}""""))
+                    .withEmittedAt(System.currentTimeMillis())
+            )
+            .withType(AirbyteMessage.Type.RECORD)
 }


### PR DESCRIPTION
## What

For the dead letter queue, we envision two main use cases:
1. we know exactly which records are being sent to the dead letter queue
2. we know the amount of records but cannot tie them back to the original records

This PR adds one helper extension for each case:
* `DestinationRecordRaw.toDlqRecord` which mutates the record with the error content while perserving the required metadata.
* `DestinationStream.newDlqRecord` which generates a new dead letter queue record for the given stream

This PR also reworks some of the integration test setups, mostly to be more specific about micronaut envs to avoid collisions and also make it easier to add dead letter queue integration tests.

Closes https://github.com/airbytehq/airbyte-internal-issues/issues/13454

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [X] YES 💚
- [ ] NO ❌
