### PR TITLE
fix(source-monday): pass query in json body instead of query params

### DIFF
--- a/airbyte-integrations/connectors/source-monday/manifest.yaml
+++ b/airbyte-integrations/connectors/source-monday/manifest.yaml
@@ -14,6 +14,7 @@ definitions:
   requester:
     type: CustomRequester
     class_name: "source_declarative_manifest.components.MondayGraphqlRequester"
+    http_method: POST
     schema_loader:
       type: InlineSchemaLoader
       schema:

--- a/airbyte-integrations/connectors/source-monday/metadata.yaml
+++ b/airbyte-integrations/connectors/source-monday/metadata.yaml
@@ -6,11 +6,11 @@ data:
     hosts:
       - api.monday.com
   connectorBuildOptions:
-    baseImage: docker.io/airbyte/source-declarative-manifest:6.60.5@sha256:79a69ff4f759e8b404c687eff62c72f53b05d567fa830b71d17b01b8deaf2189
+    baseImage: docker.io/airbyte/source-declarative-manifest:6.60.12@sha256:b236b4ff8351a7d7f0ff7f938bbf0ab7b455c4c9e6e7cc93933f4aa9201d66cb
   connectorSubtype: api
   connectorType: source
   definitionId: 80a54ea2-9959-4040-aac1-eee42423ec9b
-  dockerImageTag: 2.4.3
+  dockerImageTag: 2.4.4
   releases:
     rolloutConfiguration:
       enableProgressiveRollout: false

--- a/airbyte-integrations/connectors/source-monday/unit_tests/integrations/monday_requests/base_requests_builder.py
+++ b/airbyte-integrations/connectors/source-monday/unit_tests/integrations/monday_requests/base_requests_builder.py
@@ -48,8 +48,8 @@ class MondayBaseRequestBuilder(MondayRequestBuilder):
         }
 
     @property
-    def request_body(self):
-        return super().request_body
+    def query_params(self):
+        return super().query_params
 
     def with_authenticator(self, authenticator: Authenticator) -> "MondayBaseRequestBuilder":
         self._authenticator: Authenticator = authenticator

--- a/airbyte-integrations/connectors/source-monday/unit_tests/integrations/monday_requests/boards_request_builder.py
+++ b/airbyte-integrations/connectors/source-monday/unit_tests/integrations/monday_requests/boards_request_builder.py
@@ -12,7 +12,7 @@ class BoardsRequestBuilder(MondayBaseRequestBuilder):
         return cls().with_authenticator(authenticator).with_board_ids(board_ids)
 
     @property
-    def query_params(self):
+    def request_body(self):
         params = super().query_params or {}
         if self._board_ids:
             board_ids = ", ".join(list(map(str, self._board_ids)))
@@ -21,7 +21,7 @@ class BoardsRequestBuilder(MondayBaseRequestBuilder):
             board_ids_str = ""
 
         params["query"] = (
-            "query{boards(limit:10%s){id,name,board_kind,type,columns{archived,description,id,settings_str,title,type,width},communication,description,groups{archived,color,deleted,id,position,title},owners{id},creator{id},permissions,state,subscribers{id},tags{id},top_group{id},updated_at,updates{id},views{id,name,settings_str,type,view_specific_data_str},workspace{id,name,kind,description}}}"
+            "{boards(limit:10%s){id,name,board_kind,type,columns{archived,description,id,settings_str,title,type,width},communication,description,groups{archived,color,deleted,id,position,title},owners{id},creator{id},permissions,state,subscribers{id},tags{id},top_group{id},updated_at,updates{id},views{id,name,settings_str,type,view_specific_data_str},workspace{id,name,kind,description}}}"
             % board_ids_str
         )
         return params

