### PR TITLE
proposal: slow migration

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/check/CheckOperationV2.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/check/CheckOperationV2.kt
@@ -1,11 +1,6 @@
-/*
- * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
- */
-
 package io.airbyte.cdk.load.check
 
 import io.airbyte.cdk.Operation
-import io.airbyte.cdk.load.command.DestinationConfiguration
 import io.airbyte.cdk.output.ExceptionHandler
 import io.airbyte.cdk.output.OutputConsumer
 import io.airbyte.protocol.models.v0.AirbyteConnectionStatus
@@ -18,17 +13,16 @@ private val logger = KotlinLogging.logger {}
 
 @Singleton
 @Requires(property = Operation.PROPERTY, value = "check")
-@Requires(missingProperty = "airbyte.destination.core.load.check.version")
+@Requires(property = "airbyte.destination.core.load.check.version", value = "v2")
 @Requires(env = ["destination"])
-class CheckOperation<C : DestinationConfiguration>(
-    val config: C,
-    val destinationChecker: DestinationChecker<C>,
+class CheckOperationV2(
+    val destinationChecker: DestinationCheckerV2,
     private val exceptionHandler: ExceptionHandler,
     private val outputConsumer: OutputConsumer,
-) : Operation {
+)  : Operation {
     override fun execute() {
         try {
-            destinationChecker.check(config)
+            destinationChecker.check()
             val successMessage =
                 AirbyteMessage()
                     .withType(AirbyteMessage.Type.CONNECTION_STATUS)
@@ -41,7 +35,7 @@ class CheckOperation<C : DestinationConfiguration>(
             logger.warn(t) { "Caught throwable during CHECK" }
             handleException(t)
         } finally {
-            destinationChecker.cleanup(config)
+            destinationChecker.cleanup()
         }
     }
 

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/check/DestinationCheckerV2.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/check/DestinationCheckerV2.kt
@@ -1,0 +1,7 @@
+package io.airbyte.cdk.load.check
+
+
+interface DestinationCheckerV2 {
+    fun check()
+    fun cleanup() {}
+}

--- a/airbyte-cdk/bulk/toolkits/load-low-code/src/main/kotlin/io/airbyte/cdk/load/checker/CompositeDlqChecker.kt
+++ b/airbyte-cdk/bulk/toolkits/load-low-code/src/main/kotlin/io/airbyte/cdk/load/checker/CompositeDlqChecker.kt
@@ -4,17 +4,17 @@
 
 package io.airbyte.cdk.load.checker
 
-import io.airbyte.cdk.load.check.DestinationChecker
+import io.airbyte.cdk.load.check.DestinationCheckerV2
 import io.airbyte.cdk.load.check.dlq.DlqChecker
-import io.airbyte.cdk.load.command.DestinationConfiguration
-import io.airbyte.cdk.load.command.dlq.ObjectStorageConfigProvider
+import io.airbyte.cdk.load.command.dlq.ObjectStorageConfig
 
-class CompositeDlqChecker<C>(
-    private val decorated: DestinationChecker<C>,
-    private val dlqChecker: DlqChecker
-) : DestinationChecker<C> where C : DestinationConfiguration, C : ObjectStorageConfigProvider {
-    override fun check(config: C) {
-        decorated.check(config)
-        dlqChecker.check(config.objectStorageConfig)
+class CompositeDlqChecker(
+    private val decorated: DestinationCheckerV2,
+    private val dlqChecker: DlqChecker,
+    private val dlqConfig: ObjectStorageConfig,
+) : DestinationCheckerV2 {
+    override fun check() {
+        decorated.check()
+        dlqChecker.check(dlqConfig)
     }
 }

--- a/airbyte-cdk/bulk/toolkits/load-low-code/src/main/kotlin/io/airbyte/cdk/load/checker/HttpRequestChecker.kt
+++ b/airbyte-cdk/bulk/toolkits/load-low-code/src/main/kotlin/io/airbyte/cdk/load/checker/HttpRequestChecker.kt
@@ -4,14 +4,13 @@
 
 package io.airbyte.cdk.load.checker
 
-import io.airbyte.cdk.load.check.DestinationChecker
-import io.airbyte.cdk.load.command.DestinationConfiguration
+import io.airbyte.cdk.load.check.DestinationCheckerV2
 import io.airbyte.cdk.load.http.HttpRequester
 import io.airbyte.cdk.load.http.consumeBodyToString
 
-class HttpRequestChecker<C : DestinationConfiguration>(private val requester: HttpRequester) :
-    DestinationChecker<C> {
-    override fun check(config: C) {
+class HttpRequestChecker(private val requester: HttpRequester) :
+    DestinationCheckerV2 {
+    override fun check() {
         val response = requester.send()
         response.use {
             if (it.statusCode != 200) {

--- a/airbyte-cdk/bulk/toolkits/load-low-code/src/main/kotlin/io/airbyte/cdk/load/lowcode/DeclarativeDestinationFactory.kt
+++ b/airbyte-cdk/bulk/toolkits/load-low-code/src/main/kotlin/io/airbyte/cdk/load/lowcode/DeclarativeDestinationFactory.kt
@@ -31,16 +31,15 @@ import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 
 class DeclarativeDestinationFactory<T>(private val config: T) where
-T : DestinationConfiguration,
 T : ObjectStorageConfigProvider {
     private val stringInterpolator: StringInterpolator = StringInterpolator()
 
-    fun createDestinationChecker(dlqChecker: DlqChecker): CompositeDlqChecker<T> {
+    fun createDestinationChecker(dlqChecker: DlqChecker): CompositeDlqChecker {
         val mapper = ObjectMapper(YAMLFactory())
         val manifestContent = ResourceUtils.readResource("manifest.yaml")
         val manifest: DeclarativeDestinationModel =
             mapper.readValue(manifestContent, DeclarativeDestinationModel::class.java)
-        return CompositeDlqChecker(createChecker(manifest.checker), dlqChecker)
+        return CompositeDlqChecker(createChecker(manifest.checker), dlqChecker, config.objectStorageConfig)
     }
 
     private fun createAuthenticator(
@@ -53,7 +52,7 @@ T : ObjectStorageConfigProvider {
 
     private fun createChecker(
         model: CheckerModel,
-    ): HttpRequestChecker<T> =
+    ): HttpRequestChecker =
         when (model) {
             is HttpRequestCheckerModel -> HttpRequestChecker(model.requester.toRequester())
         }

--- a/airbyte-integrations/connectors/destination-customer-io/src/main/kotlin/CustomerIoBeanFactory.kt
+++ b/airbyte-integrations/connectors/destination-customer-io/src/main/kotlin/CustomerIoBeanFactory.kt
@@ -5,7 +5,7 @@
 package io.airbyte.integrations.destination.customerio
 
 import dev.failsafe.RetryPolicy
-import io.airbyte.cdk.load.check.DestinationChecker
+import io.airbyte.cdk.load.check.DestinationCheckerV2
 import io.airbyte.cdk.load.check.dlq.DlqChecker
 import io.airbyte.cdk.load.command.DestinationCatalog
 import io.airbyte.cdk.load.command.DestinationConfiguration
@@ -26,7 +26,7 @@ class CustomerIoBeanFactory {
     fun check(
         factory: DeclarativeDestinationFactory<CustomerIoConfiguration>,
         checker: DlqChecker,
-    ): DestinationChecker<CustomerIoConfiguration> = factory.createDestinationChecker(checker)
+    ): DestinationCheckerV2 = factory.createDestinationChecker(checker)
 
     @Singleton
     fun factory(

--- a/airbyte-integrations/connectors/destination-customer-io/src/main/resources/application-connector.yaml
+++ b/airbyte-integrations/connectors/destination-customer-io/src/main/resources/application-connector.yaml
@@ -1,0 +1,6 @@
+airbyte:
+  destination:
+    core:
+      load:
+        check:
+          version: v2


### PR DESCRIPTION
## What
We assume that the cleanup of the spec/config in the Bulk CDK will require a breaking change. We have a couple of options here:
* Migrate all the destinations at the same time
* Allow a slow migration through feature flags
* Lie down and cry

This PR proposes a way to introduce feature flags.

As for the breaking change, the proposal is to have the config never be exposed to the Operations. The design would look like this:
<img width="666" height="557" alt="image" src="https://github.com/user-attachments/assets/9f728de0-f037-46d1-bc8b-d1d44bed6487" />

Example of spec and config implementation:
```
interface DestinationSpec(private val klazz: : Class<T>, private val advancedAuth) {
  fun connectionSpecification(): JsonNode = ValidatedJsonUtils.generateAirbyteJsonSchema(klazz)
  fun advancedAuth(): AdvancedAuth = advancedAuth
}

class KotlinSpec(private val klazz: : Class<T>, private val advancedAuth): DestinationSpec {
  fun connectionSpecification(): JsonNode = ValidatedJsonUtils.generateAirbyteJsonSchema(klazz)
  fun advancedAuth(): AdvancedAuth = advancedAuth

class LowCodeSpec(private val specFromYamlDefinition: JsonNode): DestinationSpec {
  fun connectionSpecification(): JsonNode = specFromYamlDefinition.get("connection_specification")
  fun advancedAuth(): AdvancedAuth = <assemble object from specFromYamlDefinition.get("advanced_auth")>

// Example that would use KotlinSpec (which is basically our current XSpecification files)
class ExampleDestinationConfig {
    @get:JsonSchemaTitle("Site ID")
    @get:JsonPropertyDescription(
        """Enter your Customer IO <a href="https://docs.customer.io/integrations/sdk/ios/getting-started/auth/#get-your-api-key">Site ID</a>.""",
    )
    @get:JsonSchemaInject(json = """{"airbyte_secret": true,"always_show": true,"order":1}""")
    val siteId: String = ""
}
```

The config would just be used to instantiate components and not actually pass the layer of the dependency injection. If things needs to be dynamically instantiated (which they already are [here](https://github.com/airbytehq/airbyte/blob/bbd4759c1052fb5927a336933df0c02fd06ff5cb/airbyte-cdk/bulk/core/base/src/main/kotlin/io/airbyte/cdk/AirbyteConnectorRunnable.kt#L29) but let's say they need to be even more dynamically instantiated), they can rely on a factory to be called in the components.

## How
Using Micronaut properties and `@Requires` annotation to decide which operations we instantiate

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
