### PR TITLE
Bulk load CDK: Move CDK tests into mock test

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/integrationTest/kotlin/io/airbyte/cdk/load/mock_integration_test/MockBasicFunctionalityIntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/integrationTest/kotlin/io/airbyte/cdk/load/mock_integration_test/MockBasicFunctionalityIntegrationTest.kt
@@ -411,7 +411,19 @@ class MockBasicFunctionalityIntegrationTestSocketProtobuf :
     BaseMockBasicFunctionalityIntegrationTest(
         DataChannelMedium.SOCKET,
         DataChannelFormat.PROTOBUF,
-    )
+    ) {
+    @Test
+    @Disabled("Sockets medium hangs when receiving an unrecognized state message")
+    override fun testCrashInInputLoop() {
+        super.testCrashInInputLoop()
+    }
+
+    @Test
+    @Disabled("Sockets medium hangs when global state contains unrecognized per-stream state")
+    override fun testGlobalStateWithUnknownStreamState() {
+        super.testGlobalStateWithUnknownStreamState()
+    }
+}
 
 // A few test classes that exist for completeness, but are disabled because we never do these things
 // in real syncs.

--- a/airbyte-cdk/bulk/core/load/src/integrationTest/kotlin/io/airbyte/cdk/load/mock_integration_test/MockBasicFunctionalityIntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/integrationTest/kotlin/io/airbyte/cdk/load/mock_integration_test/MockBasicFunctionalityIntegrationTest.kt
@@ -5,7 +5,12 @@
 package io.airbyte.cdk.load.mock_integration_test
 
 import io.airbyte.cdk.load.command.Append
+import io.airbyte.cdk.load.command.DestinationCatalog
 import io.airbyte.cdk.load.command.DestinationStream
+import io.airbyte.cdk.load.command.NamespaceMapper
+import io.airbyte.cdk.load.config.DataChannelMedium
+import io.airbyte.cdk.load.config.NamespaceDefinitionType
+import io.airbyte.cdk.load.config.NamespaceMappingConfig
 import io.airbyte.cdk.load.data.ObjectType
 import io.airbyte.cdk.load.message.CheckpointMessage.Checkpoint
 import io.airbyte.cdk.load.message.InputGlobalCheckpoint
@@ -16,6 +21,7 @@ import io.airbyte.cdk.load.test.mock.MockDestinationDataDumper
 import io.airbyte.cdk.load.test.mock.MockDestinationSpecification
 import io.airbyte.cdk.load.test.util.NoopDestinationCleaner
 import io.airbyte.cdk.load.test.util.NoopNameMapper
+import io.airbyte.cdk.load.test.util.OutputRecord
 import io.airbyte.cdk.load.test.util.UncoercedExpectedRecordMapper
 import io.airbyte.cdk.load.test.util.destination_process.DestinationUncleanExitException
 import io.airbyte.cdk.load.util.Jsons
@@ -31,6 +37,9 @@ import io.airbyte.protocol.models.v0.AirbyteStateStats
 import io.airbyte.protocol.models.v0.AirbyteStreamState
 import io.airbyte.protocol.models.v0.StreamDescriptor
 import kotlin.test.assertEquals
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 
@@ -249,5 +258,131 @@ class MockBasicFunctionalityIntegrationTest :
                 ),
             returnedStateMessage,
         )
