### PR TITLE
fix(Source-Airtable): Bump Memory for Discovery to 2GB

### DIFF
--- a/airbyte-integrations/connectors/source-airtable/metadata.yaml
+++ b/airbyte-integrations/connectors/source-airtable/metadata.yaml
@@ -11,15 +11,15 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 14c6e7ea-97ed-4f5e-a7b5-25e9a80b8212
-  dockerImageTag: 4.6.3
+  dockerImageTag: 4.6.4
   dockerRepository: airbyte/source-airtable
   documentationUrl: https://docs.airbyte.com/integrations/sources/airtable
   resourceRequirements:
     jobSpecific:
       - jobType: discover_schema
         resourceRequirements:
-          memory_limit: 1536Mi
-          memory_request: 1536Mi
+          memory_limit: 2048Mi
+          memory_request: 2048Mi
   githubIssueLabel: source-airtable
   icon: airtable.svg
   license: MIT

--- a/docs/integrations/sources/airtable.md
+++ b/docs/integrations/sources/airtable.md
@@ -137,7 +137,7 @@ See information about rate limits [here](https://airtable.com/developers/web/api
 
 | Version    | Date       | Pull Request                                             | Subject                                                                                 |
 |:-----------|:-----------|:---------------------------------------------------------|:----------------------------------------------------------------------------------------|
-| 4.6.4      | 2025-07-10 | [XXXXX](https://github.com/airbytehq/airbyte/pull/XXXXX) | Bump default Memory on DISCOVER to 2GB                                                  |
+| 4.6.4      | 2025-07-10 | [62894](https://github.com/airbytehq/airbyte/pull/62894) | Bump default Memory on DISCOVER to 2GB                                                  |
 | 4.6.3      | 2025-07-03 | [62118](https://github.com/airbytehq/airbyte/pull/62118) | Bump default Memory on DISCOVER to 1.5 GB                                                   |
 | 4.6.2      | 2025-06-17 | [61643](https://github.com/airbytehq/airbyte/pull/61643) | Bump default Memory on DISCOVER to 1GB                                                  |
 | 4.6.1      | 2025-06-05 | [61394](https://github.com/airbytehq/airbyte/pull/61394) | Fix schema issue related to migration                                                   |

--- a/docs/integrations/sources/airtable.md
+++ b/docs/integrations/sources/airtable.md
@@ -137,6 +137,7 @@ See information about rate limits [here](https://airtable.com/developers/web/api
 
 | Version    | Date       | Pull Request                                             | Subject                                                                                 |
 |:-----------|:-----------|:---------------------------------------------------------|:----------------------------------------------------------------------------------------|
+| 4.6.4      | 2025-07-10 | [XXXXX](https://github.com/airbytehq/airbyte/pull/XXXXX) | Bump default Memory on DISCOVER to 2GB                                                  |
 | 4.6.3      | 2025-07-03 | [62118](https://github.com/airbytehq/airbyte/pull/62118) | Bump default Memory on DISCOVER to 1.5 GB                                                   |
 | 4.6.2      | 2025-06-17 | [61643](https://github.com/airbytehq/airbyte/pull/61643) | Bump default Memory on DISCOVER to 1GB                                                  |
 | 4.6.1      | 2025-06-05 | [61394](https://github.com/airbytehq/airbyte/pull/61394) | Fix schema issue related to migration                                                   |


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->
Follow up to: https://github.com/airbytehq/oncall/issues/7842

User is still getting 137 OOM on Discovery. 
## How
<!--
* Describe how code changes achieve the solution.
-->
Bump the memory to 2GB for that job type. 
## Review guide
<!--
1. `x.py`
2. `y.py`
-->
Update in metadata.yml
## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ X] YES 💚
- [ ] NO ❌
