### PR TITLE
ClickHouse v2: doc updates

### DIFF
--- a/airbyte-integrations/connectors/destination-clickhouse/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-clickhouse/metadata.yaml
@@ -19,7 +19,7 @@ data:
   releases:
     breakingChanges:
       2.0.0:
-        message: "This connector has been re-written from scratch. Data will now be typed and stored in final (non-raw) tables. The connector should function without changes, but downstream pipelines may be affected."
+        message: "This connector has been re-written from scratch. Data will now be typed and stored in final (non-raw) tables. The connector may require changes to its configuration to function properly and downstream pipelines may be affected."
         upgradeDeadline: "2025-08-19"
   documentationUrl: https://docs.airbyte.com/integrations/destinations/clickhouse
   tags:

--- a/docs/integrations/destinations/clickhouse-migrations.md
+++ b/docs/integrations/destinations/clickhouse-migrations.md
@@ -15,8 +15,24 @@ different form. So any downstream pipelines will need updating to ingest the new
 data location / format.
 
 ## Gotchas
-* If the "Hostname" property in your configuration contains the protocol ("http 
-or "https"), you need to remove it. 
+
+### Namespaces and the default database
+
+In V2 namespaces are treated as equivalent to a ClickHouse "database". This
+means if you set a custom namespace for your connection that will be the
+database the connector will use for queries instead of the "database"
+configured in the Destination settings.
+
+Previously, namespaces where added as a prefix to the table name. If you have
+existing connections configured in this fashion you may want to remove them.
+
+### Hostname
+
+If the "Hostname" property in your configuration contains the protocol ("http
+or "https"), you will need to remove it.
+
+The previous versions incidentally tolerated the protocol being stored in the
+hostname field.
 
 ## Migrating existing data to the new format
 

--- a/docs/integrations/destinations/clickhouse-migrations.md
+++ b/docs/integrations/destinations/clickhouse-migrations.md
@@ -1,5 +1,10 @@
 # Clickhouse Migration Guide
 
+## SSH Support :warning:
+
+SSH is not yet implemented for the new connector. If you require SSH support,
+please hold off on migrating for now.
+
 ## Upgrading to 2.0.0
 
 This version differs from 1.0.0 radically. Whereas 1.0.0 wrote all your data
@@ -13,6 +18,20 @@ While is treated as a "breaking change", connections should continue to function
 with no changes, albeit writing data to a completely different location and in a
 different form. So any downstream pipelines will need updating to ingest the new
 data location / format.
+
+## Migrating existing data to the new format
+
+Unfortunately Airbyte has no way to migrate the existing raw tables to the new
+typed format. The only "out of the box" way to get your data into the new format
+is to re-sync it from scratch.
+
+## Removing the old tables
+
+Because the new destination has no knowledge of the old destination's table
+naming semantics, we will not remove existing data. If you would like to, you
+will need to delete all the tables saved in the old format, which for most
+people should be under `airbyte_internal.{database}_raw__`, but may vary based
+on your specific configuration.
 
 ## Gotchas
 
@@ -33,22 +52,3 @@ or "https"), you will need to remove it.
 
 The previous versions incidentally tolerated the protocol being stored in the
 hostname field.
-
-## Migrating existing data to the new format
-
-Unfortunately Airbyte has no way to migrate the existing raw tables to the new
-typed format. The only "out of the box" way to get your data into the new format
-is to re-sync it from scratch.
-
-## Removing the old tables
-
-Because the new destination has no knowledge of the old destination's table
-naming semantics, we will not remove existing data. If you would like to, you
-will need to delete all the tables saved in the old format, which for most
-people should be under `airbyte_internal.{database}_raw__`, but may vary based
-on your specific configuration.
-
-## SSH Support
-
-SSH is not yet implemented for the new connector. If you require SSH support,
-please hold off on migrating for now.

--- a/docs/integrations/destinations/clickhouse.md
+++ b/docs/integrations/destinations/clickhouse.md
@@ -50,24 +50,41 @@ Make sure your ClickHouse database can be accessed by Airbyte. If your database 
 You need a ClickHouse user with the following permissions:
 
 - can create tables and write rows.
-- can create databases e.g:
+- can create databases
+- can alter, drop and exchange tables
 
-You can create such a user by running:
+You can create such a user by running the following:
 
 ```
 GRANT CREATE ON * TO airbyte_user;
-GRANT CREATE ON {your configured default database} * TO airbyte_user;
 GRANT DROP ON * TO airbyte_user;
-GRANT TRUNCATE ON * TO airbyte_user;
-GRANT INSERT ON * TO airbyte_user;
-GRANT SELECT ON * TO airbyte_user;
-GRANT CREATE DATABASE ON airbyte_internal.* TO airbyte_user;
-GRANT CREATE TABLE ON airbyte_internal.* TO airbyte_user;
-GRANT DROP ON airbyte_internal.* TO airbyte_user;
-GRANT TRUNCATE ON airbyte_internal.* TO airbyte_user;
-GRANT INSERT ON airbyte_internal.* TO airbyte_user;
-GRANT SELECT ON airbyte_internal.* TO airbyte_user;
+GRANT CREATE ON {database}.* TO airbyte_user;
+GRANT DROP ON {database}.* TO airbyte_user;
+GRANT ALTER ON {database}.* TO airbyte_user;
+GRANT TRUNCATE ON {database}.* TO airbyte_user;
+GRANT INSERT ON {database}.* TO airbyte_user;
+GRANT SELECT ON {database}.* TO airbyte_user;
+GRANT CREATE DATABASE ON {database}.* TO airbyte_user;
+GRANT CREATE TABLE ON {database}.* TO airbyte_user;
 ```
+
+Where `{database}` is the database configured on your connector.
+
+Then for each connection using this connector with a custom namespace, run:
+
+```
+GRANT CREATE ON {namespace}.* TO airbyte_user;
+GRANT DROP ON {namespace}.* TO airbyte_user;
+GRANT ALTER ON {namespace}.* TO airbyte_user;
+GRANT TRUNCATE ON {namespace}.* TO airbyte_user;
+GRANT INSERT ON {namespace}.* TO airbyte_user;
+GRANT SELECT ON {namespace}.* TO airbyte_user;
+GRANT CREATE DATABASE ON {namespace}.* TO airbyte_user;
+GRANT CREATE TABLE ON {namespace}.* TO airbyte_user;
+```
+
+Where `{namespace}` is the custom namespace configured for that connection.
+
 
 You can also use a pre-existing user but we highly recommend creating a dedicated user for Airbyte.
 


### PR DESCRIPTION
## What
Updates the docs / migration blurb with gotchas and more differences

## Why
The previous connector only having raw tables definitely encourage people to use namespace in an odd way (e.g. use separators like `_` as the namespace). In v2 namespace is `database` so that makes things goofy.

Make SSH issue more obvious.

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._