### PR TITLE
run-agg-and-flush-on-diff-dispatchers

### DIFF
--- a/airbyte-cdk/bulk/build.gradle
+++ b/airbyte-cdk/bulk/build.gradle
@@ -6,7 +6,7 @@ import javax.xml.xpath.XPathFactory
 import org.w3c.dom.Document
 
 allprojects {
-    version = "0.1.16"
+    version = "0.1.17"
     apply plugin: 'java-library'
     apply plugin: 'maven-publish'
 

--- a/airbyte-cdk/bulk/changelog.md
+++ b/airbyte-cdk/bulk/changelog.md
@@ -1,14 +1,20 @@
-## Version 0.1.15
+## Version 0.1.16
 
-**Extract CDK**
+**Load CDK**
 
-* **Changed:** Extract CDK logs DB version during Check for all JDBC databases.
+* **Changed:** Run aggregate and flush steps on different dispatchers (default and IO respectively).
 
 ## Version 0.1.16
 
 **Load CDK**
 
 * **Changed:** Ensure sequential state emission. Remove flushed state/partition keys.
+
+## Version 0.1.15
+
+**Extract CDK**
+
+* **Changed:** Extract CDK logs DB version during Check for all JDBC databases.
 
 ## Version 0.1.14
 


### PR DESCRIPTION
## What
Flushing of aggregates no longer blocks aggregation of incoming data.

## How
Aggregate and Flush now run on separate dispatchers — Default and IO respectively

`flowOn` is great

## Notes on Dispatchers

`DEFAULT` — max threads equal to the number of CPU cores or 2 (whichever is higher). Good for CPU intensive tasks. The default dispatcher if not specified.

`IO` — max of 64 threads, but configurable. Good for long running IO tasks. Can be further restricted via `IO.limitedParallelism(number)`

Both dispatcher run on the _same_ backing thread pool. The difference is how many threads they are allowed to eat.
