### PR TITLE
feat: add auto-approve workflow for PRs with auto-merge labels

### DIFF
--- a/.github/workflows/auto_approve_prs.yml
+++ b/.github/workflows/auto_approve_prs.yml
@@ -1,3 +1,16 @@
+# Auto Approve PRs Workflow
+#
+# This workflow automatically approves pull requests that have specific auto-merge labels attached.
+# It is intended to eventually replace the existing auto_merge workflow by splitting approval and merge
+# into separate workflows.
+#
+# Labels that trigger auto-approval:
+# - "auto-merge": Standard auto-merge label for PRs that should be automatically approved and merged
+# - "auto-merge/bypass-ci-checks": Auto-merge label that bypasses certain CI checks
+#
+# The workflow runs every 15 minutes and searches for open PRs targeting the master branch with
+# these labels, then approves each matching PR using the octavia-bot GitHub App.
+
 name: Auto Approve PRs
 
 on:
@@ -14,9 +27,6 @@ jobs:
   find_prs:
     name: Find PRs to approve
     runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
-      has_prs: ${{ steps.set-matrix.outputs.has_prs }}
     steps:
       - name: Find PRs with auto-merge labels
         id: find-prs
@@ -28,7 +38,7 @@ jobs:
             --method GET \
             --field q="repo:airbytehq/airbyte is:pr label:auto-merge OR label:auto-merge/bypass-ci-checks base:master state:open" \
             --jq '.items[] | {number: .number, title: .title}')
-          
+
           # Convert to JSON array for matrix
           if [ -n "$prs" ]; then
             echo "prs<<EOF" >> $GITHUB_OUTPUT
@@ -52,6 +62,9 @@ jobs:
             echo "has_prs=false" >> $GITHUB_OUTPUT
             echo "No PRs found to approve"
           fi
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+      has_prs: ${{ steps.set-matrix.outputs.has_prs }}
 
   approve_prs:
     name: Approve PR #${{ matrix.pr_number }}
@@ -84,5 +97,5 @@ jobs:
           issue-number: ${{ matrix.pr_number }}
           body: |
             ✅ **Auto-approved by octavia-bot**
-            
+
             This PR has been automatically approved based on its labels. The PR can now be merged when all other requirements are met.

--- a/.github/workflows/auto_approve_prs.yml
+++ b/.github/workflows/auto_approve_prs.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           if [ -n "${{ steps.find-prs.outputs.prs }}" ]; then
             # Build matrix from PR data
-            matrix=$(echo '${{ steps.find-prs.outputs.prs }}' | jq -s 'map({pr_number: .number, pr_title: .title})')
+            matrix=$(echo '${{ steps.find-prs.outputs.prs }}' | jq -r 'map({pr_number: .number, pr_title: .title})')
             echo "matrix={\"include\":$(echo "$matrix")}" >> $GITHUB_OUTPUT
             echo "has_prs=true" >> $GITHUB_OUTPUT
             echo "Found PRs to approve: $(echo "$matrix" | jq length)"

--- a/.github/workflows/auto_approve_prs.yml
+++ b/.github/workflows/auto_approve_prs.yml
@@ -75,27 +75,20 @@ jobs:
       max-parallel: 30
       matrix: ${{ fromJson(needs.find_prs.outputs.matrix) }}
     steps:
-      - name: Generate octavia-bot token
-        id: app-token
-        uses: actions/create-github-app-token@v2
-        with:
-          app-id: ${{ secrets.OCTAVIA_BOT_APP_ID }}
-          private-key: ${{ secrets.OCTAVIA_BOT_PRIVATE_KEY }}
-
       - name: Approve Pull Request #${{ matrix.pr_number }}
         uses: juliangruber/approve-pull-request-action@v2
         with:
-          github-token: ${{ steps.app-token.outputs.token }}
+          github-token: ${{ secrets.GH_PAT_MAINTENANCE_OSS }}
           repo: airbytehq/airbyte
           number: ${{ matrix.pr_number }}
 
       - name: Add approval comment
         uses: peter-evans/create-or-update-comment@v2
         with:
-          token: ${{ steps.app-token.outputs.token }}
+          token: ${{ secrets.GH_PAT_MAINTENANCE_OSS }}
           repository: airbytehq/airbyte
           issue-number: ${{ matrix.pr_number }}
           body: |
