### PR TITLE
CH: Add bespoke validation for protocol.

### DIFF
--- a/airbyte-integrations/connectors/destination-clickhouse/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-clickhouse/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: ce0d828e-1dc4-496c-b122-2da42e637e48
-  dockerImageTag: 2.0.0
+  dockerImageTag: 2.0.1
   dockerRepository: airbyte/destination-clickhouse
   githubIssueLabel: destination-clickhouse
   icon: clickhouse.svg

--- a/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/check/ClickhouseChecker.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/check/ClickhouseChecker.kt
@@ -7,7 +7,7 @@ package io.airbyte.integrations.destination.clickhouse.check
 import com.clickhouse.data.ClickHouseFormat
 import com.google.common.annotations.VisibleForTesting
 import io.airbyte.cdk.load.check.DestinationChecker
-import io.airbyte.integrations.destination.clickhouse.check.ClickhouseChecker.Constants.HTTP
+import io.airbyte.integrations.destination.clickhouse.check.ClickhouseChecker.Constants.PROTOCOL
 import io.airbyte.integrations.destination.clickhouse.check.ClickhouseChecker.Constants.PROTOCOL_ERR_MESSAGE
 import io.airbyte.integrations.destination.clickhouse.check.ClickhouseChecker.Constants.TEST_DATA
 import io.airbyte.integrations.destination.clickhouse.config.ClickhouseBeanFactory
