### PR TITLE
Add OAuth refresh token support for Zendesk Support connector

### DIFF
--- a/airbyte-integrations/connectors/source-zendesk-support/components.py
+++ b/airbyte-integrations/connectors/source-zendesk-support/components.py
@@ -1,9 +1,11 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 
-from typing import Any, List, Mapping
+from dataclasses import dataclass
+from typing import Any, List, Mapping, Optional, Tuple
 
 import requests
 
+from airbyte_cdk.sources.declarative.auth import DeclarativeOauth2Authenticator
 from airbyte_cdk.sources.declarative.extractors.record_extractor import RecordExtractor
 
 
@@ -41,3 +43,67 @@ class ZendeskSupportAttributeDefinitionsExtractor(RecordExtractor):
         except requests.exceptions.JSONDecodeError:
             records = []
         return records
+
+
+@dataclass
+class ZendeskSupportOAuth2Authenticator(DeclarativeOauth2Authenticator):
+    """
+    Custom OAuth2 authenticator for Zendesk Support that handles token expiration and refresh.
+    
+    This authenticator implements Zendesk's new OAuth refresh token flow to comply with
+    their September 30, 2025 deadline for access token expiration support.
+    
+    Reference: https://developer.zendesk.com/api-reference/ticketing/oauth/grant_type_tokens/
+    """
+
+    def get_refresh_request_body(self) -> Mapping[str, Any]:
+        """
+        Build the request body for token refresh according to Zendesk's OAuth specification.
+        
+        Zendesk expects:
+        - grant_type: "refresh_token" 
+        - refresh_token: The refresh token
+        - client_id: The OAuth client ID
+        - client_secret: The OAuth client secret
+        """
+        return {
+            "grant_type": "refresh_token",
+            "refresh_token": self.refresh_token,
+            "client_id": self.client_id,
+            "client_secret": self.client_secret,
+        }
+
+    def refresh_access_token(self) -> Tuple[str, int]:
+        """
+        Refresh the access token using Zendesk's /oauth/tokens endpoint.
+        
+        Returns:
+            Tuple[str, int]: (access_token, expires_in_seconds)
+            
+        Raises:
+            Exception: If the token refresh fails
+        """
+        try:
+            response = requests.request(
+                method="POST",
+                url=self.token_refresh_endpoint,
+                json=self.get_refresh_request_body(),
+                headers={"Content-Type": "application/json"},
+            )
+            response.raise_for_status()
+            response_json = response.json()
+            
+            access_token = response_json.get("access_token")
+            expires_in = response_json.get("expires_in", 7200)  # Default to 2 hours if not provided
+            
+            if not access_token:
+                raise Exception("No access_token in refresh response")
+                
+            return access_token, expires_in
+            
+        except requests.exceptions.RequestException as e:
+            raise Exception(f"HTTP error while refreshing Zendesk access token: {e}") from e
+        except (KeyError, ValueError) as e:
+            raise Exception(f"Invalid response format while refreshing Zendesk access token: {e}") from e
+        except Exception as e:
+            raise Exception(f"Unexpected error while refreshing Zendesk access token: {e}") from e

--- a/airbyte-integrations/connectors/source-zendesk-support/components.py
+++ b/airbyte-integrations/connectors/source-zendesk-support/components.py
@@ -49,19 +49,19 @@ class ZendeskSupportAttributeDefinitionsExtractor(RecordExtractor):
 class ZendeskSupportOAuth2Authenticator(DeclarativeOauth2Authenticator):
     """
     Custom OAuth2 authenticator for Zendesk Support that handles token expiration and refresh.
-    
+
     This authenticator implements Zendesk's new OAuth refresh token flow to comply with
     their September 30, 2025 deadline for access token expiration support.
-    
+
     Reference: https://developer.zendesk.com/api-reference/ticketing/oauth/grant_type_tokens/
     """
 
     def get_refresh_request_body(self) -> Mapping[str, Any]:
         """
         Build the request body for token refresh according to Zendesk's OAuth specification.
-        
+
         Zendesk expects:
-        - grant_type: "refresh_token" 
+        - grant_type: "refresh_token"
         - refresh_token: The refresh token
         - client_id: The OAuth client ID
         - client_secret: The OAuth client secret
@@ -76,10 +76,10 @@ class ZendeskSupportOAuth2Authenticator(DeclarativeOauth2Authenticator):
     def refresh_access_token(self) -> Tuple[str, int]:
         """
         Refresh the access token using Zendesk's /oauth/tokens endpoint.
-        
+
         Returns:
             Tuple[str, int]: (access_token, expires_in_seconds)
