### PR TITLE
feat: add region to the gsm provider

### DIFF
--- a/docs/platform/deploying-airbyte/chart-v2-community.mdx
+++ b/docs/platform/deploying-airbyte/chart-v2-community.mdx
@@ -228,6 +228,7 @@ global:
     googleSecretManager:
       projectId: <project-id>
       credentialsSecretKey: gcp.json
+      region: <region> # Optional - specify region for regional Secret Manager endpoints
 
     # OR
 

--- a/docs/platform/deploying-airbyte/integrations/secrets.md
+++ b/docs/platform/deploying-airbyte/integrations/secrets.md
@@ -137,6 +137,8 @@ To decrypt secrets in the secret manager with AWS KMS, configure the `kms` field
 
 Ensure you've already created a Kubernetes secret containing the credentials blob for the service account to be assumed by the cluster. By default, secrets are expected in the `airbyte-config-secrets` Kubernetes secret, under a `gcp.json` file. Steps to configure these are in the above [prerequisites](#secrets). For simplicity, we recommend provisioning a single service account with access to both GCS and GSM.
 
+Optionally, you can specify a `region` to use Google Secret Manager's regional endpoints. When specified, Airbyte will use the regional endpoint `secretmanager.<region>.rep.googleapis.com` instead of the global endpoint. This ensures data residency compliance by keeping secrets within a specific geographic region.
+
 <Tabs groupId="helm-chart-version">
 <TabItem value='helm-1' label='Helm chart V1' default>
 
@@ -148,6 +150,7 @@ global:
     googleSecretManager:
       projectId: <project-id>
       credentialsSecretKey: gcp.json
+      region: <region> # Optional - specify region for regional Secret Manager endpoints (e.g. us-east1)
 ```
 
 </TabItem>
@@ -156,11 +159,12 @@ global:
 ```yaml title="values.yaml"
 global:
   secretsManager:
-    type: GOOGLE_SECRET_MANAGE
+    type: GOOGLE_SECRET_MANAGER
     secretName: "airbyte-config-secrets" # Name of your Kubernetes secret.
     googleSecretManager:
       projectId: <project-id>
       credentialsSecretKey: gcp.json
+      region: <region> # Optional - specify region for regional Secret Manager endpoints (e.g. us-east1)
 ```
 
 </TabItem>

--- a/docs/platform/enterprise-setup/chart-v2-enterprise.mdx
+++ b/docs/platform/enterprise-setup/chart-v2-enterprise.mdx
@@ -294,6 +294,7 @@ global:
     googleSecretManager:
       projectId: <project-id>
       credentialsSecretKey: gcp.json
+      region: <region> # Optional - specify region for regional Secret Manager endpoints
 
     # OR
 

--- a/docs/platform/enterprise-setup/implementation-guide.md
+++ b/docs/platform/enterprise-setup/implementation-guide.md
@@ -703,6 +703,7 @@ secretsManager:
   googleSecretManager:
     projectId: <project-id>
     credentialsSecretKey: gcp.json
+    region: <region> # Optional - specify region for regional Secret Manager endpoints
 ```
 
 </TabItem>
@@ -717,6 +718,7 @@ global:
     googleSecretManager:
       projectId: <project-id>
       credentialsSecretKey: gcp.json
+      region: <region> # Optional - specify region for regional Secret Manager endpoints
 ```
 
 </TabItem>


### PR DESCRIPTION
## What
adds a region field to the gsm provider so that users can use a region specific endpoint to ensure data tenancy.

## How
adds a new nullable field to the configuration and wires that into the gsm client.

## Can this PR be safely reverted and rolled back?
<!--
* If you know that your be safely rolled back, check YES.*
* If that is not the case (e.g. a database migration), check NO.
* If unsure, leave it blank.*
-->
- [x] YES 💚
- [ ] NO ❌