### PR TITLE
Add test-integration-tests-no-creds Poe task for all connector types

### DIFF
--- a/buildSrc/src/main/groovy/airbyte-bulk-connector.gradle
+++ b/buildSrc/src/main/groovy/airbyte-bulk-connector.gradle
@@ -235,6 +235,35 @@ class AirbyteBulkConnectorPlugin implements Plugin<Project> {
                 integrationTestLegacyImplementation project.sourceSets.integrationTest.output
             }
 
+            // Identical to integrationTestJava except excludes tests marked with @Tag("requires-creds")
+            // Future maintainers: copy changes from integrationTestJava and re-apply the excludeTags() difference
+            project.tasks.register('integrationTestJavaNoCreds', Test) {
+                description = 'Runs the integration tests in docker mode, excluding tests that require external credentials.'
+                group = 'verification'
+                testClassesDirs = project.sourceSets.integrationTest.output.classesDirs + project.sourceSets.integrationTestLegacy.output.classesDirs
+                classpath = project.sourceSets.integrationTest.runtimeClasspath + project.sourceSets.integrationTestLegacy.runtimeClasspath
+                useJUnitPlatform {
+                    excludeTags("requires-creds")
+                }
+                // We need a docker image to run this task, so depend on assemble
+                dependsOn project.tasks.assemble
+                environment "AIRBYTE_CONNECTOR_INTEGRATION_TEST_RUNNER", "docker"
+
+                jvmArgs = project.test.jvmArgs
+                systemProperties = project.test.systemProperties
+                maxParallelForks = project.test.maxParallelForks
+                maxHeapSize = project.test.maxHeapSize
+
+                testLogging() {
+                    events 'skipped', 'started', 'passed', 'failed'
+                    exceptionFormat 'full'
+                    showStandardStreams = true
+                }
+
+                // Always re-run integration tests no matter what.
+                outputs.upToDateWhen { false }
+            }
+
             project.tasks.named('build').configure {
                 dependsOn project.tasks.integrationTestJava
             }

--- a/buildSrc/src/main/groovy/airbyte-java-connector.gradle
+++ b/buildSrc/src/main/groovy/airbyte-java-connector.gradle
@@ -229,6 +229,48 @@ class AirbyteJavaConnectorPlugin implements Plugin<Project> {
             dependsOn project.tasks.matching { it.name == 'assemble' }
             onlyIf { withSlowTests }
         }
+        // Identical to integrationTestJava except excludes tests marked with @Tag("requires-creds")
+        // Future maintainers: copy changes from integrationTestJava and re-apply the excludeTags() difference
+        def integrationTestJavaNoCreds = project.tasks.register('integrationTestJavaNoCreds', Test) {
+            testClassesDirs = project.sourceSets.integrationTestJava.output.classesDirs
+            classpath += project.sourceSets.integrationTestJava.runtimeClasspath
+
+            useJUnitPlatform {
+                excludeTags("requires-creds")
+            }
+            testLogging() {
+                events 'skipped', 'started', 'passed', 'failed'
+                exceptionFormat 'full'
+                showStandardStreams = true
+            }
+
+            jvmArgs = project.test.jvmArgs
+            maxParallelForks = project.test.maxParallelForks
+            maxHeapSize = project.test.maxHeapSize
+            // Reduce parallelization to get tests passing
+            // TODO: Fix the actual issue causing concurrent tests to hang.
+            systemProperties = project.test.systemProperties + [
+                'junit.jupiter.execution.parallel.enabled': 'true',
+                'junit.jupiter.execution.parallel.config.strategy': 'fixed',
+                'junit.jupiter.execution.parallel.config.fixed.parallelism': Math.min((Runtime.runtime.availableProcessors() / 2).toInteger(), 1).toString()
+            ]
+
+            // Tone down the JIT when running the containerized connector to improve overall performance.
+            // The JVM default settings are optimized for long-lived processes in steady-state operation.
+            // Unlike in production, the connector containers in these tests are always short-lived.
+            // It's very much worth injecting a JAVA_OPTS environment variable into the container with
+            // flags which will reduce startup time at the detriment of long-term performance.
+            environment 'JOB_DEFAULT_ENV_JAVA_OPTS', '-XX:TieredStopAtLevel=1'
+
+            // Always re-run integration tests no matter what.
+            outputs.upToDateWhen { false }
+        }
+        integrationTestJavaNoCreds.configure {
+            mustRunAfter project.tasks.named('check')
+            dependsOn project.tasks.matching { it.name == 'assemble' }
+            onlyIf { withSlowTests }
+        }
+
         project.tasks.register('integrationTest').configure {
             dependsOn integrationTestJava
         }

