### PR TITLE
Rbroughan/move cdk test overrides

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/test/config/TestBeanOverrideFactory.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/test/config/TestBeanOverrideFactory.kt
@@ -1,0 +1,24 @@
+package io.airbyte.cdk.load.test.config
+
+import io.airbyte.cdk.load.dataflow.config.MemoryAndParallelismConfig
+import io.micronaut.context.annotation.Factory
+import io.micronaut.context.annotation.Primary
+import io.micronaut.context.annotation.Requires
+import io.micronaut.context.env.Environment
+import jakarta.inject.Singleton
+
+/**
+ * Why is this not in a test package?
+ *
+ * We have to include this in the source so it's built in the docker image for the docker tests.
+ */
+@Factory
+@Requires(env = [Environment.TEST])
+class TestBeanOverrideFactory {
+    @Singleton
+    @Primary
+    fun testConfig() = MemoryAndParallelismConfig(
+        // Set this to 1 so we flush aggregates immediately for easier testing.
+        maxRecordsPerAgg = 1,
+    )
+}


### PR DESCRIPTION
## What
Moves test memory / config overrides to cdk source so it's included for docker builds
