### PR TITLE
✨ Destination BigQuery: Add configuration to support MaxBadRecords

### DIFF
--- a/airbyte-integrations/connectors/destination-bigquery/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-bigquery/metadata.yaml
@@ -6,7 +6,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: 22f6c74f-5699-40ff-833c-4a879ea40133
-  dockerImageTag: 3.0.4
+  dockerImageTag: 3.1.0
   dockerRepository: airbyte/destination-bigquery
   documentationUrl: https://docs.airbyte.com/integrations/destinations/bigquery
   githubIssueLabel: destination-bigquery

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/BigQueryConsts.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/BigQueryConsts.kt
@@ -22,4 +22,7 @@ object BigQueryConsts {
     const val CDC_DELETION_MODE: String = "cdc_deletion_mode"
     const val NAMESPACE_PREFIX: String = "n"
     const val NULL_MARKER: String = "\\N"
+    const val GCS_LOAD_MAX_BAD_RECORDS: String = "max_bad_records"
+    const val GCS_BUCKET_PATH_BAD_RECORDS: String = "gcs_bucket_path_bad_records"
+    const val GCS_KEEP_BAD_RECORDS: String = "keep_bad_records"
 }

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/spec/BigqueryConfiguration.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/spec/BigqueryConfiguration.kt
@@ -33,6 +33,9 @@ data object BatchedStandardInsertConfiguration : LoadingMethodConfiguration
 data class GcsStagingConfiguration(
     val gcsClientConfig: GcsClientConfiguration,
     val filePostProcessing: GcsFilePostProcessing,
+    val maxBadRecords: Int,
+    val shouldKeepBadRecords: Boolean,
+    val gcsBucketPathBadRecords: String,
 ) : LoadingMethodConfiguration
 
 @Singleton
@@ -46,6 +49,9 @@ class BigqueryConfigurationFactory :
                     GcsStagingConfiguration(
                         GcsClientConfiguration(gcsStagingSpec, pojo.datasetLocation.gcsRegion),
                         gcsStagingSpec.filePostProcessing ?: GcsFilePostProcessing.DELETE,
+                        gcsStagingSpec.maxBadRecords,
+                        gcsStagingSpec.shouldKeepBadRecords,
+                        gcsStagingSpec.pathBadRecords
                     )
                 }
                 is BatchedStandardInsertSpecification,

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/spec/BigquerySpecification.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/spec/BigquerySpecification.kt
@@ -148,6 +148,24 @@ class GcsStagingSpecification :
     override val path: String = ""
     override val credential: GcsAuthSpecification =
         GcsHmacKeySpecification(accessKeyId = "", secretAccessKey = "")
+
+    @get:JsonProperty("max_bad_records", defaultValue = "0")
+    @get:JsonSchemaTitle("Max bad records per load query")
+    @get:JsonPropertyDescription(
+        """The maximum number of bad records that BigQuery can ignore when running a load job."""
+    )
+    @get:JsonSchemaInject(json = """{"order": 4}""")
+    val maxBadRecords: Int = 0
+
+    @get:JsonProperty("keep_bad_records", defaultValue = "false")
+    @get:JsonSchemaTitle("Copy data with bad records to another GCS location.")
+    @get:JsonSchemaInject(json = """{"default": false, "order": 5}""")
+    val shouldKeepBadRecords: Boolean = false
+
+    @get:JsonProperty("gcs_bucket_path_bad_records", defaultValue = "airbyte/bad_records")
+    @get:JsonSchemaTitle("GCS path prefix for files containing bad Records")
+    @get:JsonSchemaInject(json = """{"examples": ["airbyte/bad_records"], "order": 6}""")
+    val pathBadRecords: String = ""
 }
 
 // bigquery supports a subset of GCS regions.

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/bulk_loader/BigQueryBulkLoader.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/bulk_loader/BigQueryBulkLoader.kt
@@ -111,11 +111,7 @@ class BigQueryBulkLoader(
 
     private suspend fun copyBadRecords(srcKey: String, destKey: String) {
         try {
-            val fileContent = storageClient.get(srcKey) { ins -> ins.readAllBytes() }
-            if (fileContent == null) {
-                logger.warn { "No content found in $srcKey, skipping bad records upload." }
-                return
-            }
+            val fileContent = storageClient.get(srcKey) { ins -> ins.use { it.readBytes() } }
             storageClient.put(destKey, fileContent)
         } catch (e: Exception) {
             logger.warn(e) {

--- a/airbyte-integrations/connectors/destination-bigquery/src/test-integration/resources/expected-spec-cloud.json
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test-integration/resources/expected-spec-cloud.json
@@ -109,9 +109,29 @@
               "title" : "GCS Bucket Path",
               "examples" : [ "data_sync/test" ],
               "order" : 2
+            },
+            "max_bad_records" : {
+              "type" : "integer",
+              "default" : 0,
+              "description" : "The maximum number of bad records that BigQuery can ignore when running a load job.",
+              "title" : "Max bad records per load query",
+              "order" : 4
+            },
+            "keep_bad_records" : {
+              "type" : "boolean",
+              "default" : false,
+              "title" : "Copy data with bad records to another GCS location.",
+              "order" : 5
+            },
+            "gcs_bucket_path_bad_records" : {
+              "type" : "string",
+              "default" : "airbyte/bad_records",
+              "title" : "GCS path prefix for files containing bad Records",
+              "examples" : [ "airbyte/bad_records" ],
+              "order" : 6
             }
           },
-          "required" : [ "method", "credential", "gcs_bucket_name", "gcs_bucket_path" ]
+          "required" : [ "method", "credential", "gcs_bucket_name", "gcs_bucket_path", "max_bad_records", "keep_bad_records", "gcs_bucket_path_bad_records" ]
         } ],
         "description" : "The way data will be uploaded to BigQuery.",
         "title" : "Loading Method",

