### PR TITLE
🐛 Source Klaviyo: Fetch Klaviyo profile subscriptions

### DIFF
--- a/airbyte-integrations/connectors/source-klaviyo/manifest.yaml
+++ b/airbyte-integrations/connectors/source-klaviyo/manifest.yaml
@@ -22,8 +22,10 @@ definitions:
           http_method: GET
           request_parameters:
             additional-fields[profile]: >-
-              {{ 'predictive_analytics' if not
-              config['disable_fetching_predictive_analytics'] else '' }}
+              {{
+                'subscriptions' ~
+                (',predictive_analytics' if not config.get('disable_fetching_predictive_analytics') else '')
+              }}
             filter: >-
               greater-than(updated,{{
               stream_interval.start_time }})

--- a/airbyte-integrations/connectors/source-klaviyo/metadata.yaml
+++ b/airbyte-integrations/connectors/source-klaviyo/metadata.yaml
@@ -8,7 +8,7 @@ data:
   definitionId: 95e8cffd-b8c4-4039-968e-d32fb4a69bde
   connectorBuildOptions:
     baseImage: docker.io/airbyte/source-declarative-manifest:6.60.16@sha256:b8126848437ec5a6cff05fb4796fd775450b83e57925674d856a1838a390a28c
-  dockerImageTag: 2.14.22
+  dockerImageTag: 2.15.0
   dockerRepository: airbyte/source-klaviyo
   githubIssueLabel: source-klaviyo
   icon: klaviyo.svg

--- a/docs/integrations/sources/klaviyo.md
+++ b/docs/integrations/sources/klaviyo.md
@@ -95,6 +95,7 @@ contain the `predictive_analytics` field and workflows depending on this field w
 
 | Version | Date       | Pull Request                                               | Subject                                                                                                                                                                |
 |:--------|:-----------|:-----------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 2.15.0 | 2025-09-04 | [65935](https://github.com/airbytehq/airbyte/pull/65935)    | Fix profile subscriptions                                                 |
 | 2.14.22 | 2025-08-25 | [65509](https://github.com/airbytehq/airbyte/pull/65509)       | Fix custom migrations to reference DeclarativeStream Pydantic model instead of runtime component                                                                       |\
 | 2.14.21 | 2025-08-23 | [65317](https://github.com/airbytehq/airbyte/pull/65317)   | Update dependencies                                                                                                                                                    |
 | 2.14.20 | 2025-08-09 | [64618](https://github.com/airbytehq/airbyte/pull/64618)   | Update dependencies                                                                                                                                                    |


### PR DESCRIPTION
## What
Fix missing Klaviyo profile subscriptions reported in the https://github.com/airbytehq/airbyte/issues/55208 issue.

Since Klaviyo API Revision 2024-10-15 returned profile subscriptions are empty by default and require passing a `additional-fields[profile]=subscriptions` parameter in the request to populate it as described in the API documentation: https://developers.klaviyo.com/en/v2024-10-15/reference/get_profiles. When Airbyte connector moved to that API revision in version 2.13.0 profile subscriptions stopped working.

## How
Add `additional-fields[profile]=subscriptions` parameter to profiles stream requests.

## Review guide
Review manifest.yaml changes

## User Impact
profiles subscription field is now populated according to the existing stream schema.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌
