### PR TITLE
fix(source-google-ads): update metadata flags for progressive rollout

### DIFF
--- a/airbyte-integrations/connectors/source-google-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-ads/metadata.yaml
@@ -11,7 +11,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 253487c0-2246-43ba-a21f-5116b20a2c50
-  dockerImageTag: 3.9.0-rc.3
+  dockerImageTag: 3.9.0-rc.4
   dockerRepository: airbyte/source-google-ads
   documentationUrl: https://docs.airbyte.com/integrations/sources/google-ads
   githubIssueLabel: source-google-ads
@@ -31,7 +31,7 @@ data:
   releaseStage: generally_available
   releases:
     rolloutConfiguration:
-      enableProgressiveRollout: false
+      enableProgressiveRollout: true
     breakingChanges:
       1.0.0:
         message: This release introduces fixes to custom query schema creation. Users should refresh the source schema and reset affected streams after upgrading to ensure uninterrupted syncs.

--- a/airbyte-integrations/connectors/source-google-ads/pyproject.toml
+++ b/airbyte-integrations/connectors/source-google-ads/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "3.9.0-rc.3"
+version = "3.9.0-rc.4"
 name = "source-google-ads"
 description = "Source implementation for Google Ads."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/docs/integrations/sources/google-ads.md
+++ b/docs/integrations/sources/google-ads.md
@@ -335,6 +335,7 @@ Due to a limitation in the Google Ads API which does not allow getting performan
 
 | Version    | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |:-----------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 3.9.0-rc.4 | 202507-03  | []() | Update rollout flag in metadata |
 | 3.9.0-rc.3 | 2025-07-03 | [62494](https://github.com/airbytehq/airbyte/pull/62494) | Handle ServiceUnavailableErrors and retry on account check |
 | 3.9.0-rc.2 | 2025-07-03 | [62505](https://github.com/airbytehq/airbyte/pull/62505) | Fix state migration for empty states                                                                                                                                   |
 | 3.9.0-rc.1 | 2025-06-18 | [61674](https://github.com/airbytehq/airbyte/pull/61674) | Migrate Campaign stream to Low Code                                                                                                                                    |

--- a/docs/integrations/sources/google-ads.md
+++ b/docs/integrations/sources/google-ads.md
@@ -335,7 +335,7 @@ Due to a limitation in the Google Ads API which does not allow getting performan
 
 | Version    | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |:-----------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 3.9.0-rc.4 | 202507-03  | []() | Update rollout flag in metadata |
+| 3.9.0-rc.4 | 202507-03  | [62513](https://github.com/airbytehq/airbyte/pull/62513) | Update rollout flag in metadata |
 | 3.9.0-rc.3 | 2025-07-03 | [62494](https://github.com/airbytehq/airbyte/pull/62494) | Handle ServiceUnavailableErrors and retry on account check |
 | 3.9.0-rc.2 | 2025-07-03 | [62505](https://github.com/airbytehq/airbyte/pull/62505) | Fix state migration for empty states                                                                                                                                   |
 | 3.9.0-rc.1 | 2025-06-18 | [61674](https://github.com/airbytehq/airbyte/pull/61674) | Migrate Campaign stream to Low Code                                                                                                                                    |


### PR DESCRIPTION
## What

Missed that the progressive rollout flag was set to `false` for 3.9.0-rc.3

## How
<!--
* Describe how code changes achieve the solution.
-->

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
