### PR TITLE
docs: improve AIRBYTE_ENTRYPOINT requirements with absolute path guidance

### DIFF
--- a/docs/platform/understanding-airbyte/airbyte-protocol-docker.md
+++ b/docs/platform/understanding-airbyte/airbyte-protocol-docker.md
@@ -58,6 +58,12 @@ The `write` command will consume `AirbyteMessage`s from STDIN.
 
 The Docker image must contain an environment variable called `AIRBYTE_ENTRYPOINT`. This must be the same as the `ENTRYPOINT` of the image.
 
+**Important**: The `AIRBYTE_ENTRYPOINT` environment variable must use absolute paths to ensure proper execution. Note that the Airbyte platform may change the working directory at runtime (for instance, to `/source` for sources and `/dest` for destinations). Using relative paths in the entrypoint can cause execution failures when the working directory is overridden.
+
+**Example**:
+- ✅ Correct: `ENV AIRBYTE_ENTRYPOINT="python /airbyte/integration_code/main.py"`
+- ❌ Incorrect: `ENV AIRBYTE_ENTRYPOINT="./main.py"`
+
 ## Non-Root User: `airbyte`
 
 The Docker image should run under a user named `airbyte`.

--- a/docusaurus/platform_versioned_docs/version-1.7/understanding-airbyte/airbyte-protocol-docker.md
+++ b/docusaurus/platform_versioned_docs/version-1.7/understanding-airbyte/airbyte-protocol-docker.md
@@ -58,6 +58,12 @@ The `write` command will consume `AirbyteMessage`s from STDIN.
 
 The Docker image must contain an environment variable called `AIRBYTE_ENTRYPOINT`. This must be the same as the `ENTRYPOINT` of the image.
 
+**Important**: The `AIRBYTE_ENTRYPOINT` environment variable must use absolute paths to ensure proper execution. Note that the Airbyte platform may change the working directory at runtime (for instance, to `/source` for sources and `/dest` for destinations). Using relative paths in the entrypoint can cause execution failures when the working directory is overridden.
+
+**Example**:
+- ✅ Correct: `ENV AIRBYTE_ENTRYPOINT="python /airbyte/integration_code/main.py"`
+- ❌ Incorrect: `ENV AIRBYTE_ENTRYPOINT="./main.py"`
+
 ## Non-Root User: `airbyte`
 
 The Docker image should run under a user named `airbyte`.


### PR DESCRIPTION
## What

Improves the Docker image requirements documentation to include critical guidance about `AIRBYTE_ENTRYPOINT` requiring absolute paths. This addresses a discovered issue where connectors using relative paths in their entrypoint fail when Airbyte platform overrides working directories at runtime.

**Root cause**: Airbyte platform explicitly sets working directories (`/source` for sources, `/dest` for destinations) which breaks relative path resolution in connector entrypoints.

## How

Enhanced the `AIRBYTE_ENTRYPOINT` section in `airbyte-protocol-docker.md` with:
- **Requirement**: Must use absolute paths for proper execution
- **Technical explanation**: Platform overrides working directories at runtime
- **Clear examples**: Shows correct vs incorrect entrypoint patterns
- **Context**: Explains why relative paths fail due to workdir overrides

Changes verified against platform code:
- `ReplicationContainerFactory.kt` sets `workingDir` to `SOURCE_DIR` and `DEST_DIR`
- `FileConstants.kt` defines `SOURCE_DIR="/source"` and `DEST_DIR="/dest"`

## Review guide

1. **Technical accuracy**: Verify the working directory override behavior described is complete and accurate
2. **Documentation consistency**: Ensure both files are updated identically:
   - `docs/platform/understanding-airbyte/airbyte-protocol-docker.md`
   - `docusaurus/platform_versioned_docs/version-1.7/understanding-airbyte/airbyte-protocol-docker.md`
3. **Clarity**: Check that the explanation is clear for connector developers
4. **Examples**: Verify the correct/incorrect examples are helpful and accurate

## User Impact

**Positive**: Connector developers will understand why absolute paths are required and avoid common execution failures.

**No negative side effects**: Documentation-only change that clarifies existing requirements.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

**Session**: https://app.devin.ai/sessions/a8f1f878ca6146bebcf89129f8dba6a5  
**Requested by**: @aaronsteers