### PR TITLE
Auth should not be set to false when SSO is enabled.

### DIFF
--- a/docs/platform/enterprise-setup/chart-v2-enterprise.mdx
+++ b/docs/platform/enterprise-setup/chart-v2-enterprise.mdx
@@ -133,7 +133,7 @@ You can implement single sign on (SSO) with OIDC or new generic OIDC. For more h
 ```yaml title="values.yaml"
 global:
   auth:
-    enabled: false # Set to false if you're using SSO
+    enabled: true
   
     # -- Admin user configuration
     instanceAdmin:
@@ -163,7 +163,7 @@ global:
 ```yaml title="values.yaml"
 global:
   auth:
-    enabled: false # Set to false if you're using SSO
+    enabled: true
   
     # -- Admin user configuration
     instanceAdmin:

--- a/docs/platform/enterprise-setup/chart-v2-enterprise.mdx
+++ b/docs/platform/enterprise-setup/chart-v2-enterprise.mdx
@@ -133,7 +133,6 @@ You can implement single sign on (SSO) with OIDC or new generic OIDC. For more h
 ```yaml title="values.yaml"
 global:
   auth:
-    enabled: true
   
     # -- Admin user configuration
     instanceAdmin:
@@ -163,7 +162,6 @@ global:
 ```yaml title="values.yaml"
 global:
   auth:
-    enabled: true
   
     # -- Admin user configuration
     instanceAdmin:

--- a/docs/platform/enterprise-setup/implementation-guide.md
+++ b/docs/platform/enterprise-setup/implementation-guide.md
@@ -260,7 +260,7 @@ Follow these instructions to add the Airbyte helm repository:
     ```yaml title="values.yaml"
     global:
       auth:
-        enabled: false # Set to false if you're using SSO
+        enabled: true
       
         # -- Admin user configuration
         instanceAdmin:
@@ -290,7 +290,7 @@ Follow these instructions to add the Airbyte helm repository:
     ```yaml title="values.yaml"
     global:
       auth:
-        enabled: false # Set to false if you're using SSO
+        enabled: true
       
         # -- Admin user configuration
         instanceAdmin:

--- a/docs/platform/enterprise-setup/implementation-guide.md
+++ b/docs/platform/enterprise-setup/implementation-guide.md
@@ -260,7 +260,6 @@ Follow these instructions to add the Airbyte helm repository:
     ```yaml title="values.yaml"
     global:
       auth:
-        enabled: true
       
         # -- Admin user configuration
         instanceAdmin:
@@ -290,7 +289,6 @@ Follow these instructions to add the Airbyte helm repository:
     ```yaml title="values.yaml"
     global:
       auth:
-        enabled: true
       
         # -- Admin user configuration
         instanceAdmin:

--- a/docusaurus/platform_versioned_docs/version-1.8/enterprise-setup/chart-v2-enterprise.mdx
+++ b/docusaurus/platform_versioned_docs/version-1.8/enterprise-setup/chart-v2-enterprise.mdx
@@ -133,7 +133,7 @@ You can implement single sign on (SSO) with OIDC or new generic OIDC. For more h
 ```yaml title="values.yaml"
 global:
   auth:
-    enabled: false # Set to false if you're using SSO
+    enabled: true
   
     # -- Admin user configuration
     instanceAdmin:
@@ -163,7 +163,7 @@ global:
 ```yaml title="values.yaml"
 global:
   auth:
-    enabled: false # Set to false if you're using SSO
+    enabled: true
   
     # -- Admin user configuration
     instanceAdmin:

--- a/docusaurus/platform_versioned_docs/version-1.8/enterprise-setup/chart-v2-enterprise.mdx
+++ b/docusaurus/platform_versioned_docs/version-1.8/enterprise-setup/chart-v2-enterprise.mdx
@@ -133,7 +133,6 @@ You can implement single sign on (SSO) with OIDC or new generic OIDC. For more h
 ```yaml title="values.yaml"
 global:
   auth:
-    enabled: true
   
     # -- Admin user configuration
     instanceAdmin:
@@ -163,7 +162,6 @@ global:
 ```yaml title="values.yaml"
 global:
   auth:
-    enabled: true
   
     # -- Admin user configuration
     instanceAdmin:

--- a/docusaurus/platform_versioned_docs/version-1.8/enterprise-setup/implementation-guide.md
+++ b/docusaurus/platform_versioned_docs/version-1.8/enterprise-setup/implementation-guide.md
@@ -260,7 +260,7 @@ Follow these instructions to add the Airbyte helm repository:
     ```yaml title="values.yaml"
     global:
       auth:
-        enabled: false # Set to false if you're using SSO
+        enabled: true
       
         # -- Admin user configuration
         instanceAdmin:
@@ -290,7 +290,7 @@ Follow these instructions to add the Airbyte helm repository:
     ```yaml title="values.yaml"
     global:
       auth:
-        enabled: false # Set to false if you're using SSO
+        enabled: true
       
         # -- Admin user configuration
         instanceAdmin:

--- a/docusaurus/platform_versioned_docs/version-1.8/enterprise-setup/implementation-guide.md
+++ b/docusaurus/platform_versioned_docs/version-1.8/enterprise-setup/implementation-guide.md
@@ -260,7 +260,6 @@ Follow these instructions to add the Airbyte helm repository:
     ```yaml title="values.yaml"
     global:
       auth:
-        enabled: true
       
         # -- Admin user configuration
         instanceAdmin:
@@ -290,7 +289,6 @@ Follow these instructions to add the Airbyte helm repository:
     ```yaml title="values.yaml"
     global:
       auth:
-        enabled: true
       
         # -- Admin user configuration
         instanceAdmin:


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->

This PR fixes a documentation problem where enterprise customers were told to disable auth when SSO was enabled. In reality when OIDC is on, most auth gets turned on anyway.

The Community deploy guide isn't affected, since we never told people to do this.

## How
<!--
* Describe how code changes achieve the solution.
-->

Updated v1.8 and future docs.

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

There are still a couple of places in the docs where we have a sample of disabled auth (mainly the places where we specifically tell people how to turn off auth). However, in general deploy instructions, we no longer set this to false.

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
