### PR TITLE
fix: PyPI publishing step of connectors publish pipeline

### DIFF
--- a/poe-tasks/publish-python-registry.sh
+++ b/poe-tasks/publish-python-registry.sh
@@ -203,9 +203,6 @@ if [[ -f "pyproject.toml" ]]; then
 
     echo "✅ Temporary override package name to '$PACKAGE_NAME' and version to '$VERSION' in pyproject.toml"
 
-    # Install dependencies
-    poetry install --all-extras
-
     # Configure Poetry for PyPI publishing
     poetry config repositories.mypypi "$REGISTRY_UPLOAD_URL"
     poetry config pypi-token.mypypi "$PYPI_TOKEN"


### PR DESCRIPTION
## What
fixes [this error](https://github.com/airbytehq/airbyte/actions/runs/17177522015/job/48735479650#step:14:33) discovered over the weekend from PRs merged by the up-to-date pipeline. 

```
pyproject.toml changed significantly since poetry.lock was last generated. Run `poetry lock [--no-update]` to fix the lock file.
```

Slack thread: https://airbytehq-team.slack.com/archives/C02U9R3AF37/p1756127599946559


## How
This error is expected when running a `poetry install` given how we are overwriting the PyPI package name and version in this CI step from the values in the metadata.yaml file. Not sure how I didn't catch this initially

A `poetry install` turns out to not be necessary in order to publish to PyPI. 

**TODO**
- After merging to master, manually republish `source-file` and `source-azure-blob-storage`

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
