### PR TITLE
fix(source-zendesk-support): p0 pin back to 4.10.7

### DIFF
--- a/airbyte-integrations/connectors/source-zendesk-support/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zendesk-support/metadata.yaml
@@ -26,6 +26,7 @@ data:
   registryOverrides:
     cloud:
       enabled: true
+      dockerImageTag: 4.10.7
     oss:
       enabled: true
   releaseStage: generally_available


### PR DESCRIPTION
## What
- Pins `source-zendesk-support` to v4.10.7 to mitigate P0
- Related: https://github.com/airbytehq/oncall/issues/8851

## User Impact
- Working syncs

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
