### PR TITLE
Add bytes to dataflow cdk emitted states

### DIFF
--- a/airbyte-cdk/bulk/build.gradle
+++ b/airbyte-cdk/bulk/build.gradle
@@ -6,7 +6,7 @@ import javax.xml.xpath.XPathFactory
 import org.w3c.dom.Document
 
 allprojects {
-    version = "0.1.23"
+    version = "0.1.24"
     apply plugin: 'java-library'
     apply plugin: 'maven-publish'
 

--- a/airbyte-cdk/bulk/changelog.md
+++ b/airbyte-cdk/bulk/changelog.md
@@ -1,5 +1,9 @@
 **Load CDK**
 
+## Version 0.1.24
+
+* **Changed:** Adds byte counts to emitted state stats.
+
 ## Version 0.1.23
 
 * **Changed:** Dataflow CDK fails syncs if there are unflushed states at the end of a sync.

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/pipeline/DataFlowStageIO.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/pipeline/DataFlowStageIO.kt
@@ -15,5 +15,6 @@ data class DataFlowStageIO(
     var partitionKey: PartitionKey? = null,
     var munged: RecordDTO? = null,
     var aggregate: Aggregate? = null,
-    var partitionHistogram: PartitionHistogram? = null,
+    var partitionCountsHistogram: PartitionHistogram? = null,
+    var partitionBytesHistogram: PartitionHistogram? = null,
 )

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/pipeline/PipelineCompletionHandler.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/pipeline/PipelineCompletionHandler.kt
@@ -32,7 +32,7 @@ class PipelineCompletionHandler(
             .map {
                 async {
                     it.value.flush()
-                    stateHistogramStore.acceptFlushedCounts(it.partitionHistogram)
+                    stateHistogramStore.acceptFlushedCounts(it.partitionCountsHistogram)
                 }
             }
             .awaitAll()

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/pipeline/PipelineCompletionHandler.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/pipeline/PipelineCompletionHandler.kt
@@ -33,6 +33,7 @@ class PipelineCompletionHandler(
                 async {
                     it.value.flush()
                     stateHistogramStore.acceptFlushedCounts(it.partitionCountsHistogram)
+                    stateHistogramStore.acceptFlushedBytes(it.partitionBytesHistogram)
                 }
             }
             .awaitAll()

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/stages/AggregateStage.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/stages/AggregateStage.kt
@@ -26,7 +26,8 @@ class AggregateStage(
             outputFlow.emit(
                 DataFlowStageIO(
                     aggregate = next.value,
-                    partitionHistogram = next.partitionHistogram,
+                    partitionCountsHistogram = next.partitionCountsHistogram,
+                    partitionBytesHistogram = next.partitionBytesHistogram,
                 )
             )
             next = store.removeNextComplete(rec.emittedAtMs)

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/stages/StateStage.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/stages/StateStage.kt
@@ -19,9 +19,11 @@ class StateStage(
     private val log = KotlinLogging.logger {}
 
     override suspend fun apply(input: DataFlowStageIO): DataFlowStageIO {
-        val stateUpdates = input.partitionHistogram!!
+        val countUpdates = input.partitionCountsHistogram!!
+        val byteUpdates = input.partitionBytesHistogram!!
 
-        stateHistogramStore.acceptFlushedCounts(stateUpdates)
+        stateHistogramStore.acceptFlushedCounts(countUpdates)
+        stateHistogramStore.acceptFlushedBytes(byteUpdates)
 
         return input
     }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/state/StateHistogram.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/state/StateHistogram.kt
@@ -23,13 +23,11 @@ data class PartitionKey(
 )
 
 open class Histogram<T>(private val map: ConcurrentMap<T, Long> = ConcurrentHashMap()) {
-    fun increment(key: T): Histogram<T> {
-        return this.apply { map.merge(key, 1, Long::plus) }
-    }
+    fun increment(key: T, quantity: Long): Histogram<T> =
+        this.apply { map.merge(key, quantity, Long::plus) }
 
-    fun merge(other: Histogram<T>): Histogram<T> {
-        return this.apply { other.map.forEach { map.merge(it.key, it.value, Long::plus) } }
-    }
+    fun merge(other: Histogram<T>): Histogram<T> =
+        this.apply { other.map.forEach { map.merge(it.key, it.value, Long::plus) } }
 
     fun get(key: T): Long? = map[key]
 

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/state/StateHistogramStore.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/state/StateHistogramStore.kt
@@ -13,9 +13,15 @@ class StateHistogramStore {
     private val flushed: PartitionHistogram = PartitionHistogram(ConcurrentHashMap())
     // Counts of expected messages by state id
     private val expected: StateHistogram = StateHistogram(ConcurrentHashMap())
+    // Counts of flushed bytes by partition id
+    private val bytes: PartitionHistogram = PartitionHistogram(ConcurrentHashMap())
 
     fun acceptFlushedCounts(value: PartitionHistogram): PartitionHistogram {
         return flushed.merge(value)
+    }
+
+    fun acceptFlushedBytes(value: PartitionHistogram): PartitionHistogram {
+        return bytes.merge(value)
     }
 
     fun acceptExpectedCounts(key: StateKey, count: Long): StateHistogram {
@@ -32,8 +38,16 @@ class StateHistogramStore {
         return expectedCount == flushedCount
     }
 
-    fun remove(key: StateKey): Long? {
-        key.partitionKeys.forEach { flushed.remove(it) }
-        return expected.remove(key)
+    fun remove(key: StateKey): StateHistogramStats {
+        val bytes =
+            key.partitionKeys.sumOf {
+                flushed.remove(it)
+                bytes.remove(it) ?: 0
+            }
+        val count = expected.remove(key) ?: 0
+
+        return StateHistogramStats(count, bytes)
     }
 }
+
+data class StateHistogramStats(val count: Long, val bytes: Long)

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/state/StateStore.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/state/StateStore.kt
@@ -39,13 +39,14 @@ class StateStore(
 
         stateSequence.incrementAndGet()
         val msg = states.remove(key)
-        val count = histogramStore.remove(key)!!
+        val stats = histogramStore.remove(key)
 
         // Add count to stats (will always equal source stats)
         // TODO: decide what we want to do with dest stats
         msg!!.updateStats(
-            destinationStats = CheckpointMessage.Stats(count),
-            totalRecords = count,
+            destinationStats = CheckpointMessage.Stats(stats.count),
+            totalRecords = stats.count,
+            totalBytes = stats.bytes,
         )
 
         return msg

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/dataflow/aggregate/AggregateStoreTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/dataflow/aggregate/AggregateStoreTest.kt
@@ -111,7 +111,8 @@ class AggregateStoreTest {
         val entry = aggregateStore.getOrCreate(testKey)
         assertEquals(1L, entry.recordCountTrigger.watermark())
         assertEquals(50L, entry.estimatedBytesTrigger.watermark())
-        assertEquals(1L, entry.partitionHistogram.get(PartitionKey("partition1")))
+        assertEquals(1L, entry.partitionCountsHistogram.get(PartitionKey("partition1")))
+        assertEquals(50L, entry.partitionBytesHistogram.get(PartitionKey("partition1")))
     }
 
     @Test
@@ -210,7 +211,8 @@ class AggregateStoreTest {
         val entry =
             AggregateEntry(
                 value = mockAggregate,
-                partitionHistogram = PartitionHistogram(),
+                partitionCountsHistogram = PartitionHistogram(),
+                partitionBytesHistogram = PartitionHistogram(),
                 stalenessTrigger = TimeTrigger(10000),
                 recordCountTrigger = SizeTrigger(10).apply { repeat(10) { increment(1) } },
                 estimatedBytesTrigger = SizeTrigger(1000)
@@ -224,7 +226,8 @@ class AggregateStoreTest {
         val entry =
             AggregateEntry(
                 value = mockAggregate,
-                partitionHistogram = PartitionHistogram(),
+                partitionCountsHistogram = PartitionHistogram(),
+                partitionBytesHistogram = PartitionHistogram(),
                 stalenessTrigger = TimeTrigger(10000),
                 recordCountTrigger = SizeTrigger(100),
                 estimatedBytesTrigger = SizeTrigger(1000).apply { increment(1000) }
@@ -238,7 +241,8 @@ class AggregateStoreTest {
         val entry =
             AggregateEntry(
                 value = mockAggregate,
-                partitionHistogram = PartitionHistogram(),
+                partitionCountsHistogram = PartitionHistogram(),
+                partitionBytesHistogram = PartitionHistogram(),
                 stalenessTrigger = TimeTrigger(10000),
                 recordCountTrigger = SizeTrigger(100),
                 estimatedBytesTrigger = SizeTrigger(1000)
@@ -252,7 +256,8 @@ class AggregateStoreTest {
         val entry =
             AggregateEntry(
                 value = mockAggregate,
-                partitionHistogram = PartitionHistogram(),
+                partitionCountsHistogram = PartitionHistogram(),
+                partitionBytesHistogram = PartitionHistogram(),
                 stalenessTrigger = TimeTrigger(1000).apply { update(5000) },
                 recordCountTrigger = SizeTrigger(100),
                 estimatedBytesTrigger = SizeTrigger(1000)

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/dataflow/pipeline/PipelineCompletionHandlerTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/dataflow/pipeline/PipelineCompletionHandlerTest.kt
@@ -60,14 +60,16 @@ class PipelineCompletionHandlerTest {
         // Given
         val mockAggregate1 = mockk<Aggregate>()
         val mockAggregate2 = mockk<Aggregate>()
-        val mockHistogram1 = mockk<PartitionHistogram>()
-        val mockHistogram2 = mockk<PartitionHistogram>()
+        val mockCountsHistogram1 = mockk<PartitionHistogram>()
+        val mockCountsHistogram2 = mockk<PartitionHistogram>()
+        val mockBytesHistogram1 = mockk<PartitionHistogram>()
+        val mockBytesHistogram2 = mockk<PartitionHistogram>()
 
         val aggregateEntry1 =
             AggregateEntry(
                 value = mockAggregate1,
-                partitionCountsHistogram = mockHistogram1,
-                partitionBytesHistogram = mockk(),
+                partitionCountsHistogram = mockCountsHistogram1,
+                partitionBytesHistogram = mockBytesHistogram1,
                 stalenessTrigger = mockk(),
                 recordCountTrigger = mockk(),
                 estimatedBytesTrigger = mockk()
@@ -76,8 +78,8 @@ class PipelineCompletionHandlerTest {
         val aggregateEntry2 =
             AggregateEntry(
                 value = mockAggregate2,
-                partitionCountsHistogram = mockHistogram2,
-                partitionBytesHistogram = mockk(),
+                partitionCountsHistogram = mockCountsHistogram2,
+                partitionBytesHistogram = mockBytesHistogram2,
                 stalenessTrigger = mockk(),
                 recordCountTrigger = mockk(),
                 estimatedBytesTrigger = mockk()
@@ -87,6 +89,7 @@ class PipelineCompletionHandlerTest {
         coEvery { mockAggregate1.flush() } just Runs
         coEvery { mockAggregate2.flush() } just Runs
         every { stateHistogramStore.acceptFlushedCounts(any()) } returns mockk()
+        every { stateHistogramStore.acceptFlushedBytes(any()) } returns mockk()
 
         // When
         pipelineCompletionHandler.apply(null)
@@ -94,8 +97,10 @@ class PipelineCompletionHandlerTest {
         // Then
         coVerify(exactly = 1) { mockAggregate1.flush() }
         coVerify(exactly = 1) { mockAggregate2.flush() }
-        verify(exactly = 1) { stateHistogramStore.acceptFlushedCounts(mockHistogram1) }
-        verify(exactly = 1) { stateHistogramStore.acceptFlushedCounts(mockHistogram2) }
+        verify(exactly = 1) { stateHistogramStore.acceptFlushedCounts(mockCountsHistogram1) }
+        verify(exactly = 1) { stateHistogramStore.acceptFlushedCounts(mockCountsHistogram2) }
+        verify(exactly = 1) { stateHistogramStore.acceptFlushedBytes(mockBytesHistogram1) }
+        verify(exactly = 1) { stateHistogramStore.acceptFlushedBytes(mockBytesHistogram2) }
     }
 
     @Test
@@ -115,14 +120,15 @@ class PipelineCompletionHandlerTest {
     fun `apply should handle aggregate flush failure`() = runTest {
         // Given
         val mockAggregate = mockk<Aggregate>()
-        val mockHistogram = mockk<PartitionHistogram>()
+        val mockCountsHistogram = mockk<PartitionHistogram>()
+        val mockBytesHistogram = mockk<PartitionHistogram>()
         val flushException = RuntimeException("Flush failed")
 
         val aggregateEntry =
             AggregateEntry(
                 value = mockAggregate,
-                partitionCountsHistogram = mockHistogram,
-                partitionBytesHistogram = mockk(),
+                partitionCountsHistogram = mockCountsHistogram,
+                partitionBytesHistogram = mockBytesHistogram,
                 stalenessTrigger = mockk(),
                 recordCountTrigger = mockk(),
                 estimatedBytesTrigger = mockk()
@@ -137,5 +143,6 @@ class PipelineCompletionHandlerTest {
         coVerify(exactly = 1) { mockAggregate.flush() }
         // Note: acceptFlushedCounts should not be called if flush fails
         verify(exactly = 0) { stateHistogramStore.acceptFlushedCounts(any()) }
+        verify(exactly = 0) { stateHistogramStore.acceptFlushedBytes(any()) }
     }
 }

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/dataflow/pipeline/PipelineCompletionHandlerTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/dataflow/pipeline/PipelineCompletionHandlerTest.kt
@@ -66,7 +66,8 @@ class PipelineCompletionHandlerTest {
         val aggregateEntry1 =
             AggregateEntry(
                 value = mockAggregate1,
-                partitionHistogram = mockHistogram1,
+                partitionCountsHistogram = mockHistogram1,
+                partitionBytesHistogram = mockk(),
                 stalenessTrigger = mockk(),
                 recordCountTrigger = mockk(),
                 estimatedBytesTrigger = mockk()
@@ -75,7 +76,8 @@ class PipelineCompletionHandlerTest {
         val aggregateEntry2 =
             AggregateEntry(
                 value = mockAggregate2,
-                partitionHistogram = mockHistogram2,
+                partitionCountsHistogram = mockHistogram2,
+                partitionBytesHistogram = mockk(),
                 stalenessTrigger = mockk(),
                 recordCountTrigger = mockk(),
                 estimatedBytesTrigger = mockk()
@@ -119,7 +121,8 @@ class PipelineCompletionHandlerTest {
         val aggregateEntry =
             AggregateEntry(
                 value = mockAggregate,
-                partitionHistogram = mockHistogram,
+                partitionCountsHistogram = mockHistogram,
+                partitionBytesHistogram = mockk(),
                 stalenessTrigger = mockk(),
                 recordCountTrigger = mockk(),
                 estimatedBytesTrigger = mockk()

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/dataflow/stages/AggregateStageTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/dataflow/stages/AggregateStageTest.kt
@@ -45,11 +45,13 @@ class AggregateStageTest {
         val input = DataFlowStageIO(raw = rawMock, munged = recordDto)
 
         val mockAggregate = mockk<Aggregate>()
-        val mockPartitionHistogram = mockk<PartitionHistogram>()
+        val mockCountsHistogram = mockk<PartitionHistogram>()
+        val mockBytesHistogram = mockk<PartitionHistogram>()
         val aggregateEntry =
             mockk<AggregateEntry> {
                 every { value } returns mockAggregate
-                every { partitionHistogram } returns mockPartitionHistogram
+                every { partitionCountsHistogram } returns mockCountsHistogram
+                every { partitionBytesHistogram } returns mockBytesHistogram
             }
         coEvery { store.acceptFor(streamDescriptor, recordDto) } returns Unit
         coEvery { store.removeNextComplete(emittedAtMs) } returns aggregateEntry andThen null
@@ -64,7 +66,8 @@ class AggregateStageTest {
             outputFlow.emit(
                 DataFlowStageIO(
                     aggregate = mockAggregate,
-                    partitionHistogram = mockPartitionHistogram
+                    partitionCountsHistogram = mockCountsHistogram,
+                    partitionBytesHistogram = mockBytesHistogram,
                 )
             )
         }
@@ -119,19 +122,23 @@ class AggregateStageTest {
         val input = DataFlowStageIO(raw = rawMock, munged = recordDto)
 
         val mockAggregate1 = mockk<Aggregate>()
-        val mockPartitionHistogram1 = mockk<PartitionHistogram>()
+        val mockCounts1 = mockk<PartitionHistogram>()
+        val mockBytes1 = mockk<PartitionHistogram>()
         val aggregateEntry1 =
             mockk<AggregateEntry> {
                 every { value } returns mockAggregate1
-                every { partitionHistogram } returns mockPartitionHistogram1
+                every { partitionCountsHistogram } returns mockCounts1
+                every { partitionBytesHistogram } returns mockBytes1
             }
 
         val mockAggregate2 = mockk<Aggregate>()
-        val mockPartitionHistogram2 = mockk<PartitionHistogram>()
+        val mockCounts2 = mockk<PartitionHistogram>()
+        val mockBytes2 = mockk<PartitionHistogram>()
         val aggregateEntry2 =
             mockk<AggregateEntry> {
                 every { value } returns mockAggregate2
-                every { partitionHistogram } returns mockPartitionHistogram2
+                every { partitionCountsHistogram } returns mockCounts2
+                every { partitionBytesHistogram } returns mockBytes2
             }
 
         coEvery { store.acceptFor(streamDescriptor, recordDto) } returns Unit
@@ -150,7 +157,8 @@ class AggregateStageTest {
             outputFlow.emit(
                 DataFlowStageIO(
                     aggregate = mockAggregate1,
-                    partitionHistogram = mockPartitionHistogram1
+                    partitionCountsHistogram = mockCounts1,
+                    partitionBytesHistogram = mockBytes1,
                 )
             )
         }
@@ -158,7 +166,8 @@ class AggregateStageTest {
             outputFlow.emit(
                 DataFlowStageIO(
                     aggregate = mockAggregate2,
-                    partitionHistogram = mockPartitionHistogram2
+                    partitionCountsHistogram = mockCounts2,
+                    partitionBytesHistogram = mockBytes2,
                 )
             )
         }

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/dataflow/stages/StateStageTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/dataflow/stages/StateStageTest.kt
@@ -27,21 +27,34 @@ class StateStageTest {
     @Test
     fun `apply happy path`() = runTest {
         // Arrange
-        val histogram = mockk<PartitionHistogram>()
-        val input = DataFlowStageIO(partitionHistogram = histogram)
+        val countsHistogram = mockk<PartitionHistogram>()
+        val bytesHistogram = mockk<PartitionHistogram>()
+        val input =
+            DataFlowStageIO(
+                partitionCountsHistogram = countsHistogram,
+                partitionBytesHistogram = bytesHistogram,
+            )
 
         // Act
         val result = stateStage.apply(input)
 
         // Assert
-        verify(exactly = 1) { stateStore.acceptFlushedCounts(histogram) }
+        verify(exactly = 1) { stateStore.acceptFlushedCounts(countsHistogram) }
+        verify(exactly = 1) { stateStore.acceptFlushedBytes(bytesHistogram) }
         assertSame(input, result, "The output should be the same as the input object")
     }
 
     @Test
-    fun `apply with null partition histogram throws exception`() = runTest {
-        val input = DataFlowStageIO(partitionHistogram = null)
+    fun `apply with null counts histogram throws exception`() = runTest {
+        val input = DataFlowStageIO(partitionCountsHistogram = null)
         assertFailsWith<NullPointerException> { stateStage.apply(input) }
         verify(exactly = 0) { stateStore.acceptFlushedCounts(any()) }
+    }
+
+    @Test
+    fun `apply with null bytes histogram throws exception`() = runTest {
+        val input = DataFlowStageIO(partitionBytesHistogram = null)
+        assertFailsWith<NullPointerException> { stateStage.apply(input) }
+        verify(exactly = 0) { stateStore.acceptFlushedBytes(any()) }
     }
 }

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/dataflow/state/StateHistogramStoreTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/dataflow/state/StateHistogramStoreTest.kt
@@ -29,7 +29,7 @@ class StateHistogramStoreTest {
         stateHistogramStore.acceptExpectedCounts(stateKey, 5L)
 
         val partitionHistogram = PartitionHistogram(ConcurrentHashMap())
-        repeat(5) { partitionHistogram.increment(partitionKey) }
+        repeat(5) { partitionHistogram.increment(partitionKey, 1) }
         stateHistogramStore.acceptFlushedCounts(partitionHistogram)
 
         // When
@@ -50,9 +50,9 @@ class StateHistogramStoreTest {
         stateHistogramStore.acceptExpectedCounts(stateKey, 15L) // 5 + 3 + 7 = 15
 
         val partitionHistogram = PartitionHistogram(ConcurrentHashMap())
-        repeat(5) { partitionHistogram.increment(partitionKey1) }
-        repeat(3) { partitionHistogram.increment(partitionKey2) }
-        repeat(7) { partitionHistogram.increment(partitionKey3) }
+        repeat(5) { partitionHistogram.increment(partitionKey1, 1) }
+        repeat(3) { partitionHistogram.increment(partitionKey2, 1) }
+        repeat(7) { partitionHistogram.increment(partitionKey3, 1) }
         stateHistogramStore.acceptFlushedCounts(partitionHistogram)
 
         // When
@@ -71,7 +71,7 @@ class StateHistogramStoreTest {
         stateHistogramStore.acceptExpectedCounts(stateKey, 10L)
 
         val partitionHistogram = PartitionHistogram(ConcurrentHashMap())
-        repeat(7) { partitionHistogram.increment(partitionKey) } // Less than expected
+        repeat(7) { partitionHistogram.increment(partitionKey, 1) } // Less than expected
         stateHistogramStore.acceptFlushedCounts(partitionHistogram)
 
         // When
@@ -90,7 +90,7 @@ class StateHistogramStoreTest {
         stateHistogramStore.acceptExpectedCounts(stateKey, 5L)
 
         val partitionHistogram = PartitionHistogram(ConcurrentHashMap())
-        repeat(8) { partitionHistogram.increment(partitionKey) } // More than expected
+        repeat(8) { partitionHistogram.increment(partitionKey, 1) } // More than expected
         stateHistogramStore.acceptFlushedCounts(partitionHistogram)
 
         // When
@@ -107,7 +107,7 @@ class StateHistogramStoreTest {
         val stateKey = StateKey(1L, listOf(partitionKey))
 
         val partitionHistogram = PartitionHistogram(ConcurrentHashMap())
-        repeat(5) { partitionHistogram.increment(partitionKey) }
+        repeat(5) { partitionHistogram.increment(partitionKey, 1) }
         stateHistogramStore.acceptFlushedCounts(partitionHistogram)
 
         // When
@@ -142,7 +142,7 @@ class StateHistogramStoreTest {
         stateHistogramStore.acceptExpectedCounts(stateKey, 3L)
 
         val partitionHistogram = PartitionHistogram(ConcurrentHashMap())
-        repeat(3) { partitionHistogram.increment(partitionKey1) }
+        repeat(3) { partitionHistogram.increment(partitionKey1, 1) }
         // partitionKey2 has no flushed counts, should be treated as 0
         stateHistogramStore.acceptFlushedCounts(partitionHistogram)
 
@@ -164,12 +164,12 @@ class StateHistogramStoreTest {
         stateHistogramStore.acceptExpectedCounts(stateKey, expectedCount)
 
         val partitionHistogram = PartitionHistogram(ConcurrentHashMap())
-        repeat(5) { partitionHistogram.increment(partitionKey1) }
-        repeat(3) { partitionHistogram.increment(partitionKey2) }
+        repeat(5) { partitionHistogram.increment(partitionKey1, 1) }
+        repeat(3) { partitionHistogram.increment(partitionKey2, 1) }
         stateHistogramStore.acceptFlushedCounts(partitionHistogram)
 
         // When
-        val count = stateHistogramStore.remove(stateKey)
+        val count = stateHistogramStore.remove(stateKey).count
 
         // Then
         assertFalse(
@@ -192,9 +192,9 @@ class StateHistogramStoreTest {
         stateHistogramStore.acceptExpectedCounts(stateKey2, 4L)
 
         val partitionHistogram = PartitionHistogram(ConcurrentHashMap())
-        repeat(5) { partitionHistogram.increment(partitionKey1) }
-        repeat(3) { partitionHistogram.increment(partitionKey2) }
-        repeat(4) { partitionHistogram.increment(partitionKey3) }
+        repeat(5) { partitionHistogram.increment(partitionKey1, 1) }
+        repeat(3) { partitionHistogram.increment(partitionKey2, 1) }
+        repeat(4) { partitionHistogram.increment(partitionKey3, 1) }
         stateHistogramStore.acceptFlushedCounts(partitionHistogram)
 
         // When

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/dataflow/state/StateHistogramStoreTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/dataflow/state/StateHistogramStoreTest.kt
@@ -154,28 +154,123 @@ class StateHistogramStoreTest {
     }
 
     @Test
-    fun `remove should delete both expected and flushed counts for state key`() {
+    fun `remove should delete both expected and flushed counts for state key and return stats`() {
         // Given
         val partitionKey1 = PartitionKey("partition-1")
         val partitionKey2 = PartitionKey("partition-2")
         val stateKey = StateKey(1L, listOf(partitionKey1, partitionKey2))
         val expectedCount = 10L
+        val bytes1 = 1000L
+        val bytes2 = 2000L
 
         stateHistogramStore.acceptExpectedCounts(stateKey, expectedCount)
 
-        val partitionHistogram = PartitionHistogram(ConcurrentHashMap())
-        repeat(5) { partitionHistogram.increment(partitionKey1, 1) }
-        repeat(3) { partitionHistogram.increment(partitionKey2, 1) }
-        stateHistogramStore.acceptFlushedCounts(partitionHistogram)
+        val partitionCountsHistogram = PartitionHistogram(ConcurrentHashMap())
+        repeat(5) { partitionCountsHistogram.increment(partitionKey1, 1) }
+        repeat(3) { partitionCountsHistogram.increment(partitionKey2, 1) }
+        stateHistogramStore.acceptFlushedCounts(partitionCountsHistogram)
+
+        val partitionBytesHistogram = PartitionHistogram(ConcurrentHashMap())
+        partitionBytesHistogram.increment(partitionKey1, bytes1)
+        partitionBytesHistogram.increment(partitionKey2, bytes2)
+        stateHistogramStore.acceptFlushedBytes(partitionBytesHistogram)
 
         // When
-        val count = stateHistogramStore.remove(stateKey).count
+        val stats = stateHistogramStore.remove(stateKey)
 
         // Then
+        assertEquals(expectedCount, stats.count)
+        assertEquals(bytes1 + bytes2, stats.bytes)
         assertFalse(
             stateHistogramStore.isComplete(stateKey)
         ) // Should be false due to missing expected count
-        assertEquals(expectedCount, count)
+    }
+
+    @Test
+    fun `remove should handle missing byte counts as zero`() {
+        // Given
+        val partitionKey = PartitionKey("partition-1")
+        val stateKey = StateKey(1L, listOf(partitionKey))
+        val expectedCount = 5L
+
+        stateHistogramStore.acceptExpectedCounts(stateKey, expectedCount)
+
+        val partitionCountsHistogram = PartitionHistogram(ConcurrentHashMap())
+        repeat(5) { partitionCountsHistogram.increment(partitionKey, 1) }
+        stateHistogramStore.acceptFlushedCounts(partitionCountsHistogram)
+
+        // No bytes histogram added - should be treated as 0
+
+        // When
+        val stats = stateHistogramStore.remove(stateKey)
+
+        // Then
+        assertEquals(expectedCount, stats.count)
+        assertEquals(0L, stats.bytes) // No bytes were added
+    }
+
+    @Test
+    fun `remove should sum bytes from multiple partitions correctly`() {
+        // Given
+        val partitionKey1 = PartitionKey("partition-1")
+        val partitionKey2 = PartitionKey("partition-2")
+        val partitionKey3 = PartitionKey("partition-3")
+        val stateKey = StateKey(1L, listOf(partitionKey1, partitionKey2, partitionKey3))
+        val expectedCount = 15L
+        val bytes1 = 5000L
+        val bytes2 = 3000L
+        val bytes3 = 7000L
+
+        stateHistogramStore.acceptExpectedCounts(stateKey, expectedCount)
+
+        val partitionCountsHistogram = PartitionHistogram(ConcurrentHashMap())
+        repeat(7) { partitionCountsHistogram.increment(partitionKey1, 1) }
+        repeat(3) { partitionCountsHistogram.increment(partitionKey2, 1) }
+        repeat(5) { partitionCountsHistogram.increment(partitionKey3, 1) }
+        stateHistogramStore.acceptFlushedCounts(partitionCountsHistogram)
+
+        val partitionBytesHistogram = PartitionHistogram(ConcurrentHashMap())
+        partitionBytesHistogram.increment(partitionKey1, bytes1)
+        partitionBytesHistogram.increment(partitionKey2, bytes2)
+        partitionBytesHistogram.increment(partitionKey3, bytes3)
+        stateHistogramStore.acceptFlushedBytes(partitionBytesHistogram)
+
+        // When
+        val stats = stateHistogramStore.remove(stateKey)
+
+        // Then
+        assertEquals(expectedCount, stats.count)
+        assertEquals(bytes1 + bytes2 + bytes3, stats.bytes)
+    }
+
+    @Test
+    fun `remove should handle partial byte counts for partitions`() {
+        // Given
+        val partitionKey1 = PartitionKey("partition-1")
+        val partitionKey2 = PartitionKey("partition-2")
+        val stateKey = StateKey(1L, listOf(partitionKey1, partitionKey2))
+        val expectedCount = 10L
+        val bytes1 = 2500L
+        // partitionKey2 will have no bytes recorded
+
+        stateHistogramStore.acceptExpectedCounts(stateKey, expectedCount)
+
+        val partitionCountsHistogram = PartitionHistogram(ConcurrentHashMap())
+        repeat(6) { partitionCountsHistogram.increment(partitionKey1, 1) }
+        repeat(4) { partitionCountsHistogram.increment(partitionKey2, 1) }
+        stateHistogramStore.acceptFlushedCounts(partitionCountsHistogram)
+
+        val partitionBytesHistogram = PartitionHistogram(ConcurrentHashMap())
+        partitionBytesHistogram.increment(partitionKey1, bytes1)
+        // No bytes for partitionKey2
+        stateHistogramStore.acceptFlushedBytes(partitionBytesHistogram)
+
+        // When
+        val stats = stateHistogramStore.remove(stateKey)
+
+        // Then
+        assertEquals(expectedCount, stats.count)
+        assertEquals(bytes1, stats.bytes) // Only bytes from partition1
     }
 
     @Test

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/dataflow/state/StateHistogramTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/dataflow/state/StateHistogramTest.kt
@@ -17,7 +17,7 @@ class StateHistogramTest {
         val stateKey = StateKey(1L, listOf(PartitionKey("partition-1")))
 
         // When
-        histogram.increment(stateKey)
+        histogram.increment(stateKey, 1)
 
         // Then
         assertEquals(1L, histogram.get(stateKey))
@@ -30,9 +30,9 @@ class StateHistogramTest {
         val stateKey = StateKey(1L, listOf(PartitionKey("partition-1")))
 
         // When
-        histogram.increment(stateKey)
-        histogram.increment(stateKey)
-        histogram.increment(stateKey)
+        histogram.increment(stateKey, 1)
+        histogram.increment(stateKey, 1)
+        histogram.increment(stateKey, 1)
 
         // Then
         assertEquals(3L, histogram.get(stateKey))
@@ -46,9 +46,9 @@ class StateHistogramTest {
         val stateKey2 = StateKey(2L, listOf(PartitionKey("partition-2")))
 
         // When
-        histogram.increment(stateKey1)
-        histogram.increment(stateKey1)
-        histogram.increment(stateKey2)
+        histogram.increment(stateKey1, 1)
+        histogram.increment(stateKey1, 1)
+        histogram.increment(stateKey2, 1)
 
         // Then
         assertEquals(2L, histogram.get(stateKey1))
@@ -77,13 +77,13 @@ class StateHistogramTest {
         val stateKey2 = StateKey(2L, listOf(PartitionKey("partition-2")))
         val sharedKey = StateKey(3L, listOf(PartitionKey("partition-3")))
 
-        histogram1.increment(stateKey1)
-        histogram1.increment(stateKey1)
-        histogram1.increment(sharedKey)
+        histogram1.increment(stateKey1, 1)
+        histogram1.increment(stateKey1, 1)
+        histogram1.increment(sharedKey, 1)
 
-        histogram2.increment(stateKey2)
-        histogram2.increment(sharedKey)
-        histogram2.increment(sharedKey)
+        histogram2.increment(stateKey2, 1)
+        histogram2.increment(sharedKey, 1)
+        histogram2.increment(sharedKey, 1)
 
         // When
         histogram1.merge(histogram2)
@@ -102,8 +102,8 @@ class StateHistogramTest {
         val stateKey1 = StateKey(1L, listOf(PartitionKey("partition-1")))
         val stateKey2 = StateKey(2L, listOf(PartitionKey("partition-2")))
 
-        histogram1.increment(stateKey1)
-        histogram2.increment(stateKey2)
+        histogram1.increment(stateKey1, 1)
+        histogram2.increment(stateKey2, 1)
 
         // When
         histogram1.merge(histogram2)
@@ -120,8 +120,8 @@ class StateHistogramTest {
         // Given
         val histogram = StateHistogram()
         val stateKey = StateKey(1L, listOf(PartitionKey("partition-1")))
-        histogram.increment(stateKey)
-        histogram.increment(stateKey)
+        histogram.increment(stateKey, 1)
+        histogram.increment(stateKey, 1)
 
         // When
         val removedValue = histogram.remove(stateKey)

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/dataflow/state/StateStoreTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/dataflow/state/StateStoreTest.kt
@@ -30,7 +30,7 @@ class StateStoreTest {
     @BeforeEach
     fun setUp() {
         stateStore = StateStore(keyClient, histogramStore)
-        every { histogramStore.remove(any()) } returns 1L
+        every { histogramStore.remove(any()) } returns StateHistogramStats(1, 1)
     }
 
     @Test

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/dataflow/state/StateStoreTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/dataflow/state/StateStoreTest.kt
@@ -230,7 +230,7 @@ class StateStoreTest {
     fun `getNextComplete should handle different byte and record counts from histogram`() {
         // Given
         val expectedRecordCount = 100L
-        val actualRecordCount = 98L // Slightly different due to filtering/dedup
+        val actualRecordCount = 98L // Slightly different
         val actualByteCount = 32768L
 
         val sourceStats = CheckpointMessage.Stats(recordCount = expectedRecordCount)


### PR DESCRIPTION
## What
Tracks and adds committed bytes to dataflow cdk emitted state stats

## How
Adds another by partition stats histogram for bytes
Passes that data around and sums it up for the states we emit