--- a/poe-tasks/gradle-connector-tasks.toml
+++ b/poe-tasks/gradle-connector-tasks.toml
@@ -63,14 +63,28 @@ set -eu # Ensure we return non-zero exit code upon failure
 if [ -d src/test-integration ]; then
   echo "Found 'src/test-integration' directory. Running integration tests without credential requirements..."
   
-  # Check if the connector has defined the integrationTestJavaNoCreds task
-  if gradle tasks --all | grep -q "integrationTestJavaNoCreds"; then
-    echo "Using dedicated integrationTestJavaNoCreds task (excludes @Tag('requires-creds') tests)"
-    gradle integrationTestJavaNoCreds
-  else
-    echo "No integrationTestJavaNoCreds task found. Running all integration tests (most Java connectors use Docker-based test harnesses that don't require external credentials)..."
+  # Create a temporary Gradle task that excludes @Tag("requires-creds") tests
+  cat > build-temp-no-creds.gradle << 'EOF'
+task integrationTestJavaNoCreds(type: Test) {
+    useJUnitPlatform {
+        excludeTags("requires-creds")
+    }
+    testClassesDirs = sourceSets.testIntegration.output.classesDirs
+    classpath = sourceSets.testIntegration.runtimeClasspath
+    group = 'verification'
+    description = 'Runs integration tests that do not require external credentials'
+}
+EOF
+  
+  # Apply the temporary build script and run the no-creds task
+  echo "Creating temporary integrationTestJavaNoCreds task (excludes @Tag('requires-creds') tests)"
+  gradle -b build-temp-no-creds.gradle integrationTestJavaNoCreds || {
+    echo "Failed to run with tag exclusion. Falling back to all integration tests (most Java connectors use Docker-based test harnesses)..."
     gradle integrationTestJava
-  fi
+  }
+  
+  # Clean up temporary file
+  rm -f build-temp-no-creds.gradle
 else
   echo "No integration tests defined; skipping integration tests."
 fi

--- a/poe-tasks/gradle-connector-tasks.toml
+++ b/poe-tasks/gradle-connector-tasks.toml
@@ -63,28 +63,14 @@ set -eu # Ensure we return non-zero exit code upon failure
 if [ -d src/test-integration ]; then
   echo "Found 'src/test-integration' directory. Running integration tests without credential requirements..."
   
-  # Create a temporary Gradle task that excludes @Tag("requires-creds") tests
-  cat > build-temp-no-creds.gradle << 'EOF'
-task integrationTestJavaNoCreds(type: Test) {
-    useJUnitPlatform {
-        excludeTags("requires-creds")
-    }
-    testClassesDirs = sourceSets.testIntegration.output.classesDirs
-    classpath = sourceSets.testIntegration.runtimeClasspath
-    group = 'verification'
-    description = 'Runs integration tests that do not require external credentials'
-}
-EOF
-  
-  # Apply the temporary build script and run the no-creds task
-  echo "Creating temporary integrationTestJavaNoCreds task (excludes @Tag('requires-creds') tests)"
-  gradle -b build-temp-no-creds.gradle integrationTestJavaNoCreds || {
-    echo "Failed to run with tag exclusion. Falling back to all integration tests (most Java connectors use Docker-based test harnesses)..."
+  # Check if the connector has the centrally-defined integrationTestJavaNoCreds task
+  if gradle tasks --all | grep -q "integrationTestJavaNoCreds"; then
+    echo "Using centrally-defined integrationTestJavaNoCreds task (excludes @Tag('requires-creds') tests)"
+    gradle integrationTestJavaNoCreds
+  else
+    echo "No integrationTestJavaNoCreds task found. Running all integration tests (most Java connectors use Docker-based test harnesses that don't require external credentials)..."
     gradle integrationTestJava
-  }
-  
-  # Clean up temporary file
-  rm -f build-temp-no-creds.gradle
+  fi
 else
   echo "No integration tests defined; skipping integration tests."
 fi

--- a/poe-tasks/gradle-connector-tasks.toml
+++ b/poe-tasks/gradle-connector-tasks.toml
@@ -57,6 +57,17 @@ else
 fi
 '''
 
+test-integration-tests-no-creds.shell = '''
+set -eu # Ensure we return non-zero exit code upon failure
+
+if [ -d src/test-integration ]; then
+  echo "Found 'src/test-integration' directory. Running integration tests (most Java connectors use Docker-based test harnesses that don't require external credentials)..."
+  gradle integrationTestJava
+else
+  echo "No integration tests defined; skipping integration tests."
+fi
+'''
+
 [tasks.gradle]
 help = "Run a gradle command on this connector. Usage: poe gradle <command> [args...]"
 shell = '''

