### PR TITLE
docs: add changelog section to destination salesforce docs

### DIFF
--- a/docs/integrations/enterprise-connectors/destination-salesforce.md
+++ b/docs/integrations/enterprise-connectors/destination-salesforce.md
@@ -208,3 +208,14 @@ For programmatic configuration, use these parameter names:
 - [Salesforce Connected Apps](https://help.salesforce.com/s/articleView?id=sf.connected_app_create.htm)
 - [Rejected Records](/platform/next/move-data/rejected-records)
 
+## Changelog
+
+<details>
+  <summary>Expand to review</summary>
+
+The connector is still incubating, this section only exists to satisfy Airbyte's QA checks.
+
+- 0.0.6
+
+</details>
+


### PR DESCRIPTION
## What
Some tests fail if the connector docs are missing a changelog section. More specifically, enterprise connectors are going to start using the same publishing workflow as other connectors, and that workflow tests if this section exists, so we need to add it where it is missing.

## How
Add a very simple changelog section on the destination salesforce enterprise connector since it is the only one failing on my tests.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
