### PR TITLE
Bulk load CDK: add integration test for weird global state message

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/integrationTest/kotlin/io/airbyte/cdk/load/mock_integration_test/MockBasicFunctionalityIntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/integrationTest/kotlin/io/airbyte/cdk/load/mock_integration_test/MockBasicFunctionalityIntegrationTest.kt
@@ -9,6 +9,7 @@ import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.data.ObjectType
 import io.airbyte.cdk.load.message.CheckpointMessage.Checkpoint
 import io.airbyte.cdk.load.message.InputGlobalCheckpoint
+import io.airbyte.cdk.load.message.InputRecord
 import io.airbyte.cdk.load.message.InputStreamCheckpoint
 import io.airbyte.cdk.load.test.mock.MockDestinationBackend.MOCK_TEST_MICRONAUT_ENVIRONMENT
 import io.airbyte.cdk.load.test.mock.MockDestinationDataDumper
@@ -23,8 +24,13 @@ import io.airbyte.cdk.load.write.DedupBehavior
 import io.airbyte.cdk.load.write.SchematizedNestedValueBehavior
 import io.airbyte.cdk.load.write.UnionBehavior
 import io.airbyte.cdk.load.write.Untyped
+import io.airbyte.protocol.models.v0.AirbyteGlobalState
+import io.airbyte.protocol.models.v0.AirbyteMessage
+import io.airbyte.protocol.models.v0.AirbyteStateMessage
+import io.airbyte.protocol.models.v0.AirbyteStateStats
+import io.airbyte.protocol.models.v0.AirbyteStreamState
+import io.airbyte.protocol.models.v0.StreamDescriptor
 import kotlin.test.assertEquals
-import org.junit.jupiter.api.Assertions.assertDoesNotThrow
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 
@@ -170,26 +176,79 @@ class MockBasicFunctionalityIntegrationTest :
                 syncId = 42,
                 namespaceMapper = namespaceMapperForMedium(),
             )
-        assertDoesNotThrow {
+
+        val returnedMessages =
             runSync(
                 updatedConfig,
                 stream,
                 listOf(
-                    // send a state message for a stream that isn't in the catalog.
-                    // this should cause the sync to crash.
+                    // Send one record, and one global state message
+                    InputRecord(stream, """{"id": 42}""", emittedAtMs = 1234),
                     InputGlobalCheckpoint(
                         Jsons.readTree("""{"foo": "bar"}"""),
                         checkpointKeyForMedium(),
                         listOf(
+                            // This stream state belongs to the stream in the catalog.
+                            Checkpoint(
+                                unmappedNamespace = randomizedNamespace,
+                                unmappedName = "test_stream",
+                                state = Jsons.readTree("""{"abc": "def"}"""),
+                            ),
+                            // This stream state belongs to a stream that isn't in the catalog.
+                            // The sync should still run successfully.
                             Checkpoint(
                                 unmappedNamespace = "potato",
                                 unmappedName = "tomato",
-                                state = Jsons.readTree("""{"foo": "bar"}""")
-                            )
-                        )
+                                state = Jsons.readTree("""{"ghi": "jkl"}"""),
+                            ),
+                        ),
+                        // Obviously doesn't match reality (we only have one InputRecord).
+                        // But the destination isn't responsible for enforcing this, so it's fine.
+                        sourceRecordCount = 42,
                     )
                 ),
             )
