### PR TITLE
fix: poe cmd for CATs

### DIFF
--- a/poe-tasks/manifest-only-connector-tasks.toml
+++ b/poe-tasks/manifest-only-connector-tasks.toml
@@ -10,7 +10,7 @@
 
 [tasks]
 
-get-connector-name = 'basename "$PWD"' # Use with -qq to get just the connector name
+get-connector-name = "basename ${POE_PWD}" # Use with -qq to get just the connector name
 fetch-secrets = "airbyte-cdk secrets fetch ${POE_PWD}"
 
 install = [


### PR DESCRIPTION
## What
Found a bug in the `poe run-cat-tests` for manifest only connectors. When run from the `source-whatever/` directory, the  command would return "`connectors`" since the `$PWD` in the `poe get-connector-name` command evaluates to the directory of where the command was initiated (i.e. the directory of the poe tasks file `airbyte-integrations/connectors/poe_tasks.toml`). This should fix the command to use the directory of the original caller of the poe task.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
