### PR TITLE
ci: migrate to GitHub Actions for preview builds

### DIFF
--- a/.github/pr-welcome-community.md
+++ b/.github/pr-welcome-community.md
@@ -23,8 +23,7 @@ If you have any questions, feel free to ask in the PR comments or join our [Slac
 
 ### Tips for Working with CI
 
-1. **"Vercel" CI failures.** You can always ignore these. These are our docs builds but they can only be run by approval. A maintainer will approve the workflow upon request, but this failure should not be of concern.
-2. **Pre-Release Checks.** Please pay attention to these, as they contain standard checks on the metadata.yaml file, docs requirements, etc. If you need help resolving a pre-release check, please ask a maintainer.
+1. **Pre-Release Checks.** Please pay attention to these, as they contain standard checks on the metadata.yaml file, docs requirements, etc. If you need help resolving a pre-release check, please ask a maintainer.
    - Note: If you are creating a new connector, please be sure to replace the default `logo.svg` file with a suitable icon.
-3. **Connector CI Tests.** Some failures here may be expected if your tests require credentials. Please review these results to ensure (1) unit tests are passing, if applicable, and (2) integration tests pass to the degree possible and expected.
-4. **(Optional.) [BYO Connector Credentials](https://docs.airbyte.com/platform/connector-development/local-connector-development#managing-connector-secrets) for tests in your fork.** You can _optionally_ set up your fork with BYO credentials for your connector. This can significantly speed up your review, ensuring your changes are fully tested before the maintainers begin their review.
+2. **Connector CI Tests.** Some failures here may be expected if your tests require credentials. Please review these results to ensure (1) unit tests are passing, if applicable, and (2) integration tests pass to the degree possible and expected.
+3. **(Optional.) [BYO Connector Credentials](https://docs.airbyte.com/platform/connector-development/local-connector-development#managing-connector-secrets) for tests in your fork.** You can _optionally_ set up your fork with BYO credentials for your connector. This can significantly speed up your review, ensuring your changes are fully tested before the maintainers begin their review.

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -79,3 +79,38 @@ jobs:
         if: steps.check-skip.outputs.skip-build != 'true'
         run: |
           poe docs-build
+
+  vercel-preview:
+    name: Vercel Preview
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    # This workflow deploys preview builds to Vercel on pull requests.
+    # Pull requests from forks are ignored.
+    env:
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
+    steps:
+      - name: Checkout Current Branch
+        uses: actions/checkout@v4.2.2
+
+      - name: Install Vercel CLI
+        run: npm install -g vercel@latest
+
+      - name: Pull Vercel Environment Information
+        run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Build Project Artifacts
+        run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Deploy Project Artifacts to Vercel
+        run: vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Deploy to Vercel
+        uses: amondnet/vercel-action@v41.1.4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          vercel-org-id: ${{ env.VERCEL_ORG_ID }}
+          vercel-project-id: ${{ env.VERCEL_PROJECT_ID }}
+          working-directory: ./docusaurus

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -108,7 +108,6 @@ jobs:
           vercel-org-id: ${{ env.VERCEL_ORG_ID }}
           vercel-project-id: ${{ env.VERCEL_PROJECT_ID }}
           vercel-args: --archive=tgz
-          # working-directory: ./docusaurus
 
       - name: Authenticate as GitHub App
         uses: actions/create-github-app-token@v2.0.6

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -98,12 +98,15 @@ jobs:
         run: npm install -g vercel@latest
 
       - name: Pull Vercel Environment Information
+        working-directory: ./docusaurus
         run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
 
       - name: Build Project Artifacts
+        working-directory: ./docusaurus
         run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
 
       - name: Deploy Project Artifacts to Vercel
+        working-directory: ./docusaurus
         run: vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }}
 
       # Alternative deployment method using a GitHub Action:

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -99,22 +99,6 @@ jobs:
         with:
           fetch-depth: 1
 
-      # - name: Install Vercel CLI
-      #   run: npm install -g vercel@latest
-
-      # - name: Pull Vercel Environment Information
-      #   working-directory: ./docusaurus
-      #   run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
-
-      # - name: Build Project Artifacts
-      #   working-directory: ./docusaurus
-      #   run: vercel build --yes --debug --token=${{ secrets.VERCEL_TOKEN }}
-
-      # - name: Deploy Project Artifacts to Vercel
-      #   working-directory: ./docusaurus
-      #   run: vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }}
-
-      # Alternative deployment method using a GitHub Action:
       - name: Deploy to Vercel
         id: deploy-vercel
         uses: amondnet/vercel-action@v41.1.4

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -117,4 +117,5 @@ jobs:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
           vercel-org-id: ${{ env.VERCEL_ORG_ID }}
           vercel-project-id: ${{ env.VERCEL_PROJECT_ID }}
+          vercel-args: --archive=tgz
           # working-directory: ./docusaurus

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -1,7 +1,7 @@
 # This workflow builds the documentation for the project using `poe` and `uv`.
 # It is redundant with the Vercel Preview deployment, but is runs unprivileged and
 # can be used on forks to verify the documentation build without deploying it.
-name: Docusaurus
+name: Docs
 on:
   pull_request:
     types: [opened, synchronize, reopened]
@@ -82,7 +82,9 @@ jobs:
 
   vercel-preview:
     name: Vercel Preview
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: >
+      github.event.pull_request.head.repo.full_name == github.repository
+    # && needs.detect-changes.outputs.changed == 'true'
     runs-on: ubuntu-latest
     # This workflow deploys preview builds to Vercel on pull requests.
     # Pull requests from forks are ignored.

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -88,7 +88,7 @@ jobs:
     # Pull requests from forks are ignored.
     env:
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+      VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID }}
 
     steps:
       - name: Checkout Current Branch

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -119,7 +119,7 @@ jobs:
         id: deploy-vercel
         uses: amondnet/vercel-action@v41.1.4
         with:
