### PR TITLE
[source-intercom] Add data export stream

### DIFF
--- a/airbyte-integrations/connectors/source-intercom/manifest.yaml
+++ b/airbyte-integrations/connectors/source-intercom/manifest.yaml
@@ -1,4 +1,4 @@
-version: 6.33.0
+version: 6.48.15
 
 type: DeclarativeSource
 
@@ -6,6 +6,7 @@ check:
   type: CheckStream
   stream_names:
     - tags
+    - dataset_export
 
 definitions:
   streams:
@@ -746,6 +747,70 @@ definitions:
         type: InlineSchemaLoader
         schema:
           $ref: "#/schemas/tickets"
+    dataset_export:
+      type: DeclarativeStream
+      name: dataset_export
+      retriever:
+        type: AsyncRetriever
+        record_selector:
+          type: RecordSelector
+          extractor:
+            type: DpathExtractor
+            field_path: []
+        status_mapping:
+          failed:
+            - failed
+          running:
+            - pending
+          timeout:
+            - timeout
+          completed:
+            - complete
+        status_extractor:
+          type: DpathExtractor
+          field_path:
+            - status
+        download_target_extractor:
+          type: DpathExtractor
+          field_path:
+            - download_url
+        decoder:
+          type: JsonDecoder
+        creation_requester:
+          type: HttpRequester
+          url_base: https://api.intercom.io/export/reporting_data/enqueue
+          authenticator:
+            type: BearerAuthenticator
+            api_token: "{{ config[\"api_key\"] }}"
+          http_method: POST
+          request_body_json:
+            end_time: "{{ config.end_time }}"
+            dataset_id: "{{ config.dataset_id }}"
+            start_time: "{{ config.start_time }}"
+            attribute_ids: "{{ config.attribute_ids }}"
+        polling_requester:
+          type: HttpRequester
+          url_base: >-
+            https://api.intercom.io/export/reporting_data/{{ creation_response['job_identifier'] }}
+          authenticator:
+            type: BearerAuthenticator
+            api_token: "{{ config[\"api_key\"] }}"
+          http_method: GET
+        download_requester:
+          type: HttpRequester
+          url_base: "{{ download_target }}"
+          authenticator:
+            type: BearerAuthenticator
+            api_token: "{{ config[\"api_key\"] }}"
+          http_method: GET
+          request_headers:
+            Accept: application/octet-stream
+        download_decoder:
+          type: CsvDecoder
+      schema_loader:
+        type: InlineSchemaLoader
+        schema:
+          $ref: "#/schemas/dataset_export"
   base_requester:
     type: HttpRequester
     url_base: https://api.intercom.io/
@@ -767,6 +832,7 @@ streams:
   - $ref: "#/definitions/streams/conversation_parts"
   - $ref: "#/definitions/streams/company_segments"
   - $ref: "#/definitions/streams/tickets"
+  - $ref: "#/definitions/streams/dataset_export"
 
 spec:
   type: Spec
@@ -832,6 +898,35 @@ spec:
         pattern: ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$
         examples:
           - "2020-11-16T00:00:00Z"
+      api_key:
+        type: string
+        description: API Key for dataset export endpoints.
+        order: 6
+        title: API Key
+        airbyte_secret: true
+      dataset_id:
+        type: string
+        description: "Example: \"conversation\""
+        order: 7
+        title: Dataset
+      attribute_ids:
+        type: array
+        description: >-
+          Example: ["conversation.id","conversation.first_user_conversation_part_created_at"]
+        items:
+          type: string
+        order: 8
+        title: Attribute IDs
+      start_time:
+        type: integer
+        description: "Example: 1717490000"
+        order: 9
+        title: Start Time
+      end_time:
+        type: integer
+        description: "Example: 1717510000"
+        order: 10
+        title: End Time
     additionalProperties: true
   advanced_auth:
       auth_flow_type: "oauth2.0"
@@ -868,6 +963,7 @@ metadata:
     conversation_parts: false
     company_segments: false
     tickets: false
+    dataset_export: true
   yamlComponents:
     streams:
       activity_logs:
@@ -901,6 +997,8 @@ metadata:
         - errorHandler
         - incrementalSync
       tickets:
+        - errorHandler
+      dataset_export:
         - errorHandler
   testedStreams:
     activity_logs:
@@ -992,6 +1090,13 @@ metadata:
       hasResponse: true
       responsesAreSuccessful: false
       hasRecords: false
+      primaryKeysArePresent: true
+      primaryKeysAreUnique: true
+    dataset_export:
+      streamHash: 1234567890abcdef1234567890abcdef12345678
+      hasResponse: true
+      responsesAreSuccessful: true
+      hasRecords: true
       primaryKeysArePresent: true
       primaryKeysAreUnique: true
   assist: {}
