### PR TITLE
feat(source-facebook-marketing): classify error subcode `2446289` as `config_error`

### DIFF
--- a/airbyte-integrations/connectors/source-facebook-marketing/metadata.yaml
+++ b/airbyte-integrations/connectors/source-facebook-marketing/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: e7778cfc-e97c-4458-9ecb-b4f2bba8946c
-  dockerImageTag: 4.0.0
+  dockerImageTag: 4.0.1
   dockerRepository: airbyte/source-facebook-marketing
   documentationUrl: https://docs.airbyte.com/integrations/sources/facebook-marketing
   githubIssueLabel: source-facebook-marketing

--- a/airbyte-integrations/connectors/source-facebook-marketing/pyproject.toml
+++ b/airbyte-integrations/connectors/source-facebook-marketing/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "4.0.0"
+version = "4.0.1"
 name = "source-facebook-marketing"
 description = "Source implementation for Facebook Marketing."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/streams/common.py
+++ b/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/streams/common.py
@@ -200,7 +200,7 @@ def traced_exception(fb_exception: FacebookRequestError):
         friendly_msg = "Please set the start date of your sync to be within the last 3 years."
     elif (fb_exception.api_error_code(), fb_exception.api_error_subcode()) in FACEBOOK_CONFIG_ERRORS_TO_CATCH:
         failure_type = FailureType.config_error
-        friendly_msg = msg  # TODO make sure this is outputting the full verbose message to the user
+        friendly_msg = msg
     elif fb_exception.api_error_code() in FACEBOOK_RATE_LIMIT_ERROR_CODES:
         return AirbyteTracedException(
             message="The maximum number of requests on the Facebook API has been reached. See https://developers.facebook.com/docs/graph-api/overview/rate-limiting/ for more information",

--- a/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/streams/common.py
+++ b/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/streams/common.py
@@ -148,6 +148,12 @@ def deep_merge(a: Any, b: Any) -> Any:
         return a if b is None else b
 
 
+FACEBOOK_CONFIG_ERRORS_TO_CATCH = [  # list of tuples (code, error_subcode)
+    (100, 2446289),
+    (100, 1487534),
+]
+
+
 def traced_exception(fb_exception: FacebookRequestError):
     """Add user-friendly message for FacebookRequestError
 
@@ -192,6 +198,9 @@ def traced_exception(fb_exception: FacebookRequestError):
     elif "The start date of the time range cannot be beyond 37 months from the current date" in msg:
         failure_type = FailureType.config_error
         friendly_msg = "Please set the start date of your sync to be within the last 3 years."
+    elif (fb_exception.api_error_code(), fb_exception.api_error_subcode()) in FACEBOOK_CONFIG_ERRORS_TO_CATCH:
+        failure_type = FailureType.config_error
+        friendly_msg = msg  # TODO make sure this is outputting the full verbose message to the user
     elif fb_exception.api_error_code() in FACEBOOK_RATE_LIMIT_ERROR_CODES:
         return AirbyteTracedException(
             message="The maximum number of requests on the Facebook API has been reached. See https://developers.facebook.com/docs/graph-api/overview/rate-limiting/ for more information",

--- a/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/streams/common.py
+++ b/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/streams/common.py
@@ -150,7 +150,6 @@ def deep_merge(a: Any, b: Any) -> Any:
 
 FACEBOOK_CONFIG_ERRORS_TO_CATCH = [  # list of tuples (code, error_subcode)
     (100, 2446289),
-    (100, 1487534),
 ]
 
 

--- a/airbyte-integrations/connectors/source-facebook-marketing/unit_tests/test_errors.py
+++ b/airbyte-integrations/connectors/source-facebook-marketing/unit_tests/test_errors.py
@@ -222,6 +222,22 @@ CONFIG_ERRORS = [
             },
         },
     ),
+    (
+        "error_100_subcode_2446289_no_access_to_resource",
+        "No access to resource.",
+        {
+            "status_code": 400,
+            "json": {
+                "error": {
+                    "message": "(#100) No access to resource.",
+                    "type": "OAuthException",
+                    "code": 100,
+                    "error_subcode": 2446289,
+                    "fbtrace_id": "Ag-P22y80OSEXM4qsGk2T9P",
+                }
+            },
+        },
+    ),
     # ("error_400_unsupported request",
     #  "Re-authenticate because current credential missing permissions",
     #  {

--- a/docs/integrations/sources/facebook-marketing.md
+++ b/docs/integrations/sources/facebook-marketing.md
@@ -356,6 +356,7 @@ This response indicates that the Facebook Graph API requires you to reduce the f
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                                                                                                                                                                                           |
 |:--------|:-----------|:---------------------------------------------------------|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 4.0.1 | 2025-09-15 | [66182](https://github.com/airbytehq/airbyte/pull/66182) | Classify subcode 2446289 error as config error |
 | 4.0.0 | 2025-08-25 | [65533](https://github.com/airbytehq/airbyte/pull/65533) | Migrate to Marketing API v23 |
 | 3.5.12 | 2025-08-23 | [65288](https://github.com/airbytehq/airbyte/pull/65288) | Update dependencies |
 | 3.5.11 | 2025-08-19 | [64911](https://github.com/airbytehq/airbyte/pull/64911) | Allow overriding action breakdowns for default Ads Insights stream. |


### PR DESCRIPTION
## What
- Classifies Facebook Marketing API error subcode `2446289` as `config_error` instead of defaulting to `system_error`. This will reduce Sentry alerts/pages for non-actionable errors.
- For reference, the associated error message with this subcode is:
> The {post_type} you selected for your ad is not available. It could be deleted or you might not have permissions to see it. Please check your ad creative and try again.

## Review Order
1. `common.py`
2. `test_errors.py`

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
