### PR TITLE
source-track-pms: improved reservations & reservations_v2 scroll index handling

### DIFF
--- a/airbyte-integrations/connectors/source-track-pms/manifest.yaml
+++ b/airbyte-integrations/connectors/source-track-pms/manifest.yaml
@@ -6274,9 +6274,10 @@ definitions:
           record_filter:
             type: RecordFilter
             condition: >-
-              {{ (record._embedded.reservation.quoteBreakdown.grossRent | float
-              > 0) or (record._embedded.reservation.quoteBreakdown.guestFees |
-              float > 0) }}
+              {{  (record._embedded.reservation.quoteBreakdown.grandTotal |
+              float > 0) or
+              (record._embedded.reservation.quoteBreakdown.payments | float > 0)
+              }}
           schema_normalization: Default
       primary_key:
         - id
@@ -7502,7 +7503,7 @@ metadata:
       responsesAreSuccessful: true
     folios_transactions:
       hasRecords: true
-      streamHash: 502376b6b85102cf7e8916465cedbe5c1c66f18a
+      streamHash: 6f440996d63e36609213138d0599a7ad8279bf95
       hasResponse: true
       primaryKeysAreUnique: true
       primaryKeysArePresent: true
@@ -7628,7 +7629,7 @@ metadata:
       responsesAreSuccessful: true
     folios_transactions_parent:
       hasRecords: true
-      streamHash: c8dabe88822e0758ad7df0c99236fa2b3776159d
+      streamHash: 91a6a21b22cdfc3bfd8deaec37caa229ce79449c
       hasResponse: true
       primaryKeysAreUnique: true
       primaryKeysArePresent: true

--- a/airbyte-integrations/connectors/source-track-pms/manifest.yaml
+++ b/airbyte-integrations/connectors/source-track-pms/manifest.yaml
@@ -1,4 +1,4 @@
-version: 6.41.5
+version: 6.48.15
 
 type: DeclarativeSource
 
@@ -2358,18 +2358,10 @@ definitions:
           type: JsonDecoder
         paginator:
           type: DefaultPaginator
-          page_size_option:
-            type: RequestOption
-            field_name: size
-            inject_into: request_parameter
-          page_token_option:
-            type: RequestOption
-            field_name: page
-            inject_into: request_parameter
           pagination_strategy:
-            type: PageIncrement
-            page_size: 100
-            start_from_page: 1
+            type: CursorPagination
+            cursor_value: "{{ response.total_items }}"
+            stop_condition: "{{ not response._embedded.reservations }}"
         requester:
           $ref: "#/definitions/base_requester"
           path: pms/reservations
@@ -2480,24 +2472,6 @@ definitions:
           field_pointers:
             - - _embedded
               - channel
-      incremental_sync:
-        type: DatetimeBasedCursor
-        cursor_field: updatedAt
-        end_datetime:
-          type: MinMaxDatetime
-          datetime: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%SZ') }}"
-          datetime_format: "%Y-%m-%dT%H:%M:%SZ"
-        start_datetime:
-          type: MinMaxDatetime
-          datetime: "1900-01-01T00:00:00+00:00"
-          datetime_format: "%Y-%m-%dT%H:%M:%S%z"
-        datetime_format: "%Y-%m-%dT%H:%M:%S%z"
-        start_time_option:
-          type: RequestOption
-          field_name: updatedSince
-          inject_into: request_parameter
-        cursor_datetime_formats:
-          - "%Y-%m-%dT%H:%M:%S%z"
     tax_policies:
       type: DeclarativeStream
       name: tax_policies
@@ -3080,19 +3054,10 @@ definitions:
           type: JsonDecoder
         paginator:
           type: DefaultPaginator
-          page_size_option:
-            type: RequestOption
-            field_name: size
-            inject_into: request_parameter
-          page_token_option:
-            type: RequestOption
-            field_name: page
-            inject_into: request_parameter
           pagination_strategy:
-            type: PageIncrement
-            page_size: 100
-            start_from_page: 1
-            inject_on_first_request: true
+            type: CursorPagination
+            cursor_value: "{{ response.total_items }}"
+            stop_condition: "{{ not response._embedded.reservations }}"
         requester:
           $ref: "#/definitions/base_requester"
           path: v2/pms/reservations
@@ -4647,21 +4612,6 @@ definitions:
         type: SimpleRetriever
         decoder:
           type: JsonDecoder
-        paginator:
-          type: DefaultPaginator
-          page_size_option:
-            type: RequestOption
-            field_name: size
-            inject_into: request_parameter
-          page_token_option:
-            type: RequestOption
-            field_name: page
-            inject_into: request_parameter
-          pagination_strategy:
-            type: PageIncrement
-            page_size: 100
-            start_from_page: 1
-            inject_on_first_request: true
         requester:
           $ref: "#/definitions/base_requester"
           path: pms/reservations
@@ -4695,6 +4645,9 @@ definitions:
                     backoff_time_in_seconds: 305
           request_headers:
             accept: application/json
+          request_parameters:
+            size: "100"
+            scroll: "1"
         record_selector:
           type: RecordSelector
           extractor:
@@ -4702,15 +4655,6 @@ definitions:
             field_path:
               - _links
               - self
-        partition_router:
-          type: ListPartitionRouter
-          values:
-            - "1"
-          cursor_field: scroll
-          request_option:
-            type: RequestOption
-            field_name: scroll
-            inject_into: request_parameter
       primary_key:
         - href
       schema_loader:
@@ -5541,21 +5485,6 @@ definitions:
         type: SimpleRetriever
         decoder:
           type: JsonDecoder
-        paginator:
-          type: DefaultPaginator
-          page_size_option:
-            type: RequestOption
-            field_name: size
-            inject_into: request_parameter
-          page_token_option:
-            type: RequestOption
-            field_name: page
-            inject_into: request_parameter
-          pagination_strategy:
-            type: PageIncrement
-            page_size: 100
-            start_from_page: 1
-            inject_on_first_request: true
         requester:
           $ref: "#/definitions/base_requester"
           path: v2/pms/reservations
@@ -5589,6 +5518,9 @@ definitions:
                     backoff_time_in_seconds: 305
           request_headers:
             accept: application/json
+          request_parameters:
+            size: "100"
+            scroll: "1"
         record_selector:
           type: RecordSelector
           extractor:
@@ -5596,15 +5528,6 @@ definitions:
             field_path:
               - _links
               - self
-        partition_router:
-          type: ListPartitionRouter
-          values:
-            - "1"
-          cursor_field: scroll
-          request_option:
-            type: RequestOption
-            field_name: scroll
-            inject_into: request_parameter
       primary_key:
         - href
       schema_loader:
@@ -7246,7 +7169,7 @@ metadata:
       responsesAreSuccessful: true
     reservations:
       hasRecords: true
-      streamHash: ef4f3761ef29139f9e4f5be4e7ad8819256ee697
+      streamHash: eea32eb9b78de8c92ebb928e7d7c4d48c61023f2
       hasResponse: true
       primaryKeysAreUnique: true
       primaryKeysArePresent: true
@@ -7302,7 +7225,7 @@ metadata:
       responsesAreSuccessful: true
     reservations_v2:
       hasRecords: true
-      streamHash: 63b219a524f9633fc3bbcd4d1eaa8322e72504b8
+      streamHash: a024843e6de1dad41bd4367445ab79765a735d6b
       hasResponse: true
       primaryKeysAreUnique: true
       primaryKeysArePresent: true
@@ -7421,7 +7344,7 @@ metadata:
       responsesAreSuccessful: true
     reservations_scroll:
       hasRecords: true
-      streamHash: 7ea079e10e9221e93e40fcbb54c662ca1b64447b
+      streamHash: 2ac9f8d18984675042bda300e65b47712b0f17a2
       hasResponse: true
       primaryKeysAreUnique: true
       primaryKeysArePresent: true
@@ -7484,7 +7407,7 @@ metadata:
       responsesAreSuccessful: true
     reservations_v2_scroll:
       hasRecords: true
-      streamHash: e2258786249661145b3c77498ba5fa460dff517f
+      streamHash: a7e18408c924b6cfaa536a6dd23e7267990447b7
       hasResponse: true
       primaryKeysAreUnique: true
       primaryKeysArePresent: true

--- a/airbyte-integrations/connectors/source-track-pms/manifest.yaml
+++ b/airbyte-integrations/connectors/source-track-pms/manifest.yaml
@@ -6274,8 +6274,9 @@ definitions:
           record_filter:
             type: RecordFilter
             condition: >-
-              {{ (record['ownerRevenue'] | default(0) | int > 0) and
-              (record['id'] != record['reservationId']) }}
+              {{ (record._embedded.reservation.quoteBreakdown.grossRent | float
+              > 0) or (record._embedded.reservation.quoteBreakdown.guestFees |
+              float > 0) }}
           schema_normalization: Default
       primary_key:
         - id
@@ -6287,9 +6288,6 @@ definitions:
         - type: RemoveFields
           field_pointers:
             - - _links
-        - type: RemoveFields
-          field_pointers:
-            - - _embedded
     units_types_pricing_parent:
       type: DeclarativeStream
       name: units_types_pricing_parent
@@ -7504,7 +7502,7 @@ metadata:
       responsesAreSuccessful: true
     folios_transactions:
       hasRecords: true
-      streamHash: 99e7003abcece7d302aa125f239462dc17ec27fd
+      streamHash: 502376b6b85102cf7e8916465cedbe5c1c66f18a
       hasResponse: true
       primaryKeysAreUnique: true
       primaryKeysArePresent: true
@@ -7630,7 +7628,7 @@ metadata:
       responsesAreSuccessful: true
     folios_transactions_parent:
       hasRecords: true
-      streamHash: 44b58d471f5aa56077808f1946d22b4277af0c84
+      streamHash: c8dabe88822e0758ad7df0c99236fa2b3776159d
       hasResponse: true
       primaryKeysAreUnique: true
       primaryKeysArePresent: true

--- a/airbyte-integrations/connectors/source-track-pms/manifest.yaml
+++ b/airbyte-integrations/connectors/source-track-pms/manifest.yaml
@@ -4484,6 +4484,8 @@ definitions:
                     backoff_time_in_seconds: 305
           request_headers:
             accept: application/json
+          request_parameters:
+            showVoids: "1"
         record_selector:
           type: RecordSelector
           extractor:
@@ -5817,6 +5819,8 @@ definitions:
                     backoff_time_in_seconds: 305
           request_headers:
             accept: application/json
+          request_parameters:
+            showVoids: "1"
         record_selector:
           type: RecordSelector
           extractor:
@@ -7493,7 +7497,7 @@ metadata:
       responsesAreSuccessful: true
     folios_transactions:
       hasRecords: true
