### PR TITLE
Fix sampling bug for DefaultJdbcCursorIncrementalPartition

### DIFF
--- a/airbyte-cdk/bulk/build.gradle
+++ b/airbyte-cdk/bulk/build.gradle
@@ -6,7 +6,7 @@ import javax.xml.xpath.XPathFactory
 import org.w3c.dom.Document
 
 allprojects {
-    version = "0.1.30"
+    version = "0.1.31"
     apply plugin: 'java-library'
     apply plugin: 'maven-publish'
 

--- a/airbyte-cdk/bulk/changelog.md
+++ b/airbyte-cdk/bulk/changelog.md
@@ -1,3 +1,9 @@
+## Version 0.1.31
+
+**Extract CDK**
+
+* **Changed:** Pass WhereNode to FromSample node so we can apply filters to the sample query.
+
 ## Version 0.1.30
 
 **Load CDK**

--- a/airbyte-cdk/bulk/toolkits/extract-jdbc/src/main/kotlin/io/airbyte/cdk/read/SelectQuerySpec.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-jdbc/src/main/kotlin/io/airbyte/cdk/read/SelectQuerySpec.kt
@@ -51,6 +51,9 @@ data class FromSample(
     val namespace: String?,
     val sampleRateInvPow2: Int,
     val sampleSize: Int,
+    val where: WhereNode? =
+        null, // Include where clause because we want to apply all filters to the inner sample
+// query, so we don't do sampling on the whole table all the time.
 ) : FromNode {
     val sampleRatePercentage: BigDecimal
         get() = sampleRate.multiply(BigDecimal.valueOf(100L))

--- a/airbyte-cdk/bulk/toolkits/extract-jdbc/src/test/kotlin/io/airbyte/cdk/read/DefaultJdbcPartitionFactoryTest.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-jdbc/src/test/kotlin/io/airbyte/cdk/read/DefaultJdbcPartitionFactoryTest.kt
@@ -135,6 +135,7 @@ class DefaultJdbcPartitionFactoryTest {
                         stream.namespace,
                         sampleRateInvPow2 = 8,
                         DefaultJdbcConstants.TABLE_SAMPLE_SIZE,
+                        NoWhere,
                     ),
                     NoWhere,
                     OrderBy(id),
@@ -205,6 +206,7 @@ class DefaultJdbcPartitionFactoryTest {
                         stream.namespace,
                         sampleRateInvPow2 = 8,
                         DefaultJdbcConstants.TABLE_SAMPLE_SIZE,
+                        NoWhere,
                     ),
                     NoWhere,
                     OrderBy(id)
@@ -311,8 +313,9 @@ class DefaultJdbcPartitionFactoryTest {
                         stream.namespace,
                         sampleRateInvPow2 = 8,
                         DefaultJdbcConstants.TABLE_SAMPLE_SIZE,
+                        Where(Or(listOf(And(listOf(Greater(id, IntCodec.encode(22))))))),
                     ),
-                    Where(Greater(id, IntCodec.encode(22))),
+                    NoWhere,
                     OrderBy(id),
                 )
             )
@@ -369,8 +372,9 @@ class DefaultJdbcPartitionFactoryTest {
                         stream.namespace,
                         sampleRateInvPow2 = 8,
                         DefaultJdbcConstants.TABLE_SAMPLE_SIZE,
+                        Where(Or(listOf(And(listOf(Greater(id, IntCodec.encode(22))))))),
                     ),
-                    Where(Greater(id, IntCodec.encode(22))),
+                    NoWhere,
                     OrderBy(id)
                 )
             )
@@ -450,13 +454,36 @@ class DefaultJdbcPartitionFactoryTest {
                         stream.namespace,
                         sampleRateInvPow2 = 8,
                         DefaultJdbcConstants.TABLE_SAMPLE_SIZE,
-                    ),
-                    Where(
-                        And(
-                            GreaterOrEqual(ts, LocalDateCodec.encode(cursorValue)),
-                            LesserOrEqual(ts, LocalDateCodec.encode(cursorUpperBound))
+                        Where(
+                            And(
+                                Or(
+                                    listOf(
+                                        And(
+                                            listOf(
+                                                GreaterOrEqual(
+                                                    ts,
+                                                    LocalDateCodec.encode(cursorValue)
+                                                )
+                                            )
+                                        )
+                                    )
+                                ),
+                                Or(
+                                    listOf(
+                                        And(
+                                            listOf(
+                                                LesserOrEqual(
+                                                    ts,
+                                                    LocalDateCodec.encode(cursorUpperBound)
+                                                )
+                                            )
+                                        )
+                                    )
+                                )
+                            )
                         ),
                     ),
+                    NoWhere,
                     OrderBy(ts)
                 )
             )

