### PR TITLE
chore: dlq-toolkit updates rejected records counts

### DIFF
--- a/airbyte-cdk/bulk/core/base/build.gradle.kts
+++ b/airbyte-cdk/bulk/core/base/build.gradle.kts
@@ -77,7 +77,7 @@ dependencies {
     api("com.fasterxml.jackson.core:jackson-databind")
     api("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
     api("com.kjetland:mbknor-jackson-jsonschema_2.13:1.0.39")
-    api("io.airbyte.airbyte-protocol:protocol-models:0.17.0") {
+    api("io.airbyte.airbyte-protocol:protocol-models:0.18.0") {
         exclude(group="com.google.guava", module="guava")
         exclude(group="com.google.api-client")
         exclude(group="org.apache.logging.log4j")

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/config/DataChannelBeanFactory.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/config/DataChannelBeanFactory.kt
@@ -289,7 +289,7 @@ class DataChannelBeanFactory {
         @Named("_pipelineInputQueue")
         pipelineInputQueue: PartitionedQueue<PipelineInputEvent>? = null,
         config: DestinationConfiguration,
-        checkpointManager: CheckpointManager<*>,
+        checkpointManager: CheckpointManager,
     ): HeartbeatTask {
         check(pipelineInputQueue != null) {
             "Pipeline input queue is not initialized. This should never happen in STDIO mode."

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/config/SyncBeanFactory.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/config/SyncBeanFactory.kt
@@ -57,9 +57,9 @@ class SyncBeanFactory {
     fun checkpointManager(
         catalog: DestinationCatalog,
         syncManager: SyncManager,
-        outputConsumer: suspend (Reserved<CheckpointMessage>, Long, Long) -> Unit,
+        outputConsumer: suspend (Reserved<CheckpointMessage>, Long, Long, Long) -> Unit,
         timeProvider: TimeProvider,
-    ): CheckpointManager<Reserved<CheckpointMessage>> =
+    ): CheckpointManager =
         CheckpointManager(
             catalog,
             syncManager,

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/state/CheckpointManager.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/state/CheckpointManager.kt
@@ -65,10 +65,10 @@ data class CheckpointKey(
  * TODO: Ensure that checkpoint is flushed at the end, and require that all checkpoints be flushed
  * before the destination can succeed.
  */
-class CheckpointManager<T>(
+class CheckpointManager(
     val catalog: DestinationCatalog,
     val syncManager: SyncManager,
-    val outputConsumer: suspend (T, Long, Long) -> Unit,
+    val outputConsumer: suspend (Reserved<CheckpointMessage>, Long, Long, Long) -> Unit,
     val timeProvider: TimeProvider,
 ) {
     private val log = KotlinLogging.logger {}
@@ -77,13 +77,13 @@ class CheckpointManager<T>(
     private val committedCount: ConcurrentHashMap<DestinationStream.Descriptor, CheckpointValue> =
         ConcurrentHashMap<DestinationStream.Descriptor, CheckpointValue>()
 
-    data class GlobalCheckpoint<T>(val checkpointMessage: T)
+    data class GlobalCheckpoint(val checkpointMessage: Reserved<CheckpointMessage>)
 
     private val checkpointsAreGlobal: AtomicReference<Boolean?> = AtomicReference(null)
     private val streamCheckpoints:
-        ConcurrentHashMap<DestinationStream.Descriptor, TreeMap<CheckpointKey, T>> =
+        ConcurrentHashMap<DestinationStream.Descriptor, TreeMap<CheckpointKey, Reserved<CheckpointMessage>>> =
         ConcurrentHashMap()
-    private val globalCheckpoints: TreeMap<CheckpointKey, GlobalCheckpoint<T>> = TreeMap()
+    private val globalCheckpoints: TreeMap<CheckpointKey, GlobalCheckpoint> = TreeMap()
     private val lastCheckpointKeyEmitted =
         ConcurrentHashMap<DestinationStream.Descriptor, CheckpointKey>()
 
@@ -94,7 +94,7 @@ class CheckpointManager<T>(
     suspend fun addStreamCheckpoint(
         streamDescriptor: DestinationStream.Descriptor,
         checkpointKey: CheckpointKey,
-        checkpointMessage: T
+        checkpointMessage: Reserved<CheckpointMessage>,
     ) {
         storedCheckpointsLock.withLock {
             if (checkpointsAreGlobal.updateAndGet { it == true } != false) {
@@ -103,7 +103,7 @@ class CheckpointManager<T>(
                 )
             }
 
-            val indexedMessages: TreeMap<CheckpointKey, T> =
+            val indexedMessages: TreeMap<CheckpointKey, Reserved<CheckpointMessage>> =
                 streamCheckpoints.getOrPut(streamDescriptor) { TreeMap() }
             indexedMessages[checkpointKey] = checkpointMessage
 
@@ -112,7 +112,7 @@ class CheckpointManager<T>(
     }
 
     // TODO: Is it an error if we don't get all the streams every time?
-    suspend fun addGlobalCheckpoint(checkpointKey: CheckpointKey, checkpointMessage: T) {
+    suspend fun addGlobalCheckpoint(checkpointKey: CheckpointKey, checkpointMessage: Reserved<CheckpointMessage>) {
         storedCheckpointsLock.withLock {
             if (checkpointsAreGlobal.updateAndGet { it != false } != true) {
                 throw IllegalStateException(
@@ -171,7 +171,7 @@ class CheckpointManager<T>(
             if (allStreamsPersisted) {
                 log.info { "Flushing global checkpoint with key ${head.key}" }
 
-                val (totalRecords, totalBytes) =
+                val aggregate =
                     catalog.streams
                         .map { stream ->
                             val delta =
@@ -182,16 +182,15 @@ class CheckpointManager<T>(
                             /* increment() returns the new aggregate for this stream. */
                             committedCount.increment(stream.mappedDescriptor, delta)
                         }
-                        .fold(0L to 0L) { acc, value ->
-                            acc.first + value.records to acc.second + value.serializedBytes
-                        }
+                        .reduce { acc, inc -> acc.plus(inc) }
 
                 sendStateMessage(
                     head.value.checkpointMessage,
                     head.key,
                     catalog.streams.map { it.mappedDescriptor },
-                    totalRecords,
-                    totalBytes
+                    aggregate.records,
+                    aggregate.serializedBytes,
+                    aggregate.rejectedRecords,
                 )
                 globalCheckpoints.remove(
                     head.key
@@ -207,9 +206,7 @@ class CheckpointManager<T>(
         descriptor: DestinationStream.Descriptor,
         delta: CheckpointValue,
     ): CheckpointValue =
-        merge(descriptor, delta) { acc, inc ->
-            CheckpointValue(acc.records + inc.records, acc.serializedBytes + inc.serializedBytes)
-        }!!
+        merge(descriptor, delta) { acc, inc -> acc.plus(inc) }!!
 
     private suspend fun flushStreamCheckpoints() {
         val noCheckpointStreams = mutableSetOf<DestinationStream.Descriptor>()
@@ -241,12 +238,19 @@ class CheckpointManager<T>(
                     val delta = manager.committedCount(nextCheckpointKey.checkpointId)
                     val aggregate = committedCount.increment(stream.mappedDescriptor, delta)
 
+                    nextMessage.value.updateStats(
+                        destinationStats = CheckpointMessage.Stats(
+                            recordCount = delta.records,
+                            rejectedRecordCount = delta.rejectedRecords,
+                        )
+                    )
                     sendStateMessage(
                         nextMessage,
                         nextCheckpointKey,
                         listOf(stream.mappedDescriptor),
                         aggregate.records,
                         aggregate.serializedBytes,
+                        aggregate.rejectedRecords,
                     )
 
                     log.info {
@@ -293,15 +297,16 @@ class CheckpointManager<T>(
     }
 
     private suspend fun sendStateMessage(
-        checkpointMessage: T,
+        checkpointMessage: Reserved<CheckpointMessage>,
         checkpointKey: CheckpointKey,
         streamCheckpoints: List<DestinationStream.Descriptor>,
         totalRecords: Long,
-        totalBytes: Long
+        totalBytes: Long,
+        totalRejectedRecords: Long,
     ) {
         streamCheckpoints.forEach { stream -> lastCheckpointKeyEmitted[stream] = checkpointKey }
         lastFlushTimeMs.set(timeProvider.currentTimeMillis())
-        outputConsumer.invoke(checkpointMessage, totalRecords, totalBytes)
+        outputConsumer.invoke(checkpointMessage, totalRecords, totalBytes, totalRejectedRecords)
     }
 
     suspend fun awaitAllCheckpointsFlushed() {
@@ -329,17 +334,23 @@ class CheckpointManager<T>(
 )
 @Singleton
 class FreeingAnnotatingCheckpointConsumer(private val consumer: OutputConsumer) :
-    suspend (Reserved<CheckpointMessage>, Long, Long) -> Unit {
+    suspend (Reserved<CheckpointMessage>, Long, Long, Long) -> Unit {
     override suspend fun invoke(
         message: Reserved<CheckpointMessage>,
         totalRecords: Long,
-        totalBytes: Long
+        totalBytes: Long,
+        totalRejectedRecords: Long,
     ) {
         message.use {
             val outMessage =
                 it.value
-                    .withTotalRecords(totalRecords = totalRecords)
-                    .withTotalBytes(totalBytes = totalBytes)
+                    .apply {
+                        updateStats(
+                            totalRecords = totalRecords,
+                            totalBytes = totalBytes,
+                            totalRejectedRecords = totalRejectedRecords,
+                        )
+                    }
                     .asProtocolMessage()
             consumer.accept(outMessage)
         }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/state/CheckpointManager.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/state/CheckpointManager.kt
@@ -81,7 +81,8 @@ class CheckpointManager(
 
     private val checkpointsAreGlobal: AtomicReference<Boolean?> = AtomicReference(null)
     private val streamCheckpoints:
-        ConcurrentHashMap<DestinationStream.Descriptor, TreeMap<CheckpointKey, Reserved<CheckpointMessage>>> =
+        ConcurrentHashMap<
+            DestinationStream.Descriptor, TreeMap<CheckpointKey, Reserved<CheckpointMessage>>> =
         ConcurrentHashMap()
     private val globalCheckpoints: TreeMap<CheckpointKey, GlobalCheckpoint> = TreeMap()
     private val lastCheckpointKeyEmitted =
@@ -112,7 +113,10 @@ class CheckpointManager(
     }
 
     // TODO: Is it an error if we don't get all the streams every time?
-    suspend fun addGlobalCheckpoint(checkpointKey: CheckpointKey, checkpointMessage: Reserved<CheckpointMessage>) {
+    suspend fun addGlobalCheckpoint(
+        checkpointKey: CheckpointKey,
+        checkpointMessage: Reserved<CheckpointMessage>
+    ) {
         storedCheckpointsLock.withLock {
             if (checkpointsAreGlobal.updateAndGet { it != false } != true) {
                 throw IllegalStateException(
@@ -205,8 +209,7 @@ class CheckpointManager(
     private fun ConcurrentHashMap<DestinationStream.Descriptor, CheckpointValue>.increment(
         descriptor: DestinationStream.Descriptor,
         delta: CheckpointValue,
-    ): CheckpointValue =
-        merge(descriptor, delta) { acc, inc -> acc.plus(inc) }!!
+    ): CheckpointValue = merge(descriptor, delta) { acc, inc -> acc.plus(inc) }!!
 
     private suspend fun flushStreamCheckpoints() {
         val noCheckpointStreams = mutableSetOf<DestinationStream.Descriptor>()
@@ -239,10 +242,11 @@ class CheckpointManager(
                     val aggregate = committedCount.increment(stream.mappedDescriptor, delta)
 
                     nextMessage.value.updateStats(
-                        destinationStats = CheckpointMessage.Stats(
-                            recordCount = delta.records,
-                            rejectedRecordCount = delta.rejectedRecords,
-                        )
+                        destinationStats =
+                            CheckpointMessage.Stats(
+                                recordCount = delta.records,
+                                rejectedRecordCount = delta.rejectedRecords,
+                            )
                     )
                     sendStateMessage(
                         nextMessage,

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/state/ReservationManager.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/state/ReservationManager.kt
@@ -13,7 +13,7 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
 /** Releasable reservation of memory. */
-class Reserved<T>(
+data class Reserved<T>(
     private val parentManager: ReservationManager? = null,
     val bytesReserved: Long = 0,
     val value: T,

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/state/StreamManager.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/state/StreamManager.kt
@@ -29,14 +29,21 @@ data object StreamProcessingSucceeded : StreamResult
 data class CheckpointValue(
     val records: Long,
     val serializedBytes: Long,
+    val rejectedRecords: Long = 0, // TODO there should not be a default here
 ) {
     operator fun plus(other: CheckpointValue): CheckpointValue {
-        return CheckpointValue(records + other.records, serializedBytes + other.serializedBytes)
+        return CheckpointValue(
+            records = records + other.records,
+            serializedBytes = serializedBytes + other.serializedBytes,
+            rejectedRecords = rejectedRecords + other.rejectedRecords,
+        )
     }
 
     override fun equals(other: Any?): Boolean {
         if (other != null && other is CheckpointValue) {
-            return this.records == other.records && this.serializedBytes == other.serializedBytes
+            return this.records == other.records
+                && this.serializedBytes == other.serializedBytes
+                && this.rejectedRecords == other.rejectedRecords
         }
         return false
     }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/state/StreamManager.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/state/StreamManager.kt
@@ -41,9 +41,9 @@ data class CheckpointValue(
 
     override fun equals(other: Any?): Boolean {
         if (other != null && other is CheckpointValue) {
-            return this.records == other.records
-                && this.serializedBytes == other.serializedBytes
-                && this.rejectedRecords == other.rejectedRecords
+            return this.records == other.records &&
+                this.serializedBytes == other.serializedBytes &&
+                this.rejectedRecords == other.rejectedRecords
         }
         return false
     }
@@ -313,11 +313,13 @@ class StreamManager(
         val persistedCount =
             checkpointCountsByState[BatchState.PERSISTED]?.get(checkpointId)?.let {
                 it.records + it.rejectedRecords
-            } ?: 0L
+            }
+                ?: 0L
         val completeCount =
             checkpointCountsByState[BatchState.COMPLETE]?.get(checkpointId)?.let {
                 it.records + it.rejectedRecords
-            } ?: 0L
+            }
+                ?: 0L
         return max(persistedCount, completeCount)
     }
 

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/implementor/FailSyncTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/implementor/FailSyncTask.kt
@@ -24,7 +24,7 @@ class FailSyncTask(
     private val destinationWriter: DestinationWriter,
     private val exception: Exception,
     private val syncManager: SyncManager,
-    private val checkpointManager: CheckpointManager<*>,
+    private val checkpointManager: CheckpointManager,
 ) : Task {
     private val log = KotlinLogging.logger {}
 
@@ -43,7 +43,7 @@ class FailSyncTask(
 @Singleton
 class FailSyncTaskFactory(
     private val syncManager: SyncManager,
-    private val checkpointManager: CheckpointManager<*>,
+    private val checkpointManager: CheckpointManager,
     private val destinationWriter: DestinationWriter
 ) {
     fun make(taskLauncher: DestinationTaskLauncher, exception: Exception): FailSyncTask {

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/implementor/TeardownTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/implementor/TeardownTask.kt
@@ -20,7 +20,7 @@ import jakarta.inject.Singleton
  * TODO: Report teardown-complete and let the task launcher decide what to do next.
  */
 class TeardownTask(
-    private val checkpointManager: CheckpointManager<*>,
+    private val checkpointManager: CheckpointManager,
     private val syncManager: SyncManager,
     private val destination: DestinationWriter,
     private val taskLauncher: DestinationTaskLauncher,
@@ -50,7 +50,7 @@ class TeardownTask(
 
 @Singleton
 class TeardownTaskFactory(
-    private val checkpointManager: CheckpointManager<*>,
+    private val checkpointManager: CheckpointManager,
     private val syncManager: SyncManager,
     private val destination: DestinationWriter,
 ) {

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/HeartbeatTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/HeartbeatTask.kt
@@ -18,7 +18,7 @@ import kotlinx.coroutines.delay
 class HeartbeatTask(
     private val config: DestinationConfiguration,
     private val outputQueue: PartitionedQueue<PipelineInputEvent>,
-    private val checkpointManager: CheckpointManager<*>,
+    private val checkpointManager: CheckpointManager,
 ) : Task {
     override val terminalCondition: TerminalCondition = OnEndOfSync
 

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/UpdateBatchStateTaskFactory.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/UpdateBatchStateTaskFactory.kt
@@ -22,7 +22,7 @@ import jakarta.inject.Singleton
 class UpdateBatchStateTask(
     private val inputQueue: QueueReader<BatchUpdate>,
     private val syncManager: SyncManager,
-    private val checkpointManager: CheckpointManager<*>,
+    private val checkpointManager: CheckpointManager,
     private val launcher: DestinationTaskLauncher
 ) : Task {
     private val log = KotlinLogging.logger {}
@@ -68,7 +68,7 @@ class UpdateBatchStateTask(
 class UpdateBatchStateTaskFactory(
     @Named("batchStateUpdateQueue") private val inputQueue: QueueReader<BatchUpdate>,
     private val syncManager: SyncManager,
-    private val checkpointManager: CheckpointManager<*>,
+    private val checkpointManager: CheckpointManager,
 ) {
     fun make(taskLauncher: DestinationTaskLauncher): UpdateBatchStateTask {
         return UpdateBatchStateTask(inputQueue, syncManager, checkpointManager, taskLauncher)

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/UpdateCheckpointsTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/UpdateCheckpointsTask.kt
@@ -4,7 +4,6 @@
 
 package io.airbyte.cdk.load.task.internal
 
-import io.airbyte.cdk.load.message.CheckpointMessage
 import io.airbyte.cdk.load.message.CheckpointMessageWrapped
 import io.airbyte.cdk.load.message.GlobalCheckpointWrapped
 import io.airbyte.cdk.load.message.MessageQueue

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/UpdateCheckpointsTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/UpdateCheckpointsTask.kt
@@ -23,7 +23,7 @@ import jakarta.inject.Singleton
 @Secondary
 class UpdateCheckpointsTask(
     private val syncManager: SyncManager,
-    private val checkpointManager: CheckpointManager<Reserved<CheckpointMessage>>,
+    private val checkpointManager: CheckpointManager,
     private val checkpointMessageQueue: MessageQueue<Reserved<CheckpointMessageWrapped>>
 ) : Task {
     val log = KotlinLogging.logger {}

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/state/StreamManagerTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/state/StreamManagerTest.kt
@@ -150,20 +150,26 @@ class StreamManagerTest {
         Assertions.assertFalse(manager.areRecordsPersistedForCheckpoint(checkpointId))
         manager.incrementCheckpointCounts(
             BatchState.PERSISTED,
-            mapOf(checkpointId to CheckpointValue(
-                records = 3,
-                serializedBytes = 5,
-                rejectedRecords = 2,
-            )),
+            mapOf(
+                checkpointId to
+                    CheckpointValue(
+                        records = 3,
+                        serializedBytes = 5,
+                        rejectedRecords = 2,
+                    )
+            ),
         )
         Assertions.assertFalse(manager.areRecordsPersistedForCheckpoint(checkpointId))
         manager.incrementCheckpointCounts(
             BatchState.PERSISTED,
-            mapOf(checkpointId to CheckpointValue(
-                records = 4,
-                serializedBytes = 5,
-                rejectedRecords = 1,
-            )),
+            mapOf(
+                checkpointId to
+                    CheckpointValue(
+                        records = 4,
+                        serializedBytes = 5,
+                        rejectedRecords = 1,
+                    )
+            ),
         )
         Assertions.assertTrue(manager.areRecordsPersistedForCheckpoint(checkpointId))
     }
@@ -288,11 +294,14 @@ class StreamManagerTest {
                     "1" ->
                         manager.incrementCheckpointCounts(
                             BatchState.COMPLETE,
-                            mapOf(checkpointId1 to CheckpointValue(
-                                records = 9,
-                                serializedBytes = 10,
-                                rejectedRecords = 1,
-                            )),
+                            mapOf(
+                                checkpointId1 to
+                                    CheckpointValue(
+                                        records = 9,
+                                        serializedBytes = 10,
+                                        rejectedRecords = 1,
+                                    )
+                            ),
                         )
                     "2" ->
                         manager.incrementCheckpointCounts(

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/state/StreamManagerTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/state/StreamManagerTest.kt
@@ -140,6 +140,35 @@ class StreamManagerTest {
     }
 
     @Test
+    fun `test persisted counts with rejected records`() {
+        val manager = StreamManager(stream1)
+        val checkpointId = manager.inferNextCheckpointKey().checkpointId
+
+        repeat(10) { manager.incrementReadCount() }
+        manager.markCheckpoint()
+
+        Assertions.assertFalse(manager.areRecordsPersistedForCheckpoint(checkpointId))
+        manager.incrementCheckpointCounts(
+            BatchState.PERSISTED,
+            mapOf(checkpointId to CheckpointValue(
+                records = 3,
+                serializedBytes = 5,
+                rejectedRecords = 2,
+            )),
+        )
+        Assertions.assertFalse(manager.areRecordsPersistedForCheckpoint(checkpointId))
+        manager.incrementCheckpointCounts(
+            BatchState.PERSISTED,
+            mapOf(checkpointId to CheckpointValue(
+                records = 4,
+                serializedBytes = 5,
+                rejectedRecords = 1,
+            )),
+        )
+        Assertions.assertTrue(manager.areRecordsPersistedForCheckpoint(checkpointId))
+    }
+
+    @Test
     fun `test persisted count for multiple checkpoints`() {
         val manager = StreamManager(stream1)
 
@@ -259,7 +288,11 @@ class StreamManagerTest {
                     "1" ->
                         manager.incrementCheckpointCounts(
                             BatchState.COMPLETE,
-                            mapOf(checkpointId1 to CheckpointValue(10, 10)),
+                            mapOf(checkpointId1 to CheckpointValue(
+                                records = 9,
+                                serializedBytes = 10,
+                                rejectedRecords = 1,
+                            )),
                         )
                     "2" ->
                         manager.incrementCheckpointCounts(

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/internal/HeartbeatTaskTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/task/internal/HeartbeatTaskTest.kt
@@ -22,7 +22,7 @@ class HeartbeatTaskTest {
     fun `heartbeat task updates every configured interval`() = runTest {
         val config = mockk<DestinationConfiguration>()
         val recordQueue = mockk<PartitionedQueue<PipelineInputEvent>>()
-        val checkpointManager = mockk<CheckpointManager<*>>()
+        val checkpointManager = mockk<CheckpointManager>()
         val task = HeartbeatTask(config, recordQueue, checkpointManager)
         every { config.heartbeatIntervalSeconds } returns 5
         coEvery { recordQueue.broadcast(any()) } returns Unit

--- a/airbyte-cdk/bulk/toolkits/load-dlq/src/integrationTest/kotlin/DlqWriteTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-dlq/src/integrationTest/kotlin/DlqWriteTest.kt
@@ -10,6 +10,7 @@ import io.airbyte.cdk.load.config.DataChannelMedium
 import io.airbyte.cdk.load.data.ObjectType
 import io.airbyte.cdk.load.integrationTest.DLQ_INTEGRATION_TEST_ENV
 import io.airbyte.cdk.load.integrationTest.DLQ_SAMPLE_TEST
+import io.airbyte.cdk.load.message.CheckpointMessage
 import io.airbyte.cdk.load.message.InputRecord
 import io.airbyte.cdk.load.message.InputStreamCheckpoint
 import io.airbyte.cdk.load.message.StreamCheckpoint
@@ -19,6 +20,7 @@ import io.airbyte.cdk.load.test.util.NoopDestinationCleaner
 import io.airbyte.cdk.load.test.util.NoopNameMapper
 import io.airbyte.cdk.load.test.util.UncoercedExpectedRecordMapper
 import io.airbyte.cdk.load.util.Jsons
+import io.airbyte.cdk.load.util.deserializeToNode
 import io.airbyte.cdk.load.write.BasicFunctionalityIntegrationTest.Companion.intType
 import io.airbyte.protocol.models.v0.AirbyteMessage
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -80,25 +82,42 @@ open class AbstractDlqWriteTest(
             val checkpoints =
                 listOf(
                     StreamCheckpoint(
-                            unmappedName = stream.unmappedName,
-                            unmappedNamespace = stream.unmappedNamespace,
-                            blob = """{"foo": "bar"}""",
-                            sourceRecordCount = 9,
-                            destinationRecordCount = 9,
+                            checkpoint = CheckpointMessage.Checkpoint(
+                                unmappedName = stream.unmappedName,
+                                unmappedNamespace = stream.unmappedNamespace,
+                                state = """{"foo": "bar"}""".deserializeToNode(),
+                            ),
+                            sourceStats = CheckpointMessage.Stats(
+                                recordCount = 9,
+                            ),
+                            destinationStats = CheckpointMessage.Stats(
+                                recordCount = 5,
+                                rejectedRecordCount = 4,
+                            ),
+                            serializedSizeBytes = 0L,
                             checkpointKey = null,
-                            totalRecords = 9L,
+                            totalRecords = 5L,
                             totalBytes = 1242,
+                            totalRejectedRecords = 4L,
                         )
                         .asProtocolMessage(),
                     StreamCheckpoint(
-                            unmappedName = stream.unmappedName,
-                            unmappedNamespace = stream.unmappedNamespace,
-                            blob = """{"foo": "bar"}""",
-                            sourceRecordCount = 2,
-                            destinationRecordCount = 2,
+                            checkpoint = CheckpointMessage.Checkpoint(
+                                unmappedName = stream.unmappedName,
+                                unmappedNamespace = stream.unmappedNamespace,
+                                state = """{"foo": "bar"}""".deserializeToNode(),
+                            ),
+                            sourceStats = CheckpointMessage.Stats(
+                                recordCount = 2,
+                            ),
+                            destinationStats = CheckpointMessage.Stats(
+                                recordCount = 2,
+                            ),
+                            serializedSizeBytes = 0L,
                             checkpointKey = null,
-                            totalRecords = 11L,
+                            totalRecords = 7L,
                             totalBytes = 1520,
+                            totalRejectedRecords = 4L,
                         )
                         .asProtocolMessage(),
                 )

--- a/airbyte-cdk/bulk/toolkits/load-dlq/src/integrationTest/kotlin/DlqWriteTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-dlq/src/integrationTest/kotlin/DlqWriteTest.kt
@@ -82,18 +82,21 @@ open class AbstractDlqWriteTest(
             val checkpoints =
                 listOf(
                     StreamCheckpoint(
-                            checkpoint = CheckpointMessage.Checkpoint(
-                                unmappedName = stream.unmappedName,
-                                unmappedNamespace = stream.unmappedNamespace,
-                                state = """{"foo": "bar"}""".deserializeToNode(),
-                            ),
-                            sourceStats = CheckpointMessage.Stats(
-                                recordCount = 9,
-                            ),
-                            destinationStats = CheckpointMessage.Stats(
-                                recordCount = 5,
-                                rejectedRecordCount = 4,
-                            ),
+                            checkpoint =
+                                CheckpointMessage.Checkpoint(
+                                    unmappedName = stream.unmappedName,
+                                    unmappedNamespace = stream.unmappedNamespace,
+                                    state = """{"foo": "bar"}""".deserializeToNode(),
+                                ),
+                            sourceStats =
+                                CheckpointMessage.Stats(
+                                    recordCount = 9,
+                                ),
+                            destinationStats =
+                                CheckpointMessage.Stats(
+                                    recordCount = 5,
+                                    rejectedRecordCount = 4,
+                                ),
                             serializedSizeBytes = 0L,
                             checkpointKey = null,
                             totalRecords = 5L,
@@ -102,17 +105,20 @@ open class AbstractDlqWriteTest(
                         )
                         .asProtocolMessage(),
                     StreamCheckpoint(
-                            checkpoint = CheckpointMessage.Checkpoint(
-                                unmappedName = stream.unmappedName,
-                                unmappedNamespace = stream.unmappedNamespace,
-                                state = """{"foo": "bar"}""".deserializeToNode(),
-                            ),
-                            sourceStats = CheckpointMessage.Stats(
-                                recordCount = 2,
-                            ),
-                            destinationStats = CheckpointMessage.Stats(
-                                recordCount = 2,
-                            ),
+                            checkpoint =
+                                CheckpointMessage.Checkpoint(
+                                    unmappedName = stream.unmappedName,
+                                    unmappedNamespace = stream.unmappedNamespace,
+                                    state = """{"foo": "bar"}""".deserializeToNode(),
+                                ),
+                            sourceStats =
+                                CheckpointMessage.Stats(
+                                    recordCount = 2,
+                                ),
+                            destinationStats =
+                                CheckpointMessage.Stats(
+                                    recordCount = 2,
+                                ),
                             serializedSizeBytes = 0L,
                             checkpointKey = null,
                             totalRecords = 7L,

--- a/airbyte-cdk/bulk/toolkits/load-dlq/src/main/kotlin/io/airbyte/cdk/load/pipeline/dlq/DlqLoaderPipelineStep.kt
+++ b/airbyte-cdk/bulk/toolkits/load-dlq/src/main/kotlin/io/airbyte/cdk/load/pipeline/dlq/DlqLoaderPipelineStep.kt
@@ -30,11 +30,10 @@ class DlqLoaderPipelineStep<S : AutoCloseable>(
     private val taskFactory: LoadPipelineStepTaskFactory,
     private val dlqLoader: DlqLoader<S>,
     private val outputQueue: PartitionedQueue<PipelineEvent<StreamKey, DestinationRecordRaw>>,
-    private val deadLetterQueueEnabled: Boolean,
 ) : LoadPipelineStep {
     override fun taskForPartition(partition: Int): Task {
         return taskFactory.createFirstStep(
-            batchAccumulator = DlqLoaderAccumulator(dlqLoader, deadLetterQueueEnabled),
+            batchAccumulator = DlqLoaderAccumulator(dlqLoader),
             outputPartitioner = PassThroughPartitioner(),
             outputQueue = FlattenQueueAdapter(outputQueue),
             part = partition,
@@ -56,7 +55,6 @@ class DlqStepOutput(
 /** Wraps a [DlqLoader] into a [BatchAccumulator] so that it fits into a [LoadPipeline]. */
 class DlqLoaderAccumulator<S>(
     private val loader: DlqLoader<S>,
-    private val deadLetterQueueEnabled: Boolean,
 ) : BatchAccumulator<S, StreamKey, DestinationRecordRaw, DlqStepOutput> {
     /** Propagates the call to the [DlqLoader] in order to create a new state for a stream. */
     override suspend fun start(key: StreamKey, part: Int): S = loader.start(key, part)
@@ -90,14 +88,8 @@ class DlqLoaderAccumulator<S>(
     }
 
     private fun getOutput(rejectedRecords: List<DestinationRecordRaw>?) =
-        if (deadLetterQueueEnabled) {
-            when (rejectedRecords) {
-                null -> DlqStepOutput(BatchState.COMPLETE, null)
-                else -> DlqStepOutput(BatchState.STAGED, rejectedRecords)
-            }
-        } else {
-            // Because Dead Letter Queue is disable, we never return rejected records.
-            // TODO: count rejected records for stats reporting
-            DlqStepOutput(BatchState.COMPLETE, null)
+        when (rejectedRecords) {
+            null -> DlqStepOutput(BatchState.COMPLETE, null)
+            else -> DlqStepOutput(BatchState.STAGED, rejectedRecords)
         }
 }

--- a/airbyte-cdk/bulk/toolkits/load-dlq/src/main/kotlin/io/airbyte/cdk/load/pipeline/dlq/DlqLoaderPipelineStep.kt
+++ b/airbyte-cdk/bulk/toolkits/load-dlq/src/main/kotlin/io/airbyte/cdk/load/pipeline/dlq/DlqLoaderPipelineStep.kt
@@ -93,7 +93,7 @@ class DlqLoaderAccumulator<S>(
         if (deadLetterQueueEnabled) {
             when (rejectedRecords) {
                 null -> DlqStepOutput(BatchState.COMPLETE, null)
-                else -> DlqStepOutput(BatchState.PERSISTED, rejectedRecords)
+                else -> DlqStepOutput(BatchState.STAGED, rejectedRecords)
             }
         } else {
             // Because Dead Letter Queue is disable, we never return rejected records.

--- a/airbyte-cdk/bulk/toolkits/load-dlq/src/main/kotlin/io/airbyte/cdk/load/pipeline/dlq/DlqNoopStep.kt
+++ b/airbyte-cdk/bulk/toolkits/load-dlq/src/main/kotlin/io/airbyte/cdk/load/pipeline/dlq/DlqNoopStep.kt
@@ -1,0 +1,61 @@
+package io.airbyte.cdk.load.pipeline.dlq
+
+import io.airbyte.cdk.load.message.BatchState
+import io.airbyte.cdk.load.message.DestinationRecordRaw
+import io.airbyte.cdk.load.message.PartitionedQueue
+import io.airbyte.cdk.load.message.PipelineEvent
+import io.airbyte.cdk.load.message.StreamKey
+import io.airbyte.cdk.load.message.WithBatchState
+import io.airbyte.cdk.load.pipeline.BatchAccumulator
+import io.airbyte.cdk.load.pipeline.BatchAccumulatorResult
+import io.airbyte.cdk.load.pipeline.FinalOutput
+import io.airbyte.cdk.load.pipeline.LoadPipelineStep
+import io.airbyte.cdk.load.task.Task
+import io.airbyte.cdk.load.task.internal.LoadPipelineStepTaskFactory
+
+/**
+ * Define a NoopStep for the Dead Letter Queue.
+ *
+ * This step skips through all records without doing anything. This is to make sure we update the
+ * counts of rejected records properly by leveraging the [FlattenQueueAdapter] and the fact that
+ * the LoadPipelineStepTask will update the rejected records count correctly on
+ * [BatchState.COMPLETE].
+ */
+class DlqNoopPipelineStep(
+    override val numWorkers: Int,
+    private val taskFactory: LoadPipelineStepTaskFactory,
+    private val dlqInputQueue: PartitionedQueue<PipelineEvent<StreamKey, DestinationRecordRaw>>,
+) : LoadPipelineStep {
+    override fun taskForPartition(partition: Int): Task {
+        return taskFactory.createFinalStep(
+            batchAccumulator = DlqNoopAccumulator(),
+            inputQueue = dlqInputQueue,
+            part = partition,
+            numWorkers = numWorkers,
+        )
+    }
+}
+
+/**
+ * See documentation of [DlqNoopPipelineStep].
+ */
+class DlqNoopAccumulator
+    : BatchAccumulator<DlqNoopState, StreamKey, DestinationRecordRaw, WithBatchState> {
+    override suspend fun start(key: StreamKey, part: Int): DlqNoopState = DlqNoopState()
+
+    override suspend fun accept(
+        input: DestinationRecordRaw,
+        state: DlqNoopState
+    ): BatchAccumulatorResult<DlqNoopState, WithBatchState> = FinalOutput(DlqNoopState())
+
+    override suspend fun finish(state: DlqNoopState): FinalOutput<DlqNoopState, WithBatchState> =
+        FinalOutput(DlqNoopState())
+}
+
+/**
+ * See documentation of [DlqNoopPipelineStep].
+ */
+class DlqNoopState : WithBatchState, AutoCloseable {
+    override val state: BatchState = BatchState.COMPLETE
+    override fun close() {}
+}

--- a/airbyte-cdk/bulk/toolkits/load-dlq/src/main/kotlin/io/airbyte/cdk/load/pipeline/dlq/DlqNoopStep.kt
+++ b/airbyte-cdk/bulk/toolkits/load-dlq/src/main/kotlin/io/airbyte/cdk/load/pipeline/dlq/DlqNoopStep.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+ */
+
 package io.airbyte.cdk.load.pipeline.dlq
 
 import io.airbyte.cdk.load.message.BatchState
@@ -17,9 +21,8 @@ import io.airbyte.cdk.load.task.internal.LoadPipelineStepTaskFactory
  * Define a NoopStep for the Dead Letter Queue.
  *
  * This step skips through all records without doing anything. This is to make sure we update the
- * counts of rejected records properly by leveraging the [FlattenQueueAdapter] and the fact that
- * the LoadPipelineStepTask will update the rejected records count correctly on
- * [BatchState.COMPLETE].
+ * counts of rejected records properly by leveraging the [FlattenQueueAdapter] and the fact that the
+ * LoadPipelineStepTask will update the rejected records count correctly on [BatchState.COMPLETE].
  */
 class DlqNoopPipelineStep(
     override val numWorkers: Int,
@@ -36,11 +39,9 @@ class DlqNoopPipelineStep(
     }
 }
 
-/**
- * See documentation of [DlqNoopPipelineStep].
- */
-class DlqNoopAccumulator
-    : BatchAccumulator<DlqNoopState, StreamKey, DestinationRecordRaw, WithBatchState> {
+/** See documentation of [DlqNoopPipelineStep]. */
+class DlqNoopAccumulator :
+    BatchAccumulator<DlqNoopState, StreamKey, DestinationRecordRaw, WithBatchState> {
     override suspend fun start(key: StreamKey, part: Int): DlqNoopState = DlqNoopState()
 
     override suspend fun accept(
@@ -52,9 +53,7 @@ class DlqNoopAccumulator
         FinalOutput(DlqNoopState())
 }
 
-/**
- * See documentation of [DlqNoopPipelineStep].
- */
+/** See documentation of [DlqNoopPipelineStep]. */
 class DlqNoopState : WithBatchState, AutoCloseable {
     override val state: BatchState = BatchState.COMPLETE
     override fun close() {}

--- a/airbyte-cdk/bulk/toolkits/load-dlq/src/main/kotlin/io/airbyte/cdk/load/pipeline/dlq/FlattenQueueAdapter.kt
+++ b/airbyte-cdk/bulk/toolkits/load-dlq/src/main/kotlin/io/airbyte/cdk/load/pipeline/dlq/FlattenQueueAdapter.kt
@@ -72,13 +72,12 @@ class FlattenQueueAdapter<K : WithStream>(
                     )
                 } else {
                     val updatedCounts =
-                        checkpointCounts
-                            .mapValues { (_, v) ->
-                                v.copy(
-                                    records = v.records - failedRecords.size,
-                                    rejectedRecords = v.rejectedRecords + failedRecords.size,
-                                )
-                            }
+                        checkpointCounts.mapValues { (_, v) ->
+                            v.copy(
+                                records = v.records - failedRecords.size,
+                                rejectedRecords = v.rejectedRecords + failedRecords.size,
+                            )
+                        }
 
                     PipelineMessage(
                         checkpointCounts = updatedCounts,

--- a/airbyte-cdk/bulk/toolkits/load-dlq/src/main/kotlin/io/airbyte/cdk/load/pipeline/dlq/FlattenQueueAdapter.kt
+++ b/airbyte-cdk/bulk/toolkits/load-dlq/src/main/kotlin/io/airbyte/cdk/load/pipeline/dlq/FlattenQueueAdapter.kt
@@ -71,8 +71,17 @@ class FlattenQueueAdapter<K : WithStream>(
                         context = context,
                     )
                 } else {
+                    val updatedCounts =
+                        checkpointCounts
+                            .mapValues { (_, v) ->
+                                v.copy(
+                                    records = v.records - failedRecords.size,
+                                    rejectedRecords = v.rejectedRecords + failedRecords.size,
+                                )
+                            }
+
                     PipelineMessage(
-                        checkpointCounts = checkpointCounts,
+                        checkpointCounts = updatedCounts,
                         key = key,
                         value = destinationRecordRaw,
                         postProcessingCallback = postProcessingCallback,

--- a/airbyte-cdk/bulk/toolkits/load-dlq/src/test/kotlin/io/airbyte/cdk/load/pipeline/dlq/FlattenQueueAdapterTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-dlq/src/test/kotlin/io/airbyte/cdk/load/pipeline/dlq/FlattenQueueAdapterTest.kt
@@ -112,11 +112,12 @@ class FlattenQueueAdapterTest {
 
         // Verifying the aggregate counts remain the same
         // However, we're substracting the rejected records from the total records count
-        val expectedCheckpointValue = CheckpointValue(
-            records = 9,
-            serializedBytes = 123,
-            rejectedRecords = 3,
-        )
+        val expectedCheckpointValue =
+            CheckpointValue(
+                records = 9,
+                serializedBytes = 123,
+                rejectedRecords = 3,
+            )
         assertEquals(mapOf(checkpointId to expectedCheckpointValue), actualCounts)
 
         // All keys and context should be equal

--- a/airbyte-cdk/bulk/toolkits/load-dlq/src/test/kotlin/io/airbyte/cdk/load/pipeline/dlq/FlattenQueueAdapterTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-dlq/src/test/kotlin/io/airbyte/cdk/load/pipeline/dlq/FlattenQueueAdapterTest.kt
@@ -67,7 +67,7 @@ class FlattenQueueAdapterTest {
     }
 
     @Test
-    fun `flattening lists preserve the total count`() {
+    fun `flattening lists preserve the total count while counting rejected records`() {
         val state = BatchState.COMPLETE
         val records =
             listOf(
@@ -109,8 +109,15 @@ class FlattenQueueAdapterTest {
                 .flatMap { it.checkpointCounts.entries }
                 .groupBy({ it.key }, { it.value })
                 .mapValues { it.value.reduce { acc, value -> acc.plus(value) } }
+
         // Verifying the aggregate counts remain the same
-        assertEquals(mapOf(checkpointId to checkpointValue), actualCounts)
+        // However, we're substracting the rejected records from the total records count
+        val expectedCheckpointValue = CheckpointValue(
+            records = 9,
+            serializedBytes = 123,
+            rejectedRecords = 3,
+        )
+        assertEquals(mapOf(checkpointId to expectedCheckpointValue), actualCounts)
 
         // All keys and context should be equal
         messages.forEach {


### PR DESCRIPTION
## What

When using the DLQ toolkit, the CDK should report the rejected records count.

High level, the `DlqLoader` interface let the implementer return a list of `DestinationRecordRaw` that are meant for the dead letter queue. The goal is to leverage this list of records to update the counts of records and rejected records.

This PR:
* Bumps the protocol to `0.18.0` which has the support for `rejectedRecordCount`
* Updates the flattening queue adapter to update the rejected record counts
* Updates the StateMessage handling to report the rejected records
* Updates the `StreamManager` to account for rejected records. This would be main change to review as it does update some of the existing counting logic.
* Adds a `NoopPipelineStep` for the dead letter queue. This is in order to hook into the current CDK internals to get the same path for updating the counts rather than having to introduce specific handling for cases where there would be no object storage configured and the pipeline ends early.

As part of this work, the PR also comes with some quality of life improvements
* adds some tests on checkpointing ordering
* simplifies the typing of the `CheckpointManager` by removing the generics. This leads to a bunch of interface changes to remove the generics.

Closes https://github.com/airbytehq/airbyte-internal-issues/issues/13303

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [X] YES 💚
- [ ] NO ❌
