### PR TITLE
feat: demonstrate datetime parsing simplification in example connectors (do not merge)

### DIFF
--- a/DATETIME_PARSING_EXAMPLES.md
+++ b/DATETIME_PARSING_EXAMPLES.md
@@ -1,0 +1,51 @@
+# Datetime Parsing Simplification Examples
+
+This document demonstrates how the enhanced DatetimeBasedCursor with robust datetime parsing fallback eliminates the need for explicit `cursor_datetime_formats` in many cases.
+
+## Changes Made
+
+### source-recurly
+**Before:**
+```yaml
+cursor_datetime_formats:
+  - "%Y-%m-%dT%H:%M:%SZ"
+datetime_format: "%Y-%m-%dT%H:%M:%SZ"
+```
+
+**After:**
+```yaml
+datetime_format: "%Y-%m-%dT%H:%M:%SZ"
+```
+
+**Rationale:** The `cursor_datetime_formats` was identical to `datetime_format`, making it redundant. The robust parsing fallback can handle this standard ISO format automatically.
+
+### source-instagram
+**Before:**
+```yaml
+datetime_format: "%Y-%m-%dT%H:%M:%S+00:00"
+cursor_datetime_formats:
+  - "%Y-%m-%dT%H:%M:%S+00:00"
+```
+
+**After:**
+```yaml
+datetime_format: "%Y-%m-%dT%H:%M:%S+00:00"
+```
+
+**Rationale:** The `cursor_datetime_formats` specified a standard ISO8601/RFC3339 format that the robust parsing fallback can handle automatically.
+
+## Benefits
+
+1. **Simplified Configuration:** Eliminates redundant datetime format specifications
+2. **Reduced Errors:** Robust fallback parsing prevents failures on valid datetime formats
+3. **Backward Compatibility:** Existing configurations continue to work unchanged
+4. **Future-Proof:** New datetime formats are automatically supported without configuration changes
+
+## How It Works
+
+The enhanced DatetimeBasedCursor now:
+1. First tries the `datetime_format` (if provided)
+2. Falls back to robust parsing using `ab_datetime_try_parse` for any ISO8601/RFC3339 compliant format
+3. Only raises an error if the datetime string is truly unparseable
+
+This eliminates the need to specify `cursor_datetime_formats` for standard datetime formats while maintaining full backward compatibility.

--- a/airbyte-integrations/connectors/source-instagram/manifest.yaml
+++ b/airbyte-integrations/connectors/source-instagram/manifest.yaml
@@ -597,8 +597,6 @@ definitions:
           datetime: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%SZ') }}"
           datetime_format: "%Y-%m-%dT%H:%M:%SZ"
         datetime_format: "%Y-%m-%dT%H:%M:%S+00:00"
-        cursor_datetime_formats:
-          - "%Y-%m-%dT%H:%M:%S+00:00"
         step: P1D
         cursor_granularity: PT0S
         start_time_option:

--- a/airbyte-integrations/connectors/source-recurly/manifest.yaml
+++ b/airbyte-integrations/connectors/source-recurly/manifest.yaml
@@ -49,8 +49,6 @@ definitions:
       incremental_sync:
         type: DatetimeBasedCursor
         cursor_field: updated_at
-        cursor_datetime_formats:
-          - "%Y-%m-%dT%H:%M:%SZ"
         datetime_format: "%Y-%m-%dT%H:%M:%SZ"
         step: "P{{ config.get('accounts_step_days', 30) }}D"
         cursor_granularity: PT1S
@@ -127,8 +125,6 @@ definitions:
       incremental_sync:
         type: DatetimeBasedCursor
         cursor_field: updated_at
-        cursor_datetime_formats:
-          - "%Y-%m-%dT%H:%M:%SZ"
         datetime_format: "%Y-%m-%dT%H:%M:%SZ"
         start_datetime:
           type: MinMaxDatetime
@@ -203,8 +199,6 @@ definitions:
       incremental_sync:
         type: DatetimeBasedCursor
         cursor_field: created_at
