### PR TITLE
chore(metadata_service): add logging to troubleshoot stale metadata report issue

### DIFF
--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/stale_metadata_report.py
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/stale_metadata_report.py
@@ -54,8 +54,14 @@ def _entry_should_be_on_gcs(metadata_model: ConnectorMetadataDefinitionV0) -> bo
         bool: True if the metadata entry should be on GCS, False otherwise.
     """
     if metadata_model.data.supportLevel and metadata_model.data.supportLevel.__root__ == "archived":
+        logger.info(
+            f"Skipping. Connector `{metadata_model.data.dockerRepository}` is archived or does not have a support level. Support level: {metadata_model.data.supportLevel.__root__}"
+        )
         return False
     if "-rc" in metadata_model.data.dockerImageTag:
+        logger.info(
+            f"Skipping. Connector `{metadata_model.data.dockerRepository}` is a release candidate. Docker image tag: {metadata_model.data.dockerImageTag}"
+        )
         return False
     return True
 
@@ -88,6 +94,10 @@ def _get_github_metadata_download_urls() -> list[str]:
             last_modified_at = commits[0].commit.author.date
             if not _is_younger_than_grace_period(last_modified_at):
                 metadata_download_urls.append(file_content.download_url)
+            else:
+                logger.info(
+                    f"Skipping. Metadata file on Github `{file_content.path}` was modified more recently than the grace period. Last modified at: {last_modified_at}"
+                )
     logger.debug(f"Found {len(metadata_download_urls)} download URLs")
 
     return metadata_download_urls

--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/stale_metadata_report.py
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/stale_metadata_report.py
@@ -124,7 +124,7 @@ def _get_and_parse_metadata_files(metadata_download_urls: list[str]) -> list[Con
             connector_metadata = ConnectorMetadataDefinitionV0.parse_obj(metadata_dict)
             connector_metadata_list.append(connector_metadata)
         except Exception as e:
-            logger.debug(f"Skipping. Failed to parse metadata for metadata at path: {metadata_download_url}. Exception: {e}")
+            logger.info(f"Skipping. Failed to parse metadata for metadata at path: {metadata_download_url}. Exception: {e}")
             continue
     logger.debug(f"Parsed {len(connector_metadata_list)} metadata files")
     return connector_metadata_list

--- a/airbyte-ci/connectors/metadata_service/lib/pyproject.toml
+++ b/airbyte-ci/connectors/metadata_service/lib/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metadata-service"
-version = "0.28.0"
+version = "0.28.1"
 description = ""
 authors = ["Airbyte <contact@airbyte.io>"]
 readme = "README.md"


### PR DESCRIPTION
## What
- Adds logging statements to stale metadata report to trouble shoot intermittent issue where ~70 connectors "randomly" were skipped.

## Review guide
stale_metadata_report.py

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
