### PR TITLE
fix(ci): allow special characters in branch name for slash commands

### DIFF
--- a/.github/workflows/bump-version-command.yml
+++ b/.github/workflows/bump-version-command.yml
@@ -128,7 +128,7 @@ jobs:
         if: steps.git-diff.outputs.changes == 'true'
         run: |
           git remote add contributor https://github.com/${{ steps.job-vars.outputs.repo }}.git
-          git push contributor HEAD:${{ steps.job-vars.outputs.branch }}
+          git push contributor HEAD:'${{ steps.job-vars.outputs.branch }}'
 
       - name: Append success comment
         uses: peter-evans/create-or-update-comment@v4

--- a/.github/workflows/format-fix-command.yml
+++ b/.github/workflows/format-fix-command.yml
@@ -113,7 +113,7 @@ jobs:
         if: steps.git-diff.outputs.changes == 'true'
         run: |
           git remote add contributor https://github.com/${{ steps.job-vars.outputs.repo }}.git
-          git push contributor HEAD:${{ steps.job-vars.outputs.branch }}
+          git push contributor HEAD:'${{ steps.job-vars.outputs.branch }}'
 
       - name: Append success comment
         uses: peter-evans/create-or-update-comment@v4


### PR DESCRIPTION
Update the CI configuration to handle branch names with special characters correctly during push operations.

Discovered here:

- https://github.com/airbytehq/airbyte/pull/63714#issuecomment-3100814817