### PR TITLE
chore: add noop slash command

### DIFF
--- a/.github/workflows/slash-commands.yml
+++ b/.github/workflows/slash-commands.yml
@@ -47,6 +47,7 @@ jobs:
             run-cat-tests
             run-connector-tests
             test-performance
+            update-connector-cdk-version
 
           # Notes regarding static-args:
           # - Slash commands can be invoked from both issues and comments.


### PR DESCRIPTION
## What
Adding a noop slash command. This command is meant to be used for updating the connectors cdk version but we need to first add is as a noop otherwise it is not possible to test it in PRs before merging (github actions quirk)

This change is part of https://github.com/airbytehq/airbyte-internal-issues/issues/14303

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