-        cursor_datetime_formats:
-          - "%Y-%m-%dT%H:%M:%SZ"
         datetime_format: "%Y-%m-%dT%H:%M:%SZ"
         start_datetime:
           type: MinMaxDatetime
@@ -270,8 +264,6 @@ definitions:
       incremental_sync:
         type: DatetimeBasedCursor
         cursor_field: updated_at
-        cursor_datetime_formats:
-          - "%Y-%m-%dT%H:%M:%SZ"
         datetime_format: "%Y-%m-%dT%H:%M:%SZ"
         start_datetime:
           type: MinMaxDatetime
@@ -346,8 +338,6 @@ definitions:
       incremental_sync:
         type: DatetimeBasedCursor
         cursor_field: updated_at
-        cursor_datetime_formats:
-          - "%Y-%m-%dT%H:%M:%SZ"
         datetime_format: "%Y-%m-%dT%H:%M:%SZ"
         start_datetime:
           type: MinMaxDatetime
@@ -413,8 +403,6 @@ definitions:
       incremental_sync:
         type: DatetimeBasedCursor
         cursor_field: updated_at
-        cursor_datetime_formats:
-          - "%Y-%m-%dT%H:%M:%SZ"
         datetime_format: "%Y-%m-%dT%H:%M:%SZ"
         start_datetime:
           type: MinMaxDatetime
@@ -480,8 +468,6 @@ definitions:
       incremental_sync:
         type: DatetimeBasedCursor
         cursor_field: updated_at
-        cursor_datetime_formats:
-          - "%Y-%m-%dT%H:%M:%SZ"
         datetime_format: "%Y-%m-%dT%H:%M:%SZ"
         start_datetime:
           type: MinMaxDatetime
@@ -569,8 +555,6 @@ definitions:
       incremental_sync:
         type: DatetimeBasedCursor
         cursor_field: updated_at
-        cursor_datetime_formats:
-          - "%Y-%m-%dT%H:%M:%SZ"
         datetime_format: "%Y-%m-%dT%H:%M:%SZ"
         start_datetime:
           type: MinMaxDatetime
@@ -636,8 +620,6 @@ definitions:
       incremental_sync:
         type: DatetimeBasedCursor
         cursor_field: updated_at
-        cursor_datetime_formats:
-          - "%Y-%m-%dT%H:%M:%SZ"
         datetime_format: "%Y-%m-%dT%H:%M:%SZ"
         start_datetime:
           type: MinMaxDatetime
@@ -703,8 +685,6 @@ definitions:
       incremental_sync:
         type: DatetimeBasedCursor
         cursor_field: updated_at
-        cursor_datetime_formats:
-          - "%Y-%m-%dT%H:%M:%SZ"
         datetime_format: "%Y-%m-%dT%H:%M:%SZ"
         start_datetime:
           type: MinMaxDatetime
@@ -770,8 +750,6 @@ definitions:
       incremental_sync:
         type: DatetimeBasedCursor
         cursor_field: updated_at
-        cursor_datetime_formats:
-          - "%Y-%m-%dT%H:%M:%SZ"
         datetime_format: "%Y-%m-%dT%H:%M:%SZ"
         start_datetime:
           type: MinMaxDatetime
@@ -845,8 +823,6 @@ definitions:
       incremental_sync:
         type: DatetimeBasedCursor
         cursor_field: updated_at
-        cursor_datetime_formats:
-          - "%Y-%m-%dT%H:%M:%SZ"
         datetime_format: "%Y-%m-%dT%H:%M:%SZ"
         start_datetime:
           type: MinMaxDatetime
@@ -912,8 +888,6 @@ definitions:
       incremental_sync:
         type: DatetimeBasedCursor
         cursor_field: updated_at
-        cursor_datetime_formats:
-          - "%Y-%m-%dT%H:%M:%SZ"
         datetime_format: "%Y-%m-%dT%H:%M:%SZ"
         start_datetime:
           type: MinMaxDatetime
