### PR TITLE
fix: have a matching key for dedup operation

### DIFF
--- a/airbyte-integrations/connectors/destination-customer-io/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-customer-io/metadata.yaml
@@ -12,7 +12,7 @@ data:
   connectorSubtype: api
   connectorType: destination
   definitionId: c101b15f-2de9-4616-b54f-0ec9d28ca64d
-  dockerImageTag: 0.0.6
+  dockerImageTag: 0.0.7
   dockerRepository: airbyte/destination-customer-io
   githubIssueLabel: destination-customer-io
   icon: icon.svg

--- a/airbyte-integrations/connectors/destination-customer-io/src/main/resources/manifest.yaml
+++ b/airbyte-integrations/connectors/destination-customer-io/src/main/resources/manifest.yaml
@@ -54,12 +54,12 @@ discover:
         type: Upsert
       schema:
         type: object
-        required:
-          - person_email
         additionalProperties: true
         properties:
           person_email:
             type: string
+      matching_keys:
+        - - person_email
     - type: StaticCatalogOperation
       object_name: person_event
       destination_import_mode:

--- a/docs/integrations/destinations/customer-io.md
+++ b/docs/integrations/destinations/customer-io.md
@@ -53,6 +53,7 @@ In order to configure this connector, you need to generate your Track API Key an
 
 | Version | Date       | Pull Request                                              | Subject                                                   |
 |:--------|:-----------|:----------------------------------------------------------|:----------------------------------------------------------|
+| 0.0.7   | 2025-09-23 | [66571](https://github.com/airbytehq/airbyte/pull/66571)      | Fix person_identify in incremental mode                   |
 | 0.0.6   | 2025-09-16 | [tbd](https://github.com/airbytehq/airbyte/pull/tbd)      | Use low-code discover definition and pin to a CDK version |
 | 0.0.5   | 2025-09-08 | [65157](https://github.com/airbytehq/airbyte/pull/65157)  | Update following breaking changes on spec                 |
 | 0.0.4   | 2025-08-20 | [#65113](https://github.com/airbytehq/airbyte/pull/65113) | Update logo                                               |


### PR DESCRIPTION
## What
destination-customer-io is failing read operations when upserting on person_identify because it is destination sync mode `append_dedup` but there are not primary keys. When we did our testing [here](https://cloud.airbyte.com/workspaces/8ba9a84d-ef49-41fb-9aaa-9f75fb0f351e/connections/cf1e851f-1042-468f-bf28-68fbfec5734d/timeline), we were not running in incremental mode which is why we haven't seen this problem. 

See https://airbytehq-team.slack.com/archives/C08BGNKAL21/p1758126825558859 for more context

Previous operation:
```
            {
                "object_name": "person_identify",
                "sync_mode": "append_dedup",
                "json_schema": {
                    "type": "object",
                    "properties": {
                        "person_email": {
                            "type": "string"
                        }
                    },
                    "required": [
                        "person_email"
                    ],
                    "additionalProperties": true
                },
                "matching_keys": []
            },
```

New operation:
```
            {
                "object_name": "person_identify",
                "sync_mode": "append_dedup",
                "json_schema": {
                    "type": "object",
                    "properties": {
                        "person_email": {
                            "type": "string"
                        }
                    },
                    "additionalProperties": true
                },
                "matching_keys": [
                    [
                        "person_email"
                    ]
                ]
            },
```

## How
Adding the `person_email` as a matching key.

Note that I assume this is a breaking change because there needs to be a primary key stored in the DB for incremental syncs but it wasn't working at all before so I'm not too worried about this. Full refresh syncs should still work even without PK

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
This should prevent syncs to fail in incremental mode

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
