### PR TITLE
fix: dlq should support empty lists

### DIFF
--- a/airbyte-cdk/bulk/toolkits/load-dlq/src/integrationTest/kotlin/DlqStateWithRecordSample.kt
+++ b/airbyte-cdk/bulk/toolkits/load-dlq/src/integrationTest/kotlin/DlqStateWithRecordSample.kt
@@ -10,7 +10,7 @@ import io.airbyte.cdk.load.message.DestinationRecordRaw
 import io.airbyte.cdk.load.message.StreamKey
 import java.math.BigInteger
 
-class DlqStateWithRecordSample : DlqTestState {
+open class DlqStateWithRecordSample : DlqTestState {
     private val records: MutableList<DestinationRecordRaw> = mutableListOf()
 
     override fun accumulate(record: DestinationRecordRaw) {

--- a/airbyte-cdk/bulk/toolkits/load-dlq/src/integrationTest/kotlin/DlqStateWithSampleAndEmptyList.kt
+++ b/airbyte-cdk/bulk/toolkits/load-dlq/src/integrationTest/kotlin/DlqStateWithSampleAndEmptyList.kt
@@ -1,0 +1,15 @@
+import io.airbyte.cdk.load.integrationTest.DlqStateFactory
+import io.airbyte.cdk.load.integrationTest.DlqTestState
+import io.airbyte.cdk.load.message.DestinationRecordRaw
+import io.airbyte.cdk.load.message.StreamKey
+
+class DlqStateWithSampleAndEmptyList : DlqStateWithRecordSample() {
+    override fun flush(): List<DestinationRecordRaw>? {
+        return super.flush() ?: listOf()
+    }
+
+    class Factory : DlqStateFactory {
+        override fun create(key: StreamKey, part: Int): DlqTestState =
+            DlqStateWithSampleAndEmptyList()
+    }
+}

--- a/airbyte-cdk/bulk/toolkits/load-dlq/src/integrationTest/kotlin/DlqStateWithSampleAndEmptyList.kt
+++ b/airbyte-cdk/bulk/toolkits/load-dlq/src/integrationTest/kotlin/DlqStateWithSampleAndEmptyList.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+ */
+
 import io.airbyte.cdk.load.integrationTest.DlqStateFactory
 import io.airbyte.cdk.load.integrationTest.DlqTestState
 import io.airbyte.cdk.load.message.DestinationRecordRaw

--- a/airbyte-cdk/bulk/toolkits/load-dlq/src/integrationTest/kotlin/DlqTestLoader.kt
+++ b/airbyte-cdk/bulk/toolkits/load-dlq/src/integrationTest/kotlin/DlqTestLoader.kt
@@ -5,6 +5,7 @@
 package io.airbyte.cdk.load.integrationTest
 
 import DlqStateWithRecordSample
+import DlqStateWithSampleAndEmptyList
 import io.airbyte.cdk.load.MockObjectStorageClient
 import io.airbyte.cdk.load.check.DestinationChecker
 import io.airbyte.cdk.load.check.dlq.DlqChecker
@@ -34,6 +35,7 @@ import jakarta.inject.Singleton
 
 const val DLQ_INTEGRATION_TEST_ENV = "dlq-integration-test"
 const val DLQ_SAMPLE_TEST = "dlq-sample-test"
+const val DLQ_SAMPLE_WITH_EMPTY_LIST_TEST = "dlq-sample-with-empty-list-test"
 
 class DlqTestSpec : ConfigurationSpecificationWithDlq()
 
@@ -124,6 +126,11 @@ class DlqTestFactory {
     @Singleton
     @Secondary
     fun dlqStateFromRecordSampleFactory(): DlqStateFactory = DlqStateWithRecordSample.Factory()
+
+    @Singleton
+    @Requires(env = [DLQ_SAMPLE_WITH_EMPTY_LIST_TEST])
+    fun dlqStateFromRecordSampleWithEmptyListFactory(): DlqStateFactory =
+        DlqStateWithSampleAndEmptyList.Factory()
 
     @Singleton
     @Requires(env = [DLQ_SAMPLE_TEST])

--- a/airbyte-cdk/bulk/toolkits/load-dlq/src/integrationTest/kotlin/DlqWriteTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-dlq/src/integrationTest/kotlin/DlqWriteTest.kt
@@ -10,6 +10,7 @@ import io.airbyte.cdk.load.config.DataChannelMedium
 import io.airbyte.cdk.load.data.ObjectType
 import io.airbyte.cdk.load.integrationTest.DLQ_INTEGRATION_TEST_ENV
 import io.airbyte.cdk.load.integrationTest.DLQ_SAMPLE_TEST
+import io.airbyte.cdk.load.integrationTest.DLQ_SAMPLE_WITH_EMPTY_LIST_TEST
 import io.airbyte.cdk.load.message.CheckpointMessage
 import io.airbyte.cdk.load.message.InputRecord
 import io.airbyte.cdk.load.message.InputStreamCheckpoint
@@ -24,9 +25,11 @@ import io.airbyte.cdk.load.util.deserializeToNode
 import io.airbyte.cdk.load.write.BasicFunctionalityIntegrationTest.Companion.intType
 import io.airbyte.protocol.models.v0.AirbyteMessage
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertAll
 
+@Disabled
 open class AbstractDlqWriteTest(
     val configContent: String,
     additionalMicronautEnvs: List<String> = listOf(),
@@ -40,7 +43,7 @@ open class AbstractDlqWriteTest(
         dataChannelFormat = DataChannelFormat.JSONL,
         additionalMicronautEnvs = additionalMicronautEnvs,
     ) {
-
+    @Test
     open fun testBasicWrite() {
         val stream =
             DestinationStream(
@@ -161,43 +164,30 @@ class NoBucketDlqWriteTest :
     AbstractDlqWriteTest(
         configContent = """{"object_storage_config":{"storage_type":"None"}}""",
         additionalMicronautEnvs = listOf(DLQ_INTEGRATION_TEST_ENV)
-    ) {
-    @Test
-    override fun testBasicWrite() {
-        super.testBasicWrite()
-    }
-}
+    )
 
 class NoBucketConfigDlqWriteTest :
     AbstractDlqWriteTest(
         configContent = """{}""",
         additionalMicronautEnvs = listOf(DLQ_INTEGRATION_TEST_ENV)
-    ) {
-    @Test
-    override fun testBasicWrite() {
-        super.testBasicWrite()
-    }
-}
+    )
 
 class MockBucketDlqFromRecordSampleTest :
     AbstractDlqWriteTest(
         configContent = """{"object_storage_config":{"storage_type":"S3"}}""",
         additionalMicronautEnvs = listOf("MockObjectStorage", DLQ_INTEGRATION_TEST_ENV),
-    ) {
-    @Test
-    override fun testBasicWrite() {
-        super.testBasicWrite()
-    }
-}
+    )
+
+class MockBucketDlqFromRecordSampleWithEmptyListTest :
+    AbstractDlqWriteTest(
+        configContent = """{"object_storage_config":{"storage_type":"S3"}}""",
+        additionalMicronautEnvs =
+            listOf("MockObjectStorage", DLQ_INTEGRATION_TEST_ENV, DLQ_SAMPLE_WITH_EMPTY_LIST_TEST),
+    )
 
 class MockBucketDlqFromNewRecordsTest :
     AbstractDlqWriteTest(
         configContent = """{"object_storage_config":{"storage_type":"S3"}}""",
         additionalMicronautEnvs =
             listOf("MockObjectStorage", DLQ_INTEGRATION_TEST_ENV, DLQ_SAMPLE_TEST),
-    ) {
-    @Test
-    override fun testBasicWrite() {
-        super.testBasicWrite()
-    }
-}
+    )

--- a/airbyte-cdk/bulk/toolkits/load-dlq/src/main/kotlin/io/airbyte/cdk/load/pipeline/dlq/DlqLoaderPipelineStep.kt
+++ b/airbyte-cdk/bulk/toolkits/load-dlq/src/main/kotlin/io/airbyte/cdk/load/pipeline/dlq/DlqLoaderPipelineStep.kt
@@ -89,7 +89,8 @@ class DlqLoaderAccumulator<S>(
 
     private fun getOutput(rejectedRecords: List<DestinationRecordRaw>?) =
         when (rejectedRecords) {
-            null, emptyList<DestinationRecordRaw>() -> DlqStepOutput(BatchState.COMPLETE, null)
+            null,
+            emptyList<DestinationRecordRaw>() -> DlqStepOutput(BatchState.COMPLETE, null)
             else -> DlqStepOutput(BatchState.STAGED, rejectedRecords)
         }
 }

--- a/airbyte-cdk/bulk/toolkits/load-dlq/src/main/kotlin/io/airbyte/cdk/load/pipeline/dlq/DlqLoaderPipelineStep.kt
+++ b/airbyte-cdk/bulk/toolkits/load-dlq/src/main/kotlin/io/airbyte/cdk/load/pipeline/dlq/DlqLoaderPipelineStep.kt
@@ -89,7 +89,7 @@ class DlqLoaderAccumulator<S>(
 
     private fun getOutput(rejectedRecords: List<DestinationRecordRaw>?) =
         when (rejectedRecords) {
-            null -> DlqStepOutput(BatchState.COMPLETE, null)
+            null, emptyList<DestinationRecordRaw>() -> DlqStepOutput(BatchState.COMPLETE, null)
             else -> DlqStepOutput(BatchState.STAGED, rejectedRecords)
         }
 }


### PR DESCRIPTION
## What

Fix a bug where the connector may hang if the `DlqLoader` returns an empty list of records.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
