### PR TITLE
Remove logging for the bench source

### DIFF
--- a/airbyte-integrations/connectors/source-e2e-test/metadata.yaml
+++ b/airbyte-integrations/connectors/source-e2e-test/metadata.yaml
@@ -4,7 +4,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: d53f9084-fa6b-4a5a-976c-5b8392f4ad8a
-  dockerImageTag: 2.2.2
+  dockerImageTag: 2.2.3
   dockerRepository: airbyte/source-e2e-test
   githubIssueLabel: source-e2e-test
   icon: airbyte.svg

--- a/airbyte-integrations/connectors/source-e2e-test/src/main/java/io/airbyte/integrations/source/e2e_test/LegacyInfiniteFeedSource.java
+++ b/airbyte-integrations/connectors/source-e2e-test/src/main/java/io/airbyte/integrations/source/e2e_test/LegacyInfiniteFeedSource.java
@@ -70,7 +70,7 @@ public class LegacyInfiniteFeedSource extends BaseConnector implements Source {
         }
 
         i.incrementAndGet();
-        LOGGER.info("source emitting record {}:", i.get());
+//        LOGGER.info("source emitting record {}:", i.get());
         return new AirbyteMessage()
             .withType(Type.RECORD)
             .withRecord(new AirbyteRecordMessage()


### PR DESCRIPTION
## What

Maybe if we remove the log it will work?
This seesm to be causing issue with the orchestrator ooming at the moment

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [X] YES 💚
- [ ] NO ❌
