### PR TITLE
not for merge: reduce page_size for ticket_comments stream from default 1000 to 100

### DIFF
--- a/airbyte-integrations/connectors/source-zendesk-support/manifest.yaml
+++ b/airbyte-integrations/connectors/source-zendesk-support/manifest.yaml
@@ -890,7 +890,7 @@ definitions:
         type: DefaultPaginator
         pagination_strategy:
           type: CursorPagination
-          page_size: 100
+          page_size: 10
           cursor_value: '{{ response.get("next_page", {}) }}'
           stop_condition: '{{ response.get("end_of_stream") }}'
         page_token_option:

--- a/airbyte-integrations/connectors/source-zendesk-support/manifest.yaml
+++ b/airbyte-integrations/connectors/source-zendesk-support/manifest.yaml
@@ -887,7 +887,19 @@ definitions:
           class_name: source_declarative_manifest.components.ZendeskSupportExtractorEvents
           field_path: ["ticket_events", "*", "child_events", "*"]
       paginator:
-        $ref: "#/definitions/end_of_stream_paginator"
+        type: DefaultPaginator
+        pagination_strategy:
+          type: CursorPagination
+          page_size: 250
+          cursor_value: '{{ response.get("next_page", {}) }}'
+          stop_condition: '{{ response.get("end_of_stream") }}'
+        page_token_option:
+          type: RequestPath
+        page_size_option:
+          type: RequestOption
+          field_name: per_page
+          inject_into: request_parameter
+
     schema_loader:
       type: InlineSchemaLoader
       schema:

--- a/airbyte-integrations/connectors/source-zendesk-support/manifest.yaml
+++ b/airbyte-integrations/connectors/source-zendesk-support/manifest.yaml
@@ -890,7 +890,7 @@ definitions:
         type: DefaultPaginator
         pagination_strategy:
           type: CursorPagination
-          page_size: 250
+          page_size: 100
           cursor_value: '{{ response.get("next_page", {}) }}'
           stop_condition: '{{ response.get("end_of_stream") }}'
         page_token_option:

--- a/airbyte-integrations/connectors/source-zendesk-support/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zendesk-support/metadata.yaml
@@ -11,7 +11,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 79c1aa37-dae3-42ae-b333-d1c105477715
-  dockerImageTag: 4.10.3
+  dockerImageTag: 4.11.0
   dockerRepository: airbyte/source-zendesk-support
   documentationUrl: https://docs.airbyte.com/integrations/sources/zendesk-support
   githubIssueLabel: source-zendesk-support


### PR DESCRIPTION
## What

The zendesk endpoint: `/api/v2/incremental/ticket_events` sometimes yields 504 gateway timeout errors and we don't know why.

Just being used to test a hypothesis of a smaller page size for the `ticket_comments` requests prevents this error from happening.

## How
<!--
* Describe how code changes achieve the solution.
-->

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
