### PR TITLE
Destination S3: Reconcile metadata

### DIFF
--- a/airbyte-integrations/connectors/destination-s3/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-s3/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: file
   connectorType: destination
   definitionId: 4816b78f-1489-44c1-9060-4b19d5fa9362
-  dockerImageTag: 1.8.7
+  dockerImageTag: 1.8.8
   dockerRepository: airbyte/destination-s3
   githubIssueLabel: destination-s3
   icon: s3.svg
@@ -12,11 +12,8 @@ data:
     baseImage: docker.io/airbyte/java-connector-base:2.0.1@sha256:ec89bd1a89e825514dd2fc8730ba299a3ae1544580a078df0e35c5202c2085b3
   registryOverrides:
     cloud:
-      # Suspect a bug in state message namespace mapping, pinning back to last known-good version
-      dockerImageTag: 1.8.6
       enabled: true
     oss:
-      dockerImageTag: 1.8.6
       enabled: true
   releaseStage: generally_available
   releases:

--- a/docs/integrations/destinations/s3.md
+++ b/docs/integrations/destinations/s3.md
@@ -544,6 +544,7 @@ To see connector limitations, or troubleshoot your S3 connector, see more [in ou
 
 | Version     | Date       | Pull Request                                               | Subject                                                                                                                                              |
 |:------------|:-----------|:-----------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| 1.8.8       | 2025-06-27 | [62127](https://github.com/airbytehq/airbyte/pull/62127)   | Identical to 1.8.6. Image was published from https://github.com/airbytehq/airbyte/pull/62071.                                                        |
 | 1.8.7       | 2025-06-13 | [61588](https://github.com/airbytehq/airbyte/pull/61588)   | ~~Publish version to account for possible duplicate publishing in pipeline. Noop change.~~ WARNING: THIS HAS A BUG. DO NOT USE.                      |
 | 1.8.6       | 2025-05-30 | [60327](https://github.com/airbytehq/airbyte/pull/60327)   | IPC Metadata, internal refactors.                                                                                                                    |
 | 1.8.5       | 2025-05-16 | [60327](https://github.com/airbytehq/airbyte/pull/60327)   | Fixes file partitioning out of bounds error.                                                                                                         |


### PR DESCRIPTION
image was published manually from https://github.com/airbytehq/airbyte/pull/62071 and is now triggering alerts about stale metadata. We should force-merge this PR to silence the alert.

(there's a check in the JVM publish path to avoid republishing existing docker images, so this should be safe)