### PR TITLE
chore: add helper to validate dlq config

### DIFF
--- a/airbyte-cdk/bulk/toolkits/load-dlq/src/integrationTest/kotlin/DlqCheckTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-dlq/src/integrationTest/kotlin/DlqCheckTest.kt
@@ -1,42 +1,54 @@
+/*
+ * Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+ */
+
 import io.airbyte.cdk.load.check.CheckIntegrationTest
 import io.airbyte.cdk.load.check.CheckTestConfig
 import io.airbyte.cdk.load.integrationTest.DLQ_INTEGRATION_TEST_ENV
 import io.airbyte.cdk.load.integrationTest.DlqTestSpec
 
-class DlqCheckTest : CheckIntegrationTest<DlqTestSpec>(
-    successConfigFilenames = listOf(
-        CheckTestConfig(
-            configContents = """
+class DlqCheckTest :
+    CheckIntegrationTest<DlqTestSpec>(
+        successConfigFilenames =
+            listOf(
+                CheckTestConfig(
+                    configContents =
+                        """
                 {
                     "objectStorageConfig":{
                         "storage_type":"None"
                     }
                 }
             """.trimIndent(),
-            name = "No Object Storage Config",
-        ),
-        // TODO, this should become an automated tests, however, the existing tooling is hardcoded
-        // to only pull credentials for a connector, not cdk/toolkits.
-//        CheckTestConfig(
-//            configContents = """
-//                {
-//                    "objectStorageConfig":{
-//                        "storage_type":"S3",
-//                        "format":{"format_type":"CSV","flattening":"Root level flattening"},
-//                        "file_name_format":"{sync_id}-{part_number}-{date}{format_extension}",
-//                        "path_format":"{sync_id}/{namespace}/{stream_name}/",
-//                        "s3_bucket_region":"us-east-2",
-//                        "s3_bucket_name":"dlq-toolkit",
-//                        "bucket_path":"rejected-records"
-//                    }
-//                }
-//            """.trimIndent(),
-//            name = "S3 Object Storage Config",
-//        ),
-    ),
-    failConfigFilenamesAndFailureReasons = mapOf(
-        CheckTestConfig(
-            configContents = """
+                    name = "No Object Storage Config",
+                ),
+                // TODO, this should become an automated tests, however, the existing tooling is
+                // hardcoded
+                // to only pull credentials for a connector, not cdk/toolkits.
+                //        CheckTestConfig(
+                //            configContents = """
+                //                {
+                //                    "objectStorageConfig":{
+                //                        "storage_type":"S3",
+                //                        "format":{"format_type":"CSV","flattening":"Root level
+                // flattening"},
+                //
+                // "file_name_format":"{sync_id}-{part_number}-{date}{format_extension}",
+                //                        "path_format":"{sync_id}/{namespace}/{stream_name}/",
+                //                        "s3_bucket_region":"us-east-2",
+                //                        "s3_bucket_name":"dlq-toolkit",
+                //                        "bucket_path":"rejected-records"
+                //                    }
+                //                }
+                //            """.trimIndent(),
+                //            name = "S3 Object Storage Config",
+                //        ),
+                ),
+        failConfigFilenamesAndFailureReasons =
+            mapOf(
+                CheckTestConfig(
+                    configContents =
+                        """
                 {
                     "objectStorageConfig":{
                         "storage_type":"S3",
@@ -49,9 +61,8 @@ class DlqCheckTest : CheckIntegrationTest<DlqTestSpec>(
                     }
                 }
             """.trimIndent(),
-            name = "S3 Object Storage Config without Credentials",
-        ) to "Could not connect with provided configuration".toPattern(),
-    ),
-    additionalMicronautEnvs = listOf(DLQ_INTEGRATION_TEST_ENV, "aws"),
-) {
-}
+                    name = "S3 Object Storage Config without Credentials",
+                ) to "Could not connect with provided configuration".toPattern(),
+            ),
+        additionalMicronautEnvs = listOf(DLQ_INTEGRATION_TEST_ENV, "aws"),
+    ) {}

