### PR TITLE
Bulk CDK: No supplier for trigger-based connectors

### DIFF
--- a/airbyte-cdk/bulk/toolkits/extract-jdbc/src/main/kotlin/io/airbyte/cdk/read/JdbcPartitionsCreatorFactory.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-jdbc/src/main/kotlin/io/airbyte/cdk/read/JdbcPartitionsCreatorFactory.kt
@@ -60,6 +60,9 @@ class JdbcConcurrentPartitionsCreatorFactory<
 }
 
 @Singleton
+// TODO: For now, trigger-based CDC connectors will use mode=concurrent_with_cdc and
+//  provide their own supplier. In the future, the CDK will directly support this execution mode.
+@Requires(property = MODE_PROPERTY, pattern = "^(sequential|concurrent)$")
 class JdbcPartitionCreatorFactorySupplier<
     T : JdbcPartitionsCreatorFactory<A, S, P>,
     A : JdbcSharedState,


### PR DESCRIPTION
This PR modifies the bean injection behavior for sources using the bulk CDK. A recent CDK change introduced the `JdbcPartitionCreatorFactorySupplier`. This cannot be successfully autowired for trigger-table based sinks in the enterprise repo. Here we instruct Micronaut not to attempt to wire the bean if the execution mode is neither sequential nor concurrent (the two supported directly by the CDK currently).

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌
