### PR TITLE
fix(source-stripe): Pin back to 5.14.1 on Cloud

### DIFF
--- a/airbyte-integrations/connectors/source-stripe/metadata.yaml
+++ b/airbyte-integrations/connectors/source-stripe/metadata.yaml
@@ -26,6 +26,7 @@ data:
   registryOverrides:
     cloud:
       enabled: true
+      dockerImageTag: 5.14.1
     oss:
       enabled: true
   releaseStage: generally_available


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->
Pin back to version 5.14.1 on Cloud due to OOM errors during the check. Oncall issue:  https://github.com/airbytehq/oncall/issues/8508
## How
<!--
* Describe how code changes achieve the solution.
-->

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._