### PR TITLE
[CI] adding more java source connectors to whitelist which contains connectors to be published using the new gradle build flow

### DIFF
--- a/poe-tasks/build-and-publish-java-connectors-with-tag.sh
+++ b/poe-tasks/build-and-publish-java-connectors-with-tag.sh
@@ -77,6 +77,10 @@ is_in_whitelist() {
     source-mysql|\
     source-mssql|\
     source-mongodb|\
+    source-db2-enterprise|\
+    source-sap-hana|\
+    source-netsuite|\
+    source-oracle-enterprise|\
     source-bigquery|\
     source-clickhouse|\
     source-clickhouse-strict-encrypt|\

--- a/poe-tasks/build-and-publish-java-connectors-with-tag.sh
+++ b/poe-tasks/build-and-publish-java-connectors-with-tag.sh
@@ -74,7 +74,25 @@ is_in_whitelist() {
     destination-yellowbrick|\
     source-e2e-test|\
     source-postgres|\
-    source-mysql)
+    source-mysql|\
+    source-mssql|\
+    source-mongodb|\
+    source-bigquery|\
+    source-clickhouse|\
+    source-clickhouse-strict-encrypt|\
+    source-cockroachdb|\
+    source-db2|\
+    source-dynamodb|\
+    source-e2e-test-cloud|\
+    source-elasticsearch|\
+    source-kafka|\
+    source-oracle|\
+    source-oracle-strict-encrypt|\
+    source-scaffold-java-jdbc|\
+    source-sftp|\
+    source-snowflake|\
+    source-teradata|\
+    source-tidb)
       return 0
       ;;
     *)


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->

Note that source-singlestore and source-redshift are still not added (ci can't pass due to issues related to integration test credential)

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._