### PR TITLE
Destination S3 Data Lake: pin back to local cdk

### DIFF
--- a/airbyte-integrations/connectors/destination-s3-data-lake/build.gradle
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/build.gradle
@@ -8,7 +8,7 @@ plugins {
 airbyteBulkConnector {
     core = 'load'
     toolkits = ['load-iceberg-parquet', 'load-aws']
-    cdk = 'local'
+    cdk = '0.602'
 }
 
 application {


### PR DESCRIPTION
0.602 published from action https://github.com/airbytehq/airbyte/actions/runs/16481543066/job/46596872819#step:6:70

not going to publish a new version for this, it would be literally identical to the previous connector version.