### PR TITLE
CDC RFR

### DIFF
--- a/airbyte-cdk/bulk/build.gradle
+++ b/airbyte-cdk/bulk/build.gradle
@@ -1,5 +1,5 @@
 allprojects {
-    version = "0.1.1"
+    version = "0.1.2"
     apply plugin: 'java-library'
     apply plugin: 'maven-publish'
 

--- a/airbyte-cdk/bulk/changelog.md
+++ b/airbyte-cdk/bulk/changelog.md
@@ -1,6 +1,6 @@
 ## Version 0.1.1
 
-* **Changed:** Extract CDK fixes for CDC in socket mode.
+* **Changed:** Extract CDK fixes for CDC in socket mode - state, partitioning and full refresh streams.
 
 ## Version 0.1.0
 

--- a/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/discover/MetaFieldDecorator.kt
+++ b/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/discover/MetaFieldDecorator.kt
@@ -6,6 +6,7 @@ package io.airbyte.cdk.discover
 
 import com.fasterxml.jackson.databind.node.ObjectNode
 import io.airbyte.cdk.command.OpaqueStateValue
+import io.airbyte.cdk.output.sockets.NativeRecordPayload
 import io.airbyte.cdk.read.Stream
 import io.airbyte.protocol.models.v0.AirbyteStream
 import java.time.OffsetDateTime
@@ -53,5 +54,12 @@ interface MetaFieldDecorator {
         globalStateValue: OpaqueStateValue?,
         stream: Stream,
         recordData: ObjectNode
+    )
+
+    fun decorateRecordData(
+        timestamp: OffsetDateTime,
+        globalStateValue: OpaqueStateValue?,
+        stream: Stream,
+        recordData: NativeRecordPayload
     )
 }

