### PR TITLE
feat: allow for kotlin like access operator in string interpolation

### DIFF
--- a/airbyte-cdk/bulk/toolkits/load-low-code/src/main/kotlin/io/airbyte/cdk/load/interpolation/StringInterpolator.kt
+++ b/airbyte-cdk/bulk/toolkits/load-low-code/src/main/kotlin/io/airbyte/cdk/load/interpolation/StringInterpolator.kt
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.module.kotlin.jacksonTypeRef
 import com.hubspot.jinjava.Jinjava
 import com.hubspot.jinjava.JinjavaConfig
 import com.hubspot.jinjava.el.JinjavaInterpreterResolver
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 import io.airbyte.cdk.util.Jsons
 import java.beans.FeatureDescriptor
 import jinjava.javax.el.CompositeELResolver
@@ -22,6 +23,10 @@ import jinjava.javax.el.PropertyNotWritableException
  * Given this class is registered as an ELResolver in the JinjavaConfig, the user will be able to
  * write `node["field"]` instead of `node.get("field").
  */
+@SuppressFBWarnings(
+    "NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE",
+    justification = "The param in getValue needs to be nullable because it's a Java class but we fail if it's null"
+)
 private class MapGetOperatorELResolver : ELResolver() {
     override fun getCommonPropertyType(context: ELContext?, base: Any?): Class<*>? {
         return if (isBaseValid(base)) {

--- a/airbyte-cdk/bulk/toolkits/load-low-code/src/main/kotlin/io/airbyte/cdk/load/interpolation/StringInterpolator.kt
+++ b/airbyte-cdk/bulk/toolkits/load-low-code/src/main/kotlin/io/airbyte/cdk/load/interpolation/StringInterpolator.kt
@@ -22,9 +22,6 @@ import jinjava.javax.el.PropertyNotWritableException
  * language would need to use textual operator `get` (which is still allowed, but less expressive).
  * Given this class is registered as an ELResolver in the JinjavaConfig, the user will be able to
  * write `node["field"]` instead of `node.get("field").
