### PR TITLE
ci: add cdk changelog update check

### DIFF
--- a/.github/workflows/changelog_update_check.yml
+++ b/.github/workflows/changelog_update_check.yml
@@ -1,0 +1,28 @@
+name: Changelog Update Check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  changelog-check:
+    name: Check Changelog Updated
+    runs-on: ubuntu-24.04
+    steps:
+      - name: CDK Changes
+        id: cdk-changes
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 #v3.0.2
+        with:
+          filters: |
+            version:
+              - 'airbyte-cdk/bulk/version.properties'
+            changelog:
+              - 'airbyte-cdk/bulk/changelog.md'
+
+      - name: Ensure Changelog Updated
+        if: steps.cdk-changes.outputs.version == 'true'
+        run: |
+          if [ "${{ steps.cdk-changes.outputs.changelog }}" != "true" ]; then
+            echo "ERROR: The changelog must be updated when the version.properties file is changed."
+            exit 1
+          fi


### PR DESCRIPTION
## What
https://github.com/airbytehq/airbyte-internal-issues/issues/14310

When updating the CDK we want to enforce the changelog to be updated, otherwise it is very easy to forget to update it.
## How
We are adding a github actions workflow that will be set as a PR check. The workflow checks that if the CDK version was  updated then the changelog should be updated too. It only checks if these files were changed, it doesn't check what the changes were. We could make it smater, but I think it is overkill.

Note: once merged, we need to add this workflow as a required check for branches merging into master.

## How did I test this?
Tested in this PR https://github.com/airbytehq/airbyte/pull/66587

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
