### PR TITLE
chore: make dlq config optional

### DIFF
--- a/airbyte-cdk/bulk/toolkits/load-dlq/src/integrationTest/kotlin/DlqCheckTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-dlq/src/integrationTest/kotlin/DlqCheckTest.kt
@@ -15,7 +15,7 @@ class DlqCheckTest :
                     configContents =
                         """
                 {
-                    "objectStorageConfig":{
+                    "object_storage_config":{
                         "storage_type":"None"
                     }
                 }
@@ -23,12 +23,11 @@ class DlqCheckTest :
                     name = "No Object Storage Config",
                 ),
                 // TODO, this should become an automated tests, however, the existing tooling is
-                // hardcoded
-                // to only pull credentials for a connector, not cdk/toolkits.
+                // hardcoded to only pull credentials for a connector, not cdk/toolkits.
                 //        CheckTestConfig(
                 //            configContents = """
                 //                {
-                //                    "objectStorageConfig":{
+                //                    "object_storage_config":{
                 //                        "storage_type":"S3",
                 //                        "format":{"format_type":"CSV","flattening":"Root level
                 // flattening"},
@@ -50,7 +49,7 @@ class DlqCheckTest :
                     configContents =
                         """
                 {
-                    "objectStorageConfig":{
+                    "object_storage_config":{
                         "storage_type":"S3",
                         "format":{"format_type":"CSV","flattening":"Root level flattening"},
                         "bucket_path":"destination-shelby",

--- a/airbyte-cdk/bulk/toolkits/load-dlq/src/integrationTest/kotlin/DlqTestLoader.kt
+++ b/airbyte-cdk/bulk/toolkits/load-dlq/src/integrationTest/kotlin/DlqTestLoader.kt
@@ -5,7 +5,6 @@
 package io.airbyte.cdk.load.integrationTest
 
 import DlqStateWithRecordSample
-import io.airbyte.cdk.command.ConfigurationSpecification
 import io.airbyte.cdk.load.MockObjectStorageClient
 import io.airbyte.cdk.load.check.DestinationChecker
 import io.airbyte.cdk.load.check.dlq.DlqChecker
@@ -13,10 +12,9 @@ import io.airbyte.cdk.load.command.DestinationCatalog
 import io.airbyte.cdk.load.command.DestinationConfiguration
 import io.airbyte.cdk.load.command.DestinationConfigurationFactory
 import io.airbyte.cdk.load.command.DestinationStream
-import io.airbyte.cdk.load.command.dlq.DisabledObjectStorageSpec
+import io.airbyte.cdk.load.command.dlq.ConfigurationSpecificationWithDlq
 import io.airbyte.cdk.load.command.dlq.ObjectStorageConfig
 import io.airbyte.cdk.load.command.dlq.ObjectStorageConfigProvider
-import io.airbyte.cdk.load.command.dlq.ObjectStorageSpec
 import io.airbyte.cdk.load.command.dlq.toObjectStorageConfig
 import io.airbyte.cdk.load.file.object_storage.ObjectStorageClient
 import io.airbyte.cdk.load.message.DestinationRecordRaw
@@ -37,9 +35,7 @@ import jakarta.inject.Singleton
 const val DLQ_INTEGRATION_TEST_ENV = "dlq-integration-test"
 const val DLQ_SAMPLE_TEST = "dlq-sample-test"
 
-class DlqTestSpec : ConfigurationSpecification() {
-    val objectStorageConfig: ObjectStorageSpec = DisabledObjectStorageSpec()
-}
+class DlqTestSpec : ConfigurationSpecificationWithDlq()
 
 class DlqTestConfig(override val objectStorageConfig: ObjectStorageConfig) :
     DestinationConfiguration(), ObjectStorageConfigProvider

--- a/airbyte-cdk/bulk/toolkits/load-dlq/src/integrationTest/kotlin/DlqWriteTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-dlq/src/integrationTest/kotlin/DlqWriteTest.kt
@@ -134,7 +134,18 @@ open class AbstractDlqWriteTest(
 
 class NoBucketDlqWriteTest :
     AbstractDlqWriteTest(
-        configContent = """{"objectStorageConfig":{"storage_type":"None"}}""",
+        configContent = """{"object_storage_config":{"storage_type":"None"}}""",
+        additionalMicronautEnvs = listOf(DLQ_INTEGRATION_TEST_ENV)
+    ) {
+    @Test
+    override fun testBasicWrite() {
+        super.testBasicWrite()
+    }
+}
+
+class NoBucketConfigDlqWriteTest :
+    AbstractDlqWriteTest(
+        configContent = """{}""",
         additionalMicronautEnvs = listOf(DLQ_INTEGRATION_TEST_ENV)
     ) {
     @Test
@@ -145,7 +156,7 @@ class NoBucketDlqWriteTest :
 
 class MockBucketDlqFromRecordSampleTest :
     AbstractDlqWriteTest(
-        configContent = """{"objectStorageConfig":{"storage_type":"S3"}}""",
+        configContent = """{"object_storage_config":{"storage_type":"S3"}}""",
         additionalMicronautEnvs = listOf("MockObjectStorage", DLQ_INTEGRATION_TEST_ENV),
     ) {
     @Test
@@ -156,7 +167,7 @@ class MockBucketDlqFromRecordSampleTest :
 
 class MockBucketDlqFromNewRecordsTest :
     AbstractDlqWriteTest(
-        configContent = """{"objectStorageConfig":{"storage_type":"S3"}}""",
+        configContent = """{"object_storage_config":{"storage_type":"S3"}}""",
         additionalMicronautEnvs =
             listOf("MockObjectStorage", DLQ_INTEGRATION_TEST_ENV, DLQ_SAMPLE_TEST),
     ) {

--- a/airbyte-cdk/bulk/toolkits/load-dlq/src/main/kotlin/io/airbyte/cdk/load/check/dlq/DlqChecker.kt
+++ b/airbyte-cdk/bulk/toolkits/load-dlq/src/main/kotlin/io/airbyte/cdk/load/check/dlq/DlqChecker.kt
@@ -55,7 +55,7 @@ class DlqChecker(private val objectStorageClientProvider: BeanProvider<ObjectSto
     T : ObjectStoragePathConfigurationProvider,
     T : ObjectStorageFormatConfigurationProvider,
     T : ObjectStorageCompressionConfigurationProvider<*> {
-        log.info { "Validating ${config.type} configuration for rejected records storage" }
+        log.info { "Validating ${config.type} configuration for object storage" }
 
         val path = ObjectStoragePathFactory.from(config).getFinalDirectory(mockStream)
         val key = Paths.get(path, "_check_test").toString()
@@ -89,7 +89,7 @@ class DlqChecker(private val objectStorageClientProvider: BeanProvider<ObjectSto
 
             val results = client.list(path).toList()
             if (results.isEmpty() || results.find { it.key == key } == null) {
-                throw IllegalStateException("Failed to write to the rejected record storage")
+                throw IllegalStateException("Failed to write to the object storage")
             }
             log.info { "Successfully wrote test file: $results" }
         } finally {

--- a/airbyte-cdk/bulk/toolkits/load-dlq/src/main/kotlin/io/airbyte/cdk/load/command/dlq/ObjectStorageConfig.kt
+++ b/airbyte-cdk/bulk/toolkits/load-dlq/src/main/kotlin/io/airbyte/cdk/load/command/dlq/ObjectStorageConfig.kt
@@ -48,8 +48,9 @@ class S3ObjectStorageConfig<T : OutputStream>(
     override val type: String = "S3"
 }
 
-fun ObjectStorageSpec.toObjectStorageConfig(): ObjectStorageConfig =
+fun ObjectStorageSpec?.toObjectStorageConfig(): ObjectStorageConfig =
     when (this) {
+        null -> DisabledObjectStorageConfig()
         is DisabledObjectStorageSpec -> DisabledObjectStorageConfig()
         is S3ObjectStorageSpec ->
             S3ObjectStorageConfig(

--- a/airbyte-cdk/bulk/toolkits/load-dlq/src/main/kotlin/io/airbyte/cdk/load/command/dlq/ObjectStorageSpec.kt
+++ b/airbyte-cdk/bulk/toolkits/load-dlq/src/main/kotlin/io/airbyte/cdk/load/command/dlq/ObjectStorageSpec.kt
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo
 import com.fasterxml.jackson.annotation.JsonValue
 import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaInject
 import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaTitle
+import io.airbyte.cdk.command.ConfigurationSpecification
 import io.airbyte.cdk.load.command.aws.AWSAccessKeySpecification
 import io.airbyte.cdk.load.command.aws.AWSArnRoleSpecification
 import io.airbyte.cdk.load.command.object_storage.CSVFormatSpecification
@@ -20,6 +21,12 @@ import io.airbyte.cdk.load.command.object_storage.ObjectStorageFormatSpecificati
 import io.airbyte.cdk.load.command.object_storage.ObjectStorageFormatSpecificationProvider
 import io.airbyte.cdk.load.command.s3.S3BucketRegion
 import io.airbyte.cdk.load.command.s3.S3BucketSpecification
+
+abstract class ConfigurationSpecificationWithDlq(
+    @get:JsonSchemaTitle("Object Storage Configuration")
+    @get:JsonProperty("object_storage_config")
+    val objectStorageConfig: ObjectStorageSpec? = DisabledObjectStorageSpec(),
+) : ConfigurationSpecification()
 
 enum class ObjectStorageType(@get:JsonValue val type: String) {
     None("None"),

--- a/airbyte-cdk/bulk/toolkits/load-dlq/src/test-integration/resources/expected-spec-cloud.json
+++ b/airbyte-cdk/bulk/toolkits/load-dlq/src/test-integration/resources/expected-spec-cloud.json
@@ -6,7 +6,7 @@
     "type" : "object",
     "additionalProperties" : true,
     "properties" : {
-      "objectStorageConfig" : {
+      "object_storage_config" : {
         "oneOf" : [ {
           "type" : "object",
           "additionalProperties" : true,
@@ -178,10 +178,10 @@
           "title" : "S3",
           "required" : [ "storage_type", "s3_bucket_name", "s3_bucket_region", "bucket_path", "format" ]
         } ],
+        "title" : "Object Storage Configuration",
         "type" : "object"
       }
-    },
-    "required" : [ "objectStorageConfig" ]
+    }
   },
   "supportsIncremental" : true,
   "supportsNormalization" : false,

--- a/airbyte-cdk/bulk/toolkits/load-dlq/src/test-integration/resources/expected-spec-oss.json
+++ b/airbyte-cdk/bulk/toolkits/load-dlq/src/test-integration/resources/expected-spec-oss.json
@@ -6,7 +6,7 @@
     "type" : "object",
     "additionalProperties" : true,
     "properties" : {
-      "objectStorageConfig" : {
+      "object_storage_config" : {
         "oneOf" : [ {
           "type" : "object",
           "additionalProperties" : true,
@@ -178,10 +178,10 @@
           "title" : "S3",
           "required" : [ "storage_type", "s3_bucket_name", "s3_bucket_region", "bucket_path", "format" ]
         } ],
+        "title" : "Object Storage Configuration",
         "type" : "object"
       }
-    },
-    "required" : [ "objectStorageConfig" ]
+    }
   },
   "supportsIncremental" : true,
   "supportsNormalization" : false,

--- a/airbyte-cdk/bulk/toolkits/load-dlq/src/test/kotlin/io/airbyte/cdk/load/write/dlq/DeadLetterQueueTestConfig.kt
+++ b/airbyte-cdk/bulk/toolkits/load-dlq/src/test/kotlin/io/airbyte/cdk/load/write/dlq/DeadLetterQueueTestConfig.kt
@@ -4,13 +4,11 @@
 
 package io.airbyte.cdk.load.write.dlq
 
-import io.airbyte.cdk.command.ConfigurationSpecification
 import io.airbyte.cdk.load.command.DestinationConfiguration
 import io.airbyte.cdk.load.command.DestinationConfigurationFactory
-import io.airbyte.cdk.load.command.dlq.DisabledObjectStorageSpec
+import io.airbyte.cdk.load.command.dlq.ConfigurationSpecificationWithDlq
 import io.airbyte.cdk.load.command.dlq.ObjectStorageConfig
 import io.airbyte.cdk.load.command.dlq.ObjectStorageConfigProvider
-import io.airbyte.cdk.load.command.dlq.ObjectStorageSpec
 import io.airbyte.cdk.load.command.dlq.toObjectStorageConfig
 import io.airbyte.cdk.load.message.DestinationRecordRaw
 import io.airbyte.cdk.load.message.StreamKey
@@ -44,10 +42,7 @@ class DeadLetterQueueTestLoader : DlqLoader<DeadLetterQueueTestAggregator> {
     }
 }
 
-@Singleton
-class DeadLetterQueueTestSpecification : ConfigurationSpecification() {
-    val objectStorageConfig: ObjectStorageSpec = DisabledObjectStorageSpec()
-}
+@Singleton class DeadLetterQueueTestSpecification : ConfigurationSpecificationWithDlq()
 
 @Singleton
 class DeadLetterQueueTestConfigurationFactory :

--- a/airbyte-cdk/bulk/toolkits/load-dlq/src/test/kotlin/io/airbyte/cdk/load/write/dlq/NoDeadLetterQueueMicronautTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-dlq/src/test/kotlin/io/airbyte/cdk/load/write/dlq/NoDeadLetterQueueMicronautTest.kt
@@ -19,7 +19,7 @@ import org.junit.jupiter.api.Test
 private const val TEST_CONFIG =
     """
     {
-        "objectStorageConfig":{
+        "object_storage_config":{
             "storage_type":"None"
         }
     }

--- a/airbyte-cdk/bulk/toolkits/load-dlq/src/test/kotlin/io/airbyte/cdk/load/write/dlq/S3DeadLetterQueueMicronautTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-dlq/src/test/kotlin/io/airbyte/cdk/load/write/dlq/S3DeadLetterQueueMicronautTest.kt
@@ -19,7 +19,7 @@ import org.junit.jupiter.api.Test
 private const val TEST_CONFIG =
     """
     {
-        "objectStorageConfig":{
+        "object_storage_config":{
             "storage_type":"S3",
             "format":{"format_type":"CSV","flattening":"Root level flattening"},
             "bucket_path":"destination-shelby",


### PR DESCRIPTION
## What

A couple more adjustments on the DLQ config:
* Make it optional in the spec but with a default to None in the code to avoid the nullable
* Add a `ConnectorSpecificationWithDlq` base class. This has the advantage to provide the config as well as keeping the annotations so that connectors inheriting this do not need to redefined the JsonSchema annotations
* Leverage the `ConnectorSpecificationWithDlq` to default the parameter name to `object_storage_config` (instead of the camelCase default).
* Since we defaulting to "object storage", align the logs in the `DlqChecker`

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
