### PR TITLE
Fix table alter for pks

### DIFF
--- a/airbyte-integrations/connectors/destination-clickhouse/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-clickhouse/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: ce0d828e-1dc4-496c-b122-2da42e637e48
-  dockerImageTag: 2.0.4
+  dockerImageTag: 2.0.5
   dockerRepository: airbyte/destination-clickhouse
   githubIssueLabel: destination-clickhouse
   icon: clickhouse.svg

--- a/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/client/ClickhouseAirbyteClient.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/client/ClickhouseAirbyteClient.kt
@@ -155,7 +155,7 @@ class ClickhouseAirbyteClient(
                 currentPKs,
             )
 
-        if (columnChanges.hasApplicableAlterations()) {
+        if (columnChanges.hasApplicableAlterations() && !columnChanges.hasDedupChange) {
             execute(
                 sqlGenerator.alterTable(
                     columnChanges,

--- a/airbyte-integrations/connectors/destination-clickhouse/src/test/kotlin/io/airbyte/integrations/destination/clickhouse/client/ClickhouseAirbyteClientTest.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/test/kotlin/io/airbyte/integrations/destination/clickhouse/client/ClickhouseAirbyteClientTest.kt
@@ -414,9 +414,7 @@ class ClickhouseAirbyteClientTest {
             }
         clickhouseAirbyteClient.ensureSchemaMatches(stream, finalTableName, columnMapping)
 
-        coVerify(exactly = 0) {
-            clickhouseSqlGenerator.alterTable(any(), any())
-        }
+        coVerify(exactly = 0) { clickhouseSqlGenerator.alterTable(any(), any()) }
 
         coVerifyOrder {
             clickhouseAirbyteClient.getChangedColumns(any(), any(), any(), any())

--- a/airbyte-integrations/connectors/destination-clickhouse/src/test/kotlin/io/airbyte/integrations/destination/clickhouse/client/ClickhouseAirbyteClientTest.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/test/kotlin/io/airbyte/integrations/destination/clickhouse/client/ClickhouseAirbyteClientTest.kt
@@ -384,7 +384,7 @@ class ClickhouseAirbyteClientTest {
             AlterationSummary(
                 added = emptyMap(),
                 modified = emptyMap(),
-                deleted = emptySet(),
+                deleted = setOf("test"),
                 hasDedupChange = true
             )
 
@@ -413,6 +413,10 @@ class ClickhouseAirbyteClientTest {
                 every { importType } returns Append
             }
         clickhouseAirbyteClient.ensureSchemaMatches(stream, finalTableName, columnMapping)
+
+        coVerify(exactly = 0) {
+            clickhouseSqlGenerator.alterTable(any(), any())
+        }
 
         coVerifyOrder {
             clickhouseAirbyteClient.getChangedColumns(any(), any(), any(), any())

--- a/docs/integrations/destinations/clickhouse.md
+++ b/docs/integrations/destinations/clickhouse.md
@@ -95,6 +95,7 @@ You can also use a pre-existing user but we highly recommend creating a dedicate
 
 | Version | Date       | Pull Request                                               | Subject                                                                        |
 |:--------|:-----------|:-----------------------------------------------------------|:-------------------------------------------------------------------------------|
+| 2.0.5   | 2025-07-22 | [\#63721](https://github.com/airbytehq/airbyte/pull/63721) | Fix schema change with PKs.                                                    |
 | 2.0.4   | 2025-07-21 | [\#62948](https://github.com/airbytehq/airbyte/pull/62948) | SSH support BETA.                                                              |
 | 2.0.3   | 2025-07-11 | [\#62946](https://github.com/airbytehq/airbyte/pull/62946) | Publish metadata changes.                                                      |
 | 2.0.2   | 2025-07-10 | [\#62928](https://github.com/airbytehq/airbyte/pull/62928) | Makes json optional in spec to work around UI issue.                           |


### PR DESCRIPTION
## What
When we have a schema change and a dedup change, we don't need to alter the table because the table will be recreated.

## How
<!--
* Describe how code changes achieve the solution.
-->

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