-          # github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
           vercel-org-id: ${{ env.VERCEL_ORG_ID }}
           vercel-project-id: ${{ env.VERCEL_PROJECT_ID }}

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -82,6 +82,7 @@ jobs:
 
   vercel-preview:
     name: Vercel Preview
+    needs: detect-changes
     if: >
       github.event.pull_request.head.repo.full_name == github.repository
     # && needs.detect-changes.outputs.changed == 'true'

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -93,13 +93,15 @@ jobs:
     steps:
       - name: Checkout Current Branch
         uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 1
 
-      - name: Install Vercel CLI
-        run: npm install -g vercel@latest
+      # - name: Install Vercel CLI
+      #   run: npm install -g vercel@latest
 
-      - name: Pull Vercel Environment Information
-        working-directory: ./docusaurus
-        run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
+      # - name: Pull Vercel Environment Information
+      #   working-directory: ./docusaurus
+      #   run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
 
       # - name: Build Project Artifacts
       #   working-directory: ./docusaurus

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -126,13 +126,11 @@ jobs:
           vercel-args: --archive=tgz
           # working-directory: ./docusaurus
 
-      - name: Create Custom Check
+      # If successful, post a check status with the Preview URL as its "details" link
+      - name: Post Custom Check with Preview URL
         uses: LouisBrunner/checks-action@v2.0.0
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          name: "Vercel Docs Preview"
+          name: "Vercel Preview Deployed" # << Name of the check
           conclusion: success
           details_url: ${{ steps.deploy-vercel.outputs.preview-url }}
-          output: |
-            title: Vercel Preview Deployed
-            summary: Click "Details" to view preview
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -103,7 +103,7 @@ jobs:
 
       - name: Build Project Artifacts
         working-directory: ./docusaurus
-        run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
+        run: vercel build --yes --debug --token=${{ secrets.VERCEL_TOKEN }}
 
       - name: Deploy Project Artifacts to Vercel
         working-directory: ./docusaurus

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -101,20 +101,20 @@ jobs:
         working-directory: ./docusaurus
         run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
 
-      - name: Build Project Artifacts
-        working-directory: ./docusaurus
-        run: vercel build --yes --debug --token=${{ secrets.VERCEL_TOKEN }}
+      # - name: Build Project Artifacts
+      #   working-directory: ./docusaurus
+      #   run: vercel build --yes --debug --token=${{ secrets.VERCEL_TOKEN }}
 
-      - name: Deploy Project Artifacts to Vercel
-        working-directory: ./docusaurus
-        run: vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }}
+      # - name: Deploy Project Artifacts to Vercel
+      #   working-directory: ./docusaurus
+      #   run: vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }}
 
       # Alternative deployment method using a GitHub Action:
