### PR TITLE
ci: upload java tar file to metadata bucket when publishing java connectors

### DIFF
--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -149,6 +149,7 @@ jobs:
         if: github.event_name == 'push' && steps.connector-metadata.outputs.connector-language == 'java'
         shell: bash
         run: ./poe-tasks/upload-java-connector-tar-file.sh --name ${{ matrix.connector }} --main-release
+        # we allow it to fail because we are testing this step. We should remove this once we are sure it works.
         continue-on-error: true
 
       - name: Determine build and publish options
@@ -231,6 +232,7 @@ jobs:
         if: (github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call') && steps.connector-metadata.outputs.connector-language == 'java'
         shell: bash
         run: ./poe-tasks/upload-java-connector-tar-file.sh --name ${{ matrix.connector }} ${{ inputs.publish-options }}
+        # we allow it to fail because we are testing this step. We should remove this once we are sure it works.
         continue-on-error: true
 
       - name: Build and publish Python and Manifest-Only connectors images [manual]

--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -149,6 +149,8 @@ jobs:
         if: github.event_name == 'push' && steps.connector-metadata.outputs.connector-language == 'java'
         shell: bash
         run: ./poe-tasks/upload-java-connector-tar-file.sh --name ${{ matrix.connector }} --main-release
+        env:
+          GCS_CREDENTIALS: ${{ secrets.METADATA_SERVICE_DEV_GCS_CREDENTIALS }}
         # we allow it to fail because we are testing this step. We should remove this once we are sure it works.
         continue-on-error: true
 
@@ -232,6 +234,8 @@ jobs:
         if: (github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call') && steps.connector-metadata.outputs.connector-language == 'java'
         shell: bash
         run: ./poe-tasks/upload-java-connector-tar-file.sh --name ${{ matrix.connector }} ${{ inputs.publish-options }}
+        env:
+          GCS_CREDENTIALS: ${{ secrets.METADATA_SERVICE_DEV_GCS_CREDENTIALS }}
         # we allow it to fail because we are testing this step. We should remove this once we are sure it works.
         continue-on-error: true
 

--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -144,6 +144,13 @@ jobs:
         run: |
           ./poe-tasks/build-and-publish-java-connectors-with-tag.sh --main-release --publish --name ${{ matrix.connector }}
 
+      - name: Publish JVM connectors tar file [On merge to master]]
+        id: publish-JVM-connectors-tar-file-master
+        if: github.event_name == 'push' && steps.connector-metadata.outputs.connector-language == 'java'
+        shell: bash
+        run: ./poe-tasks/upload-java-connector-tar-file.sh --name ${{ matrix.connector }} --main-release
+        continue-on-error: true
+
       - name: Determine build and publish options
         id: get-connector-options
         if: steps.connector-metadata.outputs.connector-language != 'java'
@@ -218,6 +225,13 @@ jobs:
         if: (github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call') && steps.connector-metadata.outputs.connector-language == 'java'
         shell: bash
         run: ./poe-tasks/build-and-publish-java-connectors-with-tag.sh  ${{ inputs.publish-options }} --name ${{ matrix.connector }} --publish
+
+      - name: Publish JVM connectors tar file [manual]
+        id: publish-JVM-connectors-tar-file-manual
+        if: (github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call') && steps.connector-metadata.outputs.connector-language == 'java'
+        shell: bash
+        run: ./poe-tasks/upload-java-connector-tar-file.sh --name ${{ matrix.connector }} ${{ inputs.publish-options }}
+        continue-on-error: true
 
       - name: Build and publish Python and Manifest-Only connectors images [manual]
         id: build-and-publish-python-manifest-only-connectors-images-manual

--- a/poe-tasks/upload-java-connector-tar-file.sh
+++ b/poe-tasks/upload-java-connector-tar-file.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+# Uploads the java tar for java connectors.
+# Usage: ./poe-tasks/upload-java-connector-tar-file.sh --name destination-bigquery [--pre-release] [--main-release]
+# You must have set the env var GCS_CREDENTIALS, which contains a JSON-formatted GCP service account key.
+# GCS_CREDENTIALS needs write access to `gs://$metadata_bucket/files/resources/java`.
+set -euo pipefail
+
+source "${BASH_SOURCE%/*}/lib/util.sh"
+source "${BASH_SOURCE%/*}/lib/parse_args.sh"
+
+metadata_bucket="dev-airbyte-cloud-connector-metadata-service"
+connector=$(get_only_connector)
+tar_file_path="${CONNECTORS_DIR}/${connector}/build/distributions/airbyte-app.tar"
+
+if ! test "$GCS_CREDENTIALS"; then
+  echo "GCS_CREDENTIALS environment variable must be set" >&2
+  exit 1
+fi
+
+# Figure out the tag that we're working on (i.e. handle the prerelease case)
+meta="${CONNECTORS_DIR}/${connector}/metadata.yaml"
+base_tag=$(yq -r '.data.dockerImageTag' "$meta")
+if test -z "$base_tag" || test "$base_tag" = "null"; then
+  echo "Error: dockerImageTag missing in ${meta}" >&2
+  exit 1
+fi
+if test "$publish_mode" = "main-release"; then
+  docker_tag="$base_tag"
+else
+  docker_tag=$(generate_dev_tag "$base_tag")
+fi
+
+gcloud_activate_service_account "$GCS_CREDENTIALS"
+gcloud storage cp "$tar_file_path" "gs://${metadata_bucket}/files/resources/java/${connector}/${docker_tag}/"

--- a/poe-tasks/upload-java-connector-tar-file.sh
+++ b/poe-tasks/upload-java-connector-tar-file.sh
@@ -3,7 +3,7 @@
 # Uploads the java tar for java connectors.
 # Usage: ./poe-tasks/upload-java-connector-tar-file.sh --name destination-bigquery [--pre-release] [--main-release]
 # You must have set the env var GCS_CREDENTIALS, which contains a JSON-formatted GCP service account key.
-# GCS_CREDENTIALS needs write access to `gs://$metadata_bucket/files/resources/java`.
+# GCS_CREDENTIALS needs write access to `gs://$metadata_bucket/resources/java`.
 set -euo pipefail
 
 source "${BASH_SOURCE%/*}/lib/util.sh"
@@ -32,4 +32,4 @@ else
 fi
 
 gcloud_activate_service_account "$GCS_CREDENTIALS"
-gcloud storage cp "$tar_file_path" "gs://${metadata_bucket}/files/resources/java/${connector}/${docker_tag}/"
+gcloud storage cp "$tar_file_path" "gs://${metadata_bucket}/resources/java/${connector}/${docker_tag}/"


### PR DESCRIPTION
## What
Adding a new step to the publish connector github actions job that will upload java connectors tar files.

## How
A new bash script was added that uses gcloud to upload the tar file. The job already had logic to:
1. know the connector name
2. know the connector language

## How did I test this?
Tested here: https://github.com/airbytehq/airbyte/actions/runs/16999556781/job/48198312780

## User Impact
N/A

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