@@ -25,7 +25,7 @@ class ClickhouseChecker(
     @VisibleForTesting val tableName = "_airbyte_check_table_${clock.millis()}"
 
     override fun check(config: ClickhouseConfiguration) {
-        assert(!config.hostname.startsWith(HTTP)) { PROTOCOL_ERR_MESSAGE }
+        assert(!config.hostname.startsWith(PROTOCOL)) { PROTOCOL_ERR_MESSAGE }
 
         val client = clientFactory.make(config)
         val resolvedTableName = "${config.database}.$tableName"
@@ -62,11 +62,11 @@ class ClickhouseChecker(
 
     object Constants {
         const val TEST_DATA = """{"test": 42}"""
-        // We concatenate to get around CI rules around the string "http".
+        // We concatenate to get around CI rules around the string we're building.
         // It will literally break your PR if it sees it.
-        const val HTTP = "htt" + "p"
+        const val PROTOCOL = "htt" + "p"
         const val PROTOCOL_ERR_MESSAGE =
-            "Please remove the protocol ($HTTP://, https://) from the hostname in your connector configuration."
+            "Please remove the protocol ($PROTOCOL://, https://) from the hostname in your connector configuration."
     }
 }
 

--- a/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/check/ClickhouseChecker.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/check/ClickhouseChecker.kt
@@ -66,7 +66,7 @@ class ClickhouseChecker(
         // It will literally break your PR if it sees it.
         const val HTTP = "htt" + "p"
         const val PROTOCOL_ERR_MESSAGE =
-            "Please remove the protocol ($HTTP://, https://) from your hostname configuration."
+            "Please remove the protocol ($HTTP://, https://) from the hostname in your connector configuration."
     }
 }
 

--- a/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/check/ClickhouseChecker.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/check/ClickhouseChecker.kt
@@ -7,6 +7,7 @@ package io.airbyte.integrations.destination.clickhouse.check
 import com.clickhouse.data.ClickHouseFormat
 import com.google.common.annotations.VisibleForTesting
 import io.airbyte.cdk.load.check.DestinationChecker
+import io.airbyte.integrations.destination.clickhouse.check.ClickhouseChecker.Constants.PROTOCOL_ERR_MESSAGE
 import io.airbyte.integrations.destination.clickhouse.check.ClickhouseChecker.Constants.TEST_DATA
 import io.airbyte.integrations.destination.clickhouse.config.ClickhouseBeanFactory
 import io.airbyte.integrations.destination.clickhouse.spec.ClickhouseConfiguration
@@ -23,6 +24,8 @@ class ClickhouseChecker(
     @VisibleForTesting val tableName = "_airbyte_check_table_${clock.millis()}"
 
     override fun check(config: ClickhouseConfiguration) {
+        assert(!config.hostname.startsWith("http")) { PROTOCOL_ERR_MESSAGE }
+
         val client = clientFactory.make(config)
         val resolvedTableName = "${config.database}.$tableName"
 
@@ -58,6 +61,7 @@ class ClickhouseChecker(
 
     object Constants {
         const val TEST_DATA = """{"test": 42}"""
+        const val PROTOCOL_ERR_MESSAGE = "Please remove the protocol (http://, https://) from your hostname configuration."
     }
 }
 

--- a/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/check/ClickhouseChecker.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/check/ClickhouseChecker.kt
@@ -7,6 +7,7 @@ package io.airbyte.integrations.destination.clickhouse.check
 import com.clickhouse.data.ClickHouseFormat
 import com.google.common.annotations.VisibleForTesting
 import io.airbyte.cdk.load.check.DestinationChecker
+import io.airbyte.integrations.destination.clickhouse.check.ClickhouseChecker.Constants.HTTP
 import io.airbyte.integrations.destination.clickhouse.check.ClickhouseChecker.Constants.PROTOCOL_ERR_MESSAGE
 import io.airbyte.integrations.destination.clickhouse.check.ClickhouseChecker.Constants.TEST_DATA
 import io.airbyte.integrations.destination.clickhouse.config.ClickhouseBeanFactory
@@ -24,7 +25,7 @@ class ClickhouseChecker(
     @VisibleForTesting val tableName = "_airbyte_check_table_${clock.millis()}"
 
     override fun check(config: ClickhouseConfiguration) {
-        assert(!config.hostname.startsWith("http")) { PROTOCOL_ERR_MESSAGE }
+        assert(!config.hostname.startsWith(HTTP)) { PROTOCOL_ERR_MESSAGE }
 
         val client = clientFactory.make(config)
         val resolvedTableName = "${config.database}.$tableName"
@@ -61,7 +62,10 @@ class ClickhouseChecker(
 
     object Constants {
         const val TEST_DATA = """{"test": 42}"""
-        const val PROTOCOL_ERR_MESSAGE = "Please remove the protocol (http://, https://) from your hostname configuration."
+        // We concatenate to get around CI rules around the string "http".
+        // It will literally break your PR if it sees it.
+        const val HTTP = "htt" + "p"
+        const val PROTOCOL_ERR_MESSAGE = "Please remove the protocol ($HTTP://, https://) from your hostname configuration."
     }
 }
 

--- a/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/check/ClickhouseChecker.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/check/ClickhouseChecker.kt
@@ -61,7 +61,8 @@ class ClickhouseChecker(
 
     object Constants {
         const val TEST_DATA = """{"test": 42}"""
-        const val PROTOCOL_ERR_MESSAGE = "Please remove the protocol (http://, https://) from your hostname configuration."
+        const val PROTOCOL_ERR_MESSAGE =
+            "Please remove the protocol (http://, https://) from your hostname configuration."
     }
 }
 

--- a/airbyte-integrations/connectors/destination-clickhouse/src/test/kotlin/io/airbyte/integrations/destination/clickhouse/check/ClickhouseCheckerTest.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/test/kotlin/io/airbyte/integrations/destination/clickhouse/check/ClickhouseCheckerTest.kt
@@ -118,9 +118,7 @@ class ClickhouseCheckerTest {
         val config = Fixtures.config()
         checker.cleanup(config)
 
-        verify {
-            client.execute("DROP TABLE IF EXISTS ${config.database}.${checker.tableName}")
-        }
+        verify { client.execute("DROP TABLE IF EXISTS ${config.database}.${checker.tableName}") }
     }
 
     @Test

--- a/airbyte-integrations/connectors/destination-clickhouse/src/test/kotlin/io/airbyte/integrations/destination/clickhouse/check/ClickhouseCheckerTest.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/test/kotlin/io/airbyte/integrations/destination/clickhouse/check/ClickhouseCheckerTest.kt
@@ -7,7 +7,7 @@ package io.airbyte.integrations.destination.clickhouse.check
 import com.clickhouse.client.api.Client
 import com.clickhouse.client.api.insert.InsertResponse
 import com.clickhouse.data.ClickHouseFormat
-import io.airbyte.integrations.destination.clickhouse.check.ClickhouseChecker.Constants.HTTP
+import io.airbyte.integrations.destination.clickhouse.check.ClickhouseChecker.Constants.PROTOCOL
 import io.airbyte.integrations.destination.clickhouse.check.ClickhouseChecker.Constants.PROTOCOL_ERR_MESSAGE
 import io.airbyte.integrations.destination.clickhouse.spec.ClickhouseConfiguration
 import io.mockk.every
@@ -86,7 +86,7 @@ class ClickhouseCheckerTest {
 
     @Test
     fun `check hostname format failure`() {
-        val httpConfig = Fixtures.config(hostname = "$HTTP://hostname")
+        val httpConfig = Fixtures.config(hostname = "$PROTOCOL://hostname")
         val httpsConfig = Fixtures.config(hostname = "https://hostname")
 
         val caught1 = assertThrows<Throwable> { checker.check(httpConfig) }

--- a/airbyte-integrations/connectors/destination-clickhouse/src/test/kotlin/io/airbyte/integrations/destination/clickhouse/check/ClickhouseCheckerTest.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/test/kotlin/io/airbyte/integrations/destination/clickhouse/check/ClickhouseCheckerTest.kt
@@ -49,16 +49,17 @@ class ClickhouseCheckerTest {
 
     @Test
     fun `check happy path - creates check table and inserts data`() {
-        checker.check(Fixtures.config())
+        val config = Fixtures.config()
+        checker.check(config)
 
         verify {
             client.execute(
-                "CREATE TABLE IF NOT EXISTS ${Fixtures.config().database}.${checker.tableName} (test UInt8) ENGINE = MergeTree ORDER BY ()"
+                "CREATE TABLE IF NOT EXISTS ${config.database}.${checker.tableName} (test UInt8) ENGINE = MergeTree ORDER BY ()"
             )
         }
         verify {
             client.insert(
-                "${Fixtures.config().database}.${checker.tableName}",
+                "${config.database}.${checker.tableName}",
                 any<InputStream>(),
                 ClickHouseFormat.JSONEachRow
             )
@@ -114,10 +115,11 @@ class ClickhouseCheckerTest {
 
     @Test
     fun `cleanup happy path - drops the check table`() {
-        checker.cleanup(Fixtures.config())
+        val config = Fixtures.config()
+        checker.cleanup(config)
 
         verify {
-            client.execute("DROP TABLE IF EXISTS ${Fixtures.config().database}.${checker.tableName}")
+            client.execute("DROP TABLE IF EXISTS ${config.database}.${checker.tableName}")
         }
     }
 

--- a/airbyte-integrations/connectors/destination-clickhouse/src/test/kotlin/io/airbyte/integrations/destination/clickhouse/check/ClickhouseCheckerTest.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/test/kotlin/io/airbyte/integrations/destination/clickhouse/check/ClickhouseCheckerTest.kt
@@ -7,6 +7,7 @@ package io.airbyte.integrations.destination.clickhouse.check
 import com.clickhouse.client.api.Client
 import com.clickhouse.client.api.insert.InsertResponse
 import com.clickhouse.data.ClickHouseFormat
+import io.airbyte.integrations.destination.clickhouse.check.ClickhouseChecker.Constants.HTTP
 import io.airbyte.integrations.destination.clickhouse.check.ClickhouseChecker.Constants.PROTOCOL_ERR_MESSAGE
 import io.airbyte.integrations.destination.clickhouse.spec.ClickhouseConfiguration
 import io.mockk.every
@@ -85,7 +86,7 @@ class ClickhouseCheckerTest {
 
     @Test
     fun `check hostname format failure`() {
-        val httpConfig = Fixtures.config(hostname = "http://hostname")
+        val httpConfig = Fixtures.config(hostname = "$HTTP://hostname")
         val httpsConfig = Fixtures.config(hostname = "https://hostname")
 
         val caught1 = assertThrows<Throwable> { checker.check(httpConfig) }

--- a/docs/integrations/destinations/clickhouse-migrations.md
+++ b/docs/integrations/destinations/clickhouse-migrations.md
@@ -14,6 +14,10 @@ with no changes, albeit writing data to a completely different location and in a
 different form. So any downstream pipelines will need updating to ingest the new
 data location / format.
 
+## Gotchas
+* If the "Hostname" property in your configuration contains the protocol ("http 
+or "https"), you need to remove it. 
+
 ## Migrating existing data to the new format
 
 Unfortunately Airbyte has no way to migrate the existing raw tables to the new

--- a/docs/integrations/destinations/clickhouse.md
+++ b/docs/integrations/destinations/clickhouse.md
@@ -78,6 +78,7 @@ You can also use a pre-existing user but we highly recommend creating a dedicate
 
 | Version | Date       | Pull Request                                                | Subject                                                                        |
 |:--------|:-----------|:------------------------------------------------------------|:-------------------------------------------------------------------------------|
+| 2.0.1   | 2025-07-10 | [\#62906](https://github.com/airbytehq/airbyte/pull/62906)  | Adds bespoke validation for legacy hostnames that contain a protocol.          |
 | 2.0.0   | 2025-07-10 | [\#62887](https://github.com/airbytehq/airbyte/pull/62887)  | Cut 2.0.0 release. Replace existing connector.                                 |
 | 0.1.11  | 2025-07-09 | [\#62883](https://github.com/airbytehq/airbyte/pull/62883)  | Only set JSON properties on client if enabled to support older CH deployments. |
 | 0.1.10  | 2025-07-08 | [\#62861](https://github.com/airbytehq/airbyte/pull/62861)  | Set user agent header for internal CH telemetry.                               |


### PR DESCRIPTION
## Context
Some existing configurations include the protocol in their hostname. 

## What
* This validates in the CHECK that the protocol is not being set and surfaces that error to the user.

* This adds a note in the migration guide to that effect
