### PR TITLE
fix: set io dispatchers on discover tests

### DIFF
--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/discover/DiscoverIntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/discover/DiscoverIntegrationTest.kt
@@ -51,7 +51,7 @@ abstract class DiscoverIntegrationTest<T : ConfigurationSpecification>(
                     featureFlags = tc.featureFlags.toTypedArray(),
                     micronautProperties = micronautProperties,
                 )
-            runBlocking((Dispatchers.IO) ) { process.run() }
+            runBlocking((Dispatchers.IO)) { process.run() }
             val messages = process.readMessages()
             val catalogMessages =
                 messages.filter { it.type == AirbyteMessage.Type.DESTINATION_CATALOG }

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/discover/DiscoverIntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/discover/DiscoverIntegrationTest.kt
@@ -15,6 +15,7 @@ import io.airbyte.cdk.load.test.util.NoopDestinationCleaner
 import io.airbyte.cdk.load.test.util.NoopExpectedRecordMapper
 import io.airbyte.protocol.models.v0.AirbyteMessage
 import kotlin.test.assertEquals
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Test
@@ -50,7 +51,7 @@ abstract class DiscoverIntegrationTest<T : ConfigurationSpecification>(
                     featureFlags = tc.featureFlags.toTypedArray(),
                     micronautProperties = micronautProperties,
                 )
-            runBlocking { process.run() }
+            runBlocking((Dispatchers.IO) ) { process.run() }
             val messages = process.readMessages()
             val catalogMessages =
                 messages.filter { it.type == AirbyteMessage.Type.DESTINATION_CATALOG }


### PR DESCRIPTION
## What
Running [SalesforceDiscoverTest](https://github.com/airbytehq/airbyte-enterprise/blob/32ac3f037590f7fcd1ca2455ba6efa7a7cd2c923/airbyte-integrations/connectors/destination-salesforce/src/test-integration/kotlin/SalesforceDiscoverTest.kt#L11) hangs. Based on what we were able to get from using a debugger, It seems like if we don't pass in dispatchers then we get stuck somewhere within this method https://github.com/airbytehq/airbyte/blob/741893caf89335426dc4357ae7845053aa3c130e/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/destination_process/DockerizedDestination.kt#L315-L403
so there's probably some sort of deadlock due to using one same thread on the two `launch` calls. Doing `runBlocking((Dispatchers.IO))` instead fixes the issue since we are now not using the same thread for the two launch calls.

Shout out to @edgao since he figured this out.

## How did I test this?
Tested this locally running `SalesforceDiscoverTest`.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
