### PR TITLE
Docs search console verification

### DIFF
--- a/docusaurus/docusaurus.config.js
+++ b/docusaurus/docusaurus.config.js
@@ -66,13 +66,6 @@ const config = {
         content: "plvcr4wcl9abmq0itvi63c",
       },
     },
-    {
-      tagName: "meta",
-      attributes: {
-        name: "google-site-verification",
-        content: "3bGvGd17EJ-wHoyGlRszHtmMGmtWGQ4dDFEQy8ampQ0",
-      },
-    },
     ...(process.env.NODE_ENV === "production" && process.env.SEGMENT_WRITE_KEY
       ? [
           {

--- a/docusaurus/static/google9094f1c5da4bb394.html
+++ b/docusaurus/static/google9094f1c5da4bb394.html
@@ -1,0 +1,1 @@
+google-site-verification: google9094f1c5da4bb394.html


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->

Google Search Console can't see the docs site verification metadata in Docusaurus. This change removes verification from the metadata and adds it to a static file so we can authenticate that way instead.

We need to do this before we can further investigate some SEO issues.

## How
<!--
* Describe how code changes achieve the solution.
-->

Adds the google search console authentication file to the static folder.

Remove the metadata code from the the configuration file.

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

I verified locally that the html file was present in the build. Then, I verified the file was present on the Vercel build: https://airbyte-docs-a9mtuokht-airbyte-growth.vercel.app/google9094f1c5da4bb394.html.

In both cases, it's there.

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
