### PR TITLE
Jose/publish java tar to metadata gcs bucket

### DIFF
--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -207,7 +207,12 @@ jobs:
         id: upload-connector-metadata-master
         if: github.event_name == 'push'
         shell: bash
-        run: ./poe-tasks/upload-connector-metadata.sh --name ${{ matrix.connector }} --main-release
+        run: |
+          publish_java_tar_flag=""
+          if [ "${{ steps.connector-metadata.outputs.connector-language }}" = "java" ]; then
+            publish_java_tar_flag="--publish-java-tar"
+          fi
+          ./poe-tasks/upload-connector-metadata.sh --name ${{ matrix.connector }} --main-release $publish_java_tar_flag
         env:
           GCS_CREDENTIALS: ${{ secrets.METADATA_SERVICE_DEV_GCS_CREDENTIALS }}
           SPEC_CACHE_GCS_CREDENTIALS: ${{ secrets.METADATA_SERVICE_DEV_GCS_CREDENTIALS }}
@@ -258,7 +263,12 @@ jobs:
         id: upload-connector-metadata-manual
         if: github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call'
         shell: bash
-        run: ./poe-tasks/upload-connector-metadata.sh --name ${{ matrix.connector }} ${{ inputs.publish-options }}
+        run: |
+          publish_java_tar_flag=""
+          if [ "${{ steps.connector-metadata.outputs.connector-language }}" = "java" ]; then
+            publish_java_tar_flag="--publish-java-tar"
+          fi
+        ./poe-tasks/upload-connector-metadata.sh --name ${{ matrix.connector }} ${{ inputs.publish-options }} $publish_java_tar_flag
         env:
           GCS_CREDENTIALS: ${{ secrets.METADATA_SERVICE_DEV_GCS_CREDENTIALS }}
           SPEC_CACHE_GCS_CREDENTIALS: ${{ secrets.METADATA_SERVICE_DEV_GCS_CREDENTIALS }}

--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/commands.py
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/commands.py
@@ -88,15 +88,16 @@ def validate(metadata_file_path: pathlib.Path, docs_path: pathlib.Path):
 @click.argument("metadata-file-path", type=click.Path(exists=True, path_type=pathlib.Path), required=True)
 @click.argument("docs-path", type=click.Path(exists=True, path_type=pathlib.Path), required=True)
 @click.argument("bucket-name", type=click.STRING, required=True)
+@click.argument("java-tar-file-path", type=click.Path(exists=True, path_type=pathlib.Path), required=False)
 @click.option("--prerelease", type=click.STRING, required=False, default=None, help="The prerelease tag of the connector.")
 @click.option("--disable-dockerhub-checks", is_flag=True, help="Disable 'image exists on DockerHub' validations.", default=False)
-def upload(metadata_file_path: pathlib.Path, docs_path: pathlib.Path, bucket_name: str, prerelease: str, disable_dockerhub_checks: bool):
+def upload(metadata_file_path: pathlib.Path, docs_path: pathlib.Path, bucket_name: str, java_tar_file_path: pathlib.Path | None, prerelease: str, disable_dockerhub_checks: bool):
     metadata_file_path = metadata_file_path if not metadata_file_path.is_dir() else metadata_file_path / METADATA_FILE_NAME
     validator_opts = ValidatorOptions(
         docs_path=str(docs_path), prerelease_tag=prerelease, disable_dockerhub_checks=disable_dockerhub_checks
     )
     try:
-        upload_info = upload_metadata_to_gcs(bucket_name, metadata_file_path, validator_opts)
+        upload_info = upload_metadata_to_gcs(bucket_name, metadata_file_path, java_tar_file_path, validator_opts)
         log_metadata_upload_info(upload_info)
     except (ValidationError, FileNotFoundError) as e:
         click.secho(f"The metadata file could not be uploaded: {str(e)}", fg="red")

