### PR TITLE
POC for iceberg polaris oauth

### DIFF
--- a/airbyte-integrations/connectors/destination-s3-data-lake/gradle.properties
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/gradle.properties
@@ -1,2 +1,2 @@
 testExecutionConcurrency=-1
-cdkVersion=0.602
+cdkVersion=local

--- a/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/io/S3DataLakeUtil.kt
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/io/S3DataLakeUtil.kt
@@ -34,6 +34,7 @@ import org.apache.iceberg.aws.AwsProperties
 import org.apache.iceberg.aws.s3.S3FileIO
 import org.apache.iceberg.aws.s3.S3FileIOProperties
 import org.apache.iceberg.catalog.Catalog
+import org.apache.iceberg.rest.auth.OAuth2Properties
 import org.projectnessie.client.NessieConfigConstants
 
 private const val AWS_REGION = "aws.region"
@@ -127,9 +128,11 @@ class S3DataLakeUtil(
                 S3FileIOProperties.ACCESS_KEY_ID to awsAccessKeyId,
                 S3FileIOProperties.SECRET_ACCESS_KEY to awsSecretAccessKey,
                 // this is the client ID + secret
-                "credential" to "root:s3cr3t",
+                OAuth2Properties.CREDENTIAL to "root:s3cr3t",
                 // we should maybe figure out if we can use a reduced scope
-                "scope" to "PRINCIPAL_ROLE:ALL",
+                OAuth2Properties.SCOPE to "PRINCIPAL_ROLE:ALL",
+                OAuth2Properties.OAUTH2_SERVER_URI to
+                    "http://localhost:8181/api/catalog/v1/oauth/tokens",
             )
 
         return restProperties + s3Properties

--- a/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/io/S3DataLakeUtil.kt
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/io/S3DataLakeUtil.kt
@@ -128,11 +128,11 @@ class S3DataLakeUtil(
                 S3FileIOProperties.ACCESS_KEY_ID to awsAccessKeyId,
                 S3FileIOProperties.SECRET_ACCESS_KEY to awsSecretAccessKey,
                 // this is the client ID + secret
-                OAuth2Properties.CREDENTIAL to "root:s3cr3t",
+                OAuth2Properties.CREDENTIAL to "<client_id>:<client_secret>",
                 // we should maybe figure out if we can use a reduced scope
-                OAuth2Properties.SCOPE to "PRINCIPAL_ROLE:ALL",
+                OAuth2Properties.SCOPE to "api://8ba0cae2-a76a-49fa-a1e0-27b78ddb10ad/.default",
                 OAuth2Properties.OAUTH2_SERVER_URI to
-                    "http://localhost:8181/api/catalog/v1/oauth/tokens",
+                    "https://login.microsoftonline.com/277f8a66-1e88-46c9-8c7b-23c442857904/oauth2/v2.0/token",
             )
 
         return restProperties + s3Properties

--- a/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/io/S3DataLakeUtil.kt
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/io/S3DataLakeUtil.kt
@@ -126,6 +126,10 @@ class S3DataLakeUtil(
                 URI to catalogConfig.serverUri,
                 S3FileIOProperties.ACCESS_KEY_ID to awsAccessKeyId,
                 S3FileIOProperties.SECRET_ACCESS_KEY to awsSecretAccessKey,
+                // this is the client ID + secret
+                "credential" to "root:s3cr3t",
+                // we should maybe figure out if we can use a reduced scope
+                "scope" to "PRINCIPAL_ROLE:ALL",
             )
 
         return restProperties + s3Properties

