### PR TITLE
Skip missing connectors

### DIFF
--- a/poe-tasks/get-modified-connectors.sh
+++ b/poe-tasks/get-modified-connectors.sh
@@ -157,7 +157,12 @@ fi
 non_java_connectors=()
 for c in "${connectors[@]}"; do
   if ! printf '%s\n' "${java_connectors[@]}" | grep -Fxq "$c"; then
-    non_java_connectors+=("$c")
+    if [[ ! -f "$metadata" ]]; then
+      echo "⚠️  metadata.yaml not found for '$c' skipping it" >&2
+      continue
+    elif
+      non_java_connectors+=("$c")
+    fi
   fi
 done
 

--- a/poe-tasks/get-modified-connectors.sh
+++ b/poe-tasks/get-modified-connectors.sh
@@ -94,7 +94,7 @@ if [ -n "$dirs" ]; then
     if [[ -d "$connector_folder" ]]; then
       connectors+=("$d")
     else
-      echo "⚠️  the connector '$c' was not found, skipping it" >&2
+      echo "⚠️  the connector '$d' was not found, skipping it" >&2
     fi
   done <<< "$(printf '%s\n' "$dirs" | sort -u)"
 fi

--- a/poe-tasks/get-modified-connectors.sh
+++ b/poe-tasks/get-modified-connectors.sh
@@ -90,7 +90,12 @@ dirs=$(printf '%s\n' "$connectors_paths" \
 connectors=()
 if [ -n "$dirs" ]; then
   while IFS= read -r d; do
-    connectors+=("$d")
+    connector_folder="airbyte-integrations/connectors/${d}"
+    if [[ -d "$connector_folder" ]]; then
+      connectors+=("$d")
+    else
+      echo "⚠️  the connector '$c' was not found, skipping it" >&2
+    fi
   done <<< "$(printf '%s\n' "$dirs" | sort -u)"
 fi
 
@@ -157,13 +162,7 @@ fi
 non_java_connectors=()
 for c in "${connectors[@]}"; do
   if ! printf '%s\n' "${java_connectors[@]}" | grep -Fxq "$c"; then
-    connector_folder="airbyte-integrations/connectors/${c}"
-    if [[ -d "$connector_folder" ]]; then
-      non_java_connectors+=("$c")
-    else
-      echo "⚠️  the connector '$c' not found, skipping it" >&2
-      continue
-    fi
+    non_java_connectors+=("$c")
   fi
 done
 

--- a/poe-tasks/get-modified-connectors.sh
+++ b/poe-tasks/get-modified-connectors.sh
@@ -157,11 +157,12 @@ fi
 non_java_connectors=()
 for c in "${connectors[@]}"; do
   if ! printf '%s\n' "${java_connectors[@]}" | grep -Fxq "$c"; then
-    if [[ ! -f "$metadata" ]]; then
-      echo "⚠️  metadata.yaml not found for '$c' skipping it" >&2
-      continue
-    elif
+    connector_folder="airbyte-integrations/connectors/${c}"
+    if [[ -d "$connector_folder" ]]; then
       non_java_connectors+=("$c")
+    else
+      echo "⚠️  the connector '$c' not found, skipping it" >&2
+      continue
     fi
   fi
 done

--- a/poe-tasks/get-modified-connectors.sh
+++ b/poe-tasks/get-modified-connectors.sh
@@ -94,7 +94,7 @@ if [ -n "$dirs" ]; then
     if [[ -d "$connector_folder" ]]; then
       connectors+=("$d")
     else
-      echo "⚠️  the connector '$d' was not found, skipping it" >&2
+      echo "⚠️ '$d' directory was not found. This can happen if a connector is removed. Skipping." >&2
     fi
   done <<< "$(printf '%s\n' "$dirs" | sort -u)"
 fi


### PR DESCRIPTION
## What
When we are removing a connector, we are still trying to build it. This is causing the build to fail (example: https://github.com/airbytehq/airbyte/actions/runs/16010953346/job/45168438261?pr=62474)

This PR skip all connectors without a folder.

## How
<!--
* Describe how code changes achieve the solution.
-->

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
