### PR TITLE
Add option to update the batch size

### DIFF
--- a/airbyte-integrations/connectors/destination-clickhouse/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-clickhouse/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: ce0d828e-1dc4-496c-b122-2da42e637e48
-  dockerImageTag: 2.0.9
+  dockerImageTag: 2.0.10
   dockerRepository: airbyte/destination-clickhouse
   githubIssueLabel: destination-clickhouse
   icon: clickhouse.svg

--- a/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/spec/ClickhouseConfiguration.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/spec/ClickhouseConfiguration.kt
@@ -18,6 +18,8 @@ data class ClickhouseConfiguration(
     val password: String,
     val enableJson: Boolean,
     val tunnelConfig: SshTunnelMethodConfiguration?,
+    val recordWindowSize: Long?,
+    val bytesWindowSize: Long?,
 ) : DestinationConfiguration() {
     val endpoint = "$protocol://$hostname:$port"
     val resolvedDatabase = database.ifEmpty { Defaults.DATABASE_NAME }
@@ -40,14 +42,16 @@ class ClickhouseConfigurationFactory :
             }
 
         return ClickhouseConfiguration(
-            pojo.hostname,
-            pojo.port,
-            protocol,
-            pojo.database,
-            pojo.username,
-            pojo.password,
-            pojo.enableJson ?: false,
-            pojo.getTunnelMethodValue(),
+            hostname = pojo.hostname,
+            port = pojo.port,
+            protocol = protocol,
+            database = pojo.database,
+            username = pojo.username,
+            password = pojo.password,
+            enableJson = pojo.enableJson ?: false,
+            tunnelConfig = pojo.getTunnelMethodValue(),
+            recordWindowSize = pojo.recordWindowSize,
+            bytesWindowSize = pojo.bytesWindowSize,
         )
     }
 
@@ -71,6 +75,8 @@ class ClickhouseConfigurationFactory :
             enableJson =
                 overrides.getOrDefault("enable_json", spec.enableJson.toString()).toBoolean(),
             tunnelConfig = spec.getTunnelMethodValue(),
+            recordWindowSize = spec.recordWindowSize,
+            bytesWindowSize = spec.bytesWindowSize,
         )
     }
 }

--- a/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/spec/ClickhouseConfiguration.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/spec/ClickhouseConfiguration.kt
@@ -19,7 +19,6 @@ data class ClickhouseConfiguration(
     val enableJson: Boolean,
     val tunnelConfig: SshTunnelMethodConfiguration?,
     val recordWindowSize: Long?,
-    val bytesWindowSize: Long?,
 ) : DestinationConfiguration() {
     val endpoint = "$protocol://$hostname:$port"
     val resolvedDatabase = database.ifEmpty { Defaults.DATABASE_NAME }
@@ -51,7 +50,6 @@ class ClickhouseConfigurationFactory :
             enableJson = pojo.enableJson ?: false,
             tunnelConfig = pojo.getTunnelMethodValue(),
             recordWindowSize = pojo.recordWindowSize,
-            bytesWindowSize = pojo.bytesWindowSize,
         )
     }
 
@@ -76,7 +74,6 @@ class ClickhouseConfigurationFactory :
                 overrides.getOrDefault("enable_json", spec.enableJson.toString()).toBoolean(),
             tunnelConfig = spec.getTunnelMethodValue(),
             recordWindowSize = spec.recordWindowSize,
-            bytesWindowSize = spec.bytesWindowSize,
         )
     }
 }

