### PR TITLE
Set it on the other client builder.

### DIFF
--- a/airbyte-integrations/connectors/destination-clickhouse-v2/src/main/kotlin/io/airbyte/integrations/destination/clickhouse_v2/config/ClickhouseBeanFactory.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse-v2/src/main/kotlin/io/airbyte/integrations/destination/clickhouse_v2/config/ClickhouseBeanFactory.kt
@@ -58,6 +58,7 @@ class ClickhouseBeanFactory {
                 // allow JSON transcoding as a string
                 .serverSetting(ServerSettings.INPUT_FORMAT_BINARY_READ_JSON_AS_STRING, "1")
                 .serverSetting(ServerSettings.OUTPUT_FORMAT_BINARY_WRITE_JSON_AS_STRING, "1")
+                .setClientName("airbyte-v2")
                 .build()
         }
     }


### PR DESCRIPTION
## What
Sets the user string header on the other client builder

## Why
We have 2 client builders for some reason—I forget why

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._