--- a/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/output/NativeRecord.kt
+++ b/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/output/NativeRecord.kt
@@ -171,6 +171,7 @@ fun NativeRecordPayload.toProtobuf(
     return recordMessageBuilder.apply {
         schema.sortedBy { it.id }.forEachIndexed { index, field ->
             this@toProtobuf[field.id]?.let { value ->
+                @Suppress("UNCHECKED_CAST")
                 setData(
                     index,
                     value.fieldValue?.let {

--- a/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/output/NativeRecord.kt
+++ b/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/output/NativeRecord.kt
@@ -172,6 +172,9 @@ fun NativeRecordPayload.toProtobuf(
         schema
             .sortedBy { it.id }
             .forEachIndexed { index, field ->
+                // Protobuf does not have field names, so we use a sorted order of fields
+                // So for destination to know which fields it is, we order the fields alphabetically
+                // to make sure that the order is consistent.
                 this@toProtobuf[field.id]?.let { value ->
                     @Suppress("UNCHECKED_CAST")
                     setData(
@@ -186,21 +189,5 @@ fun NativeRecordPayload.toProtobuf(
                     )
                 }
             }
-        // We use toSortedMap() to ensure that the order is consistent
-        // Since protobuf has no field name the contract with destination is that
-        // field are alphabetically ordered.
-        /*this@toProtobuf.toSortedMap().onEachIndexed { index, entry ->
-            @Suppress("UNCHECKED_CAST")
-            setData(
-                index,
-                entry.value.fieldValue?.let {
-                    (entry.value.jsonEncoder.toProtobufEncoder() as ProtoEncoder<Any>).encode(
-                        valueBuilder.clear(),
-                        entry.value.fieldValue!!
-                    )
-                }
-                    ?: nullProtoEncoder.encode(valueBuilder.clear(), null)
-            )
-        }*/
     }
 }

--- a/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/output/NativeRecord.kt
+++ b/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/output/NativeRecord.kt
@@ -179,7 +179,7 @@ fun NativeRecordPayload.toProtobuf(
                         value.fieldValue?.let {
                             (value.jsonEncoder.toProtobufEncoder() as ProtoEncoder<Any>).encode(
                                 valueBuilder.clear(),
-                                value.fieldValue!!
+                                value.fieldValue
                             )
                         }
                             ?: nullProtoEncoder.encode(valueBuilder.clear(), null)

--- a/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/output/NativeRecord.kt
+++ b/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/output/NativeRecord.kt
@@ -169,20 +169,23 @@ fun NativeRecordPayload.toProtobuf(
     valueBuilder: AirbyteRecordMessage.AirbyteValueProtobuf.Builder
 ): AirbyteRecordMessageProtobuf.Builder {
     return recordMessageBuilder.apply {
-        schema.sortedBy { it.id }.forEachIndexed { index, field ->
-            this@toProtobuf[field.id]?.let { value ->
-                @Suppress("UNCHECKED_CAST")
-                setData(
-                    index,
-                    value.fieldValue?.let {
-                        (value.jsonEncoder.toProtobufEncoder() as ProtoEncoder<Any>).encode(
-                            valueBuilder.clear(),
-                            value.fieldValue!!
-                        )
-                    } ?: nullProtoEncoder.encode(valueBuilder.clear(), null)
-                )
+        schema
+            .sortedBy { it.id }
+            .forEachIndexed { index, field ->
+                this@toProtobuf[field.id]?.let { value ->
+                    @Suppress("UNCHECKED_CAST")
+                    setData(
+                        index,
+                        value.fieldValue?.let {
+                            (value.jsonEncoder.toProtobufEncoder() as ProtoEncoder<Any>).encode(
+                                valueBuilder.clear(),
+                                value.fieldValue!!
+                            )
+                        }
+                            ?: nullProtoEncoder.encode(valueBuilder.clear(), null)
+                    )
+                }
             }
-        }
         // We use toSortedMap() to ensure that the order is consistent
         // Since protobuf has no field name the contract with destination is that
         // field are alphabetically ordered.

--- a/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/output/NativeRecord.kt
+++ b/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/output/NativeRecord.kt
@@ -121,7 +121,7 @@ val offsetTimeProtoEncoder =
     }
 val localDateTimeProtoEncoder =
     generateProtoEncoder<LocalDateTime> { builder, value ->
-        builder.setString(value.format(OffsetTimeCodec.formatter))
+        builder.setString(value.format(LocalDateTimeCodec.formatter))
     }
 val localTimeProtoEncoder =
     generateProtoEncoder<LocalTime> { builder, time ->

--- a/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/output/sockets/SocketDataChannel.kt
+++ b/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/output/sockets/SocketDataChannel.kt
@@ -59,7 +59,7 @@ class UnixDomainSocketDataChannel(
     private val probePacket: ProbePacket
 ) : SocketDataChannel {
 
-    private var socketStatus = AtomicReference<SocketDataChannel.SocketStatus>(SOCKET_CLOSED)
+    private var socketStatus = AtomicReference(SOCKET_CLOSED)
     private var socketBound = AtomicBoolean(false)
 
     override var outputStream: OutputStream? = null

--- a/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/read/FeedBootstrap.kt
+++ b/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/read/FeedBootstrap.kt
@@ -234,7 +234,9 @@ sealed class FeedBootstrap<T : Feed>(
             changes: Map<Field, FieldValueChange>?
         ) {
             if (changes.isNullOrEmpty()) {
-                acceptWithoutChanges(recordData.toProtobuf(stream.schema, defaultRecordData, valueVBuilder))
+                acceptWithoutChanges(
+                    recordData.toProtobuf(stream.schema, defaultRecordData, valueVBuilder)
+                )
             } else {
                 val rm = AirbyteRecordMessageMetaOuterClass.AirbyteRecordMessageMeta.newBuilder()
                 val c =
@@ -246,7 +248,10 @@ sealed class FeedBootstrap<T : Feed>(
                         .setReason(fieldValueChange.protobufReason())
                     rm.addChanges(c)
                 }
-                acceptWithChanges(recordData.toProtobuf(stream.schema, defaultRecordData, valueVBuilder), rm)
+                acceptWithChanges(
+                    recordData.toProtobuf(stream.schema, defaultRecordData, valueVBuilder),
+                    rm
+                )
             }
         }
 
@@ -300,7 +305,10 @@ sealed class FeedBootstrap<T : Feed>(
                     val decoratingFields: NativeRecordPayload = mutableMapOf()
                     if (feed is Stream && precedingGlobalFeed != null || isTriggerBasedCdc) {
                         metaFieldDecorator.decorateRecordData(
-                            timestamp = socketProtobufOutputConsumer.recordEmittedAt.atOffset(ZoneOffset.UTC),
+                            timestamp =
+                                socketProtobufOutputConsumer.recordEmittedAt.atOffset(
+                                    ZoneOffset.UTC
+                                ),
                             globalStateValue =
                                 if (precedingGlobalFeed != null)
                                     stateManager.scoped(precedingGlobalFeed).current()
@@ -317,7 +325,9 @@ sealed class FeedBootstrap<T : Feed>(
                                 when {
                                     decoratingFields.keys.contains(field.id) -> {
                                         @Suppress("UNCHECKED_CAST")
-                                        (decoratingFields[field.id]!!.jsonEncoder.toProtobufEncoder() as ProtoEncoder<Any> )
+                                        (decoratingFields[field.id]!!
+                                                .jsonEncoder
+                                                .toProtobufEncoder() as ProtoEncoder<Any>)
                                             .encode(
                                                 valueVBuilder.clear(),
                                                 /*decoratingFields[field.id]!!.fieldValue*/

--- a/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/read/FeedBootstrap.kt
+++ b/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/read/FeedBootstrap.kt
@@ -234,7 +234,7 @@ sealed class FeedBootstrap<T : Feed>(
             changes: Map<Field, FieldValueChange>?
         ) {
             if (changes.isNullOrEmpty()) {
-                acceptWithoutChanges(recordData.toProtobuf(defaultRecordData, valueVBuilder))
+                acceptWithoutChanges(recordData.toProtobuf(stream.schema, defaultRecordData, valueVBuilder))
             } else {
                 val rm = AirbyteRecordMessageMetaOuterClass.AirbyteRecordMessageMeta.newBuilder()
                 val c =
@@ -246,7 +246,7 @@ sealed class FeedBootstrap<T : Feed>(
                         .setReason(fieldValueChange.protobufReason())
                     rm.addChanges(c)
                 }
-                acceptWithChanges(recordData.toProtobuf(defaultRecordData, valueVBuilder), rm)
+                acceptWithChanges(recordData.toProtobuf(stream.schema, defaultRecordData, valueVBuilder), rm)
             }
         }
 

--- a/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/read/FeedBootstrap.kt
+++ b/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/read/FeedBootstrap.kt
@@ -316,6 +316,7 @@ sealed class FeedBootstrap<T : Feed>(
                             builder.addData(
                                 when {
                                     decoratingFields.keys.contains(field.id) -> {
+                                        @Suppress("UNCHECKED_CAST")
                                         (decoratingFields[field.id]!!.jsonEncoder.toProtobufEncoder() as ProtoEncoder<Any> )
                                             .encode(
                                                 valueVBuilder.clear(),

--- a/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/read/FeedBootstrap.kt
+++ b/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/read/FeedBootstrap.kt
@@ -319,7 +319,7 @@ sealed class FeedBootstrap<T : Feed>(
                     }
 
                     // Unlike STDIO mode, in socket mode we always include all scehma fields
-                    // Including decoraiton even when it has to value.
+                    // Including decorating field even when it has NULL value.
                     // This is necessary beacuse in PROTOBUF mode we don't have field names so
                     // the sorted order of fields is used to determine the field position on the
                     // other side.

--- a/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/read/FeedBootstrap.kt
+++ b/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/read/FeedBootstrap.kt
@@ -318,19 +318,22 @@ sealed class FeedBootstrap<T : Feed>(
                         )
                     }
 
+                    // Unlike STDIO mode, in socket mode we always include all scehma fields
+                    // Including decoraiton even when it has to value.
+                    // This is necessary beacuse in PROTOBUF mode we don't have field names so
+                    // the sorted order of fields is used to determine the field position on the
+                    // other side.
                     stream.schema
                         .sortedBy { it.id }
                         .forEach { field ->
                             builder.addData(
                                 when {
                                     decoratingFields.keys.contains(field.id) -> {
-                                        @Suppress("UNCHECKED_CAST")
                                         (decoratingFields[field.id]!!
                                                 .jsonEncoder
                                                 .toProtobufEncoder() as ProtoEncoder<Any>)
                                             .encode(
                                                 valueVBuilder.clear(),
-                                                /*decoratingFields[field.id]!!.fieldValue*/
                                                 decoratingFields[field.id]!!.fieldValue!!
                                             )
                                     }

--- a/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/read/FeedBootstrap.kt
+++ b/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/read/FeedBootstrap.kt
@@ -329,6 +329,7 @@ sealed class FeedBootstrap<T : Feed>(
                             builder.addData(
                                 when {
                                     decoratingFields.keys.contains(field.id) -> {
+                                        @Suppress("UNCHECKED_CAST")
                                         (decoratingFields[field.id]!!
                                                 .jsonEncoder
                                                 .toProtobufEncoder() as ProtoEncoder<Any>)

--- a/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/read/StateManagerFactory.kt
+++ b/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/read/StateManagerFactory.kt
@@ -88,6 +88,9 @@ class StateManagerFactory(
                         stream.copy(schema = stream.schema + metaFieldDecorator.globalMetaFields)
                     ConfiguredSyncMode.FULL_REFRESH ->
                         when (DataChannelMedium.valueOf(dataChannelMedium)) {
+                            // Because socket protobuf mode is using a sorted list of fields
+                            // Without including field id's we need to always send the full
+                            // set of fields as in the schema so sorting is maintained.
                             DataChannelMedium.SOCKET ->
                                 stream.copy(
                                     schema = stream.schema + metaFieldDecorator.globalMetaFields

--- a/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/read/StateManagerFactory.kt
+++ b/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/read/StateManagerFactory.kt
@@ -86,12 +86,14 @@ class StateManagerFactory(
                 when (stream.configuredSyncMode) {
                     ConfiguredSyncMode.INCREMENTAL ->
                         stream.copy(schema = stream.schema + metaFieldDecorator.globalMetaFields)
-                    ConfiguredSyncMode.FULL_REFRESH -> when (DataChannelMedium.valueOf(dataChannelMedium)) {
-                        DataChannelMedium.SOCKET -> stream.copy(schema = stream.schema + metaFieldDecorator.globalMetaFields)
-                        DataChannelMedium.STDIO -> stream
-                    }
-
-
+                    ConfiguredSyncMode.FULL_REFRESH ->
+                        when (DataChannelMedium.valueOf(dataChannelMedium)) {
+                            DataChannelMedium.SOCKET ->
+                                stream.copy(
+                                    schema = stream.schema + metaFieldDecorator.globalMetaFields
+                                )
+                            DataChannelMedium.STDIO -> stream
+                        }
                 }
             }
         val globalStreams: List<Stream> =

--- a/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/read/StateManagerFactory.kt
+++ b/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/read/StateManagerFactory.kt
@@ -20,6 +20,7 @@ import io.airbyte.cdk.discover.MetaField
 import io.airbyte.cdk.discover.MetaFieldDecorator
 import io.airbyte.cdk.discover.MetadataQuerier
 import io.airbyte.cdk.output.CatalogValidationFailureHandler
+import io.airbyte.cdk.output.DataChannelMedium
 import io.airbyte.cdk.output.FieldNotFound
 import io.airbyte.cdk.output.FieldTypeMismatch
 import io.airbyte.cdk.output.InvalidIncrementalSyncMode
@@ -28,11 +29,13 @@ import io.airbyte.cdk.output.MultipleStreamsFound
 import io.airbyte.cdk.output.OutputConsumer
 import io.airbyte.cdk.output.StreamHasNoFields
 import io.airbyte.cdk.output.StreamNotFound
+import io.airbyte.cdk.output.sockets.DATA_CHANNEL_PROPERTY_PREFIX
 import io.airbyte.protocol.models.v0.AirbyteErrorTraceMessage
 import io.airbyte.protocol.models.v0.AirbyteStream
 import io.airbyte.protocol.models.v0.ConfiguredAirbyteCatalog
 import io.airbyte.protocol.models.v0.ConfiguredAirbyteStream
 import io.airbyte.protocol.models.v0.SyncMode
+import io.micronaut.context.annotation.Value
 import jakarta.inject.Singleton
 
 /**
@@ -45,6 +48,7 @@ class StateManagerFactory(
     val metaFieldDecorator: MetaFieldDecorator,
     val outputConsumer: OutputConsumer,
     val handler: CatalogValidationFailureHandler,
+    @Value("\${${DATA_CHANNEL_PROPERTY_PREFIX}.medium}") val dataChannelMedium: String,
 ) {
     /** Generates a [StateManager] instance based on the provided inputs. */
     fun create(
@@ -82,7 +86,12 @@ class StateManagerFactory(
                 when (stream.configuredSyncMode) {
                     ConfiguredSyncMode.INCREMENTAL ->
                         stream.copy(schema = stream.schema + metaFieldDecorator.globalMetaFields)
-                    ConfiguredSyncMode.FULL_REFRESH -> stream
+                    ConfiguredSyncMode.FULL_REFRESH -> when (DataChannelMedium.valueOf(dataChannelMedium)) {
+                        DataChannelMedium.SOCKET -> stream.copy(schema = stream.schema + metaFieldDecorator.globalMetaFields)
+                        DataChannelMedium.STDIO -> stream
+                    }
+
+
                 }
             }
         val globalStreams: List<Stream> =

--- a/airbyte-cdk/bulk/core/extract/src/test/kotlin/io/airbyte/cdk/read/RootReaderIntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/extract/src/test/kotlin/io/airbyte/cdk/read/RootReaderIntegrationTest.kt
@@ -13,6 +13,7 @@ import io.airbyte.cdk.discover.MetaFieldDecorator
 import io.airbyte.cdk.output.BufferingOutputConsumer
 import io.airbyte.cdk.output.DataChannelFormat
 import io.airbyte.cdk.output.DataChannelMedium
+import io.airbyte.cdk.output.sockets.NativeRecordPayload
 import io.airbyte.cdk.util.Jsons
 import io.airbyte.protocol.models.v0.AirbyteMessage
 import io.airbyte.protocol.models.v0.AirbyteStateMessage
@@ -727,6 +728,13 @@ data object NoOpMetaFieldDecorator : MetaFieldDecorator {
         globalStateValue: OpaqueStateValue?,
         stream: Stream,
         recordData: ObjectNode
+    ) {}
+
+    override fun decorateRecordData(
+        timestamp: OffsetDateTime,
+        globalStateValue: OpaqueStateValue?,
+        stream: Stream,
+        recordData: NativeRecordPayload
     ) {}
 }
 

--- a/airbyte-cdk/bulk/core/extract/src/test/kotlin/io/airbyte/cdk/read/StateManagerGlobalStatesTest.kt
+++ b/airbyte-cdk/bulk/core/extract/src/test/kotlin/io/airbyte/cdk/read/StateManagerGlobalStatesTest.kt
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test
 @Property(name = "airbyte.connector.config.database", value = "testdb")
 @Property(name = "airbyte.connector.config.cursor.cursor_method", value = "cdc")
 @Property(name = "metadata.resource", value = "discover/metadata-valid.json")
+@Property(name = "airbyte.connector.data-channel.medium", value = "STDIO")
 class StateManagerGlobalStatesTest {
     @Inject lateinit var config: SourceConfiguration
 

--- a/airbyte-cdk/bulk/core/extract/src/test/kotlin/io/airbyte/cdk/read/StateManagerStreamStatesTest.kt
+++ b/airbyte-cdk/bulk/core/extract/src/test/kotlin/io/airbyte/cdk/read/StateManagerStreamStatesTest.kt
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test
 @Property(name = "airbyte.connector.config.database", value = "testdb")
 @Property(name = "airbyte.connector.config.cursor.cursor_method", value = "user_defined")
 @Property(name = "metadata.resource", value = "discover/metadata-valid.json")
+@Property(name = "airbyte.connector.data-channel.medium", value = "STDIO")
 class StateManagerStreamStatesTest {
     @Inject lateinit var config: SourceConfiguration
 

--- a/airbyte-cdk/bulk/core/extract/src/testFixtures/kotlin/io/airbyte/cdk/discover/TestMetaFieldDecorator.kt
+++ b/airbyte-cdk/bulk/core/extract/src/testFixtures/kotlin/io/airbyte/cdk/discover/TestMetaFieldDecorator.kt
@@ -7,6 +7,7 @@ package io.airbyte.cdk.discover
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.node.ObjectNode
 import io.airbyte.cdk.command.OpaqueStateValue
+import io.airbyte.cdk.output.sockets.NativeRecordPayload
 import io.airbyte.cdk.read.Stream
 import io.micronaut.context.annotation.Requires
 import io.micronaut.context.env.Environment
@@ -47,5 +48,14 @@ class TestMetaFieldDecorator : MetaFieldDecorator {
                 CdcStringMetaFieldType.jsonEncoder.encode(globalStateValue.toString())
             }
         )
+    }
+
+    override fun decorateRecordData(
+        timestamp: OffsetDateTime,
+        globalStateValue: OpaqueStateValue?,
+        stream: Stream,
+        recordData: NativeRecordPayload
+    ) {
+        // no-op
     }
 }

--- a/airbyte-cdk/bulk/toolkits/extract-jdbc/src/test/kotlin/io/airbyte/cdk/read/TestFixtures.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-jdbc/src/test/kotlin/io/airbyte/cdk/read/TestFixtures.kt
@@ -202,6 +202,13 @@ object TestFixtures {
             stream: Stream,
             recordData: ObjectNode
         ) {}
+
+        override fun decorateRecordData(
+            timestamp: OffsetDateTime,
+            globalStateValue: OpaqueStateValue?,
+            stream: Stream,
+            recordData: NativeRecordPayload
+        ) {}
     }
 
     fun Stream.bootstrap(opaqueStateValue: OpaqueStateValue?): StreamFeedBootstrap =

--- a/airbyte-cdk/bulk/toolkits/extract-jdbc/src/testFixtures/kotlin/io/airbyte/cdk/h2source/H2SourceOperations.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-jdbc/src/testFixtures/kotlin/io/airbyte/cdk/h2source/H2SourceOperations.kt
@@ -35,6 +35,7 @@ import io.airbyte.cdk.jdbc.ShortFieldType
 import io.airbyte.cdk.jdbc.StringFieldType
 import io.airbyte.cdk.jdbc.UrlFieldType
 import io.airbyte.cdk.jdbc.XmlFieldType
+import io.airbyte.cdk.output.sockets.NativeRecordPayload
 import io.airbyte.cdk.read.And
 import io.airbyte.cdk.read.Equal
 import io.airbyte.cdk.read.From
@@ -100,6 +101,15 @@ class H2SourceOperations :
         recordData.putNull(H2GlobalCursor.id)
         recordData.putNull(CommonMetaField.CDC_UPDATED_AT.id)
         recordData.putNull(CommonMetaField.CDC_DELETED_AT.id)
+    }
+
+    override fun decorateRecordData(
+        timestamp: OffsetDateTime,
+        globalStateValue: OpaqueStateValue?,
+        stream: Stream,
+        recordData: NativeRecordPayload
+    ) {
+        // no-op
     }
 
     override fun toFieldType(c: JdbcMetadataQuerier.ColumnMetadata): FieldType =

--- a/airbyte-integrations/connectors/source-mysql/src/main/kotlin/io/airbyte/integrations/source/mysql/MySqlSourceJdbcPartitionFactory.kt
+++ b/airbyte-integrations/connectors/source-mysql/src/main/kotlin/io/airbyte/integrations/source/mysql/MySqlSourceJdbcPartitionFactory.kt
@@ -595,7 +595,7 @@ class MySqlSourceJdbcPartitionFactory(
         val effectiveLowerBound = lowerBound ?: Long.MIN_VALUE
         val eachStep: Long = (upperBound - effectiveLowerBound) / num
         for (i in 1..(num - 1)) {
-            queryPlan.add(i * eachStep)
+            queryPlan.add(effectiveLowerBound + i * eachStep)
         }
 
         val lbs: List<Long> = listOf(effectiveLowerBound) + queryPlan
@@ -613,7 +613,7 @@ class MySqlSourceJdbcPartitionFactory(
         val effectiveLowerBound = lowerBound ?: Double.MIN_VALUE
         val eachStep: Double = (upperBound - effectiveLowerBound) / num
         for (i in 1..(num - 1)) {
-            queryPlan.add(i * eachStep)
+            queryPlan.add(effectiveLowerBound + i * eachStep)
         }
         val lbs: List<Double> = listOf(effectiveLowerBound) + queryPlan
         val ubs: List<Double?> = queryPlan + null

--- a/airbyte-integrations/connectors/source-mysql/src/main/kotlin/io/airbyte/integrations/source/mysql/MySqlSourceJdbcPartitionFactory.kt
+++ b/airbyte-integrations/connectors/source-mysql/src/main/kotlin/io/airbyte/integrations/source/mysql/MySqlSourceJdbcPartitionFactory.kt
@@ -520,7 +520,7 @@ class MySqlSourceJdbcPartitionFactory(
             }
 
         return calculateBoundaries(num, lowerBound, upperBound)?.map { (l, u) ->
-            MySqlSourceJdbcSplittableCdcRfrSnapshotPartition(
+            MySqlSourceJdbcSplittableRfrSnapshotPartition(
                 selectQueryGenerator,
                 streamState,
                 checkpointColumns,

--- a/airbyte-integrations/connectors/source-mysql/src/main/kotlin/io/airbyte/integrations/source/mysql/MySqlSourceJdbcPartitionFactory.kt
+++ b/airbyte-integrations/connectors/source-mysql/src/main/kotlin/io/airbyte/integrations/source/mysql/MySqlSourceJdbcPartitionFactory.kt
@@ -452,6 +452,8 @@ class MySqlSourceJdbcPartitionFactory(
                 unsplitPartition.split(opaqueStateValues.size, upperBoundVal, lowerBoundVal)
             is MySqlSourceJdbcCdcSnapshotPartition ->
                 unsplitPartition.split(opaqueStateValues.size, upperBoundVal, lowerBoundVal)
+            is MySqlSourceJdbcCdcRfrSnapshotPartition ->
+                unsplitPartition.split(opaqueStateValues.size, upperBoundVal, lowerBoundVal)
             else -> null
         }
             ?: listOf(unsplitPartition)
@@ -496,6 +498,29 @@ class MySqlSourceJdbcPartitionFactory(
 
         return calculateBoundaries(num, lowerBound, upperBound)?.map { (l, u) ->
             MySqlSourceJdbcSplittableRfrSnapshotPartition(
+                selectQueryGenerator,
+                streamState,
+                checkpointColumns,
+                listOf(stateValueToJsonNode(checkpointColumns[0], l.toString())),
+                u?.let { listOf(stateValueToJsonNode(checkpointColumns[0], u.toString())) },
+            )
+        }
+    }
+
+    private fun MySqlSourceJdbcCdcRfrSnapshotPartition.split(
+        num: Int,
+        upperBound: Any?,
+        effectiveLowerBound: Any?
+    ): List<MySqlSourceJdbcResumablePartition>? {
+        val type = checkpointColumns[0].type as LosslessJdbcFieldType<*, *>
+        val lowerBound =
+            when (lowerBound.isNullOrEmpty()) {
+                true -> effectiveLowerBound
+                false -> type.jsonDecoder.decode(lowerBound[0])
+            }
+
+        return calculateBoundaries(num, lowerBound, upperBound)?.map { (l, u) ->
+            MySqlSourceJdbcSplittableCdcRfrSnapshotPartition(
                 selectQueryGenerator,
                 streamState,
                 checkpointColumns,

--- a/airbyte-integrations/connectors/source-mysql/src/main/kotlin/io/airbyte/integrations/source/mysql/MySqlSourceJdbcPartitionFactory.kt
+++ b/airbyte-integrations/connectors/source-mysql/src/main/kotlin/io/airbyte/integrations/source/mysql/MySqlSourceJdbcPartitionFactory.kt
@@ -235,7 +235,7 @@ class MySqlSourceJdbcPartitionFactory(
 
             if (stream.configuredSyncMode == ConfiguredSyncMode.FULL_REFRESH) {
                 val upperBound = findPkUpperBound(stream, pkChosenFromCatalog)
-                if (sv.pkVal == upperBound.asText()) {
+                if (sv.pkVal == upperBound.asText() || sv.pkVal == null) {
                     return null
                 }
                 val pkLowerBound: JsonNode = stateValueToJsonNode(pkChosenFromCatalog[0], sv.pkVal)

--- a/airbyte-integrations/connectors/source-mysql/src/main/kotlin/io/airbyte/integrations/source/mysql/MySqlSourceOperations.kt
+++ b/airbyte-integrations/connectors/source-mysql/src/main/kotlin/io/airbyte/integrations/source/mysql/MySqlSourceOperations.kt
@@ -34,6 +34,8 @@ import io.airbyte.cdk.jdbc.OffsetDateTimeFieldType
 import io.airbyte.cdk.jdbc.PokemonFieldType
 import io.airbyte.cdk.jdbc.ShortFieldType
 import io.airbyte.cdk.jdbc.StringFieldType
+import io.airbyte.cdk.output.sockets.FieldValueEncoder
+import io.airbyte.cdk.output.sockets.NativeRecordPayload
 import io.airbyte.cdk.read.And
 import io.airbyte.cdk.read.Equal
 import io.airbyte.cdk.read.From
@@ -84,6 +86,34 @@ class MySqlSourceOperations :
             MySqlSourceCdcMetaFields.CDC_LOG_FILE,
             MySqlSourceCdcMetaFields.CDC_LOG_POS
         )
+
+    override fun decorateRecordData(
+        timestamp: OffsetDateTime,
+        globalStateValue: OpaqueStateValue?,
+        stream: Stream,
+        recordData: NativeRecordPayload
+    ) {
+        recordData.set(
+            CommonMetaField.CDC_UPDATED_AT.id,
+            FieldValueEncoder(timestamp, CdcOffsetDateTimeMetaFieldType.jsonEncoder))
+        recordData.set(
+            MySqlSourceCdcMetaFields.CDC_LOG_POS.id,
+            FieldValueEncoder(0, CdcIntegerMetaFieldType.jsonEncoder)
+        )
+        if (globalStateValue == null) {
+            return
+        }
+        val offset: DebeziumOffset =
+            MySqlSourceDebeziumOperations.deserializeStateUnvalidated(globalStateValue).offset
+        val position: MySqlSourceCdcPosition = MySqlSourceDebeziumOperations.position(offset)
+        recordData.set(
+            MySqlSourceCdcMetaFields.CDC_LOG_FILE.id,
+            FieldValueEncoder(position.fileName, CdcStringMetaFieldType.jsonEncoder))
+        recordData.set(
+            MySqlSourceCdcMetaFields.CDC_LOG_POS.id,
+            FieldValueEncoder(position.position, CdcIntegerMetaFieldType.jsonEncoder)
+        )
+    }
 
     override fun decorateRecordData(
         timestamp: OffsetDateTime,

--- a/airbyte-integrations/connectors/source-mysql/src/main/kotlin/io/airbyte/integrations/source/mysql/MySqlSourceOperations.kt
+++ b/airbyte-integrations/connectors/source-mysql/src/main/kotlin/io/airbyte/integrations/source/mysql/MySqlSourceOperations.kt
@@ -95,7 +95,8 @@ class MySqlSourceOperations :
     ) {
         recordData.set(
             CommonMetaField.CDC_UPDATED_AT.id,
-            FieldValueEncoder(timestamp, CdcOffsetDateTimeMetaFieldType.jsonEncoder))
+            FieldValueEncoder(timestamp, CdcOffsetDateTimeMetaFieldType.jsonEncoder)
+        )
         recordData.set(
             MySqlSourceCdcMetaFields.CDC_LOG_POS.id,
             FieldValueEncoder(0, CdcIntegerMetaFieldType.jsonEncoder)
@@ -108,7 +109,8 @@ class MySqlSourceOperations :
         val position: MySqlSourceCdcPosition = MySqlSourceDebeziumOperations.position(offset)
         recordData.set(
             MySqlSourceCdcMetaFields.CDC_LOG_FILE.id,
-            FieldValueEncoder(position.fileName, CdcStringMetaFieldType.jsonEncoder))
+            FieldValueEncoder(position.fileName, CdcStringMetaFieldType.jsonEncoder)
+        )
         recordData.set(
             MySqlSourceCdcMetaFields.CDC_LOG_POS.id,
             FieldValueEncoder(position.position, CdcIntegerMetaFieldType.jsonEncoder)

--- a/airbyte-integrations/connectors/source-mysql/src/test/kotlin/io/airbyte/integrations/source/mysql/MySqlSourceJdbcPartitionFactoryTest.kt
+++ b/airbyte-integrations/connectors/source-mysql/src/test/kotlin/io/airbyte/integrations/source/mysql/MySqlSourceJdbcPartitionFactoryTest.kt
@@ -20,6 +20,7 @@ import io.airbyte.cdk.jdbc.OffsetDateTimeFieldType
 import io.airbyte.cdk.output.BufferingOutputConsumer
 import io.airbyte.cdk.output.DataChannelFormat
 import io.airbyte.cdk.output.DataChannelMedium
+import io.airbyte.cdk.output.sockets.NativeRecordPayload
 import io.airbyte.cdk.read.ConcurrencyResource
 import io.airbyte.cdk.read.ConfiguredSyncMode
 import io.airbyte.cdk.read.DefaultJdbcSharedState
@@ -154,6 +155,15 @@ class MySqlSourceJdbcPartitionFactoryTest {
                             stream: Stream,
                             recordData: ObjectNode
                         ) {}
+
+                        override fun decorateRecordData(
+                            timestamp: OffsetDateTime,
+                            globalStateValue: OpaqueStateValue?,
+                            stream: Stream,
+                            recordData: NativeRecordPayload
+                        ) {
+                            // no-op
+                        }
                     },
                 stateManager =
                     StateManager(initialStreamStates = mapOf(stream to incumbentStateValue)),


### PR DESCRIPTION
Fixes for full refresh streams in CDC syncs when running in speed mode.
Also fixes for correct ordering of columns in protobuf records - we must always include all fields including all decorating _ab_cdc_updated_at, _ab_cdc_deleted_at etc. on every sync in order to maintain order of fields as protobuf has no space for field name.