### PR TITLE
Rbroughan/fix proto input stream hang

### DIFF
--- a/airbyte-cdk/bulk/changelog.md
+++ b/airbyte-cdk/bulk/changelog.md
@@ -1,3 +1,7 @@
+## Version 0.1.42
+
+Datflow Load CDK: Fixes hang when one of many parallel pipelines fails. Organizes thread pools. 
+
 ## Version 0.1.41
 
 **Extract CDK**
@@ -11,6 +15,8 @@ Add gradle task to bump CDK version + add changelog entry
 ## Version 0.1.39
 
 Minor fixes with stream completion logic + proto conversion in Load CDK.
+
+* **Changed:** Minor fixes with stream completion logic + proto conversion
 
 ## Version 0.1.38
 

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/config/ConnectorInputStreams.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/config/ConnectorInputStreams.kt
@@ -11,4 +11,6 @@ import java.io.InputStream
  * subject to Micronaut merging like beans into a single list leading to injecting unexpected extra
  * input streams.
  */
-class ConnectorInputStreams(private val values: List<InputStream>) : List<InputStream> by values
+class ConnectorInputStreams(private val values: List<InputStream>) : List<InputStream> by values {
+    fun closeAll() = values.forEach { it.close() }
+}

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/config/DispatcherBeanFactory.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/config/DispatcherBeanFactory.kt
@@ -13,9 +13,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.asCoroutineDispatcher
 
