### PR TITLE
move metadata validation from airbyte-ci into vanilla GHA

### DIFF
--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -71,18 +71,18 @@ jobs:
         with:
           version: 1.8.5
 
-      - name: Build and publish JVM connectors images [On merge to master]
-        id: build-and-publish-JVM-connectors-images-master
-        if: github.event_name == 'push'
-        shell: bash
-        run: ./poe-tasks/get-modified-connectors.sh --prev-commit --json  --java | ./poe-tasks/build-and-publish-java-connectors-with-tag.sh --main-release --publish
-
       # If you modify this step, remember to also modify publish-connector-metadata-manual.
       - name: Publish connector metadata [On merge to master]
         id: publish-connector-metadata-master
         if: github.event_name == 'push'
         shell: bash
         run: ./poe-tasks/get-modified-connectors.sh --prev-commit --json | ./poe-tasks/publish-connector-metadata.sh
+
+      - name: Build and publish JVM connectors images [On merge to master]
+        id: build-and-publish-JVM-connectors-images-master
+        if: github.event_name == 'push'
+        shell: bash
+        run: ./poe-tasks/get-modified-connectors.sh --prev-commit --json  --java | ./poe-tasks/build-and-publish-java-connectors-with-tag.sh --main-release --publish
 
       - name: Publish modified connectors [On merge to master]
         # JVM docker images are published beforehand so Airbyte-CI only does registry publishing.
@@ -108,18 +108,18 @@ jobs:
           max_attempts: 2
           retry_wait_seconds: 600 # 10 minutes
 
-      - name: Build and publish JVM connectors images [manual]
-        id: build-and-publish-JVM-connectors-images-manual
-        if: github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call'
-        shell: bash
-        run: ./poe-tasks/build-and-publish-java-connectors-with-tag.sh  ${{ inputs.publish-options }} ${{ inputs.connectors-options }} --publish
-
       # If you modify this step, remember to also modify publish-connector-metadata-master.
       - name: Publish connector metadata [manual]
         id: publish-connector-metadata-manual
         if: github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call'
         shell: bash
         run: ./poe-tasks/publish-connector-metadata.sh ${{ inputs.publish-options }} ${{ inputs.connectors-options }}
+
+      - name: Build and publish JVM connectors images [manual]
+        id: build-and-publish-JVM-connectors-images-manual
+        if: github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call'
+        shell: bash
+        run: ./poe-tasks/build-and-publish-java-connectors-with-tag.sh  ${{ inputs.publish-options }} ${{ inputs.connectors-options }} --publish
 
       - name: Publish connectors [manual]
         id: publish-connectors

--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -58,6 +58,19 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}
 
+      - name: Set up Python
+        # v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        with:
+          python-version: "3.11"
+          check-latest: true
+          update-environment: true
+      - name: Install and configure Poetry
+        # v1
+        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a
+        with:
+          version: 1.8.5
+
       - name: Build and publish JVM connectors images [On merge to master]
         id: build-and-publish-JVM-connectors-images-master
         if: github.event_name == 'push'

--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -64,6 +64,13 @@ jobs:
         shell: bash
         run: ./poe-tasks/get-modified-connectors.sh --prev-commit --json  --java | ./poe-tasks/build-and-publish-java-connectors-with-tag.sh --main-release --publish
 
+      # If you modify this step, remember to also modify publish-connector-metadata-manual.
+      - name: Publish connector metadata [On merge to master]
+        id: publish-connector-metadata-master
+        if: github.event_name == 'push'
+        shell: bash
+        run: ./poe-tasks/get-modified-connectors.sh --prev-commit --json | ./poe-tasks/publish-connector-metadata.sh
+
       - name: Publish modified connectors [On merge to master]
         # JVM docker images are published beforehand so Airbyte-CI only does registry publishing.
         id: publish-modified-connectors
@@ -93,6 +100,13 @@ jobs:
         if: github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call'
         shell: bash
         run: ./poe-tasks/build-and-publish-java-connectors-with-tag.sh  ${{ inputs.publish-options }} ${{ inputs.connectors-options }} --publish
+
+      # If you modify this step, remember to also modify publish-connector-metadata-master.
+      - name: Publish connector metadata [manual]
+        id: publish-connector-metadata-manual
+        if: github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call'
+        shell: bash
+        run: ./poe-tasks/publish-connector-metadata.sh ${{ inputs.publish-options }} ${{ inputs.connectors-options }}
 
       - name: Publish connectors [manual]
         id: publish-connectors

--- a/airbyte-ci/connectors/pipelines/README.md
+++ b/airbyte-ci/connectors/pipelines/README.md
@@ -822,6 +822,7 @@ airbyte-ci connectors --language=low-code migrate-to-manifest-only
 
 | Version | PR                                                          | Description                                                                                                                  |
 | ------- | ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| 5.5.0   | [#64164](https://github.com/airbytehq/airbyte/pull/64164)  | Remove the `MetadataValidation` step from the airbyte-ci pipeline. This is now done via a shell script. |
 | 5.4.0   | [#64135](https://github.com/airbytehq/airbyte/pull/64135)  | Delete the base_images sub-package. Connector base images are now built using Dockerfiles |
 | 5.3.0   | [#61598](https://github.com/airbytehq/airbyte/pull/61598)  | Add trackable commit text and github-native auto-merge in up-to-date, auto-merge, rc-promote, and rc-rollback |
 | 5.2.5   | [#60325](https://github.com/airbytehq/airbyte/pull/60325)  | Update slack team to oc-extensibility-critical-systems |

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/publish/pipeline.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/publish/pipeline.py
@@ -518,13 +518,6 @@ async def run_connector_publish_pipeline(context: PublishConnectorContext, semap
         async with context:
             results = []
 
-            metadata_validation_results = await MetadataValidation(context).run()
-            results.append(metadata_validation_results)
-
-            # Exit early if the metadata file is invalid.
-            if metadata_validation_results.status is not StepStatus.SUCCESS:
-                return create_connector_report(results, context)
-
             # Check if the connector image is already published to the registry.
             check_connector_image_results = await CheckConnectorImageDoesNotExist(context).run()
             results.append(check_connector_image_results)

--- a/airbyte-ci/connectors/pipelines/pyproject.toml
+++ b/airbyte-ci/connectors/pipelines/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pipelines"
-version = "5.4.0"
+version = "5.5.0"
 description = "Packaged maintained by the connector operations team to perform CI for connectors' pipelines"
 authors = ["Airbyte <contact@airbyte.io>"]
 

--- a/airbyte-ci/connectors/pipelines/tests/test_publish.py
+++ b/airbyte-ci/connectors/pipelines/tests/test_publish.py
@@ -164,7 +164,6 @@ class TestUploadSpecToCache:
 
 
 STEPS_TO_PATCH = [
-    (publish_pipeline, "MetadataValidation"),
     (publish_pipeline, "MetadataUpload"),
     (publish_pipeline, "CheckConnectorImageDoesNotExist"),
     (publish_pipeline, "UploadSpecToCache"),
@@ -174,34 +173,6 @@ STEPS_TO_PATCH = [
     (publish_pipeline, "CheckPythonRegistryPackageDoesNotExist"),
     (publish_pipeline, "UploadSbom"),
 ]
-
-
-@pytest.mark.parametrize("pre_release", [True, False])
-async def test_run_connector_publish_pipeline_when_failed_validation(mocker, pre_release):
-    """We validate that no other steps are called if the metadata validation step fails."""
-    for module, to_mock in STEPS_TO_PATCH:
-        mocker.patch.object(module, to_mock, return_value=mocker.AsyncMock())
-
-    run_metadata_validation = publish_pipeline.MetadataValidation.return_value.run
-    run_metadata_validation.return_value = mocker.Mock(status=StepStatus.FAILURE)
-
-    context = mocker.MagicMock(pre_release=pre_release, rollout_mode=RolloutMode.PUBLISH)
-    semaphore = anyio.Semaphore(1)
-    report = await publish_pipeline.run_connector_publish_pipeline(context, semaphore)
-    run_metadata_validation.assert_called_once()
-
-    # Check that nothing else is called
-    for module, to_mock in STEPS_TO_PATCH:
-        if to_mock != "MetadataValidation":
-            getattr(module, to_mock).return_value.run.assert_not_called()
-
-    assert (
-        report.steps_results
-        == context.report.steps_results
-        == [
-            run_metadata_validation.return_value,
-        ]
-    )
 
 
 @pytest.mark.parametrize(
@@ -224,9 +195,6 @@ async def test_run_connector_publish_pipeline_when_image_exists_or_failed(mocker
     for module, to_mock in STEPS_TO_PATCH:
         mocker.patch.object(module, to_mock, return_value=mocker.AsyncMock())
 
-    run_metadata_validation = publish_pipeline.MetadataValidation.return_value.run
-    run_metadata_validation.return_value = mocker.Mock(status=StepStatus.SUCCESS)
-
     # ensure spec and sbom upload always succeeds
     run_upload_spec_to_cache = publish_pipeline.UploadSpecToCache.return_value.run
     run_upload_spec_to_cache.return_value = mocker.Mock(status=StepStatus.SUCCESS)
@@ -240,12 +208,11 @@ async def test_run_connector_publish_pipeline_when_image_exists_or_failed(mocker
 
     semaphore = anyio.Semaphore(1)
     report = await publish_pipeline.run_connector_publish_pipeline(publish_context, semaphore)
-    run_metadata_validation.assert_called_once()
     run_check_connector_image_does_not_exist.assert_called_once()
 
     # Check that nothing else is called
     for module, to_mock in STEPS_TO_PATCH:
-        if to_mock not in ["MetadataValidation", "MetadataUpload", "CheckConnectorImageDoesNotExist", "UploadSpecToCache", "UploadSbom"]:
+        if to_mock not in ["MetadataUpload", "CheckConnectorImageDoesNotExist", "UploadSpecToCache", "UploadSbom"]:
             getattr(module, to_mock).return_value.run.assert_not_called()
 
     if check_image_exists_status is StepStatus.SKIPPED and not pre_release:
@@ -254,7 +221,6 @@ async def test_run_connector_publish_pipeline_when_image_exists_or_failed(mocker
             report.steps_results
             == publish_context.report.steps_results
             == [
-                run_metadata_validation.return_value,
                 run_check_connector_image_does_not_exist.return_value,
                 run_upload_spec_to_cache.return_value,
                 run_upload_sbom.return_value,
@@ -271,7 +237,6 @@ async def test_run_connector_publish_pipeline_when_image_exists_or_failed(mocker
             report.steps_results
             == publish_context.report.steps_results
             == [
-                run_metadata_validation.return_value,
                 run_check_connector_image_does_not_exist.return_value,
             ]
         )
@@ -301,9 +266,6 @@ async def test_run_connector_publish_pipeline_when_image_does_not_exist(
     """We check that the full pipeline is executed as expected when the connector image does not exist and the metadata validation passed."""
     for module, to_mock in STEPS_TO_PATCH:
         mocker.patch.object(module, to_mock, return_value=mocker.AsyncMock())
-    publish_pipeline.MetadataValidation.return_value.run.return_value = mocker.Mock(
-        name="metadata_validation_result", status=StepStatus.SUCCESS
-    )
     publish_pipeline.CheckConnectorImageDoesNotExist.return_value.run.return_value = mocker.Mock(
         name="check_connector_image_does_not_exist_result", status=StepStatus.SUCCESS
     )
@@ -336,7 +298,6 @@ async def test_run_connector_publish_pipeline_when_image_does_not_exist(
     report = await publish_pipeline.run_connector_publish_pipeline(context, semaphore)
 
     steps_to_run = [
-        publish_pipeline.MetadataValidation.return_value.run,
         publish_pipeline.CheckConnectorImageDoesNotExist.return_value.run,
         publish_pipeline.steps.run_connector_build,
         publish_pipeline.PushConnectorImageToRegistry.return_value.run,
@@ -393,7 +354,6 @@ async def test_run_connector_python_registry_publish_pipeline(
     )
 
     for step in [
-        publish_pipeline.MetadataValidation,
         publish_pipeline.CheckConnectorImageDoesNotExist,
         publish_pipeline.UploadSpecToCache,
         publish_pipeline.MetadataUpload,

--- a/airbyte-integrations/connectors/destination-bigquery/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-bigquery/metadata.yaml
@@ -6,7 +6,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: 22f6c74f-5699-40ff-833c-4a879ea40133
-  dockerImageTag: 3.0.6
+  sdockerImageTag: 3.0.6
   dockerRepository: airbyte/destination-bigquery
   documentationUrl: https://docs.airbyte.com/integrations/destinations/bigquery
   githubIssueLabel: destination-bigquery

--- a/airbyte-integrations/connectors/destination-bigquery/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-bigquery/metadata.yaml
@@ -6,7 +6,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: 22f6c74f-5699-40ff-833c-4a879ea40133
-  sdockerImageTag: 3.0.6
+  dockerImageTag: 3.0.6
   dockerRepository: airbyte/destination-bigquery
   documentationUrl: https://docs.airbyte.com/integrations/destinations/bigquery
   githubIssueLabel: destination-bigquery

--- a/poe-tasks/build-and-publish-java-connectors-with-tag.sh
+++ b/poe-tasks/build-and-publish-java-connectors-with-tag.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 # This script builds and optionally publishes Java connector Docker images.
 #
 # Flag descriptions:
@@ -34,67 +35,7 @@
 #   ./build-and-publish-java-connectors-with-tag.sh --publish foo-conn
 set -euo pipefail
 
-CONNECTORS_DIR="airbyte-integrations/connectors"
-
-# ------ Defaults & arg parsing -------
-publish_mode="pre-release"
-do_publish=false
-connectors=()
-
-while [[ $# -gt 0 ]]; do
-  case "$1" in
-    -h|--help)
-      sed -n '1,34p' "$0"
-      exit 0
-      ;;
-    --main-release)
-      publish_mode="main-release"
-      shift
-      ;;
-    --pre-release)
-      publish_mode="pre-release"
-      shift
-      ;;
-    --publish)
-      do_publish=true
-      shift
-      ;;
-    --name=*)
-      connectors=("${1#*=}")
-      shift
-      ;;
-    --name)
-      connectors=("$2")
-      shift 2
-      ;;
-    --*)
-      echo "Error: Unknown flag $1" >&2
-      exit 1
-      ;;
-    *)
-      connectors+=("$1")
-      shift
-      ;;
-  esac
-done
-
-# ---------- helper: collect connector names ----------
-get_connectors() {
-  if [ "${#connectors[@]}" -gt 0 ]; then
-      # only look at non-empty strings
-      for c in "${connectors[@]}"; do
-          [[ -n "$c" ]] && printf "%s\n" "$c"
-      done
-  else
-    # read JSON from stdin
-    if [ -t 0 ]; then
-      echo "Error:  No --name given and nothing piped to stdin." >&2
-      exit 1
-    fi
-    # select only non-empty strings out of the JSON array
-    jq -r '.connector[] | select(. != "")'
-  fi
-}
+source "${BASH_SOURCE%/*}/lib/util.sh"
 
 dockerhub_tag_exists() {
   local image="$1"   # e.g. airbyte/destination-postgres
@@ -128,15 +69,9 @@ dockerhub_tag_exists() {
   exit 1
 }
 
-generate_dev_tag() {
-  local base="$1"
-  # force a 10-char short hash to match existing airbyte-ci behaviour.
-  local hash
-  hash=$(git rev-parse --short=10 HEAD)
-  echo "${base}-dev.${hash}"
-}
-
 # ---------- main loop ----------
+source "${BASH_SOURCE%/*}/lib/parse_args.sh"
+
 while read -r connector; do
   meta="${CONNECTORS_DIR}/${connector}/metadata.yaml"
   if [[ ! -f "$meta" ]]; then

--- a/poe-tasks/lib/parse_args.sh
+++ b/poe-tasks/lib/parse_args.sh
@@ -26,11 +26,11 @@ while [[ $# -gt 0 ]]; do
       shift
       ;;
     --name=*)
-      connectors=("${1#*=}")
+      connectors+=("${1#*=}")
       shift
       ;;
     --name)
-      connectors=("$2")
+      connectors+=("$2")
       shift 2
       ;;
     --*)

--- a/poe-tasks/lib/parse_args.sh
+++ b/poe-tasks/lib/parse_args.sh
@@ -1,0 +1,45 @@
+# Parse the command-line args that we care about.
+# Scripts sourcing this script can be invoked as either:
+# ./foo.sh [--pre-release] [--main-release] [--publish] [--name=<source/destination-foo>]* [--name <source/destination-foo>]*
+# Or, if invoked with no `--name` flags:
+# ./get-modified-connectors.sh --json | ./foo.sh [--pre-release] [--main-release] [--publish]
+publish_mode="pre-release"
+do_publish=false
+connectors=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help)
+      sed -n '1,34p' "$0"
+      exit 0
+      ;;
+    --main-release)
+      publish_mode="main-release"
+      shift
+      ;;
+    --pre-release)
+      publish_mode="pre-release"
+      shift
+      ;;
+    --publish)
+      do_publish=true
+      shift
+      ;;
+    --name=*)
+      connectors=("${1#*=}")
+      shift
+      ;;
+    --name)
+      connectors=("$2")
+      shift 2
+      ;;
+    --*)
+      echo "Error: Unknown flag $1" >&2
+      exit 1
+      ;;
+    *)
+      connectors+=("$1")
+      shift
+      ;;
+  esac
+done

--- a/poe-tasks/lib/util.sh
+++ b/poe-tasks/lib/util.sh
@@ -1,0 +1,35 @@
+# A collection of utility functions and constants.
+# Usage (assuming your script is in `poe-tasks`): Add `source "${BASH_SOURCE%/*}/lib/util.sh"` to your script.
+# You can't just `source lib/util.sh`, because the current working directory probably isn't `poe-tasks`.
+
+CONNECTORS_DIR="airbyte-integrations/connectors"
+
+# ---------- helper: collect connector names ----------
+# Read a list of connector names from a variable, or parse stdin.
+# Expects that you have populated a $connectors variable as an array.
+# If you sourced the parse_args.sh script, this is already handled for you.
+get_connectors() {
+  if [ "${#connectors[@]}" -gt 0 ]; then
+      # only look at non-empty strings
+      for c in "${connectors[@]}"; do
+          [[ -n "$c" ]] && printf "%s\n" "$c"
+      done
+  else
+    # read JSON from stdin
+    if [ -t 0 ]; then
+      echo "Error:  No --name given and nothing piped to stdin." >&2
+      exit 1
+    fi
+    # select only non-empty strings out of the JSON array
+    jq -r '.connector[] | select(. != "")'
+  fi
+}
+
+# Generate the prerelease image tag (e.g. `1.2.3-dev.abcde12345`).
+generate_dev_tag() {
+  local base="$1"
+  # force a 10-char short hash to match existing airbyte-ci behaviour.
+  local hash
+  hash=$(git rev-parse --short=10 HEAD)
+  echo "${base}-dev.${hash}"
+}

--- a/poe-tasks/lib/util.sh
+++ b/poe-tasks/lib/util.sh
@@ -3,6 +3,18 @@
 # You can't just `source lib/util.sh`, because the current working directory probably isn't `poe-tasks`.
 
 CONNECTORS_DIR="airbyte-integrations/connectors"
+DOCS_BASE_DIR="docs/integrations"
+
+# Usage: connector_docs_path "source-foo"
+# Returns a string "docs/integrations/sources/foo.md"
+connector_docs_path() {
+  # The regex '^(source|destination)-(.*)' matches strings like source-whatever or destination-something-like-this,
+  # capturing the connector type (source/destination) and the connector name (whatever / something-like-this).
+  # We then output '\1s/\2.md', which inserts the captured values as `\1` and `\2`.
+  # This produces a string like `sources/whatever.md`.
+  # Then we prepend the 'docs/integrations/' path.
+  echo $DOCS_BASE_DIR/$(echo $1 | sed -r 's@^(source|destination)-(.*)@\1s/\2.md@')
+}
 
 # ---------- helper: collect connector names ----------
 # Read a list of connector names from a variable, or parse stdin.

--- a/poe-tasks/publish-connector-metadata.sh
+++ b/poe-tasks/publish-connector-metadata.sh
@@ -3,11 +3,27 @@ set -euo pipefail
 
 source "${BASH_SOURCE%/*}/lib/util.sh"
 
-# This script wraps the `metadata_service validate` command.
-# That Python script performs some basic checks that a connector has valid
-# metadata.yaml and <name>.md docs file.
 source "${BASH_SOURCE%/*}/lib/parse_args.sh"
 
-# read connectors list from stdin,
-# somehow invoke `poetry run metadata_service validate airbyte-integrations/connectors/destination-bigquery/metadata.yaml docs/integrations/destinations/bigquery.md`
-# (presumably need to install metadata_service?)
+metadata_service_path='airbyte-ci/connectors/metadata_service/lib'
+poetry install --directory $metadata_service_path
+
+exit_code=0
+while read -r connector; do
+  echo "---- PROCESSING METADATA FOR $connector ----"
+  meta="${CONNECTORS_DIR}/${connector}/metadata.yaml"
+  doc="$(connector_docs_path $connector)"
+  # Don't exit immediately. We should run against all connectors.
+  set +e
+  if ! poetry run --directory $metadata_service_path metadata_service validate "$meta" "$doc"; then
+    exit_code=1
+  fi
+  # Reenable the "exit on error" option.
+  set -e
+done < <(get_connectors)
+
+if test $exit_code -ne 0; then
+  echo '------------'
+  echo 'One or more connectors failed to validate/upload metadata. See previous logs for more information.'
+  exit $exit_code
+fi

--- a/poe-tasks/publish-connector-metadata.sh
+++ b/poe-tasks/publish-connector-metadata.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# This script wraps the `metadata_service validate` command.
+# That Python script performs some basic checks that a connector has valid
+# metadata.yaml and <name>.md docs file.
+
+# read connectors list from stdin,
+# somehow invoke `poetry run metadata_service validate airbyte-integrations/connectors/destination-bigquery/metadata.yaml docs/integrations/destinations/bigquery.md`
+# (presumably need to install metadata_service?)

--- a/poe-tasks/publish-connector-metadata.sh
+++ b/poe-tasks/publish-connector-metadata.sh
@@ -1,9 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+source "${BASH_SOURCE%/*}/lib/util.sh"
+
 # This script wraps the `metadata_service validate` command.
 # That Python script performs some basic checks that a connector has valid
 # metadata.yaml and <name>.md docs file.
+source "${BASH_SOURCE%/*}/lib/parse_args.sh"
 
 # read connectors list from stdin,
 # somehow invoke `poetry run metadata_service validate airbyte-integrations/connectors/destination-bigquery/metadata.yaml docs/integrations/destinations/bigquery.md`


### PR DESCRIPTION
## What
closes https://github.com/airbytehq/airbyte-internal-issues/issues/13847

Move `metadata_service validate` call out of airbyte-ci.

(I'll revert the metadata.yaml change before merging - that's just there to demo an example metadata validation failure.)

## How
airbyte-ci was already just shelling out to metadata_service. Move that logic into a shell script. Opportunistically extract some shared shell code to a common lib.

I don't see a great way to test the actual GHA, but I did some local tests of the shell scripts.

Manually ran `./poe-tasks/publish-connector-metadata.sh --name destination-bigquery --name source-faker`. Output in screenshot - note that (a) bigquery prints some logs about why the metadata.yaml is invalid, and (b) the overall exit code is `1`.

<img width="1169" height="771" alt="image" src="https://github.com/user-attachments/assets/9a174b6e-7d5f-441d-b762-63ed7951f392" />

Also verified that the `build-and-publish-java-connectors-with-tag.sh` still works as expected:

<img width="1307" height="105" alt="image" src="https://github.com/user-attachments/assets/70e5b170-72cf-4b0f-998c-7870308e9427" />


## Review guide
Recommend reviewing by commit (mostly b/c the "extract some shared shell code" makes the overall diff hard to read).

## User Impact
None.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
