### PR TITLE
source-sftp-bulk increase memory for check and discover.yaml

### DIFF
--- a/airbyte-integrations/connectors/source-sftp-bulk/metadata.yaml
+++ b/airbyte-integrations/connectors/source-sftp-bulk/metadata.yaml
@@ -1,4 +1,14 @@
 data:
+  resourceRequirements:
+    jobSpecific:
+      - jobType: check_connection
+        resourceRequirements:
+          memory_limit: 4096mi
+          memory_request: 4096mi
+      - jobType: discover_schema
+        resourceRequirements:
+          memory_limit: 4096mi
+          memory_request: 4096mi
   ab_internal:
     ql: 200
     sl: 300


### PR DESCRIPTION
Bumps Memory on CHECK and DISCOVER to 4gb.


## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