--- a/airbyte-integrations/connectors/source-monday/unit_tests/integrations/monday_requests/items_request_builder.py
+++ b/airbyte-integrations/connectors/source-monday/unit_tests/integrations/monday_requests/items_request_builder.py
@@ -12,7 +12,7 @@ class ItemsRequestBuilder(MondayBaseRequestBuilder):
         return cls().with_authenticator(authenticator).with_board_ids(board_ids)
 
     @property
-    def query_params(self):
+    def request_body(self):
         params = super().query_params or {}
         if self._board_ids:
             board_ids = ", ".join(list(map(str, self._board_ids)))
@@ -21,7 +21,7 @@ class ItemsRequestBuilder(MondayBaseRequestBuilder):
             board_ids_str = ""
 
         params["query"] = (
-            "query{boards(limit:1%s){items_page(limit:20){cursor,items{id,name,assets{created_at,file_extension,file_size,id,name,original_geometry,public_url,uploaded_by{id},url,url_thumbnail},board{id,name},column_values{id,text,type,value,... on MirrorValue{display_value},... on BoardRelationValue{display_value},... on DependencyValue{display_value}},created_at,creator_id,group{id},parent_item{id},state,subscribers{id},updated_at,updates{id}}}}}"
+            "{boards(limit:1%s){items_page(limit:20){cursor,items{id,name,assets{created_at,file_extension,file_size,id,name,original_geometry,public_url,uploaded_by{id},url,url_thumbnail},board{id,name},column_values{id,text,type,value,... on MirrorValue{display_value},... on BoardRelationValue{display_value},... on DependencyValue{display_value}},created_at,creator_id,group{id},parent_item{id},state,subscribers{id},updated_at,updates{id}}}}}"
             % board_ids_str
         )
         return params

--- a/airbyte-integrations/connectors/source-monday/unit_tests/integrations/monday_requests/teams_requests_builder.py
+++ b/airbyte-integrations/connectors/source-monday/unit_tests/integrations/monday_requests/teams_requests_builder.py
@@ -10,7 +10,7 @@ class TeamsRequestBuilder(MondayBaseRequestBuilder):
         return cls().with_authenticator(authenticator)
 
     @property
-    def query_params(self):
+    def request_body(self):
         params = super().query_params or {}
-        params["query"] = "query{teams{id,name,picture_url,users{id}}}"
+        params["query"] = "{teams{id,name,picture_url,users{id}}}"
         return params

--- a/airbyte-integrations/connectors/source-monday/unit_tests/integrations/test_boards_stream.py
+++ b/airbyte-integrations/connectors/source-monday/unit_tests/integrations/test_boards_stream.py
@@ -24,7 +24,7 @@ class TestBoardsStreamFullRefresh(TestCase):
         config = ConfigBuilder().with_api_token_credentials("api-token").build()
         api_token_authenticator = self.get_authenticator(config)
 
-        http_mocker.get(
+        http_mocker.post(
             BoardsRequestBuilder.boards_endpoint(api_token_authenticator).build(),
             BoardsResponseBuilder.boards_response()
             .with_record(BoardsRecordBuilder.boards_record())
@@ -44,7 +44,7 @@ class TestBoardsStreamFullRefresh(TestCase):
         config = ConfigBuilder().with_api_token_credentials("api-token").with_board_ids(board_ids).build()
         api_token_authenticator = self.get_authenticator(config)
 
-        http_mocker.get(
+        http_mocker.post(
             BoardsRequestBuilder.boards_endpoint(api_token_authenticator, board_ids).build(),
             BoardsResponseBuilder.boards_response().with_record(BoardsRecordBuilder.boards_record()).build(),
         )

--- a/airbyte-integrations/connectors/source-monday/unit_tests/integrations/test_items_stream.py
+++ b/airbyte-integrations/connectors/source-monday/unit_tests/integrations/test_items_stream.py
@@ -24,7 +24,7 @@ class TestItemsStreamFullRefresh(TestCase):
         config = ConfigBuilder().with_api_token_credentials("api-token").build()
         api_token_authenticator = self.get_authenticator(config)
 
-        http_mocker.get(
+        http_mocker.post(
             ItemsRequestBuilder.items_endpoint(api_token_authenticator).build(),
             ItemsResponseBuilder.items_response()
             .with_record(ItemsRecordBuilder.items_record())
@@ -44,7 +44,7 @@ class TestItemsStreamFullRefresh(TestCase):
         config = ConfigBuilder().with_api_token_credentials("api-token").with_board_ids(board_ids).build()
         api_token_authenticator = self.get_authenticator(config)
 
-        http_mocker.get(
+        http_mocker.post(
             ItemsRequestBuilder.items_endpoint(api_token_authenticator, board_ids).build(),
             ItemsResponseBuilder.items_response().with_record(ItemsRecordBuilder.items_record()).build(),
         )

--- a/airbyte-integrations/connectors/source-monday/unit_tests/integrations/test_teams_stream.py
+++ b/airbyte-integrations/connectors/source-monday/unit_tests/integrations/test_teams_stream.py
@@ -31,7 +31,7 @@ class TestTeamsStreamFullRefresh(TestCase):
         """
         api_token_authenticator = self.get_authenticator(self._config)
 
-        http_mocker.get(
+        http_mocker.post(
             TeamsRequestBuilder.teams_endpoint(api_token_authenticator).build(),
             TeamsResponseBuilder.teams_response().with_record(TeamsRecordBuilder.teams_record()).build(),
         )
@@ -53,7 +53,7 @@ class TestTeamsStreamFullRefresh(TestCase):
             response, error_code = test_values[0], test_values[1]
             api_token_authenticator = self.get_authenticator(self._config)
 
-            http_mocker.get(
+            http_mocker.post(
                 TeamsRequestBuilder.teams_endpoint(api_token_authenticator).build(),
                 [
                     ErrorResponseBuilder.response_with_status(200).build(response),
@@ -80,7 +80,7 @@ class TestTeamsStreamFullRefresh(TestCase):
         """
         api_token_authenticator = self.get_authenticator(self._config)
 
-        http_mocker.get(
+        http_mocker.post(
             TeamsRequestBuilder.teams_endpoint(api_token_authenticator).build(), ErrorResponseBuilder.response_with_status(200).build()
         )
 
@@ -103,7 +103,7 @@ class TestTeamsStreamFullRefresh(TestCase):
         """
         api_token_authenticator = self.get_authenticator(self._config)
 
-        http_mocker.get(
+        http_mocker.post(
             TeamsRequestBuilder.teams_endpoint(api_token_authenticator).build(), ErrorResponseBuilder.response_with_status(500).build()
         )
 
@@ -127,7 +127,7 @@ class TestTeamsStreamFullRefresh(TestCase):
         """
         api_token_authenticator = self.get_authenticator(self._config)
 
-        http_mocker.get(
+        http_mocker.post(
             TeamsRequestBuilder.teams_endpoint(api_token_authenticator).build(), ErrorResponseBuilder.response_with_status(403).build()
         )
 

--- a/airbyte-integrations/connectors/source-monday/unit_tests/test_graphql_requester.py
+++ b/airbyte-integrations/connectors/source-monday/unit_tests/test_graphql_requester.py
@@ -38,7 +38,7 @@ nested_array_schema = {
             nested_object_schema,
             "test_stream",
             {},
-            {"query": "query{test_stream(limit:100,page:2){root{nested{nested_of_nested}},sibling}}"},
+            {"query": "{test_stream(limit:100,page:2){root{nested{nested_of_nested}},sibling}}"},
             {"next_page_token": 2},
             id="test_get_request_params_produces_graphql_query_for_object_items",
         ),
@@ -46,7 +46,7 @@ nested_array_schema = {
             nested_array_schema,
             "test_stream",
             {},
-            {"query": "query{test_stream(limit:100,page:2){root{nested{nested_of_nested}},sibling}}"},
+            {"query": "{test_stream(limit:100,page:2){root{nested{nested_of_nested}},sibling}}"},
             {"next_page_token": 2},
             id="test_get_request_params_produces_graphql_query_for_array_items",
         ),
@@ -54,7 +54,7 @@ nested_array_schema = {
             nested_array_schema,
             "items",
             {},
-            {"query": 'query{next_items_page(limit:100,cursor:"cursor_bla"){cursor,items{root{nested{nested_of_nested}},sibling}}}'},
+            {"query": '{next_items_page(limit:100,cursor:"cursor_bla"){cursor,items{root{nested{nested_of_nested}},sibling}}}'},
             {"next_page_token": (2, "cursor_bla")},
             id="test_get_request_params_produces_graphql_query_for_items_stream",
         ),
@@ -62,7 +62,7 @@ nested_array_schema = {
             nested_array_schema,
             "teams",
             {"teams_limit": 100},
-            {"query": "query{teams(limit:100,page:2){id,name,picture_url,users(limit:100){id}}}"},
+            {"query": "{teams(limit:100,page:2){id,name,picture_url,users(limit:100){id}}}"},
             {"next_page_token": 2},
             id="test_get_request_params_produces_graphql_query_for_teams_optimized_stream",
         ),
@@ -70,7 +70,7 @@ nested_array_schema = {
             nested_array_schema,
             "teams",
             {},
-            {"query": "query{teams(limit:100,page:2){root{nested{nested_of_nested}},sibling}}"},
+            {"query": "{teams(limit:100,page:2){root{nested{nested_of_nested}},sibling}}"},
             {"next_page_token": 2},
             id="test_get_request_params_produces_graphql_query_for_teams_stream",
         ),
@@ -97,7 +97,7 @@ def test_get_request_params(components_module, input_schema, graphql_query, stre
         parameters={"name": stream_name, "items_per_page": 100, "nested_items_per_page": 100},
         config=config,
     )
-    assert requester.get_request_params(stream_state={}, stream_slice={}, next_page_token=next_page_token) == graphql_query
+    assert requester.get_request_body_json(stream_state={}, stream_slice={}, next_page_token=next_page_token) == graphql_query
 
 
 @pytest.fixture

--- a/docs/integrations/sources/monday.md
+++ b/docs/integrations/sources/monday.md
@@ -75,53 +75,54 @@ The Monday connector should not run into Monday API limitations under normal usa
 <details>
   <summary>Expand to review</summary>
 
-| Version | Date       | Pull Request                                              | Subject                                                                                           |
-|:--------|:-----------| :-------------------------------------------------------- | :------------------------------------------------------------------------------------------------ |
-| 2.4.3 | 2025-08-02 | [64220](https://github.com/airbytehq/airbyte/pull/64220) | Update dependencies |
-| 2.4.2 | 2025-07-26 | [63835](https://github.com/airbytehq/airbyte/pull/63835) | Update dependencies |
-| 2.4.1 | 2025-07-19 | [63206](https://github.com/airbytehq/airbyte/pull/63206) | Update dependencies |
-| 2.4.0 | 2025-07-09 | [62886](https://github.com/airbytehq/airbyte/pull/62886) | Promoting release candidate 2.4.0-rc.1 to a main version. |
-| 2.4.0-rc.1 | 2025-07-02 | [62444](https://github.com/airbytehq/airbyte/pull/62444) | Migrate connector to manifest-only |
-| 2.3.1 | 2025-05-31 | [53828](https://github.com/airbytehq/airbyte/pull/53828) | Update dependencies |
-| 2.3.0 | 2025-04-02 | [56967](https://github.com/airbytehq/airbyte/pull/56967) | Promoting release candidate 2.3.0-rc.1 to a main version. |
-| 2.3.0-rc.1   | 2025-03-18 | [55225](https://github.com/airbytehq/airbyte/pull/55225) | Update CDK to v6 |
-| 2.2.0   | 2025-03-14 | [52780](https://github.com/airbytehq/airbyte/pull/52780) | Add optional config parameter to control which boards are fetched when syncing the `Boards` stream |
-| 2.1.13  | 2025-02-01 | [52780](https://github.com/airbytehq/airbyte/pull/52780) | Update dependencies |
-| 2.1.12  | 2025-01-25 | [51833](https://github.com/airbytehq/airbyte/pull/51833) | Update dependencies |
-| 2.1.11  | 2025-01-14 | [51147](https://github.com/airbytehq/airbyte/pull/10311) | Update API version to 2024-10 |
-| 2.1.10  | 2025-01-11 | [51147](https://github.com/airbytehq/airbyte/pull/51147) | Update dependencies |
-| 2.1.9   | 2025-01-08 | [50984](https://github.com/airbytehq/airbyte/pull/50984) | Update the `spec` to support `Jinja` style variables for `DeclarativeOAuthFlow` |
-| 2.1.8   | 2024-12-28 | [50624](https://github.com/airbytehq/airbyte/pull/50624) | Update dependencies |
-| 2.1.7   | 2024-12-21 | [43901](https://github.com/airbytehq/airbyte/pull/43901) | Starting with this version, the Docker image is now rootless. Please note that this and future versions will not be compatible with Airbyte versions earlier than 0.64 |
-| 2.1.6   | 2024-12-19 | [49943](https://github.com/airbytehq/airbyte/pull/49943) | Pin CDK constraint to avoid breaking change in newer versions |
-| 2.1.5   | 2024-10-31 | [48054](https://github.com/airbytehq/airbyte/pull/48054) | Moved to `DeclarativeOAuthFlow` specification |
-| 2.1.4   | 2024-08-17 | [44201](https://github.com/airbytehq/airbyte/pull/44201) | Add boards name to the `items` stream |
-| 2.1.3   | 2024-06-04 | [38958](https://github.com/airbytehq/airbyte/pull/38958) | [autopull] Upgrade base image to v1.2.1 |
-| 2.1.2   | 2024-04-30 | [37722](https://github.com/airbytehq/airbyte/pull/37722) | Fetch `display_value` field for column values of `Mirror`, `Dependency` and `Connect Board` types |
-| 2.1.1   | 2024-04-05 | [36717](https://github.com/airbytehq/airbyte/pull/36717) | Add handling of complexityBudgetExhausted error. |
-| 2.1.0   | 2024-04-03 | [36746](https://github.com/airbytehq/airbyte/pull/36746) | Pin airbyte-cdk version to `^0` |
-| 2.0.4   | 2024-02-28 | [35696](https://github.com/airbytehq/airbyte/pull/35696) | Fix extraction for `null` value in stream `Activity logs` |
-| 2.0.3   | 2024-02-21 | [35506](https://github.com/airbytehq/airbyte/pull/35506) | Support for column values of the mirror type for the `Items` stream. |
-| 2.0.2   | 2024-02-12 | [35146](https://github.com/airbytehq/airbyte/pull/35146) | Manage dependencies with Poetry. |
-| 2.0.1   | 2024-02-08 | [35016](https://github.com/airbytehq/airbyte/pull/35016) | Migrated to the latest airbyte cdk |
-| 2.0.0   | 2024-01-12 | [34108](https://github.com/airbytehq/airbyte/pull/34108) | Migrated to the latest API version: 2024-01 |
-| 1.1.4   | 2023-12-13 | [33448](https://github.com/airbytehq/airbyte/pull/33448) | Increase test coverage and migrate to base image |
-| 1.1.3   | 2023-09-23 | [30248](https://github.com/airbytehq/airbyte/pull/30248) | Add new field "type" to board stream |
-| 1.1.2   | 2023-08-23 | [29777](https://github.com/airbytehq/airbyte/pull/29777) | Add retry for `502` error |
-| 1.1.1   | 2023-08-15 | [29429](https://github.com/airbytehq/airbyte/pull/29429) | Ignore `null` records in response |
-| 1.1.0   | 2023-07-05 | [27944](https://github.com/airbytehq/airbyte/pull/27944) | Add incremental sync for Items and Boards streams |
-| 1.0.0   | 2023-06-20 | [27410](https://github.com/airbytehq/airbyte/pull/27410) | Add new streams: Tags, Workspaces. Add new fields for existing streams. |
-| 0.2.6   | 2023-06-12 | [27244](https://github.com/airbytehq/airbyte/pull/27244) | Added http error handling for `403` and `500` HTTP errors |
-| 0.2.5   | 2023-05-22 | [225881](https://github.com/airbytehq/airbyte/pull/25881) | Fix pagination for the items stream                                                               |
-| 0.2.4   | 2023-04-26 | [25277](https://github.com/airbytehq/airbyte/pull/25277)  | Increase row limit to 100                                                                         |
-| 0.2.3   | 2023-03-06 | [23231](https://github.com/airbytehq/airbyte/pull/23231)  | Publish using low-code CDK Beta version                                                           |
-| 0.2.2   | 2023-01-04 | [20996](https://github.com/airbytehq/airbyte/pull/20996)  | Fix json schema loader                                                                            |
-| 0.2.1   | 2022-12-15 | [20533](https://github.com/airbytehq/airbyte/pull/20533)  | Bump CDK version                                                                                  |
-| 0.2.0   | 2022-12-13 | [19586](https://github.com/airbytehq/airbyte/pull/19586)  | Migrate to low-code                                                                               |
-| 0.1.4   | 2022-06-06 | [14443](https://github.com/airbytehq/airbyte/pull/14443)  | Increase retry_factor for Items stream                                                            |
-| 0.1.3   | 2021-12-23 | [8172](https://github.com/airbytehq/airbyte/pull/8172)    | Add oauth2.0 support                                                                              |
-| 0.1.2   | 2021-12-07 | [8429](https://github.com/airbytehq/airbyte/pull/8429)    | Update titles and descriptions                                                                    |
-| 0.1.1   | 2021-11-18 | [8016](https://github.com/airbytehq/airbyte/pull/8016)    | 🐛 Source Monday: fix pagination and schema bug                                                   |
-| 0.1.0   | 2021-11-07 | [7168](https://github.com/airbytehq/airbyte/pull/7168)    | 🎉 New Source: Monday                                                                             |
+| Version    | Date       | Pull Request                                              | Subject                                                                                                                                                                |
+|:-----------|:-----------|:----------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 2.4.4      | 2025-08-11 | [64878](https://github.com/airbytehq/airbyte/pull/64878)  | Pass query in json body of request instead of query params.                                                                                                            |
+| 2.4.3      | 2025-08-02 | [64220](https://github.com/airbytehq/airbyte/pull/64220)  | Update dependencies                                                                                                                                                    |
+| 2.4.2      | 2025-07-26 | [63835](https://github.com/airbytehq/airbyte/pull/63835)  | Update dependencies                                                                                                                                                    |
+| 2.4.1      | 2025-07-19 | [63206](https://github.com/airbytehq/airbyte/pull/63206)  | Update dependencies                                                                                                                                                    |
+| 2.4.0      | 2025-07-09 | [62886](https://github.com/airbytehq/airbyte/pull/62886)  | Promoting release candidate 2.4.0-rc.1 to a main version.                                                                                                              |
+| 2.4.0-rc.1 | 2025-07-02 | [62444](https://github.com/airbytehq/airbyte/pull/62444)  | Migrate connector to manifest-only                                                                                                                                     |
+| 2.3.1      | 2025-05-31 | [53828](https://github.com/airbytehq/airbyte/pull/53828)  | Update dependencies                                                                                                                                                    |
+| 2.3.0      | 2025-04-02 | [56967](https://github.com/airbytehq/airbyte/pull/56967)  | Promoting release candidate 2.3.0-rc.1 to a main version.                                                                                                              |
+| 2.3.0-rc.1 | 2025-03-18 | [55225](https://github.com/airbytehq/airbyte/pull/55225)  | Update CDK to v6                                                                                                                                                       |
+| 2.2.0      | 2025-03-14 | [52780](https://github.com/airbytehq/airbyte/pull/52780)  | Add optional config parameter to control which boards are fetched when syncing the `Boards` stream                                                                     |
+| 2.1.13     | 2025-02-01 | [52780](https://github.com/airbytehq/airbyte/pull/52780)  | Update dependencies                                                                                                                                                    |
+| 2.1.12     | 2025-01-25 | [51833](https://github.com/airbytehq/airbyte/pull/51833)  | Update dependencies                                                                                                                                                    |
+| 2.1.11     | 2025-01-14 | [51147](https://github.com/airbytehq/airbyte/pull/10311)  | Update API version to 2024-10                                                                                                                                          |
+| 2.1.10     | 2025-01-11 | [51147](https://github.com/airbytehq/airbyte/pull/51147)  | Update dependencies                                                                                                                                                    |
+| 2.1.9      | 2025-01-08 | [50984](https://github.com/airbytehq/airbyte/pull/50984)  | Update the `spec` to support `Jinja` style variables for `DeclarativeOAuthFlow`                                                                                        |
+| 2.1.8      | 2024-12-28 | [50624](https://github.com/airbytehq/airbyte/pull/50624)  | Update dependencies                                                                                                                                                    |
+| 2.1.7      | 2024-12-21 | [43901](https://github.com/airbytehq/airbyte/pull/43901)  | Starting with this version, the Docker image is now rootless. Please note that this and future versions will not be compatible with Airbyte versions earlier than 0.64 |
+| 2.1.6      | 2024-12-19 | [49943](https://github.com/airbytehq/airbyte/pull/49943)  | Pin CDK constraint to avoid breaking change in newer versions                                                                                                          |
+| 2.1.5      | 2024-10-31 | [48054](https://github.com/airbytehq/airbyte/pull/48054)  | Moved to `DeclarativeOAuthFlow` specification                                                                                                                          |
+| 2.1.4      | 2024-08-17 | [44201](https://github.com/airbytehq/airbyte/pull/44201)  | Add boards name to the `items` stream                                                                                                                                  |
+| 2.1.3      | 2024-06-04 | [38958](https://github.com/airbytehq/airbyte/pull/38958)  | [autopull] Upgrade base image to v1.2.1                                                                                                                                |
+| 2.1.2      | 2024-04-30 | [37722](https://github.com/airbytehq/airbyte/pull/37722)  | Fetch `display_value` field for column values of `Mirror`, `Dependency` and `Connect Board` types                                                                      |
+| 2.1.1      | 2024-04-05 | [36717](https://github.com/airbytehq/airbyte/pull/36717)  | Add handling of complexityBudgetExhausted error.                                                                                                                       |
+| 2.1.0      | 2024-04-03 | [36746](https://github.com/airbytehq/airbyte/pull/36746)  | Pin airbyte-cdk version to `^0`                                                                                                                                        |
+| 2.0.4      | 2024-02-28 | [35696](https://github.com/airbytehq/airbyte/pull/35696)  | Fix extraction for `null` value in stream `Activity logs`                                                                                                              |
+| 2.0.3      | 2024-02-21 | [35506](https://github.com/airbytehq/airbyte/pull/35506)  | Support for column values of the mirror type for the `Items` stream.                                                                                                   |
+| 2.0.2      | 2024-02-12 | [35146](https://github.com/airbytehq/airbyte/pull/35146)  | Manage dependencies with Poetry.                                                                                                                                       |
+| 2.0.1      | 2024-02-08 | [35016](https://github.com/airbytehq/airbyte/pull/35016)  | Migrated to the latest airbyte cdk                                                                                                                                     |
+| 2.0.0      | 2024-01-12 | [34108](https://github.com/airbytehq/airbyte/pull/34108)  | Migrated to the latest API version: 2024-01                                                                                                                            |
+| 1.1.4      | 2023-12-13 | [33448](https://github.com/airbytehq/airbyte/pull/33448)  | Increase test coverage and migrate to base image                                                                                                                       |
+| 1.1.3      | 2023-09-23 | [30248](https://github.com/airbytehq/airbyte/pull/30248)  | Add new field "type" to board stream                                                                                                                                   |
+| 1.1.2      | 2023-08-23 | [29777](https://github.com/airbytehq/airbyte/pull/29777)  | Add retry for `502` error                                                                                                                                              |
+| 1.1.1      | 2023-08-15 | [29429](https://github.com/airbytehq/airbyte/pull/29429)  | Ignore `null` records in response                                                                                                                                      |
+| 1.1.0      | 2023-07-05 | [27944](https://github.com/airbytehq/airbyte/pull/27944)  | Add incremental sync for Items and Boards streams                                                                                                                      |
+| 1.0.0      | 2023-06-20 | [27410](https://github.com/airbytehq/airbyte/pull/27410)  | Add new streams: Tags, Workspaces. Add new fields for existing streams.                                                                                                |
+| 0.2.6      | 2023-06-12 | [27244](https://github.com/airbytehq/airbyte/pull/27244)  | Added http error handling for `403` and `500` HTTP errors                                                                                                              |
+| 0.2.5      | 2023-05-22 | [225881](https://github.com/airbytehq/airbyte/pull/25881) | Fix pagination for the items stream                                                                                                                                    |
+| 0.2.4      | 2023-04-26 | [25277](https://github.com/airbytehq/airbyte/pull/25277)  | Increase row limit to 100                                                                                                                                              |
+| 0.2.3      | 2023-03-06 | [23231](https://github.com/airbytehq/airbyte/pull/23231)  | Publish using low-code CDK Beta version                                                                                                                                |
+| 0.2.2      | 2023-01-04 | [20996](https://github.com/airbytehq/airbyte/pull/20996)  | Fix json schema loader                                                                                                                                                 |
+| 0.2.1      | 2022-12-15 | [20533](https://github.com/airbytehq/airbyte/pull/20533)  | Bump CDK version                                                                                                                                                       |
+| 0.2.0      | 2022-12-13 | [19586](https://github.com/airbytehq/airbyte/pull/19586)  | Migrate to low-code                                                                                                                                                    |
+| 0.1.4      | 2022-06-06 | [14443](https://github.com/airbytehq/airbyte/pull/14443)  | Increase retry_factor for Items stream                                                                                                                                 |
+| 0.1.3      | 2021-12-23 | [8172](https://github.com/airbytehq/airbyte/pull/8172)    | Add oauth2.0 support                                                                                                                                                   |
+| 0.1.2      | 2021-12-07 | [8429](https://github.com/airbytehq/airbyte/pull/8429)    | Update titles and descriptions                                                                                                                                         |
+| 0.1.1      | 2021-11-18 | [8016](https://github.com/airbytehq/airbyte/pull/8016)    | 🐛 Source Monday: fix pagination and schema bug                                                                                                                        |
+| 0.1.0      | 2021-11-07 | [7168](https://github.com/airbytehq/airbyte/pull/7168)    | 🎉 New Source: Monday                                                                                                                                                  |
 
 </details>


### PR DESCRIPTION
## What
Monday API started to return bad requests for requests with query passed in query params.
[slack thread](https://airbytehq-team.slack.com/archives/C045F3WEJ6A/p1754571609909079)
[monday community](https://community.monday.com/t/anyone-else-400-invalid-graphql-request-error-from-api-with-make-monday-modules/118566/4)
Error: `Request body must be a JSON with query.`

## How
Updated Requester to pass query in json body instead of query params.

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
