### PR TITLE
chore: connector publish shell scripts only need to handle one connector

### DIFF
--- a/poe-tasks/build-and-publish-java-connectors-with-tag.sh
+++ b/poe-tasks/build-and-publish-java-connectors-with-tag.sh
@@ -96,7 +96,7 @@ if $do_publish; then
 
   if dockerhub_tag_exists "airbyte/${connector}" "$docker_tag"; then
     echo "ℹ️  Skipping publish — tag airbyte/${connector}:${docker_tag} already exists."
-    continue
+    exit
   fi
 
   echo "airbyte/${connector}:${docker_tag} image does not exists on Docker. Publishing..."

--- a/poe-tasks/build-and-publish-java-connectors-with-tag.sh
+++ b/poe-tasks/build-and-publish-java-connectors-with-tag.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 # This script builds and optionally publishes Java connector Docker images.
+# Usage: ./build-and-publish-java-connectors-with-tag.sh --name <name> [--pre-release] [--main-release] [--publish]
 #
 # Flag descriptions:
 #   --main-release: Publishes images with the exact version from metadata.yaml.
@@ -15,23 +16,17 @@
 #                   and only shows what would be published without actually publishing.
 #
 # Usage examples:
-#   ./get-modified-connectors.sh --prev-commit --json | ./build-and-publish-java-connectors-with-tag.sh
+#   ./build-and-publish-java-connectors-with-tag.sh --name destination-bigquery --pre-release --publish
 #
 # Specific to this script:
 #   1) Default (pre-release) on a single connector
 #   ./build-and-publish-java-connectors-with-tag.sh foo-conn
 #   ./build-and-publish-java-connectors-with-tag.sh --name=foo-conn
 #
-#   2) Explicit main-release with multiple connectors
-#   ./build-and-publish-java-connectors-with-tag.sh --main-release foo-conn bar-conn
-#
-#   3) Pre-release (dev tag) via JSON pipe
-#   echo '{"connector":["foo-conn","bar-conn"]}' | ./build-and-publish-java-connectors-with-tag.sh --pre-release
-#
-#   4) Mixed: positional + pre-release
+#   2) Mixed: positional + pre-release
 #   ./build-and-publish-java-connectors-with-tag.sh --pre-release foo-conn
 #
-#   5) Enable actual publishing (default is dry-run mode)
+#   3) Enable actual publishing (default is dry-run mode)
 #   ./build-and-publish-java-connectors-with-tag.sh --publish foo-conn
 set -euo pipefail
 
@@ -69,52 +64,50 @@ dockerhub_tag_exists() {
   exit 1
 }
 
-# ---------- main loop ----------
 source "${BASH_SOURCE%/*}/lib/parse_args.sh"
+connector=$(get_only_connector)
 
-while read -r connector; do
-  meta="${CONNECTORS_DIR}/${connector}/metadata.yaml"
-  if [[ ! -f "$meta" ]]; then
-    echo "Error: metadata.yaml not found for ${connector}" >&2
-    exit 1
-  fi
+meta="${CONNECTORS_DIR}/${connector}/metadata.yaml"
+if [[ ! -f "$meta" ]]; then
+  echo "Error: metadata.yaml not found for ${connector}" >&2
+  exit 1
+fi
 
-  # Check if this is a Java connector
-  if ! grep -qE 'language:\s*java' "$meta"; then
-    echo "ℹ️  Skipping ${connector} — this script only supports JVM connectors for now."
+# Check if this is a Java connector
+if ! grep -qE 'language:\s*java' "$meta"; then
+  echo "ℹ️  Skipping ${connector} — this script only supports JVM connectors for now."
+  continue
+fi
+
+base_tag=$(yq -r '.data.dockerImageTag' "$meta")
+if [[ -z "$base_tag" || "$base_tag" == "null" ]]; then
+  echo "Error:  dockerImageTag missing in ${meta}" >&2
+  exit 1
+fi
+
+if [[ "$publish_mode" == "main-release" ]]; then
+  docker_tag="$base_tag"
+else
+  docker_tag=$(generate_dev_tag "$base_tag")
+fi
+
+if $do_publish; then
+  echo "Building & publishing ${connector} with tag ${docker_tag}"
+
+  if dockerhub_tag_exists "airbyte/${connector}" "$docker_tag"; then
+    echo "ℹ️  Skipping publish — tag airbyte/${connector}:${docker_tag} already exists."
     continue
   fi
 
