### PR TITLE
feat(source-microsoft-lists-gen2): Add Gen2 Microsoft Lists connector with dynamic streams (do not merge)

### DIFF
--- a/airbyte-integrations/connectors/source-microsoft-lists-gen2/icon.svg
+++ b/airbyte-integrations/connectors/source-microsoft-lists-gen2/icon.svg
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<svg version="1.1" id="Livello_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 250 250" enable-background="new 0 0 250 250" xml:space="preserve">
+<path fill="#FEE200" d="M125,91.1l125-28.6V9.9l0,0c0-5.5-4.4-9.9-9.9-9.9H62.5L0,62.5L125,91.1z"/>
+<linearGradient id="SVGID_1_" gradientUnits="userSpaceOnUse" x1="38.7" y1="62.5" x2="38.7" y2="122.9034">
+	<stop  offset="0" style="stop-color:#DE4A01"/>
+	<stop  offset="1" style="stop-color:#E15900"/>
+</linearGradient>
+<polygon fill="url(#SVGID_1_)" points="62.5,62.5 0,62.5 0,155.1 77.4,123.1 "/>
+<linearGradient id="SVGID_2_" gradientUnits="userSpaceOnUse" x1="156.25" y1="118.6523" x2="156.25" y2="68.182">
+	<stop  offset="0" style="stop-color:#F08B09"/>
+	<stop  offset="1" style="stop-color:#EB770A"/>
+</linearGradient>
+<polygon fill="url(#SVGID_2_)" points="147.7,141.7 62.5,126.5 62.5,62.5 250,62.5 250,125.7 "/>
+<linearGradient id="SVGID_3_" gradientUnits="userSpaceOnUse" x1="149.4" y1="199.4" x2="149.4" y2="125">
+	<stop  offset="0" style="stop-color:#D73A00"/>
+	<stop  offset="1" style="stop-color:#CD2901"/>
+</linearGradient>
+<polygon fill="url(#SVGID_3_)" points="172.6,199.4 48.8,187.9 48.8,125 250,125 250,187.5 "/>
+<linearGradient id="SVGID_4_" gradientUnits="userSpaceOnUse" x1="31.25" y1="183.4025" x2="31.25" y2="128.5908">
+	<stop  offset="0" style="stop-color:#BE3106"/>
+	<stop  offset="1" style="stop-color:#AD3007"/>
+</linearGradient>
+<polygon fill="url(#SVGID_4_)" points="62.5,125 0,125 0,208.3 62.5,187.5 "/>
+<linearGradient id="SVGID_5_" gradientUnits="userSpaceOnUse" x1="151.45" y1="250" x2="151.45" y2="187.5">
+	<stop  offset="0" style="stop-color:#844980"/>
+	<stop  offset="1" style="stop-color:#703F6C"/>
+</linearGradient>
+<polygon fill="url(#SVGID_5_)" points="250,187.5 187.5,250 62.5,250 52.9,217.3 62.5,187.5 "/>
+<linearGradient id="SVGID_6_" gradientUnits="userSpaceOnUse" x1="31.25" y1="249.9" x2="31.25" y2="187.4">
+	<stop  offset="0" style="stop-color:#6F3C6D"/>
+	<stop  offset="1" style="stop-color:#663764"/>
+</linearGradient>
+<path fill="url(#SVGID_6_)" d="M0,187.5v48.7c0,7.6,6.2,13.7,13.8,13.7h48.7l0,0v-62.5l0,0H0V187.5z"/>
+</svg>

--- a/airbyte-integrations/connectors/source-microsoft-lists-gen2/manifest.yaml
+++ b/airbyte-integrations/connectors/source-microsoft-lists-gen2/manifest.yaml
@@ -33,6 +33,7 @@ streams:
           grant_type: client_credentials
           client_secret: "{{ config[\"client_secret\"] }}"
           refresh_request_body:
+            Content-Type: application/x-www-form-urlencoded
             scope: "{{ config['application_id_uri'] }}"
           token_refresh_endpoint: >-
             https://login.microsoftonline.com/{{ config['tenant_id']
@@ -82,6 +83,7 @@ dynamic_streams:
             grant_type: client_credentials
             client_secret: "{{ config[\"client_secret\"] }}"
             refresh_request_body:
+              Content-Type: application/x-www-form-urlencoded
               scope: "{{ config['application_id_uri'] }}"
             token_refresh_endpoint: >-
               https://login.microsoftonline.com/{{ config['tenant_id']
@@ -127,6 +129,7 @@ dynamic_streams:
             grant_type: client_credentials
             client_secret: "{{ config[\"client_secret\"] }}"
             refresh_request_body:
