### PR TITLE
🐛Source-Paddle - Added constant retry - API docs state wait 60 seconds

### DIFF
--- a/airbyte-integrations/connectors/source-paddle/manifest.yaml
+++ b/airbyte-integrations/connectors/source-paddle/manifest.yaml
@@ -1872,15 +1872,19 @@ schemas:
           - "null"
       customer_id:
         type:
+          - string
           - "null"
       address_id:
         type:
+          - string
           - "null"
       business_id:
         type:
+          - string
           - "null"
       custom_data:
         type:
+          - object
           - "null"
       origin:
         type:
@@ -1892,18 +1896,23 @@ schemas:
           - "null"
       subscription_id:
         type:
+          - string
           - "null"
       invoice_id:
         type:
+          - string
           - "null"
       invoice_number:
         type:
+          - string
           - "null"
       billing_details:
         type:
+          - object
           - "null"
       billing_period:
         type:
+          - object
           - "null"
       currency_code:
         type:
@@ -1911,6 +1920,7 @@ schemas:
           - "null"
       discount_id:
         type:
+          - string
           - "null"
       created_at:
         type:
@@ -1922,9 +1932,11 @@ schemas:
           - "null"
       billed_at:
         type:
+          - string
           - "null"
       revised_at:
         type:
+          - string
           - "null"
       items:
         type:

--- a/airbyte-integrations/connectors/source-paddle/manifest.yaml
+++ b/airbyte-integrations/connectors/source-paddle/manifest.yaml
@@ -624,7 +624,14 @@ definitions:
     authenticator:
       type: BearerAuthenticator
       api_token: "{{ config[\"api_key\"] }}"
-
+    error_handler:
+      type: CompositeErrorHandler
+      error_handlers:
+        - type: DefaultErrorHandler
+          max_retries: 5
+          backoff_strategies:
+            - type: ConstantBackoffStrategy
+              backoff_time_in_seconds: 62
 streams:
   - $ref: "#/definitions/streams/customers"
   - $ref: "#/definitions/streams/customer_addresses"

--- a/airbyte-integrations/connectors/source-paddle/metadata.yaml
+++ b/airbyte-integrations/connectors/source-paddle/metadata.yaml
@@ -17,7 +17,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: eb34e66a-c9b5-41ca-974f-2b82c26ae71a
-  dockerImageTag: 0.0.10
+  dockerImageTag: 0.0.11
   dockerRepository: airbyte/source-paddle
   githubIssueLabel: source-paddle
   icon: icon.svg

--- a/docs/integrations/sources/paddle.md
+++ b/docs/integrations/sources/paddle.md
@@ -33,6 +33,7 @@ API Reference: https://developer.paddle.com/api-reference/overview
 
 | Version          | Date              | Pull Request | Subject        |
 |------------------|-------------------|--------------|----------------|
+| 0.0.11 | 2025-07-01 | [62461](https://github.com/airbytehq/airbyte/pull/62461) | Add constant retry backoff per Paddle API Docs |
 | 0.0.10 | 2025-06-28 | [62318](https://github.com/airbytehq/airbyte/pull/62318) | Update dependencies |
 | 0.0.9 | 2025-06-21 | [61917](https://github.com/airbytehq/airbyte/pull/61917) | Update dependencies |
 | 0.0.8 | 2025-06-14 | [60485](https://github.com/airbytehq/airbyte/pull/60485) | Update dependencies |


### PR DESCRIPTION
## What
This PR adds constant retry to all Paddle API requests following the constant 60 second guidance provided by Paddle API docs: https://developer.paddle.com/api-reference/about/rate-limiting

While in here, I also fixed some bad data types on the transaction stream where strings were getting stored as JSONB strings vs plain strings. 

## How
Added a 62 second constant backoff with 5 retries to the `base_requester `definition.

## Review guide
1. source-paddle/manifest.yaml
2. source-paddle/metadata.yaml
3. docs/integration/sources/paddle.md

## User Impact
API Limits don't cause the connector to fail.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌
