### PR TITLE
Update metadata to Increase Memory for Check and Discover.yaml

### DIFF
--- a/airbyte-integrations/connectors/source-sftp-bulk/metadata.yaml
+++ b/airbyte-integrations/connectors/source-sftp-bulk/metadata.yaml
@@ -1,4 +1,14 @@
 data:
+  resourceRequirements:
+    jobSpecific:
+    - jobType: check_connection
+      resourceRequirements:
+        memory_limit: 4096Mi
+        memory_request: 4096Mi
+    - jobType: discover_schema
+      resourceRequirements:
+        memory_limit: 4096Mi
+        memory_request: 4096Mi
   ab_internal:
     ql: 200
     sl: 300


### PR DESCRIPTION
Declares resources for Check and Discover to:
  resourceRequirements:
    jobSpecific:
    - jobType: check_connection
      resourceRequirements:
        memory_limit: 4096Mi
        memory_request: 4096Mi
    - jobType: discover_schema
      resourceRequirements:
        memory_limit: 4096Mi
        memory_request: 4096Mi

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._

> [!NOTE]
> **Auto-merge may have been disabled. Please check the PR status to confirm.**