--- a/poe-tasks/gradle-connector-tasks.toml
+++ b/poe-tasks/gradle-connector-tasks.toml
@@ -61,8 +61,16 @@ test-integration-tests-no-creds.shell = '''
 set -eu # Ensure we return non-zero exit code upon failure
 
 if [ -d src/test-integration ]; then
-  echo "Found 'src/test-integration' directory. Running integration tests (most Java connectors use Docker-based test harnesses that don't require external credentials)..."
-  gradle integrationTestJava
+  echo "Found 'src/test-integration' directory. Running integration tests without credential requirements..."
+  
+  # Check if the connector has defined the integrationTestJavaNoCreds task
+  if gradle tasks --all | grep -q "integrationTestJavaNoCreds"; then
+    echo "Using dedicated integrationTestJavaNoCreds task (excludes @Tag('requires-creds') tests)"
+    gradle integrationTestJavaNoCreds
+  else
+    echo "No integrationTestJavaNoCreds task found. Running all integration tests (most Java connectors use Docker-based test harnesses that don't require external credentials)..."
+    gradle integrationTestJava
+  fi
 else
   echo "No integration tests defined; skipping integration tests."
 fi

--- a/poe-tasks/gradle-connector-tasks.toml
+++ b/poe-tasks/gradle-connector-tasks.toml
@@ -57,6 +57,7 @@ else
 fi
 '''
 
+# Identical to test-integration-tests except excludes tests marked with @Tag("requires-creds")
 test-integration-tests-no-creds.shell = '''
 set -eu # Ensure we return non-zero exit code upon failure
 

--- a/poe-tasks/manifest-only-connector-tasks.toml
+++ b/poe-tasks/manifest-only-connector-tasks.toml
@@ -44,6 +44,7 @@ else
 fi
 '''
 test-integration-tests = "airbyte-cdk connector test ${POE_PWD}"
+test-integration-tests-no-creds = "airbyte-cdk connector test ${POE_PWD} --pytest-arg='-m' --pytest-arg='not requires_creds'"
 format-check = "echo 'No format check step for this connector.'"
 lint-check = "echo 'No lint check step for this connector."
 

--- a/poe-tasks/manifest-only-connector-tasks.toml
+++ b/poe-tasks/manifest-only-connector-tasks.toml
@@ -44,6 +44,7 @@ else
 fi
 '''
 test-integration-tests = "airbyte-cdk connector test ${POE_PWD}"
+# Identical to test-integration-tests except excludes tests marked with @pytest.mark.requires_creds
 test-integration-tests-no-creds = "airbyte-cdk connector test ${POE_PWD} --pytest-arg='-m' --pytest-arg='not requires_creds'"
 format-check = "echo 'No format check step for this connector.'"
 lint-check = "echo 'No lint check step for this connector."

--- a/poe-tasks/poetry-connector-tasks.toml
+++ b/poe-tasks/poetry-connector-tasks.toml
@@ -24,6 +24,7 @@ install-project = "poetry install --all-extras"
 install-cdk-cli = "uv tool install --upgrade 'airbyte-cdk[dev]'"
 test-all = ["test-unit-tests", "test-integration-tests"]
 test-integration-tests = ["pytest-integration-tests"]
+# Identical to test-integration-tests except excludes tests marked with @pytest.mark.requires_creds
 test-integration-tests-no-creds = ["pytest-integration-tests-no-creds"]
 test-unit-tests = ["pytest-unit-tests"]
 test-fast = ["pytest-fast"]
@@ -58,6 +59,7 @@ else
 fi
 '''
 
