### PR TITLE
chore: Refactor workflows to use resolve-ci-vars-action (do not merge)

### DIFF
--- a/.github/workflows/approve-regression-tests-command.yml
+++ b/.github/workflows/approve-regression-tests-command.yml
@@ -33,20 +33,9 @@ jobs:
     name: "Approve Regression Tests"
     runs-on: ubuntu-24.04
     steps:
-      - name: Get job variables
-        id: job-vars
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        shell: bash
-        run: |
-          PR_JSON=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.inputs.pr }})
-          echo "PR_JSON: $PR_JSON"
-          echo "repo=$(echo "$PR_JSON" | jq -r .head.repo.full_name)" >> $GITHUB_OUTPUT
-          BRANCH=$(echo "$PR_JSON" | jq -r .head.ref)
-          echo "branch=$BRANCH" >> $GITHUB_OUTPUT
-          echo "run-url=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" >> $GITHUB_OUTPUT
-          LATEST_COMMIT=$(gh api repos/${{ github.repository }}/commits/$BRANCH | jq -r .sha)
-          echo "latest_commit=$LATEST_COMMIT" >> $GITHUB_OUTPUT
+      - name: Resolve workflow variables
+        id: vars
+        uses: aaronsteers/resolve-ci-vars-action@v0
 
       - name: Append comment with job run link
         # If comment-id is not provided, this will create a new
@@ -60,7 +49,7 @@ jobs:
 
             > [Check job output.][1]
 
-            [1]: ${{ steps.job-vars.outputs.run-url }}
+            [1]: ${{ steps.vars.outputs.run-url }}
 
       - name: Approve regression tests
         id: approve-regression-tests
@@ -69,7 +58,7 @@ jobs:
           echo "approving regression test status check for ${{ github.event.inputs.connector-name }} if it exists ...."
           response=$(curl --write-out '%{http_code}' --silent --output /dev/null \
             --request POST \
-            --url ${{ github.api_url }}/repos/${{ github.repository }}/statuses/${{ steps.job-vars.outputs.latest_commit }} \
+            --url ${{ github.api_url }}/repos/${{ github.repository }}/statuses/${{ steps.vars.outputs.pr-source-git-sha }} \
             --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
             --header 'content-type: application/json' \
             --data '{
@@ -91,7 +80,7 @@ jobs:
           echo "updating regression test approval status check if it exists ...."
           response=$(curl --write-out '%{http_code}' --silent --output /dev/null \
             --request POST \
-            --url ${{ github.api_url }}/repos/${{ github.repository }}/statuses/${{ steps.job-vars.outputs.latest_commit }} \
+            --url ${{ github.api_url }}/repos/${{ github.repository }}/statuses/${{ steps.vars.outputs.pr-source-git-sha }} \
             --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
             --header 'content-type: application/json' \
             --data '{

--- a/.github/workflows/build-connector-images-command.yml
+++ b/.github/workflows/build-connector-images-command.yml
@@ -31,13 +31,17 @@ jobs:
     name: "Initialize Workflow"
     runs-on: ubuntu-24.04
     steps:
+      - name: Resolve workflow variables
+        id: vars
+        uses: aaronsteers/resolve-ci-vars-action@v0
+
       - name: Get job variables
         id: job-vars
         # Create the job run variables.
         # We intentionally ignore `inputs.repo` because the check run will be run on the
         # current repository, not the one with the commit being tested.
         run: |
-          echo "run-url=https://github.com/${{ github.repository }}/actions/runs/$GITHUB_RUN_ID" >> $GITHUB_OUTPUT
+          echo "run-url=${{ steps.vars.outputs.run-url }}" >> $GITHUB_OUTPUT
           echo "image-name=ghcr.io/airbytehq/${{ inputs.repo || github.repository }}:${{ inputs.gitref || github.ref_name }}" >> $GITHUB_OUTPUT
           echo "pr-number=${{ github.event_name == 'pull_request' && github.event.pull_request.number || inputs.pr }}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/bump-version-command.yml
+++ b/.github/workflows/bump-version-command.yml
@@ -43,23 +43,15 @@ jobs:
     name: "Bump version of connectors in this PR"
     runs-on: ubuntu-24.04
     steps:
-      - name: Get job variables
-        id: job-vars
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        shell: bash
-        run: |
-          PR_JSON=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.inputs.pr }})
-          echo "repo=$(echo "$PR_JSON" | jq -r .head.repo.full_name)" >> $GITHUB_OUTPUT
-          echo "branch=$(echo "$PR_JSON" | jq -r .head.ref)" >> $GITHUB_OUTPUT
-          echo "pr_title=$(echo "$PR_JSON" | jq -r .title)" >> $GITHUB_OUTPUT
-          echo "run-url=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" >> $GITHUB_OUTPUT
+      - name: Resolve workflow variables
+        id: vars
+        uses: aaronsteers/resolve-ci-vars-action@v0
 
       - name: Checkout Airbyte
         uses: actions/checkout@v4
         with:
