### PR TITLE
Fix(Source-TikTok-Marketing): Hourly Streams Only Syncing 1HR

### DIFF
--- a/airbyte-integrations/connectors/source-tiktok-marketing/manifest.yaml
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/manifest.yaml
@@ -468,7 +468,7 @@ definitions:
         dimensions: '{{ parameters["dimensions"] | string }}'
         metrics: '{{ (parameters.get("report_metrics", []) + ["spend", "cpc", "cpm", "impressions", "clicks", "ctr", "reach", "cost_per_1000_reached", "frequency", "video_play_actions", "video_watched_2s", "video_watched_6s", "average_video_play", "average_video_play_per_user", "video_views_p25", "video_views_p50", "video_views_p75", "video_views_p100", "profile_visits", "likes", "comments", "shares", "follows", "clicks_on_music_disc", "real_time_app_install", "real_time_app_install_cost", "app_install"]) | string }}'
         start_date: "{{ format_datetime(stream_interval['start_time'], '%Y-%m-%d', '%Y-%m-%d %H:%M:%S') }}"
-        end_date: "{{ format_datetime(stream_interval['start_time'], '%Y-%m-%d', '%Y-%m-%d %H:%M:%S') }}"
+        end_date: "{{ format_datetime(stream_interval['end_time'], '%Y-%m-%d', '%Y-%m-%d %H:%M:%S') }}"
         filtering: '{{ parameters["filtering"] | string if parameters.get("filtering") and config.get("include_deleted", False)}}'
       authenticator:
         $ref: "#/definitions/authenticator"

--- a/airbyte-integrations/connectors/source-tiktok-marketing/metadata.yaml
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/metadata.yaml
@@ -11,7 +11,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 4bfac00d-ce15-44ff-95b9-9e3c3e8fbd35
-  dockerImageTag: 4.8.0
+  dockerImageTag: 4.8.1
   dockerRepository: airbyte/source-tiktok-marketing
   documentationUrl: https://docs.airbyte.com/integrations/sources/tiktok-marketing
   githubIssueLabel: source-tiktok-marketing

--- a/docs/integrations/sources/tiktok-marketing.md
+++ b/docs/integrations/sources/tiktok-marketing.md
@@ -147,6 +147,7 @@ The connector is restricted by [requests limitation](https://business-api.tiktok
 
 | Version   | Date       | Pull Request                                              | Subject                                                                                                                                                                |
 |:----------|:-----------|:----------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 4.8.1 | 2025-07-11 | [XXXXX](https://github.com/airbytehq/airbyte/pull/XXXXX) | Fix Hourly Streams Syncing only 1 hour|
 | 4.8.0 | 2025-06-24 | [62048](https://github.com/airbytehq/airbyte/pull/62048) | Promoting release candidate 4.8.0-rc.1 to a main version. |
 | 4.8.0-rc.1     | 2025-06-16 | [61580](https://github.com/airbytehq/airbyte/pull/61580)  | Convert to manifest-only format                                                                                                                               |
 | 4.7.0     | 2025-03-10 | [55681](https://github.com/airbytehq/airbyte/pull/55681)  | Ads / AdGroups report by country streams                                                                                                                               |

--- a/docs/integrations/sources/tiktok-marketing.md
+++ b/docs/integrations/sources/tiktok-marketing.md
@@ -147,7 +147,7 @@ The connector is restricted by [requests limitation](https://business-api.tiktok
 
 | Version   | Date       | Pull Request                                              | Subject                                                                                                                                                                |
 |:----------|:-----------|:----------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 4.8.1 | 2025-07-11 | [XXXXX](https://github.com/airbytehq/airbyte/pull/XXXXX) | Fix Hourly Streams Syncing only 1 hour|
+| 4.8.1 | 2025-07-11 | [62937](https://github.com/airbytehq/airbyte/pull/62937) | Fix Hourly Streams Syncing only 1 hour|
 | 4.8.0 | 2025-06-24 | [62048](https://github.com/airbytehq/airbyte/pull/62048) | Promoting release candidate 4.8.0-rc.1 to a main version. |
 | 4.8.0-rc.1     | 2025-06-16 | [61580](https://github.com/airbytehq/airbyte/pull/61580)  | Convert to manifest-only format                                                                                                                               |
 | 4.7.0     | 2025-03-10 | [55681](https://github.com/airbytehq/airbyte/pull/55681)  | Ads / AdGroups report by country streams                                                                                                                               |


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->
Solves: #8347
## How
<!--
* Describe how code changes achieve the solution.
-->
Within `base_report_hourly_retriever`, there is a typo where `start_date` and `end_date` are both set to `stream_interval['start_time']`. 

We should update `end_date` to `stream_interval['end_time']`
## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [X ] YES 💚
- [ ] NO ❌
