### PR TITLE
fix: revert new connector build process

### DIFF
--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -168,16 +168,16 @@ jobs:
             echo "Using a dev tag for a pre-release build: ${tag_override}"
           fi
 
-      - name: Build and publish Python and Manifest-Only connectors images [On merge to master]
-        id: build-and-publish-python-manifest-only-connectors-images-master
-        if: github.event_name == 'push' && steps.connector-metadata.outputs.connector-language != 'java'
-        uses: ./.github/actions/connector-image-build-push
-        with:
-          connector-name: ${{ matrix.connector }}
-          push-latest: ${{ steps.get-connector-options.outputs.push-latest }}
-          dry-run: "false"
-          docker-hub-username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          docker-hub-password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+      # - name: Build and publish Python and Manifest-Only connectors images [On merge to master]
+      #   id: build-and-publish-python-manifest-only-connectors-images-master
+      #   if: github.event_name == 'push' && steps.connector-metadata.outputs.connector-language != 'java'
+      #   uses: ./.github/actions/connector-image-build-push
+      #   with:
+      #     connector-name: ${{ matrix.connector }}
+      #     push-latest: ${{ steps.get-connector-options.outputs.push-latest }}
+      #     dry-run: "false"
+      #     docker-hub-username: ${{ secrets.DOCKER_HUB_USERNAME }}
+      #     docker-hub-password: ${{ secrets.DOCKER_HUB_PASSWORD }}
 
       - name: Publish connectors [On merge to master]
         # JVM docker images are published beforehand so Airbyte-CI only does registry publishing.
@@ -219,17 +219,17 @@ jobs:
         shell: bash
         run: ./poe-tasks/build-and-publish-java-connectors-with-tag.sh  ${{ inputs.publish-options }} --name ${{ matrix.connector }} --publish
 
-      - name: Build and publish Python and Manifest-Only connectors images [manual]
-        id: build-and-publish-python-manifest-only-connectors-images-manual
-        if: (github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call') && steps.connector-metadata.outputs.connector-language != 'java'
-        uses: ./.github/actions/connector-image-build-push
-        with:
-          connector-name: ${{ matrix.connector }}
-          push-latest: ${{ steps.get-connector-options.outputs.push-latest }}
-          tag-override: ${{ steps.get-connector-options.outputs.tag-override }}
-          dry-run: "false"
-          docker-hub-username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          docker-hub-password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+      # - name: Build and publish Python and Manifest-Only connectors images [manual]
+      #   id: build-and-publish-python-manifest-only-connectors-images-manual
+      #   if: (github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call') && steps.connector-metadata.outputs.connector-language != 'java'
+      #   uses: ./.github/actions/connector-image-build-push
+      #   with:
+      #     connector-name: ${{ matrix.connector }}
+      #     push-latest: ${{ steps.get-connector-options.outputs.push-latest }}
+      #     tag-override: ${{ steps.get-connector-options.outputs.tag-override }}
+      #     dry-run: "false"
+      #     docker-hub-username: ${{ secrets.DOCKER_HUB_USERNAME }}
+      #     docker-hub-password: ${{ secrets.DOCKER_HUB_PASSWORD }}
 
       - name: Publish connectors [manual]
         id: publish-connectors-manual


### PR DESCRIPTION
## What
Falling back on airbyte-ci to build and publish python and manifest only connectors while I track down a potential issue with the new process.

Context: we are seeing this error with `source-snapchat-marketing:1.5.16` which was one of the first M-O connectors to have been released since the build process changed.

```
The main container of the SPEC operation returned an exit code 2
```

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