+    }
+
+    private fun testNamespaceMapping(
+        namespaceMappingConfig: NamespaceMappingConfig,
+        namespaceValidator: (String?, String?, String, String) -> Unit
+    ) {
+        assumeTrue(dataChannelMedium == DataChannelMedium.SOCKET)
+        val stream =
+            DestinationStream(
+                unmappedNamespace = randomizedNamespace,
+                unmappedName = "test_stream__$randomizedNamespace", // in case namespace == null
+                Append,
+                ObjectType(linkedMapOf("id" to intType)),
+                generationId = 1,
+                minimumGenerationId = 1,
+                syncId = 42,
+                namespaceMapper =
+                    NamespaceMapper(
+                        namespaceDefinitionType = namespaceMappingConfig.namespaceDefinitionType,
+                        streamPrefix = namespaceMappingConfig.streamPrefix,
+                        namespaceFormat = namespaceMappingConfig.namespaceFormat
+                    )
+            )
+        namespaceValidator(
+            stream.unmappedNamespace,
+            stream.mappedDescriptor.namespace,
+            stream.unmappedName,
+            stream.mappedDescriptor.name,
+        )
+        runSync(
+            updatedConfig,
+            DestinationCatalog(listOf(stream)),
+            listOf(
+                InputRecord(
+                    stream,
+                    """{"id": 42}""",
+                    emittedAtMs = 1234L,
+                    checkpointId = checkpointKeyForMedium()?.checkpointId
+                )
+            ),
+            useFileTransfer = false,
+            destinationProcessFactory = destinationProcessFactory,
+            namespaceMappingConfig = namespaceMappingConfig
+        )
+        dumpAndDiffRecords(
+            parsedConfig,
+            listOf(
+                OutputRecord(
+                    extractedAt = 1234L,
+                    generationId = 1,
+                    data = mapOf("id" to 42),
+                    airbyteMeta = OutputRecord.Meta(syncId = 42),
+                )
+            ),
+            stream,
+            primaryKey = listOf(listOf("id")),
+            cursor = null,
+        )
+    }
+
+    @Test
+    open fun testNamespaceMappingDestinationNoPrefix() {
+        testNamespaceMapping(
+            NamespaceMappingConfig(namespaceDefinitionType = NamespaceDefinitionType.DESTINATION)
+        ) { _, mappedNamespace, unmappedName, mappedName ->
+            // For destination namespace mapping, the namespace should be the unmapped name.
+            assertNull(mappedNamespace)
+            assertEquals(unmappedName, mappedName)
+        }
+    }
+
+    @Test
+    open fun testNamespaceMappingDestinationWithPrefix() {
+        testNamespaceMapping(
+            NamespaceMappingConfig(
+                namespaceDefinitionType = NamespaceDefinitionType.DESTINATION,
+                streamPrefix = "prefix_",
+            )
+        ) { _, mappedNamespace, unmappedName, mappedName ->
+            // For destination namespace mapping, the namespace should be the unmapped name.
+            assertNull(mappedNamespace)
+            assertEquals("prefix_$unmappedName", mappedName)
+        }
+    }
+
+    @Test
+    open fun testNamespaceMappingSourceWithPrefix() {
+        testNamespaceMapping(
+            NamespaceMappingConfig(
+                namespaceDefinitionType = NamespaceDefinitionType.SOURCE,
+                streamPrefix = "prefix_",
+            )
+        ) { unmappedNamespace, mappedNamespace, unmappedName, mappedName ->
+            // For source namespace mapping, the namespace should be the unmapped namespace.
+            assertEquals(unmappedNamespace, mappedNamespace)
+            assertEquals("prefix_$unmappedName", mappedName)
+        }
+    }
+
+    @Test
+    open fun testNamespaceMappingCustomFormatNoPrefix() {
+        testNamespaceMapping(
+            NamespaceMappingConfig(
+                namespaceDefinitionType = NamespaceDefinitionType.CUSTOM_FORMAT,
+                namespaceFormat = "custom_\${SOURCE_NAMESPACE}_namespace",
+            )
+        ) { _, mappedNamespace, unmappedName, mappedName ->
+            // For custom namespace mapping, the namespace should be the custom format.
+            assertEquals("custom_${randomizedNamespace}_namespace", mappedNamespace)
+            assertEquals(unmappedName, mappedName)
+        }
+    }
+
+    @Test
+    open fun testNamespaceMappingCustomFormatNoMacroWithPrefix() {
+        testNamespaceMapping(
+            NamespaceMappingConfig(
+                namespaceDefinitionType = NamespaceDefinitionType.CUSTOM_FORMAT,
+                namespaceFormat = "custom_$randomizedNamespace",
+                streamPrefix = "prefix_",
+            )
+        ) { _, mappedNamespace, unmappedName, mappedName ->
+            // For custom namespace mapping, the namespace should be the custom format.
+            assertEquals("custom_${randomizedNamespace}", mappedNamespace)
+            assertEquals("prefix_$unmappedName", mappedName)
+        }
     }
 }

