### PR TITLE
fix(ci): ensure get-modified-connectors.sh always returns valid JSON

### DIFF
--- a/poe-tasks/get-modified-connectors.sh
+++ b/poe-tasks/get-modified-connectors.sh
@@ -77,25 +77,18 @@ fi
 # 4) merge into one list
 all_changes=$(printf '%s\n%s\n%s\n%s' "$committed" "$staged" "$unstaged" "$untracked")
 
-# 4.5) Define helper function to return empty JSON when no connectors are found
-return_empty_json() {
-  if [ "$JSON" = true ]; then
-    echo '{"connector": [""]}'
-  fi
-  exit 0
-}
 
 # 5) drop ignored files
 filtered=$(printf '%s\n' "$all_changes" | grep -v -E "/${ignore_globs}") || {
-  echo "⚠️ Warning: No files remaining after filtering. Returning empty connector list." >&2
-  return_empty_json
+  echo "⚠️ Warning: No files remaining after filtering." >&2
+  filtered=""
 }
 
 # 6) keep only connector paths
 set +e # Ignore errors from grep if no matches are found
 connectors_paths=$(printf '%s\n' "$filtered" | grep -E '^airbyte-integrations/connectors/(source-[^/]+|destination-[^/]+)(/|$)') || {
-  echo "⚠️ Warning: No connector paths found. Returning empty connector list." >&2
-  return_empty_json
+  echo "⚠️ Warning: No connector paths found." >&2
+  connectors_paths=""
 }
 set -e
 
@@ -103,8 +96,8 @@ set -e
 dirs=$(printf '%s\n' "$connectors_paths" \
   | sed -E 's|airbyte-integrations/connectors/([^/]+).*|\1|' \
 ) || {
-  echo "⚠️ Warning: Failed to extract connector directories. Returning empty connector list." >&2
-  return_empty_json
+  echo "⚠️ Warning: Failed to extract connector directories." >&2
+  dirs=""
 }
 
 # 8) unique list of modified connectors

--- a/poe-tasks/get-modified-connectors.sh
+++ b/poe-tasks/get-modified-connectors.sh
@@ -77,18 +77,25 @@ fi
 # 4) merge into one list
 all_changes=$(printf '%s\n%s\n%s\n%s' "$committed" "$staged" "$unstaged" "$untracked")
 
+# 4.5) Define helper function to return empty JSON when no connectors are found
+return_empty_json() {
+  if [ "$JSON" = true ]; then
+    echo '{"connector": [""]}'
+  fi
+  exit 0
+}
 
 # 5) drop ignored files
 filtered=$(printf '%s\n' "$all_changes" | grep -v -E "/${ignore_globs}") || {
-  echo "⚠️ Warning: No files remaining after filtering." >&2
-  filtered=""
+  echo "⚠️ Warning: No files remaining after filtering. Returning empty connector list." >&2
+  return_empty_json
 }
 
 # 6) keep only connector paths
 set +e # Ignore errors from grep if no matches are found
 connectors_paths=$(printf '%s\n' "$filtered" | grep -E '^airbyte-integrations/connectors/(source-[^/]+|destination-[^/]+)(/|$)') || {
-  echo "⚠️ Warning: No connector paths found." >&2
-  connectors_paths=""
+  echo "⚠️ Warning: No connector paths found. Returning empty connector list." >&2
+  return_empty_json
 }
 set -e
 
@@ -96,8 +103,8 @@ set -e
 dirs=$(printf '%s\n' "$connectors_paths" \
   | sed -E 's|airbyte-integrations/connectors/([^/]+).*|\1|' \
 ) || {
-  echo "⚠️ Warning: Failed to extract connector directories." >&2
-  dirs=""
+  echo "⚠️ Warning: Failed to extract connector directories. Returning empty connector list." >&2
+  return_empty_json
 }
 
 # 8) unique list of modified connectors

--- a/poe-tasks/get-modified-connectors.sh
+++ b/poe-tasks/get-modified-connectors.sh
@@ -80,6 +80,9 @@ all_changes=$(printf '%s\n%s\n%s\n%s' "$committed" "$staged" "$unstaged" "$untra
 # 4.5) Define helper function to return empty JSON when no connectors are found
 return_empty_json() {
   if [ "$JSON" = true ]; then
+    # When the list is empty and JSON is requested, send one item as empty string.
+    # This allows the matrix to run once as a no-op, and be marked as complete for purposes
+    # of required checks.
     echo '{"connector": [""]}'
   fi
   exit 0
@@ -136,9 +139,8 @@ print_list() {
   # If JSON is requested, convert the list to JSON format.
   # This is pre-formatted to send to a GitHub Actions Matrix
   # with 'connector' as the matrix key.
-  # JSON mode: emit {"connector": […]}
+  # E.g.: {"connector": […]}
   if [ $# -eq 0 ]; then
-    # If the list is empty, use the centralized empty JSON function
     return_empty_json
   else
     # If the list is not empty, convert it to JSON format.

--- a/poe-tasks/get-modified-connectors.sh
+++ b/poe-tasks/get-modified-connectors.sh
@@ -86,26 +86,29 @@ return_empty_json() {
 }
 
 # 5) drop ignored files
-filtered=$(printf '%s\n' "$all_changes" | grep -v -E "/${ignore_globs}") || {
+filtered=$(printf '%s\n' "$all_changes" | grep -v -E "/${ignore_globs}")
+if [ $? -ne 0 ] || [ -z "$filtered" ]; then
   echo "⚠️ Warning: No files remaining after filtering. Returning empty connector list." >&2
   return_empty_json
-}
+fi
 
 # 6) keep only connector paths
 set +e # Ignore errors from grep if no matches are found
-connectors_paths=$(printf '%s\n' "$filtered" | grep -E '^airbyte-integrations/connectors/(source-[^/]+|destination-[^/]+)(/|$)') || {
+connectors_paths=$(printf '%s\n' "$filtered" | grep -E '^airbyte-integrations/connectors/(source-[^/]+|destination-[^/]+)(/|$)')
+if [ $? -ne 0 ] || [ -z "$connectors_paths" ]; then
   echo "⚠️ Warning: No connector paths found. Returning empty connector list." >&2
   return_empty_json
-}
+fi
 set -e
 
 # 7) extract just the connector directory name
 dirs=$(printf '%s\n' "$connectors_paths" \
   | sed -E 's|airbyte-integrations/connectors/([^/]+).*|\1|' \
-) || {
+)
+if [ $? -ne 0 ] || [ -z "$dirs" ]; then
   echo "⚠️ Warning: Failed to extract connector directories. Returning empty connector list." >&2
   return_empty_json
-}
+fi
 
 # 8) unique list of modified connectors
 connectors=()

--- a/poe-tasks/get-modified-connectors.sh
+++ b/poe-tasks/get-modified-connectors.sh
@@ -87,7 +87,7 @@ return_empty_json() {
 
 # 5) drop ignored files
 filtered=$(printf '%s\n' "$all_changes" | grep -v -E "/${ignore_globs}")
-if [ $? -ne 0 ] || [ -z "$filtered" ]; then
+if [ -z "$filtered" ]; then
   echo "⚠️ Warning: No files remaining after filtering. Returning empty connector list." >&2
   return_empty_json
 fi
@@ -95,7 +95,7 @@ fi
 # 6) keep only connector paths
 set +e # Ignore errors from grep if no matches are found
 connectors_paths=$(printf '%s\n' "$filtered" | grep -E '^airbyte-integrations/connectors/(source-[^/]+|destination-[^/]+)(/|$)')
-if [ $? -ne 0 ] || [ -z "$connectors_paths" ]; then
+if [ -z "$connectors_paths" ]; then
   echo "⚠️ Warning: No connector paths found. Returning empty connector list." >&2
   return_empty_json
 fi
@@ -105,7 +105,7 @@ set -e
 dirs=$(printf '%s\n' "$connectors_paths" \
   | sed -E 's|airbyte-integrations/connectors/([^/]+).*|\1|' \
 )
-if [ $? -ne 0 ] || [ -z "$dirs" ]; then
+if [ -z "$dirs" ]; then
   echo "⚠️ Warning: Failed to extract connector directories. Returning empty connector list." >&2
   return_empty_json
 fi
@@ -138,10 +138,8 @@ print_list() {
   # with 'connector' as the matrix key.
   # JSON mode: emit {"connector": […]}
   if [ $# -eq 0 ]; then
-    # If the list is empty, send one item as empty string.
-    # This allows the matrix to run once as a no-op, and be marked as complete for purposes
-    # of required checks.
-    echo '{"connector": [""]}'
+    # If the list is empty, use the centralized empty JSON function
+    return_empty_json
   else
     # If the list is not empty, convert it to JSON format.
     # This is pre-formatted to send to a GitHub Actions Matrix

--- a/poe-tasks/get-modified-connectors.sh
+++ b/poe-tasks/get-modified-connectors.sh
@@ -77,23 +77,25 @@ fi
 # 4) merge into one list
 all_changes=$(printf '%s\n%s\n%s\n%s' "$committed" "$staged" "$unstaged" "$untracked")
 
-# 5) drop ignored files
-filtered=$(printf '%s\n' "$all_changes" | grep -v -E "/${ignore_globs}") || {
-  echo "⚠️ Warning: No files remaining after filtering. Returning empty connector list." >&2
+# 4.5) Define helper function to return empty JSON when no connectors are found
+return_empty_json() {
   if [ "$JSON" = true ]; then
     echo '{"connector": [""]}'
   fi
   exit 0
 }
 
+# 5) drop ignored files
+filtered=$(printf '%s\n' "$all_changes" | grep -v -E "/${ignore_globs}") || {
+  echo "⚠️ Warning: No files remaining after filtering. Returning empty connector list." >&2
+  return_empty_json
+}
+
 # 6) keep only connector paths
 set +e # Ignore errors from grep if no matches are found
 connectors_paths=$(printf '%s\n' "$filtered" | grep -E '^airbyte-integrations/connectors/(source-[^/]+|destination-[^/]+)(/|$)') || {
   echo "⚠️ Warning: No connector paths found. Returning empty connector list." >&2
-  if [ "$JSON" = true ]; then
-    echo '{"connector": [""]}'
-  fi
-  exit 0
+  return_empty_json
 }
 set -e
 
@@ -102,10 +104,7 @@ dirs=$(printf '%s\n' "$connectors_paths" \
   | sed -E 's|airbyte-integrations/connectors/([^/]+).*|\1|' \
 ) || {
   echo "⚠️ Warning: Failed to extract connector directories. Returning empty connector list." >&2
-  if [ "$JSON" = true ]; then
-    echo '{"connector": [""]}'
-  fi
-  exit 0
+  return_empty_json
 }
 
 # 8) unique list of modified connectors


### PR DESCRIPTION
## What

Fixes GitHub Actions `fromJson` failures in the `connector-ci-checks` workflow when only ignored files (like `README.md`) are modified. The `get-modified-connectors.sh` script was returning empty strings instead of valid JSON objects, causing CI to fail on documentation-only PRs.

Related to issue reported by Alexandre Girard where documentation PRs were being blocked by failing CI checks.

## How

* Added `return_empty_json()` helper function that outputs `{"connector": [""]}` for JSON mode
* Added error handling after three pipeline steps to catch when no connectors are found:
  - File filtering after ignore patterns are applied  
  - Connector path extraction via grep
  - Directory name extraction via sed
* Modified `print_list` function to call `return_empty_json()` for centralized empty JSON handling
* Added warning messages to stderr for debugging while preserving JSON output to stdout
* Script now exits cleanly with valid JSON instead of failing silently with empty output

## Review guide

1. **`poe-tasks/get-modified-connectors.sh`** - Focus on:
   - Verify `{"connector": [""]}` JSON format matches GitHub Actions workflow expectations (lines 82-85)
   - Test script behavior when only ignored files (README.md, docs/*) are modified
   - Ensure warning messages go to stderr and don't interfere with JSON parsing (lines 91, 99, 109)
   - Confirm normal connector detection still works for actual connector changes
   - Check error handling logic covers all edge cases (lines 90-93, 98-101, 108-111)

**⚠️ Key testing scenarios:**
- Documentation-only PRs (should return `{"connector": [""]}`)
- Normal connector changes (should return actual connector names)
- Mixed changes (docs + connectors)
- Edge cases (empty repos, unusual git states)

**⚠️ Critical validation:**
- JSON output format must exactly match GitHub Actions `fromJson()` expectations
- Stderr warnings must not interfere with stdout JSON parsing

## User Impact

* Documentation and other ignored file changes no longer block CI workflows
* Contributors can merge README/docs updates without requiring force-merge permissions  
* No impact on normal connector change detection

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

**Link to Devin run:** https://app.devin.ai/sessions/ba52a58af9ae45cb8956f6d64198b242  
**Requested by:** @aaronsteers

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._