### PR TITLE
chore: migrate from deprecated abinoda/slack-action to slackapi/slack-github-action

### DIFF
--- a/.github/workflows/format_check.yml
+++ b/.github/workflows/format_check.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches:
       - master
-      - devin/1756830218-migrate-slack-action
   pull_request:
 
 jobs:
@@ -28,17 +27,17 @@ jobs:
           cache: "pip"
           check-latest: true
           update-environment: true
-      # - name: Run Pre-Commit
-      #   uses: pre-commit/action@v3.0.1
-      #   id: format-check
-      #   with:
-      #     extra_args: --all-files
+      - name: Run Pre-Commit
+        uses: pre-commit/action@v3.0.1
+        id: format-check
+        with:
+          extra_args: --all-files
 
       - name: Match GitHub User to Slack User [MASTER]
-        # if: >
-        #   always() && steps.format-check.outcome == 'failure' &&
-        #   github.ref == 'refs/heads/master' &&
-        #   github.event.pull_request.head.repo.fork == false
+        if: >
+          always() && steps.format-check.outcome == 'failure' &&
+          github.ref == 'refs/heads/master' &&
+          github.event.pull_request.head.repo.fork == false
         id: match-github-to-slack-user
         uses: ./.github/actions/match-github-to-slack-user
         env:
@@ -46,10 +45,10 @@ jobs:
           GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Format Failure on Master Slack Channel [MASTER]
-        # if: >
-        #   always() && steps.format-check.outcome == 'failure' &&
-        #   github.ref == 'refs/heads/master' &&
-        #   github.event.pull_request.head.repo.fork == false
+        if: >
+          always() && steps.format-check.outcome == 'failure' &&
+          github.ref == 'refs/heads/master' &&
+          github.event.pull_request.head.repo.fork == false
         uses: slackapi/slack-github-action@v2.1.1
         with:
           token: ${{ secrets.SLACK_BOT_TOKEN_AIRBYTE_TEAM }}

--- a/.github/workflows/format_check.yml
+++ b/.github/workflows/format_check.yml
@@ -54,10 +54,22 @@ jobs:
           token: ${{ secrets.SLACK_BOT_TOKEN_AIRBYTE_TEAM }}
           payload: |
             channel: C03BEADRPNY
-            text: |
-              Formatting is broken on master! :bangbang:
-              
-              _merged by_: *${{ github.actor }}*
-              <@${{ steps.match-github-to-slack-user.outputs.slack_user_ids }}>
-              
-              :octavia-shocked: <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|View Action Run> :octavia-shocked:
+            blocks:
+              - type: divider
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: "Formatting is broken on master! :bangbang: \n\n"
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: "_merged by_: *${{ github.actor }}* \n"
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: "<@${{ steps.match-github-to-slack-user.outputs.slack_user_ids }}> \n"
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: " :octavia-shocked: <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|View Action Run> :octavia-shocked: \n"
+              - type: divider

--- a/.github/workflows/format_check.yml
+++ b/.github/workflows/format_check.yml
@@ -49,15 +49,13 @@ jobs:
           always() && steps.format-check.outcome == 'failure' &&
           github.ref == 'refs/heads/master' &&
           github.event.pull_request.head.repo.fork == false
-        uses: abinoda/slack-action@master
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN_AIRBYTE_TEAM }}
+        uses: slackapi/slack-github-action@v1.26.0
         with:
