### PR TITLE
feat: implement dataflow cdk artifacts

### DIFF
--- a/airbyte-integrations/connectors/destination-snowflake/build.gradle
+++ b/airbyte-integrations/connectors/destination-snowflake/build.gradle
@@ -19,25 +19,32 @@ java {
 
 application {
     mainClass = 'io.airbyte.integrations.destination.snowflake.SnowflakeDestinationKt'
-    applicationDefaultJvmArgs = ['-XX:+ExitOnOutOfMemoryError', '-XX:MaxRAMPercentage=75.0',
-                                 '-XX:NativeMemoryTracking=detail', '-XX:+UnlockDiagnosticVMOptions',
-                                 '-XX:GCLockerRetryAllocationCount=100',
+// enable when profiling
+    applicationDefaultJvmArgs = [
+            '-XX:+ExitOnOutOfMemoryError',
+            '-XX:MaxRAMPercentage=75.0',
+            '-XX:NativeMemoryTracking=detail',
+            '-XX:+UnlockDiagnosticVMOptions',
+            '-XX:GCLockerRetryAllocationCount=100',
+//            '-XX:NativeMemoryTracking=detail',
 //            '-Djava.rmi.server.hostname=localhost',
 //            '-Dcom.sun.management.jmxremote=true',
 //            '-Dcom.sun.management.jmxremote.port=6000',
 //            '-Dcom.sun.management.jmxremote.rmi.port=6000',
-//            '-Dcom.sun.management.jmxremote.local.only=false',
+//            '-Dcom.sun.management.jmxremote.local.only=false'
 //            '-Dcom.sun.management.jmxremote.authenticate=false',
-//            '-Dcom.sun.management.jmxremote.ssl=false'
+//            '-Dcom.sun.management.jmxremote.ssl=false',
     ]
 
 }
 
-//integrationTestJava {
-//    // This is needed to make the destination-snowflake tests succeed - https://github.com/snowflakedb/snowflake-jdbc/issues/589#issuecomment-983944767
-//    jvmArgs = ["--add-opens=java.base/java.nio=ALL-UNNAMED"]
-//}
-
 dependencies {
     implementation 'net.snowflake:snowflake-jdbc:3.26.1'
+
+    testImplementation "io.mockk:mockk:1.14.5"
+    testImplementation "org.junit.jupiter:junit-jupiter-api:5.13.4"
+    testImplementation "org.junit.jupiter:junit-jupiter:5.13.4"
+    testRuntimeOnly "org.junit.platform:junit-platform-engine:1.13.4"
+    testRuntimeOnly "org.junit.platform:junit-platform-launcher:1.13.4"
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.13.4"
 }

--- a/airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/cdk/WriteOperationV2.kt
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/cdk/WriteOperationV2.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination.snowflake.cdk
+
+import io.airbyte.cdk.Operation
+import io.airbyte.cdk.load.dataflow.DestinationLifecycle
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.micronaut.context.annotation.Primary
+import io.micronaut.context.annotation.Requires
+import jakarta.inject.Singleton
+
+@Primary
+@Singleton
+@Requires(property = Operation.PROPERTY, value = "write")
+class WriteOperationV2(
+    private val d: DestinationLifecycle,
+) : Operation {
+    private val log = KotlinLogging.logger {}
+
+    override fun execute() {
+        log.info { "Running new pipe..." }
+        d.run()
+        log.info { "New pipe complete :tada:" }
+    }
+}

--- a/airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/dataflow/SnowflakeAggregate.kt
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/dataflow/SnowflakeAggregate.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination.snowflake.dataflow
+
+import io.airbyte.cdk.load.dataflow.aggregate.Aggregate
+import io.airbyte.cdk.load.dataflow.transform.RecordDTO
+import io.airbyte.integrations.destination.snowflake.write.load.SnowflakeInsertBuffer
+
+class SnowflakeAggregate(
+    private val buffer: SnowflakeInsertBuffer,
+) : Aggregate {
+    override fun accept(record: RecordDTO) {
+        buffer.accumulate(record.fields)
+    }
+
+    override suspend fun flush() {
+        buffer.flush()
+    }
+}

--- a/airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/dataflow/SnowflakeAggregateFactory.kt
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/dataflow/SnowflakeAggregateFactory.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination.snowflake.dataflow
+
+import io.airbyte.cdk.load.dataflow.aggregate.Aggregate
+import io.airbyte.cdk.load.dataflow.aggregate.AggregateFactory
+import io.airbyte.cdk.load.dataflow.aggregate.StoreKey
+import io.airbyte.cdk.load.orchestration.db.direct_load_table.DirectLoadTableExecutionConfig
+import io.airbyte.cdk.load.write.StreamStateStore
+import io.airbyte.integrations.destination.snowflake.write.load.SnowflakeInsertBuffer
+import jakarta.inject.Singleton
+
+@Singleton
+class SnowflakeAggregateFactory(
+    // TODO - Inject Snowflake client
+    private val streamStateStore: StreamStateStore<DirectLoadTableExecutionConfig>,
+) : AggregateFactory {
+
+    override fun create(key: StoreKey): Aggregate {
+        val tableName = streamStateStore.get(key)!!.tableName
+
+        val buffer = SnowflakeInsertBuffer(tableName = tableName)
+
+        return SnowflakeAggregate(buffer = buffer)
+    }
+}

--- a/airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/write/load/SnowflakeInsertBuffer.kt
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/write/load/SnowflakeInsertBuffer.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination.snowflake.write.load
+
+import io.airbyte.cdk.load.data.AirbyteValue
+import io.airbyte.cdk.load.orchestration.db.TableName
+import io.github.oshai.kotlinlogging.KotlinLogging
+
+private val logger = KotlinLogging.logger {}
+
+class SnowflakeInsertBuffer(
+    private val tableName: TableName,
+// TODO inject client and any other information required to write to Snowflake
+) {
+
+    fun accumulate(recordFields: Map<String, AirbyteValue>) {
+        recordFields.forEach {
+            // TODO implement accumulation
+        }
+    }
+
+    suspend fun flush() {
+        logger.info { "Beginning insert into ${tableName.name}" }
+        // TODO implement flush
+        logger.info { "Finished insert of rows into ${tableName.name}" }
+    }
+}

--- a/airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/write/transform/SnowflakeRecordMunger.kt
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/write/transform/SnowflakeRecordMunger.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination.snowflake.write.transform
+
+import io.airbyte.cdk.load.data.AirbyteValue
+import io.airbyte.cdk.load.dataflow.transform.DataMunger
+import io.airbyte.cdk.load.message.DestinationRecordRaw
+import io.airbyte.cdk.load.orchestration.db.legacy_typing_deduping.TableCatalog
+import jakarta.inject.Singleton
+
+@Singleton
+class SnowflakeRecordMunger(
+    private val catalogInfo: TableCatalog,
+) : DataMunger {
+    override fun transformForDest(msg: DestinationRecordRaw): Map<String, AirbyteValue> {
+        // this actually munges and coerces data
+        val enriched =
+            msg.asEnrichedDestinationRecordAirbyteValue(extractedAtAsTimestampWithTimezone = true)
+
+        val munged =
+            enriched.declaredFields.entries
+                .associate { field ->
+                    val mappedKey = catalogInfo.getMappedColumnName(msg.stream, field.key)!!
+
+                    // TODO do any required data conversion/coercion here
+
+                    mappedKey to field.value.abValue
+                }
+                .toMutableMap()
+
+        // must be called second so it picks up any meta changes from above
+        enriched.airbyteMetaFields.forEach { munged[it.key] = it.value.abValue }
+
+        return munged
+    }
+}

--- a/airbyte-integrations/connectors/destination-snowflake/src/test/kotlin/io/airbyte/integrations/destination/snowflake/cdk/WriteOperationV2Test.kt
+++ b/airbyte-integrations/connectors/destination-snowflake/src/test/kotlin/io/airbyte/integrations/destination/snowflake/cdk/WriteOperationV2Test.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination.snowflake.cdk
+
+import io.airbyte.cdk.load.dataflow.DestinationLifecycle
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Test
+
+internal class WriteOperationV2Test {
+
+    @Test
+    fun testWriteOperation() {
+        val destinationLifecycle = mockk<DestinationLifecycle> { every { run() } returns Unit }
+        val writeOperation = WriteOperationV2(destinationLifecycle)
+        writeOperation.execute()
+        verify(exactly = 1) { destinationLifecycle.run() }
+    }
+}

--- a/airbyte-integrations/connectors/destination-snowflake/src/test/kotlin/io/airbyte/integrations/destination/snowflake/dataflow/SnowflakeAggregateFactoryTest.kt
+++ b/airbyte-integrations/connectors/destination-snowflake/src/test/kotlin/io/airbyte/integrations/destination/snowflake/dataflow/SnowflakeAggregateFactoryTest.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination.snowflake.dataflow
+
+import io.airbyte.cdk.load.command.DestinationStream.Descriptor
+import io.airbyte.cdk.load.dataflow.aggregate.StoreKey
+import io.airbyte.cdk.load.orchestration.db.TableName
+import io.airbyte.cdk.load.orchestration.db.direct_load_table.DirectLoadTableExecutionConfig
+import io.airbyte.cdk.load.write.StreamStateStore
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Test
+
+internal class SnowflakeAggregateFactoryTest {
+    @Test
+    fun testCreatingAggregate() {
+        val descriptor = Descriptor(namespace = "namespace", name = "name")
+        val directLoadTableExecutionConfig =
+            DirectLoadTableExecutionConfig(
+                tableName =
+                    TableName(
+                        namespace = descriptor.namespace!!,
+                        name = descriptor.name,
+                    )
+            )
+        val key = StoreKey(namespace = descriptor.namespace!!, name = descriptor.name)
+        val streamStore = StreamStateStore<DirectLoadTableExecutionConfig>()
+        streamStore.put(descriptor, directLoadTableExecutionConfig)
+        val factory = SnowflakeAggregateFactory(streamStore)
+        val aggregate = factory.create(key)
+        assertNotNull(aggregate)
+        assertEquals(SnowflakeAggregate::class, aggregate::class)
+    }
+}

--- a/airbyte-integrations/connectors/destination-snowflake/src/test/kotlin/io/airbyte/integrations/destination/snowflake/dataflow/SnowflakeAggregateTest.kt
+++ b/airbyte-integrations/connectors/destination-snowflake/src/test/kotlin/io/airbyte/integrations/destination/snowflake/dataflow/SnowflakeAggregateTest.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination.snowflake.dataflow
+
+import io.airbyte.cdk.load.dataflow.transform.RecordDTO
+import io.airbyte.integrations.destination.snowflake.write.load.SnowflakeInsertBuffer
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+
+internal class SnowflakeAggregateTest {
+
+    @Test
+    fun testAcceptingRecordsForAggregation() {
+        val record = mockk<RecordDTO>(relaxed = true)
+        val buffer = mockk<SnowflakeInsertBuffer>(relaxed = true)
+        val aggregate = SnowflakeAggregate(buffer)
+        aggregate.accept(record)
+        verify(exactly = 1) { buffer.accumulate(any()) }
+    }
+
+    @Test
+    fun testFlushingRecordsForAggregation() {
+        val record = mockk<RecordDTO>(relaxed = true)
+        val buffer = mockk<SnowflakeInsertBuffer>(relaxed = true)
+        val aggregate = SnowflakeAggregate(buffer)
+        aggregate.accept(record)
+        runBlocking { aggregate.flush() }
+        coVerify(exactly = 1) { buffer.flush() }
+    }
+}

--- a/airbyte-integrations/connectors/destination-snowflake/src/test/kotlin/io/airbyte/integrations/destination/snowflake/write/transform/SnowflakeRecordMungerTest.kt
+++ b/airbyte-integrations/connectors/destination-snowflake/src/test/kotlin/io/airbyte/integrations/destination/snowflake/write/transform/SnowflakeRecordMungerTest.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination.snowflake.write.transform
+
+import io.airbyte.cdk.load.command.DestinationStream
+import io.airbyte.cdk.load.data.AirbyteValue.Companion.from
+import io.airbyte.cdk.load.data.EnrichedAirbyteValue
+import io.airbyte.cdk.load.data.IntegerType
+import io.airbyte.cdk.load.data.IntegerValue
+import io.airbyte.cdk.load.message.DestinationRecordRaw
+import io.airbyte.cdk.load.message.EnrichedDestinationRecordAirbyteValue
+import io.airbyte.cdk.load.message.Meta
+import io.airbyte.cdk.load.orchestration.db.legacy_typing_deduping.TableCatalog
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+internal class SnowflakeRecordMungerTest {
+
+    @Test
+    fun testTransformation() {
+        val rawId = 1
+        val id = 2
+        val idColumnName = "id"
+        val enrichedAirbyteMetaFields = LinkedHashMap<String, EnrichedAirbyteValue>()
+        val enrichedDeclaredFields = LinkedHashMap<String, EnrichedAirbyteValue>()
+
+        enrichedAirbyteMetaFields[Meta.AirbyteMetaFields.RAW_ID.name] =
+            EnrichedAirbyteValue(
+                abValue = from(rawId),
+                name = Meta.AirbyteMetaFields.RAW_ID.name,
+                type = IntegerType,
+                changes = mutableListOf(),
+                airbyteMetaField = null,
+            )
+
+        enrichedDeclaredFields[idColumnName] =
+            EnrichedAirbyteValue(
+                abValue = from(id),
+                name = idColumnName,
+                type = IntegerType,
+                changes = mutableListOf(),
+                airbyteMetaField = null,
+            )
+
+        val tableCatalog =
+            mockk<TableCatalog> { every { getMappedColumnName(any(), any()) } returnsArgument (1) }
+        val enrichedDestinationRecordAirbyteValue =
+            mockk<EnrichedDestinationRecordAirbyteValue> {
+                every { airbyteMetaFields } returns enrichedAirbyteMetaFields
+                every { declaredFields } returns enrichedDeclaredFields
+            }
+        val destinationRecordRaw =
+            mockk<DestinationRecordRaw> {
+                every { asEnrichedDestinationRecordAirbyteValue(any()) } returns
+                    enrichedDestinationRecordAirbyteValue
+                every { stream } returns mockk<DestinationStream>()
+            }
+        val munger = SnowflakeRecordMunger(catalogInfo = tableCatalog)
+        val transformed = munger.transformForDest(destinationRecordRaw)
+        assertEquals(
+            rawId,
+            (transformed[Meta.AirbyteMetaFields.RAW_ID.name] as IntegerValue).value.toInt()
+        )
+        assertEquals(id, (transformed[idColumnName] as IntegerValue).value.toInt())
+    }
+}


### PR DESCRIPTION
## What
* Initial pass at defining destination bulk load data flow CDK interfaces

## How
* Implement write operation override
* Implement `Aggregate` interface
* Implement `AggregateFactory` interface
* Implement buffer
* Implement `DataMunger` interface

Note that this does not implement the actual upload/Snowflake client interaction -- just the pieces around those.  We will fill those in once we implement the direct loader.  This pass also does not implement any coercion/type changing.  That too will be done as loading is implemented.

## Review guide
1. `WriteOperationV2.kt`
2. `SnowflakeAggregate.kt`
3. `SnowflakeAggregateFactory.kt`
4. `SnowflakeInsertBuffer.kt`
5. `SnowflakeRecordMunger.kt`

## Can this PR be safely reverted and rolled back?
- [X] YES 💚
- [ ] NO ❌
