### PR TITLE
fix one more reference to the old dev bucket

### DIFF
--- a/.github/workflows/generate-connector-registries.yml
+++ b/.github/workflows/generate-connector-registries.yml
@@ -146,4 +146,4 @@ jobs:
         env:
           GCS_CREDENTIALS: ${{ secrets.METADATA_SERVICE_DEV_GCS_CREDENTIALS }}
         # Note: --project because we're on poetry 2.x
-        run: poetry run --project airbyte-ci/connectors/metadata_service/lib metadata_service generate-registry-report dev-airbyte-cloud-connector-metadata-service
+        run: poetry run --project airbyte-ci/connectors/metadata_service/lib metadata_service generate-registry-report dev-airbyte-cloud-connector-metadata-service-2


### PR DESCRIPTION
missed this in https://github.com/airbytehq/airbyte/pull/65561

grep says the only remaining references are in the orchestrator (so we don't care), and in terraform (wtf, but we probably still don't care)