### PR TITLE
Troubleshooting abctl secure cookies message

### DIFF
--- a/docs/platform/deploying-airbyte/troubleshoot-deploy.md
+++ b/docs/platform/deploying-airbyte/troubleshoot-deploy.md
@@ -1,6 +1,6 @@
 # Troubleshooting abctl
 
-This guide will help you navigate any issues with deploying Airbyte. This guide is intended for users of `abctl`.
+This guide will help you navigate any issues with deploying Airbyte with `abctl`.
 
 ## Common Errors
 
@@ -164,7 +164,11 @@ Upgrade to version `>0.15.1`
 
 Version `0.15.0` had a bug when users have `secrets.yaml` file. You must upgrade your `abctl` to fix this issue.
 
----
+### Make sure you have disabled secure cookies
+
+- Error: `Your credentials were correct, but the server failed to set a cookie. You appear to have deployed over HTTP. Make sure you have disabled secure cookies.`
+- Cause: You have deployed Airbyte to an insecure (non-HTTPS) host, but you haven't turned off secure cookies.
+- Fix: Deploy Airbyte again and set the `--insecure-cookies` flag. For example, `abctl local install --host example.com --insecure-cookies`.
 
 ## FAQ
 

--- a/docs/platform/deploying-airbyte/troubleshoot-deploy.md
+++ b/docs/platform/deploying-airbyte/troubleshoot-deploy.md
@@ -168,7 +168,8 @@ Version `0.15.0` had a bug when users have `secrets.yaml` file. You must upgrade
 
 - Error: `Your credentials were correct, but the server failed to set a cookie. You appear to have deployed over HTTP. Make sure you have disabled secure cookies.`
 - Cause: You have deployed Airbyte to an insecure (non-HTTPS) host, but you haven't turned off secure cookies.
-- Fix: Deploy Airbyte again and set the `--insecure-cookies` flag. For example, `abctl local install --host example.com --insecure-cookies`.
+- Fix 1: Upgrade abctl to version 0.29 or higher. A bug in previous versions caused this message to appear even when it should not have.
+- Fix 2: Deploy Airbyte again and set the `--insecure-cookies` flag. For example, `abctl local install --host example.com --insecure-cookies`.
 
 ## FAQ
 

--- a/docs/platform/deploying-airbyte/troubleshoot-deploy.md
+++ b/docs/platform/deploying-airbyte/troubleshoot-deploy.md
@@ -1,6 +1,6 @@
 # Troubleshooting abctl
 
-This guide will help you navigate any issues with deploying Airbyte with `abctl`.
+This guide helps you navigate any issues when you deploy Airbyte with `abctl`.
 
 ## Common Errors
 


### PR DESCRIPTION
## What

Responding to user feedback on the docs, I've added a troubleshooting entry for what to do when you see the error `Your credentials were correct, but the server failed to set a cookie. You appear to have deployed over HTTP. Make sure you have disabled secure cookies.`

## How

Added a new entry to the abctl troubleshooting page.

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._