### PR TITLE
chore: enforce version publishing for connectors that aren't worked on often.

### DIFF
--- a/airbyte-integrations/connectors/destination-csv/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-csv/metadata.yaml
@@ -2,7 +2,6 @@ data:
   ab_internal:
     ql: 100
     sl: 100
-    requireVersionIncrementsInPullRequests: false
   connectorBuildOptions:
     baseImage: docker.io/airbyte/java-connector-base:2.0.1@sha256:ec89bd1a89e825514dd2fc8730ba299a3ae1544580a078df0e35c5202c2085b3
   connectorSubtype: file

--- a/airbyte-integrations/connectors/destination-dynamodb/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-dynamodb/metadata.yaml
@@ -22,7 +22,6 @@ data:
   ab_internal:
     sl: 100
     ql: 200
-    requireVersionIncrementsInPullRequests: false
   supportLevel: community
   connectorTestSuitesOptions:
     - suite: unitTests

--- a/airbyte-integrations/connectors/destination-gcs/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-gcs/metadata.yaml
@@ -2,7 +2,6 @@ data:
   ab_internal:
     ql: 300
     sl: 100
-    requireVersionIncrementsInPullRequests: false
   connectorBuildOptions:
     baseImage: docker.io/airbyte/java-connector-base:2.0.1@sha256:ec89bd1a89e825514dd2fc8730ba299a3ae1544580a078df0e35c5202c2085b3
   connectorSubtype: file

--- a/airbyte-integrations/connectors/destination-kafka/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-kafka/metadata.yaml
@@ -22,7 +22,6 @@ data:
   ab_internal:
     sl: 100
     ql: 100
-    requireVersionIncrementsInPullRequests: false
   supportLevel: community
   connectorTestSuitesOptions:
     - suite: unitTests

--- a/airbyte-integrations/connectors/destination-local-json/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-local-json/metadata.yaml
@@ -2,7 +2,6 @@ data:
   ab_internal:
     ql: 100
     sl: 100
-    requireVersionIncrementsInPullRequests: false
   connectorBuildOptions:
     baseImage: docker.io/airbyte/java-connector-base:2.0.1@sha256:ec89bd1a89e825514dd2fc8730ba299a3ae1544580a078df0e35c5202c2085b3
   connectorSubtype: file

--- a/airbyte-integrations/connectors/destination-mongodb-strict-encrypt/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-mongodb-strict-encrypt/metadata.yaml
@@ -1,6 +1,4 @@
 data:
-  ab_internal:
-    requireVersionIncrementsInPullRequests: false
   connectorBuildOptions:
     baseImage: docker.io/airbyte/java-connector-base:2.0.2@sha256:f8e47304842a2c4d75ac223cf4b3c4117aa1c5c9207149369d296616815fe5b0
   registryOverrides:

--- a/airbyte-integrations/connectors/destination-mongodb/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-mongodb/metadata.yaml
@@ -23,7 +23,6 @@ data:
   ab_internal:
     sl: 100
     ql: 100
-    requireVersionIncrementsInPullRequests: false
   supportLevel: community
   connectorTestSuitesOptions:
     - suite: unitTests

--- a/airbyte-integrations/connectors/destination-mysql-strict-encrypt/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-mysql-strict-encrypt/metadata.yaml
@@ -1,6 +1,4 @@
 data:
-  ab_internal:
-    requireVersionIncrementsInPullRequests: false
   connectorBuildOptions:
     baseImage: docker.io/airbyte/java-connector-base:2.0.1@sha256:ec89bd1a89e825514dd2fc8730ba299a3ae1544580a078df0e35c5202c2085b3
   connectorSubtype: database

--- a/airbyte-integrations/connectors/destination-mysql/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-mysql/metadata.yaml
@@ -2,7 +2,6 @@ data:
   ab_internal:
     ql: 200
     sl: 100
-    requireVersionIncrementsInPullRequests: false
   connectorBuildOptions:
     baseImage: docker.io/airbyte/java-connector-base:2.0.1@sha256:ec89bd1a89e825514dd2fc8730ba299a3ae1544580a078df0e35c5202c2085b3
   connectorSubtype: database

