### PR TITLE
Fix the testGetMappedColumnName from SnowflakeColumnNameMapperTest

### DIFF
--- a/airbyte-integrations/connectors/destination-snowflake/src/test/kotlin/io/airbyte/integrations/destination/snowflake/write/transform/SnowflakeColumnNameMapperTest.kt
+++ b/airbyte-integrations/connectors/destination-snowflake/src/test/kotlin/io/airbyte/integrations/destination/snowflake/write/transform/SnowflakeColumnNameMapperTest.kt
@@ -5,6 +5,8 @@
 package io.airbyte.integrations.destination.snowflake.write.transform
 
 import io.airbyte.cdk.load.command.DestinationStream
+import io.airbyte.cdk.load.orchestration.db.legacy_typing_deduping.TableCatalog
+import io.mockk.every
 import io.mockk.mockk
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -14,9 +16,15 @@ internal class SnowflakeColumnNameMapperTest {
     @Test
     fun testGetMappedColumnName() {
         val columnName = "test-column-name"
+        val expectedMappedName = "TEST_COLUMN_NAME"
         val stream = mockk<DestinationStream>()
-        val mapper = SnowflakeColumnNameMapper()
+        val tableCatalog = mockk<TableCatalog>()
+
+        // Configure the mock to return the expected mapped column name
+        every { tableCatalog.getMappedColumnName(stream, columnName) } returns expectedMappedName
+
+        val mapper = SnowflakeColumnNameMapper(tableCatalog)
         val result = mapper.getMappedColumnName(stream = stream, columnName = columnName)
-        assertEquals(columnName, result)
+        assertEquals(expectedMappedName, result)
     }
 }

--- a/airbyte-integrations/connectors/destination-snowflake/src/test/kotlin/io/airbyte/integrations/destination/snowflake/write/transform/SnowflakeColumnNameMapperTest.kt
+++ b/airbyte-integrations/connectors/destination-snowflake/src/test/kotlin/io/airbyte/integrations/destination/snowflake/write/transform/SnowflakeColumnNameMapperTest.kt
@@ -15,16 +15,16 @@ internal class SnowflakeColumnNameMapperTest {
 
     @Test
     fun testGetMappedColumnName() {
-        val columnName = "test-column-name"
-        val expectedMappedName = "TEST_COLUMN_NAME"
+        val columnName = "tést-column-name"
+        val expectedName = "test-column-name"
         val stream = mockk<DestinationStream>()
         val tableCatalog = mockk<TableCatalog>()
 
         // Configure the mock to return the expected mapped column name
-        every { tableCatalog.getMappedColumnName(stream, columnName) } returns expectedMappedName
+        every { tableCatalog.getMappedColumnName(stream, columnName) } returns expectedName
 
         val mapper = SnowflakeColumnNameMapper(tableCatalog)
         val result = mapper.getMappedColumnName(stream = stream, columnName = columnName)
-        assertEquals(expectedMappedName, result)
+        assertEquals(expectedName, result)
     }
 }


### PR DESCRIPTION
## What

Just fixing the test because it is broken at the moment
It should have been updated when I updated the ColumnNameMapper earlier

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [X] YES 💚
- [ ] NO ❌
