### PR TITLE
fix docker test input stream

### DIFF
--- a/airbyte-cdk/bulk/changelog.md
+++ b/airbyte-cdk/bulk/changelog.md
@@ -1,3 +1,7 @@
+## Version 0.1.35
+
+* **Changed:** Fix input stream wiring for dockerized acceptance tests
+
 ## Version 0.1.34
 
 * **Changed:** Moved version declaration from build.gradle to version.properties

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/config/ConnectorInputStreams.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/config/ConnectorInputStreams.kt
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.load.dataflow.config
+
+import java.io.InputStream
+
+/**
+ * Micronaut work around - wraps the input streams to avoid injecting a List directly, and being
+ * subject to Micronaut merging like beans into a single list leading to injecting unexpected extra
+ * input streams.
+ */
+class ConnectorInputStreams(private val values: List<InputStream>) : List<InputStream> by values

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/config/InputBeanFactory.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/config/InputBeanFactory.kt
@@ -26,10 +26,8 @@ import io.airbyte.cdk.load.message.ProtocolMessageDeserializer
 import io.micronaut.context.annotation.Factory
 import io.micronaut.context.annotation.Requires
 import io.micronaut.context.annotation.Value
-import io.micronaut.context.env.Environment
 import jakarta.inject.Named
 import jakarta.inject.Singleton
-import java.io.InputStream
 import kotlinx.coroutines.flow.Flow
 
 /**
@@ -56,23 +54,21 @@ class InputBeanFactory {
         }
 
     @Requires(property = "airbyte.destination.core.data-channel.medium", value = "SOCKET")
-    @Requires(notEnv = [Environment.TEST])
     @Named("inputStreams")
     @Singleton
     fun socketStreams(
         sockets: List<ClientSocket>,
-    ): List<InputStream> = sockets.map(ClientSocket::openInputStream)
+    ) = ConnectorInputStreams(sockets.map(ClientSocket::openInputStream))
 
     @Requires(property = "airbyte.destination.core.data-channel.medium", value = "STDIO")
-    @Requires(notEnv = [Environment.TEST])
     @Named("inputStreams")
     @Singleton
-    fun stdInStreams(): List<InputStream> = listOf(System.`in`)
+    fun stdInStreams() = ConnectorInputStreams(listOf(System.`in`))
 
     @Named("messageFlows")
     @Singleton
     fun messageFlows(
-        @Named("inputStreams") inputStreams: List<InputStream>,
+        @Named("inputStreams") inputStreams: ConnectorInputStreams,
         @Value("\${airbyte.destination.core.data-channel.format}")
         dataChannelFormat: DataChannelFormat,
         deserializer: ProtocolMessageDeserializer,

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/test/config/TestBeanOverrideFactory.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/test/config/TestBeanOverrideFactory.kt
@@ -4,6 +4,7 @@
 
 package io.airbyte.cdk.load.test.config
 
+import io.airbyte.cdk.load.dataflow.config.ConnectorInputStreams
 import io.airbyte.cdk.load.dataflow.config.MemoryAndParallelismConfig
 import io.micronaut.context.annotation.Factory
 import io.micronaut.context.annotation.Primary
@@ -32,7 +33,7 @@ class TestBeanOverrideFactory {
     @Named("inputStreams")
     fun testStdInStreams(
         @Named("inputStream") testInputStream: InputStream,
-    ): List<InputStream> = listOf(testInputStream)
+    ) = ConnectorInputStreams(listOf(testInputStream))
 
     @Singleton
     @Primary

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/dataflow/config/InputBeanFactoryTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/dataflow/config/InputBeanFactoryTest.kt
@@ -172,7 +172,7 @@ class InputBeanFactoryTest {
         // Given
         val inputStream1 = ByteArrayInputStream("stream1".toByteArray())
         val inputStream2 = ByteArrayInputStream("stream2".toByteArray())
-        val inputStreams = listOf(inputStream1, inputStream2)
+        val inputStreams = ConnectorInputStreams(listOf(inputStream1, inputStream2))
 
         // When
         val result =
@@ -285,7 +285,7 @@ class InputBeanFactoryTest {
 
         every { aggregateStoreFactory.make() } returns mockk()
 
-        val inputStreams = listOf(mockInputStream1, mockInputStream2)
+        val inputStreams = ConnectorInputStreams(listOf(mockInputStream1, mockInputStream2))
 
         val messageFlows =
             factory.messageFlows(

--- a/airbyte-cdk/bulk/version.properties
+++ b/airbyte-cdk/bulk/version.properties
@@ -1,1 +1,1 @@
-version=0.1.34
+version=0.1.35


### PR DESCRIPTION
## What
Std-in input stream bean created for dockerized tests

## How
Creates wrapper micronaut class for input streams list to avoid micronaut merging Lists of things

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._