### PR TITLE
bulk CDK: fix test timeouts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -194,6 +194,9 @@ allprojects {
         } else {
             junitMethodExecutionTimeout = '1 m'
         }
+
+        systemProperty 'junit.jupiter.execution.timeout.default', junitMethodExecutionTimeout
+        // This is used by the "old" cdk (i.e. airbyte-cdk/java)
         systemProperty 'JunitMethodExecutionTimeout', junitMethodExecutionTimeout
     }
 


### PR DESCRIPTION
part of https://github.com/airbytehq/airbyte-internal-issues/issues/14305 

we're currently not enforcing a test timeout at all in the bulk CDK - this was previously enforced by some [magic class](https://github.com/airbytehq/airbyte/blob/master/airbyte-cdk/java/airbyte-cdk/core/src/testFixtures/kotlin/io/airbyte/cdk/extensions/LoggingInvocationInterceptor.kt#L252-L255), which I think isn't used in the bulk CDK

so just set the appropriate junit system property instead.

This will enable timeouts on all bulk CDK connectors (defaulting to 1 minute) - if you run into problems, you can add something like `JunitMethodExecutionTimeout=5m` to the connector's `gradle.properties`.