### PR TITLE
fix(source-snapchat-marketing): Fix end datetime to include today

### DIFF
--- a/airbyte-integrations/connectors/source-snapchat-marketing/manifest.yaml
+++ b/airbyte-integrations/connectors/source-snapchat-marketing/manifest.yaml
@@ -64,7 +64,7 @@ definitions:
         cursor_field: updated_at
         end_datetime:
           type: MinMaxDatetime
-          datetime: "{{ config.get('end_date', now_utc().strftime('%Y-%m-%d')) }}"
+          datetime: "{{ config.get('end_date', day_delta(1, format='%Y-%m-%d')) }}"
           datetime_format: "%Y-%m-%d"
         start_datetime:
           type: MinMaxDatetime
@@ -142,7 +142,7 @@ definitions:
         cursor_field: updated_at
         end_datetime:
           type: MinMaxDatetime
-          datetime: "{{ config.get('end_date', now_utc().strftime('%Y-%m-%d')) }}"
+          datetime: "{{ config.get('end_date', day_delta(1, format='%Y-%m-%d')) }}"
           datetime_format: "%Y-%m-%d"
         start_datetime:
           type: MinMaxDatetime
@@ -211,7 +211,7 @@ definitions:
         cursor_field: updated_at
         end_datetime:
           type: MinMaxDatetime
-          datetime: "{{ config.get('end_date', now_utc().strftime('%Y-%m-%d')) }}"
+          datetime: "{{ config.get('end_date', day_delta(1, format='%Y-%m-%d')) }}"
           datetime_format: "%Y-%m-%d"
         start_datetime:
           type: MinMaxDatetime
@@ -280,7 +280,7 @@ definitions:
         cursor_field: updated_at
         end_datetime:
           type: MinMaxDatetime
-          datetime: "{{ config.get('end_date', now_utc().strftime('%Y-%m-%d')) }}"
+          datetime: "{{ config.get('end_date', day_delta(1, format='%Y-%m-%d')) }}"
           datetime_format: "%Y-%m-%d"
         start_datetime:
           type: MinMaxDatetime
@@ -349,7 +349,7 @@ definitions:
         cursor_field: updated_at
         end_datetime:
           type: MinMaxDatetime
-          datetime: "{{ config.get('end_date', now_utc().strftime('%Y-%m-%d')) }}"
+          datetime: "{{ config.get('end_date', day_delta(1, format='%Y-%m-%d')) }}"
           datetime_format: "%Y-%m-%d"
         start_datetime:
           type: MinMaxDatetime
@@ -418,7 +418,7 @@ definitions:
         cursor_field: updated_at
         end_datetime:
           type: MinMaxDatetime
-          datetime: "{{ config.get('end_date', now_utc().strftime('%Y-%m-%d')) }}"
+          datetime: "{{ config.get('end_date', day_delta(1, format='%Y-%m-%d')) }}"
           datetime_format: "%Y-%m-%d"
         start_datetime:
           type: MinMaxDatetime
@@ -487,7 +487,7 @@ definitions:
         cursor_field: updated_at
         end_datetime:
           type: MinMaxDatetime
-          datetime: "{{ config.get('end_date', now_utc().strftime('%Y-%m-%d')) }}"
+          datetime: "{{ config.get('end_date', day_delta(1, format='%Y-%m-%d')) }}"
           datetime_format: "%Y-%m-%d"
         start_datetime:
           type: MinMaxDatetime
@@ -556,7 +556,7 @@ definitions:
         cursor_field: updated_at
         end_datetime:
           type: MinMaxDatetime
-          datetime: "{{ config.get('end_date', now_utc().strftime('%Y-%m-%d')) }}"
+          datetime: "{{ config.get('end_date', day_delta(1, format='%Y-%m-%d')) }}"
           datetime_format: "%Y-%m-%d"
         start_datetime:
           type: MinMaxDatetime
@@ -636,7 +636,7 @@ definitions:
         cursor_field: start_time
         end_datetime:
           type: MinMaxDatetime
-          datetime: "{{ config.get('end_date', now_utc().strftime('%Y-%m-%d')) }}"
+          datetime: "{{ config.get('end_date', day_delta(1, format='%Y-%m-%d')) }}"
           datetime_format: "%Y-%m-%d"
         start_datetime:
           type: MinMaxDatetime
@@ -749,7 +749,7 @@ definitions:
         cursor_field: start_time
         end_datetime:
           type: MinMaxDatetime
