### PR TITLE
(do not merge) Test CI for Microsoft Auth 400 error investigation - Bing Ads connector

### DIFF
--- a/airbyte-integrations/connectors/source-bing-ads/manifest.yaml
+++ b/airbyte-integrations/connectors/source-bing-ads/manifest.yaml
@@ -1,5 +1,7 @@
 version: 6.7.0
 
+# Test change to trigger CI for Microsoft Auth 400 error investigation
+
 type: DeclarativeSource
 
 check:


### PR DESCRIPTION
## What
This PR is created solely to investigate Microsoft Auth 400 errors that were reported in Bing Ads connector CI yesterday evening. A minimal dummy change (test comment) was added to trigger CI testing and monitor for authentication failures with Microsoft's OAuth endpoints.

**This is a test/investigation PR and should NOT be merged.**

Related to reported issues with Microsoft Auth returning 400 errors around 5:30pm yesterday, affecting both Bing Ads and other connectors using Microsoft authentication.

## How
Added a single test comment to `airbyte-integrations/connectors/source-bing-ads/manifest.yaml` to ensure the Bing Ads connector is included in CI test runs. This triggers the connector's acceptance tests which use live Microsoft Auth connections configured in the metadata.yaml.

## Review guide
1. `airbyte-integrations/connectors/source-bing-ads/manifest.yaml` - Verify only a harmless test comment was added
2. Confirm this PR is marked as draft and labeled "do not merge"
3. **Primary focus should be on CI results, not code changes** - monitor for Microsoft Auth 400 errors in test runs

## User Impact
None - this is purely for CI investigation. The comment addition has no functional impact on the connector.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚

---
**Investigation Details:**
- Connector uses Microsoft OAuth with `login.microsoftonline.com/{{ config["tenant_id"] }}/oauth2/v2.0/token`
- Online reports show recent Microsoft Graph API 400 errors including authorization issues from ~5 days ago
- Will monitor CI for authentication failures and close PR after analysis

**Link to Devin run:** https://app.devin.ai/sessions/2095fed2b4ca4519bab19d7de7fbadf9  
**Requested by:** @aaronsteers