### PR TITLE
regression tests dispatch default commands

### DIFF
--- a/.github/workflows/regression_tests.yml
+++ b/.github/workflows/regression_tests.yml
@@ -20,6 +20,7 @@ on:
       connection_id:
         description: ID of the connection to test; use "auto" to let the connection retriever choose a connection
         required: true
+        default: auto
       pr_url:
         description: URL of the PR containing the code change
         required: true
@@ -41,6 +42,7 @@ on:
         description: The subset of connections to select from.
         required: true
         type: choice
+        default: all
         options:
           - sandboxes
           - all


### PR DESCRIPTION
## What
Pretty self-explanatory. We tend to use these values, why not make them defaults to save us a bit of typing?

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._