### PR TITLE
feat: reducing number of assembling between layers

### DIFF
--- a/airbyte-cdk/bulk/toolkits/load-csv/src/main/kotlin/io/airbyte/cdk/load/file/csv/CsvDecoder.kt
+++ b/airbyte-cdk/bulk/toolkits/load-csv/src/main/kotlin/io/airbyte/cdk/load/file/csv/CsvDecoder.kt
@@ -19,10 +19,8 @@ class CsvDecoder(
 ) {
     private val mapper: ObjectMapper = ObjectMapper()
 
-    fun decode(input: InputStream): Stream<JsonNode> {
+    fun decode(input: InputStream): Stream<Map<String, String>> {
         val parser = CSVParser(InputStreamReader(input, StandardCharsets.UTF_8), csvFormat)
-        return parser.stream().map { csvRecord ->
-            mapper.convertValue(csvRecord.toMap(), JsonNode::class.java)
-        }
+        return parser.stream().map { it.toMap() }
     }
 }

--- a/airbyte-cdk/bulk/toolkits/load-csv/src/main/kotlin/io/airbyte/cdk/load/file/csv/CsvDecoder.kt
+++ b/airbyte-cdk/bulk/toolkits/load-csv/src/main/kotlin/io/airbyte/cdk/load/file/csv/CsvDecoder.kt
@@ -4,7 +4,6 @@
 
 package io.airbyte.cdk.load.file.csv
 
-import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import java.io.InputStream
 import java.io.InputStreamReader

--- a/airbyte-cdk/bulk/toolkits/load-csv/src/test/kotlin/io/airbyte/cdk/load/file/csv/CsvDecoderTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-csv/src/test/kotlin/io/airbyte/cdk/load/file/csv/CsvDecoderTest.kt
@@ -4,8 +4,6 @@
 
 package io.airbyte.cdk.load.file.csv
 
-import com.fasterxml.jackson.databind.JsonNode
-import io.airbyte.cdk.util.Jsons
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test

--- a/airbyte-cdk/bulk/toolkits/load-csv/src/test/kotlin/io/airbyte/cdk/load/file/csv/CsvDecoderTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-csv/src/test/kotlin/io/airbyte/cdk/load/file/csv/CsvDecoderTest.kt
@@ -34,12 +34,7 @@ class CsvDecoderTest {
         Assertions.assertEquals(csvEntries[1], recordAtIndex(1))
     }
 
-    private fun recordAtIndex(index: Int): JsonNode {
-        return Jsons.readTree("""
-{
-    "id": "ID_${index}",
-    "value": "value_${index}"
-}
-""")
+    private fun recordAtIndex(index: Int): Map<String, String> {
+        return mapOf("id" to "ID_${index}", "value" to "value_${index}")
     }
 }


### PR DESCRIPTION
## What
Right now for salesforce when parsing failed results, we map from csv -> map -> jsonnode -> map -> dlqrecord. The mapping to jsonnode in the middle is unnecessary hence why we are removing it

[This Salesforce PR](https://github.com/airbytehq/airbyte-enterprise/pull/193) will be updated shortly. EDIT: see [this commit](https://github.com/airbytehq/airbyte-enterprise/pull/193/commits/8b6a156e04b007fbee53b276d5f375aa2f311467)

## How
Return the map directly on the CsvDecoder level. Note that this is breaking change but only salesforce should use it and we'll update it asap so we don't expect much impact here

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
Performance boost probably

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
