### PR TITLE
[Snowflake] Update the spec to get in line with previous specs

### DIFF
--- a/airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/spec/SnowflakeSpecification.kt
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/spec/SnowflakeSpecification.kt
@@ -85,7 +85,7 @@ open class SnowflakeSpecification : ConfigurationSpecification() {
     @get:JsonSchemaDescription("Determines the type of authentication that should be used.")
     @get:JsonProperty("credentials")
     @get:JsonSchemaInject(json = """{"group": "connection", "order":6}""")
-    val credentials: CredentialsSpecification? = UsernamePasswordAuthSpecification()
+    val credentials: CredentialsSpecification? = null
 
     @get:JsonSchemaTitle("CDC deletion mode")
     @get:JsonPropertyDescription(

--- a/airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/spec/SnowflakeSpecification.kt
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/spec/SnowflakeSpecification.kt
@@ -85,7 +85,7 @@ open class SnowflakeSpecification : ConfigurationSpecification() {
     @get:JsonSchemaDescription("Determines the type of authentication that should be used.")
     @get:JsonProperty("credentials")
     @get:JsonSchemaInject(json = """{"group": "connection", "order":6}""")
-    val credentials: CredentialsSpecification? = KeyPairAuthSpecification()
+    val credentials: CredentialsSpecification? = UsernamePasswordAuthSpecification()
 
     @get:JsonSchemaTitle("CDC deletion mode")
     @get:JsonPropertyDescription(

--- a/airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/spec/SnowflakeSpecification.kt
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/spec/SnowflakeSpecification.kt
@@ -81,10 +81,11 @@ open class SnowflakeSpecification : ConfigurationSpecification() {
     )
     val username: String = ""
 
-    @JsonSchemaTitle("Authorization Method")
-    @JsonSchemaDescription("Determines the type of authentication that should be used.")
-    @get:JsonSchemaInject(json = """{"group": "connection", "always_show": true,"order":6}""")
-    val credentials: CredentialsSpecification? = null
+    @get:JsonSchemaTitle("Authorization Method")
+    @get:JsonSchemaDescription("Determines the type of authentication that should be used.")
+    @get:JsonProperty("credentials")
+    @get:JsonSchemaInject(json = """{"group": "connection", "order":6}""")
+    val credentials: CredentialsSpecification? = KeyPairAuthSpecification()
 
     @get:JsonSchemaTitle("CDC deletion mode")
     @get:JsonPropertyDescription(
@@ -157,7 +158,7 @@ open class SnowflakeSpecification : ConfigurationSpecification() {
         name = "Username and Password"
     )
 )
-sealed class CredentialsSpecification(@get:JsonProperty("auth_type") val auth_type: Type) {
+sealed class CredentialsSpecification(@JsonProperty("auth_type") val auth_type: Type) {
     /** Enumeration of possible credential types. */
     enum class Type(@get:JsonValue val authTypeName: String) {
         PRIVATE_KEY("Key Pair Authentication"),

--- a/airbyte-integrations/connectors/destination-snowflake/src/test-integration/resources/expected-spec-cloud.json
+++ b/airbyte-integrations/connectors/destination-snowflake/src/test-integration/resources/expected-spec-cloud.json
@@ -6,6 +6,56 @@
     "type" : "object",
     "additionalProperties" : true,
     "properties" : {
+      "host" : {
+        "type" : "string",
+        "description" : "Enter your Snowflake account's <a href=\"https://docs.snowflake.com/en/user-guide/admin-account-identifier.html#using-an-account-locator-as-an-identifier\">locator</a> (in the format <account_locator>.<region>.<cloud>.snowflakecomputing.com)",
+        "title" : "Host",
+        "group" : "connection",
+        "order" : 0,
+        "examples" : [ "accountname.us-east-2.aws.snowflakecomputing.com", "accountname.snowflakecomputing.com" ],
+        "pattern" : "^(http(s)?:\\/\\/)?([^./?#]+\\.)?([^./?#]+\\.)?([^./?#]+\\.)?([^./?#]+\\.(snowflakecomputing\\.com|localstack\\.cloud))$",
+        "pattern_descriptor" : "{account_name}.snowflakecomputing.com or {accountname}.{aws_location}.aws.snowflakecomputing.com"
+      },
+      "role" : {
+        "type" : "string",
+        "description" : "Enter the <a href=\"https://docs.snowflake.com/en/user-guide/security-access-control-overview.html#roles\">role</a> that you want to use to access Snowflake",
+        "title" : "Role",
+        "group" : "connection",
+        "order" : 1,
+        "examples" : [ "AIRBYTE_ROLE" ]
+      },
+      "warehouse" : {
+        "type" : "string",
+        "description" : "Enter the name of the <a href=\"https://docs.snowflake.com/en/user-guide/warehouses-overview.html#overview-of-warehouses\">warehouse</a> that you want to use as a compute cluster",
+        "title" : "Warehouse",
+        "group" : "connection",
+        "order" : 2,
+        "examples" : [ "AIRBYTE_WAREHOUSE" ]
+      },
+      "database" : {
+        "type" : "string",
+        "description" : "Enter the name of the <a href=\"https://docs.snowflake.com/en/sql-reference/ddl-database.html#database-schema-share-ddl\">database</a> you want to sync data into",
+        "title" : "Database",
+        "group" : "connection",
+        "order" : 3,
+        "examples" : [ "AIRBYTE_DATABASE" ]
+      },
+      "schema" : {
+        "type" : "string",
+        "description" : "Enter the name of the default <a href=\"https://docs.snowflake.com/en/sql-reference/ddl-database.html#database-schema-share-ddl\">schema</a>",
+        "title" : "Default Schema",
+        "group" : "connection",
+        "order" : 4,
+        "examples" : [ "AIRBYTE_SCHEMA" ]
+      },
+      "username" : {
+        "type" : "string",
+        "description" : "Enter the name of the user you want to use to access the database",
+        "title" : "Username",
+        "group" : "connection",
+        "order" : 5,
+        "examples" : [ "AIRBYTE_USER" ]
+      },
       "credentials" : {
         "oneOf" : [ {
           "title" : "Key Pair Authentication",
@@ -58,59 +108,8 @@
         "description" : "Determines the type of authentication that should be used.",
         "title" : "Authorization Method",
         "group" : "connection",
-        "always_show" : true,
         "order" : 6,
         "type" : "object"
-      },
-      "host" : {
-        "type" : "string",
-        "description" : "Enter your Snowflake account's <a href=\"https://docs.snowflake.com/en/user-guide/admin-account-identifier.html#using-an-account-locator-as-an-identifier\">locator</a> (in the format <account_locator>.<region>.<cloud>.snowflakecomputing.com)",
-        "title" : "Host",
-        "group" : "connection",
-        "order" : 0,
-        "examples" : [ "accountname.us-east-2.aws.snowflakecomputing.com", "accountname.snowflakecomputing.com" ],
-        "pattern" : "^(http(s)?:\\/\\/)?([^./?#]+\\.)?([^./?#]+\\.)?([^./?#]+\\.)?([^./?#]+\\.(snowflakecomputing\\.com|localstack\\.cloud))$",
-        "pattern_descriptor" : "{account_name}.snowflakecomputing.com or {accountname}.{aws_location}.aws.snowflakecomputing.com"
-      },
-      "role" : {
-        "type" : "string",
-        "description" : "Enter the <a href=\"https://docs.snowflake.com/en/user-guide/security-access-control-overview.html#roles\">role</a> that you want to use to access Snowflake",
-        "title" : "Role",
-        "group" : "connection",
-        "order" : 1,
-        "examples" : [ "AIRBYTE_ROLE" ]
-      },
-      "warehouse" : {
-        "type" : "string",
-        "description" : "Enter the name of the <a href=\"https://docs.snowflake.com/en/user-guide/warehouses-overview.html#overview-of-warehouses\">warehouse</a> that you want to use as a compute cluster",
-        "title" : "Warehouse",
-        "group" : "connection",
-        "order" : 2,
-        "examples" : [ "AIRBYTE_WAREHOUSE" ]
-      },
-      "database" : {
-        "type" : "string",
-        "description" : "Enter the name of the <a href=\"https://docs.snowflake.com/en/sql-reference/ddl-database.html#database-schema-share-ddl\">database</a> you want to sync data into",
-        "title" : "Database",
-        "group" : "connection",
-        "order" : 3,
-        "examples" : [ "AIRBYTE_DATABASE" ]
-      },
-      "schema" : {
-        "type" : "string",
-        "description" : "Enter the name of the default <a href=\"https://docs.snowflake.com/en/sql-reference/ddl-database.html#database-schema-share-ddl\">schema</a>",
-        "title" : "Default Schema",
-        "group" : "connection",
-        "order" : 4,
-        "examples" : [ "AIRBYTE_SCHEMA" ]
-      },
-      "username" : {
-        "type" : "string",
-        "description" : "Enter the name of the user you want to use to access the database",
-        "title" : "Username",
-        "group" : "connection",
-        "order" : 5,
-        "examples" : [ "AIRBYTE_USER" ]
       },
       "cdc_deletion_mode" : {
         "type" : "string",

--- a/airbyte-integrations/connectors/destination-snowflake/src/test-integration/resources/expected-spec-oss.json
+++ b/airbyte-integrations/connectors/destination-snowflake/src/test-integration/resources/expected-spec-oss.json
@@ -6,6 +6,56 @@
     "type" : "object",
     "additionalProperties" : true,
     "properties" : {
+      "host" : {
+        "type" : "string",
+        "description" : "Enter your Snowflake account's <a href=\"https://docs.snowflake.com/en/user-guide/admin-account-identifier.html#using-an-account-locator-as-an-identifier\">locator</a> (in the format <account_locator>.<region>.<cloud>.snowflakecomputing.com)",
+        "title" : "Host",
+        "group" : "connection",
+        "order" : 0,
+        "examples" : [ "accountname.us-east-2.aws.snowflakecomputing.com", "accountname.snowflakecomputing.com" ],
+        "pattern" : "^(http(s)?:\\/\\/)?([^./?#]+\\.)?([^./?#]+\\.)?([^./?#]+\\.)?([^./?#]+\\.(snowflakecomputing\\.com|localstack\\.cloud))$",
+        "pattern_descriptor" : "{account_name}.snowflakecomputing.com or {accountname}.{aws_location}.aws.snowflakecomputing.com"
+      },
+      "role" : {
+        "type" : "string",
+        "description" : "Enter the <a href=\"https://docs.snowflake.com/en/user-guide/security-access-control-overview.html#roles\">role</a> that you want to use to access Snowflake",
+        "title" : "Role",
+        "group" : "connection",
+        "order" : 1,
+        "examples" : [ "AIRBYTE_ROLE" ]
+      },
+      "warehouse" : {
+        "type" : "string",
+        "description" : "Enter the name of the <a href=\"https://docs.snowflake.com/en/user-guide/warehouses-overview.html#overview-of-warehouses\">warehouse</a> that you want to use as a compute cluster",
+        "title" : "Warehouse",
+        "group" : "connection",
+        "order" : 2,
+        "examples" : [ "AIRBYTE_WAREHOUSE" ]
+      },
+      "database" : {
+        "type" : "string",
+        "description" : "Enter the name of the <a href=\"https://docs.snowflake.com/en/sql-reference/ddl-database.html#database-schema-share-ddl\">database</a> you want to sync data into",
+        "title" : "Database",
+        "group" : "connection",
+        "order" : 3,
+        "examples" : [ "AIRBYTE_DATABASE" ]
+      },
+      "schema" : {
+        "type" : "string",
+        "description" : "Enter the name of the default <a href=\"https://docs.snowflake.com/en/sql-reference/ddl-database.html#database-schema-share-ddl\">schema</a>",
+        "title" : "Default Schema",
+        "group" : "connection",
+        "order" : 4,
+        "examples" : [ "AIRBYTE_SCHEMA" ]
+      },
+      "username" : {
+        "type" : "string",
+        "description" : "Enter the name of the user you want to use to access the database",
+        "title" : "Username",
+        "group" : "connection",
+        "order" : 5,
+        "examples" : [ "AIRBYTE_USER" ]
+      },
       "credentials" : {
         "oneOf" : [ {
           "title" : "Key Pair Authentication",
@@ -58,59 +108,8 @@
         "description" : "Determines the type of authentication that should be used.",
         "title" : "Authorization Method",
         "group" : "connection",
-        "always_show" : true,
         "order" : 6,
         "type" : "object"
-      },
-      "host" : {
-        "type" : "string",
-        "description" : "Enter your Snowflake account's <a href=\"https://docs.snowflake.com/en/user-guide/admin-account-identifier.html#using-an-account-locator-as-an-identifier\">locator</a> (in the format <account_locator>.<region>.<cloud>.snowflakecomputing.com)",
-        "title" : "Host",
-        "group" : "connection",
-        "order" : 0,
-        "examples" : [ "accountname.us-east-2.aws.snowflakecomputing.com", "accountname.snowflakecomputing.com" ],
-        "pattern" : "^(http(s)?:\\/\\/)?([^./?#]+\\.)?([^./?#]+\\.)?([^./?#]+\\.)?([^./?#]+\\.(snowflakecomputing\\.com|localstack\\.cloud))$",
-        "pattern_descriptor" : "{account_name}.snowflakecomputing.com or {accountname}.{aws_location}.aws.snowflakecomputing.com"
-      },
-      "role" : {
-        "type" : "string",
-        "description" : "Enter the <a href=\"https://docs.snowflake.com/en/user-guide/security-access-control-overview.html#roles\">role</a> that you want to use to access Snowflake",
-        "title" : "Role",
-        "group" : "connection",
-        "order" : 1,
-        "examples" : [ "AIRBYTE_ROLE" ]
-      },
-      "warehouse" : {
-        "type" : "string",
-        "description" : "Enter the name of the <a href=\"https://docs.snowflake.com/en/user-guide/warehouses-overview.html#overview-of-warehouses\">warehouse</a> that you want to use as a compute cluster",
-        "title" : "Warehouse",
-        "group" : "connection",
-        "order" : 2,
-        "examples" : [ "AIRBYTE_WAREHOUSE" ]
-      },
-      "database" : {
-        "type" : "string",
-        "description" : "Enter the name of the <a href=\"https://docs.snowflake.com/en/sql-reference/ddl-database.html#database-schema-share-ddl\">database</a> you want to sync data into",
-        "title" : "Database",
-        "group" : "connection",
-        "order" : 3,
-        "examples" : [ "AIRBYTE_DATABASE" ]
-      },
-      "schema" : {
-        "type" : "string",
-        "description" : "Enter the name of the default <a href=\"https://docs.snowflake.com/en/sql-reference/ddl-database.html#database-schema-share-ddl\">schema</a>",
-        "title" : "Default Schema",
-        "group" : "connection",
-        "order" : 4,
-        "examples" : [ "AIRBYTE_SCHEMA" ]
-      },
-      "username" : {
-        "type" : "string",
-        "description" : "Enter the name of the user you want to use to access the database",
-        "title" : "Username",
-        "group" : "connection",
-        "order" : 5,
-        "examples" : [ "AIRBYTE_USER" ]
       },
       "cdc_deletion_mode" : {
         "type" : "string",


### PR DESCRIPTION
## What

See title.
I was trying to get rid of the `"required" : [ "auth_type", "private_key" ]`. It used to be `"required" : [ "private_key" ]`, but it looks like we had the same thing in the past with BQ and that did not cause any problem.

So I think this is more a cleanup

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [X] YES 💚
- [ ] NO ❌
