### PR TITLE
Rbroughan/cleanup stringify unions

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/DestinationRecordRaw.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/DestinationRecordRaw.kt
@@ -25,10 +25,16 @@ data class DestinationRecordRaw(
     val checkpointId: CheckpointId? = null,
     val airbyteRawId: UUID,
 ) {
-    val schema = stream.schema
-
     // Currently file transfer is only supported for non-socket implementations
     val fileReference: FileReference? = rawData.fileReference
+
+    val schema = stream.schema
+
+    val schemaFields: SequencedMap<String, FieldType> =
+        when (schema) {
+            is ObjectType -> schema.properties
+            else -> linkedMapOf()
+        }
 
     /**
      * DEPRECATED: Now that we support multiple formats for speed, this is no longer an
@@ -59,13 +65,6 @@ data class DestinationRecordRaw(
         extractedAtAsTimestampWithTimezone: Boolean = false
     ): EnrichedDestinationRecordAirbyteValue {
         val rawJson = asJsonRecord()
-
-        // Get the fields from the schema
-        val schemaFields: SequencedMap<String, FieldType> =
-            when (schema) {
-                is ObjectType -> schema.properties
-                else -> linkedMapOf()
-            }
 
         val declaredFields = LinkedHashMap<String, EnrichedAirbyteValue>()
         val undeclaredFields = LinkedHashMap<String, JsonNode>()

--- a/airbyte-integrations/connectors/destination-azure-blob-storage/build.gradle
+++ b/airbyte-integrations/connectors/destination-azure-blob-storage/build.gradle
@@ -8,7 +8,7 @@ plugins {
 airbyteBulkConnector {
     core = 'load'
     toolkits = ['load-object-storage', 'load-azure-blob-storage']
-    cdk = 'local'
+    cdk = '0.428'
 }
 
 application {

--- a/airbyte-integrations/connectors/destination-clickhouse-v2/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-clickhouse-v2/metadata.yaml
@@ -16,7 +16,7 @@ data:
     oss:
       enabled: true
   releaseStage: alpha
-  documentationUrl: https://docs.airbyte.com/integrations/destinations/clickhouse
+  documentationUrl: https://docs.airbyte.com/integrations/destinations/clickhouse-v2
   tags:
     - language:java
   ab_internal:

--- a/airbyte-integrations/connectors/destination-clickhouse-v2/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-clickhouse-v2/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: c4510ac6-094f-4ac3-8811-a5582346b9b9
-  dockerImageTag: 0.1.8
+  dockerImageTag: 0.1.9
   dockerRepository: airbyte/destination-clickhouse-v2
   githubIssueLabel: destination-clickhouse-v2
   icon: clickhouse.svg

--- a/airbyte-integrations/connectors/destination-clickhouse-v2/src/main/kotlin/io/airbyte/integrations/destination/clickhouse_v2/write/load/BinaryRowInsertBuffer.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse-v2/src/main/kotlin/io/airbyte/integrations/destination/clickhouse_v2/write/load/BinaryRowInsertBuffer.kt
@@ -6,40 +6,24 @@ package io.airbyte.integrations.destination.clickhouse_v2.write.load
 
 import com.clickhouse.client.api.Client
 import com.clickhouse.client.api.data_formats.RowBinaryFormatWriter
-import com.clickhouse.client.api.metadata.TableSchema
 import com.clickhouse.data.ClickHouseFormat
 import com.google.common.annotations.VisibleForTesting
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
-import io.airbyte.cdk.load.data.AirbyteType
 import io.airbyte.cdk.load.data.AirbyteValue
 import io.airbyte.cdk.load.data.ArrayValue
-import io.airbyte.cdk.load.data.BooleanType
 import io.airbyte.cdk.load.data.BooleanValue
-import io.airbyte.cdk.load.data.DateType
 import io.airbyte.cdk.load.data.DateValue
-import io.airbyte.cdk.load.data.FieldType
-import io.airbyte.cdk.load.data.IntegerType
 import io.airbyte.cdk.load.data.IntegerValue
 import io.airbyte.cdk.load.data.NullValue
-import io.airbyte.cdk.load.data.NumberType
 import io.airbyte.cdk.load.data.NumberValue
 import io.airbyte.cdk.load.data.ObjectValue
-import io.airbyte.cdk.load.data.StringType
 import io.airbyte.cdk.load.data.StringValue
-import io.airbyte.cdk.load.data.TimeTypeWithTimezone
-import io.airbyte.cdk.load.data.TimeTypeWithoutTimezone
 import io.airbyte.cdk.load.data.TimeWithTimezoneValue
 import io.airbyte.cdk.load.data.TimeWithoutTimezoneValue
-import io.airbyte.cdk.load.data.TimestampTypeWithTimezone
-import io.airbyte.cdk.load.data.TimestampTypeWithoutTimezone
 import io.airbyte.cdk.load.data.TimestampWithTimezoneValue
 import io.airbyte.cdk.load.data.TimestampWithoutTimezoneValue
-import io.airbyte.cdk.load.data.UnknownType
-import io.airbyte.cdk.load.message.Meta
-import io.airbyte.cdk.load.message.Meta.Companion.COLUMN_NAMES
 import io.airbyte.cdk.load.orchestration.db.TableName
 import io.airbyte.cdk.load.util.serializeToString
-import io.airbyte.integrations.destination.clickhouse_v2.config.toClickHouseCompatibleName
 import io.github.oshai.kotlinlogging.KotlinLogging
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
@@ -53,41 +37,20 @@ private val log = KotlinLogging.logger {}
  */
 @SuppressFBWarnings(
     value = ["NP_NONNULL_PARAM_VIOLATION"],
-    justification = "suspend and fb's non-null analysis don't play well",
+    justification = "suspend and fb's non-null analysis don't play well"
 )
 class BinaryRowInsertBuffer(
     val tableName: TableName,
     private val clickhouseClient: Client,
-    airbyteSchema: AirbyteType
 ) {
     // Initialize the inner buffer
-    private val schema: TableSchema =
-        clickhouseClient.getTableSchema(tableName.name, tableName.namespace)
+    private val schema = clickhouseClient.getTableSchema(tableName.name, tableName.namespace)
     @VisibleForTesting internal var inner = InputOutputBuffer()
     @VisibleForTesting
     internal var writer = RowBinaryFormatWriter(inner, schema, ClickHouseFormat.RowBinary)
 
-    @VisibleForTesting
-    internal var formattedSchema: Map<String, FieldType> =
-        airbyteSchema.asColumns().mapKeys { (k, _) -> k.toClickHouseCompatibleName() }
-
     fun accumulate(recordFields: Map<String, AirbyteValue>) {
-        recordFields.forEach {
-            val airbyteType: AirbyteType =
-                if (COLUMN_NAMES.contains(it.key)) {
-                    when (it.key) {
-                        Meta.COLUMN_NAME_AB_RAW_ID -> StringType
-                        Meta.COLUMN_NAME_AB_META -> StringType
-                        Meta.COLUMN_NAME_AB_EXTRACTED_AT -> DateType
-                        Meta.COLUMN_NAME_AB_GENERATION_ID -> IntegerType
-                        else -> // Unreachable
-                        StringType
-                    }
-                } else {
-                    formattedSchema[it.key]!!.type
-                }
-            writeAirbyteValue(it.key, it.value, airbyteType)
-        }
+        recordFields.forEach { writeAirbyteValue(it.key, it.value) }
 
         writer.commitRow()
     }
@@ -100,73 +63,28 @@ class BinaryRowInsertBuffer(
                 .insert(
                     "`${tableName.namespace}`.`${tableName.name}`",
                     inner.toInputStream(),
-                    ClickHouseFormat.RowBinary,
+                    ClickHouseFormat.RowBinary
                 )
                 .await()
 
         log.info { "Finished insert of ${insertResult.writtenRows} rows into ${tableName.name}" }
     }
 
-    internal fun writeAirbyteValue(
-        columnName: String,
-        abValue: AirbyteValue,
-        dataType: AirbyteType,
-    ) {
+    private fun writeAirbyteValue(columnName: String, abValue: AirbyteValue) {
         when (abValue) {
             // TODO: let's consider refactoring AirbyteValue so we don't have to do this
             is NullValue -> writer.setValue(columnName, null)
             is ObjectValue -> writer.setValue(columnName, abValue.values.serializeToString())
             is ArrayValue -> writer.setValue(columnName, abValue.values.serializeToString())
-            is BooleanValue ->
-                write(columnName, abValue.value, dataType is BooleanType || dataType is UnknownType)
-            is IntegerValue ->
-                write(columnName, abValue.value, dataType is IntegerType || dataType is UnknownType)
-            is NumberValue ->
-                write(columnName, abValue.value, dataType is NumberType || dataType is UnknownType)
-            is StringValue ->
-                write(columnName, abValue.value, dataType is StringType || dataType is UnknownType)
-            is DateValue ->
-                write(columnName, abValue.value, dataType is DateType || dataType is UnknownType)
-            is TimeWithTimezoneValue ->
-                write(
-                    columnName,
-                    abValue.value,
-                    dataType is TimeTypeWithTimezone ||
-                        dataType is DateType ||
-                        dataType is UnknownType
-                )
-            is TimeWithoutTimezoneValue ->
-                write(
-                    columnName,
-                    abValue.value,
-                    dataType is TimeTypeWithoutTimezone ||
-                        dataType is DateType ||
-                        dataType is UnknownType
-                )
-            is TimestampWithTimezoneValue ->
-                write(
-                    columnName,
-                    abValue.value,
-                    dataType is TimestampTypeWithTimezone ||
-                        dataType is DateType ||
-                        dataType is UnknownType
-                )
-            is TimestampWithoutTimezoneValue ->
-                write(
-                    columnName,
-                    abValue.value,
-                    dataType is TimestampTypeWithoutTimezone ||
-                        dataType is DateType ||
-                        dataType is UnknownType
-                )
-        }
-    }
-
-    internal fun <V> write(columnName: String, value: V, matchType: Boolean) {
-        if (matchType) {
-            writer.setValue(columnName, value)
-        } else {
-            writer.setValue(columnName, value.serializeToString())
+            is BooleanValue -> writer.setValue(columnName, abValue.value)
+            is IntegerValue -> writer.setValue(columnName, abValue.value)
+            is NumberValue -> writer.setValue(columnName, abValue.value)
+            is StringValue -> writer.setValue(columnName, abValue.value)
+            is DateValue -> writer.setValue(columnName, abValue.value)
+            is TimeWithTimezoneValue -> writer.setValue(columnName, abValue.value)
+            is TimeWithoutTimezoneValue -> writer.setValue(columnName, abValue.value)
+            is TimestampWithTimezoneValue -> writer.setValue(columnName, abValue.value)
+            is TimestampWithoutTimezoneValue -> writer.setValue(columnName, abValue.value)
         }
     }
 

--- a/airbyte-integrations/connectors/destination-clickhouse-v2/src/main/kotlin/io/airbyte/integrations/destination/clickhouse_v2/write/load/ClickhouseDirectLoaderFactory.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse-v2/src/main/kotlin/io/airbyte/integrations/destination/clickhouse_v2/write/load/ClickhouseDirectLoaderFactory.kt
@@ -5,7 +5,6 @@
 package io.airbyte.integrations.destination.clickhouse_v2.write.load
 
 import com.clickhouse.client.api.Client
-import io.airbyte.cdk.load.command.DestinationCatalog
 import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.orchestration.db.direct_load_table.DirectLoadTableExecutionConfig
 import io.airbyte.cdk.load.write.DirectLoaderFactory
@@ -21,7 +20,6 @@ class ClickhouseDirectLoaderFactory(
     private val clickhouseClient: Client,
     private val stateStore: StreamStateStore<DirectLoadTableExecutionConfig>,
     private val munger: RecordMunger,
-    private val catalog: DestinationCatalog,
 ) : DirectLoaderFactory<ClickhouseDirectLoader> {
     override val maxNumOpenLoaders = 2
 
@@ -30,12 +28,7 @@ class ClickhouseDirectLoaderFactory(
         part: Int
     ): ClickhouseDirectLoader {
         val tableName = stateStore.get(streamDescriptor)!!.tableName
-        val buffer =
-            BinaryRowInsertBuffer(
-                tableName,
-                clickhouseClient,
-                catalog.getStream(streamDescriptor).schema,
-            )
+        val buffer = BinaryRowInsertBuffer(tableName, clickhouseClient)
 
         return ClickhouseDirectLoader(
             munger,

--- a/airbyte-integrations/connectors/destination-clickhouse-v2/src/main/kotlin/io/airbyte/integrations/destination/clickhouse_v2/write/transform/ClickhouseCoercer.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse-v2/src/main/kotlin/io/airbyte/integrations/destination/clickhouse_v2/write/transform/ClickhouseCoercer.kt
@@ -41,20 +41,21 @@ import java.time.ZoneOffset
 @Singleton
 class ClickhouseCoercer {
     fun toJsonStringValue(value: EnrichedAirbyteValue): EnrichedAirbyteValue {
-        value.abValue = when (val abValue = value.abValue) {
-            is ObjectValue -> StringValue(abValue.values.serializeToString())
-            is ArrayValue -> StringValue(abValue.values.serializeToString())
-            is BooleanValue -> StringValue(abValue.value.serializeToString())
-            is IntegerValue -> StringValue(abValue.value.serializeToString())
-            is NumberValue -> StringValue(abValue.value.serializeToString())
-            is DateValue -> StringValue(abValue.value.serializeToString())
-            is TimeWithTimezoneValue -> StringValue(abValue.value.serializeToString())
-            is TimeWithoutTimezoneValue -> StringValue(abValue.value.serializeToString())
-            is TimestampWithTimezoneValue -> StringValue(abValue.value.serializeToString())
-            is TimestampWithoutTimezoneValue -> StringValue(abValue.value.serializeToString())
-            is StringValue -> StringValue(abValue.value.serializeToString())
-            is NullValue -> abValue // Consider null a valid string
-        }
+        value.abValue =
+            when (val abValue = value.abValue) {
+                is ObjectValue -> StringValue(abValue.values.serializeToString())
+                is ArrayValue -> StringValue(abValue.values.serializeToString())
+                is BooleanValue -> StringValue(abValue.value.serializeToString())
+                is IntegerValue -> StringValue(abValue.value.serializeToString())
+                is NumberValue -> StringValue(abValue.value.serializeToString())
+                is DateValue -> StringValue(abValue.value.serializeToString())
+                is TimeWithTimezoneValue -> StringValue(abValue.value.serializeToString())
+                is TimeWithoutTimezoneValue -> StringValue(abValue.value.serializeToString())
+                is TimestampWithTimezoneValue -> StringValue(abValue.value.serializeToString())
+                is TimestampWithoutTimezoneValue -> StringValue(abValue.value.serializeToString())
+                is StringValue -> StringValue(abValue.value.serializeToString())
+                is NullValue -> abValue // Consider null a valid string
+            }
 
         return value
     }

--- a/airbyte-integrations/connectors/destination-clickhouse-v2/src/main/kotlin/io/airbyte/integrations/destination/clickhouse_v2/write/transform/ClickhouseCoercer.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse-v2/src/main/kotlin/io/airbyte/integrations/destination/clickhouse_v2/write/transform/ClickhouseCoercer.kt
@@ -47,12 +47,12 @@ class ClickhouseCoercer {
             is BooleanValue -> StringValue(abValue.value.serializeToString())
             is IntegerValue -> StringValue(abValue.value.serializeToString())
             is NumberValue -> StringValue(abValue.value.serializeToString())
-            is StringValue -> StringValue(abValue.value.serializeToString())
             is DateValue -> StringValue(abValue.value.serializeToString())
             is TimeWithTimezoneValue -> StringValue(abValue.value.serializeToString())
             is TimeWithoutTimezoneValue -> StringValue(abValue.value.serializeToString())
             is TimestampWithTimezoneValue -> StringValue(abValue.value.serializeToString())
             is TimestampWithoutTimezoneValue -> StringValue(abValue.value.serializeToString())
+            is StringValue -> abValue // Already a string
             is NullValue -> abValue // Consider null a valid string
         }
 

--- a/airbyte-integrations/connectors/destination-clickhouse-v2/src/main/kotlin/io/airbyte/integrations/destination/clickhouse_v2/write/transform/ClickhouseCoercer.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse-v2/src/main/kotlin/io/airbyte/integrations/destination/clickhouse_v2/write/transform/ClickhouseCoercer.kt
@@ -40,7 +40,7 @@ import java.time.ZoneOffset
  */
 @Singleton
 class ClickhouseCoercer {
-    fun stringify(value: EnrichedAirbyteValue): EnrichedAirbyteValue {
+    fun toJsonStringValue(value: EnrichedAirbyteValue): EnrichedAirbyteValue {
         value.abValue = when (val abValue = value.abValue) {
             is ObjectValue -> StringValue(abValue.values.serializeToString())
             is ArrayValue -> StringValue(abValue.values.serializeToString())
@@ -52,7 +52,7 @@ class ClickhouseCoercer {
             is TimeWithoutTimezoneValue -> StringValue(abValue.value.serializeToString())
             is TimestampWithTimezoneValue -> StringValue(abValue.value.serializeToString())
             is TimestampWithoutTimezoneValue -> StringValue(abValue.value.serializeToString())
-            is StringValue -> abValue // Already a string
+            is StringValue -> StringValue(abValue.value.serializeToString())
             is NullValue -> abValue // Consider null a valid string
         }
 

--- a/airbyte-integrations/connectors/destination-clickhouse-v2/src/main/kotlin/io/airbyte/integrations/destination/clickhouse_v2/write/transform/RecordMunger.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse-v2/src/main/kotlin/io/airbyte/integrations/destination/clickhouse_v2/write/transform/RecordMunger.kt
@@ -35,7 +35,7 @@ class RecordMunger(
             val fieldType = record.schemaFields[it.key]!!
 
             var mappedValue = it.value
-                .let { v -> if (fieldType.type is UnionType) coercer.stringify(v) else v }
+                .let { v -> if (fieldType.type is UnionType) coercer.toJsonStringValue(v) else v }
                 .let { v -> coercer.validate(v) }
 
             mappedValue = coercer.validate(mappedValue)

--- a/airbyte-integrations/connectors/destination-clickhouse-v2/src/main/kotlin/io/airbyte/integrations/destination/clickhouse_v2/write/transform/RecordMunger.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse-v2/src/main/kotlin/io/airbyte/integrations/destination/clickhouse_v2/write/transform/RecordMunger.kt
@@ -30,13 +30,14 @@ class RecordMunger(
             )
 
         val munged = HashMap<String, AirbyteValue>()
-        enriched.declaredFields.forEach {
-            val mappedKey = catalogInfo.getMappedColumnName(record.stream, it.key)!!
-            val fieldType = record.schemaFields[it.key]!!
+        enriched.declaredFields.forEach { field ->
+            val mappedKey = catalogInfo.getMappedColumnName(record.stream, field.key)!!
+            val fieldType = record.schemaFields[field.key]!!
 
-            var mappedValue = it.value
-                .let { v -> if (fieldType.type is UnionType) coercer.toJsonStringValue(v) else v }
-                .let { v -> coercer.validate(v) }
+            var mappedValue =
+                field.value
+                    .let { if (fieldType.type is UnionType) coercer.toJsonStringValue(it) else it }
+                    .let { coercer.validate(it) }
 
             mappedValue = coercer.validate(mappedValue)
 

--- a/airbyte-integrations/connectors/destination-clickhouse-v2/src/main/kotlin/io/airbyte/integrations/destination/clickhouse_v2/write/transform/RecordMunger.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse-v2/src/main/kotlin/io/airbyte/integrations/destination/clickhouse_v2/write/transform/RecordMunger.kt
@@ -5,13 +5,14 @@
 package io.airbyte.integrations.destination.clickhouse_v2.write.transform
 
 import io.airbyte.cdk.load.data.AirbyteValue
+import io.airbyte.cdk.load.data.UnionType
 import io.airbyte.cdk.load.message.DestinationRecordRaw
 import io.airbyte.cdk.load.orchestration.db.legacy_typing_deduping.TableCatalog
 import jakarta.inject.Singleton
 
 /*
  * Munges values and keys into a simple map form. Encapsulates
- * EnrichedAirybteValue logic from other classes, so it can be replaced if
+ * EnrichedAirbyteValue logic from other classes, so it can be replaced if
  * necessary, as we know it's slow.
  *
  * The HashMap construction is deliberate for speed considerations.
@@ -19,7 +20,7 @@ import jakarta.inject.Singleton
 @Singleton
 class RecordMunger(
     private val catalogInfo: TableCatalog,
-    private val validator: ClickhouseCoercingValidator,
+    private val coercer: ClickhouseCoercer,
 ) {
     fun transformForDest(record: DestinationRecordRaw): Map<String, AirbyteValue> {
         // this actually munges and coerces data
@@ -31,7 +32,14 @@ class RecordMunger(
         val munged = HashMap<String, AirbyteValue>()
         enriched.declaredFields.forEach {
             val mappedKey = catalogInfo.getMappedColumnName(record.stream, it.key)!!
-            val mappedValue = validator.validateAndCoerce(it.value)
+            val fieldType = record.schemaFields[it.key]!!
+
+            var mappedValue = it.value
+                .let { v -> if (fieldType.type is UnionType) coercer.stringify(v) else v }
+                .let { v -> coercer.validate(v) }
+
+            mappedValue = coercer.validate(mappedValue)
+
             munged[mappedKey] = mappedValue.abValue
         }
         // must be called second so it picks up any meta changes from above

--- a/airbyte-integrations/connectors/destination-clickhouse-v2/src/test-integration/resources/expected-spec-cloud.json
+++ b/airbyte-integrations/connectors/destination-clickhouse-v2/src/test-integration/resources/expected-spec-cloud.json
@@ -1,5 +1,5 @@
 {
-  "documentationUrl" : "https://docs.airbyte.com/integrations/destinations/clickhouse",
+  "documentationUrl" : "https://docs.airbyte.com/integrations/destinations/clickhouse-v2",
   "connectionSpecification" : {
     "$schema" : "http://json-schema.org/draft-07/schema#",
     "title" : "Clickhouse Specification Cloud",

--- a/airbyte-integrations/connectors/destination-clickhouse-v2/src/test-integration/resources/expected-spec-oss.json
+++ b/airbyte-integrations/connectors/destination-clickhouse-v2/src/test-integration/resources/expected-spec-oss.json
@@ -1,5 +1,5 @@
 {
-  "documentationUrl" : "https://docs.airbyte.com/integrations/destinations/clickhouse",
+  "documentationUrl" : "https://docs.airbyte.com/integrations/destinations/clickhouse-v2",
   "connectionSpecification" : {
     "$schema" : "http://json-schema.org/draft-07/schema#",
     "title" : "Clickhouse Specification Oss",

--- a/airbyte-integrations/connectors/destination-clickhouse-v2/src/test/kotlin/io/airbyte/integrations/destination/clickhouse_v2/write/load/ClickhouseDirectLoaderFactoryTest.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse-v2/src/test/kotlin/io/airbyte/integrations/destination/clickhouse_v2/write/load/ClickhouseDirectLoaderFactoryTest.kt
@@ -5,7 +5,6 @@
 package io.airbyte.integrations.destination.clickhouse_v2.write.load
 
 import com.clickhouse.client.api.Client
-import io.airbyte.cdk.load.command.DestinationCatalog
 import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.orchestration.db.TableName
 import io.airbyte.cdk.load.orchestration.db.direct_load_table.DirectLoadTableExecutionConfig
@@ -29,13 +28,11 @@ class ClickhouseDirectLoaderFactoryTest {
 
     @MockK lateinit var munger: RecordMunger
 
-    @MockK(relaxed = true) lateinit var catalog: DestinationCatalog
-
     private lateinit var factory: ClickhouseDirectLoaderFactory
 
     @BeforeEach
     fun setup() {
-        factory = ClickhouseDirectLoaderFactory(clickhouseClient, stateStore, munger, catalog)
+        factory = ClickhouseDirectLoaderFactory(clickhouseClient, stateStore, munger)
     }
 
     @ParameterizedTest

--- a/airbyte-integrations/connectors/destination-clickhouse-v2/src/test/kotlin/io/airbyte/integrations/destination/clickhouse_v2/write/transform/ClickhouseCoercerTest.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse-v2/src/test/kotlin/io/airbyte/integrations/destination/clickhouse_v2/write/transform/ClickhouseCoercerTest.kt
@@ -196,19 +196,19 @@ class ClickhouseCoercerTest {
 
     @ParameterizedTest
     @MethodSource("nonNullValues")
-    fun `stringify turns non-null values into a string`(value: AirbyteValue) {
+    fun `toJsonString turns non-null values into a string`(value: AirbyteValue) {
         val input = Fixtures.mockCoercedValue(value)
 
-        val result = coercer.stringify(input)
+        val result = coercer.toJsonStringValue(input)
 
         assert(result.abValue is StringValue)
     }
 
     @Test
-    fun `stringify passes through null values`() {
+    fun `toJsonString passes through null values`() {
         val input = Fixtures.mockCoercedValue(NullValue)
 
-        val result = coercer.stringify(input)
+        val result = coercer.toJsonStringValue(input)
 
         assertEquals(NullValue, result.abValue)
     }

--- a/airbyte-integrations/connectors/destination-clickhouse-v2/src/test/kotlin/io/airbyte/integrations/destination/clickhouse_v2/write/transform/ClickhouseCoercerTest.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse-v2/src/test/kotlin/io/airbyte/integrations/destination/clickhouse_v2/write/transform/ClickhouseCoercerTest.kt
@@ -294,7 +294,11 @@ class ClickhouseCoercerTest {
                 Arguments.of(NumberValue(BigDecimal("89214.7834"))),
                 Arguments.of(IntegerValue(BigInteger("72317631278"))),
                 Arguments.of(StringValue("this should just stay the same")),
-                Arguments.of(ObjectValue(linkedMapOf("cat" to StringValue("dog"), "bird" to StringValue("dog")))),
+                Arguments.of(
+                    ObjectValue(
+                        linkedMapOf("cat" to StringValue("dog"), "bird" to StringValue("dog"))
+                    )
+                ),
                 Arguments.of(ArrayValue(listOf(StringValue("cat"), StringValue("dog")))),
                 Arguments.of(BooleanValue(true)),
                 Arguments.of(BooleanValue(false)),
@@ -313,9 +317,15 @@ class ClickhouseCoercerTest {
 
         fun Long.toAirbyteDateValue() = DateValue(LocalDate.ofEpochDay(this))
 
-        fun Long.toAirbyteTimestampWithTimezoneValue() = TimestampWithTimezoneValue(LocalDateTime.of(LocalDate.ofEpochDay(this), LocalTime.MAX).atOffset(ZoneOffset.UTC))
+        fun Long.toAirbyteTimestampWithTimezoneValue() =
+            TimestampWithTimezoneValue(
+                LocalDateTime.of(LocalDate.ofEpochDay(this), LocalTime.MAX).atOffset(ZoneOffset.UTC)
+            )
 
-        fun Long.toAirbyteTimestampWithoutTimezoneValue() = TimestampWithoutTimezoneValue(LocalDateTime.of(LocalDate.ofEpochDay(this), LocalTime.MAX))
+        fun Long.toAirbyteTimestampWithoutTimezoneValue() =
+            TimestampWithoutTimezoneValue(
+                LocalDateTime.of(LocalDate.ofEpochDay(this), LocalTime.MAX)
+            )
 
         fun mockCoercedValue(value: AirbyteValue) =
             EnrichedAirbyteValue(

--- a/airbyte-integrations/connectors/destination-clickhouse-v2/src/test/kotlin/io/airbyte/integrations/destination/clickhouse_v2/write/transform/ClickhouseCoercerTest.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse-v2/src/test/kotlin/io/airbyte/integrations/destination/clickhouse_v2/write/transform/ClickhouseCoercerTest.kt
@@ -5,12 +5,18 @@
 package io.airbyte.integrations.destination.clickhouse_v2.write.transform
 
 import io.airbyte.cdk.load.data.AirbyteValue
+import io.airbyte.cdk.load.data.ArrayValue
+import io.airbyte.cdk.load.data.BooleanValue
 import io.airbyte.cdk.load.data.DateValue
 import io.airbyte.cdk.load.data.EnrichedAirbyteValue
 import io.airbyte.cdk.load.data.IntegerValue
 import io.airbyte.cdk.load.data.NullValue
 import io.airbyte.cdk.load.data.NumberValue
+import io.airbyte.cdk.load.data.ObjectValue
 import io.airbyte.cdk.load.data.StringType
+import io.airbyte.cdk.load.data.StringValue
+import io.airbyte.cdk.load.data.TimeWithTimezoneValue
+import io.airbyte.cdk.load.data.TimeWithoutTimezoneValue
 import io.airbyte.cdk.load.data.TimestampWithTimezoneValue
 import io.airbyte.cdk.load.data.TimestampWithoutTimezoneValue
 import io.airbyte.integrations.destination.clickhouse_v2.write.transform.ClickhouseCoercer.Constants.DATE32_MAX
@@ -19,8 +25,11 @@ import io.airbyte.integrations.destination.clickhouse_v2.write.transform.Clickho
 import io.airbyte.integrations.destination.clickhouse_v2.write.transform.ClickhouseCoercer.Constants.DECIMAL128_MIN
 import io.airbyte.integrations.destination.clickhouse_v2.write.transform.ClickhouseCoercer.Constants.INT64_MAX
 import io.airbyte.integrations.destination.clickhouse_v2.write.transform.ClickhouseCoercer.Constants.INT64_MIN
+import io.airbyte.integrations.destination.clickhouse_v2.write.transform.ClickhouseCoercerTest.Fixtures.toAirbyteDateValue
 import io.airbyte.integrations.destination.clickhouse_v2.write.transform.ClickhouseCoercerTest.Fixtures.toAirbyteIntegerValue
 import io.airbyte.integrations.destination.clickhouse_v2.write.transform.ClickhouseCoercerTest.Fixtures.toAirbyteNumberValue
+import io.airbyte.integrations.destination.clickhouse_v2.write.transform.ClickhouseCoercerTest.Fixtures.toAirbyteTimestampWithTimezoneValue
+import io.airbyte.integrations.destination.clickhouse_v2.write.transform.ClickhouseCoercerTest.Fixtures.toAirbyteTimestampWithoutTimezoneValue
 import io.airbyte.protocol.models.v0.AirbyteRecordMessageMetaChange
 import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.junit5.MockKExtension
@@ -29,7 +38,9 @@ import java.math.BigInteger
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
+import java.time.OffsetTime
 import java.time.ZoneOffset
+import kotlin.test.Test
 import kotlin.test.assertEquals
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
@@ -96,8 +107,8 @@ class ClickhouseCoercerTest {
     @ParameterizedTest
     @MethodSource("validDates")
     fun `validate and coerces dates - valid values are left unchanged`(value: Long) {
-        val date = LocalDate.ofEpochDay(value)
-        val input = Fixtures.mockCoercedValue(DateValue(date))
+        val date = value.toAirbyteDateValue()
+        val input = Fixtures.mockCoercedValue(date)
 
         val result = coercer.validate(input)
 
@@ -109,8 +120,8 @@ class ClickhouseCoercerTest {
     @ParameterizedTest
     @MethodSource("invalidDates")
     fun `validate and coerces dates - invalid values are nulled`(value: Long) {
-        val date = LocalDate.ofEpochDay(value)
-        val input = Fixtures.mockCoercedValue(DateValue(date))
+        val date = value.toAirbyteDateValue()
+        val input = Fixtures.mockCoercedValue(date)
 
         val result = coercer.validate(input)
 
@@ -126,9 +137,8 @@ class ClickhouseCoercerTest {
     fun `validate and coerces timestamps with timezones - valid values are left unchanged`(
         value: Long
     ) {
-        val timestamp =
-            LocalDateTime.of(LocalDate.ofEpochDay(value), LocalTime.MAX).atOffset(ZoneOffset.UTC)
-        val input = Fixtures.mockCoercedValue(TimestampWithTimezoneValue(timestamp))
+        val timestamp = value.toAirbyteTimestampWithTimezoneValue()
+        val input = Fixtures.mockCoercedValue(timestamp)
 
         val result = coercer.validate(input)
 
@@ -140,9 +150,8 @@ class ClickhouseCoercerTest {
     @ParameterizedTest
     @MethodSource("invalidDates")
     fun `validate and coerces timestamps with timezones - invalid values are nulled`(value: Long) {
-        val timestamp =
-            LocalDateTime.of(LocalDate.ofEpochDay(value), LocalTime.MAX).atOffset(ZoneOffset.UTC)
-        val input = Fixtures.mockCoercedValue(TimestampWithTimezoneValue(timestamp))
+        val timestamp = value.toAirbyteTimestampWithTimezoneValue()
+        val input = Fixtures.mockCoercedValue(timestamp)
 
         val result = coercer.validate(input)
 
@@ -158,8 +167,8 @@ class ClickhouseCoercerTest {
     fun `validate and coerces timestamps without timezones - valid values are left unchanged`(
         value: Long
     ) {
-        val timestamp = LocalDateTime.of(LocalDate.ofEpochDay(value), LocalTime.MAX)
-        val input = Fixtures.mockCoercedValue(TimestampWithoutTimezoneValue(timestamp))
+        val timestamp = value.toAirbyteTimestampWithoutTimezoneValue()
+        val input = Fixtures.mockCoercedValue(timestamp)
 
         val result = coercer.validate(input)
 
@@ -173,8 +182,8 @@ class ClickhouseCoercerTest {
     fun `validate and coerces timestamps without timezones - invalid values are nulled`(
         value: Long
     ) {
-        val timestamp = LocalDateTime.of(LocalDate.ofEpochDay(value), LocalTime.MAX)
-        val input = Fixtures.mockCoercedValue(TimestampWithoutTimezoneValue(timestamp))
+        val timestamp = value.toAirbyteTimestampWithoutTimezoneValue()
+        val input = Fixtures.mockCoercedValue(timestamp)
 
         val result = coercer.validate(input)
 
@@ -183,6 +192,25 @@ class ClickhouseCoercerTest {
             AirbyteRecordMessageMetaChange.Reason.DESTINATION_FIELD_SIZE_LIMITATION,
             result.changes[0].reason
         )
+    }
+
+    @ParameterizedTest
+    @MethodSource("nonNullValues")
+    fun `stringify turns non-null values into a string`(value: AirbyteValue) {
+        val input = Fixtures.mockCoercedValue(value)
+
+        val result = coercer.stringify(input)
+
+        assert(result.abValue is StringValue)
+    }
+
+    @Test
+    fun `stringify passes through null values`() {
+        val input = Fixtures.mockCoercedValue(NullValue)
+
+        val result = coercer.stringify(input)
+
+        assertEquals(NullValue, result.abValue)
     }
 
     companion object {
@@ -259,12 +287,35 @@ class ClickhouseCoercerTest {
                 Arguments.of(255670),
                 Arguments.of(-255670),
             )
+
+        @JvmStatic
+        fun nonNullValues() =
+            listOf(
+                Arguments.of(NumberValue(BigDecimal("89214.7834"))),
+                Arguments.of(IntegerValue(BigInteger("72317631278"))),
+                Arguments.of(StringValue("this should just stay the same")),
+                Arguments.of(ObjectValue(linkedMapOf("cat" to StringValue("dog"), "bird" to StringValue("dog")))),
+                Arguments.of(ArrayValue(listOf(StringValue("cat"), StringValue("dog")))),
+                Arguments.of(BooleanValue(true)),
+                Arguments.of(BooleanValue(false)),
+                Arguments.of(1241124L.toAirbyteDateValue()),
+                Arguments.of(9924124L.toAirbyteTimestampWithTimezoneValue()),
+                Arguments.of(16524124L.toAirbyteTimestampWithoutTimezoneValue()),
+                Arguments.of(TimeWithoutTimezoneValue(LocalTime.now())),
+                Arguments.of(TimeWithTimezoneValue(OffsetTime.now())),
+            )
     }
 
     object Fixtures {
         fun String.toAirbyteNumberValue() = NumberValue(BigDecimal(this))
 
         fun String.toAirbyteIntegerValue() = IntegerValue(BigInteger(this))
+
+        fun Long.toAirbyteDateValue() = DateValue(LocalDate.ofEpochDay(this))
+
+        fun Long.toAirbyteTimestampWithTimezoneValue() = TimestampWithTimezoneValue(LocalDateTime.of(LocalDate.ofEpochDay(this), LocalTime.MAX).atOffset(ZoneOffset.UTC))
+
+        fun Long.toAirbyteTimestampWithoutTimezoneValue() = TimestampWithoutTimezoneValue(LocalDateTime.of(LocalDate.ofEpochDay(this), LocalTime.MAX))
 
         fun mockCoercedValue(value: AirbyteValue) =
             EnrichedAirbyteValue(

--- a/airbyte-integrations/connectors/destination-clickhouse-v2/src/test/kotlin/io/airbyte/integrations/destination/clickhouse_v2/write/transform/RecordMungerTest.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse-v2/src/test/kotlin/io/airbyte/integrations/destination/clickhouse_v2/write/transform/RecordMungerTest.kt
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 class RecordMungerTest {
     @MockK lateinit var catalogInfo: TableCatalog
 
-    @MockK lateinit var validator: ClickhouseCoercingValidator
+    @MockK lateinit var validator: ClickhouseCoercer
 
     private lateinit var munger: RecordMunger
 
@@ -44,7 +44,7 @@ class RecordMungerTest {
                 secondArg<String>() + "_munged"
             }
 
-        every { validator.validateAndCoerce(any()) } answers { firstArg() }
+        every { validator.validate(any()) } answers { firstArg() }
 
         // mock coercion output
         val userFields =
@@ -78,7 +78,7 @@ class RecordMungerTest {
         verify {
             input.asEnrichedDestinationRecordAirbyteValue(extractedAtAsTimestampWithTimezone = true)
         }
-        coerced.declaredFields.forEach { verify { validator.validateAndCoerce(it.value) } }
+        coerced.declaredFields.forEach { verify { validator.validate(it.value) } }
 
         // munged keys map to unwrapped / coerced values
         val expected =

--- a/airbyte-integrations/connectors/destination-clickhouse-v2/src/test/kotlin/io/airbyte/integrations/destination/clickhouse_v2/write/transform/RecordMungerTest.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse-v2/src/test/kotlin/io/airbyte/integrations/destination/clickhouse_v2/write/transform/RecordMungerTest.kt
@@ -5,11 +5,16 @@
 package io.airbyte.integrations.destination.clickhouse_v2.write.transform
 
 import io.airbyte.cdk.load.data.AirbyteValue
+import io.airbyte.cdk.load.data.BooleanType
 import io.airbyte.cdk.load.data.BooleanValue
 import io.airbyte.cdk.load.data.EnrichedAirbyteValue
+import io.airbyte.cdk.load.data.FieldType
+import io.airbyte.cdk.load.data.IntegerType
 import io.airbyte.cdk.load.data.IntegerValue
+import io.airbyte.cdk.load.data.ObjectValue
 import io.airbyte.cdk.load.data.StringType
 import io.airbyte.cdk.load.data.StringValue
+import io.airbyte.cdk.load.data.UnionType
 import io.airbyte.cdk.load.message.DestinationRecordRaw
 import io.airbyte.cdk.load.message.EnrichedDestinationRecordAirbyteValue
 import io.airbyte.cdk.load.orchestration.db.legacy_typing_deduping.TableCatalog
@@ -46,14 +51,19 @@ class RecordMungerTest {
 
         every { validator.validate(any()) } answers { firstArg() }
 
+        val stringfiedValue = Fixtures.mockCoercedValue(StringValue("stringified"))
+        every { validator.stringify(any()) } answers { stringfiedValue }
+
         // mock coercion output
-        val userFields =
+        val nonUnionUserFields =
             linkedMapOf(
                 "user_field_1" to Fixtures.mockCoercedValue(StringValue("test1")),
                 "user_field_2" to Fixtures.mockCoercedValue(StringValue("test2")),
                 "user_field_3" to Fixtures.mockCoercedValue(IntegerValue(777)),
                 "user_field_4" to Fixtures.mockCoercedValue(BooleanValue(false)),
             )
+        val unionUserField = "user_field_5" to Fixtures.mockCoercedValue(ObjectValue(linkedMapOf()))
+        val userFields = (nonUnionUserFields + unionUserField) as LinkedHashMap<String, EnrichedAirbyteValue>
         val internalFields =
             mapOf(
                 "internal_field_1" to Fixtures.mockCoercedValue(StringValue("internal1")),
@@ -69,6 +79,14 @@ class RecordMungerTest {
         val input =
             mockk<DestinationRecordRaw>(relaxed = true) {
                 every { asEnrichedDestinationRecordAirbyteValue(any()) } answers { coerced }
+                every { schemaFields } returns linkedMapOf(
+                    "user_field_1" to FieldType(StringType, false),
+                    "user_field_2" to FieldType(StringType, false),
+                    "user_field_3" to FieldType(IntegerType, false),
+                    "user_field_4" to FieldType(BooleanType, false),
+                    // this field is a union type so it should be stringified
+                    "user_field_5" to FieldType(UnionType(setOf(), false), false),
+                )
             }
 
         val output = munger.transformForDest(input)
@@ -78,7 +96,10 @@ class RecordMungerTest {
         verify {
             input.asEnrichedDestinationRecordAirbyteValue(extractedAtAsTimestampWithTimezone = true)
         }
-        coerced.declaredFields.forEach { verify { validator.validate(it.value) } }
+        // we validate each non-union field directly
+        nonUnionUserFields.forEach { verify { validator.validate(it.value) } }
+        // the stringified field is also validated
+        verify { validator.validate(stringfiedValue) }
 
         // munged keys map to unwrapped / coerced values
         val expected =
@@ -88,6 +109,8 @@ class RecordMungerTest {
                 "user_field_2_munged" to StringValue("test2"),
                 "user_field_3_munged" to IntegerValue(777),
                 "user_field_4_munged" to BooleanValue(false),
+                // union is stringified
+                "user_field_5_munged" to stringfiedValue.abValue,
                 // internal cols are not munged for now
                 "internal_field_1" to StringValue("internal1"),
                 "internal_field_2" to IntegerValue(0),

--- a/airbyte-integrations/connectors/destination-clickhouse-v2/src/test/kotlin/io/airbyte/integrations/destination/clickhouse_v2/write/transform/RecordMungerTest.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse-v2/src/test/kotlin/io/airbyte/integrations/destination/clickhouse_v2/write/transform/RecordMungerTest.kt
@@ -63,7 +63,8 @@ class RecordMungerTest {
                 "user_field_4" to Fixtures.mockCoercedValue(BooleanValue(false)),
             )
         val unionUserField = "user_field_5" to Fixtures.mockCoercedValue(ObjectValue(linkedMapOf()))
-        val userFields = (nonUnionUserFields + unionUserField) as LinkedHashMap<String, EnrichedAirbyteValue>
+        val userFields =
+            (nonUnionUserFields + unionUserField) as LinkedHashMap<String, EnrichedAirbyteValue>
         val internalFields =
             mapOf(
                 "internal_field_1" to Fixtures.mockCoercedValue(StringValue("internal1")),

--- a/airbyte-integrations/connectors/destination-clickhouse-v2/src/test/kotlin/io/airbyte/integrations/destination/clickhouse_v2/write/transform/RecordMungerTest.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse-v2/src/test/kotlin/io/airbyte/integrations/destination/clickhouse_v2/write/transform/RecordMungerTest.kt
@@ -51,7 +51,8 @@ class RecordMungerTest {
 
         every { validator.validate(any()) } answers { firstArg() }
 
-        val stringfiedValue = Fixtures.mockCoercedValue(StringValue("{ \"json\": \"stringified\" }"))
+        val stringfiedValue =
+            Fixtures.mockCoercedValue(StringValue("{ \"json\": \"stringified\" }"))
         every { validator.toJsonStringValue(any()) } answers { stringfiedValue }
 
         // mock coercion output

--- a/airbyte-integrations/connectors/destination-clickhouse-v2/src/test/kotlin/io/airbyte/integrations/destination/clickhouse_v2/write/transform/RecordMungerTest.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse-v2/src/test/kotlin/io/airbyte/integrations/destination/clickhouse_v2/write/transform/RecordMungerTest.kt
@@ -81,14 +81,15 @@ class RecordMungerTest {
         val input =
             mockk<DestinationRecordRaw>(relaxed = true) {
                 every { asEnrichedDestinationRecordAirbyteValue(any()) } answers { coerced }
-                every { schemaFields } returns linkedMapOf(
-                    "user_field_1" to FieldType(StringType, false),
-                    "user_field_2" to FieldType(StringType, false),
-                    "user_field_3" to FieldType(IntegerType, false),
-                    "user_field_4" to FieldType(BooleanType, false),
-                    // this field is a union type so it should be turned into a json string
-                    "user_field_5" to FieldType(UnionType(setOf(), false), false),
-                )
+                every { schemaFields } returns
+                    linkedMapOf(
+                        "user_field_1" to FieldType(StringType, false),
+                        "user_field_2" to FieldType(StringType, false),
+                        "user_field_3" to FieldType(IntegerType, false),
+                        "user_field_4" to FieldType(BooleanType, false),
+                        // this field is a union type so it should be turned into a json string
+                        "user_field_5" to FieldType(UnionType(setOf(), false), false),
+                    )
             }
 
         val output = munger.transformForDest(input)

--- a/airbyte-integrations/connectors/destination-clickhouse-v2/src/test/kotlin/io/airbyte/integrations/destination/clickhouse_v2/write/transform/RecordMungerTest.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse-v2/src/test/kotlin/io/airbyte/integrations/destination/clickhouse_v2/write/transform/RecordMungerTest.kt
@@ -51,8 +51,8 @@ class RecordMungerTest {
 
         every { validator.validate(any()) } answers { firstArg() }
 
-        val stringfiedValue = Fixtures.mockCoercedValue(StringValue("stringified"))
-        every { validator.stringify(any()) } answers { stringfiedValue }
+        val stringfiedValue = Fixtures.mockCoercedValue(StringValue("{ \"json\": \"stringified\" }"))
+        every { validator.toJsonStringValue(any()) } answers { stringfiedValue }
 
         // mock coercion output
         val nonUnionUserFields =
@@ -84,7 +84,7 @@ class RecordMungerTest {
                     "user_field_2" to FieldType(StringType, false),
                     "user_field_3" to FieldType(IntegerType, false),
                     "user_field_4" to FieldType(BooleanType, false),
-                    // this field is a union type so it should be stringified
+                    // this field is a union type so it should be turned into a json string
                     "user_field_5" to FieldType(UnionType(setOf(), false), false),
                 )
             }

--- a/docs/integrations/destinations/clickhouse-v2.md
+++ b/docs/integrations/destinations/clickhouse-v2.md
@@ -23,18 +23,16 @@ All sync modes are supported.
 
 Each stream will be output into its own table in ClickHouse in either the configured default database (`default`) or a database corresponding to the specified namespace on the stream.
 
-The types we are using have the following properties:
+Airbyte types will be converted to ClickHouse types as follows:
 
-- The decimal types have a precision of 9 digits, we are using the ClickHouse type NUMBER128(9)
-- The Timestamp types have a millisecond precision, we are using the ClickHouse type DATETIME64(3)
-- The object type is converted to JSON **if the JSON option is selected**; otherwise it will be a String
-- The integers are Int64
-- The booleans are Bool
-- The strings are String
-- The unions will be converted as a String
-- The times will be converted to a String
-- The arrays will be converted to a String
-
+- Decimal types are NUMBER128(9) — 9 digit precision
+- Timestamp are DateTime64(3) — millisecond precision
+- Object types are JSON **if JSON is enabled in the actor config**; otherwise they are converted to String
+- Integers are Int64
+- Booleans are Bool
+- Strings are String
+- Unions will be converted to String
+- Arrays will be converted to String
 
 ### Requirements
 

--- a/docs/integrations/destinations/clickhouse-v2.md
+++ b/docs/integrations/destinations/clickhouse-v2.md
@@ -78,7 +78,7 @@ You can also use a pre-existing user but we highly recommend creating a dedicate
 
 | Version | Date       | Pull Request                                                  | Subject                                             |
 |:--------|:-----------|:--------------------------------------------------------------|:----------------------------------------------------|
-| 0.1.9   | 2025-06-30 | [\#62509](https://github.com/airbytehq/airbyte/pull/62509)    | Simplify union stringification behavior.            |
+| 0.1.9   | 2025-07-03 | [\#62509](https://github.com/airbytehq/airbyte/pull/62509)    | Simplify union stringification behavior.            |
 | 0.1.8   | 2025-06-30 | [\#62100](https://github.com/airbytehq/airbyte/pull/62100)    | Add JSON support.                                   |
 | 0.1.7   | 2025-06-24 | [\#62047](https://github.com/airbytehq/airbyte/pull/62047)    | Remove the use of the internal namespace.           |
 | 0.1.6   | 2025-06-24 | [\#62047](https://github.com/airbytehq/airbyte/pull/62047)    | Hide protocol option when running on cloud.         |

--- a/docs/integrations/destinations/clickhouse-v2.md
+++ b/docs/integrations/destinations/clickhouse-v2.md
@@ -76,16 +76,16 @@ You can also use a pre-existing user but we highly recommend creating a dedicate
 <details>
   <summary>Expand to review</summary>
 
-| Version | Date       | Pull Request                                               | Subject                                             |
-|:--------|:-----------|:-----------------------------------------------------------|:----------------------------------------------------|
-| 0.1.9   | 2025-06-30 | [\#tbd](https://github.com/airbytehq/airbyte/pull/tbd)     | Simplify union stringification behavior.            |
-| 0.1.8   | 2025-06-30 | [\#62100](https://github.com/airbytehq/airbyte/pull/62100) | Add JSON support.                                   |
-| 0.1.7   | 2025-06-24 | [\#62047](https://github.com/airbytehq/airbyte/pull/62047) | Remove the use of the internal namespace.           |
-| 0.1.6   | 2025-06-24 | [\#62047](https://github.com/airbytehq/airbyte/pull/62047) | Hide protocol option when running on cloud.         |
-| 0.1.5   | 2025-06-24 | [\#62043](https://github.com/airbytehq/airbyte/pull/62043) | Expose database protocol config option.             |
-| 0.1.4   | 2025-06-24 | [\#62040](https://github.com/airbytehq/airbyte/pull/62040) | Checker inserts into configured DB.                 |
-| 0.1.3   | 2025-06-24 | [\#62038](https://github.com/airbytehq/airbyte/pull/62038) | Allow the client to connect to the resolved DB.     |
-| 0.1.2   | 2025-06-23 | [\#62028](https://github.com/airbytehq/airbyte/pull/62028) | Enable the registry in OSS and cloud.               |
-| 0.1.1   | 2025-06-23 | [\#62022](https://github.com/airbytehq/airbyte/pull/62022) | Publish first beta version and pin the CDK version. |
-| 0.1.0   | 2025-06-23 | [\#62024](https://github.com/airbytehq/airbyte/pull/62024) | Release first beta version.                         |
+| Version | Date       | Pull Request                                                  | Subject                                             |
+|:--------|:-----------|:--------------------------------------------------------------|:----------------------------------------------------|
+| 0.1.9   | 2025-06-30 | [\#62509](https://github.com/airbytehq/airbyte/pull/62509)    | Simplify union stringification behavior.            |
+| 0.1.8   | 2025-06-30 | [\#62100](https://github.com/airbytehq/airbyte/pull/62100)    | Add JSON support.                                   |
+| 0.1.7   | 2025-06-24 | [\#62047](https://github.com/airbytehq/airbyte/pull/62047)    | Remove the use of the internal namespace.           |
+| 0.1.6   | 2025-06-24 | [\#62047](https://github.com/airbytehq/airbyte/pull/62047)    | Hide protocol option when running on cloud.         |
+| 0.1.5   | 2025-06-24 | [\#62043](https://github.com/airbytehq/airbyte/pull/62043)    | Expose database protocol config option.             |
+| 0.1.4   | 2025-06-24 | [\#62040](https://github.com/airbytehq/airbyte/pull/62040)    | Checker inserts into configured DB.                 |
+| 0.1.3   | 2025-06-24 | [\#62038](https://github.com/airbytehq/airbyte/pull/62038)    | Allow the client to connect to the resolved DB.     |
+| 0.1.2   | 2025-06-23 | [\#62028](https://github.com/airbytehq/airbyte/pull/62028)    | Enable the registry in OSS and cloud.               |
+| 0.1.1   | 2025-06-23 | [\#62022](https://github.com/airbytehq/airbyte/pull/62022)    | Publish first beta version and pin the CDK version. |
+| 0.1.0   | 2025-06-23 | [\#62024](https://github.com/airbytehq/airbyte/pull/62024)    | Release first beta version.                         |
 </details>

--- a/docs/integrations/destinations/clickhouse-v2.md
+++ b/docs/integrations/destinations/clickhouse-v2.md
@@ -78,7 +78,8 @@ You can also use a pre-existing user but we highly recommend creating a dedicate
 
 | Version | Date       | Pull Request                                               | Subject                                             |
 |:--------|:-----------|:-----------------------------------------------------------|:----------------------------------------------------|
-| 0.1.8   | 2025-06-30 | [\#62100](https://github.com/airbytehq/airbyte/pull/62100) | Add JSON support.                                       |
+| 0.1.9   | 2025-06-30 | [\#tbd](https://github.com/airbytehq/airbyte/pull/tbd)     | Simplify union stringification behavior.            |
+| 0.1.8   | 2025-06-30 | [\#62100](https://github.com/airbytehq/airbyte/pull/62100) | Add JSON support.                                   |
 | 0.1.7   | 2025-06-24 | [\#62047](https://github.com/airbytehq/airbyte/pull/62047) | Remove the use of the internal namespace.           |
 | 0.1.6   | 2025-06-24 | [\#62047](https://github.com/airbytehq/airbyte/pull/62047) | Hide protocol option when running on cloud.         |
 | 0.1.5   | 2025-06-24 | [\#62043](https://github.com/airbytehq/airbyte/pull/62043) | Expose database protocol config option.             |


### PR DESCRIPTION
## What
Factors the union -> json stringification out to the ClickHouse-specific coercer

## How
It's mostly reverts and unit tests. 

Just look at the `toJsonString` method in `ClickhouseCoercer` and the `RecordMunger`.

## Other
* Exposes `DestinationRecordRaw#schemaFields`
* renames some stuff

## Note
I am not adding a meta change to the row when I stringify a union. There is no "String conversion" meta change in the protocol.