-  base_tag=$(yq -r '.data.dockerImageTag' "$meta")
-  if [[ -z "$base_tag" || "$base_tag" == "null" ]]; then
-    echo "Error:  dockerImageTag missing in ${meta}" >&2
-    exit 1
-  fi
-
-  if [[ "$publish_mode" == "main-release" ]]; then
-    docker_tag="$base_tag"
-  else
-    docker_tag=$(generate_dev_tag "$base_tag")
-  fi
-
-  if $do_publish; then
-    echo "Building & publishing ${connector} with tag ${docker_tag}"
-
-    if dockerhub_tag_exists "airbyte/${connector}" "$docker_tag"; then
-      echo "ℹ️  Skipping publish — tag airbyte/${connector}:${docker_tag} already exists."
-      continue
-    fi
-
-    echo "airbyte/${connector}:${docker_tag} image does not exists on Docker. Publishing..."
-    ./gradlew -Pdocker.publish \
-              -DciMode=true \
-              -Psbom=false \
-              -Pdocker.tag="${docker_tag}" \
-              ":${CONNECTORS_DIR//\//:}:${connector}:assemble"
-  else
-    echo "DRY RUN: Would build & publish ${connector} with tag ${docker_tag}"
-  fi
-done < <(get_connectors)
+  echo "airbyte/${connector}:${docker_tag} image does not exists on Docker. Publishing..."
+  ./gradlew -Pdocker.publish \
+            -DciMode=true \
+            -Psbom=false \
+            -Pdocker.tag="${docker_tag}" \
+            ":${CONNECTORS_DIR//\//:}:${connector}:assemble"
+else
+  echo "DRY RUN: Would build & publish ${connector} with tag ${docker_tag}"
+fi
 if $do_publish; then
   echo "Done building & publishing."
 else

--- a/poe-tasks/lib/util.sh
+++ b/poe-tasks/lib/util.sh
@@ -22,9 +22,10 @@ connector_docs_path() {
   echo $DOCS_BASE_DIR/$(echo $connector_name | sed -r 's@^(source|destination)-(.*)@\1s/\2.md@')
 }
 
