### PR TITLE
fix(source-google-ads): Update custom query URL to use Google Ads API v20

### DIFF
--- a/airbyte-integrations/connectors/source-google-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-ads/metadata.yaml
@@ -11,7 +11,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 253487c0-2246-43ba-a21f-5116b20a2c50
-  dockerImageTag: "4.1.0-rc.1"
+  dockerImageTag: "4.1.0-rc.2"
   dockerRepository: airbyte/source-google-ads
   documentationUrl: https://docs.airbyte.com/integrations/sources/google-ads
   githubIssueLabel: source-google-ads
@@ -31,7 +31,7 @@ data:
   releaseStage: generally_available
   releases:
     rolloutConfiguration:
-      enableProgressiveRollout: false
+      enableProgressiveRollout: true
     breakingChanges:
       1.0.0:
         message: This release introduces fixes to custom query schema creation. Users should refresh the source schema and reset affected streams after upgrading to ensure uninterrupted syncs.

--- a/airbyte-integrations/connectors/source-google-ads/pyproject.toml
+++ b/airbyte-integrations/connectors/source-google-ads/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "4.1.0-rc.1"
+version = "4.1.1"
 name = "source-google-ads"
 description = "Source implementation for Google Ads."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-google-ads/pyproject.toml
+++ b/airbyte-integrations/connectors/source-google-ads/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "4.1.1"
+version = "4.1.0-rc.2"
 name = "source-google-ads"
 description = "Source implementation for Google Ads."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-google-ads/source_google_ads/components.py
+++ b/airbyte-integrations/connectors/source-google-ads/source_google_ads/components.py
@@ -804,7 +804,7 @@ class CustomGAQuerySchemaLoader(SchemaLoader):
         return field_value
 
     def _get_field_metadata(self, field: str) -> Dict[str, Any]:
-        url = f"https://googleads.googleapis.com/v18/googleAdsFields/{field}"
+        url = f"https://googleads.googleapis.com/v20/googleAdsFields/{field}"
         logger.debug(f"`GET` request for field metadata for {field}, url: {url}")
         response = requests.get(
             url=url,
@@ -860,8 +860,8 @@ class CustomGAQuerySchemaLoader(SchemaLoader):
         except ValueError:
             raise AirbyteTracedException(
                 failure_type=FailureType.config_error,
-                internal_message=f"The provided query is invalid: {query}. Please refer to the Google Ads API documentation for the correct syntax: https://developers.google.com/google-ads/api/fields/v18/overview and test validate your query using the Google Ads Query Builder: https://developers.google.com/google-ads/api/fields/v18/query_validator",
-                message=f"The provided query is invalid: {query}. Please refer to the Google Ads API documentation for the correct syntax: https://developers.google.com/google-ads/api/fields/v18/overview and test validate your query using the Google Ads Query Builder: https://developers.google.com/google-ads/api/fields/v18/query_validator",
+                internal_message=f"The provided query is invalid: {query}. Please refer to the Google Ads API documentation for the correct syntax: https://developers.google.com/google-ads/api/fields/v20/overview and test validate your query using the Google Ads Query Builder: https://developers.google.com/google-ads/api/fields/v20/query_validator",
+                message=f"The provided query is invalid: {query}. Please refer to the Google Ads API documentation for the correct syntax: https://developers.google.com/google-ads/api/fields/v20/overview and test validate your query using the Google Ads Query Builder: https://developers.google.com/google-ads/api/fields/v20/query_validator",
             )
 
 

--- a/airbyte-integrations/connectors/source-google-ads/source_google_ads/manifest.yaml
+++ b/airbyte-integrations/connectors/source-google-ads/source_google_ads/manifest.yaml
@@ -444,7 +444,7 @@ definitions:
       class_name: "source_google_ads.components.CustomGAQuerySchemaLoader"
       requester:
         $ref: "#/definitions/base_requester"
-        url: "https://googleads.googleapis.com/v18/googleAdsFields"
+        url: "https://googleads.googleapis.com/v20/googleAdsFields"
         http_method: GET
         error_handler:
           $ref: "#/definitions/base_error_handler"

--- a/airbyte-integrations/connectors/source-google-ads/unit_tests/test_components.py
+++ b/airbyte-integrations/connectors/source-google-ads/unit_tests/test_components.py
@@ -14,7 +14,7 @@ from airbyte_cdk.sources.declarative.schema import InlineSchemaLoader
 class TestCustomGAQuerySchemaLoader:
     def test_custom_ga_query_schema_loader_returns_expected_schema(self, config_for_custom_query_tests, requests_mock):
         requests_mock.get(
-            "https://googleads.googleapis.com/v18/googleAdsFields/campaign_budget.name",
+            "https://googleads.googleapis.com/v20/googleAdsFields/campaign_budget.name",
             json={
                 "resourceName": "googleAdsFields/campaign_budget.name",
                 "category": "ATTRIBUTE",
@@ -28,7 +28,7 @@ class TestCustomGAQuerySchemaLoader:
             },
         )
         requests_mock.get(
-            "https://googleads.googleapis.com/v18/googleAdsFields/campaign.name",
+            "https://googleads.googleapis.com/v20/googleAdsFields/campaign.name",
             json={
                 "resourceName": "googleAdsFields/campaign.name",
                 "category": "ATTRIBUTE",
@@ -42,7 +42,7 @@ class TestCustomGAQuerySchemaLoader:
             },
         )
         requests_mock.get(
-            "https://googleads.googleapis.com/v18/googleAdsFields/metrics.interaction_event_types",
+            "https://googleads.googleapis.com/v20/googleAdsFields/metrics.interaction_event_types",
             json={
                 "resourceName": "googleAdsFields/metrics.interaction_event_types",
                 "category": "METRIC",
@@ -52,7 +52,7 @@ class TestCustomGAQuerySchemaLoader:
                 "filterable": True,
                 "sortable": False,
                 "enumValues": ["UNSPECIFIED", "UNKNOWN", "CLICK", "ENGAGEMENT", "VIDEO_VIEW", "NONE"],
-                "typeUrl": "google.ads.googleads.v18.enums.InteractionEventTypeEnum.InteractionEventType",
+                "typeUrl": "google.ads.googleads.v20.enums.InteractionEventTypeEnum.InteractionEventType",
                 "isRepeated": True,
             },
         )
@@ -85,7 +85,7 @@ class TestCustomGAQuerySchemaLoader:
 
     def test_custom_ga_query_schema_loader_with_cursor_field_returns_expected_schema(self, config_for_custom_query_tests, requests_mock):
         requests_mock.get(
-            "https://googleads.googleapis.com/v18/googleAdsFields/campaign_budget.name",
+            "https://googleads.googleapis.com/v20/googleAdsFields/campaign_budget.name",
             json={
                 "resourceName": "googleAdsFields/campaign_budget.name",
                 "category": "ATTRIBUTE",
@@ -99,7 +99,7 @@ class TestCustomGAQuerySchemaLoader:
             },
         )
         requests_mock.get(
-            "https://googleads.googleapis.com/v18/googleAdsFields/campaign.name",
+            "https://googleads.googleapis.com/v20/googleAdsFields/campaign.name",
             json={
                 "resourceName": "googleAdsFields/campaign.name",
                 "category": "ATTRIBUTE",
@@ -113,7 +113,7 @@ class TestCustomGAQuerySchemaLoader:
             },
         )
         requests_mock.get(
-            "https://googleads.googleapis.com/v18/googleAdsFields/metrics.interaction_event_types",
+            "https://googleads.googleapis.com/v20/googleAdsFields/metrics.interaction_event_types",
             json={
                 "resourceName": "googleAdsFields/metrics.interaction_event_types",
                 "category": "METRIC",
@@ -123,12 +123,12 @@ class TestCustomGAQuerySchemaLoader:
                 "filterable": True,
                 "sortable": False,
                 "enumValues": ["UNSPECIFIED", "UNKNOWN", "CLICK", "ENGAGEMENT", "VIDEO_VIEW", "NONE"],
-                "typeUrl": "google.ads.googleads.v18.enums.InteractionEventTypeEnum.InteractionEventType",
+                "typeUrl": "google.ads.googleads.v20.enums.InteractionEventTypeEnum.InteractionEventType",
                 "isRepeated": True,
             },
         )
         requests_mock.get(
-            "https://googleads.googleapis.com/v18/googleAdsFields/segments.date",
+            "https://googleads.googleapis.com/v20/googleAdsFields/segments.date",
             json={
                 "resourceName": "googleAdsFields/segments.date",
                 "category": "SEGMENT",
@@ -169,7 +169,7 @@ class TestCustomGAQuerySchemaLoader:
         config = config_for_custom_query_tests
         config["custom_queries_array"][0]["query"] = "SELECT invalid_field FROM campaign_budget"
         requests_mock.get(
-            "https://googleads.googleapis.com/v18/googleAdsFields/invalid_field",
+            "https://googleads.googleapis.com/v20/googleAdsFields/invalid_field",
             json={"error": {"code": 404, "message": "Requested entity was not found.", "status": "NOT_FOUND"}},
         )
         mock_requester = Mock()

--- a/airbyte-integrations/connectors/source-google-ads/unit_tests/test_empty_streams.py
+++ b/airbyte-integrations/connectors/source-google-ads/unit_tests/test_empty_streams.py
@@ -169,7 +169,7 @@ def test_custom_query_stream(customers, config_for_custom_query_tests, requests_
     # Register mocks
     requests_mock.register_uri("POST", "https://www.googleapis.com/oauth2/v3/token", access_token_response)
     requests_mock.get(
-        "https://googleads.googleapis.com/v18/googleAdsFields/campaign_budget.name",
+        "https://googleads.googleapis.com/v20/googleAdsFields/campaign_budget.name",
         json={
             "resourceName": "googleAdsFields/campaign_budget.name",
             "category": "ATTRIBUTE",
@@ -183,7 +183,7 @@ def test_custom_query_stream(customers, config_for_custom_query_tests, requests_
         },
     )
     requests_mock.get(
-        "https://googleads.googleapis.com/v18/googleAdsFields/campaign.name",
+        "https://googleads.googleapis.com/v20/googleAdsFields/campaign.name",
         json={
             "resourceName": "googleAdsFields/campaign.name",
             "category": "ATTRIBUTE",
@@ -197,7 +197,7 @@ def test_custom_query_stream(customers, config_for_custom_query_tests, requests_
         },
     )
     requests_mock.get(
-        "https://googleads.googleapis.com/v18/googleAdsFields/metrics.interaction_event_types",
+        "https://googleads.googleapis.com/v20/googleAdsFields/metrics.interaction_event_types",
         json={
             "resourceName": "googleAdsFields/metrics.interaction_event_types",
             "category": "METRIC",
@@ -207,12 +207,12 @@ def test_custom_query_stream(customers, config_for_custom_query_tests, requests_
             "filterable": True,
             "sortable": False,
             "enumValues": ["UNSPECIFIED", "UNKNOWN", "CLICK", "ENGAGEMENT", "VIDEO_VIEW", "NONE"],
-            "typeUrl": "google.ads.googleads.v18.enums.InteractionEventTypeEnum.InteractionEventType",
+            "typeUrl": "google.ads.googleads.v20.enums.InteractionEventTypeEnum.InteractionEventType",
             "isRepeated": True,
         },
     )
     requests_mock.get(
-        "https://googleads.googleapis.com/v18/googleAdsFields/segments.date",
+        "https://googleads.googleapis.com/v20/googleAdsFields/segments.date",
         json={
             "resourceName": "googleAdsFields/segments.date",
             "category": "SEGMENT",

--- a/airbyte-integrations/connectors/source-google-ads/unit_tests/test_migrations/custom_query/test_config.json
+++ b/airbyte-integrations/connectors/source-google-ads/unit_tests/test_migrations/custom_query/test_config.json
@@ -1,1 +1,18 @@
-{"credentials": {"developer_token": "developer_token", "client_id": "client_id", "client_secret": "client_secret", "refresh_token": "refresh_token"}, "customer_id": "1234567890", "start_date": "2023-09-04", "conversion_window_days": 14, "custom_queries": [{"query": "SELECT campaign.name, metrics.clicks FROM campaign", "primary_key": null, "table_name": "test_query"}]}
+{
+  "credentials": {
+    "developer_token": "developer_token",
+    "client_id": "client_id",
+    "client_secret": "client_secret",
+    "refresh_token": "refresh_token"
+  },
+  "customer_id": "1234567890",
+  "start_date": "2023-09-04",
+  "conversion_window_days": 14,
+  "custom_queries": [
+    {
+      "query": "SELECT campaign.name, metrics.clicks FROM campaign",
+      "primary_key": null,
+      "table_name": "test_query"
+    }
+  ]
+}

--- a/airbyte-integrations/connectors/source-google-ads/unit_tests/test_migrations/custom_query/test_config.json
+++ b/airbyte-integrations/connectors/source-google-ads/unit_tests/test_migrations/custom_query/test_config.json
@@ -1,18 +1,1 @@
-{
-  "credentials": {
-    "developer_token": "developer_token",
-    "client_id": "client_id",
-    "client_secret": "client_secret",
-    "refresh_token": "refresh_token"
-  },
-  "customer_id": "1234567890",
-  "start_date": "2023-09-04",
-  "conversion_window_days": 14,
-  "custom_queries": [
-    {
-      "query": "SELECT campaign.name, metrics.clicks FROM campaign",
-      "primary_key": null,
-      "table_name": "test_query"
-    }
-  ]
-}
+{"credentials": {"developer_token": "developer_token", "client_id": "client_id", "client_secret": "client_secret", "refresh_token": "refresh_token"}, "customer_id": "1234567890", "start_date": "2023-09-04", "conversion_window_days": 14, "custom_queries": [{"query": "SELECT campaign.name, metrics.clicks FROM campaign", "primary_key": null, "table_name": "test_query"}]}

--- a/docs/integrations/sources/google-ads.md
+++ b/docs/integrations/sources/google-ads.md
@@ -335,6 +335,7 @@ Due to a limitation in the Google Ads API which does not allow getting performan
 
 | Version     | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |:------------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 4.1.1 | 2025-08-22 | [65149](https://github.com/airbytehq/airbyte/pull/65149) | Update custom query URL to use Google Ads API v20 |
 | 4.1.0-rc.1 | 2025-08-19 | [63344](https://github.com/airbytehq/airbyte/pull/63344) | Migrate `custom_queries` streams to low-code           |
 | 4.0.2 | 2025-08-16 | [64987](https://github.com/airbytehq/airbyte/pull/64987) | Update dependencies |
 | 4.0.1 | 2025-08-09 | [64612](https://github.com/airbytehq/airbyte/pull/64612) | Update dependencies |

--- a/docs/integrations/sources/google-ads.md
+++ b/docs/integrations/sources/google-ads.md
@@ -335,7 +335,7 @@ Due to a limitation in the Google Ads API which does not allow getting performan
 
 | Version     | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |:------------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 4.1.1 | 2025-08-22 | [65149](https://github.com/airbytehq/airbyte/pull/65149) | Update custom query URL to use Google Ads API v20 |
+| 4.1.0-rc.2 | 2025-08-22 | [65149](https://github.com/airbytehq/airbyte/pull/65149) | Update custom query URL to use Google Ads API v20 |
 | 4.1.0-rc.1 | 2025-08-19 | [63344](https://github.com/airbytehq/airbyte/pull/63344) | Migrate `custom_queries` streams to low-code           |
 | 4.0.2 | 2025-08-16 | [64987](https://github.com/airbytehq/airbyte/pull/64987) | Update dependencies |
 | 4.0.1 | 2025-08-09 | [64612](https://github.com/airbytehq/airbyte/pull/64612) | Update dependencies |


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->
Update the URL used by custom queries to use Google Ads API v20.

## How
<!--
* Describe how code changes achieve the solution.
-->

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
