### PR TITLE
fix(source-hubspot): rollback version on cloud

### DIFF
--- a/airbyte-integrations/connectors/source-hubspot/metadata.yaml
+++ b/airbyte-integrations/connectors/source-hubspot/metadata.yaml
@@ -36,6 +36,7 @@ data:
   registryOverrides:
     cloud:
       enabled: true
+      dockerImageTag: 6.0.1
     oss:
       enabled: true
   releaseStage: generally_available


### PR DESCRIPTION
## What
- rolling back `source-hubspot` to 6.0.1 which resolve the datatyping issue issue implemented in 6.0.2
    - there seems to be a bug in the way either the CDK handles multiple possible datatypes for dynamic schemas OR the way the platform infers these datatypes
    - Specifically, when there are multiple types with `{ "oneOf": [{ "type": ["null", "number"]}, {"type": ["null", "string"]}]}`, the platform does not know how to interpret the datatype and renders an `Unknown` datatype.
- Mitigates issue noted in: https://github.com/airbytehq/oncall/issues/9368

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._