### PR TITLE
ci: add more clarity when running connector-ci checks from fork

### DIFF
--- a/.github/workflows/connector-ci-checks.yml
+++ b/.github/workflows/connector-ci-checks.yml
@@ -182,7 +182,7 @@ jobs:
         run: poe install
 
       - name: Fetch connector secrets
-        # This will be skipped if the repo or fork doesn't set the GCP_PROJECT_ID env var.
+        # This will be skipped if the repo or fork does not set GCP_PROJECT_ID, or if it is set to an empty value.
         # Later integration tests will likely fail in this case, but we at least let them run.
         if: matrix.connector && env.GCP_PROJECT_ID != ''
         run: |

--- a/.github/workflows/connector-ci-checks.yml
+++ b/.github/workflows/connector-ci-checks.yml
@@ -182,19 +182,19 @@ jobs:
         run: poe install
 
       - name: Fetch connector secrets
-        # This will be skipped if the repo or fork doesn't set the GCP_GSM_CREDENTIALS secret.
+        # This will be skipped if the repo or fork doesn't set the GCP_PROJECT_ID env var.
         # Later integration tests will likely fail in this case, but we at least let them run.
-        if: matrix.connector && env.GCP_GSM_CREDENTIALS != ''
+        if: matrix.connector && env.GCP_PROJECT_ID != ''
         run: |
           airbyte-cdk secrets fetch ${{ matrix.connector }} \
             --print-ci-secrets-masks
 
-      - name: Run Unit Tests
+      - name: Run Unit Tests ${{ env.GCP_PROJECT_ID == '' && ' [Unprivileged, Executed from Fork]' || '' }}
         if: matrix.connector
         working-directory: airbyte-integrations/connectors/${{ matrix.connector }}
         run: poe test-unit-tests
 
-      - name: Run Integration Tests
+      - name: Run Integration Tests ${{ env.GCP_PROJECT_ID == '' && ' [Unprivileged, Executed from Fork]' || '' }}
         if: matrix.connector
         working-directory: airbyte-integrations/connectors/${{ matrix.connector }}
         run: poe test-integration-tests

--- a/.github/workflows/connector-ci-checks.yml
+++ b/.github/workflows/connector-ci-checks.yml
@@ -192,7 +192,11 @@ jobs:
       - name: Run Unit Tests ${{ env.GCP_PROJECT_ID == '' && ' [Unprivileged, Executed from Fork]' || '' }}
         if: matrix.connector
         working-directory: airbyte-integrations/connectors/${{ matrix.connector }}
-        run: poe test-unit-tests
+        run: |
+          echo "DEBUG: ${{ env.GCP_PROJECT_ID }} </DEBUG>"
+          echo "DEBUG2:  ${{ env.GCP_PROJECT_ID == '' && ' [Unprivileged, Executed from Fork]' || '' }}"
+          echo "DEBUG3:  ${{ (env.GCP_PROJECT_ID == '') && ' [Unprivileged, Executed from Fork]' || '' }}"
+          poe test-unit-tests
 
       - name: Run Integration Tests ${{ env.GCP_PROJECT_ID == '' && ' [Unprivileged, Executed from Fork]' || '' }}
         if: matrix.connector

--- a/.github/workflows/connector-ci-checks.yml
+++ b/.github/workflows/connector-ci-checks.yml
@@ -280,19 +280,19 @@ jobs:
         run: poe install
 
       - name: Fetch connector secrets
-        # This will be skipped if the repo or fork doesn't set the GCP_GSM_CREDENTIALS secret.
+        # This will be skipped if the repo or fork does not set GCP_PROJECT_ID, or if it is set to an empty value.
         # Later integration tests will likely fail in this case, but we at least let them run.
-        if: matrix.connector && env.GCP_GSM_CREDENTIALS != ''
+        if: matrix.connector && env.GCP_PROJECT_ID != ''
         run: |
           airbyte-cdk secrets fetch ${{ matrix.connector }} \
             --print-ci-secrets-masks
 
-      - name: Run Unit Tests
+      - name: Run Unit Tests ${{ env.GCP_PROJECT_ID == '' && ' [Unprivileged, Executed from Fork]' || '' }}
         if: matrix.connector
         working-directory: airbyte-integrations/connectors/${{ matrix.connector }}
         run: poe test-unit-tests
 
-      - name: Run Integration Tests
+      - name: Run Integration Tests ${{ env.GCP_PROJECT_ID == '' && ' [Unprivileged, Executed from Fork]' || '' }}
         if: matrix.connector
         working-directory: airbyte-integrations/connectors/${{ matrix.connector }}
         run: poe test-integration-tests

--- a/.github/workflows/connector-ci-checks.yml
+++ b/.github/workflows/connector-ci-checks.yml
@@ -119,6 +119,7 @@ jobs:
       jvm-runner-type: ${{ steps.set-jvm-runner-type.outputs.jvm-runner-type }}
       # The commit SHA of the current branch, used to report test results:
       commit-sha: ${{ steps.checkout.outputs.commit }}
