### PR TITLE
[Snowflake] Adding the SnowflakeWriter

### DIFF
--- a/airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/write/SnowflakeWriter.kt
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/write/SnowflakeWriter.kt
@@ -4,14 +4,72 @@
 
 package io.airbyte.integrations.destination.snowflake.write
 
+import io.airbyte.cdk.SystemErrorException
 import io.airbyte.cdk.load.command.DestinationStream
+import io.airbyte.cdk.load.orchestration.db.DatabaseInitialStatusGatherer
+import io.airbyte.cdk.load.orchestration.db.TempTableNameGenerator
+import io.airbyte.cdk.load.orchestration.db.direct_load_table.DirectLoadInitialStatus
+import io.airbyte.cdk.load.orchestration.db.direct_load_table.DirectLoadTableAppendStreamLoader
+import io.airbyte.cdk.load.orchestration.db.direct_load_table.DirectLoadTableAppendTruncateStreamLoader
+import io.airbyte.cdk.load.orchestration.db.direct_load_table.DirectLoadTableExecutionConfig
+import io.airbyte.cdk.load.orchestration.db.legacy_typing_deduping.TableCatalog
 import io.airbyte.cdk.load.write.DestinationWriter
 import io.airbyte.cdk.load.write.StreamLoader
+import io.airbyte.cdk.load.write.StreamStateStore
+import io.airbyte.integrations.destination.snowflake.client.SnowflakeAirbyteClient
 import jakarta.inject.Singleton
 
 @Singleton
-class SnowflakeWriter : DestinationWriter {
+class SnowflakeWriter(
+    private val names: TableCatalog,
+    private val stateGatherer: DatabaseInitialStatusGatherer<DirectLoadInitialStatus>,
+    private val streamStateStore: StreamStateStore<DirectLoadTableExecutionConfig>,
+    private val snowflakeClient: SnowflakeAirbyteClient,
+    private val tempTableNameGenerator: TempTableNameGenerator,
+) : DestinationWriter {
+    private lateinit var initialStatuses: Map<DestinationStream, DirectLoadInitialStatus>
+
+    override suspend fun setup() {
+        names.values
+            .map { (tableNames, _) -> tableNames.finalTableName!!.namespace }
+            .forEach { snowflakeClient.createNamespace(it) }
+
+        initialStatuses = stateGatherer.gatherInitialStatus(names)
+    }
+
     override fun createStreamLoader(stream: DestinationStream): StreamLoader {
-        TODO("Not yet implemented")
+        val initialStatus = initialStatuses[stream]!!
+        val tableNameInfo = names[stream]!!
+        val realTableName = tableNameInfo.tableNames.finalTableName!!
+        val tempTableName = tempTableNameGenerator.generate(realTableName)
+        val columnNameMapping = tableNameInfo.columnNameMapping
+        return when (stream.minimumGenerationId) {
+            0L ->
+                DirectLoadTableAppendStreamLoader(
+                    stream,
+                    initialStatus,
+                    realTableName = realTableName,
+                    tempTableName = tempTableName,
+                    columnNameMapping,
+                    snowflakeClient,
+                    snowflakeClient,
+                    streamStateStore,
+                )
+            stream.generationId ->
+                DirectLoadTableAppendTruncateStreamLoader(
+                    stream,
+                    initialStatus,
+                    realTableName = realTableName,
+                    tempTableName = tempTableName,
+                    columnNameMapping,
+                    snowflakeClient,
+                    snowflakeClient,
+                    streamStateStore,
+                )
+            else ->
+                throw SystemErrorException(
+                    "Cannot execute a hybrid refresh - current generation ${stream.generationId}; minimum generation ${stream.minimumGenerationId}"
+                )
+        }
     }
 }


### PR DESCRIPTION
## What

This PR introduces the `SnowflakeWriter` class.
This will need to use the `ensureSchemaMatches` from the client which does not exists at the moment.
So this will fail until we have that

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [X] YES 💚
- [ ] NO ❌
