### PR TITLE
docs(source-salesforce): Remove unconfirmed PermissionSet stream and temper security claims

### DIFF
--- a/docs/integrations/sources/salesforce.md
+++ b/docs/integrations/sources/salesforce.md
@@ -154,29 +154,31 @@ Common use cases for syncing Salesforce permission data include:
 The following streams contain security and permission-related data:
 
 - **[`User`](https://developer.salesforce.com/docs/atlas.en-us.object_reference.meta/object_reference/sforce_api_objects_user.htm)** - Core user accounts with security-related fields including profiles, roles, and user permissions. Contains information about user status, login history, and assigned licenses.
-- **[`PermissionSet`](https://developer.salesforce.com/docs/atlas.en-us.object_reference.meta/object_reference/sforce_api_objects_permissionset.htm)** - Represents sets of permissions used to grant additional access to users without changing their profile. Contains user, object, and field permissions as well as setup entity access settings.
 - **[`ActivePermSetLicenseMetric`](https://developer.salesforce.com/docs/atlas.en-us.object_reference.meta/object_reference/sforce_api_objects_activepermsetlicensemetric.htm)** - Tracks permission set license usage metrics including assigned user counts, active user counts, and total available licenses.
 - **[`ActiveProfileMetric`](https://developer.salesforce.com/docs/atlas.en-us.object_reference.meta/object_reference/sforce_api_objects_activeprofilemetric.htm)** - Provides metrics about user profile usage including user license associations and assignment counts.
 
+For comprehensive information about Salesforce security objects, refer to the [Salesforce Object Reference](https://developer.salesforce.com/docs/atlas.en-us.object_reference.meta/object_reference/sforce_api_objects_concepts.htm) documentation.
+
 ### How Salesforce Permission Syncing Works
 
-Salesforce provides security data through its standard object model:
+Salesforce provides some security-related data through its standard object model:
 
-1. **Dynamic Object Discovery**: The connector automatically discovers all available Salesforce objects (sobjects) based on the authenticated user's permissions.
-2. **Permission-Based Access**: Which security objects are available depends on the permissions granted to the Salesforce user used for authentication.
-3. **Standard Object Syncing**: Security artifacts are available as regular Salesforce objects through the same sync mechanisms as other business data.
+1. **Dynamic Object Discovery**: The connector automatically discovers available Salesforce objects (sobjects) based on the authenticated user's permissions.
+2. **Permission-Based Access**: Which security objects are available depends on the permissions granted to the Salesforce user used for authentication and your Salesforce environment configuration.
+3. **Standard Object Syncing**: Available security-related objects are synced as regular Salesforce objects through the same sync mechanisms as other business data.
 
 :::note
-Security objects can be large datasets in organizations with many users, so monitor your Salesforce API limits accordingly.
+Security-related object availability varies by Salesforce environment (production vs sandbox) and user permissions. Security objects can be large datasets in organizations with many users, so monitor your Salesforce API limits accordingly.
 :::
 
 ### Permissions Needed to Sync Permissions Data {#permissions-to-sync-permissions}
 
 To sync security-related data from Salesforce, the authenticated Salesforce user must have appropriate permissions to read security objects. Consider granting these permissions through a dedicated permission set:
 
-   - "View Setup and Configuration" - Required to access PermissionSet objects.
    - "View All Users" - Required to access comprehensive User data.
    - Standard read permissions for the specific objects you want to sync.
+
+For more information about Salesforce security and permissions, refer to the official Salesforce documentation on [User Permissions](https://help.salesforce.com/s/articleView?id=sf.admin_userperms.htm&type=5) and [Permission Sets](https://help.salesforce.com/s/articleView?id=sf.perm_sets_overview.htm&type=5).
 
 ## Limitations & Troubleshooting
 


### PR DESCRIPTION
## What

This PR updates the Salesforce connector documentation to remove mention of the `PermissionSet` stream and temper claims about security object access based on integration testing findings. The testing showed that the `PermissionSet` stream was not discoverable in any of the tested environments (production BULK API, production REST API, or sandbox), and there were significant differences in stream availability between environments.

Related to the original documentation addition in PR #65075.

## How

* **Removed `PermissionSet` stream** from the Available Security-Related Streams section since it was not found in any tested environment
* **Tempered language** in "How Salesforce Permission Syncing Works" section to be more conservative (changed "security data" to "some security-related data" and added environment configuration dependencies)
* **Added environment availability note** mentioning that security object availability varies by Salesforce environment (production vs sandbox) and user permissions
* **Removed PermissionSet-specific permission requirements** ("View Setup and Configuration") from the Permissions Needed section
* **Added links to official Salesforce documentation** for User Permissions and Permission Sets to provide authoritative guidance
* **Added reference** to Salesforce Object Reference documentation for comprehensive security object information

## Review guide

1. `docs/integrations/sources/salesforce.md` - Check the security streams section (lines ~154-182) for:
   - Removal of PermissionSet stream documentation
   - Updated language that's appropriately conservative but still useful
   - Correct links to official Salesforce documentation
   - Adequate permission guidance after removing PermissionSet-specific requirements

## User Impact

**Positive:**
* Users will have more accurate documentation that doesn't promise access to streams that may not be available
* Users get direct links to authoritative Salesforce documentation for security guidance
* Documentation now acknowledges environment-specific limitations discovered through testing

**Potential concerns:**
* Users who previously relied on PermissionSet stream documentation will need to refer to official Salesforce docs
* More conservative language might make some users uncertain about what security data they can actually access

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

This is a documentation-only change that removes unverified claims and adds conservative language. It can be safely reverted if needed.

---

**Link to Devin run:** https://app.devin.ai/sessions/510d599da4f446fb90b491b474a871e2

**Requested by:** @aaronsteers

**Testing context:** Based on PyAirbyte testing using GSM secrets that showed PermissionSet stream was not discoverable across production BULK (15 streams), production REST (15 streams), and sandbox (178 streams) environments.