### PR TITLE
fix: modify script to only build JVM connectors

### DIFF
--- a/poe-tasks/build-and-publish-java-connectors-with-tag.sh
+++ b/poe-tasks/build-and-publish-java-connectors-with-tag.sh
@@ -144,6 +144,12 @@ while read -r connector; do
     exit 1
   fi
 
+  # Check if this is a Java connector
+  if ! grep -qE 'language:\s*java' "$meta"; then
+    echo "ℹ️  Skipping ${connector} — this script only supports JVM connectors for now."
+    continue
+  fi
+
   base_tag=$(yq -r '.data.dockerImageTag' "$meta")
   if [[ -z "$base_tag" || "$base_tag" == "null" ]]; then
     echo "Error:  dockerImageTag missing in ${meta}" >&2


### PR DESCRIPTION
## What
We previously removed the whitelist here since all JVM connectors were migrated.

However this script doesn't work for non-JVM connectors for now. Fix this to only build images for JVM connectors.

## How
Only build image if the connector has a java language.

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