--- a/airbyte-integrations/connectors/destination-bigquery/src/test-integration/resources/expected-spec-oss.json
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test-integration/resources/expected-spec-oss.json
@@ -109,9 +109,29 @@
               "title" : "GCS Bucket Path",
               "examples" : [ "data_sync/test" ],
               "order" : 2
+            },
+            "max_bad_records" : {
+              "type" : "integer",
+              "default" : 0,
+              "description" : "The maximum number of bad records that BigQuery can ignore when running a load job.",
+              "title" : "Max bad records per load query",
+              "order" : 4
+            },
+            "keep_bad_records" : {
+              "type" : "boolean",
+              "default" : false,
+              "title" : "Copy data with bad records to another GCS location.",
+              "order" : 5
+            },
+            "gcs_bucket_path_bad_records" : {
+              "type" : "string",
+              "default" : "airbyte/bad_records",
+              "title" : "GCS path prefix for files containing bad Records",
+              "examples" : [ "airbyte/bad_records" ],
+              "order" : 6
             }
           },
-          "required" : [ "method", "credential", "gcs_bucket_name", "gcs_bucket_path" ]
+          "required" : [ "method", "credential", "gcs_bucket_name", "gcs_bucket_path", "max_bad_records", "keep_bad_records", "gcs_bucket_path_bad_records" ]
         } ],
         "description" : "The way data will be uploaded to BigQuery.",
         "title" : "Loading Method",


### PR DESCRIPTION
## What

This PR adds some extra configuration to the BigQuery destination when the GCS Loading method is used.
It allows to set the `MaxBadRecords` [CSV option](https://cloud.google.com/bigquery/docs/loading-data-cloud-storage-csv#csv-options) and optionally to keep a copy of the CSV that contained some bad records.

This can be useful when source have incompatible data with the destination, such as in [this issue](https://github.com/airbytehq/airbyte/issues/62134) (although in that specific case the fix for the root cause is in the BigQuery Java SDK) or when a row is too large to be loaded in BigQuery. If it is acceptable to only do partial load, this PR allow to skip some bad records.

## How

Add 3 parameters to the spec and configuration:
- max_bad_records: The amount of bad records allowed per Load query
- keep_bad_records: Flag to keep a copy of the file that contained bad records
- gcs_bucket_path_bad_records: A path prefix within the same GCS bucket under which the files containing bad records would be copied.

The connector default behavior remains unchanged, and therefore does not allow for any bad records.

## User Impact

The user is able to configure a tolerated maximum of bad record in the connector configuration:

<img width="790" height="678" alt="image" src="https://github.com/user-attachments/assets/8b7f6c7c-186f-493c-8482-8c65d290507a" />

Most of the time, this parameter should be set to 0, but occasionally can be set to a specific value to sync most records excluding a few per load query.

The downside is that this parameter is applied to each load query, so it is not a hard limit over a whole sync / stream.

## Can this PR be safely reverted and rolled back?

- [ ] YES 💚
- [ ] NO ❌

## Related issue

- https://github.com/airbytehq/airbyte/issues/62134