### PR TITLE
log out regression test inputs

### DIFF
--- a/.github/workflows/regression_tests.yml
+++ b/.github/workflows/regression_tests.yml
@@ -57,7 +57,11 @@ jobs:
         run: |
           echo "Job Inputs:"
           echo "  Connector name: ${{ github.event.inputs.connector_name }}"
-          echo "  Connection ID: ${{ github.event.inputs.connection_id }}"
+            if [[ "${{ github.event.inputs.connection_id }}" == "auto" ]]; then
+            echo "  Connection ID: auto"
+            else
+            echo "  Connection ID: $(echo "${{ github.event.inputs.connection_id }}" | cut -c1-8)"
+            fi
           echo "  PR URL: ${{ github.event.inputs.pr_url }}"
           echo "  Streams: ${{ github.event.inputs.streams }}"
           echo "  Should read with state: ${{ github.event.inputs.should_read_with_state }}"

--- a/.github/workflows/regression_tests.yml
+++ b/.github/workflows/regression_tests.yml
@@ -53,6 +53,18 @@ jobs:
     runs-on: linux-24.04-large # Custom runner, defined in GitHub org settings
     timeout-minutes: 360 # 6 hours
     steps:
+      - name: Print inputs
+        run: |
+          echo "Job Inputs:"
+          echo "  Connector name: ${{ github.event.inputs.connector_name }}"
+          echo "  Connection ID: ${{ github.event.inputs.connection_id }}"
+          echo "  PR URL: ${{ github.event.inputs.pr_url }}"
+          echo "  Streams: ${{ github.event.inputs.streams }}"
+          echo "  Should read with state: ${{ github.event.inputs.should_read_with_state }}"
+          echo "  Use local CDK: ${{ github.event.inputs.use_local_cdk }}"
+          echo "  Disable proxy: ${{ github.event.inputs.disable_proxy }}"
+          echo "  Connection subset: ${{ github.event.inputs.connection_subset }}"
+
       - name: Install Python
         id: install_python
         uses: actions/setup-python@v4


### PR DESCRIPTION
## What
It's difficult to assess the parameters used in a prior execution of the regression test tool. This PR logs out all input parameters so that we can more easily notice trends in failure cases.

This is what it looks like:
<img width="508" height="280" alt="image" src="https://github.com/user-attachments/assets/80f9a672-2ef5-4882-97db-f80a19942134" />


## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
