### PR TITLE
Custom properties in HubSpot cause syncs to be slower

### DIFF
--- a/docs/integrations/sources/hubspot.md
+++ b/docs/integrations/sources/hubspot.md
@@ -249,8 +249,6 @@ Then, go to the schema tab of your connection and click **refresh source schema*
 Expand to see details about Hubspot connector limitations and troubleshooting.
 </summary>
 
-### Connector limitations
-
 ### Rate limiting
 
 The connector is restricted by normal HubSpot [rate limitations](https://legacydocs.hubspot.com/apps/api_guidelines).
@@ -260,6 +258,10 @@ The connector is restricted by normal HubSpot [rate limitations](https://legacyd
 | `Free & Starter`            | Burst: 100/10 seconds, Daily: 250,000   |
 | `Professional & Enterprise` | Burst: 150/10 seconds, Daily: 500,000   |
 | `API add-on (any tier)`     | Burst: 200/10 seconds, Daily: 1,000,000 |
+
+### Custom properties sync slowly
+
+If you use [custom properties](https://knowledge.hubspot.com/properties/create-and-edit-properties) in HubSpot, syncs take longer. Airbyte doesn't alert you to the presence of custom properties, but you can check if you're using them with HubSpot's UI.
 
 ### Troubleshooting
 


### PR DESCRIPTION
## What

Add a small note to the HubSpot limitations section that custom properties cause the connector to sync more slowly. I've also removed an orphaned heading.

## How
<!--
* Describe how code changes achieve the solution.
-->

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
