### PR TITLE
Improve table display

### DIFF
--- a/docusaurus/src/css/custom.css
+++ b/docusaurus/src/css/custom.css
@@ -297,7 +297,6 @@ table {
   border-spacing: 0;
   border-collapse: separate;
   overflow-x: auto;
-  word-break: break-word; /* Prevents long words from causing tables to overflow their containing element */
 }
 
 /* Add these new styles */


### PR DESCRIPTION
## What

Fixes certain cases where tables with a lot of content rendered strangely. Reverts a change to improve some other tables that rendered weirdly, but it's had negative consequences on others that I didn't test. We can find a different way.

## How

Disables `word-break: break-word` in the custom global CSS.

## Review guide


## User Impact


## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌
