### PR TITLE
Better error message for unexpected existing table

### DIFF
--- a/airbyte-integrations/connectors/destination-clickhouse/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-clickhouse/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: ce0d828e-1dc4-496c-b122-2da42e637e48
-  dockerImageTag: 2.0.7
+  dockerImageTag: 2.0.8
   dockerRepository: airbyte/destination-clickhouse
   githubIssueLabel: destination-clickhouse
   icon: clickhouse.svg

--- a/airbyte-integrations/connectors/destination-clickhouse/src/test/kotlin/io/airbyte/integrations/destination/clickhouse/client/ClickhouseAirbyteClientTest.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/test/kotlin/io/airbyte/integrations/destination/clickhouse/client/ClickhouseAirbyteClientTest.kt
@@ -6,7 +6,6 @@ package io.airbyte.integrations.destination.clickhouse.client
 
 import com.clickhouse.client.api.Client as ClickHouseClientRaw
 import com.clickhouse.client.api.command.CommandResponse
-import com.clickhouse.client.api.metadata.TableSchema
 import com.clickhouse.client.api.query.QueryResponse
 import com.clickhouse.data.ClickHouseColumn
 import com.clickhouse.data.ClickHouseDataType
@@ -342,12 +341,13 @@ class ClickhouseAirbyteClientTest {
     private fun mockCHSchemaWithAirbyteColumns() {
         every { client.getTableSchema(any(), any()) } returns
             mockk {
-                every { columns } returns  listOf(
-                    mockk { every { columnName } returns Meta.COLUMN_NAME_AB_RAW_ID },
-                    mockk { every { columnName } returns Meta.COLUMN_NAME_AB_EXTRACTED_AT },
-                    mockk { every { columnName } returns Meta.COLUMN_NAME_AB_META },
-                    mockk { every { columnName } returns Meta.COLUMN_NAME_AB_GENERATION_ID },
-                )
+                every { columns } returns
+                    listOf(
+                        mockk { every { columnName } returns Meta.COLUMN_NAME_AB_RAW_ID },
+                        mockk { every { columnName } returns Meta.COLUMN_NAME_AB_EXTRACTED_AT },
+                        mockk { every { columnName } returns Meta.COLUMN_NAME_AB_META },
+                        mockk { every { columnName } returns Meta.COLUMN_NAME_AB_GENERATION_ID },
+                    )
             }
     }
 
@@ -465,7 +465,9 @@ class ClickhouseAirbyteClientTest {
                     }
             }
 
-        assertThrows<ConfigErrorException> { clickhouseAirbyteClient.ensureSchemaMatches(stream, finalTableName, columnMapping) }
+        assertThrows<ConfigErrorException> {
+            clickhouseAirbyteClient.ensureSchemaMatches(stream, finalTableName, columnMapping)
+        }
     }
 
     @Test

--- a/airbyte-integrations/connectors/destination-clickhouse/src/test/kotlin/io/airbyte/integrations/destination/clickhouse/client/ClickhouseAirbyteClientTest.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/test/kotlin/io/airbyte/integrations/destination/clickhouse/client/ClickhouseAirbyteClientTest.kt
@@ -6,13 +6,16 @@ package io.airbyte.integrations.destination.clickhouse.client
 
 import com.clickhouse.client.api.Client as ClickHouseClientRaw
 import com.clickhouse.client.api.command.CommandResponse
+import com.clickhouse.client.api.metadata.TableSchema
 import com.clickhouse.client.api.query.QueryResponse
 import com.clickhouse.data.ClickHouseColumn
 import com.clickhouse.data.ClickHouseDataType
+import io.airbyte.cdk.ConfigErrorException
 import io.airbyte.cdk.load.command.Append
 import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.data.FieldType
 import io.airbyte.cdk.load.data.StringType
+import io.airbyte.cdk.load.message.Meta
 import io.airbyte.cdk.load.orchestration.db.ColumnNameMapping
 import io.airbyte.cdk.load.orchestration.db.TableName
 import io.airbyte.cdk.load.orchestration.db.TempTableNameGenerator
@@ -30,6 +33,7 @@ import java.util.concurrent.CompletableFuture
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 
 class ClickhouseAirbyteClientTest {
     // Mocks
@@ -335,6 +339,18 @@ class ClickhouseAirbyteClientTest {
         Assertions.assertEquals(expected4, actual4)
     }
 
+    private fun mockCHSchemaWithAirbyteColumns() {
+        every { client.getTableSchema(any(), any()) } returns
+            mockk {
+                every { columns } returns  listOf(
+                    mockk { every { columnName } returns Meta.COLUMN_NAME_AB_RAW_ID },
+                    mockk { every { columnName } returns Meta.COLUMN_NAME_AB_EXTRACTED_AT },
+                    mockk { every { columnName } returns Meta.COLUMN_NAME_AB_META },
+                    mockk { every { columnName } returns Meta.COLUMN_NAME_AB_GENERATION_ID },
+                )
+            }
+    }
+
     @Test
     fun `test ensure schema matches`() = runTest {
         val alterationSummary =
@@ -355,6 +371,8 @@ class ClickhouseAirbyteClientTest {
         coEvery { clickhouseAirbyteClient.execute(alterTableStatement) } returns
             mockk(relaxed = true)
         every { clickhouseFinalTableNameGenerator.getTableName(any()) } returns mockTableName
+
+        mockCHSchemaWithAirbyteColumns()
 
         val columnMapping = ColumnNameMapping(mapOf())
         val stream =
@@ -399,6 +417,8 @@ class ClickhouseAirbyteClientTest {
         every { tempTableNameGenerator.generate(any()) } returns tempTableName
         every { clickhouseFinalTableNameGenerator.getTableName(any()) } returns finalTableName
 
+        mockCHSchemaWithAirbyteColumns()
+
         val columnMapping = ColumnNameMapping(mapOf())
         val stream =
             mockk<DestinationStream>() {
@@ -427,6 +447,25 @@ class ClickhouseAirbyteClientTest {
             clickhouseSqlGenerator.dropTable(tempTableName)
         }
         coVerify(exactly = 5) { clickhouseAirbyteClient.execute(any()) }
+    }
+
+    @Test
+    fun `test ensure schema matches fails if no airbyte columns`() = runTest {
+        val finalTableName = TableName("fin", "al")
+
+        every { clickhouseFinalTableNameGenerator.getTableName(any()) } returns finalTableName
+
+        val columnMapping = ColumnNameMapping(mapOf())
+        val stream =
+            mockk<DestinationStream>() {
+                every { mappedDescriptor } returns
+                    mockk(relaxed = true) {
+                        every { name } returns "my_table"
+                        every { namespace } returns "my_namespace"
+                    }
+            }
+
+        assertThrows<ConfigErrorException> { clickhouseAirbyteClient.ensureSchemaMatches(stream, finalTableName, columnMapping) }
     }
 
     @Test

--- a/docs/integrations/destinations/clickhouse.md
+++ b/docs/integrations/destinations/clickhouse.md
@@ -95,6 +95,7 @@ You can also use a pre-existing user but we highly recommend creating a dedicate
 
 | Version | Date       | Pull Request                                               | Subject                                                                        |
 |:--------|:-----------|:-----------------------------------------------------------|:-------------------------------------------------------------------------------|
+| 2.0.8   | 2025-07-23 | [\#63760](https://github.com/airbytehq/airbyte/pull/63760) | Throw an error if an invalid target table exist before the first sync.         |
 | 2.0.7   | 2025-07-23 | [\#63751](https://github.com/airbytehq/airbyte/pull/63751) | Only copy intersection columns when there is a dedup change.                   |
 | 2.0.6   | 2025-07-22 | [\#63724](https://github.com/airbytehq/airbyte/pull/63724) | Apply clickhouse column name transformation for columns.                       |
 | 2.0.5   | 2025-07-22 | [\#63721](https://github.com/airbytehq/airbyte/pull/63721) | Fix schema change with PKs.                                                    |


### PR DESCRIPTION
## What
Some connections are targeting an existing table which doesn't contains the airbyte columns. This PR is making the connection to fail and prevent retries as well as providing a better error message.

## How
<!--
* Describe how code changes achieve the solution.
-->

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._