### PR TITLE
fix: re-enable validation of meta changes in integration tests

### DIFF
--- a/airbyte-integrations/connectors/destination-snowflake/src/test-integration/kotlin/io/airbyte/integrations/destination/snowflake/write/SnowflakeAcceptanceTest.kt
+++ b/airbyte-integrations/connectors/destination-snowflake/src/test-integration/kotlin/io/airbyte/integrations/destination/snowflake/write/SnowflakeAcceptanceTest.kt
@@ -46,6 +46,7 @@ import io.airbyte.integrations.destination.snowflake.spec.SnowflakeSpecification
 import io.airbyte.integrations.destination.snowflake.sql.QUOTE
 import io.airbyte.integrations.destination.snowflake.write.transform.isValid
 import io.airbyte.protocol.models.v0.AirbyteRecordMessageMetaChange
+import io.airbyte.protocol.models.v0.AirbyteRecordMessageMetaChange.Change
 import java.math.BigDecimal
 import java.nio.file.Files
 import java.nio.file.Path
@@ -120,8 +121,14 @@ object SnowflakeExpectedRecordMapper : ExpectedRecordMapper {
                     .mapValuesTo(linkedMapOf()) { (_, value) -> mapAirbyteValue(value) }
                     .mapKeysTo(linkedMapOf()) { it.key.toSnowflakeCompatibleName() }
             )
-        // Null out the Airbyte metadata to avoid failures
-        return expectedRecord.copy(data = mappedData, airbyteMeta = null)
+
+        val mappedAirbyteMetadata =
+            mapAirbyteMetadata(
+                originalData = expectedRecord.data,
+                mappedData = mappedData,
+                airbyteMetadata = expectedRecord.airbyteMeta
+            )
+        return expectedRecord.copy(data = mappedData, airbyteMeta = mappedAirbyteMetadata)
     }
 
     private fun mapAirbyteValue(value: AirbyteValue): AirbyteValue {
@@ -134,6 +141,44 @@ object SnowflakeExpectedRecordMapper : ExpectedRecordMapper {
             }
         } else {
             NullValue
+        }
+    }
+
+    private fun mapAirbyteMetadata(
+        originalData: ObjectValue,
+        mappedData: ObjectValue,
+        airbyteMetadata: OutputRecord.Meta?
+    ): OutputRecord.Meta? {
+        val nullValues =
+        // Find all values that the test has converted to a NullValue because the actual
+        // value will fail the validation performed by the SnowflakeValueCoercer at runtime.
+        // This excludes any "_ab" prefixed metadata columns or any columns that are already
+        // null in the input data for the test.
+        mappedData.values.entries.filter {
+                !it.key.startsWith("_ab") &&
+                    it.value is NullValue &&
+                    originalData.values[it.key] != NullValue
+            }
+        return if (nullValues.isNotEmpty()) {
+            val changes =
+                nullValues
+                    // If the field null-ed out by this mapper is already in the input metadata
+                    // change list, ignore it.  Otherwise, add it to the collection of changes
+                    // to synthesize the validation null-ing of the field.
+                    .filter { (k, _) -> airbyteMetadata?.changes?.find { it.field == k } == null }
+                    .map { (k, _) ->
+                        Meta.Change(
+                            field = k,
+                            change = Change.NULLED,
+                            reason =
+                                AirbyteRecordMessageMetaChange.Reason
+                                    .DESTINATION_FIELD_SIZE_LIMITATION
+                        )
+                    }
+            airbyteMetadata?.copy(changes = changes + airbyteMetadata.changes)
+                ?: OutputRecord.Meta(changes = changes, syncId = null)
+        } else {
+            airbyteMetadata
         }
     }
 }
@@ -185,12 +230,10 @@ fun stringToMeta(metaAsString: String?): OutputRecord.Meta? {
             )
         }
 
-    //    return OutputRecord.Meta(
-    //        changes = changes,
-    //        syncId = metaJson["sync_id"].longValue(),
-    //    )
-    // Null out the airbyte metadata to avoid failures
-    return null
+    return OutputRecord.Meta(
+        changes = changes,
+        syncId = metaJson["sync_id"].longValue(),
+    )
 }
 
 class SnowflakeDataDumper(


### PR DESCRIPTION
## What
* Validate meta changes added to records as part of Snowflake integration tests

## How
* Add custom logic to the expected record mapper implementation to synthesize airbyte metadata changes to match the ones added by the connector's coercer implementation

## Review guide
1. `SnowflakeAcceptanceTest.kt`

## Can this PR be safely reverted and rolled back?
- [X] YES 💚
- [ ] NO ❌
