### PR TITLE
Redirect /changelog to /release_notes

### DIFF
--- a/docusaurus/vercel.json
+++ b/docusaurus/vercel.json
@@ -42,6 +42,11 @@
       "statusCode": 301
     },
     {
+      "source": "/changelog",
+      "destination": "/release_notes",
+      "statusCode": 301
+    },
+    {
       "source": "/connector-development/config-based/understanding-the-yaml-file/stream-slicers",
       "destination": "/platform/connector-development/config-based/understanding-the-yaml-file/partition-router",
       "statusCode": 301


### PR DESCRIPTION
## What

Redirects /changelog to /release_notes.

## How

Updates vercel.json with a new 301 redirect.

## Review guide

In the Vercel test build, /changelog should not produce a 404 error.

## User Impact


## Can this PR be safely reverted and rolled back?

- [ ] YES 💚
- [ ] NO ❌
