### PR TITLE
feat: de-daggerize python connector PyPI publishing

### DIFF
--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -143,15 +143,13 @@ jobs:
         working-directory: airbyte-integrations/connectors/${{ matrix.connector }}
         shell: bash
         run: |
-          ./poe-tasks/publish-python-registry.sh \
-            --name ${{ matrix.connector }}
+          ./poe-tasks/publish-python-registry.sh --name ${{ matrix.connector }}
         env:
           PYTHON_REGISTRY_TOKEN: ${{ secrets.PYPI_TOKEN }}
 
       - name: Publish to Python Registry [Manual]
         id: publish-python-registry-manual
         if: (github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call') && steps.connector-metadata.outputs.connector-language == 'python'
-        working-directory: airbyte-integrations/connectors/${{ matrix.connector }}
         shell: bash
         run: |
           # Determine if this is a pre-release
@@ -162,9 +160,7 @@ jobs:
             PRE_RELEASE_FLAG=""
           fi
 
-          ./poe-tasks/publish-python-registry.sh \
-            --name ${{ matrix.connector }} \
-            $PRE_RELEASE_FLAG
+          ./poe-tasks/publish-python-registry.sh --name ${{ matrix.connector }} $PRE_RELEASE_FLAG
         env:
           PYTHON_REGISTRY_TOKEN: ${{ secrets.PYPI_TOKEN }}
 

--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -137,6 +137,71 @@ jobs:
         shell: bash
         run: ./poe-tasks/validate-connector-metadata.sh --name ${{ matrix.connector }}
 
+      - name: Publish to Python Registry [On merge to master]
+        id: publish-python-registry-master
+        if: github.event_name == 'push' && steps.connector-metadata.outputs.connector-language == 'python'
+        working-directory: airbyte-integrations/connectors/${{ matrix.connector }}
+        shell: bash
+        run: |
+          ./poe-tasks/publish-python-registry.sh \
+            --name ${{ matrix.connector }}
+        env:
+          PYTHON_REGISTRY_TOKEN: ${{ secrets.PYPI_TOKEN }}
+
+      - name: Publish to Python Registry [Manual]
+        id: publish-python-registry-manual
+        if: (github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call') && steps.connector-metadata.outputs.connector-language == 'python'
+        working-directory: airbyte-integrations/connectors/${{ matrix.connector }}
+        shell: bash
+        run: |
+          # Determine if this is a pre-release
+          is_pre_release=$(echo "${{ inputs.publish-options }}" | grep -c -- '--pre-release' || true)
+          if [[ $is_pre_release -gt 0 ]]; then
+            PRE_RELEASE_FLAG="--pre-release"
+          else
+            PRE_RELEASE_FLAG=""
+          fi
+
+          ./poe-tasks/publish-python-registry.sh \
+            --name ${{ matrix.connector }} \
+            $PRE_RELEASE_FLAG
+        env:
+          PYTHON_REGISTRY_TOKEN: ${{ secrets.PYPI_TOKEN }}
+
+      - name: Upload Python Dependencies to GCS [On merge to master]
+        id: upload-python-dependencies-master
+        if: github.event_name == 'push' && contains(fromJSON('["python", "low-code"]'), steps.connector-metadata.outputs.connector-language)
+        shell: bash
+        run: |
+          # Create temporary credentials file
+          TEMP_CREDS=$(mktemp)
+          echo "${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}" > "$TEMP_CREDS"
+
+          ./poe-tasks/upload-python-dependencies.sh \
+            --name ${{ matrix.connector }} \
+            --bucket metadata-service-prod \
+            --credentials "$TEMP_CREDS"
+
+          # Cleanup
+          rm -f "$TEMP_CREDS"
+
+      - name: Upload Python Dependencies to GCS [Manual]
+        id: upload-python-dependencies-manual
+        if: (github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call') && contains(fromJSON('["python", "low-code"]'), steps.connector-metadata.outputs.connector-language)
+        shell: bash
+        run: |
+          # Create temporary credentials file
+          TEMP_CREDS=$(mktemp)
+          echo "${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}" > "$TEMP_CREDS"
+
+          ./poe-tasks/upload-python-dependencies.sh \
+            --name ${{ matrix.connector }} \
+            --bucket metadata-service-prod \
+            --credentials "$TEMP_CREDS"
+
+          # Cleanup
+          rm -f "$TEMP_CREDS"
+
       - name: Build and publish JVM connectors images [On merge to master]
         id: build-and-publish-JVM-connectors-images-master
         if: github.event_name == 'push' && steps.connector-metadata.outputs.connector-language == 'java'
@@ -212,6 +277,23 @@ jobs:
           GCS_CREDENTIALS: ${{ secrets.METADATA_SERVICE_DEV_GCS_CREDENTIALS }}
           SPEC_CACHE_GCS_CREDENTIALS: ${{ secrets.METADATA_SERVICE_DEV_GCS_CREDENTIALS }}
           METADATA_SERVICE_GCS_CREDENTIALS: ${{ secrets.METADATA_SERVICE_DEV_GCS_CREDENTIALS }}
+
+      - name: Upload Python Connector Dependencies to GCS [On merge to master]
+        id: upload-python-dependencies-master
+        if: github.event_name == 'push' && steps.connector-metadata.outputs.connector-language == 'python'
+        shell: bash
+        run: |
+          # Create temporary credentials file
+          TEMP_CREDS=$(mktemp)
+          echo "${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}" > "$TEMP_CREDS"
+
+          ./poe-tasks/upload-python-dependencies.sh \
+            --name ${{ matrix.connector }} \
+            --bucket metadata-service-prod \
+            --credentials "$TEMP_CREDS"
+
+          # Cleanup
+          rm -f "$TEMP_CREDS"
 
       - name: Build and publish JVM connectors images [manual]
         id: build-and-publish-JVM-connectors-images-manual

--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -164,40 +164,6 @@ jobs:
         env:
           PYTHON_REGISTRY_TOKEN: ${{ secrets.PYPI_TOKEN }}
 
-      - name: Upload Python Dependencies to GCS [On merge to master]
-        id: upload-python-dependencies-master
-        if: github.event_name == 'push' && contains(fromJSON('["python", "low-code"]'), steps.connector-metadata.outputs.connector-language)
-        shell: bash
-        run: |
-          # Create temporary credentials file
-          TEMP_CREDS=$(mktemp)
-          echo "${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}" > "$TEMP_CREDS"
-
-          ./poe-tasks/upload-python-dependencies.sh \
-            --name ${{ matrix.connector }} \
-            --bucket metadata-service-prod \
-            --credentials "$TEMP_CREDS"
-
-          # Cleanup
-          rm -f "$TEMP_CREDS"
-
-      - name: Upload Python Dependencies to GCS [Manual]
-        id: upload-python-dependencies-manual
-        if: (github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call') && contains(fromJSON('["python", "low-code"]'), steps.connector-metadata.outputs.connector-language)
-        shell: bash
-        run: |
-          # Create temporary credentials file
-          TEMP_CREDS=$(mktemp)
-          echo "${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}" > "$TEMP_CREDS"
-
-          ./poe-tasks/upload-python-dependencies.sh \
-            --name ${{ matrix.connector }} \
-            --bucket metadata-service-prod \
-            --credentials "$TEMP_CREDS"
-
-          # Cleanup
-          rm -f "$TEMP_CREDS"
-
       - name: Build and publish JVM connectors images [On merge to master]
         id: build-and-publish-JVM-connectors-images-master
         if: github.event_name == 'push' && steps.connector-metadata.outputs.connector-language == 'java'
@@ -273,23 +239,6 @@ jobs:
           GCS_CREDENTIALS: ${{ secrets.METADATA_SERVICE_DEV_GCS_CREDENTIALS }}
           SPEC_CACHE_GCS_CREDENTIALS: ${{ secrets.METADATA_SERVICE_DEV_GCS_CREDENTIALS }}
           METADATA_SERVICE_GCS_CREDENTIALS: ${{ secrets.METADATA_SERVICE_DEV_GCS_CREDENTIALS }}
-
-      - name: Upload Python Connector Dependencies to GCS [On merge to master]
-        id: upload-python-dependencies-master
-        if: github.event_name == 'push' && steps.connector-metadata.outputs.connector-language == 'python'
-        shell: bash
-        run: |
-          # Create temporary credentials file
-          TEMP_CREDS=$(mktemp)
-          echo "${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}" > "$TEMP_CREDS"
-
-          ./poe-tasks/upload-python-dependencies.sh \
-            --name ${{ matrix.connector }} \
-            --bucket metadata-service-prod \
-            --credentials "$TEMP_CREDS"
-
-          # Cleanup
-          rm -f "$TEMP_CREDS"
 
       - name: Build and publish JVM connectors images [manual]
         id: build-and-publish-JVM-connectors-images-manual

--- a/poe-tasks/publish-python-registry.sh
+++ b/poe-tasks/publish-python-registry.sh
@@ -1,0 +1,171 @@
+#!/bin/bash
+#
+# Publish a Python connector to PyPI registry
+# Extracted from airbyte-ci publish pipeline for GitHub Actions integration
+#
+
+set -euo pipefail
+
+function usage() {
+    cat << EOF
+Usage: $0 [options]
+
+Publish a Python connector to PyPI registry.
+
+Options:
+    -n, --name CONNECTOR_NAME     Connector name (required)
+    -t, --token TOKEN             PyPI token (required)
+    -v, --version VERSION        Override version (optional)
+    --pre-release                publish as a pre-release (uses a dev version derived from the current timestamp)
+    -h, --help                   Show this help message
+
+Environment Variables:
+    PYTHON_REGISTRY_TOKEN        PyPI token (alternative to --token)
+
+Examples:
+    $0 --name source-faker --token \$PYPI_TOKEN
+    $0 --name source-faker --token \$PYPI_TOKEN --pre-release
+EOF
+}
+
+function should_publish_pypi() {
+    # Check if the connector is enabled for PyPI publishing
+    if yq eval '.data.remoteRegistries.pypi.enabled' ${POE_PWD}/metadata.yaml 2>/dev/null | grep -q 'true'; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+function get_pypi_package_name() {
+    # Extract the package name from metadata.yaml
+    yq eval '.data.remoteRegistries.pypi.packageName' ${POE_PWD}/metadata.yaml
+}
+
+# Default values
+REGISTRY_URL="https://upload.pypi.org/legacy/"
+PRE_RELEASE=false
+CONNECTOR_NAME=""
+PYPI_TOKEN=""
+VERSION_OVERRIDE=""
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -n|--name)
+            CONNECTOR_NAME="$2"
+            shift 2
+            ;;
+        -t|--token)
+            PYPI_TOKEN="$2"
+            shift 2
+            ;;
+        -v|--version)
+            VERSION_OVERRIDE="$2"
+            shift 2
+            ;;
+        --pre-release)
+            PRE_RELEASE=true
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            usage >&2
+            exit 1
+            ;;
+    esac
+done
+
+# Validate required parameters
+if [[ -z "$CONNECTOR_NAME" ]]; then
+    echo "Error: Connector name is required" >&2
+    usage >&2
+    exit 1
+fi
+
+# Use environment variables as fallback
+if [[ -z "$PYPI_TOKEN" && -n "${PYTHON_REGISTRY_TOKEN:-}" ]]; then
+    PYPI_TOKEN="$PYTHON_REGISTRY_TOKEN"
+fi
+
+if [[ -z "$PYPI_TOKEN" ]]; then
+    echo "Error: PyPI token is required (use --token or set PYTHON_REGISTRY_TOKEN in your environment)" >&2
+    exit 1
+fi
+
+
+# Navigate to connector directory
+CONNECTOR_DIR="airbyte-integrations/connectors/$CONNECTOR_NAME"
+if [[ ! -d "$CONNECTOR_DIR" ]]; then
+    echo "Error: Connector directory not found: $CONNECTOR_DIR" >&2
+    exit 1
+fi
+
+cd "$CONNECTOR_DIR"
+
+echo "Publishing connector: $CONNECTOR_NAME"
+echo "Registry URL: $REGISTRY_URL"
+
+# Check if PyPI publishing is enabled in metadata
+if ! should_publish; then
+    echo "PyPI publishing is not enabled for this connector. Skipping."
+    exit 0
+fi
+
+# Get package metadata from metadata.yaml
+PACKAGE_NAME=$(get_pypi_package_name)
+if [[ -z "$PACKAGE_NAME" ]]; then
+    echo "Error: Package name not found in metadata.yaml" >&2
+    exit 1
+fi
+BASE_VERSION=$(poe -qq get-version)
+
+# Determine version to use
+if [[ -n "$VERSION_OVERRIDE" ]]; then
+    VERSION="$VERSION_OVERRIDE"
+elif [[ "$PRE_RELEASE" == "true" ]]; then
+    # Add current timestamp for pre-release.
+    # we can't use the git revision because not all python registries allow local version identifiers. 
+    # Public version identifiers must conform to PEP 440 and only allow digits.
+    TIMESTAMP=$(date +"%Y%m%d%H%M")
+    VERSION="${BASE_VERSION}.dev${TIMESTAMP}"
+else
+    VERSION="$BASE_VERSION"
+fi
+
+echo "Package name: $PACKAGE_NAME"
+echo "Version: $VERSION"
+
+# Check if package already exists
+CHECK_URL="https://pypi.org/pypi"
+
+# Simple check for existing package
+if [[ $(curl -s -o /dev/null -w "%{http_code}" "$CHECK_URL/$PACKAGE_NAME/$VERSION/json") == "200" ]]; then
+    echo "Package $PACKAGE_NAME version $VERSION already exists. Skipping."
+    exit 0
+fi
+
+# Assumes the connector uses Poetry for packaging and has a pyproject.toml
+if [[ -f "pyproject.toml" ]]; then
+    echo "Detected Poetry project"
+    
+    # Install dependencies
+    poetry install --all-extras
+    
+    # Configure and publish with Poetry
+    poetry config repositories.mypypi "$REGISTRY_URL"
+    poetry config pypi-token.mypypi "$PYPI_TOKEN"
+    poetry config requests.timeout 60
+    
+    poetry publish --build --repository mypypi --no-interaction -vvv
+    
+else
+    echo "Error: No pyproject.toml, skipping publishing to PyPI" >&2
+    exit 0
+fi
+
+echo "Successfully published $PACKAGE_NAME version $VERSION to PyPI"

--- a/poe-tasks/publish-python-registry.sh
+++ b/poe-tasks/publish-python-registry.sh
@@ -162,6 +162,7 @@ fi
 
 echo "Package name: $PACKAGE_NAME"
 echo "Version: $VERSION"
+echo
 
 # Check if package already exists
 if [[ $(curl -s -o /dev/null -w "%{http_code}" "$REGISTRY_CHECK_URL/$PACKAGE_NAME/$VERSION/json") == "200" ]]; then
@@ -176,13 +177,12 @@ fi
 if [[ -f "pyproject.toml" ]]; then
     echo "Detected Poetry project"
 
-    VENV_DIR=.build-publish-venv
-    POETRY_VERSION=2.1.3
-
     # runs automatically on script error or exit
     cleanup() {
-        mv pyproject.toml.bak pyproject.toml
-        echo "Restored original pyproject.toml"
+        if [[ -f pyproject.toml.bak ]]; then
+            mv pyproject.toml.bak pyproject.toml
+            echo "Restored original pyproject.toml"
+        fi
     }
     trap cleanup EXIT   
 


### PR DESCRIPTION
## What
resolves [#13882](https://github.com/airbytehq/airbyte-internal-issues/issues/13882)

This pulls the logic we use to publish python connectors to PyPI (e.g. [source-slack](https://pypi.org/project/airbyte-source-slack/)) out of Airbyte-CI / dagger and into a standalone shell script. 

This script can be run locally from the root of the airbyte repository and builds and publishes the python connector using `poetry publish`. 

Notably
-  `--pre-release` flag generates a dev version derived from the current timestamp (mirrors airbyte-ci behavior)
- **new**  `--test-registry` allows the script to publish to https://test.pypi.org which in my understanding is intended for this exact purpose.

The full functionality is documented in a help message. 

There is a bit of funkiness in that we are temporarily overwriting the package name and version in `pyproject.toml` ahead of building and publishing the connector in order to allow us to specify this information in the metadata.yaml file and publish pre-release versions. This behavior is copied form how things were being done in airbyte-ci

This PR also hooks the script up to the connector publish pipeline in `publish_connectors.yml` as two steps (manual and master merge) upstream of the `airbyte-ci connectors publish` step which contains the old functionality. I believe airbyte-ci will no-op if the package already exists per [this logic](https://github.com/airbytehq/airbyte/blob/349bf390db78a6bc471b5a560cb542654fa9d625/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/publish/pipeline.py#L621) and not fail the pipeline

## Questions
Should I do more to make this script robust / self contained? For example, it might make sense to have the script install all dependencies it needs (e.g. poetry) and do everything inside an isolated virtual environment. The script currently needs to run from the root of the airbyte repo (documented) but could be made more flexible. It also does not clean up build artifacts after it exits.

## Testing
I tested the script out extensively locally publishing to the test PyPI registry. I also tested the manual invocation of the publish pipeline using the Github UI interface.

## Review guide
1. poe-tasks/publish-python-registry.sh
2. .github/workflows/publish_connectors.yml

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
