### PR TITLE
Only copy intersection

### DIFF
--- a/airbyte-integrations/connectors/destination-clickhouse/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-clickhouse/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: ce0d828e-1dc4-496c-b122-2da42e637e48
-  dockerImageTag: 2.0.6
+  dockerImageTag: 2.0.7
   dockerRepository: airbyte/destination-clickhouse
   githubIssueLabel: destination-clickhouse
   icon: clickhouse.svg

--- a/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/client/ClickhouseAirbyteClient.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/client/ClickhouseAirbyteClient.kt
@@ -160,7 +160,12 @@ class ClickhouseAirbyteClient(
             log.info {
                 "Detected deduplication change for table $properTableName, applying deduplication changes"
             }
-            applyDeduplicationChanges(stream, properTableName, columnNameMapping, tableSchemaWithoutAirbyteColumns)
+            applyDeduplicationChanges(
+                stream,
+                properTableName,
+                columnNameMapping,
+                tableSchemaWithoutAirbyteColumns
+            )
         }
     }
 
@@ -199,7 +204,9 @@ class ClickhouseAirbyteClient(
         val clickhouseColumnsName = tableSchemaWithoutAirbyteColumns.map { it.columnName }
         execute(
             sqlGenerator.copyTable(
-                ColumnNameMapping(columnNameMapping.filter { clickhouseColumnsName.contains(it.value) }),
+                ColumnNameMapping(
+                    columnNameMapping.filter { clickhouseColumnsName.contains(it.value) }
+                ),
                 properTableName,
                 tempTableName,
             ),

--- a/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/client/ClickhouseAirbyteClient.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/client/ClickhouseAirbyteClient.kt
@@ -160,26 +160,50 @@ class ClickhouseAirbyteClient(
             log.info {
                 "Detected deduplication change for table $properTableName, applying deduplication changes"
             }
-            val tempTableName = tempTableNameGenerator.generate(properTableName)
-            execute(sqlGenerator.createNamespace(tempTableName.namespace))
-            execute(
-                sqlGenerator.createTable(
-                    stream,
-                    tempTableName,
-                    columnNameMapping,
-                    true,
-                ),
-            )
-            execute(
-                sqlGenerator.copyTable(
-                    columnNameMapping,
-                    properTableName,
-                    tempTableName,
-                ),
-            )
-            execute(sqlGenerator.exchangeTable(tempTableName, properTableName))
-            execute(sqlGenerator.dropTable(tempTableName))
+            applyDeduplicationChanges(stream, properTableName, columnNameMapping, tableSchemaWithoutAirbyteColumns)
         }
+    }
+
+    private suspend fun applyDeduplicationChanges(
+        stream: DestinationStream,
+        properTableName: TableName,
+        columnNameMapping: ColumnNameMapping,
+        tableSchemaWithoutAirbyteColumns: List<ClickHouseColumn>
+    ) {
+        val tempTableName = tempTableNameGenerator.generate(properTableName)
+        execute(sqlGenerator.createNamespace(tempTableName.namespace))
+        execute(
+            sqlGenerator.createTable(
+                stream,
+                tempTableName,
+                columnNameMapping,
+                true,
+            ),
+        )
+        copyIntersectionColumn(
+            tableSchemaWithoutAirbyteColumns,
+            columnNameMapping,
+            properTableName,
+            tempTableName
+        )
+        execute(sqlGenerator.exchangeTable(tempTableName, properTableName))
+        execute(sqlGenerator.dropTable(tempTableName))
+    }
+
+    internal suspend fun copyIntersectionColumn(
+        tableSchemaWithoutAirbyteColumns: List<ClickHouseColumn>,
+        columnNameMapping: ColumnNameMapping,
+        properTableName: TableName,
+        tempTableName: TableName
+    ) {
+        val clickhouseColumnsName = tableSchemaWithoutAirbyteColumns.map { it.columnName }
+        execute(
+            sqlGenerator.copyTable(
+                ColumnNameMapping(columnNameMapping.filter { clickhouseColumnsName.contains(it.value) }),
+                properTableName,
+                tempTableName,
+            ),
+        )
     }
 
     internal fun getAirbyteSchemaWithClickhouseType(

--- a/airbyte-integrations/connectors/destination-clickhouse/src/test/kotlin/io/airbyte/integrations/destination/clickhouse/client/ClickhouseAirbyteClientTest.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/test/kotlin/io/airbyte/integrations/destination/clickhouse/client/ClickhouseAirbyteClientTest.kt
@@ -483,18 +483,14 @@ class ClickhouseAirbyteClientTest {
 
     @Test
     fun `test copyIntersectionColumn`() = runTest {
-        val chColumn1 = mockk<ClickHouseColumn>() {
-            every { columnName } returns "column1"
-        }
-        val chColumn2 = mockk<ClickHouseColumn>() {
-            every { columnName } returns "column2"
-        }
-        val tableSchemaWithoutAirbyteColumns = listOf(
-            chColumn1, chColumn2,
-        )
-        val columnNameMapping = ColumnNameMapping(
-            mapOf("2" to "column2", "3" to "column3")
-        )
+        val chColumn1 = mockk<ClickHouseColumn>() { every { columnName } returns "column1" }
+        val chColumn2 = mockk<ClickHouseColumn>() { every { columnName } returns "column2" }
+        val tableSchemaWithoutAirbyteColumns =
+            listOf(
+                chColumn1,
+                chColumn2,
+            )
+        val columnNameMapping = ColumnNameMapping(mapOf("2" to "column2", "3" to "column3"))
         val properTableName = TableName("table", "name")
         val tempTableName = TableName("table", "tmp")
 
@@ -507,11 +503,13 @@ class ClickhouseAirbyteClientTest {
             tempTableName,
         )
 
-        verify { clickhouseSqlGenerator.copyTable(
-            ColumnNameMapping(mapOf("2" to "column2")),
-            properTableName,
-            tempTableName,
-        ) }
+        verify {
+            clickhouseSqlGenerator.copyTable(
+                ColumnNameMapping(mapOf("2" to "column2")),
+                properTableName,
+                tempTableName,
+            )
+        }
     }
 
     companion object {

--- a/airbyte-integrations/connectors/destination-clickhouse/src/test/kotlin/io/airbyte/integrations/destination/clickhouse/client/ClickhouseAirbyteClientTest.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/test/kotlin/io/airbyte/integrations/destination/clickhouse/client/ClickhouseAirbyteClientTest.kt
@@ -481,6 +481,39 @@ class ClickhouseAirbyteClientTest {
         Assertions.assertEquals(expected, actual)
     }
 
+    @Test
+    fun `test copyIntersectionColumn`() = runTest {
+        val chColumn1 = mockk<ClickHouseColumn>() {
+            every { columnName } returns "column1"
+        }
+        val chColumn2 = mockk<ClickHouseColumn>() {
+            every { columnName } returns "column2"
+        }
+        val tableSchemaWithoutAirbyteColumns = listOf(
+            chColumn1, chColumn2,
+        )
+        val columnNameMapping = ColumnNameMapping(
+            mapOf("2" to "column2", "3" to "column3")
+        )
+        val properTableName = TableName("table", "name")
+        val tempTableName = TableName("table", "tmp")
+
+        coEvery { clickhouseAirbyteClient.execute(any()) } returns mockk()
+
+        clickhouseAirbyteClient.copyIntersectionColumn(
+            tableSchemaWithoutAirbyteColumns,
+            columnNameMapping,
+            properTableName,
+            tempTableName,
+        )
+
+        verify { clickhouseSqlGenerator.copyTable(
+            ColumnNameMapping(mapOf("2" to "column2")),
+            properTableName,
+            tempTableName,
+        ) }
+    }
+
     companion object {
         // Constants
         private const val COL1 = "col1"

--- a/docs/integrations/destinations/clickhouse.md
+++ b/docs/integrations/destinations/clickhouse.md
@@ -95,6 +95,7 @@ You can also use a pre-existing user but we highly recommend creating a dedicate
 
 | Version | Date       | Pull Request                                               | Subject                                                                        |
 |:--------|:-----------|:-----------------------------------------------------------|:-------------------------------------------------------------------------------|
+| 2.0.7   | 2025-07-23 | [\#63751](https://github.com/airbytehq/airbyte/pull/63751) | Only copy intersection columns when there is a dedup change.                   |
 | 2.0.6   | 2025-07-22 | [\#63724](https://github.com/airbytehq/airbyte/pull/63724) | Apply clickhouse column name transformation for columns.                       |
 | 2.0.5   | 2025-07-22 | [\#63721](https://github.com/airbytehq/airbyte/pull/63721) | Fix schema change with PKs.                                                    |
 | 2.0.4   | 2025-07-21 | [\#62948](https://github.com/airbytehq/airbyte/pull/62948) | SSH support BETA.                                                              |


### PR DESCRIPTION
## What
When we are copying a table in case of a schema change related to a PK, we need to make sure that we copy only the intersection of the columns between the catalog schema and the existing table.

## How
<!--
* Describe how code changes achieve the solution.
-->

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
