### PR TITLE
Fix non dockerized test input

### DIFF
--- a/airbyte-cdk/bulk/build.gradle
+++ b/airbyte-cdk/bulk/build.gradle
@@ -6,7 +6,7 @@ import javax.xml.xpath.XPathFactory
 import org.w3c.dom.Document
 
 allprojects {
-    version = "0.1.31"
+    version = "0.1.32"
     apply plugin: 'java-library'
     apply plugin: 'maven-publish'
 

--- a/airbyte-cdk/bulk/changelog.md
+++ b/airbyte-cdk/bulk/changelog.md
@@ -1,3 +1,9 @@
+## Version 0.1.32
+
+**Load CDK**
+
+* **Changed:** Fix input stream wiring for non-dockerized acceptance tests
+
 ## Version 0.1.31
 
 **Extract CDK**

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/config/InputBeanFactory.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/config/InputBeanFactory.kt
@@ -26,6 +26,7 @@ import io.airbyte.cdk.load.message.ProtocolMessageDeserializer
 import io.micronaut.context.annotation.Factory
 import io.micronaut.context.annotation.Requires
 import io.micronaut.context.annotation.Value
+import io.micronaut.context.env.Environment
 import jakarta.inject.Named
 import jakarta.inject.Singleton
 import java.io.InputStream
@@ -55,6 +56,7 @@ class InputBeanFactory {
         }
 
     @Requires(property = "airbyte.destination.core.data-channel.medium", value = "SOCKET")
+    @Requires(notEnv = [Environment.TEST])
     @Named("inputStreams")
     @Singleton
     fun socketStreams(
@@ -62,6 +64,7 @@ class InputBeanFactory {
     ): List<InputStream> = sockets.map(ClientSocket::openInputStream)
 
     @Requires(property = "airbyte.destination.core.data-channel.medium", value = "STDIO")
+    @Requires(notEnv = [Environment.TEST])
     @Named("inputStreams")
     @Singleton
     fun stdInStreams(): List<InputStream> = listOf(System.`in`)

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/test/config/TestBeanOverrideFactory.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/test/config/TestBeanOverrideFactory.kt
@@ -11,6 +11,7 @@ import io.micronaut.context.annotation.Requires
 import io.micronaut.context.env.Environment
 import jakarta.inject.Named
 import jakarta.inject.Singleton
+import java.io.InputStream
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.toJavaDuration
 
@@ -22,6 +23,17 @@ import kotlin.time.toJavaDuration
 @Factory
 @Requires(env = [Environment.TEST])
 class TestBeanOverrideFactory {
+    // non-dockerized std-in acceptance tests create an input stream bean at runtime it uses
+    // to send messages to the destination, so we must wire that up here
+    @Requires(notEnv = ["docker"])
+    @Requires(property = "airbyte.destination.core.data-channel.medium", value = "STDIO")
+    @Singleton
+    @Primary
+    @Named("inputStreams")
+    fun testStdInStreams(
+        @Named("inputStream") testInputStream: InputStream,
+    ): List<InputStream> = listOf(testInputStream)
+
     @Singleton
     @Primary
     fun testConfig() =

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/destination_process/DockerizedDestination.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/destination_process/DockerizedDestination.kt
@@ -187,7 +187,7 @@ class DockerizedDestination(
         val micronautEnvEnvVar =
             listOf(
                 "-e",
-                "MICRONAUT_ENVIRONMENTS=test,cli,destination,connector",
+                "MICRONAUT_ENVIRONMENTS=test,docker,cli,destination,connector",
             )
 
         val additionalEnvEntries =


### PR DESCRIPTION
## What
Wires up the dataflow pipeline to the run time created bean for non-dockerized destination tests

## How
* Use the runtime bean when we are in std io for non-dockerized test
* Add `docker` env to the dockerized tests to distinguish

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._