### PR TITLE
fix(source-hubspot): Add error handler to the underlying associations requester so OAuth refresh on 401 is handled properly

### DIFF
--- a/airbyte-integrations/connectors/source-hubspot/components.py
+++ b/airbyte-integrations/connectors/source-hubspot/components.py
@@ -432,7 +432,7 @@ class EntitySchemaNormalization(TypeTransformer):
         try:
             return ab_datetime_parse(datetime_str)
         except (ValueError, TypeError, OverflowError) as ex:
-            logger.warning(f"Couldn't parse date/datetime string field. Timestamp field value: {datetime_str}. Ex: {ex}")
+            pass
 
         try:
             return ab_datetime_parse(int(datetime_str) // 1000)

--- a/airbyte-integrations/connectors/source-hubspot/components.py
+++ b/airbyte-integrations/connectors/source-hubspot/components.py
@@ -27,6 +27,12 @@ from airbyte_cdk.sources.declarative.interpolation import InterpolatedString
 from airbyte_cdk.sources.declarative.migrations.state_migration import StateMigration
 from airbyte_cdk.sources.declarative.partition_routers.list_partition_router import ListPartitionRouter
 from airbyte_cdk.sources.declarative.requesters import HttpRequester
+from airbyte_cdk.sources.declarative.requesters.error_handlers.backoff_strategies import (
+    ExponentialBackoffStrategy,
+    WaitTimeFromHeaderBackoffStrategy,
+)
+from airbyte_cdk.sources.declarative.requesters.error_handlers.default_error_handler import DefaultErrorHandler
+from airbyte_cdk.sources.declarative.requesters.error_handlers.http_response_filter import HttpResponseFilter
 from airbyte_cdk.sources.declarative.requesters.paginators.strategies.pagination_strategy import PaginationStrategy
 from airbyte_cdk.sources.declarative.requesters.request_options import InterpolatedRequestOptionsProvider
 from airbyte_cdk.sources.declarative.requesters.requester import Requester
@@ -612,6 +618,58 @@ def build_associations_retriever(
         authenticator=authenticator,
         request_options_provider=InterpolatedRequestOptionsProvider(
             request_body_json={"inputs": "{{ stream_slice.extra_fields['record_ids'] }}"},
+            config=config,
+            parameters=parameters,
+        ),
+        error_handler=DefaultErrorHandler(
+            backoff_strategies=[
+                WaitTimeFromHeaderBackoffStrategy(header="Retry-After", config=config, parameters=parameters),
+                ExponentialBackoffStrategy(config=config, parameters=parameters),
+            ],
+            response_filters=[
+                HttpResponseFilter(
+                    action="RETRY",
+                    http_codes={429},
+                    error_message="HubSpot rate limit reached (429). Backoff based on 'Retry-After' header, then exponential backoff fallback.",
+                    config=config,
+                    parameters=parameters,
+                ),
+                HttpResponseFilter(
+                    action="RETRY",
+                    http_codes={502, 503},
+                    error_message="HubSpot server error (5xx). Retrying with exponential backoff...",
+                    config=config,
+                    parameters=parameters,
+                ),
+                HttpResponseFilter(
+                    action="RETRY",
+                    http_codes={401},
+                    error_message="Authentication to HubSpot has expired. Authentication will be retried, but if this issue persists, re-authenticate to restore access to HubSpot.",
+                    config=config,
+                    parameters=parameters,
+                ),
+                HttpResponseFilter(
+                    action="FAIL",
+                    http_codes={530},
+                    error_message="The user cannot be authorized with provided credentials. Please verify that your credentials are valid and try again.",
+                    config=config,
+                    parameters=parameters,
+                ),
+                HttpResponseFilter(
+                    action="FAIL",
+                    http_codes={403},
+                    error_message="Access denied (403). The authenticated user does not have permissions to access the resource.",
+                    config=config,
+                    parameters=parameters,
+                ),
+                HttpResponseFilter(
+                    action="FAIL",
+                    http_codes={400},
+                    error_message="Bad request (400). Please verify your credentials and try again.",
+                    config=config,
+                    parameters=parameters,
+                ),
+            ],
             config=config,
             parameters=parameters,
         ),

--- a/airbyte-integrations/connectors/source-hubspot/metadata.yaml
+++ b/airbyte-integrations/connectors/source-hubspot/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 36c891d9-4bd9-43ac-bad2-10e12756272c
-  dockerImageTag: 5.8.10
+  dockerImageTag: 5.8.11-rc.1
   dockerRepository: airbyte/source-hubspot
   documentationUrl: https://docs.airbyte.com/integrations/sources/hubspot
   resourceRequirements:
@@ -37,7 +37,7 @@ data:
   releaseStage: generally_available
   releases:
     rolloutConfiguration:
-      enableProgressiveRollout: false
+      enableProgressiveRollout: true
     breakingChanges:
       5.0.0:
         message: >-

--- a/docs/integrations/sources/hubspot.md
+++ b/docs/integrations/sources/hubspot.md
@@ -333,6 +333,7 @@ The connector is restricted by normal HubSpot [rate limitations](https://legacyd
 
 | Version    | Date       | Pull Request                                             | Subject                                                                                                                                                                                                                      |
 |:-----------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 5.8.11-rc.1 | 2025-07-02 | [62481](https://github.com/airbytehq/airbyte/pull/62481) | For CRMSearch streams, fix retry behavior for the underlying associations HttpRequester to retry 401 errors |
 | 5.8.10 | 2025-06-28 | [62179](https://github.com/airbytehq/airbyte/pull/62179) | Update dependencies |
 | 5.8.9 | 2025-06-21 | [61842](https://github.com/airbytehq/airbyte/pull/61842) | Update dependencies |
 | 5.8.8 | 2025-06-14 | [60640](https://github.com/airbytehq/airbyte/pull/60640) | Update dependencies |


### PR DESCRIPTION
Fixes https://github.com/airbytehq/airbyte/issues/62467

## What

We had a few users reach out about a bug when pulling records from the `contacts` stream where we were not refreshing the OAuth token and therefore very large or long running would not complete properly.

## How

The reason this was happening was that we never instantiated an ErrorHandler on the underlying HttpRequester that we use to fetch associations for a given `contact` (or other CRMSearch stream).

The default error handling logic allowed for most types of retries, but this went unnoticed because Hubspot's returns a 401 response when the OAuth token has expired. The default behavior for 401 Unauthorized is rightfully non-retryable, but for Hubspot specifically we need to retry in order to fetch and use a new token.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌
