### PR TITLE
Rbroughan/more state tweaks and tests

### DIFF
--- a/airbyte-cdk/bulk/build.gradle
+++ b/airbyte-cdk/bulk/build.gradle
@@ -6,7 +6,11 @@ import javax.xml.xpath.XPathFactory
 import org.w3c.dom.Document
 
 allprojects {
+<<<<<<< HEAD
     version = "0.1.16"
+=======
+    version = "0.1.13"
+>>>>>>> 6770ab1ee1f (Rev version.)
     apply plugin: 'java-library'
     apply plugin: 'maven-publish'
 

--- a/airbyte-cdk/bulk/build.gradle
+++ b/airbyte-cdk/bulk/build.gradle
@@ -6,11 +6,7 @@ import javax.xml.xpath.XPathFactory
 import org.w3c.dom.Document
 
 allprojects {
-<<<<<<< HEAD
     version = "0.1.16"
-=======
-    version = "0.1.13"
->>>>>>> 6770ab1ee1f (Rev version.)
     apply plugin: 'java-library'
     apply plugin: 'maven-publish'
 

--- a/airbyte-cdk/bulk/build.gradle
+++ b/airbyte-cdk/bulk/build.gradle
@@ -6,7 +6,7 @@ import javax.xml.xpath.XPathFactory
 import org.w3c.dom.Document
 
 allprojects {
-    version = "0.1.15"
+    version = "0.1.16"
     apply plugin: 'java-library'
     apply plugin: 'maven-publish'
 

--- a/airbyte-cdk/bulk/changelog.md
+++ b/airbyte-cdk/bulk/changelog.md
@@ -4,6 +4,12 @@
 
 * **Changed:** Extract CDK logs DB version during Check for all JDBC databases.
 
+## Version 0.1.16
+
+**Load CDK**
+
+* **Changed:** Ensure sequential state emission. Remove flushed state/partition keys.
+
 ## Version 0.1.14
 
 * **Changed:** Add agent.

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/PipelineCompletionHandler.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/PipelineCompletionHandler.kt
@@ -5,8 +5,8 @@
 package io.airbyte.cdk.load.dataflow
 
 import io.airbyte.cdk.load.dataflow.aggregate.AggregateStore
+import io.airbyte.cdk.load.dataflow.state.StateHistogramStore
 import io.airbyte.cdk.load.dataflow.state.StateReconciler
-import io.airbyte.cdk.load.dataflow.state.StateStore
 import io.github.oshai.kotlinlogging.KotlinLogging
 import jakarta.inject.Singleton
 import kotlinx.coroutines.async
@@ -16,7 +16,7 @@ import kotlinx.coroutines.coroutineScope
 @Singleton
 class PipelineCompletionHandler(
     private val aggStore: AggregateStore,
-    private val stateWatermarkStore: StateStore,
+    private val stateHistogramStore: StateHistogramStore,
     private val reconciler: StateReconciler,
 ) {
     private val log = KotlinLogging.logger {}
@@ -38,7 +38,7 @@ class PipelineCompletionHandler(
             .map {
                 async {
                     it.value.flush()
-                    stateWatermarkStore.acceptFlushedCounts(it.partitionHistogram)
+                    stateHistogramStore.acceptFlushedCounts(it.partitionHistogram)
                 }
             }
             .awaitAll()

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/PipelineStartHandler.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/PipelineStartHandler.kt
@@ -7,6 +7,8 @@ package io.airbyte.cdk.load.dataflow
 import io.airbyte.cdk.load.dataflow.state.StateReconciler
 import io.github.oshai.kotlinlogging.KotlinLogging
 import jakarta.inject.Singleton
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 
 @Singleton
 class PipelineStartHandler(
@@ -17,6 +19,6 @@ class PipelineStartHandler(
     fun run() {
         log.info { "Destination Pipeline Starting..." }
 
-        reconciler.run()
+        reconciler.run(CoroutineScope(Dispatchers.IO))
     }
 }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/stages/StateStage.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/stages/StateStage.kt
@@ -6,7 +6,7 @@ package io.airbyte.cdk.load.dataflow.stages
 
 import io.airbyte.cdk.load.dataflow.DataFlowStage
 import io.airbyte.cdk.load.dataflow.DataFlowStageIO
-import io.airbyte.cdk.load.dataflow.state.StateStore
+import io.airbyte.cdk.load.dataflow.state.StateHistogramStore
 import io.github.oshai.kotlinlogging.KotlinLogging
 import jakarta.inject.Named
 import jakarta.inject.Singleton
@@ -14,14 +14,14 @@ import jakarta.inject.Singleton
 @Named("state")
 @Singleton
 class StateStage(
-    val stateStore: StateStore,
+    private val stateHistogramStore: StateHistogramStore,
 ) : DataFlowStage {
     private val log = KotlinLogging.logger {}
 
     override suspend fun apply(input: DataFlowStageIO): DataFlowStageIO {
         val stateUpdates = input.partitionHistogram!!
 
-        stateStore.acceptFlushedCounts(stateUpdates)
+        stateHistogramStore.acceptFlushedCounts(stateUpdates)
 
         return input
     }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/state/StateHistogram.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/state/StateHistogram.kt
@@ -22,7 +22,7 @@ data class PartitionKey(
     val id: String,
 )
 
-open class Histogram<T>(open val map: ConcurrentMap<T, Long> = ConcurrentHashMap()) {
+open class Histogram<T>(private val map: ConcurrentMap<T, Long> = ConcurrentHashMap()) {
     fun increment(key: T): Histogram<T> {
         return this.apply { map.merge(key, 1, Long::plus) }
     }
@@ -30,6 +30,8 @@ open class Histogram<T>(open val map: ConcurrentMap<T, Long> = ConcurrentHashMap
     fun merge(other: Histogram<T>): Histogram<T> {
         return this.apply { other.map.forEach { map.merge(it.key, it.value, Long::plus) } }
     }
+
+    fun get(key: T): Long? = map[key]
 
     fun remove(key: T): Long? = map.remove(key)
 }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/state/StateHistogramStore.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/state/StateHistogramStore.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.load.dataflow.state
+
+import jakarta.inject.Singleton
+import java.util.concurrent.ConcurrentHashMap
+
+@Singleton
+class StateHistogramStore {
+    // Counts of flushed messages by partition id
+    private val flushed: PartitionHistogram = PartitionHistogram(ConcurrentHashMap())
+    // Counts of expected messages by state id
+    private val expected: StateHistogram = StateHistogram(ConcurrentHashMap())
+
+    fun acceptFlushedCounts(value: PartitionHistogram): PartitionHistogram {
+        return flushed.merge(value)
+    }
+
+    fun acceptExpectedCounts(key: StateKey, count: Long): StateHistogram {
+        val inner = ConcurrentHashMap<StateKey, Long>()
+        inner[key] = count
+
+        return expected.merge(StateHistogram(inner))
+    }
+
+    fun isComplete(key: StateKey): Boolean {
+        val expectedCount = expected.get(key)
+        val flushedCount = key.partitionKeys.sumOf { flushed.get(it) ?: 0 }
+
+        return expectedCount == flushedCount
+    }
+
+    fun remove(key: StateKey) {
+        expected.remove(key)
+        key.partitionKeys.forEach {
+            flushed.remove(it)
+        }
+    }
+}

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/state/StateHistogramStore.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/state/StateHistogramStore.kt
@@ -34,8 +34,6 @@ class StateHistogramStore {
 
     fun remove(key: StateKey) {
         expected.remove(key)
-        key.partitionKeys.forEach {
-            flushed.remove(it)
-        }
+        key.partitionKeys.forEach { flushed.remove(it) }
     }
 }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/state/StateReconciler.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/state/StateReconciler.kt
@@ -24,9 +24,9 @@ class StateReconciler(
     private val iterationDuration: Duration = 30.seconds
     private lateinit var job: Job
 
-    fun run() {
+    fun run(scope: CoroutineScope = CoroutineScope(Dispatchers.IO)) {
         job =
-            CoroutineScope(Dispatchers.IO).launch {
+            scope.launch {
                 while (true) {
                     delay(iterationDuration)
                     flushCompleteStates()

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/state/StateReconciler.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/state/StateReconciler.kt
@@ -10,7 +10,6 @@ import jakarta.inject.Singleton
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.delay
@@ -24,7 +23,7 @@ class StateReconciler(
     private val iterationDuration: Duration = 30.seconds
     private lateinit var job: Job
 
-    fun run(scope: CoroutineScope = CoroutineScope(Dispatchers.IO)) {
+    fun run(scope: CoroutineScope) {
         job =
             scope.launch {
                 while (true) {

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/dataflow/PipelineCompletionHandlerTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/dataflow/PipelineCompletionHandlerTest.kt
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.load.dataflow
+
+import io.airbyte.cdk.load.dataflow.aggregate.Aggregate
+import io.airbyte.cdk.load.dataflow.aggregate.AggregateEntry
+import io.airbyte.cdk.load.dataflow.aggregate.AggregateStore
+import io.airbyte.cdk.load.dataflow.state.PartitionHistogram
+import io.airbyte.cdk.load.dataflow.state.StateHistogramStore
+import io.airbyte.cdk.load.dataflow.state.StateReconciler
+import io.mockk.Runs
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(MockKExtension::class)
+class PipelineCompletionHandlerTest {
+
+    @MockK
+    private lateinit var aggStore: AggregateStore
+
+    @MockK
+    private lateinit var stateHistogramStore: StateHistogramStore
+
+    @MockK
+    private lateinit var reconciler: StateReconciler
+
+    private lateinit var pipelineCompletionHandler: PipelineCompletionHandler
+
+    @BeforeEach
+    fun setUp() {
+        pipelineCompletionHandler = PipelineCompletionHandler(
+            aggStore = aggStore,
+            stateHistogramStore = stateHistogramStore,
+            reconciler = reconciler
+        )
+    }
+
+    @Test
+    fun `apply should throw exception when cause is provided`() = runTest {
+        // Given
+        val testException = RuntimeException("Test exception")
+
+        // When & Then
+        val thrownException = assertThrows<RuntimeException> {
+            pipelineCompletionHandler.apply(testException)
+        }
+
+        assertEquals("Test exception", thrownException.message)
+    }
+
+    @Test
+    fun `apply flushes remaining aggregates and states if no cause is provided`() = runTest {
+        // Given
+        val mockAggregate1 = mockk<Aggregate>()
+        val mockAggregate2 = mockk<Aggregate>()
+        val mockHistogram1 = mockk<PartitionHistogram>()
+        val mockHistogram2 = mockk<PartitionHistogram>()
+
+        val aggregateEntry1 = AggregateEntry(
+            value = mockAggregate1,
+            partitionHistogram = mockHistogram1,
+            stalenessTrigger = mockk(),
+            recordCountTrigger = mockk(),
+            estimatedBytesTrigger = mockk()
+        )
+
+        val aggregateEntry2 = AggregateEntry(
+            value = mockAggregate2,
+            partitionHistogram = mockHistogram2,
+            stalenessTrigger = mockk(),
+            recordCountTrigger = mockk(),
+            estimatedBytesTrigger = mockk()
+        )
+
+        every { aggStore.getAll() } returns listOf(aggregateEntry1, aggregateEntry2)
+        coEvery { mockAggregate1.flush() } just Runs
+        coEvery { mockAggregate2.flush() } just Runs
+        every { stateHistogramStore.acceptFlushedCounts(any()) } returns mockk()
+        coEvery { reconciler.disable() } just Runs
+        every { reconciler.flushCompleteStates() } just Runs
+
+        // When
+        pipelineCompletionHandler.apply(null)
+
+        // Then
+        coVerify(exactly = 1) { mockAggregate1.flush() }
+        coVerify(exactly = 1) { mockAggregate2.flush() }
+        verify(exactly = 1) { stateHistogramStore.acceptFlushedCounts(mockHistogram1) }
+        verify(exactly = 1) { stateHistogramStore.acceptFlushedCounts(mockHistogram2) }
+        coVerify(exactly = 1) { reconciler.disable() }
+        verify(exactly = 1) { reconciler.flushCompleteStates() }
+    }
+
+    @Test
+    fun `apply should handle empty aggregates list`() = runTest {
+        // Given
+        every { aggStore.getAll() } returns emptyList()
+        coEvery { reconciler.disable() } just Runs
+        every { reconciler.flushCompleteStates() } just Runs
+
+        // When
+        pipelineCompletionHandler.apply(null)
+
+        // Then
+        verify(exactly = 1) { aggStore.getAll() }
+        coVerify(exactly = 1) { reconciler.disable() }
+        verify(exactly = 1) { reconciler.flushCompleteStates() }
+        verify(exactly = 0) { stateHistogramStore.acceptFlushedCounts(any()) }
+    }
+
+    @Test
+    fun `apply should handle aggregate flush failure`() = runTest {
+        // Given
+        val mockAggregate = mockk<Aggregate>()
+        val mockHistogram = mockk<PartitionHistogram>()
+        val flushException = RuntimeException("Flush failed")
+
+        val aggregateEntry = AggregateEntry(
+            value = mockAggregate,
+            partitionHistogram = mockHistogram,
+            stalenessTrigger = mockk(),
+            recordCountTrigger = mockk(),
+            estimatedBytesTrigger = mockk()
+        )
+
+        every { aggStore.getAll() } returns listOf(aggregateEntry)
+        coEvery { mockAggregate.flush() } throws flushException
+        coEvery { reconciler.disable() } just Runs
+        every { reconciler.flushCompleteStates() } just Runs
+
+        // When & Then
+        assertThrows<RuntimeException> {
+            pipelineCompletionHandler.apply(null)
+        }
+
+        coVerify(exactly = 1) { mockAggregate.flush() }
+        // Note: acceptFlushedCounts should not be called if flush fails
+        verify(exactly = 0) { stateHistogramStore.acceptFlushedCounts(any()) }
+    }
+}

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/dataflow/PipelineCompletionHandlerTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/dataflow/PipelineCompletionHandlerTest.kt
@@ -29,24 +29,22 @@ import org.junit.jupiter.api.extension.ExtendWith
 @ExtendWith(MockKExtension::class)
 class PipelineCompletionHandlerTest {
 
-    @MockK
-    private lateinit var aggStore: AggregateStore
+    @MockK private lateinit var aggStore: AggregateStore
 
-    @MockK
-    private lateinit var stateHistogramStore: StateHistogramStore
+    @MockK private lateinit var stateHistogramStore: StateHistogramStore
 
-    @MockK
-    private lateinit var reconciler: StateReconciler
+    @MockK private lateinit var reconciler: StateReconciler
 
     private lateinit var pipelineCompletionHandler: PipelineCompletionHandler
 
     @BeforeEach
     fun setUp() {
-        pipelineCompletionHandler = PipelineCompletionHandler(
-            aggStore = aggStore,
-            stateHistogramStore = stateHistogramStore,
-            reconciler = reconciler
-        )
+        pipelineCompletionHandler =
+            PipelineCompletionHandler(
+                aggStore = aggStore,
+                stateHistogramStore = stateHistogramStore,
+                reconciler = reconciler
+            )
     }
 
     @Test
@@ -55,9 +53,8 @@ class PipelineCompletionHandlerTest {
         val testException = RuntimeException("Test exception")
 
         // When & Then
-        val thrownException = assertThrows<RuntimeException> {
-            pipelineCompletionHandler.apply(testException)
-        }
+        val thrownException =
+            assertThrows<RuntimeException> { pipelineCompletionHandler.apply(testException) }
 
         assertEquals("Test exception", thrownException.message)
     }
@@ -70,21 +67,23 @@ class PipelineCompletionHandlerTest {
         val mockHistogram1 = mockk<PartitionHistogram>()
         val mockHistogram2 = mockk<PartitionHistogram>()
 
-        val aggregateEntry1 = AggregateEntry(
-            value = mockAggregate1,
-            partitionHistogram = mockHistogram1,
-            stalenessTrigger = mockk(),
-            recordCountTrigger = mockk(),
-            estimatedBytesTrigger = mockk()
-        )
+        val aggregateEntry1 =
+            AggregateEntry(
+                value = mockAggregate1,
+                partitionHistogram = mockHistogram1,
+                stalenessTrigger = mockk(),
+                recordCountTrigger = mockk(),
+                estimatedBytesTrigger = mockk()
+            )
 
-        val aggregateEntry2 = AggregateEntry(
-            value = mockAggregate2,
-            partitionHistogram = mockHistogram2,
-            stalenessTrigger = mockk(),
-            recordCountTrigger = mockk(),
-            estimatedBytesTrigger = mockk()
-        )
+        val aggregateEntry2 =
+            AggregateEntry(
+                value = mockAggregate2,
+                partitionHistogram = mockHistogram2,
+                stalenessTrigger = mockk(),
+                recordCountTrigger = mockk(),
+                estimatedBytesTrigger = mockk()
+            )
 
         every { aggStore.getAll() } returns listOf(aggregateEntry1, aggregateEntry2)
         coEvery { mockAggregate1.flush() } just Runs
@@ -129,13 +128,14 @@ class PipelineCompletionHandlerTest {
         val mockHistogram = mockk<PartitionHistogram>()
         val flushException = RuntimeException("Flush failed")
 
-        val aggregateEntry = AggregateEntry(
-            value = mockAggregate,
-            partitionHistogram = mockHistogram,
-            stalenessTrigger = mockk(),
-            recordCountTrigger = mockk(),
-            estimatedBytesTrigger = mockk()
-        )
+        val aggregateEntry =
+            AggregateEntry(
+                value = mockAggregate,
+                partitionHistogram = mockHistogram,
+                stalenessTrigger = mockk(),
+                recordCountTrigger = mockk(),
+                estimatedBytesTrigger = mockk()
+            )
 
         every { aggStore.getAll() } returns listOf(aggregateEntry)
         coEvery { mockAggregate.flush() } throws flushException
@@ -143,9 +143,7 @@ class PipelineCompletionHandlerTest {
         every { reconciler.flushCompleteStates() } just Runs
 
         // When & Then
-        assertThrows<RuntimeException> {
-            pipelineCompletionHandler.apply(null)
-        }
+        assertThrows<RuntimeException> { pipelineCompletionHandler.apply(null) }
 
         coVerify(exactly = 1) { mockAggregate.flush() }
         // Note: acceptFlushedCounts should not be called if flush fails

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/dataflow/PipelineStartHandlerTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/dataflow/PipelineStartHandlerTest.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.load.dataflow
+
+import io.airbyte.cdk.load.dataflow.state.StateReconciler
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.just
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(MockKExtension::class)
+class PipelineStartHandlerTest {
+
+    @MockK
+    private lateinit var reconciler: StateReconciler
+
+    private lateinit var pipelineStartHandler: PipelineStartHandler
+
+    @BeforeEach
+    fun setUp() {
+        pipelineStartHandler = PipelineStartHandler(reconciler)
+    }
+
+    @Test
+    fun `run should call reconciler run method`() {
+        // Given
+        every { reconciler.run() } just Runs
+
+        // When
+        pipelineStartHandler.run()
+
+        // Then
+        verify(exactly = 1) { reconciler.run() }
+    }
+
+}

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/dataflow/PipelineStartHandlerTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/dataflow/PipelineStartHandlerTest.kt
@@ -18,8 +18,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 @ExtendWith(MockKExtension::class)
 class PipelineStartHandlerTest {
 
-    @MockK
-    private lateinit var reconciler: StateReconciler
+    @MockK private lateinit var reconciler: StateReconciler
 
     private lateinit var pipelineStartHandler: PipelineStartHandler
 
@@ -31,13 +30,13 @@ class PipelineStartHandlerTest {
     @Test
     fun `run should call reconciler run method`() {
         // Given
-        every { reconciler.run() } just Runs
+
+        every { reconciler.run(any()) } just Runs
 
         // When
         pipelineStartHandler.run()
 
         // Then
-        verify(exactly = 1) { reconciler.run() }
+        verify(exactly = 1) { reconciler.run(any()) }
     }
-
 }

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/dataflow/state/StateHistogramStoreTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/dataflow/state/StateHistogramStoreTest.kt
@@ -1,0 +1,203 @@
+/*
+ * Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.load.dataflow.state
+
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.util.concurrent.ConcurrentHashMap
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class StateHistogramStoreTest {
+
+    private lateinit var stateHistogramStore: StateHistogramStore
+
+    @BeforeEach
+    fun setUp() {
+        stateHistogramStore = StateHistogramStore()
+    }
+
+    @Test
+    fun `isComplete should return true when flushed count equals expected count for single partition`() {
+        // Given
+        val partitionKey = PartitionKey("partition-1")
+        val stateKey = StateKey(1L, listOf(partitionKey))
+        
+        stateHistogramStore.acceptExpectedCounts(stateKey, 5L)
+        
+        val partitionHistogram = PartitionHistogram(ConcurrentHashMap())
+        repeat(5) { partitionHistogram.increment(partitionKey) }
+        stateHistogramStore.acceptFlushedCounts(partitionHistogram)
+
+        // When
+        val result = stateHistogramStore.isComplete(stateKey)
+
+        // Then
+        assertTrue(result)
+    }
+
+    @Test
+    fun `isComplete should return true when flushed count equals expected count for multiple partitions`() {
+        // Given
+        val partitionKey1 = PartitionKey("partition-1")
+        val partitionKey2 = PartitionKey("partition-2")
+        val partitionKey3 = PartitionKey("partition-3")
+        val stateKey = StateKey(1L, listOf(partitionKey1, partitionKey2, partitionKey3))
+        
+        stateHistogramStore.acceptExpectedCounts(stateKey, 15L) // 5 + 3 + 7 = 15
+        
+        val partitionHistogram = PartitionHistogram(ConcurrentHashMap())
+        repeat(5) { partitionHistogram.increment(partitionKey1) }
+        repeat(3) { partitionHistogram.increment(partitionKey2) }
+        repeat(7) { partitionHistogram.increment(partitionKey3) }
+        stateHistogramStore.acceptFlushedCounts(partitionHistogram)
+
+        // When
+        val result = stateHistogramStore.isComplete(stateKey)
+
+        // Then
+        assertTrue(result)
+    }
+
+    @Test
+    fun `isComplete should return false when flushed count is less than expected count`() {
+        // Given
+        val partitionKey = PartitionKey("partition-1")
+        val stateKey = StateKey(1L, listOf(partitionKey))
+        
+        stateHistogramStore.acceptExpectedCounts(stateKey, 10L)
+        
+        val partitionHistogram = PartitionHistogram(ConcurrentHashMap())
+        repeat(7) { partitionHistogram.increment(partitionKey) } // Less than expected
+        stateHistogramStore.acceptFlushedCounts(partitionHistogram)
+
+        // When
+        val result = stateHistogramStore.isComplete(stateKey)
+
+        // Then
+        assertFalse(result)
+    }
+
+    @Test
+    fun `isComplete should return false when flushed count is greater than expected count`() {
+        // Given
+        val partitionKey = PartitionKey("partition-1")
+        val stateKey = StateKey(1L, listOf(partitionKey))
+        
+        stateHistogramStore.acceptExpectedCounts(stateKey, 5L)
+        
+        val partitionHistogram = PartitionHistogram(ConcurrentHashMap())
+        repeat(8) { partitionHistogram.increment(partitionKey) } // More than expected
+        stateHistogramStore.acceptFlushedCounts(partitionHistogram)
+
+        // When
+        val result = stateHistogramStore.isComplete(stateKey)
+
+        // Then
+        assertFalse(result)
+    }
+
+    @Test
+    fun `isComplete should return false when no expected count is set`() {
+        // Given
+        val partitionKey = PartitionKey("partition-1")
+        val stateKey = StateKey(1L, listOf(partitionKey))
+        
+        val partitionHistogram = PartitionHistogram(ConcurrentHashMap())
+        repeat(5) { partitionHistogram.increment(partitionKey) }
+        stateHistogramStore.acceptFlushedCounts(partitionHistogram)
+
+        // When
+        val result = stateHistogramStore.isComplete(stateKey)
+
+        // Then
+        assertFalse(result) // null != 5
+    }
+
+    @Test
+    fun `isComplete should return false when no flushed counts exist`() {
+        // Given
+        val partitionKey = PartitionKey("partition-1")
+        val stateKey = StateKey(1L, listOf(partitionKey))
+        
+        stateHistogramStore.acceptExpectedCounts(stateKey, 5L)
+
+        // When
+        val result = stateHistogramStore.isComplete(stateKey)
+
+        // Then
+        assertFalse(result) // 5 != 0
+    }
+
+    @Test
+    fun `isComplete should handle missing partition counts as zero`() {
+        // Given
+        val partitionKey1 = PartitionKey("partition-1")
+        val partitionKey2 = PartitionKey("partition-2") // No flushed count for this
+        val stateKey = StateKey(1L, listOf(partitionKey1, partitionKey2))
+        
+        stateHistogramStore.acceptExpectedCounts(stateKey, 3L)
+        
+        val partitionHistogram = PartitionHistogram(ConcurrentHashMap())
+        repeat(3) { partitionHistogram.increment(partitionKey1) }
+        // partitionKey2 has no flushed counts, should be treated as 0
+        stateHistogramStore.acceptFlushedCounts(partitionHistogram)
+
+        // When
+        val result = stateHistogramStore.isComplete(stateKey)
+
+        // Then
+        assertTrue(result) // 3 + 0 = 3
+    }
+
+    @Test
+    fun `remove should delete both expected and flushed counts for state key`() {
+        // Given
+        val partitionKey1 = PartitionKey("partition-1")
+        val partitionKey2 = PartitionKey("partition-2")
+        val stateKey = StateKey(1L, listOf(partitionKey1, partitionKey2))
+        
+        stateHistogramStore.acceptExpectedCounts(stateKey, 10L)
+        
+        val partitionHistogram = PartitionHistogram(ConcurrentHashMap())
+        repeat(5) { partitionHistogram.increment(partitionKey1) }
+        repeat(3) { partitionHistogram.increment(partitionKey2) }
+        stateHistogramStore.acceptFlushedCounts(partitionHistogram)
+
+        // When
+        stateHistogramStore.remove(stateKey)
+
+        // Then
+        assertFalse(stateHistogramStore.isComplete(stateKey)) // Should be false due to missing expected count
+    }
+
+    @Test
+    fun `remove should only affect specified state key and partitions`() {
+        // Given
+        val partitionKey1 = PartitionKey("partition-1")
+        val partitionKey2 = PartitionKey("partition-2")
+        val partitionKey3 = PartitionKey("partition-3")
+        
+        val stateKey1 = StateKey(1L, listOf(partitionKey1, partitionKey2))
+        val stateKey2 = StateKey(2L, listOf(partitionKey3))
+        
+        stateHistogramStore.acceptExpectedCounts(stateKey1, 8L)
+        stateHistogramStore.acceptExpectedCounts(stateKey2, 4L)
+        
+        val partitionHistogram = PartitionHistogram(ConcurrentHashMap())
+        repeat(5) { partitionHistogram.increment(partitionKey1) }
+        repeat(3) { partitionHistogram.increment(partitionKey2) }
+        repeat(4) { partitionHistogram.increment(partitionKey3) }
+        stateHistogramStore.acceptFlushedCounts(partitionHistogram)
+
+        // When
+        stateHistogramStore.remove(stateKey1)
+
+        // Then
+        assertFalse(stateHistogramStore.isComplete(stateKey1)) // Should be false after removal
+        assertTrue(stateHistogramStore.isComplete(stateKey2)) // Should still be complete
+    }
+}

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/dataflow/state/StateHistogramStoreTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/dataflow/state/StateHistogramStoreTest.kt
@@ -4,12 +4,11 @@
 
 package io.airbyte.cdk.load.dataflow.state
 
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.test.assertFalse
-import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 class StateHistogramStoreTest {
 
@@ -25,9 +24,9 @@ class StateHistogramStoreTest {
         // Given
         val partitionKey = PartitionKey("partition-1")
         val stateKey = StateKey(1L, listOf(partitionKey))
-        
+
         stateHistogramStore.acceptExpectedCounts(stateKey, 5L)
-        
+
         val partitionHistogram = PartitionHistogram(ConcurrentHashMap())
         repeat(5) { partitionHistogram.increment(partitionKey) }
         stateHistogramStore.acceptFlushedCounts(partitionHistogram)
@@ -46,9 +45,9 @@ class StateHistogramStoreTest {
         val partitionKey2 = PartitionKey("partition-2")
         val partitionKey3 = PartitionKey("partition-3")
         val stateKey = StateKey(1L, listOf(partitionKey1, partitionKey2, partitionKey3))
-        
+
         stateHistogramStore.acceptExpectedCounts(stateKey, 15L) // 5 + 3 + 7 = 15
-        
+
         val partitionHistogram = PartitionHistogram(ConcurrentHashMap())
         repeat(5) { partitionHistogram.increment(partitionKey1) }
         repeat(3) { partitionHistogram.increment(partitionKey2) }
@@ -67,9 +66,9 @@ class StateHistogramStoreTest {
         // Given
         val partitionKey = PartitionKey("partition-1")
         val stateKey = StateKey(1L, listOf(partitionKey))
-        
+
         stateHistogramStore.acceptExpectedCounts(stateKey, 10L)
-        
+
         val partitionHistogram = PartitionHistogram(ConcurrentHashMap())
         repeat(7) { partitionHistogram.increment(partitionKey) } // Less than expected
         stateHistogramStore.acceptFlushedCounts(partitionHistogram)
@@ -86,9 +85,9 @@ class StateHistogramStoreTest {
         // Given
         val partitionKey = PartitionKey("partition-1")
         val stateKey = StateKey(1L, listOf(partitionKey))
-        
+
         stateHistogramStore.acceptExpectedCounts(stateKey, 5L)
-        
+
         val partitionHistogram = PartitionHistogram(ConcurrentHashMap())
         repeat(8) { partitionHistogram.increment(partitionKey) } // More than expected
         stateHistogramStore.acceptFlushedCounts(partitionHistogram)
@@ -105,7 +104,7 @@ class StateHistogramStoreTest {
         // Given
         val partitionKey = PartitionKey("partition-1")
         val stateKey = StateKey(1L, listOf(partitionKey))
-        
+
         val partitionHistogram = PartitionHistogram(ConcurrentHashMap())
         repeat(5) { partitionHistogram.increment(partitionKey) }
         stateHistogramStore.acceptFlushedCounts(partitionHistogram)
@@ -122,7 +121,7 @@ class StateHistogramStoreTest {
         // Given
         val partitionKey = PartitionKey("partition-1")
         val stateKey = StateKey(1L, listOf(partitionKey))
-        
+
         stateHistogramStore.acceptExpectedCounts(stateKey, 5L)
 
         // When
@@ -138,9 +137,9 @@ class StateHistogramStoreTest {
         val partitionKey1 = PartitionKey("partition-1")
         val partitionKey2 = PartitionKey("partition-2") // No flushed count for this
         val stateKey = StateKey(1L, listOf(partitionKey1, partitionKey2))
-        
+
         stateHistogramStore.acceptExpectedCounts(stateKey, 3L)
-        
+
         val partitionHistogram = PartitionHistogram(ConcurrentHashMap())
         repeat(3) { partitionHistogram.increment(partitionKey1) }
         // partitionKey2 has no flushed counts, should be treated as 0
@@ -159,9 +158,9 @@ class StateHistogramStoreTest {
         val partitionKey1 = PartitionKey("partition-1")
         val partitionKey2 = PartitionKey("partition-2")
         val stateKey = StateKey(1L, listOf(partitionKey1, partitionKey2))
-        
+
         stateHistogramStore.acceptExpectedCounts(stateKey, 10L)
-        
+
         val partitionHistogram = PartitionHistogram(ConcurrentHashMap())
         repeat(5) { partitionHistogram.increment(partitionKey1) }
         repeat(3) { partitionHistogram.increment(partitionKey2) }
@@ -171,7 +170,9 @@ class StateHistogramStoreTest {
         stateHistogramStore.remove(stateKey)
 
         // Then
-        assertFalse(stateHistogramStore.isComplete(stateKey)) // Should be false due to missing expected count
+        assertFalse(
+            stateHistogramStore.isComplete(stateKey)
+        ) // Should be false due to missing expected count
     }
 
     @Test
@@ -180,13 +181,13 @@ class StateHistogramStoreTest {
         val partitionKey1 = PartitionKey("partition-1")
         val partitionKey2 = PartitionKey("partition-2")
         val partitionKey3 = PartitionKey("partition-3")
-        
+
         val stateKey1 = StateKey(1L, listOf(partitionKey1, partitionKey2))
         val stateKey2 = StateKey(2L, listOf(partitionKey3))
-        
+
         stateHistogramStore.acceptExpectedCounts(stateKey1, 8L)
         stateHistogramStore.acceptExpectedCounts(stateKey2, 4L)
-        
+
         val partitionHistogram = PartitionHistogram(ConcurrentHashMap())
         repeat(5) { partitionHistogram.increment(partitionKey1) }
         repeat(3) { partitionHistogram.increment(partitionKey2) }

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/dataflow/state/StateHistogramTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/dataflow/state/StateHistogramTest.kt
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.load.dataflow.state
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class StateHistogramTest {
+
+    @Test
+    fun `increment should add new key with count 1`() {
+        // Given
+        val histogram = StateHistogram()
+        val stateKey = StateKey(1L, listOf(PartitionKey("partition-1")))
+
+        // When
+        histogram.increment(stateKey)
+
+        // Then
+        assertEquals(1L, histogram.get(stateKey))
+    }
+
+    @Test
+    fun `increment should increase existing key count`() {
+        // Given
+        val histogram = StateHistogram()
+        val stateKey = StateKey(1L, listOf(PartitionKey("partition-1")))
+
+        // When
+        histogram.increment(stateKey)
+        histogram.increment(stateKey)
+        histogram.increment(stateKey)
+
+        // Then
+        assertEquals(3L, histogram.get(stateKey))
+    }
+
+    @Test
+    fun `increment should handle multiple different keys`() {
+        // Given
+        val histogram = StateHistogram()
+        val stateKey1 = StateKey(1L, listOf(PartitionKey("partition-1")))
+        val stateKey2 = StateKey(2L, listOf(PartitionKey("partition-2")))
+
+        // When
+        histogram.increment(stateKey1)
+        histogram.increment(stateKey1)
+        histogram.increment(stateKey2)
+
+        // Then
+        assertEquals(2L, histogram.get(stateKey1))
+        assertEquals(1L, histogram.get(stateKey2))
+    }
+
+    @Test
+    fun `get should return null for non-existent key`() {
+        // Given
+        val histogram = StateHistogram()
+        val stateKey = StateKey(1L, listOf(PartitionKey("partition-1")))
+
+        // When
+        val result = histogram.get(stateKey)
+
+        // Then
+        assertNull(result)
+    }
+
+    @Test
+    fun `merge should combine two histograms correctly`() {
+        // Given
+        val histogram1 = StateHistogram()
+        val histogram2 = StateHistogram()
+        val stateKey1 = StateKey(1L, listOf(PartitionKey("partition-1")))
+        val stateKey2 = StateKey(2L, listOf(PartitionKey("partition-2")))
+        val sharedKey = StateKey(3L, listOf(PartitionKey("partition-3")))
+
+        histogram1.increment(stateKey1)
+        histogram1.increment(stateKey1)
+        histogram1.increment(sharedKey)
+
+        histogram2.increment(stateKey2)
+        histogram2.increment(sharedKey)
+        histogram2.increment(sharedKey)
+
+        // When
+        histogram1.merge(histogram2)
+
+        // Then
+        assertEquals(2L, histogram1.get(stateKey1))
+        assertEquals(1L, histogram1.get(stateKey2))
+        assertEquals(3L, histogram1.get(sharedKey)) // 1 + 2
+    }
+
+    @Test
+    fun `merge should not modify the source histogram`() {
+        // Given
+        val histogram1 = StateHistogram()
+        val histogram2 = StateHistogram()
+        val stateKey1 = StateKey(1L, listOf(PartitionKey("partition-1")))
+        val stateKey2 = StateKey(2L, listOf(PartitionKey("partition-2")))
+
+        histogram1.increment(stateKey1)
+        histogram2.increment(stateKey2)
+
+        // When
+        histogram1.merge(histogram2)
+
+        // Then
+        assertEquals(1L, histogram1.get(stateKey1))
+        assertEquals(1L, histogram1.get(stateKey2))
+        assertEquals(1L, histogram2.get(stateKey2)) // histogram2 unchanged
+        assertNull(histogram2.get(stateKey1)) // histogram2 unchanged
+    }
+
+    @Test
+    fun `remove should return and delete existing key`() {
+        // Given
+        val histogram = StateHistogram()
+        val stateKey = StateKey(1L, listOf(PartitionKey("partition-1")))
+        histogram.increment(stateKey)
+        histogram.increment(stateKey)
+
+        // When
+        val removedValue = histogram.remove(stateKey)
+
+        // Then
+        assertEquals(2L, removedValue)
+        assertNull(histogram.get(stateKey))
+    }
+
+    @Test
+    fun `remove should return null for non-existent key`() {
+        // Given
+        val histogram = StateHistogram()
+        val stateKey = StateKey(1L, listOf(PartitionKey("partition-1")))
+
+        // When
+        val removedValue = histogram.remove(stateKey)
+
+        // Then
+        assertNull(removedValue)
+    }
+
+    @Test
+    fun `StateKey should be comparable by id`() {
+        // Given
+        val stateKey1 = StateKey(1L, listOf(PartitionKey("partition-1")))
+        val stateKey2 = StateKey(2L, listOf(PartitionKey("partition-2")))
+        val stateKey3 = StateKey(1L, listOf(PartitionKey("partition-3")))
+
+        // When & Then
+        assert(stateKey1 < stateKey2)
+        assert(stateKey2 > stateKey1)
+        assertEquals(0, stateKey1.compareTo(stateKey3))
+    }
+}

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/dataflow/state/StateHistogramTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/dataflow/state/StateHistogramTest.kt
@@ -4,9 +4,9 @@
 
 package io.airbyte.cdk.load.dataflow.state
 
-import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
+import org.junit.jupiter.api.Test
 
 class StateHistogramTest {
 

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/dataflow/state/StateKeyClientTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/dataflow/state/StateKeyClientTest.kt
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.load.dataflow.state
+
+import io.airbyte.cdk.load.message.CheckpointMessage
+import io.airbyte.cdk.load.state.CheckpointId
+import io.airbyte.cdk.load.message.DestinationRecordRaw
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class StateKeyClientTest {
+
+    @Test
+    fun `SelfDescribingStateKeyClient#getPartitionKey should use checkpoint id from message`() {
+        // Given
+        val client = SelfDescribingStateKeyClient()
+        val message = mockk<DestinationRecordRaw>()
+        every { message.checkpointId!!.value } returns "test-partition-123"
+
+        // When
+        val result = client.getPartitionKey(message)
+
+        // Then
+        assertEquals(PartitionKey("test-partition-123"), result)
+    }
+
+    @Test
+    fun `SelfDescribingStateKeyClient#getStateKey should use ordinal and partition ids from checkpoint message`() {
+        // Given
+        val client = SelfDescribingStateKeyClient()
+        val message = mockk<CheckpointMessage>()
+        
+        every { message.checkpointOrdinalRaw } returns 42
+        every { message.checkpointPartitionIds } returns listOf("partition-1", "partition-2", "partition-3")
+
+        // When
+        val result = client.getStateKey(message)
+
+        // Then
+        val expectedPartitions = listOf(
+            PartitionKey("partition-1"),
+            PartitionKey("partition-2"), 
+            PartitionKey("partition-3")
+        )
+        assertEquals(StateKey(42L, expectedPartitions), result)
+    }
+
+    @Test
+    fun `InferredStateKeyClient#getPartitionKey should return sequential counter as string`() {
+        // Given
+        val client = InferredStateKeyClient()
+        val message1 = mockk<DestinationRecordRaw>()
+        val message2 = mockk<DestinationRecordRaw>()
+
+        // When
+        val result1 = client.getPartitionKey(message1)
+        val result2 = client.getPartitionKey(message2)
+
+        // Then
+        assertEquals(PartitionKey("1"), result1)
+        assertEquals(PartitionKey("1"), result2) // Should not increment for getPartitionKey
+    }
+
+    @Test
+    fun `InferredStateKeyClient#getStateKey should increment counter and create single partition`() {
+        // Given
+        val client = InferredStateKeyClient()
+        val message1 = mockk<CheckpointMessage>()
+        val message2 = mockk<CheckpointMessage>()
+        val message3 = mockk<CheckpointMessage>()
+
+        // When
+        val result1 = client.getStateKey(message1)
+        val result2 = client.getStateKey(message2)
+        val result3 = client.getStateKey(message3)
+
+        // Then
+        assertEquals(StateKey(1L, listOf(PartitionKey("1"))), result1)
+        assertEquals(StateKey(2L, listOf(PartitionKey("2"))), result2)
+        assertEquals(StateKey(3L, listOf(PartitionKey("3"))), result3)
+    }
+
+    @Test
+    fun `InferredStateKeyClient#getPartitionKey should use current counter value without incrementing`() {
+        // Given
+        val client = InferredStateKeyClient()
+        val recordMessage = mockk<DestinationRecordRaw>()
+        val checkpointMessage = mockk<CheckpointMessage>()
+
+        // When
+        val partitionKey1 = client.getPartitionKey(recordMessage)
+        val stateKey1 = client.getStateKey(checkpointMessage) // This increments
+        val partitionKey2 = client.getPartitionKey(recordMessage)
+
+        // Then
+        assertEquals(PartitionKey("1"), partitionKey1) // Initial value
+        assertEquals(StateKey(1L, listOf(PartitionKey("1"))), stateKey1) // Incremented to 2 internally
+        assertEquals(PartitionKey("2"), partitionKey2) // Current value after increment
+    }
+
+    @Test
+    fun `SelfDescribingStateKeyClient#getStateKey should handle empty partition list`() {
+        // Given
+        val client = SelfDescribingStateKeyClient()
+        val message = mockk<CheckpointMessage>()
+        
+        every { message.checkpointOrdinalRaw } returns 100
+        every { message.checkpointPartitionIds } returns emptyList()
+
+        // When
+        val result = client.getStateKey(message)
+
+        // Then
+        assertEquals(StateKey(100L, emptyList()), result)
+    }
+
+    @Test
+    fun `SelfDescribingStateKeyClient#getStateKey should handle single partition`() {
+        // Given
+        val client = SelfDescribingStateKeyClient()
+        val message = mockk<CheckpointMessage>()
+        
+        every { message.checkpointOrdinalRaw } returns 5
+        every { message.checkpointPartitionIds } returns listOf("single-partition")
+
+        // When
+        val result = client.getStateKey(message)
+
+        // Then
+        assertEquals(StateKey(5L, listOf(PartitionKey("single-partition"))), result)
+    }
+}

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/dataflow/state/StateKeyClientTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/dataflow/state/StateKeyClientTest.kt
@@ -5,12 +5,11 @@
 package io.airbyte.cdk.load.dataflow.state
 
 import io.airbyte.cdk.load.message.CheckpointMessage
-import io.airbyte.cdk.load.state.CheckpointId
 import io.airbyte.cdk.load.message.DestinationRecordRaw
 import io.mockk.every
 import io.mockk.mockk
-import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
+import org.junit.jupiter.api.Test
 
 class StateKeyClientTest {
 
@@ -33,19 +32,21 @@ class StateKeyClientTest {
         // Given
         val client = SelfDescribingStateKeyClient()
         val message = mockk<CheckpointMessage>()
-        
+
         every { message.checkpointOrdinalRaw } returns 42
-        every { message.checkpointPartitionIds } returns listOf("partition-1", "partition-2", "partition-3")
+        every { message.checkpointPartitionIds } returns
+            listOf("partition-1", "partition-2", "partition-3")
 
         // When
         val result = client.getStateKey(message)
 
         // Then
-        val expectedPartitions = listOf(
-            PartitionKey("partition-1"),
-            PartitionKey("partition-2"), 
-            PartitionKey("partition-3")
-        )
+        val expectedPartitions =
+            listOf(
+                PartitionKey("partition-1"),
+                PartitionKey("partition-2"),
+                PartitionKey("partition-3")
+            )
         assertEquals(StateKey(42L, expectedPartitions), result)
     }
 
@@ -98,7 +99,10 @@ class StateKeyClientTest {
 
         // Then
         assertEquals(PartitionKey("1"), partitionKey1) // Initial value
-        assertEquals(StateKey(1L, listOf(PartitionKey("1"))), stateKey1) // Incremented to 2 internally
+        assertEquals(
+            StateKey(1L, listOf(PartitionKey("1"))),
+            stateKey1
+        ) // Incremented to 2 internally
         assertEquals(PartitionKey("2"), partitionKey2) // Current value after increment
     }
 
@@ -107,7 +111,7 @@ class StateKeyClientTest {
         // Given
         val client = SelfDescribingStateKeyClient()
         val message = mockk<CheckpointMessage>()
-        
+
         every { message.checkpointOrdinalRaw } returns 100
         every { message.checkpointPartitionIds } returns emptyList()
 
@@ -123,7 +127,7 @@ class StateKeyClientTest {
         // Given
         val client = SelfDescribingStateKeyClient()
         val message = mockk<CheckpointMessage>()
-        
+
         every { message.checkpointOrdinalRaw } returns 5
         every { message.checkpointPartitionIds } returns listOf("single-partition")
 

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/dataflow/state/StateReconcilerTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/dataflow/state/StateReconcilerTest.kt
@@ -8,8 +8,6 @@ import io.airbyte.cdk.load.message.CheckpointMessage
 import io.airbyte.cdk.output.OutputConsumer
 import io.airbyte.protocol.models.v0.AirbyteMessage
 import io.mockk.Runs
-import io.mockk.coEvery
-import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
@@ -17,24 +15,21 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
 import io.mockk.verifyOrder
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
-import kotlin.time.Duration.Companion.seconds
 
 @ExtendWith(MockKExtension::class)
 @OptIn(ExperimentalCoroutinesApi::class)
 class StateReconcilerTest {
 
-    @MockK
-    private lateinit var stateStore: StateStore
+    @MockK private lateinit var stateStore: StateStore
 
-    @MockK
-    private lateinit var consumer: OutputConsumer
+    @MockK private lateinit var consumer: OutputConsumer
 
     private lateinit var stateReconciler: StateReconciler
 
@@ -58,12 +53,8 @@ class StateReconcilerTest {
         every { checkpointMessage3.asProtocolMessage() } returns protocolMessage3
         every { consumer.accept(any<AirbyteMessage>()) } just Runs
 
-        every { stateStore.getNextComplete() } returnsMany listOf(
-            checkpointMessage1,
-            checkpointMessage2,
-            checkpointMessage3,
-            null
-        )
+        every { stateStore.getNextComplete() } returnsMany
+            listOf(checkpointMessage1, checkpointMessage2, checkpointMessage3, null)
 
         // When
         stateReconciler.flushCompleteStates()
@@ -153,11 +144,8 @@ class StateReconcilerTest {
         every { checkpointMessage2.asProtocolMessage() } returns protocolMessage2
         every { consumer.accept(any<AirbyteMessage>()) } just Runs
 
-        every { stateStore.getNextComplete() } returnsMany listOf(
-            checkpointMessage1,
-            checkpointMessage2,
-            null
-        )
+        every { stateStore.getNextComplete() } returnsMany
+            listOf(checkpointMessage1, checkpointMessage2, null)
 
         // When
         stateReconciler.flushCompleteStates()

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/dataflow/state/StateReconcilerTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/dataflow/state/StateReconcilerTest.kt
@@ -1,0 +1,228 @@
+/*
+ * Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.load.dataflow.state
+
+import io.airbyte.cdk.load.message.CheckpointMessage
+import io.airbyte.cdk.output.OutputConsumer
+import io.airbyte.protocol.models.v0.AirbyteMessage
+import io.mockk.Runs
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
+import io.mockk.verifyOrder
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import kotlin.time.Duration.Companion.seconds
+
+@ExtendWith(MockKExtension::class)
+@OptIn(ExperimentalCoroutinesApi::class)
+class StateReconcilerTest {
+
+    @MockK
+    private lateinit var stateStore: StateStore
+
+    @MockK
+    private lateinit var consumer: OutputConsumer
+
+    private lateinit var stateReconciler: StateReconciler
+
+    @BeforeEach
+    fun setUp() {
+        stateReconciler = StateReconciler(stateStore, consumer)
+    }
+
+    @Test
+    fun `flushCompleteStates should publish all complete states from store`() {
+        // Given
+        val checkpointMessage1 = mockk<CheckpointMessage>()
+        val checkpointMessage2 = mockk<CheckpointMessage>()
+        val checkpointMessage3 = mockk<CheckpointMessage>()
+        val protocolMessage1 = mockk<AirbyteMessage>()
+        val protocolMessage2 = mockk<AirbyteMessage>()
+        val protocolMessage3 = mockk<AirbyteMessage>()
+
+        every { checkpointMessage1.asProtocolMessage() } returns protocolMessage1
+        every { checkpointMessage2.asProtocolMessage() } returns protocolMessage2
+        every { checkpointMessage3.asProtocolMessage() } returns protocolMessage3
+        every { consumer.accept(any<AirbyteMessage>()) } just Runs
+
+        every { stateStore.getNextComplete() } returnsMany listOf(
+            checkpointMessage1,
+            checkpointMessage2,
+            checkpointMessage3,
+            null
+        )
+
+        // When
+        stateReconciler.flushCompleteStates()
+
+        // Then
+        verify(exactly = 4) { stateStore.getNextComplete() }
+        verify { consumer.accept(protocolMessage1) }
+        verify { consumer.accept(protocolMessage2) }
+        verify { consumer.accept(protocolMessage3) }
+    }
+
+    @Test
+    fun `flushCompleteStates should handle empty state store`() {
+        // Given
+        every { stateStore.getNextComplete() } returns null
+
+        // When
+        stateReconciler.flushCompleteStates()
+
+        // Then
+        verify(exactly = 1) { stateStore.getNextComplete() }
+        verify(exactly = 0) { consumer.accept(any<AirbyteMessage>()) }
+    }
+
+    @Test
+    fun `publish should convert checkpoint message to protocol message and send to consumer`() {
+        // Given
+        val checkpointMessage = mockk<CheckpointMessage>()
+        val protocolMessage = mockk<AirbyteMessage>()
+
+        every { checkpointMessage.asProtocolMessage() } returns protocolMessage
+        every { consumer.accept(protocolMessage) } just Runs
+
+        // When
+        stateReconciler.publish(checkpointMessage)
+
+        // Then
+        verify { checkpointMessage.asProtocolMessage() }
+        verify { consumer.accept(protocolMessage) }
+    }
+
+    @Test
+    fun `run should start coroutine that periodically flushes complete states`() = runTest {
+        // Given
+        every { stateStore.getNextComplete() } returns null
+
+        // When
+        stateReconciler.run()
+
+        // Advance time by 30 seconds to trigger first flush
+        advanceTimeBy(30.seconds)
+
+        // Then
+        verify(atLeast = 1) { stateStore.getNextComplete() }
+    }
+
+    @Test
+    fun `run should continue flushing states at regular intervals`() = runTest {
+        // Given
+        every { stateStore.getNextComplete() } returns null
+
+        // When
+        stateReconciler.run()
+
+        // Advance time to trigger multiple flushes
+        advanceTimeBy(30.seconds) // First flush
+        advanceTimeBy(30.seconds) // Second flush
+        advanceTimeBy(30.seconds) // Third flush
+
+        // Then
+        verify(atLeast = 3) { stateStore.getNextComplete() }
+    }
+
+    @Test
+    fun `disable should cancel and join the running job`() = runTest {
+        // Given
+        every { stateStore.getNextComplete() } returns null
+
+        // Start the reconciler
+        stateReconciler.run()
+
+        // When
+        stateReconciler.disable()
+
+        // Then
+        // The job should be cancelled and the coroutine should stop
+        // We can verify this by advancing time and ensuring no more flushes occur
+        advanceTimeBy(60.seconds)
+        
+        // Should have had initial flushes but then stopped after disable
+        verify(atMost = 2) { stateStore.getNextComplete() }
+    }
+
+    @Test
+    fun `flushCompleteStates should process states in correct order`() {
+        // Given
+        val checkpointMessage1 = mockk<CheckpointMessage>()
+        val checkpointMessage2 = mockk<CheckpointMessage>()
+        val protocolMessage1 = mockk<AirbyteMessage>()
+        val protocolMessage2 = mockk<AirbyteMessage>()
+
+        every { checkpointMessage1.asProtocolMessage() } returns protocolMessage1
+        every { checkpointMessage2.asProtocolMessage() } returns protocolMessage2
+        every { consumer.accept(any<AirbyteMessage>()) } just Runs
+
+        every { stateStore.getNextComplete() } returnsMany listOf(
+            checkpointMessage1,
+            checkpointMessage2,
+            null
+        )
+
+        // When
+        stateReconciler.flushCompleteStates()
+
+        // Then
+        verifyOrder {
+            stateStore.getNextComplete() // Gets first message
+            consumer.accept(protocolMessage1) // Publishes first message
+            stateStore.getNextComplete() // Gets second message
+            consumer.accept(protocolMessage2) // Publishes second message
+            stateStore.getNextComplete() // Gets null, ends loop
+        }
+    }
+
+    @Test
+    fun `publish should handle exception from consumer gracefully`() {
+        // Given
+        val checkpointMessage = mockk<CheckpointMessage>()
+        val protocolMessage = mockk<AirbyteMessage>()
+
+        every { checkpointMessage.asProtocolMessage() } returns protocolMessage
+        every { consumer.accept(protocolMessage) } throws RuntimeException("Consumer error")
+
+        // When & Then
+        try {
+            stateReconciler.publish(checkpointMessage)
+        } catch (e: RuntimeException) {
+            // Expected - let the exception propagate
+            assert(e.message == "Consumer error")
+        }
+
+        verify { checkpointMessage.asProtocolMessage() }
+        verify { consumer.accept(protocolMessage) }
+    }
+
+    @Test
+    fun `flushCompleteStates should handle exception from state store gracefully`() {
+        // Given
+        every { stateStore.getNextComplete() } throws RuntimeException("StateStore error")
+
+        // When & Then
+        try {
+            stateReconciler.flushCompleteStates()
+        } catch (e: RuntimeException) {
+            // Expected - let the exception propagate
+            assert(e.message == "StateStore error")
+        }
+
+        verify { stateStore.getNextComplete() }
+        verify(exactly = 0) { consumer.accept(any<AirbyteMessage>()) }
+    }
+}

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/dataflow/state/StateStoreTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/dataflow/state/StateStoreTest.kt
@@ -10,20 +10,18 @@ import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
 import io.mockk.mockk
 import io.mockk.verify
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
-import kotlin.test.assertEquals
-import kotlin.test.assertNull
 
 @ExtendWith(MockKExtension::class)
 class StateStoreTest {
 
-    @MockK
-    private lateinit var keyClient: StateKeyClient
+    @MockK private lateinit var keyClient: StateKeyClient
 
-    @MockK
-    private lateinit var histogramStore: StateHistogramStore
+    @MockK private lateinit var histogramStore: StateHistogramStore
 
     private lateinit var stateStore: StateStore
 
@@ -147,7 +145,7 @@ class StateStoreTest {
         // Then
         assertEquals(checkpointMessage, result)
         verify { histogramStore.isComplete(stateKey) }
-        
+
         // Verify state was removed
         val secondResult = stateStore.getNextComplete()
         assertNull(secondResult)
@@ -213,7 +211,7 @@ class StateStoreTest {
 
         // When
         val result1 = stateStore.getNextComplete() // should be null because state 1 is incomplete
-        
+
         // Make state 1 complete now
         every { histogramStore.isComplete(stateKey1) } returns true
         val result2 = stateStore.getNextComplete() // should return state 1

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/dataflow/state/StateStoreTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/dataflow/state/StateStoreTest.kt
@@ -1,0 +1,225 @@
+/*
+ * Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.load.dataflow.state
+
+import io.airbyte.cdk.load.message.CheckpointMessage
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+@ExtendWith(MockKExtension::class)
+class StateStoreTest {
+
+    @MockK
+    private lateinit var keyClient: StateKeyClient
+
+    @MockK
+    private lateinit var histogramStore: StateHistogramStore
+
+    private lateinit var stateStore: StateStore
+
+    @BeforeEach
+    fun setUp() {
+        stateStore = StateStore(keyClient, histogramStore)
+    }
+
+    @Test
+    fun `accept should store checkpoint message and update histogram`() {
+        // Given
+        val checkpointMessage = mockk<CheckpointMessage>()
+        val sourceStats = mockk<CheckpointMessage.Stats>()
+        val stateKey = StateKey(1L, listOf(PartitionKey("partition-1")))
+
+        every { checkpointMessage.sourceStats } returns sourceStats
+        every { sourceStats.recordCount } returns 100L
+        every { keyClient.getStateKey(checkpointMessage) } returns stateKey
+        every { histogramStore.acceptExpectedCounts(stateKey, 100L) } returns mockk()
+
+        // When
+        stateStore.accept(checkpointMessage)
+
+        // Then
+        verify { keyClient.getStateKey(checkpointMessage) }
+        verify { histogramStore.acceptExpectedCounts(stateKey, 100L) }
+    }
+
+    @Test
+    fun `remove should return and remove the checkpoint message for given key`() {
+        // Given
+        val checkpointMessage = mockk<CheckpointMessage>()
+        val sourceStats = mockk<CheckpointMessage.Stats>()
+        val stateKey = StateKey(1L, listOf(PartitionKey("partition-1")))
+
+        every { checkpointMessage.sourceStats } returns sourceStats
+        every { sourceStats.recordCount } returns 100L
+        every { keyClient.getStateKey(checkpointMessage) } returns stateKey
+        every { histogramStore.acceptExpectedCounts(any(), any()) } returns mockk()
+
+        stateStore.accept(checkpointMessage)
+
+        // When
+        val removedMessage = stateStore.remove(stateKey)
+
+        // Then
+        assertEquals(checkpointMessage, removedMessage)
+    }
+
+    @Test
+    fun `getNextComplete should return null when no states exist`() {
+        // When
+        val result = stateStore.getNextComplete()
+
+        // Then
+        assertNull(result)
+    }
+
+    @Test
+    fun `getNextComplete should return null when first state id does not match sequence`() {
+        // Given
+        val checkpointMessage = mockk<CheckpointMessage>()
+        val sourceStats = mockk<CheckpointMessage.Stats>()
+        val stateKey = StateKey(5L, listOf(PartitionKey("partition-1"))) // Not sequence 1
+
+        every { checkpointMessage.sourceStats } returns sourceStats
+        every { sourceStats.recordCount } returns 100L
+        every { keyClient.getStateKey(checkpointMessage) } returns stateKey
+        every { histogramStore.acceptExpectedCounts(any(), any()) } returns mockk()
+
+        stateStore.accept(checkpointMessage)
+
+        // When
+        val result = stateStore.getNextComplete()
+
+        // Then
+        assertNull(result)
+    }
+
+    @Test
+    fun `getNextComplete should return null when state is not complete`() {
+        // Given
+        val checkpointMessage = mockk<CheckpointMessage>()
+        val sourceStats = mockk<CheckpointMessage.Stats>()
+        val stateKey = StateKey(1L, listOf(PartitionKey("partition-1")))
+
+        every { checkpointMessage.sourceStats } returns sourceStats
+        every { sourceStats.recordCount } returns 100L
+        every { keyClient.getStateKey(checkpointMessage) } returns stateKey
+        every { histogramStore.acceptExpectedCounts(any(), any()) } returns mockk()
+        every { histogramStore.isComplete(stateKey) } returns false
+
+        stateStore.accept(checkpointMessage)
+
+        // When
+        val result = stateStore.getNextComplete()
+
+        // Then
+        assertNull(result)
+        verify { histogramStore.isComplete(stateKey) }
+    }
+
+    @Test
+    fun `getNextComplete should return and remove state when it matches sequence and is complete`() {
+        // Given
+        val checkpointMessage = mockk<CheckpointMessage>()
+        val sourceStats = mockk<CheckpointMessage.Stats>()
+        val stateKey = StateKey(1L, listOf(PartitionKey("partition-1")))
+
+        every { checkpointMessage.sourceStats } returns sourceStats
+        every { sourceStats.recordCount } returns 100L
+        every { keyClient.getStateKey(checkpointMessage) } returns stateKey
+        every { histogramStore.acceptExpectedCounts(any(), any()) } returns mockk()
+        every { histogramStore.isComplete(stateKey) } returns true
+
+        stateStore.accept(checkpointMessage)
+
+        // When
+        val result = stateStore.getNextComplete()
+
+        // Then
+        assertEquals(checkpointMessage, result)
+        verify { histogramStore.isComplete(stateKey) }
+        
+        // Verify state was removed
+        val secondResult = stateStore.getNextComplete()
+        assertNull(secondResult)
+    }
+
+    @Test
+    fun `getNextComplete should process states in sequence order`() {
+        // Given
+        val checkpointMessage1 = mockk<CheckpointMessage>()
+        val checkpointMessage2 = mockk<CheckpointMessage>()
+        val checkpointMessage3 = mockk<CheckpointMessage>()
+        val sourceStats = mockk<CheckpointMessage.Stats>()
+
+        val stateKey1 = StateKey(1L, listOf(PartitionKey("partition-1")))
+        val stateKey2 = StateKey(2L, listOf(PartitionKey("partition-2")))
+        val stateKey3 = StateKey(3L, listOf(PartitionKey("partition-3")))
+
+        every { checkpointMessage1.sourceStats } returns sourceStats
+        every { checkpointMessage2.sourceStats } returns sourceStats
+        every { checkpointMessage3.sourceStats } returns sourceStats
+        every { sourceStats.recordCount } returns 100L
+
+        every { keyClient.getStateKey(checkpointMessage1) } returns stateKey1
+        every { keyClient.getStateKey(checkpointMessage2) } returns stateKey2
+        every { keyClient.getStateKey(checkpointMessage3) } returns stateKey3
+        every { histogramStore.acceptExpectedCounts(any(), any()) } returns mockk()
+        every { histogramStore.isComplete(any()) } returns true
+
+        // Add in reverse order
+        stateStore.accept(checkpointMessage3)
+        stateStore.accept(checkpointMessage1)
+        stateStore.accept(checkpointMessage2)
+
+        // When & Then
+        assertEquals(checkpointMessage1, stateStore.getNextComplete()) // sequence 1
+        assertEquals(checkpointMessage2, stateStore.getNextComplete()) // sequence 2
+        assertEquals(checkpointMessage3, stateStore.getNextComplete()) // sequence 3
+        assertNull(stateStore.getNextComplete()) // no more states
+    }
+
+    @Test
+    fun `getNextComplete should skip incomplete states and not advance sequence`() {
+        // Given
+        val checkpointMessage1 = mockk<CheckpointMessage>()
+        val checkpointMessage2 = mockk<CheckpointMessage>()
+        val sourceStats = mockk<CheckpointMessage.Stats>()
+
+        val stateKey1 = StateKey(1L, listOf(PartitionKey("partition-1")))
+        val stateKey2 = StateKey(2L, listOf(PartitionKey("partition-2")))
+
+        every { checkpointMessage1.sourceStats } returns sourceStats
+        every { checkpointMessage2.sourceStats } returns sourceStats
+        every { sourceStats.recordCount } returns 100L
+
+        every { keyClient.getStateKey(checkpointMessage1) } returns stateKey1
+        every { keyClient.getStateKey(checkpointMessage2) } returns stateKey2
+        every { histogramStore.acceptExpectedCounts(any(), any()) } returns mockk()
+        every { histogramStore.isComplete(stateKey1) } returns false // incomplete
+        every { histogramStore.isComplete(stateKey2) } returns true
+
+        stateStore.accept(checkpointMessage1)
+        stateStore.accept(checkpointMessage2)
+
+        // When
+        val result1 = stateStore.getNextComplete() // should be null because state 1 is incomplete
+        
+        // Make state 1 complete now
+        every { histogramStore.isComplete(stateKey1) } returns true
+        val result2 = stateStore.getNextComplete() // should return state 1
+
+        // Then
+        assertNull(result1)
+        assertEquals(checkpointMessage1, result2)
+    }
+}


### PR DESCRIPTION
## What
Ensures states are emitted sequentially in order
Removes complete state / partition keys to avoid memory leak
Adds unit tests for `state` and `handler` packages