### PR TITLE
Remove IDs from H1s in connector documentation

### DIFF
--- a/docusaurus/src/components/HeaderDecoration.jsx
+++ b/docusaurus/src/components/HeaderDecoration.jsx
@@ -334,10 +334,10 @@ const ConnectorMetadataCallout = ({
   </Callout>
 );
 
-const ConnectorTitle = ({ iconUrl, originalTitle, originalId, isArchived }) => (
+const ConnectorTitle = ({ iconUrl, originalTitle, isArchived }) => (
   <div className={styles.header}>
     <img src={iconUrl} alt="" className={styles.connectorIcon} />
-    <h1 id={originalId}>
+    <h1>
       {isArchived ? (
         <span>
           {originalTitle} <span style={{ color: "gray" }}>[ARCHIVED]</span>
@@ -357,7 +357,6 @@ export const HeaderDecoration = ({
   supportLevel,
   iconUrl,
   originalTitle,
-  originalId,
   github_url,
   cdkVersion,
   isLatestCDKString,
@@ -382,7 +381,6 @@ export const HeaderDecoration = ({
         <ConnectorTitle
           iconUrl={iconUrl}
           originalTitle={originalTitle}
-          originalId={originalId}
           isArchived={isArchived}
         />
         <CopyPageButton />

--- a/docusaurus/src/css/custom.css
+++ b/docusaurus/src/css/custom.css
@@ -406,6 +406,3 @@ nav a.navbar__link--active {
 header h1 {
   margin-bottom: 0;
 }
-html {
-  scroll-padding-top: calc(var(--ifm-navbar-height) + 50px);
-}

--- a/docusaurus/src/css/custom.css
+++ b/docusaurus/src/css/custom.css
@@ -406,3 +406,6 @@ nav a.navbar__link--active {
 header h1 {
   margin-bottom: 0;
 }
+html {
+  scroll-padding-top: calc(var(--ifm-navbar-height) + 50px);
+}

--- a/docusaurus/src/remark/docsHeaderDecoration.js
+++ b/docusaurus/src/remark/docsHeaderDecoration.js
@@ -29,7 +29,6 @@ const plugin = () => {
     visit(ast, "heading", (node) => {
       if (firstHeading && node.depth === 1 && node.children.length === 1) {
         const originalTitle = node.children[0].value;
-        const originalId = node.data.hProperties.id;
 
         const rawCDKVersion = getFromPaths(
           registryEntry,
@@ -62,7 +61,6 @@ const plugin = () => {
           github_url: registryEntry.github_url,
           issue_url: registryEntry.issue_url,
           originalTitle,
-          originalId,
           cdkVersion: version,
           isLatestCDKString: boolToBoolString(isLatest),
           cdkVersionUrl: url,

--- a/docusaurus/src/remark/enterpriseDocsHeaderInformation.js
+++ b/docusaurus/src/remark/enterpriseDocsHeaderInformation.js
@@ -42,7 +42,6 @@ const plugin = () => {
     visit(ast, "heading", (node) => {
       if (firstHeading && node.depth === 1 && node.children.length === 1) {
         const originalTitle = node.children[0].value;
-        const originalId = node.data.hProperties.id;
 
         const attrDict = {
           isOss: false,
@@ -53,7 +52,6 @@ const plugin = () => {
           dockerImageTag: version,
           github_url: undefined,
           originalTitle,
-          originalId,
         };
 
         firstHeading = false;


### PR DESCRIPTION
## What

There's a supremely annoying pattern in the Algolia site search on docs.airbyte.com. When you search for a connector, then click that connector's title in the search results, the page loads to slightly below the top of the page. As a result, the page title (arguably the most important thing on the page) is obscured by the nav bar.

I've also heard from AEs that about their least favorite part of the job is trying to send connector docs to customers, then stripping out the hashtag from the URL.

This small PR theoretically fixes these things.

<img width="1919" height="528" alt="image" src="https://github.com/user-attachments/assets/c5401b2c-3e1d-4538-90b9-c76a5511ceb0" />

## How

This is happening because heading level 1s are assigned IDs by the HeaderDecoration component, and Algolia indexes those IDs, expecting that this is a deep link within the page as it would be with headings 2 and beyond.

I removed the code that added IDs to heading level 1 in the connector documentation. In theory, this makes H1s on connector docs behave exactly like platform and release notes docs. Those instances don't have IDs on H1s, and display normally after clicking a search result.

H2s+ do need autogenerated IDs so Docusaurus can generate the table of contents on the right. So, I can't disable the capability entirely as we do normally need the IDs.

The addition of the ID to this heading on connectors goes back to 2023, actually to the very start of the HeaderDecoration file. I have been unable to identify why it was added, or any other function that relies on these IDs existing. However, Algolia indexes these IDs as hashtags and this creates the weird search result experience. My theory is it's safe to remove this code.

## Review guide

It's impossible to properly test this. We need to publish it to production, allow Algolia to reindex the site and get rid of the hashtags in its index URLs, then see what happens. Worst case scenario we roll back the change.

For now I think the best review is to ensure I haven't broken anything critical :) 

## User Impact

Not experiencing thousands of tiny UX paper cuts. :) 

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
