### PR TITLE
chore: add a quick one liner to fetch the latest version of the bulk cdk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,4 +46,7 @@ tools.git-hooks.install: tools.airbyte-ci.install tools.pre-commit.install.$(OS)
 
 tools.install: tools.airbyte-ci.install tools.pre-commit.install.$(OS)
 
+version.bulk.cdk:
+	@echo "Latest version of the Bulk CDK is $(shell curl -k --silent "https://airbyte.mycloudrepo.io/public/repositories/airbyte-public-jars/io/airbyte/bulk-cdk/bulk-cdk-core-load/maven-metadata.xml" | sed -ne 's:.*<latest>\(.*\)</latest>:\1:p')"
+
 .PHONY: tools.install tools.pre-commit.install tools.git-hooks.install tools.git-hooks.clean tools.airbyte-ci.install tools.airbyte-ci-dev.install tools.airbyte-ci.check tools.airbyte-ci.clean


### PR DESCRIPTION
## What

Add a quick one liner to fetch the latest version of the bulk cdk.

Example:

```
$ make version.bulk.cdk 
Latest version of the Bulk CDK is 0.512
```

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
