### PR TITLE
ClickHouse V2: Adds ssh tunneling support 

### DIFF
--- a/airbyte-integrations/connectors/destination-clickhouse/build.gradle
+++ b/airbyte-integrations/connectors/destination-clickhouse/build.gradle
@@ -7,7 +7,7 @@ plugins {
 
 airbyteBulkConnector {
     core = 'load'
-    toolkits = ['load-gcs', 'load-db', 'load-s3']
+    toolkits = ['load-db']
     cdk = 'local'
 }
 

--- a/airbyte-integrations/connectors/destination-clickhouse/build.gradle
+++ b/airbyte-integrations/connectors/destination-clickhouse/build.gradle
@@ -35,6 +35,9 @@ application {
 dependencies {
     implementation 'com.clickhouse:client-v2:0.9.0'
 
+    implementation("io.micronaut:micronaut-inject:4.8.18")
+    ksp 'io.micronaut:micronaut-inject-kotlin:4.8.18'
+
     testImplementation("io.mockk:mockk:1.14.2")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2")
     // This is being used in the test to check that the generated SQL can be parsed correctly.

--- a/airbyte-integrations/connectors/destination-clickhouse/build.gradle
+++ b/airbyte-integrations/connectors/destination-clickhouse/build.gradle
@@ -35,9 +35,6 @@ application {
 dependencies {
     implementation 'com.clickhouse:client-v2:0.9.0'
 
-    implementation("io.micronaut:micronaut-inject:4.8.18")
-    ksp 'io.micronaut:micronaut-inject-kotlin:4.8.18'
-
     testImplementation("io.mockk:mockk:1.14.2")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2")
     // This is being used in the test to check that the generated SQL can be parsed correctly.

--- a/airbyte-integrations/connectors/destination-clickhouse/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-clickhouse/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: ce0d828e-1dc4-496c-b122-2da42e637e48
-  dockerImageTag: 2.0.3
+  dockerImageTag: 2.0.4
   dockerRepository: airbyte/destination-clickhouse
   githubIssueLabel: destination-clickhouse
   icon: clickhouse.svg
@@ -19,7 +19,7 @@ data:
   releases:
     breakingChanges:
       2.0.0:
-        message: "This connector has been re-written from scratch. Data will now be typed and stored in final (non-raw) tables. The connector may require changes to its configuration to function properly and downstream pipelines may be affected. Warning: SSH tunneling is still a WIP. Please hold off on upgrading if you need SSH tunneling."
+        message: "This connector has been re-written from scratch. Data will now be typed and stored in final (non-raw) tables. The connector may require changes to its configuration to function properly and downstream pipelines may be affected. Warning: SSH tunneling is in Beta."
         upgradeDeadline: "2025-08-19"
   documentationUrl: https://docs.airbyte.com/integrations/destinations/clickhouse
   tags:

--- a/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/check/ClickhouseChecker.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/check/ClickhouseChecker.kt
@@ -4,6 +4,7 @@
 
 package io.airbyte.integrations.destination.clickhouse.check
 
+import com.clickhouse.client.api.Client
 import com.clickhouse.data.ClickHouseFormat
 import com.google.common.annotations.VisibleForTesting
 import io.airbyte.cdk.load.check.DestinationChecker
@@ -73,5 +74,9 @@ class ClickhouseChecker(
 // This exists solely for testing. It will hopefully be deleted once we fix DI.
 @Singleton
 class RawClickHouseClientFactory {
-    fun make(config: ClickhouseConfiguration) = ClickhouseBeanFactory().clickhouseClient(config)
+    fun make(config: ClickhouseConfiguration): Client {
+        val factory = ClickhouseBeanFactory()
+        val tunnel = factory.tunnel(config)
+        return ClickhouseBeanFactory().clickhouseClient(config, tunnel)
+    }
 }

--- a/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/check/ClickhouseChecker.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/check/ClickhouseChecker.kt
@@ -76,7 +76,7 @@ class ClickhouseChecker(
 class RawClickHouseClientFactory {
     fun make(config: ClickhouseConfiguration): Client {
         val factory = ClickhouseBeanFactory()
-        val tunnel = factory.tunnel(config)
-        return ClickhouseBeanFactory().clickhouseClient(config, tunnel)
+        val endpoint = factory.resolvedEndpoint(config)
+        return ClickhouseBeanFactory().clickhouseClient(config, endpoint)
     }
 }

--- a/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/config/ClickhouseBeanFactory.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/config/ClickhouseBeanFactory.kt
@@ -19,23 +19,26 @@ import io.airbyte.integrations.destination.clickhouse.spec.ClickhouseConfigurati
 import io.airbyte.integrations.destination.clickhouse.spec.ClickhouseSpecification
 import io.micronaut.context.annotation.Factory
 import jakarta.inject.Singleton
-import org.apache.sshd.common.util.net.SshdSocketAddress
 import java.util.*
+import org.apache.sshd.common.util.net.SshdSocketAddress
 
 @Factory
 class ClickhouseBeanFactory {
     @Singleton
-    fun tunnel(config: ClickhouseConfiguration): Optional<TunnelSession> { // Micronaut won't let me just do null with `?`
-        val tun = when (val ssh = config.tunnelConfig) {
-            is SshKeyAuthTunnelMethod,
-            is SshPasswordAuthTunnelMethod -> {
-                val remote = SshdSocketAddress(config.hostname, config.port.toInt())
-                val sshConnectionOptions: SshConnectionOptions =
-                    SshConnectionOptions.fromAdditionalProperties(emptyMap())
-                createTunnelSession(remote, ssh, sshConnectionOptions)
+    fun tunnel(
+        config: ClickhouseConfiguration
+    ): Optional<TunnelSession> { // Micronaut won't let me just do null with `?`
+        val tun =
+            when (val ssh = config.tunnelConfig) {
+                is SshKeyAuthTunnelMethod,
+                is SshPasswordAuthTunnelMethod -> {
+                    val remote = SshdSocketAddress(config.hostname, config.port.toInt())
+                    val sshConnectionOptions: SshConnectionOptions =
+                        SshConnectionOptions.fromAdditionalProperties(emptyMap())
+                    createTunnelSession(remote, ssh, sshConnectionOptions)
+                }
+                else -> null
             }
-            else -> null
-        }
 
         return Optional.ofNullable(tun)
     }

--- a/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/config/ClickhouseBeanFactory.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/config/ClickhouseBeanFactory.kt
@@ -9,15 +9,15 @@ import com.clickhouse.client.api.internal.ServerSettings
 import io.airbyte.cdk.command.ConfigurationSpecificationSupplier
 import io.airbyte.cdk.load.orchestration.db.DefaultTempTableNameGenerator
 import io.airbyte.cdk.load.orchestration.db.TempTableNameGenerator
-import io.airbyte.integrations.destination.clickhouse.spec.ClickhouseConfiguration
-import io.airbyte.integrations.destination.clickhouse.spec.ClickhouseConfigurationFactory
-import io.airbyte.integrations.destination.clickhouse.spec.ClickhouseSpecification
-import io.micronaut.context.annotation.Factory
 import io.airbyte.cdk.ssh.SshConnectionOptions
 import io.airbyte.cdk.ssh.SshKeyAuthTunnelMethod
 import io.airbyte.cdk.ssh.SshPasswordAuthTunnelMethod
 import io.airbyte.cdk.ssh.TunnelSession
 import io.airbyte.cdk.ssh.createTunnelSession
+import io.airbyte.integrations.destination.clickhouse.spec.ClickhouseConfiguration
+import io.airbyte.integrations.destination.clickhouse.spec.ClickhouseConfigurationFactory
+import io.airbyte.integrations.destination.clickhouse.spec.ClickhouseSpecification
+import io.micronaut.context.annotation.Factory
 import jakarta.inject.Singleton
 import org.apache.sshd.common.util.net.SshdSocketAddress
 
@@ -28,13 +28,11 @@ class ClickhouseBeanFactory {
         return when (val ssh = config.tunnelConfig) {
             is SshKeyAuthTunnelMethod,
             is SshPasswordAuthTunnelMethod -> {
-                val remote =
-                    SshdSocketAddress(config.hostname, config.port.toInt())
+                val remote = SshdSocketAddress(config.hostname, config.port.toInt())
                 val sshConnectionOptions: SshConnectionOptions =
                     SshConnectionOptions.fromAdditionalProperties(emptyMap())
                 createTunnelSession(remote, ssh, sshConnectionOptions)
             }
-
             else -> null
         }
     }
@@ -44,10 +42,9 @@ class ClickhouseBeanFactory {
         config: ClickhouseConfiguration,
         tunnel: TunnelSession?,
     ): Client {
-        val endpoint = if (tunnel != null)
-            "${tunnel.address.hostName}:${tunnel.address.port}"
-        else
-            config.endpoint
+        val endpoint =
+            if (tunnel != null) "${tunnel.address.hostName}:${tunnel.address.port}"
+            else config.endpoint
 
         val builder =
             Client.Builder()

--- a/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/config/ClickhouseBeanFactory.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/config/ClickhouseBeanFactory.kt
@@ -18,7 +18,12 @@ import jakarta.inject.Singleton
 @Factory
 class ClickhouseBeanFactory {
     @Singleton
+    fun sshClient() {}
+
+    @Singleton
     fun clickhouseClient(config: ClickhouseConfiguration): Client {
+        config.tunnelConfiguration
+
         val builder =
             Client.Builder()
                 .addEndpoint(config.endpoint)

--- a/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/config/ClickhouseBeanFactory.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/config/ClickhouseBeanFactory.kt
@@ -18,14 +18,21 @@ import jakarta.inject.Singleton
 @Factory
 class ClickhouseBeanFactory {
     @Singleton
-    fun sshClient() {}
+    fun sshClient(): SSHClient? {}
 
     @Singleton
-    fun clickhouseClient(config: ClickhouseConfiguration): Client {
-        config.tunnelConfiguration
+    fun clickhouseClient(
+        config: ClickhouseConfiguration,
+        client: SHHClient?,
+    ): Client {
+        if (client != null) {
+            "${client.url}:${client.port}"
+            
+        }
 
         val builder =
             Client.Builder()
+                .addEndpoint(config.endpoint)
                 .addEndpoint(config.endpoint)
                 .setUsername(config.username)
                 .setPassword(config.password)

--- a/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/config/ClickhouseBeanFactory.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/config/ClickhouseBeanFactory.kt
@@ -19,8 +19,8 @@ import io.airbyte.integrations.destination.clickhouse.spec.ClickhouseConfigurati
 import io.airbyte.integrations.destination.clickhouse.spec.ClickhouseSpecification
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.micronaut.context.annotation.Factory
-import jakarta.inject.Singleton
 import jakarta.inject.Named
+import jakarta.inject.Singleton
 import org.apache.sshd.common.util.net.SshdSocketAddress
 
 private val log = KotlinLogging.logger {}
@@ -38,12 +38,10 @@ class ClickhouseBeanFactory {
         return when (val ssh = config.tunnelConfig) {
             is SshKeyAuthTunnelMethod,
             is SshPasswordAuthTunnelMethod -> {
-                val remote =
-                    SshdSocketAddress(config.hostname, config.port.toInt())
+                val remote = SshdSocketAddress(config.hostname, config.port.toInt())
                 val sshConnectionOptions: SshConnectionOptions =
                     SshConnectionOptions.fromAdditionalProperties(emptyMap())
-                val tunnel =
-                    createTunnelSession(remote, ssh, sshConnectionOptions)
+                val tunnel = createTunnelSession(remote, ssh, sshConnectionOptions)
                 "${config.protocol}://${tunnel.address.hostName}:${tunnel.address.port}"
             }
             is SshNoTunnelMethod,

--- a/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/config/ClickhouseBeanFactory.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/config/ClickhouseBeanFactory.kt
@@ -17,18 +17,18 @@ import jakarta.inject.Singleton
 
 @Factory
 class ClickhouseBeanFactory {
-    @Singleton
-    fun sshClient(): SSHClient? {}
+//    @Singleton
+//    fun sshClient(): SSHClient? {}
 
     @Singleton
     fun clickhouseClient(
         config: ClickhouseConfiguration,
-        client: SHHClient?,
+//        client: SHHClient?,
     ): Client {
-        if (client != null) {
-            "${client.url}:${client.port}"
-            
-        }
+//        if (client != null) {
+//            "${client.url}:${client.port}"
+//
+//        }
 
         val builder =
             Client.Builder()

--- a/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/spec/ClickhouseConfiguration.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/spec/ClickhouseConfiguration.kt
@@ -6,6 +6,7 @@ package io.airbyte.integrations.destination.clickhouse.spec
 
 import io.airbyte.cdk.load.command.DestinationConfiguration
 import io.airbyte.cdk.load.command.DestinationConfigurationFactory
+import io.airbyte.cdk.ssh.SshTunnelMethodConfiguration
 import jakarta.inject.Singleton
 
 data class ClickhouseConfiguration(
@@ -16,6 +17,7 @@ data class ClickhouseConfiguration(
     val username: String,
     val password: String,
     val enableJson: Boolean,
+    val tunnelConfig: SshTunnelMethodConfiguration?,
 ) : DestinationConfiguration() {
     val endpoint = "$protocol://$hostname:$port"
     val resolvedDatabase = database.ifEmpty { Defaults.DATABASE_NAME }
@@ -45,6 +47,7 @@ class ClickhouseConfigurationFactory :
             pojo.username,
             pojo.password,
             pojo.enableJson ?: false,
+            pojo.tunnelConfig,
         )
     }
 
@@ -67,6 +70,7 @@ class ClickhouseConfigurationFactory :
             username = overrides.getOrDefault("username", spec.username),
             enableJson =
                 overrides.getOrDefault("enable_json", spec.enableJson.toString()).toBoolean(),
+            tunnelConfig = spec.tunnelConfig,
         )
     }
 }

--- a/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/spec/ClickhouseConfiguration.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/spec/ClickhouseConfiguration.kt
@@ -47,7 +47,7 @@ class ClickhouseConfigurationFactory :
             pojo.username,
             pojo.password,
             pojo.enableJson ?: false,
-            pojo.tunnelConfig,
+            pojo.getTunnelMethodValue(),
         )
     }
 
@@ -70,7 +70,7 @@ class ClickhouseConfigurationFactory :
             username = overrides.getOrDefault("username", spec.username),
             enableJson =
                 overrides.getOrDefault("enable_json", spec.enableJson.toString()).toBoolean(),
-            tunnelConfig = spec.tunnelConfig,
+            tunnelConfig = spec.getTunnelMethodValue(),
         )
     }
 }

--- a/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/spec/ClickhouseSpecification.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/spec/ClickhouseSpecification.kt
@@ -4,15 +4,21 @@
 
 package io.airbyte.integrations.destination.clickhouse.spec
 
+import com.fasterxml.jackson.annotation.JsonGetter
+import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonPropertyDescription
+import com.fasterxml.jackson.annotation.JsonSetter
 import com.fasterxml.jackson.annotation.JsonValue
 import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaInject
 import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaTitle
 import io.airbyte.cdk.command.AIRBYTE_CLOUD_ENV
 import io.airbyte.cdk.command.ConfigurationSpecification
 import io.airbyte.cdk.load.spec.DestinationSpecificationExtension
+import io.airbyte.cdk.ssh.MicronautPropertiesFriendlySshTunnelMethodConfigurationSpecification
+import io.airbyte.cdk.ssh.SshTunnelMethodConfiguration
 import io.airbyte.protocol.models.v0.DestinationSyncMode
+import io.micronaut.context.annotation.ConfigurationBuilder
 import io.micronaut.context.annotation.Requires
 import jakarta.inject.Singleton
 
@@ -24,6 +30,7 @@ sealed class ClickhouseSpecification : ConfigurationSpecification() {
     abstract val username: String
     abstract val password: String
     abstract val enableJson: Boolean?
+    abstract val tunnelConfig: SshTunnelMethodConfiguration?
 }
 
 @Singleton
@@ -72,6 +79,28 @@ class ClickhouseSpecificationOss : ClickhouseSpecification() {
     @get:JsonProperty("enable_json")
     @get:JsonSchemaInject(json = """{"order": 6, "default": false}""")
     override val enableJson: Boolean? = false
+
+    @JsonIgnore
+    @ConfigurationBuilder(configurationPrefix = "tunnel_method")
+    val tunnelMethod = MicronautPropertiesFriendlySshTunnelMethodConfigurationSpecification()
+
+    @JsonIgnore
+    override var tunnelConfig: SshTunnelMethodConfiguration? = null
+
+    @JsonSetter("tunnel_method")
+    fun setTunnelMethodValue(value: SshTunnelMethodConfiguration?) {
+        tunnelConfig = value
+    }
+
+    @JsonGetter("tunnel_method")
+    @JsonSchemaTitle("SSH Tunnel Method")
+    @JsonPropertyDescription(
+        "Whether to initiate an SSH tunnel before connecting to the database," +
+            " and if so, which kind of authentication to use.",
+    )
+    @JsonSchemaInject(json = """{"order":5}""")
+    fun getTunnelMethodValue(): SshTunnelMethodConfiguration =
+        tunnelConfig ?: tunnelMethod.asSshTunnelMethod()
 }
 
 @Singleton
@@ -120,6 +149,28 @@ open class ClickhouseSpecificationCloud : ClickhouseSpecification() {
     @get:JsonProperty("enable_json")
     @get:JsonSchemaInject(json = """{"order": 6, "default": false}""")
     override val enableJson: Boolean? = false
+
+    @JsonIgnore
+    @ConfigurationBuilder(configurationPrefix = "tunnel_method")
+    val tunnelMethod = MicronautPropertiesFriendlySshTunnelMethodConfigurationSpecification()
+
+    @JsonIgnore
+    override var tunnelConfig: SshTunnelMethodConfiguration? = null
+
+    @JsonSetter("tunnel_method")
+    fun setTunnelMethodValue(value: SshTunnelMethodConfiguration?) {
+        tunnelConfig = value
+    }
+
+    @JsonGetter("tunnel_method")
+    @JsonSchemaTitle("SSH Tunnel Method")
+    @JsonPropertyDescription(
+        "Whether to initiate an SSH tunnel before connecting to the database," +
+            " and if so, which kind of authentication to use.",
+    )
+    @JsonSchemaInject(json = """{"order":7}""")
+    fun getTunnelMethodValue(): SshTunnelMethodConfiguration =
+        tunnelConfig ?: tunnelMethod.asSshTunnelMethod()
 }
 
 enum class ClickhouseConnectionProtocol(@get:JsonValue val value: String) {

--- a/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/spec/ClickhouseSpecification.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/spec/ClickhouseSpecification.kt
@@ -99,7 +99,7 @@ class ClickhouseSpecificationOss : ClickhouseSpecification() {
             " and if so, which kind of authentication to use.",
     )
     @JsonSchemaInject(json = """{"order":5}""")
-    fun getTunnelMethodValue(): SshTunnelMethodConfiguration =
+    fun getTunnelMethodValue(): SshTunnelMethodConfiguration? =
         tunnelConfig ?: tunnelMethod.asSshTunnelMethod()
 }
 
@@ -169,7 +169,7 @@ open class ClickhouseSpecificationCloud : ClickhouseSpecification() {
             " and if so, which kind of authentication to use.",
     )
     @JsonSchemaInject(json = """{"order":7}""")
-    fun getTunnelMethodValue(): SshTunnelMethodConfiguration =
+    fun getTunnelMethodValue(): SshTunnelMethodConfiguration? =
         tunnelConfig ?: tunnelMethod.asSshTunnelMethod()
 }
 

--- a/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/spec/ClickhouseSpecification.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/spec/ClickhouseSpecification.kt
@@ -84,8 +84,7 @@ class ClickhouseSpecificationOss : ClickhouseSpecification() {
     @ConfigurationBuilder(configurationPrefix = "tunnel_method")
     val tunnelMethod = MicronautPropertiesFriendlySshTunnelMethodConfigurationSpecification()
 
-    @JsonIgnore
-    override var tunnelConfig: SshTunnelMethodConfiguration? = null
+    @JsonIgnore override var tunnelConfig: SshTunnelMethodConfiguration? = null
 
     @JsonSetter("tunnel_method")
     fun setTunnelMethodValue(value: SshTunnelMethodConfiguration?) {
@@ -154,8 +153,7 @@ open class ClickhouseSpecificationCloud : ClickhouseSpecification() {
     @ConfigurationBuilder(configurationPrefix = "tunnel_method")
     val tunnelMethod = MicronautPropertiesFriendlySshTunnelMethodConfigurationSpecification()
 
-    @JsonIgnore
-    override var tunnelConfig: SshTunnelMethodConfiguration? = null
+    @JsonIgnore override var tunnelConfig: SshTunnelMethodConfiguration? = null
 
     @JsonSetter("tunnel_method")
     fun setTunnelMethodValue(value: SshTunnelMethodConfiguration?) {

--- a/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/spec/ClickhouseSpecification.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/spec/ClickhouseSpecification.kt
@@ -30,7 +30,7 @@ sealed class ClickhouseSpecification : ConfigurationSpecification() {
     abstract val username: String
     abstract val password: String
     abstract val enableJson: Boolean?
-    abstract val tunnelConfig: SshTunnelMethodConfiguration?
+    abstract fun getTunnelMethodValue(): SshTunnelMethodConfiguration?
 }
 
 @Singleton
@@ -84,7 +84,7 @@ class ClickhouseSpecificationOss : ClickhouseSpecification() {
     @ConfigurationBuilder(configurationPrefix = "tunnel_method")
     val tunnelMethod = MicronautPropertiesFriendlySshTunnelMethodConfigurationSpecification()
 
-    @JsonIgnore override var tunnelConfig: SshTunnelMethodConfiguration? = null
+    @JsonIgnore var tunnelConfig: SshTunnelMethodConfiguration? = null
 
     @JsonSetter("tunnel_method")
     fun setTunnelMethodValue(value: SshTunnelMethodConfiguration?) {
@@ -98,7 +98,7 @@ class ClickhouseSpecificationOss : ClickhouseSpecification() {
             " and if so, which kind of authentication to use.",
     )
     @JsonSchemaInject(json = """{"order":5}""")
-    fun getTunnelMethodValue(): SshTunnelMethodConfiguration? =
+    override fun getTunnelMethodValue(): SshTunnelMethodConfiguration? =
         tunnelConfig ?: tunnelMethod.asSshTunnelMethod()
 }
 
@@ -153,7 +153,7 @@ open class ClickhouseSpecificationCloud : ClickhouseSpecification() {
     @ConfigurationBuilder(configurationPrefix = "tunnel_method")
     val tunnelMethod = MicronautPropertiesFriendlySshTunnelMethodConfigurationSpecification()
 
-    @JsonIgnore override var tunnelConfig: SshTunnelMethodConfiguration? = null
+    @JsonIgnore var tunnelConfig: SshTunnelMethodConfiguration? = null
 
     @JsonSetter("tunnel_method")
     fun setTunnelMethodValue(value: SshTunnelMethodConfiguration?) {
@@ -167,7 +167,7 @@ open class ClickhouseSpecificationCloud : ClickhouseSpecification() {
             " and if so, which kind of authentication to use.",
     )
     @JsonSchemaInject(json = """{"order":7}""")
-    fun getTunnelMethodValue(): SshTunnelMethodConfiguration? =
+    override fun getTunnelMethodValue(): SshTunnelMethodConfiguration? =
         tunnelConfig ?: tunnelMethod.asSshTunnelMethod()
 }
 

--- a/airbyte-integrations/connectors/destination-clickhouse/src/test-integration/kotlin/io/airbyte/integrations/destination/clickhouse/write/load/ClickhouseDirectLoadWriter.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/test-integration/kotlin/io/airbyte/integrations/destination/clickhouse/write/load/ClickhouseDirectLoadWriter.kt
@@ -65,6 +65,7 @@ class ClickhouseDirectLoadWriterWithoutJson :
         true,
     )
 
+@Disabled("Requires local bastion and CH instance to pass")
 class ClickhouseDirectLoadWriterWithoutJsonSshTunnel :
     ClickhouseDirectLoadWriter(
         Path.of("secrets/ssh-tunnel.json"),

--- a/airbyte-integrations/connectors/destination-clickhouse/src/test-integration/kotlin/io/airbyte/integrations/destination/clickhouse/write/load/ClickhouseDirectLoadWriter.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/test-integration/kotlin/io/airbyte/integrations/destination/clickhouse/write/load/ClickhouseDirectLoadWriter.kt
@@ -36,13 +36,15 @@ import io.airbyte.integrations.destination.clickhouse.spec.ClickhouseSpecificati
 import io.airbyte.integrations.destination.clickhouse.write.load.ClientProvider.getClient
 import io.airbyte.protocol.models.v0.AirbyteRecordMessageMetaChange
 import java.nio.file.Files
+import java.nio.file.Path
 import java.time.ZonedDateTime
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
 
 class ClickhouseDirectLoadWriterWithJson :
     ClickhouseDirectLoadWriter(
-        "valid_connection.json",
+        Utils.getConfigPath("valid_connection.json"),
         SchematizedNestedValueBehavior.PASS_THROUGH,
         false,
     ) {
@@ -58,18 +60,30 @@ class ClickhouseDirectLoadWriterWithJson :
 
 class ClickhouseDirectLoadWriterWithoutJson :
     ClickhouseDirectLoadWriter(
-        "valid_connection_no_json.json",
+        Utils.getConfigPath("valid_connection_no_json.json"),
         SchematizedNestedValueBehavior.STRINGIFY,
         true,
     )
 
+class ClickhouseDirectLoadWriterWithoutJsonSshTunnel :
+    ClickhouseDirectLoadWriter(
+        Path.of("secrets/ssh-tunnel.json"),
+        SchematizedNestedValueBehavior.STRINGIFY,
+        true,
+    ) {
+    @Test
+    override fun testBasicWrite() {
+        super.testBasicWrite()
+    }
+}
+
 abstract class ClickhouseDirectLoadWriter(
-    specFile: String,
+    configPath: Path,
     schematizedObjectBehavior: SchematizedNestedValueBehavior,
     stringifySchemalessObjects: Boolean
 ) :
     BasicFunctionalityIntegrationTest(
-        configContents = Files.readString(Utils.getConfigPath(specFile)),
+        configContents = Files.readString(configPath),
         configSpecClass = ClickhouseSpecificationOss::class.java,
         dataDumper =
             ClickhouseDataDumper { spec ->

--- a/airbyte-integrations/connectors/destination-clickhouse/src/test-integration/resources/expected-spec-cloud.json
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/test-integration/resources/expected-spec-cloud.json
@@ -160,7 +160,7 @@
         "type" : "object"
       }
     },
-    "required" : [ "host", "port", "protocol", "database", "username", "password", "tunnel_method" ],
+    "required" : [ "host", "port", "protocol", "database", "username", "password" ],
     "groups" : [ {
       "id" : "connection",
       "title" : "Connection"

--- a/airbyte-integrations/connectors/destination-clickhouse/src/test-integration/resources/expected-spec-cloud.json
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/test-integration/resources/expected-spec-cloud.json
@@ -55,9 +55,112 @@
         "title" : "Enable JSON",
         "order" : 6,
         "default" : false
+      },
+      "tunnel_method" : {
+        "oneOf" : [ {
+          "title" : "No Tunnel",
+          "type" : "object",
+          "additionalProperties" : true,
+          "description" : "No ssh tunnel needed to connect to database",
+          "properties" : {
+            "tunnel_method" : {
+              "type" : "string",
+              "enum" : [ "NO_TUNNEL" ],
+              "default" : "NO_TUNNEL"
+            }
+          },
+          "required" : [ "tunnel_method" ]
+        }, {
+          "title" : "SSH Key Authentication",
+          "type" : "object",
+          "additionalProperties" : true,
+          "description" : "Connect through a jump server tunnel host using username and ssh key",
+          "properties" : {
+            "tunnel_method" : {
+              "type" : "string",
+              "enum" : [ "SSH_KEY_AUTH" ],
+              "default" : "SSH_KEY_AUTH"
+            },
+            "tunnel_host" : {
+              "type" : "string",
+              "description" : "Hostname of the jump server host that allows inbound ssh tunnel.",
+              "title" : "SSH Tunnel Jump Server Host",
+              "order" : 1
+            },
+            "tunnel_port" : {
+              "type" : "integer",
+              "default" : 22,
+              "description" : "Port on the proxy/jump server that accepts inbound ssh connections.",
+              "title" : "SSH Connection Port",
+              "order" : 2,
+              "minimum" : 0,
+              "maximum" : 65536
+            },
+            "tunnel_user" : {
+              "type" : "string",
+              "description" : "OS-level username for logging into the jump server host",
+              "title" : "SSH Login Username",
+              "order" : 3
+            },
+            "ssh_key" : {
+              "type" : "string",
+              "description" : "OS-level user account ssh key credentials in RSA PEM format ( created with ssh-keygen -t rsa -m PEM -f myuser_rsa )",
+              "title" : "SSH Private Key",
+              "order" : 4,
+              "multiline" : true,
+              "airbyte_secret" : true
+            }
+          },
+          "required" : [ "tunnel_method", "tunnel_host", "tunnel_port", "tunnel_user", "ssh_key" ]
+        }, {
+          "title" : "Password Authentication",
+          "type" : "object",
+          "additionalProperties" : true,
+          "description" : "Connect through a jump server tunnel host using username and password authentication",
+          "properties" : {
+            "tunnel_method" : {
+              "type" : "string",
+              "enum" : [ "SSH_PASSWORD_AUTH" ],
+              "default" : "SSH_PASSWORD_AUTH"
+            },
+            "tunnel_host" : {
+              "type" : "string",
+              "description" : "Hostname of the jump server host that allows inbound ssh tunnel.",
+              "title" : "SSH Tunnel Jump Server Host",
+              "order" : 1
+            },
+            "tunnel_port" : {
+              "type" : "integer",
+              "default" : 22,
+              "description" : "Port on the proxy/jump server that accepts inbound ssh connections.",
+              "title" : "SSH Connection Port",
+              "order" : 2,
+              "minimum" : 0,
+              "maximum" : 65536
+            },
+            "tunnel_user" : {
+              "type" : "string",
+              "description" : "OS-level username for logging into the jump server host",
+              "title" : "SSH Login Username",
+              "order" : 3
+            },
+            "tunnel_user_password" : {
+              "type" : "string",
+              "description" : "OS-level password for logging into the jump server host",
+              "title" : "Password",
+              "order" : 4,
+              "airbyte_secret" : true
+            }
+          },
+          "required" : [ "tunnel_method", "tunnel_host", "tunnel_port", "tunnel_user", "tunnel_user_password" ]
+        } ],
+        "description" : "Whether to initiate an SSH tunnel before connecting to the database, and if so, which kind of authentication to use.",
+        "title" : "SSH Tunnel Method",
+        "order" : 7,
+        "type" : "object"
       }
     },
-    "required" : [ "host", "port", "protocol", "database", "username", "password" ],
+    "required" : [ "host", "port", "protocol", "database", "username", "password", "tunnel_method" ],
     "groups" : [ {
       "id" : "connection",
       "title" : "Connection"

--- a/airbyte-integrations/connectors/destination-clickhouse/src/test-integration/resources/expected-spec-oss.json
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/test-integration/resources/expected-spec-oss.json
@@ -54,9 +54,112 @@
         "title" : "Enable JSON",
         "order" : 6,
         "default" : false
+      },
+      "tunnel_method" : {
+        "oneOf" : [ {
+          "title" : "No Tunnel",
+          "type" : "object",
+          "additionalProperties" : true,
+          "description" : "No ssh tunnel needed to connect to database",
+          "properties" : {
+            "tunnel_method" : {
+              "type" : "string",
+              "enum" : [ "NO_TUNNEL" ],
+              "default" : "NO_TUNNEL"
+            }
+          },
+          "required" : [ "tunnel_method" ]
+        }, {
+          "title" : "SSH Key Authentication",
+          "type" : "object",
+          "additionalProperties" : true,
+          "description" : "Connect through a jump server tunnel host using username and ssh key",
+          "properties" : {
+            "tunnel_method" : {
+              "type" : "string",
+              "enum" : [ "SSH_KEY_AUTH" ],
+              "default" : "SSH_KEY_AUTH"
+            },
+            "tunnel_host" : {
+              "type" : "string",
+              "description" : "Hostname of the jump server host that allows inbound ssh tunnel.",
+              "title" : "SSH Tunnel Jump Server Host",
+              "order" : 1
+            },
+            "tunnel_port" : {
+              "type" : "integer",
+              "default" : 22,
+              "description" : "Port on the proxy/jump server that accepts inbound ssh connections.",
+              "title" : "SSH Connection Port",
+              "order" : 2,
+              "minimum" : 0,
+              "maximum" : 65536
+            },
+            "tunnel_user" : {
+              "type" : "string",
+              "description" : "OS-level username for logging into the jump server host",
+              "title" : "SSH Login Username",
+              "order" : 3
+            },
+            "ssh_key" : {
+              "type" : "string",
+              "description" : "OS-level user account ssh key credentials in RSA PEM format ( created with ssh-keygen -t rsa -m PEM -f myuser_rsa )",
+              "title" : "SSH Private Key",
+              "order" : 4,
+              "multiline" : true,
+              "airbyte_secret" : true
+            }
+          },
+          "required" : [ "tunnel_method", "tunnel_host", "tunnel_port", "tunnel_user", "ssh_key" ]
+        }, {
+          "title" : "Password Authentication",
+          "type" : "object",
+          "additionalProperties" : true,
+          "description" : "Connect through a jump server tunnel host using username and password authentication",
+          "properties" : {
+            "tunnel_method" : {
+              "type" : "string",
+              "enum" : [ "SSH_PASSWORD_AUTH" ],
+              "default" : "SSH_PASSWORD_AUTH"
+            },
+            "tunnel_host" : {
+              "type" : "string",
+              "description" : "Hostname of the jump server host that allows inbound ssh tunnel.",
+              "title" : "SSH Tunnel Jump Server Host",
+              "order" : 1
+            },
+            "tunnel_port" : {
+              "type" : "integer",
+              "default" : 22,
+              "description" : "Port on the proxy/jump server that accepts inbound ssh connections.",
+              "title" : "SSH Connection Port",
+              "order" : 2,
+              "minimum" : 0,
+              "maximum" : 65536
+            },
+            "tunnel_user" : {
+              "type" : "string",
+              "description" : "OS-level username for logging into the jump server host",
+              "title" : "SSH Login Username",
+              "order" : 3
+            },
+            "tunnel_user_password" : {
+              "type" : "string",
+              "description" : "OS-level password for logging into the jump server host",
+              "title" : "Password",
+              "order" : 4,
+              "airbyte_secret" : true
+            }
+          },
+          "required" : [ "tunnel_method", "tunnel_host", "tunnel_port", "tunnel_user", "tunnel_user_password" ]
+        } ],
+        "description" : "Whether to initiate an SSH tunnel before connecting to the database, and if so, which kind of authentication to use.",
+        "title" : "SSH Tunnel Method",
+        "order" : 5,
+        "type" : "object"
       }
     },
-    "required" : [ "host", "port", "protocol", "database", "username", "password" ],
+    "required" : [ "host", "port", "protocol", "database", "username", "password", "tunnel_method" ],
     "groups" : [ {
       "id" : "connection",
       "title" : "Connection"

--- a/airbyte-integrations/connectors/destination-clickhouse/src/test-integration/resources/expected-spec-oss.json
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/test-integration/resources/expected-spec-oss.json
@@ -159,7 +159,7 @@
         "type" : "object"
       }
     },
-    "required" : [ "host", "port", "protocol", "database", "username", "password", "tunnel_method" ],
+    "required" : [ "host", "port", "protocol", "database", "username", "password" ],
     "groups" : [ {
       "id" : "connection",
       "title" : "Connection"

--- a/airbyte-integrations/connectors/destination-clickhouse/src/test/kotlin/io/airbyte/integrations/destination/clickhouse/check/ClickhouseCheckerTest.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/test/kotlin/io/airbyte/integrations/destination/clickhouse/check/ClickhouseCheckerTest.kt
@@ -151,6 +151,7 @@ class ClickhouseCheckerTest {
                 username,
                 password,
                 enableJson,
+                tunnelConfig = null,
             )
     }
 }

--- a/docs/integrations/destinations/clickhouse-migrations.md
+++ b/docs/integrations/destinations/clickhouse-migrations.md
@@ -2,8 +2,8 @@
 
 ## SSH Support :warning:
 
-SSH is not yet implemented for the new connector. If you require SSH support,
-please hold off on migrating for now.
+SSH is implementation for the new connector is in Beta. If you upgrade and SSH
+does not work for you, please reach out to support.
 
 ## Upgrading to 2.0.0
 

--- a/docs/integrations/destinations/clickhouse.md
+++ b/docs/integrations/destinations/clickhouse.md
@@ -95,6 +95,7 @@ You can also use a pre-existing user but we highly recommend creating a dedicate
 
 | Version | Date       | Pull Request                                               | Subject                                                                        |
 |:--------|:-----------|:-----------------------------------------------------------|:-------------------------------------------------------------------------------|
+| 2.0.4   | 2025-07-21 | [\#62948](https://github.com/airbytehq/airbyte/pull/62948) | SSH support BETA.                                                              |
 | 2.0.3   | 2025-07-11 | [\#62946](https://github.com/airbytehq/airbyte/pull/62946) | Publish metadata changes.                                                      |
 | 2.0.2   | 2025-07-10 | [\#62928](https://github.com/airbytehq/airbyte/pull/62928) | Makes json optional in spec to work around UI issue.                           |
 | 2.0.1   | 2025-07-10 | [\#62906](https://github.com/airbytehq/airbyte/pull/62906) | Adds bespoke validation for legacy hostnames that contain a protocol.          |


### PR DESCRIPTION
## What
Cribs from other destinations

## Status
I was unable to test against a local version but we appear to fail on the SSL handshake against cloud (https). My various attempts to hack around this have not worked.

I'd like to get this out since we currently have no SSH support anyway, so even if it's broken it doesn't regress per se. Meanwhile SSH users can attempt the new flow and we can get better feedback and allow users to upgrade without losing their config.

## Todo
Unit tests
Manually test this against an SSH server somewhere

## Other
Removes unused object storage toolkits

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._