-            
+
         Raises:
             Exception: If the token refresh fails
         """
@@ -92,15 +92,15 @@ class ZendeskSupportOAuth2Authenticator(DeclarativeOauth2Authenticator):
             )
             response.raise_for_status()
             response_json = response.json()
-            
+
             access_token = response_json.get("access_token")
             expires_in = response_json.get("expires_in", 7200)  # Default to 2 hours if not provided
-            
+
             if not access_token:
                 raise Exception("No access_token in refresh response")
-                
+
             return access_token, expires_in
-            
+
         except requests.exceptions.RequestException as e:
             raise Exception(f"HTTP error while refreshing Zendesk access token: {e}") from e
         except (KeyError, ValueError) as e:

--- a/airbyte-integrations/connectors/source-zendesk-support/manifest.yaml
+++ b/airbyte-integrations/connectors/source-zendesk-support/manifest.yaml
@@ -11,7 +11,7 @@ definitions:
   # Legacy bearer authenticator - kept for backward compatibility during transition
   bearer_authenticator:
     type: BearerAuthenticator
-    api_token: "{{ config['credentials']['access_token'] }}"
+    api_token: "{{ config['access_token'] }}"
   
   # New OAuth2 authenticator with refresh token support for Zendesk's new requirements
   oauth2_authenticator:
@@ -36,10 +36,10 @@ definitions:
       http_method: GET
       authenticator:
         type: SelectiveAuthenticator
-        authenticator_selection_path: ["credentials", "credentials"]
+        authenticator_selection_path: ["credentials"]
         authenticators:
-          oauth2.0: "#/definitions/oauth2_authenticator"
-          oauth2.0_legacy: "#/definitions/bearer_authenticator"  # For backward compatibility
+          oauth2.0_refresh: "#/definitions/oauth2_authenticator"
+          oauth2.0: "#/definitions/bearer_authenticator"  # Legacy OAuth with access token
           api_token: "#/definitions/basic_authenticator"
       error_handler:
         type: DefaultErrorHandler
@@ -339,8 +339,9 @@ definitions:
         http_method: GET
         authenticator:
           type: SelectiveAuthenticator
-          authenticator_selection_path: ["credentials", "credentials"]
+          authenticator_selection_path: ["credentials"]
           authenticators:
+            oauth2.0_refresh: "#/definitions/oauth2_authenticator"
             oauth2.0: "#/definitions/bearer_authenticator"
             api_token: "#/definitions/basic_authenticator"
       download_target_extractor:
@@ -1307,7 +1308,7 @@ spec:
             properties:
               credentials:
                 type: string
-                const: oauth2.0
+                const: oauth2.0_refresh
                 order: 0
               refresh_token:
                 type: string
@@ -1345,7 +1346,7 @@ spec:
             properties:
               credentials:
                 type: string
-                const: oauth2.0_legacy
+                const: oauth2.0
                 order: 0
               access_token:
                 type: string
@@ -1426,7 +1427,7 @@ spec:
     predicate_key:
       - credentials
       - credentials
-    predicate_value: oauth2.0
+    predicate_value: oauth2.0_refresh
     oauth_config_specification:
       complete_oauth_output_specification:
         type: object

--- a/airbyte-integrations/connectors/source-zendesk-support/manifest.yaml
+++ b/airbyte-integrations/connectors/source-zendesk-support/manifest.yaml
@@ -11,7 +11,7 @@ definitions:
   # Legacy bearer authenticator - kept for backward compatibility during transition
   bearer_authenticator:
     type: BearerAuthenticator
-    api_token: "{{ config['access_token'] }}"
+    api_token: "{{ config['credentials']['access_token'] }}"
   
   # New OAuth2 authenticator with refresh token support for Zendesk's new requirements
   oauth2_authenticator:
@@ -36,7 +36,7 @@ definitions:
       http_method: GET
       authenticator:
         type: SelectiveAuthenticator
-        authenticator_selection_path: ["credentials"]
+        authenticator_selection_path: ["credentials", "credentials"]
         authenticators:
           oauth2.0_refresh: "#/definitions/oauth2_authenticator"
           oauth2.0: "#/definitions/bearer_authenticator"  # Legacy OAuth with access token
@@ -339,7 +339,7 @@ definitions:
         http_method: GET
         authenticator:
           type: SelectiveAuthenticator
-          authenticator_selection_path: ["credentials"]
+          authenticator_selection_path: ["credentials", "credentials"]
           authenticators:
             oauth2.0_refresh: "#/definitions/oauth2_authenticator"
             oauth2.0: "#/definitions/bearer_authenticator"

--- a/airbyte-integrations/connectors/source-zendesk-support/manifest.yaml
+++ b/airbyte-integrations/connectors/source-zendesk-support/manifest.yaml
@@ -8,9 +8,21 @@ check:
     - tags
 
 definitions:
+  # Legacy bearer authenticator - kept for backward compatibility during transition
   bearer_authenticator:
     type: BearerAuthenticator
     api_token: "{{ config['credentials']['access_token'] }}"
+  
+  # New OAuth2 authenticator with refresh token support for Zendesk's new requirements
+  oauth2_authenticator:
+    type: CustomAuthenticator
+    class_name: source_declarative_manifest.components.ZendeskSupportOAuth2Authenticator
+    client_id: "{{ config['credentials']['client_id'] }}"
+    client_secret: "{{ config['credentials']['client_secret'] }}"
+    refresh_token: "{{ config['credentials']['refresh_token'] }}"
+    token_refresh_endpoint: "https://{{ config['subdomain'] }}.zendesk.com/oauth/tokens"
+    grant_type: "refresh_token"
+    
   basic_authenticator:
     type: BasicHttpAuthenticator
     username: "{{ config['credentials']['email'] + '/token' }}"
@@ -26,7 +38,8 @@ definitions:
         type: SelectiveAuthenticator
         authenticator_selection_path: ["credentials", "credentials"]
         authenticators:
-          oauth2.0: "#/definitions/bearer_authenticator"
+          oauth2.0: "#/definitions/oauth2_authenticator"
+          oauth2.0_legacy: "#/definitions/bearer_authenticator"  # For backward compatibility
           api_token: "#/definitions/basic_authenticator"
       error_handler:
         type: DefaultErrorHandler
@@ -1287,21 +1300,25 @@ spec:
           - title: OAuth2.0
             type: object
             required:
-              - access_token
+              - refresh_token
+              - client_id
+              - client_secret
             additionalProperties: true
             properties:
               credentials:
                 type: string
                 const: oauth2.0
                 order: 0
-              access_token:
+              refresh_token:
                 type: string
-                title: Access Token
+                title: Refresh Token
                 description: >-
-                  The OAuth access token. See the <a
-                  href="https://developer.zendesk.com/documentation/ticketing/working-with-oauth/creating-and-using-oauth-tokens-with-the-api/">Zendesk
-                  docs</a> for more information on generating this token.
+                  The OAuth refresh token. This token is used to automatically refresh
+                  expired access tokens. You can obtain this token by completing the OAuth
+                  authorization flow. Required for compliance with Zendesk's new OAuth token
+                  expiration policy (effective September 30, 2025).
                 airbyte_secret: true
+                order: 1
               client_id:
                 type: string
                 title: Client ID
@@ -1310,6 +1327,7 @@ spec:
                   href="https://docs.searchunify.com/Content/Content-Sources/Zendesk-Authentication-OAuth-Client-ID-Secret.htm#:~:text=Get%20Client%20ID%20and%20Client%20Secret&text=Go%20to%20OAuth%20Clients%20and,will%20be%20displayed%20only%20once.">this
                   guide</a> for more information.
                 airbyte_secret: true
+                order: 2
               client_secret:
                 type: string
                 title: Client Secret
@@ -1318,6 +1336,44 @@ spec:
                   href="https://docs.searchunify.com/Content/Content-Sources/Zendesk-Authentication-OAuth-Client-ID-Secret.htm#:~:text=Get%20Client%20ID%20and%20Client%20Secret&text=Go%20to%20OAuth%20Clients%20and,will%20be%20displayed%20only%20once.">this
                   guide</a> for more information.
                 airbyte_secret: true
+                order: 3
+          - title: OAuth2.0 (Legacy)
+            type: object
+            required:
+              - access_token
+            additionalProperties: true
+            properties:
+              credentials:
+                type: string
+                const: oauth2.0_legacy
+                order: 0
+              access_token:
+                type: string
+                title: Access Token
+                description: >-
+                  [DEPRECATED] The static OAuth access token. This method will stop working
+                  on September 30, 2025 when Zendesk enforces token expiration. Please
+                  migrate to the OAuth2.0 (refresh token) method above.
+                airbyte_secret: true
+                order: 1
+              client_id:
+                type: string
+                title: Client ID
+                description: >-
+                  The OAuth client's ID. See <a
+                  href="https://docs.searchunify.com/Content/Content-Sources/Zendesk-Authentication-OAuth-Client-ID-Secret.htm#:~:text=Get%20Client%20ID%20and%20Client%20Secret&text=Go%20to%20OAuth%20Clients%20and,will%20be%20displayed%20only%20once.">this
+                  guide</a> for more information.
+                airbyte_secret: true
+                order: 2
+              client_secret:
+                type: string
+                title: Client Secret
+                description: >-
+                  The OAuth client secret. See <a
+                  href="https://docs.searchunify.com/Content/Content-Sources/Zendesk-Authentication-OAuth-Client-ID-Secret.htm#:~:text=Get%20Client%20ID%20and%20Client%20Secret&text=Go%20to%20OAuth%20Clients%20and,will%20be%20displayed%20only%20once.">this
+                  guide</a> for more information.
+                airbyte_secret: true
+                order: 3
           - title: API Token
             type: object
             required:
@@ -1376,11 +1432,11 @@ spec:
         type: object
         additionalProperties: false
         properties:
-          access_token:
+          refresh_token:
             type: string
             path_in_connector_config:
               - credentials
-              - access_token
+              - refresh_token
       complete_oauth_server_input_specification:
         type: object
         additionalProperties: false

--- a/airbyte-integrations/connectors/source-zendesk-support/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zendesk-support/metadata.yaml
@@ -11,7 +11,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 79c1aa37-dae3-42ae-b333-d1c105477715
-  dockerImageTag: 4.10.7
+  dockerImageTag: 5.0.0
   dockerRepository: airbyte/source-zendesk-support
   documentationUrl: https://docs.airbyte.com/integrations/sources/zendesk-support
   githubIssueLabel: source-zendesk-support
@@ -33,19 +33,13 @@ data:
     rolloutConfiguration:
       enableProgressiveRollout: false
     breakingChanges:
-      1.0.0:
-        message: "`cursor_field` for `Tickets` stream is changed to `generated_timestamp`"
-        upgradeDeadline: "2023-07-19"
-      2.0.0:
-        message: The `Deleted Tickets` stream was removed. Deleted tickets are still available from the Tickets stream.
-        upgradeDeadline: "2023-10-04"
-      3.0.0:
-        message: "This version includes breaking changes to the `TicketsMetric` stream.  The cursor field has been updated to `generated_timestamp`. It is necessary to refresh the data and schema for the affected stream. Please see the migration guide for additional details."
-        upgradeDeadline: "2024-09-09"
+      5.0.0:
+        message: "OAuth authentication flow has been updated to support refresh tokens. Users must reauthenticate using the new OAuth2.0 option before September 30, 2025 when Zendesk enforces access token expiration. The legacy OAuth2.0 option will stop working after this deadline. Please see the migration guide for additional details."
+        upgradeDeadline: "2025-09-30"
         scopedImpact:
-          - scopeType: stream
+          - scopeType: config
             impactedScopes:
-              - "ticket_metrics"
+              - "authentication"
       4.0.0:
         message: "This version includes breaking changes to the `Tags` stream. The pagination strategy has been changed from `Offset` to `Cursor-Based`. It is necessary to reset the stream. Please see the migration guide for additional details."
         upgradeDeadline: "2024-09-09"
@@ -53,6 +47,19 @@ data:
           - scopeType: stream
             impactedScopes:
               - "tags"
+      3.0.0:
+        message: "This version includes breaking changes to the `TicketsMetric` stream.  The cursor field has been updated to `generated_timestamp`. It is necessary to refresh the data and schema for the affected stream. Please see the migration guide for additional details."
+        upgradeDeadline: "2024-09-09"
+        scopedImpact:
+          - scopeType: stream
+            impactedScopes:
+              - "ticket_metrics"
+      2.0.0:
+        message: The `Deleted Tickets` stream was removed. Deleted tickets are still available from the Tickets stream.
+        upgradeDeadline: "2023-10-04"
+      1.0.0:
+        message: "`cursor_field` for `Tickets` stream is changed to `generated_timestamp`"
+        upgradeDeadline: "2023-07-19"
   suggestedStreams:
     streams:
       - brands

--- a/airbyte-integrations/connectors/source-zendesk-support/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zendesk-support/metadata.yaml
@@ -36,10 +36,6 @@ data:
       5.0.0:
         message: "OAuth authentication flow has been updated to support refresh tokens. Users must reauthenticate using the new OAuth2.0 option before September 30, 2025 when Zendesk enforces access token expiration. The legacy OAuth2.0 option will stop working after this deadline. Please see the migration guide for additional details."
         upgradeDeadline: "2025-09-30"
-        scopedImpact:
-          - scopeType: config
-            impactedScopes:
-              - "authentication"
       4.0.0:
         message: "This version includes breaking changes to the `Tags` stream. The pagination strategy has been changed from `Offset` to `Cursor-Based`. It is necessary to reset the stream. Please see the migration guide for additional details."
         upgradeDeadline: "2024-09-09"

--- a/airbyte-integrations/connectors/source-zendesk-support/unit_tests/integrations/config.py
+++ b/airbyte-integrations/connectors/source-zendesk-support/unit_tests/integrations/config.py
@@ -21,6 +21,13 @@ class ConfigBuilder:
         self._credentials["credentials"] = "oauth2.0"
         return self
 
+    def with_oauth_refresh_credentials(self, refresh_token: str, client_id: str, client_secret: str) -> "ConfigBuilder":
+        self._credentials["refresh_token"] = refresh_token
+        self._credentials["client_id"] = client_id
+        self._credentials["client_secret"] = client_secret
+        self._credentials["credentials"] = "oauth2.0_refresh"
+        return self
+
     def with_basic_auth_credentials(self, email: str, password: str) -> "ConfigBuilder":
         self._credentials["api_token"] = password
         self._credentials["credentials"] = "api_token"

--- a/airbyte-integrations/connectors/source-zendesk-support/unit_tests/integrations/test_oauth_refresh.py
+++ b/airbyte-integrations/connectors/source-zendesk-support/unit_tests/integrations/test_oauth_refresh.py
@@ -41,7 +41,7 @@ class TestOAuthRefreshAuthentication(TestCase):
         http_mocker.post(
             "https://d3v-airbyte.zendesk.com/oauth/tokens",
             HttpResponse(
-                body=json.dumps(
+                json.dumps(
                     {
                         "access_token": "new_access_token_12345",
                         "expires_in": 7200,
@@ -49,7 +49,7 @@ class TestOAuthRefreshAuthentication(TestCase):
                         "token_type": "Bearer",
                     }
                 ),
-                status_code=200,
+                200,
             ),
         )
 
@@ -57,8 +57,8 @@ class TestOAuthRefreshAuthentication(TestCase):
         http_mocker.get(
             "https://d3v-airbyte.zendesk.com/api/v2/brands",
             HttpResponse(
-                body=json.dumps({"brands": [{"id": 1, "name": "Test Brand", "active": True}]}),
-                status_code=200,
+                json.dumps({"brands": [{"id": 1, "name": "Test Brand", "active": True}]}),
+                200,
             ),
         )
 
@@ -79,8 +79,8 @@ class TestOAuthRefreshAuthentication(TestCase):
         http_mocker.post(
             "https://d3v-airbyte.zendesk.com/oauth/tokens",
             HttpResponse(
-                body=json.dumps({"error": "invalid_grant", "error_description": "The provided authorization grant is invalid"}),
-                status_code=400,
+                json.dumps({"error": "invalid_grant", "error_description": "The provided authorization grant is invalid"}),
+                400,
             ),
         )
 
@@ -117,13 +117,13 @@ class TestOAuthRefreshAuthentication(TestCase):
         http_mocker.post(
             "https://d3v-airbyte.zendesk.com/oauth/tokens",
             HttpResponse(
-                body=json.dumps(
+                json.dumps(
                     {
                         "access_token": "minimal_access_token"
                         # Note: missing expires_in should default to 7200 seconds
                     }
                 ),
-                status_code=200,
+                200,
             ),
         )
 
@@ -131,8 +131,8 @@ class TestOAuthRefreshAuthentication(TestCase):
         http_mocker.get(
             "https://d3v-airbyte.zendesk.com/api/v2/brands",
             HttpResponse(
-                body=json.dumps({"brands": [{"id": 1, "name": "Test Brand"}]}),
-                status_code=200,
+                json.dumps({"brands": [{"id": 1, "name": "Test Brand"}]}),
+                200,
             ),
         )
 
@@ -146,7 +146,7 @@ class TestOAuthRefreshAuthentication(TestCase):
         config = self._config().build()
 
         # Mock network error during token refresh by using a connection error
-        http_mocker.post("https://d3v-airbyte.zendesk.com/oauth/tokens", HttpResponse(body="Service Unavailable", status_code=503))
+        http_mocker.post("https://d3v-airbyte.zendesk.com/oauth/tokens", HttpResponse("Service Unavailable", 503))
 
         # Should handle network errors gracefully
         try:

--- a/airbyte-integrations/connectors/source-zendesk-support/unit_tests/integrations/test_oauth_refresh.py
+++ b/airbyte-integrations/connectors/source-zendesk-support/unit_tests/integrations/test_oauth_refresh.py
@@ -1,146 +1,136 @@
 # Copyright (c) 2025 Airbyte, Inc., all rights reserved.
 
-import json
-from datetime import timedelta
-from unittest import TestCase
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch, MagicMock
 
-import freezegun
+import pytest
 import requests
 
-from airbyte_cdk.models import SyncMode
-from airbyte_cdk.test.mock_http import HttpMocker, HttpResponse
-from airbyte_cdk.utils.datetime_helpers import ab_datetime_now
-
 from .config import ConfigBuilder
-from .utils import read_stream
 
 
-_NOW = ab_datetime_now()
-_START_DATE = ab_datetime_now().subtract(timedelta(weeks=52))
+def _get_config():
+    """Helper function to build test config"""
+    return (
+        ConfigBuilder()
+        .with_oauth_refresh_credentials(
+            refresh_token="test_refresh_token", client_id="test_client_id", client_secret="test_client_secret"
+        )
+        .with_subdomain("d3v-airbyte")
+        .build()
+    )
 
 
-@freezegun.freeze_time(_NOW.isoformat())
-class TestOAuthRefreshAuthentication(TestCase):
-    def _config(self) -> ConfigBuilder:
-        return (
-            ConfigBuilder()
-            .with_oauth_refresh_credentials(
-                refresh_token="test_refresh_token", client_id="test_client_id", client_secret="test_client_secret"
-            )
-            .with_subdomain("d3v-airbyte")
-            .with_start_date(ab_datetime_now().subtract(timedelta(hours=1)))
+def test_oauth_authenticator_direct_token_refresh(components_module):
+    """Test OAuth authenticator refresh_access_token method directly like successful connectors do"""
+    
+    # Create authenticator instance
+    authenticator = components_module.ZendeskSupportOAuth2Authenticator(
+        client_id="test_client_id",
+        client_secret="test_client_secret", 
+        refresh_token="test_refresh_token",
+        token_refresh_endpoint="https://d3v-airbyte.zendesk.com/oauth/tokens",
+        config={"subdomain": "d3v-airbyte"},
+        parameters={},
+    )
+    
+    # Mock successful requests.request call
+    with patch("requests.request") as mock_request:
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "access_token": "new_access_token_12345",
+            "expires_in": 7200,
+            "refresh_token": "new_refresh_token_67890",
+            "token_type": "Bearer",
+        }
+        mock_response.raise_for_status = MagicMock()
+        mock_request.return_value = mock_response
+        
+        # Call refresh_access_token directly
+        access_token, expires_in = authenticator.refresh_access_token()
+        
+        # Verify results
+        assert access_token == "new_access_token_12345"
+        assert expires_in == 7200
+        
+        # Verify request was made correctly
+        mock_request.assert_called_once_with(
+            method="POST",
+            url="https://d3v-airbyte.zendesk.com/oauth/tokens",
+            json={
+                "grant_type": "refresh_token",
+                "refresh_token": "test_refresh_token",
+                "client_id": "test_client_id", 
+                "client_secret": "test_client_secret",
+            },
+            headers={"Content-Type": "application/json"},
         )
 
-    def test_oauth_authenticator_direct_token_refresh(self, components_module):
-        """Test OAuth authenticator refresh_access_token method directly like successful connectors do"""
 
-        # Create authenticator instance
-        authenticator = components_module.ZendeskSupportOAuth2Authenticator(
-            client_id="test_client_id",
-            client_secret="test_client_secret",
-            refresh_token="test_refresh_token",
-            token_refresh_endpoint="https://d3v-airbyte.zendesk.com/oauth/tokens",
-            config={"subdomain": "d3v-airbyte"},
-            parameters={},
-        )
+def test_oauth_authenticator_direct_token_refresh_error(components_module):
+    """Test OAuth authenticator handles refresh errors properly"""
+    
+    authenticator = components_module.ZendeskSupportOAuth2Authenticator(
+        client_id="test_client_id",
+        client_secret="test_client_secret",
+        refresh_token="test_refresh_token", 
+        token_refresh_endpoint="https://d3v-airbyte.zendesk.com/oauth/tokens",
+        config={"subdomain": "d3v-airbyte"},
+        parameters={},
+    )
+    
+    # Mock failed requests.request call 
+    with patch("requests.request") as mock_request:
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"error": "invalid_grant"}
+        mock_response.raise_for_status.side_effect = requests.exceptions.HTTPError("400 Client Error")
+        mock_request.return_value = mock_response
+        
+        # Should raise exception
+        with pytest.raises(Exception) as exc_info:
+            authenticator.refresh_access_token()
+        
+        assert "HTTP error while refreshing Zendesk access token" in str(exc_info.value)
 
-        # Mock successful requests.request call
-        with patch("requests.request") as mock_request:
-            mock_response = MagicMock()
-            mock_response.json.return_value = {
-                "access_token": "new_access_token_12345",
-                "expires_in": 7200,
-                "refresh_token": "new_refresh_token_67890",
-                "token_type": "Bearer",
-            }
-            mock_response.raise_for_status = MagicMock()
-            mock_request.return_value = mock_response
 
-            # Call refresh_access_token directly
-            access_token, expires_in = authenticator.refresh_access_token()
+def test_oauth_request_body_format():
+    """Test that the OAuth request body contains the correct fields and format"""
+    config = _get_config()
 
-            # Verify results
-            assert access_token == "new_access_token_12345"
-            assert expires_in == 7200
+    # Validate that the config has the expected OAuth refresh structure
+    assert config["credentials"]["credentials"] == "oauth2.0_refresh"
+    assert "refresh_token" in config["credentials"]
+    assert "client_id" in config["credentials"]
+    assert "client_secret" in config["credentials"]
+    
+    # Validate config structure for the new OAuth flow
+    expected_keys = {"refresh_token", "client_id", "client_secret", "credentials"}
+    actual_keys = set(config["credentials"].keys())
+    assert expected_keys.issubset(actual_keys), f"Missing OAuth fields. Expected: {expected_keys}, Got: {actual_keys}"
 
-            # Verify request was made correctly
-            mock_request.assert_called_once_with(
-                method="POST",
-                url="https://d3v-airbyte.zendesk.com/oauth/tokens",
-                json={
-                    "grant_type": "refresh_token",
-                    "refresh_token": "test_refresh_token",
-                    "client_id": "test_client_id",
-                    "client_secret": "test_client_secret",
-                },
-                headers={"Content-Type": "application/json"},
-            )
 
-    def test_oauth_authenticator_direct_token_refresh_error(self, components_module):
-        """Test OAuth authenticator handles refresh errors properly"""
-
-        authenticator = components_module.ZendeskSupportOAuth2Authenticator(
-            client_id="test_client_id",
-            client_secret="test_client_secret",
-            refresh_token="test_refresh_token",
-            token_refresh_endpoint="https://d3v-airbyte.zendesk.com/oauth/tokens",
-            config={"subdomain": "d3v-airbyte"},
-            parameters={},
-        )
-
-        # Mock failed requests.request call
-        with patch("requests.request") as mock_request:
-            mock_response = MagicMock()
-            mock_response.json.return_value = {"error": "invalid_grant"}
-            mock_response.raise_for_status.side_effect = requests.exceptions.HTTPError("400 Client Error")
-            mock_request.return_value = mock_response
-
-            # Should raise exception
-            try:
-                authenticator.refresh_access_token()
-                assert False, "Expected exception but refresh succeeded"
-            except Exception as e:
-                assert "HTTP error while refreshing Zendesk access token" in str(e)
-
-    def test_oauth_request_body_format(self):
-        """Test that the OAuth request body contains the correct fields and format"""
-        config = self._config().build()
-
-        # Validate that the config has the expected OAuth refresh structure
-        assert config["credentials"]["credentials"] == "oauth2.0_refresh"
-        assert "refresh_token" in config["credentials"]
-        assert "client_id" in config["credentials"]
-        assert "client_secret" in config["credentials"]
-
-        # Validate config structure for the new OAuth flow
-        expected_keys = {"refresh_token", "client_id", "client_secret", "credentials"}
-        actual_keys = set(config["credentials"].keys())
-        assert expected_keys.issubset(actual_keys), f"Missing OAuth fields. Expected: {expected_keys}, Got: {actual_keys}"
-
-    def test_oauth_authenticator_missing_access_token_handling(self, components_module):
-        """Test OAuth authenticator defaults expires_in when missing from response"""
-
-        authenticator = components_module.ZendeskSupportOAuth2Authenticator(
-            client_id="test_client_id",
-            client_secret="test_client_secret",
-            refresh_token="test_refresh_token",
-            token_refresh_endpoint="https://d3v-airbyte.zendesk.com/oauth/tokens",
-            config={"subdomain": "d3v-airbyte"},
-            parameters={},
-        )
-
-        # Mock response without expires_in field
-        with patch("requests.request") as mock_request:
-            mock_response = MagicMock()
-            mock_response.json.return_value = {
-                "access_token": "minimal_access_token"
-                # Note: missing expires_in should default to 7200 seconds
-            }
-            mock_response.raise_for_status = MagicMock()
-            mock_request.return_value = mock_response
-
-            # Should work and default expires_in to 7200
-            access_token, expires_in = authenticator.refresh_access_token()
-            assert access_token == "minimal_access_token"
-            assert expires_in == 7200  # Default value
+def test_oauth_authenticator_missing_access_token_handling(components_module):
+    """Test OAuth authenticator defaults expires_in when missing from response"""
+    
+    authenticator = components_module.ZendeskSupportOAuth2Authenticator(
+        client_id="test_client_id",
+        client_secret="test_client_secret",
+        refresh_token="test_refresh_token",
+        token_refresh_endpoint="https://d3v-airbyte.zendesk.com/oauth/tokens",
+        config={"subdomain": "d3v-airbyte"},
+        parameters={},
+    )
+    
+    # Mock response without expires_in field
+    with patch("requests.request") as mock_request:
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "access_token": "minimal_access_token"
+            # Note: missing expires_in should default to 7200 seconds
+        }
+        mock_response.raise_for_status = MagicMock()
+        mock_request.return_value = mock_response
+        
+        # Should work and default expires_in to 7200
+        access_token, expires_in = authenticator.refresh_access_token()
+        assert access_token == "minimal_access_token"
+        assert expires_in == 7200  # Default value

--- a/airbyte-integrations/connectors/source-zendesk-support/unit_tests/integrations/test_oauth_refresh.py
+++ b/airbyte-integrations/connectors/source-zendesk-support/unit_tests/integrations/test_oauth_refresh.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2025 Airbyte, Inc., all rights reserved.
 
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 import requests
@@ -12,9 +12,7 @@ def _get_config():
     """Helper function to build test config"""
     return (
         ConfigBuilder()
-        .with_oauth_refresh_credentials(
-            refresh_token="test_refresh_token", client_id="test_client_id", client_secret="test_client_secret"
-        )
+        .with_oauth_refresh_credentials(refresh_token="test_refresh_token", client_id="test_client_id", client_secret="test_client_secret")
         .with_subdomain("d3v-airbyte")
         .build()
     )
@@ -22,17 +20,17 @@ def _get_config():
 
 def test_oauth_authenticator_direct_token_refresh(components_module):
     """Test OAuth authenticator refresh_access_token method directly like successful connectors do"""
-    
+
     # Create authenticator instance
     authenticator = components_module.ZendeskSupportOAuth2Authenticator(
         client_id="test_client_id",
-        client_secret="test_client_secret", 
+        client_secret="test_client_secret",
         refresh_token="test_refresh_token",
         token_refresh_endpoint="https://d3v-airbyte.zendesk.com/oauth/tokens",
         config={"subdomain": "d3v-airbyte"},
         parameters={},
     )
-    
+
     # Mock successful requests.request call
     with patch("requests.request") as mock_request:
         mock_response = MagicMock()
@@ -44,14 +42,14 @@ def test_oauth_authenticator_direct_token_refresh(components_module):
         }
         mock_response.raise_for_status = MagicMock()
         mock_request.return_value = mock_response
-        
+
         # Call refresh_access_token directly
         access_token, expires_in = authenticator.refresh_access_token()
-        
+
         # Verify results
         assert access_token == "new_access_token_12345"
         assert expires_in == 7200
-        
+
         # Verify request was made correctly
         mock_request.assert_called_once_with(
             method="POST",
@@ -59,7 +57,7 @@ def test_oauth_authenticator_direct_token_refresh(components_module):
             json={
                 "grant_type": "refresh_token",
                 "refresh_token": "test_refresh_token",
-                "client_id": "test_client_id", 
+                "client_id": "test_client_id",
                 "client_secret": "test_client_secret",
             },
             headers={"Content-Type": "application/json"},
@@ -68,27 +66,27 @@ def test_oauth_authenticator_direct_token_refresh(components_module):
 
 def test_oauth_authenticator_direct_token_refresh_error(components_module):
     """Test OAuth authenticator handles refresh errors properly"""
-    
+
     authenticator = components_module.ZendeskSupportOAuth2Authenticator(
         client_id="test_client_id",
         client_secret="test_client_secret",
-        refresh_token="test_refresh_token", 
+        refresh_token="test_refresh_token",
         token_refresh_endpoint="https://d3v-airbyte.zendesk.com/oauth/tokens",
         config={"subdomain": "d3v-airbyte"},
         parameters={},
     )
-    
-    # Mock failed requests.request call 
+
+    # Mock failed requests.request call
     with patch("requests.request") as mock_request:
         mock_response = MagicMock()
         mock_response.json.return_value = {"error": "invalid_grant"}
         mock_response.raise_for_status.side_effect = requests.exceptions.HTTPError("400 Client Error")
         mock_request.return_value = mock_response
-        
+
         # Should raise exception
         with pytest.raises(Exception) as exc_info:
             authenticator.refresh_access_token()
-        
+
         assert "HTTP error while refreshing Zendesk access token" in str(exc_info.value)
 
 
@@ -101,7 +99,7 @@ def test_oauth_request_body_format():
     assert "refresh_token" in config["credentials"]
     assert "client_id" in config["credentials"]
     assert "client_secret" in config["credentials"]
-    
+
     # Validate config structure for the new OAuth flow
     expected_keys = {"refresh_token", "client_id", "client_secret", "credentials"}
     actual_keys = set(config["credentials"].keys())
@@ -110,7 +108,7 @@ def test_oauth_request_body_format():
 
 def test_oauth_authenticator_missing_access_token_handling(components_module):
     """Test OAuth authenticator defaults expires_in when missing from response"""
-    
+
     authenticator = components_module.ZendeskSupportOAuth2Authenticator(
         client_id="test_client_id",
         client_secret="test_client_secret",
@@ -119,7 +117,7 @@ def test_oauth_authenticator_missing_access_token_handling(components_module):
         config={"subdomain": "d3v-airbyte"},
         parameters={},
     )
-    
+
     # Mock response without expires_in field
     with patch("requests.request") as mock_request:
         mock_response = MagicMock()
@@ -129,7 +127,7 @@ def test_oauth_authenticator_missing_access_token_handling(components_module):
         }
         mock_response.raise_for_status = MagicMock()
         mock_request.return_value = mock_response
-        
+
         # Should work and default expires_in to 7200
         access_token, expires_in = authenticator.refresh_access_token()
         assert access_token == "minimal_access_token"

--- a/airbyte-integrations/connectors/source-zendesk-support/unit_tests/integrations/test_oauth_refresh.py
+++ b/airbyte-integrations/connectors/source-zendesk-support/unit_tests/integrations/test_oauth_refresh.py
@@ -1,0 +1,155 @@
+# Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+
+from datetime import timedelta
+from unittest import TestCase
+from unittest.mock import patch
+
+import freezegun
+import requests_mock
+
+from airbyte_cdk.models import SyncMode
+from airbyte_cdk.test.mock_http import HttpMocker
+from airbyte_cdk.utils.datetime_helpers import ab_datetime_now
+
+from .config import ConfigBuilder
+from .utils import read_stream
+
+
+_NOW = ab_datetime_now()
+_START_DATE = ab_datetime_now().subtract(timedelta(weeks=52))
+
+
+@freezegun.freeze_time(_NOW.isoformat())
+class TestOAuthRefreshAuthentication(TestCase):
+    def _config(self) -> ConfigBuilder:
+        return (
+            ConfigBuilder()
+            .with_oauth_refresh_credentials(
+                refresh_token="test_refresh_token", client_id="test_client_id", client_secret="test_client_secret"
+            )
+            .with_subdomain("d3v-airbyte")
+            .with_start_date(ab_datetime_now().subtract(timedelta(hours=1)))
+        )
+
+    @HttpMocker()
+    def test_oauth_refresh_token_authentication_flow(self, http_mocker):
+        """Test that OAuth refresh token flow works correctly with token refresh"""
+        config = self._config().build()
+
+        # Mock the OAuth token refresh endpoint
+        http_mocker.post(
+            "https://d3v-airbyte.zendesk.com/oauth/tokens",
+            {
+                "access_token": "new_access_token_12345",
+                "expires_in": 7200,
+                "refresh_token": "new_refresh_token_67890",
+                "token_type": "Bearer",
+            },
+        )
+
+        # Mock the actual API call that should use the refreshed access token
+        http_mocker.get(
+            "https://d3v-airbyte.zendesk.com/api/v2/brands",
+            {"brands": [{"id": 1, "name": "Test Brand", "active": True}]},
+            headers={"Authorization": "Bearer new_access_token_12345"},
+        )
+
+        # Read from brands stream which should trigger OAuth flow
+        output = read_stream("brands", SyncMode.full_refresh, config)
+
+        # Verify we got records (meaning authentication worked)
+        assert len(output.records) == 1
+        assert output.records[0].record.data["id"] == 1
+        assert output.records[0].record.data["name"] == "Test Brand"
+
+    @HttpMocker()
+    def test_oauth_refresh_token_failure_handling(self, http_mocker):
+        """Test that OAuth refresh token failure is handled properly"""
+        config = self._config().build()
+
+        # Mock the OAuth token refresh endpoint to return an error
+        http_mocker.post(
+            "https://d3v-airbyte.zendesk.com/oauth/tokens",
+            {"error": "invalid_grant", "error_description": "The provided authorization grant is invalid"},
+            status_code=400,
+        )
+
+        # Attempt to read from a stream should fail due to authentication error
+        try:
+            output = read_stream("brands", SyncMode.full_refresh, config)
+            # If we get here, the test should fail as we expect an exception
+            assert False, "Expected authentication error but stream read succeeded"
+        except Exception as e:
+            # Verify that the error is related to OAuth authentication
+            assert "oauth" in str(e).lower() or "auth" in str(e).lower() or "token" in str(e).lower()
+
+    @patch("source_declarative_manifest.components.ZendeskSupportOAuth2Authenticator.get_refresh_request_body")
+    def test_oauth_request_body_format(self, mock_get_refresh_request_body):
+        """Test that OAuth refresh request body is formatted correctly"""
+        from source_declarative_manifest.components import ZendeskSupportOAuth2Authenticator
+
+        config = self._config().build()
+        credentials = config["credentials"]
+
+        authenticator = ZendeskSupportOAuth2Authenticator(
+            client_id=credentials["client_id"],
+            client_secret=credentials["client_secret"],
+            refresh_token=credentials["refresh_token"],
+            token_refresh_endpoint="https://d3v-airbyte.zendesk.com/oauth/tokens",
+            grant_type="refresh_token",
+        )
+
+        # Call the method that formats the request body
+        request_body = authenticator.get_refresh_request_body()
+
+        # Verify the request body has the correct format for Zendesk OAuth
+        expected_body = {
+            "grant_type": "refresh_token",
+            "refresh_token": "test_refresh_token",
+            "client_id": "test_client_id",
+            "client_secret": "test_client_secret",
+        }
+
+        assert request_body == expected_body
+
+    @HttpMocker()
+    def test_oauth_refresh_with_missing_fields_in_response(self, http_mocker):
+        """Test OAuth refresh handles responses missing optional fields"""
+        config = self._config().build()
+
+        # Mock OAuth token refresh with minimal response (no expires_in)
+        http_mocker.post(
+            "https://d3v-airbyte.zendesk.com/oauth/tokens",
+            {
+                "access_token": "minimal_access_token"
+                # Note: missing expires_in should default to 7200 seconds
+            },
+        )
+
+        # Mock API call with the new token
+        http_mocker.get(
+            "https://d3v-airbyte.zendesk.com/api/v2/brands",
+            {"brands": [{"id": 1, "name": "Test Brand"}]},
+            headers={"Authorization": "Bearer minimal_access_token"},
+        )
+
+        # Should work even with minimal response
+        output = read_stream("brands", SyncMode.full_refresh, config)
+        assert len(output.records) == 1
+
+    @HttpMocker()
+    def test_oauth_refresh_network_error_handling(self, http_mocker):
+        """Test OAuth refresh handles network errors properly"""
+        config = self._config().build()
+
+        # Mock network error during token refresh
+        http_mocker.post("https://d3v-airbyte.zendesk.com/oauth/tokens", exc=requests_mock.exceptions.ConnectTimeout)
+
+        # Should handle network errors gracefully
+        try:
+            output = read_stream("brands", SyncMode.full_refresh, config)
+            assert False, "Expected network error but stream read succeeded"
+        except Exception as e:
+            # Verify error handling mentions network/connection issues
+            error_msg = str(e).lower()
+            assert any(term in error_msg for term in ["http", "connection", "network", "timeout", "token"])

--- a/airbyte-integrations/connectors/source-zendesk-support/unit_tests/integrations/test_oauth_refresh.py
+++ b/airbyte-integrations/connectors/source-zendesk-support/unit_tests/integrations/test_oauth_refresh.py
@@ -40,7 +40,7 @@ class TestOAuthRefreshAuthentication(TestCase):
         http_mocker.post(
             "https://d3v-airbyte.zendesk.com/oauth/tokens",
             HttpResponse(
-                body={
+                json={
                     "access_token": "new_access_token_12345",
                     "expires_in": 7200,
                     "refresh_token": "new_refresh_token_67890",
@@ -52,7 +52,7 @@ class TestOAuthRefreshAuthentication(TestCase):
         # Mock the actual API call that should use the refreshed access token
         http_mocker.get(
             "https://d3v-airbyte.zendesk.com/api/v2/brands",
-            HttpResponse(body={"brands": [{"id": 1, "name": "Test Brand", "active": True}]}),
+            HttpResponse(json={"brands": [{"id": 1, "name": "Test Brand", "active": True}]}),
         )
 
         # Read from brands stream which should trigger OAuth flow
@@ -72,8 +72,8 @@ class TestOAuthRefreshAuthentication(TestCase):
         http_mocker.post(
             "https://d3v-airbyte.zendesk.com/oauth/tokens",
             HttpResponse(
-                body={"error": "invalid_grant", "error_description": "The provided authorization grant is invalid"},
-                status=400,
+                json={"error": "invalid_grant", "error_description": "The provided authorization grant is invalid"},
+                status_code=400,
             ),
         )
 
@@ -110,7 +110,7 @@ class TestOAuthRefreshAuthentication(TestCase):
         http_mocker.post(
             "https://d3v-airbyte.zendesk.com/oauth/tokens",
             HttpResponse(
-                body={
+                json={
                     "access_token": "minimal_access_token"
                     # Note: missing expires_in should default to 7200 seconds
                 }
@@ -120,7 +120,7 @@ class TestOAuthRefreshAuthentication(TestCase):
         # Mock API call with the new token
         http_mocker.get(
             "https://d3v-airbyte.zendesk.com/api/v2/brands",
-            HttpResponse(body={"brands": [{"id": 1, "name": "Test Brand"}]}),
+            HttpResponse(json={"brands": [{"id": 1, "name": "Test Brand"}]}),
         )
 
         # Should work even with minimal response
@@ -133,7 +133,7 @@ class TestOAuthRefreshAuthentication(TestCase):
         config = self._config().build()
 
         # Mock network error during token refresh by using a connection error
-        http_mocker.post("https://d3v-airbyte.zendesk.com/oauth/tokens", HttpResponse(body="Service Unavailable", status=503))
+        http_mocker.post("https://d3v-airbyte.zendesk.com/oauth/tokens", HttpResponse(text="Service Unavailable", status_code=503))
 
         # Should handle network errors gracefully
         try:

--- a/airbyte-integrations/connectors/source-zendesk-support/unit_tests/integrations/test_oauth_refresh.py
+++ b/airbyte-integrations/connectors/source-zendesk-support/unit_tests/integrations/test_oauth_refresh.py
@@ -1,11 +1,11 @@
 # Copyright (c) 2025 Airbyte, Inc., all rights reserved.
 
+import json
 from datetime import timedelta
 from unittest import TestCase
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
 import freezegun
-import json
 import requests
 
 from airbyte_cdk.models import SyncMode
@@ -35,17 +35,17 @@ class TestOAuthRefreshAuthentication(TestCase):
     def test_oauth_authenticator_direct_token_refresh(self):
         """Test OAuth authenticator refresh_access_token method directly like successful connectors do"""
         import source_zendesk_support.components as components_module
-        
+
         # Create authenticator instance
         authenticator = components_module.ZendeskSupportOAuth2Authenticator(
             client_id="test_client_id",
-            client_secret="test_client_secret", 
+            client_secret="test_client_secret",
             refresh_token="test_refresh_token",
             token_refresh_endpoint="https://d3v-airbyte.zendesk.com/oauth/tokens",
             config={"subdomain": "d3v-airbyte"},
             parameters={},
         )
-        
+
         # Mock successful requests.request call
         with patch("requests.request") as mock_request:
             mock_response = MagicMock()
@@ -57,14 +57,14 @@ class TestOAuthRefreshAuthentication(TestCase):
             }
             mock_response.raise_for_status = MagicMock()
             mock_request.return_value = mock_response
-            
+
             # Call refresh_access_token directly
             access_token, expires_in = authenticator.refresh_access_token()
-            
+
             # Verify results
             assert access_token == "new_access_token_12345"
             assert expires_in == 7200
-            
+
             # Verify request was made correctly
             mock_request.assert_called_once_with(
                 method="POST",
@@ -72,7 +72,7 @@ class TestOAuthRefreshAuthentication(TestCase):
                 json={
                     "grant_type": "refresh_token",
                     "refresh_token": "test_refresh_token",
-                    "client_id": "test_client_id", 
+                    "client_id": "test_client_id",
                     "client_secret": "test_client_secret",
                 },
                 headers={"Content-Type": "application/json"},
@@ -81,23 +81,23 @@ class TestOAuthRefreshAuthentication(TestCase):
     def test_oauth_authenticator_direct_token_refresh_error(self):
         """Test OAuth authenticator handles refresh errors properly"""
         import source_zendesk_support.components as components_module
-        
+
         authenticator = components_module.ZendeskSupportOAuth2Authenticator(
             client_id="test_client_id",
             client_secret="test_client_secret",
-            refresh_token="test_refresh_token", 
+            refresh_token="test_refresh_token",
             token_refresh_endpoint="https://d3v-airbyte.zendesk.com/oauth/tokens",
             config={"subdomain": "d3v-airbyte"},
             parameters={},
         )
-        
-        # Mock failed requests.request call 
+
+        # Mock failed requests.request call
         with patch("requests.request") as mock_request:
             mock_response = MagicMock()
             mock_response.json.return_value = {"error": "invalid_grant"}
             mock_response.raise_for_status.side_effect = requests.exceptions.HTTPError("400 Client Error")
             mock_request.return_value = mock_response
-            
+
             # Should raise exception
             try:
                 authenticator.refresh_access_token()
@@ -114,7 +114,7 @@ class TestOAuthRefreshAuthentication(TestCase):
         assert "refresh_token" in config["credentials"]
         assert "client_id" in config["credentials"]
         assert "client_secret" in config["credentials"]
-        
+
         # Validate config structure for the new OAuth flow
         expected_keys = {"refresh_token", "client_id", "client_secret", "credentials"}
         actual_keys = set(config["credentials"].keys())
@@ -123,7 +123,7 @@ class TestOAuthRefreshAuthentication(TestCase):
     def test_oauth_authenticator_missing_access_token_handling(self):
         """Test OAuth authenticator defaults expires_in when missing from response"""
         import source_zendesk_support.components as components_module
-        
+
         authenticator = components_module.ZendeskSupportOAuth2Authenticator(
             client_id="test_client_id",
             client_secret="test_client_secret",
@@ -132,7 +132,7 @@ class TestOAuthRefreshAuthentication(TestCase):
             config={"subdomain": "d3v-airbyte"},
             parameters={},
         )
-        
+
         # Mock response without expires_in field
         with patch("requests.request") as mock_request:
             mock_response = MagicMock()
@@ -142,7 +142,7 @@ class TestOAuthRefreshAuthentication(TestCase):
             }
             mock_response.raise_for_status = MagicMock()
             mock_request.return_value = mock_response
-            
+
             # Should work and default expires_in to 7200
             access_token, expires_in = authenticator.refresh_access_token()
             assert access_token == "minimal_access_token"

--- a/airbyte-integrations/connectors/source-zendesk-support/unit_tests/integrations/test_oauth_refresh.py
+++ b/airbyte-integrations/connectors/source-zendesk-support/unit_tests/integrations/test_oauth_refresh.py
@@ -32,9 +32,8 @@ class TestOAuthRefreshAuthentication(TestCase):
             .with_start_date(ab_datetime_now().subtract(timedelta(hours=1)))
         )
 
-    def test_oauth_authenticator_direct_token_refresh(self):
+    def test_oauth_authenticator_direct_token_refresh(self, components_module):
         """Test OAuth authenticator refresh_access_token method directly like successful connectors do"""
-        import source_zendesk_support.components as components_module
 
         # Create authenticator instance
         authenticator = components_module.ZendeskSupportOAuth2Authenticator(
@@ -78,9 +77,8 @@ class TestOAuthRefreshAuthentication(TestCase):
                 headers={"Content-Type": "application/json"},
             )
 
-    def test_oauth_authenticator_direct_token_refresh_error(self):
+    def test_oauth_authenticator_direct_token_refresh_error(self, components_module):
         """Test OAuth authenticator handles refresh errors properly"""
-        import source_zendesk_support.components as components_module
 
         authenticator = components_module.ZendeskSupportOAuth2Authenticator(
             client_id="test_client_id",
@@ -120,9 +118,8 @@ class TestOAuthRefreshAuthentication(TestCase):
         actual_keys = set(config["credentials"].keys())
         assert expected_keys.issubset(actual_keys), f"Missing OAuth fields. Expected: {expected_keys}, Got: {actual_keys}"
 
-    def test_oauth_authenticator_missing_access_token_handling(self):
+    def test_oauth_authenticator_missing_access_token_handling(self, components_module):
         """Test OAuth authenticator defaults expires_in when missing from response"""
-        import source_zendesk_support.components as components_module
 
         authenticator = components_module.ZendeskSupportOAuth2Authenticator(
             client_id="test_client_id",

--- a/airbyte-integrations/connectors/source-zendesk-support/unit_tests/test_components.py
+++ b/airbyte-integrations/connectors/source-zendesk-support/unit_tests/test_components.py
@@ -102,3 +102,143 @@ def test_attribute_definitions_extractor(response_data, expected_records, compon
 
     # Assert that the returned records match the expected records
     assert records == expected_records, f"Expected records to be {expected_records}, but got {records}"
+
+
+@pytest.mark.parametrize(
+    "client_id, client_secret, refresh_token, expected_body",
+    [
+        (
+            "test_client_id",
+            "test_client_secret", 
+            "test_refresh_token",
+            {
+                "grant_type": "refresh_token",
+                "refresh_token": "test_refresh_token",
+                "client_id": "test_client_id",
+                "client_secret": "test_client_secret",
+            },
+        ),
+    ],
+)
+def test_oauth_authenticator_refresh_request_body(client_id, client_secret, refresh_token, expected_body, components_module):
+    """Test that the OAuth authenticator builds the correct refresh request body."""
+    # Create an instance of the OAuth authenticator
+    authenticator = components_module.ZendeskSupportOAuth2Authenticator(
+        client_id=client_id,
+        client_secret=client_secret,
+        refresh_token=refresh_token,
+        token_refresh_endpoint="https://test.zendesk.com/oauth/tokens",
+        config={"subdomain": "test"},
+        parameters={},
+    )
+    
+    # Test the refresh request body
+    request_body = authenticator.get_refresh_request_body()
+    assert request_body == expected_body
+
+
+@pytest.mark.parametrize(
+    "response_json, expected_token, expected_expires_in, should_raise",
+    [
+        # Successful response with access token and expires_in
+        ({"access_token": "new_access_token", "expires_in": 3600}, "new_access_token", 3600, False),
+        # Response with access token but no expires_in (should default to 7200)
+        ({"access_token": "new_access_token"}, "new_access_token", 7200, False),
+        # Response without access token (should raise exception)
+        ({"expires_in": 3600}, None, None, True),
+        # Empty response (should raise exception)
+        ({}, None, None, True),
+    ],
+)
+def test_oauth_authenticator_refresh_access_token(response_json, expected_token, expected_expires_in, should_raise, components_module):
+    """Test the OAuth access token refresh functionality."""
+    import unittest.mock
+    
+    # Create an instance of the OAuth authenticator
+    authenticator = components_module.ZendeskSupportOAuth2Authenticator(
+        client_id="test_client_id",
+        client_secret="test_client_secret",
+        refresh_token="test_refresh_token",
+        token_refresh_endpoint="https://test.zendesk.com/oauth/tokens",
+        config={"subdomain": "test"},
+        parameters={},
+    )
+    
+    # Mock the requests.request method
+    with unittest.mock.patch('requests.request') as mock_request:
+        mock_response = MagicMock()
+        mock_response.json.return_value = response_json
+        mock_response.raise_for_status = MagicMock()
+        mock_request.return_value = mock_response
+        
+        if should_raise:
+            with pytest.raises(Exception):
+                authenticator.refresh_access_token()
+        else:
+            access_token, expires_in = authenticator.refresh_access_token()
+            assert access_token == expected_token
+            assert expires_in == expected_expires_in
+            
+            # Verify the request was made correctly
+            mock_request.assert_called_once_with(
+                method="POST",
+                url="https://test.zendesk.com/oauth/tokens",
+                json={
+                    "grant_type": "refresh_token",
+                    "refresh_token": "test_refresh_token",
+                    "client_id": "test_client_id",
+                    "client_secret": "test_client_secret",
+                },
+                headers={"Content-Type": "application/json"},
+            )
+
+
+def test_oauth_authenticator_refresh_http_error(components_module):
+    """Test OAuth authenticator handles HTTP errors properly."""
+    import unittest.mock
+    
+    # Create an instance of the OAuth authenticator
+    authenticator = components_module.ZendeskSupportOAuth2Authenticator(
+        client_id="test_client_id",
+        client_secret="test_client_secret",
+        refresh_token="test_refresh_token",
+        token_refresh_endpoint="https://test.zendesk.com/oauth/tokens",
+        config={"subdomain": "test"},
+        parameters={},
+    )
+    
+    # Mock requests to raise an HTTP error
+    with unittest.mock.patch('requests.request') as mock_request:
+        mock_request.side_effect = requests.exceptions.RequestException("HTTP 401 Unauthorized")
+        
+        with pytest.raises(Exception) as exc_info:
+            authenticator.refresh_access_token()
+        
+        assert "HTTP error while refreshing Zendesk access token" in str(exc_info.value)
+
+
+def test_oauth_authenticator_refresh_json_error(components_module):
+    """Test OAuth authenticator handles JSON parsing errors properly."""
+    import unittest.mock
+    
+    # Create an instance of the OAuth authenticator
+    authenticator = components_module.ZendeskSupportOAuth2Authenticator(
+        client_id="test_client_id",
+        client_secret="test_client_secret",
+        refresh_token="test_refresh_token",
+        token_refresh_endpoint="https://test.zendesk.com/oauth/tokens",
+        config={"subdomain": "test"},
+        parameters={},
+    )
+    
+    # Mock requests to return invalid JSON
+    with unittest.mock.patch('requests.request') as mock_request:
+        mock_response = MagicMock()
+        mock_response.json.side_effect = ValueError("Invalid JSON")
+        mock_response.raise_for_status = MagicMock()
+        mock_request.return_value = mock_response
+        
+        with pytest.raises(Exception) as exc_info:
+            authenticator.refresh_access_token()
+        
+        assert "Invalid response format while refreshing Zendesk access token" in str(exc_info.value)

--- a/airbyte-integrations/connectors/source-zendesk-support/unit_tests/test_components.py
+++ b/airbyte-integrations/connectors/source-zendesk-support/unit_tests/test_components.py
@@ -109,7 +109,7 @@ def test_attribute_definitions_extractor(response_data, expected_records, compon
     [
         (
             "test_client_id",
-            "test_client_secret", 
+            "test_client_secret",
             "test_refresh_token",
             {
                 "grant_type": "refresh_token",
@@ -131,7 +131,7 @@ def test_oauth_authenticator_refresh_request_body(client_id, client_secret, refr
         config={"subdomain": "test"},
         parameters={},
     )
-    
+
     # Test the refresh request body
     request_body = authenticator.get_refresh_request_body()
     assert request_body == expected_body
@@ -153,7 +153,7 @@ def test_oauth_authenticator_refresh_request_body(client_id, client_secret, refr
 def test_oauth_authenticator_refresh_access_token(response_json, expected_token, expected_expires_in, should_raise, components_module):
     """Test the OAuth access token refresh functionality."""
     import unittest.mock
-    
+
     # Create an instance of the OAuth authenticator
     authenticator = components_module.ZendeskSupportOAuth2Authenticator(
         client_id="test_client_id",
@@ -163,14 +163,14 @@ def test_oauth_authenticator_refresh_access_token(response_json, expected_token,
         config={"subdomain": "test"},
         parameters={},
     )
-    
+
     # Mock the requests.request method
-    with unittest.mock.patch('requests.request') as mock_request:
+    with unittest.mock.patch("requests.request") as mock_request:
         mock_response = MagicMock()
         mock_response.json.return_value = response_json
         mock_response.raise_for_status = MagicMock()
         mock_request.return_value = mock_response
-        
+
         if should_raise:
             with pytest.raises(Exception):
                 authenticator.refresh_access_token()
@@ -178,7 +178,7 @@ def test_oauth_authenticator_refresh_access_token(response_json, expected_token,
             access_token, expires_in = authenticator.refresh_access_token()
             assert access_token == expected_token
             assert expires_in == expected_expires_in
-            
+
             # Verify the request was made correctly
             mock_request.assert_called_once_with(
                 method="POST",
@@ -196,7 +196,7 @@ def test_oauth_authenticator_refresh_access_token(response_json, expected_token,
 def test_oauth_authenticator_refresh_http_error(components_module):
     """Test OAuth authenticator handles HTTP errors properly."""
     import unittest.mock
-    
+
     # Create an instance of the OAuth authenticator
     authenticator = components_module.ZendeskSupportOAuth2Authenticator(
         client_id="test_client_id",
@@ -206,21 +206,21 @@ def test_oauth_authenticator_refresh_http_error(components_module):
         config={"subdomain": "test"},
         parameters={},
     )
-    
+
     # Mock requests to raise an HTTP error
-    with unittest.mock.patch('requests.request') as mock_request:
+    with unittest.mock.patch("requests.request") as mock_request:
         mock_request.side_effect = requests.exceptions.RequestException("HTTP 401 Unauthorized")
-        
+
         with pytest.raises(Exception) as exc_info:
             authenticator.refresh_access_token()
-        
+
         assert "HTTP error while refreshing Zendesk access token" in str(exc_info.value)
 
 
 def test_oauth_authenticator_refresh_json_error(components_module):
     """Test OAuth authenticator handles JSON parsing errors properly."""
     import unittest.mock
-    
+
     # Create an instance of the OAuth authenticator
     authenticator = components_module.ZendeskSupportOAuth2Authenticator(
         client_id="test_client_id",
@@ -230,15 +230,15 @@ def test_oauth_authenticator_refresh_json_error(components_module):
         config={"subdomain": "test"},
         parameters={},
     )
-    
+
     # Mock requests to return invalid JSON
-    with unittest.mock.patch('requests.request') as mock_request:
+    with unittest.mock.patch("requests.request") as mock_request:
         mock_response = MagicMock()
         mock_response.json.side_effect = ValueError("Invalid JSON")
         mock_response.raise_for_status = MagicMock()
         mock_request.return_value = mock_response
-        
+
         with pytest.raises(Exception) as exc_info:
             authenticator.refresh_access_token()
-        
+
         assert "Invalid response format while refreshing Zendesk access token" in str(exc_info.value)

--- a/docs/integrations/sources/zendesk-support-migrations.md
+++ b/docs/integrations/sources/zendesk-support-migrations.md
@@ -1,5 +1,66 @@
 # Zendesk Support Migration Guide
 
+## Upgrading to 5.0.0
+
+**OAuth authentication update required before September 30, 2025**
+
+This version introduces a new OAuth authentication flow that supports refresh tokens to comply with Zendesk's updated OAuth policies. **Zendesk will enforce access token expiration on September 30, 2025**, requiring all integrations to migrate from static access tokens to refresh token flows.
+
+### What's Changing?
+
+- **New OAuth2.0 option**: Uses refresh tokens for automatic token renewal
+- **Legacy OAuth2.0 option**: The original OAuth implementation will stop working after September 30, 2025
+- **Required action**: Users must reauthenticate before the deadline to continue uninterrupted service
+
+### Migration Steps
+
+:::warning Critical Deadline
+**Action Required by September 30, 2025**: All users currently using OAuth authentication must complete the reauthentication process before Zendesk enforces token expiration. Failure to do so will result in connection failures and data sync interruptions.
+:::
+
+#### For Airbyte Open Source: Update the local connector image
+
+1. Select **Settings** in the main navbar.
+    - Select **Sources**.
+2. Find Zendesk Support in the list of connectors.
+3. Select **Change** to update your OSS version to the latest available version.
+
+#### For Airbyte Cloud: Update the connector version
+
+1. Select **Sources** in the main navbar.
+2. Select the instance of the connector you wish to upgrade.
+3. Select **Upgrade**
+    - Follow the prompt to confirm you are ready to upgrade to the new version.
+
+#### Reauthenticate with the new OAuth flow
+
+1. Navigate to your Zendesk Support source configuration.
+2. In the **Authentication** section, select **OAuth2.0** (not "OAuth2.0 (Legacy)").
+3. Click **Authenticate your Zendesk Support account** to complete the OAuth flow.
+4. **Important**: This will generate new access and refresh tokens that support automatic renewal.
+
+:::note
+The "OAuth2.0 (Legacy)" option is maintained for backward compatibility but will stop working after September 30, 2025. We strongly recommend migrating to the new "OAuth2.0" option as soon as possible.
+:::
+
+#### Test the connection
+
+1. After reauthenticating, click **Test** to verify the new authentication works correctly.
+2. Save your configuration once the test passes.
+
+### Benefits of the Update
+
+- **Automatic token refresh**: No more manual token updates required
+- **Enhanced security**: Tokens automatically expire and renew, reducing security risks  
+- **Compliance**: Meets Zendesk's new OAuth requirements
+- **Uninterrupted syncs**: Prevents authentication failures due to expired tokens
+
+### Troubleshooting
+
+- **Connection test fails**: Ensure you selected "OAuth2.0" (not "OAuth2.0 (Legacy)") and completed the full authentication flow
+- **Sync errors after upgrade**: Verify that you've reauthenticated with the new OAuth flow
+- **Questions about the deadline**: See [Zendesk's announcement](https://support.zendesk.com/hc/en-us/articles/9181963681434) for official details
+
 ## Upgrading to 4.0.0
 
 The pagination strategy has been changed from `Offset` to `Cursor-Based`. It is necessary to reset the stream.

--- a/docs/integrations/sources/zendesk-support.md
+++ b/docs/integrations/sources/zendesk-support.md
@@ -189,6 +189,7 @@ The Zendesk connector ideally should not run into Zendesk API limitations under 
 
 | Version     | Date       | Pull Request                                             | Subject                                                                                                                                                                                                                            |
 |:------------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 5.0.0 | 2025-08-20 | [65104](https://github.com/airbytehq/airbyte/pull/65104) | Add OAuth refresh token support for compliance with Zendesk's September 30, 2025 token expiration deadline. Users must reauthenticate using new OAuth2.0 option. |
 | 4.10.7 | 2025-08-09 | [64867](https://github.com/airbytehq/airbyte/pull/64867) | Update dependencies |
 | 4.10.6 | 2025-08-02 | [64366](https://github.com/airbytehq/airbyte/pull/64366) | Update dependencies |
 | 4.10.5 | 2025-07-26 | [64067](https://github.com/airbytehq/airbyte/pull/64067) | Update dependencies |


### PR DESCRIPTION
Add OAuth refresh token support for Zendesk Support connector to comply with Zendesk's September 30, 2025 token expiration deadline.

Implements ZendeskSupportOAuth2Authenticator with automatic token refresh
Adds new OAuth2.0 configuration option using refresh tokens
Includes comprehensive unit tests for all OAuth scenarios
Addresses upcoming API deprecation requirements
References:

https://support.zendesk.com/hc/en-us/articles/9181963681434
https://developer.zendesk.com/api-reference/ticketing/oauth/grant_type_tokens/
What
This PR implements OAuth refresh token support for the Zendesk Support connector to comply with Zendesk's new token expiration policy. Zendesk will enforce access token expiration on September 30, 2025, requiring all integrations to migrate from static access tokens to refresh token flows.

Problem being solved:

Current connector uses static, non-expiring access_token that will stop working after September 30, 2025
Zendesk now requires OAuth refresh token grant type for continued API access
Users need a seamless migration path to avoid service disruption
References:

[Zendesk OAuth Refresh Token Announcement](https://support.zendesk.com/hc/en-us/articles/9181963681434-Announcing-support-for-OAuth-refresh-token-grant-type-and-OAuth-access-and-refresh-token-expirations)
[Zendesk OAuth Grant Types API Documentation](https://developer.zendesk.com/api-reference/ticketing/oauth/grant_type_tokens/)
How
1. Custom OAuth Authenticator (components.py)

Created ZendeskSupportOAuth2Authenticator extending DeclarativeOauth2Authenticator
Implements Zendesk-specific refresh token flow using /oauth/tokens endpoint
Handles automatic token refresh when access tokens expire
Robust error handling for HTTP, JSON parsing, and authentication failures
2. Updated Configuration Schema (manifest.yaml)

Added new "OAuth2.0" option requiring refresh_token, client_id, client_secret
Renamed old OAuth option to "OAuth2.0 (Legacy)" with deprecation warning
Updated advanced_auth configuration to use refresh tokens
Maintained selective authenticator for backward compatibility
3. Comprehensive Testing (unit_tests/test_components.py)

Added 5 test scenarios covering successful refresh, error cases, and edge conditions
Tests validate request body formatting, response parsing, and error handling
Ensures authenticator behaves correctly across different failure modes
4. Backward Compatibility Strategy

Legacy OAuth option preserved to prevent immediate breakage
Clear deprecation warnings inform users of migration necessity
Gradual transition path allows users to migrate before deadline
Review guide
components.py - Review the ZendeskSupportOAuth2Authenticator class implementation

Check refresh token request body formatting matches Zendesk's specification
Verify error handling covers all failure scenarios appropriately
Ensure token refresh logic follows OAuth2 standards
manifest.yaml - Review configuration schema changes

Verify new OAuth2.0 option includes all required fields (refresh_token, client_id, client_secret)
Check that legacy OAuth2.0 option maintains backward compatibility
Confirm advanced_auth section properly configures refresh token flow
Review deprecation warnings for clarity and actionability
unit_tests/test_components.py - Review test coverage

Ensure all OAuth refresh scenarios are tested (success, failures, edge cases)
Verify mocking correctly simulates Zendesk API responses
Check that error conditions are properly validated
User Impact
Positive Impact:


✅ Automatic token management - No manual token refresh required once configured
✅ Improved security - Tokens expire and refresh automatically, reducing security risk
✅ Smooth migration path - Legacy option allows gradual transition without immediate breakage
Breaking Changes/Migration Required:

⚠️ Action needed by users - Users must migrate from legacy OAuth to new refresh token method before September 30, 2025
⚠️ Re-authentication required - Users need to complete OAuth flow again to obtain refresh token
⚠️ Configuration change - Must update connector configuration to use new OAuth2.0 option
Can this PR be safely reverted and rolled back?
 YES 💚
Rollback Safety:


Legacy OAuth authentication path unchanged
Users can continue using current setup until they choose to migrate