### PR TITLE
chore(metadata-service): enable 5 min scheduled registry generation workflow

### DIFF
--- a/.github/workflows/generate-connector-registries.yml
+++ b/.github/workflows/generate-connector-registries.yml
@@ -8,7 +8,7 @@ on:
         required: false
         type: string
   schedule:
-    - cron: '*/5 * * * *'  # Run every 5 minutes
+    - cron: "*/5 * * * *"  # Run every 5 minutes
 
 permissions:
   contents: read

--- a/.github/workflows/generate-connector-registries.yml
+++ b/.github/workflows/generate-connector-registries.yml
@@ -8,7 +8,7 @@ on:
         required: false
         type: string
   schedule:
-    - cron: "*/5 * * * *"  # Run every 5 minutes
+    - cron: "*/5 * * * *"
 
 permissions:
   contents: read

--- a/.github/workflows/generate-connector-registries.yml
+++ b/.github/workflows/generate-connector-registries.yml
@@ -7,9 +7,8 @@ on:
         description: "The git ref to check out from the repository"
         required: false
         type: string
-# TODO: uncomment once ready to implement schedule
-#   schedule:
-#     - cron: '*/5 * * * *'  # Run every 5 minutes
+  schedule:
+    - cron: '*/5 * * * *'  # Run every 5 minutes
 
 permissions:
   contents: read


### PR DESCRIPTION
## What
- Enables 5 min cron registry generation worklow
- Still uploads to dev bucket

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [X] YES 💚
- [ ] NO ❌

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._