### PR TITLE
fix: release airbyte-ci 5.0.4

### DIFF
--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -822,7 +822,7 @@ airbyte-ci connectors --language=low-code migrate-to-manifest-only
 
 | Version | PR                                                          | Description                                                                                                                  |
 | ------- | ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| 5.4.0   | [#61598](https://github.com/airbytehq/airbyte/pull/61598)  | Delete the base_images sub-package. Connector base images are now built using Dockerfiles |
+| 5.4.0   | [#64135](https://github.com/airbytehq/airbyte/pull/64135)  | Delete the base_images sub-package. Connector base images are now built using Dockerfiles |
 | 5.3.0   | [#61598](https://github.com/airbytehq/airbyte/pull/61598)  | Add trackable commit text and github-native auto-merge in up-to-date, auto-merge, rc-promote, and rc-rollback |
 | 5.2.5   | [#60325](https://github.com/airbytehq/airbyte/pull/60325)  | Update slack team to oc-extensibility-critical-systems |
 | 5.2.4   | [#59724](https://github.com/airbytehq/airbyte/pull/59724)  | Fix components mounting and test dependencies for manifest-only unit tests |

--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -822,6 +822,7 @@ airbyte-ci connectors --language=low-code migrate-to-manifest-only
 
 | Version | PR                                                          | Description                                                                                                                  |
 | ------- | ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| 5.4.0   | [#61598](https://github.com/airbytehq/airbyte/pull/61598)  | Delete the base_images sub-package. Connector base images are now built using Dockerfiles |
 | 5.3.0   | [#61598](https://github.com/airbytehq/airbyte/pull/61598)  | Add trackable commit text and github-native auto-merge in up-to-date, auto-merge, rc-promote, and rc-rollback |
 | 5.2.5   | [#60325](https://github.com/airbytehq/airbyte/pull/60325)  | Update slack team to oc-extensibility-critical-systems |
 | 5.2.4   | [#59724](https://github.com/airbytehq/airbyte/pull/59724)  | Fix components mounting and test dependencies for manifest-only unit tests |

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "5.3.0"
+version = "5.4.0"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 


### PR DESCRIPTION
## What
I forgot to bump the version of airbyte-ci in [my last PR](https://github.com/airbytehq/airbyte/pull/64135). This updates the pyproject version and the Changelog
