### PR TITLE
[Snowflake] Implement CDCDelete mode

### DIFF
--- a/airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/sql/SnowflakeDirectLoadSqlGenerator.kt
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/sql/SnowflakeDirectLoadSqlGenerator.kt
@@ -174,7 +174,7 @@ class SnowflakeDirectLoadSqlGenerator(
         val cdcSkipInsertClause: String
         if (
             stream.schema.asColumns().containsKey(CDC_DELETED_AT_COLUMN) &&
-            cdcDeletionMode == CdcDeletionMode.HARD_DELETE
+                cdcDeletionMode == CdcDeletionMode.HARD_DELETE
         ) {
             // Execute CDC deletions if there's already a record
             cdcDeleteClause =
@@ -189,8 +189,9 @@ class SnowflakeDirectLoadSqlGenerator(
         }
 
         // Build the MERGE statement
-        val mergeStatement = if (cdcDeleteClause.isNotEmpty()) {
-            """
+        val mergeStatement =
+            if (cdcDeleteClause.isNotEmpty()) {
+                """
             MERGE INTO ${targetTableName.toPrettyString(QUOTE)} AS target_table
             USING (
               $selectSourceRecords
@@ -205,8 +206,8 @@ class SnowflakeDirectLoadSqlGenerator(
               $newRecordColumnList
             )
         """.trimIndent()
-        } else {
-            """
+            } else {
+                """
             MERGE INTO ${targetTableName.toPrettyString(QUOTE)} AS target_table
             USING (
               $selectSourceRecords
@@ -220,7 +221,7 @@ class SnowflakeDirectLoadSqlGenerator(
               $newRecordColumnList
             )
         """.trimIndent()
-        }
+            }
 
         return mergeStatement.andLog()
     }

--- a/airbyte-integrations/connectors/destination-snowflake/src/test/kotlin/io/airbyte/integrations/destination/snowflake/sql/SnowflakeDirectLoadSqlGeneratorTest.kt
+++ b/airbyte-integrations/connectors/destination-snowflake/src/test/kotlin/io/airbyte/integrations/destination/snowflake/sql/SnowflakeDirectLoadSqlGeneratorTest.kt
@@ -6,8 +6,12 @@ package io.airbyte.integrations.destination.snowflake.sql
 
 import io.airbyte.cdk.load.command.Dedupe
 import io.airbyte.cdk.load.command.DestinationStream
+import io.airbyte.cdk.load.data.FieldType
+import io.airbyte.cdk.load.data.ObjectType
 import io.airbyte.cdk.load.data.StringType
+import io.airbyte.cdk.load.data.TimestampTypeWithTimezone
 import io.airbyte.cdk.load.message.Meta.Companion.COLUMN_NAME_AB_GENERATION_ID
+import io.airbyte.cdk.load.orchestration.db.CDC_DELETED_AT_COLUMN
 import io.airbyte.cdk.load.orchestration.db.ColumnNameMapping
 import io.airbyte.cdk.load.orchestration.db.TableName
 import io.airbyte.integrations.destination.snowflake.db.toSnowflakeCompatibleName
@@ -15,6 +19,7 @@ import io.airbyte.integrations.destination.snowflake.spec.CdcDeletionMode
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
@@ -286,6 +291,285 @@ new_record."_airbyte_generation_id"
         val sql = snowflakeDirectLoadSqlGenerator.copyFromStage(tableName)
         assertEquals(
             "COPY INTO ${tableName.toPrettyString(quote=QUOTE)}\nFROM @\"${tableName.namespace}\".\"$STAGE_NAME_PREFIX${tableName.name}\"\nFILE_FORMAT = $STAGE_FORMAT_NAME\nON_ERROR = 'ABORT_STATEMENT'",
+            sql
+        )
+    }
+
+    @Test
+    fun testGenerateUpsertTableWithCdcHardDelete() {
+        // Test with CDC hard delete mode when _ab_cdc_deleted_at column is present
+        val primaryKey = listOf(listOf("id"))
+        val cursor = listOf("updated_at")
+
+        // Create schema with CDC deletion column
+        val schemaWithCdc =
+            ObjectType(
+                properties =
+                    linkedMapOf(
+                        "id" to FieldType(StringType, nullable = false),
+                        "name" to FieldType(StringType, nullable = true),
+                        "updated_at" to FieldType(TimestampTypeWithTimezone, nullable = true),
+                        CDC_DELETED_AT_COLUMN to
+                            FieldType(TimestampTypeWithTimezone, nullable = true)
+                    )
+            )
+
+        val stream =
+            mockk<DestinationStream> {
+                every { importType } returns
+                    Dedupe(
+                        primaryKey = primaryKey,
+                        cursor = cursor,
+                    )
+                every { schema } returns schemaWithCdc
+            }
+
+        val columnNameMapping =
+            ColumnNameMapping(
+                mapOf(
+                    "id" to "id",
+                    "name" to "name",
+                    "updated_at" to "updated_at",
+                    CDC_DELETED_AT_COLUMN to "_ab_cdc_deleted_at"
+                )
+            )
+        val sourceTableName = TableName(namespace = "test_ns", name = "source")
+        val targetTableName = TableName(namespace = "test_ns", name = "target")
+
+        every { columnUtils.columnsAndTypes(any(), columnNameMapping) } returns
+            listOf(
+                ColumnAndType("id", "VARCHAR"),
+                ColumnAndType("name", "VARCHAR"),
+                ColumnAndType("updated_at", "TIMESTAMP_TZ"),
+                ColumnAndType("_ab_cdc_deleted_at", "TIMESTAMP_TZ")
+            ) + DEFAULT_COLUMNS
+
+        val sql =
+            snowflakeDirectLoadSqlGenerator.upsertTable(
+                stream = stream,
+                columnNameMapping = columnNameMapping,
+                sourceTableName = sourceTableName,
+                targetTableName = targetTableName,
+            )
+
+        // Should include the DELETE clause and skip insert clause
+        assert(sql.contains("WHEN MATCHED AND new_record.\"_ab_cdc_deleted_at\" IS NOT NULL"))
+        assert(sql.contains("THEN DELETE"))
+        assert(
+            sql.contains(
+                "WHEN NOT MATCHED AND new_record.\"_ab_cdc_deleted_at\" IS NULL THEN INSERT"
+            )
+        )
+    }
+
+    @Test
+    fun testGenerateUpsertTableWithCdcSoftDelete() {
+        // Test with CDC soft delete mode - should NOT add delete clauses
+        val softDeleteGenerator =
+            SnowflakeDirectLoadSqlGenerator(
+                columnUtils = columnUtils,
+                cdcDeletionMode = CdcDeletionMode.SOFT_DELETE,
+            )
+
+        val primaryKey = listOf(listOf("id"))
+        val cursor = listOf("updated_at")
+
+        // Create schema with CDC deletion column
+        val schemaWithCdc =
+            ObjectType(
+                properties =
+                    linkedMapOf(
+                        "id" to FieldType(StringType, nullable = false),
+                        "name" to FieldType(StringType, nullable = true),
+                        "updated_at" to FieldType(TimestampTypeWithTimezone, nullable = true),
+                        CDC_DELETED_AT_COLUMN to
+                            FieldType(TimestampTypeWithTimezone, nullable = true)
+                    )
+            )
+
+        val stream =
+            mockk<DestinationStream> {
+                every { importType } returns
+                    Dedupe(
+                        primaryKey = primaryKey,
+                        cursor = cursor,
+                    )
+                every { schema } returns schemaWithCdc
+            }
+
+        val columnNameMapping =
+            ColumnNameMapping(
+                mapOf(
+                    "id" to "id",
+                    "name" to "name",
+                    "updated_at" to "updated_at",
+                    CDC_DELETED_AT_COLUMN to "_ab_cdc_deleted_at"
+                )
+            )
+        val sourceTableName = TableName(namespace = "test_ns", name = "source")
+        val targetTableName = TableName(namespace = "test_ns", name = "target")
+
+        every { columnUtils.columnsAndTypes(any(), columnNameMapping) } returns
+            listOf(
+                ColumnAndType("id", "VARCHAR"),
+                ColumnAndType("name", "VARCHAR"),
+                ColumnAndType("updated_at", "TIMESTAMP_TZ"),
+                ColumnAndType("_ab_cdc_deleted_at", "TIMESTAMP_TZ")
+            ) + DEFAULT_COLUMNS
+
+        val sql =
+            softDeleteGenerator.upsertTable(
+                stream = stream,
+                columnNameMapping = columnNameMapping,
+                sourceTableName = sourceTableName,
+                targetTableName = targetTableName,
+            )
+
+        // Should NOT include DELETE clause in soft delete mode
+        assert(!sql.contains("THEN DELETE"))
+        assert(sql.contains("WHEN NOT MATCHED THEN INSERT"))
+        assert(!sql.contains("AND new_record.\"_ab_cdc_deleted_at\" IS NULL"))
+    }
+
+    @Test
+    fun testGenerateUpsertTableWithoutCdcColumn() {
+        // Test that CDC deletion logic is NOT applied when column is absent
+        val primaryKey = listOf(listOf("id"))
+        val cursor = listOf("updated_at")
+
+        // Schema without CDC deletion column
+        val schemaWithoutCdc =
+            ObjectType(
+                properties =
+                    linkedMapOf(
+                        "id" to FieldType(StringType, nullable = false),
+                        "name" to FieldType(StringType, nullable = true),
+                        "updated_at" to FieldType(TimestampTypeWithTimezone, nullable = true)
+                    )
+            )
+
+        val stream =
+            mockk<DestinationStream> {
+                every { importType } returns
+                    Dedupe(
+                        primaryKey = primaryKey,
+                        cursor = cursor,
+                    )
+                every { schema } returns schemaWithoutCdc
+            }
+
+        val columnNameMapping =
+            ColumnNameMapping(mapOf("id" to "id", "name" to "name", "updated_at" to "updated_at"))
+        val sourceTableName = TableName(namespace = "test_ns", name = "source")
+        val targetTableName = TableName(namespace = "test_ns", name = "target")
+
+        every { columnUtils.columnsAndTypes(any(), columnNameMapping) } returns
+            listOf(
+                ColumnAndType("id", "VARCHAR"),
+                ColumnAndType("name", "VARCHAR"),
+                ColumnAndType("updated_at", "TIMESTAMP_TZ")
+            ) + DEFAULT_COLUMNS
+
+        val sql =
+            snowflakeDirectLoadSqlGenerator.upsertTable(
+                stream = stream,
+                columnNameMapping = columnNameMapping,
+                sourceTableName = sourceTableName,
+                targetTableName = targetTableName,
+            )
+
+        // Should NOT include any CDC-related clauses
+        assert(!sql.contains("_ab_cdc_deleted_at"))
+        assert(!sql.contains("THEN DELETE"))
+        assert(sql.contains("WHEN NOT MATCHED THEN INSERT"))
+    }
+
+    @Test
+    fun testGenerateUpsertTableWithNoCursor() {
+        // Test upsert with no cursor field
+        val primaryKey = listOf(listOf("id"))
+
+        val schemaWithoutCursor =
+            ObjectType(
+                properties =
+                    linkedMapOf(
+                        "id" to FieldType(StringType, nullable = false),
+                        "name" to FieldType(StringType, nullable = true)
+                    )
+            )
+
+        val stream =
+            mockk<DestinationStream> {
+                every { importType } returns
+                    Dedupe(
+                        primaryKey = primaryKey,
+                        cursor = emptyList(), // No cursor
+                    )
+                every { schema } returns schemaWithoutCursor
+            }
+
+        val columnNameMapping = ColumnNameMapping(mapOf("id" to "id", "name" to "name"))
+        val sourceTableName = TableName(namespace = "test_ns", name = "source")
+        val targetTableName = TableName(namespace = "test_ns", name = "target")
+
+        every { columnUtils.columnsAndTypes(any(), columnNameMapping) } returns
+            listOf(ColumnAndType("id", "VARCHAR"), ColumnAndType("name", "VARCHAR")) +
+                DEFAULT_COLUMNS
+
+        val sql =
+            snowflakeDirectLoadSqlGenerator.upsertTable(
+                stream = stream,
+                columnNameMapping = columnNameMapping,
+                sourceTableName = sourceTableName,
+                targetTableName = targetTableName,
+            )
+
+        // Should use only _airbyte_extracted_at for comparison when no cursor
+        assert(
+            sql.contains(
+                "target_table.\"_airbyte_extracted_at\" < new_record.\"_airbyte_extracted_at\""
+            )
+        )
+        assert(!sql.contains("target_table.\"cursor\"")) // No cursor field reference
+    }
+
+    @Test
+    fun testGenerateUpsertTableWithoutPrimaryKeyThrowsException() {
+        // Test that upsert without primary key throws an exception
+        val stream =
+            mockk<DestinationStream> {
+                every { importType } returns
+                    Dedupe(
+                        primaryKey = emptyList(), // No primary key
+                        cursor = listOf("updated_at"),
+                    )
+                every { schema } returns StringType
+            }
+
+        val columnNameMapping = ColumnNameMapping(emptyMap())
+        val sourceTableName = TableName(namespace = "test_ns", name = "source")
+        val targetTableName = TableName(namespace = "test_ns", name = "target")
+
+        val exception =
+            assertThrows(IllegalArgumentException::class.java) {
+                snowflakeDirectLoadSqlGenerator.upsertTable(
+                    stream = stream,
+                    columnNameMapping = columnNameMapping,
+                    sourceTableName = sourceTableName,
+                    targetTableName = targetTableName,
+                )
+            }
+
+        assertEquals("Cannot perform upsert without primary key", exception.message)
+    }
+
+    @Test
+    fun testGenerateSwapTable() {
+        val sourceTableName = TableName(namespace = "namespace", name = "source")
+        val targetTableName = TableName(namespace = "namespace", name = "target")
+        val sql = snowflakeDirectLoadSqlGenerator.swapTableWith(sourceTableName, targetTableName)
+        assertEquals(
+            "ALTER TABLE ${sourceTableName.toPrettyString(quote = QUOTE)} SWAP WITH ${targetTableName.toPrettyString(quote = QUOTE)};",
             sql
         )
     }

--- a/airbyte-integrations/connectors/destination-snowflake/src/test/kotlin/io/airbyte/integrations/destination/snowflake/sql/SnowflakeDirectLoadSqlGeneratorTest.kt
+++ b/airbyte-integrations/connectors/destination-snowflake/src/test/kotlin/io/airbyte/integrations/destination/snowflake/sql/SnowflakeDirectLoadSqlGeneratorTest.kt
@@ -11,6 +11,7 @@ import io.airbyte.cdk.load.message.Meta.Companion.COLUMN_NAME_AB_GENERATION_ID
 import io.airbyte.cdk.load.orchestration.db.ColumnNameMapping
 import io.airbyte.cdk.load.orchestration.db.TableName
 import io.airbyte.integrations.destination.snowflake.db.toSnowflakeCompatibleName
+import io.airbyte.integrations.destination.snowflake.spec.CdcDeletionMode
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -28,6 +29,7 @@ internal class SnowflakeDirectLoadSqlGeneratorTest {
         snowflakeDirectLoadSqlGenerator =
             SnowflakeDirectLoadSqlGenerator(
                 columnUtils = columnUtils,
+                cdcDeletionMode = CdcDeletionMode.HARD_DELETE,
             )
     }
 


### PR DESCRIPTION
## What

1. SnowflakeDirectLoadSqlGenerator.kt:
    - Added cdcDeletionMode: CdcDeletionMode parameter to the constructor
    - Imported CDC_DELETED_AT_COLUMN constant and CdcDeletionMode type
    - Updated the upsertTable method to handle CDC deletions:
        - When cdcDeletionMode == HARD_DELETE and the stream contains _ab_cdc_deleted_at:
            - Adds a DELETE clause to remove records marked for deletion
        - Prevents inserting new records that are already marked as deleted
      - Uses conditional logic to build different MERGE statements based on whether CDC deletion is active
  2. SnowflakeDirectLoadSqlGeneratorTest.kt:
    - Updated to provide CdcDeletionMode.HARD_DELETE when creating the generator instance
    - Added the necessary import for CdcDeletionMode

## How

When CDC deletion mode is set to HARD_DELETE and a stream contains the _ab_cdc_deleted_at column:

  1. For matched records: If _ab_cdc_deleted_at is NOT NULL and the record is newer (based on cursor comparison), the record is physically DELETED from the target table
  2. For unmatched records: If _ab_cdc_deleted_at is NOT NULL, the insertion is skipped entirely (handles cases where a deletion event arrives before the initial insert)

The implementation mirrors the BigQuery approach but adapts to Snowflake's SQL syntax. The configuration infrastructure was already in place (from lines 99 and 72 of SnowflakeSpecification.kt and SnowflakeConfiguration.kt), so the SQL generator now properly uses this configuration to determine how to
   handle CDC deletions.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [X] YES 💚
- [ ] NO ❌
