### PR TITLE
enterprise repo bypasses version checks

### DIFF
--- a/airbyte-ci/connectors/connectors_qa/src/connectors_qa/checks/version.py
+++ b/airbyte-ci/connectors/connectors_qa/src/connectors_qa/checks/version.py
@@ -38,6 +38,7 @@ class CheckVersionIncrement(Check):
     def _reason_to_skip(self, connector: Connector) -> str | None:
         # TODO: don't run if only files changed are in the bypass list or running in the context of the master branch
         # TODO: get this to work on the private airbyte-enterprise repo
+        print(Path.cwd().absolute().parts)
         if "airbyte-enterprise" in Path.cwd().absolute().parts:
             return "Version bump not enforced for enterprise repo"
         if connector.metadata and connector.metadata.get("ab_internal", {}).get("requireVersionIncrementsInPullRequests") is False:

--- a/airbyte-ci/connectors/connectors_qa/src/connectors_qa/checks/version.py
+++ b/airbyte-ci/connectors/connectors_qa/src/connectors_qa/checks/version.py
@@ -35,13 +35,15 @@ class CheckVersionIncrement(Check):
     # ]
 
     def _should_run(self) -> bool:
-        # Always run
         # TODO: don't run if only files changed are in the bypass list or running in the context of the master branch
+        # TODO: get this to work on the private airbyte-enterprise repo
+        if "airbyte-enterprise" in Path.cwd().absolute():
+            return False
         return True
 
     def _get_master_metadata(self, connector: Connector) -> Dict[str, Any] | None:
         """Get the metadata from the master branch or None if unable to retrieve."""
-        # TODO: test out if this works on the private airbyte-enterprise repo - consider using git-based approach
+        # TODO: get this to work on the private airbyte-enterprise repo
         github_url_prefix = "https://raw.githubusercontent.com/airbytehq/airbyte/master/airbyte-integrations/connectors"
         master_metadata_url = f"{github_url_prefix}/{connector.technical_name}/{consts.METADATA_FILE_NAME}"
         response = requests.get(master_metadata_url)

--- a/airbyte-ci/connectors/connectors_qa/src/connectors_qa/checks/version.py
+++ b/airbyte-ci/connectors/connectors_qa/src/connectors_qa/checks/version.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Airbyte, Inc., all rights reserved.
 
+from pathlib import Path
 from typing import Any, Dict
 
 import requests  # type: ignore

--- a/airbyte-ci/connectors/connectors_qa/src/connectors_qa/checks/version.py
+++ b/airbyte-ci/connectors/connectors_qa/src/connectors_qa/checks/version.py
@@ -38,7 +38,7 @@ class CheckVersionIncrement(Check):
     def _should_run(self) -> bool:
         # TODO: don't run if only files changed are in the bypass list or running in the context of the master branch
         # TODO: get this to work on the private airbyte-enterprise repo
-        if "airbyte-enterprise" in Path.cwd().absolute():
+        if "airbyte-enterprise" in Path.cwd().absolute().parts:
             return False
         return True
 


### PR DESCRIPTION
The connector version check currently only looks at the connectors in the open-source repo. This means that enterprise connectors typically aren't found, and the check allows them to pass as if they are new connectors. If the enterprise connector happens to share a directory name with an open source connector however, the check will erroneously fail and block CI.

In the future, we should improve this check as follows:
- repo-awareness
- key on the connector's docker image name, not the directory name in the source code

For now, we punt on making the version check more sophisticated and simply bypass it for the enterprise repo.

## User Impact
Unblocks CI for DB2 and Oracle enterprise connectors.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
