### PR TITLE
switch to concurrency-limited, workflow-triggered registry generation

### DIFF
--- a/.github/workflows/generate-connector-registries.yml
+++ b/.github/workflows/generate-connector-registries.yml
@@ -7,11 +7,18 @@ on:
         description: "The git ref to check out from the repository"
         required: false
         type: string
-  schedule:
-    - cron: "*/5 * * * *"
+  workflow_call:
 
 permissions:
   contents: read
+
+concurrency:
+  # Only allow one active run, and one pending run.
+  # This prevents race conditions between multiple runs of this workflow.
+  group: generate-connector-registry
+  # If a new run is triggered while there's already one in-progress,
+  # allow the in-progress run to finish.
+  cancel-in-progress: false
 
 jobs:
   generate-cloud-registry:

--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -329,6 +329,7 @@ jobs:
     name: Generate connector registry
     needs: [publish_connector_registry_entries]
     uses: ./.github/workflows/generate-connector-registries.yml
+    secrets: inherit
 
   notify-failure-slack-channel:
     name: "Notify Slack Channel on Publish Failures"

--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -325,6 +325,11 @@ jobs:
           GCS_CREDENTIALS: ${{ secrets.METADATA_SERVICE_DEV_GCS_CREDENTIALS }}
           SLACK_TOKEN: ${{ secrets.SLACK_BOT_TOKEN_AIRBYTE_TEAM }}
 
+  generate_connector_registry:
+    name: Generate connector registry
+    needs: [publish_connector_registry_entries]
+    uses: ./.github/workflows/generate-connector-registries.yml
+
   notify-failure-slack-channel:
     name: "Notify Slack Channel on Publish Failures"
     runs-on: ubuntu-24.04


### PR DESCRIPTION
## What
Instead of running the registry generation as a cron, run it as a job at the end of publish_connectors.yml

## How
* add a workflow_call trigger to the registries workflow; remove the cron trigger
    * and add a concurrency group
* publish_connectors calls the generate-connector-registries workflow after publish_connector_registry_entries finishes

Tested by manually triggering a few concurrent runs on the publish workflow:
* https://github.com/airbytehq/airbyte/actions/runs/17415304476
    * this workflow started running the registry generation workflow first, and ran normally
* https://github.com/airbytehq/airbyte/actions/runs/17415301861
    * this workflow tried to trigger registry generation while the first workflow was still in progress, so was pending for a while
* https://github.com/airbytehq/airbyte/actions/runs/17415313341
    * this workflow triggered registry generation last. It cancelled registry generation on the second workflow, waited for the first workflow to finish, then ran its own registry generation.

It's a little wonky that the second workflow is marked as cancelled, but it did at least run all the relevant things.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