-            ✅ **Auto-approved by octavia-bot**
+            ✅ **Auto-approved by maintenance bot**
 
             This PR has been automatically approved based on its labels. The PR can now be merged when all other requirements are met.

--- a/.github/workflows/auto_approve_prs.yml
+++ b/.github/workflows/auto_approve_prs.yml
@@ -20,9 +20,9 @@ on:
   workflow_dispatch:
     inputs:
       dry_run:
-        description: 'Run in dry-run mode (find PRs but do not approve them)'
+        description: "Run in dry-run mode (find PRs but do not approve them)"
         required: false
-        default: 'false'
+        default: "false"
         type: boolean
 
 concurrency:
@@ -77,7 +77,7 @@ jobs:
       has_prs: ${{ steps.set-matrix.outputs.has_prs }}
 
   approve_prs:
-    name: ${{ inputs.dry_run == true && 'Dry-run: Would approve' || 'Approve' }} PR #${{ matrix.pr_number }}
+    name: "Approve PR #${{ matrix.pr_number }}"
     runs-on: ubuntu-latest
     needs: find_prs
     if: needs.find_prs.outputs.has_prs == 'true'
@@ -90,7 +90,7 @@ jobs:
         run: |
           echo "🔍 DRY-RUN MODE: Would approve PR #${{ matrix.pr_number }}: ${{ matrix.pr_title }}"
           echo "In normal mode, this PR would be automatically approved."
-          
+
       - name: Approve Pull Request #${{ matrix.pr_number }}
         if: ${{ inputs.dry_run != true }}
         uses: juliangruber/approve-pull-request-action@v2

--- a/.github/workflows/auto_approve_prs.yml
+++ b/.github/workflows/auto_approve_prs.yml
@@ -26,7 +26,7 @@ jobs:
           # Search for open PRs with auto-merge labels targeting master branch
           prs=$(gh api search/issues \
             --method GET \
-            --field q="repo:airbytehq/airbyte is:pr label:auto-merge,auto-merge/bypass-ci-checks base:master state:open" \
+            --field q="repo:airbytehq/airbyte is:pr label:auto-merge OR label:auto-merge/bypass-ci-checks base:master state:open" \
             --jq '.items[] | {number: .number, title: .title}')
           
           # Convert to JSON array for matrix

--- a/.github/workflows/auto_approve_prs.yml
+++ b/.github/workflows/auto_approve_prs.yml
@@ -14,9 +14,9 @@
 name: Auto Approve PRs
 
 on:
-  schedule:
-    # Every 15 minutes
-    - cron: "*/15 * * * *"
+  # schedule:
+  #   # Every 15 minutes
+  #   - cron: "*/15 * * * *"
   workflow_dispatch:
     inputs:
       dry_run:

--- a/.github/workflows/auto_approve_prs.yml
+++ b/.github/workflows/auto_approve_prs.yml
@@ -18,6 +18,12 @@ on:
     # Every 15 minutes
     - cron: "*/15 * * * *"
   workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Run in dry-run mode (find PRs but do not approve them)'
+        required: false
+        default: 'false'
+        type: boolean
 
 concurrency:
   group: auto-approve-prs
@@ -71,7 +77,7 @@ jobs:
       has_prs: ${{ steps.set-matrix.outputs.has_prs }}
 
   approve_prs:
-    name: Approve PR #${{ matrix.pr_number }}
+    name: ${{ inputs.dry_run == true && 'Dry-run: Would approve' || 'Approve' }} PR #${{ matrix.pr_number }}
     runs-on: ubuntu-latest
     needs: find_prs
     if: needs.find_prs.outputs.has_prs == 'true'
@@ -79,7 +85,14 @@ jobs:
       max-parallel: 30
       matrix: ${{ fromJson(needs.find_prs.outputs.matrix) }}
     steps:
+      - name: Dry-run check
+        if: ${{ inputs.dry_run == true }}
+        run: |
+          echo "🔍 DRY-RUN MODE: Would approve PR #${{ matrix.pr_number }}: ${{ matrix.pr_title }}"
+          echo "In normal mode, this PR would be automatically approved."
+          
       - name: Approve Pull Request #${{ matrix.pr_number }}