+              Content-Type: application/x-www-form-urlencoded
               scope: "{{ config['application_id_uri'] }}"
             token_refresh_endpoint: >-
               https://login.microsoftonline.com/{{ config['tenant_id']

--- a/airbyte-integrations/connectors/source-microsoft-lists-gen2/manifest.yaml
+++ b/airbyte-integrations/connectors/source-microsoft-lists-gen2/manifest.yaml
@@ -1,0 +1,445 @@
+version: 5.12.0
+
+type: DeclarativeSource
+
+description: >-
+  Microsoft Lists Gen2 connector enables seamless data integration and
+  synchronization between Microsoft Lists and other destinations. This Gen2 version
+  uses dynamic streams to create individual streams for each list, with each stream
+  returning the list items for its respective list. The connector leverages 
+  Microsoft Graph API to retrieve list items efficiently, ensuring smooth workflows 
+  and real-time data accessibility.
+
+check:
+  type: CheckStream
+  stream_names:
+    - lists
+
+streams:
+  - type: DeclarativeStream
+    name: lists
+    primary_key:
+      - id
+    retriever:
+      type: SimpleRetriever
+      requester:
+        type: HttpRequester
+        url_base: https://graph.microsoft.com/v1.0
+        path: /sites/{{ config['site_id'] }}/lists
+        http_method: GET
+        authenticator:
+          type: OAuthAuthenticator
+          client_id: "{{ config[\"client_id\"] }}"
+          grant_type: client_credentials
+          client_secret: "{{ config[\"client_secret\"] }}"
+          refresh_request_body:
+            scope: "{{ config['application_id_uri'] }}"
+          token_refresh_endpoint: >-
+            https://login.microsoftonline.com/{{ config['tenant_id']
+            }}/oauth2/v2.0/token
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path:
+            - value
+      paginator:
+        type: DefaultPaginator
+        page_token_option:
+          type: RequestPath
+        pagination_strategy:
+          type: CursorPagination
+          cursor_value: "{{ response.get('@odata.nextLink') }}"
+          stop_condition: "{{ response.get('@odata.nextLink') is not defined }}"
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        $ref: "#/schemas/lists"
+
+dynamic_streams:
+  - type: DynamicDeclarativeStream
+    stream_template:
+      type: DeclarativeStream
+      name: ""
+      $parameters:
+        list_id: ""
+        list_name: ""
+        list_display_name: ""
+      primary_key:
+        - id
+      retriever:
+        type: SimpleRetriever
+        requester:
+          type: HttpRequester
+          url_base: https://graph.microsoft.com/v1.0
+          path: /sites/{{ config['site_id'] }}/lists/{{ parameters['list_id'] }}/items
+          http_method: GET
+          request_parameters:
+            expand: fields
+          authenticator:
+            type: OAuthAuthenticator
+            client_id: "{{ config[\"client_id\"] }}"
+            grant_type: client_credentials
+            client_secret: "{{ config[\"client_secret\"] }}"
+            refresh_request_body:
+              scope: "{{ config['application_id_uri'] }}"
+            token_refresh_endpoint: >-
+              https://login.microsoftonline.com/{{ config['tenant_id']
+              }}/oauth2/v2.0/token
+        record_selector:
+          type: RecordSelector
+          extractor:
+            type: DpathExtractor
+            field_path:
+              - value
+        paginator:
+          type: DefaultPaginator
+          page_token_option:
+            type: RequestPath
+          pagination_strategy:
+            type: CursorPagination
+            cursor_value: "{{ response.get('@odata.nextLink') }}"
+            stop_condition: "{{ response.get('@odata.nextLink') is none }}"
+      schema_loader:
+        type: InlineSchemaLoader
+        schema:
+          $ref: "#/schemas/list_items"
+      transformations:
+        - type: AddFields
+          fields:
+            - type: AddedFieldDefinition
+              path:
+                - list_info
+              value: >-
+                {{ { "list_id": parameters['list_id'], "list_name": parameters['list_name'], "list_display_name": parameters['list_display_name'] } }}
+    components_resolver:
+      type: HttpComponentsResolver
+      retriever:
+        type: SimpleRetriever
+        requester:
+          type: HttpRequester
+          url_base: https://graph.microsoft.com/v1.0
+          path: /sites/{{ config['site_id'] }}/lists
+          http_method: GET
+          authenticator:
+            type: OAuthAuthenticator
+            client_id: "{{ config[\"client_id\"] }}"
+            grant_type: client_credentials
+            client_secret: "{{ config[\"client_secret\"] }}"
+            refresh_request_body:
+              scope: "{{ config['application_id_uri'] }}"
+            token_refresh_endpoint: >-
+              https://login.microsoftonline.com/{{ config['tenant_id']
+              }}/oauth2/v2.0/token
+        record_selector:
+          type: RecordSelector
+          extractor:
+            type: DpathExtractor
+            field_path:
+              - value
+        paginator:
+          type: DefaultPaginator
+          page_token_option:
+            type: RequestPath
+          pagination_strategy:
+            type: CursorPagination
+            cursor_value: "{{ response.get('@odata.nextLink') }}"
+            stop_condition: "{{ response.get('@odata.nextLink') is not defined }}"
+      components_mapping:
+        - type: ComponentMappingDefinition
+          field_path: ["name"]
+          value: "list_items_{{ components_values.name | default(components_values.displayName) | lower | replace(' ', '_') | replace('-', '_') }}"
+        - type: ComponentMappingDefinition
+          field_path: ["$parameters", "list_id"]
+          value: "{{ components_values.id }}"
+        - type: ComponentMappingDefinition
+          field_path: ["$parameters", "list_name"]
+          value: "{{ components_values.name | default(components_values.displayName) | lower | replace(' ', '_') | replace('-', '_') }}"
+        - type: ComponentMappingDefinition
+          field_path: ["$parameters", "list_display_name"]
+          value: "{{ components_values.displayName | default(components_values.name) }}"
+
+spec:
+  type: Spec
+  connection_specification:
+    type: object
+    $schema: http://json-schema.org/draft-07/schema#
+    required:
+      - site_id
+      - client_id
+      - client_secret
+      - application_id_uri
+      - tenant_id
+      - domain
+    properties:
+      site_id:
+        type: string
+        order: 0
+        title: Site Id
+      client_id:
+        type: string
+        order: 1
+        title: Client ID
+        airbyte_secret: true
+      client_secret:
+        type: string
+        order: 2
+        title: Client secret
+        airbyte_secret: true
+      application_id_uri:
+        type: string
+        order: 3
+        title: Application Id URI
+      tenant_id:
+        type: string
+        order: 4
+        title: Tenant Id
+        airbyte_secret: true
+      domain:
+        type: string
+        order: 5
+        title: Domain
+        airbyte_secret: true
+    additionalProperties: true
+
+schemas:
+  lists:
+    type: object
+    $schema: http://json-schema.org/schema#
+    additionalProperties: true
+    properties:
+      description:
+        type:
+          - string
+          - "null"
+      "@odata.etag":
+        type:
+          - string
+          - "null"
+      createdBy:
+        type:
+          - object
+          - "null"
+        properties:
+          user:
+            type:
+              - object
+              - "null"
+            properties:
+              displayName:
+                type:
+                  - string
+                  - "null"
+              email:
+                type:
+                  - string
+                  - "null"
+              id:
+                type:
+                  - string
+                  - "null"
+      createdDateTime:
+        type:
+          - string
+          - "null"
+      displayName:
+        type:
+          - string
+          - "null"
+      eTag:
+        type:
+          - string
+          - "null"
+      id:
+        type: string
+      lastModifiedBy:
+        type:
+          - object
+          - "null"
+        properties:
+          user:
+            type:
+              - object
+              - "null"
+            properties:
+              displayName:
+                type:
+                  - string
+                  - "null"
+              email:
+                type:
+                  - string
+                  - "null"
+              id:
+                type:
+                  - string
+                  - "null"
+      lastModifiedDateTime:
+        type:
+          - string
+          - "null"
+      list:
+        type:
+          - object
+          - "null"
+        properties:
+          contentTypesEnabled:
+            type:
+              - boolean
+              - "null"
+          hidden:
+            type:
+              - boolean
+              - "null"
+          template:
+            type:
+              - string
+              - "null"
+      name:
+        type:
+          - string
+          - "null"
+      parentReference:
+        type:
+          - object
+          - "null"
+        properties:
+          siteId:
+            type:
+              - string
+              - "null"
+      webUrl:
+        type:
+          - string
+          - "null"
+    required:
+      - id
+  list_items:
+    type: object
+    $schema: http://json-schema.org/schema#
+    additionalProperties: true
+    properties:
+      "@odata.context":
+        type:
+          - string
+          - "null"
+      "@odata.etag":
+        type:
+          - string
+          - "null"
+      contentType:
+        type:
+          - object
+          - "null"
+        properties:
+          id:
+            type:
+              - string
+              - "null"
+          name:
+            type:
+              - string
+              - "null"
+      createdBy:
+        type:
+          - object
+          - "null"
+        properties:
+          user:
+            type:
+              - object
+              - "null"
+            properties:
+              displayName:
+                type:
+                  - string
+                  - "null"
+              email:
+                type:
+                  - string
+                  - "null"
+              id:
+                type:
+                  - string
+                  - "null"
+      createdDateTime:
+        type:
+          - string
+          - "null"
+      eTag:
+        type:
+          - string
+          - "null"
+      fields:
+        type:
+          - object
+          - "null"
+        additionalProperties: true
+      fields@odata.context:
+        type:
+          - string
+          - "null"
+      id:
+        type: string
+      lastModifiedBy:
+        type:
+          - object
+          - "null"
+        properties:
+          user:
+            type:
+              - object
+              - "null"
+            properties:
+              displayName:
+                type:
+                  - string
+                  - "null"
+              email:
+                type:
+                  - string
+                  - "null"
+              id:
+                type:
+                  - string
+                  - "null"
+      lastModifiedDateTime:
+        type:
+          - string
+          - "null"
+      parentReference:
+        type:
+          - object
+          - "null"
+        properties:
+          id:
+            type:
+              - string
+              - "null"
+          siteId:
+            type:
+              - string
+              - "null"
+      webUrl:
+        type:
+          - string
+          - "null"
+      list_info:
+        type:
+          - object
+          - "null"
+        properties:
+          list_id:
+            type:
+              - string
+              - "null"
+          list_name:
+            type:
+              - string
+              - "null"
+          list_display_name:
+            type:
+              - string
+              - "null"
+    required:
+      - id

