### PR TITLE
chore: refactor metadata validation step

### DIFF
--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -71,6 +71,9 @@ jobs:
         with:
           version: 1.8.5
 
+      - name: Install metadata_service
+        run: ./poe-tasks/setup-metadata-service.sh
+
       # If you modify this step, remember to also modify validate-connector-metadata-manual.
       - name: Validate connector metadata [On merge to master]
         id: validate-connector-metadata-master

--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -72,7 +72,7 @@ jobs:
           version: 1.8.5
 
       - name: Install metadata_service
-        run: ./poe-tasks/setup-metadata-service.sh
+        run: poetry install --directory airbyte-ci/connectors/metadata_service/lib
 
       # If you modify this step, remember to also modify validate-connector-metadata-manual.
       - name: Validate connector metadata [On merge to master]

--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -71,12 +71,12 @@ jobs:
         with:
           version: 1.8.5
 
-      # If you modify this step, remember to also modify publish-connector-metadata-manual.
-      - name: Publish connector metadata [On merge to master]
-        id: publish-connector-metadata-master
+      # If you modify this step, remember to also modify validate-connector-metadata-manual.
+      - name: Validate connector metadata [On merge to master]
+        id: validate-connector-metadata-master
         if: github.event_name == 'push'
         shell: bash
-        run: ./poe-tasks/get-modified-connectors.sh --prev-commit --json | ./poe-tasks/publish-connector-metadata.sh
+        run: ./poe-tasks/get-modified-connectors.sh --prev-commit --json | ./poe-tasks/validate-connector-metadata.sh
 
       - name: Build and publish JVM connectors images [On merge to master]
         id: build-and-publish-JVM-connectors-images-master
@@ -108,12 +108,12 @@ jobs:
           max_attempts: 2
           retry_wait_seconds: 600 # 10 minutes
 
-      # If you modify this step, remember to also modify publish-connector-metadata-master.
-      - name: Publish connector metadata [manual]
-        id: publish-connector-metadata-manual
+      # If you modify this step, remember to also modify validate-connector-metadata-master.
+      - name: Validate connector metadata [manual]
+        id: validate-connector-metadata-manual
         if: github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call'
         shell: bash
-        run: ./poe-tasks/publish-connector-metadata.sh ${{ inputs.publish-options }} ${{ inputs.connectors-options }}
+        run: ./poe-tasks/validate-connector-metadata.sh ${{ inputs.publish-options }} ${{ inputs.connectors-options }}
 
       - name: Build and publish JVM connectors images [manual]
         id: build-and-publish-JVM-connectors-images-manual

--- a/poe-tasks/lib/util.sh
+++ b/poe-tasks/lib/util.sh
@@ -4,6 +4,7 @@
 
 CONNECTORS_DIR="airbyte-integrations/connectors"
 DOCS_BASE_DIR="docs/integrations"
+METADATA_SERVICE_PATH='airbyte-ci/connectors/metadata_service/lib'
 
 # Usage: connector_docs_path "source-foo"
 # Returns a string "docs/integrations/sources/foo.md"

--- a/poe-tasks/setup-metadata-service.sh
+++ b/poe-tasks/setup-metadata-service.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source "${BASH_SOURCE%/*}/lib/util.sh"
+
+poetry install --directory $METADATA_SERVICE_PATH

--- a/poe-tasks/setup-metadata-service.sh
+++ b/poe-tasks/setup-metadata-service.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-source "${BASH_SOURCE%/*}/lib/util.sh"
-
-poetry install --directory $METADATA_SERVICE_PATH

--- a/poe-tasks/validate-connector-metadata.sh
+++ b/poe-tasks/validate-connector-metadata.sh
@@ -24,6 +24,6 @@ done < <(get_connectors)
 
 if test $exit_code -ne 0; then
   echo '------------'
-  echo 'One or more connectors failed to validate/upload metadata. See previous logs for more information.'
+  echo 'One or more connectors had invalid metadata.yaml. See previous logs for more information.'
   exit $exit_code
 fi

--- a/poe-tasks/validate-connector-metadata.sh
+++ b/poe-tasks/validate-connector-metadata.sh
@@ -5,9 +5,6 @@ source "${BASH_SOURCE%/*}/lib/util.sh"
 
 source "${BASH_SOURCE%/*}/lib/parse_args.sh"
 
-metadata_service_path='airbyte-ci/connectors/metadata_service/lib'
-poetry install --directory $metadata_service_path
-
 exit_code=0
 while read -r connector; do
   echo "---- PROCESSING METADATA FOR $connector ----"
@@ -15,7 +12,7 @@ while read -r connector; do
   doc="$(connector_docs_path $connector)"
   # Don't exit immediately. We should run against all connectors.
   set +e
-  if ! poetry run --directory $metadata_service_path metadata_service validate "$meta" "$doc"; then
+  if ! poetry run --directory $METADATA_SERVICE_PATH metadata_service validate "$meta" "$doc"; then
     exit_code=1
   fi
   # Reenable the "exit on error" option.


### PR DESCRIPTION
## What
non-functional changes to clean stuff up

## How
* rename publish -> validate, to reflect what it actually does. We'll need to add an actual `publish-connector-metadata` step _after_ the docker image publish.
* extract the poetry install to a separate step (because that publish step also needs it)

## Review guide
* review each commit separately

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
