### PR TITLE
fix: disable dockerhub checks for metadata upload step of connector publish pipeline

### DIFF
--- a/poe-tasks/upload-connector-metadata.sh
+++ b/poe-tasks/upload-connector-metadata.sh
@@ -113,4 +113,8 @@ else
   metadata_upload_prerelease_flag="--prerelease $docker_tag"
 fi
 # Under the hood, this reads the GCS_CREDENTIALS environment variable
-poetry run --directory $METADATA_SERVICE_PATH metadata_service upload "$meta" "$DOCS_ROOT/" "$metadata_bucket" $metadata_upload_prerelease_flag
+# TODO: remove the `--disable-dockerhub-checks` flag once we stop supporting strict-encrypt connectors
+#   | For strict-encrypt connectors the dockerhub checks enforce that both {connector}:{version} and {connector}-strict-encrypt:{version}
+#   | Docker images must be published prior to metadata upload. With our current connector publishing process, these images are 
+#   | published in parallel and will not necessarily exist before metadata upload.
+poetry run --directory $METADATA_SERVICE_PATH metadata_service upload --disable-dockerhub-checks "$meta" "$DOCS_ROOT/" "$metadata_bucket" $metadata_upload_prerelease_flag


### PR DESCRIPTION
## What
See the comment I added in the code.

[Slack thread](https://airbytehq-team.slack.com/archives/C096K6HEM8X/p1755827274172639?thread_ts=1755620943.583859&cid=C096K6HEM8X) with more context

This seems to be a relatively low-effort path forward. We should be able to revisit this along with other pieces of the connector publish pipeline once strict encrypt connectors no longer exist. 

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