@@ -1164,6 +1269,9 @@ schemas:
           - "null"
           - string
         description: Name of the tag used for identification.
+  dataset_export:
+    type: object
+    additionalProperties: true
   teams:
     type: object
     additionalProperties: true
@@ -2964,7 +3072,7 @@ schemas:
             type:
               - "null"
               - string
-            description: The URL to access additional linked objects, if applicable  
+            description: The URL to access additional linked objects, if applicable
       ai_agent_participated:
         type:
           - "null"
@@ -3680,3 +3788,6 @@ schemas:
           - integer
           - "null"
         description: The last time the ticket was updated as a UTC Unix timestamp.
+    dataset_export:
+      type: object
+      additionalProperties: true

--- a/airbyte-integrations/connectors/source-intercom/manifest.yaml
+++ b/airbyte-integrations/connectors/source-intercom/manifest.yaml
@@ -776,32 +776,32 @@ definitions:
             - download_url
         decoder:
           type: JsonDecoder
-        creation_requester:
-          type: HttpRequester
-          url_base: https://api.intercom.io/export/reporting_data/enqueue
-          authenticator:
-            type: BearerAuthenticator
-            api_token: "{{ config[\"api_key\"] }}"
+            creation_requester:
+      type: HttpRequester
+      url_base: https://api.intercom.io/export/reporting_data/enqueue
+      authenticator:
+        type: BearerAuthenticator
+        api_token: "{{ config[\"access_token\"] }}"
           http_method: POST
           request_body_json:
             end_time: "{{ config.end_time }}"
-            dataset_id: "{{ config.dataset_id }}"
+            report_dataset_id: "{{ config.report_dataset_id }}"
             start_time: "{{ config.start_time }}"
             attribute_ids: "{{ config.attribute_ids }}"
-        polling_requester:
-          type: HttpRequester
-          url_base: >-
-            https://api.intercom.io/export/reporting_data/{{ creation_response['job_identifier'] }}
-          authenticator:
-            type: BearerAuthenticator
-            api_token: "{{ config[\"api_key\"] }}"
+            polling_requester:
+      type: HttpRequester
+      url_base: >-
+        https://api.intercom.io/export/reporting_data/{{ creation_response['job_identifier'] }}
+      authenticator:
+        type: BearerAuthenticator
+        api_token: "{{ config[\"access_token\"] }}"
           http_method: GET
-        download_requester:
-          type: HttpRequester
-          url_base: "{{ download_target }}"
-          authenticator:
-            type: BearerAuthenticator
-            api_token: "{{ config[\"api_key\"] }}"
+            download_requester:
+      type: HttpRequester
+      url_base: "{{ download_target }}"
+      authenticator:
+        type: BearerAuthenticator
+        api_token: "{{ config[\"access_token\"] }}"
           http_method: GET
           request_headers:
             Accept: application/octet-stream
@@ -898,13 +898,8 @@ spec:
         pattern: ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$
         examples:
           - "2020-11-16T00:00:00Z"
-      api_key:
-        type: string
-        description: API Key for dataset export endpoints.
-        order: 6
-        title: API Key
-        airbyte_secret: true
-      dataset_id:
+
+      report_dataset_id:
         type: string
         description: "Example: \"conversation\""
         order: 7


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->
Adds the new **`dataset_export`** stream to the **source-intercom** connector, enabling users to pull historical data through Intercom’s “Reporting Data Export” async API  
(see issue #<issue-number> and Intercom docs: (https://developers.intercom.com/docs/references/unstable/rest-api/api.intercom.io/reporting-data-export/paths/~1export~1reporting_data~1enqueue/post).

Key capabilities introduced
* Supports all Intercom datasets (pass `dataset_id`) and attribute whitelisting.
* Extends connector spec with new config fields (`api_key`, `dataset_id`, `attribute_ids`, `start_time`, `end_time`).

## How
<!--
* Describe how code changes achieve the solution.
-->
**`manifest.yaml`**
   * Version bump to `6.48.15`.
   * Added complete DeclarativeStream definition for `dataset_export`.
   * Appended stream to `check.stream_names` and `streams:` list.
   * Extended `spec.connection_specification` with the five new parameters.


## Review guide
<!--
1. `x.py`
2. `y.py`
-->
1. `airbyte-integrations/connectors/source-intercom/manifest.yaml` – entire stream & spec changes.

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->
Positive:
* Users can now export complete historical datasets (e.g., conversations) that were previously impossible or slow with paginated APIs.
* No changes required for existing syncs; new fields only matter if the stream is selected.

Potential caveats:
* The new stream was tested in isolation and merged into existing streams

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