--- a/airbyte-integrations/connectors/destination-s3-data-lake/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_data_lake/S3DataLakeWriteTest.kt
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_data_lake/S3DataLakeWriteTest.kt
@@ -243,8 +243,13 @@ class NessieMinioWriteTest : S3DataLakeWriteTest(getConfig(), SimpleTableIdGener
 // even across multiple streams.
 // so run singlethreaded.
 @Execution(ExecutionMode.SAME_THREAD)
-@Disabled("Tests failing in master")
+// @Disabled("Tests failing in master")
 class RestWriteTest : S3DataLakeWriteTest(getConfig(), SimpleTableIdGenerator()) {
+
+    @Test
+    override fun testBasicWrite() {
+        super.testBasicWrite()
+    }
 
     @Test
     @Disabled("https://github.com/airbytehq/airbyte-internal-issues/issues/11439")
@@ -264,22 +269,24 @@ class RestWriteTest : S3DataLakeWriteTest(getConfig(), SimpleTableIdGenerator())
 
         fun getConfig(): String {
             // We retrieve the ephemeral host/port from the updated RestTestContainers
-            val minioEndpoint = RestTestContainers.testcontainers.getServiceHost("minio", 9000)
-            val restEndpoint = RestTestContainers.testcontainers.getServiceHost("rest", 8181)
+            //            val minioEndpoint =
+            // RestTestContainers.testcontainers.getServiceHost("minio", 9000)
+            //            val restEndpoint =
+            // RestTestContainers.testcontainers.getServiceHost("rest", 8181)
 
             return """
             {
                 "catalog_type": {
                   "catalog_type": "REST",
-                  "server_uri": "http://$restEndpoint:8181",
+                  "server_uri": "http://localhost:8181/api/catalog",
                   "namespace": "<DEFAULT_NAMESPACE_PLACEHOLDER>"
                 },
-                "s3_bucket_name": "warehouse",
+                "s3_bucket_name": "bucket123",
                 "s3_bucket_region": "us-east-1",
-                "access_key_id": "admin",
-                "secret_access_key": "password",
-                "s3_endpoint": "http://$minioEndpoint:9100",
-                "warehouse_location": "s3://warehouse/",
+                "access_key_id": "minio_root",
+                "secret_access_key": "m1n1opwd",
+                "s3_endpoint": "http://localhost:9000",
+                "warehouse_location": "quickstart_catalog",
                 "main_branch_name": "main"
             }
             """.trimIndent()
@@ -289,7 +296,7 @@ class RestWriteTest : S3DataLakeWriteTest(getConfig(), SimpleTableIdGenerator())
         @BeforeAll
         fun setup() {
             // Start the testcontainers environment once before any tests run
-            RestTestContainers.start()
+            //            RestTestContainers.start()
         }
     }
 }


### PR DESCRIPTION
## tl;dr

* polaris has built-in oauth idp - it's deprecated, but still available. Possibly will be removed soon though... https://github.com/apache/iceberg/issues/10537
* integrating with the builtin idp is easy, no need for user interactive oauthentication. Just get the client ID + client secret via the connector config
    * we should figure out what scopes we actually need, or if `PRINCIPAL_ROLE:ALL` is correct
    * integrating with other IDPs - definitely not a thing we should have in scope, but we should structure the spec to make this easy in the future (`{oneOf: [ { polaris builtin } ] }`)
* running polaris is kind of tricky, the quickstart docker compose file does a ton of stuff, and it's not obvious how much of it we actually need
    * the more we can cut, the better (docker networking in CI...)
    * we should probably replace the exiting REST test with polaris
    * in principle, we should be able to just spin up a minio container + the polaris container manually, + execute some REST calls to set up polaris - I couldn't get this to work, but I also didn't spend a tooon of time on this
* our connector seems to Just Work (iceberg fulfills its promise!)

## Testing
Start the polaris + minio containers:
```shell
git clone https://github.com/apache/polaris
cd polaris
./gradlew :polaris-server:assemble -Dquarkus.container-image.build=true
docker compose -f getting-started/minio/docker-compose.yml up
```

run anything from `RestWriteTest` in non-docker mode, observe that it succeeds
<img width="282" height="34" alt="image" src="https://github.com/user-attachments/assets/9bc24be4-6eb1-41ab-b1f5-927b20f105ca" />

## random curl commands to talk to polaris

```shell
export ASSETS_PATH=$(pwd)/getting-started/assets/
export QUARKUS_DATASOURCE_JDBC_URL=jdbc:postgresql://postgres:5432/POLARIS
export QUARKUS_DATASOURCE_USERNAME=postgres
export QUARKUS_DATASOURCE_PASSWORD=postgres
export CLIENT_ID=root
export CLIENT_SECRET=s3cr3t

# get an access token
export POLARIS_TOKEN=$(curl -s http://polaris:8181/api/catalog/v1/oauth/tokens \
   --resolve polaris:8181:127.0.0.1 \
   --user ${CLIENT_ID}:${CLIENT_SECRET} \
   -d 'grant_type=client_credentials' \
   -d 'scope=PRINCIPAL_ROLE:ALL' | jq -r .access_token)

# create a minio-backed catalog
curl -v -X POST -H "Authorization: Bearer $POLARIS_TOKEN" \
  -H "Content-Type: application/json" \
  "http://localhost:8181/api/management/v1/catalogs" \
  -d '{
        "catalog": {
          "name": "my_cool_warehouse",
          "type": "INTERNAL",
          "properties": {
            "default-base-location": "s3://thebucket/"
          },
          "storageConfigInfo": {
            "storageType": "S3",
            "endpoint": "http://localhost:9000",
            "pathStyleAccess": true,
            "region": "us-east2",
            "allowedLocations": [
              "s3://thebucket/"
            ]
          }
        }
      }'
```

largely taken from:
* https://polaris.apache.org/releases/1.0.0/getting-started/quickstart/
* https://polaris.apache.org/releases/1.1.0/getting-started/minio/
* https://github.com/apache/iceberg/blob/main/open-api/rest-catalog-open-api.yaml
* https://github.com/apache/polaris/blob/main/spec/polaris-management-service.yml