### PR TITLE
ClickHouse: Post release tweaks

### DIFF
--- a/airbyte-integrations/connectors/destination-clickhouse/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-clickhouse/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: ce0d828e-1dc4-496c-b122-2da42e637e48
-  dockerImageTag: 2.0.1
+  dockerImageTag: 2.0.2
   dockerRepository: airbyte/destination-clickhouse
   githubIssueLabel: destination-clickhouse
   icon: clickhouse.svg

--- a/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/spec/ClickhouseConfiguration.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/spec/ClickhouseConfiguration.kt
@@ -44,7 +44,7 @@ class ClickhouseConfigurationFactory :
             pojo.database,
             pojo.username,
             pojo.password,
-            pojo.enableJson,
+            pojo.enableJson ?: false,
         )
     }
 

--- a/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/spec/ClickhouseSpecification.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/spec/ClickhouseSpecification.kt
@@ -23,7 +23,7 @@ sealed class ClickhouseSpecification : ConfigurationSpecification() {
     abstract val database: String
     abstract val username: String
     abstract val password: String
-    abstract val enableJson: Boolean
+    abstract val enableJson: Boolean?
 }
 
 @Singleton
@@ -71,7 +71,7 @@ class ClickhouseSpecificationOss : ClickhouseSpecification() {
     )
     @get:JsonProperty("enable_json")
     @get:JsonSchemaInject(json = """{"order": 6, "default": false}""")
-    override val enableJson: Boolean = false
+    override val enableJson: Boolean? = false
 }
 
 @Singleton
@@ -119,7 +119,7 @@ open class ClickhouseSpecificationCloud : ClickhouseSpecification() {
     )
     @get:JsonProperty("enable_json")
     @get:JsonSchemaInject(json = """{"order": 6, "default": false}""")
-    override val enableJson: Boolean = false
+    override val enableJson: Boolean? = false
 }
 
 enum class ClickhouseConnectionProtocol(@get:JsonValue val value: String) {

--- a/airbyte-integrations/connectors/destination-clickhouse/src/test-integration/resources/expected-spec-cloud.json
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/test-integration/resources/expected-spec-cloud.json
@@ -57,7 +57,7 @@
         "default" : false
       }
     },
-    "required" : [ "host", "port", "protocol", "database", "username", "password", "enable_json" ],
+    "required" : [ "host", "port", "protocol", "database", "username", "password" ],
     "groups" : [ {
       "id" : "connection",
       "title" : "Connection"

--- a/airbyte-integrations/connectors/destination-clickhouse/src/test-integration/resources/expected-spec-oss.json
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/test-integration/resources/expected-spec-oss.json
@@ -56,7 +56,7 @@
         "default" : false
       }
     },
