### PR TITLE
update generic-oidc key to genericOidc

### DIFF
--- a/docs/platform/access-management/sso-providers/azure-entra-id.md
+++ b/docs/platform/access-management/sso-providers/azure-entra-id.md
@@ -246,7 +246,7 @@ global:
   auth:
     identityProvider: 
       type: generic-oidc
-      generic-oidc: 
+      genericOidc: 
         clientId: YOUR_CLIENT_ID
         audience: YOUR_AUDIENCE
         extraScopes: YOUR_EXTRA_SCOPES

--- a/docs/platform/access-management/sso-providers/okta.md
+++ b/docs/platform/access-management/sso-providers/okta.md
@@ -264,7 +264,7 @@ global:
   auth:
     identityProvider: 
       type: generic-oidc
-      generic-oidc: 
+      genericOidc: 
         clientId: YOUR_CLIENT_ID
         audience: YOUR_AUDIENCE
         extraScopes: YOUR_EXTRA_SCOPES

--- a/docusaurus/platform_versioned_docs/version-1.8/access-management/sso-providers/azure-entra-id.md
+++ b/docusaurus/platform_versioned_docs/version-1.8/access-management/sso-providers/azure-entra-id.md
@@ -246,7 +246,7 @@ global:
   auth:
     identityProvider: 
       type: generic-oidc
-      generic-oidc: 
+      genericOidc: 
         clientId: YOUR_CLIENT_ID
         audience: YOUR_AUDIENCE
         extraScopes: YOUR_EXTRA_SCOPES

--- a/docusaurus/platform_versioned_docs/version-1.8/access-management/sso-providers/okta.md
+++ b/docusaurus/platform_versioned_docs/version-1.8/access-management/sso-providers/okta.md
@@ -264,7 +264,7 @@ global:
   auth:
     identityProvider: 
       type: generic-oidc
-      generic-oidc: 
+      genericOidc: 
         clientId: YOUR_CLIENT_ID
         audience: YOUR_AUDIENCE
         extraScopes: YOUR_EXTRA_SCOPES


### PR DESCRIPTION
## What

The docs were erroneously stating that the Helm v2 chart was using `generic-oidc` for the key, where it was `genericOidc` instead. This PR just updates the docs to state the correct key to avoid frustration.

## How

Docs update.

## Review guide

Validate the accuracy of the updates.

## User Impact

n/a

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
