### PR TITLE
Fix ClickHouse protocol validation

### DIFF
--- a/airbyte-integrations/connectors/destination-clickhouse/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-clickhouse/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: ce0d828e-1dc4-496c-b122-2da42e637e48
-  dockerImageTag: 2.0.11
+  dockerImageTag: 2.0.12
   dockerRepository: airbyte/destination-clickhouse
   githubIssueLabel: destination-clickhouse
   icon: clickhouse.svg

--- a/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/check/ClickhouseChecker.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/check/ClickhouseChecker.kt
@@ -26,8 +26,6 @@ class ClickhouseChecker(
     @VisibleForTesting val tableName = "_airbyte_check_table_${clock.millis()}"
 
     override fun check(config: ClickhouseConfiguration) {
-        assert(!config.hostname.startsWith(PROTOCOL)) { PROTOCOL_ERR_MESSAGE }
-
         val client = clientFactory.make(config)
         val resolvedTableName = "${config.database}.$tableName"
 
@@ -47,7 +45,7 @@ class ClickhouseChecker(
                 )
                 .get(10, TimeUnit.SECONDS)
 
-        assert(insert.writtenRows == 1L) {
+        require(insert.writtenRows == 1L) {
             "Failed to insert expected rows into check table. Actual written: ${insert.writtenRows}"
         }
     }
@@ -75,6 +73,8 @@ class ClickhouseChecker(
 @Singleton
 class RawClickHouseClientFactory {
     fun make(config: ClickhouseConfiguration): Client {
+        require(!config.hostname.startsWith(PROTOCOL)) { PROTOCOL_ERR_MESSAGE }
+
         val factory = ClickhouseBeanFactory()
         val endpoint = factory.resolvedEndpoint(config)
         return ClickhouseBeanFactory().clickhouseClient(config, endpoint)

--- a/airbyte-integrations/connectors/destination-clickhouse/src/test/kotlin/io/airbyte/integrations/destination/clickhouse/check/ClickhouseCheckerTest.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/test/kotlin/io/airbyte/integrations/destination/clickhouse/check/ClickhouseCheckerTest.kt
@@ -88,11 +88,12 @@ class ClickhouseCheckerTest {
     fun `check hostname format failure`() {
         val httpConfig = Fixtures.config(hostname = "$PROTOCOL://hostname")
         val httpsConfig = Fixtures.config(hostname = "https://hostname")
+        val clientFactory = RawClickHouseClientFactory()
 
-        val caught1 = assertThrows<Throwable> { checker.check(httpConfig) }
+        val caught1 = assertThrows<Throwable> { clientFactory.make(httpConfig) }
         assertEquals(PROTOCOL_ERR_MESSAGE, caught1.message)
 
-        val caught2 = assertThrows<Throwable> { checker.check(httpsConfig) }
+        val caught2 = assertThrows<Throwable> { clientFactory.make(httpsConfig) }
         assertEquals(PROTOCOL_ERR_MESSAGE, caught2.message)
     }
 

--- a/docs/integrations/destinations/clickhouse.md
+++ b/docs/integrations/destinations/clickhouse.md
@@ -95,7 +95,7 @@ You can also use a pre-existing user but we highly recommend creating a dedicate
 
 | Version | Date       | Pull Request                                               | Subject                                                                        |
 |:--------|:-----------|:-----------------------------------------------------------|:-------------------------------------------------------------------------------|
-| 2.0.11  | 2025-08-20 | [\#65120](https://github.com/airbytehq/airbyte/pull/65120) | Check should properly surface protocol related config errors.                  |
+| 2.0.12  | 2025-08-20 | [\#65120](https://github.com/airbytehq/airbyte/pull/65120) | Check should properly surface protocol related config errors.                  |
 | 2.0.11  | 2025-07-23 | [\#65117](https://github.com/airbytehq/airbyte/pull/65117) | Fix a bug related to the column duplicates name.                               |
 | 2.0.10  | 2025-07-23 | [\#64104](https://github.com/airbytehq/airbyte/pull/64104) | Add an option to configure the batch size (both bytes and number of records).  |
 | 2.0.9   | 2025-07-23 | [\#63738](https://github.com/airbytehq/airbyte/pull/63738) | Set clickhouse as an airbyte connector.                                        |

--- a/docs/integrations/destinations/clickhouse.md
+++ b/docs/integrations/destinations/clickhouse.md
@@ -95,6 +95,7 @@ You can also use a pre-existing user but we highly recommend creating a dedicate
 
 | Version | Date       | Pull Request                                               | Subject                                                                        |
 |:--------|:-----------|:-----------------------------------------------------------|:-------------------------------------------------------------------------------|
+| 2.0.11  | 2025-08-20 | [\#tbd](https://github.com/airbytehq/airbyte/pull/tbd)     | Check should properly surface protocol related config errors.                  |
 | 2.0.11  | 2025-07-23 | [\#65117](https://github.com/airbytehq/airbyte/pull/65117) | Fix a bug related to the column duplicates name.                               |
 | 2.0.10  | 2025-07-23 | [\#64104](https://github.com/airbytehq/airbyte/pull/64104) | Add an option to configure the batch size (both bytes and number of records).  |
 | 2.0.9   | 2025-07-23 | [\#63738](https://github.com/airbytehq/airbyte/pull/63738) | Set clickhouse as an airbyte connector.                                        |

--- a/docs/integrations/destinations/clickhouse.md
+++ b/docs/integrations/destinations/clickhouse.md
@@ -95,7 +95,7 @@ You can also use a pre-existing user but we highly recommend creating a dedicate
 
 | Version | Date       | Pull Request                                               | Subject                                                                        |
 |:--------|:-----------|:-----------------------------------------------------------|:-------------------------------------------------------------------------------|
-| 2.0.11  | 2025-08-20 | [\#tbd](https://github.com/airbytehq/airbyte/pull/tbd)     | Check should properly surface protocol related config errors.                  |
+| 2.0.11  | 2025-08-20 | [\#65120](https://github.com/airbytehq/airbyte/pull/65120) | Check should properly surface protocol related config errors.                  |
 | 2.0.11  | 2025-07-23 | [\#65117](https://github.com/airbytehq/airbyte/pull/65117) | Fix a bug related to the column duplicates name.                               |
 | 2.0.10  | 2025-07-23 | [\#64104](https://github.com/airbytehq/airbyte/pull/64104) | Add an option to configure the batch size (both bytes and number of records).  |
 | 2.0.9   | 2025-07-23 | [\#63738](https://github.com/airbytehq/airbyte/pull/63738) | Set clickhouse as an airbyte connector.                                        |


### PR DESCRIPTION
## What
Fixes protocol validation

## How
`assert` requires a jvm flag to do anything while `require` does not. Do the `require` call in the factory so it's surfaced in both the check / cleanup.
