### PR TITLE
[ci]fix]: improve semver detection for pre-release versions

### DIFF
--- a/poe-tasks/detect-python-cdk.py
+++ b/poe-tasks/detect-python-cdk.py
@@ -100,7 +100,10 @@ def is_prerelease_version(version_str) -> bool:
     if not version_str:
         return True
 
-    version_pattern = r"^[~^>=<]*\d+\.\d+\.\d+([a-zA-Z0-9\-\.]*)?$"
+    # Allow comma-separated constraints, each matching the version pattern (no prerelease suffixes)
+    single_semver_constraint = r"[~=^><!]*\d+(\.\d+){0,2}"
+    version_pattern = rf"^{single_semver_constraint}(,{single_semver_constraint})*$"
+    is_prod_version = bool(re.match(version_pattern, version_str.strip()))
     is_prod_version = bool(re.match(version_pattern, version_str.strip()))
     return not is_prod_version
 


### PR DESCRIPTION
## What

- Allows "`^7`" as well as "`^7.0.0`"
- Disallows pre-release suffixes like "`-rc1`"
- Allows version constraints in sequence: `>7.1.1,<8,!=7.3.3`

Tests here:

https://regex101.com/r/Phu6wo/1

<img width="691" height="309" alt="image" src="https://github.com/user-attachments/assets/3768c1b2-6bbb-439d-bd01-3783301b8d3e" />


## How
<!--
* Describe how code changes achieve the solution.
-->

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
