### PR TITLE
fix: metadata upload is conditional

### DIFF
--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -154,6 +154,7 @@ jobs:
 
       - name: Upload connector metadata [On merge to master]
         id: upload-connector-metadata-master
+        if: github.event_name == 'push'
         shell: bash
         run: ./poe-tasks/upload-connector-metadata.sh --name ${{ matrix.connector }} --main-release
         env:
@@ -194,6 +195,7 @@ jobs:
 
       - name: Upload connector metadata [Manual]
         id: upload-connector-metadata-manual
+        if: github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call'
         shell: bash
         run: ./poe-tasks/upload-connector-metadata.sh --name ${{ matrix.connector }} ${{ inputs.publish-options }}
         env:


### PR DESCRIPTION
https://github.com/airbytehq/airbyte/pull/64886 split the metadata upload step into manual+merge, but we're running both >.> add the appropriate `if` clauses to each. Example failure - https://github.com/airbytehq/airbyte/actions/runs/16905539138/job/47894364199

This is probably breaking prerelease publishes, but nobody has tried that yet.

this isn't causing any correctness problems, b/c the new action is only pushing into the dev bucket. Just causes the publish to fail. It's not even _really_ blocking master-merge, b/c we still run all the necessary steps to publish the connector.