--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/gcs_upload.py
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/gcs_upload.py
@@ -388,7 +388,7 @@ def _apply_modifications_to_metadata_file(
 # 💎 Main Logic
 
 
-def upload_metadata_to_gcs(bucket_name: str, metadata_file_path: Path, validator_opts: ValidatorOptions) -> MetadataUploadInfo:
+def upload_metadata_to_gcs(bucket_name: str, metadata_file_path: Path, java_tar_file_path: Path | None, validator_opts: ValidatorOptions) -> MetadataUploadInfo:
     """Upload a metadata file to a GCS bucket.
 
     If the per 'version' key already exists it won't be overwritten.
@@ -464,6 +464,20 @@ def upload_metadata_to_gcs(bucket_name: str, metadata_file_path: Path, validator
             override_destination_file_name=METADATA_FILE_NAME,
         )
         uploaded_files.extend(release_candidate_files_uploaded)
+
+    # Java tar upload
+
+    metadata_files_uploaded = _file_upload(
+        file_key="java_tar",
+        local_path=java_tar_file_path,
+        gcp_connector_dir=gcp_connector_dir,
+        bucket=bucket,
+        version_folder=version_folder,
+        upload_as_version=True,
+        upload_as_latest=should_upload_latest,
+        disable_cache=True
+    )
+    uploaded_files.extend(metadata_files_uploaded)
 
     # Icon upload
 

--- a/poe-tasks/lib/parse_args.sh
+++ b/poe-tasks/lib/parse_args.sh
@@ -1,10 +1,11 @@
 # Parse the command-line args that we care about.
 # Scripts sourcing this script can be invoked as either:
-# ./foo.sh [--pre-release] [--main-release] [--publish] [--name=<source/destination-foo>]* [--name <source/destination-foo>]*
+# ./foo.sh [--pre-release] [--main-release] [--publish] [--publish-java-tar] [--name=<source/destination-foo>]* [--name <source/destination-foo>]*
 # Or, if invoked with no `--name` flags:
 # ./get-modified-connectors.sh --json | ./foo.sh [--pre-release] [--main-release] [--publish]
 publish_mode="pre-release"
 do_publish=false
+publish_java_tar=false
 connectors=()
 
 while [[ $# -gt 0 ]]; do
@@ -32,6 +33,10 @@ while [[ $# -gt 0 ]]; do
     --name)
       connectors+=("$2")
       shift 2
+      ;;
+    --publish-java-tar)
+      publish_java_tar=true
+      shift
       ;;
     --*)
       echo "Error: Unknown flag $1" >&2

--- a/poe-tasks/upload-connector-metadata.sh
+++ b/poe-tasks/upload-connector-metadata.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Uploads the metadata (+SBOM+spec cache) to GCS.
-# Usage: ./poe-tasks/upload-connector-metadata.sh --name destination-bigquery [--pre-release] [--main-release]
+# Uploads the metadata (+SBOM+spec cache) to GCS. Can also upload the java jar for java connectors.
+# Usage: ./poe-tasks/upload-connector-metadata.sh --name destination-bigquery [--pre-release] [--main-release] [--publish-java-jar]
 # You must have three environment variables set (GCS_CREDENTIALS, METADATA_SERVICE_GCS_CREDENTIALS, SPEC_CACHE_GCS_CREDENTIALS),
 # each containing a JSON-formatted GCP service account key.
 # SPEC_CACHE_GCS_CREDENTIALS needs write access to `gs://$spec_cache_bucket/specs`.
@@ -112,5 +112,11 @@ else
   # yes, it's --prerelease and not --pre-release
   metadata_upload_prerelease_flag="--prerelease $docker_tag"
 fi
+
+java_tar_path=""
+if $publish_java_tar; then
+  java_tar_path="${CONNECTORS_DIR}/${connector}/build/distributions/airbyte-app.tar"
+else
+fi
 # Under the hood, this reads the GCS_CREDENTIALS environment variable
-poetry run --directory $METADATA_SERVICE_PATH metadata_service upload "$meta" "$DOCS_ROOT/" "$metadata_bucket" $metadata_upload_prerelease_flag
+poetry run --directory $METADATA_SERVICE_PATH metadata_service upload "$meta" "$DOCS_ROOT/" "$metadata_bucket" $metadata_upload_prerelease_flag $java_tar_path

--- a/poe-tasks/upload-connector-metadata.sh
+++ b/poe-tasks/upload-connector-metadata.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Uploads the metadata (+SBOM+spec cache) to GCS. Can also upload the java jar for java connectors.
-# Usage: ./poe-tasks/upload-connector-metadata.sh --name destination-bigquery [--pre-release] [--main-release] [--publish-java-jar]
+# Uploads the metadata (+SBOM+spec cache) to GCS. Can also upload the java tar for java connectors.
+# Usage: ./poe-tasks/upload-connector-metadata.sh --name destination-bigquery [--pre-release] [--main-release] [--publish-java-tar]
 # You must have three environment variables set (GCS_CREDENTIALS, METADATA_SERVICE_GCS_CREDENTIALS, SPEC_CACHE_GCS_CREDENTIALS),
 # each containing a JSON-formatted GCP service account key.
 # SPEC_CACHE_GCS_CREDENTIALS needs write access to `gs://$spec_cache_bucket/specs`.


### PR DESCRIPTION
Note: I haven't tested this at all, I'd like to get feedback first to see if people find this reasonable.

IMO this is not great since I think it's weird to upload the java tar alongside all the connector metadata, it seems out of place. I think it would be better to have the logic of uploading the tar separate from the metadata stuff, even in a different bucket. Having said that, the nice thing about uploading the tar alongside the metadata is that we don't really have to add any more logic to deal with tar versioning.