### PR TITLE
fix(destination-motherduck): declare `HOME` env var explicitly (resolves #63710)

### DIFF
--- a/airbyte-integrations/connectors/destination-motherduck/acceptance-test-config.yml
+++ b/airbyte-integrations/connectors/destination-motherduck/acceptance-test-config.yml
@@ -8,3 +8,5 @@ acceptance_tests:
     tests:
       - config_path: "integration_tests/config.json"
         status: "succeed"
+      - config_path: "secrets/config.json"
+        status: "succeed"

--- a/airbyte-integrations/connectors/destination-motherduck/destination_motherduck/run.py
+++ b/airbyte-integrations/connectors/destination-motherduck/destination_motherduck/run.py
@@ -9,12 +9,12 @@ def run() -> None:
     if "HOME" not in os.environ:
         # Temporary fix for unset "HOME" variable leading to failure on '/nonexistent' path:
         # https://github.com/airbytehq/airbyte/issues/63710
-        print("Warning: 'HOME' environment variable is not set.", file=sys.stderr)
+        print("Warning: 'HOME' environment variable is not set.")
         if Path("/airbyte").exists():
-            print("Found /airbyte directory. Setting as home.", file=sys.stderr)
+            print("Found /airbyte directory. Setting as home.")
             os.environ["HOME"] = "/airbyte"
     else:
-        print("Using HOME:", os.environ["HOME"], file=sys.stderr)
+        print("Using HOME:", os.environ["HOME"])
 
     # Defer import to ensure env var is set prior to loading the DuckDB engine.
     from destination_motherduck import DestinationMotherDuck

--- a/airbyte-integrations/connectors/destination-motherduck/destination_motherduck/run.py
+++ b/airbyte-integrations/connectors/destination-motherduck/destination_motherduck/run.py
@@ -8,10 +8,15 @@ from destination_motherduck import DestinationMotherDuck
 
 
 def run() -> None:
-    if "HOME" not in os.environ and Path("/airbyte").exists():
+    if "HOME" not in os.environ:
         # Temporary fix for unset "HOME" variable leading to failure on '/nonexistent' path:
         # https://github.com/airbytehq/airbyte/issues/63710
-        os.environ["HOME"] = "/airbyte"
+        print("Warning: 'HOME' environment variable is not set.", file=sys.stderr)
+        if Path("/airbyte").exists():
+            print("Found /airbyte directory. Setting as home.", file=sys.stderr)
+            os.environ["HOME"] = "/airbyte"
+    else:
+        print("Using HOME:", os.environ["HOME"], file=sys.stderr)
 
     DestinationMotherDuck().run(sys.argv[1:])
 

--- a/airbyte-integrations/connectors/destination-motherduck/destination_motherduck/run.py
+++ b/airbyte-integrations/connectors/destination-motherduck/destination_motherduck/run.py
@@ -1,11 +1,15 @@
 # Copyright (c) 2024 Airbyte, Inc., all rights reserved.
 
+import os
 import sys
 
 from destination_motherduck import DestinationMotherDuck
 
 
 def run() -> None:
+    # Resolve unset "HOME" variable and lack of access to '/nonexistent' path
+    os.environ["HOME"] = "/airbyte"
+
     DestinationMotherDuck().run(sys.argv[1:])
 
 

--- a/airbyte-integrations/connectors/destination-motherduck/destination_motherduck/run.py
+++ b/airbyte-integrations/connectors/destination-motherduck/destination_motherduck/run.py
@@ -9,8 +9,9 @@ from destination_motherduck import DestinationMotherDuck
 
 
 def run() -> None:
-    # Resolve unset "HOME" variable and lack of access to '/nonexistent' path
     if "HOME" not in os.environ and Path("/airbyte").exists():
+        # Temporary fix for unset "HOME" variable leading to failure on '/nonexistent' path:
+        # https://github.com/airbytehq/airbyte/issues/63710
         os.environ["HOME"] = "/airbyte"
 
     DestinationMotherDuck().run(sys.argv[1:])

--- a/airbyte-integrations/connectors/destination-motherduck/destination_motherduck/run.py
+++ b/airbyte-integrations/connectors/destination-motherduck/destination_motherduck/run.py
@@ -4,8 +4,6 @@ import os
 import sys
 from pathlib import Path
 
-from destination_motherduck import DestinationMotherDuck
-
 
 def run() -> None:
     if "HOME" not in os.environ:
@@ -18,6 +16,8 @@ def run() -> None:
     else:
         print("Using HOME:", os.environ["HOME"], file=sys.stderr)
 
+    # Defer import to ensure env var is set prior to loading the DuckDB engine.
+    from destination_motherduck import DestinationMotherDuck
     DestinationMotherDuck().run(sys.argv[1:])
 
 

--- a/airbyte-integrations/connectors/destination-motherduck/destination_motherduck/run.py
+++ b/airbyte-integrations/connectors/destination-motherduck/destination_motherduck/run.py
@@ -13,8 +13,15 @@ def run() -> None:
         if Path("/airbyte").exists():
             print("Found /airbyte directory. Setting as home.")
             os.environ["HOME"] = "/airbyte"
+    elif os.environ["HOME"].strip() == "/nonexistent":
+        print(f"Warning: 'HOME' env var is set to '{os.environ['HOME']}'.")
+        if Path("/airbyte").exists():
+            print("Found '/airbyte' directory. Setting as new 'HOME'.")
+            os.environ["HOME"] = "/airbyte"
+        else:
+            print(f"No valid home directory found. Using default: '{os.environ['HOME']}'.")
     else:
-        print("Using HOME:", os.environ["HOME"])
+        print(f"Using HOME: '{os.environ['HOME']}'")
 
     # Defer import to ensure env var is set prior to loading the DuckDB engine.
     from destination_motherduck import DestinationMotherDuck

--- a/airbyte-integrations/connectors/destination-motherduck/destination_motherduck/run.py
+++ b/airbyte-integrations/connectors/destination-motherduck/destination_motherduck/run.py
@@ -2,7 +2,6 @@
 
 import os
 import sys
-
 from pathlib import Path
 
 from destination_motherduck import DestinationMotherDuck

--- a/airbyte-integrations/connectors/destination-motherduck/destination_motherduck/run.py
+++ b/airbyte-integrations/connectors/destination-motherduck/destination_motherduck/run.py
@@ -3,12 +3,15 @@
 import os
 import sys
 
+from pathlib import Path
+
 from destination_motherduck import DestinationMotherDuck
 
 
 def run() -> None:
     # Resolve unset "HOME" variable and lack of access to '/nonexistent' path
-    os.environ["HOME"] = "/airbyte"
+    if "HOME" not in os.environ and Path("/airbyte").exists():
+        os.environ["HOME"] = "/airbyte"
 
     DestinationMotherDuck().run(sys.argv[1:])
 

--- a/airbyte-integrations/connectors/destination-motherduck/destination_motherduck/run.py
+++ b/airbyte-integrations/connectors/destination-motherduck/destination_motherduck/run.py
@@ -18,6 +18,7 @@ def run() -> None:
 
     # Defer import to ensure env var is set prior to loading the DuckDB engine.
     from destination_motherduck import DestinationMotherDuck
+
     DestinationMotherDuck().run(sys.argv[1:])
 
 

--- a/airbyte-integrations/connectors/destination-motherduck/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-motherduck/metadata.yaml
@@ -4,7 +4,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: 042ee9b5-eb98-4e99-a4e5-3f0d573bee66
-  dockerImageTag: 0.1.20
+  dockerImageTag: 0.1.21
   dockerRepository: airbyte/destination-motherduck
   githubIssueLabel: destination-motherduck
   icon: duckdb.svg

--- a/airbyte-integrations/connectors/destination-motherduck/pyproject.toml
+++ b/airbyte-integrations/connectors/destination-motherduck/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "airbyte-destination-motherduck"
-version = "0.1.20"
+version = "0.1.21"
 description = "Destination implementation for MotherDuck."
 authors = ["Guen Prawiroatmodjo, Simon Späti, Airbyte"]
 license = "MIT"

--- a/docs/integrations/destinations/motherduck.md
+++ b/docs/integrations/destinations/motherduck.md
@@ -72,7 +72,7 @@ This connector is primarily designed to work with MotherDuck and local DuckDB fi
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                          |
 | :------ | :--------- | :------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------- |
-| 0.1.21 | 2025-07-22 | [63709](https://github.com/airbytehq/airbyte/pull/63709) | fix: declare  env var explicitly |
+| 0.1.21 | 2025-07-22 | [63709](https://github.com/airbytehq/airbyte/pull/63709) | fix: resolve error "Can't find the home directory at '/nonexistent'"  |
 | 0.1.21 | 2025-07-06 | [62133](https://github.com/airbytehq/airbyte/pull/62133) | fix: when `primary_key` is not defined in the catalog, use `source_defined_primary_key` if available |
 | 0.1.20 | 2025-06-27 | [48673](https://github.com/airbytehq/airbyte/pull/48673) | Update dependencies |
 | 0.1.19 | 2025-05-25 | [60905](https://github.com/airbytehq/airbyte/pull/60905) | Allow unicode characters in database/table names |

--- a/docs/integrations/destinations/motherduck.md
+++ b/docs/integrations/destinations/motherduck.md
@@ -72,6 +72,7 @@ This connector is primarily designed to work with MotherDuck and local DuckDB fi
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                          |
 | :------ | :--------- | :------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------- |
+| 0.1.21 | 2025-07-22 | [63709](https://github.com/airbytehq/airbyte/pull/63709) | fix: declare  env var explicitly |
 | 0.1.21 | 2025-07-06 | [62133](https://github.com/airbytehq/airbyte/pull/62133) | fix: when `primary_key` is not defined in the catalog, use `source_defined_primary_key` if available |
 | 0.1.20 | 2025-06-27 | [48673](https://github.com/airbytehq/airbyte/pull/48673) | Update dependencies |
 | 0.1.19 | 2025-05-25 | [60905](https://github.com/airbytehq/airbyte/pull/60905) | Allow unicode characters in database/table names |

--- a/docs/integrations/destinations/motherduck.md
+++ b/docs/integrations/destinations/motherduck.md
@@ -72,7 +72,7 @@ This connector is primarily designed to work with MotherDuck and local DuckDB fi
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                          |
 | :------ | :--------- | :------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------- |
-| 0.1.21 | 2025-07-22 | [63709](https://github.com/airbytehq/airbyte/pull/63709) | fix: resolve error "Can't find the home directory at '/nonexistent'"  |
+| 0.1.21 | 2025-07-22 | [63709](https://github.com/airbytehq/airbyte/pull/63709) | fix: resolve error "Can't find the home directory at '/nonexistent'" [#63710](https://github.com/airbytehq/airbyte/issues/63710)  |
 | 0.1.21 | 2025-07-06 | [62133](https://github.com/airbytehq/airbyte/pull/62133) | fix: when `primary_key` is not defined in the catalog, use `source_defined_primary_key` if available |
 | 0.1.20 | 2025-06-27 | [48673](https://github.com/airbytehq/airbyte/pull/48673) | Update dependencies |
 | 0.1.19 | 2025-05-25 | [60905](https://github.com/airbytehq/airbyte/pull/60905) | Allow unicode characters in database/table names |


### PR DESCRIPTION
Resolves https://github.com/airbytehq/airbyte/issues/63710

- https://github.com/airbytehq/airbyte/issues/63710

## What

This is a temporary (read: hacky, non-ideal) fix to an issue in the base image and/or in the connector image. The ideal fix is to ensure the connector has a properly set `HOME` directory, with write access. As a temporary fix, this should resolve #63710 while we resolve the base image issue.

Context: The challenge with resolving the core base image issue is that we are in the middle of migrating off of Dagger, and we have limited ability to test and deploy connector images until that migration is complete.


`Configuration check failed`
`An exception occurred: OperationalError("(duckdb.duckdb.IOException) IO Error: Can't find the home directory at '/nonexistent'\nSpecify a home directory using the SET home_directory='/path/to/dir' option.")`

## Context from Linked Issue

> Additional context after some digging. The connector doesn't declare a home directory (~), which is probably a factor in this issue. Note below I can repro the issue in the terminal and resolve by declaring a HOME env var.
> 
> https://airbytehq-team.slack.com/archives/C05KJKWHNAJ/p1752688059321379?thread_ts=1752669535.630459&cid=C05KJKWHNAJ
> 
> ```bash
> ajsteers$ docker run -it --rm --entrypoint=bash airbyte/destination-motherduck
> airbyte@67a1443c8f6b:/airbyte/integration_code$ touch ~/tmp.txt
> touch: cannot touch '/nonexistent/tmp.txt': No such file or directory
> airbyte@67a1443c8f6b:/airbyte/integration_code$ HOME=/airbyte
> airbyte@67a1443c8f6b:~/integration_code$ touch ~/tmp.txt
> airbyte@67a1443c8f6b:~/integration_code$ ls ~/tmp.txt
> /airbyte/tmp.txt
> ```