### PR TITLE
ci: update PR welcome message with new poe slash command tips

### DIFF
--- a/.github/pr-welcome-internal.md
+++ b/.github/pr-welcome-internal.md
@@ -22,7 +22,8 @@ Airbyte Maintainers (that's you!) can execute the following slash commands on yo
   - Leaving the changelog arg blank will auto-populate the changelog from the PR title.
 - `/run-cat-tests` - Runs legacy CAT tests (Connector Acceptance Tests)
 - `/build-connector-images` - Builds and publishes a pre-release docker image for the modified connector(s).
-- `/poe source example lock` - Run the Poe `lock` task on the `source-example` connector, committing the results back to the branch.
+- `/poe connector source-example lock` - Run the Poe `lock` task on the `source-example` connector, committing the results back to the branch.
+- `/poe source example lock` - Alias for `/poe connector source-example lock`.
 - `/poe source example use-cdk-branch my/branch` - Pin the `source-example` CDK reference to the branch name specified.
 - `/poe source example use-cdk-latest` - Update the `source-example` CDK dependency to the latest available version.
 

--- a/.github/pr-welcome-internal.md
+++ b/.github/pr-welcome-internal.md
@@ -1,4 +1,4 @@
-## 👋 Greetings, Contributor!
+## 👋 Greetings, Airbyte Team Member!
 
 Here are some helpful tips and reminders for your convenience.
 
@@ -22,5 +22,8 @@ Airbyte Maintainers (that's you!) can execute the following slash commands on yo
   - Leaving the changelog arg blank will auto-populate the changelog from the PR title.
 - `/run-cat-tests` - Runs legacy CAT tests (Connector Acceptance Tests)
 - `/build-connector-images` - Builds and publishes a pre-release docker image for the modified connector(s).
+- `/poe source example lock` - Run the Poe `lock` task on the `source-example` connector, committing the results back to the branch.
+- `/poe source example use-cdk-branch my/branch` - Pin the `source-example` CDK reference to the branch name specified.
+- `/poe source example use-cdk-latest` - Update the `source-example` CDK depdendency to the latest available version.
 
 [📝 _Edit this welcome message._](https://github.com/airbytehq/airbyte/blob/master/.github/pr-welcome-internal.md)

--- a/.github/pr-welcome-internal.md
+++ b/.github/pr-welcome-internal.md
@@ -24,6 +24,6 @@ Airbyte Maintainers (that's you!) can execute the following slash commands on yo
 - `/build-connector-images` - Builds and publishes a pre-release docker image for the modified connector(s).
 - `/poe source example lock` - Run the Poe `lock` task on the `source-example` connector, committing the results back to the branch.
 - `/poe source example use-cdk-branch my/branch` - Pin the `source-example` CDK reference to the branch name specified.
-- `/poe source example use-cdk-latest` - Update the `source-example` CDK depdendency to the latest available version.
+- `/poe source example use-cdk-latest` - Update the `source-example` CDK dependency to the latest available version.
 
 [📝 _Edit this welcome message._](https://github.com/airbytehq/airbyte/blob/master/.github/pr-welcome-internal.md)


### PR DESCRIPTION
## What

Document some of the new things you can do with CDK refs and Poe slash commands:

> - `/poe connector source-example lock` - Run the Poe `lock` task on the `source-example` connector, committing the results back to the branch.
> - `/poe source example lock` - Alias for `/poe connector source-example lock`.
> - `/poe source example use-cdk-branch my/branch` - Pin the `source-example` CDK reference to the branch name specified.
> - `/poe source example use-cdk-latest` - Update the `source-example` CDK dependency to the latest available version.

All of these are normal 'poe' tasks, but we use a wrapper poe command "source" or "destination" that finds the named connector and then calls Poe again from the proper subdirectory. The code for how this works is here:

https://github.com/airbytehq/airbyte/blob/42833757371c9b50cac47df06cfca2f7b6375daf/poe-tasks/repo-root-tasks.toml#L54-L62

## Known Issues

1. The `use-cdk-*` Poe tasks are not yet extras-aware. If you accidentally lose your extras declaration, you will need re-add it manually. (Hopefully this is super easy to catch in the PR.
   - A fix is available but I want to make it shorter if I can: https://github.com/airbytehq/airbyte/pull/62436
2. The PR pre-release checks don't currently prevent you from merging PRs using git-backed CDK references. As of now, it is up to the PR author to remember to pin back to a production CDK reference before merging their PR.
3. Some of these might not work with non-Python connectors yet, although it should be easy to expand support as desired. Whatever is defined for a specific connector in their poe connector tasks file should be available here to run as a slash command.


## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._

> [!NOTE]
> **Auto-merge may have been disabled. Please check the PR status to confirm.**