### PR TITLE
fix(source-track-pms): update base docker image sha to allow connector to be published

### DIFF
--- a/airbyte-integrations/connectors/source-track-pms/metadata.yaml
+++ b/airbyte-integrations/connectors/source-track-pms/metadata.yaml
@@ -13,7 +13,7 @@ data:
       enabled: false
       packageName: airbyte-source-track-pms
   connectorBuildOptions:
-    baseImage: docker.io/airbyte/source-declarative-manifest:6.56.7@sha256:7088625f34003128db3c15998910300890bddec564771a0b6e3a58e56601adf9
+    baseImage: docker.io/airbyte/source-declarative-manifest:6.56.7@sha256:41be3ac5f569004b6a25507cd40f5152e3691aecd2a9a3f873eb4c559903412d
   connectorSubtype: api
   connectorType: source
   definitionId: aa0373c1-a7a6-48ff-8277-e5fe6cecff75


### PR DESCRIPTION
## What
This connector wasn't properly published because the metadata file failed our automated checks. See this trace:

```
Validating airbyte-integrations/connectors/source-track-pms/metadata.yaml...
Running validator: validate_all_tags_are_keyvalue_pairs
Running validator: validate_at_least_one_language_tag
Running validator: validate_major_version_bump_has_breaking_change_entry
Running validator: validate_docs_path_exists
Running validator: validate_metadata_base_images_in_dockerhub
Checking that the base images is on dockerhub: docker.io/airbyte/source-declarative-manifest:6.56.7@sha256:7088625f34003128db3c15998910300890bddec564771a0b6e3a58e56601adf9
airbyte-integrations/connectors/source-track-pms/metadata.yaml is not a valid ConnectorMetadataDefinitionV0 YAML file.
Validation error: Image docker.io/airbyte/source-declarative-manifest:6.56.7@sha256:7088625f34003128db3c15998910300890bddec564771a0b6e3a58e56601adf9 does not exist in DockerHub
```

I found the correct image SHA by going to Dockerhub listing for `airbyte/source-declarative-manifest`

## How
<!--
* Describe how code changes achieve the solution.
-->

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
