### PR TITLE
upload metadata to dev bucket via GHA

### DIFF
--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -184,7 +184,7 @@ jobs:
         run: ./poe-tasks/upload-connector-metadata.sh --name ${{ matrix.connector }}
         env:
           GCS_CREDENTIALS: ${{ secrets.METADATA_SERVICE_DEV_GCS_CREDENTIALS }}
-          GCP_GSM_CREDENTIALS: ${{ secrets.METADATA_SERVICE_DEV_GCS_CREDENTIALS }}
+          SPEC_CACHE_GCS_CREDENTIALS: ${{ secrets.METADATA_SERVICE_DEV_GCS_CREDENTIALS }}
           METADATA_SERVICE_GCS_CREDENTIALS: ${{ secrets.METADATA_SERVICE_DEV_GCS_CREDENTIALS }}
 
   notify-failure-slack-channel:

--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -103,6 +103,10 @@ jobs:
         with:
           version: 1.8.5
 
+      - name: Install gcloud
+        # v2.1.5
+        uses: google-github-actions/setup-gcloud@6a7c903a70c8625ed6700fa299f5ddb4ca6022e9
+
       - name: Install metadata_service
         run: poetry install --directory airbyte-ci/connectors/metadata_service/lib
 
@@ -173,6 +177,15 @@ jobs:
           python_registry_token: ${{ secrets.PYPI_TOKEN }}
           airbyte_ci_binary_url: ${{ inputs.airbyte_ci_binary_url }}
           max_attempts: 2
+
+      - name: Upload connector metadata
+        id: publish-connector-metadata
+        shell: bash
+        run: ./poe-tasks/upload-connector-metadata.sh --name ${{ matrix.connector }}
+        env:
+          GCS_CREDENTIALS: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
+          GCP_GSM_CREDENTIALS: ${{ secrets.GCP_GSM_CREDENTIALS }}
+          METADATA_SERVICE_GCS_CREDENTIALS: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
 
   notify-failure-slack-channel:
     name: "Notify Slack Channel on Publish Failures"

--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -123,29 +123,29 @@ jobs:
         shell: bash
         run: ./poe-tasks/build-and-publish-java-connectors-with-tag.sh --main-release --publish --name ${{ matrix.connector }}
 
-      - name: Publish connectors [On merge to master]
-        # JVM docker images are published beforehand so Airbyte-CI only does registry publishing.
-        id: publish-connectors-master
-        if: github.event_name == 'push'
-        uses: ./.github/actions/run-airbyte-ci
-        with:
-          context: "master"
-          dagger_cloud_token: ${{ secrets.DAGGER_CLOUD_TOKEN_CACHE_4 }}
-          docker_hub_password: ${{ secrets.DOCKER_HUB_PASSWORD }}
-          docker_hub_username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          gcp_gsm_credentials: ${{ secrets.GCP_GSM_CREDENTIALS }}
-          gcs_credentials: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          metadata_service_gcs_credentials: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
-          sentry_dsn: ${{ secrets.SENTRY_AIRBYTE_CI_DSN }}
-          slack_webhook_url: ${{ secrets.PUBLISH_ON_MERGE_SLACK_WEBHOOK }}
-          spec_cache_gcs_credentials: ${{ secrets.SPEC_CACHE_SERVICE_ACCOUNT_KEY_PUBLISH }}
-          s3_build_cache_access_key_id: ${{ secrets.SELF_RUNNER_AWS_ACCESS_KEY_ID }}
-          s3_build_cache_secret_key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
-          subcommand: "connectors --name ${{ matrix.connector }} publish --main-release"
-          python_registry_token: ${{ secrets.PYPI_TOKEN }}
-          max_attempts: 2
-          retry_wait_seconds: 600 # 10 minutes
+      # - name: Publish connectors [On merge to master]
+      #   # JVM docker images are published beforehand so Airbyte-CI only does registry publishing.
+      #   id: publish-connectors-master
+      #   if: github.event_name == 'push'
+      #   uses: ./.github/actions/run-airbyte-ci
+      #   with:
+      #     context: "master"
+      #     dagger_cloud_token: ${{ secrets.DAGGER_CLOUD_TOKEN_CACHE_4 }}
+      #     docker_hub_password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+      #     docker_hub_username: ${{ secrets.DOCKER_HUB_USERNAME }}
+      #     gcp_gsm_credentials: ${{ secrets.GCP_GSM_CREDENTIALS }}
+      #     gcs_credentials: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
+      #     github_token: ${{ secrets.GITHUB_TOKEN }}
+      #     metadata_service_gcs_credentials: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
+      #     sentry_dsn: ${{ secrets.SENTRY_AIRBYTE_CI_DSN }}
+      #     slack_webhook_url: ${{ secrets.PUBLISH_ON_MERGE_SLACK_WEBHOOK }}
+      #     spec_cache_gcs_credentials: ${{ secrets.SPEC_CACHE_SERVICE_ACCOUNT_KEY_PUBLISH }}
+      #     s3_build_cache_access_key_id: ${{ secrets.SELF_RUNNER_AWS_ACCESS_KEY_ID }}
+      #     s3_build_cache_secret_key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
+      #     subcommand: "connectors --name ${{ matrix.connector }} publish --main-release"
+      #     python_registry_token: ${{ secrets.PYPI_TOKEN }}
+      #     max_attempts: 2
+      #     retry_wait_seconds: 600 # 10 minutes
 
       - name: Build and publish JVM connectors images [manual]
         id: build-and-publish-JVM-connectors-images-manual
@@ -155,28 +155,28 @@ jobs:
         shell: bash
         run: ./poe-tasks/build-and-publish-java-connectors-with-tag.sh  ${{ inputs.publish-options }} --name ${{ matrix.connector }} --publish
 
