### PR TITLE
Fix(Source-TikTok-Marketing): Rate Limiting - Add API Budget

### DIFF
--- a/airbyte-integrations/connectors/source-tiktok-marketing/manifest.yaml
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/manifest.yaml
@@ -5776,6 +5776,14 @@ spec:
         default: false
         order: 4
         type: boolean
+      api_requests_per_minute:
+        title: The Maximum Number of API Requests to Send Per Minute For Each Type of API Endpoint.
+        description: Default is 600. Increase this if you have higher limits for this API for faster syncs.
+        minimum: 600
+        default: 600
+        order: 5
+        type: integer
+
   advanced_auth:
     auth_flow_type: oauth2.0
     predicate_key:
@@ -5829,12 +5837,25 @@ spec:
           - secret
 
 # Based on https://developers.tiktok.com/doc/tiktok-api-v2-rate-limit, the rate limiting for the API on all endpoint is 600 requests per minutes.
-# This means 10 requests per second. Assuming response time of 250 ms (there is very little based for this response time though) and a bit of time for processing the responses, it would mean a thread can do ~3 requests per second.
-# If time allows it, we can definitely try to scope this number a bit better empirically.
+# With API Budget, we can set the default concurrency to 20, and the rate limit to 600 requests per minute. This to account for users with higher rate limits.
+# Those users can increase the rate limit in the config by setting api_requests_per_minute to a higher value.
 concurrency_level:
   type: ConcurrencyLevel
-  default_concurrency: "{{ config.get('concurrency_level', 3) }}"
+  default_concurrency: "{{ config.get('concurrency_level', 20) }}"
   max_concurrency: 20
+
+api_budget:
+  type: HTTPAPIBudget
+  status_codes_for_ratelimit_hit: [429]
+  policies:
+    - type: MovingWindowCallRatePolicy
+      rates:
+        - limit: "{{config.get('api_requests_per_minute', 600)}}"
+          interval: "PT1M"  # 1-minute sliding window
+      matchers:
+        - method: "GET"
+          url_base: "{{ config['subdomain'] }}"
+          url_path_pattern: ".*"  # Match all paths
 
 metadata:
   autoImportSchema:

--- a/airbyte-integrations/connectors/source-tiktok-marketing/metadata.yaml
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/metadata.yaml
@@ -11,7 +11,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 4bfac00d-ce15-44ff-95b9-9e3c3e8fbd35
-  dockerImageTag: 4.8.0
+  dockerImageTag: 4.8.1
   dockerRepository: airbyte/source-tiktok-marketing
   documentationUrl: https://docs.airbyte.com/integrations/sources/tiktok-marketing
   githubIssueLabel: source-tiktok-marketing

--- a/docs/integrations/sources/tiktok-marketing.md
+++ b/docs/integrations/sources/tiktok-marketing.md
@@ -147,6 +147,7 @@ The connector is restricted by [requests limitation](https://business-api.tiktok
 
 | Version   | Date       | Pull Request                                              | Subject                                                                                                                                                                |
 |:----------|:-----------|:----------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 4.8.1 | 2025-09-05 | [XXXXX](https://github.com/airbytehq/airbyte/pull/XXXXX) | Add API Budget to prevent Rate-Limiting|
 | 4.8.0 | 2025-06-24 | [62048](https://github.com/airbytehq/airbyte/pull/62048) | Promoting release candidate 4.8.0-rc.1 to a main version. |
 | 4.8.0-rc.1     | 2025-06-16 | [61580](https://github.com/airbytehq/airbyte/pull/61580)  | Convert to manifest-only format                                                                                                                               |
 | 4.7.0     | 2025-03-10 | [55681](https://github.com/airbytehq/airbyte/pull/55681)  | Ads / AdGroups report by country streams                                                                                                                               |

--- a/docs/integrations/sources/tiktok-marketing.md
+++ b/docs/integrations/sources/tiktok-marketing.md
@@ -68,6 +68,24 @@ To access the Sandbox environment:
 6. Click `Set up source`.
 <!-- /env:oss -->
 
+## Configuration
+
+### API Request Rate Limiting
+
+The TikTok Marketing connector includes configurable rate limiting to optimize sync performance while respecting API limits. You can configure the following parameter:
+
+- **API Requests Per Minute**: Controls the maximum number of API requests sent per minute for each type of API endpoint. The default value is 600 requests per minute, which aligns with TikTok's standard rate limits.
+
+If you have higher API limits for your TikTok Marketing account, you can increase this value to achieve faster sync times. To modify this setting:
+
+1. In your connector configuration, locate the "API Requests Per Minute" field
+2. Increase the value above 600 if your account has higher limits
+3. Save the configuration
+
+:::info
+The minimum value is 600 requests per minute. Setting a value higher than your actual API limits may result in rate limiting errors. Contact TikTok support to confirm your account's specific rate limits before increasing this value.
+:::
+
 ## Supported sync modes
 
 The TikTok Marketing source connector supports the following [sync modes](https://docs.airbyte.com/platform/using-airbyte/core-concepts/#connection):
@@ -147,7 +165,7 @@ The connector is restricted by [requests limitation](https://business-api.tiktok
 
 | Version   | Date       | Pull Request                                              | Subject                                                                                                                                                                |
 |:----------|:-----------|:----------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 4.8.1 | 2025-09-05 | [XXXXX](https://github.com/airbytehq/airbyte/pull/XXXXX) | Add API Budget to prevent Rate-Limiting|
+| 4.8.1 | 2025-09-05 | [65957](https://github.com/airbytehq/airbyte/pull/65957) | Add API Budget to prevent Rate-Limiting|
 | 4.8.0 | 2025-06-24 | [62048](https://github.com/airbytehq/airbyte/pull/62048) | Promoting release candidate 4.8.0-rc.1 to a main version. |
 | 4.8.0-rc.1     | 2025-06-16 | [61580](https://github.com/airbytehq/airbyte/pull/61580)  | Convert to manifest-only format                                                                                                                               |
 | 4.7.0     | 2025-03-10 | [55681](https://github.com/airbytehq/airbyte/pull/55681)  | Ads / AdGroups report by country streams                                                                                                                               |


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->
Integration Test fails with our a test account due to rate-limiting, preventing other PRs from being merged without a force-merge for this connector.

The fix is to add the API Budget so we don't exceed the concurrency limit. 
Docs allow 600 per endpoint per minute: https://developers.tiktok.com/doc/tiktok-api-v2-rate-limit

However, users can get more by reaching out to them, so we also need to account for users with higher limits. 
## How
<!--
* Describe how code changes achieve the solution.
-->
Add api budget with a sliding window of 1 minute and limit based on the user config, with the default and minimum set to 600.

I also increased the concurrency level to account for users with higher limits, which shouldn't affect rate limits now that there is an API budget.

## Review guide
<!--
1. `x.py`
2. `y.py`
-->
manifest.yaml, api_budget, concurrency_level, and spec blocks. 
## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->
Users with higher limits may get slightly slower sync, but can update the config to bring their speeds back up. 
## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ X] YES 💚
- [ ] NO ❌