+      creds-available: ${{ (secrets.GCP_PROJECT_ID == '') && (vars.GCP_PROJECT_ID == '') && 'false' || 'true' }}
 
   jvm-connectors-test:
     needs: [generate-matrix]
@@ -132,7 +133,7 @@ jobs:
       matrix: ${{ fromJson(needs.generate-matrix.outputs.jvm-connectors-matrix) }}
       max-parallel: 5 # Limit number of parallel jobs
       fail-fast: false # Don't stop on first failure
-    name: Test ${{ matrix.connector }} Connector ${{ ! matrix.connector && ' (no JVM-based connectors modified)' || '' }}
+    name: Test ${{ matrix.connector }} Connector ${{ ! matrix.connector && ' (no JVM-based connectors modified)' || ( ! needs.generate-matrix.outputs.creds-available == 'true' && '[With Creds]' || '[No Creds]') }}
     steps:
       - name: Checkout Airbyte
         if: matrix.connector
@@ -294,7 +295,11 @@ jobs:
       - name: Run Unit Tests ${{ env.GCP_PROJECT_ID == '' && ' [Unprivileged, Executed from Fork]' || '' }}
         if: matrix.connector
         working-directory: airbyte-integrations/connectors/${{ matrix.connector }}
-        run: poe test-unit-tests
+        run: |
+          echo "DEBUG: ${{ env.GCP_PROJECT_ID }} </DEBUG>"
+          echo "DEBUG2:  ${{ env.GCP_PROJECT_ID == '' && ' [Unprivileged, Executed from Fork]' || '' }}"
+          echo "DEBUG3:  ${{ (env.GCP_PROJECT_ID == '') && ' [Unprivileged, Executed from Fork]' || '' }}"
+          poe test-unit-tests
 
       - name: Run Integration Tests ${{ env.GCP_PROJECT_ID == '' && ' [Unprivileged, Executed from Fork]' || '' }}
         if: matrix.connector

--- a/.github/workflows/connector-ci-checks.yml
+++ b/.github/workflows/connector-ci-checks.yml
@@ -226,7 +226,7 @@ jobs:
       matrix: ${{ fromJson(needs.generate-matrix.outputs.non-jvm-connectors-matrix) }}
       max-parallel: 5 # Limit number of parallel jobs
       fail-fast: false # Don't stop on first failure
-    name: Test ${{ matrix.connector }} Connector ${{ ! matrix.connector && ' (no non-JVM-based connectors modified)' || '' }}
+    name: Test ${{ matrix.connector }} Connector ${{ ! matrix.connector && ' (no non-JVM-based connectors modified)' ||  ( ! needs.generate-matrix.outputs.creds-available == 'true' && '[With Creds]' || '[No Creds]')  }}
     steps:
       - name: Checkout Airbyte
         if: matrix.connector

--- a/.github/workflows/connector-ci-checks.yml
+++ b/.github/workflows/connector-ci-checks.yml
@@ -185,7 +185,7 @@ jobs:
       - name: Fetch connector secrets
         # This will be skipped if the repo or fork does not set GCP_PROJECT_ID, or if it is set to an empty value.
         # Later integration tests will likely fail in this case, but we at least let them run.
-        if: matrix.connector && env.GCP_PROJECT_ID != ''
+        if: matrix.connector && needs.generate-matrix.outputs.creds-available == 'true'
         run: |
           airbyte-cdk secrets fetch ${{ matrix.connector }} \
             --print-ci-secrets-masks
@@ -288,16 +288,12 @@ jobs:
           airbyte-cdk secrets fetch ${{ matrix.connector }} \
             --print-ci-secrets-masks
 
-      - name: Run Unit Tests ${{ env.GCP_PROJECT_ID == '' && ' [Unprivileged, Executed from Fork]' || '' }}
+      - name: Run Unit Tests ${{ needs.generate-matrix.outputs.creds-available == 'false' && '[Unprivileged, Executed from Fork]' || '' }}
         if: matrix.connector
         working-directory: airbyte-integrations/connectors/${{ matrix.connector }}
-        run: |
-          echo "DEBUG: ${{ env.GCP_PROJECT_ID }} </DEBUG>"
-          echo "DEBUG2:  ${{ env.GCP_PROJECT_ID == '' && ' [Unprivileged, Executed from Fork]' || '' }}"
-          echo "DEBUG3:  ${{ (env.GCP_PROJECT_ID == '') && ' [Unprivileged, Executed from Fork]' || '' }}"
-          poe test-unit-tests
+        run: poe test-unit-tests
 
