### PR TITLE
fix the "bump bulk CDK + release connectors" action

### DIFF
--- a/.github/workflows/bump-bulk-cdk-and-release-connectors-command.yml
+++ b/.github/workflows/bump-bulk-cdk-and-release-connectors-command.yml
@@ -11,7 +11,7 @@ on:
           - airbytehq/airbyte
 jobs:
   publish-bulk-cdk:
-    uses: ./.github/workflows/publish-bulk-cdk.yml
+    uses: ./.github/workflows/java-bulk-cdk-publish.yml
     secrets: inherit
   bump-cdk-version:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
https://github.com/airbytehq/airbyte/pull/60967/files#diff-296be4b1e9e68376b78234efc977b40af99aa6a072cc4efb0784e7e81eb5a243 - renamed `publish-bulk-cdk.yml` -> `java-bulk-cdk-publish.yml`

update our workflow to match that rename.