### PR TITLE
fix(source-google-analytics-data-api): Increase the cursor granularity so that concurrent date range partitions are merged correctly

### DIFF
--- a/airbyte-integrations/connectors/source-google-analytics-data-api/manifest.yaml
+++ b/airbyte-integrations/connectors/source-google-analytics-data-api/manifest.yaml
@@ -1016,7 +1016,7 @@ dynamic_streams:
               cursor_field: {{ ns.cursor }}
               lookback_window: "P{{ config.get('lookback_window', 2) }}D"
               step: "P{{ config.get('window_in_days', 365) }}D"
-              cursor_granularity: PT1S
+              cursor_granularity: P1D
               cursor_datetime_formats:
                 - "%Y%m%d"
                 - "%Y%m"

--- a/airbyte-integrations/connectors/source-google-analytics-data-api/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-analytics-data-api/metadata.yaml
@@ -12,7 +12,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 3cc2eafd-84aa-4dca-93af-322d9dfeec1a
-  dockerImageTag: 2.9.2
+  dockerImageTag: 2.9.3
   dockerRepository: airbyte/source-google-analytics-data-api
   documentationUrl: https://docs.airbyte.com/integrations/sources/google-analytics-data-api
   resourceRequirements:

--- a/airbyte-integrations/connectors/source-google-analytics-data-api/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-analytics-data-api/metadata.yaml
@@ -12,7 +12,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 3cc2eafd-84aa-4dca-93af-322d9dfeec1a
-  dockerImageTag: 2.9.3
+  dockerImageTag: 2.9.3-rc.1
   dockerRepository: airbyte/source-google-analytics-data-api
   documentationUrl: https://docs.airbyte.com/integrations/sources/google-analytics-data-api
   resourceRequirements:

--- a/docs/integrations/sources/google-analytics-data-api.md
+++ b/docs/integrations/sources/google-analytics-data-api.md
@@ -272,7 +272,7 @@ The Google Analytics connector is subject to Google Analytics Data API quotas. P
 
 | Version        | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |:---------------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 2.9.3 | 2025-07-15 | [tbd](https://github.com/airbytehq/airbyte/pull/tbd) | Fix bug where concurrent partitions are not merged back together properly so sequential state can't progress to the latest record |
+| 2.9.3-rc.1 | 2025-07-15 | [63297](https://github.com/airbytehq/airbyte/pull/63297) | Fix bug where concurrent partitions are not merged back together properly so sequential state can't progress to the latest record |
 | 2.9.2 | 2025-07-12 | [63129](https://github.com/airbytehq/airbyte/pull/63129) | Update dependencies |
 | 2.9.1 | 2025-07-05 | [61135](https://github.com/airbytehq/airbyte/pull/61135) | Update dependencies |
 | 2.9.0 | 2025-07-03 | [62507](https://github.com/airbytehq/airbyte/pull/62507) | Promoting release candidate 2.9.0-rc.1 to a main version. |

--- a/docs/integrations/sources/google-analytics-data-api.md
+++ b/docs/integrations/sources/google-analytics-data-api.md
@@ -272,6 +272,7 @@ The Google Analytics connector is subject to Google Analytics Data API quotas. P
 
 | Version        | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |:---------------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 2.9.3 | 2025-07-15 | [tbd](https://github.com/airbytehq/airbyte/pull/tbd) | Fix bug where concurrent partitions are not merged back together properly so sequential state can't progress to the latest record |
 | 2.9.2 | 2025-07-12 | [63129](https://github.com/airbytehq/airbyte/pull/63129) | Update dependencies |
 | 2.9.1 | 2025-07-05 | [61135](https://github.com/airbytehq/airbyte/pull/61135) | Update dependencies |
 | 2.9.0 | 2025-07-03 | [62507](https://github.com/airbytehq/airbyte/pull/62507) | Promoting release candidate 2.9.0-rc.1 to a main version. |


### PR DESCRIPTION
## What

We are seeing that the final stream state is not being updated to the latest record emitted.

After inspecting the date range partitions we’re creating for the streams, I noticed that we are not properly merging each partition back into each other. And because we’re not merging each concurrent partition back together, when we convert state back to sequential format with a singular checkpoint value, we end up using the latest record of the earliest first partition.

I confirmed this using our local credentials by switching to `is_sequential_state` to False and I saw that partitions aren’t merged together.

## How

We need to fix the cursor_granularity of the cursor so that it can properly merge partitions back together and so the final state we emit at the end of the sync represents the latest record after properly merging the partitions back.

The fix in this PR is to increase the granularity to P1D, that retains the same date ranges as the existing implementation, however, it increases the range to which we will merge adjacent partitions from 1 second to 1 day which is needed because each partition is separated by 1 day:

For example:
{“startDate":"2023-05-09","endDate":"2023-06-07”}
{"startDate":"2023-06-08","endDate":"2023-07-07"}

The alternative would be to set the granularity to `PT0S` and while this guarantees we won’t miss records, it does result in a lot of duplicates. It also deviates from the previous Python behavior where slices did not intersect. Google’s API accepts incoming date ranges in YYYY-MM-DD format

https://developers.google.com/analytics/devguides/reporting/data/v1/rest/v1beta/DateRange

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌
