### PR TITLE
[Snowflake] Add support for `overwriteTable`

### DIFF
--- a/airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/client/SnowflakeAirbyteClient.kt
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/client/SnowflakeAirbyteClient.kt
@@ -68,7 +68,8 @@ class SnowflakeAirbyteClient(
     }
 
     override suspend fun overwriteTable(sourceTableName: TableName, targetTableName: TableName) {
-        TODO("Not yet implemented")
+        execute(sqlGenerator.swapTableWith(sourceTableName, targetTableName))
+        execute(sqlGenerator.dropTable(sourceTableName))
     }
 
     override suspend fun copyTable(

--- a/airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/sql/SnowflakeDirectLoadSqlGenerator.kt
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/sql/SnowflakeDirectLoadSqlGenerator.kt
@@ -321,4 +321,16 @@ class SnowflakeDirectLoadSqlGenerator(
             .trimIndent()
             .andLog()
     }
+
+    fun swapTableWith(sourceTableName: TableName, targetTableName: TableName): String {
+        return """
+            ALTER TABLE ${sourceTableName.toPrettyString(quote = QUOTE)} SWAP WITH ${
+            targetTableName.toPrettyString(
+                quote = QUOTE
+            )
+        };
+        """
+            .trimIndent()
+            .andLog()
+    }
 }

--- a/airbyte-integrations/connectors/destination-snowflake/src/test-integration/kotlin/io/airbyte/integrations/destination/snowflake/write/SnowflakeAcceptanceTest.kt
+++ b/airbyte-integrations/connectors/destination-snowflake/src/test-integration/kotlin/io/airbyte/integrations/destination/snowflake/write/SnowflakeAcceptanceTest.kt
@@ -209,8 +209,9 @@ class SnowflakeMigrationConfigurationUpdater : ConfigurationUpdater {
     override fun setDefaultNamespace(
         config: String,
         defaultNamespace: String
-    ): DefaultNamespaceResult = DefaultNamespaceResult(
-        updatedConfig = config.replace("TEXT_SCHEMA", defaultNamespace),
-        actualDefaultNamespace = defaultNamespace
-    )
+    ): DefaultNamespaceResult =
+        DefaultNamespaceResult(
+            updatedConfig = config.replace("TEXT_SCHEMA", defaultNamespace),
+            actualDefaultNamespace = defaultNamespace
+        )
 }

--- a/airbyte-integrations/connectors/destination-snowflake/src/test/kotlin/io/airbyte/integrations/destination/snowflake/write/SnowflakeWriterTest.kt
+++ b/airbyte-integrations/connectors/destination-snowflake/src/test/kotlin/io/airbyte/integrations/destination/snowflake/write/SnowflakeWriterTest.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+ */
+
 package io.airbyte.integrations.destination.snowflake.write
 
 import io.airbyte.cdk.SystemErrorException


### PR DESCRIPTION
## What

Implement the `overwriteTable` method in the `SnowflakeAirbyteClient`
This was the last missing method in there (other than `ensureSchemaMatches`)

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [X] YES 💚
- [ ] NO ❌
