### PR TITLE
fix: add per-test additional properties for spec integration test

### DIFF
--- a/airbyte-cdk/bulk/build.gradle
+++ b/airbyte-cdk/bulk/build.gradle
@@ -6,7 +6,7 @@ import javax.xml.xpath.XPathFactory
 import org.w3c.dom.Document
 
 allprojects {
-    version = "0.1.26"
+    version = "0.1.27"
     apply plugin: 'java-library'
     apply plugin: 'maven-publish'
 

--- a/airbyte-cdk/bulk/changelog.md
+++ b/airbyte-cdk/bulk/changelog.md
@@ -1,5 +1,9 @@
 **Load CDK**
 
+## Version 0.1.27
+
+* **Changed:** Allow per-test properties for spec integration test
+
 ## Version 0.1.26
 
 * **Changed:** Improve load-azure-blob-storage documentation.

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/command/EnvVarConstants.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/command/EnvVarConstants.kt
@@ -21,6 +21,7 @@ package io.airbyte.cdk.load.command
 data class Property(val micronautProperty: String, val environmentVariable: String)
 
 object EnvVarConstants {
+    val AIRBYTE_EDITION = Property("airbyte.edition", "AIRBYTE_EDITION")
     val FILE_TRANSFER_ENABLED =
         Property(
             "airbyte.destination.core.file-transfer.enabled",

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/spec/SpecTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/spec/SpecTest.kt
@@ -12,6 +12,7 @@ import com.deblock.jsondiff.matcher.StrictJsonObjectPartialMatcher
 import com.deblock.jsondiff.matcher.StrictPrimitivePartialMatcher
 import com.deblock.jsondiff.viewer.OnlyErrorDiffViewer
 import io.airbyte.cdk.command.FeatureFlag
+import io.airbyte.cdk.load.command.EnvVarConstants.AIRBYTE_EDITION
 import io.airbyte.cdk.load.command.Property
 import io.airbyte.cdk.load.test.util.FakeDataDumper
 import io.airbyte.cdk.load.test.util.IntegrationTest
@@ -50,16 +51,24 @@ abstract class SpecTest(
 
     @Test
     fun testSpecOss() {
-        testSpec("expected-spec-oss.json")
+        testSpec(
+            expectedSpecFilename = "expected-spec-oss.json",
+            additionalProperties = mapOf(AIRBYTE_EDITION to "OSS")
+        )
     }
 
     @Test
     fun testSpecCloud() {
-        testSpec("expected-spec-cloud.json", FeatureFlag.AIRBYTE_CLOUD_DEPLOYMENT)
+        testSpec(
+            expectedSpecFilename = "expected-spec-cloud.json",
+            additionalProperties = mapOf(AIRBYTE_EDITION to "CLOUD"),
+            featureFlags = arrayOf(FeatureFlag.AIRBYTE_CLOUD_DEPLOYMENT)
+        )
     }
 
     private fun testSpec(
         expectedSpecFilename: String,
+        additionalProperties: Map<Property, String> = emptyMap(),
         vararg featureFlags: FeatureFlag,
     ) {
         val expectedSpecPath = testResourcesPath.resolve(expectedSpecFilename)
@@ -73,7 +82,7 @@ abstract class SpecTest(
             destinationProcessFactory.createDestinationProcess(
                 "spec",
                 featureFlags = featureFlags,
-                micronautProperties = micronautProperties
+                micronautProperties = micronautProperties + additionalProperties,
             )
         runBlocking { process.run() }
         val messages = process.readMessages()


### PR DESCRIPTION
## What
* Ensure that the `AIRBYTE_EDITION` env var can be set on spec integration tests

## How
* Modify the internal method to take in additional per-test properties to add to the micronaut properties

## Review guide
1. `SpecTest.kt`
2. `EnvVarConstants.kt`

## User Impact

## Can this PR be safely reverted and rolled back?
- [X] YES 💚
- [ ] NO ❌