-    "required" : [ "host", "port", "protocol", "database", "username", "password", "enable_json" ],
+    "required" : [ "host", "port", "protocol", "database", "username", "password" ],
     "groups" : [ {
       "id" : "connection",
       "title" : "Connection"

--- a/docs/integrations/destinations/clickhouse-migrations.md
+++ b/docs/integrations/destinations/clickhouse-migrations.md
@@ -31,3 +31,8 @@ naming semantics, we will not remove existing data. If you would like to, you
 will need to delete all the tables saved in the old format, which for most
 people should be under `airbyte_internal.{database}_raw__`, but may vary based
 on your specific configuration.
+
+## SSH Support
+
+SSH is not yet implemented for the new connector. If you require SSH support,
+please hold off on migrating for now.

--- a/docs/integrations/destinations/clickhouse.md
+++ b/docs/integrations/destinations/clickhouse.md
@@ -78,7 +78,7 @@ You can also use a pre-existing user but we highly recommend creating a dedicate
 
 | Version | Date       | Pull Request                                               | Subject                                                                        |
 |:--------|:-----------|:-----------------------------------------------------------|:-------------------------------------------------------------------------------|
-| 2.0.2   | 2025-07-10 | [\#62906](https://github.com/airbytehq/airbyte/pull/tbd)   | Makes json optional in spec to work around UI issue.                           |
+| 2.0.2   | 2025-07-10 | [\#62928](https://github.com/airbytehq/airbyte/pull/62928)   | Makes json optional in spec to work around UI issue.                           |
 | 2.0.1   | 2025-07-10 | [\#62906](https://github.com/airbytehq/airbyte/pull/62906) | Adds bespoke validation for legacy hostnames that contain a protocol.          |
 | 2.0.0   | 2025-07-10 | [\#62887](https://github.com/airbytehq/airbyte/pull/62887) | Cut 2.0.0 release. Replace existing connector.                                 |
 | 0.1.11  | 2025-07-09 | [\#62883](https://github.com/airbytehq/airbyte/pull/62883) | Only set JSON properties on client if enabled to support older CH deployments. |

--- a/docs/integrations/destinations/clickhouse.md
+++ b/docs/integrations/destinations/clickhouse.md
@@ -76,20 +76,21 @@ You can also use a pre-existing user but we highly recommend creating a dedicate
 <details>
   <summary>Expand to review</summary>
 
-| Version | Date       | Pull Request                                                | Subject                                                                        |
-|:--------|:-----------|:------------------------------------------------------------|:-------------------------------------------------------------------------------|
-| 2.0.1   | 2025-07-10 | [\#62906](https://github.com/airbytehq/airbyte/pull/62906)  | Adds bespoke validation for legacy hostnames that contain a protocol.          |
-| 2.0.0   | 2025-07-10 | [\#62887](https://github.com/airbytehq/airbyte/pull/62887)  | Cut 2.0.0 release. Replace existing connector.                                 |
-| 0.1.11  | 2025-07-09 | [\#62883](https://github.com/airbytehq/airbyte/pull/62883)  | Only set JSON properties on client if enabled to support older CH deployments. |
-| 0.1.10  | 2025-07-08 | [\#62861](https://github.com/airbytehq/airbyte/pull/62861)  | Set user agent header for internal CH telemetry.                               |
-| 0.1.9   | 2025-07-03 | [\#62509](https://github.com/airbytehq/airbyte/pull/62509)  | Simplify union stringification behavior.                                       |
-| 0.1.8   | 2025-06-30 | [\#62100](https://github.com/airbytehq/airbyte/pull/62100)  | Add JSON support.                                                              |
-| 0.1.7   | 2025-06-24 | [\#62047](https://github.com/airbytehq/airbyte/pull/62047)  | Remove the use of the internal namespace.                                      |
-| 0.1.6   | 2025-06-24 | [\#62047](https://github.com/airbytehq/airbyte/pull/62047)  | Hide protocol option when running on cloud.                                    |
-| 0.1.5   | 2025-06-24 | [\#62043](https://github.com/airbytehq/airbyte/pull/62043)  | Expose database protocol config option.                                        |
-| 0.1.4   | 2025-06-24 | [\#62040](https://github.com/airbytehq/airbyte/pull/62040)  | Checker inserts into configured DB.                                            |
-| 0.1.3   | 2025-06-24 | [\#62038](https://github.com/airbytehq/airbyte/pull/62038)  | Allow the client to connect to the resolved DB.                                |
-| 0.1.2   | 2025-06-23 | [\#62028](https://github.com/airbytehq/airbyte/pull/62028)  | Enable the registry in OSS and cloud.                                          |
-| 0.1.1   | 2025-06-23 | [\#62022](https://github.com/airbytehq/airbyte/pull/62022)  | Publish first beta version and pin the CDK version.                            |
-| 0.1.0   | 2025-06-23 | [\#62024](https://github.com/airbytehq/airbyte/pull/62024)  | Release first beta version.                                                    |
+| Version | Date       | Pull Request                                               | Subject                                                                        |
+|:--------|:-----------|:-----------------------------------------------------------|:-------------------------------------------------------------------------------|
+| 2.0.2   | 2025-07-10 | [\#62906](https://github.com/airbytehq/airbyte/pull/tbd)   | Makes json optional in spec to work around UI issue.                           |
+| 2.0.1   | 2025-07-10 | [\#62906](https://github.com/airbytehq/airbyte/pull/62906) | Adds bespoke validation for legacy hostnames that contain a protocol.          |
+| 2.0.0   | 2025-07-10 | [\#62887](https://github.com/airbytehq/airbyte/pull/62887) | Cut 2.0.0 release. Replace existing connector.                                 |
+| 0.1.11  | 2025-07-09 | [\#62883](https://github.com/airbytehq/airbyte/pull/62883) | Only set JSON properties on client if enabled to support older CH deployments. |
+| 0.1.10  | 2025-07-08 | [\#62861](https://github.com/airbytehq/airbyte/pull/62861) | Set user agent header for internal CH telemetry.                               |
+| 0.1.9   | 2025-07-03 | [\#62509](https://github.com/airbytehq/airbyte/pull/62509) | Simplify union stringification behavior.                                       |
+| 0.1.8   | 2025-06-30 | [\#62100](https://github.com/airbytehq/airbyte/pull/62100) | Add JSON support.                                                              |
+| 0.1.7   | 2025-06-24 | [\#62047](https://github.com/airbytehq/airbyte/pull/62047) | Remove the use of the internal namespace.                                      |
+| 0.1.6   | 2025-06-24 | [\#62047](https://github.com/airbytehq/airbyte/pull/62047) | Hide protocol option when running on cloud.                                    |
+| 0.1.5   | 2025-06-24 | [\#62043](https://github.com/airbytehq/airbyte/pull/62043) | Expose database protocol config option.                                        |
+| 0.1.4   | 2025-06-24 | [\#62040](https://github.com/airbytehq/airbyte/pull/62040) | Checker inserts into configured DB.                                            |
+| 0.1.3   | 2025-06-24 | [\#62038](https://github.com/airbytehq/airbyte/pull/62038) | Allow the client to connect to the resolved DB.                                |
+| 0.1.2   | 2025-06-23 | [\#62028](https://github.com/airbytehq/airbyte/pull/62028) | Enable the registry in OSS and cloud.                                          |
+| 0.1.1   | 2025-06-23 | [\#62022](https://github.com/airbytehq/airbyte/pull/62022) | Publish first beta version and pin the CDK version.                            |
+| 0.1.0   | 2025-06-23 | [\#62024](https://github.com/airbytehq/airbyte/pull/62024) | Release first beta version.                                                    |
 </details>


### PR DESCRIPTION
## What
Makes enable json optional so existing clickhouse connectors can work.

## Context
Workaround for UI not populating default values

## Other
Adds note about SSH support not being available