-        }
+
+        val returnedStateMessages = returnedMessages.filter { it.type == AirbyteMessage.Type.STATE }
+        assertEquals(
+            1,
+            returnedStateMessages.size,
+            "Expected sync to return exactly one state message. Got $returnedStateMessages",
+        )
+        val returnedStateMessage = returnedStateMessages.first().state
+        assertEquals(
+            AirbyteStateMessage()
+                .withType(AirbyteStateMessage.AirbyteStateType.GLOBAL)
+                // Preserve the original source record count
+                .withSourceStats(AirbyteStateStats().withRecordCount(42.0))
+                // Attach our new destination record count
+                .withDestinationStats(AirbyteStateStats().withRecordCount(1.0))
+                // idk
+                .withAdditionalProperty("committedBytesCount", 139)
+                .withAdditionalProperty("committedRecordsCount", 1)
+                .withGlobal(
+                    AirbyteGlobalState()
+                        .withSharedState(Jsons.readTree("""{"foo": "bar"}"""))
+                        .withStreamStates(
+                            listOf(
+                                AirbyteStreamState()
+                                    .withStreamDescriptor(
+                                        StreamDescriptor()
+                                            .withNamespace(randomizedNamespace)
+                                            .withName("test_stream")
+                                    )
+                                    .withStreamState(Jsons.readTree("""{"abc": "def"}""")),
+                                AirbyteStreamState()
+                                    .withStreamDescriptor(
+                                        StreamDescriptor()
+                                            .withNamespace("potato")
+                                            .withName("tomato")
+                                    )
+                                    .withStreamState(Jsons.readTree("""{"ghi": "jkl"}""")),
+                            )
+                        )
+                ),
+            returnedStateMessage,
+        )
     }
 }

--- a/airbyte-cdk/bulk/core/load/src/integrationTest/kotlin/io/airbyte/cdk/load/mock_integration_test/MockBasicFunctionalityIntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/integrationTest/kotlin/io/airbyte/cdk/load/mock_integration_test/MockBasicFunctionalityIntegrationTest.kt
@@ -223,7 +223,7 @@ class MockBasicFunctionalityIntegrationTest :
                 .withSourceStats(AirbyteStateStats().withRecordCount(42.0))
                 // Attach our new destination record count
                 .withDestinationStats(AirbyteStateStats().withRecordCount(1.0))
-                // idk
+                // attach stats for speed mode
                 .withAdditionalProperty("committedBytesCount", 139)
                 .withAdditionalProperty("committedRecordsCount", 1)
                 .withGlobal(

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/InputMessage.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/InputMessage.kt
@@ -30,6 +30,7 @@ import io.airbyte.protocol.models.v0.AirbyteMessage
 import io.airbyte.protocol.models.v0.AirbyteRecordMessage
 import io.airbyte.protocol.models.v0.AirbyteRecordMessageFileReference
 import io.airbyte.protocol.models.v0.AirbyteStateMessage
+import io.airbyte.protocol.models.v0.AirbyteStateStats
 import io.airbyte.protocol.protobuf.AirbyteMessage.AirbyteMessageProtobuf
 import io.airbyte.protocol.protobuf.AirbyteRecordMessage.AirbyteRecordMessageProtobuf
 import io.airbyte.protocol.protobuf.AirbyteRecordMessage.AirbyteValueProtobuf
@@ -215,6 +216,7 @@ data class InputGlobalCheckpoint(
     val sharedState: JsonNode?,
     val checkpointKey: CheckpointKey? = null,
     val streamStates: List<Checkpoint> = emptyList(),
+    val sourceRecordCount: Long? = null,
 ) : InputCheckpoint {
     override fun asProtocolMessage(): AirbyteMessage =
         AirbyteMessage()
@@ -232,6 +234,10 @@ data class InputGlobalCheckpoint(
                             it.additionalProperties["partition_id"] =
                                 checkpointKey.checkpointId.value
                             it.additionalProperties["id"] = checkpointKey.checkpointIndex.value
+                        }
+                        if (sourceRecordCount != null) {
+                            it.sourceStats =
+                                AirbyteStateStats().withRecordCount(sourceRecordCount.toDouble())
                         }
                     }
             )


### PR DESCRIPTION
## What
for https://github.com/airbytehq/airbyte-internal-issues/issues/13409. I'll see if I can find a place to add actual unit tests, but this at least gives us coverage on the thing that bit us last time.

## How
* add a globalState.streamState entry for a stream that _does_ exist in the catalog
* assert that the returned state message is correct

## Review guide
* InputMessage.kt - InputStreamCheckpoint already had a sourceRecordCount field; do the same for InputGlobalCheckpoint
* MockBasicFunctionalityIntegrationTest.kt - add more stuff to the test

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
