### PR TITLE
ci: stop hardcoding repo in ci checks summary job

### DIFF
--- a/.github/workflows/connector-ci-checks.yml
+++ b/.github/workflows/connector-ci-checks.yml
@@ -494,8 +494,6 @@ jobs:
         if: always() && !cancelled()
         continue-on-error: true
         with:
-          owner: "airbytehq"
-          repositories: "airbyte"
           app-id: ${{ secrets.OCTAVIA_BOT_APP_ID }}
           private-key: ${{ secrets.OCTAVIA_BOT_PRIVATE_KEY }}
 
@@ -506,7 +504,6 @@ jobs:
         uses: LouisBrunner/checks-action@v2.0.0
         with:
           name: "Connector CI Checks Summary" # << Name of the 'Required' check
-          repo: "airbytehq/airbyte" # Post to the main repo, not the fork
           sha: ${{ needs.generate-matrix.outputs.commit-sha }}
           status: completed
           conclusion: ${{ steps.evaluate-status.outputs.result }}


### PR DESCRIPTION
## What
Stop hardcoding repo in ci checks summary job, use current repo instead. Without this, workflow calls from other repos fail. Here's an example:
<img width="596" height="366" alt="Screenshot 2025-09-10 at 5 29 45 PM" src="https://github.com/user-attachments/assets/718abd66-7175-4d1d-ae88-bdbbacb7f3dd" />

## How did I test this?

I tested this in this PR https://github.com/airbytehq/airbyte-enterprise/pull/234 where the aggregate results check is not failing anymore

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
