### PR TITLE
fix: connector publish workflow set entrypoint as absolute path

### DIFF
--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - dbgold17/fix-connector-publish-workflow
     paths:
       - "airbyte-integrations/connectors/**/metadata.yaml"
   workflow_call:
@@ -168,16 +169,16 @@ jobs:
             echo "Using a dev tag for a pre-release build: ${tag_override}"
           fi
 
-      # - name: Build and publish Python and Manifest-Only connectors images [On merge to master]
-      #   id: build-and-publish-python-manifest-only-connectors-images-master
-      #   if: github.event_name == 'push' && steps.connector-metadata.outputs.connector-language != 'java'
-      #   uses: ./.github/actions/connector-image-build-push
-      #   with:
-      #     connector-name: ${{ matrix.connector }}
-      #     push-latest: ${{ steps.get-connector-options.outputs.push-latest }}
-      #     dry-run: "false"
-      #     docker-hub-username: ${{ secrets.DOCKER_HUB_USERNAME }}
-      #     docker-hub-password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+      - name: Build and publish Python and Manifest-Only connectors images [On merge to master]
+        id: build-and-publish-python-manifest-only-connectors-images-master
+        if: github.event_name == 'push' && steps.connector-metadata.outputs.connector-language != 'java'
+        uses: ./.github/actions/connector-image-build-push
+        with:
+          connector-name: ${{ matrix.connector }}
+          push-latest: ${{ steps.get-connector-options.outputs.push-latest }}
+          dry-run: "false"
+          docker-hub-username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          docker-hub-password: ${{ secrets.DOCKER_HUB_PASSWORD }}
 
       - name: Publish connectors [On merge to master]
         # JVM docker images are published beforehand so Airbyte-CI only does registry publishing.
@@ -219,17 +220,17 @@ jobs:
         shell: bash
         run: ./poe-tasks/build-and-publish-java-connectors-with-tag.sh  ${{ inputs.publish-options }} --name ${{ matrix.connector }} --publish
 
-      # - name: Build and publish Python and Manifest-Only connectors images [manual]
-      #   id: build-and-publish-python-manifest-only-connectors-images-manual
-      #   if: (github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call') && steps.connector-metadata.outputs.connector-language != 'java'
-      #   uses: ./.github/actions/connector-image-build-push
-      #   with:
-      #     connector-name: ${{ matrix.connector }}
-      #     push-latest: ${{ steps.get-connector-options.outputs.push-latest }}
-      #     tag-override: ${{ steps.get-connector-options.outputs.tag-override }}
-      #     dry-run: "false"
-      #     docker-hub-username: ${{ secrets.DOCKER_HUB_USERNAME }}
-      #     docker-hub-password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+      - name: Build and publish Python and Manifest-Only connectors images [manual]
+        id: build-and-publish-python-manifest-only-connectors-images-manual
+        if: (github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call') && steps.connector-metadata.outputs.connector-language != 'java'
+        uses: ./.github/actions/connector-image-build-push
+        with:
+          connector-name: ${{ matrix.connector }}
+          push-latest: ${{ steps.get-connector-options.outputs.push-latest }}
+          tag-override: ${{ steps.get-connector-options.outputs.tag-override }}
+          dry-run: "false"
+          docker-hub-username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          docker-hub-password: ${{ secrets.DOCKER_HUB_PASSWORD }}
 
       - name: Publish connectors [manual]
         id: publish-connectors-manual

--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - dbgold17/fix-connector-publish-workflow
     paths:
       - "airbyte-integrations/connectors/**/metadata.yaml"
   workflow_call:

--- a/docker-images/Dockerfile.manifest-only-connector
+++ b/docker-images/Dockerfile.manifest-only-connector
@@ -26,6 +26,8 @@ RUN cp manifest.yaml ./source_declarative_manifest/manifest.yaml
 # Copy components.py if it exists (optional)
 RUN if [ -f components.py ]; then cp components.py ./source_declarative_manifest/components.py; fi
 
-# Set entrypoint explicitly as required for manifest-only connectors
-ENV AIRBYTE_ENTRYPOINT="python ./main.py"
-ENTRYPOINT ["python", "./main.py"]
+# Set user and entrypoint explicitly
+# This is the same as defined in the source-declarative-manifest base image
+USER airbyte
+ENV AIRBYTE_ENTRYPOINT="python /airbyte/integration_code/main.py"
+ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]

--- a/docker-images/Dockerfile.manifest-only-connector
+++ b/docker-images/Dockerfile.manifest-only-connector
@@ -28,6 +28,5 @@ RUN if [ -f components.py ]; then cp components.py ./source_declarative_manifest
 
 # Set user and entrypoint explicitly
 # This is the same as defined in the source-declarative-manifest base image
-USER airbyte
-ENV AIRBYTE_ENTRYPOINT="python /airbyte/integration_code/main.py"
-ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
+ENV AIRBYTE_ENTRYPOINT="python ./main.py"
+ENTRYPOINT ["python", "./main.py"]

--- a/docker-images/Dockerfile.manifest-only-connector
+++ b/docker-images/Dockerfile.manifest-only-connector
@@ -30,3 +30,4 @@ RUN if [ -f components.py ]; then cp components.py ./source_declarative_manifest
 # This is the same as defined in the source-declarative-manifest base image
 ENV AIRBYTE_ENTRYPOINT="python ./main.py"
 ENTRYPOINT ["python", "./main.py"]
+RUN echo "This should be broken!!!"

--- a/docker-images/Dockerfile.manifest-only-connector
+++ b/docker-images/Dockerfile.manifest-only-connector
@@ -28,6 +28,6 @@ RUN if [ -f components.py ]; then cp components.py ./source_declarative_manifest
 
 # Set user and entrypoint explicitly
 # This is the same as defined in the source-declarative-manifest base image
-ENV AIRBYTE_ENTRYPOINT="python ./main.py"
-ENTRYPOINT ["python", "./main.py"]
-RUN echo "This should be broken!!!"
+USER airbyte
+ENV AIRBYTE_ENTRYPOINT="python /airbyte/integration_code/main.py"
+ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]


### PR DESCRIPTION
## What
Set the entrypoint using an absolute path instead of a relative path. I believe the Airbyte Platform is changing the working directory [here](https://github.com/airbytehq/airbyte-platform-internal/blob/afe4649213c3432fd99ff1cc62dc11de002283c4/oss/airbyte-commons-worker/src/main/kotlin/io/airbyte/workers/pod/FileConstants.kt) and therefore the entrypoint ends up pointing to a non existent file. 

This fixes an error we were seeing on Cloud for `source-snapchat-marketing`

I verified the fix works by setting up a custom connection on Cloud using a pre-release version of snapchat-marketing I built with the new build process.

[connection logs](https://cloud.airbyte.com/workspaces/2c76f7af-a9db-407d-8d1d-ad0d76bd0dfb/connections/3000c594-0009-4ae5-b805-05feaaa593c7/timeline) with the error

error message:
```
ERROR python: can't open file '/source/./main.py': [Errno 2] No such file or directory
```

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
