### PR TITLE
feat(poe): add local connector image build script and poe tasks (prints final image, auto-detects platform)

### DIFF
--- a/poe-tasks/build-connector-image.sh
+++ b/poe-tasks/build-connector-image.sh
@@ -41,7 +41,6 @@ command -v docker >/dev/null 2>&1 || die "Docker is not installed or not on PATH
 REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
 [[ -n "${REPO_ROOT}" ]] || die "Not inside the airbyte repository."
 CONNECTOR_DIR="${POE_PWD:-$PWD}"
-[[ -f "${CONNECTOR_DIR}/metadata.yaml" ]] || die "metadata.yaml not found in ${CONNECTOR_DIR}. Run inside a connector directory or via 'poe connector <name> image build'."
 
 TAG=""
 if [[ $# -gt 0 && "${1-}" != "--tag" && "${1-}" != "-h" && "${1-}" != "--help" ]]; then
@@ -55,6 +54,8 @@ while [[ $# -gt 0 ]]; do
     *) usage >&2; die "Unknown argument: $1";;
   esac
 done
+
+[[ -f "${CONNECTOR_DIR}/metadata.yaml" ]] || die "metadata.yaml not found in ${CONNECTOR_DIR}. Run inside a connector directory or via 'poe connector <name> image build'."
 
 ARCH_RAW="$(docker info --format '{{.Architecture}}' 2>/dev/null || true)"
 if [[ -z "${ARCH_RAW}" ]]; then

--- a/poe-tasks/build-connector-image.sh
+++ b/poe-tasks/build-connector-image.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+RED="❌"; GREEN="✅"; INFO="ℹ️"; HAMMER="🛠️"; WHALE="🐳"; SPARKLES="✨"
+
+die() { echo "${RED} $*"; exit 1; }
+log() { echo "${INFO} $*"; }
+
+command -v docker >/dev/null 2>&1 || die "Docker is not installed or not on PATH."
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+[[ -n "${REPO_ROOT}" ]] || die "Not inside the airbyte repository."
+CONNECTOR_DIR="${POE_PWD:-$PWD}"
+[[ -f "${CONNECTOR_DIR}/metadata.yaml" ]] || die "metadata.yaml not found in ${CONNECTOR_DIR}. Run inside a connector directory or via 'poe connector <name> image build'."
+
+TAG=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --tag) TAG="$2"; shift 2;;
+    *) die "Unknown argument: $1 (only --tag <tag> is supported)";;
+  esac
+done
+
+ARCH_RAW="$(docker info --format '{{.Architecture}}' 2>/dev/null || true)"
+if [[ -z "${ARCH_RAW}" ]]; then
+  U="$(uname -m)"
+  case "${U}" in
+    x86_64|amd64) ARCH_RAW="amd64";;
+    aarch64|arm64) ARCH_RAW="arm64";;
+    *) die "Unsupported architecture '${U}'. Supported: amd64, arm64.";;
+  esac
+fi
+case "${ARCH_RAW}" in
+  amd64|x86_64) PLATFORM="amd64";;
+  arm64|aarch64) PLATFORM="arm64";;
+  *) die "Unsupported docker architecture '${ARCH_RAW}'. Supported: amd64, arm64.";;
+esac
+DEFAULT_TAG="dev-${PLATFORM}"
+TAG="${TAG:-${DEFAULT_TAG}}"
+
+pushd "${CONNECTOR_DIR}" >/dev/null
+  command -v poe >/dev/null 2>&1 || die "poe (poethepoet) is required."
+  LANGUAGE="$(poe -qq get-language)"
+  BASE_IMAGE="$(poe -qq get-base-image)"
+popd >/dev/null
+
+[[ -n "${LANGUAGE}" ]] || die "Could not determine connector language."
+[[ -n "${BASE_IMAGE}" ]] || die "Could not determine base image from metadata.yaml."
+
+case "${LANGUAGE}" in
+  python) DOCKERFILE_SUFFIX="python-connector";;
+  java) DOCKERFILE_SUFFIX="java-connector";;
+  manifest-only) DOCKERFILE_SUFFIX="manifest-only-connector";;
+  *) die "Unsupported connector language: ${LANGUAGE}";;
+esac
+
+DOCKERFILE="${REPO_ROOT}/docker-images/Dockerfile.${DOCKERFILE_SUFFIX}"
+[[ -f "${DOCKERFILE}" ]] || die "Dockerfile not found: ${DOCKERFILE}"
+
+command -v yq >/dev/null 2>&1 || die "yq is required to parse metadata.yaml."
+DOCKER_REPO="$(yq eval '.data.dockerRepository' "${CONNECTOR_DIR}/metadata.yaml")"
+[[ -n "${DOCKER_REPO}" ]] || die "Failed to read .data.dockerRepository from metadata.yaml."
+CONNECTOR_NAME="$(basename "${DOCKER_REPO}")"
+FINAL_IMAGE="${DOCKER_REPO}:${TAG}"
+BUILD_ARGS=( --build-arg "BASE_IMAGE=${BASE_IMAGE}" --build-arg "CONNECTOR_NAME=${CONNECTOR_NAME}" )
+
+if [[ "${LANGUAGE}" == "java" ]]; then
+  log "${HAMMER} Building Java connector tarball via Gradle..."
+  ( cd "${REPO_ROOT}" && ./gradlew ":airbyte-integrations:connectors:${CONNECTOR_NAME}:distTar" )
+fi
+
+log "${WHALE} Building image for ${CONNECTOR_NAME} -> ${FINAL_IMAGE} (platform linux/${PLATFORM})"
+docker buildx build \
+  --platform "linux/${PLATFORM}" \
+  --file "${DOCKERFILE}" \
+  "${BUILD_ARGS[@]}" \
+  -t "${FINAL_IMAGE}" \
+  --load \
+  "${CONNECTOR_DIR}"
+
+echo "${GREEN} Build complete."
+echo "${SPARKLES} Image loaded into local Docker: ${FINAL_IMAGE}"
+echo "${FINAL_IMAGE}"

