### PR TITLE
feat: set dlq checker in low-code and apply to destination-customer-io

### DIFF
--- a/airbyte-cdk/bulk/toolkits/load-low-code/build.gradle
+++ b/airbyte-cdk/bulk/toolkits/load-low-code/build.gradle
@@ -2,6 +2,7 @@ dependencies {
     implementation project(':airbyte-cdk:bulk:core:bulk-cdk-core-base')
     implementation project(':airbyte-cdk:bulk:core:bulk-cdk-core-load')
 
+    api project(':airbyte-cdk:bulk:toolkits:bulk-cdk-toolkit-load-dlq')
     implementation project(':airbyte-cdk:bulk:toolkits:bulk-cdk-toolkit-load-http')
     api 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
     api 'com.fasterxml.jackson.module:jackson-module-kotlin'

--- a/airbyte-cdk/bulk/toolkits/load-low-code/src/main/kotlin/io/airbyte/cdk/load/checker/CompositeDlqChecker.kt
+++ b/airbyte-cdk/bulk/toolkits/load-low-code/src/main/kotlin/io/airbyte/cdk/load/checker/CompositeDlqChecker.kt
@@ -1,15 +1,20 @@
- package io.airbyte.cdk.load.checker
+/*
+ * Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+ */
 
- import io.airbyte.cdk.load.check.DestinationChecker
- import io.airbyte.cdk.load.check.dlq.DlqChecker
- import io.airbyte.cdk.load.command.DestinationConfiguration
- import io.airbyte.cdk.load.command.dlq.ObjectStorageConfigProvider
+package io.airbyte.cdk.load.checker
 
- class CompositeDlqChecker<C>(private val decorated: DestinationChecker<C>, private val
- dlqChecker: DlqChecker): DestinationChecker<C>
-    where C : DestinationConfiguration, C : ObjectStorageConfigProvider {
+import io.airbyte.cdk.load.check.DestinationChecker
+import io.airbyte.cdk.load.check.dlq.DlqChecker
+import io.airbyte.cdk.load.command.DestinationConfiguration
+import io.airbyte.cdk.load.command.dlq.ObjectStorageConfigProvider
+
+class CompositeDlqChecker<C>(
+    private val decorated: DestinationChecker<C>,
+    private val dlqChecker: DlqChecker
+) : DestinationChecker<C> where C : DestinationConfiguration, C : ObjectStorageConfigProvider {
     override fun check(config: C) {
         decorated.check(config)
         dlqChecker.check(config.objectStorageConfig)
     }
- }
+}

--- a/airbyte-cdk/bulk/toolkits/load-low-code/src/main/kotlin/io/airbyte/cdk/load/checker/CompositeDlqChecker.kt
+++ b/airbyte-cdk/bulk/toolkits/load-low-code/src/main/kotlin/io/airbyte/cdk/load/checker/CompositeDlqChecker.kt
@@ -1,0 +1,15 @@
+ package io.airbyte.cdk.load.checker
+
+ import io.airbyte.cdk.load.check.DestinationChecker
+ import io.airbyte.cdk.load.check.dlq.DlqChecker
+ import io.airbyte.cdk.load.command.DestinationConfiguration
+ import io.airbyte.cdk.load.command.dlq.ObjectStorageConfigProvider
+
+ class CompositeDlqChecker<C>(private val decorated: DestinationChecker<C>, private val
+ dlqChecker: DlqChecker): DestinationChecker<C>
+    where C : DestinationConfiguration, C : ObjectStorageConfigProvider {
+    override fun check(config: C) {
+        decorated.check(config)
+        dlqChecker.check(config.objectStorageConfig)
+    }
+ }

--- a/airbyte-cdk/bulk/toolkits/load-low-code/src/main/kotlin/io/airbyte/cdk/load/lowcode/DeclarativeDestinationFactory.kt
+++ b/airbyte-cdk/bulk/toolkits/load-low-code/src/main/kotlin/io/airbyte/cdk/load/lowcode/DeclarativeDestinationFactory.kt
@@ -28,7 +28,9 @@ import io.airbyte.cdk.util.ResourceUtils
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 
-class DeclarativeDestinationFactory<T>(private val config: T) where T : DestinationConfiguration, T : ObjectStorageConfigProvider {
+class DeclarativeDestinationFactory<T>(private val config: T) where
+T : DestinationConfiguration,
+T : ObjectStorageConfigProvider {
     private val stringInterpolator: StringInterpolator = StringInterpolator()
 
     fun createDestinationChecker(dlqChecker: DlqChecker): CompositeDlqChecker<T> {

--- a/airbyte-cdk/bulk/toolkits/load-low-code/src/main/kotlin/io/airbyte/cdk/load/lowcode/DeclarativeDestinationFactory.kt
+++ b/airbyte-cdk/bulk/toolkits/load-low-code/src/main/kotlin/io/airbyte/cdk/load/lowcode/DeclarativeDestinationFactory.kt
@@ -7,8 +7,11 @@ package io.airbyte.cdk.load.lowcode
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import dev.failsafe.RetryPolicy
+import io.airbyte.cdk.load.check.dlq.DlqChecker
+import io.airbyte.cdk.load.checker.CompositeDlqChecker
 import io.airbyte.cdk.load.checker.HttpRequestChecker
 import io.airbyte.cdk.load.command.DestinationConfiguration
+import io.airbyte.cdk.load.command.dlq.ObjectStorageConfigProvider
 import io.airbyte.cdk.load.http.HttpRequester
 import io.airbyte.cdk.load.http.RequestMethod
 import io.airbyte.cdk.load.http.authentication.BasicAccessAuthenticator
@@ -25,15 +28,15 @@ import io.airbyte.cdk.util.ResourceUtils
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 
-class DeclarativeDestinationFactory<T : DestinationConfiguration>(private val config: T) {
+class DeclarativeDestinationFactory<T>(private val config: T) where T : DestinationConfiguration, T : ObjectStorageConfigProvider {
     private val stringInterpolator: StringInterpolator = StringInterpolator()
 
-    fun createDestinationChecker(): HttpRequestChecker<T> {
+    fun createDestinationChecker(dlqChecker: DlqChecker): CompositeDlqChecker<T> {
         val mapper = ObjectMapper(YAMLFactory())
         val manifestContent = ResourceUtils.readResource("manifest.yaml")
         val manifest: DeclarativeDestinationModel =
             mapper.readValue(manifestContent, DeclarativeDestinationModel::class.java)
-        return createChecker(manifest.checker)
+        return CompositeDlqChecker(createChecker(manifest.checker), dlqChecker)
     }
 
     private fun createAuthenticator(

--- a/airbyte-cdk/bulk/toolkits/load-low-code/src/test/kotlin/io/airbyte/cdk/load/lowcode/DeclarativeDestinationFactoryTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-low-code/src/test/kotlin/io/airbyte/cdk/load/lowcode/DeclarativeDestinationFactoryTest.kt
@@ -4,6 +4,7 @@
 
 package io.airbyte.cdk.load.lowcode
 
+import io.airbyte.cdk.load.check.dlq.DlqChecker
 import io.airbyte.cdk.load.command.DestinationConfiguration
 import io.airbyte.cdk.load.command.dlq.DisabledObjectStorageConfig
 import io.airbyte.cdk.load.command.dlq.ObjectStorageConfig
@@ -48,9 +49,11 @@ class DeclarativeDestinationFactoryTest {
         )
         mockkConstructor(BasicAccessAuthenticator::class)
         val config = MockConfig(VALID_API_ID, VALID_API_TOKEN)
+        val dlqChecker = mockk<DlqChecker>()
+        every { dlqChecker.check(any()) } returns Unit
 
         try {
-            DeclarativeDestinationFactory(config).createDestinationChecker(mockk()).check(config)
+            DeclarativeDestinationFactory(config).createDestinationChecker(dlqChecker).check(config)
 
             verify {
                 constructedWith<BasicAccessAuthenticator>(

--- a/airbyte-cdk/bulk/toolkits/load-low-code/src/test/kotlin/io/airbyte/cdk/load/lowcode/DeclarativeDestinationFactoryTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-low-code/src/test/kotlin/io/airbyte/cdk/load/lowcode/DeclarativeDestinationFactoryTest.kt
@@ -5,10 +5,14 @@
 package io.airbyte.cdk.load.lowcode
 
 import io.airbyte.cdk.load.command.DestinationConfiguration
+import io.airbyte.cdk.load.command.dlq.DisabledObjectStorageConfig
+import io.airbyte.cdk.load.command.dlq.ObjectStorageConfig
+import io.airbyte.cdk.load.command.dlq.ObjectStorageConfigProvider
 import io.airbyte.cdk.load.http.authentication.BasicAccessAuthenticator
 import io.airbyte.cdk.util.ResourceUtils
 import io.mockk.EqMatcher
 import io.mockk.every
+import io.mockk.mockk
 import io.mockk.mockkConstructor
 import io.mockk.mockkStatic
 import io.mockk.unmockkStatic
@@ -18,7 +22,8 @@ import org.junit.jupiter.api.Test
 class MockConfig(
     val apiId: String,
     val apiToken: String,
-) : DestinationConfiguration()
+    override val objectStorageConfig: ObjectStorageConfig = DisabledObjectStorageConfig(),
+) : DestinationConfiguration(), ObjectStorageConfigProvider
 
 val VALID_API_ID: String = "api_id"
 val VALID_API_TOKEN: String = "api_token"
@@ -45,7 +50,7 @@ class DeclarativeDestinationFactoryTest {
         val config = MockConfig(VALID_API_ID, VALID_API_TOKEN)
 
         try {
-            DeclarativeDestinationFactory(config).createDestinationChecker().check(config)
+            DeclarativeDestinationFactory(config).createDestinationChecker(mockk()).check(config)
 
             verify {
                 constructedWith<BasicAccessAuthenticator>(

--- a/airbyte-integrations/connectors/destination-customer-io/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-customer-io/metadata.yaml
@@ -12,7 +12,7 @@ data:
   connectorSubtype: api
   connectorType: destination
   definitionId: c101b15f-2de9-4616-b54f-0ec9d28ca64d
-  dockerImageTag: 0.0.1
+  dockerImageTag: 0.0.2
   dockerRepository: airbyte/destination-customer-io
   githubIssueLabel: destination-customer-io
   icon: icon.svg

--- a/airbyte-integrations/connectors/destination-customer-io/src/main/kotlin/CustomerIoBeanFactory.kt
+++ b/airbyte-integrations/connectors/destination-customer-io/src/main/kotlin/CustomerIoBeanFactory.kt
@@ -6,6 +6,7 @@ package io.airbyte.integrations.destination.customerio
 
 import dev.failsafe.RetryPolicy
 import io.airbyte.cdk.load.check.DestinationChecker
+import io.airbyte.cdk.load.check.dlq.DlqChecker
 import io.airbyte.cdk.load.command.DestinationCatalog
 import io.airbyte.cdk.load.command.DestinationConfiguration
 import io.airbyte.cdk.load.http.HttpClient
@@ -23,8 +24,9 @@ import okhttp3.OkHttpClient
 class CustomerIoBeanFactory {
     @Singleton
     fun check(
-        factory: DeclarativeDestinationFactory<CustomerIoConfiguration>
-    ): DestinationChecker<CustomerIoConfiguration> = factory.createDestinationChecker()
+        factory: DeclarativeDestinationFactory<CustomerIoConfiguration>,
+        checker: DlqChecker,
+    ): DestinationChecker<CustomerIoConfiguration> = factory.createDestinationChecker(checker)
 
     @Singleton
     fun factory(

--- a/docs/integrations/destinations/customer-io.md
+++ b/docs/integrations/destinations/customer-io.md
@@ -41,4 +41,5 @@ In order to configure this connector, you only have to generate your API key (Wo
 
 | Version | Date       | Pull Request                                             | Subject                                                  |
 |:--------|:-----------|:---------------------------------------------------------|:---------------------------------------------------------|
-| 0.0.1   | 2025-06-26 | [#xxxxx](https://github.com/airbytehq/airbyte/pull/xxxxx) | Initial release of the Customer IO destination connector |
+| 0.0.2   | 2025-07-08 | [#xxxxx](https://github.com/airbytehq/airbyte/pull/xxxxx) | Checker should validate DLQ                              |
+| 0.0.1   | 2025-07-07 | [#62083](https://github.com/airbytehq/airbyte/pull/62083) | Initial release of the Customer IO destination connector |

--- a/docs/integrations/destinations/customer-io.md
+++ b/docs/integrations/destinations/customer-io.md
@@ -41,5 +41,5 @@ In order to configure this connector, you only have to generate your API key (Wo
 
 | Version | Date       | Pull Request                                             | Subject                                                  |
 |:--------|:-----------|:---------------------------------------------------------|:---------------------------------------------------------|
-| 0.0.2   | 2025-07-08 | [#xxxxx](https://github.com/airbytehq/airbyte/pull/xxxxx) | Checker should validate DLQ                              |
+| 0.0.2   | 2025-07-08 | [#62843](https://github.com/airbytehq/airbyte/pull/62843) | Checker should validate DLQ                              |
 | 0.0.1   | 2025-07-07 | [#62083](https://github.com/airbytehq/airbyte/pull/62083) | Initial release of the Customer IO destination connector |


### PR DESCRIPTION
## What
Ensure DQL is validated in low-code and apply this change to destination-customer-io

## How
Add a composite class that takes both the low-code checker and the dlq one

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
If someone misconfigures the DLQ for customer-io, it'll not pass the check

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [X] YES 💚
- [ ] NO ❌