--- a/airbyte-integrations/connectors/source-microsoft-lists-gen2/manifest.yaml
+++ b/airbyte-integrations/connectors/source-microsoft-lists-gen2/manifest.yaml
@@ -61,7 +61,7 @@ dynamic_streams:
   - type: DynamicDeclarativeStream
     stream_template:
       type: DeclarativeStream
-      name: ""
+      name: "{{ parameters['list_name'] }}"
       $parameters:
         list_id: ""
         list_name: ""

--- a/airbyte-integrations/connectors/source-microsoft-lists-gen2/manifest.yaml
+++ b/airbyte-integrations/connectors/source-microsoft-lists-gen2/manifest.yaml
@@ -190,6 +190,7 @@ spec:
         type: string
         order: 3
         title: Application Id URI
+        default: "https://graph.microsoft.com/.default"
       tenant_id:
         type: string
         order: 4

--- a/airbyte-integrations/connectors/source-microsoft-lists-gen2/manifest.yaml
+++ b/airbyte-integrations/connectors/source-microsoft-lists-gen2/manifest.yaml
@@ -33,7 +33,6 @@ streams:
           grant_type: client_credentials
           client_secret: "{{ config[\"client_secret\"] }}"
           refresh_request_body:
-            Content-Type: application/x-www-form-urlencoded
             scope: "{{ config['application_id_uri'] }}"
           token_refresh_endpoint: >-
             https://login.microsoftonline.com/{{ config['tenant_id']