-/**
- * The dispatchers (think views of thread pools) and static scopes we use for dataflow.
- */
+/** The dispatchers (think views of thread pools) and static scopes we use for dataflow. */
 @Factory
 class DispatcherBeanFactory {
     @Named("pipelineRunnerDispatcher")

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/config/DispatcherBeanFactory.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/config/DispatcherBeanFactory.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.load.dataflow.config
+
+import io.micronaut.context.annotation.Factory
+import jakarta.inject.Named
+import jakarta.inject.Singleton
+import java.util.concurrent.Executors
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.asCoroutineDispatcher
+
+/**
+ * The dispatchers (think views of thread pools) and static scopes we use for dataflow.
+ */
+@Factory
+class DispatcherBeanFactory {
+    @Named("pipelineRunnerDispatcher")
+    @Singleton
+    fun pipelineRunnerDispatcher() = Dispatchers.Default
+
+    @Named("stateReconcilerDispatcher") @Singleton fun stateReconcilerDispatcher() = Dispatchers.IO
+
+    @Named("aggregationDispatcher")
+    @Singleton
+    fun aggregationDispatcher(
+        @Named("inputStreams") inputStreams: ConnectorInputStreams,
+    ) = Executors.newFixedThreadPool(inputStreams.size).asCoroutineDispatcher()
+
+    @Named("flushDispatcher") @Singleton fun flushDispatcher() = Dispatchers.IO
+
+    @Named("pipelineRunnerScope")
+    @Singleton
+    fun pipelineRunnerDispatcher(
+        @Named("pipelineRunnerDispatcher") dispatcher: CoroutineDispatcher,
+    ) = CoroutineScope(dispatcher)
+
+    @Named("stateReconcilerScope")
+    @Singleton
+    fun stateDispatcher(
+        @Named("stateReconcilerDispatcher") dispatcher: CoroutineDispatcher,
+    ) = CoroutineScope(dispatcher)
+}

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/config/InputBeanFactory.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/config/InputBeanFactory.kt
@@ -30,6 +30,7 @@ import io.micronaut.context.annotation.Requires
 import io.micronaut.context.annotation.Value
 import jakarta.inject.Named
 import jakarta.inject.Singleton
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
 
 /**
@@ -134,6 +135,8 @@ class InputBeanFactory {
         stateHistogramStore: StateHistogramStore,
         statsStore: CommittedStatsStore,
         memoryAndParallelismConfig: MemoryAndParallelismConfig,
+        @Named("aggregationDispatcher") aggregationDispatcher: CoroutineDispatcher,
+        @Named("flushDispatcher") flushDispatcher: CoroutineDispatcher,
     ): List<DataFlowPipeline> =
         inputFlows.map {
             val aggStore = aggregateStoreFactory.make()
@@ -153,6 +156,8 @@ class InputBeanFactory {
                 state = state,
                 completionHandler = completionHandler,
                 memoryAndParallelismConfig = memoryAndParallelismConfig,
+                aggregationDispatcher = aggregationDispatcher,
+                flushDispatcher = flushDispatcher,
             )
         }
 }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/input/ProtobufDestinationMessageInputFlow.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/input/ProtobufDestinationMessageInputFlow.kt
@@ -13,6 +13,10 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.withContext
 
+/**
+ * Performs non-cooperative blocking IO. Does not respond directly to coroutine
+ * CancellationExceptions.
+ */
 class ProtobufDestinationMessageInputFlow(
     private val inputStream: InputStream,
     private val reader: ProtobufDataChannelReader,

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/pipeline/DataFlowPipeline.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/pipeline/DataFlowPipeline.kt
@@ -6,9 +6,7 @@ package io.airbyte.cdk.load.dataflow.pipeline
 
 import io.airbyte.cdk.load.dataflow.config.MemoryAndParallelismConfig
 import io.airbyte.cdk.load.dataflow.stages.AggregateStage
-import java.util.concurrent.Executors
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.buffer
 import kotlinx.coroutines.flow.flowOn
@@ -24,19 +22,19 @@ class DataFlowPipeline(
     private val state: DataFlowStage,
     private val completionHandler: PipelineCompletionHandler,
     private val memoryAndParallelismConfig: MemoryAndParallelismConfig,
+    private val aggregationDispatcher: CoroutineDispatcher,
+    private val flushDispatcher: CoroutineDispatcher,
 ) {
-    private val customDispatcher = Executors.newSingleThreadExecutor().asCoroutineDispatcher()
-
     suspend fun run() {
         input
             .map(parse::apply)
             .transform { aggregate.apply(it, this) }
             .buffer(capacity = memoryAndParallelismConfig.maxBufferedAggregates)
-            .flowOn(customDispatcher)
+            .flowOn(aggregationDispatcher)
             .map(flush::apply)
             .map(state::apply)
             .onCompletion { completionHandler.apply(it) }
-            .flowOn(Dispatchers.IO)
+            .flowOn(flushDispatcher)
             .collect {}
     }
 }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/pipeline/PipelineCompletionHandler.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/pipeline/PipelineCompletionHandler.kt
@@ -23,7 +23,6 @@ class PipelineCompletionHandler(
         cause: Throwable?,
     ) = coroutineScope {
         if (cause != null) {
-            log.error { "Destination Pipeline Completed — Exceptionally" }
             throw cause
         }
 

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/pipeline/PipelineRunner.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/pipeline/PipelineRunner.kt
@@ -47,9 +47,9 @@ class PipelineRunner(
         log.info { "Disabling state reconciler..." }
         reconciler.disable()
 
-        if (terminalException != null) {
-            log.info { "Destination Pipeline Completed — Exceptionally: $terminalException" }
-            throw terminalException as Throwable
+        terminalException?.let {
+            log.error(terminalException) { "Destination Pipeline Completed — Exceptionally" }
+            throw it
         }
 
         log.info { "Flushing final states..." }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/pipeline/PipelineRunner.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/pipeline/PipelineRunner.kt
@@ -56,7 +56,8 @@ class PipelineRunner(
         reconciler.flushCompleteStates()
 
         if (store.hasStates()) {
-            val stateException = IllegalStateException("Sync completed, but unflushed states were detected.")
+            val stateException =
+                IllegalStateException("Sync completed, but unflushed states were detected.")
             log.info { "Destination Pipeline Completed — Exceptionally: $stateException" }
             throw stateException
         }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/pipeline/PipelineRunner.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/pipeline/PipelineRunner.kt
@@ -4,48 +4,74 @@
 
 package io.airbyte.cdk.load.dataflow.pipeline
 
+import io.airbyte.cdk.load.dataflow.config.ConnectorInputStreams
 import io.airbyte.cdk.load.dataflow.state.StateReconciler
 import io.airbyte.cdk.load.dataflow.state.StateStore
 import io.github.oshai.kotlinlogging.KotlinLogging
+import jakarta.inject.Named
 import jakarta.inject.Singleton
 import java.lang.IllegalStateException
+import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
 
+/**
+ * Orchestrates the running of pipelines in parallel, handles and propagates errors and manages the
+ * state reconciler lifecycle.
+ */
 @Singleton
 class PipelineRunner(
     private val reconciler: StateReconciler,
     private val store: StateStore,
-    val pipelines: List<DataFlowPipeline>,
+    private val pipelines: List<DataFlowPipeline>,
+    private val inputStreams: ConnectorInputStreams,
+    @Named("pipelineRunnerScope") private val pipelineScope: CoroutineScope,
 ) {
     private val log = KotlinLogging.logger {}
 
-    suspend fun run() = coroutineScope {
+    private var terminalException: Throwable? = null
+
+    suspend fun run() {
         log.info { "Destination Pipeline Starting..." }
-        log.info { "Running with ${pipelines.size} input streams..." }
 
-        reconciler.run(CoroutineScope(Dispatchers.IO))
+        log.info { "Starting state reconciler..." }
+        reconciler.run()
 
-        try {
-            pipelines.map { p -> launch { p.run() } }.joinAll()
-            log.info { "Individual pipelines complete..." }
-        } finally {
-            // shutdown the reconciler regardless of success or failure, so we don't hang
-            log.info { "Disabling reconciler..." }
-            reconciler.disable()
+        log.info { "Starting ${pipelines.size} pipelines..." }
+        pipelines.map { p -> pipelineScope.launch(exceptionHandler) { p.run() } }.joinAll()
+        log.info { "Individual pipelines complete..." }
+
+        // shutdown the reconciler regardless of success or failure, so we don't hang
+        log.info { "Disabling state reconciler..." }
+        reconciler.disable()
+
+        if (terminalException != null) {
+            log.info { "Destination Pipeline Completed — Exceptionally: $terminalException" }
+            throw terminalException as Throwable
         }
 
         log.info { "Flushing final states..." }
         reconciler.flushCompleteStates()
 
-        log.info { "Destination Pipeline Completed — Successfully" }
-
         if (store.hasStates()) {
-            log.info { "Unflushed states detected. Failing sync." }
-            throw IllegalStateException("Sync completed, but unflushed states were detected.")
+            val stateException = IllegalStateException("Sync completed, but unflushed states were detected.")
+            log.info { "Destination Pipeline Completed — Exceptionally: $stateException" }
+            throw stateException
         }
+
+        log.info { "Destination Pipeline Completed — Successfully" }
+    }
+
+    // ensure all pipelines close when a single pipeline throws an exception
+    private val exceptionHandler = CoroutineExceptionHandler { context, exception ->
+        log.error { "Caught Pipeline Exception: $exception\n Cancelling Destination Pipeline..." }
+        // close each input stream to cancel any blocking reads on them that would prevent shutdown
+        inputStreams.closeAll()
+        context.cancel()
+        // capture the child exception to re-throw (core-CDK relies on catching thrown exceptions)
+        // exceptions directly thrown from within this block will be suppressed
+        terminalException = exception
     }
 }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/pipeline/PipelineRunner.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/pipeline/PipelineRunner.kt
@@ -11,8 +11,10 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import jakarta.inject.Named
 import jakarta.inject.Singleton
 import java.lang.IllegalStateException
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExecutorCoroutineDispatcher
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
@@ -28,6 +30,7 @@ class PipelineRunner(
     private val pipelines: List<DataFlowPipeline>,
     private val inputStreams: ConnectorInputStreams,
     @Named("pipelineRunnerScope") private val pipelineScope: CoroutineScope,
+    @Named("aggregationDispatcher") private val aggregationDispatcher: CoroutineDispatcher,
 ) {
     private val log = KotlinLogging.logger {}
 
@@ -44,8 +47,14 @@ class PipelineRunner(
         log.info { "Individual pipelines complete..." }
 
         // shutdown the reconciler regardless of success or failure, so we don't hang
-        log.info { "Disabling state reconciler..." }
-        reconciler.disable()
+        try {
+            log.info { "Disabling state reconciler..." }
+            reconciler.disable()
+        } finally {
+            if (aggregationDispatcher is ExecutorCoroutineDispatcher) {
+                aggregationDispatcher.close()
+            }
+        }
 
         terminalException?.let {
             log.error(terminalException) { "Destination Pipeline Completed — Exceptionally" }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/state/StateReconciler.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/state/StateReconciler.kt
@@ -24,18 +24,18 @@ class StateReconciler(
     private val stateStore: StateStore,
     private val emittedStatsStore: EmittedStatsStore,
     private val consumer: OutputConsumer,
-    @Named("stateReconciliationInterval")
-    reconciliationInterval: Duration?, // only java durations can be injected
+    @Named("stateReconcilerScope") private val scope: CoroutineScope,
+    @Named("stateReconcilerInterval") interval: Duration?, // only java durations can be injected
 ) {
     // allow overriding this for test purposes
-    private val reconciliationInterval = reconciliationInterval?.toKotlinDuration() ?: 30.seconds
+    private val interval = interval?.toKotlinDuration() ?: 30.seconds
     private lateinit var job: Job
 
-    fun run(scope: CoroutineScope) {
+    fun run() {
         job =
             scope.launch {
                 while (true) {
-                    delay(reconciliationInterval)
+                    delay(interval)
                     flushCompleteStates()
                     flushEmittedStats()
                 }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/file/ClientSocket.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/file/ClientSocket.kt
@@ -90,20 +90,6 @@ class ClientSocket(
         // will break tests. TODO: Anything else.
         log.info { "Socket file $socketPath connected for reading" }
 
-        val inputStream = Channels.newInputStream(openedSocket).buffered(bufferSizeBytes)
-
-        return inputStream
-    }
-}
-
-class SocketInputStream(
-    private val socketChannel: SocketChannel,
-    private val inputStream: InputStream,
-) : InputStream() {
-    override fun read(): Int = inputStream.read()
-
-    override fun close() {
-        inputStream.close()
-        socketChannel.close()
+        return Channels.newInputStream(openedSocket).buffered(bufferSizeBytes)
     }
 }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/file/ClientSocket.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/file/ClientSocket.kt
@@ -92,7 +92,7 @@ class ClientSocket(
 
         val inputStream = Channels.newInputStream(openedSocket).buffered(bufferSizeBytes)
 
-        return SocketInputStream(openedSocket, inputStream)
+        return inputStream
     }
 }
 

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/file/ProtobufDataChannelReader.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/file/ProtobufDataChannelReader.kt
@@ -11,6 +11,7 @@ import io.airbyte.protocol.protobuf.AirbyteMessage.AirbyteMessageProtobuf
 import java.io.InputStream
 import kotlin.NoSuchElementException
 
+/** Performs non-cooperative blocking IO. */
 class ProtobufDataChannelReader(
     private val factory: DestinationMessageFactory,
     private val bufferSize: Int = 16 * 1024,

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/dataflow/config/ConnectorInputStreamsTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/dataflow/config/ConnectorInputStreamsTest.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.load.dataflow.config
+
+import io.mockk.mockk
+import io.mockk.verify
+import java.io.InputStream
+import org.junit.jupiter.api.Test
+
+class ConnectorInputStreamsTest {
+    @Test
+    fun `closeAll should close all input streams`() {
+        // Given
+        val stream1 = mockk<InputStream>(relaxed = true)
+        val stream2 = mockk<InputStream>(relaxed = true)
+        val stream3 = mockk<InputStream>(relaxed = true)
+        val streams = listOf(stream1, stream2, stream3)
+        val connectorInputStreams = ConnectorInputStreams(streams)
+
+        // When
+        connectorInputStreams.closeAll()
+
+        // Then
+        verify(exactly = 1) { stream1.close() }
+        verify(exactly = 1) { stream2.close() }
+        verify(exactly = 1) { stream3.close() }
+    }
+}

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/dataflow/config/InputBeanFactoryTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/dataflow/config/InputBeanFactoryTest.kt
@@ -26,6 +26,7 @@ import io.mockk.mockk
 import io.mockk.unmockkAll
 import io.mockk.verify
 import java.io.ByteArrayInputStream
+import kotlinx.coroutines.CoroutineDispatcher
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
@@ -59,6 +60,10 @@ class InputBeanFactoryTest {
     @MockK private lateinit var emittedStatsStore: EmittedStatsStore
 
     @MockK private lateinit var committedStatsStore: CommittedStatsStore
+
+    @MockK private lateinit var aggregationDispatcher: CoroutineDispatcher
+
+    @MockK private lateinit var flushDispatcher: CoroutineDispatcher
 
     private var memoryAndParallelismConfig = MemoryAndParallelismConfig()
 
@@ -239,6 +244,8 @@ class InputBeanFactoryTest {
                 stateHistogramStore = stateHistogramStore,
                 statsStore = committedStatsStore,
                 memoryAndParallelismConfig = memoryAndParallelismConfig,
+                aggregationDispatcher = aggregationDispatcher,
+                flushDispatcher = flushDispatcher,
             )
 
         // Then
@@ -274,6 +281,8 @@ class InputBeanFactoryTest {
                 stateHistogramStore = stateHistogramStore,
                 statsStore = committedStatsStore,
                 memoryAndParallelismConfig = memoryAndParallelismConfig,
+                aggregationDispatcher = aggregationDispatcher,
+                flushDispatcher = flushDispatcher,
             )
 
         // Then
@@ -324,6 +333,8 @@ class InputBeanFactoryTest {
                 stateHistogramStore = stateHistogramStore,
                 statsStore = committedStatsStore,
                 memoryAndParallelismConfig = memoryAndParallelismConfig,
+                aggregationDispatcher = aggregationDispatcher,
+                flushDispatcher = flushDispatcher,
             )
 
         // Then

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/dataflow/pipeline/DataFlowPipelineTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/dataflow/pipeline/DataFlowPipelineTest.kt
@@ -9,18 +9,19 @@ import io.airbyte.cdk.load.dataflow.stages.AggregateStage
 import io.mockk.coEvery
 import io.mockk.coVerifySequence
 import io.mockk.mockk
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
-@ExperimentalCoroutinesApi
 class DataFlowPipelineTest {
     private val parse = mockk<DataFlowStage>()
     private val aggregate = mockk<AggregateStage>()
     private val flush = mockk<DataFlowStage>()
     private val state = mockk<DataFlowStage>()
     private val completionHandler = mockk<PipelineCompletionHandler>()
+
     private val memoryAndParallelismConfig =
         MemoryAndParallelismConfig(
             maxOpenAggregates = 2,
@@ -29,6 +30,11 @@ class DataFlowPipelineTest {
 
     @Test
     fun `pipeline execution flow`() = runTest {
+        // Create test scope and dispatchers
+        val testScope = TestScope(this.testScheduler)
+        val aggregationDispatcher = StandardTestDispatcher(testScope.testScheduler)
+        val flushDispatcher = StandardTestDispatcher(testScope.testScheduler)
+        
         // Given
         val initialIO = mockk<DataFlowStageIO>()
         val input = flowOf(initialIO)
@@ -40,7 +46,9 @@ class DataFlowPipelineTest {
                 flush,
                 state,
                 completionHandler,
-                memoryAndParallelismConfig
+                memoryAndParallelismConfig,
+                aggregationDispatcher,
+                flushDispatcher,
             )
 
         val parsedIO = mockk<DataFlowStageIO>()
@@ -60,6 +68,9 @@ class DataFlowPipelineTest {
 
         // When
         pipeline.run()
+        
+        // Advance the test scheduler to process all coroutines
+        testScope.testScheduler.advanceUntilIdle()
 
         // Then
         coVerifySequence {

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/dataflow/pipeline/DataFlowPipelineTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/dataflow/pipeline/DataFlowPipelineTest.kt
@@ -34,7 +34,7 @@ class DataFlowPipelineTest {
         val testScope = TestScope(this.testScheduler)
         val aggregationDispatcher = StandardTestDispatcher(testScope.testScheduler)
         val flushDispatcher = StandardTestDispatcher(testScope.testScheduler)
-        
+
         // Given
         val initialIO = mockk<DataFlowStageIO>()
         val input = flowOf(initialIO)
@@ -68,7 +68,7 @@ class DataFlowPipelineTest {
 
         // When
         pipeline.run()
-        
+
         // Advance the test scheduler to process all coroutines
         testScope.testScheduler.advanceUntilIdle()
 

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/dataflow/state/StateReconcilerTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/dataflow/state/StateReconcilerTest.kt
@@ -18,7 +18,10 @@ import io.mockk.verify
 import io.mockk.verifyOrder
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.toJavaDuration
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.BeforeEach
@@ -37,15 +40,23 @@ class StateReconcilerTest {
 
     private val interval = 30.seconds
 
+    private lateinit var testScope: TestScope
+
+    private lateinit var reconcilerScope: CoroutineScope
+
     private lateinit var stateReconciler: StateReconciler
 
     @BeforeEach
     fun setUp() {
+        testScope = TestScope(StandardTestDispatcher())
+        reconcilerScope = CoroutineScope(testScope.coroutineContext)
+        
         stateReconciler =
             StateReconciler(
                 stateStore,
                 emittedStatsStore,
                 consumer,
+                reconcilerScope,
                 interval.toJavaDuration(),
             )
     }
@@ -135,8 +146,19 @@ class StateReconcilerTest {
         every { emittedStatsStore.getStats() } returns statsList
 
         every { consumer.accept(any<AirbyteMessage>()) } just Runs
+        
+        // Create a new reconciler with the test scope for this test
+        val localReconciler =
+            StateReconciler(
+                stateStore,
+                emittedStatsStore,
+                consumer,
+                this.backgroundScope,
+                interval.toJavaDuration(),
+            )
+        
         // When
-        stateReconciler.run(this.backgroundScope)
+        localReconciler.run()
 
         // Advance time to trigger multiple flushes
         advanceTimeBy(interval) // First flush
@@ -168,11 +190,21 @@ class StateReconcilerTest {
         every { stateStore.getNextComplete() } returns null
         every { emittedStatsStore.getStats() } returns null
 
+        // Create a new reconciler with the test scope for this test
+        val localReconciler =
+            StateReconciler(
+                stateStore,
+                emittedStatsStore,
+                consumer,
+                this.backgroundScope,
+                interval.toJavaDuration(),
+            )
+
         // Start the reconciler
-        stateReconciler.run(this.backgroundScope)
+        localReconciler.run()
 
         // When
-        stateReconciler.disable()
+        localReconciler.disable()
 
         // Then
         advanceTimeBy(60.seconds)

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/dataflow/state/StateReconcilerTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/dataflow/state/StateReconcilerTest.kt
@@ -50,7 +50,7 @@ class StateReconcilerTest {
     fun setUp() {
         testScope = TestScope(StandardTestDispatcher())
         reconcilerScope = CoroutineScope(testScope.coroutineContext)
-        
+
         stateReconciler =
             StateReconciler(
                 stateStore,
@@ -146,7 +146,7 @@ class StateReconcilerTest {
         every { emittedStatsStore.getStats() } returns statsList
 
         every { consumer.accept(any<AirbyteMessage>()) } just Runs
-        
+
         // Create a new reconciler with the test scope for this test
         val localReconciler =
             StateReconciler(
@@ -156,7 +156,7 @@ class StateReconcilerTest {
                 this.backgroundScope,
                 interval.toJavaDuration(),
             )
-        
+
         // When
         localReconciler.run()
 

--- a/airbyte-cdk/bulk/version.properties
+++ b/airbyte-cdk/bulk/version.properties
@@ -1,1 +1,1 @@
-version=0.1.41
+version=0.1.42


### PR DESCRIPTION
## What
Fixes hanging in other pipelines when one parallel pipeline would fail when using PROTO data medium.

## How
* The proto reader is blocking
* When one pipeline fails we close all input streams which unblocks the proto reader and allows the pipelines to cancel as expected
* We run the jobs on a dedicated scope so we can better control the cooperative cancelling
* Rearranges things to make them more readable now that we have this extra logic

## To Read
1) `PipelineRunner` — adds `ExceptionHandler` for propagating input stream closes and capturing failure cause to rethrow

## Other
* Moves dispatcher (thread pool) instantiation into `DispatcherBeanFactory`
* Re-organizes `PipelineRunner.kt` for legibility 
* Removes unnecessary `SocketInputStream` — closing the upstream channel causes a source exception to take precedence over the destination exception and must be avoided.
