### PR TITLE
feat(source-cal-com) Add updatedAt, rescheduledByEmail, cancelledByEmail and cancellationReason support for get bookings

### DIFF
--- a/airbyte-integrations/connectors/source-cal-com/manifest.yaml
+++ b/airbyte-integrations/connectors/source-cal-com/manifest.yaml
@@ -860,6 +860,22 @@ schemas:
         type:
           - boolean
           - "null"
+      updatedAt:
+        type:
+          - string
+          - "null"
+      cancelledByEmail:
+        type:
+          - string
+          - "null"
+      cancellationReason:
+        type:
+          - string
+          - "null"
+      rescheduledByEmail:
+        type:
+          - string
+          - "null"
     required:
       - id
   conferencing:

--- a/airbyte-integrations/connectors/source-cal-com/metadata.yaml
+++ b/airbyte-integrations/connectors/source-cal-com/metadata.yaml
@@ -17,7 +17,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 3db8a652-88f7-41ee-91a3-2f745322d9ae
-  dockerImageTag: 0.0.28
+  dockerImageTag: 0.0.29
   dockerRepository: airbyte/source-cal-com
   githubIssueLabel: source-cal-com
   icon: icon.svg

--- a/docs/integrations/sources/cal-com.md
+++ b/docs/integrations/sources/cal-com.md
@@ -25,7 +25,7 @@ The Cal.com connector enables seamless data synchronization between Cal.com’s 
 
 | Version          | Date              | Pull Request | Subject        |
 |------------------|-------------------|--------------|----------------|
-| 0.0.29 | 2025-06-26 | [64095](https://github.com/airbytehq/airbyte/pull/64095) | Add support for updatedAt, cancelledByEmail, rescheduledByEmail and cancellationReason fields in GET Bookings |
+| 0.0.29 | 2025-06-26 | [64099](https://github.com/airbytehq/airbyte/pull/64099) | Add support for updatedAt, cancelledByEmail, rescheduledByEmail and cancellationReason fields in GET Bookings |
 | 0.0.28 | 2025-07-26 | [63787](https://github.com/airbytehq/airbyte/pull/63787) | Update dependencies |
 | 0.0.27 | 2025-07-19 | [63486](https://github.com/airbytehq/airbyte/pull/63486) | Update dependencies |
 | 0.0.26 | 2025-07-12 | [63075](https://github.com/airbytehq/airbyte/pull/63075) | Update dependencies |

--- a/docs/integrations/sources/cal-com.md
+++ b/docs/integrations/sources/cal-com.md
@@ -25,6 +25,7 @@ The Cal.com connector enables seamless data synchronization between Cal.com’s 
 
 | Version          | Date              | Pull Request | Subject        |
 |------------------|-------------------|--------------|----------------|
+| 0.0.29 | 2025-06-26 | [64095](https://github.com/airbytehq/airbyte/pull/64095) | Add support for updatedAt, cancelledByEmail, rescheduledByEmail and cancellationReason fields in GET Bookings |
 | 0.0.28 | 2025-07-26 | [63787](https://github.com/airbytehq/airbyte/pull/63787) | Update dependencies |
 | 0.0.27 | 2025-07-19 | [63486](https://github.com/airbytehq/airbyte/pull/63486) | Update dependencies |
 | 0.0.26 | 2025-07-12 | [63075](https://github.com/airbytehq/airbyte/pull/63075) | Update dependencies |


### PR DESCRIPTION
## What
Add updatedAt, rescheduledByEmail, cancelledByEmail and cancellationReason support for get bookings

## How
By recognizing the fields sent via API V2 payload

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
Users who wish to have access to these fields would have access now

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