-      streamHash: d20e2cc3cfccd7ddb981f9197cf8d6df56e518f3
+      streamHash: 7466e7caf2a6561f8850e5dd5989bb0b94df35ae
       hasResponse: true
       primaryKeysAreUnique: true
       primaryKeysArePresent: true
@@ -7584,7 +7588,7 @@ metadata:
       responsesAreSuccessful: true
     accounting_transactions:
       hasRecords: true
-      streamHash: b3542497fbbfc850b96e7ced0fd6586589b4eec9
+      streamHash: a93ad7377d04d30996b2a9e82fe5d93e4e0e304b
       hasResponse: true
       primaryKeysAreUnique: true
       primaryKeysArePresent: true

--- a/airbyte-integrations/connectors/source-track-pms/manifest.yaml
+++ b/airbyte-integrations/connectors/source-track-pms/manifest.yaml
@@ -4430,6 +4430,91 @@ definitions:
         - type: RemoveFields
           field_pointers:
             - - _embedded
+    folios_transactions:
+      type: DeclarativeStream
+      name: folios_transactions
+      retriever:
+        type: SimpleRetriever
+        decoder:
+          type: JsonDecoder
+        paginator:
+          type: DefaultPaginator
+          page_size_option:
+            type: RequestOption
+            field_name: size
+            inject_into: request_parameter
+          page_token_option:
+            type: RequestOption
+            field_name: page
+            inject_into: request_parameter
+          pagination_strategy:
+            type: PageIncrement
+            page_size: 100
+            start_from_page: 1
+        requester:
+          $ref: "#/definitions/base_requester"
+          path: pms/folios/{{ stream_partition.folio_id | int }}/transactions
+          http_method: GET
+          error_handler:
+            type: CompositeErrorHandler
+            error_handlers:
+              - type: DefaultErrorHandler
+                response_filters:
+                  - type: HttpResponseFilter
+                    action: IGNORE
+                    predicate: >-
+                      {{ response.status == 409 and response.detail == 'Invalid
+                      page provided' }}
+                    http_codes: []
+                    error_message: >-
+                      Track's inappropriate 409 for page numbers too high.
+                      Nothing to do but continue to work with the vendor.
+              - type: DefaultErrorHandler
+                max_retries: 3
+                response_filters:
+                  - type: HttpResponseFilter
+                    action: RATE_LIMITED
+                    predicate: "{{ response.status == 429 }}"
+                    http_codes: []
+                    error_message: >-
+                      Track rate limit (10,000 requests per 5 minutes) met,
+                      waiting 5 minutes and 5 seconds to reset.
+                backoff_strategies:
+                  - type: ConstantBackoffStrategy
+                    backoff_time_in_seconds: 305
+          request_headers:
+            accept: application/json
+        record_selector:
+          type: RecordSelector
+          extractor:
+            type: DpathExtractor
+            field_path:
+              - _embedded
+              - folioTransactions
+        partition_router:
+          type: SubstreamPartitionRouter
+          parent_stream_configs:
+            - type: ParentStreamConfig
+              stream:
+                $ref: "#/definitions/streams/folios_transactions_parent"
+              parent_key: id
+              partition_field: folio_id
+      primary_key:
+        - id
+      schema_loader:
+        type: InlineSchemaLoader
+        schema:
+          $ref: "#/schemas/folios_transactions"
+      transformations:
+        - type: RemoveFields
+          field_pointers:
+            - - _links
+        - type: AddFields
+          fields:
+            - type: AddedFieldDefinition
+              path:
+                - folio_id
+              value: "{{ stream_interval.folio_id }}"
     owners_pii_redacted:
       type: DeclarativeStream
       name: owners_pii_redacted
@@ -6125,6 +6210,86 @@ definitions:
         - type: RemoveFields
           field_pointers:
             - - _links
+    folios_transactions_parent:
+      type: DeclarativeStream
+      name: folios_transactions_parent
+      retriever:
+        type: SimpleRetriever
+        decoder:
+          type: JsonDecoder
+        paginator:
+          type: DefaultPaginator
+          page_size_option:
+            type: RequestOption
+            field_name: size
+            inject_into: request_parameter
+          page_token_option:
+            type: RequestOption
+            field_name: page
+            inject_into: request_parameter
+          pagination_strategy:
+            type: PageIncrement
+            page_size: 100
+            start_from_page: 1
+        requester:
+          $ref: "#/definitions/base_requester"
+          path: pms/folios
+          http_method: GET
+          error_handler:
+            type: CompositeErrorHandler
+            error_handlers:
+              - type: DefaultErrorHandler
+                response_filters:
+                  - type: HttpResponseFilter
+                    action: IGNORE
+                    predicate: >-
+                      {{ response.status == 409 and response.detail == 'Invalid
+                      page provided' }}
+                    http_codes: []
+                    error_message: >-
+                      Track's inappropriate 409 for page numbers too high.
+                      Nothing to do but continue to work with the vendor.
+              - type: DefaultErrorHandler
+                max_retries: 3
+                response_filters:
+                  - type: HttpResponseFilter
+                    action: RATE_LIMITED
+                    predicate: "{{ response.status == 429 }}"
+                    http_codes: []
+                    error_message: >-
+                      Track rate limit (10,000 requests per 5 minutes) met,
+                      waiting 5 minutes and 5 seconds to reset.
+                backoff_strategies:
+                  - type: ConstantBackoffStrategy
+                    backoff_time_in_seconds: 305
+          request_headers:
+            accept: application/json
+        record_selector:
+          type: RecordSelector
+          extractor:
+            type: DpathExtractor
+            field_path:
+              - _embedded
+              - folios
+          record_filter:
+            type: RecordFilter
+            condition: >-
+              {{ (record['ownerRevenue'] | default(0) | int > 0) and
+              (record['id'] != record['reservationId']) }}
+          schema_normalization: Default
+      primary_key:
+        - id
+      schema_loader:
+        type: InlineSchemaLoader
+        schema:
+          $ref: "#/schemas/folios_transactions_parent"
+      transformations:
+        - type: RemoveFields
+          field_pointers:
+            - - _links
+        - type: RemoveFields
+          field_pointers:
+            - - _embedded
     units_types_pricing_parent:
       type: DeclarativeStream
       name: units_types_pricing_parent
@@ -6878,6 +7043,8 @@ streams:
   - $ref: "#/definitions/streams/folios"
   - $ref: "#/definitions/streams/folios_logs"
   - $ref: "#/definitions/streams/folios_rules"
+  - $ref: "#/definitions/streams/folios_transactions"
+  - $ref: "#/definitions/streams/folios_transactions_parent"
   - $ref: "#/definitions/streams/fractionals"
   - $ref: "#/definitions/streams/fractionals_inventory"
   - $ref: "#/definitions/streams/fractionals_owners"
@@ -7335,6 +7502,13 @@ metadata:
       primaryKeysAreUnique: true
       primaryKeysArePresent: true
       responsesAreSuccessful: true
+    folios_transactions:
+      hasRecords: true
+      streamHash: 99e7003abcece7d302aa125f239462dc17ec27fd
+      hasResponse: true
+      primaryKeysAreUnique: true
+      primaryKeysArePresent: true
+      responsesAreSuccessful: true
     owners_pii_redacted:
       hasRecords: true
       streamHash: c3c6e4699af6f36068b3827bd59567398e45c41a
@@ -7450,6 +7624,13 @@ metadata:
     travel_insurance_products:
       hasRecords: true
       streamHash: e25d49699eb55659538ce4623b5c5556d438dd71
+      hasResponse: true
+      primaryKeysAreUnique: true
+      primaryKeysArePresent: true
+      responsesAreSuccessful: true
+    folios_transactions_parent:
+      hasRecords: true
+      streamHash: 44b58d471f5aa56077808f1946d22b4277af0c84
       hasResponse: true
       primaryKeysAreUnique: true
       primaryKeysArePresent: true
@@ -7571,6 +7752,7 @@ metadata:
     users_pii_redacted: false
     accounting_accounts: false
     accounting_deposits: false
+    folios_transactions: false
     owners_pii_redacted: false
     reservations_scroll: false
     maintenance_problems: false
@@ -7588,6 +7770,7 @@ metadata:
     housekeeping_clean_types: false
     housekeeping_work_orders: false
     travel_insurance_products: false
+    folios_transactions_parent: false
     units_types_pricing_parent: false
     units_charge_pricing_parent: false
     units_type_daily_pricing_v2: false
@@ -22789,6 +22972,2321 @@ schemas:
           - array
           - "null"
     additionalProperties: true
+  folios_transactions:
+    type: object
+    $schema: http://json-schema.org/schema#
+    required:
+      - id
+    properties:
+      type:
+        type:
+          - string
+          - "null"
+      id:
+        type: number
+      memo:
+        type:
+          - string
+          - "null"
+      lines:
+        type:
+          - array
+          - "null"
+        items:
+          type:
+            - object
+            - "null"
+          properties:
+            type:
+              type:
+                - string
+                - "null"
+            description:
+              type:
+                - string
+                - "null"
+            id:
+              type:
+                - number
+                - "null"
+            amount:
+              type:
+                - string
+                - "null"
+            itemId:
+              type:
+                - number
+                - "null"
+            unitId:
+              type:
+                - number
+                - "null"
+            account:
+              type:
+                - string
+                - "null"
+            quantity:
+              type:
+                - string
+                - "null"
+            unitName:
+              type:
+                - string
+                - "null"
+            accountId:
+              type:
+                - number
+                - "null"
+            netAmount:
+              type:
+                - string
+                - "null"
+            taxAmount:
+              type:
+                - string
+                - "null"
+            unitAmount:
+              type:
+                - string
+                - "null"
+            taxOnMarkUp:
+              type:
+                - boolean
+                - "null"
+            remittanceBillId:
+              type:
+                - number
+                - "null"
+      payer:
+        type:
+          - string
+          - "null"
+      amount:
+        type:
+          - string
+          - "null"
+      unitId:
+        type:
+          - number
+          - "null"
+      txnDate:
+        type:
+          - string
+          - "null"
+      currency:
+        type:
+          - string
+          - "null"
+      folio_id:
+        type:
+          - number
+          - "null"
+      isVoided:
+        type:
+          - boolean
+          - "null"
+      subTotal:
+        type:
+          - string
+          - "null"
+      _embedded:
+        type:
+          - object
+          - "null"
+        properties:
+          unit:
+            type:
+              - object
+              - "null"
+            properties:
+              id:
+                type:
+                  - number
+                  - "null"
+              area:
+                type:
+                  - number
+                  - "null"
+              name:
+                type:
+                  - string
+                  - "null"
+              phone:
+                type:
+                  - string
+                  - "null"
+              roles:
+                type:
+                  - array
+                  - "null"
+              _links:
+                type:
+                  - object
+                  - "null"
+                properties:
+                  self:
+                    type:
+                      - object
+                      - "null"
+                    properties:
+                      href:
+                        type:
+                          - string
+                          - "null"
+              custom:
+                type:
+                  - object
+                  - "null"
+                properties:
+                  pms_units_source_unit_id:
+                    type:
+                      - string
+                      - "null"
+              floors:
+                type:
+                  - number
+                  - "null"
+              nodeId:
+                type:
+                  - number
+                  - "null"
+              postal:
+                type:
+                  - string
+                  - "null"
+              region:
+                type:
+                  - string
+                  - "null"
+              typeId:
+                type:
+                  - number
+                  - "null"
+              country:
+                type:
+                  - string
+                  - "null"
+              maxPets:
+                type:
+                  - number
+                  - "null"
+              bedTypes:
+                type:
+                  - array
+                  - "null"
+              bedrooms:
+                type:
+                  - number
+                  - "null"
+              isActive:
+                type:
+                  - boolean
+                  - "null"
+              latitude:
+                type:
+                  - string
+                  - "null"
+              locality:
+                type:
+                  - string
+                  - "null"
+              timezone:
+                type:
+                  - string
+                  - "null"
+              unitCode:
+                type:
+                  - string
+                  - "null"
+              _embedded:
+                type:
+                  - object
+                  - "null"
+                properties:
+                  type:
+                    type:
+                      - object
+                      - "null"
+                    properties:
+                      id:
+                        type:
+                          - number
+                          - "null"
+                      name:
+                        type:
+                          - string
+                          - "null"
+                      roles:
+                        type:
+                          - array
+                          - "null"
+                      _links:
+                        type:
+                          - object
+                          - "null"
+                        properties:
+                          self:
+                            type:
+                              - object
+                              - "null"
+                            properties:
+                              href:
+                                type:
+                                  - string
+                                  - "null"
+                      custom:
+                        type:
+                          - array
+                          - "null"
+                      updated:
+                        type:
+                          - object
+                          - "null"
+                        properties:
+                          content:
+                            type:
+                              - string
+                              - "null"
+                          pricing:
+                            type:
+                              - string
+                              - "null"
+                          availability:
+                            type:
+                              - string
+                              - "null"
+                      bedTypes:
+                        type:
+                          - array
+                          - "null"
+                      bedrooms:
+                        type:
+                          - number
+                          - "null"
+                      isActive:
+                        type:
+                          - boolean
+                          - "null"
+                      typeCode:
+                        type:
+                          - string
+                          - "null"
+                      _embedded:
+                        type:
+                          - object
+                          - "null"
+                        properties:
+                          lodgingType:
+                            type:
+                              - object
+                              - "null"
+                            properties:
+                              _links:
+                                type:
+                                  - object
+                                  - "null"
+                                properties:
+                                  self:
+                                    type:
+                                      - object
+                                      - "null"
+                                    properties:
+                                      href:
+                                        type:
+                                          - string
+                                          - "null"
+                      createdAt:
+                        type:
+                          - string
+                          - "null"
+                      createdBy:
+                        type:
+                          - string
+                          - "null"
+                      shortName:
+                        type:
+                          - string
+                          - "null"
+                      updatedAt:
+                        type:
+                          - string
+                          - "null"
+                      updatedBy:
+                        type:
+                          - string
+                          - "null"
+                      isBookable:
+                        type:
+                          - boolean
+                          - "null"
+                      gatewaysIds:
+                        type:
+                          - array
+                          - "null"
+                      petFriendly:
+                        type:
+                          - boolean
+                          - "null"
+                      useBedTypes:
+                        type:
+                          - boolean
+                          - "null"
+                      amenitiesIds:
+                        type:
+                          - array
+                          - "null"
+                        items:
+                          type:
+                            - number
+                            - "null"
+                      documentsIds:
+                        type:
+                          - array
+                          - "null"
+                      isAccessible:
+                        type:
+                          - boolean
+                          - "null"
+                      quickCheckin:
+                        type:
+                          - boolean
+                          - "null"
+                      allowOversell:
+                        type:
+                          - boolean
+                          - "null"
+                      eventsAllowed:
+                        type:
+                          - boolean
+                          - "null"
+                      lodgingTypeId:
+                        type:
+                          - number
+                          - "null"
+                      oversellLimit:
+                        type:
+                          - number
+                          - "null"
+                      quickCheckout:
+                        type:
+                          - boolean
+                          - "null"
+                      allowUnitRates:
+                        type:
+                          - boolean
+                          - "null"
+                      folioException:
+                        type:
+                          - boolean
+                          - "null"
+                      smokingAllowed:
+                        type:
+                          - boolean
+                          - "null"
+                      childrenAllowed:
+                        type:
+                          - boolean
+                          - "null"
+                      hasEarlyCheckin:
+                        type:
+                          - boolean
+                          - "null"
+                      hasLateCheckout:
+                        type:
+                          - boolean
+                          - "null"
+                      securityDeposit:
+                        type:
+                          - string
+                          - "null"
+                      guaranteePoliciesIds:
+                        type:
+                          - array
+                          - "null"
+                      insuranceProductsIds:
+                        type:
+                          - array
+                          - "null"
+                      useRoomConfiguration:
+                        type:
+                          - boolean
+                          - "null"
+                      cancellationPoliciesIds:
+                        type:
+                          - array
+                          - "null"
+                  node:
+                    type:
+                      - object
+                      - "null"
+                    properties:
+                      id:
+                        type:
+                          - number
+                          - "null"
+                      name:
+                        type:
+                          - string
+                          - "null"
+                      phone:
+                        type:
+                          - string
+                          - "null"
+                      roles:
+                        type:
+                          - array
+                          - "null"
+                      _links:
+                        type:
+                          - object
+                          - "null"
+                        properties:
+                          self:
+                            type:
+                              - object
+                              - "null"
+                            properties:
+                              href:
+                                type:
+                                  - string
+                                  - "null"
+                      custom:
+                        type:
+                          - object
+                          - "null"
+                        properties:
+                          pms_nodes_concierge_email:
+                            type:
+                              - string
+                              - "null"
+                          pms_nodes_concierge_phone:
+                            type:
+                              - string
+                              - "null"
+                          pms_nodes_concierge_information:
+                            type:
+                              - string
+                              - "null"
+                          pms_nodes_owner_relations_email:
+                            type:
+                              - string
+                              - "null"
+                      postal:
+                        type:
+                          - string
+                          - "null"
+                      region:
+                        type:
+                          - string
+                          - "null"
+                      typeId:
+                        type:
+                          - number
+                          - "null"
+                      country:
+                        type:
+                          - string
+                          - "null"
+                      maxPets:
+                        type:
+                          - number
+                          - "null"
+                      locality:
+                        type:
+                          - string
+                          - "null"
+                      parentId:
+                        type:
+                          - number
+                          - "null"
+                      timezone:
+                        type:
+                          - string
+                          - "null"
+                      _embedded:
+                        type:
+                          - object
+                          - "null"
+                        properties:
+                          type:
+                            type:
+                              - object
+                              - "null"
+                            properties:
+                              _links:
+                                type:
+                                  - object
+                                  - "null"
+                                properties:
+                                  self:
+                                    type:
+                                      - object
+                                      - "null"
+                                    properties:
+                                      href:
+                                        type:
+                                          - string
+                                          - "null"
+                          parent:
+                            type:
+                              - object
+                              - "null"
+                            properties:
+                              _links:
+                                type:
+                                  - object
+                                  - "null"
+                                properties:
+                                  self:
+                                    type:
+                                      - object
+                                      - "null"
+                                    properties:
+                                      href:
+                                        type:
+                                          - string
+                                          - "null"
+                          localOffice:
+                            type:
+                              - object
+                              - "null"
+                            properties:
+                              _links:
+                                type:
+                                  - object
+                                  - "null"
+                                properties:
+                                  self:
+                                    type:
+                                      - object
+                                      - "null"
+                                    properties:
+                                      href:
+                                        type:
+                                          - string
+                                          - "null"
+                          taxDistrict:
+                            type:
+                              - object
+                              - "null"
+                            properties:
+                              _links:
+                                type:
+                                  - object
+                                  - "null"
+                                properties:
+                                  self:
+                                    type:
+                                      - object
+                                      - "null"
+                                    properties:
+                                      href:
+                                        type:
+                                          - string
+                                          - "null"
+                      createdAt:
+                        type:
+                          - string
+                          - "null"
+                      createdBy:
+                        type:
+                          - string
+                          - "null"
+                      updatedAt:
+                        type:
+                          - string
+                          - "null"
+                      updatedBy:
+                        type:
+                          - string
+                          - "null"
+                      websiteUrl:
+                        type:
+                          - string
+                          - "null"
+                      checkinTime:
+                        type:
+                          - string
+                          - "null"
+                      gatewaysIds:
+                        type:
+                          - array
+                          - "null"
+                        items:
+                          type:
+                            - number
+                            - "null"
+                      petFriendly:
+                        type:
+                          - boolean
+                          - "null"
+                      amenitiesIds:
+                        type:
+                          - array
+                          - "null"
+                        items:
+                          type:
+                            - number
+                            - "null"
+                      checkoutTime:
+                        type:
+                          - string
+                          - "null"
+                      documentsIds:
+                        type:
+                          - array
+                          - "null"
+                        items:
+                          type:
+                            - number
+                            - "null"
+                      isAccessible:
+                        type:
+                          - boolean
+                          - "null"
+                      quickCheckin:
+                        type:
+                          - boolean
+                          - "null"
+                      eventsAllowed:
+                        type:
+                          - boolean
+                          - "null"
+                      localOfficeId:
+                        type:
+                          - number
+                          - "null"
+                      quickCheckout:
+                        type:
+                          - boolean
+                          - "null"
+                      streetAddress:
+                        type:
+                          - string
+                          - "null"
+                      taxDistrictId:
+                        type:
+                          - number
+                          - "null"
+                      smokingAllowed:
+                        type:
+                          - boolean
+                          - "null"
+                      childrenAllowed:
+                        type:
+                          - boolean
+                          - "null"
+                      hasEarlyCheckin:
+                        type:
+                          - boolean
+                          - "null"
+                      hasLateCheckout:
+                        type:
+                          - boolean
+                          - "null"
+                      minimumAgeLimit:
+                        type:
+                          - number
+                          - "null"
+                      earlyCheckinTime:
+                        type:
+                          - string
+                          - "null"
+                      lateCheckoutTime:
+                        type:
+                          - string
+                          - "null"
+                      guaranteePoliciesIds:
+                        type:
+                          - array
+                          - "null"
+                        items:
+                          type:
+                            - number
+                            - "null"
+                      insuranceProductsIds:
+                        type:
+                          - array
+                          - "null"
+                        items:
+                          type:
+                            - number
+                            - "null"
+                      cancellationPoliciesIds:
+                        type:
+                          - array
+                          - "null"
+                        items:
+                          type:
+                            - number
+                            - "null"
+                  cleanStatus:
+                    type:
+                      - object
+                      - "null"
+                    properties:
+                      type:
+                        type:
+                          - string
+                          - "null"
+                      id:
+                        type:
+                          - number
+                          - "null"
+                      code:
+                        type:
+                          - string
+                          - "null"
+                      name:
+                        type:
+                          - string
+                          - "null"
+                      _links:
+                        type:
+                          - array
+                          - "null"
+                      isActive:
+                        type:
+                          - boolean
+                          - "null"
+                  localOffice:
+                    type:
+                      - object
+                      - "null"
+                    properties:
+                      id:
+                        type:
+                          - number
+                          - "null"
+                      name:
+                        type:
+                          - string
+                          - "null"
+                      email:
+                        type:
+                          - string
+                          - "null"
+                      phone:
+                        type:
+                          - string
+                          - "null"
+                      _links:
+                        type:
+                          - object
+                          - "null"
+                        properties:
+                          self:
+                            type:
+                              - object
+                              - "null"
+                            properties:
+                              href:
+                                type:
+                                  - string
+                                  - "null"
+                      region:
+                        type:
+                          - string
+                          - "null"
+                      country:
+                        type:
+                          - string
+                          - "null"
+                      latitude:
+                        type:
+                          - string
+                          - "null"
+                      locality:
+                        type:
+                          - string
+                          - "null"
+                      createdAt:
+                        type:
+                          - string
+                          - "null"
+                      createdBy:
+                        type:
+                          - string
+                          - "null"
+                      longitude:
+                        type:
+                          - string
+                          - "null"
+                      updatedAt:
+                        type:
+                          - string
+                          - "null"
+                      updatedBy:
+                        type:
+                          - string
+                          - "null"
+                      directions:
+                        type:
+                          - string
+                          - "null"
+                      postalCode:
+                        type:
+                          - string
+                          - "null"
+                      streetAddress:
+                        type:
+                          - string
+                          - "null"
+                      extendedAddress:
+                        type:
+                          - string
+                          - "null"
+                  lodgingType:
+                    type:
+                      - object
+                      - "null"
+                    properties:
+                      id:
+                        type:
+                          - number
+                          - "null"
+                      code:
+                        type:
+                          - string
+                          - "null"
+                      name:
+                        type:
+                          - string
+                          - "null"
+                      _links:
+                        type:
+                          - object
+                          - "null"
+                        properties:
+                          self:
+                            type:
+                              - object
+                              - "null"
+                            properties:
+                              href:
+                                type:
+                                  - string
+                                  - "null"
+                      isActive:
+                        type:
+                          - boolean
+                          - "null"
+                      createdAt:
+                        type:
+                          - string
+                          - "null"
+                      createdBy:
+                        type:
+                          - string
+                          - "null"
+                      updatedAt:
+                        type:
+                          - string
+                          - "null"
+                      updatedBy:
+                        type:
+                          - string
+                          - "null"
+                      homeawayType:
+                        type:
+                          - string
+                          - "null"
+                      marriottType:
+                        type:
+                          - string
+                          - "null"
+                      airbnbRoomType:
+                        type:
+                          - string
+                          - "null"
+                      airbnbTypeGroup:
+                        type:
+                          - string
+                          - "null"
+                      airbnbTypeCategory:
+                        type:
+                          - string
+                          - "null"
+                  taxDistrict:
+                    type:
+                      - object
+                      - "null"
+                    properties:
+                      id:
+                        type:
+                          - number
+                          - "null"
+                      name:
+                        type:
+                          - string
+                          - "null"
+                      _links:
+                        type:
+                          - object
+                          - "null"
+                        properties:
+                          self:
+                            type:
+                              - object
+                              - "null"
+                            properties:
+                              href:
+                                type:
+                                  - string
+                                  - "null"
+                      isActive:
+                        type:
+                          - boolean
+                          - "null"
+                      _embedded:
+                        type:
+                          - object
+                          - "null"
+                        properties:
+                          shortTermPolicy:
+                            type:
+                              - object
+                              - "null"
+                            properties:
+                              _links:
+                                type:
+                                  - object
+                                  - "null"
+                                properties:
+                                  self:
+                                    type:
+                                      - object
+                                      - "null"
+                                    properties:
+                                      href:
+                                        type:
+                                          - string
+                                          - "null"
+                      createdAt:
+                        type:
+                          - string
+                          - "null"
+                      createdBy:
+                        type:
+                          - string
+                          - "null"
+                      taxMarkup:
+                        type:
+                          - boolean
+                          - "null"
+                      updatedAt:
+                        type:
+                          - string
+                          - "null"
+                      updatedBy:
+                        type:
+                          - string
+                          - "null"
+                      breakpoint:
+                        type:
+                          - number
+                          - "null"
+                      hasBreakpoint:
+                        type:
+                          - boolean
+                          - "null"
+                      shortTermPolicyId:
+                        type:
+                          - number
+                          - "null"
+              createdAt:
+                type:
+                  - string
+                  - "null"
+              createdBy:
+                type:
+                  - string
+                  - "null"
+              isLimited:
+                type:
+                  - boolean
+                  - "null"
+              longitude:
+                type:
+                  - string
+                  - "null"
+              shortName:
+                type:
+                  - string
+                  - "null"
+              updatedAt:
+                type:
+                  - string
+                  - "null"
+              updatedBy:
+                type:
+                  - string
+                  - "null"
+              composites:
+                type:
+                  - array
+                  - "null"
+                items:
+                  type:
+                    - object
+                    - "null"
+                  properties:
+                    type:
+                      type:
+                        - string
+                        - "null"
+                    unitId:
+                      type:
+                        - number
+                        - "null"
+              isBookable:
+                type:
+                  - boolean
+                  - "null"
+              websiteUrl:
+                type:
+                  - string
+                  - "null"
+              checkinTime:
+                type:
+                  - string
+                  - "null"
+              gatewaysIds:
+                type:
+                  - array
+                  - "null"
+                items:
+                  type:
+                    - number
+                    - "null"
+              petFriendly:
+                type:
+                  - boolean
+                  - "null"
+              useBedTypes:
+                type:
+                  - boolean
+                  - "null"
+              amenitiesIds:
+                type:
+                  - array
+                  - "null"
+                items:
+                  type:
+                    - number
+                    - "null"
+              checkoutTime:
+                type:
+                  - string
+                  - "null"
+              documentsIds:
+                type:
+                  - array
+                  - "null"
+                items:
+                  type:
+                    - number
+                    - "null"
+              isAccessible:
+                type:
+                  - boolean
+                  - "null"
+              maxOccupancy:
+                type:
+                  - number
+                  - "null"
+              quickCheckin:
+                type:
+                  - boolean
+                  - "null"
+              cleanStatusId:
+                type:
+                  - number
+                  - "null"
+              eventsAllowed:
+                type:
+                  - boolean
+                  - "null"
+              fullBathrooms:
+                type:
+                  - number
+                  - "null"
+              halfBathrooms:
+                type:
+                  - number
+                  - "null"
+              localOfficeId:
+                type:
+                  - number
+                  - "null"
+              lodgingTypeId:
+                type:
+                  - number
+                  - "null"
+              quickCheckout:
+                type:
+                  - boolean
+                  - "null"
+              streetAddress:
+                type:
+                  - string
+                  - "null"
+              taxDistrictId:
+                type:
+                  - number
+                  - "null"
+              folioException:
+                type:
+                  - boolean
+                  - "null"
+              smokingAllowed:
+                type:
+                  - boolean
+                  - "null"
+              childrenAllowed:
+                type:
+                  - boolean
+                  - "null"
+              hasEarlyCheckin:
+                type:
+                  - boolean
+                  - "null"
+              hasLateCheckout:
+                type:
+                  - boolean
+                  - "null"
+              minimumAgeLimit:
+                type:
+                  - number
+                  - "null"
+              securityDeposit:
+                type:
+                  - string
+                  - "null"
+              earlyCheckinTime:
+                type:
+                  - string
+                  - "null"
+              lateCheckoutTime:
+                type:
+                  - string
+                  - "null"
+              availabilityOrder:
+                type:
+                  - number
+                  - "null"
+              guaranteePoliciesIds:
+                type:
+                  - array
+                  - "null"
+                items:
+                  type:
+                    - number
+                    - "null"
+              insuranceProductsIds:
+                type:
+                  - array
+                  - "null"
+                items:
+                  type:
+                    - number
+                    - "null"
+              useRoomConfiguration:
+                type:
+                  - boolean
+                  - "null"
+              threeQuarterBathrooms:
+                type:
+                  - number
+                  - "null"
+              cancellationPoliciesIds:
+                type:
+                  - array
+                  - "null"
+                items:
+                  type:
+                    - number
+                    - "null"
+              travelInsuranceProductId:
+                type:
+                  - number
+                  - "null"
+          children:
+            type:
+              - array
+              - "null"
+            items:
+              type:
+                - object
+                - "null"
+              properties:
+                type:
+                  type:
+                    - string
+                    - "null"
+                id:
+                  type:
+                    - number
+                    - "null"
+                lines:
+                  type:
+                    - array
+                    - "null"
+                  items:
+                    type:
+                      - object
+                      - "null"
+                    properties:
+                      type:
+                        type:
+                          - string
+                          - "null"
+                      description:
+                        type:
+                          - string
+                          - "null"
+                      id:
+                        type:
+                          - number
+                          - "null"
+                      amount:
+                        type:
+                          - string
+                          - "null"
+                      itemId:
+                        type:
+                          - number
+                          - "null"
+                      unitId:
+                        type:
+                          - number
+                          - "null"
+                      account:
+                        type:
+                          - string
+                          - "null"
+                      quantity:
+                        type:
+                          - string
+                          - "null"
+                      unitName:
+                        type:
+                          - string
+                          - "null"
+                      accountId:
+                        type:
+                          - number
+                          - "null"
+                      netAmount:
+                        type:
+                          - string
+                          - "null"
+                      taxAmount:
+                        type:
+                          - string
+                          - "null"
+                      unitAmount:
+                        type:
+                          - string
+                          - "null"
+                      taxOnMarkUp:
+                        type:
+                          - boolean
+                          - "null"
+                      remittanceBillId:
+                        type:
+                          - number
+                          - "null"
+                _links:
+                  type:
+                    - object
+                    - "null"
+                  properties:
+                    self:
+                      type:
+                        - object
+                        - "null"
+                      properties:
+                        href:
+                          type:
+                            - string
+                            - "null"
+                amount:
+                  type:
+                    - string
+                    - "null"
+                unitId:
+                  type:
+                    - number
+                    - "null"
+                txnDate:
+                  type:
+                    - string
+                    - "null"
+                currency:
+                  type:
+                    - string
+                    - "null"
+                isVoided:
+                  type:
+                    - boolean
+                    - "null"
+                parentId:
+                  type:
+                    - number
+                    - "null"
+                subTotal:
+                  type:
+                    - string
+                    - "null"
+                _embedded:
+                  type:
+                    - object
+                    - "null"
+                  properties:
+                    unit:
+                      type:
+                        - object
+                        - "null"
+                      properties:
+                        _links:
+                          type:
+                            - object
+                            - "null"
+                          properties:
+                            self:
+                              type:
+                                - object
+                                - "null"
+                              properties:
+                                href:
+                                  type:
+                                    - string
+                                    - "null"
+                    parent:
+                      type:
+                        - object
+                        - "null"
+                      properties:
+                        _links:
+                          type:
+                            - object
+                            - "null"
+                          properties:
+                            self:
+                              type:
+                                - object
+                                - "null"
+                              properties:
+                                href:
+                                  type:
+                                    - string
+                                    - "null"
+                    reservation:
+                      type:
+                        - object
+                        - "null"
+                      properties:
+                        _links:
+                          type:
+                            - object
+                            - "null"
+                          properties:
+                            self:
+                              type:
+                                - object
+                                - "null"
+                              properties:
+                                href:
+                                  type:
+                                    - string
+                                    - "null"
+                companyId:
+                  type:
+                    - number
+                    - "null"
+                createdAt:
+                  type:
+                    - string
+                    - "null"
+                createdBy:
+                  type:
+                    - string
+                    - "null"
+                isPending:
+                  type:
+                    - boolean
+                    - "null"
+                taxAmount:
+                  type:
+                    - string
+                    - "null"
+                taxExempt:
+                  type:
+                    - boolean
+                    - "null"
+                updatedAt:
+                  type:
+                    - string
+                    - "null"
+                updatedBy:
+                  type:
+                    - string
+                    - "null"
+                isDeferred:
+                  type:
+                    - boolean
+                    - "null"
+                ownerTransaction:
+                  type:
+                    - object
+                    - "null"
+                  properties:
+                    type:
+                      type:
+                        - string
+                        - "null"
+                    id:
+                      type:
+                        - number
+                        - "null"
+                    folioId:
+                      type:
+                        - number
+                        - "null"
+                    ownerId:
+                      type:
+                        - number
+                        - "null"
+                    statementId:
+                      type:
+                        - number
+                        - "null"
+          paymentType:
+            type:
+              - object
+              - "null"
+            properties:
+              type:
+                type:
+                  - string
+                  - "null"
+              id:
+                type:
+                  - number
+                  - "null"
+              label:
+                type:
+                  - string
+                  - "null"
+              _links:
+                type:
+                  - object
+                  - "null"
+                properties:
+                  self:
+                    type:
+                      - object
+                      - "null"
+                    properties:
+                      href:
+                        type:
+                          - string
+                          - "null"
+              handle:
+                type:
+                  - string
+                  - "null"
+              isActive:
+                type:
+                  - boolean
+                  - "null"
+              _embedded:
+                type:
+                  - object
+                  - "null"
+                properties:
+                  account:
+                    type:
+                      - object
+                      - "null"
+                    properties:
+                      description:
+                        type:
+                          - string
+                          - "null"
+                      id:
+                        type:
+                          - number
+                          - "null"
+                      code:
+                        type:
+                          - string
+                          - "null"
+                      name:
+                        type:
+                          - string
+                          - "null"
+                      _links:
+                        type:
+                          - object
+                          - "null"
+                        properties:
+                          self:
+                            type:
+                              - object
+                              - "null"
+                            properties:
+                              href:
+                                type:
+                                  - string
+                                  - "null"
+                      category:
+                        type:
+                          - string
+                          - "null"
+                      isActive:
+                        type:
+                          - boolean
+                          - "null"
+                      createdAt:
+                        type:
+                          - string
+                          - "null"
+                      createdBy:
+                        type:
+                          - string
+                          - "null"
+                      updatedAt:
+                        type:
+                          - string
+                          - "null"
+                      updatedBy:
+                        type:
+                          - string
+                          - "null"
+                      achEnabled:
+                        type:
+                          - boolean
+                          - "null"
+                      accountType:
+                        type:
+                          - string
+                          - "null"
+                      enableRefunds:
+                        type:
+                          - boolean
+                          - "null"
+                      currentBalance:
+                        type:
+                          - string
+                          - "null"
+                      recursiveBalance:
+                        type:
+                          - string
+                          - "null"
+                      allowOwnerPayments:
+                        type:
+                          - boolean
+                          - "null"
+                      defaultRefundAccount:
+                        type:
+                          - boolean
+                          - "null"
+              accountId:
+                type:
+                  - number
+                  - "null"
+              createdAt:
+                type:
+                  - string
+                  - "null"
+              createdBy:
+                type:
+                  - string
+                  - "null"
+              updatedAt:
+                type:
+                  - string
+                  - "null"
+              updatedBy:
+                type:
+                  - string
+                  - "null"
+          reservation:
+            type:
+              - object
+              - "null"
+            properties:
+              id:
+                type:
+                  - number
+                  - "null"
+              _links:
+                type:
+                  - object
+                  - "null"
+                properties:
+                  self:
+                    type:
+                      - object
+                      - "null"
+                    properties:
+                      href:
+                        type:
+                          - string
+                          - "null"
+              nights:
+                type:
+                  - number
+                  - "null"
+              status:
+                type:
+                  - string
+                  - "null"
+              unitId:
+                type:
+                  - number
+                  - "null"
+              softEnd:
+                type:
+                  - string
+                  - "null"
+              bookedAt:
+                type:
+                  - string
+                  - "null"
+              isLocked:
+                type:
+                  - boolean
+                  - "null"
+              _embedded:
+                type:
+                  - object
+                  - "null"
+                properties:
+                  unit:
+                    type:
+                      - object
+                      - "null"
+                    properties:
+                      id:
+                        type:
+                          - number
+                          - "null"
+                      area:
+                        type:
+                          - number
+                          - "null"
+                      name:
+                        type:
+                          - string
+                          - "null"
+                      phone:
+                        type:
+                          - string
+                          - "null"
+                      roles:
+                        type:
+                          - array
+                          - "null"
+                      _links:
+                        type:
+                          - object
+                          - "null"
+                        properties:
+                          self:
+                            type:
+                              - object
+                              - "null"
+                            properties:
+                              href:
+                                type:
+                                  - string
+                                  - "null"
+                      custom:
+                        type:
+                          - object
+                          - "null"
+                        properties:
+                          pms_units_source_unit_id:
+                            type:
+                              - string
+                              - "null"
+                      floors:
+                        type:
+                          - number
+                          - "null"
+                      nodeId:
+                        type:
+                          - number
+                          - "null"
+                      postal:
+                        type:
+                          - string
+                          - "null"
+                      region:
+                        type:
+                          - string
+                          - "null"
+                      typeId:
+                        type:
+                          - number
+                          - "null"
+                      country:
+                        type:
+                          - string
+                          - "null"
+                      maxPets:
+                        type:
+                          - number
+                          - "null"
+                      bedTypes:
+                        type:
+                          - array
+                          - "null"
+                      bedrooms:
+                        type:
+                          - number
+                          - "null"
+                      isActive:
+                        type:
+                          - boolean
+                          - "null"
+                      latitude:
+                        type:
+                          - string
+                          - "null"
+                      locality:
+                        type:
+                          - string
+                          - "null"
+                      timezone:
+                        type:
+                          - string
+                          - "null"
+                      unitCode:
+                        type:
+                          - string
+                          - "null"
+                      _embedded:
+                        type:
+                          - object
+                          - "null"
+                        properties:
+                          type:
+                            type:
+                              - object
+                              - "null"
+                            properties:
+                              _links:
+                                type:
+                                  - object
+                                  - "null"
+                                properties:
+                                  self:
+                                    type:
+                                      - object
+                                      - "null"
+                                    properties:
+                                      href:
+                                        type:
+                                          - string
+                                          - "null"
+                          node:
+                            type:
+                              - object
+                              - "null"
+                            properties:
+                              _links:
+                                type:
+                                  - object
+                                  - "null"
+                                properties:
+                                  self:
+                                    type:
+                                      - object
+                                      - "null"
+                                    properties:
+                                      href:
+                                        type:
+                                          - string
+                                          - "null"
+                          cleanStatus:
+                            type:
+                              - object
+                              - "null"
+                            properties:
+                              _links:
+                                type:
+                                  - array
+                                  - "null"
+                          localOffice:
+                            type:
+                              - object
+                              - "null"
+                            properties:
+                              _links:
+                                type:
+                                  - object
+                                  - "null"
+                                properties:
+                                  self:
+                                    type:
+                                      - object
+                                      - "null"
+                                    properties:
+                                      href:
+                                        type:
+                                          - string
+                                          - "null"
+                          lodgingType:
+                            type:
+                              - object
+                              - "null"
+                            properties:
+                              _links:
+                                type:
+                                  - object
+                                  - "null"
+                                properties:
+                                  self:
+                                    type:
+                                      - object
+                                      - "null"
+                                    properties:
+                                      href:
+                                        type:
+                                          - string
+                                          - "null"
+                          taxDistrict:
+                            type:
+                              - object
+                              - "null"
+                            properties:
+                              _links:
+                                type:
+                                  - object
+                                  - "null"
+                                properties:
+                                  self:
+                                    type:
+                                      - object
+                                      - "null"
+                                    properties:
+                                      href:
+                                        type:
+                                          - string
+                                          - "null"
+                      createdAt:
+                        type:
+                          - string
+                          - "null"
+                      createdBy:
+                        type:
+                          - string
+                          - "null"
+                      isLimited:
+                        type:
+                          - boolean
+                          - "null"
+                      longitude:
+                        type:
+                          - string
+                          - "null"
+                      shortName:
+                        type:
+                          - string
+                          - "null"
+                      updatedAt:
+                        type:
+                          - string
+                          - "null"
+                      updatedBy:
+                        type:
+                          - string
+                          - "null"
+                      composites:
+                        type:
+                          - array
+                          - "null"
+                        items:
+                          type:
+                            - object
+                            - "null"
+                          properties:
+                            type:
+                              type:
+                                - string
+                                - "null"
+                            unitId:
+                              type:
+                                - number
+                                - "null"
+                      isBookable:
+                        type:
+                          - boolean
+                          - "null"
+                      websiteUrl:
+                        type:
+                          - string
+                          - "null"
+                      checkinTime:
+                        type:
+                          - string
+                          - "null"
+                      gatewaysIds:
+                        type:
+                          - array
+                          - "null"
+                        items:
+                          type:
+                            - number
+                            - "null"
+                      petFriendly:
+                        type:
+                          - boolean
+                          - "null"
+                      useBedTypes:
+                        type:
+                          - boolean
+                          - "null"
+                      amenitiesIds:
+                        type:
+                          - array
+                          - "null"
+                        items:
+                          type:
+                            - number
+                            - "null"
+                      checkoutTime:
+                        type:
+                          - string
+                          - "null"
+                      documentsIds:
+                        type:
+                          - array
+                          - "null"
+                        items:
+                          type:
+                            - number
+                            - "null"
+                      isAccessible:
+                        type:
+                          - boolean
+                          - "null"
+                      maxOccupancy:
+                        type:
+                          - number
+                          - "null"
+                      quickCheckin:
+                        type:
+                          - boolean
+                          - "null"
+                      cleanStatusId:
+                        type:
+                          - number
+                          - "null"
+                      eventsAllowed:
+                        type:
+                          - boolean
+                          - "null"
+                      fullBathrooms:
+                        type:
+                          - number
+                          - "null"
+                      halfBathrooms:
+                        type:
+                          - number
+                          - "null"
+                      localOfficeId:
+                        type:
+                          - number
+                          - "null"
+                      lodgingTypeId:
+                        type:
+                          - number
+                          - "null"
+                      quickCheckout:
+                        type:
+                          - boolean
+                          - "null"
+                      streetAddress:
+                        type:
+                          - string
+                          - "null"
+                      taxDistrictId:
+                        type:
+                          - number
+                          - "null"
+                      folioException:
+                        type:
+                          - boolean
+                          - "null"
+                      smokingAllowed:
+                        type:
+                          - boolean
+                          - "null"
+                      childrenAllowed:
+                        type:
+                          - boolean
+                          - "null"
+                      hasEarlyCheckin:
+                        type:
+                          - boolean
+                          - "null"
+                      hasLateCheckout:
+                        type:
+                          - boolean
+                          - "null"
+                      minimumAgeLimit:
+                        type:
+                          - number
+                          - "null"
+                      securityDeposit:
+                        type:
+                          - string
+                          - "null"
+                      earlyCheckinTime:
+                        type:
+                          - string
+                          - "null"
+                      lateCheckoutTime:
+                        type:
+                          - string
+                          - "null"
+                      availabilityOrder:
+                        type:
+                          - number
+                          - "null"
+                      guaranteePoliciesIds:
+                        type:
+                          - array
+                          - "null"
+                        items:
+                          type:
+                            - number
+                            - "null"
+                      insuranceProductsIds:
+                        type:
+                          - array
+                          - "null"
+                        items:
+                          type:
+                            - number
+                            - "null"
+                      useRoomConfiguration:
+                        type:
+                          - boolean
+                          - "null"
+                      threeQuarterBathrooms:
+                        type:
+                          - number
+                          - "null"
+                      cancellationPoliciesIds:
+                        type:
+                          - array
+                          - "null"
+                        items:
+                          type:
+                            - number
+                            - "null"
+                      travelInsuranceProductId:
+                        type:
+                          - number
+                          - "null"
+              createdAt:
+                type:
+                  - string
+                  - "null"
+              occupants:
+                type:
+                  - object
+                  - "null"
+                properties:
+                  "1":
+                    type:
+                      - number
+                      - "null"
+                  "2":
+                    type:
+                      - number
+                      - "null"
+              softStart:
+                type:
+                  - string
+                  - "null"
+              updatedAt:
+                type:
+                  - string
+                  - "null"
+              arrivalDate:
+                type:
+                  - string
+                  - "null"
+              arrivalTime:
+                type:
+                  - string
+                  - "null"
+              earlyArrival:
+                type:
+                  - boolean
+                  - "null"
+              isUnitLocked:
+                type:
+                  - boolean
+                  - "null"
+              departureDate:
+                type:
+                  - string
+                  - "null"
+              departureTime:
+                type:
+                  - string
+                  - "null"
+              lateDeparture:
+                type:
+                  - boolean
+                  - "null"
+              isUnitAssigned:
+                type:
+                  - boolean
+                  - "null"
+              isUnitTypeLocked:
+                type:
+                  - boolean
+                  - "null"
+              requiredSecurityDeposit:
+                type:
+                  - string
+                  - "null"
+              remainingSecurityDeposit:
+                type:
+                  - number
+                  - "null"
+      contactId:
+        type:
+          - number
+          - "null"
+      createdAt:
+        type:
+          - string
+          - "null"
+      createdBy:
+        type:
+          - string
+          - "null"
+      depositId:
+        type:
+          - number
+          - "null"
+      isPending:
+        type:
+          - boolean
+          - "null"
+      taxAmount:
+        type:
+          - string
+          - "null"
+      taxExempt:
+        type:
+          - boolean
+          - "null"
+      updatedAt:
+        type:
+          - string
+          - "null"
+      updatedBy:
+        type:
+          - string
+          - "null"
+      isAuthOnly:
+        type:
+          - boolean
+          - "null"
+      isDeferred:
+        type:
+          - boolean
+          - "null"
+      vaultToken:
+        type:
+          - string
+          - "null"
+      paymentTypeId:
+        type:
+          - number
+          - "null"
+      folioTransaction:
+        type:
+          - object
+          - "null"
+        properties:
+          type:
+            type:
+              - string
+              - "null"
+          id:
+            type:
+              - number
+              - "null"
+          nights:
+            type:
+              - number
+              - "null"
+          folioId:
+            type:
+              - number
+              - "null"
+          chargeId:
+            type:
+              - number
+              - "null"
+          isManual:
+            type:
+              - boolean
+              - "null"
+          roomNight:
+            type:
+              - string
+              - "null"
+          reservationFeeId:
+            type:
+              - number
+              - "null"
+          isSecurityDeposit:
+            type:
+              - boolean
+              - "null"
+          securityDepositResolved:
+            type:
+              - boolean
+              - "null"
+      ownerTransaction:
+        type:
+          - object
+          - "null"
+        properties:
+          type:
+            type:
+              - string
+              - "null"
+          id:
+            type:
+              - number
+              - "null"
+          folioId:
+            type:
+              - number
+              - "null"
+          ownerId:
+            type:
+              - number
+              - "null"
+          statementId:
+            type:
+              - number
+              - "null"
+    additionalProperties: true
   owners_pii_redacted:
     type: object
     $schema: http://json-schema.org/schema#
@@ -28240,6 +30738,119 @@ schemas:
       allowExternalNotification:
         type:
           - boolean
+          - "null"
+    additionalProperties: true
+  folios_transactions_parent:
+    type: object
+    $schema: http://json-schema.org/schema#
+    required:
+      - id
+    properties:
+      type:
+        type:
+          - string
+          - "null"
+      id:
+        type: number
+      name:
+        type:
+          - string
+          - "null"
+      status:
+        type:
+          - string
+          - "null"
+      endDate:
+        type:
+          - string
+          - "null"
+      posAllow:
+        type:
+          - boolean
+          - "null"
+      posLimit:
+        type:
+          - string
+          - "null"
+      accountId:
+        type:
+          - number
+          - "null"
+      contactId:
+        type:
+          - number
+          - "null"
+      createdAt:
+        type:
+          - string
+          - "null"
+      createdBy:
+        type:
+          - string
+          - "null"
+      startDate:
+        type:
+          - string
+          - "null"
+      taxExempt:
+        type:
+          - boolean
+          - "null"
+      updatedAt:
+        type:
+          - string
+          - "null"
+      updatedBy:
+        type:
+          - string
+          - "null"
+      closedDate:
+        type:
+          - string
+          - "null"
+      checkInDate:
+        type:
+          - string
+          - "null"
+      checkOutDate:
+        type:
+          - string
+          - "null"
+      hasException:
+        type:
+          - boolean
+          - "null"
+      ownerRevenue:
+        type:
+          - string
+          - "null"
+      generatedName:
+        type:
+          - string
+          - "null"
+      reservationId:
+        type:
+          - number
+          - "null"
+      travelAgentId:
+        type:
+          - number
+          - "null"
+      currentBalance:
+        type:
+          - string
+          - "null"
+      agentCommission:
+        type:
+          - string
+          - "null"
+      ownerCommission:
+        type:
+          - string
+          - "null"
+      realizedBalance:
+        type:
+          - string
           - "null"
     additionalProperties: true
   units_types_pricing_parent:

--- a/airbyte-integrations/connectors/source-track-pms/manifest.yaml
+++ b/airbyte-integrations/connectors/source-track-pms/manifest.yaml
@@ -6268,13 +6268,6 @@ definitions:
             field_path:
               - _embedded
               - folios
-          record_filter:
-            type: RecordFilter
-            condition: >-
-              {{  (record._embedded.reservation.quoteBreakdown.grandTotal |
-              float > 0) or
-              (record._embedded.reservation.quoteBreakdown.payments | float > 0)
-              }}
           schema_normalization: Default
       primary_key:
         - id
@@ -7500,7 +7493,7 @@ metadata:
       responsesAreSuccessful: true
     folios_transactions:
       hasRecords: true
-      streamHash: 6f440996d63e36609213138d0599a7ad8279bf95
+      streamHash: d20e2cc3cfccd7ddb981f9197cf8d6df56e518f3
       hasResponse: true
       primaryKeysAreUnique: true
       primaryKeysArePresent: true
@@ -7626,7 +7619,7 @@ metadata:
       responsesAreSuccessful: true
     folios_transactions_parent:
       hasRecords: true
-      streamHash: 91a6a21b22cdfc3bfd8deaec37caa229ce79449c
+      streamHash: 55a7d9503d084e230cad9fdef6a314ee07312a93
       hasResponse: true
       primaryKeysAreUnique: true
       primaryKeysArePresent: true

--- a/airbyte-integrations/connectors/source-track-pms/manifest.yaml
+++ b/airbyte-integrations/connectors/source-track-pms/manifest.yaml
@@ -5834,9 +5834,6 @@ definitions:
         - type: RemoveFields
           field_pointers:
             - - _links
-        - type: RemoveFields
-          field_pointers:
-            - - _embedded
     maintenance_work_orders:
       type: DeclarativeStream
       name: maintenance_work_orders
@@ -7594,7 +7591,7 @@ metadata:
       responsesAreSuccessful: true
     accounting_transactions:
       hasRecords: true
-      streamHash: 4966753d7bd488d2ff542428f09b47d4affe9220
+      streamHash: b3542497fbbfc850b96e7ced0fd6586589b4eec9
       hasResponse: true
       primaryKeysAreUnique: true
       primaryKeysArePresent: true

--- a/airbyte-integrations/connectors/source-track-pms/manifest.yaml
+++ b/airbyte-integrations/connectors/source-track-pms/manifest.yaml
@@ -2360,7 +2360,7 @@ definitions:
           type: DefaultPaginator
           pagination_strategy:
             type: CursorPagination
-            cursor_value: "{{ response.total_items }}"
+            cursor_value: "{{ response.scroll }}"
             stop_condition: "{{ not response._embedded.reservations }}"
         requester:
           $ref: "#/definitions/base_requester"
@@ -2395,6 +2395,12 @@ definitions:
                     backoff_time_in_seconds: 305
           request_headers:
             accept: application/json
+          request_parameters:
+            size: "100"
+            scroll: >-
+              {{ next_page_token['next_page_token'] if next_page_token else '1'
+              }}
+            sortColumn: id
         record_selector:
           type: RecordSelector
           extractor:
@@ -2402,18 +2408,6 @@ definitions:
             field_path:
               - _embedded
               - reservations
-        partition_router:
-          type: SubstreamPartitionRouter
-          parent_stream_configs:
-            - type: ParentStreamConfig
-              stream:
-                $ref: "#/definitions/streams/reservations_scroll"
-              parent_key: scroll_id
-              request_option:
-                type: RequestOption
-                field_name: scroll
-                inject_into: request_parameter
-              partition_field: scroll_id
       primary_key:
         - id
       schema_loader:
@@ -2472,6 +2466,20 @@ definitions:
           field_pointers:
             - - _embedded
               - channel
+      incremental_sync:
+        type: DatetimeBasedCursor
+        cursor_field: updatedAt
+        start_datetime:
+          type: MinMaxDatetime
+          datetime: "1900-01-01T00:00:00+00:00"
+          datetime_format: "%Y-%m-%dT%H:%M:%S%z"
+        datetime_format: "%Y-%m-%dT%H:%M:%S%z"
+        start_time_option:
+          type: RequestOption
+          field_name: updatedSince
+          inject_into: request_parameter
+        cursor_datetime_formats:
+          - "%Y-%m-%dT%H:%M:%S%z"
     tax_policies:
       type: DeclarativeStream
       name: tax_policies
@@ -3056,7 +3064,7 @@ definitions:
           type: DefaultPaginator
           pagination_strategy:
             type: CursorPagination
-            cursor_value: "{{ response.total_items }}"
+            cursor_value: "{{ response.scroll }}"
             stop_condition: "{{ not response._embedded.reservations }}"
         requester:
           $ref: "#/definitions/base_requester"
@@ -3091,6 +3099,12 @@ definitions:
                     backoff_time_in_seconds: 305
           request_headers:
             accept: application/json
+          request_parameters:
+            size: "100"
+            scroll: >-
+              {{ next_page_token['next_page_token'] if next_page_token else '1'
+              }}
+            sortColumn: id
         record_selector:
           type: RecordSelector
           extractor:
@@ -3098,18 +3112,6 @@ definitions:
             field_path:
               - _embedded
               - reservations
-        partition_router:
-          type: SubstreamPartitionRouter
-          parent_stream_configs:
-            - type: ParentStreamConfig
-              stream:
-                $ref: "#/definitions/streams/reservations_v2_scroll"
-              parent_key: scroll_id
-              request_option:
-                type: RequestOption
-                field_name: scroll
-                inject_into: request_parameter
-              partition_field: scroll_id
       primary_key:
         - id
       schema_loader:
@@ -4692,124 +4694,6 @@ definitions:
           inject_into: request_parameter
         cursor_datetime_formats:
           - "%Y-%m-%dT%H:%M:%S%z"
-    reservations_scroll:
-      type: DeclarativeStream
-      name: reservations_scroll
-      retriever:
-        type: SimpleRetriever
-        decoder:
-          type: JsonDecoder
-        requester:
-          $ref: "#/definitions/base_requester"
-          path: pms/reservations
-          http_method: GET
-          error_handler:
-            type: CompositeErrorHandler
-            error_handlers:
-              - type: DefaultErrorHandler
-                response_filters:
-                  - type: HttpResponseFilter
-                    action: IGNORE
-                    predicate: >-
-                      {{ response.status == 409 and response.detail == 'Invalid
-                      page provided' }}
-                    http_codes: []
-                    error_message: >-
-                      Track's inappropriate 409 for page numbers too high.
-                      Nothing to do but continue to work with the vendor.
-              - type: DefaultErrorHandler
-                max_retries: 3
-                response_filters:
-                  - type: HttpResponseFilter
-                    action: RATE_LIMITED
-                    predicate: "{{ response.status == 429 }}"
-                    http_codes: []
-                    error_message: >-
-                      Track rate limit (10,000 requests per 5 minutes) met,
-                      waiting 5 minutes and 5 seconds to reset.
-                backoff_strategies:
-                  - type: ConstantBackoffStrategy
-                    backoff_time_in_seconds: 305
-          request_headers:
-            accept: application/json
-          request_parameters:
-            size: "100"
-            scroll: "1"
-        record_selector:
-          type: RecordSelector
-          extractor:
-            type: DpathExtractor
-            field_path:
-              - _links
-              - self
-      primary_key:
-        - href
-      schema_loader:
-        type: InlineSchemaLoader
-        schema:
-          $ref: "#/schemas/reservations_scroll"
-      transformations:
-        - type: RemoveFields
-          field_pointers:
-            - - _embedded
-              - unit
-        - type: RemoveFields
-          field_pointers:
-            - - _links
-        - type: RemoveFields
-          field_pointers:
-            - - _embedded
-              - links
-        - type: RemoveFields
-          field_pointers:
-            - - _embedded
-              - guaranteePolicy
-        - type: RemoveFields
-          field_pointers:
-            - - _embedded
-              - contact
-        - type: RemoveFields
-          field_pointers:
-            - - _embedded
-              - cancellationPolicy
-        - type: RemoveFields
-          field_pointers:
-            - - _embedded
-              - cancellationReason
-        - type: RemoveFields
-          field_pointers:
-            - - _embedded
-              - user
-        - type: RemoveFields
-          field_pointers:
-            - - _embedded
-              - type
-        - type: RemoveFields
-          field_pointers:
-            - - _embedded
-              - rateType
-        - type: RemoveFields
-          field_pointers:
-            - - _embedded
-              - cancelledBy
-        - type: RemoveFields
-          field_pointers:
-            - - _embedded
-              - paymentMethod
-        - type: RemoveFields
-          field_pointers:
-            - - guestBreakdown
-              - rates
-        - type: RemoveFields
-          field_pointers:
-            - - _embedded
-              - channel
-        - type: AddFields
-          fields:
-            - type: AddedFieldDefinition
-              path:
-                - scroll_id
-              value: "{{ record['href'] | regex_search('scroll=([^&]+)')  }}"
     maintenance_problems:
       type: DeclarativeStream
       name: maintenance_problems
@@ -5565,124 +5449,6 @@ definitions:
               - tasks
               - "*"
               - _links
-    reservations_v2_scroll:
-      type: DeclarativeStream
-      name: reservations_v2_scroll
-      retriever:
-        type: SimpleRetriever
-        decoder:
-          type: JsonDecoder
-        requester:
-          $ref: "#/definitions/base_requester"
-          path: v2/pms/reservations
-          http_method: GET
-          error_handler:
-            type: CompositeErrorHandler
-            error_handlers:
-              - type: DefaultErrorHandler
-                response_filters:
-                  - type: HttpResponseFilter
-                    action: IGNORE
-                    predicate: >-
-                      {{ response.status == 409 and response.detail == 'Invalid
-                      page provided' }}
-                    http_codes: []
-                    error_message: >-
-                      Track's inappropriate 409 for page numbers too high.
-                      Nothing to do but continue to work with the vendor.
-              - type: DefaultErrorHandler
-                max_retries: 3
-                response_filters:
-                  - type: HttpResponseFilter
-                    action: RATE_LIMITED
-                    predicate: "{{ response.status == 429 }}"
-                    http_codes: []
-                    error_message: >-
-                      Track rate limit (10,000 requests per 5 minutes) met,
-                      waiting 5 minutes and 5 seconds to reset.
-                backoff_strategies:
-                  - type: ConstantBackoffStrategy
-                    backoff_time_in_seconds: 305
-          request_headers:
-            accept: application/json
-          request_parameters:
-            size: "100"
-            scroll: "1"
-        record_selector:
-          type: RecordSelector
-          extractor:
-            type: DpathExtractor
-            field_path:
-              - _links
-              - self
-      primary_key:
-        - href
-      schema_loader:
-        type: InlineSchemaLoader
-        schema:
-          $ref: "#/schemas/reservations_v2_scroll"
-      transformations:
-        - type: RemoveFields
-          field_pointers:
-            - - _embedded
-              - unit
-        - type: RemoveFields
-          field_pointers:
-            - - _links
-        - type: RemoveFields
-          field_pointers:
-            - - _embedded
-              - links
-        - type: RemoveFields
-          field_pointers:
-            - - _embedded
-              - guaranteePolicy
-        - type: RemoveFields
-          field_pointers:
-            - - _embedded
-              - contact
-        - type: RemoveFields
-          field_pointers:
-            - - _embedded
-              - cancellationPolicy
-        - type: RemoveFields
-          field_pointers:
-            - - _embedded
-              - cancellationReason
-        - type: RemoveFields
-          field_pointers:
-            - - _embedded
-              - user
-        - type: RemoveFields
-          field_pointers:
-            - - _embedded
-              - type
-        - type: RemoveFields
-          field_pointers:
-            - - _embedded
-              - rateType
-        - type: RemoveFields
-          field_pointers:
-            - - _embedded
-              - cancelledBy
-        - type: RemoveFields
-          field_pointers:
-            - - _embedded
-              - paymentMethod
-        - type: RemoveFields
-          field_pointers:
-            - - guestBreakdown
-              - rates
-        - type: RemoveFields
-          field_pointers:
-            - - _embedded
-              - channel
-        - type: AddFields
-          fields:
-            - type: AddedFieldDefinition
-              path:
-                - scroll_id
-              value: "{{ record['href'] | regex_search('scroll=([^&]+)')  }}"
     units_daily_pricing_v2:
       type: DeclarativeStream
       name: units_daily_pricing_v2
@@ -7067,10 +6833,8 @@ streams:
   - $ref: "#/definitions/streams/reservations_cancellation_reasons"
   - $ref: "#/definitions/streams/reservations_discount_reasons"
   - $ref: "#/definitions/streams/reservations_guarantee_policies"
-  - $ref: "#/definitions/streams/reservations_scroll"
   - $ref: "#/definitions/streams/reservations_types"
   - $ref: "#/definitions/streams/reservations_v2"
-  - $ref: "#/definitions/streams/reservations_v2_scroll"
   - $ref: "#/definitions/streams/reviews"
   - $ref: "#/definitions/streams/roles"
   - $ref: "#/definitions/streams/suspend_code_reasons"
@@ -7329,7 +7093,7 @@ metadata:
       responsesAreSuccessful: true
     reservations:
       hasRecords: true
-      streamHash: eea32eb9b78de8c92ebb928e7d7c4d48c61023f2
+      streamHash: bf8428719cc9a2c9b8b1ebd8aa5dd42205fa1ff5
       hasResponse: true
       primaryKeysAreUnique: true
       primaryKeysArePresent: true
@@ -7385,7 +7149,7 @@ metadata:
       responsesAreSuccessful: true
     reservations_v2:
       hasRecords: true
-      streamHash: a024843e6de1dad41bd4367445ab79765a735d6b
+      streamHash: 7822ec41443ce43888d42cd4d582c36211cdc32b
       hasResponse: true
       primaryKeysAreUnique: true
       primaryKeysArePresent: true
@@ -7509,13 +7273,6 @@ metadata:
       primaryKeysAreUnique: true
       primaryKeysArePresent: true
       responsesAreSuccessful: true
-    reservations_scroll:
-      hasRecords: true
-      streamHash: 2ac9f8d18984675042bda300e65b47712b0f17a2
-      hasResponse: true
-      primaryKeysAreUnique: true
-      primaryKeysArePresent: true
-      responsesAreSuccessful: true
     maintenance_problems:
       hasRecords: true
       streamHash: 39414501a14cd019a8a48cafdc1c8f6e3ab98cfb
@@ -7568,13 +7325,6 @@ metadata:
     housekeeping_task_list:
       hasRecords: true
       streamHash: a896ef3904bb357b70319a2214a83b10c02382ec
-      hasResponse: true
-      primaryKeysAreUnique: true
-      primaryKeysArePresent: true
-      responsesAreSuccessful: true
-    reservations_v2_scroll:
-      hasRecords: true
-      streamHash: a7e18408c924b6cfaa536a6dd23e7267990447b7
       hasResponse: true
       primaryKeysAreUnique: true
       primaryKeysArePresent: true
@@ -7747,7 +7497,6 @@ metadata:
     accounting_deposits: false
     folios_transactions: false
     owners_pii_redacted: false
-    reservations_scroll: false
     maintenance_problems: false
     suspend_code_reasons: false
     units_amenity_groups: false
@@ -7756,7 +7505,6 @@ metadata:
     fractionals_inventory: false
     crm_company_attachment: false
     housekeeping_task_list: false
-    reservations_v2_scroll: false
     units_daily_pricing_v2: false
     accounting_transactions: false
     maintenance_work_orders: false
@@ -25489,19 +25237,6 @@ schemas:
           - boolean
           - "null"
     additionalProperties: true
-  reservations_scroll:
-    type: object
-    $schema: http://json-schema.org/schema#
-    required:
-      - href
-    properties:
-      href:
-        type: string
-      scroll_id:
-        type:
-          - string
-          - "null"
-    additionalProperties: true
   maintenance_problems:
     type: object
     $schema: http://json-schema.org/schema#
@@ -28794,19 +28529,6 @@ schemas:
           - string
           - "null"
       updatedBy:
-        type:
-          - string
-          - "null"
-    additionalProperties: true
-  reservations_v2_scroll:
-    type: object
-    $schema: http://json-schema.org/schema#
-    required:
-      - href
-    properties:
-      href:
-        type: string
-      scroll_id:
         type:
           - string
           - "null"

--- a/airbyte-integrations/connectors/source-track-pms/metadata.yaml
+++ b/airbyte-integrations/connectors/source-track-pms/metadata.yaml
@@ -13,11 +13,11 @@ data:
       enabled: false
       packageName: airbyte-source-track-pms
   connectorBuildOptions:
-    baseImage: docker.io/airbyte/source-declarative-manifest:6.56.7@sha256:41be3ac5f569004b6a25507cd40f5152e3691aecd2a9a3f873eb4c559903412d
+    baseImage: docker.io/airbyte/source-declarative-manifest:6.60.12@sha256:b236b4ff8351a7d7f0ff7f938bbf0ab7b455c4c9e6e7cc93933f4aa9201d66cb
   connectorSubtype: api
   connectorType: source
   definitionId: aa0373c1-a7a6-48ff-8277-e5fe6cecff75
-  dockerImageTag: 4.1.0
+  dockerImageTag: 4.2.0
   dockerRepository: airbyte/source-track-pms
   githubIssueLabel: source-track-pms
   icon: icon.svg

--- a/docs/integrations/sources/track-pms.md
+++ b/docs/integrations/sources/track-pms.md
@@ -102,6 +102,7 @@ Authentication Docs: https://developer.trackhs.com/docs/authentication#authentic
 
 | Version          | Date       | Subject        |
 |------------------|------------|----------------|
+| 4.2.0 | 2025-06-30 | Improved reservations & reservations_v2 scroll index handling |
 | 4.1.0 | 2025-06-30 | Fix error handler, add scroll parameter for reservations endpoints, add booking fees endpoint, schema updates |
 | 4.0.0 | 2025-03-30 | Prune units schema; fix docs; update error handler; diable connector auto schema determination |
 | 3.0.0 | 2025-02-26 | Drop redundant streams & omit unneeded sensitive fields from accounting_* streams |

--- a/docs/integrations/sources/track-pms.md
+++ b/docs/integrations/sources/track-pms.md
@@ -39,6 +39,7 @@ Authentication Docs: https://developer.trackhs.com/docs/authentication#authentic
 | folios | id | DefaultPaginator | ✅ |  ❌  | [Link](https://developer.trackhs.com/reference/getfolioscollection) |
 | folios_logs | folio_id.id | DefaultPaginator | ✅ |  ❌  | Undocumented |
 | folios_rules | id | DefaultPaginator | ✅ |  ❌  | [Link](https://developer.trackhs.com/reference/getfoliorulescollection) |
+| folios_transactions | id | DefaultPaginator | ✅ |  ❌  | [Link](https://developer.trackhs.com/reference/getfolioidtransactionscollection) |
 | fractionals | id | DefaultPaginator | ✅ |  ❌  | [Link](https://developer.trackhs.com/reference/get-pms-fractionals) |
 | fractionals_inventory | fraction_id.id | DefaultPaginator | ✅ |  ❌  | [Link](https://developer.trackhs.com/reference/get-pms-fractionals-fractionalid-invetories) |
 | fractionals_owners | fraction_id.id | DefaultPaginator | ✅ |  ❌  | [Link](https://developer.trackhs.com/reference/get-pms-fractionals-owners) |
@@ -63,13 +64,13 @@ Authentication Docs: https://developer.trackhs.com/docs/authentication#authentic
 | promo_codes | id | DefaultPaginator | ✅ |  ❌  | [Link](https://developer.trackhs.com/reference/getpromocodesv2) |
 | quotes | id | DefaultPaginator | ✅ |  ❌  | [Link](https://developer.trackhs.com/reference/getquotescollectionv2) |
 | rate_types | id | DefaultPaginator | ✅ |  ❌  | Undocumented |
-| reservations | id | DefaultPaginator | ✅ |  ✅  | [Link](https://developer.trackhs.com/reference/getreservations) |
+| reservations | id | Elastic Search PIT | ✅ |  ✅  | [Link](https://developer.trackhs.com/reference/getreservations) |
 | reservations_cancellation_policies | id | DefaultPaginator | ✅ |  ❌  | [Link](https://developer.trackhs.com/reference/getcancellationpolicies) |
 | reservations_cancellation_reasons | id | DefaultPaginator | ✅ |  ❌  | [Link](https://developer.trackhs.com/reference/getcancellationreasons) |
 | reservations_discount_reasons | id | DefaultPaginator | ✅ |  ❌  | [Link](https://developer.trackhs.com/reference/getdiscountreasons) |
 | reservations_guarantee_policies | id | DefaultPaginator | ✅ |  ❌  | [Link](https://developer.trackhs.com/reference/get-pms-reservations-policies-guaranties) |
 | reservations_types | id | DefaultPaginator | ✅ |  ❌  | [Link](https://developer.trackhs.com/reference/getreservationtypes) |
-| reservations_v2 | id | DefaultPaginator | ✅ |  ✅  | [Link](https://developer.trackhs.com/reference/getreservations-1) |
+| reservations_v2 | id | Elastic Search PIT | ✅ |  ✅  | [Link](https://developer.trackhs.com/reference/getreservations-1) |
 | reviews | id | DefaultPaginator | ✅ |  ❌  | [Link](https://developer.trackhs.com/reference/getreviewscollection) |
 | roles | id | DefaultPaginator | ✅ |  ❌  | Undocumented |
 | suspend_code_reasons | id | DefaultPaginator | ✅ |  ❌  | [Link](https://developer.trackhs.com/reference/getsuspendcodereasons) |
@@ -102,7 +103,7 @@ Authentication Docs: https://developer.trackhs.com/docs/authentication#authentic
 
 | Version          | Date       | Subject        |
 |------------------|------------|----------------|
-| 4.2.0 | 2025-06-30 | Improved reservations & reservations_v2 scroll index handling |
+| 4.2.0 | 2025-07-20 | Improved reservations & reservations_v2 scroll index handling; add folios_transactions stream |
 | 4.1.0 | 2025-06-30 | Fix error handler, add scroll parameter for reservations endpoints, add booking fees endpoint, schema updates |
 | 4.0.0 | 2025-03-30 | Prune units schema; fix docs; update error handler; diable connector auto schema determination |
 | 3.0.0 | 2025-02-26 | Drop redundant streams & omit unneeded sensitive fields from accounting_* streams |


### PR DESCRIPTION
## What
Significantly improve two key streams: `reservations` and `reservations_v2`. Fixes the issue of missing API endpoint data, issue [64895](https://github.com/airbytehq/airbyte/issues/64895).

## How
The scroll indexes do not use explicit pagination - these are believed to be elastic search PIT ids, which simply return additional results when the query is repeated. [In the Elastic Search API, there is no specification of `page number`]( https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-open-point-in-time#:~:text=Elasticsearch%20pit%20(point%20in%20time,the%20same%20point%20in%20time ).

For this source API to return results > 10k (it is not well documented):
1. The first query must have a `scroll=1`in the URL, which then returns a scroll token. 
1. That scroll token is then used in the URL in a second query as `scroll=<scroll token>`.
1. That same second URL (`scroll=<scroll token>`) is repeated until no more results are returned.

**Returned data is on every single page, including the first `scroll=1` page.**

Configuring this in the low code editor was a bit tricky, but the following is working:
* Use Cursor Pagination:
    * Set the Cursor Value to `{{ response.scroll }}`
    * Set Stop Condition to `{{ not response._embedded.reservations }}`
* Set Query Parameters `scroll` to `{{ next_page_token['next_page_token'] if next_page_token else '1' }}`

We also set Query Parameters `sortColumn` to `id` so we can verify, but is not strictly necessary. 

Using the `if/else` allowed the first `scroll=1` to be added to the url, and the returned cursor was available via the `next_page_token['next_page_token']` value.

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
This update should transparently sync all but one page of api endpoint data - significantly more than was being synced prior.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