-          repository: ${{ steps.job-vars.outputs.repo }}
-          ref: ${{ steps.job-vars.outputs.branch }}
+          repository: ${{ steps.vars.outputs.pr-source-repo-name-full }}
+          ref: ${{ steps.vars.outputs.pr-source-git-branch }}
           fetch-depth: 1
           # Important that token is a PAT so that CI checks are triggered again.
           # Without this we would be forever waiting on required checks to pass.
@@ -77,14 +69,14 @@ jobs:
 
             > Bump Version job started... [Check job output.][1]
 
-            [1]: ${{ steps.job-vars.outputs.run-url }}
+            [1]: ${{ steps.vars.outputs.run-url }}
 
       - name: Log changelog source
         run: |
           if [ -n "${{ github.event.inputs.changelog }}" ]; then
             echo "Using user-provided changelog: ${{ github.event.inputs.changelog }}"
           else
-            echo "Using PR title as changelog: ${{ steps.job-vars.outputs.pr_title }}"
+            echo "Using PR title as changelog: ${{ steps.vars.outputs.pr-title }}"
           fi
 
       - name: Run airbyte-ci connectors --modified bump-version
@@ -95,11 +87,11 @@ jobs:
           gcs_credentials: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
           sentry_dsn: ${{ secrets.SENTRY_AIRBYTE_CI_DSN }}
           github_token: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}
-          git_repo_url: https://github.com/${{ steps.job-vars.outputs.repo }}.git
+          git_repo_url: https://github.com/${{ steps.vars.outputs.pr-source-repo-name-full }}.git
           subcommand: |
             connectors --modified bump-version \
               ${{ github.event.inputs.type }} \
-              "${{ github.event.inputs.changelog != '' && github.event.inputs.changelog || steps.job-vars.outputs.pr_title }}" \
+              "${{ github.event.inputs.changelog != '' && github.event.inputs.changelog || steps.vars.outputs.pr-title }}" \
               --pr-number ${{ github.event.inputs.pr }}
 
       # This is helpful in the case that we change a previously committed generated file to be ignored by git.
@@ -124,11 +116,11 @@ jobs:
           git commit -m "chore: bump-version ${{ github.event.inputs.bump-type }}"
           echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 
-      - name: Push changes to '(${{ steps.job-vars.outputs.repo }})'
+      - name: Push changes to '(${{ steps.vars.outputs.pr-source-repo-name-full }})'
         if: steps.git-diff.outputs.changes == 'true'
         run: |
-          git remote add contributor https://github.com/${{ steps.job-vars.outputs.repo }}.git
-          git push contributor HEAD:'${{ steps.job-vars.outputs.branch }}'
+          git remote add contributor https://github.com/${{ steps.vars.outputs.pr-source-repo-name-full }}.git
+          git push contributor HEAD:'${{ steps.vars.outputs.pr-source-git-branch }}'
 
       - name: Append success comment
         uses: peter-evans/create-or-update-comment@v4

--- a/.github/workflows/connector-performance-command.yml
+++ b/.github/workflows/connector-performance-command.yml
@@ -127,6 +127,10 @@ jobs:
     needs: start-test-runner
     runs-on: ${{ needs.start-test-runner.outputs.label }}
     steps:
+      - name: Resolve workflow variables
+        id: vars
+        uses: aaronsteers/resolve-ci-vars-action@v0
+
       - name: Link comment to workflow run
         if: inputs.comment-id
         uses: peter-evans/create-or-update-comment@v1
