### PR TITLE
Rename state as a CDK state to avoid confusion

### DIFF
--- a/airbyte-cdk/bulk/build.gradle
+++ b/airbyte-cdk/bulk/build.gradle
@@ -1,5 +1,5 @@
 allprojects {
-    version = "0.1.0"
+    version = "0.1.1"
     apply plugin: 'java-library'
     apply plugin: 'maven-publish'
 

--- a/airbyte-cdk/bulk/changelog.md
+++ b/airbyte-cdk/bulk/changelog.md
@@ -1,4 +1,9 @@
 ## Version 0.1.0
 
+* **Changed:** Rename cdk `State` classes to `CdkState`.
+
+
+## Version 0.1.0
+
 * **Changed:** Adopted Semantic Versioning (SemVer) for the CDK to provide more meaningful version numbers.
 * **Action Required:** The CDK version must now be set manually in the `build.gradle` file.

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/BatchCdkState.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/BatchCdkState.kt
@@ -8,15 +8,15 @@ package io.airbyte.cdk.load.message
  * Represents the state of a batch of records as it moves through processing. These are generic
  * stages for bookkeeping, which CDK interface devs can assign to processing stages as they see fit.
  * The only significant values are
- * - [BatchState.PERSISTED] Records will be considered recoverably persisted and checkpoints will be
- * acked to the orchestrator.
- * - [BatchState.COMPLETE] All per-batch processing is done. (Post-processing may still occur during
- * close-of-stream). Records are considered PERSISTED (ie, will be acked if not already). If all
- * records are COMPLETE, and end-of-stream has been read, the stream will be considered complete and
- * will be closed.
+ * - [BatchCdkState.PERSISTED] Records will be considered recoverably persisted and checkpoints will
+ * be acked to the orchestrator.
+ * - [BatchCdkState.COMPLETE] All per-batch processing is done. (Post-processing may still occur
+ * during close-of-stream). Records are considered PERSISTED (ie, will be acked if not already). If
+ * all records are COMPLETE, and end-of-stream has been read, the stream will be considered complete
+ * and will be closed.
  * - All other values are for bookkeeping convenience only.
  */
-enum class BatchState {
+enum class BatchCdkState {
     PROCESSED, // records have been seen and transformed/formatted/validated (ie, create a part)
     STAGED, // staged locally or remotely-but-not-yet-complete (ie, partial multi-part upload)
     LOADED, // staged remotely but in a non-recoverable way (ie, a remote object in bulk load)

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/WithBatchState.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/message/WithBatchState.kt
@@ -11,5 +11,5 @@ package io.airbyte.cdk.load.message
  * internal state.
  */
 interface WithBatchState {
-    val state: BatchState
+    val state: BatchCdkState
 }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/pipeline/BatchCdkStateUpdate.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/pipeline/BatchCdkStateUpdate.kt
@@ -5,7 +5,7 @@
 package io.airbyte.cdk.load.pipeline
 
 import io.airbyte.cdk.load.command.DestinationStream
-import io.airbyte.cdk.load.message.BatchState
+import io.airbyte.cdk.load.message.BatchCdkState
 import io.airbyte.cdk.load.state.CheckpointId
 import io.airbyte.cdk.load.state.CheckpointValue
 
@@ -16,10 +16,10 @@ sealed interface BatchUpdate {
     val part: Int
 }
 
-data class BatchStateUpdate(
+data class BatchCdkStateUpdate(
     override val stream: DestinationStream.Descriptor,
     val checkpointCounts: Map<CheckpointId, CheckpointValue>,
-    val state: BatchState,
+    val cdkState: BatchCdkState,
     override val taskName: String,
     override val part: Int,
     val inputCount: Long = 0L

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/pipeline/DirectLoadRecordAccumulator.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/pipeline/DirectLoadRecordAccumulator.kt
@@ -4,7 +4,7 @@
 
 package io.airbyte.cdk.load.pipeline
 
-import io.airbyte.cdk.load.message.BatchState
+import io.airbyte.cdk.load.message.BatchCdkState
 import io.airbyte.cdk.load.message.DestinationRecordRaw
 import io.airbyte.cdk.load.message.WithBatchState
 import io.airbyte.cdk.load.message.WithStream
@@ -14,7 +14,7 @@ import io.airbyte.cdk.load.write.DirectLoaderFactory
 import io.micronaut.context.annotation.Requires
 import jakarta.inject.Singleton
 
-data class DirectLoadAccResult(override val state: BatchState) : WithBatchState
+data class DirectLoadAccResult(override val state: BatchCdkState) : WithBatchState
 
 /**
  * Used internally by the CDK to wrap the client-provided DirectLoader in a generic
@@ -37,13 +37,13 @@ class DirectLoadRecordAccumulator<S : DirectLoader, K : WithStream>(
         state.accept(input).let {
             return when (it) {
                 is Incomplete -> NoOutput(state)
-                is Complete -> FinalOutput(DirectLoadAccResult(BatchState.COMPLETE))
+                is Complete -> FinalOutput(DirectLoadAccResult(BatchCdkState.COMPLETE))
             }
         }
     }
 
     override suspend fun finish(state: S): FinalOutput<S, DirectLoadAccResult> {
         state.finish()
-        return FinalOutput(DirectLoadAccResult(BatchState.COMPLETE))
+        return FinalOutput(DirectLoadAccResult(BatchCdkState.COMPLETE))
     }
 }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/DestinationTaskLauncher.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/DestinationTaskLauncher.kt
@@ -21,7 +21,7 @@ import io.airbyte.cdk.load.task.implementor.TeardownTaskFactory
 import io.airbyte.cdk.load.task.internal.HeartbeatTask
 import io.airbyte.cdk.load.task.internal.InputConsumerTask
 import io.airbyte.cdk.load.task.internal.StatsEmitter
-import io.airbyte.cdk.load.task.internal.UpdateBatchStateTaskFactory
+import io.airbyte.cdk.load.task.internal.UpdateBatchCdkStateTaskFactory
 import io.airbyte.cdk.load.task.internal.UpdateCheckpointsTask
 import io.airbyte.cdk.load.util.setOnce
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -76,7 +76,7 @@ class DestinationTaskLauncher(
     // Internal Tasks
     private val inputConsumerTask: InputConsumerTask? = null,
     private val heartbeatTask: HeartbeatTask? = null,
-    private val updateBatchTask: UpdateBatchStateTaskFactory,
+    private val updateBatchTask: UpdateBatchCdkStateTaskFactory,
     private val statsEmitter: StatsEmitter? = null,
 
     // Implementor Tasks

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/LoadPipelineStepTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/LoadPipelineStepTask.kt
@@ -19,8 +19,8 @@ import io.airbyte.cdk.load.message.StreamKey
 import io.airbyte.cdk.load.message.WithBatchState
 import io.airbyte.cdk.load.message.WithStream
 import io.airbyte.cdk.load.pipeline.BatchAccumulator
+import io.airbyte.cdk.load.pipeline.BatchCdkStateUpdate
 import io.airbyte.cdk.load.pipeline.BatchEndOfStream
-import io.airbyte.cdk.load.pipeline.BatchStateUpdate
 import io.airbyte.cdk.load.pipeline.BatchUpdate
 import io.airbyte.cdk.load.pipeline.OutputPartitioner
 import io.airbyte.cdk.load.pipeline.PipelineFlushStrategy
@@ -312,10 +312,10 @@ class LoadPipelineStepTask<S : AutoCloseable, K1 : WithStream, T, K2 : WithStrea
         // If the output contained a global batch state, publish an update.
         if (output is WithBatchState) {
             val update =
-                BatchStateUpdate(
+                BatchCdkStateUpdate(
                     stream = inputKey.stream,
                     checkpointCounts = checkpointCounts.toMap(),
-                    state = output.state,
+                    cdkState = output.state,
                     taskName = stepId,
                     part = part,
                     inputCount = inputCount

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/LoadPipelineStepTask.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/task/internal/LoadPipelineStepTask.kt
@@ -110,7 +110,9 @@ class LoadPipelineStepTask<S : AutoCloseable, K1 : WithStream, T, K2 : WithStrea
                             ) {
                                 // Pick the key with the highest input count
                                 val (key, state) =
-                                    stateStore.cdkStateWithCounts.maxByOrNull { it.value.inputCount }!!
+                                    stateStore.cdkStateWithCounts.maxByOrNull {
+                                        it.value.inputCount
+                                    }!!
                                 stateStore.cdkStateWithCounts.remove(key)
                                 log.info {
                                     "Saw greater than $maxNumConcurrentKeys keys, evicting highest accumulating $key (inputs=${state.inputCount})"
@@ -150,7 +152,8 @@ class LoadPipelineStepTask<S : AutoCloseable, K1 : WithStream, T, K2 : WithStrea
                             it()
                         } // TODO: Accumulate and release when persisted
                         input.checkpointCounts.forEach {
-                            cdkStateWithCounts.checkpointCounts.merge(it.key, it.value) { old, new ->
+                            cdkStateWithCounts.checkpointCounts.merge(it.key, it.value) { old, new
+                                ->
                                 old.plus(new)
                             }
                         }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/write/StreamCdkStateStore.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/write/StreamCdkStateStore.kt
@@ -14,7 +14,7 @@ import java.util.concurrent.ConcurrentHashMap
  * for making state generated during initialization generally available to the Loaders.
  */
 @Singleton
-class StreamStateStore<S> {
+class StreamCdkStateStore<S> {
     private val store = ConcurrentHashMap<DestinationStream.Descriptor, S>()
 
     fun put(stream: DestinationStream.Descriptor, state: S) {

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/state/StreamManagerTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/state/StreamManagerTest.kt
@@ -6,7 +6,7 @@ package io.airbyte.cdk.load.state
 
 import io.airbyte.cdk.load.command.MockDestinationCatalogFactory.Companion.stream1
 import io.airbyte.cdk.load.command.MockDestinationCatalogFactory.Companion.stream2
-import io.airbyte.cdk.load.message.BatchState
+import io.airbyte.cdk.load.message.BatchCdkState
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -128,12 +128,12 @@ class StreamManagerTest {
 
         Assertions.assertFalse(manager.areRecordsPersistedForCheckpoint(checkpointId))
         manager.incrementCheckpointCounts(
-            BatchState.PERSISTED,
+            BatchCdkState.PERSISTED,
             mapOf(checkpointId to CheckpointValue(5, 5)),
         )
         Assertions.assertFalse(manager.areRecordsPersistedForCheckpoint(checkpointId))
         manager.incrementCheckpointCounts(
-            BatchState.PERSISTED,
+            BatchCdkState.PERSISTED,
             mapOf(checkpointId to CheckpointValue(5, 5)),
         )
         Assertions.assertTrue(manager.areRecordsPersistedForCheckpoint(checkpointId))
@@ -149,7 +149,7 @@ class StreamManagerTest {
 
         Assertions.assertFalse(manager.areRecordsPersistedForCheckpoint(checkpointId))
         manager.incrementCheckpointCounts(
-            BatchState.PERSISTED,
+            BatchCdkState.PERSISTED,
             mapOf(
                 checkpointId to
                     CheckpointValue(
@@ -161,7 +161,7 @@ class StreamManagerTest {
         )
         Assertions.assertFalse(manager.areRecordsPersistedForCheckpoint(checkpointId))
         manager.incrementCheckpointCounts(
-            BatchState.PERSISTED,
+            BatchCdkState.PERSISTED,
             mapOf(
                 checkpointId to
                     CheckpointValue(
@@ -190,14 +190,14 @@ class StreamManagerTest {
         Assertions.assertFalse(manager.areRecordsPersistedForCheckpoint(checkpointId2))
 
         manager.incrementCheckpointCounts(
-            BatchState.PERSISTED,
+            BatchCdkState.PERSISTED,
             mapOf(checkpointId1 to CheckpointValue(10, 10)),
         )
         Assertions.assertTrue(manager.areRecordsPersistedForCheckpoint(checkpointId1))
         Assertions.assertFalse(manager.areRecordsPersistedForCheckpoint(checkpointId2))
 
         manager.incrementCheckpointCounts(
-            BatchState.PERSISTED,
+            BatchCdkState.PERSISTED,
             mapOf(checkpointId2 to CheckpointValue(15, 15)),
         )
         Assertions.assertTrue(manager.areRecordsPersistedForCheckpoint(checkpointId1))
@@ -222,14 +222,14 @@ class StreamManagerTest {
         Assertions.assertFalse(manager.areRecordsPersistedForCheckpoint(checkpointId2))
 
         manager.incrementCheckpointCounts(
-            BatchState.PERSISTED,
+            BatchCdkState.PERSISTED,
             mapOf(checkpointId2 to CheckpointValue(15, 15)),
         )
         Assertions.assertFalse(manager.areRecordsPersistedForCheckpoint(checkpointId1))
         Assertions.assertTrue(manager.areRecordsPersistedForCheckpoint(checkpointId2))
 
         manager.incrementCheckpointCounts(
-            BatchState.PERSISTED,
+            BatchCdkState.PERSISTED,
             mapOf(checkpointId1 to CheckpointValue(10, 10)),
         )
         Assertions.assertTrue(manager.areRecordsPersistedForCheckpoint(checkpointId1))
@@ -247,19 +247,19 @@ class StreamManagerTest {
 
         Assertions.assertFalse(manager.areRecordsPersistedForCheckpoint(checkpointId1))
         manager.incrementCheckpointCounts(
-            BatchState.COMPLETE,
+            BatchCdkState.COMPLETE,
             mapOf(checkpointId1 to CheckpointValue(4, 4)),
         )
         Assertions.assertFalse(manager.areRecordsPersistedForCheckpoint(checkpointId1))
         manager.incrementCheckpointCounts(
-            BatchState.COMPLETE,
+            BatchCdkState.COMPLETE,
             mapOf(checkpointId1 to CheckpointValue(6, 6)),
         )
         Assertions.assertTrue(manager.areRecordsPersistedForCheckpoint(checkpointId1))
 
         // Can still count persisted (but without effect)
         manager.incrementCheckpointCounts(
-            BatchState.PERSISTED,
+            BatchCdkState.PERSISTED,
             mapOf(checkpointId1 to CheckpointValue(10, 10)),
         )
         Assertions.assertTrue(manager.areRecordsPersistedForCheckpoint(checkpointId1))
@@ -293,7 +293,7 @@ class StreamManagerTest {
                 when (step) {
                     "1" ->
                         manager.incrementCheckpointCounts(
-                            BatchState.COMPLETE,
+                            BatchCdkState.COMPLETE,
                             mapOf(
                                 checkpointId1 to
                                     CheckpointValue(
@@ -305,7 +305,7 @@ class StreamManagerTest {
                         )
                     "2" ->
                         manager.incrementCheckpointCounts(
-                            BatchState.COMPLETE,
+                            BatchCdkState.COMPLETE,
                             mapOf(checkpointId2 to CheckpointValue(20, 20)),
                         )
                     "end" -> manager.markEndOfStream(true)
@@ -333,7 +333,7 @@ class StreamManagerTest {
 
         repeat(10) { manager1.incrementReadCount() }
         manager1.incrementCheckpointCounts(
-            BatchState.PERSISTED,
+            BatchCdkState.PERSISTED,
             mapOf(manager1.inferNextCheckpointKey().checkpointId to CheckpointValue(10, 10)),
         )
         assertDoesNotThrow { manager1.markCheckpoint() }

--- a/airbyte-cdk/bulk/toolkits/load-db/src/main/kotlin/io/airbyte/cdk/load/orchestration/db/direct_load_table/DirectLoadTableStreamLoader.kt
+++ b/airbyte-cdk/bulk/toolkits/load-db/src/main/kotlin/io/airbyte/cdk/load/orchestration/db/direct_load_table/DirectLoadTableStreamLoader.kt
@@ -9,8 +9,8 @@ import io.airbyte.cdk.load.orchestration.db.ColumnNameMapping
 import io.airbyte.cdk.load.orchestration.db.TableName
 import io.airbyte.cdk.load.orchestration.db.TempTableNameGenerator
 import io.airbyte.cdk.load.state.StreamProcessingFailed
-import io.airbyte.cdk.load.write.StreamLoader
 import io.airbyte.cdk.load.write.StreamCdkStateStore
+import io.airbyte.cdk.load.write.StreamLoader
 import io.github.oshai.kotlinlogging.KotlinLogging
 
 private val logger = KotlinLogging.logger {}
@@ -54,7 +54,10 @@ class DirectLoadTableAppendStreamLoader(
             sqlTableOperations.dropTable(tempTableName)
         }
 
-        streamCdkStateStore.put(stream.mappedDescriptor, DirectLoadTableExecutionConfig(realTableName))
+        streamCdkStateStore.put(
+            stream.mappedDescriptor,
+            DirectLoadTableExecutionConfig(realTableName)
+        )
     }
 
     override suspend fun close(hadNonzeroRecords: Boolean, streamFailure: StreamProcessingFailed?) {
@@ -92,7 +95,10 @@ class DirectLoadTableDedupStreamLoader(
             sqlTableOperations.createTable(stream, tempTableName, columnNameMapping, replace = true)
         }
 
-        streamCdkStateStore.put(stream.mappedDescriptor, DirectLoadTableExecutionConfig(tempTableName))
+        streamCdkStateStore.put(
+            stream.mappedDescriptor,
+            DirectLoadTableExecutionConfig(tempTableName)
+        )
     }
 
     override suspend fun close(hadNonzeroRecords: Boolean, streamFailure: StreamProcessingFailed?) {
@@ -304,7 +310,10 @@ class DirectLoadTableDedupTruncateStreamLoader(
             shouldCheckRealTableGeneration = true
         }
 
-        streamCdkStateStore.put(stream.mappedDescriptor, DirectLoadTableExecutionConfig(tempTableName))
+        streamCdkStateStore.put(
+            stream.mappedDescriptor,
+            DirectLoadTableExecutionConfig(tempTableName)
+        )
     }
 
     override suspend fun close(hadNonzeroRecords: Boolean, streamFailure: StreamProcessingFailed?) {

--- a/airbyte-cdk/bulk/toolkits/load-db/src/main/kotlin/io/airbyte/cdk/load/orchestration/db/direct_load_table/DirectLoadTableWriter.kt
+++ b/airbyte-cdk/bulk/toolkits/load-db/src/main/kotlin/io/airbyte/cdk/load/orchestration/db/direct_load_table/DirectLoadTableWriter.kt
@@ -14,8 +14,8 @@ import io.airbyte.cdk.load.orchestration.db.DatabaseInitialStatusGatherer
 import io.airbyte.cdk.load.orchestration.db.TempTableNameGenerator
 import io.airbyte.cdk.load.orchestration.db.legacy_typing_deduping.TableCatalog
 import io.airbyte.cdk.load.write.DestinationWriter
-import io.airbyte.cdk.load.write.StreamLoader
 import io.airbyte.cdk.load.write.StreamCdkStateStore
+import io.airbyte.cdk.load.write.StreamLoader
 
 /**
  * @param directLoadTableTempTableNameMigration Iff you are implementing a destination which
@@ -23,14 +23,14 @@ import io.airbyte.cdk.load.write.StreamCdkStateStore
  * with `_airbyte_tmp`), you MUST provide this object.
  */
 class DirectLoadTableWriter(
-  private val internalNamespace: String,
-  private val names: TableCatalog,
-  private val stateGatherer: DatabaseInitialStatusGatherer<DirectLoadInitialStatus>,
-  private val destinationHandler: DatabaseHandler,
-  private val nativeTableOperations: DirectLoadTableNativeOperations,
-  private val sqlTableOperations: DirectLoadTableSqlOperations,
-  private val streamCdkStateStore: StreamCdkStateStore<DirectLoadTableExecutionConfig>,
-  private val tempTableNameGenerator: TempTableNameGenerator,
+    private val internalNamespace: String,
+    private val names: TableCatalog,
+    private val stateGatherer: DatabaseInitialStatusGatherer<DirectLoadInitialStatus>,
+    private val destinationHandler: DatabaseHandler,
+    private val nativeTableOperations: DirectLoadTableNativeOperations,
+    private val sqlTableOperations: DirectLoadTableSqlOperations,
+    private val streamCdkStateStore: StreamCdkStateStore<DirectLoadTableExecutionConfig>,
+    private val tempTableNameGenerator: TempTableNameGenerator,
 ) : DestinationWriter {
     private lateinit var initialStatuses: Map<DestinationStream, DirectLoadInitialStatus>
     override suspend fun setup() {

--- a/airbyte-cdk/bulk/toolkits/load-db/src/main/kotlin/io/airbyte/cdk/load/orchestration/db/direct_load_table/DirectLoadTableWriter.kt
+++ b/airbyte-cdk/bulk/toolkits/load-db/src/main/kotlin/io/airbyte/cdk/load/orchestration/db/direct_load_table/DirectLoadTableWriter.kt
@@ -15,7 +15,7 @@ import io.airbyte.cdk.load.orchestration.db.TempTableNameGenerator
 import io.airbyte.cdk.load.orchestration.db.legacy_typing_deduping.TableCatalog
 import io.airbyte.cdk.load.write.DestinationWriter
 import io.airbyte.cdk.load.write.StreamLoader
-import io.airbyte.cdk.load.write.StreamStateStore
+import io.airbyte.cdk.load.write.StreamCdkStateStore
 
 /**
  * @param directLoadTableTempTableNameMigration Iff you are implementing a destination which
@@ -23,14 +23,14 @@ import io.airbyte.cdk.load.write.StreamStateStore
  * with `_airbyte_tmp`), you MUST provide this object.
  */
 class DirectLoadTableWriter(
-    private val internalNamespace: String,
-    private val names: TableCatalog,
-    private val stateGatherer: DatabaseInitialStatusGatherer<DirectLoadInitialStatus>,
-    private val destinationHandler: DatabaseHandler,
-    private val nativeTableOperations: DirectLoadTableNativeOperations,
-    private val sqlTableOperations: DirectLoadTableSqlOperations,
-    private val streamStateStore: StreamStateStore<DirectLoadTableExecutionConfig>,
-    private val tempTableNameGenerator: TempTableNameGenerator,
+  private val internalNamespace: String,
+  private val names: TableCatalog,
+  private val stateGatherer: DatabaseInitialStatusGatherer<DirectLoadInitialStatus>,
+  private val destinationHandler: DatabaseHandler,
+  private val nativeTableOperations: DirectLoadTableNativeOperations,
+  private val sqlTableOperations: DirectLoadTableSqlOperations,
+  private val streamCdkStateStore: StreamCdkStateStore<DirectLoadTableExecutionConfig>,
+  private val tempTableNameGenerator: TempTableNameGenerator,
 ) : DestinationWriter {
     private lateinit var initialStatuses: Map<DestinationStream, DirectLoadInitialStatus>
     override suspend fun setup() {
@@ -60,7 +60,7 @@ class DirectLoadTableWriter(
                             columnNameMapping,
                             nativeTableOperations,
                             sqlTableOperations,
-                            streamStateStore,
+                            streamCdkStateStore,
                         )
                     is Dedupe ->
                         DirectLoadTableDedupStreamLoader(
@@ -71,7 +71,7 @@ class DirectLoadTableWriter(
                             columnNameMapping,
                             nativeTableOperations,
                             sqlTableOperations,
-                            streamStateStore,
+                            streamCdkStateStore,
                         )
                     else -> throw SystemErrorException("Unsupported Sync Mode: $this")
                 }
@@ -87,7 +87,7 @@ class DirectLoadTableWriter(
                             columnNameMapping,
                             nativeTableOperations,
                             sqlTableOperations,
-                            streamStateStore,
+                            streamCdkStateStore,
                         )
                     is Dedupe ->
                         DirectLoadTableDedupTruncateStreamLoader(
@@ -98,7 +98,7 @@ class DirectLoadTableWriter(
                             columnNameMapping,
                             nativeTableOperations,
                             sqlTableOperations,
-                            streamStateStore,
+                            streamCdkStateStore,
                             tempTableNameGenerator,
                         )
                     else -> throw SystemErrorException("Unsupported Sync Mode: $this")

--- a/airbyte-cdk/bulk/toolkits/load-db/src/main/kotlin/io/airbyte/cdk/load/orchestration/db/legacy_typing_deduping/TypingDedupingStreamLoader.kt
+++ b/airbyte-cdk/bulk/toolkits/load-db/src/main/kotlin/io/airbyte/cdk/load/orchestration/db/legacy_typing_deduping/TypingDedupingStreamLoader.kt
@@ -10,22 +10,22 @@ import io.airbyte.cdk.load.orchestration.db.TableNames
 import io.airbyte.cdk.load.orchestration.db.TableNames.Companion.NO_SUFFIX
 import io.airbyte.cdk.load.orchestration.db.TableNames.Companion.TMP_TABLE_SUFFIX
 import io.airbyte.cdk.load.state.StreamProcessingFailed
-import io.airbyte.cdk.load.write.StreamLoader
 import io.airbyte.cdk.load.write.StreamCdkStateStore
+import io.airbyte.cdk.load.write.StreamLoader
 import io.github.oshai.kotlinlogging.KotlinLogging
 import java.time.Instant
 
 private val logger = KotlinLogging.logger {}
 
 class TypingDedupingStreamLoader(
-  override val stream: DestinationStream,
-  private val initialStatus: TypingDedupingDatabaseInitialStatus,
-  private val tableNames: TableNames,
-  private val columnNameMapping: ColumnNameMapping,
-  private val rawTableOperations: TypingDedupingRawTableOperations,
-  private val finalTableOperations: TypingDedupingFinalTableOperations,
-  private val disableTypeDedupe: Boolean,
-  private val streamCdkStateStore: StreamCdkStateStore<TypingDedupingExecutionConfig>,
+    override val stream: DestinationStream,
+    private val initialStatus: TypingDedupingDatabaseInitialStatus,
+    private val tableNames: TableNames,
+    private val columnNameMapping: ColumnNameMapping,
+    private val rawTableOperations: TypingDedupingRawTableOperations,
+    private val finalTableOperations: TypingDedupingFinalTableOperations,
+    private val disableTypeDedupe: Boolean,
+    private val streamCdkStateStore: StreamCdkStateStore<TypingDedupingExecutionConfig>,
 ) : StreamLoader {
     private val isTruncateSync =
         when (stream.minimumGenerationId) {

--- a/airbyte-cdk/bulk/toolkits/load-db/src/main/kotlin/io/airbyte/cdk/load/orchestration/db/legacy_typing_deduping/TypingDedupingStreamLoader.kt
+++ b/airbyte-cdk/bulk/toolkits/load-db/src/main/kotlin/io/airbyte/cdk/load/orchestration/db/legacy_typing_deduping/TypingDedupingStreamLoader.kt
@@ -11,21 +11,21 @@ import io.airbyte.cdk.load.orchestration.db.TableNames.Companion.NO_SUFFIX
 import io.airbyte.cdk.load.orchestration.db.TableNames.Companion.TMP_TABLE_SUFFIX
 import io.airbyte.cdk.load.state.StreamProcessingFailed
 import io.airbyte.cdk.load.write.StreamLoader
-import io.airbyte.cdk.load.write.StreamStateStore
+import io.airbyte.cdk.load.write.StreamCdkStateStore
 import io.github.oshai.kotlinlogging.KotlinLogging
 import java.time.Instant
 
 private val logger = KotlinLogging.logger {}
 
 class TypingDedupingStreamLoader(
-    override val stream: DestinationStream,
-    private val initialStatus: TypingDedupingDatabaseInitialStatus,
-    private val tableNames: TableNames,
-    private val columnNameMapping: ColumnNameMapping,
-    private val rawTableOperations: TypingDedupingRawTableOperations,
-    private val finalTableOperations: TypingDedupingFinalTableOperations,
-    private val disableTypeDedupe: Boolean,
-    private val streamStateStore: StreamStateStore<TypingDedupingExecutionConfig>,
+  override val stream: DestinationStream,
+  private val initialStatus: TypingDedupingDatabaseInitialStatus,
+  private val tableNames: TableNames,
+  private val columnNameMapping: ColumnNameMapping,
+  private val rawTableOperations: TypingDedupingRawTableOperations,
+  private val finalTableOperations: TypingDedupingFinalTableOperations,
+  private val disableTypeDedupe: Boolean,
+  private val streamCdkStateStore: StreamCdkStateStore<TypingDedupingExecutionConfig>,
 ) : StreamLoader {
     private val isTruncateSync =
         when (stream.minimumGenerationId) {
@@ -63,7 +63,7 @@ class TypingDedupingStreamLoader(
             finalTmpTableSuffix = NO_SUFFIX
         }
 
-        streamStateStore.put(
+        streamCdkStateStore.put(
             stream.mappedDescriptor,
             TypingDedupingExecutionConfig(rawTableSuffix),
         )

--- a/airbyte-cdk/bulk/toolkits/load-db/src/main/kotlin/io/airbyte/cdk/load/orchestration/db/legacy_typing_deduping/TypingDedupingWriter.kt
+++ b/airbyte-cdk/bulk/toolkits/load-db/src/main/kotlin/io/airbyte/cdk/load/orchestration/db/legacy_typing_deduping/TypingDedupingWriter.kt
@@ -8,21 +8,21 @@ import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.orchestration.db.DatabaseHandler
 import io.airbyte.cdk.load.orchestration.db.DatabaseInitialStatusGatherer
 import io.airbyte.cdk.load.write.DestinationWriter
-import io.airbyte.cdk.load.write.StreamLoader
 import io.airbyte.cdk.load.write.StreamCdkStateStore
+import io.airbyte.cdk.load.write.StreamLoader
 import java.util.concurrent.Executors
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 
 class TypingDedupingWriter(
-  private val names: TableCatalog,
-  private val stateGatherer: DatabaseInitialStatusGatherer<TypingDedupingDatabaseInitialStatus>,
-  private val databaseHandler: DatabaseHandler,
-  private val rawTableOperations: TypingDedupingRawTableOperations,
-  private val finalTableOperations: TypingDedupingFinalTableOperations,
-  private val disableTypeDedupe: Boolean,
-  private val streamCdkStateStore: StreamCdkStateStore<TypingDedupingExecutionConfig>,
+    private val names: TableCatalog,
+    private val stateGatherer: DatabaseInitialStatusGatherer<TypingDedupingDatabaseInitialStatus>,
+    private val databaseHandler: DatabaseHandler,
+    private val rawTableOperations: TypingDedupingRawTableOperations,
+    private val finalTableOperations: TypingDedupingFinalTableOperations,
+    private val disableTypeDedupe: Boolean,
+    private val streamCdkStateStore: StreamCdkStateStore<TypingDedupingExecutionConfig>,
 ) : DestinationWriter {
     private lateinit var initialStatuses:
         Map<DestinationStream, TypingDedupingDatabaseInitialStatus>

--- a/airbyte-cdk/bulk/toolkits/load-db/src/main/kotlin/io/airbyte/cdk/load/orchestration/db/legacy_typing_deduping/TypingDedupingWriter.kt
+++ b/airbyte-cdk/bulk/toolkits/load-db/src/main/kotlin/io/airbyte/cdk/load/orchestration/db/legacy_typing_deduping/TypingDedupingWriter.kt
@@ -9,20 +9,20 @@ import io.airbyte.cdk.load.orchestration.db.DatabaseHandler
 import io.airbyte.cdk.load.orchestration.db.DatabaseInitialStatusGatherer
 import io.airbyte.cdk.load.write.DestinationWriter
 import io.airbyte.cdk.load.write.StreamLoader
-import io.airbyte.cdk.load.write.StreamStateStore
+import io.airbyte.cdk.load.write.StreamCdkStateStore
 import java.util.concurrent.Executors
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 
 class TypingDedupingWriter(
-    private val names: TableCatalog,
-    private val stateGatherer: DatabaseInitialStatusGatherer<TypingDedupingDatabaseInitialStatus>,
-    private val databaseHandler: DatabaseHandler,
-    private val rawTableOperations: TypingDedupingRawTableOperations,
-    private val finalTableOperations: TypingDedupingFinalTableOperations,
-    private val disableTypeDedupe: Boolean,
-    private val streamStateStore: StreamStateStore<TypingDedupingExecutionConfig>,
+  private val names: TableCatalog,
+  private val stateGatherer: DatabaseInitialStatusGatherer<TypingDedupingDatabaseInitialStatus>,
+  private val databaseHandler: DatabaseHandler,
+  private val rawTableOperations: TypingDedupingRawTableOperations,
+  private val finalTableOperations: TypingDedupingFinalTableOperations,
+  private val disableTypeDedupe: Boolean,
+  private val streamCdkStateStore: StreamCdkStateStore<TypingDedupingExecutionConfig>,
 ) : DestinationWriter {
     private lateinit var initialStatuses:
         Map<DestinationStream, TypingDedupingDatabaseInitialStatus>
@@ -82,7 +82,7 @@ class TypingDedupingWriter(
             rawTableOperations,
             finalTableOperations,
             disableTypeDedupe = disableTypeDedupe,
-            streamStateStore,
+            streamCdkStateStore,
         )
     }
 }

--- a/airbyte-cdk/bulk/toolkits/load-db/src/main/kotlin/io/airbyte/cdk/load/pipeline/db/BulkLoaderTableLoader.kt
+++ b/airbyte-cdk/bulk/toolkits/load-db/src/main/kotlin/io/airbyte/cdk/load/pipeline/db/BulkLoaderTableLoader.kt
@@ -6,7 +6,7 @@ package io.airbyte.cdk.load.pipeline.db
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 import io.airbyte.cdk.load.file.object_storage.RemoteObject
-import io.airbyte.cdk.load.message.BatchState
+import io.airbyte.cdk.load.message.BatchCdkState
 import io.airbyte.cdk.load.message.WithBatchState
 import io.airbyte.cdk.load.message.WithStream
 import io.airbyte.cdk.load.pipeline.BatchAccumulator
@@ -33,7 +33,7 @@ class BulkLoaderTableLoader<K : WithStream, T : RemoteObject<*>>(
         BulkLoaderTableLoader.LoadResult
     > {
     data object LoadResult : WithBatchState {
-        override val state: BatchState = BatchState.COMPLETE
+        override val state: BatchCdkState = BatchCdkState.COMPLETE
     }
 
     override suspend fun start(key: K, part: Int): BulkLoader<T> {

--- a/airbyte-cdk/bulk/toolkits/load-db/src/main/kotlin/io/airbyte/cdk/load/pipeline/db/InsertLoaderRequestBuilderAccumulator.kt
+++ b/airbyte-cdk/bulk/toolkits/load-db/src/main/kotlin/io/airbyte/cdk/load/pipeline/db/InsertLoaderRequestBuilderAccumulator.kt
@@ -4,7 +4,7 @@
 
 package io.airbyte.cdk.load.pipeline.db
 
-import io.airbyte.cdk.load.message.BatchState
+import io.airbyte.cdk.load.message.BatchCdkState
 import io.airbyte.cdk.load.message.DestinationRecordRaw
 import io.airbyte.cdk.load.message.StreamKey
 import io.airbyte.cdk.load.message.WithBatchState
@@ -33,7 +33,7 @@ class InsertLoaderRequestBuilderAccumulator<Q : InsertLoaderRequest>(
     > {
 
     data class Result<Q>(val request: Q) : WithBatchState {
-        override val state: BatchState = BatchState.PROCESSED
+        override val state: BatchCdkState = BatchCdkState.PROCESSED
     }
 
     override suspend fun start(key: StreamKey, part: Int): InsertLoaderRequestBuilder<Q> {

--- a/airbyte-cdk/bulk/toolkits/load-db/src/main/kotlin/io/airbyte/cdk/load/pipeline/db/InsertLoaderRequestExecutorAccumulator.kt
+++ b/airbyte-cdk/bulk/toolkits/load-db/src/main/kotlin/io/airbyte/cdk/load/pipeline/db/InsertLoaderRequestExecutorAccumulator.kt
@@ -5,7 +5,7 @@
 package io.airbyte.cdk.load.pipeline.db
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
-import io.airbyte.cdk.load.message.BatchState
+import io.airbyte.cdk.load.message.BatchCdkState
 import io.airbyte.cdk.load.message.StreamKey
 import io.airbyte.cdk.load.message.WithBatchState
 import io.airbyte.cdk.load.pipeline.BatchAccumulator
@@ -32,7 +32,7 @@ class InsertLoaderRequestExecutorAccumulator<Q : InsertLoaderRequest>(
     > {
 
     data object Result : WithBatchState {
-        override val state: BatchState = BatchState.COMPLETE
+        override val state: BatchCdkState = BatchCdkState.COMPLETE
     }
 
     override suspend fun start(key: StreamKey, part: Int): Closeable {

--- a/airbyte-cdk/bulk/toolkits/load-db/src/main/kotlin/io/airbyte/cdk/load/write/db/BulkLoader.kt
+++ b/airbyte-cdk/bulk/toolkits/load-db/src/main/kotlin/io/airbyte/cdk/load/write/db/BulkLoader.kt
@@ -5,7 +5,7 @@
 package io.airbyte.cdk.load.write.db
 
 import io.airbyte.cdk.load.file.object_storage.RemoteObject
-import io.airbyte.cdk.load.message.BatchState
+import io.airbyte.cdk.load.message.BatchCdkState
 import io.airbyte.cdk.load.message.WithStream
 import io.airbyte.cdk.load.write.object_storage.ObjectLoader
 
@@ -51,6 +51,6 @@ interface BulkLoaderFactory<K : WithStream, T : RemoteObject<*>> : ObjectLoader 
 
     // Override the bookkeeping state for objects in object storage
     // from the default of "COMPLETE". Connector devs can ignore this.
-    override val stateAfterUpload: BatchState
-        get() = BatchState.LOADED
+    override val stateAfterUpload: BatchCdkState
+        get() = BatchCdkState.LOADED
 }

--- a/airbyte-cdk/bulk/toolkits/load-dlq/src/main/kotlin/io/airbyte/cdk/load/pipeline/dlq/DlqLoaderPipelineStep.kt
+++ b/airbyte-cdk/bulk/toolkits/load-dlq/src/main/kotlin/io/airbyte/cdk/load/pipeline/dlq/DlqLoaderPipelineStep.kt
@@ -4,7 +4,7 @@
 
 package io.airbyte.cdk.load.pipeline.dlq
 
-import io.airbyte.cdk.load.message.BatchState
+import io.airbyte.cdk.load.message.BatchCdkState
 import io.airbyte.cdk.load.message.DestinationRecordRaw
 import io.airbyte.cdk.load.message.PartitionedQueue
 import io.airbyte.cdk.load.message.PipelineEvent
@@ -48,7 +48,7 @@ class DlqLoaderPipelineStep<S : AutoCloseable>(
  * - [rejectedRecords] are records meant for the DeadLetterQueue.
  */
 class DlqStepOutput(
-    override val state: BatchState,
+    override val state: BatchCdkState,
     val rejectedRecords: List<DestinationRecordRaw>? = null,
 ) : WithBatchState
 
@@ -90,7 +90,7 @@ class DlqLoaderAccumulator<S>(
     private fun getOutput(rejectedRecords: List<DestinationRecordRaw>?) =
         when (rejectedRecords) {
             null,
-            emptyList<DestinationRecordRaw>() -> DlqStepOutput(BatchState.COMPLETE, null)
-            else -> DlqStepOutput(BatchState.STAGED, rejectedRecords)
+            emptyList<DestinationRecordRaw>() -> DlqStepOutput(BatchCdkState.COMPLETE, null)
+            else -> DlqStepOutput(BatchCdkState.STAGED, rejectedRecords)
         }
 }

--- a/airbyte-cdk/bulk/toolkits/load-dlq/src/main/kotlin/io/airbyte/cdk/load/pipeline/dlq/DlqNoopStep.kt
+++ b/airbyte-cdk/bulk/toolkits/load-dlq/src/main/kotlin/io/airbyte/cdk/load/pipeline/dlq/DlqNoopStep.kt
@@ -4,7 +4,7 @@
 
 package io.airbyte.cdk.load.pipeline.dlq
 
-import io.airbyte.cdk.load.message.BatchState
+import io.airbyte.cdk.load.message.BatchCdkState
 import io.airbyte.cdk.load.message.DestinationRecordRaw
 import io.airbyte.cdk.load.message.PartitionedQueue
 import io.airbyte.cdk.load.message.PipelineEvent
@@ -22,7 +22,8 @@ import io.airbyte.cdk.load.task.internal.LoadPipelineStepTaskFactory
  *
  * This step skips through all records without doing anything. This is to make sure we update the
  * counts of rejected records properly by leveraging the [FlattenQueueAdapter] and the fact that the
- * LoadPipelineStepTask will update the rejected records count correctly on [BatchState.COMPLETE].
+ * LoadPipelineStepTask will update the rejected records count correctly on [BatchCdkState.COMPLETE]
+ * .
  */
 class DlqNoopPipelineStep(
     override val numWorkers: Int,
@@ -55,6 +56,6 @@ class DlqNoopAccumulator :
 
 /** See documentation of [DlqNoopPipelineStep]. */
 class DlqNoopState : WithBatchState, AutoCloseable {
-    override val state: BatchState = BatchState.COMPLETE
+    override val state: BatchCdkState = BatchCdkState.COMPLETE
     override fun close() {}
 }

--- a/airbyte-cdk/bulk/toolkits/load-dlq/src/test/kotlin/io/airbyte/cdk/load/pipeline/dlq/FlattenQueueAdapterTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-dlq/src/test/kotlin/io/airbyte/cdk/load/pipeline/dlq/FlattenQueueAdapterTest.kt
@@ -8,7 +8,7 @@ import io.airbyte.cdk.load.command.Append
 import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.command.NamespaceMapper
 import io.airbyte.cdk.load.data.ObjectTypeWithoutSchema
-import io.airbyte.cdk.load.message.BatchState
+import io.airbyte.cdk.load.message.BatchCdkState
 import io.airbyte.cdk.load.message.DestinationRecordJsonSource
 import io.airbyte.cdk.load.message.DestinationRecordRaw
 import io.airbyte.cdk.load.message.PartitionedQueue
@@ -68,7 +68,7 @@ class FlattenQueueAdapterTest {
 
     @Test
     fun `flattening lists preserve the total count while counting rejected records`() {
-        val state = BatchState.COMPLETE
+        val state = BatchCdkState.COMPLETE
         val records =
             listOf(
                 record(1),

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/pipline/object_storage/ObjectLoaderPartFormatter.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/pipline/object_storage/ObjectLoaderPartFormatter.kt
@@ -11,7 +11,7 @@ import io.airbyte.cdk.load.file.object_storage.BufferedFormattingWriterFactory
 import io.airbyte.cdk.load.file.object_storage.Part
 import io.airbyte.cdk.load.file.object_storage.PartFactory
 import io.airbyte.cdk.load.file.object_storage.PathFactory
-import io.airbyte.cdk.load.message.BatchState
+import io.airbyte.cdk.load.message.BatchCdkState
 import io.airbyte.cdk.load.message.DestinationRecordRaw
 import io.airbyte.cdk.load.message.StreamKey
 import io.airbyte.cdk.load.message.WithBatchState
@@ -68,7 +68,7 @@ class ObjectLoaderPartFormatter<T : OutputStream>(
 
     data class FormattedPart(
         val part: Part,
-        override val state: BatchState = BatchState.PROCESSED
+        override val state: BatchCdkState = BatchCdkState.PROCESSED
     ) : WithBatchState
 
     private suspend fun newState(stream: DestinationStream): State<T> {

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/pipline/object_storage/ObjectLoaderPartLoader.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/pipline/object_storage/ObjectLoaderPartLoader.kt
@@ -9,7 +9,7 @@ import io.airbyte.cdk.load.command.DestinationConfiguration
 import io.airbyte.cdk.load.file.object_storage.ObjectStorageClient
 import io.airbyte.cdk.load.file.object_storage.RemoteObject
 import io.airbyte.cdk.load.file.object_storage.StreamingUpload
-import io.airbyte.cdk.load.message.BatchState
+import io.airbyte.cdk.load.message.BatchCdkState
 import io.airbyte.cdk.load.message.WithBatchState
 import io.airbyte.cdk.load.pipeline.BatchAccumulator
 import io.airbyte.cdk.load.pipeline.BatchAccumulatorResult
@@ -74,10 +74,10 @@ class ObjectLoaderPartLoader<T : RemoteObject<*>>(
         // keep track of whether it's empty so the bookkeeper can ignore it
         val empty: Boolean = false,
     ) : PartResult<T> {
-        override val state: BatchState = BatchState.STAGED
+        override val state: BatchCdkState = BatchCdkState.STAGED
     }
     data class NoPart<T : RemoteObject<*>>(override val objectKey: String) : PartResult<T> {
-        override val state: BatchState = BatchState.STAGED
+        override val state: BatchCdkState = BatchCdkState.STAGED
     }
 
     override suspend fun start(key: ObjectKey, part: Int): State<T> {

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/pipline/object_storage/ObjectLoaderUploadCompleter.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/pipline/object_storage/ObjectLoaderUploadCompleter.kt
@@ -7,7 +7,7 @@ package io.airbyte.cdk.load.pipline.object_storage
 import io.airbyte.cdk.load.file.object_storage.Part
 import io.airbyte.cdk.load.file.object_storage.PartBookkeeper
 import io.airbyte.cdk.load.file.object_storage.RemoteObject
-import io.airbyte.cdk.load.message.BatchState
+import io.airbyte.cdk.load.message.BatchCdkState
 import io.airbyte.cdk.load.message.WithBatchState
 import io.airbyte.cdk.load.pipeline.BatchAccumulator
 import io.airbyte.cdk.load.pipeline.BatchAccumulatorResult
@@ -36,7 +36,7 @@ class ObjectLoaderUploadCompleter<T : RemoteObject<*>>(val objectLoader: ObjectL
         }
     }
 
-    data class UploadResult<T>(override val state: BatchState, val remoteObject: T?) :
+    data class UploadResult<T>(override val state: BatchCdkState, val remoteObject: T?) :
         WithBatchState
 
     override suspend fun start(key: ObjectKey, part: Int): State {

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/write/object_storage/ObjectLoader.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/main/kotlin/io/airbyte/cdk/load/write/object_storage/ObjectLoader.kt
@@ -6,7 +6,7 @@ package io.airbyte.cdk.load.write.object_storage
 
 import io.airbyte.cdk.load.command.DestinationConfiguration
 import io.airbyte.cdk.load.command.DestinationStream
-import io.airbyte.cdk.load.message.BatchState
+import io.airbyte.cdk.load.message.BatchCdkState
 import io.airbyte.cdk.load.write.LoadStrategy
 
 /**
@@ -67,9 +67,9 @@ import io.airbyte.cdk.load.write.LoadStrategy
  * [io.airbyte.cdk.load.pipeline.db.BulkLoadCompletedUploadPartitioner] for an example.
  *
  * Additionally, CDK devs building new interfaces will should set [stateAfterUpload] to something
- * other than [BatchState.COMPLETE] to avoid prematurely closing the stream. Specifically, if the
- * destination can recover a loaded object after a failed sync, use [BatchState.PERSISTED] to
- * indicate records loaded objects can be checkpointed. Otherwise, use [BatchState.LOADED].
+ * other than [BatchCdkState.COMPLETE] to avoid prematurely closing the stream. Specifically, if the
+ * destination can recover a loaded object after a failed sync, use [BatchCdkState.PERSISTED] to
+ * indicate records loaded objects can be checkpointed. Otherwise, use [BatchCdkState.LOADED].
  */
 interface ObjectLoader : LoadStrategy {
     val numPartWorkers: Int
@@ -88,8 +88,8 @@ interface ObjectLoader : LoadStrategy {
     override val inputPartitions: Int
         get() = numPartWorkers
 
-    val stateAfterUpload: BatchState
-        get() = BatchState.COMPLETE
+    val stateAfterUpload: BatchCdkState
+        get() = BatchCdkState.COMPLETE
 }
 
 fun DestinationConfiguration.metadataFor(stream: DestinationStream): Map<String, String> =

--- a/airbyte-cdk/bulk/toolkits/load-object-storage/src/test/kotlin/io/airbyte/cdk/load/pipeline/object_storage/file/ForwardFileRecordTaskTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-object-storage/src/test/kotlin/io/airbyte/cdk/load/pipeline/object_storage/file/ForwardFileRecordTaskTest.kt
@@ -11,7 +11,7 @@ import io.airbyte.cdk.load.command.NamespaceMapper
 import io.airbyte.cdk.load.data.FieldType
 import io.airbyte.cdk.load.data.ObjectType
 import io.airbyte.cdk.load.data.StringType
-import io.airbyte.cdk.load.message.BatchState
+import io.airbyte.cdk.load.message.BatchCdkState
 import io.airbyte.cdk.load.message.DestinationRecordJsonSource
 import io.airbyte.cdk.load.message.DestinationRecordRaw
 import io.airbyte.cdk.load.message.PartitionedQueue
@@ -101,7 +101,7 @@ class ForwardFileRecordTaskTest {
                 )
             val result =
                 ObjectLoaderUploadCompleter.UploadResult<String>(
-                    state = BatchState.LOADED,
+                    state = BatchCdkState.LOADED,
                     remoteObject = null
                 )
             val input =
@@ -127,7 +127,7 @@ class ForwardFileRecordTaskTest {
             )
         val result =
             ObjectLoaderUploadCompleter.UploadResult(
-                state = BatchState.LOADED,
+                state = BatchCdkState.LOADED,
                 remoteObject = "uploaded thing"
             )
         val input =

--- a/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/write/ClickHouseWriter.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/write/ClickHouseWriter.kt
@@ -15,7 +15,7 @@ import io.airbyte.cdk.load.orchestration.db.direct_load_table.DirectLoadTableExe
 import io.airbyte.cdk.load.orchestration.db.legacy_typing_deduping.TableCatalog
 import io.airbyte.cdk.load.write.DestinationWriter
 import io.airbyte.cdk.load.write.StreamLoader
-import io.airbyte.cdk.load.write.StreamStateStore
+import io.airbyte.cdk.load.write.StreamCdkStateStore
 import io.airbyte.integrations.destination.clickhouse.client.ClickhouseAirbyteClient
 import jakarta.inject.Singleton
 
@@ -23,7 +23,7 @@ import jakarta.inject.Singleton
 class ClickHouseWriter(
     private val names: TableCatalog,
     private val stateGatherer: DatabaseInitialStatusGatherer<DirectLoadInitialStatus>,
-    private val streamStateStore: StreamStateStore<DirectLoadTableExecutionConfig>,
+    private val streamCdkStateStore: StreamCdkStateStore<DirectLoadTableExecutionConfig>,
     private val clickhouseClient: ClickhouseAirbyteClient,
     private val tempTableNameGenerator: TempTableNameGenerator,
 ) : DestinationWriter {
@@ -53,7 +53,7 @@ class ClickHouseWriter(
                     columnNameMapping,
                     clickhouseClient,
                     clickhouseClient,
-                    streamStateStore,
+                    streamCdkStateStore,
                 )
             stream.generationId ->
                 DirectLoadTableAppendTruncateStreamLoader(
@@ -64,7 +64,7 @@ class ClickHouseWriter(
                     columnNameMapping,
                     clickhouseClient,
                     clickhouseClient,
-                    streamStateStore,
+                    streamCdkStateStore,
                 )
             else ->
                 throw SystemErrorException(

--- a/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/write/ClickHouseWriter.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/write/ClickHouseWriter.kt
@@ -14,8 +14,8 @@ import io.airbyte.cdk.load.orchestration.db.direct_load_table.DirectLoadTableApp
 import io.airbyte.cdk.load.orchestration.db.direct_load_table.DirectLoadTableExecutionConfig
 import io.airbyte.cdk.load.orchestration.db.legacy_typing_deduping.TableCatalog
 import io.airbyte.cdk.load.write.DestinationWriter
-import io.airbyte.cdk.load.write.StreamLoader
 import io.airbyte.cdk.load.write.StreamCdkStateStore
+import io.airbyte.cdk.load.write.StreamLoader
 import io.airbyte.integrations.destination.clickhouse.client.ClickhouseAirbyteClient
 import jakarta.inject.Singleton
 

--- a/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/write/load/ClickhouseDirectLoaderFactory.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/write/load/ClickhouseDirectLoaderFactory.kt
@@ -8,7 +8,7 @@ import com.clickhouse.client.api.Client
 import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.orchestration.db.direct_load_table.DirectLoadTableExecutionConfig
 import io.airbyte.cdk.load.write.DirectLoaderFactory
-import io.airbyte.cdk.load.write.StreamStateStore
+import io.airbyte.cdk.load.write.StreamCdkStateStore
 import io.airbyte.integrations.destination.clickhouse.write.transform.RecordMunger
 import jakarta.inject.Singleton
 
@@ -17,9 +17,9 @@ import jakarta.inject.Singleton
  */
 @Singleton
 class ClickhouseDirectLoaderFactory(
-    private val clickhouseClient: Client,
-    private val stateStore: StreamStateStore<DirectLoadTableExecutionConfig>,
-    private val munger: RecordMunger,
+  private val clickhouseClient: Client,
+  private val stateStore: StreamCdkStateStore<DirectLoadTableExecutionConfig>,
+  private val munger: RecordMunger,
 ) : DirectLoaderFactory<ClickhouseDirectLoader> {
     override val maxNumOpenLoaders = 2
 

--- a/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/write/load/ClickhouseDirectLoaderFactory.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/write/load/ClickhouseDirectLoaderFactory.kt
@@ -17,9 +17,9 @@ import jakarta.inject.Singleton
  */
 @Singleton
 class ClickhouseDirectLoaderFactory(
-  private val clickhouseClient: Client,
-  private val stateStore: StreamCdkStateStore<DirectLoadTableExecutionConfig>,
-  private val munger: RecordMunger,
+    private val clickhouseClient: Client,
+    private val stateStore: StreamCdkStateStore<DirectLoadTableExecutionConfig>,
+    private val munger: RecordMunger,
 ) : DirectLoaderFactory<ClickhouseDirectLoader> {
     override val maxNumOpenLoaders = 2
 

--- a/airbyte-integrations/connectors/destination-clickhouse/src/test/kotlin/io/airbyte/integrations/destination/clickhouse/write/load/ClickhouseDirectLoaderFactoryTest.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/test/kotlin/io/airbyte/integrations/destination/clickhouse/write/load/ClickhouseDirectLoaderFactoryTest.kt
@@ -8,7 +8,7 @@ import com.clickhouse.client.api.Client
 import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.orchestration.db.TableName
 import io.airbyte.cdk.load.orchestration.db.direct_load_table.DirectLoadTableExecutionConfig
-import io.airbyte.cdk.load.write.StreamStateStore
+import io.airbyte.cdk.load.write.StreamCdkStateStore
 import io.airbyte.integrations.destination.clickhouse.write.transform.RecordMunger
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
@@ -24,7 +24,7 @@ import org.junit.jupiter.params.provider.MethodSource
 class ClickhouseDirectLoaderFactoryTest {
     @MockK(relaxed = true) lateinit var clickhouseClient: Client
 
-    @MockK lateinit var stateStore: StreamStateStore<DirectLoadTableExecutionConfig>
+    @MockK lateinit var stateStore: StreamCdkStateStore<DirectLoadTableExecutionConfig>
 
     @MockK lateinit var munger: RecordMunger
 

--- a/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLBulkLoadStreamLoader.kt
+++ b/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLBulkLoadStreamLoader.kt
@@ -8,18 +8,18 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.file.azureBlobStorage.AzureBlobClient
 import io.airbyte.cdk.load.state.StreamProcessingFailed
-import io.airbyte.cdk.load.write.StreamStateStore
+import io.airbyte.cdk.load.write.StreamCdkStateStore
 import javax.sql.DataSource
 import kotlinx.coroutines.runBlocking
 
 @SuppressFBWarnings("NP_NONNULL_PARAM_VIOLATION")
 class MSSQLBulkLoadStreamLoader(
-    override val stream: DestinationStream,
-    dataSource: DataSource,
-    sqlBuilder: MSSQLQueryBuilder,
-    private val defaultSchema: String,
-    private val azureBlobClient: AzureBlobClient,
-    private val streamStateStore: StreamStateStore<MSSQLStreamState>,
+  override val stream: DestinationStream,
+  dataSource: DataSource,
+  sqlBuilder: MSSQLQueryBuilder,
+  private val defaultSchema: String,
+  private val azureBlobClient: AzureBlobClient,
+  private val streamCdkStateStore: StreamCdkStateStore<MSSQLStreamState>,
 ) : AbstractMSSQLStreamLoader(dataSource, stream, sqlBuilder) {
 
     // Bulk-load related collaborators
@@ -36,7 +36,7 @@ class MSSQLBulkLoadStreamLoader(
         super.start() // calls ensureTableExists()
         formatFilePath = mssqlFormatFileCreator.createAndUploadFormatFile(defaultSchema).key
         val state = MSSQLBulkLoaderStreamState(dataSource, formatFilePath)
-        streamStateStore.put(stream.mappedDescriptor, state)
+        streamCdkStateStore.put(stream.mappedDescriptor, state)
     }
 
     /**

--- a/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLBulkLoadStreamLoader.kt
+++ b/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLBulkLoadStreamLoader.kt
@@ -14,12 +14,12 @@ import kotlinx.coroutines.runBlocking
 
 @SuppressFBWarnings("NP_NONNULL_PARAM_VIOLATION")
 class MSSQLBulkLoadStreamLoader(
-  override val stream: DestinationStream,
-  dataSource: DataSource,
-  sqlBuilder: MSSQLQueryBuilder,
-  private val defaultSchema: String,
-  private val azureBlobClient: AzureBlobClient,
-  private val streamCdkStateStore: StreamCdkStateStore<MSSQLStreamState>,
+    override val stream: DestinationStream,
+    dataSource: DataSource,
+    sqlBuilder: MSSQLQueryBuilder,
+    private val defaultSchema: String,
+    private val azureBlobClient: AzureBlobClient,
+    private val streamCdkStateStore: StreamCdkStateStore<MSSQLStreamState>,
 ) : AbstractMSSQLStreamLoader(dataSource, stream, sqlBuilder) {
 
     // Bulk-load related collaborators

--- a/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLBulkLoader.kt
+++ b/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLBulkLoader.kt
@@ -14,7 +14,7 @@ import io.airbyte.cdk.load.file.azureBlobStorage.AzureBlob
 import io.airbyte.cdk.load.file.azureBlobStorage.AzureBlobClient
 import io.airbyte.cdk.load.message.StreamKey
 import io.airbyte.cdk.load.pipeline.RoundRobinInputPartitioner
-import io.airbyte.cdk.load.write.StreamStateStore
+import io.airbyte.cdk.load.write.StreamCdkStateStore
 import io.airbyte.cdk.load.write.db.BulkLoader
 import io.airbyte.cdk.load.write.db.BulkLoaderFactory
 import io.airbyte.integrations.destination.mssql.v2.config.MSSQLBulkLoadConfiguration
@@ -112,7 +112,7 @@ class MSSQLBulkLoaderFactory(
     private val catalog: DestinationCatalog,
     private val config: MSSQLConfiguration,
     private val bulkLoadConfig: MSSQLBulkLoadConfiguration,
-    private val streamStateStore: StreamStateStore<MSSQLStreamState>
+    private val streamCdkStateStore: StreamCdkStateStore<MSSQLStreamState>
 ) : BulkLoaderFactory<StreamKey, AzureBlob> {
     override val numPartWorkers: Int = 2
     override val numUploadWorkers: Int = 10
@@ -129,13 +129,13 @@ class MSSQLBulkLoaderFactory(
         val stream = catalog.getStream(key.stream)
         val mssqlBulkLoadHandler =
             MSSQLBulkLoadHandler(
-                streamStateStore.get(key.stream)!!.dataSource,
+                streamCdkStateStore.get(key.stream)!!.dataSource,
                 stream.mappedDescriptor.namespace ?: defaultSchema,
                 stream.mappedDescriptor.name,
                 bulkLoadConfig.dataSource,
                 MSSQLQueryBuilder(config.schema, stream)
             )
-        val state = streamStateStore.get(key.stream)
+        val state = streamCdkStateStore.get(key.stream)
         check(state != null && state is MSSQLBulkLoaderStreamState) {
             "Stream state not properly initialized for stream ${key.stream}"
         }

--- a/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLDirectLoader.kt
+++ b/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLDirectLoader.kt
@@ -18,11 +18,11 @@ import jakarta.inject.Singleton
 
 @SuppressFBWarnings("NP_NONNULL_PARAM_VIOLATION", "kotlin coroutines")
 class MSSQLDirectLoader(
-  config: MSSQLConfiguration,
-  stateStore: StreamCdkStateStore<MSSQLStreamState>,
-  private val streamDescriptor: DestinationStream.Descriptor,
-  private val batch: Int,
-  private val parent: MSSQLDirectLoaderFactory
+    config: MSSQLConfiguration,
+    stateStore: StreamCdkStateStore<MSSQLStreamState>,
+    private val streamDescriptor: DestinationStream.Descriptor,
+    private val batch: Int,
+    private val parent: MSSQLDirectLoaderFactory
 ) : DirectLoader {
     private val log = KotlinLogging.logger {}
     private val recordCommitBatchSize = config.batchEveryNRecords
@@ -96,8 +96,8 @@ class MSSQLDirectLoader(
 @Singleton
 @Requires(condition = MSSQLIsNotConfiguredForBulkLoad::class)
 class MSSQLDirectLoaderFactory(
-  val config: MSSQLConfiguration,
-  val stateStore: StreamCdkStateStore<MSSQLStreamState>,
+    val config: MSSQLConfiguration,
+    val stateStore: StreamCdkStateStore<MSSQLStreamState>,
 ) : DirectLoaderFactory<MSSQLDirectLoader> {
     private val log = KotlinLogging.logger {}
 

--- a/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLDirectLoader.kt
+++ b/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLDirectLoader.kt
@@ -9,7 +9,7 @@ import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.message.DestinationRecordRaw
 import io.airbyte.cdk.load.write.DirectLoader
 import io.airbyte.cdk.load.write.DirectLoaderFactory
-import io.airbyte.cdk.load.write.StreamStateStore
+import io.airbyte.cdk.load.write.StreamCdkStateStore
 import io.airbyte.integrations.destination.mssql.v2.config.MSSQLConfiguration
 import io.airbyte.integrations.destination.mssql.v2.config.MSSQLIsNotConfiguredForBulkLoad
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -18,11 +18,11 @@ import jakarta.inject.Singleton
 
 @SuppressFBWarnings("NP_NONNULL_PARAM_VIOLATION", "kotlin coroutines")
 class MSSQLDirectLoader(
-    config: MSSQLConfiguration,
-    stateStore: StreamStateStore<MSSQLStreamState>,
-    private val streamDescriptor: DestinationStream.Descriptor,
-    private val batch: Int,
-    private val parent: MSSQLDirectLoaderFactory
+  config: MSSQLConfiguration,
+  stateStore: StreamCdkStateStore<MSSQLStreamState>,
+  private val streamDescriptor: DestinationStream.Descriptor,
+  private val batch: Int,
+  private val parent: MSSQLDirectLoaderFactory
 ) : DirectLoader {
     private val log = KotlinLogging.logger {}
     private val recordCommitBatchSize = config.batchEveryNRecords
@@ -96,8 +96,8 @@ class MSSQLDirectLoader(
 @Singleton
 @Requires(condition = MSSQLIsNotConfiguredForBulkLoad::class)
 class MSSQLDirectLoaderFactory(
-    val config: MSSQLConfiguration,
-    val stateStore: StreamStateStore<MSSQLStreamState>,
+  val config: MSSQLConfiguration,
+  val stateStore: StreamCdkStateStore<MSSQLStreamState>,
 ) : DirectLoaderFactory<MSSQLDirectLoader> {
     private val log = KotlinLogging.logger {}
 

--- a/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLStreamLoader.kt
+++ b/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLStreamLoader.kt
@@ -5,19 +5,19 @@
 package io.airbyte.integrations.destination.mssql.v2
 
 import io.airbyte.cdk.load.command.DestinationStream
-import io.airbyte.cdk.load.write.StreamStateStore
+import io.airbyte.cdk.load.write.StreamCdkStateStore
 import javax.sql.DataSource
 
 class MSSQLStreamLoader(
     dataSource: DataSource,
     override val stream: DestinationStream,
     sqlBuilder: MSSQLQueryBuilder,
-    private val streamStateStore: StreamStateStore<MSSQLStreamState>
+    private val streamCdkStateStore: StreamCdkStateStore<MSSQLStreamState>
 ) : AbstractMSSQLStreamLoader(dataSource, stream, sqlBuilder) {
 
     override suspend fun start() {
         super.start()
-        streamStateStore.put(
+        streamCdkStateStore.put(
             stream.mappedDescriptor,
             MSSQLDirectLoaderStreamState(dataSource, sqlBuilder)
         )

--- a/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLWriter.kt
+++ b/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLWriter.kt
@@ -8,7 +8,7 @@ import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.state.DestinationFailure
 import io.airbyte.cdk.load.write.DestinationWriter
 import io.airbyte.cdk.load.write.StreamLoader
-import io.airbyte.cdk.load.write.StreamStateStore
+import io.airbyte.cdk.load.write.StreamCdkStateStore
 import io.airbyte.integrations.destination.mssql.v2.config.AzureBlobStorageClientCreator
 import io.airbyte.integrations.destination.mssql.v2.config.BulkLoadConfiguration
 import io.airbyte.integrations.destination.mssql.v2.config.InsertLoadTypeConfiguration
@@ -19,9 +19,9 @@ import javax.sql.DataSource
 
 @Singleton
 class MSSQLWriter(
-    private val config: MSSQLConfiguration,
-    private val dataSourceFactory: MSSQLDataSourceFactory,
-    private val streamStateStore: StreamStateStore<MSSQLStreamState>,
+  private val config: MSSQLConfiguration,
+  private val dataSourceFactory: MSSQLDataSourceFactory,
+  private val streamCdkStateStore: StreamCdkStateStore<MSSQLStreamState>,
 ) : DestinationWriter {
 
     /** Lazily initialized when [setup] is called. */
@@ -47,7 +47,7 @@ class MSSQLWriter(
                     defaultSchema = config.schema,
                     azureBlobClient =
                         AzureBlobStorageClientCreator.createAzureBlobClient(loadConfig),
-                    streamStateStore = streamStateStore,
+                    streamCdkStateStore = streamCdkStateStore,
                 )
             }
             is InsertLoadTypeConfiguration -> {
@@ -55,7 +55,7 @@ class MSSQLWriter(
                     dataSource = dataSourceNotNull,
                     stream = stream,
                     sqlBuilder = sqlBuilder,
-                    streamStateStore = streamStateStore
+                    streamCdkStateStore = streamCdkStateStore
                 )
             }
         }

--- a/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLWriter.kt
+++ b/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLWriter.kt
@@ -7,8 +7,8 @@ package io.airbyte.integrations.destination.mssql.v2
 import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.state.DestinationFailure
 import io.airbyte.cdk.load.write.DestinationWriter
-import io.airbyte.cdk.load.write.StreamLoader
 import io.airbyte.cdk.load.write.StreamCdkStateStore
+import io.airbyte.cdk.load.write.StreamLoader
 import io.airbyte.integrations.destination.mssql.v2.config.AzureBlobStorageClientCreator
 import io.airbyte.integrations.destination.mssql.v2.config.BulkLoadConfiguration
 import io.airbyte.integrations.destination.mssql.v2.config.InsertLoadTypeConfiguration
@@ -19,9 +19,9 @@ import javax.sql.DataSource
 
 @Singleton
 class MSSQLWriter(
-  private val config: MSSQLConfiguration,
-  private val dataSourceFactory: MSSQLDataSourceFactory,
-  private val streamCdkStateStore: StreamCdkStateStore<MSSQLStreamState>,
+    private val config: MSSQLConfiguration,
+    private val dataSourceFactory: MSSQLDataSourceFactory,
+    private val streamCdkStateStore: StreamCdkStateStore<MSSQLStreamState>,
 ) : DestinationWriter {
 
     /** Lazily initialized when [setup] is called. */


### PR DESCRIPTION
## What
The naming for the cdk state object is confusing and make you think that it is related to the Airbyte state.
This PR is a renaming of the *State* class to *CdkState*.

## How
<!--
* Describe how code changes achieve the solution.
-->

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
