### PR TITLE
Destination Dev Null: test release; pin to CDK artifact

### DIFF
--- a/airbyte-integrations/connectors/destination-dev-null/build.gradle
+++ b/airbyte-integrations/connectors/destination-dev-null/build.gradle
@@ -8,7 +8,7 @@ plugins {
 airbyteBulkConnector {
     core = 'load'
     toolkits = []
-    cdk = '0.1.11'
+    cdk = 'local'
 }
 
 application {

--- a/airbyte-integrations/connectors/destination-dev-null/build.gradle
+++ b/airbyte-integrations/connectors/destination-dev-null/build.gradle
@@ -8,7 +8,7 @@ plugins {
 airbyteBulkConnector {
     core = 'load'
     toolkits = []
-    cdk = 'local'
+    cdk = '0.1.11'
 }
 
 application {

--- a/airbyte-integrations/connectors/destination-dev-null/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-dev-null/metadata.yaml
@@ -16,7 +16,7 @@ data:
     - suite: integrationTests
   connectorType: destination
   definitionId: a7bcc9d8-13b3-4e49-b80d-d020b90045e3
-  dockerImageTag: 0.8.1
+  dockerImageTag: 0.8.2
   dockerRepository: airbyte/destination-dev-null
   documentationUrl: https://docs.airbyte.com/integrations/destinations/dev-null
   githubIssueLabel: destination-dev-null

--- a/docs/integrations/destinations/dev-null.md
+++ b/docs/integrations/destinations/dev-null.md
@@ -49,7 +49,7 @@ The OSS and Cloud variants have the same version number starting from version `0
 
 | Version     | Date       | Pull Request                                             | Subject                                                                                      |
 |:------------|:-----------|:---------------------------------------------------------|:---------------------------------------------------------------------------------------------|
-| 0.8.2       | 2025-08-12 | [64897](https://github.com/airbytehq/airbyte/pull/64897) | Testing publishing flow.                                                                     |
+| 0.8.2       | 2025-08-12 | [64897](https://github.com/airbytehq/airbyte/pull/64897) | Testing publishing flow; pin to latest CDK.                                                  |
 | 0.8.1       | 2025-07-30 | [64117](https://github.com/airbytehq/airbyte/pull/64117) | Re-release with latest CDK for socket related fixes.                                         |
 | 0.8.0       | 2025-06-17 | [61585](https://github.com/airbytehq/airbyte/pull/61585) | Upgrade dev null to the new data channel based architecture.                                 |
 | 0.7.27      | 2025-06-13 | [61587](https://github.com/airbytehq/airbyte/pull/61587) | Test publishing logic.                                                                       |

--- a/docs/integrations/destinations/dev-null.md
+++ b/docs/integrations/destinations/dev-null.md
@@ -49,7 +49,7 @@ The OSS and Cloud variants have the same version number starting from version `0
 
 | Version     | Date       | Pull Request                                             | Subject                                                                                      |
 |:------------|:-----------|:---------------------------------------------------------|:---------------------------------------------------------------------------------------------|
-| 0.8.2       | 2025-08-12 | [64897](https://github.com/airbytehq/airbyte/pull/64897) | Testing publishing flow; pin to latest CDK.                                                  |
+| 0.8.2       | 2025-08-12 | [64897](https://github.com/airbytehq/airbyte/pull/64897) | Testing publishing flow.                                                                     |
 | 0.8.1       | 2025-07-30 | [64117](https://github.com/airbytehq/airbyte/pull/64117) | Re-release with latest CDK for socket related fixes.                                         |
 | 0.8.0       | 2025-06-17 | [61585](https://github.com/airbytehq/airbyte/pull/61585) | Upgrade dev null to the new data channel based architecture.                                 |
 | 0.7.27      | 2025-06-13 | [61587](https://github.com/airbytehq/airbyte/pull/61587) | Test publishing logic.                                                                       |

--- a/docs/integrations/destinations/dev-null.md
+++ b/docs/integrations/destinations/dev-null.md
@@ -49,7 +49,8 @@ The OSS and Cloud variants have the same version number starting from version `0
 
 | Version     | Date       | Pull Request                                             | Subject                                                                                      |
 |:------------|:-----------|:---------------------------------------------------------|:---------------------------------------------------------------------------------------------|
-| 0.8.1       | 2025-07-30 | [61585](https://github.com/airbytehq/airbyte/pull/61585) | Re-release with latest CDK for socket related fixes.                                         |
+| 0.8.2       | 2025-08-12 | [64897](https://github.com/airbytehq/airbyte/pull/64897) | Testing publishing flow.                                                                     |
+| 0.8.1       | 2025-07-30 | [64117](https://github.com/airbytehq/airbyte/pull/64117) | Re-release with latest CDK for socket related fixes.                                         |
 | 0.8.0       | 2025-06-17 | [61585](https://github.com/airbytehq/airbyte/pull/61585) | Upgrade dev null to the new data channel based architecture.                                 |
 | 0.7.27      | 2025-06-13 | [61587](https://github.com/airbytehq/airbyte/pull/61587) | Test publishing logic.                                                                       |
 | 0.7.26      | 2025-05-27 | [60938](https://github.com/airbytehq/airbyte/pull/60938) | Revert to base 2.0.1, test default IPC Options                                               |


### PR DESCRIPTION
noop release just to test some new publish workflow stuff

also firing a prerelease here https://github.com/airbytehq/airbyte/actions/runs/16913838696. Validated that its metadata got uploaded to the dev bucket identically as airbyte-ci's real upload:
```shell
diff <(gsutil cat gs://io-airbyte-cloud-spec-cache/specs/airbyte/destination-dev-null/0.8.2-dev.e6b32cbfcf/spec.json | jq) <(gsutil cat gs://dev-airbyte-cloud-connector-metadata-service/specs/airbyte/destination-dev-null/0.8.2-dev.e6b32cbfcf/spec.json | jq)
diff <(gsutil cat gs://io-airbyte-cloud-spec-cache/specs/airbyte/destination-dev-null/0.8.2-dev.e6b32cbfcf/spec.cloud.json | jq) <(gsutil cat gs://dev-airbyte-cloud-connector-metadata-service/specs/airbyte/destination-dev-null/0.8.2-dev.e6b32cbfcf/spec.cloud.json | jq)
diff <(gsutil cat gs://prod-airbyte-cloud-connector-metadata-service/sbom/airbyte/destination-dev-null/0.8.2-dev.e6b32cbfcf.spdx.json | jq) <(gsutil cat gs://dev-airbyte-cloud-connector-metadata-service/sbom/airbyte/destination-dev-null/0.8.2-dev.e6b32cbfcf.spdx.json | jq)
diff <(gsutil cat gs://prod-airbyte-cloud-connector-metadata-service/metadata/airbyte/destination-dev-null/0.8.2-dev.e6b32cbfcf/doc.md) <(gsutil cat gs://dev-airbyte-cloud-connector-metadata-service/metadata/airbyte/destination-dev-null/0.8.2-dev.e6b32cbfcf/doc.md)
diff <(gsutil cat gs://prod-airbyte-cloud-connector-metadata-service/metadata/airbyte/destination-dev-null/0.8.2-dev.e6b32cbfcf/metadata.yaml) <(gsutil cat gs://dev-airbyte-cloud-connector-metadata-service/metadata/airbyte/destination-dev-null/0.8.2-dev.e6b32cbfcf/metadata.yaml)
```

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._

> [!NOTE]
> **Auto-merge may have been disabled. Please check the PR status to confirm.**