### PR TITLE
ci(fix): conclusion 'failure' instead of failed

### DIFF
--- a/.github/workflows/connector-ci-checks.yml
+++ b/.github/workflows/connector-ci-checks.yml
@@ -456,7 +456,7 @@ jobs:
                 "${{ needs.connectors-lint.result }}" == "success" ]]; then
             echo "result=success" | tee -a $GITHUB_OUTPUT
           else
-            echo "result=failed" | tee -a $GITHUB_OUTPUT
+            echo "result=failure" | tee -a $GITHUB_OUTPUT
           fi
 
       # In slash commands and when not running within a fork, we want to upload


### PR DESCRIPTION
## What

Fixes an issue where the wrong conclusion code is used.

https://chatgpt.com/share/686c1833-4d4c-8004-85f6-397fce738c56

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._

> [!NOTE]
> **Auto-merge may have been disabled. Please check the PR status to confirm.**