### PR TITLE
use composite key for workflow runs to keep all attempt

### DIFF
--- a/airbyte-integrations/connectors/source-github/source_github/streams.py
+++ b/airbyte-integrations/connectors/source-github/source_github/streams.py
@@ -1446,6 +1446,7 @@ class WorkflowRuns(SemiIncrementalMixin, GithubStream):
     API documentation: https://docs.github.com/en/rest/actions/workflow-runs?apiVersion=2022-11-28#list-workflow-runs-for-a-repository
     """
 
+    primary_key = ["id", "run_attempt"]
     # key for accessing slice value from record
     record_slice_key = ["repository", "full_name"]
 


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->
Currently we randomly keep workflow runs rows when there are many attempt for the same workflow run.

## How
The correct primary key to use to keep all attemps is the combination of the id of the workflow run and the number of attempt

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->
User will always have all attempt.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [X] YES 💚
- [ ] NO ❌