--- a/poe-tasks/build-connector-image.sh
+++ b/poe-tasks/build-connector-image.sh
@@ -13,10 +13,14 @@ CONNECTOR_DIR="${POE_PWD:-$PWD}"
 [[ -f "${CONNECTOR_DIR}/metadata.yaml" ]] || die "metadata.yaml not found in ${CONNECTOR_DIR}. Run inside a connector directory or via 'poe connector <name> image build'."
 
 TAG=""
+if [[ $# -gt 0 && "${1-}" != "--tag" ]]; then
+  TAG="$1"
+  shift
+fi
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --tag) TAG="$2"; shift 2;;
-    *) die "Unknown argument: $1 (only --tag <tag> is supported)";;
+    *) die "Unknown argument: $1 (supported: [<tag>] or --tag <tag>)";;
   esac
 done
 

--- a/poe-tasks/gradle-connector-tasks.toml
+++ b/poe-tasks/gradle-connector-tasks.toml
@@ -89,11 +89,9 @@ shell = "airbyte-ci connectors --name=`poe -qq get-connector-name` test --only-s
 help = "Run the legacy Airbyte-CI acceptance tests (CAT tests)."
 
 [tasks.image]
-help = "Tasks for building connector Docker images."
-
-[tasks.image.build]
-help = "Build and load the connector image locally (docker buildx --load). Optional: --tag <tag> (default: dev-{platform})."
+help = "Build and load the connector image locally (docker buildx --load). Usage: poe image [build] [--tag <tag>] (default tag: dev-{platform})."
 shell = "${POE_GIT_DIR}/poe-tasks/build-connector-image.sh ${tag}"
 args = [
+  { name = "subcommand", positional = true, default = "build", help = "Subcommand (only 'build' is supported)" },
   { name = "tag", positional = false, options = ["--tag"], help = "Image tag to use (default dev-{platform})" },
 ]

