### PR TITLE
ci(jvm-connectors): Add and implement gradle `integrationTestJavaNoCreds` task for JVM connectors when running without creds

### DIFF
--- a/buildSrc/src/main/groovy/airbyte-bulk-connector.gradle
+++ b/buildSrc/src/main/groovy/airbyte-bulk-connector.gradle
@@ -235,6 +235,35 @@ class AirbyteBulkConnectorPlugin implements Plugin<Project> {
                 integrationTestLegacyImplementation project.sourceSets.integrationTest.output
             }
 
+            // Identical to integrationTestJava except excludes tests marked with @Tag("requires-creds")
+            // Future maintainers: copy changes from integrationTestJava and re-apply the excludeTags() difference
+            project.tasks.register('integrationTestJavaNoCreds', Test) {
+                description = 'Runs the integration tests in docker mode, excluding tests that require external credentials.'
+                group = 'verification'
+                testClassesDirs = project.sourceSets.integrationTest.output.classesDirs + project.sourceSets.integrationTestLegacy.output.classesDirs
+                classpath = project.sourceSets.integrationTest.runtimeClasspath + project.sourceSets.integrationTestLegacy.runtimeClasspath
+                useJUnitPlatform {
+                    excludeTags("requires-creds")
+                }
+                // We need a docker image to run this task, so depend on assemble
+                dependsOn project.tasks.assemble
+                environment "AIRBYTE_CONNECTOR_INTEGRATION_TEST_RUNNER", "docker"
+
+                jvmArgs = project.test.jvmArgs
+                systemProperties = project.test.systemProperties
+                maxParallelForks = project.test.maxParallelForks
+                maxHeapSize = project.test.maxHeapSize
+
+                testLogging() {
+                    events 'skipped', 'started', 'passed', 'failed'
+                    exceptionFormat 'full'
+                    showStandardStreams = true
+                }
+
+                // Always re-run integration tests no matter what.
+                outputs.upToDateWhen { false }
+            }
+
             project.tasks.named('build').configure {
                 dependsOn project.tasks.integrationTestJava
             }

--- a/buildSrc/src/main/groovy/airbyte-java-connector.gradle
+++ b/buildSrc/src/main/groovy/airbyte-java-connector.gradle
@@ -229,6 +229,48 @@ class AirbyteJavaConnectorPlugin implements Plugin<Project> {
             dependsOn project.tasks.matching { it.name == 'assemble' }
             onlyIf { withSlowTests }
         }
+        // Identical to integrationTestJava except excludes tests marked with @Tag("requires-creds")
+        // Future maintainers: copy changes from integrationTestJava and re-apply the excludeTags() difference
+        def integrationTestJavaNoCreds = project.tasks.register('integrationTestJavaNoCreds', Test) {
+            testClassesDirs = project.sourceSets.integrationTestJava.output.classesDirs
+            classpath += project.sourceSets.integrationTestJava.runtimeClasspath
+
+            useJUnitPlatform {
+                excludeTags("requires-creds")
+            }
+            testLogging() {
+                events 'skipped', 'started', 'passed', 'failed'
+                exceptionFormat 'full'
+                showStandardStreams = true
+            }
+
+            jvmArgs = project.test.jvmArgs
+            maxParallelForks = project.test.maxParallelForks
+            maxHeapSize = project.test.maxHeapSize
+            // Reduce parallelization to get tests passing
+            // TODO: Fix the actual issue causing concurrent tests to hang.
+            systemProperties = project.test.systemProperties + [
+                'junit.jupiter.execution.parallel.enabled': 'true',
+                'junit.jupiter.execution.parallel.config.strategy': 'fixed',
+                'junit.jupiter.execution.parallel.config.fixed.parallelism': Math.min((Runtime.runtime.availableProcessors() / 2).toInteger(), 1).toString()
+            ]
+
+            // Tone down the JIT when running the containerized connector to improve overall performance.
+            // The JVM default settings are optimized for long-lived processes in steady-state operation.
+            // Unlike in production, the connector containers in these tests are always short-lived.
+            // It's very much worth injecting a JAVA_OPTS environment variable into the container with
+            // flags which will reduce startup time at the detriment of long-term performance.
+            environment 'JOB_DEFAULT_ENV_JAVA_OPTS', '-XX:TieredStopAtLevel=1'
+
+            // Always re-run integration tests no matter what.
+            outputs.upToDateWhen { false }
+        }
+        integrationTestJavaNoCreds.configure {
+            mustRunAfter project.tasks.named('check')
+            dependsOn project.tasks.matching { it.name == 'assemble' }
+            onlyIf { withSlowTests }
+        }
+
         project.tasks.register('integrationTest').configure {
             dependsOn integrationTestJava
         }


### PR DESCRIPTION
## What

Adds new Gradle tasks `integrationTestJavaNoCreds` to both `airbyte-java-connector` and `airbyte-bulk-connector` plugins. These tasks enable running integration tests for Java/Kotlin connectors while excluding tests that require external credentials.

This is part of a larger effort to provide credential-free testing capabilities across all connector types. This PR specifically addresses JVM-based connectors (both source and destination).

## How

- **Source connectors**: Added `integrationTestJavaNoCreds` task to `airbyte-java-connector.gradle` plugin with `excludeTags("requires-creds")` configuration
- **Destination connectors**: Added `integrationTestJavaNoCreds` task to `airbyte-bulk-connector.gradle` plugin with `excludeTags("requires-creds")` configuration
- Both tasks are identical to their respective `integrationTestJava` tasks except for the tag exclusion
- Added comprehensive inline comments explaining the maintenance relationship between original and no-creds tasks

The tasks use JUnit Platform's `excludeTags()` functionality to filter out tests annotated with `@Tag("requires-creds")`. When developers add this annotation to tests that require external credentials, those tests will be automatically excluded from the no-creds task runs.

## Review guide

1. **`buildSrc/src/main/groovy/airbyte-java-connector.gradle`** (lines ~232-274)
   - Verify the new `integrationTestJavaNoCreds` task configuration matches `integrationTestJava` exactly except for `excludeTags("requires-creds")`
   - Check that all JVM args, system properties, and test execution settings are copied correctly
   - Confirm the inline comments adequately explain the maintenance burden

2. **`buildSrc/src/main/groovy/airbyte-bulk-connector.gradle`** (lines ~238-266)
   - Verify the new task handles both `integrationTest` and `integrationTestLegacy` source sets like the original
   - Check that Docker environment configuration is preserved
   - Confirm consistency with the source connector implementation

## User Impact

- **Positive**: JVM connector developers can now run integration tests that exclude credential-requiring tests using `gradle integrationTestJavaNoCreds`
- **Future adoption required**: The feature only provides value once developers add `@Tag("requires-creds")` annotations to appropriate tests
- **No breaking changes**: Existing `integrationTestJava` tasks remain unchanged

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

The changes only add new Gradle tasks without modifying existing functionality. Reverting would simply remove the new tasks, leaving all existing workflows intact.

---

**Link to Devin run**: https://app.devin.ai/sessions/507b5c0b6fde4ba8a95794bf1707dd06

**Requested by**: @aaronsteers