### PR TITLE
ci: update publish workflow to enable publishing enterprise connectors

### DIFF
--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -82,6 +82,7 @@ jobs:
       # Exactly one of the manual/master steps will run, so just OR them together.
       connectors-to-publish: ${{ steps.list-connectors-manual.outputs.connectors-to-publish || steps.list-connectors-master.outputs.connectors-to-publish }}
       release-type: ${{ steps.resolve-release-type.outputs.release-type }}
+      # publishing java tars is not optional if triggered by push to master (in the non-enterprise repo).
       publish-java-tars: ${{ inputs.publish-java-tars || github.event_name == 'push' }}
   publish_connectors:
     name: Publish connectors

--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -54,6 +54,7 @@ jobs:
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
         with:
           fetch-depth: 2 # Required so we can conduct a diff from the previous commit to understand what connectors have changed.
+          submodules: true
       - name: List connectors to publish [manual]
         id: list-connectors-manual
         if: github.event_name == 'workflow_dispatch' || inputs.original-trigger == 'manual'
@@ -97,6 +98,7 @@ jobs:
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
         with:
           fetch-depth: 2 # Required so we can conduct a diff from the previous commit to understand what connectors have changed.
+          submodules: true
 
       - name: Create docker buildx builder
         id: create-buildx-builder
@@ -246,6 +248,7 @@ jobs:
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
         with:
           fetch-depth: 2 # Required so we can conduct a diff from the previous commit to understand what connectors have changed.
+          submodules: true
 
       - name: Set up Python
         # v5

--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -21,6 +21,11 @@ on:
         required: false
         default: false
         type: boolean
+      original-trigger:
+        description: "The original trigger that caused this workflow to be called. The two possible values are `push-to-master` and `manual`"
+        required: false
+        default: "manual"
+        type: string
   workflow_dispatch:
     inputs:
       connectors:
@@ -51,13 +56,13 @@ jobs:
           fetch-depth: 2 # Required so we can conduct a diff from the previous commit to understand what connectors have changed.
       - name: List connectors to publish [manual]
         id: list-connectors-manual
-        if: github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call'
+        if: github.event_name == 'workflow_dispatch' || inputs.original-trigger == 'manual'
         shell: bash
         # When invoked manually, we run on the connectors specified in the input.
         run: echo connectors-to-publish=$(./poe-tasks/parse-connector-name-args.sh ${{ inputs.connectors }}) | tee -a $GITHUB_OUTPUT
       - name: List connectors to publish [On merge to master]
         id: list-connectors-master
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' || inputs.original-trigger == 'push-to-master'
         shell: bash
         # When merging to master, we run on connectors that have changed since the previous commit.
         run: echo connectors-to-publish=$(./poe-tasks/get-modified-connectors.sh --prev-commit --json) | tee -a $GITHUB_OUTPUT
@@ -67,7 +72,7 @@ jobs:
         run: |
           # If workflow is triggered on merge to master, do a main release.
           # If workflow is triggered manually, use the input release type.
-          if [[ "${{ github.event_name }}" == "push" ]]; then
+          if [[ "${{ github.event_name }}" == "push" || "${{ inputs.original-trigger }}" == "push-to-master" ]]; then
             echo "release-type=main-release" | tee -a $GITHUB_OUTPUT
           else
             echo "release-type=${{ inputs.release-type }}" | tee -a $GITHUB_OUTPUT

--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -16,6 +16,11 @@ on:
         description: "Whether to publish as a pre-release (tagged for development) or as a main-release (production)"
         default: pre-release
         type: string
+      publish-java-tars:
+        description: "Whether to publish Java connector tar files."
+        required: false
+        default: false
+        type: boolean
   workflow_dispatch:
     inputs:
       connectors:
@@ -29,6 +34,11 @@ on:
         options:
           - pre-release
           - main-release
+      publish-java-tars:
+        description: "Whether to publish Java connector tar files."
+        required: false
+        default: false
+        type: boolean
 jobs:
   publish_options:
     name: Resolve options for connector publishing
@@ -66,6 +76,7 @@ jobs:
       # Exactly one of the manual/master steps will run, so just OR them together.
       connectors-to-publish: ${{ steps.list-connectors-manual.outputs.connectors-to-publish || steps.list-connectors-master.outputs.connectors-to-publish }}
       release-type: ${{ steps.resolve-release-type.outputs.release-type }}
+      publish-java-tars: ${{ inputs.publish-java-tars || github.event_name == 'push' }}
   publish_connectors:
     name: Publish connectors
     needs: [publish_options]
@@ -178,7 +189,7 @@ jobs:
 
       - name: Publish JVM connectors tar file
         id: publish-JVM-connectors-tar-file
-        if: steps.connector-metadata.outputs.connector-language == 'java'
+        if: steps.connector-metadata.outputs.connector-language == 'java' && needs.publish_options.outputs.publish-java-tars == 'true'
         shell: bash
         run: ./poe-tasks/upload-java-connector-tar-file.sh --name ${{ matrix.connector }} --release-type ${{ needs.publish_options.outputs.release-type }}
         env:

--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -54,7 +54,7 @@ jobs:
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
         with:
           fetch-depth: 2 # Required so we can conduct a diff from the previous commit to understand what connectors have changed.
-          submodules: true
+          submodules: true # Required for the enterprise repo since it uses a submodule that needs to exist for this workflow to run successfully.
       - name: List connectors to publish [manual]
         id: list-connectors-manual
         if: github.event_name == 'workflow_dispatch' || inputs.original-trigger == 'manual'
@@ -99,7 +99,7 @@ jobs:
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
         with:
           fetch-depth: 2 # Required so we can conduct a diff from the previous commit to understand what connectors have changed.
-          submodules: true
+          submodules: true # Required for the enterprise repo since it uses a submodule that needs to exist for this workflow to run successfully.
 
       - name: Create docker buildx builder
         id: create-buildx-builder
@@ -249,7 +249,7 @@ jobs:
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
         with:
           fetch-depth: 2 # Required so we can conduct a diff from the previous commit to understand what connectors have changed.
-          submodules: true
+          submodules: true # Required for the enterprise repo since it uses a submodule that needs to exist for this workflow to run successfully.
 
       - name: Set up Python
         # v5


### PR DESCRIPTION
## What
Updating the connector publishing workflow so that it can be used to publish enterprise connectors as well using workflow call.

## How
- making publishing java tars optional since we don't want to publish enterprise connectors tars.
- The workflow behaves differently depending on whether it is triggered by a push to or a workflow dispatch (manually), and we need a way to have the same behavior when using workflow call. For this, we can now specify if a workflow call was triggered by either a push to master or manually. 
- check out submodules since the enterprise repo needs submodules to exist for it to reuse the publishing workflow.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
