### PR TITLE
feat: load-http: improve retrying policies

### DIFF
--- a/airbyte-cdk/bulk/toolkits/load-http/src/main/kotlin/io/airbyte/cdk/load/http/authentication/OAuthAuthenticator.kt
+++ b/airbyte-cdk/bulk/toolkits/load-http/src/main/kotlin/io/airbyte/cdk/load/http/authentication/OAuthAuthenticator.kt
@@ -25,7 +25,7 @@ class OAuthAuthenticator(
     private val clientSecret: String,
     private val refreshToken: String,
     private val httpClient: HttpClient =
-        AirbyteOkHttpClient(OkHttpClient.Builder().build(), RetryPolicy.ofDefaults())
+        AirbyteOkHttpClient(OkHttpClient.Builder().build())
 ) : Interceptor {
     object Constants {
         const val CLIENT_ID_FIELD_NAME: String = "client_id"

--- a/airbyte-cdk/bulk/toolkits/load-http/src/main/kotlin/io/airbyte/cdk/load/http/okhttp/AirbyteOkHttpClient.kt
+++ b/airbyte-cdk/bulk/toolkits/load-http/src/main/kotlin/io/airbyte/cdk/load/http/okhttp/AirbyteOkHttpClient.kt
@@ -16,8 +16,17 @@ import okhttp3.RequestBody.Companion.toRequestBody
 
 class AirbyteOkHttpClient(
     private val client: OkHttpClient,
-    private val retryPolicy: RetryPolicy<okhttp3.Response>
+    private val retryPolicies: List<RetryPolicy<okhttp3.Response>>
 ) : HttpClient {
+
+    constructor(
+        client: OkHttpClient,
+        retryPolicy: RetryPolicy<okhttp3.Response>
+    )  : this(client, listOf(retryPolicy))
+
+    constructor(
+        client: OkHttpClient,
+    )  : this(client, RetryPolicyFactory().createDefault())
 
     override fun send(request: Request): Response {
         val url = createUrl(request)
@@ -29,7 +38,7 @@ class AirbyteOkHttpClient(
                 .apply { request.headers.forEach { header -> addHeader(header.key, header.value) } }
                 .build()
         val response: okhttp3.Response =
-            FailsafeCall.with(retryPolicy).compose(client.newCall(okhttpRequest)).execute()
+            FailsafeCall.with(retryPolicies[0], *retryPolicies.drop(1).toTypedArray()).compose(client.newCall(okhttpRequest)).execute()
         return OkHttpResponse(response)
     }
 

--- a/airbyte-cdk/bulk/toolkits/load-http/src/main/kotlin/io/airbyte/cdk/load/http/okhttp/AirbyteOkHttpClient.kt
+++ b/airbyte-cdk/bulk/toolkits/load-http/src/main/kotlin/io/airbyte/cdk/load/http/okhttp/AirbyteOkHttpClient.kt
@@ -37,8 +37,10 @@ class AirbyteOkHttpClient(
                 .method(request.method.toString(), request.body?.toRequestBody())
                 .apply { request.headers.forEach { header -> addHeader(header.key, header.value) } }
                 .build()
-        val response: okhttp3.Response =
-            FailsafeCall.with(retryPolicies[0], *retryPolicies.drop(1).toTypedArray()).compose(client.newCall(okhttpRequest)).execute()
+        val response = when (retryPolicies.isEmpty()) {
+            true -> client.newCall(okhttpRequest).execute()
+            false -> FailsafeCall.with(retryPolicies[0], *retryPolicies.drop(1).toTypedArray()).compose(client.newCall(okhttpRequest)).execute()
+        }
         return OkHttpResponse(response)
     }
 

--- a/airbyte-cdk/bulk/toolkits/load-http/src/main/kotlin/io/airbyte/cdk/load/http/okhttp/RetryPolicyFactory.kt
+++ b/airbyte-cdk/bulk/toolkits/load-http/src/main/kotlin/io/airbyte/cdk/load/http/okhttp/RetryPolicyFactory.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+ */
+
 package io.airbyte.cdk.load.http.okhttp
 
 import dev.failsafe.RetryPolicy

--- a/airbyte-cdk/bulk/toolkits/load-http/src/main/kotlin/io/airbyte/cdk/load/http/okhttp/RetryPolicyFactory.kt
+++ b/airbyte-cdk/bulk/toolkits/load-http/src/main/kotlin/io/airbyte/cdk/load/http/okhttp/RetryPolicyFactory.kt
@@ -26,13 +26,13 @@ class RetryPolicyFactory {
                 .withBackoff(1, 300, ChronoUnit.SECONDS)
                 .withMaxAttempts(10)
                 .onFailedAttempt{ e -> logger.warn { "Request got rate limited. Response body is: ${e.lastResult.body?.string() ?: "<empty>"}" } }
-                .onRetry{ e -> logger.warn { "Retrying rate limited request..." } }
+                .onRetry{ _ -> logger.warn { "Retrying rate limited request..." } }
                 .build(),
             fromPredicate{ response ->  response.code in 500..< 600 }
                 .withBackoff(1, 60, ChronoUnit.SECONDS)
                 .withMaxDuration(Duration.ofMinutes(10))
                 .onFailedAttempt{ e -> logger.warn { "Server error with status ${e.lastResult?.code}. . Response body is: ${e.lastResult?.body?.string() ?: "<empty>"}" } }
-                .onRetry{ e -> logger.warn { "Retrying request with server error..." } }
+                .onRetry{ _ -> logger.warn { "Retrying request with server error..." } }
                 .build(),
         )
     }
@@ -41,6 +41,6 @@ class RetryPolicyFactory {
         RetryPolicy.builder<Response>()
             .handleResultIf { predicate.test(it) }
             // Specifying handleIf is very weird because we don't care about exceptions here but the retry policy will fail if we don't check the exceptions and there is an exception. See: https://github.com/failsafe-lib/failsafe/blob/98bb496198e18436e654ddca39358a4634ca32bd/core/src/main/java/dev/failsafe/spi/FailurePolicy.java#L59-L60
-            .handleIf { exception ->  false}
+            .handleIf { _ ->  false}
 
 }

--- a/airbyte-cdk/bulk/toolkits/load-http/src/main/kotlin/io/airbyte/cdk/load/http/okhttp/RetryPolicyFactory.kt
+++ b/airbyte-cdk/bulk/toolkits/load-http/src/main/kotlin/io/airbyte/cdk/load/http/okhttp/RetryPolicyFactory.kt
@@ -1,0 +1,42 @@
+package io.airbyte.cdk.load.http.okhttp
+
+import dev.failsafe.RetryPolicy
+import dev.failsafe.RetryPolicyBuilder
+import dev.failsafe.function.CheckedPredicate
+import io.github.oshai.kotlinlogging.KotlinLogging
+import java.time.Duration
+import java.time.temporal.ChronoUnit
+import kotlin.text.toLong
+import okhttp3.Response
+
+private val logger = KotlinLogging.logger {}
+
+class RetryPolicyFactory {
+    fun createDefault(): List<RetryPolicy<Response>> {
+        return listOf(
+            // at the time of this comment, `ofDefaults()` means `3 execution attempts max with no delay when there is an exception`
+            RetryPolicy.ofDefaults(),
+            fromPredicate{ response -> response.code == 429 }
+                // when the delay function return a negative number, it'll fall back on any other DelayablePolicy defined (in this case, `withBackoff`)
+                .withDelayFn{ ctx -> Duration.ofSeconds(ctx.lastResult?.headers?.get("retry-after")?.toLong() ?: -1) }
+                .withBackoff(1, 300, ChronoUnit.SECONDS)
+                .withMaxAttempts(10)
+                .onFailedAttempt{ e -> logger.warn { "Request got rate limited. Response body is: ${e.lastResult.body?.string() ?: "<empty>"}" } }
+                .onRetry{ e -> logger.warn { "Retrying rate limited request..." } }
+                .build(),
+            fromPredicate{ response ->  response.code in 500..< 600 }
+                .withBackoff(1, 60, ChronoUnit.SECONDS)
+                .withMaxDuration(Duration.ofMinutes(10))
+                .onFailedAttempt{ e -> logger.warn { "Server error with status ${e.lastResult?.code}. . Response body is: ${e.lastResult?.body?.string() ?: "<empty>"}" } }
+                .onRetry{ e -> logger.warn { "Retrying request with server error..." } }
+                .build(),
+        )
+    }
+
+    private fun fromPredicate(predicate: CheckedPredicate<Response>): RetryPolicyBuilder<Response> =
+        RetryPolicy.builder<Response>()
+            .handleResultIf { predicate.test(it) }
+            // Specifying handleIf is very weird because we don't care about exceptions here but the retry policy will fail if we don't check the exceptions and there is an exception. See: https://github.com/failsafe-lib/failsafe/blob/98bb496198e18436e654ddca39358a4634ca32bd/core/src/main/java/dev/failsafe/spi/FailurePolicy.java#L59-L60
+            .handleIf { exception ->  false}
+
+}


### PR DESCRIPTION
## What
There are some basic cases where the probably always want to retry on HTTP requests. This PR introduce two of these and fallback to the default that was already present:
* rate limiting
* internal server errors
* default (just retry blindly twice)

## How
Allowing multiple retry policies in the http client and having a default sets of those retry policies.

Note that this PR depends on https://github.com/airbytehq/airbyte/pull/62936 if we want to keep the `..<` in the code

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
Given one of those errors, the connector will not fail immediately and try again

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
