### PR TITLE
[Snowflake] Update the SQLGenerator and the SnowflakeAirbyteClient to support the COPY INTO operation

### DIFF
--- a/airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/client/SnowflakeAirbyteClient.kt
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/client/SnowflakeAirbyteClient.kt
@@ -91,6 +91,22 @@ class SnowflakeAirbyteClient(
         }
     }
 
+    suspend fun createFileFormat() {
+        execute(sqlGenerator.createFileFormat())
+    }
+
+    suspend fun createSnowflakeStage(tableName: TableName) {
+        execute(sqlGenerator.createSnowflakeStage(tableName))
+    }
+
+    suspend fun putInStage(tableName: TableName, tempFilePath: String) {
+        execute(sqlGenerator.putInStage(tableName, tempFilePath))
+    }
+
+    suspend fun copyFromStage(tableName: TableName) {
+        execute(sqlGenerator.copyFromStage(tableName))
+    }
+
     internal fun execute(query: String): ResultSet {
         return dataSource.connection.use { connection ->
             connection.createStatement().executeQuery(query)

--- a/airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/client/SnowflakeDirectLoadSqlGenerator.kt
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/client/SnowflakeDirectLoadSqlGenerator.kt
@@ -309,7 +309,9 @@ class SnowflakeDirectLoadSqlGenerator() {
             TRIM_SPACE = TRUE
             ERROR_ON_COLUMN_COUNT_MISMATCH = FALSE
             REPLACE_INVALID_CHARACTERS = TRUE
-        """.trimIndent().andLog()
+        """
+            .trimIndent()
+            .andLog()
     }
 
     private fun buildSnowflakeStageName(tableName: TableName): String {
@@ -321,7 +323,9 @@ class SnowflakeDirectLoadSqlGenerator() {
         return """
             CREATE OR REPLACE STAGE $stageName
                 FILE_FORMAT = my_csv_format;
-        """.trimIndent().andLog()
+        """
+            .trimIndent()
+            .andLog()
     }
 
     fun putInStage(tableName: TableName, tempFilePath: String): String {
@@ -330,12 +334,14 @@ class SnowflakeDirectLoadSqlGenerator() {
             PUT 'file://$tempFilePath' @$stageName
             AUTO_COMPRESS = TRUE
             OVERWRITE = TRUE
-        """.trimIndent().andLog()
+        """
+            .trimIndent()
+            .andLog()
     }
 
     fun copyFromStage(tableName: TableName): String {
         val stageName = buildSnowflakeStageName(tableName)
-        
+
         return """
             COPY INTO ${tableName.toPrettyString(QUOTE)}
             FROM @$stageName
@@ -343,7 +349,9 @@ class SnowflakeDirectLoadSqlGenerator() {
             MATCH_BY_COLUMN_NAME = 'CASE_INSENSITIVE'
             ON_ERROR = 'ABORT_STATEMENT'
             PURGE = TRUE
-        """.trimIndent().andLog()
+        """
+            .trimIndent()
+            .andLog()
     }
 
     companion object {

--- a/airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/client/SnowflakeDirectLoadSqlGenerator.kt
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/client/SnowflakeDirectLoadSqlGenerator.kt
@@ -298,8 +298,25 @@ class SnowflakeDirectLoadSqlGenerator() {
             .andLog()
     }
 
+    fun createFileFormat(): String {
+        return """
+            CREATE OR REPLACE FILE FORMAT $STAGE_FORMAT_NAME
+            TYPE = 'CSV'
+            FIELD_DELIMITER = ','
+            RECORD_DELIMITER = '\n'
+            SKIP_HEADER = 1
+            FIELD_OPTIONALLY_ENCLOSED_BY = '"'
+            TRIM_SPACE = TRUE
+            ERROR_ON_COLUMN_COUNT_MISMATCH = FALSE
+            REPLACE_INVALID_CHARACTERS = TRUE
+        """.trimIndent().andLog()
+    }
+
+    
+
     companion object {
         const val QUOTE: String = "\""
+        const val STAGE_FORMAT_NAME: String = "airbyte_csv_format"
 
         fun toDialectType(type: AirbyteType): String =
             when (type) {

--- a/airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/dataflow/SnowflakeAggregateFactory.kt
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/dataflow/SnowflakeAggregateFactory.kt
@@ -9,19 +9,20 @@ import io.airbyte.cdk.load.dataflow.aggregate.AggregateFactory
 import io.airbyte.cdk.load.dataflow.aggregate.StoreKey
 import io.airbyte.cdk.load.orchestration.db.direct_load_table.DirectLoadTableExecutionConfig
 import io.airbyte.cdk.load.write.StreamStateStore
+import io.airbyte.integrations.destination.snowflake.client.SnowflakeAirbyteClient
 import io.airbyte.integrations.destination.snowflake.write.load.SnowflakeInsertBuffer
 import jakarta.inject.Singleton
 
 @Singleton
 class SnowflakeAggregateFactory(
-    // TODO - Inject Snowflake client
+    private val snowflakeClient: SnowflakeAirbyteClient,
     private val streamStateStore: StreamStateStore<DirectLoadTableExecutionConfig>,
 ) : AggregateFactory {
 
     override fun create(key: StoreKey): Aggregate {
         val tableName = streamStateStore.get(key)!!.tableName
 
-        val buffer = SnowflakeInsertBuffer(tableName = tableName)
+        val buffer = SnowflakeInsertBuffer(tableName = tableName, snowflakeClient = snowflakeClient)
 
         return SnowflakeAggregate(buffer = buffer)
     }

--- a/airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/write/load/SnowflakeInsertBuffer.kt
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/write/load/SnowflakeInsertBuffer.kt
@@ -6,13 +6,14 @@ package io.airbyte.integrations.destination.snowflake.write.load
 
 import io.airbyte.cdk.load.data.AirbyteValue
 import io.airbyte.cdk.load.orchestration.db.TableName
+import io.airbyte.integrations.destination.snowflake.client.SnowflakeAirbyteClient
 import io.github.oshai.kotlinlogging.KotlinLogging
 
 private val logger = KotlinLogging.logger {}
 
 class SnowflakeInsertBuffer(
     private val tableName: TableName,
-// TODO inject client and any other information required to write to Snowflake
+    private val snowflakeClient: SnowflakeAirbyteClient
 ) {
 
     fun accumulate(recordFields: Map<String, AirbyteValue>) {

--- a/airbyte-integrations/connectors/destination-snowflake/src/test/kotlin/io/airbyte/integrations/destination/snowflake/dataflow/SnowflakeAggregateFactoryTest.kt
+++ b/airbyte-integrations/connectors/destination-snowflake/src/test/kotlin/io/airbyte/integrations/destination/snowflake/dataflow/SnowflakeAggregateFactoryTest.kt
@@ -9,6 +9,8 @@ import io.airbyte.cdk.load.dataflow.aggregate.StoreKey
 import io.airbyte.cdk.load.orchestration.db.TableName
 import io.airbyte.cdk.load.orchestration.db.direct_load_table.DirectLoadTableExecutionConfig
 import io.airbyte.cdk.load.write.StreamStateStore
+import io.airbyte.integrations.destination.snowflake.client.SnowflakeAirbyteClient
+import io.mockk.mockk
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Test
@@ -28,7 +30,8 @@ internal class SnowflakeAggregateFactoryTest {
         val key = StoreKey(namespace = descriptor.namespace!!, name = descriptor.name)
         val streamStore = StreamStateStore<DirectLoadTableExecutionConfig>()
         streamStore.put(descriptor, directLoadTableExecutionConfig)
-        val factory = SnowflakeAggregateFactory(streamStore)
+        val snowflakeClient = mockk<SnowflakeAirbyteClient>(relaxed = true)
+        val factory = SnowflakeAggregateFactory(snowflakeClient, streamStore)
         val aggregate = factory.create(key)
         assertNotNull(aggregate)
         assertEquals(SnowflakeAggregate::class, aggregate::class)


### PR DESCRIPTION
## What

This should allow us to have a starting point for the COPY INTO operation that should be happening in the aggregate through the buffer `SnowflakeInsertBuffer`...

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [X] YES 💚
- [ ] NO ❌
