### PR TITLE
fix: update source-avni baseImage to python-connector-base:4.0.2

### DIFF
--- a/airbyte-integrations/connectors/source-avni/metadata.yaml
+++ b/airbyte-integrations/connectors/source-avni/metadata.yaml
@@ -13,7 +13,7 @@ data:
       packageName: airbyte-source-avni
   connectorSubtype: api
   connectorBuildOptions:
-    baseImage: docker.io/airbyte/python-connector-base:1.2.2@sha256:57703de3b4c4204bd68a7b13c9300f8e03c0189bffddaffc796f1da25d2dbea0
+    baseImage: docker.io/airbyte/python-connector-base:4.0.2@sha256:9fdb1888c4264cf6fee473649ecb593f56f58e5d0096a87ee0b231777e2e3e73
   connectorType: source
   definitionId: 5d297ac7-355e-4a04-be75-a5e7e175fc4e
   dockerImageTag: 0.1.1

--- a/airbyte-integrations/connectors/source-avni/metadata.yaml
+++ b/airbyte-integrations/connectors/source-avni/metadata.yaml
@@ -16,7 +16,7 @@ data:
     baseImage: docker.io/airbyte/python-connector-base:4.0.2@sha256:9fdb1888c4264cf6fee473649ecb593f56f58e5d0096a87ee0b231777e2e3e73
   connectorType: source
   definitionId: 5d297ac7-355e-4a04-be75-a5e7e175fc4e
-  dockerImageTag: 0.1.1
+  dockerImageTag: 0.1.2
   dockerRepository: airbyte/source-avni
   githubIssueLabel: source-avni
   icon: avni.svg

--- a/airbyte-integrations/connectors/source-avni/pyproject.toml
+++ b/airbyte-integrations/connectors/source-avni/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "0.1.1"
+version = "0.1.2"
 name = "source-avni"
 description = "Source implementation for Avni."
 authors = [ "Airbyte <contact@airbyte.io>",]


### PR DESCRIPTION
Bump the baseImage for source-avni connector from 1.2.2 to 4.0.2 

attempts to fix this error: https://github.com/airbytehq/airbyte/actions/runs/16999898078/job/48199381059

🤖 Generated with [Claude Code](https://claude.ai/code)

## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->

## How
<!--
* Describe how code changes achieve the solution.
-->

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