--- a/airbyte-cdk/bulk/toolkits/load-dlq/src/integrationTest/kotlin/DlqCheckTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-dlq/src/integrationTest/kotlin/DlqCheckTest.kt
@@ -1,0 +1,57 @@
+import io.airbyte.cdk.load.check.CheckIntegrationTest
+import io.airbyte.cdk.load.check.CheckTestConfig
+import io.airbyte.cdk.load.integrationTest.DLQ_INTEGRATION_TEST_ENV
+import io.airbyte.cdk.load.integrationTest.DlqTestSpec
+
+class DlqCheckTest : CheckIntegrationTest<DlqTestSpec>(
+    successConfigFilenames = listOf(
+        CheckTestConfig(
+            configContents = """
+                {
+                    "objectStorageConfig":{
+                        "storage_type":"None"
+                    }
+                }
+            """.trimIndent(),
+            name = "No Object Storage Config",
+        ),
+        // TODO, this should become an automated tests, however, the existing tooling is hardcoded
+        // to only pull credentials for a connector, not cdk/toolkits.
+//        CheckTestConfig(
+//            configContents = """
+//                {
+//                    "objectStorageConfig":{
+//                        "storage_type":"S3",
+//                        "format":{"format_type":"CSV","flattening":"Root level flattening"},
+//                        "file_name_format":"{sync_id}-{part_number}-{date}{format_extension}",
+//                        "path_format":"{sync_id}/{namespace}/{stream_name}/",
+//                        "s3_bucket_region":"us-east-2",
+//                        "s3_bucket_name":"dlq-toolkit",
+//                        "bucket_path":"rejected-records"
+//                    }
+//                }
+//            """.trimIndent(),
+//            name = "S3 Object Storage Config",
+//        ),
+    ),
+    failConfigFilenamesAndFailureReasons = mapOf(
+        CheckTestConfig(
+            configContents = """
+                {
+                    "objectStorageConfig":{
+                        "storage_type":"S3",
+                        "format":{"format_type":"CSV","flattening":"Root level flattening"},
+                        "bucket_path":"destination-shelby",
+                        "file_name_format":"{sync_id}-{part_number}-{date}{format_extension}",
+                        "path_format":"{namespace}/{stream_name}/",
+                        "s3_bucket_name":"yolo",
+                        "s3_bucket_region":"us-west-1"
+                    }
+                }
+            """.trimIndent(),
+            name = "S3 Object Storage Config without Credentials",
+        ) to "Could not connect with provided configuration".toPattern(),
+    ),
+    additionalMicronautEnvs = listOf(DLQ_INTEGRATION_TEST_ENV, "aws"),
+) {
+}

--- a/airbyte-cdk/bulk/toolkits/load-dlq/src/integrationTest/kotlin/DlqTestLoader.kt
+++ b/airbyte-cdk/bulk/toolkits/load-dlq/src/integrationTest/kotlin/DlqTestLoader.kt
@@ -7,6 +7,8 @@ package io.airbyte.cdk.load.integrationTest
 import DlqStateWithRecordSample
 import io.airbyte.cdk.command.ConfigurationSpecification
 import io.airbyte.cdk.load.MockObjectStorageClient
+import io.airbyte.cdk.load.check.DestinationChecker
+import io.airbyte.cdk.load.check.dlq.DlqChecker
 import io.airbyte.cdk.load.command.DestinationCatalog
 import io.airbyte.cdk.load.command.DestinationConfiguration
 import io.airbyte.cdk.load.command.DestinationConfigurationFactory