--- a/airbyte-cdk/bulk/core/load/src/integrationTest/kotlin/io/airbyte/cdk/load/mock_integration_test/MockBasicFunctionalityIntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/integrationTest/kotlin/io/airbyte/cdk/load/mock_integration_test/MockBasicFunctionalityIntegrationTest.kt
@@ -31,6 +31,7 @@ import io.airbyte.cdk.load.write.BasicFunctionalityIntegrationTest
 import io.airbyte.cdk.load.write.DedupBehavior
 import io.airbyte.cdk.load.write.SchematizedNestedValueBehavior
 import io.airbyte.cdk.load.write.UnionBehavior
+import io.airbyte.cdk.load.write.UnknownTypesBehavior
 import io.airbyte.cdk.load.write.Untyped
 import io.airbyte.protocol.models.v0.AirbyteGlobalState
 import io.airbyte.protocol.models.v0.AirbyteMessage
@@ -73,6 +74,12 @@ abstract class BaseMockBasicFunctionalityIntegrationTest(
         dataChannelMedium = dataChannelMedium,
         dataChannelFormat = dataChannelFormat,
         nullEqualsUnset = dataChannelFormat == DataChannelFormat.PROTOBUF,
+        unknownTypesBehavior =
+            if (dataChannelFormat == DataChannelFormat.PROTOBUF) {
+                UnknownTypesBehavior.NULL
+            } else {
+                UnknownTypesBehavior.PASS_THROUGH
+            },
     ) {
     @Test
     override fun testBasicWrite() {
@@ -432,6 +439,20 @@ class MockBasicFunctionalityIntegrationTestSocketProtobuf :
         DataChannelMedium.SOCKET,
         DataChannelFormat.PROTOBUF,
     ) {
+    // java.time.format.DateTimeParseException: Text 'foo' could not be parsed at index 0
+    // expected, protobuf mode assumes valid values.
+    @Test
+    @Disabled(
+        "we need a separate test case that exercises all types, but without bad values - https://github.com/airbytehq/airbyte-internal-issues/issues/13708"
+    )
+    override fun testBasicTypes() {
+        super.testBasicTypes()
+    }
+
+    // not suuuper important - this only happens if the source/platform have a bug,
+    // and send us a weird state message.
+    // probably should fix at some point (probably indicates bad exception handling somewhere),
+    // but IMO not critical.
     @Test
     @Disabled("Sockets medium hangs when receiving an unrecognized state message")
     override fun testCrashInInputLoop() {

--- a/airbyte-cdk/bulk/core/load/src/integrationTest/kotlin/io/airbyte/cdk/load/mock_integration_test/MockDestinationDirectLoader.kt
+++ b/airbyte-cdk/bulk/core/load/src/integrationTest/kotlin/io/airbyte/cdk/load/mock_integration_test/MockDestinationDirectLoader.kt
@@ -5,6 +5,7 @@
 package io.airbyte.cdk.load.mock_integration_test
 
 import io.airbyte.cdk.load.command.DestinationStream
+import io.airbyte.cdk.load.config.DataChannelFormat
 import io.airbyte.cdk.load.data.ObjectValue
 import io.airbyte.cdk.load.message.DestinationRecordRaw
 import io.airbyte.cdk.load.test.mock.MockDestinationBackend
@@ -14,6 +15,7 @@ import io.airbyte.cdk.load.test.util.OutputRecord
 import io.airbyte.cdk.load.write.DirectLoader
 import io.airbyte.cdk.load.write.DirectLoaderFactory
 import io.micronaut.context.annotation.Requires
+import jakarta.inject.Named
 import jakarta.inject.Singleton
 import java.time.Instant
 import java.util.UUID
@@ -22,15 +24,25 @@ import kotlinx.coroutines.runBlocking
 
 @Singleton
 @Requires(env = [MOCK_TEST_MICRONAUT_ENVIRONMENT])
-class MockDestinationDirectLoaderFactory : DirectLoaderFactory<MockDestinationDirectLoader> {
+class MockDestinationDirectLoaderFactory(
+    @Named("dataChannelFormat") private val dataChannelFormat: DataChannelFormat
+) : DirectLoaderFactory<MockDestinationDirectLoader> {
     override fun create(streamDescriptor: DestinationStream.Descriptor, part: Int) =
-        MockDestinationDirectLoader()
+        MockDestinationDirectLoader(dataChannelFormat)
 }
 
-class MockDestinationDirectLoader : DirectLoader {
+class MockDestinationDirectLoader(
+    private val dataChannelFormat: DataChannelFormat,
+) : DirectLoader {
     override suspend fun accept(record: DestinationRecordRaw): DirectLoader.DirectLoadResult {
         val recordAirbyteValue = record.asDestinationRecordAirbyteValue()
         val filename = getFilename(record.stream.mappedDescriptor, staging = true)
+        val dataChannelFormatInducedChanges =
+            if (dataChannelFormat == DataChannelFormat.PROTOBUF) {
+                record.stream.unknownColumnChanges
+            } else {
+                emptyList()
+            }
         val outputRecord =
             OutputRecord(
                 UUID.randomUUID(),
@@ -39,7 +51,8 @@ class MockDestinationDirectLoader : DirectLoader {
                 record.stream.generationId,
                 recordAirbyteValue.data as ObjectValue,
                 OutputRecord.Meta(
-                    changes = recordAirbyteValue.meta?.changes ?: listOf(),
+                    changes = (recordAirbyteValue.meta?.changes
+                            ?: listOf()) + dataChannelFormatInducedChanges,
                     syncId = record.stream.syncId
                 ),
             )

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/command/DestinationStream.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/command/DestinationStream.kt
@@ -7,9 +7,12 @@ package io.airbyte.cdk.load.command
 import io.airbyte.cdk.load.data.AirbyteType
 import io.airbyte.cdk.load.data.AirbyteValueProxy
 import io.airbyte.cdk.load.data.ObjectType
+import io.airbyte.cdk.load.data.collectUnknownPaths
 import io.airbyte.cdk.load.data.json.AirbyteTypeToJsonSchema
 import io.airbyte.cdk.load.data.json.JsonSchemaToAirbyteType
 import io.airbyte.cdk.load.message.DestinationRecord
+import io.airbyte.cdk.load.message.Meta
+import io.airbyte.protocol.models.v0.AirbyteRecordMessageMetaChange
 import io.airbyte.protocol.models.v0.AirbyteStream
 import io.airbyte.protocol.models.v0.ConfiguredAirbyteStream
 import io.airbyte.protocol.models.v0.DestinationSyncMode
@@ -64,6 +67,15 @@ data class DestinationStream(
     private val namespaceMapper: NamespaceMapper
 ) {
     val mappedDescriptor = namespaceMapper.map(namespace = unmappedNamespace, name = unmappedName)
+    val unknownColumnChanges by lazy {
+        schema.collectUnknownPaths().map {
+            Meta.Change(
+                it,
+                AirbyteRecordMessageMetaChange.Change.NULLED,
+                AirbyteRecordMessageMetaChange.Reason.DESTINATION_SERIALIZATION_ERROR,
+            )
+        }
+    }
 
     data class Descriptor(val namespace: String?, val name: String) {
         fun asProtocolObject(): StreamDescriptor =

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/write/BasicFunctionalityIntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/write/BasicFunctionalityIntegrationTest.kt
@@ -3903,7 +3903,10 @@ abstract class BasicFunctionalityIntegrationTest(
             runSync(
                 updatedConfig,
                 stream,
-                messages = listOf(InputGlobalCheckpoint(null, checkpointKeyForMedium()))
+                messages =
+                    listOf(
+                        InputGlobalCheckpoint(null, checkpointKeyForMedium(), sourceRecordCount = 0)
+                    )
             )
         }
     }

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/write/BasicFunctionalityIntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/write/BasicFunctionalityIntegrationTest.kt
@@ -2292,9 +2292,9 @@ abstract class BasicFunctionalityIntegrationTest(
                 namespaceMapper = namespaceMapperForMedium()
             )
         val stream1 = makeStream("cursor1")
-        fun makeRecord(cursorName: String, emittedAtMs: Long) =
+        fun makeRecord(stream: DestinationStream, cursorName: String, emittedAtMs: Long) =
             InputRecord(
-                stream1,
+                stream,
                 data = """{"id": 1, "$cursorName": 1, "name": "foo_$cursorName"}""",
                 emittedAtMs = emittedAtMs,
                 checkpointId = checkpointKeyForMedium()?.checkpointId
@@ -2302,10 +2302,10 @@ abstract class BasicFunctionalityIntegrationTest(
         runSync(
             updatedConfig,
             stream1,
-            listOf(makeRecord("cursor1", emittedAtMs = 100)),
+            listOf(makeRecord(stream1, "cursor1", emittedAtMs = 100)),
         )
         val stream2 = makeStream("cursor2")
-        runSync(updatedConfig, stream2, listOf(makeRecord("cursor2", emittedAtMs = 200)))
+        runSync(updatedConfig, stream2, listOf(makeRecord(stream2, "cursor2", emittedAtMs = 200)))
         dumpAndDiffRecords(
             parsedConfig,
             listOf(

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/file/object_storage/ProtoToJsonFormatter.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/file/object_storage/ProtoToJsonFormatter.kt
@@ -6,12 +6,9 @@ package io.airbyte.cdk.load.file.object_storage
 import com.fasterxml.jackson.core.JsonEncoding
 import com.fasterxml.jackson.core.JsonGenerator
 import io.airbyte.cdk.load.command.DestinationStream
-import io.airbyte.cdk.load.data.collectUnknownPaths
 import io.airbyte.cdk.load.message.DestinationRecordProtobufSource
 import io.airbyte.cdk.load.message.DestinationRecordRaw
-import io.airbyte.cdk.load.message.Meta
 import io.airbyte.cdk.util.Jsons
-import io.airbyte.protocol.models.v0.AirbyteRecordMessageMetaChange
 import java.io.OutputStream
 
 class ProtoToJsonFormatter(
@@ -22,14 +19,7 @@ class ProtoToJsonFormatter(
 
     private val fastWriter =
         ProtoToJsonWriter(stream.airbyteValueProxyFieldAccessors, rootLevelFlattening)
-    private val unknownColumnChanges =
-        stream.schema.collectUnknownPaths().map {
-            Meta.Change(
-                it,
-                AirbyteRecordMessageMetaChange.Change.NULLED,
-                AirbyteRecordMessageMetaChange.Reason.DESTINATION_SERIALIZATION_ERROR,
-            )
-        }
+    private val unknownColumnChanges = stream.unknownColumnChanges
 
     private val generator =
         Jsons.disable(JsonGenerator.Feature.AUTO_CLOSE_TARGET)

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/test/kotlin/io/airbyte/cdk/load/file/object_storage/ProtoFixtures.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/test/kotlin/io/airbyte/cdk/load/file/object_storage/ProtoFixtures.kt
@@ -6,6 +6,7 @@ package io.airbyte.cdk.load.file.object_storage
 
 import com.google.protobuf.kotlin.toByteString
 import io.airbyte.cdk.load.command.DestinationStream
+import io.airbyte.cdk.load.command.computeUnknownColumnChanges
 import io.airbyte.cdk.load.data.AirbyteType
 import io.airbyte.cdk.load.data.AirbyteValueProxy
 import io.airbyte.cdk.load.data.ArrayType
@@ -216,6 +217,8 @@ abstract class ProtoFixtures(private val addUnknownTypeToSchema: Boolean) {
             every { this@mockk.generationId } returns this@ProtoFixtures.generationId
             every { this@mockk.schema } returns dummyType
             every { this@mockk.mappedDescriptor } returns DestinationStream.Descriptor("", "dummy")
+            every { this@mockk.unknownColumnChanges } returns
+                dummyType.computeUnknownColumnChanges()
         }
 
         record =


### PR DESCRIPTION
## What
The namespace mapper tests don't need to run against all connectors, they're purely exercising CDK code. Move them into the mock test.

But, we should run those tests against speed mode. So add a sockets+proto test class to the mock test.

## How
* Move test methods into MockBasicFunctionalityIntegrationTest
* turn that class into a an abstract class, implement it for all medium x format pairs
* disable broken tests - see code comments for explanation

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
