### PR TITLE
bug(source-github): problem getting author for contributor_activity stream

### DIFF
--- a/airbyte-integrations/connectors/source-github/metadata.yaml
+++ b/airbyte-integrations/connectors/source-github/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: ef69ef6e-aa7f-4af1-a01d-ef775033524e
-  dockerImageTag: 1.8.30
+  dockerImageTag: 1.8.31
   dockerRepository: airbyte/source-github
   documentationUrl: https://docs.airbyte.com/integrations/sources/github
   erdUrl: https://dbdocs.io/airbyteio/source-github?view=relationships

--- a/airbyte-integrations/connectors/source-github/pyproject.toml
+++ b/airbyte-integrations/connectors/source-github/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "1.8.30"
+version = "1.8.31"
 name = "source-github"
 description = "Source implementation for GitHub."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-github/source_github/streams.py
+++ b/airbyte-integrations/connectors/source-github/source_github/streams.py
@@ -1633,7 +1633,11 @@ class ContributorActivity(GithubStream):
 
     def transform(self, record: MutableMapping[str, Any], stream_slice: Mapping[str, Any]) -> MutableMapping[str, Any]:
         record["repository"] = stream_slice["repository"]
-        record.update(record.pop("author"))
+        try:
+            record.update(record.pop("author"))
+        except Exception as ex:
+            self.logger.info(f'Failed to extract author from repo {stream_slice["repository"]}. Error: {ex}')
+            raise ex
         return record
 
     def get_error_handler(self) -> Optional[ErrorHandler]:

--- a/airbyte-integrations/connectors/source-github/source_github/streams.py
+++ b/airbyte-integrations/connectors/source-github/source_github/streams.py
@@ -4,6 +4,7 @@
 
 import re
 from abc import ABC, abstractmethod
+from copy import deepcopy
 from typing import Any, Iterable, List, Mapping, MutableMapping, Optional, Union
 from urllib import parse
 
@@ -1633,11 +1634,10 @@ class ContributorActivity(GithubStream):
 
     def transform(self, record: MutableMapping[str, Any], stream_slice: Mapping[str, Any]) -> MutableMapping[str, Any]:
         record["repository"] = stream_slice["repository"]
-        try:
-            record.update(record.pop("author"))
-        except Exception as ex:
-            self.logger.info(f'Failed to extract author from repo {stream_slice["repository"]}. Error: {ex}')
-            raise ex
+        author = record.pop("author", None)
+        # It's been found that the author field can be None, so we check for it
+        if author:
+            record.update(author)
         return record
 
     def get_error_handler(self) -> Optional[ErrorHandler]:

--- a/airbyte-integrations/connectors/source-github/source_github/streams.py
+++ b/airbyte-integrations/connectors/source-github/source_github/streams.py
@@ -4,7 +4,6 @@
 
 import re
 from abc import ABC, abstractmethod
-from copy import deepcopy
 from typing import Any, Iterable, List, Mapping, MutableMapping, Optional, Union
 from urllib import parse
 