@@ -979,8 +953,6 @@ definitions:
       incremental_sync:
         type: DatetimeBasedCursor
         cursor_field: updated_at
-        cursor_datetime_formats:
-          - "%Y-%m-%dT%H:%M:%SZ"
         datetime_format: "%Y-%m-%dT%H:%M:%SZ"
         start_datetime:
           type: MinMaxDatetime
@@ -1046,8 +1018,6 @@ definitions:
       incremental_sync:
         type: DatetimeBasedCursor
         cursor_field: updated_at
-        cursor_datetime_formats:
-          - "%Y-%m-%dT%H:%M:%SZ"
         datetime_format: "%Y-%m-%dT%H:%M:%SZ"
         start_datetime:
           type: MinMaxDatetime
@@ -1121,8 +1091,6 @@ definitions:
       incremental_sync:
         type: DatetimeBasedCursor
         cursor_field: updated_at
-        cursor_datetime_formats:
-          - "%Y-%m-%dT%H:%M:%SZ"
         datetime_format: "%Y-%m-%dT%H:%M:%SZ"
         start_datetime:
           type: MinMaxDatetime
@@ -1191,8 +1159,6 @@ definitions:
       incremental_sync:
         type: DatetimeBasedCursor
         cursor_field: updated_at
-        cursor_datetime_formats:
-          - "%Y-%m-%dT%H:%M:%SZ"
         datetime_format: "%Y-%m-%dT%H:%M:%SZ"
         start_datetime:
           type: MinMaxDatetime


### PR DESCRIPTION
## What

This PR demonstrates the datetime parsing simplification enabled by enhanced DatetimeBasedCursor functionality. It removes redundant `cursor_datetime_formats` specifications from example connectors where they duplicate the `datetime_format` field, relying instead on robust fallback parsing.

**⚠️ This PR is for discussion/demonstration only and should NOT be merged.**

This PR depends on: 
- airbytehq/airbyte-python-cdk#735

## How

The changes remove redundant `cursor_datetime_formats` entries from:
- **source-instagram**: 1 stream where `cursor_datetime_formats: ["%Y-%m-%dT%H:%M:%S+00:00"]` was identical to `datetime_format`
- **source-recurly**: 16 streams where `cursor_datetime_formats: ["%Y-%m-%dT%H:%M:%SZ"]` was identical to `datetime_format`

The enhanced DatetimeBasedCursor now:
1. First tries the `datetime_format` (existing behavior)
2. Falls back to robust parsing using `ab_datetime_try_parse` for ISO8601/RFC3339 formats
3. Only raises errors for truly unparseable datetime strings

## Review guide

1. **`DATETIME_PARSING_EXAMPLES.md`** - Documentation explaining the changes and benefits
2. **`airbyte-integrations/connectors/source-instagram/manifest.yaml`** - Removed redundant cursor format specification 
3. **`airbyte-integrations/connectors/source-recurly/manifest.yaml`** - Removed redundant cursor format specifications from 16 streams

**⚠️ Critical Review Points:**
- [ ] Verify CDK dependency is available before testing
- [ ] Test source-instagram and source-recurly incremental syncs with various datetime formats
- [ ] Confirm fallback parsing produces identical behavior to explicit formats
- [ ] Validate that state cursor values remain consistent

## User Impact

**Positive:**
- Simplified connector configuration (eliminates redundant format specifications)
- Reduced likelihood of datetime parsing errors for standard ISO formats
- Future-proof against new datetime formats without configuration changes

**Potential Risks:**
- Behavioral differences between explicit format parsing and fallback parsing
- Dependency on CDK changes that may introduce parsing inconsistencies

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

The changes only remove redundant configuration - reverting would restore explicit format specifications that provide the same functionality.

---

**Session Info:** Requested by AJ Steers (@aaronsteers) in [Devin session](https://app.devin.ai/sessions/18f0d77923df402bab74cda8d9108655)