@@ -137,7 +141,7 @@ jobs:
             `bottleneck_stream1`, `bottleneck_stream_randomseed. For destinations only: you can also use `stream-numbers=N`
             to simulate N number of parallel streams. Additionally, `sync-mode=incremental` is supported for destinations.
             For example: `dataset=1m stream-numbers=2 sync-mode=incremental`
-            > :runner: ${{inputs.connector}} https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}.
+            > :runner: ${{inputs.connector}} ${{ steps.vars.outputs.run-url }}.
       - name: Search for valid connector name format
         id: regex
         uses: AsasInnab/regex-action@v1

--- a/.github/workflows/format-fix-command.yml
+++ b/.github/workflows/format-fix-command.yml
@@ -32,22 +32,15 @@ jobs:
     name: "Run pre-commit fix"
     runs-on: ubuntu-24.04
     steps:
-      - name: Get job variables
-        id: job-vars
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        shell: bash
-        run: |
-          PR_JSON=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.inputs.pr }})
-          echo "repo=$(echo "$PR_JSON" | jq -r .head.repo.full_name)" >> $GITHUB_OUTPUT
-          echo "branch=$(echo "$PR_JSON" | jq -r .head.ref)" >> $GITHUB_OUTPUT
-          echo "run-url=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" >> $GITHUB_OUTPUT
+      - name: Resolve workflow variables
+        id: vars
+        uses: aaronsteers/resolve-ci-vars-action@v0
 
       - name: Checkout Airbyte
         uses: actions/checkout@v3
         with:
-          repository: ${{ steps.job-vars.outputs.repo }}
-          ref: ${{ steps.job-vars.outputs.branch }}
+          repository: ${{ steps.vars.outputs.pr-source-repo-name-full }}
+          ref: ${{ steps.vars.outputs.pr-source-git-branch }}
           fetch-depth: 1
           # Important that token is a PAT so that CI checks are triggered again.
           # Without this we would be forever waiting on required checks to pass.
@@ -65,7 +58,7 @@ jobs:
 
             > Format-fix job started... [Check job output.][1]
 
-            [1]: ${{ steps.job-vars.outputs.run-url }}
+            [1]: ${{ steps.vars.outputs.run-url }}
 
       # Compare the below to the `format_check.yml` workflow
       - name: Setup Java
@@ -109,11 +102,11 @@ jobs:
           git commit -m "chore: auto-fix lint and format issues"
           echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 
-      - name: Push changes to '(${{ steps.job-vars.outputs.repo }})'
+      - name: Push changes to '(${{ steps.vars.outputs.pr-source-repo-name-full }})'
         if: steps.git-diff.outputs.changes == 'true'
         run: |
-          git remote add contributor https://github.com/${{ steps.job-vars.outputs.repo }}.git
-          git push contributor HEAD:'${{ steps.job-vars.outputs.branch }}'
+          git remote add contributor https://github.com/${{ steps.vars.outputs.pr-source-repo-name-full }}.git
+          git push contributor HEAD:'${{ steps.vars.outputs.pr-source-git-branch }}'
 
       - name: Append success comment
         uses: peter-evans/create-or-update-comment@v4

--- a/.github/workflows/format_check.yml
+++ b/.github/workflows/format_check.yml
@@ -14,6 +14,10 @@ jobs:
     name: "Format Check"
     runs-on: ubuntu-24.04
     steps:
+      - name: Resolve workflow variables
+        id: vars
+        uses: aaronsteers/resolve-ci-vars-action@v0
+
       - uses: actions/checkout@v4
       - name: Setup Java
         uses: actions/setup-java@v3
@@ -59,5 +63,5 @@ jobs:
             {\"type\":\"section\",\"text\":{\"type\":\"mrkdwn\",\"text\":\"Formatting is broken on master! :bangbang: \n\n\"}},
             {\"type\":\"section\",\"text\":{\"type\":\"mrkdwn\",\"text\":\"_merged by_: *${{ github.actor }}* \n\"}},
             {\"type\":\"section\",\"text\":{\"type\":\"mrkdwn\",\"text\":\"<@${{ steps.match-github-to-slack-user.outputs.slack_user_ids }}> \n\"}},
-            {\"type\":\"section\",\"text\":{\"type\":\"mrkdwn\",\"text\":\" :octavia-shocked: <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|View Action Run> :octavia-shocked: \n\"}},
+            {\"type\":\"section\",\"text\":{\"type\":\"mrkdwn\",\"text\":\" :octavia-shocked: <${{ steps.vars.outputs.run-url }}|View Action Run> :octavia-shocked: \n\"}},
             {\"type\":\"divider\"}]}

--- a/.github/workflows/java-bulk-cdk-publish.yml
+++ b/.github/workflows/java-bulk-cdk-publish.yml
@@ -29,6 +29,10 @@ jobs:
     runs-on: linux-24.04-large # Custom runner, defined in GitHub org settings
     timeout-minutes: 30
     steps:
+      - name: Resolve workflow variables
+        id: vars
+        uses: aaronsteers/resolve-ci-vars-action@v0
+
       - name: Checkout Airbyte
         uses: actions/checkout@v3
 
@@ -100,7 +104,7 @@ jobs:
                         "type": "section",
                         "text": {
                             "type": "mrkdwn",
-                            "text": "See details on <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|GitHub>\n"
+                            "text": "See details on <${{ steps.vars.outputs.run-url }}|GitHub>\n"
                         }
                     }
                 ]
@@ -129,7 +133,7 @@ jobs:
                         "type": "section",
                         "text": {
                             "type": "mrkdwn",
-                            "text": "See details on <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|GitHub>\n"
+                            "text": "See details on <${{ steps.vars.outputs.run-url }}|GitHub>\n"
                         }
                     }
                 ]

--- a/.github/workflows/publish-java-cdk-command.yml
+++ b/.github/workflows/publish-java-cdk-command.yml
@@ -68,8 +68,8 @@ concurrency:
 env:
   # Use the provided GITREF or default to the branch triggering the workflow.
   GITREF: ${{ github.event.inputs.gitref || github.ref }}
-  FORCE: "${{ github.event_name == 'push' || github.event.inputs.force == null && 'false' ||  github.event.inputs.force }}"
-  DRY_RUN: "${{ github.event_name == 'push' && 'false' || github.event.inputs.dry-run == null && 'true' || github.event.inputs.dry-run }}"
+  FORCE: "${{ github.event_name == 'push' || (github.event.inputs.force == null && 'false') || github.event.inputs.force }}"
+  DRY_RUN: "${{ (github.event_name == 'push' && 'false') || (github.event.inputs.dry-run == null && 'true') || github.event.inputs.dry-run }}"
   CDK_VERSION_FILE_PATH: "./airbyte-cdk/java/airbyte-cdk/core/src/main/resources/version.properties"
   S3_BUILD_CACHE_ACCESS_KEY_ID: ${{ secrets.SELF_RUNNER_AWS_ACCESS_KEY_ID }}
   S3_BUILD_CACHE_SECRET_KEY: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
@@ -80,13 +80,17 @@ jobs:
     runs-on: linux-24.04-large # Custom runner, defined in GitHub org settings
     timeout-minutes: 30
     steps:
+      - name: Resolve workflow variables
+        id: vars
+        uses: aaronsteers/resolve-ci-vars-action@v0
+
       - name: Link comment to Workflow Run
         if: github.event.inputs.comment-id
         uses: peter-evans/create-or-update-comment@v1
         with:
           comment-id: ${{ github.event.inputs.comment-id }}
           body: |
-            > :clock2: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
+            > :clock2: ${{ steps.vars.outputs.run-url }}
 
       - name: Checkout Airbyte
         uses: actions/checkout@v3
@@ -197,7 +201,7 @@ jobs:
                         "type": "section",
                         "text": {
                             "type": "mrkdwn",
-                            "text": "See details on <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|GitHub>\n"
+                            "text": "See details on <${{ steps.vars.outputs.run-url }}|GitHub>\n"
                         }
                     }
                 ]
@@ -226,7 +230,7 @@ jobs:
                         "type": "section",
                         "text": {
                             "type": "mrkdwn",
-                            "text": "See details on <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|GitHub>\n"
+                            "text": "See details on <${{ steps.vars.outputs.run-url }}|GitHub>\n"
                         }
                     }
                 ]

--- a/.github/workflows/run-cat-tests-command.yml
+++ b/.github/workflows/run-cat-tests-command.yml
@@ -33,17 +33,9 @@ jobs:
     name: "On-Demand CAT Tests"
     runs-on: ubuntu-24.04
     steps:
-      - name: Get job variables
-        id: job-vars
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        shell: bash
-        run: |
-          PR_JSON=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.inputs.pr }})
-          echo "repo=$(echo "$PR_JSON" | jq -r .head.repo.full_name)" >> $GITHUB_OUTPUT
-          echo "branch=$(echo "$PR_JSON" | jq -r .head.ref)" >> $GITHUB_OUTPUT
-          echo "pr_title=$(echo "$PR_JSON" | jq -r .title)" >> $GITHUB_OUTPUT
-          echo "run-url=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" >> $GITHUB_OUTPUT
+      - name: Resolve workflow variables
+        id: vars
+        uses: aaronsteers/resolve-ci-vars-action@v0
 
       - name: Append comment with job run link
         # If comment-id is not provided, this will create a new
@@ -54,7 +46,7 @@ jobs:
           comment-id: ${{ github.event.inputs.comment-id }}
           issue-number: ${{ github.event.inputs.pr }}
           body: |
-            > Connector CAT tests started... [Check job output.](${{ steps.job-vars.outputs.run-url }})
+            > Connector CAT tests started... [Check job output.](${{ steps.vars.outputs.run-url }})
             >
             > If the connector supports live tests or regression tests, you may want to run those now also:
             > - [Run Live Tests](https://github.com/airbytehq/airbyte/actions/workflows/live_tests.yml)
@@ -64,8 +56,8 @@ jobs:
       - name: Checkout Airbyte
         uses: actions/checkout@v4
         with:
-          repository: ${{ steps.job-vars.outputs.repo }}
-          ref: ${{ steps.job-vars.outputs.branch }}
+          repository: ${{ steps.vars.outputs.pr-source-repo-name-full }}
+          ref: ${{ steps.vars.outputs.pr-source-git-branch }}
           fetch-depth: 0
 
       - name: Run CAT tests with `airbyte-ci`
@@ -82,8 +74,8 @@ jobs:
           github_token: ${{ secrets.GH_PAT_APPROVINGTON_OCTAVIA }}
           s3_build_cache_access_key_id: ${{ secrets.SELF_RUNNER_AWS_ACCESS_KEY_ID }}
           s3_build_cache_secret_key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
-          git_branch: ${{ steps.job-vars.outputs.branch }}
-          git_revision: ${{ steps.job-vars.outputs.commit_id }}
+          git_branch: ${{ steps.vars.outputs.pr-source-git-branch }}
+          git_revision: ${{ steps.vars.outputs.pr-source-git-sha }}
           subcommand: "connectors --modified test --only-step=acceptance"
 
       - name: Append completion comment

--- a/.github/workflows/run-connector-tests-command.yml
+++ b/.github/workflows/run-connector-tests-command.yml
@@ -50,6 +50,10 @@ jobs:
       github.event_name != 'push' &&
       needs.get-context.outputs.skip != 'true'
     steps:
+      - name: Resolve workflow variables
+        id: vars
+        uses: aaronsteers/resolve-ci-vars-action@v0
+
       - name: Append start comment
         id: post-start-comment
         uses: peter-evans/create-or-update-comment@v4
@@ -62,7 +66,7 @@ jobs:
             >
             > These tests will leverage Airbyte's integration test credentials.
             >
-            > [Check job output.](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id}})
+            > [Check job output.](${{ steps.vars.outputs.run-url }})
     outputs:
       comment-id: ${{ steps.post-start-comment.outputs.comment-id }}
 

--- a/.github/workflows/test-performance-command.yml
+++ b/.github/workflows/test-performance-command.yml
@@ -62,6 +62,10 @@ jobs:
     needs: start-test-runner
     runs-on: ${{ needs.start-test-runner.outputs.label }}
     steps:
+      - name: Resolve workflow variables
+        id: vars
+        uses: aaronsteers/resolve-ci-vars-action@v0
+
       - name: Search for valid connector name format
         id: regex
         uses: AsasInnab/regex-action@v1
@@ -78,7 +82,7 @@ jobs:
         with:
           comment-id: ${{ github.event.inputs.comment-id }}
           body: |
-            > :clock2: ${{github.event.inputs.connector}} https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
+            > :clock2: ${{github.event.inputs.connector}} ${{ steps.vars.outputs.run-url }}
       - name: Checkout Airbyte
         uses: actions/checkout@v3
         with:
@@ -159,7 +163,7 @@ jobs:
         with:
           comment-id: ${{ github.event.inputs.comment-id }}
           body: |
-            > :white_check_mark: ${{github.event.inputs.connector}} https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
+            > :white_check_mark: ${{github.event.inputs.connector}} ${{ steps.vars.outputs.run-url }}
             ${{env.PYTHON_UNITTEST_COVERAGE_REPORT}}
       - name: Add Failure Comment
         if: github.event.inputs.comment-id && failure()
@@ -167,7 +171,7 @@ jobs:
         with:
           comment-id: ${{ github.event.inputs.comment-id }}
           body: |
-            > :x: ${{github.event.inputs.connector}} https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
+            > :x: ${{github.event.inputs.connector}} ${{ steps.vars.outputs.run-url }}
             > :bug: ${{env.GRADLE_SCAN_LINK}}
   # In case of self-hosted EC2 errors, remove this block.
   stop-test-runner:


### PR DESCRIPTION
## What

This PR refactors GitHub Actions workflows in the airbyte repository to eliminate non-DRY patterns and replace custom bash eval steps with the reusable `aaronsteers/resolve-ci-vars-action@v0`. This is a spike/research PR to demonstrate the refactoring approach across multiple workflows.

**This PR should NOT be merged** - it's labeled as "do not merge" and intended for review and discussion only.

Related to: https://github.com/aaronsteers/resolve-ci-vars-action/discussions/7

## How

The refactoring replaces three main patterns:

1. **Custom bash eval steps** that use `gh api` and `jq` to extract PR information:
   ```yaml
   # Before
   - name: Get job variables
     run: |
       PR_JSON=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.inputs.pr }})
       echo "repo=$(echo "$PR_JSON" | jq -r .head.repo.full_name)" >> $GITHUB_OUTPUT
   
   # After  
   - name: Resolve workflow variables
     id: vars
     uses: aaronsteers/resolve-ci-vars-action@v0
   ```

2. **Manual GitHub Actions run URL construction**:
   ```yaml
   # Before
   https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
   
   # After
   ${{ steps.vars.outputs.run-url }}
   ```

3. **Step output reference updates** to use standardized names:
   - `steps.job-vars.outputs.repo` → `steps.vars.outputs.pr-source-repo-name-full`
   - `steps.job-vars.outputs.branch` → `steps.vars.outputs.pr-source-git-branch`
   - `steps.job-vars.outputs.pr_title` → `steps.vars.outputs.pr-title`
   - etc.

4. **Simplified complex ternary expressions** in environment variables for better readability.

## Review guide

⚠️ **Critical**: This PR was not tested - workflows need verification before any potential merge.

1. **Primary workflow files** (most critical changes):
   - `run-cat-tests-command.yml` - Replaced bash eval and updated all references
   - `approve-regression-tests-command.yml` - Replaced bash eval, updated commit SHA references  
   - `bump-version-command.yml` - Replaced bash eval, updated repo/branch references
   - `format-fix-command.yml` - Replaced bash eval, updated push logic

2. **Secondary workflow files**:
   - `publish-java-cdk-command.yml` - Boolean logic simplification, URL replacement
   - `test-performance-command.yml` - URL replacement
   - `connector-performance-command.yml` - URL replacement
   - `format_check.yml` - URL replacement
   - `java-bulk-cdk-publish.yml` - URL replacement
   - `run-connector-tests-command.yml` - Added resolve-ci-vars-action step
   - `build-connector-images-command.yml` - Added resolve-ci-vars-action step

3. **Key items to verify**:
   - [ ] All old `steps.job-vars.outputs.*` references were updated correctly
   - [ ] The `aaronsteers/resolve-ci-vars-action@v0` provides all expected outputs
   - [ ] Boolean logic changes in `publish-java-cdk-command.yml` maintain same behavior
   - [ ] No functionality was lost in the bash-to-action conversion
   - [ ] Workflows can still access PR information, commit SHAs, and run URLs correctly

## User Impact

**Positive impacts:**
- Eliminates duplicate bash code across workflows
- Provides consistent variable naming and outputs  
- Reduces maintenance burden for workflow updates
- Follows DRY principles

**Potential negative impacts:**
- Risk of workflow failures if action doesn't provide expected outputs
- Dependency on external action that could have breaking changes
- Possible edge cases not handled by the standardized action

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

This only changes workflow files and doesn't affect application code. A revert would restore the original bash eval patterns.

---

**Requested by:** @aaronsteers  
**Devin session:** https://app.devin.ai/sessions/5a0b2f53b02347c4a8802f164b0d1231