--- a/docs/integrations/sources/github.md
+++ b/docs/integrations/sources/github.md
@@ -225,7 +225,7 @@ Your token should have at least the `repo` scope. Depending on which streams you
 
 | Version | Date       | Pull Request                                                                                                      | Subject                                                                                                                                                             |
 |:--------|:-----------|:------------------------------------------------------------------------------------------------------------------|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 1.8.31 | 2025-06-24 | [XXXXX](https://github.com/airbytehq/airbyte/pull/XXXXX) | Fix problem with `contributor_activity` stream flatting the author field |
+| 1.8.31 | 2025-06-25 | [62504](https://github.com/airbytehq/airbyte/pull/62504) | Fix problem with `contributor_activity` stream when author is not present/none |
 | 1.8.30 | 2025-06-23 | [61742](https://github.com/airbytehq/airbyte/pull/61742) | Handle conflict when empty repositories, we will ignore |
 | 1.8.29 | 2025-06-21 | [61857](https://github.com/airbytehq/airbyte/pull/61857) | Update dependencies |
 | 1.8.28 | 2025-06-15 | [61603](https://github.com/airbytehq/airbyte/pull/61603) | Update dependencies |

--- a/docs/integrations/sources/github.md
+++ b/docs/integrations/sources/github.md
@@ -225,7 +225,7 @@ Your token should have at least the `repo` scope. Depending on which streams you
 
 | Version | Date       | Pull Request                                                                                                      | Subject                                                                                                                                                             |
 |:--------|:-----------|:------------------------------------------------------------------------------------------------------------------|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 1.8.31 | 2025-06-25 | [62504](https://github.com/airbytehq/airbyte/pull/62504) | Fix problem with `contributor_activity` stream when author is not present/none |
+| 1.8.31 | 2025-06-25 | [62054](https://github.com/airbytehq/airbyte/pull/62054) | Fix problem with `contributor_activity` stream when author is not present/none |
 | 1.8.30 | 2025-06-23 | [61742](https://github.com/airbytehq/airbyte/pull/61742) | Handle conflict when empty repositories, we will ignore |
 | 1.8.29 | 2025-06-21 | [61857](https://github.com/airbytehq/airbyte/pull/61857) | Update dependencies |
 | 1.8.28 | 2025-06-15 | [61603](https://github.com/airbytehq/airbyte/pull/61603) | Update dependencies |

--- a/docs/integrations/sources/github.md
+++ b/docs/integrations/sources/github.md
@@ -225,6 +225,7 @@ Your token should have at least the `repo` scope. Depending on which streams you
 
 | Version | Date       | Pull Request                                                                                                      | Subject                                                                                                                                                             |
 |:--------|:-----------|:------------------------------------------------------------------------------------------------------------------|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 1.8.31 | 2025-06-24 | [XXXXX](https://github.com/airbytehq/airbyte/pull/XXXXX) | Fix problem with `contributor_activity` stream flatting the author field |
 | 1.8.30 | 2025-06-23 | [61742](https://github.com/airbytehq/airbyte/pull/61742) | Handle conflict when empty repositories, we will ignore |
 | 1.8.29 | 2025-06-21 | [61857](https://github.com/airbytehq/airbyte/pull/61857) | Update dependencies |
 | 1.8.28 | 2025-06-15 | [61603](https://github.com/airbytehq/airbyte/pull/61603) | Update dependencies |


### PR DESCRIPTION
## What
Author field in response to "https://api.github.com/repos/some-root/repo/stats/contributors" can be None. This would cause a problem flattening the record.

```
2025-06-24 21:53:37 source ERROR Encountered an exception while reading stream contributor_activity
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/airbyte_cdk/sources/abstract_source.py", line 133, in read
    yield from self._read_stream(
  File "/usr/local/lib/python3.11/site-packages/airbyte_cdk/sources/abstract_source.py", line 239, in _read_stream
    for record_data_or_message in record_iterator:
  File "/usr/local/lib/python3.11/site-packages/airbyte_cdk/sources/streams/core.py", line 192, in read
    for record_data_or_message in records:
  File "/airbyte/integration_code/source_github/streams.py", line 1666, in read_records
    yield from super().read_records(stream_slice=stream_slice, **kwargs)
  File "/airbyte/integration_code/source_github/streams.py", line 130, in read_records
    yield from super().read_records(stream_slice=stream_slice, **kwargs)
  File "/usr/local/lib/python3.11/site-packages/airbyte_cdk/sources/streams/http/http.py", line 335, in read_records
    yield from self._read_pages(
  File "/usr/local/lib/python3.11/site-packages/airbyte_cdk/sources/streams/http/http.py", line 388, in _read_pages
    yield from records_generator_fn(request, response, stream_state, stream_slice)
  File "/airbyte/integration_code/source_github/streams.py", line 1659, in parse_response
    yield from super().parse_response(
  File "/airbyte/integration_code/source_github/streams.py", line 232, in parse_response
    yield from super().parse_response(
  File "/airbyte/integration_code/source_github/streams.py", line 105, in parse_response
    yield self.transform(record=record, stream_slice=stream_slice)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/airbyte/integration_code/source_github/streams.py", line 1640, in transform
    raise ex
  File "/airbyte/integration_code/source_github/streams.py", line 1637, in transform
    record.update(record.pop("author"))
TypeError: 'NoneType' object is not iterable
```
## How
Let's check if it is None and not flatten the author fields to the root, as per the schema, all fields are nullable.

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
We will able to process contributions without an author.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
