### PR TITLE
fix: handle strict-encrypt connectors in metadata validation

### DIFF
--- a/poe-tasks/lib/util.sh
+++ b/poe-tasks/lib/util.sh
@@ -9,12 +9,17 @@ METADATA_SERVICE_PATH='airbyte-ci/connectors/metadata_service/lib'
 # Usage: connector_docs_path "source-foo"
 # Returns a string "docs/integrations/sources/foo.md"
 connector_docs_path() {
+  # First, remove -strict-encrypt suffix since these connectors
+  # share documentation with their base connector
+  local connector_name="$1"
+  connector_name=$(echo "$connector_name" | sed -r 's/-strict-encrypt$//')
+  
   # The regex '^(source|destination)-(.*)' matches strings like source-whatever or destination-something-like-this,
   # capturing the connector type (source/destination) and the connector name (whatever / something-like-this).
   # We then output '\1s/\2.md', which inserts the captured values as `\1` and `\2`.
   # This produces a string like `sources/whatever.md`.
   # Then we prepend the 'docs/integrations/' path.
-  echo $DOCS_BASE_DIR/$(echo $1 | sed -r 's@^(source|destination)-(.*)@\1s/\2.md@')
+  echo $DOCS_BASE_DIR/$(echo $connector_name | sed -r 's@^(source|destination)-(.*)@\1s/\2.md@')
 }
 
 # ---------- helper: collect connector names ----------


### PR DESCRIPTION
## What
The validate-connector-metadata.sh script was failing for strict-encrypt connectors because it was looking for documentation files like "postgres-strict-encrypt.md" when these connectors actually share documentation with their base connector (e.g., "postgres.md").

🤖 Generated with [Claude Code](https://claude.ai/code)

## How
This change modifies the connector_docs_path function to strip the "-strict-encrypt" suffix before generating the documentation path, ensuring that strict-encrypt connectors correctly resolve to their base connector's documentation file.

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
