### PR TITLE
Run Up-to-Date pipeline Tuesday mornings

### DIFF
--- a/.github/workflows/connectors_up_to_date.yml
+++ b/.github/workflows/connectors_up_to_date.yml
@@ -5,8 +5,8 @@ concurrency:
 
 on:
   schedule:
-    # Runs everyday Tuesday at 12:00 UTC
-    - cron: "0 12 * * 2"
+    # Runs everyday Tuesday at 10:00 UTC (3:00 PDT / 2:00 PST)
+    - cron: "0 10 * * 2"
   workflow_dispatch:
     inputs:
       connectors-options:

--- a/.github/workflows/connectors_up_to_date.yml
+++ b/.github/workflows/connectors_up_to_date.yml
@@ -5,8 +5,8 @@ concurrency:
 
 on:
   schedule:
-    # Runs everyday Saturday at 12:00 UTC
-    - cron: "0 12 * * 6"
+    # Runs everyday Tuesday at 12:00 UTC
+    - cron: "0 12 * * 2"
   workflow_dispatch:
     inputs:
       connectors-options:


### PR DESCRIPTION
## What
Per our [discussion](https://airbytehq-team.slack.com/archives/C02U9R3AF37/p1756413291969469), moving the CRON for the up-to-date pipeline to run Tuesday mornings (3am PDT). This aims to prevent potential issues with releasing updated connectors from occurring over the weekend.


## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
