### PR TITLE
fix(source-google-sheets): handle empty properties_to_match key

### DIFF
--- a/airbyte-integrations/connectors/source-google-sheets/components.py
+++ b/airbyte-integrations/connectors/source-google-sheets/components.py
@@ -12,7 +12,6 @@ from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Optional,
 import dpath
 import requests
 import unidecode
-from pydantic.v1 import BaseModel, Extra
 
 from airbyte_cdk.sources.declarative.decoders.json_decoder import JsonDecoder
 from airbyte_cdk.sources.declarative.extractors.dpath_extractor import DpathExtractor
@@ -36,7 +35,7 @@ class RangePartitionRouter(SinglePartitionRouter):
         self.parameters = parameters
         self.sheet_row_count = parameters.get("row_count", 0)
         self.sheet_id = parameters.get("sheet_id")
-        self.batch_size = parameters.get("batch_size")
+        self.batch_size = parameters.get("batch_size", 1000000)
 
     def stream_slices(self) -> Iterable[StreamSlice]:
         start_range = 2  # skip 1 row, as expected column (fields) names there
@@ -187,8 +186,9 @@ class DpathSchemaMatchingExtractor(DpathExtractor, RawSchemaParser):
         self._values_to_match_key = parameters["values_to_match_key"]
         schema_type_identifier = parameters["schema_type_identifier"]
         names_conversion = self.config.get("names_conversion", False)
+        properties_to_match = parameters.get("properties_to_match", {})
         self._indexed_properties_to_match = self.extract_properties_to_match(
-            parameters["properties_to_match"], schema_type_identifier, names_conversion=names_conversion
+            properties_to_match, schema_type_identifier, names_conversion=names_conversion
         )
 
     def extract_properties_to_match(self, properties_to_match, schema_type_identifier, names_conversion):

--- a/airbyte-integrations/connectors/source-google-sheets/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-sheets/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: file
   connectorType: source
   definitionId: 71607ba1-c0ac-4799-8049-7f4b90dd50f7
-  dockerImageTag: 0.12.0-rc.1
+  dockerImageTag: 0.12.0-rc.2
   dockerRepository: airbyte/source-google-sheets
   documentationUrl: https://docs.airbyte.com/integrations/sources/google-sheets
   githubIssueLabel: source-google-sheets

--- a/airbyte-integrations/connectors/source-google-sheets/unit_tests/test_components.py
+++ b/airbyte-integrations/connectors/source-google-sheets/unit_tests/test_components.py
@@ -268,3 +268,24 @@ def test_multiple_flags_with_special_characters():
         )
         == "50th_percentile"
     )
+
+
+def test_dpath_schema_matching_extractor_without_properties_to_match():
+    """
+    Test that DpathSchemaMatchingExtractor can be instantiated without the
+    "properties_to_match" parameter in cases where it is not provided.
+    """
+    parameters_without_properties = {
+        "values_to_match_key": "values",
+        "schema_type_identifier": {"key_pointer": ["formattedValue"], "schema_pointer": ["values"]},
+    }
+
+    # This should not raise an exception
+    extractor = DpathSchemaMatchingExtractor(
+        field_path=_FIELD_PATH, config=config, decoder=decoder_json, parameters=parameters_without_properties
+    )
+
+    # Verify that the extractor was created successfully
+    assert extractor is not None
+    assert extractor._values_to_match_key == "values"
+    assert extractor._indexed_properties_to_match == {}

--- a/docs/integrations/sources/google-sheets.md
+++ b/docs/integrations/sources/google-sheets.md
@@ -287,6 +287,7 @@ Airbyte batches requests to the API in order to efficiently pull data and respec
 
 | Version    | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |------------|------------|----------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 0.12.0-rc.2| 2025-07-10 | []() | Fix: handle empty `propeties_to_match` in SchmemaMatchingExtractor |
 | 0.12.0-rc.1| 2025-07-02 | [62456](https://github.com/airbytehq/airbyte/pull/62456) | Feature: migrate connector to manifest-only format                                                                                                                     |
 | 0.11.0     | 2025-06-11 | [61489](https://github.com/airbytehq/airbyte/pull/61489) | Feature: Added Streeam Name Override Options                                                                                                                           |
 | 0.10.0     | 2025-06-09 | [60836](https://github.com/airbytehq/airbyte/pull/60836) | Feature: Added additional sanitization flags when using Convert Column Names to SQL-Compliant Format (names_conversion)                                                |

--- a/docs/integrations/sources/google-sheets.md
+++ b/docs/integrations/sources/google-sheets.md
@@ -287,7 +287,7 @@ Airbyte batches requests to the API in order to efficiently pull data and respec
 
 | Version    | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |------------|------------|----------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 0.12.0-rc.2| 2025-07-10 | []() | Fix: handle empty `propeties_to_match` in SchmemaMatchingExtractor |
+| 0.12.0-rc.2| 2025-07-11 | [62931](https://github.com/airbytehq/airbyte/pull/62931) | Fix: handle empty `propeties_to_match` in SchmemaMatchingExtractor |
 | 0.12.0-rc.1| 2025-07-02 | [62456](https://github.com/airbytehq/airbyte/pull/62456) | Feature: migrate connector to manifest-only format                                                                                                                     |
 | 0.11.0     | 2025-06-11 | [61489](https://github.com/airbytehq/airbyte/pull/61489) | Feature: Added Streeam Name Override Options                                                                                                                           |
 | 0.10.0     | 2025-06-09 | [60836](https://github.com/airbytehq/airbyte/pull/60836) | Feature: Added additional sanitization flags when using Convert Column Names to SQL-Compliant Format (names_conversion)                                                |


### PR DESCRIPTION
## What

There was a minor regression in the manifest-only migration where in some cases, the value of `properties_to_match` is not populated at source instantiation, leading to failures since we didn't have a default value set. We caught the bug in progressive rollout and are pre-emptively deploying the fix.

## User Impact

Syncs won't fail on KeyError: `properties_to_match`.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
