### PR TITLE
refactor: push path fix down into readers

### DIFF
--- a/airbyte-cdk/bulk/toolkits/load-avro/src/testFixtures/kotlin/io/airbyte/cdk/load/file/avro/AvroReader.kt
+++ b/airbyte-cdk/bulk/toolkits/load-avro/src/testFixtures/kotlin/io/airbyte/cdk/load/file/avro/AvroReader.kt
@@ -5,6 +5,7 @@
 package io.airbyte.cdk.load.file.avro
 
 import io.airbyte.cdk.load.command.DestinationStream
+import io.airbyte.cdk.load.data.Transformations
 import java.io.Closeable
 import java.io.InputStream
 import kotlin.io.path.outputStream
@@ -38,7 +39,8 @@ fun InputStream.toAvroReader(streamDescriptor: DestinationStream.Descriptor): Av
     val reader = GenericDatumReader<GenericRecord>()
     val tmpFile =
         kotlin.io.path.createTempFile(
-            prefix = "${streamDescriptor.namespace}.${streamDescriptor.name}",
+            prefix =
+                "${streamDescriptor.namespace}.${Transformations.toAlphanumericAndUnderscore(streamDescriptor.name)}",
             suffix = ".avro",
         )
     tmpFile.outputStream().use { outputStream -> this.copyTo(outputStream) }

--- a/airbyte-cdk/bulk/toolkits/load-parquet/src/testFixtures/kotlin/io/airbyte/cdk/load/file/parquet/ParquetReader.kt
+++ b/airbyte-cdk/bulk/toolkits/load-parquet/src/testFixtures/kotlin/io/airbyte/cdk/load/file/parquet/ParquetReader.kt
@@ -5,6 +5,7 @@
 package io.airbyte.cdk.load.file.parquet
 
 import io.airbyte.cdk.load.command.DestinationStream
+import io.airbyte.cdk.load.data.Transformations
 import java.io.Closeable
 import java.io.File
 import java.io.InputStream
@@ -34,7 +35,8 @@ class ParquetReader(
 fun InputStream.toParquetReader(descriptor: DestinationStream.Descriptor): ParquetReader {
     val tmpFile =
         kotlin.io.path.createTempFile(
-            prefix = "${descriptor.namespace}.${descriptor.name}",
+            prefix =
+                "${descriptor.namespace}.${Transformations.toAlphanumericAndUnderscore(descriptor.name)}",
             suffix = ".avro"
         )
     tmpFile.outputStream().use { outputStream -> this.copyTo(outputStream) }


### PR DESCRIPTION
## What
* Push fix to transform name into readers

## How
* Move the use fo `Transformations` into the specific test readers

## Review guide
1. `AvroReader.kt`
2. `ParquetReader.kt`
3. `ObjectStorageDataDumper.kt`

## Can this PR be safely reverted and rolled back?
- [X] YES 💚
- [ ] NO ❌