-      - name: Publish connectors [manual]
-        id: publish-connectors-manual
-        if: github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call'
-        uses: ./.github/actions/run-airbyte-ci
-        with:
-          context: "manual"
-          dagger_cloud_token: ${{ secrets.DAGGER_CLOUD_TOKEN_CACHE_4 }}
-          docker_hub_password: ${{ secrets.DOCKER_HUB_PASSWORD }}
-          docker_hub_username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          gcp_gsm_credentials: ${{ secrets.GCP_GSM_CREDENTIALS }}
-          gcs_credentials: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          metadata_service_gcs_credentials: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
-          sentry_dsn: ${{ secrets.SENTRY_AIRBYTE_CI_DSN }}
-          slack_webhook_url: ${{ secrets.PUBLISH_ON_MERGE_SLACK_WEBHOOK }}
-          spec_cache_gcs_credentials: ${{ secrets.SPEC_CACHE_SERVICE_ACCOUNT_KEY_PUBLISH }}
-          s3_build_cache_access_key_id: ${{ secrets.SELF_RUNNER_AWS_ACCESS_KEY_ID }}
-          s3_build_cache_secret_key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
-          subcommand: "connectors --name ${{ matrix.connector }} publish ${{ inputs.publish-options }}"
-          python_registry_token: ${{ secrets.PYPI_TOKEN }}
-          airbyte_ci_binary_url: ${{ inputs.airbyte_ci_binary_url }}
-          max_attempts: 2
+      # - name: Publish connectors [manual]
+      #   id: publish-connectors-manual
+      #   if: github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call'
+      #   uses: ./.github/actions/run-airbyte-ci
+      #   with:
+      #     context: "manual"
+      #     dagger_cloud_token: ${{ secrets.DAGGER_CLOUD_TOKEN_CACHE_4 }}
+      #     docker_hub_password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+      #     docker_hub_username: ${{ secrets.DOCKER_HUB_USERNAME }}
+      #     gcp_gsm_credentials: ${{ secrets.GCP_GSM_CREDENTIALS }}
+      #     gcs_credentials: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
+      #     github_token: ${{ secrets.GITHUB_TOKEN }}
+      #     metadata_service_gcs_credentials: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
+      #     sentry_dsn: ${{ secrets.SENTRY_AIRBYTE_CI_DSN }}
+      #     slack_webhook_url: ${{ secrets.PUBLISH_ON_MERGE_SLACK_WEBHOOK }}
+      #     spec_cache_gcs_credentials: ${{ secrets.SPEC_CACHE_SERVICE_ACCOUNT_KEY_PUBLISH }}
+      #     s3_build_cache_access_key_id: ${{ secrets.SELF_RUNNER_AWS_ACCESS_KEY_ID }}
+      #     s3_build_cache_secret_key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
+      #     subcommand: "connectors --name ${{ matrix.connector }} publish ${{ inputs.publish-options }}"
+      #     python_registry_token: ${{ secrets.PYPI_TOKEN }}
+      #     airbyte_ci_binary_url: ${{ inputs.airbyte_ci_binary_url }}
+      #     max_attempts: 2
 
       - name: Upload connector metadata
         id: publish-connector-metadata

--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -128,29 +128,29 @@ jobs:
         shell: bash
         run: ./poe-tasks/build-and-publish-java-connectors-with-tag.sh --main-release --publish --name ${{ matrix.connector }}
 
-      # - name: Publish connectors [On merge to master]
-      #   # JVM docker images are published beforehand so Airbyte-CI only does registry publishing.
-      #   id: publish-connectors-master
-      #   if: github.event_name == 'push'
-      #   uses: ./.github/actions/run-airbyte-ci
-      #   with:
-      #     context: "master"
-      #     dagger_cloud_token: ${{ secrets.DAGGER_CLOUD_TOKEN_CACHE_4 }}
-      #     docker_hub_password: ${{ secrets.DOCKER_HUB_PASSWORD }}
-      #     docker_hub_username: ${{ secrets.DOCKER_HUB_USERNAME }}
-      #     gcp_gsm_credentials: ${{ secrets.GCP_GSM_CREDENTIALS }}
-      #     gcs_credentials: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
-      #     github_token: ${{ secrets.GITHUB_TOKEN }}
-      #     metadata_service_gcs_credentials: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
-      #     sentry_dsn: ${{ secrets.SENTRY_AIRBYTE_CI_DSN }}
-      #     slack_webhook_url: ${{ secrets.PUBLISH_ON_MERGE_SLACK_WEBHOOK }}
-      #     spec_cache_gcs_credentials: ${{ secrets.SPEC_CACHE_SERVICE_ACCOUNT_KEY_PUBLISH }}
-      #     s3_build_cache_access_key_id: ${{ secrets.SELF_RUNNER_AWS_ACCESS_KEY_ID }}
-      #     s3_build_cache_secret_key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
-      #     subcommand: "connectors --name ${{ matrix.connector }} publish --main-release"
-      #     python_registry_token: ${{ secrets.PYPI_TOKEN }}
-      #     max_attempts: 2
-      #     retry_wait_seconds: 600 # 10 minutes
+      - name: Publish connectors [On merge to master]
+        # JVM docker images are published beforehand so Airbyte-CI only does registry publishing.
+        id: publish-connectors-master
+        if: github.event_name == 'push'
+        uses: ./.github/actions/run-airbyte-ci
+        with:
+          context: "master"
+          dagger_cloud_token: ${{ secrets.DAGGER_CLOUD_TOKEN_CACHE_4 }}
+          docker_hub_password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+          docker_hub_username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          gcp_gsm_credentials: ${{ secrets.GCP_GSM_CREDENTIALS }}
+          gcs_credentials: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          metadata_service_gcs_credentials: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
+          sentry_dsn: ${{ secrets.SENTRY_AIRBYTE_CI_DSN }}
+          slack_webhook_url: ${{ secrets.PUBLISH_ON_MERGE_SLACK_WEBHOOK }}
+          spec_cache_gcs_credentials: ${{ secrets.SPEC_CACHE_SERVICE_ACCOUNT_KEY_PUBLISH }}
+          s3_build_cache_access_key_id: ${{ secrets.SELF_RUNNER_AWS_ACCESS_KEY_ID }}
+          s3_build_cache_secret_key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
+          subcommand: "connectors --name ${{ matrix.connector }} publish --main-release"
+          python_registry_token: ${{ secrets.PYPI_TOKEN }}
+          max_attempts: 2
+          retry_wait_seconds: 600 # 10 minutes
 
       - name: Build and publish JVM connectors images [manual]
         id: build-and-publish-JVM-connectors-images-manual