--- a/airbyte-integrations/connectors/destination-oracle-strict-encrypt/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-oracle-strict-encrypt/metadata.yaml
@@ -1,8 +1,6 @@
 data:
   connectorBuildOptions:
     baseImage: docker.io/airbyte/java-connector-base:2.0.2@sha256:f8e47304842a2c4d75ac223cf4b3c4117aa1c5c9207149369d296616815fe5b0
-  ab_internal:
-    requireVersionIncrementsInPullRequests: false
   registryOverrides:
     cloud:
       enabled: false # strict encrypt connectors are deployed to Cloud by their non strict encrypt sibling.

--- a/airbyte-integrations/connectors/destination-oracle/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-oracle/metadata.yaml
@@ -34,7 +34,6 @@ data:
   ab_internal:
     sl: 100
     ql: 200
-    requireVersionIncrementsInPullRequests: false
   supportLevel: community
   connectorTestSuitesOptions:
     - suite: unitTests

--- a/airbyte-integrations/connectors/destination-postgres-strict-encrypt/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-postgres-strict-encrypt/metadata.yaml
@@ -1,6 +1,4 @@
 data:
-  ab_internal:
-    requireVersionIncrementsInPullRequests: false
   connectorSubtype: database
   connectorType: destination
   definitionId: 25c5221d-dce2-4163-ade9-739ef790f503

--- a/airbyte-integrations/connectors/destination-postgres/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-postgres/metadata.yaml
@@ -2,7 +2,6 @@ data:
   ab_internal:
     ql: 200
     sl: 100
-    requireVersionIncrementsInPullRequests: false
   connectorSubtype: database
   connectorType: destination
   definitionId: 25c5221d-dce2-4163-ade9-739ef790f503

--- a/airbyte-integrations/connectors/destination-redis/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-redis/metadata.yaml
@@ -22,7 +22,6 @@ data:
   ab_internal:
     sl: 100
     ql: 100
-    requireVersionIncrementsInPullRequests: false
   supportLevel: community
   connectorTestSuitesOptions:
     - suite: unitTests

--- a/airbyte-integrations/connectors/destination-singlestore/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-singlestore/metadata.yaml
@@ -1,6 +1,4 @@
 data:
-  ab_internal:
-    requireVersionIncrementsInPullRequests: false
   connectorBuildOptions:
     baseImage: docker.io/airbyte/java-connector-base:2.0.2@sha256:f8e47304842a2c4d75ac223cf4b3c4117aa1c5c9207149369d296616815fe5b0
   connectorSubtype: database

--- a/airbyte-integrations/connectors/destination-starburst-galaxy/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-starburst-galaxy/metadata.yaml
@@ -22,7 +22,6 @@ data:
   ab_internal:
     sl: 100
     ql: 100
-    requireVersionIncrementsInPullRequests: false
   supportLevel: community
   connectorTestSuitesOptions:
     - suite: unitTests

--- a/airbyte-integrations/connectors/destination-teradata/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-teradata/metadata.yaml
@@ -29,7 +29,6 @@ data:
   ab_internal:
     sl: 100
     ql: 100
-    requireVersionIncrementsInPullRequests: false
   supportLevel: community
   connectorTestSuitesOptions:
     - suite: unitTests

--- a/airbyte-integrations/connectors/destination-yellowbrick/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-yellowbrick/metadata.yaml
@@ -4,7 +4,6 @@ data:
   ab_internal:
     ql: 200
     sl: 100
-    requireVersionIncrementsInPullRequests: false
   connectorSubtype: database
   connectorType: destination
   definitionId: 1f7bac7e-53ff-4e0b-b6df-b74aa85cf703


### PR DESCRIPTION
## What
As title.

Enforcing version publishing was disabled as part of moving to the new Gradle flow since there was not a good reason to publish these + some of these connectors have red builds we aren't fixing.

Reenabling them so it's clear the connector hasn't accrued code since the last published version.

Some of these builds **WILL** fail as they've been red for a while now.

## How
Re-enable.

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