--- a/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/spec/ClickhouseSpecification.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/spec/ClickhouseSpecification.kt
@@ -115,7 +115,7 @@ class ClickhouseSpecificationOss : ClickhouseSpecification() {
 
     @get:JsonSchemaTitle("Bytes Window Size")
     @get:JsonPropertyDescription(
-        "Tuning this parameter can impact the performances. The maximum number of bytes that should be written to a batch."
+        "Warning: Tuning this parameter can impact the performances. The maximum number of bytes that should be written to a batch."
     )
     @get:JsonProperty("bytes_window_size")
     @get:JsonSchemaInject(json = """{"order": 9}""")
@@ -200,7 +200,7 @@ open class ClickhouseSpecificationCloud : ClickhouseSpecification() {
 
     @get:JsonSchemaTitle("Bytes Window Size")
     @get:JsonPropertyDescription(
-        "Tuning this parameter can impact the performances. The maximum number of bytes that should be written to a batch."
+        "Warning: Tuning this parameter can impact the performances. The maximum number of bytes that should be written to a batch."
     )
     @get:JsonProperty("bytes_window_size")
     @get:JsonSchemaInject(json = """{"order": 9}""")

--- a/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/spec/ClickhouseSpecification.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/spec/ClickhouseSpecification.kt
@@ -34,7 +34,6 @@ sealed class ClickhouseSpecification : ConfigurationSpecification() {
     abstract val enableJson: Boolean?
     abstract fun getTunnelMethodValue(): SshTunnelMethodConfiguration?
     abstract val recordWindowSize: Long?
-    abstract val bytesWindowSize: Long?
 }
 
 @Singleton
@@ -107,19 +106,11 @@ class ClickhouseSpecificationOss : ClickhouseSpecification() {
 
     @get:JsonSchemaTitle("Record Window Size")
     @get:JsonPropertyDescription(
-        "Warning: Tuning this parameter can impact the performances. The maximum number of records that should be written to a batch."
+        "Warning: Tuning this parameter can impact the performances. The maximum number of records that should be written to a batch. The batch size limit is still limited to 70 Mb"
     )
     @get:JsonProperty("record_window_size")
     @get:JsonSchemaInject(json = """{"order": 8}""")
     override val recordWindowSize: Long? = MAX_BATCH_SIZE_RECORDS
-
-    @get:JsonSchemaTitle("Bytes Window Size")
-    @get:JsonPropertyDescription(
-        "Warning: Tuning this parameter can impact the performances. The maximum number of bytes that should be written to a batch."
-    )
-    @get:JsonProperty("bytes_window_size")
-    @get:JsonSchemaInject(json = """{"order": 9}""")
-    override val bytesWindowSize: Long? = MAX_BATCH_SIZE_BYTES
 }
 
 @Singleton
@@ -192,19 +183,11 @@ open class ClickhouseSpecificationCloud : ClickhouseSpecification() {
 
     @get:JsonSchemaTitle("Record Window Size")
     @get:JsonPropertyDescription(
-        "Warning: Tuning this parameter can impact the performances. The maximum number of records that should be written to a batch."
+        "Warning: Tuning this parameter can impact the performances. The maximum number of records that should be written to a batch. The batch size limit is still limited to 70 Mb"
     )
     @get:JsonProperty("record_window_size")
     @get:JsonSchemaInject(json = """{"order": 8}""")
     override val recordWindowSize: Long? = MAX_BATCH_SIZE_RECORDS
-
-    @get:JsonSchemaTitle("Bytes Window Size")
-    @get:JsonPropertyDescription(
-        "Warning: Tuning this parameter can impact the performances. The maximum number of bytes that should be written to a batch."
-    )
-    @get:JsonProperty("bytes_window_size")
-    @get:JsonSchemaInject(json = """{"order": 9}""")
-    override val bytesWindowSize: Long? = MAX_BATCH_SIZE_BYTES
 }
 
 enum class ClickhouseConnectionProtocol(@get:JsonValue val value: String) {

--- a/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/spec/ClickhouseSpecification.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/spec/ClickhouseSpecification.kt
@@ -105,17 +105,21 @@ class ClickhouseSpecificationOss : ClickhouseSpecification() {
     override fun getTunnelMethodValue(): SshTunnelMethodConfiguration? =
         tunnelConfig ?: tunnelMethod.asSshTunnelMethod()
 
-    @get:JsonSchemaTitle("Record Sized Window")
-    @get:JsonPropertyDescription("The maximum number of records that should be written to a batch.")
-    @get:JsonProperty("record_sized_window")
+    @get:JsonSchemaTitle("Record Window Size")
+    @get:JsonPropertyDescription(
+        "Warning: Tuning this parameter can impact the performances. The maximum number of records that should be written to a batch."
+    )
+    @get:JsonProperty("record_window_size")
     @get:JsonSchemaInject(json = """{"order": 8}""")
     override val recordWindowSize: Long? = MAX_BATCH_SIZE_RECORDS
 
-    @get:JsonSchemaTitle("Bytes Sized Window")
-    @get:JsonPropertyDescription("The maximum number of bytes that should be written to a batch.")
-    @get:JsonProperty("bytes_sized_window")
+    @get:JsonSchemaTitle("Bytes Window Size")
+    @get:JsonPropertyDescription(
+        "Tuning this parameter can impact the performances. The maximum number of bytes that should be written to a batch."
+    )
+    @get:JsonProperty("bytes_window_size")
     @get:JsonSchemaInject(json = """{"order": 9}""")
-    override val bytesWindowSize: Long? = MAX_BATCH_SIZE_RECORDS
+    override val bytesWindowSize: Long? = MAX_BATCH_SIZE_BYTES
 }
 
 @Singleton

--- a/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/spec/ClickhouseSpecification.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/spec/ClickhouseSpecification.kt
@@ -17,7 +17,6 @@ import io.airbyte.cdk.command.ConfigurationSpecification
 import io.airbyte.cdk.load.spec.DestinationSpecificationExtension
 import io.airbyte.cdk.ssh.MicronautPropertiesFriendlySshTunnelMethodConfigurationSpecification
 import io.airbyte.cdk.ssh.SshTunnelMethodConfiguration
-import io.airbyte.integrations.destination.clickhouse.write.load.ClickhouseDirectLoader.Constants.MAX_BATCH_SIZE_BYTES
 import io.airbyte.integrations.destination.clickhouse.write.load.ClickhouseDirectLoader.Constants.MAX_BATCH_SIZE_RECORDS
 import io.airbyte.protocol.models.v0.DestinationSyncMode
 import io.micronaut.context.annotation.ConfigurationBuilder

--- a/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/write/load/ClickhouseDirectLoader.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/write/load/ClickhouseDirectLoader.kt
@@ -17,12 +17,18 @@ import io.airbyte.integrations.destination.clickhouse.write.transform.RecordMung
 class ClickhouseDirectLoader(
     @VisibleForTesting val munger: RecordMunger,
     @VisibleForTesting val buffer: BinaryRowInsertBuffer,
+    @VisibleForTesting val configuredRecordCountWindow: Long?,
+    @VisibleForTesting val configuredBytesWindow: Long?,
 ) : DirectLoader {
-    private var recordCountWindow = SizedWindow(Constants.MAX_BATCH_SIZE_RECORDS)
+    private var recordCountWindow =
+        SizedWindow(configuredRecordCountWindow ?: Constants.MAX_BATCH_SIZE_RECORDS)
     // the sum of serialized json bytes we've accumulated
-    private var bytesWindow = SizedWindow(Constants.MAX_BATCH_SIZE_BYTES)
+    private var bytesWindow = SizedWindow(configuredBytesWindow ?: Constants.MAX_BATCH_SIZE_BYTES)
 
     override suspend fun accept(record: DestinationRecordRaw): DirectLoader.DirectLoadResult {
+        io.airbyte.integrations.destination.clickhouse.client.log.error {
+            "recordCountWindow: $configuredRecordCountWindow, bytesWindow: $configuredBytesWindow"
+        }
         val munged = munger.transformForDest(record)
         buffer.accumulate(munged)
 

--- a/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/write/load/ClickhouseDirectLoader.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/write/load/ClickhouseDirectLoader.kt
@@ -18,17 +18,13 @@ class ClickhouseDirectLoader(
     @VisibleForTesting val munger: RecordMunger,
     @VisibleForTesting val buffer: BinaryRowInsertBuffer,
     @VisibleForTesting val configuredRecordCountWindow: Long?,
-    @VisibleForTesting val configuredBytesWindow: Long?,
 ) : DirectLoader {
     private var recordCountWindow =
         SizedWindow(configuredRecordCountWindow ?: Constants.MAX_BATCH_SIZE_RECORDS)
     // the sum of serialized json bytes we've accumulated
-    private var bytesWindow = SizedWindow(configuredBytesWindow ?: Constants.MAX_BATCH_SIZE_BYTES)
+    private var bytesWindow = SizedWindow(Constants.MAX_BATCH_SIZE_BYTES)
 
     override suspend fun accept(record: DestinationRecordRaw): DirectLoader.DirectLoadResult {
-        io.airbyte.integrations.destination.clickhouse.client.log.error {
-            "recordCountWindow: $configuredRecordCountWindow, bytesWindow: $configuredBytesWindow"
-        }
         val munged = munger.transformForDest(record)
         buffer.accumulate(munged)
 

--- a/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/write/load/ClickhouseDirectLoaderFactory.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/write/load/ClickhouseDirectLoaderFactory.kt
@@ -9,6 +9,7 @@ import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.orchestration.db.direct_load_table.DirectLoadTableExecutionConfig
 import io.airbyte.cdk.load.write.DirectLoaderFactory
 import io.airbyte.cdk.load.write.StreamStateStore
+import io.airbyte.integrations.destination.clickhouse.spec.ClickhouseConfiguration
 import io.airbyte.integrations.destination.clickhouse.write.transform.RecordMunger
 import jakarta.inject.Singleton
 
@@ -20,6 +21,7 @@ class ClickhouseDirectLoaderFactory(
     private val clickhouseClient: Client,
     private val stateStore: StreamStateStore<DirectLoadTableExecutionConfig>,
     private val munger: RecordMunger,
+    private val clickhouseConfiguration: ClickhouseConfiguration,
 ) : DirectLoaderFactory<ClickhouseDirectLoader> {
     override val maxNumOpenLoaders = 2
 
@@ -31,8 +33,10 @@ class ClickhouseDirectLoaderFactory(
         val buffer = BinaryRowInsertBuffer(tableName, clickhouseClient)
 
         return ClickhouseDirectLoader(
-            munger,
-            buffer,
+            munger = munger,
+            buffer = buffer,
+            configuredRecordCountWindow = clickhouseConfiguration.recordWindowSize,
+            configuredBytesWindow = clickhouseConfiguration.bytesWindowSize,
         )
     }
 }

--- a/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/write/load/ClickhouseDirectLoaderFactory.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/write/load/ClickhouseDirectLoaderFactory.kt
@@ -36,7 +36,6 @@ class ClickhouseDirectLoaderFactory(
             munger = munger,
             buffer = buffer,
             configuredRecordCountWindow = clickhouseConfiguration.recordWindowSize,
-            configuredBytesWindow = clickhouseConfiguration.bytesWindowSize,
         )
     }
 }

--- a/airbyte-integrations/connectors/destination-clickhouse/src/test-integration/resources/expected-spec-cloud.json
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/test-integration/resources/expected-spec-cloud.json
@@ -58,15 +58,9 @@
       },
       "record_window_size" : {
         "type" : "integer",
-        "description" : "Warning: Tuning this parameter can impact the performances. The maximum number of records that should be written to a batch.",
+        "description" : "Warning: Tuning this parameter can impact the performances. The maximum number of records that should be written to a batch. The batch size limit is still limited to 70 Mb",
         "title" : "Record Window Size",
         "order" : 8
-      },
-      "bytes_window_size" : {
-        "type" : "integer",
-        "description" : "Warning: Tuning this parameter can impact the performances. The maximum number of bytes that should be written to a batch.",
-        "title" : "Bytes Window Size",
-        "order" : 9
       },
       "tunnel_method" : {
         "oneOf" : [ {

--- a/airbyte-integrations/connectors/destination-clickhouse/src/test-integration/resources/expected-spec-cloud.json
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/test-integration/resources/expected-spec-cloud.json
@@ -56,6 +56,18 @@
         "order" : 6,
         "default" : false
       },
+      "record_window_size" : {
+        "type" : "integer",
+        "description" : "Warning: Tuning this parameter can impact the performances. The maximum number of records that should be written to a batch.",
+        "title" : "Record Window Size",
+        "order" : 8
+      },
+      "bytes_window_size" : {
+        "type" : "integer",
+        "description" : "Tuning this parameter can impact the performances. The maximum number of bytes that should be written to a batch.",
+        "title" : "Bytes Window Size",
+        "order" : 9
+      },
       "tunnel_method" : {
         "oneOf" : [ {
           "title" : "No Tunnel",

--- a/airbyte-integrations/connectors/destination-clickhouse/src/test-integration/resources/expected-spec-cloud.json
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/test-integration/resources/expected-spec-cloud.json
@@ -64,7 +64,7 @@
       },
       "bytes_window_size" : {
         "type" : "integer",
-        "description" : "Tuning this parameter can impact the performances. The maximum number of bytes that should be written to a batch.",
+        "description" : "Warning: Tuning this parameter can impact the performances. The maximum number of bytes that should be written to a batch.",
         "title" : "Bytes Window Size",
         "order" : 9
       },

--- a/airbyte-integrations/connectors/destination-clickhouse/src/test-integration/resources/expected-spec-oss.json
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/test-integration/resources/expected-spec-oss.json
@@ -57,15 +57,9 @@
       },
       "record_window_size" : {
         "type" : "integer",
-        "description" : "Warning: Tuning this parameter can impact the performances. The maximum number of records that should be written to a batch.",
+        "description" : "Warning: Tuning this parameter can impact the performances. The maximum number of records that should be written to a batch. The batch size limit is still limited to 70 Mb",
         "title" : "Record Window Size",
         "order" : 8
-      },
-      "bytes_window_size" : {
-        "type" : "integer",
-        "description" : "Warning: Tuning this parameter can impact the performances. The maximum number of bytes that should be written to a batch.",
-        "title" : "Bytes Window Size",
-        "order" : 9
       },
       "tunnel_method" : {
         "oneOf" : [ {

--- a/airbyte-integrations/connectors/destination-clickhouse/src/test-integration/resources/expected-spec-oss.json
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/test-integration/resources/expected-spec-oss.json
@@ -63,7 +63,7 @@
       },
       "bytes_window_size" : {
         "type" : "integer",
-        "description" : "Tuning this parameter can impact the performances. The maximum number of bytes that should be written to a batch.",
+        "description" : "Warning: Tuning this parameter can impact the performances. The maximum number of bytes that should be written to a batch.",
         "title" : "Bytes Window Size",
         "order" : 9
       },

--- a/airbyte-integrations/connectors/destination-clickhouse/src/test-integration/resources/expected-spec-oss.json
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/test-integration/resources/expected-spec-oss.json
@@ -55,16 +55,16 @@
         "order" : 6,
         "default" : false
       },
-      "record_sized_window" : {
+      "record_window_size" : {
         "type" : "integer",
-        "description" : "The maximum number of records that should be written to a batch.",
-        "title" : "Record Sized Window",
+        "description" : "Warning: Tuning this parameter can impact the performances. The maximum number of records that should be written to a batch.",
+        "title" : "Record Window Size",
         "order" : 8
       },
-      "bytes_sized_window" : {
+      "bytes_window_size" : {
         "type" : "integer",
-        "description" : "The maximum number of bytes that should be written to a batch.",
-        "title" : "Bytes Sized Window",
+        "description" : "Tuning this parameter can impact the performances. The maximum number of bytes that should be written to a batch.",
+        "title" : "Bytes Window Size",
         "order" : 9
       },
       "tunnel_method" : {

--- a/airbyte-integrations/connectors/destination-clickhouse/src/test-integration/resources/expected-spec-oss.json
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/test-integration/resources/expected-spec-oss.json
@@ -55,6 +55,18 @@
         "order" : 6,
         "default" : false
       },
+      "record_sized_window" : {
+        "type" : "integer",
+        "description" : "The maximum number of records that should be written to a batch.",
+        "title" : "Record Sized Window",
+        "order" : 8
+      },
+      "bytes_sized_window" : {
+        "type" : "integer",
+        "description" : "The maximum number of bytes that should be written to a batch.",
+        "title" : "Bytes Sized Window",
+        "order" : 9
+      },
       "tunnel_method" : {
         "oneOf" : [ {
           "title" : "No Tunnel",

--- a/airbyte-integrations/connectors/destination-clickhouse/src/test/kotlin/io/airbyte/integrations/destination/clickhouse/check/ClickhouseCheckerTest.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/test/kotlin/io/airbyte/integrations/destination/clickhouse/check/ClickhouseCheckerTest.kt
@@ -142,16 +142,20 @@ class ClickhouseCheckerTest {
             username: String = "username",
             password: String = "password",
             enableJson: Boolean = false,
+            recordWindow: Long = 42000,
+            bytesWindow: Long = 42000000
         ): ClickhouseConfiguration =
             ClickhouseConfiguration(
-                hostname,
-                port,
-                protocol,
-                database,
-                username,
-                password,
-                enableJson,
+                hostname = hostname,
+                port = port,
+                protocol = protocol,
+                database = database,
+                username = username,
+                password = password,
+                enableJson = enableJson,
                 tunnelConfig = null,
+                recordWindowSize = recordWindow,
+                bytesWindowSize = bytesWindow,
             )
     }
 }

--- a/airbyte-integrations/connectors/destination-clickhouse/src/test/kotlin/io/airbyte/integrations/destination/clickhouse/check/ClickhouseCheckerTest.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/test/kotlin/io/airbyte/integrations/destination/clickhouse/check/ClickhouseCheckerTest.kt
@@ -143,7 +143,6 @@ class ClickhouseCheckerTest {
             password: String = "password",
             enableJson: Boolean = false,
             recordWindow: Long = 42000,
-            bytesWindow: Long = 42000000
         ): ClickhouseConfiguration =
             ClickhouseConfiguration(
                 hostname = hostname,
@@ -155,7 +154,6 @@ class ClickhouseCheckerTest {
                 enableJson = enableJson,
                 tunnelConfig = null,
                 recordWindowSize = recordWindow,
-                bytesWindowSize = bytesWindow,
             )
     }
 }

--- a/airbyte-integrations/connectors/destination-clickhouse/src/test/kotlin/io/airbyte/integrations/destination/clickhouse/write/load/ClickhouseDirectLoaderFactoryTest.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/test/kotlin/io/airbyte/integrations/destination/clickhouse/write/load/ClickhouseDirectLoaderFactoryTest.kt
@@ -53,16 +53,13 @@ class ClickhouseDirectLoaderFactoryTest {
         every { stateStore.get(stream) } returns DirectLoadTableExecutionConfig(table)
 
         val recordWindowSized = 123L
-        val bytesWindowSized = 456L
         every { clickhouseConfiguration.recordWindowSize } returns recordWindowSized
-        every { clickhouseConfiguration.bytesWindowSize } returns bytesWindowSized
 
         val result = factory.create(stream, 0) // part isn't used
 
         assertEquals(table, result.buffer.tableName)
         assertEquals(munger, result.munger)
         assertEquals(recordWindowSized, result.configuredRecordCountWindow)
-        assertEquals(bytesWindowSized, result.configuredBytesWindow)
     }
 
     companion object {

--- a/airbyte-integrations/connectors/destination-clickhouse/src/test/kotlin/io/airbyte/integrations/destination/clickhouse/write/load/ClickhouseDirectLoaderTest.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/test/kotlin/io/airbyte/integrations/destination/clickhouse/write/load/ClickhouseDirectLoaderTest.kt
@@ -28,10 +28,12 @@ class ClickhouseDirectLoaderTest {
 
     private lateinit var loader: ClickhouseDirectLoader
 
+    private val configuredRecordBatchSize = 42L
+
     @BeforeEach
     fun setup() {
         every { munger.transformForDest(any()) } returns Fixtures.mungedRecord
-        loader = ClickhouseDirectLoader(munger, buffer, 42, 42)
+        loader = ClickhouseDirectLoader(munger, buffer, configuredRecordBatchSize)
     }
 
     @Test
@@ -65,7 +67,7 @@ class ClickhouseDirectLoaderTest {
             val input = mockk<DestinationRecordRaw>(relaxed = true)
 
             // fill the batch minuses one
-            val batchSize = ClickhouseDirectLoader.Constants.MAX_BATCH_SIZE_RECORDS.toInt()
+            val batchSize = configuredRecordBatchSize.toInt()
             var result: DirectLoader.DirectLoadResult = DirectLoader.Incomplete
             repeat(batchSize - 1) { result = loader.accept(input) }
             // we're still incomplete

--- a/airbyte-integrations/connectors/destination-clickhouse/src/test/kotlin/io/airbyte/integrations/destination/clickhouse/write/load/ClickhouseDirectLoaderTest.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/test/kotlin/io/airbyte/integrations/destination/clickhouse/write/load/ClickhouseDirectLoaderTest.kt
@@ -31,7 +31,7 @@ class ClickhouseDirectLoaderTest {
     @BeforeEach
     fun setup() {
         every { munger.transformForDest(any()) } returns Fixtures.mungedRecord
-        loader = ClickhouseDirectLoader(munger, buffer)
+        loader = ClickhouseDirectLoader(munger, buffer, 42, 42)
     }
 
     @Test

--- a/docs/integrations/destinations/clickhouse.md
+++ b/docs/integrations/destinations/clickhouse.md
@@ -95,6 +95,7 @@ You can also use a pre-existing user but we highly recommend creating a dedicate
 
 | Version | Date       | Pull Request                                               | Subject                                                                        |
 |:--------|:-----------|:-----------------------------------------------------------|:-------------------------------------------------------------------------------|
+| 2.0.9   | 2025-07-23 | [\#63738](https://github.com/airbytehq/airbyte/pull/63738) | Add an option to configure the batch size (both bytes and number of records).  |
 | 2.0.9   | 2025-07-23 | [\#63738](https://github.com/airbytehq/airbyte/pull/63738) | Set clickhouse as an airbyte connector.                                        |
 | 2.0.8   | 2025-07-23 | [\#63760](https://github.com/airbytehq/airbyte/pull/63760) | Throw an error if an invalid target table exist before the first sync.         |
 | 2.0.7   | 2025-07-23 | [\#63751](https://github.com/airbytehq/airbyte/pull/63751) | Only copy intersection columns when there is a dedup change.                   |

--- a/docs/integrations/destinations/clickhouse.md
+++ b/docs/integrations/destinations/clickhouse.md
@@ -95,7 +95,7 @@ You can also use a pre-existing user but we highly recommend creating a dedicate
 
 | Version | Date       | Pull Request                                               | Subject                                                                        |
 |:--------|:-----------|:-----------------------------------------------------------|:-------------------------------------------------------------------------------|
-| 2.0.9   | 2025-07-23 | [\#63738](https://github.com/airbytehq/airbyte/pull/63738) | Add an option to configure the batch size (both bytes and number of records).  |
+| 2.0.10  | 2025-07-23 | [\#64104](https://github.com/airbytehq/airbyte/pull/64104) | Add an option to configure the batch size (both bytes and number of records).  |
 | 2.0.9   | 2025-07-23 | [\#63738](https://github.com/airbytehq/airbyte/pull/63738) | Set clickhouse as an airbyte connector.                                        |
 | 2.0.8   | 2025-07-23 | [\#63760](https://github.com/airbytehq/airbyte/pull/63760) | Throw an error if an invalid target table exist before the first sync.         |
 | 2.0.7   | 2025-07-23 | [\#63751](https://github.com/airbytehq/airbyte/pull/63751) | Only copy intersection columns when there is a dedup change.                   |


### PR DESCRIPTION
## What
Some user would like to configure the batch size that we are sending to clickhouse.

This PR is adding an option to do that.

This feature has been asked [here](https://airbytehq.slack.com/archives/C01A4CAP81L/p1750780480634359)

## How
Update the specs to add the option and update the `ClickhouseDirectLoader` to consume it.

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
