### PR TITLE
fix(source-katana): update stream `shipping_fee` and add `error_handler`

### DIFF
--- a/airbyte-integrations/connectors/source-katana/manifest.yaml
+++ b/airbyte-integrations/connectors/source-katana/manifest.yaml
@@ -978,6 +978,23 @@ definitions:
     authenticator:
       type: BearerAuthenticator
       api_token: "{{ config[\"api_key\"] }}"
+    error_handler:
+      type: DefaultErrorHandler
+      max_retries: 3
+      response_filters:
+        - type: HttpResponseFilter
+          action: RETRY
+          http_codes:
+            - 429
+          error_message: Rate limit exceeded
+      backoff_strategies:
+        - type: WaitTimeFromHeader
+          header: Retry-After
+        - type: WaitUntilTimeFromHeader
+          header: X-Ratelimit-Reset
+        - type: ExponentialBackoffStrategy
+          factor: 2
+          max_retries: 3
 
 streams:
   - $ref: "#/definitions/streams/customers"
@@ -1326,35 +1343,26 @@ schemas:
     $schema: http://json-schema.org/schema#
     additionalProperties: true
     properties:
-      data:
+      description:
         type:
-          - array
+          - string
           - "null"
-        items:
-          type:
-            - object
-            - "null"
-          properties:
-            description:
-              type:
-                - string
-                - "null"
-            amount:
-              type:
-                - string
-                - "null"
-            id:
-              type:
-                - number
-                - "null"
-            sales_order_id:
-              type:
-                - number
-                - "null"
-            tax_rate_id:
-              type:
-                - number
-                - "null"
+      amount:
+        type:
+          - string
+          - "null"
+      id:
+        type:
+          - number
+          - "null"
+      sales_order_id:
+        type:
+          - number
+          - "null"
+      tax_rate_id:
+        type:
+          - number
+          - "null"
   costs:
     type: object
     $schema: http://json-schema.org/schema#

--- a/airbyte-integrations/connectors/source-katana/metadata.yaml
+++ b/airbyte-integrations/connectors/source-katana/metadata.yaml
@@ -17,7 +17,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 7408d324-0442-488c-95e3-9d3ec1d3cf59
-  dockerImageTag: 0.0.38
+  dockerImageTag: 0.0.39
   dockerRepository: airbyte/source-katana
   githubIssueLabel: source-katana
   icon: icon.svg

--- a/docs/integrations/sources/katana.md
+++ b/docs/integrations/sources/katana.md
@@ -45,6 +45,7 @@ To generate a live API key: log in to your Katana account.  Go to Settings &gt; 
 
 | Version          | Date              | Pull Request | Subject        |
 |------------------|-------------------|--------------|----------------|
+| 0.0.39 | 2025-09-17 | [62899](https://github.com/airbytehq/airbyte/pull/62899) | Update stream `shipping_fee` |
 | 0.0.38 | 2025-10-14 | [67937](https://github.com/airbytehq/airbyte/pull/67937) | Update dependencies |
 | 0.0.37 | 2025-10-07 | [67357](https://github.com/airbytehq/airbyte/pull/67357) | Update dependencies |
 | 0.0.36 | 2025-09-30 | [66795](https://github.com/airbytehq/airbyte/pull/66795) | Update dependencies |


### PR DESCRIPTION
## What

Fixes issue #62897

## How

* update schema for stream `shipping_fee`
* add `error_handler` to expect Katana's API rate limit.

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
