### PR TITLE
skip version inc check on enterprise connectors

### DIFF
--- a/airbyte-integrations/connectors/source-apptivo/metadata.yaml
+++ b/airbyte-integrations/connectors/source-apptivo/metadata.yaml
@@ -21,7 +21,7 @@ data:
   dockerRepository: airbyte/source-apptivo
   githubIssueLabel: source-apptivo
   icon: icon.svg
-  license: MIT
+  license: Airbyte Enterprise
   name: Apptivo
   releaseDate: 2024-11-09
   releaseStage: alpha

--- a/airbyte-integrations/connectors/source-asana/source_asana/run.py
+++ b/airbyte-integrations/connectors/source-asana/source_asana/run.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2024 Airbyte, Inc., all rights reserved.
 #
 
-
+# dummy change
 import sys
 import traceback
 from datetime import datetime


### PR DESCRIPTION
## What
Skips the `VersionIncrementCheck` that is part of the `connectors-qa` pre-release checks for enterprise connectors. This is a temporary workaround until we can fix the check to properly compare the local connector version to the most recently released version. 

## How
conditionally skip the test if the `license` key of the connector's metadata file is `Airbyte Enterprise`

I tested this change out by modifying two connectors, triggering the pre-release checks on CI.
`source-asana` is a regular connector with `license` set to `MIT`
`source-apptivo` has been modified to look like an enterprise connector.

The VersionIncrementCheck is appropriately skipped for `source-apptivo`

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