-      - name: Run Integration Tests ${{ env.GCP_PROJECT_ID == '' && ' [Unprivileged, Executed from Fork]' || '' }}
+      - name: Run Integration Tests ${{ needs.generate-matrix.outputs.creds-available == 'false' && '[Unprivileged, Executed from Fork]' || '' }}
         if: matrix.connector
         working-directory: airbyte-integrations/connectors/${{ matrix.connector }}
         run: poe test-integration-tests

--- a/.github/workflows/connector-ci-checks.yml
+++ b/.github/workflows/connector-ci-checks.yml
@@ -133,7 +133,7 @@ jobs:
       matrix: ${{ fromJson(needs.generate-matrix.outputs.jvm-connectors-matrix) }}
       max-parallel: 5 # Limit number of parallel jobs
       fail-fast: false # Don't stop on first failure
-    name: Test ${{ matrix.connector }} Connector ${{ ! matrix.connector && ' (no JVM-based connectors modified)' || ( ! needs.generate-matrix.outputs.creds-available == 'true' && '[With Creds]' || '[No Creds]') }}
+    name: Test ${{ matrix.connector }} Connector ${{ ! matrix.connector && ' (no JVM-based connectors modified)' || ( needs.generate-matrix.outputs.creds-available == 'false' && ' [No Creds]' || '') }}
     steps:
       - name: Checkout Airbyte
         if: matrix.connector
@@ -190,16 +190,12 @@ jobs:
           airbyte-cdk secrets fetch ${{ matrix.connector }} \
             --print-ci-secrets-masks
 
-      - name: Run Unit Tests ${{ env.GCP_PROJECT_ID == '' && ' [Unprivileged, Executed from Fork]' || '' }}
+      - name: Run Unit Tests ${{ needs.generate-matrix.outputs.creds-available == 'false' && '[Unprivileged, Executed from Fork]' || '' }}
         if: matrix.connector
         working-directory: airbyte-integrations/connectors/${{ matrix.connector }}
-        run: |
-          echo "DEBUG: ${{ env.GCP_PROJECT_ID }} </DEBUG>"
-          echo "DEBUG2:  ${{ env.GCP_PROJECT_ID == '' && ' [Unprivileged, Executed from Fork]' || '' }}"
-          echo "DEBUG3:  ${{ (env.GCP_PROJECT_ID == '') && ' [Unprivileged, Executed from Fork]' || '' }}"
-          poe test-unit-tests
+        run: poe test-unit-tests
 
-      - name: Run Integration Tests ${{ env.GCP_PROJECT_ID == '' && ' [Unprivileged, Executed from Fork]' || '' }}
+      - name: Run Integration Tests ${{ needs.generate-matrix.outputs.creds-available == 'false' && '[Unprivileged, Executed from Fork]' || '' }}
         if: matrix.connector
         working-directory: airbyte-integrations/connectors/${{ matrix.connector }}
         run: poe test-integration-tests
@@ -226,7 +222,7 @@ jobs:
       matrix: ${{ fromJson(needs.generate-matrix.outputs.non-jvm-connectors-matrix) }}
       max-parallel: 5 # Limit number of parallel jobs
       fail-fast: false # Don't stop on first failure
-    name: Test ${{ matrix.connector }} Connector ${{ ! matrix.connector && ' (no non-JVM-based connectors modified)' ||  ( ! needs.generate-matrix.outputs.creds-available == 'true' && '[With Creds]' || '[No Creds]')  }}
+    name: Test ${{ matrix.connector }} Connector ${{ ! matrix.connector && ' (no non-JVM-based connectors modified)' || ( needs.generate-matrix.outputs.creds-available == 'false' && ' [No Creds]' || '') }}
     steps:
       - name: Checkout Airbyte
         if: matrix.connector

--- a/airbyte-integrations/connectors/source-file/pyproject.toml
+++ b/airbyte-integrations/connectors/source-file/pyproject.toml
@@ -55,4 +55,3 @@ include = [
     # Run `poe` or `poe --help` to see the list of available tasks.
     "${POE_GIT_DIR}/poe-tasks/poetry-connector-tasks.toml",
 ]
-# dummy-change (revert me)

--- a/airbyte-integrations/connectors/source-file/pyproject.toml
+++ b/airbyte-integrations/connectors/source-file/pyproject.toml
@@ -55,3 +55,4 @@ include = [
     # Run `poe` or `poe --help` to see the list of available tasks.
     "${POE_GIT_DIR}/poe-tasks/poetry-connector-tasks.toml",
 ]
+# dummy-change (revert me)


### PR DESCRIPTION
## What

This PR aims to clarify the question for community members who create PRs, as well as to maintainers who are reviewing PRs.

The PR aims to specifically answer the question:
- Did this fail because we (Airbyte) don't have creds, or because it was run from an unprivileged context?

And otherwise, it should just be way more clear when you are looking at a *privileged* CI execution (triggered by internal PRs and by our Slash command) vs when you are looking at a CI execution that was run without privileges - such as on the default "pull_request" event trigger on PRs from forks.

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._