### PR TITLE
Change the decimal type

### DIFF
--- a/airbyte-integrations/connectors/destination-clickhouse/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-clickhouse/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: ce0d828e-1dc4-496c-b122-2da42e637e48
-  dockerImageTag: 2.1.0
+  dockerImageTag: 2.1.1
   dockerRepository: airbyte/destination-clickhouse
   githubIssueLabel: destination-clickhouse
   icon: clickhouse.svg

--- a/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/client/ClickhouseAirbyteClient.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/client/ClickhouseAirbyteClient.kt
@@ -114,7 +114,8 @@ class ClickhouseAirbyteClient(
         columnNameMapping: ColumnNameMapping
     ) {
         val properTableName = nameGenerator.getTableName(stream.mappedDescriptor)
-        val tableSchema: TableSchema = client.getTableSchema(properTableName.name, properTableName.namespace)
+        val tableSchema: TableSchema =
+            client.getTableSchema(properTableName.name, properTableName.namespace)
 
         log.info { "Fetch the clickhouse table schema: $tableSchema" }
 
@@ -278,12 +279,13 @@ class ClickhouseAirbyteClient(
         val hasDedupChange =
             !(clickhousePks.containsAll(airbytePks) && airbytePks.containsAll(clickhousePks))
 
-        val alterationSummary = AlterationSummary(
-            added = added,
-            modified = modified,
-            deleted = deleted,
-            hasDedupChange = hasDedupChange
-        )
+        val alterationSummary =
+            AlterationSummary(
+                added = added,
+                modified = modified,
+                deleted = deleted,
+                hasDedupChange = hasDedupChange
+            )
 
         log.info { "Alteration summary: $alterationSummary" }
 

--- a/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/client/ClickhouseAirbyteClient.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/client/ClickhouseAirbyteClient.kt
@@ -7,6 +7,7 @@ package io.airbyte.integrations.destination.clickhouse.client
 import com.clickhouse.client.api.Client as ClickHouseClientRaw
 import com.clickhouse.client.api.command.CommandResponse
 import com.clickhouse.client.api.data_formats.ClickHouseBinaryFormatReader
+import com.clickhouse.client.api.metadata.TableSchema
 import com.clickhouse.client.api.query.QueryResponse
 import com.clickhouse.data.ClickHouseColumn
 import com.clickhouse.data.ClickHouseDataType
@@ -113,7 +114,9 @@ class ClickhouseAirbyteClient(
         columnNameMapping: ColumnNameMapping
     ) {
         val properTableName = nameGenerator.getTableName(stream.mappedDescriptor)
-        val tableSchema = client.getTableSchema(properTableName.name, properTableName.namespace)
+        val tableSchema: TableSchema = client.getTableSchema(properTableName.name, properTableName.namespace)
+
+        log.info { "Fetch the clickhouse table schema: $tableSchema" }
 
         val hasAllAirbyteColumn =
             tableSchema.columns.map { it.columnName }.containsAll(COLUMN_NAMES)
@@ -128,6 +131,8 @@ class ClickhouseAirbyteClient(
         val tableSchemaWithoutAirbyteColumns: List<ClickHouseColumn> =
             tableSchema.columns.filterNot { column -> column.columnName in COLUMN_NAMES }
 
+        log.info { "Found Clickhouse columns: $tableSchemaWithoutAirbyteColumns" }
+
         if (!stream.schema.isObject) {
             val error =
                 "The root of the schema is not an Object which is not expected, the schema changes won't be propagated"
@@ -137,6 +142,8 @@ class ClickhouseAirbyteClient(
 
         val airbyteSchemaWithClickhouseType: Map<String, String> =
             getAirbyteSchemaWithClickhouseType(stream)
+
+        log.info { "Airbyte columns: $airbyteSchemaWithClickhouseType" }
 
         val clickhousePks: List<String> =
             tableSchemaWithoutAirbyteColumns.filterNot { it.isNullable }.map { it.columnName }
@@ -271,12 +278,16 @@ class ClickhouseAirbyteClient(
         val hasDedupChange =
             !(clickhousePks.containsAll(airbytePks) && airbytePks.containsAll(clickhousePks))
 
-        return AlterationSummary(
+        val alterationSummary = AlterationSummary(
             added = added,
             modified = modified,
             deleted = deleted,
             hasDedupChange = hasDedupChange
         )
+
+        log.info { "Alteration summary: $alterationSummary" }
+
+        return alterationSummary
     }
 
     override suspend fun countTable(tableName: TableName): Long? {

--- a/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/client/ClickhouseSqlGenerator.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/client/ClickhouseSqlGenerator.kt
@@ -376,7 +376,7 @@ class ClickhouseSqlGenerator(
 
     companion object {
         const val DATETIME_WITH_PRECISION = "DateTime64(3)"
-        const val DECIMAL_WITH_PRECISION_AND_SCALE = "DECIMAL128(9)"
+        const val DECIMAL_WITH_PRECISION_AND_SCALE = "Decimal(38, 9)"
     }
 }
 

--- a/docs/integrations/destinations/clickhouse.md
+++ b/docs/integrations/destinations/clickhouse.md
@@ -94,7 +94,8 @@ You can also use a pre-existing user but we highly recommend creating a dedicate
 
 | Version    | Date       | Pull Request                                               | Subject                                                                        |
 |:-----------|:-----------|:-----------------------------------------------------------|:-------------------------------------------------------------------------------|
-| 2.1.0 | 2025-09-03 | [65929](https://github.com/airbytehq/airbyte/pull/65929) | Promoting release candidate 2.1.0-rc.2 to a main version. |
+| 2.1.1      | 2025-09-09 | [66134](https://github.com/airbytehq/airbyte/pull/66134) | Update the type we are setting for the number type to `Decimal(38, 9)`.        |
+| 2.1.0      | 2025-09-03 | [65929](https://github.com/airbytehq/airbyte/pull/65929) | Promoting release candidate 2.1.0-rc.2 to a main version.                      |
 | 2.1.0-rc.2 | 2025-08-29 | [\#65626](https://github.com/airbytehq/airbyte/pull/65626) | Pick up CDK fix for rare array OOB exception.                                  |
 | 2.1.0-rc.1 | 2025-08-21 | [\#65144](https://github.com/airbytehq/airbyte/pull/65144) | Migrate to dataflow model.                                                     |
 | 2.0.13     | 2025-08-20 | [\#65125](https://github.com/airbytehq/airbyte/pull/65125) | Update docs permissioning advice.                                              |


### PR DESCRIPTION
## What
In clickhouse `DECIMAL128(9)` is an alias which simplify the type Decimal. It is representing the type `Decimal(38, 9)`.

So when we create column with the type `DECIMAL128(9)` the clickhouse table will have the type `Decimal(38, 9)` (tested on our clickhouse instance).

This is messing with the schema change detection, all the decimal columns are detected a changed column which can create issues.

Additionally this PR is adding logs.

## How
<!--
* Describe how code changes achieve the solution.
-->

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