--- a/poe-tasks/gradle-connector-tasks.toml
+++ b/poe-tasks/gradle-connector-tasks.toml
@@ -90,7 +90,7 @@ help = "Run the legacy Airbyte-CI acceptance tests (CAT tests)."
 
 [tasks.image]
 help = "Build and load the connector image locally (docker buildx --load). Usage: poe image [build] [--tag <tag>] (default tag: dev-{platform})."
-shell = "${POE_ROOT}/poe-tasks/build-connector-image.sh ${tag}"
+shell = "${POE_GIT_ROOT}/poe-tasks/build-connector-image.sh ${tag}"
 args = [
   { name = "subcommand", positional = true, default = "build", help = "Subcommand (only 'build' is supported)" },
   { name = "tag", positional = false, options = ["--tag"], help = "Image tag to use (default dev-{platform})" },

--- a/poe-tasks/gradle-connector-tasks.toml
+++ b/poe-tasks/gradle-connector-tasks.toml
@@ -90,7 +90,7 @@ help = "Run the legacy Airbyte-CI acceptance tests (CAT tests)."
 
 [tasks.image]
 help = "Build and load the connector image locally (docker buildx --load). Usage: poe image [build] [--tag <tag>] (default tag: dev-{platform})."
-shell = "${POE_GIT_DIR}/poe-tasks/build-connector-image.sh ${tag}"
+shell = "${POE_ROOT}/poe-tasks/build-connector-image.sh ${tag}"
 args = [
   { name = "subcommand", positional = true, default = "build", help = "Subcommand (only 'build' is supported)" },
   { name = "tag", positional = false, options = ["--tag"], help = "Image tag to use (default dev-{platform})" },

--- a/poe-tasks/gradle-connector-tasks.toml
+++ b/poe-tasks/gradle-connector-tasks.toml
@@ -90,7 +90,7 @@ help = "Run the legacy Airbyte-CI acceptance tests (CAT tests)."
 
 [tasks.image]
 help = "Build and load the connector image locally (docker buildx --load). Usage: poe image [build] [--tag <tag>] (default tag: dev-{platform})."
-shell = "${POE_GIT_ROOT}/poe-tasks/build-connector-image.sh ${tag}"
+shell = '$(git rev-parse --show-toplevel)/poe-tasks/build-connector-image.sh ${tag}'
 args = [
   { name = "subcommand", positional = true, default = "build", help = "Subcommand (only 'build' is supported)" },
   { name = "tag", positional = false, options = ["--tag"], help = "Image tag to use (default dev-{platform})" },

--- a/poe-tasks/gradle-connector-tasks.toml
+++ b/poe-tasks/gradle-connector-tasks.toml
@@ -87,3 +87,13 @@ help = "Get the version of the connector from its metadata.yaml file."
 [tasks.run-cat-tests]
 shell = "airbyte-ci connectors --name=`poe -qq get-connector-name` test --only-step=acceptance"
 help = "Run the legacy Airbyte-CI acceptance tests (CAT tests)."
+
+[tasks.image]
+help = "Tasks for building connector Docker images."
+
+[tasks.image.build]
+help = "Build and load the connector image locally (docker buildx --load). Optional: --tag <tag> (default: dev-{platform})."
+shell = "${POE_GIT_DIR}/poe-tasks/build-connector-image.sh ${tag}"
+args = [
+  { name = "tag", positional = false, options = ["--tag"], help = "Image tag to use (default dev-{platform})" },
+]

--- a/poe-tasks/manifest-only-connector-tasks.toml
+++ b/poe-tasks/manifest-only-connector-tasks.toml
@@ -71,7 +71,7 @@ help = "Get the base image of the connector from its metadata.yaml file."
 
 [tasks.image]
 help = "Build and load the connector image locally (docker buildx --load). Usage: poe image [build] [--tag <tag>] (default tag: dev-{platform})."
-shell = "${POE_GIT_DIR}/poe-tasks/build-connector-image.sh ${tag}"
+shell = "${POE_ROOT}/poe-tasks/build-connector-image.sh ${tag}"
 args = [
   { name = "subcommand", positional = true, default = "build", help = "Subcommand (only 'build' is supported)" },
   { name = "tag", positional = false, options = ["--tag"], help = "Image tag to use (default dev-{platform})" },

--- a/poe-tasks/manifest-only-connector-tasks.toml
+++ b/poe-tasks/manifest-only-connector-tasks.toml
@@ -70,12 +70,10 @@ cmd = """yq eval '.data.connectorBuildOptions.baseImage' ${POE_PWD}/metadata.yam
 help = "Get the base image of the connector from its metadata.yaml file."
 
 [tasks.image]
-help = "Tasks for building connector Docker images."
-
-[tasks.image.build]
-help = "Build and load the connector image locally (docker buildx --load). Optional: --tag <tag> (default: dev-{platform})."
+help = "Build and load the connector image locally (docker buildx --load). Usage: poe image [build] [--tag <tag>] (default tag: dev-{platform})."
 shell = "${POE_GIT_DIR}/poe-tasks/build-connector-image.sh ${tag}"
 args = [
+  { name = "subcommand", positional = true, default = "build", help = "Subcommand (only 'build' is supported)" },
   { name = "tag", positional = false, options = ["--tag"], help = "Image tag to use (default dev-{platform})" },
 ]
 

--- a/poe-tasks/manifest-only-connector-tasks.toml
+++ b/poe-tasks/manifest-only-connector-tasks.toml
@@ -71,7 +71,7 @@ help = "Get the base image of the connector from its metadata.yaml file."
 
 [tasks.image]
 help = "Build and load the connector image locally (docker buildx --load). Usage: poe image [build] [--tag <tag>] (default tag: dev-{platform})."
-shell = "${POE_GIT_ROOT}/poe-tasks/build-connector-image.sh ${tag}"
+shell = '$(git rev-parse --show-toplevel)/poe-tasks/build-connector-image.sh ${tag}'
 args = [
   { name = "subcommand", positional = true, default = "build", help = "Subcommand (only 'build' is supported)" },
   { name = "tag", positional = false, options = ["--tag"], help = "Image tag to use (default dev-{platform})" },

--- a/poe-tasks/manifest-only-connector-tasks.toml
+++ b/poe-tasks/manifest-only-connector-tasks.toml
@@ -69,6 +69,16 @@ help = "Get the language of the connector from its metadata.yaml file. Use with 
 cmd = """yq eval '.data.connectorBuildOptions.baseImage' ${POE_PWD}/metadata.yaml"""
 help = "Get the base image of the connector from its metadata.yaml file."
 
+[tasks.image]
+help = "Tasks for building connector Docker images."
+
+[tasks.image.build]
+help = "Build and load the connector image locally (docker buildx --load). Optional: --tag <tag> (default: dev-{platform})."
+shell = "${POE_GIT_DIR}/poe-tasks/build-connector-image.sh ${tag}"
+args = [
+  { name = "tag", positional = false, options = ["--tag"], help = "Image tag to use (default dev-{platform})" },
+]
+
 [tasks.get-version]
 cmd = """yq eval '.data.dockerImageTag' ${POE_PWD}/metadata.yaml"""
 help = "Get the version of the connector from its metadata.yaml file."

--- a/poe-tasks/manifest-only-connector-tasks.toml
+++ b/poe-tasks/manifest-only-connector-tasks.toml
@@ -71,7 +71,7 @@ help = "Get the base image of the connector from its metadata.yaml file."
 
 [tasks.image]
 help = "Build and load the connector image locally (docker buildx --load). Usage: poe image [build] [--tag <tag>] (default tag: dev-{platform})."
-shell = "${POE_ROOT}/poe-tasks/build-connector-image.sh ${tag}"
+shell = "${POE_GIT_ROOT}/poe-tasks/build-connector-image.sh ${tag}"
 args = [
   { name = "subcommand", positional = true, default = "build", help = "Subcommand (only 'build' is supported)" },
   { name = "tag", positional = false, options = ["--tag"], help = "Image tag to use (default dev-{platform})" },

--- a/poe-tasks/poetry-connector-tasks.toml
+++ b/poe-tasks/poetry-connector-tasks.toml
@@ -135,6 +135,16 @@ help = "Get the language of the connector from its metadata.yaml file. Use with 
 cmd = """yq eval '.data.connectorBuildOptions.baseImage' ${POE_PWD}/metadata.yaml"""
 help = "Get the base image of the connector from its metadata.yaml file."
 
+[tool.poe.tasks.image]
+help = "Tasks for building connector Docker images."
+
+[tool.poe.tasks.image.build]
+help = "Build and load the connector image locally (docker buildx --load). Optional: --tag <tag> (default: dev-{platform})."
+shell = "${POE_GIT_DIR}/poe-tasks/build-connector-image.sh ${tag}"
+args = [
+  { name = "tag", positional = false, options = ["--tag"], help = "Image tag to use (default dev-{platform})" },
+]
+
 [tool.poe.tasks.get-version]
 cmd = """yq eval '.data.dockerImageTag' ${POE_PWD}/metadata.yaml"""
 help = "Get the version of the connector from its metadata.yaml file."

--- a/poe-tasks/poetry-connector-tasks.toml
+++ b/poe-tasks/poetry-connector-tasks.toml
@@ -137,7 +137,7 @@ help = "Get the base image of the connector from its metadata.yaml file."
 
 [tool.poe.tasks.image]
 help = "Build and load the connector image locally (docker buildx --load). Usage: poe image [build] [--tag <tag>] (default tag: dev-{platform})."
-shell = "${POE_GIT_DIR}/poe-tasks/build-connector-image.sh ${tag}"
+shell = "${POE_ROOT}/poe-tasks/build-connector-image.sh ${tag}"
 args = [
   { name = "subcommand", positional = true, default = "build", help = "Subcommand (only 'build' is supported)" },
   { name = "tag", positional = false, options = ["--tag"], help = "Image tag to use (default dev-{platform})" },

--- a/poe-tasks/poetry-connector-tasks.toml
+++ b/poe-tasks/poetry-connector-tasks.toml
@@ -136,12 +136,10 @@ cmd = """yq eval '.data.connectorBuildOptions.baseImage' ${POE_PWD}/metadata.yam
 help = "Get the base image of the connector from its metadata.yaml file."
 
 [tool.poe.tasks.image]
-help = "Tasks for building connector Docker images."
-
-[tool.poe.tasks.image.build]
-help = "Build and load the connector image locally (docker buildx --load). Optional: --tag <tag> (default: dev-{platform})."
+help = "Build and load the connector image locally (docker buildx --load). Usage: poe image [build] [--tag <tag>] (default tag: dev-{platform})."
 shell = "${POE_GIT_DIR}/poe-tasks/build-connector-image.sh ${tag}"
 args = [
+  { name = "subcommand", positional = true, default = "build", help = "Subcommand (only 'build' is supported)" },
   { name = "tag", positional = false, options = ["--tag"], help = "Image tag to use (default dev-{platform})" },
 ]
 

--- a/poe-tasks/poetry-connector-tasks.toml
+++ b/poe-tasks/poetry-connector-tasks.toml
@@ -137,7 +137,7 @@ help = "Get the base image of the connector from its metadata.yaml file."
 
 [tool.poe.tasks.image]
 help = "Build and load the connector image locally (docker buildx --load). Usage: poe image [build] [--tag <tag>] (default tag: dev-{platform})."
-shell = "${POE_ROOT}/poe-tasks/build-connector-image.sh ${tag}"
+shell = "${POE_GIT_ROOT}/poe-tasks/build-connector-image.sh ${tag}"
 args = [
   { name = "subcommand", positional = true, default = "build", help = "Subcommand (only 'build' is supported)" },
   { name = "tag", positional = false, options = ["--tag"], help = "Image tag to use (default dev-{platform})" },

--- a/poe-tasks/poetry-connector-tasks.toml
+++ b/poe-tasks/poetry-connector-tasks.toml
@@ -137,7 +137,7 @@ help = "Get the base image of the connector from its metadata.yaml file."
 
 [tool.poe.tasks.image]
 help = "Build and load the connector image locally (docker buildx --load). Usage: poe image [build] [--tag <tag>] (default tag: dev-{platform})."
-shell = "${POE_GIT_ROOT}/poe-tasks/build-connector-image.sh ${tag}"
+shell = '$(git rev-parse --show-toplevel)/poe-tasks/build-connector-image.sh ${tag}'
 args = [
   { name = "subcommand", positional = true, default = "build", help = "Subcommand (only 'build' is supported)" },
   { name = "tag", positional = false, options = ["--tag"], help = "Image tag to use (default dev-{platform})" },


### PR DESCRIPTION
## What

Adds a developer-friendly script to build connector Docker images locally and load them into the local Docker daemon. This addresses the need for developers to quickly build and test connector images without going through CI/CD pipelines.

**Link to Devin run:** https://app.devin.ai/sessions/f55dda4672d646679c152e82fc1be62b
**Requested by:** @dbgold17

## How

1. **New bash script** (`poe-tasks/build-connector-image.sh`):
   - Auto-detects local architecture (amd64/arm64) using `docker info` or `uname -m` fallback
   - Uses existing poe tasks (`poe -qq get-language`, `poe -qq get-base-image`) to determine Dockerfile and base image
   - Maps connector languages to appropriate Dockerfiles (`docker-images/Dockerfile.{language}-connector`)
   - For Java connectors: runs `gradle distTar` before building (matches CI behavior)
   - Builds with `docker buildx --platform --load` to load image locally
   - Prints final image name for easy copy/paste

2. **Poe task integration**: Added `image` task to three connector task files:
   - `poetry-connector-tasks.toml` (Python connectors)
   - `manifest-only-connector-tasks.toml` (Manifest-only connectors)  
   - `gradle-connector-tasks.toml` (Java/Kotlin connectors)

## Review guide

1. **`poe-tasks/build-connector-image.sh`** - Main logic: architecture detection, external tool validation, argument parsing, docker build execution
2. **`poe-tasks/poetry-connector-tasks.toml`** - Python connector task definition (note `[tool.poe.tasks.*]` table structure)
3. **`poe-tasks/manifest-only-connector-tasks.toml`** - Manifest connector task definition (note `[tasks.*]` table structure) 
4. **`poe-tasks/gradle-connector-tasks.toml`** - Java/Kotlin connector task definition (note `[tasks.*]` table structure)

**Focus areas:**
- Bash script error handling and external dependencies (docker, yq, poe, git)
- TOML syntax correctness across different table structures
- Architecture detection logic robustness
- Dockerfile path resolution and language mapping accuracy

## User Impact

**Positive:**
- Developers can run `poe image build` from any connector directory to build locally
- Auto-detects platform and uses sensible defaults (`dev-amd64`/`dev-arm64` tags)
- Supports custom tags: `poe image build --tag my-custom-tag`
- Clear emoji-based feedback and prints final image name
- Works for Python, Java, and manifest-only connectors

**Potential issues:**
- Requires external tools (docker with buildx, yq, poe) - script will error with helpful messages if missing
- Repo-root shortcut (`poe connector source-faker image build`) may have path resolution issues in some environments

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

This only adds new functionality without modifying existing workflows. Reverting would simply remove the new `image` tasks and build script.