### PR TITLE
fix(source-pokeapi): fix nidoran names

### DIFF
--- a/airbyte-integrations/connectors/source-pokeapi/manifest.yaml
+++ b/airbyte-integrations/connectors/source-pokeapi/manifest.yaml
@@ -78,10 +78,10 @@ spec:
           - raichu
           - sandshrew
           - sandslash
-          - nidoranf
+          - nidoran-f
           - nidorina
           - nidoqueen
-          - nidoranm
+          - nidoran-m
           - nidorino
           - nidoking
           - clefairy

--- a/airbyte-integrations/connectors/source-pokeapi/metadata.yaml
+++ b/airbyte-integrations/connectors/source-pokeapi/metadata.yaml
@@ -19,7 +19,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 6371b14b-bc68-4236-bfbd-468e8df8e968
-  dockerImageTag: 0.3.26
+  dockerImageTag: 0.3.27
   dockerRepository: airbyte/source-pokeapi
   githubIssueLabel: source-pokeapi
   icon: pokeapi.svg

--- a/docs/integrations/sources/pokeapi.md
+++ b/docs/integrations/sources/pokeapi.md
@@ -39,7 +39,7 @@ The PokéAPI uses the same [JSONSchema](https://json-schema.org/understanding-js
 
 | Version | Date       | Pull Request                                             | Subject                                         |
 | :------ | :--------- | :------------------------------------------------------- | :---------------------------------------------- |
-| 0.3.27 | 2025-06-26 | | Fix `nidoran` names |
+| 0.3.27 | 2025-06-26 | [62103](https://github.com/airbytehq/airbyte/pull/62103) | Fix `nidoran` names |
 | 0.3.26 | 2025-06-21 | [61935](https://github.com/airbytehq/airbyte/pull/61935) | Update dependencies |
 | 0.3.25 | 2025-06-14 | [61063](https://github.com/airbytehq/airbyte/pull/61063) | Update dependencies |
 | 0.3.24 | 2025-05-24 | [60437](https://github.com/airbytehq/airbyte/pull/60437) | Update dependencies |

--- a/docs/integrations/sources/pokeapi.md
+++ b/docs/integrations/sources/pokeapi.md
@@ -39,6 +39,7 @@ The PokéAPI uses the same [JSONSchema](https://json-schema.org/understanding-js
 
 | Version | Date       | Pull Request                                             | Subject                                         |
 | :------ | :--------- | :------------------------------------------------------- | :---------------------------------------------- |
+| 0.3.27 | 2025-06-26 | | Fix `nidoran` names |
 | 0.3.26 | 2025-06-21 | [61935](https://github.com/airbytehq/airbyte/pull/61935) | Update dependencies |
 | 0.3.25 | 2025-06-14 | [61063](https://github.com/airbytehq/airbyte/pull/61063) | Update dependencies |
 | 0.3.24 | 2025-05-24 | [60437](https://github.com/airbytehq/airbyte/pull/60437) | Update dependencies |


### PR DESCRIPTION
## What

Renamed `nidoranm` and `nidoranf` to `nidoran-m` and `nidoran-f`.

## User Impact

Nidoran is queryable

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._