### PR TITLE
refactor: fully qualify all snowflake resource names

### DIFF
--- a/airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/SnowflakeBeanFactory.kt
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/SnowflakeBeanFactory.kt
@@ -6,7 +6,6 @@ package io.airbyte.integrations.destination.snowflake
 
 import com.zaxxer.hikari.HikariConfig
 import com.zaxxer.hikari.HikariDataSource
-import io.airbyte.cdk.load.dataflow.config.MemoryAndParallelismConfig
 import io.airbyte.cdk.Operation
 import io.airbyte.cdk.load.check.CheckOperationV2
 import io.airbyte.cdk.load.check.DestinationCheckerV2

--- a/airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/check/SnowflakeChecker.kt
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/check/SnowflakeChecker.kt
@@ -65,7 +65,6 @@ class SnowflakeChecker(
             )
         runBlocking {
             try {
-                snowflakeAirbyteClient.useDatabase(snowflakeConfiguration.database)
                 snowflakeAirbyteClient.createNamespace(outputSchema)
                 snowflakeAirbyteClient.createTable(
                     stream = destinationStream,

--- a/airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/client/SnowflakeAirbyteClient.kt
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/client/SnowflakeAirbyteClient.kt
@@ -55,10 +55,6 @@ class SnowflakeAirbyteClient(
             null
         }
 
-    suspend fun useDatabase(database: String) {
-        execute(sqlGenerator.useDatabase(database))
-    }
-
     override suspend fun createNamespace(namespace: String) {
         // Create the schema if it doesn't exist
         execute(sqlGenerator.createNamespace(namespace))

--- a/airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/sql/SnowflakeDirectLoadSqlGenerator.kt
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/sql/SnowflakeDirectLoadSqlGenerator.kt
@@ -14,7 +14,6 @@ import io.airbyte.cdk.load.orchestration.db.ColumnNameMapping
 import io.airbyte.cdk.load.orchestration.db.TableName
 import io.airbyte.cdk.load.util.UUIDGenerator
 import io.airbyte.integrations.destination.snowflake.db.ColumnDefinition
-import io.airbyte.integrations.destination.snowflake.db.toSnowflakeCompatibleName
 import io.airbyte.integrations.destination.snowflake.spec.CdcDeletionMode
 import io.airbyte.integrations.destination.snowflake.spec.SnowflakeConfiguration
 import io.airbyte.integrations.destination.snowflake.write.load.CSV_FORMAT
@@ -22,17 +21,6 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import jakarta.inject.Singleton
 
 internal const val COUNT_TOTAL_ALIAS = "total"
-internal const val STAGE_FORMAT_NAME: String = "airbyte_csv_format"
-internal const val STAGE_NAME_PREFIX = "airbyte_stage_"
-const val QUOTE: String = "\""
-
-internal fun buildSnowflakeStageName(tableName: TableName): String {
-    return "\"${tableName.namespace}\".\"$STAGE_NAME_PREFIX${tableName.name}\""
-}
-
-internal fun buildSnowflakeFormatName(namespace: String): String {
-    return "\"${namespace.toSnowflakeCompatibleName()}\".\"$STAGE_FORMAT_NAME\""
-}
 
 private val log = KotlinLogging.logger {}
 
@@ -41,6 +29,7 @@ class SnowflakeDirectLoadSqlGenerator(
     private val columnUtils: SnowflakeColumnUtils,
     private val uuidGenerator: UUIDGenerator,
     private val snowflakeConfiguration: SnowflakeConfiguration,
+    private val snowflakeSqlNameUtils: SnowflakeSqlNameUtils,
 ) {
 
     /**
@@ -52,16 +41,12 @@ class SnowflakeDirectLoadSqlGenerator(
         return this
     }
 
-    fun useDatabase(databaseName: String): String {
-        return "USE DATABASE \"${databaseName.toSnowflakeCompatibleName()}\"".andLog()
-    }
-
     fun countTable(tableName: TableName): String {
-        return "SELECT COUNT(*) AS \"$COUNT_TOTAL_ALIAS\" FROM ${tableName.toPrettyString(quote=QUOTE)}".andLog()
+        return "SELECT COUNT(*) AS \"$COUNT_TOTAL_ALIAS\" FROM ${snowflakeSqlNameUtils.fullyQualifiedName(tableName)}".andLog()
     }
 
     fun createNamespace(namespace: String): String {
-        return "CREATE SCHEMA IF NOT EXISTS \"${namespace.toSnowflakeCompatibleName()}\"".andLog()
+        return "CREATE SCHEMA IF NOT EXISTS ${snowflakeSqlNameUtils.fullyQualifiedNamespace(namespace)}".andLog()
     }
 
     fun createTable(
@@ -80,7 +65,7 @@ class SnowflakeDirectLoadSqlGenerator(
 
         val createTableStatement =
             """
-            $createOrReplace TABLE ${tableName.toPrettyString(quote=QUOTE)} (
+            $createOrReplace TABLE ${snowflakeSqlNameUtils.fullyQualifiedName(tableName)} (
                 $columnDeclarations
             )
         """.trimIndent()
@@ -89,7 +74,7 @@ class SnowflakeDirectLoadSqlGenerator(
     }
 
     fun showColumns(tableName: TableName): String =
-        "SHOW COLUMNS IN TABLE ${tableName.toPrettyString(quote=QUOTE)};"
+        "SHOW COLUMNS IN TABLE ${snowflakeSqlNameUtils.fullyQualifiedName(tableName)}".andLog()
 
     fun copyTable(
         columnNameMapping: ColumnNameMapping,
@@ -103,13 +88,13 @@ class SnowflakeDirectLoadSqlGenerator(
                     .joinToString(",") { "\"$it\"" }
 
         return """
-            INSERT INTO ${targetTableName.toPrettyString(quote=QUOTE)}
+            INSERT INTO ${snowflakeSqlNameUtils.fullyQualifiedName(targetTableName)} 
             (
                 $columnNames
             )
             SELECT
                 $columnNames
-            FROM ${sourceTableName.toPrettyString(quote=QUOTE)}
+            FROM ${snowflakeSqlNameUtils.fullyQualifiedName(sourceTableName)}
             """
             .trimIndent()
             .andLog()
@@ -209,7 +194,7 @@ class SnowflakeDirectLoadSqlGenerator(
         val mergeStatement =
             if (cdcDeleteClause.isNotEmpty()) {
                 """
-            MERGE INTO ${targetTableName.toPrettyString(QUOTE)} AS target_table
+            MERGE INTO ${snowflakeSqlNameUtils.fullyQualifiedName(targetTableName)} AS target_table
             USING (
               $selectSourceRecords
             ) AS new_record
@@ -225,7 +210,7 @@ class SnowflakeDirectLoadSqlGenerator(
         """.trimIndent()
             } else {
                 """
-            MERGE INTO ${targetTableName.toPrettyString(QUOTE)} AS target_table
+            MERGE INTO ${snowflakeSqlNameUtils.fullyQualifiedName(targetTableName)} AS target_table
             USING (
               $selectSourceRecords
             ) AS new_record
@@ -286,7 +271,7 @@ class SnowflakeDirectLoadSqlGenerator(
             WITH records AS (
               SELECT
                 $columnList
-              FROM ${sourceTableName.toPrettyString(QUOTE)}
+              FROM ${snowflakeSqlNameUtils.fullyQualifiedName(sourceTableName)}
             ), numbered_rows AS (
               SELECT *, ROW_NUMBER() OVER (
                 PARTITION BY $pkList ORDER BY $cursorOrderClause "$COLUMN_NAME_AB_EXTRACTED_AT" DESC
@@ -302,11 +287,11 @@ class SnowflakeDirectLoadSqlGenerator(
     }
 
     fun dropTable(tableName: TableName): String {
-        return "DROP TABLE IF EXISTS ${tableName.toPrettyString(QUOTE)}".andLog()
+        return "DROP TABLE IF EXISTS ${snowflakeSqlNameUtils.fullyQualifiedName(tableName)}".andLog()
     }
 
     fun dropStage(tableName: TableName): String {
-        return "DROP STAGE IF EXISTS ${buildSnowflakeStageName(tableName)}".andLog()
+        return "DROP STAGE IF EXISTS ${snowflakeSqlNameUtils.fullyQualifiedStageName(tableName)}".andLog()
     }
 
     fun getGenerationId(
@@ -314,7 +299,7 @@ class SnowflakeDirectLoadSqlGenerator(
     ): String {
         return """
             SELECT "$COLUMN_NAME_AB_GENERATION_ID"
-            FROM ${tableName.toPrettyString(QUOTE)} 
+            FROM ${snowflakeSqlNameUtils.fullyQualifiedName(tableName)} 
             LIMIT 1
         """
             .trimIndent()
@@ -322,7 +307,7 @@ class SnowflakeDirectLoadSqlGenerator(
     }
 
     fun createFileFormat(namespace: String): String {
-        val formatName = buildSnowflakeFormatName(namespace)
+        val formatName = snowflakeSqlNameUtils.fullyQualifiedFormatName(namespace)
         return """
             CREATE OR REPLACE FILE FORMAT $formatName
             TYPE = 'CSV'
@@ -336,8 +321,8 @@ class SnowflakeDirectLoadSqlGenerator(
     }
 
     fun createSnowflakeStage(tableName: TableName): String {
-        val stageName = buildSnowflakeStageName(tableName)
-        val formatName = buildSnowflakeFormatName(tableName.namespace)
+        val stageName = snowflakeSqlNameUtils.fullyQualifiedStageName(tableName)
+        val formatName = snowflakeSqlNameUtils.fullyQualifiedFormatName(tableName.namespace)
         return """
             CREATE OR REPLACE STAGE $stageName
                 FILE_FORMAT = $formatName;
@@ -347,7 +332,7 @@ class SnowflakeDirectLoadSqlGenerator(
     }
 
     fun putInStage(tableName: TableName, tempFilePath: String): String {
-        val stageName = buildSnowflakeStageName(tableName)
+        val stageName = snowflakeSqlNameUtils.fullyQualifiedStageName(tableName)
         return """
             PUT 'file://$tempFilePath' @$stageName
             AUTO_COMPRESS = TRUE
@@ -358,11 +343,11 @@ class SnowflakeDirectLoadSqlGenerator(
     }
 
     fun copyFromStage(tableName: TableName): String {
-        val stageName = buildSnowflakeStageName(tableName)
-        val formatName = buildSnowflakeFormatName(tableName.namespace)
+        val stageName = snowflakeSqlNameUtils.fullyQualifiedStageName(tableName)
+        val formatName = snowflakeSqlNameUtils.fullyQualifiedFormatName(tableName.namespace)
 
         return """
-            COPY INTO ${tableName.toPrettyString(quote=QUOTE)}
+            COPY INTO ${snowflakeSqlNameUtils.fullyQualifiedName(tableName)}
             FROM @$stageName
             FILE_FORMAT = $formatName
             ON_ERROR = 'ABORT_STATEMENT'
@@ -374,11 +359,7 @@ class SnowflakeDirectLoadSqlGenerator(
 
     fun swapTableWith(sourceTableName: TableName, targetTableName: TableName): String {
         return """
-            ALTER TABLE ${sourceTableName.toPrettyString(quote = QUOTE)} SWAP WITH ${
-            targetTableName.toPrettyString(
-                quote = QUOTE
-            )
-        };
+            ALTER TABLE ${snowflakeSqlNameUtils.fullyQualifiedName(sourceTableName)} SWAP WITH ${snowflakeSqlNameUtils.fullyQualifiedName(targetTableName)}
         """
             .trimIndent()
             .andLog()
@@ -388,7 +369,7 @@ class SnowflakeDirectLoadSqlGenerator(
         // Snowflake RENAME TO only accepts the table name, not a fully qualified name
         // The renamed table stays in the same schema
         return """
-            ALTER TABLE ${sourceTableName.toPrettyString(quote = QUOTE)} RENAME TO ${targetTableName.toPrettyString(quote = QUOTE)};
+            ALTER TABLE ${snowflakeSqlNameUtils.fullyQualifiedName(sourceTableName)} RENAME TO ${snowflakeSqlNameUtils.fullyQualifiedName(targetTableName)}
         """
             .trimIndent()
             .andLog()
@@ -397,7 +378,8 @@ class SnowflakeDirectLoadSqlGenerator(
     fun describeTable(
         schemaName: String,
         tableName: String,
-    ): String = """DESCRIBE TABLE "$schemaName"."$tableName" """.andLog()
+    ): String =
+        """DESCRIBE TABLE ${snowflakeSqlNameUtils.fullyQualifiedName(TableName(schemaName, tableName))}""".andLog()
 
     fun alterTable(
         tableName: TableName,
@@ -406,7 +388,7 @@ class SnowflakeDirectLoadSqlGenerator(
         modifiedColumns: Set<ColumnDefinition>,
     ): Set<String> {
         val clauses = mutableSetOf<String>()
-        val prettyTableName = tableName.toPrettyString(quote = QUOTE)
+        val prettyTableName = snowflakeSqlNameUtils.fullyQualifiedName(tableName)
         addedColumns.forEach {
             clauses.add(
                 "ALTER TABLE $prettyTableName ADD COLUMN \"${it.name}\" ${it.type};".andLog()

--- a/airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/sql/SnowflakeSqlNameUtils.kt
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/sql/SnowflakeSqlNameUtils.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination.snowflake.sql
+
+import io.airbyte.cdk.load.orchestration.db.TableName
+import io.airbyte.integrations.destination.snowflake.db.toSnowflakeCompatibleName
+import io.airbyte.integrations.destination.snowflake.spec.SnowflakeConfiguration
+import jakarta.inject.Singleton
+
+internal const val STAGE_FORMAT_NAME: String = "airbyte_csv_format"
+internal const val STAGE_NAME_PREFIX = "airbyte_stage_"
+internal const val QUOTE: String = "\""
+
+@Singleton
+class SnowflakeSqlNameUtils(
+    private val snowflakeConfiguration: SnowflakeConfiguration,
+) {
+
+    fun fullyQualifiedName(tableName: TableName): String =
+        combineParts(listOf(getDatabaseName(), tableName.namespace, tableName.name))
+    fun fullyQualifiedNamespace(namespace: String) =
+        combineParts(listOf(getDatabaseName(), namespace))
+
+    fun fullyQualifiedStageName(tableName: TableName): String =
+        combineParts(
+            listOf(getDatabaseName(), tableName.namespace, "$STAGE_NAME_PREFIX${tableName.name}")
+        )
+
+    fun fullyQualifiedFormatName(namespace: String): String =
+        combineParts(listOf(getDatabaseName(), namespace, STAGE_FORMAT_NAME))
+
+    fun combineParts(parts: List<String>): String =
+        parts.joinToString(separator = ".") {
+            if (!it.startsWith(QUOTE)) {
+                "$QUOTE${it.toSnowflakeCompatibleName()}$QUOTE"
+            } else {
+                it.toSnowflakeCompatibleName()
+            }
+        }
+
+    private fun getDatabaseName() = snowflakeConfiguration.database
+}

--- a/airbyte-integrations/connectors/destination-snowflake/src/test-integration/kotlin/io/airbyte/integrations/destination/snowflake/write/SnowflakeAcceptanceTest.kt
+++ b/airbyte-integrations/connectors/destination-snowflake/src/test-integration/kotlin/io/airbyte/integrations/destination/snowflake/write/SnowflakeAcceptanceTest.kt
@@ -43,7 +43,7 @@ import io.airbyte.integrations.destination.snowflake.db.toSnowflakeCompatibleNam
 import io.airbyte.integrations.destination.snowflake.spec.SnowflakeConfiguration
 import io.airbyte.integrations.destination.snowflake.spec.SnowflakeConfigurationFactory
 import io.airbyte.integrations.destination.snowflake.spec.SnowflakeSpecification
-import io.airbyte.integrations.destination.snowflake.sql.QUOTE
+import io.airbyte.integrations.destination.snowflake.sql.SnowflakeSqlNameUtils
 import io.airbyte.integrations.destination.snowflake.write.transform.isValid
 import io.airbyte.protocol.models.v0.AirbyteRecordMessageMetaChange
 import io.airbyte.protocol.models.v0.AirbyteRecordMessageMetaChange.Change
@@ -248,6 +248,7 @@ class SnowflakeDataDumper(
         stream: DestinationStream
     ): List<OutputRecord> {
         val config = configProvider(spec)
+        val sqlUtils = SnowflakeSqlNameUtils(config)
         val dataSource =
             SnowflakeBeanFactory()
                 .snowflakeDataSource(snowflakeConfiguration = config, airbyteEdition = "COMMUNITY")
@@ -284,7 +285,7 @@ class SnowflakeDataDumper(
 
                 val resultSet =
                     statement.executeQuery(
-                        "SELECT * FROM ${tableName.toPrettyString(quote = QUOTE)}"
+                        "SELECT * FROM ${sqlUtils.fullyQualifiedName(tableName)}"
                     )
 
                 while (resultSet.next()) {

--- a/airbyte-integrations/connectors/destination-snowflake/src/test/kotlin/io/airbyte/integrations/destination/snowflake/sql/SnowflakeDirectLoadSqlGeneratorTest.kt
+++ b/airbyte-integrations/connectors/destination-snowflake/src/test/kotlin/io/airbyte/integrations/destination/snowflake/sql/SnowflakeDirectLoadSqlGeneratorTest.kt
@@ -33,16 +33,20 @@ internal class SnowflakeDirectLoadSqlGeneratorTest {
     private lateinit var snowflakeDirectLoadSqlGenerator: SnowflakeDirectLoadSqlGenerator
     private val uuidGenerator: UUIDGenerator = mockk()
     private val snowflakeConfiguration: SnowflakeConfiguration = mockk()
+    private lateinit var snowflakeSqlNameUtils: SnowflakeSqlNameUtils
 
     @BeforeEach
     fun setUp() {
         every { snowflakeConfiguration.cdcDeletionMode } returns CdcDeletionMode.HARD_DELETE
+        every { snowflakeConfiguration.database } returns "test-database"
         columnUtils = mockk()
+        snowflakeSqlNameUtils = SnowflakeSqlNameUtils(snowflakeConfiguration)
         snowflakeDirectLoadSqlGenerator =
             SnowflakeDirectLoadSqlGenerator(
                 columnUtils = columnUtils,
                 uuidGenerator = uuidGenerator,
                 snowflakeConfiguration = snowflakeConfiguration,
+                snowflakeSqlNameUtils = snowflakeSqlNameUtils,
             )
     }
 
@@ -51,7 +55,7 @@ internal class SnowflakeDirectLoadSqlGeneratorTest {
         val tableName = TableName(namespace = "namespace", name = "name")
         val sql = snowflakeDirectLoadSqlGenerator.countTable(tableName)
         assertEquals(
-            "SELECT COUNT(*) AS \"total\" FROM ${tableName.toPrettyString(quote=QUOTE)}",
+            "SELECT COUNT(*) AS \"total\" FROM ${snowflakeSqlNameUtils.fullyQualifiedName(tableName)}",
             sql
         )
     }
@@ -60,7 +64,10 @@ internal class SnowflakeDirectLoadSqlGeneratorTest {
     fun testGenerateNamespaceStatement() {
         val namespace = "namespace"
         val sql = snowflakeDirectLoadSqlGenerator.createNamespace(namespace)
-        assertEquals("CREATE SCHEMA IF NOT EXISTS \"$namespace\"", sql)
+        assertEquals(
+            "CREATE SCHEMA IF NOT EXISTS ${snowflakeSqlNameUtils.fullyQualifiedNamespace(namespace)}",
+            sql
+        )
     }
 
     @Test
@@ -82,7 +89,7 @@ internal class SnowflakeDirectLoadSqlGeneratorTest {
                 replace = true
             )
         assertEquals(
-            "CREATE OR REPLACE TABLE ${tableName.toPrettyString(quote=QUOTE)} (\n    $columnAndType\n)",
+            "CREATE OR REPLACE TABLE ${snowflakeSqlNameUtils.fullyQualifiedName(tableName)} (\n    $columnAndType\n)",
             sql
         )
     }
@@ -106,7 +113,7 @@ internal class SnowflakeDirectLoadSqlGeneratorTest {
                 replace = false
             )
         assertEquals(
-            "CREATE TABLE ${tableName.toPrettyString(quote=QUOTE)} (\n    $columnAndType\n)",
+            "CREATE TABLE ${snowflakeSqlNameUtils.fullyQualifiedName(tableName)} (\n    $columnAndType\n)",
             sql
         )
     }
@@ -115,7 +122,10 @@ internal class SnowflakeDirectLoadSqlGeneratorTest {
     fun testGenerateShowColumns() {
         val tableName = TableName(namespace = "namespace", name = "name")
         val sql = snowflakeDirectLoadSqlGenerator.showColumns(tableName)
-        assertEquals("SHOW COLUMNS IN TABLE ${tableName.toPrettyString(quote=QUOTE)};", sql)
+        assertEquals(
+            "SHOW COLUMNS IN TABLE ${snowflakeSqlNameUtils.fullyQualifiedName(tableName)}",
+            sql
+        )
     }
 
     @Test
@@ -131,13 +141,13 @@ internal class SnowflakeDirectLoadSqlGeneratorTest {
         val destinationTableName = TableName(namespace = "namespace", name = "destination")
         val expected =
             """
-            INSERT INTO ${destinationTableName.toPrettyString(quote = QUOTE)}
+            INSERT INTO ${snowflakeSqlNameUtils.fullyQualifiedName(destinationTableName)} 
             (
                 $columnNames
             )
             SELECT
                 $columnNames
-            FROM ${sourceTableName.toPrettyString(quote=QUOTE)}
+            FROM ${snowflakeSqlNameUtils.fullyQualifiedName(sourceTableName)}
             """.trimIndent()
         val sql =
             snowflakeDirectLoadSqlGenerator.copyTable(
@@ -169,7 +179,7 @@ internal class SnowflakeDirectLoadSqlGeneratorTest {
 
         val expected =
             """
-            MERGE INTO "namespace"."destination" AS target_table
+            MERGE INTO "test_database"."namespace"."destination" AS target_table
             USING (
                           WITH records AS (
               SELECT
@@ -177,7 +187,7 @@ internal class SnowflakeDirectLoadSqlGeneratorTest {
 "_airbyte_extracted_at",
 "_airbyte_meta",
 "_airbyte_generation_id"
-              FROM "namespace"."source"
+              FROM "test_database"."namespace"."source"
             ), numbered_rows AS (
               SELECT *, ROW_NUMBER() OVER (
                 PARTITION BY "primaryKey" ORDER BY "cursor" DESC NULLS LAST, "_airbyte_extracted_at" DESC
@@ -229,7 +239,10 @@ new_record."_airbyte_generation_id"
     fun testGenerateDropTable() {
         val tableName = TableName(namespace = "namespace", name = "name")
         val sql = snowflakeDirectLoadSqlGenerator.dropTable(tableName)
-        assertEquals("DROP TABLE IF EXISTS ${tableName.toPrettyString(QUOTE)}", sql)
+        assertEquals(
+            "DROP TABLE IF EXISTS ${snowflakeSqlNameUtils.fullyQualifiedName(tableName)}",
+            sql
+        )
     }
 
     @Test
@@ -237,7 +250,7 @@ new_record."_airbyte_generation_id"
         val tableName = TableName(namespace = "namespace", name = "name")
         val sql = snowflakeDirectLoadSqlGenerator.dropStage(tableName)
         assertEquals(
-            "DROP STAGE IF EXISTS \"${tableName.namespace}\".\"airbyte_stage_${tableName.name}\"",
+            "DROP STAGE IF EXISTS ${snowflakeSqlNameUtils.fullyQualifiedStageName(tableName)}",
             sql
         )
     }
@@ -247,7 +260,7 @@ new_record."_airbyte_generation_id"
         val tableName = TableName(namespace = "namespace", name = "name")
         val sql = snowflakeDirectLoadSqlGenerator.getGenerationId(tableName = tableName)
         assertEquals(
-            "SELECT \"$COLUMN_NAME_AB_GENERATION_ID\"\nFROM ${tableName.toPrettyString(QUOTE)} \nLIMIT 1",
+            "SELECT \"$COLUMN_NAME_AB_GENERATION_ID\"\nFROM ${snowflakeSqlNameUtils.fullyQualifiedName(tableName)} \nLIMIT 1",
             sql
         )
     }
@@ -255,9 +268,10 @@ new_record."_airbyte_generation_id"
     @Test
     fun testGenerateCreateFileFormat() {
         val namespace = "test-namespace"
+        val fileFormatName = snowflakeSqlNameUtils.fullyQualifiedFormatName(namespace)
         val expected =
             """
-            CREATE OR REPLACE FILE FORMAT ${buildSnowflakeFormatName(namespace)}
+            CREATE OR REPLACE FILE FORMAT $fileFormatName
             TYPE = 'CSV'
             FIELD_DELIMITER = '${CSV_FORMAT.delimiterString}'
             RECORD_DELIMITER = '${CSV_FORMAT.recordSeparator}'
@@ -273,9 +287,11 @@ new_record."_airbyte_generation_id"
     @Test
     fun testGenerateCreateStage() {
         val tableName = TableName(namespace = "namespace", name = "name")
+        val stagingTableName = snowflakeSqlNameUtils.fullyQualifiedStageName(tableName)
+        val fileFormat = snowflakeSqlNameUtils.fullyQualifiedFormatName(tableName.namespace)
         val sql = snowflakeDirectLoadSqlGenerator.createSnowflakeStage(tableName)
         assertEquals(
-            "CREATE OR REPLACE STAGE ${buildSnowflakeStageName(tableName)}\n    FILE_FORMAT = ${buildSnowflakeFormatName(tableName.namespace)};",
+            "CREATE OR REPLACE STAGE $stagingTableName\n    FILE_FORMAT = $fileFormat;",
             sql
         )
     }
@@ -284,9 +300,10 @@ new_record."_airbyte_generation_id"
     fun testGeneratePutInStage() {
         val tableName = TableName(namespace = "namespace", name = "name")
         val tempFilePath = "/some/file/path.csv"
+        val stagingTableName = snowflakeSqlNameUtils.fullyQualifiedStageName(tableName)
         val sql = snowflakeDirectLoadSqlGenerator.putInStage(tableName, tempFilePath)
         assertEquals(
-            "PUT 'file://$tempFilePath' @${buildSnowflakeStageName(tableName)}\nAUTO_COMPRESS = TRUE\nOVERWRITE = TRUE",
+            "PUT 'file://$tempFilePath' @$stagingTableName\nAUTO_COMPRESS = TRUE\nOVERWRITE = TRUE",
             sql
         )
     }
@@ -294,9 +311,12 @@ new_record."_airbyte_generation_id"
     @Test
     fun testGenerateCopyFromStage() {
         val tableName = TableName(namespace = "namespace", name = "name")
+        val targetTableName = snowflakeSqlNameUtils.fullyQualifiedName(tableName)
+        val stagingTableName = snowflakeSqlNameUtils.fullyQualifiedStageName(tableName)
+        val fileFormat = snowflakeSqlNameUtils.fullyQualifiedFormatName(tableName.namespace)
         val sql = snowflakeDirectLoadSqlGenerator.copyFromStage(tableName)
         assertEquals(
-            "COPY INTO ${tableName.toPrettyString(quote=QUOTE)}\nFROM @${buildSnowflakeStageName(tableName)}\nFILE_FORMAT = ${buildSnowflakeFormatName(tableName.namespace)}\nON_ERROR = 'ABORT_STATEMENT'\nPURGE = TRUE;",
+            "COPY INTO $targetTableName\nFROM @$stagingTableName\nFILE_FORMAT = $fileFormat\nON_ERROR = 'ABORT_STATEMENT'\nPURGE = TRUE;",
             sql
         )
     }
@@ -377,6 +397,7 @@ new_record."_airbyte_generation_id"
                 columnUtils = columnUtils,
                 uuidGenerator = uuidGenerator,
                 snowflakeConfiguration = snowflakeConfiguration,
+                snowflakeSqlNameUtils = snowflakeSqlNameUtils,
             )
 
         val primaryKey = listOf(listOf("id"))
@@ -577,7 +598,7 @@ new_record."_airbyte_generation_id"
         val targetTableName = TableName(namespace = "namespace", name = "target")
         val sql = snowflakeDirectLoadSqlGenerator.swapTableWith(sourceTableName, targetTableName)
         assertEquals(
-            "ALTER TABLE ${sourceTableName.toPrettyString(quote = QUOTE)} SWAP WITH ${targetTableName.toPrettyString(quote = QUOTE)};",
+            "ALTER TABLE ${snowflakeSqlNameUtils.fullyQualifiedName(sourceTableName)} SWAP WITH ${snowflakeSqlNameUtils.fullyQualifiedName(targetTableName)}",
             sql
         )
     }
@@ -600,15 +621,15 @@ new_record."_airbyte_generation_id"
 
         assertEquals(
             setOf(
-                """ALTER TABLE "namespace"."name" ADD COLUMN "col1" TEXT;""",
-                """ALTER TABLE "namespace"."name" DROP COLUMN "col2";""",
-                """ALTER TABLE "namespace"."name" ADD COLUMN "col3_${uuid}" TEXT;""",
-                """UPDATE "namespace"."name" SET "col3_${uuid}" = CAST("col3" AS TEXT);""",
-                """ALTER TABLE "namespace"."name"
+                """ALTER TABLE "test_database"."namespace"."name" ADD COLUMN "col1" TEXT;""",
+                """ALTER TABLE "test_database"."namespace"."name" DROP COLUMN "col2";""",
+                """ALTER TABLE "test_database"."namespace"."name" ADD COLUMN "col3_${uuid}" TEXT;""",
+                """UPDATE "test_database"."namespace"."name" SET "col3_${uuid}" = CAST("col3" AS TEXT);""",
+                """ALTER TABLE "test_database"."namespace"."name"
                 RENAME COLUMN "col3" TO "col3_${uuid}_backup";""".trimIndent(),
-                """ALTER TABLE "namespace"."name"
+                """ALTER TABLE "test_database"."namespace"."name"
                 RENAME COLUMN "col3_${uuid}" TO "col3";""".trimIndent(),
-                """ALTER TABLE "namespace"."name" DROP COLUMN "col3_${uuid}_backup";"""
+                """ALTER TABLE "test_database"."namespace"."name" DROP COLUMN "col3_${uuid}_backup";"""
             ),
             sql
         )

--- a/airbyte-integrations/connectors/destination-snowflake/src/test/kotlin/io/airbyte/integrations/destination/snowflake/sql/SnowflakeSqlNameUtilsTest.kt
+++ b/airbyte-integrations/connectors/destination-snowflake/src/test/kotlin/io/airbyte/integrations/destination/snowflake/sql/SnowflakeSqlNameUtilsTest.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination.snowflake.sql
+
+import io.airbyte.cdk.load.orchestration.db.TableName
+import io.airbyte.integrations.destination.snowflake.spec.SnowflakeConfiguration
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class SnowflakeSqlNameUtilsTest {
+
+    private lateinit var snowflakeConfiguration: SnowflakeConfiguration
+    private lateinit var snowflakeSqlNameUtils: SnowflakeSqlNameUtils
+
+    @BeforeEach
+    fun setUp() {
+        snowflakeConfiguration = mockk(relaxed = true)
+        snowflakeSqlNameUtils =
+            SnowflakeSqlNameUtils(snowflakeConfiguration = snowflakeConfiguration)
+    }
+
+    @Test
+    fun testFullyQualifiedName() {
+        val databaseName = "test-database"
+        val namespace = "test-namespace"
+        val name = "test=name"
+        val tableName = TableName(namespace = namespace, name = name)
+        every { snowflakeConfiguration.database } returns databaseName
+
+        val expectedName =
+            snowflakeSqlNameUtils.combineParts(
+                listOf(databaseName, tableName.namespace, tableName.name)
+            )
+        val fullyQualifiedName = snowflakeSqlNameUtils.fullyQualifiedName(tableName)
+        assertEquals(expectedName, fullyQualifiedName)
+    }
+
+    @Test
+    fun testFullyQualifiedNamespace() {
+        val databaseName = "test-database"
+        val namespace = "test-namespace"
+        every { snowflakeConfiguration.database } returns databaseName
+
+        val expectedNamespace = snowflakeSqlNameUtils.combineParts(listOf(databaseName, namespace))
+        val fullyQualifiedNamespace = snowflakeSqlNameUtils.fullyQualifiedNamespace(namespace)
+        assertEquals(expectedNamespace, fullyQualifiedNamespace)
+    }
+
+    @Test
+    fun testFullyQualifiedStageName() {
+        val databaseName = "test-database"
+        val namespace = "test-namespace"
+        val name = "test=name"
+        val tableName = TableName(namespace = namespace, name = name)
+        every { snowflakeConfiguration.database } returns databaseName
+
+        val expectedName =
+            snowflakeSqlNameUtils.combineParts(
+                listOf(databaseName, namespace, "$STAGE_NAME_PREFIX$name")
+            )
+        val fullyQualifiedName = snowflakeSqlNameUtils.fullyQualifiedStageName(tableName)
+        assertEquals(expectedName, fullyQualifiedName)
+    }
+
+    @Test
+    fun testFullyQualifiedFormatName() {
+        val databaseName = "test-database"
+        val namespace = "test-namespace"
+        every { snowflakeConfiguration.database } returns databaseName
+
+        val expectedNamespace =
+            snowflakeSqlNameUtils.combineParts(listOf(databaseName, namespace, STAGE_FORMAT_NAME))
+        val fullyQualifiedNamespace = snowflakeSqlNameUtils.fullyQualifiedFormatName(namespace)
+        assertEquals(expectedNamespace, fullyQualifiedNamespace)
+    }
+}


### PR DESCRIPTION
## What
* Ensure that all Snowflake resource names are fully qualified to avoid invalid access
* Follow https://docs.snowflake.com/en/sql-reference/name-resolution

## How
* Ensure that the database name is prefixed to all resource names to avoid resolution issues

## Review guide
1. `SnowflakeSqlNameUtils.kt`
2. `SnowflakeDirectLoadSqlGenerator.kt`

## Can this PR be safely reverted and rolled back?
- [X] YES 💚
- [ ] NO ❌
