### PR TITLE
Docs for speed in 1.8

### DIFF
--- a/docs/integrations/speed-improvements.md
+++ b/docs/integrations/speed-improvements.md
@@ -1,0 +1,26 @@
+---
+products: all
+---
+
+# Faster sync speed
+
+Airbyte is making major investments into the platform's sync speed. This page explains more about how Airbyte is improving sync speeds and how it's rolling out those changes to you.
+
+## What is faster sync speed?
+
+Faster sync speed is an initiative that drastically improves Airbyte's sync speeds. Initial benchmarking from MySQL to S3 has produced sync speeds up to 100 megabytes per second, depending on factors like compute infrastructure and data format. This is many times the old benchmark for this combination of connectors, but it might not be typical of all environments.
+
+At this time, this capability is turned on for a small subset of connectors. At a point in the future, Airbyte expects to make this technology generally available, and to turn on support for a broad set of connectors. At that time, we'll communicate more about the expected benefits and speed benchmarks.
+
+## How to be eligible for improved speed
+
+The following platform versions are eligible to use these speed enhancements.
+
+- Self-Managed Community or Enterprise version 1.8 and later
+- Cloud
+
+Improved speed isn't widely usable with most connectors yet. To benefit from faster sync speeds, a connection needs to use a source connector _and_ destination connector for which Airbyte has turned on faster syncs. You also need to upgrade to the version of that connector that supports faster speed.
+
+Airbyte may enable additional connector combinations as the team works toward general availability. If you're using the latest connector versions, you might notice increases in sync speed for certain connections. This is Airbyte expanding the roll out.
+
+## What connectors use improved speeds

--- a/docs/integrations/speed-improvements.md
+++ b/docs/integrations/speed-improvements.md
@@ -21,6 +21,14 @@ The following platform versions are eligible to use these speed enhancements.
 
 Improved speed isn't widely usable with most connectors yet. To benefit from faster sync speeds, a connection needs to use a source connector _and_ destination connector for which Airbyte has turned on faster syncs. You also need to upgrade to the version of that connector that supports faster speed.
 
+## What connectors use improved speeds
+
 Airbyte may enable additional connector combinations as the team works toward general availability. If you're using the latest connector versions, you might notice increases in sync speed for certain connections. This is Airbyte expanding the roll out.
 
-## What connectors use improved speeds
+### Sources
+
+- MySQL
+
+### Destinations
+
+- S3

--- a/docs/integrations/speed-improvements.md
+++ b/docs/integrations/speed-improvements.md
@@ -4,7 +4,7 @@ products: all
 
 # Faster sync speed
 
-Airbyte is making major investments into the platform's sync speed. This page explains more about how Airbyte is improving sync speeds and how it's rolling out those changes to you.
+Airbyte is making major investments into the platform's sync speed. This page explains what you need to know about these speed improvements and how we're rolling them out.
 
 ## What is faster sync speed?
 
@@ -12,18 +12,20 @@ Faster sync speed is an initiative that drastically improves Airbyte's sync spee
 
 At this time, this capability is turned on for a small subset of connectors. At a point in the future, Airbyte expects to make this technology generally available, and to turn on support for a broad set of connectors. At that time, we'll communicate more about the expected benefits and speed benchmarks.
 
-## How to be eligible for improved speed
+## How to use faster sync speed
 
-The following platform versions are eligible to use these speed enhancements.
+The following Airbyte versions are eligible to use these speed enhancements.
 
 - Self-Managed Community or Enterprise version 1.8 and later
 - Cloud
 
-Improved speed isn't widely usable with most connectors yet. To benefit from faster sync speeds, a connection needs to use a source connector _and_ destination connector for which Airbyte has turned on faster syncs. You also need to upgrade to the version of that connector that supports faster speed.
+To use faster sync speeds, a connection needs to use a source connector _and_ destination connector for which Airbyte has turned on faster syncs. You also need to upgrade to a version of those connectors that supports faster speed. You don't need to configure anything else.
 
 ## What connectors use improved speeds
 
 Airbyte may enable additional connector combinations as the team works toward general availability. If you're using the latest connector versions, you might notice increases in sync speed for certain connections. This is Airbyte expanding the roll out.
+
+Currently, these are the source and destination connectors that support faster sync speed.
 
 ### Sources
 

--- a/docusaurus/sidebar-connectors.js
+++ b/docusaurus/sidebar-connectors.js
@@ -412,6 +412,7 @@ function buildConnectorSidebar() {
         id: "custom-connectors",
       },
       "locating-files-local-destination",
+      "speed-improvements",
     ],
   };
 }


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->

This PR adds a page to the Connectors section. It provides a very basic explanation of faster sync speeds. Currently, the page is manually updated. 

Although I had hoped to automate this, further investigation is needed. The docs can only consume metadata in the connector registry, and my attempts to read connector metadata directly have not been successful. We'll probably need to make a more significant change later to accomodate this idea. Most likely, getting the data into the public connector registry is the most direct route.

## How
<!--
* Describe how code changes achieve the solution.
-->

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
