### PR TITLE
ci: put gradle-diff check in correct CI bucket

### DIFF
--- a/.github/workflows/gradle-dependency-diff.yml
+++ b/.github/workflows/gradle-dependency-diff.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Authenticate as GitHub App
         uses: actions/create-github-app-token@v2
         # We can't get app creds from forks, so we skip this step if the PR is from a fork.
-        if: github.event.pull_request.head.repo.fork == false
+        if: github.event.pull_request.head.repo.fork != true
         id: get-app-token
         with:
           owner: "airbytehq"

--- a/.github/workflows/gradle-dependency-diff.yml
+++ b/.github/workflows/gradle-dependency-diff.yml
@@ -16,5 +16,19 @@ jobs:
         with:
           distribution: temurin
           java-version: 21
+
+      - name: Authenticate as GitHub App
+        uses: actions/create-github-app-token@v2
+        # We can't get app creds from forks, so we skip this step if the PR is from a fork.
+        if: github.event.pull_request.head.repo.fork == false
+        id: get-app-token
+        with:
+          owner: "airbytehq"
+          repositories: "airbyte"
+          app-id: ${{ secrets.OCTAVIA_BOT_APP_ID }}
+          private-key: ${{ secrets.OCTAVIA_BOT_PRIVATE_KEY }}
+
       - name: Run Gradle Dependency Diff
         uses: be-hase/gradle-dependency-diff-action@v2
+        with:
+          token: ${{ steps.get-app-token.outputs.token || secrets.GITHUB_TOKEN }}


### PR DESCRIPTION

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._

## What

GitHub Actions has a bug, where custom check statuses posted from PATs or the default GitHub token do not land under the correct header - instead landing under a random workflow name that does not actually match the check itself.

This PR logs in as the octavia-bot app, and uses that token to post the status.


## Current Status

As of now, this (at least sometimes) shows under a random performance-check workflow name:

<img width="876" height="633" alt="image" src="https://github.com/user-attachments/assets/1939f276-45cf-4647-88a5-baa0de21a8fe" />

## Expected Result

After the change, this should show up similar to other custom checks posted from the GitHub app, under `octavia-bot`:

<img width="608" height="242" alt="image" src="https://github.com/user-attachments/assets/2fddd65b-2309-47a0-8be0-f9f44fc857f9" />

While not super-descriptive, at least it is not under an incorrect bucket.

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
