### PR TITLE
Pin these destinations with flakey testing to latest CDK.

### DIFF
--- a/airbyte-integrations/connectors/destination-azure-blob-storage/build.gradle
+++ b/airbyte-integrations/connectors/destination-azure-blob-storage/build.gradle
@@ -8,7 +8,7 @@ plugins {
 airbyteBulkConnector {
     core = 'load'
     toolkits = ['load-object-storage', 'load-azure-blob-storage']
-    cdk = 'local'
+    cdk = '0.1.19'
 }
 
 application {

--- a/airbyte-integrations/connectors/destination-bigquery/build.gradle
+++ b/airbyte-integrations/connectors/destination-bigquery/build.gradle
@@ -8,7 +8,7 @@ plugins {
 airbyteBulkConnector {
     core = 'load'
     toolkits = ['load-gcs', 'load-db', 'load-s3']
-    cdk = 'local'
+    cdk = '0.1.19'
 }
 
 java {

--- a/airbyte-integrations/connectors/destination-s3/build.gradle
+++ b/airbyte-integrations/connectors/destination-s3/build.gradle
@@ -8,7 +8,7 @@ plugins {
 airbyteBulkConnector {
     core = 'load'
     toolkits = ['load-s3', 'load-avro', 'load-aws']
-    cdk = 'local'
+    cdk = '0.1.19'
 }
 
 application {

--- a/buildSrc/src/main/groovy/airbyte-bulk-connector.gradle
+++ b/buildSrc/src/main/groovy/airbyte-bulk-connector.gradle
@@ -32,7 +32,7 @@ class AirbyteBulkConnectorExtension {
 
     void setCdk(String cdk) {
         this.cdk = cdk
-        if (cdk != "local" && !cdk.matches("^[0-9]+\\.[0-9]+")) {
+        if (cdk != "local" && !(cdk.matches("^[0-9]+\\.[0-9]+") || cdk.matches("^[0-9]+\\.[0-9]+\\.[0-9]+"))) {
             throw new IllegalArgumentException("'cdk' should be either a well-formed version number or 'local'")
         }
 


### PR DESCRIPTION
## What
Pins the connectors so we can stop running their tests which hang constantly

## Why
The acceptance tests for the speed enabled connectors hang and fail a lot due to concurrency issues, poor setup, etc.