+# Identical to pytest-integration-tests except excludes tests marked with @pytest.mark.requires_creds
 pytest-integration-tests-no-creds.shell = '''
 set -eu # Ensure we return non-zero exit code upon failure
 

--- a/poe-tasks/poetry-connector-tasks.toml
+++ b/poe-tasks/poetry-connector-tasks.toml
@@ -24,6 +24,7 @@ install-project = "poetry install --all-extras"
 install-cdk-cli = "uv tool install --upgrade 'airbyte-cdk[dev]'"
 test-all = ["test-unit-tests", "test-integration-tests"]
 test-integration-tests = ["pytest-integration-tests"]
+test-integration-tests-no-creds = ["pytest-integration-tests-no-creds"]
 test-unit-tests = ["pytest-unit-tests"]
 test-fast = ["pytest-fast"]
 format-check = ["check-ruff-format"]
@@ -52,6 +53,16 @@ set -eu # Ensure we return non-zero exit code upon failure
 
 if ls integration_tests/test_*.py >/dev/null 2>&1; then
   poetry run pytest --junitxml=build/test-results/pytest-integration-tests-junit.xml integration_tests
+else
+  echo "No 'integration_tests' directory found; skipping integration tests."
+fi
+'''
+
+pytest-integration-tests-no-creds.shell = '''
+set -eu # Ensure we return non-zero exit code upon failure
+
+if ls integration_tests/test_*.py >/dev/null 2>&1; then
+  poetry run pytest -m 'not requires_creds' --junitxml=build/test-results/pytest-integration-tests-no-creds-junit.xml integration_tests
 else
   echo "No 'integration_tests' directory found; skipping integration tests."
 fi


### PR DESCRIPTION
## What

Adds a new Poe task `test-integration-tests-no-creds` for all three connector types (Poetry, Manifest-only, and Gradle) to enable running integration tests that don't require external credentials. This addresses the need to run integration tests in environments where credentials are not available or for tests that use self-contained Docker harnesses.

## How

**Poetry Connectors (`poe-tasks/poetry-connector-tasks.toml`)**
- Added task using pytest with `-m 'not requires_creds'` marker, following the existing pattern from `pytest-fast` task
- Creates separate shell script `pytest-integration-tests-no-creds` that mirrors existing integration test structure

**Manifest-only Connectors (`poe-tasks/manifest-only-connector-tasks.toml`)**  
- Added task using `airbyte-cdk connector test` with `--pytest-arg='-m'` and `--pytest-arg='not requires_creds'` parameters
- Leverages existing airbyte-cdk CLI pytest argument passing

**Gradle Connectors (`poe-tasks/gradle-connector-tasks.toml`)**
- Implements intelligent task detection that first checks for dedicated `integrationTestJavaNoCreds` task
- Falls back to regular `integrationTestJava` if dedicated task doesn't exist
- Added central `integrationTestJavaNoCreds` task definition to `airbyte-java-connector.gradle` plugin

**Central Plugin Changes (`buildSrc/src/main/groovy/airbyte-java-connector.gradle`)**
- Added `integrationTestJavaNoCreds` task with `excludeTags("requires-creds")` configuration
- Task inherits all configuration from existing `integrationTestJava` task
- Includes comprehensive inline comments for future maintainers

## Review guide

1. **`poe-tasks/poetry-connector-tasks.toml`** - Verify pytest marker assumption (`@pytest.mark.requires_creds`) is consistently used across Poetry connectors
2. **`poe-tasks/manifest-only-connector-tasks.toml`** - Check airbyte-cdk CLI argument syntax and marker consistency
3. **`poe-tasks/gradle-connector-tasks.toml`** - Review Gradle task detection logic (`gradle tasks --all | grep -q`) for robustness and potential brittleness
4. **`buildSrc/src/main/groovy/airbyte-java-connector.gradle`** - **CRITICAL**: Central plugin changes affect ALL Java connectors automatically - verify no unintended side effects
5. **Test marker consistency** - Confirm that `@Tag("requires-creds")` pattern will be adopted consistently across Java/Kotlin connectors

**Key areas of concern:**
- **Pytest marker assumptions**: Implementation assumes `requires_creds` markers are consistently applied across connectors - this may not be universal
- **Gradle task detection**: The shell script detection logic could be fragile if Gradle output format changes
- **Fallback behavior**: For connectors without proper test tagging, the no-creds task might still attempt to run credential-requiring tests
- **Central plugin impact**: Changes to airbyte-java-connector.gradle affect hundreds of connectors automatically

## User Impact

**Positive:**
- Connector developers can now run integration tests without external credentials using `poe test-integration-tests-no-creds`
- Enables testing in CI environments without credential access
- Supports local development without setting up external services  
- Faster test feedback loops for Docker-based test harnesses

**Potential negative impacts:**
- For connectors without proper test tagging, the no-creds task might still attempt to run credential-requiring tests
- Java/Kotlin connectors currently lack widespread `@Tag("requires-creds")` annotations, so behavior depends on fallback logic
- If test marker conventions aren't followed consistently, users may get unexpected test execution behavior

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

This change only adds new Poe tasks and a new Gradle task without modifying existing functionality. Reverting would simply remove the new tasks without affecting current workflows. The central plugin change adds a new task but doesn't modify existing tasks.

---

**Manual Testing Results:**
- ✅ Poetry connector (source-faker): Successfully skipped integration tests  
- ✅ Gradle connector (source-postgres): Successfully ran with appropriate messaging
- ✅ Manifest-only connector (source-pokeapi): Task executed correctly with expected test filtering

**Link to Devin run:** https://app.devin.ai/sessions/507b5c0b6fde4ba8a95794bf1707dd06  
**Requested by:** @aaronsteers