- *
- * Note that this class relies on Maps to be InterpolatedMap so JsonNode will need to be wrapped as
- * InterpolatedMap before being passed as a binding to the render method.
  */
 private class MapGetOperatorELResolver : ELResolver() {
     override fun getCommonPropertyType(context: ELContext?, base: Any?): Class<*>? {

--- a/airbyte-cdk/bulk/toolkits/load-low-code/src/main/kotlin/io/airbyte/cdk/load/interpolation/StringInterpolator.kt
+++ b/airbyte-cdk/bulk/toolkits/load-low-code/src/main/kotlin/io/airbyte/cdk/load/interpolation/StringInterpolator.kt
@@ -25,7 +25,8 @@ import jinjava.javax.el.PropertyNotWritableException
  */
 @SuppressFBWarnings(
     "NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE",
-    justification = "The param in getValue needs to be nullable because it's a Java class but we fail if it's null"
+    justification =
+        "The param in getValue needs to be nullable because it's a Java class but we fail if it's null"
 )
 private class MapGetOperatorELResolver : ELResolver() {
     override fun getCommonPropertyType(context: ELContext?, base: Any?): Class<*>? {

--- a/airbyte-cdk/bulk/toolkits/load-low-code/src/main/kotlin/io/airbyte/cdk/load/interpolation/StringInterpolator.kt
+++ b/airbyte-cdk/bulk/toolkits/load-low-code/src/main/kotlin/io/airbyte/cdk/load/interpolation/StringInterpolator.kt
@@ -5,7 +5,6 @@
 package io.airbyte.cdk.load.interpolation
 
 import com.fasterxml.jackson.databind.JsonNode
-import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.jacksonTypeRef
 import com.hubspot.jinjava.Jinjava
 import com.hubspot.jinjava.JinjavaConfig
@@ -88,5 +87,4 @@ class StringInterpolator {
     }
 }
 
-fun JsonNode.toInterpolationContext(): Any =
-    Jsons.convertValue(this, jacksonTypeRef<Any>())
+fun JsonNode.toInterpolationContext(): Any = Jsons.convertValue(this, jacksonTypeRef<Any>())

--- a/airbyte-cdk/bulk/toolkits/load-low-code/src/main/kotlin/io/airbyte/cdk/load/interpolation/StringInterpolator.kt
+++ b/airbyte-cdk/bulk/toolkits/load-low-code/src/main/kotlin/io/airbyte/cdk/load/interpolation/StringInterpolator.kt
@@ -4,12 +4,91 @@
 
 package io.airbyte.cdk.load.interpolation
 
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.jacksonTypeRef
 import com.hubspot.jinjava.Jinjava
+import com.hubspot.jinjava.JinjavaConfig
+import com.hubspot.jinjava.el.JinjavaInterpreterResolver
+import java.beans.FeatureDescriptor
+import jinjava.javax.el.CompositeELResolver
+import jinjava.javax.el.ELContext
+import jinjava.javax.el.ELResolver
+import jinjava.javax.el.PropertyNotWritableException
+
+/**
+ * This class allows for Kotlin/Python-like map accessor. Without this, the users of the low-code
+ * language would need to use textual operator `get` (which is still allowed, but less expressive).
+ * Given this class is registered as an ELResolver in the JinjavaConfig, the user will be able to
+ * write `node["field"]` instead of `node.get("field").
+ *
+ * Note that this class relies on Maps to be InterpolatedMap so JsonNode will need to be wrapped as
+ * InterpolatedMap before being passed as a binding to the render method.
+ */
+private class MapGetOperatorELResolver : ELResolver() {
+    override fun getCommonPropertyType(context: ELContext?, base: Any?): Class<*>? {
+        return if (isBaseValid(base)) {
+            String::class.java
+        } else null
+    }
+
+    override fun getFeatureDescriptors(
+        context: ELContext?,
+        base: Any?
+    ): Iterator<FeatureDescriptor?>? {
+        return null
+    }
+
+    override fun getType(context: ELContext?, base: Any?, property: Any?): Class<*>? {
+        return getValue(context, base, property)?.javaClass ?: Unit.javaClass
+    }
+
+    override fun getValue(context: ELContext?, base: Any?, property: Any?): Any? {
+        if (context == null) {
+            throw NullPointerException("context is null")
+        } else {
+            if (this.isResolvable(base, property)) {
+                val value = (base as Map<*, *>).get(property as String)
+                context.isPropertyResolved = true
+                return value
+            }
+
+            return null
+        }
+    }
+
+    override fun isReadOnly(p0: ELContext?, p1: Any?, p2: Any?): Boolean = true
+
+    override fun setValue(p0: ELContext?, p1: Any?, p2: Any?, p3: Any?) {
+        throw PropertyNotWritableException("resolver is read-only")
+    }
+
+    private fun isResolvable(base: Any?, property: Any?): Boolean {
+        val baseValid = isBaseValid(base)
+        val propertyValid = property != null && property is String
+        return baseValid and propertyValid
+    }
+
+    private fun isBaseValid(base: Any?): Boolean = base != null && base is Map<*, *>
+}
 
 class StringInterpolator {
-    private val interpolator = Jinjava()
+    private val interpolator =
+        Jinjava(
+            JinjavaConfig.newBuilder()
+                .withElResolver(
+                    CompositeELResolver().apply {
+                        this.add(MapGetOperatorELResolver())
+                        this.add(JinjavaInterpreterResolver.DEFAULT_RESOLVER_READ_ONLY)
+                    }
+                )
+                .build()
+        )
 
     fun interpolate(string: String, context: Map<String, Any>): String {
         return interpolator.render(string, context)
     }
 }
+
+fun JsonNode.toInterpolationContext(): Any =
+    ObjectMapper().convertValue(this, jacksonTypeRef<Any>())

--- a/airbyte-cdk/bulk/toolkits/load-low-code/src/main/kotlin/io/airbyte/cdk/load/interpolation/StringInterpolator.kt
+++ b/airbyte-cdk/bulk/toolkits/load-low-code/src/main/kotlin/io/airbyte/cdk/load/interpolation/StringInterpolator.kt
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.module.kotlin.jacksonTypeRef
 import com.hubspot.jinjava.Jinjava
 import com.hubspot.jinjava.JinjavaConfig
 import com.hubspot.jinjava.el.JinjavaInterpreterResolver
+import io.airbyte.cdk.util.Jsons
 import java.beans.FeatureDescriptor
 import jinjava.javax.el.CompositeELResolver
 import jinjava.javax.el.ELContext
@@ -91,4 +92,4 @@ class StringInterpolator {
 }
 
 fun JsonNode.toInterpolationContext(): Any =
-    ObjectMapper().convertValue(this, jacksonTypeRef<Any>())
+    Jsons.convertValue(this, jacksonTypeRef<Any>())

--- a/airbyte-cdk/bulk/toolkits/load-low-code/src/test/kotlin/io/airbyte/cdk/load/interpolation/StringInterpolationTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-low-code/src/test/kotlin/io/airbyte/cdk/load/interpolation/StringInterpolationTest.kt
@@ -67,10 +67,7 @@ class StringInterpolationTest {
 
     @Test
     internal fun `test given ObjectNode when eval then extract values from ObjectNode`() {
-        val objectNode =
-            Jsons.objectNode().apply {
-                this.putObject("modificationMetadata").put("readOnlyValue", "readonly")
-            }
+        val objectNode = Jsons.readTree("""{"modificationMetadata": {"readOnlyValue": "readonly"}}""")
 
         val interpolatedValue =
             StringInterpolator()
@@ -83,10 +80,7 @@ class StringInterpolationTest {
 
     @Test
     internal fun `test given InterpolatedMap with get method when eval then return value`() {
-        val objectNode =
-            Jsons.objectNode().apply {
-                this.putObject("modificationMetadata").put("readOnlyValue", "readonly")
-            }
+        val objectNode = Jsons.readTree("""{"modificationMetadata": {"readOnlyValue": "readonly"}}""")
 
         val interpolatedValue =
             StringInterpolator()
@@ -99,10 +93,7 @@ class StringInterpolationTest {
 
     @Test
     internal fun `test given InterpolatedMap with get accessor when eval then return value`() {
-        val objectNode =
-            Jsons.objectNode().apply {
-                this.putObject("modificationMetadata").put("readOnlyValue", "readonly")
-            }
+        val objectNode = Jsons.readTree("""{"modificationMetadata": {"readOnlyValue": "readonly"}}""")
 
         val interpolatedValue =
             StringInterpolator()
@@ -115,10 +106,7 @@ class StringInterpolationTest {
 
     @Test
     internal fun `test given ObjectNode with condition when eval then compare the value of the node and not the node itself`() {
-        val objectNode =
-            Jsons.objectNode().apply {
-                this.putObject("modificationMetadata").put("readOnlyValue", "readonly")
-            }
+        val objectNode = Jsons.readTree("""{"modificationMetadata": {"readOnlyValue": "readonly"}}""")
 
         val interpolatedValue =
             StringInterpolator()

--- a/airbyte-cdk/bulk/toolkits/load-low-code/src/test/kotlin/io/airbyte/cdk/load/interpolation/StringInterpolationTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-low-code/src/test/kotlin/io/airbyte/cdk/load/interpolation/StringInterpolationTest.kt
@@ -69,15 +69,63 @@ class StringInterpolationTest {
     internal fun `test given ObjectNode when eval then extract values from ObjectNode`() {
         val objectNode =
             Jsons.objectNode().apply {
-                this.putObject("modificationMetadata").put("readOnlyValue", false)
+                this.putObject("modificationMetadata").put("readOnlyValue", "readonly")
             }
 
         val interpolatedValue =
             StringInterpolator()
                 .interpolate(
                     """{{ response.get("modificationMetadata").get("readOnlyValue") }}""",
-                    mapOf("response" to objectNode)
+                    mapOf("response" to objectNode.toInterpolationContext())
                 )
-        assertEquals("false", interpolatedValue)
+        assertEquals("readonly", interpolatedValue)
+    }
+
+    @Test
+    internal fun `test given InterpolatedMap with get method when eval then return value`() {
+        val objectNode =
+            Jsons.objectNode().apply {
+                this.putObject("modificationMetadata").put("readOnlyValue", "readonly")
+            }
+
+        val interpolatedValue =
+            StringInterpolator()
+                .interpolate(
+                    """{{ response.get("modificationMetadata").get("readOnlyValue") }}""",
+                    mapOf("response" to objectNode.toInterpolationContext())
+                )
+        assertEquals("readonly", interpolatedValue)
+    }
+
+    @Test
+    internal fun `test given InterpolatedMap with get accessor when eval then return value`() {
+        val objectNode =
+            Jsons.objectNode().apply {
+                this.putObject("modificationMetadata").put("readOnlyValue", "readonly")
+            }
+
+        val interpolatedValue =
+            StringInterpolator()
+                .interpolate(
+                    """{{ response["modificationMetadata"]["readOnlyValue"] }}""",
+                    mapOf("response" to objectNode.toInterpolationContext())
+                )
+        assertEquals("readonly", interpolatedValue)
+    }
+
+    @Test
+    internal fun `test given ObjectNode with condition when eval then compare the value of the node and not the node itself`() {
+        val objectNode =
+            Jsons.objectNode().apply {
+                this.putObject("modificationMetadata").put("readOnlyValue", "readonly")
+            }
+
+        val interpolatedValue =
+            StringInterpolator()
+                .interpolate(
+                    """{{ response["modificationMetadata"]["readOnlyValue"] == "readonly" }}""",
+                    mapOf("response" to objectNode.toInterpolationContext())
+                )
+        assertEquals("true", interpolatedValue)
     }
 }

--- a/airbyte-cdk/bulk/toolkits/load-low-code/src/test/kotlin/io/airbyte/cdk/load/interpolation/StringInterpolationTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-low-code/src/test/kotlin/io/airbyte/cdk/load/interpolation/StringInterpolationTest.kt
@@ -79,20 +79,7 @@ class StringInterpolationTest {
     }
 
     @Test
-    internal fun `test given InterpolatedMap with get method when eval then return value`() {
-        val objectNode = Jsons.readTree("""{"modificationMetadata": {"readOnlyValue": "readonly"}}""")
-
-        val interpolatedValue =
-            StringInterpolator()
-                .interpolate(
-                    """{{ response.get("modificationMetadata").get("readOnlyValue") }}""",
-                    mapOf("response" to objectNode.toInterpolationContext())
-                )
-        assertEquals("readonly", interpolatedValue)
-    }
-
-    @Test
-    internal fun `test given InterpolatedMap with get accessor when eval then return value`() {
+    internal fun `test given ObjectNode with get accessor when eval then return value`() {
         val objectNode = Jsons.readTree("""{"modificationMetadata": {"readOnlyValue": "readonly"}}""")
 
         val interpolatedValue =

--- a/airbyte-cdk/bulk/toolkits/load-low-code/src/test/kotlin/io/airbyte/cdk/load/interpolation/StringInterpolationTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-low-code/src/test/kotlin/io/airbyte/cdk/load/interpolation/StringInterpolationTest.kt
@@ -67,7 +67,8 @@ class StringInterpolationTest {
 
     @Test
     internal fun `test given ObjectNode when eval then extract values from ObjectNode`() {
-        val objectNode = Jsons.readTree("""{"modificationMetadata": {"readOnlyValue": "readonly"}}""")
+        val objectNode =
+            Jsons.readTree("""{"modificationMetadata": {"readOnlyValue": "readonly"}}""")
 
         val interpolatedValue =
             StringInterpolator()
@@ -80,7 +81,8 @@ class StringInterpolationTest {
 
     @Test
     internal fun `test given ObjectNode with get accessor when eval then return value`() {
-        val objectNode = Jsons.readTree("""{"modificationMetadata": {"readOnlyValue": "readonly"}}""")
+        val objectNode =
+            Jsons.readTree("""{"modificationMetadata": {"readOnlyValue": "readonly"}}""")
 
         val interpolatedValue =
             StringInterpolator()
@@ -93,7 +95,8 @@ class StringInterpolationTest {
 
     @Test
     internal fun `test given ObjectNode with condition when eval then compare the value of the node and not the node itself`() {
-        val objectNode = Jsons.readTree("""{"modificationMetadata": {"readOnlyValue": "readonly"}}""")
+        val objectNode =
+            Jsons.readTree("""{"modificationMetadata": {"readOnlyValue": "readonly"}}""")
 
         val interpolatedValue =
             StringInterpolator()


### PR DESCRIPTION
## What
Allows for Kotlin/Python-like map accessor. Without this, the users of the low-code language would need to use textual operator `get` (which is still allowed, but less expressive). Given this class is registered as an ELResolver in the JinjavaConfig, the user will be able to write `node["field"]` instead of `node.get("field").

## How
Adding a ELResolver that handles operation []

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
Users can now write Kotlin/Python like dictionary access

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [X] YES 💚
- [ ] NO ❌