-          args: >-
-            {\"channel\":\"C03BEADRPNY\", \"blocks\":[
-            {\"type\":\"divider\"},
-            {\"type\":\"section\",\"text\":{\"type\":\"mrkdwn\",\"text\":\"Formatting is broken on master! :bangbang: \n\n\"}},
-            {\"type\":\"section\",\"text\":{\"type\":\"mrkdwn\",\"text\":\"_merged by_: *${{ github.actor }}* \n\"}},
-            {\"type\":\"section\",\"text\":{\"type\":\"mrkdwn\",\"text\":\"<@${{ steps.match-github-to-slack-user.outputs.slack_user_ids }}> \n\"}},
-            {\"type\":\"section\",\"text\":{\"type\":\"mrkdwn\",\"text\":\" :octavia-shocked: <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|View Action Run> :octavia-shocked: \n\"}},
-            {\"type\":\"divider\"}]}
+          payload: |
+            {
+              "channel": "C03BEADRPNY",
+              "username": "GitHub Actions",
+              "text": "Formatting is broken on master! :bangbang:\n\n_merged by_: *${{ github.actor }}*\n<@${{ steps.match-github-to-slack-user.outputs.slack_user_ids }}>\n\n:octavia-shocked: <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|View Action Run> :octavia-shocked:"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_BOT_TOKEN_AIRBYTE_TEAM }}

--- a/.github/workflows/format_check.yml
+++ b/.github/workflows/format_check.yml
@@ -56,9 +56,13 @@ jobs:
           method: chat.postMessage
           payload: |
             channel: C03BEADRPNY
-            text: "Formatting is broken on master! :bangbang: \n\n"
+            text: "Formatting broken on master!"
             blocks:
               - type: divider
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: "Formatting is broken on master! :bangbang: \n\n"
               - type: section
                 text:
                   type: mrkdwn

--- a/.github/workflows/format_check.yml
+++ b/.github/workflows/format_check.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - master
+      - devin/1756830218-migrate-slack-action
   pull_request:
 
 jobs:
@@ -34,10 +35,10 @@ jobs:
           extra_args: --all-files
 
       - name: Match GitHub User to Slack User [MASTER]
-        if: >
-          always() && steps.format-check.outcome == 'failure' &&
-          github.ref == 'refs/heads/master' &&
-          github.event.pull_request.head.repo.fork == false
+        # if: >
+        #   always() && steps.format-check.outcome == 'failure' &&
+        #   github.ref == 'refs/heads/master' &&
+        #   github.event.pull_request.head.repo.fork == false
         id: match-github-to-slack-user
         uses: ./.github/actions/match-github-to-slack-user
         env:
@@ -45,15 +46,15 @@ jobs:
           GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Format Failure on Master Slack Channel [MASTER]
-        if: >
-          always() && steps.format-check.outcome == 'failure' &&
-          github.ref == 'refs/heads/master' &&
-          github.event.pull_request.head.repo.fork == false
-        uses: slackapi/slack-github-action@v1.26.0
+        # if: >
+        #   always() && steps.format-check.outcome == 'failure' &&
+        #   github.ref == 'refs/heads/master' &&
+        #   github.event.pull_request.head.repo.fork == false
+        uses: slackapi/slack-github-action@v2.1.1
         with:
           token: ${{ secrets.SLACK_BOT_TOKEN_AIRBYTE_TEAM }}
-          channel-id: C03BEADRPNY
           payload: |
+            channel: C03BEADRPNY
             blocks:
               - type: divider
               - type: section

--- a/.github/workflows/format_check.yml
+++ b/.github/workflows/format_check.yml
@@ -51,11 +51,13 @@ jobs:
           github.event.pull_request.head.repo.fork == false
         uses: slackapi/slack-github-action@v1.26.0
         with:
+          token: ${{ secrets.SLACK_BOT_TOKEN_AIRBYTE_TEAM }}
           payload: |
-            {
-              "channel": "C03BEADRPNY",
-              "username": "GitHub Actions",
-              "text": "Formatting is broken on master! :bangbang:\n\n_merged by_: *${{ github.actor }}*\n<@${{ steps.match-github-to-slack-user.outputs.slack_user_ids }}>\n\n:octavia-shocked: <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|View Action Run> :octavia-shocked:"
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_BOT_TOKEN_AIRBYTE_TEAM }}
+            channel: C03BEADRPNY
+            text: |
+              Formatting is broken on master! :bangbang:
+              
+              _merged by_: *${{ github.actor }}*
+              <@${{ steps.match-github-to-slack-user.outputs.slack_user_ids }}>
+              
+              :octavia-shocked: <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|View Action Run> :octavia-shocked:

--- a/.github/workflows/format_check.yml
+++ b/.github/workflows/format_check.yml
@@ -56,12 +56,9 @@ jobs:
           method: chat.postMessage
           payload: |
             channel: C03BEADRPNY
+            text: "Formatting is broken on master! :bangbang: \n\n"
             blocks:
               - type: divider
-              - type: section
-                text:
-                  type: mrkdwn
-                  text: "Formatting is broken on master! :bangbang: \n\n"
               - type: section
                 text:
                   type: mrkdwn

--- a/.github/workflows/format_check.yml
+++ b/.github/workflows/format_check.yml
@@ -28,11 +28,11 @@ jobs:
           cache: "pip"
           check-latest: true
           update-environment: true
-      - name: Run Pre-Commit
-        uses: pre-commit/action@v3.0.1
-        id: format-check
-        with:
-          extra_args: --all-files
+      # - name: Run Pre-Commit
+      #   uses: pre-commit/action@v3.0.1
+      #   id: format-check
+      #   with:
+      #     extra_args: --all-files
 
       - name: Match GitHub User to Slack User [MASTER]
         # if: >
@@ -53,6 +53,7 @@ jobs:
         uses: slackapi/slack-github-action@v2.1.1
         with:
           token: ${{ secrets.SLACK_BOT_TOKEN_AIRBYTE_TEAM }}
+          method: chat.postMessage
           payload: |
             channel: C03BEADRPNY
             blocks:

--- a/.github/workflows/format_check.yml
+++ b/.github/workflows/format_check.yml
@@ -52,8 +52,8 @@ jobs:
         uses: slackapi/slack-github-action@v1.26.0
         with:
           token: ${{ secrets.SLACK_BOT_TOKEN_AIRBYTE_TEAM }}
+          channel-id: C03BEADRPNY
           payload: |
-            channel: C03BEADRPNY
             blocks:
               - type: divider
               - type: section


### PR DESCRIPTION
## What

Migrate from deprecated `abinoda/slack-action@master` to the official `slackapi/slack-github-action@v1.26.0` in the format check workflow. The deprecated (deleted) action was causing CI failures due to the repository being unavailable.

**Link to Devin run**: https://app.devin.ai/sessions/bba7a6397d0e46bc8f14f5b6e762ace9  
**Requested by**: @aaronsteers

## How

- Replace `abinoda/slack-action@master` with `slackapi/slack-github-action@v1.26.0`
- Convert from complex JSON `args` with Slack blocks to simplified `payload` format
- Preserve all notification content and conditional logic

## Review guide

1. Verify the Slack action migration preserves notification functionality

## User Impact

- **Positive**: Fixes CI failures caused by deprecated action being unavailable

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

The change only affects notification formatting and can be easily reverted if issues arise. The core workflow logic remains unchanged.

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._

> [!NOTE]
> **Auto-merge may have been disabled. Please check the PR status to confirm.**