### PR TITLE
chore(destination-customer-io): convert kotlin discover implemention to low-code manifest

### DIFF
--- a/airbyte-integrations/connectors/destination-customer-io/build.gradle.kts
+++ b/airbyte-integrations/connectors/destination-customer-io/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 airbyteBulkConnector {
     core = "load"
     toolkits = listOf("load-csv", "load-dlq", "load-http", "load-low-code")
-    cdk = "local"
+    cdk = "0.1.30"
 }
 
 application {

--- a/airbyte-integrations/connectors/destination-customer-io/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-customer-io/metadata.yaml
@@ -12,7 +12,7 @@ data:
   connectorSubtype: api
   connectorType: destination
   definitionId: c101b15f-2de9-4616-b54f-0ec9d28ca64d
-  dockerImageTag: 0.0.5
+  dockerImageTag: 0.0.6
   dockerRepository: airbyte/destination-customer-io
   githubIssueLabel: destination-customer-io
   icon: icon.svg

--- a/airbyte-integrations/connectors/destination-customer-io/src/main/kotlin/CustomerIoBeanFactory.kt
+++ b/airbyte-integrations/connectors/destination-customer-io/src/main/kotlin/CustomerIoBeanFactory.kt
@@ -58,7 +58,10 @@ class CustomerIoBeanFactory {
         factory: DeclarativeDestinationFactory,
     ): SpecificationFactory = factory.createSpecificationFactory()
 
-    @Singleton fun discover() = CustomerIoDiscoverer()
+    @Singleton
+    fun discover(
+        factory: DeclarativeDestinationFactory,
+    ) = CustomerIoDiscoverer(factory.createOperationProvider())
 
     @Singleton
     fun objectLoader(): ObjectLoader =

--- a/airbyte-integrations/connectors/destination-customer-io/src/main/kotlin/CustomerIoDiscoverer.kt
+++ b/airbyte-integrations/connectors/destination-customer-io/src/main/kotlin/CustomerIoDiscoverer.kt
@@ -4,50 +4,13 @@
 
 package io.airbyte.integrations.destination.customerio
 
-import io.airbyte.cdk.load.command.Append
-import io.airbyte.cdk.load.command.Dedupe
 import io.airbyte.cdk.load.command.DestinationDiscoverCatalog
-import io.airbyte.cdk.load.command.DestinationOperation
-import io.airbyte.cdk.load.data.FieldType
-import io.airbyte.cdk.load.data.IntegerType
-import io.airbyte.cdk.load.data.ObjectType
-import io.airbyte.cdk.load.data.StringType
 import io.airbyte.cdk.load.discover.DestinationDiscoverer
+import io.airbyte.cdk.load.discoverer.operation.OperationProvider
 
-class CustomerIoDiscoverer() : DestinationDiscoverer {
+class CustomerIoDiscoverer(private val operationProvider: OperationProvider) :
+    DestinationDiscoverer {
     override fun discover(): DestinationDiscoverCatalog {
-        return DestinationDiscoverCatalog(
-            listOf(
-                DestinationOperation(
-                    "person_identify",
-                    Dedupe(emptyList(), emptyList()),
-                    ObjectType(
-                        properties =
-                            linkedMapOf(
-                                "person_email" to FieldType(StringType, false),
-                            ),
-                        additionalProperties = true,
-                        required = listOf("person_email"),
-                    ),
-                    matchingKeys = emptyList()
-                ),
-                DestinationOperation(
-                    "person_event",
-                    Append,
-                    ObjectType(
-                        properties =
-                            linkedMapOf(
-                                "person_email" to FieldType(StringType, false),
-                                "event_name" to FieldType(StringType, false),
-                                "event_id" to FieldType(StringType, false),
-                                "timestamp" to FieldType(IntegerType, false),
-                            ),
-                        additionalProperties = true,
-                        required = listOf("person_email", "event_name"),
-                    ),
-                    matchingKeys = emptyList()
-                )
-            )
-        )
+        return DestinationDiscoverCatalog(operationProvider.get())
     }
 }

--- a/airbyte-integrations/connectors/destination-customer-io/src/main/resources/manifest.yaml
+++ b/airbyte-integrations/connectors/destination-customer-io/src/main/resources/manifest.yaml
@@ -45,3 +45,37 @@ spec:
           - apiKey
     required:
       - credentials
+discover:
+  type: CompositeCatalogOperations
+  operations:
+    - type: StaticCatalogOperation
+      object_name: person_identify
+      destination_import_mode:
+        type: Upsert
+      schema:
+        type: object
+        required:
+          - person_email
+        additionalProperties: true
+        properties:
+          person_email:
+            type: string
+    - type: StaticCatalogOperation
+      object_name: person_event
+      destination_import_mode:
+        type: Insert
+      schema:
+        type: object
+        required:
+          - person_email
+          - event_name
+        additionalProperties: true
+        properties:
+          person_email:
+            type: string
+          event_name:
+            type: string
+          event_id:
+            type: string
+          timestamp:
+            type: integer

--- a/docs/integrations/destinations/customer-io.md
+++ b/docs/integrations/destinations/customer-io.md
@@ -51,10 +51,11 @@ In order to configure this connector, you need to generate your Track API Key an
 
 ## Changelog
 
-| Version | Date       | Pull Request                                             | Subject                                                  |
-|:--------|:-----------|:---------------------------------------------------------|:---------------------------------------------------------|
-| 0.0.5   | 2025-09-08 | [65157](https://github.com/airbytehq/airbyte/pull/65157)        | Update following breaking changes on spec |
-| 0.0.4   | 2025-08-20 | [#65113](https://github.com/airbytehq/airbyte/pull/65113) | Update logo                                              |
-| 0.0.3   | 2025-07-08 | [#62848](https://github.com/airbytehq/airbyte/pull/62848) | Improve UX on connector configuration                    |
-| 0.0.2   | 2025-07-08 | [#62843](https://github.com/airbytehq/airbyte/pull/62843) | Checker should validate DLQ                              |
-| 0.0.1   | 2025-07-07 | [#62083](https://github.com/airbytehq/airbyte/pull/62083) | Initial release of the Customer IO destination connector |
+| Version | Date       | Pull Request                                              | Subject                                                   |
+|:--------|:-----------|:----------------------------------------------------------|:----------------------------------------------------------|
+| 0.0.6   | 2025-09-16 | [tbd](https://github.com/airbytehq/airbyte/pull/tbd)      | Use low-code discover definition and pin to a CDK version |
+| 0.0.5   | 2025-09-08 | [65157](https://github.com/airbytehq/airbyte/pull/65157)  | Update following breaking changes on spec                 |
+| 0.0.4   | 2025-08-20 | [#65113](https://github.com/airbytehq/airbyte/pull/65113) | Update logo                                               |
+| 0.0.3   | 2025-07-08 | [#62848](https://github.com/airbytehq/airbyte/pull/62848) | Improve UX on connector configuration                     |
+| 0.0.2   | 2025-07-08 | [#62843](https://github.com/airbytehq/airbyte/pull/62843) | Checker should validate DLQ                               |
+| 0.0.1   | 2025-07-07 | [#62083](https://github.com/airbytehq/airbyte/pull/62083) | Initial release of the Customer IO destination connector  |


### PR DESCRIPTION
## What

use low-code discover inestead of kotlin components for operation discover

## How

I also pinned the CDK version which is probably how we should manage versioning, but I can remove if this if we want to trade a little bit of development speed at the cost of stable versioning

## User Impact

none

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌
