### PR TITLE
fix: connector metadata upload needs pre/main-release

### DIFF
--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -152,6 +152,15 @@ jobs:
           max_attempts: 2
           retry_wait_seconds: 600 # 10 minutes
 
+      - name: Upload connector metadata [On merge to master]
+        id: upload-connector-metadata-master
+        shell: bash
+        run: ./poe-tasks/upload-connector-metadata.sh --name ${{ matrix.connector }} --main-release
+        env:
+          GCS_CREDENTIALS: ${{ secrets.METADATA_SERVICE_DEV_GCS_CREDENTIALS }}
+          SPEC_CACHE_GCS_CREDENTIALS: ${{ secrets.METADATA_SERVICE_DEV_GCS_CREDENTIALS }}
+          METADATA_SERVICE_GCS_CREDENTIALS: ${{ secrets.METADATA_SERVICE_DEV_GCS_CREDENTIALS }}
+
       - name: Build and publish JVM connectors images [manual]
         id: build-and-publish-JVM-connectors-images-manual
         if: >
@@ -183,10 +192,10 @@ jobs:
           airbyte_ci_binary_url: ${{ inputs.airbyte_ci_binary_url }}
           max_attempts: 2
 
-      - name: Upload connector metadata
-        id: upload-connector-metadata
+      - name: Upload connector metadata [Manual]
+        id: upload-connector-metadata-manual
         shell: bash
-        run: ./poe-tasks/upload-connector-metadata.sh --name ${{ matrix.connector }}
+        run: ./poe-tasks/upload-connector-metadata.sh --name ${{ matrix.connector }} ${{ inputs.publish-options }}
         env:
           GCS_CREDENTIALS: ${{ secrets.METADATA_SERVICE_DEV_GCS_CREDENTIALS }}
           SPEC_CACHE_GCS_CREDENTIALS: ${{ secrets.METADATA_SERVICE_DEV_GCS_CREDENTIALS }}


### PR DESCRIPTION
fixes https://github.com/airbytehq/airbyte/actions/runs/16892884146/job/47856626230

problem was that I was passing neither`--pre-release` nor `--main-release` to the upload script, so it defaulted to prerelease.

fix for now is to do the same manual/merge split we have everywhere else. `merge` uses mainrelease; `manual` passes through the flags on the workflow input. We really need to do https://github.com/airbytehq/airbyte-internal-issues/issues/13874...

(b/c I didn't test a mainrelease >.> )