### PR TITLE
fix: correct file ownership in java-connector-base Dockerfile

### DIFF
--- a/docker-images/Dockerfile.java-connector-base
+++ b/docker-images/Dockerfile.java-connector-base
@@ -44,3 +44,6 @@ ADD https://raw.githubusercontent.com/airbytehq/airbyte/6d8a3a2bc4f4ca79f1016444
     /airbyte/javabase.sh
 ADD https://dtdg.co/latest-java-tracer \
     /airbyte/dd-java-agent.jar
+
+RUN chown airbyte:airbyte /airbyte/base.sh /airbyte/javabase.sh /airbyte/dd-java-agent.jar && \
+    chmod 750 /airbyte/base.sh /airbyte/javabase.sh


### PR DESCRIPTION
## Summary

Fixes file ownership issue in `java-connector-base` Docker image that was causing connector `spec` command failures.

## Problem

The java-connector-base:2.0.3 image was failing with error:
```
[dumb-init] spec: No such file or directory.
```

**Root Cause:** The `ADD` commands in the Dockerfile were downloading files as `root` user, overwriting the previously set `airbyte:airbyte` ownership. This meant the `airbyte` user couldn't access the required scripts.

**Investigation Results:**
- ✅ java-connector-base:2.0.1: Files owned by `airbyte:airbyte` (works)
- ❌ java-connector-base:2.0.3: Files owned by `root:root` (fails)

## Changes

1. **Added ownership fix after ADD commands** in `docker-images/Dockerfile.java-connector-base`:
   ```dockerfile
   # Fix ownership and permissions after ADD commands
   RUN chown airbyte:airbyte /airbyte/base.sh /airbyte/javabase.sh /airbyte/dd-java-agent.jar && \
       chmod 750 /airbyte/base.sh /airbyte/javabase.sh
   ```

2. **Reverted source-snowflake back to 2.0.1** until 2.0.3 is fixed

## Test Plan

- [x] Verified file ownership differences between 2.0.1 and 2.0.3 images
- [x] Confirmed the root cause through container inspection
- [ ] Build and test the corrected image
- [ ] Verify spec command works with airbyte user

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>