@@ -83,7 +82,6 @@ dynamic_streams:
             grant_type: client_credentials
             client_secret: "{{ config[\"client_secret\"] }}"
             refresh_request_body:
-              Content-Type: application/x-www-form-urlencoded
               scope: "{{ config['application_id_uri'] }}"
             token_refresh_endpoint: >-
               https://login.microsoftonline.com/{{ config['tenant_id']
@@ -129,7 +127,6 @@ dynamic_streams:
             grant_type: client_credentials
             client_secret: "{{ config[\"client_secret\"] }}"
             refresh_request_body:
-              Content-Type: application/x-www-form-urlencoded
               scope: "{{ config['application_id_uri'] }}"
             token_refresh_endpoint: >-
               https://login.microsoftonline.com/{{ config['tenant_id']

--- a/airbyte-integrations/connectors/source-microsoft-lists-gen2/metadata.yaml
+++ b/airbyte-integrations/connectors/source-microsoft-lists-gen2/metadata.yaml
@@ -1,0 +1,43 @@
+metadataSpecVersion: "1.0"
+data:
+  allowedHosts:
+    hosts:
+      - "graph.microsoft.com"
+  registryOverrides:
+    oss:
+      enabled: true
+    cloud:
+      enabled: true
+  remoteRegistries:
+    pypi:
+      enabled: false
+      packageName: airbyte-source-microsoft-lists-gen2
+  connectorBuildOptions:
+    baseImage: docker.io/airbyte/source-declarative-manifest:6.60.12@sha256:b236b4ff8351a7d7f0ff7f938bbf0ab7b455c4c9e6e7cc93933f4aa9201d66cb
+  connectorSubtype: api
+  connectorType: source
+  definitionId: 18ea5fae-f0b1-4d82-9aef-832bb922a5b6
+  dockerImageTag: 0.0.1
+  dockerRepository: airbyte/source-microsoft-lists-gen2
+  githubIssueLabel: source-microsoft-lists-gen2
+  icon: icon.svg
+  license: ELv2
+  name: Microsoft Lists Gen2
+  releaseDate: 2024-10-18
+  releaseStage: alpha
+  supportLevel: community
+  connectorTestSuitesOptions:
+    - suite: integrationTests
+      testSecrets:
+        - name: SECRET_SOURCE-MICROSOFT-LISTS_CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
+  documentationUrl: https://docs.airbyte.com/integrations/sources/microsoft-lists
+  tags:
+    - language:manifest-only
+    - cdk:low-code
+  ab_internal:
+    ql: 100
+    sl: 100


