### PR TITLE
[discuss] Kotlin connectors: enable -Xdebug when building locally

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,7 +78,7 @@ allprojects {
             jvmTarget = JvmTarget.JVM_21
             languageVersion = KotlinVersion.KOTLIN_1_9
             allWarningsAsErrors = isInCi()
-            freeCompilerArgs = ["-Xjvm-default=all"]
+            freeCompilerArgs = ["-Xjvm-default=all"] + getKotlinCompilerArgs()
         }
         dependsOn {
             tasks.matching { it.name == 'generate' }
@@ -89,7 +89,7 @@ allprojects {
             jvmTarget = JvmTarget.JVM_21
             languageVersion = KotlinVersion.KOTLIN_1_9
             allWarningsAsErrors = isInCi()
-            freeCompilerArgs = ["-Xjvm-default=all"]
+            freeCompilerArgs = ["-Xjvm-default=all"] + getKotlinCompilerArgs()
         }
         dependsOn {
             tasks.matching { it.name == 'generate' }
@@ -100,7 +100,7 @@ allprojects {
             jvmTarget = JvmTarget.JVM_21
             languageVersion = KotlinVersion.KOTLIN_1_9
             allWarningsAsErrors = isInCi()
-            freeCompilerArgs = ["-Xjvm-default=all"]
+            freeCompilerArgs = ["-Xjvm-default=all"] + getKotlinCompilerArgs()
         }
         dependsOn {
             tasks.matching { it.name == 'generate' }
@@ -246,5 +246,13 @@ static def getJavaCompilerArgs() {
         return ["-Werror"]
     } else {
         return []
+    }
+}
+
+static def getKotlinCompilerArgs() {
+    if (isInCi()) {
+        return []
+    } else {
+        return ["-Xdebug"]
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -78,7 +78,7 @@ allprojects {
             jvmTarget = JvmTarget.JVM_21
             languageVersion = KotlinVersion.KOTLIN_1_9
             allWarningsAsErrors = isInCi()
-            freeCompilerArgs = ["-Xjvm-default=all"] + getKotlinCompilerArgs()
+            freeCompilerArgs = ["-Xjvm-default=all"]
         }
         dependsOn {
             tasks.matching { it.name == 'generate' }
@@ -89,7 +89,7 @@ allprojects {
             jvmTarget = JvmTarget.JVM_21
             languageVersion = KotlinVersion.KOTLIN_1_9
             allWarningsAsErrors = isInCi()
-            freeCompilerArgs = ["-Xjvm-default=all"] + getKotlinCompilerArgs()
+            freeCompilerArgs = ["-Xjvm-default=all"]
         }
         dependsOn {
             tasks.matching { it.name == 'generate' }
@@ -100,10 +100,40 @@ allprojects {
             jvmTarget = JvmTarget.JVM_21
             languageVersion = KotlinVersion.KOTLIN_1_9
             allWarningsAsErrors = isInCi()
-            freeCompilerArgs = ["-Xjvm-default=all"] + getKotlinCompilerArgs()
+            freeCompilerArgs = ["-Xjvm-default=all"]
         }
         dependsOn {
             tasks.matching { it.name == 'generate' }
+        }
+    }
+
+    if (!isInCi()) {
+        // -Xdebug is dangerous to run in production (can cause memory leaks)
+        // so only add it if if we're not trying to build a docker image.
+        // This only matters if anyone is doing weird things
+        // (e.g. trying to build+publish locally), but we might as well
+        // protect ourselves from a footgun.
+        afterEvaluate {
+            gradle.taskGraph.whenReady { taskGraph ->
+                var willRunDockerBuild = taskGraph.allTasks.any { it.name == "dockerBuildx" }
+                if (!willRunDockerBuild) {
+                    tasks.named('compileKotlin') {
+                        compilerOptions {
+                            freeCompilerArgs.add("-Xdebug")
+                        }
+                    }
+                    tasks.named('compileTestKotlin') {
+                        compilerOptions {
+                            freeCompilerArgs.add("-Xdebug")
+                        }
+                    }
+                    tasks.named('compileTestFixturesKotlin') {
+                        compilerOptions {
+                            freeCompilerArgs.add("-Xdebug")
+                        }
+                    }
+                }
+            }
         }
     }
 
@@ -246,13 +276,5 @@ static def getJavaCompilerArgs() {
         return ["-Werror"]
     } else {
         return []
-    }
-}
-
-static def getKotlinCompilerArgs() {
-    if (isInCi()) {
-        return []
-    } else {
-        return ["-Xdebug"]
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -78,7 +78,7 @@ allprojects {
             jvmTarget = JvmTarget.JVM_21
             languageVersion = KotlinVersion.KOTLIN_1_9
             allWarningsAsErrors = isInCi()
-            freeCompilerArgs = ["-Xjvm-default=all"]
+            freeCompilerArgs = ["-Xjvm-default=all"] + getKotlinCompilerArgs()
         }
         dependsOn {
             tasks.matching { it.name == 'generate' }
@@ -89,7 +89,7 @@ allprojects {
             jvmTarget = JvmTarget.JVM_21
             languageVersion = KotlinVersion.KOTLIN_1_9
             allWarningsAsErrors = isInCi()
-            freeCompilerArgs = ["-Xjvm-default=all"]
+            freeCompilerArgs = ["-Xjvm-default=all"] + getKotlinCompilerArgs()
         }
         dependsOn {
             tasks.matching { it.name == 'generate' }
@@ -100,40 +100,10 @@ allprojects {
             jvmTarget = JvmTarget.JVM_21
             languageVersion = KotlinVersion.KOTLIN_1_9
             allWarningsAsErrors = isInCi()
-            freeCompilerArgs = ["-Xjvm-default=all"]
+            freeCompilerArgs = ["-Xjvm-default=all"] + getKotlinCompilerArgs()
         }
         dependsOn {
             tasks.matching { it.name == 'generate' }
-        }
-    }
-
-    if (!isInCi()) {
-        // -Xdebug is dangerous to run in production (can cause memory leaks)
-        // so only add it if if we're not trying to build a docker image.
-        // This only matters if anyone is doing weird things
-        // (e.g. trying to build+publish locally), but we might as well
-        // protect ourselves from a footgun.
-        afterEvaluate {
-            gradle.taskGraph.whenReady { taskGraph ->
-                var willRunDockerBuild = taskGraph.allTasks.any { it.name == "dockerBuildx" }
-                if (!willRunDockerBuild) {
-                    tasks.named('compileKotlin') {
-                        compilerOptions {
-                            freeCompilerArgs.add("-Xdebug")
-                        }
-                    }
-                    tasks.named('compileTestKotlin') {
-                        compilerOptions {
-                            freeCompilerArgs.add("-Xdebug")
-                        }
-                    }
-                    tasks.named('compileTestFixturesKotlin') {
-                        compilerOptions {
-                            freeCompilerArgs.add("-Xdebug")
-                        }
-                    }
-                }
-            }
         }
     }
 
@@ -276,5 +246,13 @@ static def getJavaCompilerArgs() {
         return ["-Werror"]
     } else {
         return []
+    }
+}
+
+static def getKotlinCompilerArgs() {
+    if (isInCi()) {
+        return []
+    } else {
+        return ["-Xdebug"]
     }
 }


### PR DESCRIPTION
tl;dr maybe we should enable `-Xdebug` when not in CI - https://kotlinlang.org/docs/debug-coroutines-with-idea.html#optimized-out-variables

curious what people think of this. It's definitely sketchy, because if we ever need to break-glass and manually build+publish an image, this would probably cause problems.
<img width="636" alt="image" src="https://github.com/user-attachments/assets/5bfa1e66-faf0-4170-93c9-dd207b238a5d" />


but debugging coroutines is pretty annoying right now because variables randomly disappear, so it would be nice to have this option _sometimes_

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._