### PR TITLE
[do not merge] downgrade the CDK to a version pre-fix for async retriever

### DIFF
--- a/airbyte-integrations/connectors/source-amazon-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-amazon-ads/metadata.yaml
@@ -9,7 +9,7 @@ data:
       - advertising-api-eu.amazon.com
       - advertising-api-fe.amazon.com
   connectorBuildOptions:
-    baseImage: docker.io/airbyte/source-declarative-manifest:6.48.12@sha256:6947070c0d1f8bb025d48ca952421b7c83795ca98f0395fe08ad29b7f3df8a33
+    baseImage: docker.io/airbyte/source-declarative-manifest:6.45.10@sha256:6947070c0d1f8bb025d48ca952421b7c83795ca98f0395fe08ad29b7f3df8a33
   connectorSubtype: api
   connectorType: source
   definitionId: c6b0a29e-1da9-4512-9002-7bfd0cba2246

--- a/airbyte-integrations/connectors/source-amazon-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-amazon-ads/metadata.yaml
@@ -9,7 +9,7 @@ data:
       - advertising-api-eu.amazon.com
       - advertising-api-fe.amazon.com
   connectorBuildOptions:
-    baseImage: docker.io/airbyte/source-declarative-manifest:6.45.10@sha256:6947070c0d1f8bb025d48ca952421b7c83795ca98f0395fe08ad29b7f3df8a33
+    baseImage: docker.io/airbyte/source-declarative-manifest:6.48.10@sha256:09947fb38d07e515f9901a12f22cc44f1512f6148703341de80403c0e0c1b8c3
   connectorSubtype: api
   connectorType: source
   definitionId: c6b0a29e-1da9-4512-9002-7bfd0cba2246

--- a/airbyte-integrations/connectors/source-amazon-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-amazon-ads/metadata.yaml
@@ -9,7 +9,7 @@ data:
       - advertising-api-eu.amazon.com
       - advertising-api-fe.amazon.com
   connectorBuildOptions:
-    baseImage: docker.io/airbyte/source-declarative-manifest:6.56.0@sha256:6947070c0d1f8bb025d48ca952421b7c83795ca98f0395fe08ad29b7f3df8a33
+    baseImage: docker.io/airbyte/source-declarative-manifest:6.48.12@sha256:6947070c0d1f8bb025d48ca952421b7c83795ca98f0395fe08ad29b7f3df8a33
   connectorSubtype: api
   connectorType: source
   definitionId: c6b0a29e-1da9-4512-9002-7bfd0cba2246


### PR DESCRIPTION
Downgrading the CDK to confirm that we have a fix on the latest CDK and that is the reason for fewer records being retrieved