--- a/airbyte-cdk/bulk/toolkits/extract-jdbc/src/test/kotlin/io/airbyte/cdk/read/JdbcPartitionsCreatorTest.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-jdbc/src/test/kotlin/io/airbyte/cdk/read/JdbcPartitionsCreatorTest.kt
@@ -67,7 +67,8 @@ class JdbcPartitionsCreatorTest {
                                         stream().name,
                                         stream().namespace,
                                         sampleRateInvPow2 = 16,
-                                        sampleSize = 4
+                                        sampleSize = 4,
+                                        where = NoWhere
                                     ),
                                     NoWhere,
                                     OrderBy(id)
@@ -83,7 +84,8 @@ class JdbcPartitionsCreatorTest {
                                         stream().name,
                                         stream().namespace,
                                         sampleRateInvPow2 = 8,
-                                        sampleSize = 4
+                                        sampleSize = 4,
+                                        where = NoWhere
                                     ),
                                     NoWhere,
                                     OrderBy(id)
@@ -143,9 +145,19 @@ class JdbcPartitionsCreatorTest {
                                         stream().name,
                                         stream().namespace,
                                         sampleRateInvPow2 = 16,
-                                        sampleSize = 4
+                                        sampleSize = 4,
+                                        where =
+                                            Where(
+                                                Or(
+                                                    listOf(
+                                                        And(
+                                                            listOf(Greater(id, IntCodec.encode(22)))
+                                                        )
+                                                    )
+                                                )
+                                            )
                                     ),
-                                    Where(Greater(id, IntCodec.encode(22))),
+                                    NoWhere,
                                     OrderBy(id)
                                 ),
                             expectedParameters = SelectQuerier.Parameters(fetchSize = null),
@@ -159,9 +171,19 @@ class JdbcPartitionsCreatorTest {
                                         stream().name,
                                         stream().namespace,
                                         sampleRateInvPow2 = 8,
-                                        sampleSize = 4
+                                        sampleSize = 4,
+                                        where =
+                                            Where(
+                                                Or(
+                                                    listOf(
+                                                        And(
+                                                            listOf(Greater(id, IntCodec.encode(22)))
+                                                        )
+                                                    )
+                                                )
+                                            )
                                     ),
-                                    Where(Greater(id, IntCodec.encode(22))),
+                                    NoWhere,
                                     OrderBy(id)
                                 ),
                             expectedParameters = SelectQuerier.Parameters(fetchSize = null),
@@ -256,9 +278,19 @@ class JdbcPartitionsCreatorTest {
                                         stream().name,
                                         stream().namespace,
                                         sampleRateInvPow2 = 16,
-                                        sampleSize = 4
+                                        sampleSize = 4,
+                                        where =
+                                            Where(
+                                                Or(
+                                                    listOf(
+                                                        And(
+                                                            listOf(Greater(id, IntCodec.encode(22)))
+                                                        )
+                                                    )
+                                                )
+                                            )
                                     ),
-                                    Where(Greater(id, IntCodec.encode(22))),
+                                    NoWhere,
                                     OrderBy(id)
                                 ),
                             expectedParameters = SelectQuerier.Parameters(fetchSize = null),
@@ -272,9 +304,19 @@ class JdbcPartitionsCreatorTest {
                                         stream().name,
                                         stream().namespace,
                                         sampleRateInvPow2 = 8,
-                                        sampleSize = 4
+                                        sampleSize = 4,
+                                        where =
+                                            Where(
+                                                Or(
+                                                    listOf(
+                                                        And(
+                                                            listOf(Greater(id, IntCodec.encode(22)))
+                                                        )
+                                                    )
+                                                )
+                                            )
                                     ),
-                                    Where(Greater(id, IntCodec.encode(22))),
+                                    NoWhere,
                                     OrderBy(id)
                                 ),
                             expectedParameters = SelectQuerier.Parameters(fetchSize = null),

--- a/airbyte-integrations/connectors/source-snowflake/build.gradle
+++ b/airbyte-integrations/connectors/source-snowflake/build.gradle
@@ -7,7 +7,7 @@ plugins {
 airbyteBulkConnector {
     core = 'extract'
     toolkits = ['extract-jdbc']
-    cdk = '0.409'
+    cdk = 'local'
 }
 
 application {

--- a/airbyte-integrations/connectors/source-snowflake/metadata.yaml
+++ b/airbyte-integrations/connectors/source-snowflake/metadata.yaml
@@ -8,7 +8,7 @@ data:
   connectorSubtype: database
   connectorType: source
   definitionId: e2d65910-8c8b-40a1-ae7d-ee2416b2bfa2
-  dockerImageTag: 1.0.6
+  dockerImageTag: 1.0.7
   dockerRepository: airbyte/source-snowflake
   documentationUrl: https://docs.airbyte.com/integrations/sources/snowflake
   githubIssueLabel: source-snowflake

--- a/airbyte-integrations/connectors/source-snowflake/src/main/kotlin/io/airbyte/integrations/source/snowflake/SnowflakeSourceOperations.kt
+++ b/airbyte-integrations/connectors/source-snowflake/src/main/kotlin/io/airbyte/integrations/source/snowflake/SnowflakeSourceOperations.kt
@@ -28,6 +28,7 @@ import io.airbyte.cdk.jdbc.LosslessJdbcFieldType
 import io.airbyte.cdk.jdbc.PokemonFieldType
 import io.airbyte.cdk.jdbc.ShortFieldType
 import io.airbyte.cdk.jdbc.StringFieldType
+import io.airbyte.cdk.output.sockets.NativeRecordPayload
 import io.airbyte.cdk.read.And
 import io.airbyte.cdk.read.Equal
 import io.airbyte.cdk.read.From
@@ -164,7 +165,7 @@ class SnowflakeSourceOperations() :
                         " SAMPLE (${sampleRatePercentage.toPlainString()})"
                     }
                 val innerFrom: String = From(name, namespace).sql() + sample
-                val inner = "SELECT * $innerFrom ORDER BY RANDOM()"
+                val inner = "SELECT * $innerFrom ${where?.sql() ?: ""} ORDER BY RANDOM()"
                 "FROM (SELECT * FROM ($inner) LIMIT $sampleSize)"
             }
         }
@@ -192,7 +193,14 @@ class SnowflakeSourceOperations() :
             is OrderBy -> "ORDER BY " + columns.joinToString(", ") { it.sql() }
         }
 
-    fun SelectQuerySpec.bindings(): List<SelectQuery.Binding> = where.bindings()
+    fun SelectQuerySpec.bindings(): List<SelectQuery.Binding> =
+        from.bindings() + where.bindings() + limit.bindings()
+
+    fun FromNode.bindings(): List<SelectQuery.Binding> =
+        when (this) {
+            is FromSample -> where?.bindings() ?: listOf()
+            else -> listOf()
+        }
 
     fun WhereNode.bindings(): List<SelectQuery.Binding> =
         when (this) {
@@ -222,6 +230,15 @@ class SnowflakeSourceOperations() :
         globalStateValue: OpaqueStateValue?,
         stream: Stream,
         recordData: ObjectNode
+    ) {
+        return
+    }
+
+    override fun decorateRecordData(
+        timestamp: OffsetDateTime,
+        globalStateValue: OpaqueStateValue?,
+        stream: Stream,
+        recordData: NativeRecordPayload
     ) {
         return
     }

--- a/airbyte-integrations/connectors/source-snowflake/src/main/resources/application.yml
+++ b/airbyte-integrations/connectors/source-snowflake/src/main/resources/application.yml
@@ -1,6 +1,10 @@
 ---
 airbyte:
   connector:
+    data-channel:
+      medium: ${DATA_CHANNEL_MEDIUM:STDIO}
+      format: ${DATA_CHANNEL_FORMAT:JSONL}
+      socket-paths: ${DATA_CHANNEL_SOCKET_PATHS}
     output:
       buffer-byte-size-threshold-for-flush: 4096
 

--- a/airbyte-integrations/connectors/source-snowflake/src/test/kotlin/io/airbyte/integrations/source/snowflake/SnowflakeSamplingQueryTest.kt
+++ b/airbyte-integrations/connectors/source-snowflake/src/test/kotlin/io/airbyte/integrations/source/snowflake/SnowflakeSamplingQueryTest.kt
@@ -1,0 +1,292 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.source.snowflake
+
+import io.airbyte.cdk.data.LocalDateCodec
+import io.airbyte.cdk.discover.Field
+import io.airbyte.cdk.jdbc.IntFieldType
+import io.airbyte.cdk.jdbc.LocalDateFieldType
+import io.airbyte.cdk.jdbc.StringFieldType
+import io.airbyte.cdk.read.*
+import io.airbyte.cdk.util.Jsons
+import java.time.LocalDate
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class SnowflakeSamplingQueryTest {
+
+    private val queryGenerator = SnowflakeSourceOperations()
+
+    @Test
+    fun testSamplingQueryWithoutWhereClause() {
+        // Test traditional sampling without a WHERE clause
+        val querySpec =
+            SelectQuerySpec(
+                select = SelectColumns(Field("id", IntFieldType), Field("name", StringFieldType)),
+                from =
+                    FromSample(
+                        name = "users",
+                        namespace = "public",
+                        sampleRateInvPow2 = 8,
+                        sampleSize = 1024
+                    )
+            )
+
+        val query = queryGenerator.generate(querySpec)
+        val expectedSql =
+            """
+            SELECT "id", "name" FROM (SELECT * FROM (SELECT * FROM "public"."users" SAMPLE (0.39062500)  ORDER BY RANDOM()) LIMIT 1024)
+        """
+                .trimIndent()
+                .replace("\n", " ")
+
+        assertEquals(expectedSql, query.sql)
+    }
+
+    @Test
+    fun testSamplingQueryWithWhereClause() {
+        // Test sampling with a WHERE clause (incremental sync scenario)
+        val cursorField = Field("updated_at", LocalDateFieldType)
+        val whereClause =
+            Where(Greater(cursorField, LocalDateCodec.encode(LocalDate.parse("2025-01-01"))))
+
+        val querySpec =
+            SelectQuerySpec(
+                select =
+                    SelectColumns(
+                        Field("id", IntFieldType),
+                        Field("name", StringFieldType),
+                        cursorField
+                    ),
+                from =
+                    FromSample(
+                        name = "orders",
+                        namespace = "sales",
+                        sampleRateInvPow2 = 16,
+                        sampleSize = 1024,
+                        where = whereClause
+                    )
+            )
+
+        val query = queryGenerator.generate(querySpec)
+        val expectedSql =
+            """
+            SELECT "id", "name", "updated_at" FROM (SELECT * FROM (SELECT * FROM "sales"."orders" SAMPLE (0.0015258789062500) WHERE "updated_at" > ? ORDER BY RANDOM()) LIMIT 1024)
+        """
+                .trimIndent()
+                .replace("\n", " ")
+
+        assertEquals(expectedSql, query.sql)
+        assertEquals(1, query.bindings.size)
+    }
+
+    @Test
+    fun testSamplingQueryWithComplexWhereClause() {
+        // Test sampling with a complex WHERE clause (multiple conditions)
+        val idField = Field("id", IntFieldType)
+        val statusField = Field("status", StringFieldType)
+        val dateField = Field("created_date", LocalDateFieldType)
+
+        val whereClause =
+            Where(
+                And(
+                    Greater(idField, Jsons.numberNode(1000)),
+                    Equal(statusField, Jsons.textNode("active")),
+                    GreaterOrEqual(dateField, LocalDateCodec.encode(LocalDate.parse("2025-01-01")))
+                )
+            )
+
+        val querySpec =
+            SelectQuerySpec(
+                select = SelectColumns(idField, statusField, dateField),
+                from =
+                    FromSample(
+                        name = "users",
+                        namespace = "public",
+                        sampleRateInvPow2 = 8,
+                        sampleSize = 512,
+                        where = whereClause
+                    )
+            )
+
+        val query = queryGenerator.generate(querySpec)
+        val expectedSql =
+            """
+            SELECT "id", "status", "created_date" FROM (SELECT * FROM (SELECT * FROM "public"."users" SAMPLE (0.39062500) WHERE ("id" > ?) AND ("status" = ?) AND ("created_date" >= ?) ORDER BY RANDOM()) LIMIT 512)
+        """
+                .trimIndent()
+                .replace("\n", " ")
+
+        assertEquals(expectedSql, query.sql)
+        assertEquals(3, query.bindings.size)
+    }
+
+    @Test
+    fun testIncrementalPartitionSamplingQuery() {
+        // Test the exact scenario from the GitHub issue
+        val cursorField = Field("airdate", LocalDateFieldType)
+        val uuidField = Field("uuid", StringFieldType)
+
+        // Simulate cursor bounds for incremental sync
+        val lowerBound = LocalDate.parse("2025-08-07")
+        val upperBound = LocalDate.parse("2025-08-08")
+
+        val whereClause =
+            Where(
+                And(
+                    Greater(cursorField, LocalDateCodec.encode(lowerBound)),
+                    LesserOrEqual(cursorField, LocalDateCodec.encode(upperBound))
+                )
+            )
+
+        val querySpec =
+            SelectQuerySpec(
+                select = SelectColumns(cursorField, uuidField),
+                from =
+                    FromSample(
+                        name = "VW_POLARIS_ADMO_AIRINGS",
+                        namespace = "POLARIS",
+                        sampleRateInvPow2 = 16,
+                        sampleSize = 1024,
+                        where = whereClause
+                    ),
+                where = whereClause,
+                orderBy = OrderBy(uuidField)
+            )
+
+        val query = queryGenerator.generate(querySpec)
+
+        // The WHERE clause should be inside the sampling subquery
+        val expectedSql =
+            """
+            SELECT "airdate", "uuid" FROM (SELECT * FROM (SELECT * FROM "POLARIS"."VW_POLARIS_ADMO_AIRINGS" SAMPLE (0.0015258789062500) WHERE ("airdate" > ?) AND ("airdate" <= ?) ORDER BY RANDOM()) LIMIT 1024) WHERE ("airdate" > ?) AND ("airdate" <= ?) ORDER BY "uuid"
+        """
+                .trimIndent()
+                .replace("\n", " ")
+
+        assertEquals(expectedSql, query.sql)
+        assertEquals(4, query.bindings.size) // Both inner and outer WHERE contribute bindings
+    }
+
+    @Test
+    fun testSamplingWithNoSampleRate() {
+        // Test when sample rate is 1 (no sampling)
+        val whereClause = Where(Greater(Field("id", IntFieldType), Jsons.numberNode(100)))
+
+        val querySpec =
+            SelectQuerySpec(
+                select = SelectColumns(Field("id", IntFieldType)),
+                from =
+                    FromSample(
+                        name = "test_table",
+                        namespace = "test_schema",
+                        sampleRateInvPow2 = 0, // 2^0 = 1, means no sampling
+                        sampleSize = 1024,
+                        where = whereClause
+                    )
+            )
+
+        val query = queryGenerator.generate(querySpec)
+
+        // When sampleRateInv is 1, no SAMPLE clause should be added
+        val expectedSql =
+            """
+            SELECT "id" FROM (SELECT * FROM (SELECT * FROM "test_schema"."test_table" WHERE "id" > ? ORDER BY RANDOM()) LIMIT 1024)
+        """
+                .trimIndent()
+                .replace("\n", " ")
+
+        assertEquals(expectedSql, query.sql)
+    }
+
+    @Test
+    fun testSamplingQueryWithNullNamespace() {
+        // Test sampling query without namespace
+        val whereClause = Where(Equal(Field("status", StringFieldType), Jsons.textNode("active")))
+
+        val querySpec =
+            SelectQuerySpec(
+                select = SelectColumns(Field("id", IntFieldType)),
+                from =
+                    FromSample(
+                        name = "users",
+                        namespace = null,
+                        sampleRateInvPow2 = 4,
+                        sampleSize = 256,
+                        where = whereClause
+                    )
+            )
+
+        val query = queryGenerator.generate(querySpec)
+        val expectedSql =
+            """
+            SELECT "id" FROM (SELECT * FROM (SELECT * FROM "users" SAMPLE (6.2500) WHERE "status" = ? ORDER BY RANDOM()) LIMIT 256)
+        """
+                .trimIndent()
+                .replace("\n", " ")
+
+        assertEquals(expectedSql, query.sql)
+    }
+
+    @Test
+    fun testRegularQueryWithoutSampling() {
+        // Test that regular queries (non-sampling) still work correctly
+        val querySpec =
+            SelectQuerySpec(
+                select = SelectColumns(Field("id", IntFieldType), Field("name", StringFieldType)),
+                from = From(name = "users", namespace = "public"),
+                where = Where(Greater(Field("id", IntFieldType), Jsons.numberNode(100))),
+                orderBy = OrderBy(Field("id", IntFieldType)),
+                limit = Limit(10)
+            )
+
+        val query = queryGenerator.generate(querySpec)
+        val expectedSql =
+            """
+            SELECT "id", "name" FROM "public"."users" WHERE "id" > ? ORDER BY "id" LIMIT ?
+        """
+                .trimIndent()
+                .replace("\n", " ")
+
+        assertEquals(expectedSql, query.sql)
+        assertEquals(2, query.bindings.size)
+    }
+
+    @Test
+    fun testEmptyBoundsHandling() {
+        // Test that when there are no bounds, we get NoWhere instead of empty And/Or clauses
+        // This simulates a fresh snapshot with no lower/upper bounds
+        val querySpec =
+            SelectQuerySpec(
+                select = SelectColumns(Field("id", IntFieldType), Field("name", StringFieldType)),
+                from =
+                    FromSample(
+                        name = "users",
+                        namespace = "test",
+                        sampleRateInvPow2 = 16,
+                        sampleSize = 1024,
+                        where = NoWhere
+                    ),
+                where = NoWhere,
+                orderBy = OrderBy(Field("id", IntFieldType))
+            )
+
+        val query = queryGenerator.generate(querySpec)
+
+        // Should generate SQL without any WHERE clause in the sampling subquery
+        val expectedSql =
+            """
+            SELECT "id", "name" FROM (SELECT * FROM (SELECT * FROM "test"."users" SAMPLE (0.0015258789062500)  ORDER BY RANDOM()) LIMIT 1024) ORDER BY "id"
+        """
+                .trimIndent()
+                .replace("\n", " ")
+
+        assertEquals(expectedSql, query.sql)
+        assertEquals(
+            listOf(Field("id", IntFieldType), Field("name", StringFieldType)),
+            query.columns
+        )
+    }
+}

--- a/docs/integrations/sources/snowflake.md
+++ b/docs/integrations/sources/snowflake.md
@@ -212,30 +212,31 @@ To read more, please check the official [Snowflake documentation](https://docs.s
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                                   |
 |:--------|:-----------|:---------------------------------------------------------|:------------------------------------------------------------------------------------------------------------------------------------------|
-| 1.0.6 | 2025-09-12 | [66226](https://github.com/airbytehq/airbyte/pull/66226) | Fix schema filtering functionality in versions 1.0.0+ - resolves "discovered zero tables" error and enables proper schema-level filtering |
-| 1.0.5 | 2025-07-28 | [63780](https://github.com/airbytehq/airbyte/pull/63780) | Fix ts data type for snowflake |
-| 1.0.3 | 2025-07-22 | [63713](https://github.com/airbytehq/airbyte/pull/63713) | Revert base image from 2.0.3 to 2.0.2 to fix SSL certificate errors |
-| 1.0.2 | 2025-07-14 | [62939](https://github.com/airbytehq/airbyte/pull/62939) | Update base image to 2.0.3 |
-| 1.0.1 | 2025-07-11 | [62929](https://github.com/airbytehq/airbyte/pull/62929) | Update test dependencies |
-| 1.0.0 | 2025-06-24 | [61535](https://github.com/airbytehq/airbyte/pull/61535) | Replace community support connector with Airbyte certified connector |
-| 0.3.6 | 2025-01-10 | [51504](https://github.com/airbytehq/airbyte/pull/51504) | Use a non root base image |
-| 0.3.5 | 2024-12-18 | [49911](https://github.com/airbytehq/airbyte/pull/49911) | Use a base image: airbyte/java-connector-base:1.0.0 |
-| 0.3.4 | 2024-10-31 | [48073](https://github.com/airbytehq/airbyte/pull/48073) | Upgrade jdbc driver |
-| 0.3.3 | 2024-06-28 | [40424](https://github.com/airbytehq/airbyte/pull/40424) | Support Snowflake key pair authentication |
-| 0.3.2 | 2024-02-13 | [38317](https://github.com/airbytehq/airbyte/pull/38317) | Hide oAuth option from connector |
-| 0.3.1 | 2024-02-13 | [35220](https://github.com/airbytehq/airbyte/pull/35220) | Adopt CDK 0.20.4 |
-| 0.3.1 | 2024-01-24 | [34453](https://github.com/airbytehq/airbyte/pull/34453) | bump CDK version |
-| 0.3.0 | 2023-12-18 | [33484](https://github.com/airbytehq/airbyte/pull/33484) | Remove LEGACY state |
-| 0.2.2 | 2023-10-20 | [31613](https://github.com/airbytehq/airbyte/pull/31613) | Fixed handling of TIMESTAMP_TZ columns. upgrade |
-| 0.2.1 | 2023-10-11 | [31252](https://github.com/airbytehq/airbyte/pull/31252) | Snowflake JDBC version upgrade |
-| 0.2.0 | 2023-06-26 | [27737](https://github.com/airbytehq/airbyte/pull/27737) | License Update: Elv2 |
-| 0.1.36 | 2023-06-20 | [27212](https://github.com/airbytehq/airbyte/pull/27212) | Fix silent exception swallowing in StreamingJdbcDatabase |
-| 0.1.35 | 2023-06-14 | [27335](https://github.com/airbytehq/airbyte/pull/27335) | Remove noisy debug logs |
-| 0.1.34 | 2023-03-30 | [24693](https://github.com/airbytehq/airbyte/pull/24693) | Fix failure with TIMESTAMP_WITH_TIMEZONE column being used as cursor |
-| 0.1.33 | 2023-03-29 | [24667](https://github.com/airbytehq/airbyte/pull/24667) | Fix bug which wont allow TIMESTAMP_WITH_TIMEZONE column to be used as a cursor |
-| 0.1.32 | 2023-03-22 | [20760](https://github.com/airbytehq/airbyte/pull/20760) | Removed redundant date-time datatypes formatting |
-| 0.1.31 | 2023-03-06 | [23455](https://github.com/airbytehq/airbyte/pull/23455) | For network isolation, source connector accepts a list of hosts it is allowed to connect to |
-| 0.1.30 | 2023-02-21 | [22358](https://github.com/airbytehq/airbyte/pull/22358) | Improved handling of big integer cursor type values. |
+| 1.0.7   | 2025-09-15 | [66200](https://github.com/airbytehq/airbyte/pull/66200) | Fix sampling bug for DefaultJdbcCursorIncrementalPartition                                                                                |
+| 1.0.6   | 2025-09-12 | [66226](https://github.com/airbytehq/airbyte/pull/66226) | Fix schema filtering functionality in versions 1.0.0+ - resolves "discovered zero tables" error and enables proper schema-level filtering |
+| 1.0.5   | 2025-07-28 | [63780](https://github.com/airbytehq/airbyte/pull/63780) | Fix ts data type for snowflake |
+| 1.0.3   | 2025-07-22 | [63713](https://github.com/airbytehq/airbyte/pull/63713) | Revert base image from 2.0.3 to 2.0.2 to fix SSL certificate errors |
+| 1.0.2   | 2025-07-14 | [62939](https://github.com/airbytehq/airbyte/pull/62939) | Update base image to 2.0.3 |
+| 1.0.1   | 2025-07-11 | [62929](https://github.com/airbytehq/airbyte/pull/62929) | Update test dependencies |
+| 1.0.0   | 2025-06-24 | [61535](https://github.com/airbytehq/airbyte/pull/61535) | Replace community support connector with Airbyte certified connector |
+| 0.3.6   | 2025-01-10 | [51504](https://github.com/airbytehq/airbyte/pull/51504) | Use a non root base image |
+| 0.3.5   | 2024-12-18 | [49911](https://github.com/airbytehq/airbyte/pull/49911) | Use a base image: airbyte/java-connector-base:1.0.0 |
+| 0.3.4   | 2024-10-31 | [48073](https://github.com/airbytehq/airbyte/pull/48073) | Upgrade jdbc driver |
+| 0.3.3   | 2024-06-28 | [40424](https://github.com/airbytehq/airbyte/pull/40424) | Support Snowflake key pair authentication |
+| 0.3.2   | 2024-02-13 | [38317](https://github.com/airbytehq/airbyte/pull/38317) | Hide oAuth option from connector |
+| 0.3.1   | 2024-02-13 | [35220](https://github.com/airbytehq/airbyte/pull/35220) | Adopt CDK 0.20.4 |
+| 0.3.1   | 2024-01-24 | [34453](https://github.com/airbytehq/airbyte/pull/34453) | bump CDK version |
+| 0.3.0   | 2023-12-18 | [33484](https://github.com/airbytehq/airbyte/pull/33484) | Remove LEGACY state |
+| 0.2.2   | 2023-10-20 | [31613](https://github.com/airbytehq/airbyte/pull/31613) | Fixed handling of TIMESTAMP_TZ columns. upgrade |
+| 0.2.1   | 2023-10-11 | [31252](https://github.com/airbytehq/airbyte/pull/31252) | Snowflake JDBC version upgrade |
+| 0.2.0   | 2023-06-26 | [27737](https://github.com/airbytehq/airbyte/pull/27737) | License Update: Elv2 |
+| 0.1.36  | 2023-06-20 | [27212](https://github.com/airbytehq/airbyte/pull/27212) | Fix silent exception swallowing in StreamingJdbcDatabase |
+| 0.1.35  | 2023-06-14 | [27335](https://github.com/airbytehq/airbyte/pull/27335) | Remove noisy debug logs |
+| 0.1.34  | 2023-03-30 | [24693](https://github.com/airbytehq/airbyte/pull/24693) | Fix failure with TIMESTAMP_WITH_TIMEZONE column being used as cursor |
+| 0.1.33  | 2023-03-29 | [24667](https://github.com/airbytehq/airbyte/pull/24667) | Fix bug which wont allow TIMESTAMP_WITH_TIMEZONE column to be used as a cursor |
+| 0.1.32  | 2023-03-22 | [20760](https://github.com/airbytehq/airbyte/pull/20760) | Removed redundant date-time datatypes formatting |
+| 0.1.31  | 2023-03-06 | [23455](https://github.com/airbytehq/airbyte/pull/23455) | For network isolation, source connector accepts a list of hosts it is allowed to connect to |
+| 0.1.30  | 2023-02-21 | [22358](https://github.com/airbytehq/airbyte/pull/22358) | Improved handling of big integer cursor type values. |
 | 0.1.29  | 2022-12-14 | [20436](https://github.com/airbytehq/airbyte/pull/20346) | Consolidate date/time values mapping for JDBC sources.                                                                                    |
 | 0.1.28  | 2023-01-06 | [20465](https://github.com/airbytehq/airbyte/pull/20465) | Improve the schema config field to only discover tables from the specified scehma and make the field optional                             |
 | 0.1.27  | 2022-12-14 | [20407](https://github.com/airbytehq/airbyte/pull/20407) | Fix an issue with integer values converted to floats during replication                                                                   |


### PR DESCRIPTION
## What
DefaultJdbcCursorIncrementalPartition is splittable so we have to do sampling. There is a bug for snowflake that when we do sampling, we sampling the whole table. However in incremental sync, we only sync records beyond the cursor position. So after we filter the record based on the cursor value, we could end up with no sample record. So there is a big chance that the incremental sync will not happen because 0 samples found in table.

https://github.com/airbytehq/oncall/issues/8733

## How
We pass where clause to from node, so we can apply where clause to sample query as well

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
