### PR TITLE
Set test env for dockerized dests tests

### DIFF
--- a/airbyte-cdk/bulk/core/base/src/main/kotlin/io/airbyte/cdk/output/StdoutOutputConsumer.kt
+++ b/airbyte-cdk/bulk/core/base/src/main/kotlin/io/airbyte/cdk/output/StdoutOutputConsumer.kt
@@ -238,5 +238,5 @@ class StdoutOutputConsumer(
 @Factory
 private class PrintStreamFactory {
 
-    @Singleton @Requires(notEnv = [Environment.TEST]) fun stdout(): PrintStream = System.out
+    @Singleton fun stdout(): PrintStream = System.out
 }

--- a/airbyte-cdk/bulk/core/base/src/main/kotlin/io/airbyte/cdk/output/StdoutOutputConsumer.kt
+++ b/airbyte-cdk/bulk/core/base/src/main/kotlin/io/airbyte/cdk/output/StdoutOutputConsumer.kt
@@ -11,10 +11,8 @@ import io.airbyte.protocol.models.v0.AirbyteMessage
 import io.airbyte.protocol.models.v0.AirbyteRecordMessage
 import io.airbyte.protocol.models.v0.AirbyteRecordMessageMeta
 import io.micronaut.context.annotation.Factory
-import io.micronaut.context.annotation.Requires
 import io.micronaut.context.annotation.Secondary
 import io.micronaut.context.annotation.Value
-import io.micronaut.context.env.Environment
 import jakarta.inject.Singleton
 import java.io.ByteArrayOutputStream
 import java.io.PrintStream

--- a/airbyte-cdk/bulk/core/base/src/testFixtures/kotlin/io/airbyte/cdk/command/CliRunnerOutputStream.kt
+++ b/airbyte-cdk/bulk/core/base/src/testFixtures/kotlin/io/airbyte/cdk/command/CliRunnerOutputStream.kt
@@ -23,6 +23,7 @@ class CliRunnerOutputStream : OutputStream() {
     val beanDefinition: RuntimeBeanDefinition<PrintStream> =
         RuntimeBeanDefinition.builder(PrintStream::class.java) { printStream }
             .singleton(true)
+            .replaces(PrintStream::class.java)
             .build()
 
     override fun write(b: Int) {

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/destination_process/DockerizedDestination.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/destination_process/DockerizedDestination.kt
@@ -179,14 +179,22 @@ class DockerizedDestination(
                 emptyList()
             }
 
+        // Why these Micronaut Envs?
+        // - test: this is only used for tests - this enables loading of test specific config
+        // - cli: in docker mode, we are running via the CLI (random beans expect this)
+        // - destination: this is DockerizedDestination - we're always a destination
+        // - connector: see above - destinations are connectors
+        val micronautEnvEnvVar =
+            listOf(
+                "-e",
+                "MICRONAUT_ENVIRONMENTS=test,cli,destination,connector",
+            )
+
         val additionalEnvEntries =
             envVars.flatMap { (key, value) ->
                 logger.info { "Env vars: $key loaded" }
                 listOf("-e", "$key=$value")
-            } + listOf(
-                "-e",
-                "MICRONAUT_ENVIRONMENTS=test,cli,destination,connector",
-            ) + socketPathEnvVarsMaybe
+            } + micronautEnvEnvVar + socketPathEnvVarsMaybe
 
         // DANGER: env vars can contain secrets, so you MUST NOT log this command.
         val cmd: MutableList<String> =

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/destination_process/DockerizedDestination.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/destination_process/DockerizedDestination.kt
@@ -183,7 +183,10 @@ class DockerizedDestination(
             envVars.flatMap { (key, value) ->
                 logger.info { "Env vars: $key loaded" }
                 listOf("-e", "$key=$value")
-            } + socketPathEnvVarsMaybe
+            } + listOf(
+                "-e",
+                "MICRONAUT_ENVIRONMENTS=test,cli,destination,connector",
+            ) + socketPathEnvVarsMaybe
 
         // DANGER: env vars can contain secrets, so you MUST NOT log this command.
         val cmd: MutableList<String> =


### PR DESCRIPTION
## What
Adds micronaut test env to envs for dockerized dest tests

## Other
Updates CliRunner PrintStream to override existing PrintStream so we don't disable the PrintStream bean in DockerizedTests