@@ -160,28 +160,28 @@ jobs:
         shell: bash
         run: ./poe-tasks/build-and-publish-java-connectors-with-tag.sh  ${{ inputs.publish-options }} --name ${{ matrix.connector }} --publish
 
-      # - name: Publish connectors [manual]
-      #   id: publish-connectors-manual
-      #   if: github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call'
-      #   uses: ./.github/actions/run-airbyte-ci
-      #   with:
-      #     context: "manual"
-      #     dagger_cloud_token: ${{ secrets.DAGGER_CLOUD_TOKEN_CACHE_4 }}
-      #     docker_hub_password: ${{ secrets.DOCKER_HUB_PASSWORD }}
-      #     docker_hub_username: ${{ secrets.DOCKER_HUB_USERNAME }}
-      #     gcp_gsm_credentials: ${{ secrets.GCP_GSM_CREDENTIALS }}
-      #     gcs_credentials: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
-      #     github_token: ${{ secrets.GITHUB_TOKEN }}
-      #     metadata_service_gcs_credentials: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
-      #     sentry_dsn: ${{ secrets.SENTRY_AIRBYTE_CI_DSN }}
-      #     slack_webhook_url: ${{ secrets.PUBLISH_ON_MERGE_SLACK_WEBHOOK }}
-      #     spec_cache_gcs_credentials: ${{ secrets.SPEC_CACHE_SERVICE_ACCOUNT_KEY_PUBLISH }}
-      #     s3_build_cache_access_key_id: ${{ secrets.SELF_RUNNER_AWS_ACCESS_KEY_ID }}
-      #     s3_build_cache_secret_key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
-      #     subcommand: "connectors --name ${{ matrix.connector }} publish ${{ inputs.publish-options }}"
-      #     python_registry_token: ${{ secrets.PYPI_TOKEN }}
-      #     airbyte_ci_binary_url: ${{ inputs.airbyte_ci_binary_url }}
-      #     max_attempts: 2
+      - name: Publish connectors [manual]
+        id: publish-connectors-manual
+        if: github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call'
+        uses: ./.github/actions/run-airbyte-ci
+        with:
+          context: "manual"
+          dagger_cloud_token: ${{ secrets.DAGGER_CLOUD_TOKEN_CACHE_4 }}
+          docker_hub_password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+          docker_hub_username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          gcp_gsm_credentials: ${{ secrets.GCP_GSM_CREDENTIALS }}
+          gcs_credentials: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          metadata_service_gcs_credentials: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
+          sentry_dsn: ${{ secrets.SENTRY_AIRBYTE_CI_DSN }}
+          slack_webhook_url: ${{ secrets.PUBLISH_ON_MERGE_SLACK_WEBHOOK }}
+          spec_cache_gcs_credentials: ${{ secrets.SPEC_CACHE_SERVICE_ACCOUNT_KEY_PUBLISH }}
+          s3_build_cache_access_key_id: ${{ secrets.SELF_RUNNER_AWS_ACCESS_KEY_ID }}
+          s3_build_cache_secret_key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
+          subcommand: "connectors --name ${{ matrix.connector }} publish ${{ inputs.publish-options }}"
+          python_registry_token: ${{ secrets.PYPI_TOKEN }}
+          airbyte_ci_binary_url: ${{ inputs.airbyte_ci_binary_url }}
+          max_attempts: 2
 
       - name: Upload connector metadata
         id: upload-connector-metadata

--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -103,6 +103,11 @@ jobs:
         with:
           version: 1.8.5
 
+      # We're intentionally not using the `google-github-actions/auth` action.
+      # The upload-connector-metadata step runs a script which handles auth manually.
+      # This is because we're writing files to multiple buckets, using different credentials
+      # for each bucket.
+      # (it's unclear whether that's actually necessary)
       - name: Install gcloud
         # v2.1.5
         uses: google-github-actions/setup-gcloud@6a7c903a70c8625ed6700fa299f5ddb4ca6022e9
@@ -179,7 +184,7 @@ jobs:
       #     max_attempts: 2
 
       - name: Upload connector metadata
-        id: publish-connector-metadata
+        id: upload-connector-metadata
         shell: bash
         run: ./poe-tasks/upload-connector-metadata.sh --name ${{ matrix.connector }}
         env:

--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -183,9 +183,9 @@ jobs:
         shell: bash
         run: ./poe-tasks/upload-connector-metadata.sh --name ${{ matrix.connector }}
         env:
-          GCS_CREDENTIALS: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
-          GCP_GSM_CREDENTIALS: ${{ secrets.GCP_GSM_CREDENTIALS }}
-          METADATA_SERVICE_GCS_CREDENTIALS: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
+          GCS_CREDENTIALS: ${{ secrets.METADATA_SERVICE_DEV_GCS_CREDENTIALS }}
+          GCP_GSM_CREDENTIALS: ${{ secrets.METADATA_SERVICE_DEV_GCS_CREDENTIALS }}
+          METADATA_SERVICE_GCS_CREDENTIALS: ${{ secrets.METADATA_SERVICE_DEV_GCS_CREDENTIALS }}
 
   notify-failure-slack-channel:
     name: "Notify Slack Channel on Publish Failures"

