### PR TITLE
fix(destination-motherduck): handle special characters in stream name when creating tables

### DIFF
--- a/airbyte-integrations/connectors/destination-motherduck/destination_motherduck/processors/duckdb.py
+++ b/airbyte-integrations/connectors/destination-motherduck/destination_motherduck/processors/duckdb.py
@@ -370,12 +370,13 @@ class DuckDBSqlProcessor(SqlProcessorBase):
             self._write_from_pa_table(temp_table_name, stream_name, pa_table)
 
         temp_table_name_dedup = self._drop_duplicates(temp_table_name, stream_name)
+        final_table_name = self.normalizer.normalize(stream_name)
 
         try:
             self._write_temp_table_to_target_table(
                 stream_name=stream_name,
                 temp_table_name=temp_table_name_dedup,
-                final_table_name=stream_name,
+                final_table_name=final_table_name,
                 sync_mode=sync_mode,
             )
         finally:

--- a/airbyte-integrations/connectors/destination-motherduck/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-motherduck/metadata.yaml
@@ -4,7 +4,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: 042ee9b5-eb98-4e99-a4e5-3f0d573bee66
-  dockerImageTag: 0.1.21
+  dockerImageTag: 0.1.22
   dockerRepository: airbyte/destination-motherduck
   githubIssueLabel: destination-motherduck
   icon: duckdb.svg

--- a/airbyte-integrations/connectors/destination-motherduck/pyproject.toml
+++ b/airbyte-integrations/connectors/destination-motherduck/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "airbyte-destination-motherduck"
-version = "0.1.21"
+version = "0.1.22"
 description = "Destination implementation for MotherDuck."
 authors = ["Guen Prawiroatmodjo, Simon Späti, Airbyte"]
 license = "MIT"

--- a/docs/integrations/destinations/motherduck.md
+++ b/docs/integrations/destinations/motherduck.md
@@ -72,7 +72,8 @@ This connector is primarily designed to work with MotherDuck and local DuckDB fi
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                          |
 | :------ | :--------- | :------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------- |
-| 0.1.21 | 2025-07-22 | [63709](https://github.com/airbytehq/airbyte/pull/63709) | fix: resolve error "Can't find the home directory at '/nonexistent'" [#63710](https://github.com/airbytehq/airbyte/issues/63710)  |
+| 0.1.22 | 2025-07-22 | [63714](https://github.com/airbytehq/airbyte/pull/63714) | fix(destination-motherduck): handle special characters in stream name when creating tables |
+| 0.1.21 | 2025-07-22 | [63709](https://github.com/airbytehq/airbyte/pull/63709) | fix: resolve error "Can't find the home directory at '/nonexistent'" [#63710](https://github.com/airbytehq/airbyte/issues/63710) |
 | 0.1.21 | 2025-07-06 | [62133](https://github.com/airbytehq/airbyte/pull/62133) | fix: when `primary_key` is not defined in the catalog, use `source_defined_primary_key` if available |
 | 0.1.20 | 2025-06-27 | [48673](https://github.com/airbytehq/airbyte/pull/48673) | Update dependencies |
 | 0.1.19 | 2025-05-25 | [60905](https://github.com/airbytehq/airbyte/pull/60905) | Allow unicode characters in database/table names |

--- a/docs/integrations/destinations/motherduck.md
+++ b/docs/integrations/destinations/motherduck.md
@@ -74,8 +74,8 @@ This connector is primarily designed to work with MotherDuck and local DuckDB fi
 | :------ | :--------- | :------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------- |
 | 0.1.22 | 2025-07-22 | [63714](https://github.com/airbytehq/airbyte/pull/63714) | fix(destination-motherduck): handle special characters in stream name when creating tables |
 | 0.1.21 | 2025-07-22 | [63709](https://github.com/airbytehq/airbyte/pull/63709) | fix: resolve error "Can't find the home directory at '/nonexistent'" [#63710](https://github.com/airbytehq/airbyte/issues/63710) |
-| 0.1.21 | 2025-07-06 | [62133](https://github.com/airbytehq/airbyte/pull/62133) | fix: when `primary_key` is not defined in the catalog, use `source_defined_primary_key` if available |
-| 0.1.20 | 2025-06-27 | [48673](https://github.com/airbytehq/airbyte/pull/48673) | Update dependencies |
+| 0.1.20 | 2025-07-06 | [62133](https://github.com/airbytehq/airbyte/pull/62133) | fix: when `primary_key` is not defined in the catalog, use `source_defined_primary_key` if available |
+| n/a    | 2025-06-27 | [48673](https://github.com/airbytehq/airbyte/pull/48673) | Update dependencies |
 | 0.1.19 | 2025-05-25 | [60905](https://github.com/airbytehq/airbyte/pull/60905) | Allow unicode characters in database/table names |
 | 0.1.18 | 2025-03-01 | [54737](https://github.com/airbytehq/airbyte/pull/54737) | Update airbyte-cdk to ^6.0.0 in destination-motherduck |
 | 0.1.17 | 2024-12-26 | [50425](https://github.com/airbytehq/airbyte/pull/50425) | Fix bug overwrite write method not saving all batches |


### PR DESCRIPTION
## What

Resolves an issue where a stream name containing special characters would not be correctly escaped - resulting in "table not found" errors.

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._