### PR DESCRIPTION
_NOTE: The point of this PR is to test out the new AI connector builder._

We likely will not merge this, but I would appreciate review if anyone who knows these better can find issues with it.

## What

This PR creates a Gen 2 version of the Microsoft Lists source connector (`source-microsoft-lists-gen2`) that implements **dynamic streams** to generate individual data streams for each Microsoft List. Instead of having a single stream that returns all list items, this connector discovers available lists and creates dedicated streams like `list_items_issue_tracker`, `list_items_events`, etc.

**Key Features:**
- Dynamic stream generation using `HttpComponentsResolver`
- Each Microsoft List gets its own stream for list items
- Maintains existing `lists` stream for list discovery
- Enhanced data with `list_info` metadata in each record
- Uses existing Microsoft Lists authentication methods
- Added sensible default for `application_id_uri`

## How

**Dynamic Stream Implementation:**
1. **HttpComponentsResolver** queries the Microsoft Graph API to discover available lists
2. **Components mapping** generates stream configurations dynamically:
   - Stream names: `list_items_<normalized_list_name>`
   - Parameters: `list_id`, `list_name`, `list_display_name`
3. **Stream template** defines the pattern for list item retrieval
4. **AddFields transformation** enriches each record with list metadata

**Technical Architecture:**
- Uses `$parameters` for passing list-specific data between resolver and stream template
- Jinja templating for dynamic stream name generation and field mapping
- Microsoft Graph API endpoints: `/sites/{site_id}/lists` and `/sites/{site_id}/lists/{list_id}/items`
- OAuth client credentials flow with `.default` scope

## Review Guide

⚠️ **Critical Areas Requiring Review:**

1. **`manifest.yaml` - Dynamic Stream Configuration (lines 109-179)**
   - Verify `HttpComponentsResolver` configuration
   - Check Jinja expressions in `components_mapping`
   - Validate `$parameters` usage in stream template

2. **`manifest.yaml` - Authentication Setup (lines 30-42, 90-102)**
   - Confirm OAuth configuration matches Microsoft Graph requirements
   - Verify default `application_id_uri` value is appropriate

3. **`manifest.yaml` - Schema Definitions (lines 209-446)**
   - Validate `list_items` schema matches actual API responses
   - Check `list_info` object structure

4. **`metadata.yaml` - Connector Configuration**
   - Review connector metadata and test configuration
   - Verify integration test secrets reference

## User Impact

**Positive Impact:**
- **Granular data access**: Users can sync specific lists instead of all list items
- **Better organization**: Each list appears as a separate stream in destinations
- **Enhanced metadata**: Each record includes list context information
- **Improved UX**: Default value for `application_id_uri` reduces configuration complexity

**Potential Negative Side Effects:**
- **More streams**: Users will see many more streams (one per list) which could be overwhelming
- **Naming complexity**: Auto-generated stream names may not always be intuitive
- **Performance**: Multiple streams means multiple API calls during discovery

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

This is a new connector (not modifying existing functionality), so reverting would simply remove the new connector without affecting existing systems.

---

**Testing Status:** ✅ Smoke test passed - Successfully discovered 6 lists and retrieved data in 3.99 seconds

**Link to Devin run:** https://app.devin.ai/sessions/9e78695b54f54a8ab22ac8c381b11b29  
**Requested by:** @aaronsteers  
**MCP Tools Used:** connector-builder-mcp for validation and testing