### PR TITLE
ClickHouse V2: Only set json properties on client when JSON enabled. Remove unnecess…

### DIFF
--- a/airbyte-integrations/connectors/destination-clickhouse-v2/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-clickhouse-v2/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: c4510ac6-094f-4ac3-8811-a5582346b9b9
-  dockerImageTag: 0.1.10
+  dockerImageTag: 0.1.11
   dockerRepository: airbyte/destination-clickhouse-v2
   githubIssueLabel: destination-clickhouse-v2
   icon: clickhouse.svg

--- a/airbyte-integrations/connectors/destination-clickhouse-v2/src/main/kotlin/io/airbyte/integrations/destination/clickhouse_v2/config/ClickhouseBeanFactory.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse-v2/src/main/kotlin/io/airbyte/integrations/destination/clickhouse_v2/config/ClickhouseBeanFactory.kt
@@ -19,48 +19,24 @@ import jakarta.inject.Singleton
 class ClickhouseBeanFactory {
     @Singleton
     fun clickhouseClient(config: ClickhouseConfiguration): Client {
-
-        val clientWithDb =
-            Client.Builder()
+        val builder = Client.Builder()
                 .addEndpoint(config.endpoint)
                 .setUsername(config.username)
                 .setPassword(config.password)
-                .setDefaultDatabase(config.resolvedDatabase)
                 .compressClientRequest(true)
+                .setClientName("airbyte-v2")
+
+        if (config.enableJson) {
+            builder
                 // allow experimental JSON type
                 .serverSetting("allow_experimental_json_type", "1")
                 // allow JSON transcoding as a string. We need this to be able to provide a string
                 // as a JSON input.
                 .serverSetting(ServerSettings.INPUT_FORMAT_BINARY_READ_JSON_AS_STRING, "1")
                 .serverSetting(ServerSettings.OUTPUT_FORMAT_BINARY_WRITE_JSON_AS_STRING, "1")
-                .setClientName("airbyte-v2")
-                .build()
-
-        return if (clientWithDb.ping()) {
-            clientWithDb
-        } else {
-            // We don't set the default database here because the client expects that database
-            // to already exist during instantiation. If we instantiate the client with a default
-            // database that does not exist, it will hard fail.
-
-            // In order to solve this chicken-and-egg problem, we avoid setting the default db on
-            // the client.
-            // Instead, we resolve the default database in the ClickhouseConfiguration, which is
-            // used for table creation when the stream descriptor does not specificy a namespace
-            // directly.
-            Client.Builder()
-                .addEndpoint(config.endpoint)
-                .setUsername(config.username)
-                .setPassword(config.password)
-                .compressClientRequest(true)
-                // allow experimental JSON type
-                .serverSetting("allow_experimental_json_type", "1")
-                // allow JSON transcoding as a string
-                .serverSetting(ServerSettings.INPUT_FORMAT_BINARY_READ_JSON_AS_STRING, "1")
-                .serverSetting(ServerSettings.OUTPUT_FORMAT_BINARY_WRITE_JSON_AS_STRING, "1")
-                .setClientName("airbyte-v2")
-                .build()
         }
+
+        return builder.build()
     }
 
     @Singleton

--- a/airbyte-integrations/connectors/destination-clickhouse-v2/src/main/kotlin/io/airbyte/integrations/destination/clickhouse_v2/config/ClickhouseBeanFactory.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse-v2/src/main/kotlin/io/airbyte/integrations/destination/clickhouse_v2/config/ClickhouseBeanFactory.kt
@@ -19,7 +19,8 @@ import jakarta.inject.Singleton
 class ClickhouseBeanFactory {
     @Singleton
     fun clickhouseClient(config: ClickhouseConfiguration): Client {
-        val builder = Client.Builder()
+        val builder =
+            Client.Builder()
                 .addEndpoint(config.endpoint)
                 .setUsername(config.username)
                 .setPassword(config.password)

--- a/docs/integrations/destinations/clickhouse-v2.md
+++ b/docs/integrations/destinations/clickhouse-v2.md
@@ -76,17 +76,18 @@ You can also use a pre-existing user but we highly recommend creating a dedicate
 <details>
   <summary>Expand to review</summary>
 
-| Version | Date       | Pull Request                                                  | Subject                                             |
-|:--------|:-----------|:--------------------------------------------------------------|:----------------------------------------------------|
-| 0.1.10  | 2025-07-08 | [\#62861](https://github.com/airbytehq/airbyte/pull/62861)    | Set user agent header for internal CH telemetry.    |
-| 0.1.9   | 2025-07-03 | [\#62509](https://github.com/airbytehq/airbyte/pull/62509)    | Simplify union stringification behavior.            |
-| 0.1.8   | 2025-06-30 | [\#62100](https://github.com/airbytehq/airbyte/pull/62100)    | Add JSON support.                                   |
-| 0.1.7   | 2025-06-24 | [\#62047](https://github.com/airbytehq/airbyte/pull/62047)    | Remove the use of the internal namespace.           |
-| 0.1.6   | 2025-06-24 | [\#62047](https://github.com/airbytehq/airbyte/pull/62047)    | Hide protocol option when running on cloud.         |
-| 0.1.5   | 2025-06-24 | [\#62043](https://github.com/airbytehq/airbyte/pull/62043)    | Expose database protocol config option.             |
-| 0.1.4   | 2025-06-24 | [\#62040](https://github.com/airbytehq/airbyte/pull/62040)    | Checker inserts into configured DB.                 |
-| 0.1.3   | 2025-06-24 | [\#62038](https://github.com/airbytehq/airbyte/pull/62038)    | Allow the client to connect to the resolved DB.     |
-| 0.1.2   | 2025-06-23 | [\#62028](https://github.com/airbytehq/airbyte/pull/62028)    | Enable the registry in OSS and cloud.               |
-| 0.1.1   | 2025-06-23 | [\#62022](https://github.com/airbytehq/airbyte/pull/62022)    | Publish first beta version and pin the CDK version. |
-| 0.1.0   | 2025-06-23 | [\#62024](https://github.com/airbytehq/airbyte/pull/62024)    | Release first beta version.                         |
+| Version | Date       | Pull Request                                               | Subject                                                                        |
+|:--------|:-----------|:-----------------------------------------------------------|:-------------------------------------------------------------------------------|
+| 0.1.11  | 2025-07-09 | [\#tbd](https://github.com/airbytehq/airbyte/pull/tbd)     | Only set JSON properties on client if enabled to support older CH deployments. |
+| 0.1.10  | 2025-07-08 | [\#62861](https://github.com/airbytehq/airbyte/pull/62861) | Set user agent header for internal CH telemetry.                               |
+| 0.1.9   | 2025-07-03 | [\#62509](https://github.com/airbytehq/airbyte/pull/62509) | Simplify union stringification behavior.                                       |
+| 0.1.8   | 2025-06-30 | [\#62100](https://github.com/airbytehq/airbyte/pull/62100) | Add JSON support.                                                              |
+| 0.1.7   | 2025-06-24 | [\#62047](https://github.com/airbytehq/airbyte/pull/62047) | Remove the use of the internal namespace.                                      |
+| 0.1.6   | 2025-06-24 | [\#62047](https://github.com/airbytehq/airbyte/pull/62047) | Hide protocol option when running on cloud.                                    |
+| 0.1.5   | 2025-06-24 | [\#62043](https://github.com/airbytehq/airbyte/pull/62043) | Expose database protocol config option.                                        |
+| 0.1.4   | 2025-06-24 | [\#62040](https://github.com/airbytehq/airbyte/pull/62040) | Checker inserts into configured DB.                                            |
+| 0.1.3   | 2025-06-24 | [\#62038](https://github.com/airbytehq/airbyte/pull/62038) | Allow the client to connect to the resolved DB.                                |
+| 0.1.2   | 2025-06-23 | [\#62028](https://github.com/airbytehq/airbyte/pull/62028) | Enable the registry in OSS and cloud.                                          |
+| 0.1.1   | 2025-06-23 | [\#62022](https://github.com/airbytehq/airbyte/pull/62022) | Publish first beta version and pin the CDK version.                            |
+| 0.1.0   | 2025-06-23 | [\#62024](https://github.com/airbytehq/airbyte/pull/62024) | Release first beta version.                                                    |
 </details>


### PR DESCRIPTION
## What
Fixes compatibility with older CH deployments

## How
Only set JSON server properties if config enables them.

## Other
Simplify client building logic by removing unnecessary defaultdb / ping check

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._