### PR TITLE
fix(docker): correct user home directory setup and improve permissions

### DIFF
--- a/airbyte-ci/connectors/base_images/README.md
+++ b/airbyte-ci/connectors/base_images/README.md
@@ -1,3 +1,6 @@
+# Note: This module is deprecated. 
+As of July 2025, we now define our connector base images using [these Dockerfiles](../../../docker-images/) and build them using Github Actions. [This workflow](../../../.github/workflows/docker-connector-base-image-tests.yml) runs on PRs to test changes to the base images and [this workflow](../../../.github/workflows/docker-connector-image-publishing.ymll) can be used to publish the base image on-demand, which we do for releases.
+
 # airbyte-connectors-base-images
 
 This python package contains the base images used by Airbyte connectors.

--- a/airbyte-ci/connectors/base_images/README.md
+++ b/airbyte-ci/connectors/base_images/README.md
@@ -1,5 +1,5 @@
 # Note: This module is deprecated. 
-As of July 2025, we now define our connector base images using [these Dockerfiles](../../../docker-images/) and build them using Github Actions. [This workflow](../../../.github/workflows/docker-connector-base-image-tests.yml) runs on PRs to test changes to the base images and [this workflow](../../../.github/workflows/docker-connector-image-publishing.ymll) can be used to publish the base image on-demand, which we do for releases.
+As of July 2025, we now define our connector base images using [these Dockerfiles](../../../docker-images/) and build them using Github Actions. [This workflow](../../../.github/workflows/docker-connector-base-image-tests.yml) runs on PRs to test changes to the base images and [this workflow](../../../.github/workflows/docker-connector-image-publishing.yml) can be used to publish the base image on-demand, which we do for releases.
 
 # airbyte-connectors-base-images
 

--- a/docker-images/Dockerfile.python-connector-base
+++ b/docker-images/Dockerfile.python-connector-base
@@ -8,15 +8,17 @@ FROM ${BASE_IMAGE}
 RUN ln -snf /usr/share/zoneinfo/Etc/UTC /etc/localtime
 
 # Set-up groups, users, and directories
-RUN adduser --uid 1000 --system --group --no-create-home airbyte
+RUN adduser --uid 1000 --system --group --home /airbyte/home airbyte
 
 # Create the cache airbyte directories and set the right permissions
 RUN mkdir --mode 755 /airbyte && \
+    mkdir --mode 755 /airbyte/home && \
     mkdir --mode 755 /custom_cache && \
     mkdir /secrets && \
     mkdir /config && \
     mkdir /nonexistent && \
     chown airbyte:airbyte /airbyte && \
+    chown -R airbyte:airbyte /airbyte/home && \
     chown -R airbyte:airbyte /custom_cache && \
     chown -R airbyte:airbyte /secrets && \
     chown -R airbyte:airbyte /config && \
@@ -39,7 +41,7 @@ RUN pip install --upgrade \
       setuptools==78.1.1 \
       poetry==1.8.4
 
-# Install system dependencies 
+# Install system dependencies
 RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get dist-upgrade -y && \

--- a/docker-images/Dockerfile.python-connector-base
+++ b/docker-images/Dockerfile.python-connector-base
@@ -7,16 +7,20 @@ FROM ${BASE_IMAGE}
 # Set the timezone to UTC
 RUN ln -snf /usr/share/zoneinfo/Etc/UTC /etc/localtime
 
-# Set-up groups, users, and directories
-RUN adduser --uid 1000 --system --group --home /airbyte/home airbyte
-
 # Create the cache airbyte directories and set the right permissions
 RUN mkdir --mode 755 /airbyte && \
+    mkdir --mode 755 /airbyte/home && \
     mkdir --mode 755 /custom_cache && \
     mkdir /secrets && \
     mkdir /config && \
-    mkdir /nonexistent && \
-    chown airbyte:airbyte /airbyte && \
+    mkdir /nonexistent
+
+# Set up the airbyte user
+RUN adduser --uid 1000 --system --group --home /airbyte/home airbyte
+
+# Set up ownership and permissions
+RUN chown airbyte:airbyte /airbyte && \
+    chown -R airbyte:airbyte /airbyte/home && \
     chown -R airbyte:airbyte /custom_cache && \
     chown -R airbyte:airbyte /secrets && \
     chown -R airbyte:airbyte /config && \

--- a/docker-images/Dockerfile.python-connector-base
+++ b/docker-images/Dockerfile.python-connector-base
@@ -17,7 +17,6 @@ RUN mkdir --mode 755 /airbyte && \
     mkdir /config && \
     mkdir /nonexistent && \
     chown airbyte:airbyte /airbyte && \
-    chown -R airbyte:airbyte /airbyte/home && \
     chown -R airbyte:airbyte /custom_cache && \
     chown -R airbyte:airbyte /secrets && \
     chown -R airbyte:airbyte /config && \

--- a/docker-images/Dockerfile.python-connector-base
+++ b/docker-images/Dockerfile.python-connector-base
@@ -12,7 +12,6 @@ RUN adduser --uid 1000 --system --group --home /airbyte/home airbyte
 
 # Create the cache airbyte directories and set the right permissions
 RUN mkdir --mode 755 /airbyte && \
-    mkdir --mode 755 /airbyte/home && \
     mkdir --mode 755 /custom_cache && \
     mkdir /secrets && \
     mkdir /config && \


### PR DESCRIPTION
## What

- Add an explicit `HOME` directory (`/airbyte/home`) for the `airbyte` user.
- Publish a new Python connector base image (`4.0.3`) with this change.

## Context

A number of connectors have failed in the past with permission errors on a `/nonexistent` error. I see references to this in slack back to 2024.

<img width="554" height="381" alt="image" src="https://github.com/user-attachments/assets/b8dc78d4-fb3b-481b-a3b7-f66fedbf3e45" />

It seems the root cause for trying to reference a (nonexistent) "/nonexistent" directory is actually due to not having `HOME` or `~` declared.

Resolution is to declare an explicit HOME directory for the `airbyte` user.

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [x] NO ❌
