### PR TITLE
chore: DRY up connector publishing pipeline [part 1]

### DIFF
--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -8,29 +8,22 @@ on:
       - "airbyte-integrations/connectors/**/metadata.yaml"
   workflow_call:
     inputs:
-      connectors-options:
-        description: "Options to pass to the 'airbyte-ci connectors' command group."
+      connectors:
+        description: "list of connectors to publish. This should be a string of the form --name=source-pokeapi --name=destination-postgres."
         default: "--name=source-pokeapi"
         type: string
       publish-options:
         description: "Options to pass to the 'airbyte-ci connectors publish' command. Use --pre-release or --main-release depending on whether you want to publish a dev image or not. "
         default: "--pre-release"
-        type: string
-      airbyte_ci_binary_url:
-        description: "URL to the airbyte-ci binary to use for the action. If not provided, the action will use the latest release of airbyte-ci."
-        default: "https://connectors.airbyte.com/airbyte-ci/releases/ubuntu/latest/airbyte-ci"
         type: string
   workflow_dispatch:
     inputs:
-      connectors-options:
-        description: "Options to pass to the 'airbyte-ci connectors' command group."
+      connectors:
+        description: "list of connectors to publish. This should be a string of the form --name=source-pokeapi --name=destination-postgres."
         default: "--name=source-pokeapi"
       publish-options:
         description: "Options to pass to the 'airbyte-ci connectors publish' command. Use --pre-release or --main-release depending on whether you want to publish a dev image or not. "
         default: "--pre-release"
-      airbyte_ci_binary_url:
-        description: "URL to the airbyte-ci binary to use for the action. If not provided, the action will use the latest release of airbyte-ci."
-        default: "https://connectors.airbyte.com/airbyte-ci/releases/ubuntu/latest/airbyte-ci"
 jobs:
   list_connectors:
     name: List connectors to publish
@@ -44,13 +37,13 @@ jobs:
         id: list-connectors-manual
         if: github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call'
         shell: bash
-        # We need to run an actual script to parse the `--name` args and filter for JVM connectors.
-        run: echo connectors-to-publish=$(./poe-tasks/parse-connector-name-args.sh ${{ inputs.connectors-options }}) | tee -a $GITHUB_OUTPUT
+        # When invoked manually, we run on the connectors specified in the input.
+        run: echo connectors-to-publish=$(./poe-tasks/parse-connector-name-args.sh ${{ inputs.connectors }}) | tee -a $GITHUB_OUTPUT
       - name: List connectors [On merge to master]
         id: list-connectors-master
         if: github.event_name == 'push'
         shell: bash
-        # get-modified-connectors.sh already prints things in the right format, so just use that output directly
+        # When merging to master, we run on connectors that have changed since the previous commit.
         run: echo connectors-to-publish=$(./poe-tasks/get-modified-connectors.sh --prev-commit --json) | tee -a $GITHUB_OUTPUT
     outputs:
       # Exactly one of the manual/master steps will run, so just OR them together.

--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -45,7 +45,7 @@ jobs:
         if: github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call'
         shell: bash
         # We need to run an actual script to parse the `--name` args and filter for JVM connectors.
-        run: ./poe-tasks/parse-connector-name-args.sh ${{ inputs.connectors-options }} | tee -a $GITHUB_OUTPUT
+        run: connectors-to-publish=$(./poe-tasks/parse-connector-name-args.sh ${{ inputs.connectors-options }}) | tee -a $GITHUB_OUTPUT
       - name: List connectors [On merge to master]
         id: list-connectors-master
         if: github.event_name == 'push'
@@ -53,11 +53,9 @@ jobs:
         # get-modified-connectors.sh already prints things in the right format, so just use that output directly
         run: |
           echo connectors-to-publish=$(./poe-tasks/get-modified-connectors.sh --prev-commit --json) | tee -a $GITHUB_OUTPUT
-          echo connectors-to-publish-jvm=$(./poe-tasks/get-modified-connectors.sh --prev-commit --java --json) | tee -a $GITHUB_OUTPUT
     outputs:
       # Exactly one of the manual/master steps will run, so just OR them together.
       connectors-to-publish: ${{ steps.list-connectors-manual.outputs.connectors-to-publish || steps.list-connectors-master.outputs.connectors-to-publish }}
-      connectors-to-publish-jvm: ${{ steps.list-connectors-manual.outputs.connectors-to-publish-jvm || steps.list-connectors-master.outputs.connectors-to-publish-jvm }}
   publish_connectors:
     name: Publish connectors
     needs: [list_connectors]

--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -45,14 +45,13 @@ jobs:
         if: github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call'
         shell: bash
         # We need to run an actual script to parse the `--name` args and filter for JVM connectors.
-        run: connectors-to-publish=$(./poe-tasks/parse-connector-name-args.sh ${{ inputs.connectors-options }}) | tee -a $GITHUB_OUTPUT
+        run: echo connectors-to-publish=$(./poe-tasks/parse-connector-name-args.sh ${{ inputs.connectors-options }}) | tee -a $GITHUB_OUTPUT
       - name: List connectors [On merge to master]
         id: list-connectors-master
         if: github.event_name == 'push'
         shell: bash
         # get-modified-connectors.sh already prints things in the right format, so just use that output directly
-        run: |
-          echo connectors-to-publish=$(./poe-tasks/get-modified-connectors.sh --prev-commit --json) | tee -a $GITHUB_OUTPUT
+        run: echo connectors-to-publish=$(./poe-tasks/get-modified-connectors.sh --prev-commit --json) | tee -a $GITHUB_OUTPUT
     outputs:
       # Exactly one of the manual/master steps will run, so just OR them together.
       connectors-to-publish: ${{ steps.list-connectors-manual.outputs.connectors-to-publish || steps.list-connectors-master.outputs.connectors-to-publish }}


### PR DESCRIPTION
## What
Tidying up arg parsing and variable resolution in this Github Workflow now that Airbyte CI is no longer used. There were a lot of optional arguments that are no longer supported, so we can simplify the interface.

Specifically in this PR
1. simplify script to parse connector names from the input list.
  - remove dependencies on other bash util scripts
  - no longer parse jvm connectors (we do this downstream based on the connector language, fetched with a poe task)
2. remove some stray references to Airbyte CI
  - no longer need the `airbyte_ci_binary_url` input parameter
  - rename `connector-options` to `connectors` since we no longer support other options

Another stacked PR to come in part 2

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
