### PR TITLE
fix(source-tiktok-marketing): include deleted ads on missing streams

### DIFF
--- a/airbyte-integrations/connectors/source-tiktok-marketing/manifest.yaml
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/manifest.yaml
@@ -524,11 +524,15 @@ definitions:
           dimensions: '{{ parameters["dimensions"] | string }}'
           metrics: '{{ (parameters.get("report_metrics", []) + ["spend", "cpc", "cpm", "impressions", "clicks", "ctr", "reach", "cost_per_1000_reached", "frequency", "video_play_actions", "video_watched_2s", "video_watched_6s", "average_video_play", "average_video_play_per_user", "video_views_p25", "video_views_p50", "video_views_p75", "video_views_p100", "profile_visits", "likes", "comments", "shares", "follows", "clicks_on_music_disc", "real_time_app_install", "real_time_app_install_cost", "app_install"]) | string }}'
           query_lifetime: "true"
-          filters: '{{ [
-            {"filter_value": ["STATUS_ALL"], "field_name": "ad_status", "filter_type": "IN"},
-            {"filter_value": ["STATUS_ALL"], "field_name": "campaign_status", "filter_type": "IN"},
-            {"filter_value": ["STATUS_ALL"], "field_name": "adgroup_status", "filter_type": "IN"},
-            ] | string if config.get("include_deleted", False)}}'
+          filtering: '{{ [{
+              "filter_value": "[\\\"STATUS_ALL\\\"]",
+              "field_name": (
+                "ad_status" if parameters["data_level"] == "AUCTION_AD" else
+                "adgroup_status" if parameters["data_level"] == "AUCTION_ADGROUP" else
+                "campaign_status" if parameters["data_level"] == "AUCTION_CAMPAIGN"
+              ),
+              "filter_type": "IN"
+            }] | string if config.get("include_deleted", False) and parameters["data_level"] in ["AUCTION_AD", "AUCTION_ADGROUP", "AUCTION_CAMPAIGN"]}}'
       paginator:
         $ref: "#/definitions/paginator_page_increment"
         pagination_strategy:
@@ -889,11 +893,15 @@ definitions:
         metrics: '{{ (parameters.get("report_metrics", []) + ["spend", "cpc", "cpm", "impressions", "clicks", "ctr"]) | string  }}'
         start_date: "{{ stream_interval['start_time'] }}"
         end_date: "{{ stream_interval['end_time'] }}"
-        filters: '{{ [
-          {"filter_value": ["STATUS_ALL"], "field_name": "ad_status", "filter_type": "IN"},
-          {"filter_value": ["STATUS_ALL"], "field_name": "campaign_status", "filter_type": "IN"},
-          {"filter_value": ["STATUS_ALL"], "field_name": "adgroup_status", "filter_type": "IN"},
-          ] | string if config.get("include_deleted", False)}}'
+        filtering: '{{ [{
+            "filter_value": "[\\\"STATUS_ALL\\\"]",
+            "field_name": (
+              "ad_status" if parameters["data_level"] == "AUCTION_AD" else
+              "adgroup_status" if parameters["data_level"] == "AUCTION_ADGROUP" else
+              "campaign_status" if parameters["data_level"] == "AUCTION_CAMPAIGN"
+            ),
+            "filter_type": "IN"
+          }] | string if config.get("include_deleted", False) and parameters["data_level"] in ["AUCTION_AD", "AUCTION_ADGROUP", "AUCTION_CAMPAIGN"]}}'
       authenticator:
         $ref: "#/definitions/authenticator"
       request_body_json: {}
@@ -1942,11 +1950,15 @@ definitions:
           start_date: '{{ day_delta(-365, "%Y-%m-%d") if config.get("start_date", "2016-09-01") < day_delta(-365, "%Y-%m-%d") else config["start_date"] }}'
           end_date: "{{ today_utc() }}"
           lifetime: "true"