--- a/poe-tasks/build-and-publish-java-connectors-with-tag.sh
+++ b/poe-tasks/build-and-publish-java-connectors-with-tag.sh
@@ -96,7 +96,7 @@ if $do_publish; then
 
   if dockerhub_tag_exists "airbyte/${connector}" "$docker_tag"; then
     echo "ℹ️  Skipping publish — tag airbyte/${connector}:${docker_tag} already exists."
-    continue
+    exit
   fi
 
   echo "airbyte/${connector}:${docker_tag} image does not exists on Docker. Publishing..."

--- a/poe-tasks/build-and-publish-java-connectors-with-tag.sh
+++ b/poe-tasks/build-and-publish-java-connectors-with-tag.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 # This script builds and optionally publishes Java connector Docker images.
+# Usage: ./build-and-publish-java-connectors-with-tag.sh --name <name> [--pre-release] [--main-release] [--publish]
 #
 # Flag descriptions:
 #   --main-release: Publishes images with the exact version from metadata.yaml.
@@ -15,23 +16,17 @@
 #                   and only shows what would be published without actually publishing.
 #
 # Usage examples:
-#   ./get-modified-connectors.sh --prev-commit --json | ./build-and-publish-java-connectors-with-tag.sh
+#   ./build-and-publish-java-connectors-with-tag.sh --name destination-bigquery --pre-release --publish
 #
 # Specific to this script:
 #   1) Default (pre-release) on a single connector
 #   ./build-and-publish-java-connectors-with-tag.sh foo-conn
 #   ./build-and-publish-java-connectors-with-tag.sh --name=foo-conn
 #
-#   2) Explicit main-release with multiple connectors
-#   ./build-and-publish-java-connectors-with-tag.sh --main-release foo-conn bar-conn
-#
-#   3) Pre-release (dev tag) via JSON pipe
-#   echo '{"connector":["foo-conn","bar-conn"]}' | ./build-and-publish-java-connectors-with-tag.sh --pre-release
-#
-#   4) Mixed: positional + pre-release
+#   2) Mixed: positional + pre-release
 #   ./build-and-publish-java-connectors-with-tag.sh --pre-release foo-conn
 #
-#   5) Enable actual publishing (default is dry-run mode)
+#   3) Enable actual publishing (default is dry-run mode)
 #   ./build-and-publish-java-connectors-with-tag.sh --publish foo-conn
 set -euo pipefail
 
@@ -69,52 +64,50 @@ dockerhub_tag_exists() {
   exit 1
 }
 
-# ---------- main loop ----------
 source "${BASH_SOURCE%/*}/lib/parse_args.sh"
+connector=$(get_only_connector)
 
-while read -r connector; do
-  meta="${CONNECTORS_DIR}/${connector}/metadata.yaml"
-  if [[ ! -f "$meta" ]]; then
-    echo "Error: metadata.yaml not found for ${connector}" >&2
-    exit 1
-  fi
+meta="${CONNECTORS_DIR}/${connector}/metadata.yaml"
+if [[ ! -f "$meta" ]]; then
+  echo "Error: metadata.yaml not found for ${connector}" >&2
+  exit 1
+fi
 
-  # Check if this is a Java connector
-  if ! grep -qE 'language:\s*java' "$meta"; then
-    echo "ℹ️  Skipping ${connector} — this script only supports JVM connectors for now."
+# Check if this is a Java connector
+if ! grep -qE 'language:\s*java' "$meta"; then
+  echo "ℹ️  Skipping ${connector} — this script only supports JVM connectors for now."
+  continue
+fi
+
+base_tag=$(yq -r '.data.dockerImageTag' "$meta")
+if [[ -z "$base_tag" || "$base_tag" == "null" ]]; then
+  echo "Error:  dockerImageTag missing in ${meta}" >&2
+  exit 1
+fi
+
+if [[ "$publish_mode" == "main-release" ]]; then
+  docker_tag="$base_tag"
+else
+  docker_tag=$(generate_dev_tag "$base_tag")
+fi
+
+if $do_publish; then
+  echo "Building & publishing ${connector} with tag ${docker_tag}"
+
+  if dockerhub_tag_exists "airbyte/${connector}" "$docker_tag"; then
+    echo "ℹ️  Skipping publish — tag airbyte/${connector}:${docker_tag} already exists."
     continue
   fi
 
-  base_tag=$(yq -r '.data.dockerImageTag' "$meta")
-  if [[ -z "$base_tag" || "$base_tag" == "null" ]]; then
-    echo "Error:  dockerImageTag missing in ${meta}" >&2
-    exit 1
-  fi
-
-  if [[ "$publish_mode" == "main-release" ]]; then
-    docker_tag="$base_tag"
-  else
-    docker_tag=$(generate_dev_tag "$base_tag")
-  fi
-
-  if $do_publish; then
-    echo "Building & publishing ${connector} with tag ${docker_tag}"
-
-    if dockerhub_tag_exists "airbyte/${connector}" "$docker_tag"; then
-      echo "ℹ️  Skipping publish — tag airbyte/${connector}:${docker_tag} already exists."
-      continue
-    fi
-
-    echo "airbyte/${connector}:${docker_tag} image does not exists on Docker. Publishing..."
-    ./gradlew -Pdocker.publish \
-              -DciMode=true \
-              -Psbom=false \
-              -Pdocker.tag="${docker_tag}" \
-              ":${CONNECTORS_DIR//\//:}:${connector}:assemble"
-  else
-    echo "DRY RUN: Would build & publish ${connector} with tag ${docker_tag}"
-  fi
-done < <(get_connectors)
+  echo "airbyte/${connector}:${docker_tag} image does not exists on Docker. Publishing..."
+  ./gradlew -Pdocker.publish \
+            -DciMode=true \
+            -Psbom=false \
+            -Pdocker.tag="${docker_tag}" \
+            ":${CONNECTORS_DIR//\//:}:${connector}:assemble"
+else
+  echo "DRY RUN: Would build & publish ${connector} with tag ${docker_tag}"
+fi
 if $do_publish; then
   echo "Done building & publishing."
 else

