### PR TITLE
ci: add support for enterprise connectors docs path

### DIFF
--- a/poe-tasks/lib/util.sh
+++ b/poe-tasks/lib/util.sh
@@ -24,8 +24,14 @@ connector_docs_path() {
     # We then output '\1s/\2.md', which inserts the captured values as `\1` and `\2`.
     # This produces a string like `sources/whatever.md`.
     # Then we prepend the 'docs/integrations/' path.
-    echo $DOCS_BASE_DIR/$(echo $connector_name | sed -r 's@^(source|destination)-(.*)@\1s/\2.md@')
+    docs_path=$DOCS_BASE_DIR/$(echo $connector_name | sed -r 's@^(source|destination)-(.*)@\1s/\2.md@')
   fi
+
+  if ! test -f "$docs_path"; then
+      echo 'Connector documentation file does not exist:' "$docs_path" >&2
+  fi
+
+  echo "$docs_path"
 }
 
 # Expects that you have populated a $connectors variable as an array.

--- a/poe-tasks/lib/util.sh
+++ b/poe-tasks/lib/util.sh
@@ -17,7 +17,7 @@ connector_docs_path() {
   connector_name=$(echo "$connector_name" | sed -r 's/-strict-encrypt$//')
 
   if [ "$is_enterprise" = "true" ]; then
-    echo "$DOCS_BASE_DIR/enterprise-connectors/$connector_name"
+    docs_path="$DOCS_BASE_DIR/enterprise-connectors/$connector_name.md"
   else
     # The regex '^(source|destination)-(.*)' matches strings like source-whatever or destination-something-like-this,
     # capturing the connector type (source/destination) and the connector name (whatever / something-like-this).

--- a/poe-tasks/lib/util.sh
+++ b/poe-tasks/lib/util.sh
@@ -13,14 +13,19 @@ connector_docs_path() {
   # First, remove -strict-encrypt suffix since these connectors
   # share documentation with their base connector
   local connector_name="$1"
+  local is_enterprise="$2"
   connector_name=$(echo "$connector_name" | sed -r 's/-strict-encrypt$//')
 
-  # The regex '^(source|destination)-(.*)' matches strings like source-whatever or destination-something-like-this,
-  # capturing the connector type (source/destination) and the connector name (whatever / something-like-this).
-  # We then output '\1s/\2.md', which inserts the captured values as `\1` and `\2`.
-  # This produces a string like `sources/whatever.md`.
-  # Then we prepend the 'docs/integrations/' path.
-  echo $DOCS_BASE_DIR/$(echo $connector_name | sed -r 's@^(source|destination)-(.*)@\1s/\2.md@')
+  if [ "$is_enterprise" = "true" ]; then
+    echo "$DOCS_BASE_DIR/enterprise-connectors/$connector_name"
+  else
+    # The regex '^(source|destination)-(.*)' matches strings like source-whatever or destination-something-like-this,
+    # capturing the connector type (source/destination) and the connector name (whatever / something-like-this).
+    # We then output '\1s/\2.md', which inserts the captured values as `\1` and `\2`.
+    # This produces a string like `sources/whatever.md`.
+    # Then we prepend the 'docs/integrations/' path.
+    echo $DOCS_BASE_DIR/$(echo $connector_name | sed -r 's@^(source|destination)-(.*)@\1s/\2.md@')
+  fi
 }
 
 # Expects that you have populated a $connectors variable as an array.

--- a/poe-tasks/upload-connector-metadata.sh
+++ b/poe-tasks/upload-connector-metadata.sh
@@ -34,7 +34,7 @@ syft_docker_image="anchore/syft:v1.6.0"
 sbom_extension="spdx.json"
 
 meta="${CONNECTORS_DIR}/${connector}/metadata.yaml"
-is_enterprise=$(yq -r '.data.ab_internal.isEnterprise' // false "$meta")
+is_enterprise=$(yq -r '.data.ab_internal.isEnterprise // false' "$meta")
 doc="$(connector_docs_path $connector $is_enterprise)"
 
 docker_repository=$(yq -r '.data.dockerRepository' "$meta")

--- a/poe-tasks/upload-connector-metadata.sh
+++ b/poe-tasks/upload-connector-metadata.sh
@@ -34,7 +34,8 @@ syft_docker_image="anchore/syft:v1.6.0"
 sbom_extension="spdx.json"
 
 meta="${CONNECTORS_DIR}/${connector}/metadata.yaml"
-doc="$(connector_docs_path $connector)"
+is_enterprise=$(yq -r '.data.ab_internal.isEnterprise' // false "$meta")
+doc="$(connector_docs_path $connector $is_enterprise)"
 
 docker_repository=$(yq -r '.data.dockerRepository' "$meta")
 if test -z "$docker_repository" || test "$docker_repository" = "null"; then

--- a/poe-tasks/upload-connector-metadata.sh
+++ b/poe-tasks/upload-connector-metadata.sh
@@ -34,6 +34,7 @@ syft_docker_image="anchore/syft:v1.6.0"
 sbom_extension="spdx.json"
 
 meta="${CONNECTORS_DIR}/${connector}/metadata.yaml"
+# isEnterprise flag is usually only set on enterprise connectors,
 is_enterprise=$(yq -r '.data.ab_internal.isEnterprise // false' "$meta")
 doc="$(connector_docs_path $connector $is_enterprise)"
 

--- a/poe-tasks/validate-connector-metadata.sh
+++ b/poe-tasks/validate-connector-metadata.sh
@@ -8,6 +8,6 @@ connector=$(get_only_connector)
 
 echo "---- PROCESSING METADATA FOR $connector ----"
 meta="${CONNECTORS_DIR}/${connector}/metadata.yaml"
-is_enterprise=$(yq -r '.data.ab_internal.isEnterprise' // false "$meta")
+is_enterprise=$(yq -r '.data.ab_internal.isEnterprise // false' "$meta")
 doc="$(connector_docs_path $connector $is_enterprise)"
 poetry run --directory $METADATA_SERVICE_PATH metadata_service validate "$meta" "$doc"

--- a/poe-tasks/validate-connector-metadata.sh
+++ b/poe-tasks/validate-connector-metadata.sh
@@ -8,5 +8,6 @@ connector=$(get_only_connector)
 
 echo "---- PROCESSING METADATA FOR $connector ----"
 meta="${CONNECTORS_DIR}/${connector}/metadata.yaml"
-doc="$(connector_docs_path $connector)"
+is_enterprise=$(yq -r '.data.ab_internal.isEnterprise' // false "$meta")
+doc="$(connector_docs_path $connector $is_enterprise)"
 poetry run --directory $METADATA_SERVICE_PATH metadata_service validate "$meta" "$doc"


### PR DESCRIPTION
## What
We're looking to reuse the publish connector workflow for our enterprise connectors. Right now, some scripts in this workflow expect the connector docs to be in a certain path, but enterprise connectors docs don't live in the same path as the other connectors.

## How
We are adding branching logic to the docs path function so that it generates a different path for enterprise connectors

## How did I test this?
Tested here https://github.com/airbytehq/airbyte/actions/runs/17437720863 confirmed that for non-enterprise connectors docs are still being uploaded to gcs correctly

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