-# Typically called immediately after sourcing parse_args.sh
-# Throws an error if zero or multiple `--name` flags were passed.
-# If exactly one `--name` flag was passed, return that connector.
+# Expects that you have populated a $connectors variable as an array.
+# If you sourced the parse_args.sh script, this is already handled for you.
+# If $connectors has exactly one element, return that element.
+# Otherwise, prints an error and crashes the script.
 get_only_connector() {
   # "${#connectors[@]}" is the length of the array
   if test "${#connectors[@]}" -eq 0; then

--- a/poe-tasks/lib/util.sh
+++ b/poe-tasks/lib/util.sh
@@ -13,34 +13,13 @@ connector_docs_path() {
   # share documentation with their base connector
   local connector_name="$1"
   connector_name=$(echo "$connector_name" | sed -r 's/-strict-encrypt$//')
-  
+
   # The regex '^(source|destination)-(.*)' matches strings like source-whatever or destination-something-like-this,
   # capturing the connector type (source/destination) and the connector name (whatever / something-like-this).
   # We then output '\1s/\2.md', which inserts the captured values as `\1` and `\2`.
   # This produces a string like `sources/whatever.md`.
   # Then we prepend the 'docs/integrations/' path.
   echo $DOCS_BASE_DIR/$(echo $connector_name | sed -r 's@^(source|destination)-(.*)@\1s/\2.md@')
-}
-
-# ---------- helper: collect connector names ----------
-# Read a list of connector names from a variable, or parse stdin.
-# Expects that you have populated a $connectors variable as an array.
-# If you sourced the parse_args.sh script, this is already handled for you.
-get_connectors() {
-  if [ "${#connectors[@]}" -gt 0 ]; then
-      # only look at non-empty strings
-      for c in "${connectors[@]}"; do
-          [[ -n "$c" ]] && printf "%s\n" "$c"
-      done
-  else
-    # read JSON from stdin
-    if [ -t 0 ]; then
-      echo "Error:  No --name given and nothing piped to stdin." >&2
-      exit 1
-    fi
-    # select only non-empty strings out of the JSON array
-    jq -r '.connector[] | select(. != "")'
-  fi
 }
 
 # Typically called immediately after sourcing parse_args.sh

--- a/poe-tasks/lib/util.sh
+++ b/poe-tasks/lib/util.sh
@@ -43,6 +43,25 @@ get_connectors() {
   fi
 }
 
+# Typically called immediately after sourcing parse_args.sh
+# Throws an error if zero or multiple `--name` flags were passed.
+# If exactly one `--name` flag was passed, return that connector.
+get_only_connector() {
+  # "${#connectors[@]}" is the length of the array
+  if test "${#connectors[@]}" -eq 0; then
+    echo 'Missing `--name <connector_name>` argument' >&2
+    exit 1
+  fi
+  if test "${#connectors[@]}" -gt 1; then
+    echo 'Expected to get exactly 1 connector. Got:' >&2
+    printf "%s\n" "${connectors[@]}" >&2
+    exit 1
+  fi
+  # we've validated that the array contains exactly one element,
+  # so get the first element.
+  echo "${connectors[@]:0:1}"
+}
+
 # Generate the prerelease image tag (e.g. `1.2.3-dev.abcde12345`).
 generate_dev_tag() {
   local base="$1"

--- a/poe-tasks/validate-connector-metadata.sh
+++ b/poe-tasks/validate-connector-metadata.sh
@@ -4,23 +4,9 @@ set -euo pipefail
 source "${BASH_SOURCE%/*}/lib/util.sh"
 
 source "${BASH_SOURCE%/*}/lib/parse_args.sh"
+connector=$(get_only_connector)
 
-exit_code=0
-while read -r connector; do
-  echo "---- PROCESSING METADATA FOR $connector ----"
-  meta="${CONNECTORS_DIR}/${connector}/metadata.yaml"
-  doc="$(connector_docs_path $connector)"
-  # Don't exit immediately. We should run against all connectors.
-  set +e
-  if ! poetry run --directory $METADATA_SERVICE_PATH metadata_service validate "$meta" "$doc"; then
-    exit_code=1
-  fi
-  # Reenable the "exit on error" option.
-  set -e
-done < <(get_connectors)
-
-if test $exit_code -ne 0; then
-  echo '------------'
-  echo 'One or more connectors had invalid metadata.yaml. See previous logs for more information.'
-  exit $exit_code
-fi
+echo "---- PROCESSING METADATA FOR $connector ----"
+meta="${CONNECTORS_DIR}/${connector}/metadata.yaml"
+doc="$(connector_docs_path $connector)"
+poetry run --directory $METADATA_SERVICE_PATH metadata_service validate "$meta" "$doc"


### PR DESCRIPTION
## What
As noted in https://github.com/airbytehq/airbyte/pull/64498#discussion_r2257559183 - now that we're using a matrix, these scripts are only ever called with a single `--name` parameter. Remove the handling for multiple `--name` flags.

Not going to merge this until tomorrow, just in case something does go wrong with the matrix stuff. Just wanted to make the change while this is still fresh in my mind.

## How
* add a `get_only_connector` function, which returns the single `--name` value
* switch the JVM publish script to use that function; update comments
* switch the validate-connector-metadata script to use that function
    * also remove the `set +e` / `set -e` stuff. The script only processes a single connector now, so we want to crash immediately if anything fails.

## Review guide
Enable the "hide whitespace" diff option.
1. util.sh
2. everything else

## User Impact
none

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