+        if: ${{ inputs.dry_run != true }}
         uses: juliangruber/approve-pull-request-action@v2
         with:
           github-token: ${{ secrets.GH_PAT_MAINTENANCE_OSS }}
@@ -87,6 +100,7 @@ jobs:
           number: ${{ matrix.pr_number }}
 
       - name: Add approval comment
+        if: ${{ inputs.dry_run != true }}
         uses: peter-evans/create-or-update-comment@v2
         with:
           token: ${{ secrets.GH_PAT_MAINTENANCE_OSS }}

--- a/.github/workflows/auto_approve_prs.yml
+++ b/.github/workflows/auto_approve_prs.yml
@@ -1,0 +1,88 @@
+name: Auto Approve PRs
+
+on:
+  schedule:
+    # Every 15 minutes
+    - cron: "*/15 * * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: auto-approve-prs
+  cancel-in-progress: false
+
+jobs:
+  find_prs:
+    name: Find PRs to approve
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+      has_prs: ${{ steps.set-matrix.outputs.has_prs }}
+    steps:
+      - name: Find PRs with auto-merge labels
+        id: find-prs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Search for open PRs with auto-merge labels targeting master branch
+          prs=$(gh api search/issues \
+            --method GET \
+            --field q="repo:airbytehq/airbyte is:pr label:auto-merge,auto-merge/bypass-ci-checks base:master state:open" \
+            --jq '.items[] | {number: .number, title: .title}')
+          
+          # Convert to JSON array for matrix
+          if [ -n "$prs" ]; then
+            echo "prs<<EOF" >> $GITHUB_OUTPUT
+            echo "$prs" >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
+          else
+            echo "prs=" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Set matrix output
+        id: set-matrix
+        run: |
+          if [ -n "${{ steps.find-prs.outputs.prs }}" ]; then
+            # Build matrix from PR data
+            matrix=$(echo '${{ steps.find-prs.outputs.prs }}' | jq -s 'map({pr_number: .number, pr_title: .title})')
+            echo "matrix={\"include\":$(echo "$matrix")}" >> $GITHUB_OUTPUT
+            echo "has_prs=true" >> $GITHUB_OUTPUT
+            echo "Found PRs to approve: $(echo "$matrix" | jq length)"
+          else
+            echo "matrix={\"include\":[]}" >> $GITHUB_OUTPUT
+            echo "has_prs=false" >> $GITHUB_OUTPUT
+            echo "No PRs found to approve"
+          fi
+
+  approve_prs:
+    name: Approve PR #${{ matrix.pr_number }}
+    runs-on: ubuntu-latest
+    needs: find_prs
+    if: needs.find_prs.outputs.has_prs == 'true'
+    strategy:
+      max-parallel: 30
+      matrix: ${{ fromJson(needs.find_prs.outputs.matrix) }}
+    steps:
+      - name: Generate octavia-bot token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.OCTAVIA_BOT_APP_ID }}
+          private-key: ${{ secrets.OCTAVIA_BOT_PRIVATE_KEY }}
+
+      - name: Approve Pull Request #${{ matrix.pr_number }}
+        uses: juliangruber/approve-pull-request-action@v2
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          repo: airbytehq/airbyte
+          number: ${{ matrix.pr_number }}
+
+      - name: Add approval comment
+        uses: peter-evans/create-or-update-comment@v2
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          repository: airbytehq/airbyte
+          issue-number: ${{ matrix.pr_number }}
+          body: |
+            ✅ **Auto-approved by octavia-bot**
+            
+            This PR has been automatically approved based on its labels. The PR can now be merged when all other requirements are met.

--- a/.github/workflows/auto_approve_prs.yml
+++ b/.github/workflows/auto_approve_prs.yml
@@ -56,11 +56,15 @@ jobs:
             matrix=$(echo '${{ steps.find-prs.outputs.prs }}' | jq -r 'map({pr_number: .number, pr_title: .title})')
             echo "matrix={\"include\":$(echo "$matrix")}" >> $GITHUB_OUTPUT
             echo "has_prs=true" >> $GITHUB_OUTPUT