-          filters: '{{ [
-            {"filter_value": ["STATUS_ALL"], "field_name": "ad_status", "filter_type": "IN"},
-            {"filter_value": ["STATUS_ALL"], "field_name": "campaign_status", "filter_type": "IN"},
-            {"filter_value": ["STATUS_ALL"], "field_name": "adgroup_status", "filter_type": "IN"},
-            ] | string if config.get("include_deleted", False)}}'
+          filtering: '{{ [{
+              "filter_value": "[\\\"STATUS_ALL\\\"]",
+              "field_name": (
+                "ad_status" if parameters["data_level"] == "AUCTION_AD" else
+                "adgroup_status" if parameters["data_level"] == "AUCTION_ADGROUP" else
+                "campaign_status" if parameters["data_level"] == "AUCTION_CAMPAIGN"
+              ),
+              "filter_type": "IN"
+            }] | string if config.get("include_deleted", False) and parameters["data_level"] in ["AUCTION_AD", "AUCTION_ADGROUP", "AUCTION_CAMPAIGN"]}}'
       record_selector:
         $ref: "#/definitions/record_selector"
       paginator:

--- a/airbyte-integrations/connectors/source-tiktok-marketing/metadata.yaml
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/metadata.yaml
@@ -11,7 +11,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 4bfac00d-ce15-44ff-95b9-9e3c3e8fbd35
-  dockerImageTag: 4.8.0
+  dockerImageTag: 4.8.1
   dockerRepository: airbyte/source-tiktok-marketing
   documentationUrl: https://docs.airbyte.com/integrations/sources/tiktok-marketing
   githubIssueLabel: source-tiktok-marketing

--- a/airbyte-integrations/connectors/source-tiktok-marketing/unit_tests/integration/test_advertisers_audience_reports.py
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/unit_tests/integration/test_advertisers_audience_reports.py
@@ -44,10 +44,6 @@ class TestAdvertiserAudienceReportsLifetime(TestCase):
             "page_size": 1000,
             "advertiser_id": self.advertiser_id,
         }
-        if include_deleted:
-            query_params["filters"] = (
-                '[{"filter_value": ["STATUS_ALL"], "field_name": "ad_status", "filter_type": "IN"}, {"filter_value": ["STATUS_ALL"], "field_name": "campaign_status", "filter_type": "IN"}, {"filter_value": ["STATUS_ALL"], "field_name": "adgroup_status", "filter_type": "IN"}]'
-            )
         http_mocker.get(
             HttpRequest(
                 url=f"https://business-api.tiktok.com/open_api/v1.3/report/integrated/get/",

--- a/docs/integrations/sources/tiktok-marketing.md
+++ b/docs/integrations/sources/tiktok-marketing.md
@@ -147,6 +147,7 @@ The connector is restricted by [requests limitation](https://business-api.tiktok
 
 | Version   | Date       | Pull Request                                              | Subject                                                                                                                                                                |
 |:----------|:-----------|:----------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 4.8.1 | 2025-06-29 | [65613](https://github.com/airbytehq/airbyte/pull/65613) | Fix missing deleted data from streams. |
 | 4.8.0 | 2025-06-24 | [62048](https://github.com/airbytehq/airbyte/pull/62048) | Promoting release candidate 4.8.0-rc.1 to a main version. |
 | 4.8.0-rc.1     | 2025-06-16 | [61580](https://github.com/airbytehq/airbyte/pull/61580)  | Convert to manifest-only format                                                                                                                               |
 | 4.7.0     | 2025-03-10 | [55681](https://github.com/airbytehq/airbyte/pull/55681)  | Ads / AdGroups report by country streams                                                                                                                               |


### PR DESCRIPTION
## What
Fixes requests being made with wrong filters, resulting in deleted ads, adgroups and campaigns missing from reports.

## How
Changes some `filters` blocks to `filtering` on the manifest, also fixes their syntax. For example, one cannot filter by `campaign_status` when the level is set to `AUCTION_AD` or `AUCTION_ADGROUP`. Also, `filtering` is not required when the data level is set to `AUCTION_ADVERTISER`.

## Review guide
Examine the documentation over at https://business-api.tiktok.com/portal/docs?id=1738864915188737 and https://business-api.tiktok.com/portal/docs?id=1751443975608321 on how to correctly apply filters, then compare the changes made on `manifest.yaml`.

Tests follow from the appropriate changes.

## User Impact
There was a unexpected behaviour where some streams would show deleted data, but others wouldn't. This fix aims to include deleted data on all streams.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [X] YES 💚
- [ ] NO ❌
