### PR TITLE
fix(source-hubspot): handle case where declared number field contains non-numeric values

### DIFF
--- a/airbyte-integrations/connectors/source-hubspot/components.py
+++ b/airbyte-integrations/connectors/source-hubspot/components.py
@@ -373,6 +373,11 @@ class EntitySchemaNormalization(TypeTransformer):
                 if "number" in target_type:
                     # do not cast numeric IDs into float, use integer instead
                     target_type = int if original_value.isnumeric() else float
+
+                    # In some cases, the returned value from Hubspot is non-numeric despite the discovered schema explicitly declaring a numeric type.
+                    # For example, a field with a type of "number" might return a string: "3092727991;3881228353;15895321999"
+                    # So, we attempt to cast the value to the declared type, and failing that, we log the error and return the original value.
+                    # This matches the previous behavior in the Python implementation.
                     try:
                         transformed_value = target_type(original_value.replace(",", ""))
                         return transformed_value

--- a/airbyte-integrations/connectors/source-hubspot/components.py
+++ b/airbyte-integrations/connectors/source-hubspot/components.py
@@ -373,8 +373,12 @@ class EntitySchemaNormalization(TypeTransformer):
                 if "number" in target_type:
                     # do not cast numeric IDs into float, use integer instead
                     target_type = int if original_value.isnumeric() else float
-                    transformed_value = target_type(original_value.replace(",", ""))
-                    return transformed_value
+                    try:
+                        transformed_value = target_type(original_value.replace(",", ""))
+                        return transformed_value
+                    except ValueError:
+                        logger.exception(f"Could not cast field value {original_value} to {target_type}")
+                        return original_value
                 if "boolean" in target_type and original_value.lower() in ["true", "false"]:
                     transformed_value = str(original_value).lower() == "true"
                     return transformed_value

--- a/airbyte-integrations/connectors/source-hubspot/metadata.yaml
+++ b/airbyte-integrations/connectors/source-hubspot/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 36c891d9-4bd9-43ac-bad2-10e12756272c
-  dockerImageTag: 5.8.11
+  dockerImageTag: 5.8.12
   dockerRepository: airbyte/source-hubspot
   documentationUrl: https://docs.airbyte.com/integrations/sources/hubspot
   resourceRequirements:

--- a/airbyte-integrations/connectors/source-hubspot/unit_tests/test_components.py
+++ b/airbyte-integrations/connectors/source-hubspot/unit_tests/test_components.py
@@ -575,6 +575,18 @@ def test_extractor_supports_associations_list_interpolation(config, associations
             "174824652345600.0",
             id="test_unparsable_overflow_error_returns_original_value",
         ),
+        pytest.param(
+            "12345;6789;1525",
+            {"type": ["null", "number"]},
+            "12345;6789;1525",
+            id="test_semicolon_separated_string_returns_original_value_for_number_type",
+        ),
+        pytest.param(
+            "abc123",
+            {"type": ["null", "number"]},
+            "abc123",
+            id="test_non_numeric_string_returns_original_value_for_number_type",
+        ),
     ],
 )
 def test_entity_schema_normalization(components_module, original_value, field_schema, expected_value):

--- a/docs/integrations/sources/hubspot.md
+++ b/docs/integrations/sources/hubspot.md
@@ -333,6 +333,7 @@ The connector is restricted by normal HubSpot [rate limitations](https://legacyd
 
 | Version    | Date       | Pull Request                                             | Subject                                                                                                                                                                                                                      |
 |:-----------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 5.8.12 | 2025-07-08 | [62866](https://github.com/airbytehq/airbyte/pull/62866) | Handle non-numeric values in fields with declared numeric type |
 | 5.8.11 | 2025-07-07 | [62838](https://github.com/airbytehq/airbyte/pull/62838) | Promoting release candidate 5.8.11-rc.1 to a main version. |
 | 5.8.11-rc.1 | 2025-07-02 | [62481](https://github.com/airbytehq/airbyte/pull/62481) | For CRMSearch streams, fix retry behavior for the underlying associations HttpRequester to retry 401 errors |
 | 5.8.10 | 2025-06-28 | [62179](https://github.com/airbytehq/airbyte/pull/62179) | Update dependencies |


### PR DESCRIPTION
## What

Resolves: https://github.com/airbytehq/oncall/issues/7937

There was a minor regression in the migration with handling mismatches in the expected type of fields from the discovered schema with actual returned values. In some instances, Hubspot's API will declare schema types incorrectly, ie:

`engagements_notes.hs_hd_ticket_ids`

Discovered schema type: [`null`, `number`]
Sample record value: `"1234;5678;9098"` <- non-numeric string 🤡 

Previously, in such instances we logged the error and simply returned the value as is. With the migration, we lost the error handling and thus attempted to cast all values to the assigned type, leading to failures when non-numeric values cannot be cast as numeric types.

## User Impact
Syncs failing since the migration due to uncastable values should now log the error and continue the sync.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._