@@ -98,6 +100,14 @@ class DlqTestFactory {
         object : ObjectLoader {
             override val inputPartitions = 1
             override val numPartWorkers = 1
+        }
+
+    @Singleton
+    fun checker(dlqChecker: DlqChecker) =
+        object : DestinationChecker<DlqTestConfig> {
+            override fun check(config: DlqTestConfig) {
+                dlqChecker.check(config.objectStorageConfig)
+            }
         }
 
     @Singleton

--- a/airbyte-cdk/bulk/toolkits/load-dlq/src/main/kotlin/io/airbyte/cdk/load/check/dlq/DlqChecker.kt
+++ b/airbyte-cdk/bulk/toolkits/load-dlq/src/main/kotlin/io/airbyte/cdk/load/check/dlq/DlqChecker.kt
@@ -1,0 +1,98 @@
+package io.airbyte.cdk.load.check.dlq
+
+import io.airbyte.cdk.load.command.Append
+import io.airbyte.cdk.load.command.DestinationStream
+import io.airbyte.cdk.load.command.NamespaceMapper
+import io.airbyte.cdk.load.command.dlq.DisabledObjectStorageConfig
+import io.airbyte.cdk.load.command.dlq.ObjectStorageConfig
+import io.airbyte.cdk.load.command.dlq.S3ObjectStorageConfig
+import io.airbyte.cdk.load.command.object_storage.ObjectStorageCompressionConfigurationProvider
+import io.airbyte.cdk.load.command.object_storage.ObjectStorageFormatConfigurationProvider
+import io.airbyte.cdk.load.command.object_storage.ObjectStoragePathConfigurationProvider
+import io.airbyte.cdk.load.data.ObjectTypeWithoutSchema
+import io.airbyte.cdk.load.file.StreamProcessor
+import io.airbyte.cdk.load.file.object_storage.ObjectStorageClient
+import io.airbyte.cdk.load.file.object_storage.ObjectStoragePathFactory
+import io.airbyte.cdk.load.file.object_storage.RemoteObject
+import io.airbyte.cdk.load.util.write
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.micronaut.context.BeanProvider
+import jakarta.inject.Singleton
+import java.io.ByteArrayOutputStream
+import java.nio.file.Paths
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
+
+/**
+ * DlqChecker helps actual connector perform a validation of the object storage configuration.
+ */
+@Singleton
+class DlqChecker(private val objectStorageClientProvider: BeanProvider<ObjectStorageClient<*>>) {
+    private val log = KotlinLogging.logger {}
+    private val mockStream = DestinationStream(
+        unmappedNamespace = "testing",
+        unmappedName = "test",
+        importType = Append,
+        schema = ObjectTypeWithoutSchema,
+        generationId = 1,
+        minimumGenerationId = 0,
+        syncId = 1,
+        namespaceMapper = NamespaceMapper()
+    )
+
+    fun check(objectStorageConfig: ObjectStorageConfig) {
+        when (objectStorageConfig) {
+            is DisabledObjectStorageConfig -> {}
+            is S3ObjectStorageConfig<*> -> writeTestBlob(objectStorageConfig)
+        }
+    }
+
+    private fun <T> writeTestBlob(config: T) where
+        T : ObjectStorageConfig,
+        T : ObjectStoragePathConfigurationProvider,
+        T : ObjectStorageFormatConfigurationProvider,
+        T : ObjectStorageCompressionConfigurationProvider<*>
+    {
+        log.info { "Validating ${config.type} configuration for rejected records storage"}
+
+        val path = ObjectStoragePathFactory.from(config).getFinalDirectory(mockStream)
+        val key = Paths.get(path, "_check_test").toString()
+        log.info { "Checking if destination can write $key" }
+
+        runBlocking {
+            writeTestBlob(
+                // We dynamically instantiate the client at this point because explicitly injecting
+                // the client in the DlqChecker would fail when the dead letter queue is disabled.
+                client = objectStorageClientProvider.get(),
+                path = path,
+                key = key,
+                compressor = config.objectStorageCompressionConfiguration.compressor,
+            )
+        }
+    }
+
+    private suspend fun <T : RemoteObject<*>> writeTestBlob(
+        client: ObjectStorageClient<T>,
+        path: String,
+        key: String,
+        compressor: StreamProcessor<*>,
+        ) {
+        var remoteObject: T? = null
+        try {
+            val upload = client.startStreamingUpload(key)
+            val byteStream = ByteArrayOutputStream()
+            compressor.wrapper(byteStream).use { it.write("""{"data":1}""") }
+            upload.uploadPart(byteStream.toByteArray(), 1)
+            remoteObject = upload.complete()
+
+            val results = client.list(path).toList()
+            if (results.isEmpty() || results.find { it.key == key } == null) {
+                throw IllegalStateException("Failed to write to the rejected record storage")
+            }
+            log.info { "Successfully wrote test file: $results"}
+        } finally {
+            remoteObject?.let { client.delete(it) }
+            log.info { "Successfully deleted test file"}
+        }
+    }
+}

--- a/airbyte-cdk/bulk/toolkits/load-dlq/src/main/kotlin/io/airbyte/cdk/load/check/dlq/DlqChecker.kt
+++ b/airbyte-cdk/bulk/toolkits/load-dlq/src/main/kotlin/io/airbyte/cdk/load/check/dlq/DlqChecker.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+ */
+
 package io.airbyte.cdk.load.check.dlq
 
 import io.airbyte.cdk.load.command.Append
@@ -23,22 +27,21 @@ import java.nio.file.Paths
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
 
-/**
- * DlqChecker helps actual connector perform a validation of the object storage configuration.
- */
+/** DlqChecker helps actual connector perform a validation of the object storage configuration. */
 @Singleton
 class DlqChecker(private val objectStorageClientProvider: BeanProvider<ObjectStorageClient<*>>) {
     private val log = KotlinLogging.logger {}
-    private val mockStream = DestinationStream(
-        unmappedNamespace = "testing",
-        unmappedName = "test",
-        importType = Append,
-        schema = ObjectTypeWithoutSchema,
-        generationId = 1,
-        minimumGenerationId = 0,
-        syncId = 1,
-        namespaceMapper = NamespaceMapper()
-    )
+    private val mockStream =
+        DestinationStream(
+            unmappedNamespace = "testing",
+            unmappedName = "test",
+            importType = Append,
+            schema = ObjectTypeWithoutSchema,
+            generationId = 1,
+            minimumGenerationId = 0,
+            syncId = 1,
+            namespaceMapper = NamespaceMapper()
+        )
 
     fun check(objectStorageConfig: ObjectStorageConfig) {
         when (objectStorageConfig) {
@@ -48,12 +51,11 @@ class DlqChecker(private val objectStorageClientProvider: BeanProvider<ObjectSto
     }
 
     private fun <T> writeTestBlob(config: T) where
-        T : ObjectStorageConfig,
-        T : ObjectStoragePathConfigurationProvider,
-        T : ObjectStorageFormatConfigurationProvider,
-        T : ObjectStorageCompressionConfigurationProvider<*>
-    {
-        log.info { "Validating ${config.type} configuration for rejected records storage"}
+    T : ObjectStorageConfig,
+    T : ObjectStoragePathConfigurationProvider,
+    T : ObjectStorageFormatConfigurationProvider,
+    T : ObjectStorageCompressionConfigurationProvider<*> {
+        log.info { "Validating ${config.type} configuration for rejected records storage" }
 
         val path = ObjectStoragePathFactory.from(config).getFinalDirectory(mockStream)
         val key = Paths.get(path, "_check_test").toString()
@@ -76,7 +78,7 @@ class DlqChecker(private val objectStorageClientProvider: BeanProvider<ObjectSto
         path: String,
         key: String,
         compressor: StreamProcessor<*>,
-        ) {
+    ) {
         var remoteObject: T? = null
         try {
             val upload = client.startStreamingUpload(key)
@@ -89,10 +91,10 @@ class DlqChecker(private val objectStorageClientProvider: BeanProvider<ObjectSto
             if (results.isEmpty() || results.find { it.key == key } == null) {
                 throw IllegalStateException("Failed to write to the rejected record storage")
             }
-            log.info { "Successfully wrote test file: $results"}
+            log.info { "Successfully wrote test file: $results" }
         } finally {
             remoteObject?.let { client.delete(it) }
-            log.info { "Successfully deleted test file"}
+            log.info { "Successfully deleted test file" }
         }
     }
 }


### PR DESCRIPTION
## What

When leveraging the `dlq-toolkit`, a connector's check operation should validate the object storage config is correct.

This PR adds a `DlqChecker` that a connector can reuse in order to validate the configuration.

Example
```
        @Singleton
        class MyChecker(private val dlqChecker: DlqChecker) : DestinationChecker<DlqTestConfig> {
            override fun check(config: DlqTestConfig) {
                // This validates the ObjectStorageConfig
                dlqChecker.check(config.objectStorageConfig)

                TODO("Validate what MyChecker actually needs")
            }
        }
```

Closes https://github.com/airbytehq/airbyte-internal-issues/issues/13339

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
