### PR TITLE
add retries to JVM connector integration tests

### DIFF
--- a/airbyte-integrations/connectors/destination-s3/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-s3/metadata.yaml
@@ -145,4 +145,3 @@ data:
             type: GSM
             alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"
-# noop change to trigger ci

--- a/airbyte-integrations/connectors/destination-s3/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-s3/metadata.yaml
@@ -145,3 +145,4 @@ data:
             type: GSM
             alias: airbyte-connector-testing-secret-store
 metadataSpecVersion: "1.0"
+# noop change to trigger ci

--- a/buildSrc/src/main/groovy/airbyte-bulk-connector.gradle
+++ b/buildSrc/src/main/groovy/airbyte-bulk-connector.gradle
@@ -226,6 +226,20 @@ class AirbyteBulkConnectorPlugin implements Plugin<Project> {
                     showStandardStreams = true
                 }
 
+                retry {
+                    // If running in CI, enable retries to mitigate flakiness
+                    if (System.getenv().containsKey("CI")) {
+                        // Run each test method up to three times
+                        maxRetries = 3
+                        // If any test method fails, disable retries for the other tests
+                        // (unintuitive: if you set this to 1, then as soon as a test case fails, it will disable retries, including for itself.
+                        // So we set to 2, which means: a test case failing will retry itself. If, after three retries, it still fails, then we disable retries globally.)
+                        maxFailures = 2
+                    }
+                    // If a test fails, but succeeds on retry - don't fail the task
+                    failOnPassedAfterRetry = false
+                }
+
                 // Always re-run integration tests no matter what.
                 outputs.upToDateWhen { false }
             }


### PR DESCRIPTION
## What
closes https://github.com/airbytehq/airbyte-internal-issues/issues/14305

Add retries to the `integrationTestJava` task

## How
we have some develocity plugin apparently? I have no idea where it gets configured, but it provides an outdated version of https://github.com/gradle/test-retry-gradle-plugin

I'll revert https://github.com/airbytehq/airbyte/pull/66670/commits/5dbcda6b022504b64b62f3bc1ffbbb7263b2e54a shortly, just needed to trigger CI

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._