-          datetime: "{{ config.get('end_date', now_utc().strftime('%Y-%m-%d')) }}"
+          datetime: "{{ config.get('end_date', day_delta(1, format='%Y-%m-%d')) }}"
           datetime_format: "%Y-%m-%d"
         start_datetime:
           type: MinMaxDatetime
@@ -933,7 +933,7 @@ definitions:
         cursor_field: start_time
         end_datetime:
           type: MinMaxDatetime
-          datetime: "{{ config.get('end_date', now_utc().strftime('%Y-%m-%d')) }}"
+          datetime: "{{ config.get('end_date', day_delta(1, format='%Y-%m-%d')) }}"
           datetime_format: "%Y-%m-%d"
         start_datetime:
           type: MinMaxDatetime
@@ -1370,7 +1370,7 @@ definitions:
         cursor_field: start_time
         end_datetime:
           type: MinMaxDatetime
-          datetime: "{{ config.get('end_date', now_utc().strftime('%Y-%m-%d')) }}"
+          datetime: "{{ config.get('end_date', day_delta(1, format='%Y-%m-%d')) }}"
           datetime_format: "%Y-%m-%d"
         start_datetime:
           type: MinMaxDatetime
@@ -2261,7 +2261,7 @@ definitions:
         cursor_field: start_time
         end_datetime:
           type: MinMaxDatetime
-          datetime: "{{ config.get('end_date', now_utc().strftime('%Y-%m-%d')) }}"
+          datetime: "{{ config.get('end_date', day_delta(1, format='%Y-%m-%d')) }}"
           datetime_format: "%Y-%m-%d"
         start_datetime:
           type: MinMaxDatetime
@@ -2698,7 +2698,7 @@ definitions:
         cursor_field: start_time
         end_datetime:
           type: MinMaxDatetime
-          datetime: "{{ config.get('end_date', now_utc().strftime('%Y-%m-%d')) }}"
+          datetime: "{{ config.get('end_date', day_delta(1, format='%Y-%m-%d')) }}"
           datetime_format: "%Y-%m-%d"
         start_datetime:
           type: MinMaxDatetime
@@ -3589,7 +3589,7 @@ definitions:
         cursor_field: start_time
         end_datetime:
           type: MinMaxDatetime
-          datetime: "{{ config.get('end_date', now_utc().strftime('%Y-%m-%d')) }}"
+          datetime: "{{ config.get('end_date', day_delta(1, format='%Y-%m-%d')) }}"
           datetime_format: "%Y-%m-%d"
         start_datetime:
           type: MinMaxDatetime
@@ -4026,7 +4026,7 @@ definitions:
         cursor_field: start_time
         end_datetime:
           type: MinMaxDatetime
-          datetime: "{{ config.get('end_date', now_utc().strftime('%Y-%m-%d')) }}"
+          datetime: "{{ config.get('end_date', day_delta(1, format='%Y-%m-%d')) }}"
           datetime_format: "%Y-%m-%d"
         start_datetime:
           type: MinMaxDatetime

--- a/airbyte-integrations/connectors/source-snapchat-marketing/metadata.yaml
+++ b/airbyte-integrations/connectors/source-snapchat-marketing/metadata.yaml
@@ -8,7 +8,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 200330b2-ea62-4d11-ac6d-cfe3e3f8ab2b
-  dockerImageTag: 1.5.12
+  dockerImageTag: 1.5.13
   dockerRepository: airbyte/source-snapchat-marketing
   githubIssueLabel: source-snapchat-marketing
   icon: snapchat.svg

--- a/docs/integrations/sources/snapchat-marketing.md
+++ b/docs/integrations/sources/snapchat-marketing.md
@@ -143,6 +143,7 @@ Syncing data with an hourly granularity often generates large data volumes and c
 
 | Version | Date       | Pull Request                                             | Subject                                                                        |
 |:--------|:-----------|:---------------------------------------------------------|:-------------------------------------------------------------------------------|
+| 1.5.13 | 2025-07-02 | [62488](https://github.com/airbytehq/airbyte/pull/62488) | Fix end datetime to include today |
 | 1.5.12 | 2025-06-28 | [60513](https://github.com/airbytehq/airbyte/pull/60513) | Update dependencies |
 | 1.5.11 | 2025-05-10 | [60113](https://github.com/airbytehq/airbyte/pull/60113) | Update dependencies |
 | 1.5.10 | 2025-05-04 | [59625](https://github.com/airbytehq/airbyte/pull/59625) | Update dependencies |


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->

Change end datetime from today to tomorrow to avoid missing records.
Resolves: https://github.com/airbytehq/oncall/issues/7815

## How
<!--
* Describe how code changes achieve the solution.
-->

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
