### PR TITLE
[S3-Data-Lake] Handle compaction and file delete on truncate refresh

### DIFF
--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/IcebergTableCleaner.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/IcebergTableCleaner.kt
@@ -42,11 +42,7 @@ class IcebergTableCleaner(private val icebergUtil: IcebergUtil) {
         }
     }
 
-    fun deleteGenerationId(
-        table: Table,
-        stagingBranchName: String,
-        stream: DestinationStream
-    ) {
+    fun deleteGenerationId(table: Table, stagingBranchName: String, stream: DestinationStream) {
         val currentGenerationIdSuffix = icebergUtil.constructGenerationIdSuffix(stream)
 
         table.newScan().planFiles().use { tasks ->

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/IcebergTableCleaner.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/IcebergTableCleaner.kt
@@ -42,7 +42,11 @@ class IcebergTableCleaner(private val icebergUtil: IcebergUtil) {
         }
     }
 
-    fun deleteIrrelevantGenerationId(table: Table, stagingBranchName: String, stream: DestinationStream) {
+    fun deleteIrrelevantGenerationId(
+        table: Table,
+        stagingBranchName: String,
+        stream: DestinationStream
+    ) {
         val currentGenerationIdSuffix = icebergUtil.constructGenerationIdSuffix(stream)
 
         table.newScan().planFiles().use { tasks ->

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/IcebergTableCleaner.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/IcebergTableCleaner.kt
@@ -4,6 +4,7 @@
 
 package io.airbyte.cdk.load.toolkits.iceberg.parquet.io
 
+import io.airbyte.cdk.load.command.DestinationStream
 import jakarta.inject.Singleton
 import org.apache.iceberg.Table
 import org.apache.iceberg.catalog.Catalog
@@ -44,7 +45,8 @@ class IcebergTableCleaner(private val icebergUtil: IcebergUtil) {
     fun deleteGenerationId(
         table: Table,
         stagingBranchName: String,
-        generationIdSuffix: List<String>
+        generationIdSuffix: List<String>,
+        stream: DestinationStream
     ) {
         val genIdsToDelete =
             generationIdSuffix

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/IcebergTableCleaner.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/IcebergTableCleaner.kt
@@ -42,7 +42,7 @@ class IcebergTableCleaner(private val icebergUtil: IcebergUtil) {
         }
     }
 
-    fun deleteGenerationId(table: Table, stagingBranchName: String, stream: DestinationStream) {
+    fun deleteIrrelevantGenerationId(table: Table, stagingBranchName: String, stream: DestinationStream) {
         val currentGenerationIdSuffix = icebergUtil.constructGenerationIdSuffix(stream)
 
         table.newScan().planFiles().use { tasks ->

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/IcebergTableCleaner.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/IcebergTableCleaner.kt
@@ -45,53 +45,29 @@ class IcebergTableCleaner(private val icebergUtil: IcebergUtil) {
     fun deleteGenerationId(
         table: Table,
         stagingBranchName: String,
-        generationIdSuffix: List<String>,
         stream: DestinationStream
     ) {
-        val genIdsToDelete =
-            generationIdSuffix
-                .filter {
-                    icebergUtil.assertGenerationIdSuffixIsOfValidFormat(it)
-                    true
+        val currentGenerationIdSuffix = icebergUtil.constructGenerationIdSuffix(stream)
+
+        table.newScan().planFiles().use { tasks ->
+            tasks
+                .filter { task ->
+                    // Delete file if it doesn't contain the current generation ID prefix
+                    // This will also include any potential compaction file from previous generation
+                    // WARNING: This approach only works if users do not run compaction while the
+                    // truncate refresh sync is running. If compaction occurs during the sync, files
+                    // from the current generation may be renamed and lose their generation ID
+                    // suffix, causing them to be incorrectly deleted and resulting in data loss.
+                    // -------
+                    !task.file().location().contains(currentGenerationIdSuffix)
                 }
-                .toSet()
-
-        if (stream.isSingleGenerationTruncate()) {
-            // WARNING: This approach only works if users do not run compaction while the truncate
-            // refresh sync is running.If compaction occurs during the sync, files from the current
-            // generation may be renamed and lose their generation ID suffix, causing them to be
-            // incorrectly deleted and resulting in data loss.
-            // -------
-            // TODO: We need to eventually be able to handle to detect when a compaction was run.
-            // If it was run during the truncate refresh run then we should remove that snapshot
-            // or more like cherry pick the "valid" ones
-            val currentGenId = icebergUtil.constructGenerationIdSuffix(stream.minimumGenerationId)
-
-            table.newScan().planFiles().use { tasks ->
-                tasks
-                    .filter { task -> !task.file().location().contains(currentGenId) }
-                    .forEach { task ->
-                        table
-                            .newDelete()
-                            .toBranch(stagingBranchName)
-                            .deleteFile(task.file().location())
-                            .commit()
-                    }
-            }
-        } else {
-            table.newScan().planFiles().use { tasks ->
-                tasks
-                    .filter { task ->
-                        genIdsToDelete.any { id -> task.file().location().contains(id) }
-                    }
-                    .forEach { task ->
-                        table
-                            .newDelete()
-                            .toBranch(stagingBranchName)
-                            .deleteFile(task.file().location())
-                            .commit()
-                    }
-            }
+                .forEach { task ->
+                    table
+                        .newDelete()
+                        .toBranch(stagingBranchName)
+                        .deleteFile(task.file().location())
+                        .commit()
+                }
         }
     }
 }

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/IcebergTableCleaner.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/IcebergTableCleaner.kt
@@ -42,7 +42,7 @@ class IcebergTableCleaner(private val icebergUtil: IcebergUtil) {
         }
     }
 
-    fun deleteIrrelevantGenerationId(
+    fun deleteOldGenerationData(
         table: Table,
         stagingBranchName: String,
         stream: DestinationStream

--- a/airbyte-integrations/connectors/destination-s3-data-lake/build.gradle
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/build.gradle
@@ -8,7 +8,7 @@ plugins {
 airbyteBulkConnector {
     core = 'load'
     toolkits = ['load-iceberg-parquet', 'load-aws']
-    cdk = '0.522'
+    cdk = 'local'
 }
 
 application {

--- a/airbyte-integrations/connectors/destination-s3-data-lake/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/metadata.yaml
@@ -32,7 +32,7 @@ data:
             alias: airbyte-connector-testing-secret-store
   connectorType: destination
   definitionId: 716ca874-520b-4902-9f80-9fad66754b89
-  dockerImageTag: 0.3.32
+  dockerImageTag: 0.3.33
   dockerRepository: airbyte/destination-s3-data-lake
   documentationUrl: https://docs.airbyte.com/integrations/destinations/s3-data-lake
   githubIssueLabel: destination-s3-data-lake

--- a/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/S3DataLakeStreamLoader.kt
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/S3DataLakeStreamLoader.kt
@@ -117,7 +117,8 @@ class S3DataLakeStreamLoader(
                 icebergTableCleaner.deleteGenerationId(
                     table,
                     stagingBranchName,
-                    generationIdsToDelete
+                    generationIdsToDelete,
+                    stream
                 )
                 //  Doing it again to push the deletes from the staging to main branch
                 logger.info {

--- a/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/S3DataLakeStreamLoader.kt
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/S3DataLakeStreamLoader.kt
@@ -105,7 +105,7 @@ class S3DataLakeStreamLoader(
             computeOrExecuteSchemaUpdate().pendingUpdate?.commit()
             table.manageSnapshots().replaceBranch(mainBranchName, stagingBranchName).commit()
 
-            if (stream.minimumGenerationId > 0) {
+            if (stream.isSingleGenerationTruncate()) {
                 logger.info {
                     "Detected a minimum generation ID (${stream.minimumGenerationId}). Preparing to delete obsolete generation IDs."
                 }

--- a/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/S3DataLakeStreamLoader.kt
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/S3DataLakeStreamLoader.kt
@@ -110,11 +110,7 @@ class S3DataLakeStreamLoader(
                     "Detected a minimum generation ID (${stream.minimumGenerationId}). Preparing to delete obsolete generation IDs."
                 }
                 val icebergTableCleaner = IcebergTableCleaner(icebergUtil = icebergUtil)
-                icebergTableCleaner.deleteIrrelevantGenerationId(
-                    table,
-                    stagingBranchName,
-                    stream
-                )
+                icebergTableCleaner.deleteIrrelevantGenerationId(table, stagingBranchName, stream)
                 //  Doing it again to push the deletes from the staging to main branch
                 logger.info {
                     "Deleted obsolete generation IDs up to ${stream.minimumGenerationId - 1}. " +

--- a/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/S3DataLakeStreamLoader.kt
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/S3DataLakeStreamLoader.kt
@@ -110,7 +110,7 @@ class S3DataLakeStreamLoader(
                     "Detected a minimum generation ID (${stream.minimumGenerationId}). Preparing to delete obsolete generation IDs."
                 }
                 val icebergTableCleaner = IcebergTableCleaner(icebergUtil = icebergUtil)
-                icebergTableCleaner.deleteIrrelevantGenerationId(table, stagingBranchName, stream)
+                icebergTableCleaner.deleteOldGenerationData(table, stagingBranchName, stream)
                 //  Doing it again to push the deletes from the staging to main branch
                 logger.info {
                     "Deleted obsolete generation IDs up to ${stream.minimumGenerationId - 1}. " +

--- a/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/S3DataLakeStreamLoader.kt
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/S3DataLakeStreamLoader.kt
@@ -109,15 +109,10 @@ class S3DataLakeStreamLoader(
                 logger.info {
                     "Detected a minimum generation ID (${stream.minimumGenerationId}). Preparing to delete obsolete generation IDs."
                 }
-                val generationIdsToDelete =
-                    (0 until stream.minimumGenerationId).map(
-                        icebergUtil::constructGenerationIdSuffix
-                    )
                 val icebergTableCleaner = IcebergTableCleaner(icebergUtil = icebergUtil)
-                icebergTableCleaner.deleteGenerationId(
+                icebergTableCleaner.deleteIrrelevantGenerationId(
                     table,
                     stagingBranchName,
-                    generationIdsToDelete,
                     stream
                 )
                 //  Doing it again to push the deletes from the staging to main branch

--- a/airbyte-integrations/connectors/destination-s3-data-lake/src/test/kotlin/io/airbyte/integrations/destination/s3_data_lake/S3DataLakeStreamLoaderTest.kt
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/src/test/kotlin/io/airbyte/integrations/destination/s3_data_lake/S3DataLakeStreamLoaderTest.kt
@@ -253,8 +253,7 @@ internal class S3DataLakeStreamLoaderTest {
                 {
                     stream.schema.withAirbyteMeta(true).toIcebergSchema(emptyList())
                 }
-            every { constructGenerationIdSuffix(any() as Long) } returns ""
-            every { assertGenerationIdSuffixIsOfValidFormat(any()) } just runs
+            every { constructGenerationIdSuffix(any<DestinationStream>()) } returns ""
         }
         val streamLoader =
             S3DataLakeStreamLoader(
@@ -407,8 +406,7 @@ internal class S3DataLakeStreamLoaderTest {
                 {
                     stream.schema.withAirbyteMeta(true).toIcebergSchema(listOf(primaryKeys))
                 }
-            every { constructGenerationIdSuffix(any() as Long) } returns ""
-            every { assertGenerationIdSuffixIsOfValidFormat(any()) } just runs
+            every { constructGenerationIdSuffix(any<DestinationStream>()) } returns ""
         }
         val streamLoader =
             S3DataLakeStreamLoader(

--- a/airbyte-integrations/connectors/destination-s3-data-lake/src/test/kotlin/io/airbyte/integrations/destination/s3_data_lake/io/S3DataLakeTableCleanerTest.kt
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/src/test/kotlin/io/airbyte/integrations/destination/s3_data_lake/io/S3DataLakeTableCleanerTest.kt
@@ -94,7 +94,6 @@ internal class S3DataLakeTableCleanerTest {
         val icebergUtil: IcebergUtil = mockk {
             every { constructGenerationIdSuffix(any<DestinationStream>()) } returns
                 "ab-generation-id-1-e"
-            every { assertGenerationIdSuffixIsOfValidFormat(any()) } returns Unit
         }
         val cleaner = IcebergTableCleaner(icebergUtil)
 

--- a/airbyte-integrations/connectors/destination-s3-data-lake/src/test/kotlin/io/airbyte/integrations/destination/s3_data_lake/io/S3DataLakeTableCleanerTest.kt
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/src/test/kotlin/io/airbyte/integrations/destination/s3_data_lake/io/S3DataLakeTableCleanerTest.kt
@@ -102,7 +102,7 @@ internal class S3DataLakeTableCleanerTest {
         val table = mockk<Table>()
         every { table.newScan().planFiles() } returns tasks
 
-        assertDoesNotThrow { cleaner.deleteIrrelevantGenerationId(table, "staging", stream) }
+        assertDoesNotThrow { cleaner.deleteOldGenerationData(table, "staging", stream) }
         verify(exactly = 0) { table.newDelete() }
     }
 
@@ -131,7 +131,7 @@ internal class S3DataLakeTableCleanerTest {
         every { delete.deleteFile(filePathToDelete) } returns delete
         every { delete.commit() } just Runs
 
-        assertDoesNotThrow { cleaner.deleteIrrelevantGenerationId(table, "staging", stream) }
+        assertDoesNotThrow { cleaner.deleteOldGenerationData(table, "staging", stream) }
 
         verify {
             table.newDelete().toBranch(eq("staging"))
@@ -165,7 +165,7 @@ internal class S3DataLakeTableCleanerTest {
         every { delete.deleteFile(filePathToDelete) } returns delete
         every { delete.commit() } just Runs
 
-        assertDoesNotThrow { cleaner.deleteIrrelevantGenerationId(table, "staging", stream) }
+        assertDoesNotThrow { cleaner.deleteOldGenerationData(table, "staging", stream) }
 
         verify {
             table.newDelete().toBranch(eq("staging"))

--- a/airbyte-integrations/connectors/destination-s3-data-lake/src/test/kotlin/io/airbyte/integrations/destination/s3_data_lake/io/S3DataLakeTableCleanerTest.kt
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/src/test/kotlin/io/airbyte/integrations/destination/s3_data_lake/io/S3DataLakeTableCleanerTest.kt
@@ -8,7 +8,6 @@ import io.airbyte.cdk.load.command.Append
 import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.command.ImportType
 import io.airbyte.cdk.load.command.NamespaceMapper
-import io.airbyte.cdk.load.command.Overwrite
 import io.airbyte.cdk.load.data.ObjectTypeWithoutSchema
 import io.airbyte.cdk.load.toolkits.iceberg.parquet.io.IcebergTableCleaner
 import io.airbyte.cdk.load.toolkits.iceberg.parquet.io.IcebergUtil
@@ -18,7 +17,6 @@ import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
-import org.apache.iceberg.DataFile
 import org.apache.iceberg.DeleteFiles
 import org.apache.iceberg.FileScanTask
 import org.apache.iceberg.Table
@@ -91,32 +89,31 @@ internal class S3DataLakeTableCleanerTest {
     }
 
     @Test
-    fun `deleteGenerationId handles empty scan results gracefully`() {
+    fun `deleteIrrelevantGenerationId handles empty scan results gracefully`() {
         val stream = mockStream()
         val icebergUtil: IcebergUtil = mockk {
+            every { constructGenerationIdSuffix(any<DestinationStream>()) } returns "ab-generation-id-1-e"
             every { assertGenerationIdSuffixIsOfValidFormat(any()) } returns Unit
         }
         val cleaner = IcebergTableCleaner(icebergUtil)
-        val generationIdSuffix = "ab-generation-id-0-e"
 
         val tasks = CloseableIterable.empty<FileScanTask>()
         val table = mockk<Table>()
         every { table.newScan().planFiles() } returns tasks
 
         assertDoesNotThrow {
-            cleaner.deleteGenerationId(table, "staging", listOf(generationIdSuffix), stream)
+            cleaner.deleteIrrelevantGenerationId(table, "staging", stream)
         }
         verify(exactly = 0) { table.newDelete() }
     }
 
     @Test
-    fun `deleteGenerationId deletes matching file via deleteFile`() {
+    fun `deleteIrrelevantGenerationId deletes matching file via deleteFile`() {
         val stream = mockStream()
         val icebergUtil: IcebergUtil = mockk {
-            every { assertGenerationIdSuffixIsOfValidFormat(any()) } returns Unit
+            every { constructGenerationIdSuffix(any<DestinationStream>()) } returns "ab-generation-id-1-e"
         }
         val cleaner = IcebergTableCleaner(icebergUtil)
-        val generationIdSuffix = "ab-generation-id-0-e"
         val filePathToDelete = "path/to/gen-5678/foo-bar-ab-generation-id-0-e.parquet"
         val fileScanTask = mockk<FileScanTask>()
         val table = mockk<Table>()
@@ -135,11 +132,10 @@ internal class S3DataLakeTableCleanerTest {
         every { delete.commit() } just Runs
 
         assertDoesNotThrow {
-            cleaner.deleteGenerationId(table, "staging", listOf(generationIdSuffix), stream)
+            cleaner.deleteIrrelevantGenerationId(table, "staging", stream)
         }
 
         verify {
-            icebergUtil.assertGenerationIdSuffixIsOfValidFormat(generationIdSuffix)
             table.newDelete().toBranch(eq("staging"))
             delete.deleteFile(filePathToDelete)
             delete.commit()
@@ -147,14 +143,13 @@ internal class S3DataLakeTableCleanerTest {
     }
 
     @Test
-    fun `deleteGenerationId should not delete non matching file via deleteFile`() {
+    fun `deleteIrrelevantGenerationId deletes files with missing generation id prefix`() {
         val stream = mockStream()
         val icebergUtil: IcebergUtil = mockk {
-            every { assertGenerationIdSuffixIsOfValidFormat(any()) } returns Unit
+            every { constructGenerationIdSuffix(any<DestinationStream>()) } returns "ab-generation-id-1-e"
         }
         val cleaner = IcebergTableCleaner(icebergUtil)
-        val generationIdSuffix = "ab-generation-id-10-e"
-        val filePathToDelete = "path/to/gen-5678/foo-bar-ab-generation-id-10-e.parquet"
+        val filePathToDelete = "path/to/gen-5678/compacted-file.parquet"
         val fileScanTask = mockk<FileScanTask>()
         val table = mockk<Table>()
 
@@ -164,99 +159,21 @@ internal class S3DataLakeTableCleanerTest {
         every { tasks.close() } just Runs
         every { table.newScan().planFiles() } returns tasks
 
-        every { fileScanTask.file().location().toString() } returns filePathToDelete
+        every { fileScanTask.file().location() } returns filePathToDelete
 
         val delete = mockk<DeleteFiles>()
         every { table.newDelete().toBranch("staging") } returns delete
-        every { delete.deleteFile(fileScanTask.file().location()) } returns delete
+        every { delete.deleteFile(filePathToDelete) } returns delete
         every { delete.commit() } just Runs
 
         assertDoesNotThrow {
-            cleaner.deleteGenerationId(table, "staging", listOf("ab-generation-id-1-e"), stream)
+            cleaner.deleteIrrelevantGenerationId(table, "staging", stream)
         }
 
-        verify(exactly = 0) {
-            icebergUtil.assertGenerationIdSuffixIsOfValidFormat(generationIdSuffix)
-            table.newDelete().toBranch(any())
-            delete.deleteFile(any<DataFile>())
-            delete.commit()
-        }
-    }
-
-    @Test
-    fun `deleteGenerationId truncate refresh - all files from current generation - no deletion`() {
-        val stream = mockStream(importType = Overwrite, generationId = 5, minimumGenerationId = 5)
-        val icebergUtil: IcebergUtil = mockk {
-            every { assertGenerationIdSuffixIsOfValidFormat(any()) } returns Unit
-            every { constructGenerationIdSuffix(5) } returns "ab-generation-id-5-e"
-        }
-        val cleaner = IcebergTableCleaner(icebergUtil)
-
-        val fileScanTask1 = mockk<FileScanTask>()
-        val fileScanTask2 = mockk<FileScanTask>()
-        val table = mockk<Table>()
-
-        every { fileScanTask1.file().location() } returns
-            "path/to/file1-ab-generation-id-5-e.parquet"
-        every { fileScanTask2.file().location() } returns
-            "path/to/file2-ab-generation-id-5-e.parquet"
-
-        val tasks = mockk<CloseableIterable<FileScanTask>>()
-        every { tasks.iterator() } returns
-            CloseableIterator.withClose(listOf(fileScanTask1, fileScanTask2).iterator())
-        every { tasks.close() } just Runs
-        every { table.newScan().planFiles() } returns tasks
-
-        assertDoesNotThrow {
-            cleaner.deleteGenerationId(table, "staging", listOf("ab-generation-id-4-e"), stream)
-        }
-
-        // Verify no deletions occurred
-        verify(exactly = 0) { table.newDelete() }
-    }
-
-    @Test
-    fun `deleteGenerationId truncate refresh - files without generation ID - delete them`() {
-        val stream = mockStream(importType = Overwrite, generationId = 5, minimumGenerationId = 5)
-        val icebergUtil: IcebergUtil = mockk {
-            every { assertGenerationIdSuffixIsOfValidFormat(any()) } returns Unit
-            every { constructGenerationIdSuffix(5) } returns "ab-generation-id-5-e"
-        }
-        val cleaner = IcebergTableCleaner(icebergUtil)
-
-        val fileScanTaskWithGen = mockk<FileScanTask>()
-        val fileScanTaskWithoutGen = mockk<FileScanTask>()
-        val table = mockk<Table>()
-
-        val fileWithGen = "path/to/file1-ab-generation-id-5-e.parquet"
-        val fileWithoutGen = "path/to/compacted-file-12345.parquet"
-
-        every { fileScanTaskWithGen.file().location() } returns fileWithGen
-        every { fileScanTaskWithoutGen.file().location() } returns fileWithoutGen
-
-        val tasks = mockk<CloseableIterable<FileScanTask>>()
-        every { tasks.iterator() } returns
-            CloseableIterator.withClose(
-                listOf(fileScanTaskWithGen, fileScanTaskWithoutGen).iterator()
-            )
-        every { tasks.close() } just Runs
-        every { table.newScan().planFiles() } returns tasks
-
-        val delete = mockk<DeleteFiles>()
-        every { table.newDelete().toBranch("staging") } returns delete
-        every { delete.deleteFile(fileWithoutGen) } returns delete
-        every { delete.commit() } just Runs
-
-        assertDoesNotThrow {
-            cleaner.deleteGenerationId(table, "staging", listOf("ab-generation-id-4-e"), stream)
-        }
-
-        // Verify only the file without generation ID was deleted
         verify {
-            table.newDelete().toBranch("staging")
-            delete.deleteFile(fileWithoutGen)
+            table.newDelete().toBranch(eq("staging"))
+            delete.deleteFile(filePathToDelete)
             delete.commit()
         }
-        verify(exactly = 0) { delete.deleteFile(fileWithGen) }
     }
 }

--- a/airbyte-integrations/connectors/destination-s3-data-lake/src/test/kotlin/io/airbyte/integrations/destination/s3_data_lake/io/S3DataLakeTableCleanerTest.kt
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/src/test/kotlin/io/airbyte/integrations/destination/s3_data_lake/io/S3DataLakeTableCleanerTest.kt
@@ -92,7 +92,8 @@ internal class S3DataLakeTableCleanerTest {
     fun `deleteIrrelevantGenerationId handles empty scan results gracefully`() {
         val stream = mockStream()
         val icebergUtil: IcebergUtil = mockk {
-            every { constructGenerationIdSuffix(any<DestinationStream>()) } returns "ab-generation-id-1-e"
+            every { constructGenerationIdSuffix(any<DestinationStream>()) } returns
+                "ab-generation-id-1-e"
             every { assertGenerationIdSuffixIsOfValidFormat(any()) } returns Unit
         }
         val cleaner = IcebergTableCleaner(icebergUtil)
@@ -101,9 +102,7 @@ internal class S3DataLakeTableCleanerTest {
         val table = mockk<Table>()
         every { table.newScan().planFiles() } returns tasks
 
-        assertDoesNotThrow {
-            cleaner.deleteIrrelevantGenerationId(table, "staging", stream)
-        }
+        assertDoesNotThrow { cleaner.deleteIrrelevantGenerationId(table, "staging", stream) }
         verify(exactly = 0) { table.newDelete() }
     }
 
@@ -111,7 +110,8 @@ internal class S3DataLakeTableCleanerTest {
     fun `deleteIrrelevantGenerationId deletes matching file via deleteFile`() {
         val stream = mockStream()
         val icebergUtil: IcebergUtil = mockk {
-            every { constructGenerationIdSuffix(any<DestinationStream>()) } returns "ab-generation-id-1-e"
+            every { constructGenerationIdSuffix(any<DestinationStream>()) } returns
+                "ab-generation-id-1-e"
         }
         val cleaner = IcebergTableCleaner(icebergUtil)
         val filePathToDelete = "path/to/gen-5678/foo-bar-ab-generation-id-0-e.parquet"
@@ -131,9 +131,7 @@ internal class S3DataLakeTableCleanerTest {
         every { delete.deleteFile(filePathToDelete) } returns delete
         every { delete.commit() } just Runs
 
-        assertDoesNotThrow {
-            cleaner.deleteIrrelevantGenerationId(table, "staging", stream)
-        }
+        assertDoesNotThrow { cleaner.deleteIrrelevantGenerationId(table, "staging", stream) }
 
         verify {
             table.newDelete().toBranch(eq("staging"))
@@ -146,7 +144,8 @@ internal class S3DataLakeTableCleanerTest {
     fun `deleteIrrelevantGenerationId deletes files with missing generation id prefix`() {
         val stream = mockStream()
         val icebergUtil: IcebergUtil = mockk {
-            every { constructGenerationIdSuffix(any<DestinationStream>()) } returns "ab-generation-id-1-e"
+            every { constructGenerationIdSuffix(any<DestinationStream>()) } returns
+                "ab-generation-id-1-e"
         }
         val cleaner = IcebergTableCleaner(icebergUtil)
         val filePathToDelete = "path/to/gen-5678/compacted-file.parquet"
@@ -166,9 +165,7 @@ internal class S3DataLakeTableCleanerTest {
         every { delete.deleteFile(filePathToDelete) } returns delete
         every { delete.commit() } just Runs
 
-        assertDoesNotThrow {
-            cleaner.deleteIrrelevantGenerationId(table, "staging", stream)
-        }
+        assertDoesNotThrow { cleaner.deleteIrrelevantGenerationId(table, "staging", stream) }
 
         verify {
             table.newDelete().toBranch(eq("staging"))

--- a/docs/integrations/destinations/s3-data-lake.md
+++ b/docs/integrations/destinations/s3-data-lake.md
@@ -312,6 +312,7 @@ Now, you can identify the latest version of the 'Alice' record by querying wheth
 
 | Version | Date       | Pull Request                                               | Subject                                                                                                                         |
 |:--------|:-----------|:-----------------------------------------------------------|:--------------------------------------------------------------------------------------------------------------------------------|
+| 0.3.33  | 2025-07-09 | [62888](https://github.com/airbytehq/airbyte/pull/62888)   | Update CDK version to handle compaction issue when deleting files in a truncate refresh scenario                                |
 | 0.3.32  | 2025-07-08 | [62852](https://github.com/airbytehq/airbyte/pull/62852)   | Fix metadata (revert accidental archiving)                                                                                      |
 | 0.3.31  | 2025-07-07 | [62835](https://github.com/airbytehq/airbyte/pull/62835)   | Pin to latest CDK version 0.522                                                                                                 |
 | 0.3.30  | 2025-06-26 | [62105](https://github.com/airbytehq/airbyte/pull/62105)   | ReplaceBranch to staging from main instead of fast forwarding                                                                   |

--- a/docs/integrations/destinations/s3-data-lake.md
+++ b/docs/integrations/destinations/s3-data-lake.md
@@ -274,6 +274,18 @@ Iceberg supports [Git-like semantics](https://iceberg.apache.org/docs/latest/bra
 At the end of stream sync, we replace the current `main` branch with the `airbyte_staging` branch we were working on. We intentionally avoid fast-forwarding to better handle potential compaction issues.
 **Important Warning**: Any changes made to the `main` branch outside of Airbyte's operations after a sync begins will be lost during this process.
 
+## Compaction
+
+:::caution
+**Do not run compaction during a truncate refresh sync to prevent data loss.**
+During a truncate refresh sync, the system deletes all files that don't belong to the latest generation. This includes:
+
+- Files without generation IDs (compacted files)
+- Files from previous generations
+
+If compaction runs simultaneously with the sync, it will delete files from the current generation, causing data loss. The system identifies generations by parsing file names for generation IDs.
+:::
+
 ## Considerations and limitations
 
 This section documents known considerations and limitations about how this Iceberg destination interacts with other products.


### PR DESCRIPTION
## What

Update the `IcebergTableCleaner` to handle potential compaction disruption on a truncate refresh scenario.
The is a bare bone solution and will require that our users are aware that they should not be running compaction while a truncate refresh sync is running.
It would break the current assumption that all compacted files (a.k.a "sad files", a.k.a "non gen files") could be removed since they would be from previous generations.

In our next iteration, we will probably want to try and detect any file that was compacted and that belong to the current generation as those would need to be cherry picked out and replaced with their "happy files" equivalent. This is also further complicated as partial compaction is also a thing that exists.

relates to https://github.com/airbytehq/airbyte-internal-issues/issues/13561

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [X] YES 💚
- [ ] NO ❌
