### PR TITLE
fix(metadata-service): swaps order of ops for generating stale metadata report

### DIFF
--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/stale_metadata_report.py
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/stale_metadata_report.py
@@ -253,8 +253,8 @@ def generate_and_publish_stale_metadata_report(bucket_name: str) -> tuple[bool, 
     Returns:
         tuple[bool, Optional[str]]: A tuple containing a boolean indicating whether the report was published and an optional error message.
     """
-    latest_metadata_versions_on_github = _get_latest_metadata_versions_on_github()
     latest_metadata_entries_on_gcs = _get_latest_metadata_entries_on_gcs(bucket_name)
+    latest_metadata_versions_on_github = _get_latest_metadata_versions_on_github()
     stale_metadata_report = _generate_stale_metadata_report(latest_metadata_versions_on_github, latest_metadata_entries_on_gcs)
     report_published, error_message = _publish_stale_metadata_report(
         stale_metadata_report, len(latest_metadata_versions_on_github), len(latest_metadata_entries_on_gcs)


### PR DESCRIPTION
## What
- Reading metadata from GCS will now occur before reading from Github
	- This prevents cases where the stale metadata report reads an older connector version from GitHub (e.g. v1.0.0), but by the time it checks GCS, a newer version has already been published (e.g. v1.0.1). In that scenario, the report would incorrectly show a diff. The issue arises because reading from GitHub is the slowest step in the report generation process.

## Review guide
1. `stale_metadata_report.py`

## User Impact
- Fewer pings about stale metadata when the up-to-date pipeline is run.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