+            
+            # Debug output for troubleshooting
             echo "Found PRs to approve: $(echo "$matrix" | jq length)"
+            echo "Generated matrix:" | tee -a $GITHUB_STEP_SUMMARY
+            echo "$matrix" | jq '.' | tee -a $GITHUB_STEP_SUMMARY
           else
             echo "matrix={\"include\":[]}" >> $GITHUB_OUTPUT
             echo "has_prs=false" >> $GITHUB_OUTPUT
-            echo "No PRs found to approve"
+            echo "No PRs found to approve" | tee -a $GITHUB_STEP_SUMMARY
           fi
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}


### PR DESCRIPTION
## What

This PR adds a new GitHub Actions workflow `auto_approve_prs.yml` that automatically approves pull requests with auto-merge labels.

**Regarding Testing**

We can't fully test this until we merge it, and then will get access to run it via workflow dispatch (from any branch).

I have disabled the cron (commenting it out) so that the first merge doesn't have any effect except to make this testable and runnable manually.

**Regarding Safety**

This is safe to iterate on, as it will have no effect besides adding an approval. The worst-case scenario is that it would allow PRs to marge after _all_ of their required tests already passing and _also_ already having the "Auto Merge" GitHub feature enabled.

This is much safer than our custom force-merge approach, since we let GitHub do its own auto-merge when/if CI checks pass, and humans can enable/disable that setting as needed. The only thing this bypasses (for auto-promotions, auto-rollbacks, and up-to-date workflows) is the need for a human to manually approve those - and the approval requirement is already ignored by our `auto_merge`. 

## Why

This workflow is intended to eventually replace the existing `auto_merge` workflow by splitting the approval and merge steps into separate workflows.

Combined with the auto-merge feature, it will eliminate the need to force-merge `up-to-date` PRs. It will not fully remove the need for the `auto_merge` workflow until 


## How

The workflow:
- Runs every 15 minutes on a schedule. (Will disable until merged and tested manually with the dry-run setting in workflow dispatch.)
- Searches for open PRs with `auto-merge` or `auto-merge/bypass-ci-checks` labels targeting the `master` branch
- Automatically approves each matching PR using the maintenance PAT. Decided not to use the GitHub App because this is inherently a spammy action, and we don't want to hit our hourly rate limits. The maintenance PAT is already the PAT we're using for these spammy actions, so we keep them isolated from other critical operations that run under the GitHub App.
- Uses a dynamic matrix strategy to handle multiple PRs concurrently (max 30 parallel jobs)

Responds to both of these labels. The first one drives `up-to-date`, and still requires CI to pass. The second is used for auto-promotion (RC to GA) and auto-rollback (to 'yank' bad versions), and they are force-merged by `auto_merge` pipeline even if tests are failing.:

<img width="344" height="249" alt="image" src="https://github.com/user-attachments/assets/924a5b1e-679a-4f3e-985c-703b7b0401cd" />

The workflow consists of two jobs:

1. **find_prs**: Uses `GITHUB_TOKEN` to search for matching PRs and builds a dynamic matrix of PR numbers
2. **approve_prs**: Uses the octavia-bot app token to approve each PR in the matrix

Key implementation details:
- Uses `gh api search/issues` to find PRs with the correct labels
- Generates a dynamic matrix JSON with PR numbers and titles for readable job names
- Authenticates as octavia-bot only for the approval action to minimize rate limit impact
- Includes concurrency control (`cancel-in-progress: false`) to queue runs instead of canceling them
- Adds an approval comment to each PR for transparency

## Review guide

1. `.github/workflows/auto_approve_prs.yml`

## User Impact

**Positive:**
- PRs with auto-merge labels will be automatically approved, reducing manual overhead
- Faster approval cycle for automated/bot PRs
- Clear audit trail with approval comments

**Potential negative side effects:**
- Risk of approving PRs incorrectly if search logic has bugs
- No auto rollback mechanism if workflow approves the wrong PRs (hence need for dry-run)

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

This only adds a new workflow file that can be safely deleted or disabled. No existing functionality is modified.

---

**Session Details:**
- Devin session: https://app.devin.ai/sessions/f48c49704e46430e9717c5f6add0fec6
- Requested by: @aaronsteers