--- a/poe-tasks/lib/util.sh
+++ b/poe-tasks/lib/util.sh
@@ -22,9 +22,10 @@ connector_docs_path() {
   echo $DOCS_BASE_DIR/$(echo $connector_name | sed -r 's@^(source|destination)-(.*)@\1s/\2.md@')
 }
 
-# Typically called immediately after sourcing parse_args.sh
-# Throws an error if zero or multiple `--name` flags were passed.
-# If exactly one `--name` flag was passed, return that connector.
+# Expects that you have populated a $connectors variable as an array.
+# If you sourced the parse_args.sh script, this is already handled for you.
+# If $connectors has exactly one element, return that element.
+# Otherwise, prints an error and crashes the script.
 get_only_connector() {
   # "${#connectors[@]}" is the length of the array
   if test "${#connectors[@]}" -eq 0; then

--- a/poe-tasks/lib/util.sh
+++ b/poe-tasks/lib/util.sh
@@ -3,7 +3,8 @@
 # You can't just `source lib/util.sh`, because the current working directory probably isn't `poe-tasks`.
 
 CONNECTORS_DIR="airbyte-integrations/connectors"
-DOCS_BASE_DIR="docs/integrations"
+DOCS_ROOT="docs"
+DOCS_BASE_DIR="$DOCS_ROOT/integrations"
 METADATA_SERVICE_PATH='airbyte-ci/connectors/metadata_service/lib'
 
 # Usage: connector_docs_path "source-foo"
@@ -49,4 +50,16 @@ generate_dev_tag() {
   local hash
   hash=$(git rev-parse --short=10 HEAD)
   echo "${base}-dev.${hash}"
+}
+
+# Authenticate to gcloud using the contents of a variable.
+# That variable should contain a JSON-formatted GCP service account key.
+gcloud_activate_service_account() {
+  touch /tmp/gcloud_creds.json
+  # revoke access to this file from group/other (`go=` means "for Group/Other, set permissions to nothing")
+  # (i.e. only the current user can interact with it)
+  chmod go= /tmp/gcloud_creds.json
+  # echo -E prevents echo from rendering \n into actual newlines.
+  echo -E "$1" > /tmp/gcloud_creds.json
+  gcloud auth activate-service-account --key-file /tmp/gcloud_creds.json
 }

--- a/poe-tasks/lib/util.sh
+++ b/poe-tasks/lib/util.sh
@@ -13,34 +13,13 @@ connector_docs_path() {
   # share documentation with their base connector
   local connector_name="$1"
   connector_name=$(echo "$connector_name" | sed -r 's/-strict-encrypt$//')
-  
+
   # The regex '^(source|destination)-(.*)' matches strings like source-whatever or destination-something-like-this,
   # capturing the connector type (source/destination) and the connector name (whatever / something-like-this).
   # We then output '\1s/\2.md', which inserts the captured values as `\1` and `\2`.
   # This produces a string like `sources/whatever.md`.
   # Then we prepend the 'docs/integrations/' path.
   echo $DOCS_BASE_DIR/$(echo $connector_name | sed -r 's@^(source|destination)-(.*)@\1s/\2.md@')
-}
-
-# ---------- helper: collect connector names ----------
-# Read a list of connector names from a variable, or parse stdin.
-# Expects that you have populated a $connectors variable as an array.
-# If you sourced the parse_args.sh script, this is already handled for you.
-get_connectors() {
-  if [ "${#connectors[@]}" -gt 0 ]; then
-      # only look at non-empty strings
-      for c in "${connectors[@]}"; do
-          [[ -n "$c" ]] && printf "%s\n" "$c"
-      done
-  else
-    # read JSON from stdin
-    if [ -t 0 ]; then
-      echo "Error:  No --name given and nothing piped to stdin." >&2
-      exit 1
-    fi
-    # select only non-empty strings out of the JSON array
-    jq -r '.connector[] | select(. != "")'
-  fi
 }
 
 # Typically called immediately after sourcing parse_args.sh

--- a/poe-tasks/lib/util.sh
+++ b/poe-tasks/lib/util.sh
@@ -43,6 +43,25 @@ get_connectors() {
   fi
 }
 
+# Typically called immediately after sourcing parse_args.sh
+# Throws an error if zero or multiple `--name` flags were passed.
+# If exactly one `--name` flag was passed, return that connector.
+get_only_connector() {
+  # "${#connectors[@]}" is the length of the array
+  if test "${#connectors[@]}" -eq 0; then
+    echo 'Missing `--name <connector_name>` argument' >&2
+    exit 1
+  fi
+  if test "${#connectors[@]}" -gt 1; then
+    echo 'Expected to get exactly 1 connector. Got:' >&2
+    printf "%s\n" "${connectors[@]}" >&2
+    exit 1
+  fi
+  # we've validated that the array contains exactly one element,
+  # so get the first element.
+  echo "${connectors[@]:0:1}"
+}
+
 # Generate the prerelease image tag (e.g. `1.2.3-dev.abcde12345`).
 generate_dev_tag() {
   local base="$1"

--- a/poe-tasks/upload-connector-metadata.sh
+++ b/poe-tasks/upload-connector-metadata.sh
@@ -58,8 +58,8 @@ full_docker_image="$docker_repository:$docker_tag"
 
 # Upload the specs to the spec cache
 run_connector_spec() {
-  deployment_mode=$1
-  output_file=$2
+  local deployment_mode=$1
+  local output_file=$2
 
   # Run the spec command, filter for SPEC messages, and write those messages to the output file.
   # The jq command has a lot going on:
@@ -72,7 +72,7 @@ run_connector_spec() {
   # Verify that we had exactly one spec message.
   # Depending on the platform, `wc -l` may return a right-padded string like "   1".
   # `tr -d ' '` deletes those spaces.
-  specMessageCount=$(cat $output_file | wc -l | tr -d ' ')
+  local specMessageCount=$(cat $output_file | wc -l | tr -d ' ')
   if test $specMessageCount -ne 1; then
     echo "Expected to get exactly one spec message from the connector when running with deployment mode '$deployment_mode'; got $specMessageCount" >&2
     exit 1

--- a/poe-tasks/upload-connector-metadata.sh
+++ b/poe-tasks/upload-connector-metadata.sh
@@ -27,8 +27,8 @@ if ! test "$GCS_CREDENTIALS"; then
   exit 1
 fi
 
-spec_cache_bucket="io-airbyte-cloud-spec-cache"
-metadata_bucket="prod-airbyte-cloud-connector-metadata-service"
+spec_cache_bucket="dev-airbyte-cloud-connector-metadata-service"
+metadata_bucket="dev-airbyte-cloud-connector-metadata-service"
 
 syft_docker_image="anchore/syft:v1.6.0"
 sbom_extension="spdx.json"

--- a/poe-tasks/upload-connector-metadata.sh
+++ b/poe-tasks/upload-connector-metadata.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Uploads the metadata (+SBOM+spec cache) to GCS.
+# Usage: ./poe-tasks/upload-connector-metadata.sh --name destination-bigquery [--pre-release] [--main-release]
+# You must have three environment variables set (GCS_CREDENTIALS, METADATA_SERVICE_GCS_CREDENTIALS, SPEC_CACHE_GCS_CREDENTIALS),
+# each containing a JSON-formatted GCP service account key.
+# SPEC_CACHE_GCS_CREDENTIALS needs write access to `gs://$spec_cache_bucket/specs`.
+# METADATA_SERVICE_GCS_CREDENTIALS needs write access to `gs://$metadata_bucket/sbom`.
+# GCS_CREDENTIALS needs write access to `gs://$metadata_bucket/metadata`.
+
+source "${BASH_SOURCE%/*}/lib/util.sh"
+
+source "${BASH_SOURCE%/*}/lib/parse_args.sh"
+connector=$(get_only_connector)
+
+if ! test "$SPEC_CACHE_GCS_CREDENTIALS"; then
+  echo "SPEC_CACHE_GCS_CREDENTIALS environment variable must be set" >&2
+  exit 1
+fi
+if ! test "$METADATA_SERVICE_GCS_CREDENTIALS"; then
+  echo "METADATA_SERVICE_GCS_CREDENTIALS environment variable must be set" >&2
+  exit 1
+fi
+if ! test "$GCS_CREDENTIALS"; then
+  echo "GCS_CREDENTIALS environment variable must be set" >&2
+  exit 1
+fi
+
+spec_cache_bucket="io-airbyte-cloud-spec-cache"
+metadata_bucket="prod-airbyte-cloud-connector-metadata-service"
+
+syft_docker_image="anchore/syft:v1.6.0"
+sbom_extension="spdx.json"
+
+meta="${CONNECTORS_DIR}/${connector}/metadata.yaml"
+doc="$(connector_docs_path $connector)"
+
+docker_repository=$(yq -r '.data.dockerRepository' "$meta")
+if test -z "$docker_repository" || test "$docker_repository" = "null"; then
+  echo "Error: docker_repository missing in ${meta}" >&2
+  exit 1
+fi
+
+# Figure out the tag that we're working on (i.e. handle the prerelease case)
+base_tag=$(yq -r '.data.dockerImageTag' "$meta")
+if test -z "$base_tag" || test "$base_tag" = "null"; then
+  echo "Error: dockerImageTag missing in ${meta}" >&2
+  exit 1
+fi
+if test "$publish_mode" = "main-release"; then
+  docker_tag="$base_tag"
+else
+  docker_tag=$(generate_dev_tag "$base_tag")
+fi
+
+full_docker_image="$docker_repository:$docker_tag"
+
+# Upload the specs to the spec cache
+run_connector_spec() {
+  deployment_mode=$1
+  output_file=$2
+
+  # Run the spec command, filter for SPEC messages, and write those messages to the output file.
+  # The jq command has a lot going on:
+  # * --raw-input is needed, because many connectors emit some log messages in non-JSON format
+  # * then we use `fromjson?` to filter for valid JSON messages
+  # * and then we select any spec message (i.e. {"type": "SPEC", "spec": {...}})
+  # * and then we extract just the `spec` field.
+  docker run --env $deployment_mode "$full_docker_image" spec | jq --raw-input --compact-output 'fromjson? | select(.type == "SPEC").spec' > $output_file
+
+  # Verify that we had exactly one spec message.
+  # Depending on the platform, `wc -l` may return a right-padded string like "   1".
+  # `tr -d ' '` deletes those spaces.
+  specMessageCount=$(cat $output_file | wc -l | tr -d ' ')
+  if test $specMessageCount -ne 1; then
+    echo "Expected to get exactly one spec message from the connector when running with deployment mode '$deployment_mode'; got $specMessageCount" >&2
+    exit 1
+  fi
+}
+echo '--- UPLOADING SPEC TO SPEC CACHE ---'
+echo 'Running spec for OSS...'
+run_connector_spec OSS spec.json
+echo 'Running spec for CLOUD...'
+run_connector_spec CLOUD spec.cloud.json
+spec_cache_base_path="gs://$spec_cache_bucket/specs/$docker_repository/$docker_tag"
+gcloud_activate_service_account "$SPEC_CACHE_GCS_CREDENTIALS"
+gsutil cp spec.json "$spec_cache_base_path/spec.json"
+# Only upload spec.cloud.json if it's different from spec.json.
+# somewhat confusingly - `diff` returns true if the files are _identical_, so we need `! diff`.
+if ! diff spec.json spec.cloud.json; then
+  gsutil cp spec.cloud.json "$spec_cache_base_path/spec.cloud.json"
+fi
+
+# Upload the SBOM
+echo '--- UPLOADING SBOM ---'
+# TODO verify the docker sock thing - the command runs fine on my laptop without this flag, and I'm not sure this flag is correct to begin with
+# Syft requires access to the docker daemon. We share the host's docker socket with the Syft container.
+docker run \
+  --volume $HOME/.docker/config.json:/config/config.json \
+  --env DOCKER_CONFIG=/config \
+  --volume /var/run/docker.sock:/var/run/docker.sock \
+  "$syft_docker_image" \
+  -o spdx-json \
+  "$full_docker_image" > "$sbom_extension"
+gcloud_activate_service_account "$METADATA_SERVICE_GCS_CREDENTIALS"
+gsutil cp "$sbom_extension" "gs://$metadata_bucket/sbom/$docker_repository/$docker_tag.$sbom_extension"
+
+# Upload the metadata
+echo '--- UPLOADING METADATA ---'
+if test "$publish_mode" = "main-release"; then
+  metadata_upload_prerelease_flag=''
+else
+  # yes, it's --prerelease and not --pre-release
+  metadata_upload_prerelease_flag="--prerelease $docker_tag"
+fi
+# Under the hood, this reads the GCS_CREDENTIALS environment variable
+poetry run --directory $METADATA_SERVICE_PATH metadata_service upload "$meta" "$DOCS_ROOT/" "$metadata_bucket" $metadata_upload_prerelease_flag

--- a/poe-tasks/upload-connector-metadata.sh
+++ b/poe-tasks/upload-connector-metadata.sh
@@ -104,6 +104,7 @@ gcloud_activate_service_account "$METADATA_SERVICE_GCS_CREDENTIALS"
 gsutil cp "$sbom_extension" "gs://$metadata_bucket/sbom/$docker_repository/$docker_tag.$sbom_extension"
 
 # Upload the metadata
+# `metadata_service upload` skips the upload if the metadata already exists in GCS.
 echo '--- UPLOADING METADATA ---'
 if test "$publish_mode" = "main-release"; then
   metadata_upload_prerelease_flag=''

--- a/poe-tasks/upload-connector-metadata.sh
+++ b/poe-tasks/upload-connector-metadata.sh
@@ -67,7 +67,7 @@ run_connector_spec() {
   # * then we use `fromjson?` to filter for valid JSON messages
   # * and then we select any spec message (i.e. {"type": "SPEC", "spec": {...}})
   # * and then we extract just the `spec` field.
-  docker run --env $deployment_mode "$full_docker_image" spec | jq --raw-input --compact-output 'fromjson? | select(.type == "SPEC").spec' > $output_file
+  docker run --env DEPLOYMENT_MODE=$deployment_mode "$full_docker_image" spec | jq --raw-input --compact-output 'fromjson? | select(.type == "SPEC").spec' > $output_file
 
   # Verify that we had exactly one spec message.
   # Depending on the platform, `wc -l` may return a right-padded string like "   1".

--- a/poe-tasks/upload-connector-metadata.sh
+++ b/poe-tasks/upload-connector-metadata.sh
@@ -94,12 +94,9 @@ fi
 
 # Upload the SBOM
 echo '--- UPLOADING SBOM ---'
-# TODO verify the docker sock thing - the command runs fine on my laptop without this flag, and I'm not sure this flag is correct to begin with
-# Syft requires access to the docker daemon. We share the host's docker socket with the Syft container.
 docker run \
   --volume $HOME/.docker/config.json:/config/config.json \
   --env DOCKER_CONFIG=/config \
-  --volume /var/run/docker.sock:/var/run/docker.sock \
   "$syft_docker_image" \
   -o spdx-json \
   "$full_docker_image" > "$sbom_extension"

--- a/poe-tasks/validate-connector-metadata.sh
+++ b/poe-tasks/validate-connector-metadata.sh
@@ -4,23 +4,9 @@ set -euo pipefail
 source "${BASH_SOURCE%/*}/lib/util.sh"
 
 source "${BASH_SOURCE%/*}/lib/parse_args.sh"
+connector=$(get_only_connector)
 
-exit_code=0
-while read -r connector; do
-  echo "---- PROCESSING METADATA FOR $connector ----"
-  meta="${CONNECTORS_DIR}/${connector}/metadata.yaml"
-  doc="$(connector_docs_path $connector)"
-  # Don't exit immediately. We should run against all connectors.
-  set +e
-  if ! poetry run --directory $METADATA_SERVICE_PATH metadata_service validate "$meta" "$doc"; then
-    exit_code=1
-  fi
-  # Reenable the "exit on error" option.
-  set -e
-done < <(get_connectors)
-
-if test $exit_code -ne 0; then
-  echo '------------'
-  echo 'One or more connectors had invalid metadata.yaml. See previous logs for more information.'
-  exit $exit_code
-fi
+echo "---- PROCESSING METADATA FOR $connector ----"
+meta="${CONNECTORS_DIR}/${connector}/metadata.yaml"
+doc="$(connector_docs_path $connector)"
+poetry run --directory $METADATA_SERVICE_PATH metadata_service validate "$meta" "$doc"


### PR DESCRIPTION
## What
Set up a parallel metadata publish pipeline, targeting the dev bucket.

branched from https://github.com/airbytehq/airbyte/pull/64533. I'll merge that PR first thing on Monday.

## How
Add an `Upload connector metadata` after the airbyte-ci `connectors ... publish` step. Currently that step is targeting the dev bucket (`dev-airbyte-cloud-connector-metadata-service`).

I did a [manual test run](https://github.com/airbytehq/airbyte/actions/runs/16842000495), then diffed the dev files against the "real" files. Then I reran the test run, to validate that we correctly didn't overwrite the metadata files. (SBOM+spec cache _do_ get overwritten, but that matches existing behavior. Which is fine, b/c those are generated by rerunning the published docker image, so the output is stable.)
```shell
diff <(gsutil cat gs://io-airbyte-cloud-spec-cache/specs/airbyte/destination-dev-null/0.8.1-dev.0b2430dc61/spec.json | jq) <(gsutil cat gs://dev-airbyte-cloud-connector-metadata-service/specs/airbyte/destination-dev-null/0.8.1-dev.0b2430dc61/spec.json | jq)
diff <(gsutil cat gs://io-airbyte-cloud-spec-cache/specs/airbyte/destination-dev-null/0.8.1-dev.0b2430dc61/spec.cloud.json | jq) <(gsutil cat gs://dev-airbyte-cloud-connector-metadata-service/specs/airbyte/destination-dev-null/0.8.1-dev.0b2430dc61/spec.cloud.json | jq)
diff <(gsutil cat gs://prod-airbyte-cloud-connector-metadata-service/sbom/airbyte/destination-dev-null/0.8.1-dev.0b2430dc61.spdx.json | jq) <(gsutil cat gs://dev-airbyte-cloud-connector-metadata-service/sbom/airbyte/destination-dev-null/0.8.1-dev.0b2430dc61.spdx.json | jq)
diff <(gsutil cat gs://prod-airbyte-cloud-connector-metadata-service/metadata/airbyte/destination-dev-null/0.8.1-dev.0b2430dc61/doc.md) <(gsutil cat gs://dev-airbyte-cloud-connector-metadata-service/metadata/airbyte/destination-dev-null/0.8.1-dev.0b2430dc61/doc.md)
diff <(gsutil cat gs://prod-airbyte-cloud-connector-metadata-service/metadata/airbyte/destination-dev-null/0.8.1-dev.0b2430dc61/metadata.yaml) <(gsutil cat gs://dev-airbyte-cloud-connector-metadata-service/metadata/airbyte/destination-dev-null/0.8.1-dev.0b2430dc61/metadata.yaml)
```
SBOM had some benign diffs:
```
6c6
<   "documentNamespace": "https://anchore.com/syft/image/airbyte/destination-dev-null-3bf03796-7d22-48f8-8230-40d06d62b373",
---
>   "documentNamespace": "https://anchore.com/syft/image/airbyte/destination-dev-null-3225c60a-184b-42ee-ae86-bfbabc7c42ba",
13c13
<     "created": "2025-08-08T22:57:32Z"
---
>     "created": "2025-08-08T22:59:00Z"
17527c17527
<           "checksumValue": "0eb6c9415163ea8b004f46a5ec3c3a6a8f8d8ea7bec53cad6122d52053edb37f"
---
>           "checksumValue": "74a90a0a3d3b2f52e6241e8e178334c4869dc56c0bc34c46c0c6fd52e64de090"
17536c17536
<           "referenceLocator": "pkg:oci/airbyte/destination-dev-null@sha256:0eb6c9415163ea8b004f46a5ec3c3a6a8f8d8ea7bec53cad6122d52053edb37f?arch=amd64&tag=0.8.1-dev.0b2430dc61"
---
>           "referenceLocator": "pkg:oci/airbyte/destination-dev-null@sha256:74a90a0a3d3b2f52e6241e8e178334c4869dc56c0bc34c46c0c6fd52e64de090?arch=amd64&tag=0.8.1-dev.0b2430dc61"
```

Also manually pinned my [connection](https://cloud.airbyte.com/workspaces/46b4844a-94a3-496f-af53-2050bf4141af/connections/e05abd20-9651-4970-8be2-ce38fc63a71c/timeline?openLogs=true&jobId=45352816) to the prerelease version - this is just to prove that the normal airbyte-ci metadata upload worked correctly.

I didn't manually test a `main-release`, but afaict all the interesting logic there is hidden inside `metadata_service upload` (i.e. uploading to the `latest` directory). The spec cache / SBOM are completely identical in prerelease/mainrelease mode.

## Release plan
This PR is pretty safe to merge, it's not actually changing any production-facing behavior (other than maybe a risk that the action fails? But that feels unlikely). I'll let this run for a few hours, and then cut over for real.

For that cutover: there's two options, both of which kind of suck:
* Wait for the python docker publish PR to merge, wait a day for that to stabilize. Delete the airbyte-ci steps completely; point the new implementation at the real GCS buckets
    * This makes us dependent on the python publish piece going in and being stable.
* Delete the metadata upload stuff from airbyte-ci, point the new implementation at the real GCS buckets
    * No dependency on other PRs. But requires us to fight through airbyte-ci unit tests

I'm inclined to go with the first option? I.e. sequencing:
* first thing monday - david merges the python docker publish; I merge https://github.com/airbytehq/airbyte/pull/64533; then I merge this PR
* monitor everything for a day
* tuesday, assuming no whammies - I'll merge a second PR to switch over the metadata upload + stop running airbyte-ci entirely

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
