### PR TITLE
Rm generation alias

### DIFF
--- a/airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/client/SnowflakeAirbyteClient.kt
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/client/SnowflakeAirbyteClient.kt
@@ -7,6 +7,7 @@ package io.airbyte.integrations.destination.snowflake.client
 import io.airbyte.cdk.load.client.AirbyteClient
 import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.message.Meta.Companion.COLUMN_NAMES
+import io.airbyte.cdk.load.message.Meta.Companion.COLUMN_NAME_AB_GENERATION_ID
 import io.airbyte.cdk.load.orchestration.db.ColumnNameMapping
 import io.airbyte.cdk.load.orchestration.db.TableName
 import io.airbyte.cdk.load.orchestration.db.direct_load_table.DirectLoadTableNativeOperations
@@ -23,7 +24,6 @@ import javax.sql.DataSource
 import net.snowflake.client.jdbc.SnowflakeSQLException
 
 internal const val DESCRIBE_TABLE_COLUMN_NAME_FIELD = "column_name"
-internal const val GENERATION_ID_ALIAS = "generation"
 
 private val log = KotlinLogging.logger {}
 
@@ -181,11 +181,11 @@ class SnowflakeAirbyteClient(
 
     override suspend fun getGenerationId(tableName: TableName): Long =
         try {
-            val sql = sqlGenerator.getGenerationId(tableName, GENERATION_ID_ALIAS)
+            val sql = sqlGenerator.getGenerationId(tableName)
             dataSource.connection.use { connection ->
                 val resultSet = connection.createStatement().executeQuery(sql)
                 if (resultSet.next()) {
-                    resultSet.getLong(GENERATION_ID_ALIAS)
+                    resultSet.getLong(COLUMN_NAME_AB_GENERATION_ID)
                 } else {
                     log.warn { "No generation ID found for table $tableName, returning 0" }
                     0L

--- a/airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/sql/SnowflakeDirectLoadSqlGenerator.kt
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/sql/SnowflakeDirectLoadSqlGenerator.kt
@@ -306,11 +306,9 @@ class SnowflakeDirectLoadSqlGenerator(
 
     fun getGenerationId(
         tableName: TableName,
-        alias: String = "",
     ): String {
-        val aliasClause = if (alias.isNotEmpty()) " AS $alias" else ""
         return """
-            SELECT "$COLUMN_NAME_AB_GENERATION_ID"$aliasClause 
+            SELECT "$COLUMN_NAME_AB_GENERATION_ID"
             FROM ${tableName.toPrettyString(QUOTE)} 
             LIMIT 1
         """

--- a/airbyte-integrations/connectors/destination-snowflake/src/test/kotlin/io/airbyte/integrations/destination/snowflake/client/SnowflakeAirbyteClientTest.kt
+++ b/airbyte-integrations/connectors/destination-snowflake/src/test/kotlin/io/airbyte/integrations/destination/snowflake/client/SnowflakeAirbyteClientTest.kt
@@ -5,6 +5,7 @@
 package io.airbyte.integrations.destination.snowflake.client
 
 import io.airbyte.cdk.load.command.DestinationStream
+import io.airbyte.cdk.load.message.Meta.Companion.COLUMN_NAME_AB_GENERATION_ID
 import io.airbyte.cdk.load.orchestration.db.ColumnNameMapping
 import io.airbyte.cdk.load.orchestration.db.TableName
 import io.airbyte.integrations.destination.snowflake.sql.COUNT_TOTAL_ALIAS
@@ -246,7 +247,7 @@ internal class SnowflakeAirbyteClientTest {
         val resultSet =
             mockk<ResultSet> {
                 every { next() } returns true
-                every { getLong(GENERATION_ID_ALIAS) } returns generationId
+                every { getLong(COLUMN_NAME_AB_GENERATION_ID) } returns generationId
             }
         val statement = mockk<Statement> { every { executeQuery(any()) } returns resultSet }
         val mockConnection =
@@ -260,7 +261,7 @@ internal class SnowflakeAirbyteClientTest {
         runBlocking {
             val result = client.getGenerationId(tableName)
             assertEquals(generationId, result)
-            verify(exactly = 1) { sqlGenerator.getGenerationId(tableName, GENERATION_ID_ALIAS) }
+            verify(exactly = 1) { sqlGenerator.getGenerationId(tableName) }
             verify(exactly = 1) { mockConnection.close() }
         }
     }
@@ -281,7 +282,7 @@ internal class SnowflakeAirbyteClientTest {
         runBlocking {
             val result = client.getGenerationId(tableName)
             assertEquals(0L, result)
-            verify(exactly = 1) { sqlGenerator.getGenerationId(tableName, GENERATION_ID_ALIAS) }
+            verify(exactly = 1) { sqlGenerator.getGenerationId(tableName) }
             verify(exactly = 1) { mockConnection.close() }
         }
     }
@@ -302,7 +303,7 @@ internal class SnowflakeAirbyteClientTest {
         runBlocking {
             val result = client.getGenerationId(tableName)
             assertEquals(0L, result)
-            verify(exactly = 1) { sqlGenerator.getGenerationId(tableName, GENERATION_ID_ALIAS) }
+            verify(exactly = 1) { sqlGenerator.getGenerationId(tableName) }
             verify(exactly = 1) { mockConnection.close() }
         }
     }

--- a/airbyte-integrations/connectors/destination-snowflake/src/test/kotlin/io/airbyte/integrations/destination/snowflake/sql/SnowflakeDirectLoadSqlGeneratorTest.kt
+++ b/airbyte-integrations/connectors/destination-snowflake/src/test/kotlin/io/airbyte/integrations/destination/snowflake/sql/SnowflakeDirectLoadSqlGeneratorTest.kt
@@ -244,18 +244,6 @@ new_record."_airbyte_generation_id"
     }
 
     @Test
-    fun testGenerateGenerationIdQueryWithAlias() {
-        val alias = "test-alias"
-        val tableName = TableName(namespace = "namespace", name = "name")
-        val sql =
-            snowflakeDirectLoadSqlGenerator.getGenerationId(tableName = tableName, alias = alias)
-        assertEquals(
-            "SELECT \"$COLUMN_NAME_AB_GENERATION_ID\" AS $alias \nFROM ${tableName.toPrettyString(QUOTE)} \nLIMIT 1",
-            sql
-        )
-    }
-
-    @Test
     fun testGenerateCreateFileFormat() {
         val namespace = "test-namespace"
         val expected =


### PR DESCRIPTION
## What
Remove the alias from the generation getter. It made the generationId retrieval disappear from the test `testAppendSchemaEvolution`.

## How
<!--
* Describe how code changes achieve the solution.
-->

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
