### PR TITLE
ch fix temp table

### DIFF
--- a/airbyte-cdk/bulk/toolkits/load-db/src/main/kotlin/io/airbyte/cdk/load/orchestration/db/DestinationNames.kt
+++ b/airbyte-cdk/bulk/toolkits/load-db/src/main/kotlin/io/airbyte/cdk/load/orchestration/db/DestinationNames.kt
@@ -101,9 +101,7 @@ open class DefaultTempTableNameGenerator(
  * Some destinations don't support moving table between namespace. This will generate a temp table
  * in the same namespace as the origin table.
  */
-class DefaultTempTableNameGeneratorPreserveNamespace(
-    internalNamespace: String,
-) : DefaultTempTableNameGenerator(internalNamespace) {
+class DefaultTempTableNameGeneratorPreserveNamespace() : DefaultTempTableNameGenerator("unused") {
     override fun generate(originalName: TableName): TableName {
         val resolvedTableName = super.generate(originalName)
 

--- a/airbyte-cdk/bulk/toolkits/load-db/src/main/kotlin/io/airbyte/cdk/load/orchestration/db/DestinationNames.kt
+++ b/airbyte-cdk/bulk/toolkits/load-db/src/main/kotlin/io/airbyte/cdk/load/orchestration/db/DestinationNames.kt
@@ -53,7 +53,7 @@ fun interface TempTableNameGenerator {
  * T+D destinations simply appended [TMP_TABLE_SUFFIX] to the table name, and should use
  * [TableName.asOldStyleTempTable] instead
  */
-class DefaultTempTableNameGenerator(
+open class DefaultTempTableNameGenerator(
     private val internalNamespace: String,
     private val affixLength: Int = 8,
     private val affixSeparator: String = "",
@@ -76,6 +76,42 @@ class DefaultTempTableNameGenerator(
             name = "$shortNamespace$shortName$hash",
             namespace = internalNamespace,
         )
+    }
+
+    /**
+     * Examples:
+     * * `"123456".takeFirstAndLastNChars(1, "_") = "1_6"`
+     * * `"123456".takeFirstAndLastNChars(2, "_") = "12_56"`
+     * * `"123456".takeFirstAndLastNChars(3, "_") = "123456"`
+     * * `"123456".takeFirstAndLastNChars(4, "_") = "123456"`
+     */
+    private fun String.takeFirstAndLastNChars(n: Int, separator: String): String {
+        if (length <= 2 * n) {
+            // if the entire string fits within the prefix+suffix substrings,
+            // then just return the original string.
+            return this
+        }
+        val prefix = substring(0, n)
+        val suffix = substring(length - n, length)
+        return "$prefix$separator$suffix"
+    }
+}
+
+/**
+ * better handling for temp table names - e.g. postgres has a 64-char table name limit, so we want
+ * to avoid running into that. This method generates a table name with (by default) at most 64
+ * characters (`4 * affixLength + 2 * affixSeparator.length + hashLength`).
+ *
+ * T+D destinations simply appended [TMP_TABLE_SUFFIX] to the table name, and should use
+ * [TableName.asOldStyleTempTable] instead
+ */
+class DefaultTempTableNameGeneratorPreserveNamespace(
+    private val internalNamespace: String,
+) : DefaultTempTableNameGenerator(internalNamespace) {
+    override fun generate(originalName: TableName): TableName {
+        val resolvedTableName = super.generate(originalName)
+
+        return TableName(name = resolvedTableName.name, namespace = originalName.namespace)
     }
 
     /**

--- a/airbyte-cdk/bulk/toolkits/load-db/src/main/kotlin/io/airbyte/cdk/load/orchestration/db/DestinationNames.kt
+++ b/airbyte-cdk/bulk/toolkits/load-db/src/main/kotlin/io/airbyte/cdk/load/orchestration/db/DestinationNames.kt
@@ -101,7 +101,7 @@ open class DefaultTempTableNameGenerator(
  * Some destinations don't support moving table between namespace. This will generate a temp table
  * in the same namespace as the origin table.
  */
-class DefaultTempTableNameGeneratorPreserveNamespace() : DefaultTempTableNameGenerator("unused") {
+class DefaultTempTableNameGeneratorPreserveNamespace : DefaultTempTableNameGenerator("unused") {
     override fun generate(originalName: TableName): TableName {
         val resolvedTableName = super.generate(originalName)
 

--- a/airbyte-cdk/bulk/toolkits/load-db/src/main/kotlin/io/airbyte/cdk/load/orchestration/db/DestinationNames.kt
+++ b/airbyte-cdk/bulk/toolkits/load-db/src/main/kotlin/io/airbyte/cdk/load/orchestration/db/DestinationNames.kt
@@ -54,7 +54,7 @@ fun interface TempTableNameGenerator {
  * [TableName.asOldStyleTempTable] instead
  */
 open class DefaultTempTableNameGenerator(
-    private val internalNamespace: String,
+    private val internalNamespace: String? = null,
     private val affixLength: Int = 8,
     private val affixSeparator: String = "",
     private val hashLength: Int = 32,
@@ -74,7 +74,7 @@ open class DefaultTempTableNameGenerator(
                 .take(hashLength)
         return TableName(
             name = "$shortNamespace$shortName$hash",
-            namespace = internalNamespace,
+            namespace = internalNamespace ?: originalName.namespace,
         )
     }
 
@@ -94,18 +94,6 @@ open class DefaultTempTableNameGenerator(
         val prefix = substring(0, n)
         val suffix = substring(length - n, length)
         return "$prefix$separator$suffix"
-    }
-}
-
-/**
- * Some destinations don't support moving table between namespace. This will generate a temp table
- * in the same namespace as the origin table.
- */
-class DefaultTempTableNameGeneratorPreserveNamespace : DefaultTempTableNameGenerator("unused") {
-    override fun generate(originalName: TableName): TableName {
-        val resolvedTableName = super.generate(originalName)
-
-        return TableName(name = resolvedTableName.name, namespace = originalName.namespace)
     }
 }
 

--- a/airbyte-cdk/bulk/toolkits/load-db/src/test/kotlin/io/airbyte/cdk/load/toolkits/load/db/orchestration/DefaultTempTableNameGeneratorTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-db/src/test/kotlin/io/airbyte/cdk/load/toolkits/load/db/orchestration/DefaultTempTableNameGeneratorTest.kt
@@ -53,4 +53,24 @@ class DefaultTempTableNameGeneratorTest {
             tempTableName,
         )
     }
+
+    @Test
+    fun testGenerateWithoutNamespace() {
+        val generator = DefaultTempTableNameGenerator()
+        val tempTableName =
+            generator.generate(
+                TableName(
+                    namespace = "a",
+                    name = "1",
+                )
+            )
+        // name and namespace are unchanged
+        // sha256(a_raw__stream_1_airbyte_tmp) is
+        //   b0b9f815c588c797c6616a082f6f2c5862bea54fff8b8c914e3310f4bba57052,
+        //   of which we take the first 32 chars (b0b9f815c588c797c6616a082f6f2c58)
+        assertEquals(
+            TableName("a", "a1b0b9f815c588c797c6616a082f6f2c58"),
+            tempTableName,
+        )
+    }
 }

--- a/airbyte-integrations/connectors/destination-clickhouse-v2/build.gradle
+++ b/airbyte-integrations/connectors/destination-clickhouse-v2/build.gradle
@@ -8,7 +8,7 @@ plugins {
 airbyteBulkConnector {
     core = 'load'
     toolkits = ['load-gcs', 'load-db', 'load-s3']
-    cdk = '0.501'
+    cdk = 'local'
 }
 
 java {

--- a/airbyte-integrations/connectors/destination-clickhouse-v2/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-clickhouse-v2/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: c4510ac6-094f-4ac3-8811-a5582346b9b9
-  dockerImageTag: 0.1.6
+  dockerImageTag: 0.1.7
   dockerRepository: airbyte/destination-clickhouse-v2
   githubIssueLabel: destination-clickhouse-v2
   icon: clickhouse.svg

--- a/airbyte-integrations/connectors/destination-clickhouse-v2/src/main/kotlin/io/airbyte/integrations/destination/clickhouse_v2/client/ClickhouseAirbyteClient.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse-v2/src/main/kotlin/io/airbyte/integrations/destination/clickhouse_v2/client/ClickhouseAirbyteClient.kt
@@ -166,13 +166,12 @@ class ClickhouseAirbyteClient(
             log.info {
                 "Detected deduplication change for table $properTableName, applying deduplication changes"
             }
-            val tempTableName = tempTableNameGenerator.generate(properTableName).name
-            val tempTableInProperNamespace = TableName(properTableName.namespace, tempTableName)
-            execute(sqlGenerator.createNamespace(tempTableInProperNamespace.namespace))
+            val tempTableName = tempTableNameGenerator.generate(properTableName)
+            execute(sqlGenerator.createNamespace(tempTableName.namespace))
             execute(
                 sqlGenerator.createTable(
                     stream,
-                    tempTableInProperNamespace,
+                    tempTableName,
                     columnNameMapping,
                     true,
                 ),
@@ -181,11 +180,11 @@ class ClickhouseAirbyteClient(
                 sqlGenerator.copyTable(
                     columnNameMapping,
                     properTableName,
-                    tempTableInProperNamespace,
+                    tempTableName,
                 ),
             )
-            execute(sqlGenerator.exchangeTable(tempTableInProperNamespace, properTableName))
-            execute(sqlGenerator.dropTable(tempTableInProperNamespace))
+            execute(sqlGenerator.exchangeTable(tempTableName, properTableName))
+            execute(sqlGenerator.dropTable(tempTableName))
         }
     }
 

--- a/airbyte-integrations/connectors/destination-clickhouse-v2/src/main/kotlin/io/airbyte/integrations/destination/clickhouse_v2/client/ClickhouseAirbyteClient.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse-v2/src/main/kotlin/io/airbyte/integrations/destination/clickhouse_v2/client/ClickhouseAirbyteClient.kt
@@ -255,10 +255,12 @@ class ClickhouseAirbyteClient(
     }
 
     internal suspend fun execute(query: String): CommandResponse {
+        log.error { "Executing: $query" }
         return client.execute(query).await()
     }
 
     internal suspend fun query(query: String): QueryResponse {
+        log.error { "Running: $query" }
         return client.query(query).await()
     }
 

--- a/airbyte-integrations/connectors/destination-clickhouse-v2/src/main/kotlin/io/airbyte/integrations/destination/clickhouse_v2/client/ClickhouseAirbyteClient.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse-v2/src/main/kotlin/io/airbyte/integrations/destination/clickhouse_v2/client/ClickhouseAirbyteClient.kt
@@ -166,12 +166,13 @@ class ClickhouseAirbyteClient(
             log.info {
                 "Detected deduplication change for table $properTableName, applying deduplication changes"
             }
-            val tempTableName = tempTableNameGenerator.generate(properTableName)
-            execute(sqlGenerator.createNamespace(tempTableName.namespace))
+            val tempTableName = tempTableNameGenerator.generate(properTableName).name
+            val tempTableInProperNamespace = TableName(properTableName.namespace, tempTableName)
+            execute(sqlGenerator.createNamespace(tempTableInProperNamespace.namespace))
             execute(
                 sqlGenerator.createTable(
                     stream,
-                    tempTableName,
+                    tempTableInProperNamespace,
                     columnNameMapping,
                     true,
                 ),
@@ -180,11 +181,11 @@ class ClickhouseAirbyteClient(
                 sqlGenerator.copyTable(
                     columnNameMapping,
                     properTableName,
-                    tempTableName,
+                    tempTableInProperNamespace,
                 ),
             )
-            execute(sqlGenerator.exchangeTable(tempTableName, properTableName))
-            execute(sqlGenerator.dropTable(tempTableName))
+            execute(sqlGenerator.exchangeTable(tempTableInProperNamespace, properTableName))
+            execute(sqlGenerator.dropTable(tempTableInProperNamespace))
         }
     }
 

--- a/airbyte-integrations/connectors/destination-clickhouse-v2/src/main/kotlin/io/airbyte/integrations/destination/clickhouse_v2/client/ClickhouseAirbyteClient.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse-v2/src/main/kotlin/io/airbyte/integrations/destination/clickhouse_v2/client/ClickhouseAirbyteClient.kt
@@ -255,12 +255,10 @@ class ClickhouseAirbyteClient(
     }
 
     internal suspend fun execute(query: String): CommandResponse {
-        log.error { "Executing: $query" }
         return client.execute(query).await()
     }
 
     internal suspend fun query(query: String): QueryResponse {
-        log.error { "Running: $query" }
         return client.query(query).await()
     }
 

--- a/airbyte-integrations/connectors/destination-clickhouse-v2/src/main/kotlin/io/airbyte/integrations/destination/clickhouse_v2/config/ClickhouseBeanFactory.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse-v2/src/main/kotlin/io/airbyte/integrations/destination/clickhouse_v2/config/ClickhouseBeanFactory.kt
@@ -6,7 +6,7 @@ package io.airbyte.integrations.destination.clickhouse_v2.config
 
 import com.clickhouse.client.api.Client
 import io.airbyte.cdk.command.ConfigurationSpecificationSupplier
-import io.airbyte.cdk.load.orchestration.db.DefaultTempTableNameGeneratorPreserveNamespace
+import io.airbyte.cdk.load.orchestration.db.DefaultTempTableNameGenerator
 import io.airbyte.cdk.load.orchestration.db.TempTableNameGenerator
 import io.airbyte.integrations.destination.clickhouse_v2.spec.ClickhouseConfiguration
 import io.airbyte.integrations.destination.clickhouse_v2.spec.ClickhouseConfigurationFactory
@@ -60,6 +60,5 @@ class ClickhouseBeanFactory {
     }
 
     @Singleton
-    fun tempTableNameGenerator(): TempTableNameGenerator =
-        DefaultTempTableNameGeneratorPreserveNamespace()
+    fun tempTableNameGenerator(): TempTableNameGenerator = DefaultTempTableNameGenerator()
 }

--- a/airbyte-integrations/connectors/destination-clickhouse-v2/src/main/kotlin/io/airbyte/integrations/destination/clickhouse_v2/config/ClickhouseBeanFactory.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse-v2/src/main/kotlin/io/airbyte/integrations/destination/clickhouse_v2/config/ClickhouseBeanFactory.kt
@@ -8,19 +8,14 @@ import com.clickhouse.client.api.Client
 import io.airbyte.cdk.command.ConfigurationSpecificationSupplier
 import io.airbyte.cdk.load.orchestration.db.DefaultTempTableNameGeneratorPreserveNamespace
 import io.airbyte.cdk.load.orchestration.db.TempTableNameGenerator
-import io.airbyte.cdk.load.write.db.DbConstants.DEFAULT_INTERNAL_NAMESPACE
 import io.airbyte.integrations.destination.clickhouse_v2.spec.ClickhouseConfiguration
 import io.airbyte.integrations.destination.clickhouse_v2.spec.ClickhouseConfigurationFactory
 import io.airbyte.integrations.destination.clickhouse_v2.spec.ClickhouseSpecification
 import io.micronaut.context.annotation.Factory
-import jakarta.inject.Named
 import jakarta.inject.Singleton
 
 @Factory
 class ClickhouseBeanFactory {
-
-    @Singleton @Named("internalNamespace") fun internalNamespace() = DEFAULT_INTERNAL_NAMESPACE
-
     @Singleton
     fun clickhouseClient(config: ClickhouseConfiguration): Client {
 
@@ -65,7 +60,6 @@ class ClickhouseBeanFactory {
     }
 
     @Singleton
-    fun tempTableNameGenerator(
-        @Named("internalNamespace") namespace: String,
-    ): TempTableNameGenerator = DefaultTempTableNameGeneratorPreserveNamespace(namespace)
+    fun tempTableNameGenerator(): TempTableNameGenerator =
+        DefaultTempTableNameGeneratorPreserveNamespace()
 }

--- a/airbyte-integrations/connectors/destination-clickhouse-v2/src/main/kotlin/io/airbyte/integrations/destination/clickhouse_v2/config/ClickhouseBeanFactory.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse-v2/src/main/kotlin/io/airbyte/integrations/destination/clickhouse_v2/config/ClickhouseBeanFactory.kt
@@ -7,6 +7,7 @@ package io.airbyte.integrations.destination.clickhouse_v2.config
 import com.clickhouse.client.api.Client
 import io.airbyte.cdk.command.ConfigurationSpecificationSupplier
 import io.airbyte.cdk.load.orchestration.db.DefaultTempTableNameGenerator
+import io.airbyte.cdk.load.orchestration.db.DefaultTempTableNameGeneratorPreserveNamespace
 import io.airbyte.cdk.load.orchestration.db.TempTableNameGenerator
 import io.airbyte.cdk.load.write.db.DbConstants.DEFAULT_INTERNAL_NAMESPACE
 import io.airbyte.integrations.destination.clickhouse_v2.spec.ClickhouseConfiguration
@@ -67,5 +68,5 @@ class ClickhouseBeanFactory {
     @Singleton
     fun tempTableNameGenerator(
         @Named("internalNamespace") namespace: String,
-    ): TempTableNameGenerator = DefaultTempTableNameGenerator(namespace)
+    ): TempTableNameGenerator = DefaultTempTableNameGeneratorPreserveNamespace(namespace)
 }

--- a/airbyte-integrations/connectors/destination-clickhouse-v2/src/main/kotlin/io/airbyte/integrations/destination/clickhouse_v2/config/ClickhouseBeanFactory.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse-v2/src/main/kotlin/io/airbyte/integrations/destination/clickhouse_v2/config/ClickhouseBeanFactory.kt
@@ -6,7 +6,6 @@ package io.airbyte.integrations.destination.clickhouse_v2.config
 
 import com.clickhouse.client.api.Client
 import io.airbyte.cdk.command.ConfigurationSpecificationSupplier
-import io.airbyte.cdk.load.orchestration.db.DefaultTempTableNameGenerator
 import io.airbyte.cdk.load.orchestration.db.DefaultTempTableNameGeneratorPreserveNamespace
 import io.airbyte.cdk.load.orchestration.db.TempTableNameGenerator
 import io.airbyte.cdk.load.write.db.DbConstants.DEFAULT_INTERNAL_NAMESPACE

--- a/airbyte-integrations/connectors/destination-clickhouse-v2/src/main/kotlin/io/airbyte/integrations/destination/clickhouse_v2/write/ClickHouseWriter.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse-v2/src/main/kotlin/io/airbyte/integrations/destination/clickhouse_v2/write/ClickHouseWriter.kt
@@ -17,12 +17,10 @@ import io.airbyte.cdk.load.write.DestinationWriter
 import io.airbyte.cdk.load.write.StreamLoader
 import io.airbyte.cdk.load.write.StreamStateStore
 import io.airbyte.integrations.destination.clickhouse_v2.client.ClickhouseAirbyteClient
-import jakarta.inject.Named
 import jakarta.inject.Singleton
 
 @Singleton
 class ClickHouseWriter(
-    @Named("internalNamespace") private val internalNamespace: String,
     private val names: TableCatalog,
     private val stateGatherer: DatabaseInitialStatusGatherer<DirectLoadInitialStatus>,
     private val streamStateStore: StreamStateStore<DirectLoadTableExecutionConfig>,
@@ -35,7 +33,6 @@ class ClickHouseWriter(
         names.values
             .map { (tableNames, _) -> tableNames.finalTableName!!.namespace }
             .forEach { clickhouseClient.createNamespace(it) }
-        clickhouseClient.createNamespace(internalNamespace)
 
         initialStatuses = stateGatherer.gatherInitialStatus(names)
     }

--- a/docs/integrations/destinations/clickhouse-v2.md
+++ b/docs/integrations/destinations/clickhouse-v2.md
@@ -80,6 +80,7 @@ You can also use a pre-existing user but we highly recommend creating a dedicate
 
 | Version | Date       | Pull Request                                               | Subject                                             |
 |:--------|:-----------|:-----------------------------------------------------------|:----------------------------------------------------|
+| 0.1.7   | 2025-06-24 | [\#62047](https://github.com/airbytehq/airbyte/pull/62047) | Remove the use of the internal namespace.           |
 | 0.1.6   | 2025-06-24 | [\#62047](https://github.com/airbytehq/airbyte/pull/62047) | Hide protocol option when running on cloud.         |
 | 0.1.5   | 2025-06-24 | [\#62043](https://github.com/airbytehq/airbyte/pull/62043) | Expose database protocol config option.             |
 | 0.1.4   | 2025-06-24 | [\#62040](https://github.com/airbytehq/airbyte/pull/62040) | Checker inserts into configured DB.                 |


### PR DESCRIPTION
## What

Clickhouse doesn't support moving data between namespace (databases in clickhouse).
It is causing issues when the sync needs to use a temp table.
This fix is using the table namespace in order to create a temp table. 
That makes the internal workspace unneeded for clickhouse.

## How
<!--
* Describe how code changes achieve the solution.
-->

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
