### PR TITLE
chore: latest security patches for java base container

### DIFF
--- a/docker-images/Dockerfile.java-connector-base
+++ b/docker-images/Dockerfile.java-connector-base
@@ -1,15 +1,17 @@
 # Migrated from airbyte-ci/connectors/base_images/README.md
 
 # https://hub.docker.com/_/amazoncorretto/tags?name=21-al2023
-ARG BASE_IMAGE=docker.io/amazoncorretto:21-al2023@sha256:b88419ff8e6f18de4e8e78b1814b12df4805cfe42dcf0c036671da86f589f35f
+ARG BASE_IMAGE=docker.io/amazoncorretto:21-al2023
 FROM ${BASE_IMAGE}
 
 # Install dependencies
-RUN sh -c set -o xtrace && \
-    yum install -y shadow-utils tar openssl findutils && \
-    yum update -y --security && \
-    yum clean all && \
-    rm -rf /var/cache/yum
+RUN set -o xtrace && \
+    dnf clean all && \
+    dnf makecache --refresh && \
+    dnf install -y shadow-utils tar openssl findutils && \
+    dnf update --releasever=latest -y --security && \
+    dnf clean all && \
+    rm -rf /var/cache/dnf
 
 # Set-up groups, users, and directories
 RUN groupadd --gid 1000 airbyte && \


### PR DESCRIPTION
## What
Install the latest security patches for Java connector base images

## How
 * Switch from yum to dnf
 * Install security patches from the latest upstream
 * Float coretto version to the latest stable to reduce the risk of incompatibility betwee latest security patches

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