-      # - name: Deploy to Vercel
-      #   uses: amondnet/vercel-action@v41.1.4
-      #   with:
-      #     github-token: ${{ secrets.GITHUB_TOKEN }}
-      #     vercel-token: ${{ secrets.VERCEL_TOKEN }}
-      #     vercel-org-id: ${{ env.VERCEL_ORG_ID }}
-      #     vercel-project-id: ${{ env.VERCEL_PROJECT_ID }}
-      #     working-directory: ./docusaurus
+      - name: Deploy to Vercel
+        uses: amondnet/vercel-action@v41.1.4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          vercel-org-id: ${{ env.VERCEL_ORG_ID }}
+          vercel-project-id: ${{ env.VERCEL_PROJECT_ID }}
+          working-directory: ./docusaurus

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -85,7 +85,7 @@ jobs:
     needs: detect-changes
     if: >
       github.event.pull_request.head.repo.full_name == github.repository
-    # && needs.detect-changes.outputs.changed == 'true'
+      && needs.detect-changes.outputs.changed == 'true'
     runs-on: ubuntu-latest
     # This workflow deploys preview builds to Vercel on pull requests.
     # Pull requests from forks are ignored.

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -116,11 +116,23 @@ jobs:
 
       # Alternative deployment method using a GitHub Action:
       - name: Deploy to Vercel
+        id: deploy-vercel
         uses: amondnet/vercel-action@v41.1.4
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          # github-token: ${{ secrets.GITHUB_TOKEN }}
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
           vercel-org-id: ${{ env.VERCEL_ORG_ID }}
           vercel-project-id: ${{ env.VERCEL_PROJECT_ID }}
           vercel-args: --archive=tgz
           # working-directory: ./docusaurus
+
+      - name: Create Custom Check
+        uses: LouisBrunner/checks-action@v2.0.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: "Vercel Docs Preview"
+          conclusion: success
+          details_url: ${{ steps.deploy-vercel.outputs.preview-url }}
+          output: |
+            title: Vercel Preview Deployed
+            summary: Click "Details" to view preview

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -117,4 +117,4 @@ jobs:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
           vercel-org-id: ${{ env.VERCEL_ORG_ID }}
           vercel-project-id: ${{ env.VERCEL_PROJECT_ID }}
-          working-directory: ./docusaurus
+          # working-directory: ./docusaurus

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -106,11 +106,12 @@ jobs:
       - name: Deploy Project Artifacts to Vercel
         run: vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }}
 
-      - name: Deploy to Vercel
-        uses: amondnet/vercel-action@v41.1.4
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          vercel-token: ${{ secrets.VERCEL_TOKEN }}
-          vercel-org-id: ${{ env.VERCEL_ORG_ID }}
-          vercel-project-id: ${{ env.VERCEL_PROJECT_ID }}
-          working-directory: ./docusaurus
+      # Alternative deployment method using a GitHub Action:
+      # - name: Deploy to Vercel
+      #   uses: amondnet/vercel-action@v41.1.4
+      #   with:
+      #     github-token: ${{ secrets.GITHUB_TOKEN }}
+      #     vercel-token: ${{ secrets.VERCEL_TOKEN }}
+      #     vercel-org-id: ${{ env.VERCEL_ORG_ID }}
+      #     vercel-project-id: ${{ env.VERCEL_PROJECT_ID }}
+      #     working-directory: ./docusaurus

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -126,11 +126,21 @@ jobs:
           vercel-args: --archive=tgz
           # working-directory: ./docusaurus
 
+      - name: Authenticate as GitHub App
+        uses: actions/create-github-app-token@v2.0.6
+        id: get-app-token
+        with:
+          owner: "airbytehq"
+          repositories: "airbyte"
+          app-id: ${{ secrets.OCTAVIA_BOT_APP_ID }}
+          private-key: ${{ secrets.OCTAVIA_BOT_PRIVATE_KEY }}
+
       # If successful, post a check status with the Preview URL as its "details" link
-      - name: Post Custom Check with Preview URL
+      - name: Post Custom Check with Preview URL (${{ steps.deploy-vercel.outputs.preview-url }})
         uses: LouisBrunner/checks-action@v2.0.0
         with:
           name: "Vercel Preview Deployed" # << Name of the check
+          status: completed
           conclusion: success
           details_url: ${{ steps.deploy-vercel.outputs.preview-url }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.get-app-token.outputs.token }}


### PR DESCRIPTION
Implement GitHub Actions to manage preview builds for documentation, while temporarily excluding the deployment of pre-built steps.

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._