### PR TITLE
chore(source-hubspot): revert `source-hubspot` code to 6.0.1

### DIFF
--- a/airbyte-integrations/connectors/source-hubspot/manifest.yaml
+++ b/airbyte-integrations/connectors/source-hubspot/manifest.yaml
@@ -197,6 +197,9 @@ definitions:
         - properties
       types_mapping:
         - type: TypesMap
+          target_type: boolean
+          current_type: bool
+        - type: TypesMap
           target_type: date
           current_type: date
         - type: TypesMap
@@ -217,16 +220,6 @@ definitions:
         - type: TypesMap
           target_type: string
           current_type: phone_number
-        - type: TypesMap
-          target_type:
-            - number
-            - string
-          current_type: number
-        - type: TypesMap
-          target_type:
-            - boolean
-            - string
-          current_type: bool
 
   deals_archived_schema_loader:
     $ref: "#/definitions/base_dynamic_schema_loader"

--- a/airbyte-integrations/connectors/source-hubspot/metadata.yaml
+++ b/airbyte-integrations/connectors/source-hubspot/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 36c891d9-4bd9-43ac-bad2-10e12756272c
-  dockerImageTag: 6.0.2
+  dockerImageTag: 6.0.3
   dockerRepository: airbyte/source-hubspot
   documentationUrl: https://docs.airbyte.com/integrations/sources/hubspot
   resourceRequirements:
@@ -36,7 +36,6 @@ data:
   registryOverrides:
     cloud:
       enabled: true
-      dockerImageTag: 6.0.1
     oss:
       enabled: true
   releaseStage: generally_available

--- a/airbyte-integrations/connectors/source-hubspot/unit_tests/test_components.py
+++ b/airbyte-integrations/connectors/source-hubspot/unit_tests/test_components.py
@@ -587,18 +587,6 @@ def test_extractor_supports_associations_list_interpolation(config, associations
             "abc123",
             id="test_non_numeric_string_returns_original_value_for_number_type",
         ),
-        pytest.param(
-            "1;2",
-            {"type": ["null", "boolean"]},
-            "1;2",
-            id="test_non_numeric_string_returns_original_value_for_boolean_type",
-        ),
-        pytest.param(
-            "1;2",
-            {"type": ["null", "number"]},
-            "1;2",
-            id="test_non_numeric_string_returns_original_value_for_number_type_2",
-        ),
     ],
 )
 def test_entity_schema_normalization(components_module, original_value, field_schema, expected_value):

--- a/airbyte-integrations/connectors/source-hubspot/unit_tests/test_streams.py
+++ b/airbyte-integrations/connectors/source-hubspot/unit_tests/test_streams.py
@@ -499,22 +499,6 @@ def test_get_custom_objects_metadata_success(
             {"hs_closed_amount": "1"},
             {"hs_closed_amount": True},
         ),
-        (
-            "deals",
-            "deal",
-            {"updatedAt": "2022-02-25T16:43:11Z"},
-            [("hs_closed_amount", "boolean")],
-            {"hs_closed_amount": "1;2"},
-            {"hs_closed_amount": "1;2"},
-        ),
-        (
-            "deals",
-            "deal",
-            {"updatedAt": "2022-02-25T16:43:11Z"},
-            [("hs_closed_amount", "number")],
-            {"hs_closed_amount": "1;2"},
-            {"hs_closed_amount": "1;2"},
-        ),
     ],
 )
 def test_cast_record_fields_if_needed(

--- a/docs/integrations/sources/hubspot.md
+++ b/docs/integrations/sources/hubspot.md
@@ -335,7 +335,7 @@ If you use [custom properties](https://knowledge.hubspot.com/properties/create-a
 
 | Version     | Date       | Pull Request                                             | Subject                                                                                                                                                                                                                      |
 |:------------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 6.0.3 | 2025-09-12 | [XXXXX](https://github.com/airbytehq/airbyte/pull/XXXXX) | Revert to 6.0.1 |
+| 6.0.3 | 2025-09-25 | [66700](https://github.com/airbytehq/airbyte/pull/66700) | Revert to 6.0.1 |
 | 6.0.2 | 2025-09-12 | [65947](https://github.com/airbytehq/airbyte/pull/65947) | Set fallback target type to 'string' for numbers and booleans |
 | 6.0.1 | 2025-09-09 | [66100](https://github.com/airbytehq/airbyte/pull/66100) | Update dependencies |
 | 6.0.0 | 2025-08-28 | [65100](https://github.com/airbytehq/airbyte/pull/65100) | Migrate Marketing Emails stream from deprecated v1 API to v3 API. Breaking change requires stream reset. This change also enables incremental syncs for `marketing_emails` stream. |

--- a/docs/integrations/sources/hubspot.md
+++ b/docs/integrations/sources/hubspot.md
@@ -335,6 +335,7 @@ If you use [custom properties](https://knowledge.hubspot.com/properties/create-a
 
 | Version     | Date       | Pull Request                                             | Subject                                                                                                                                                                                                                      |
 |:------------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 6.0.3 | 2025-09-12 | [XXXXX](https://github.com/airbytehq/airbyte/pull/XXXXX) | Revert to 6.0.1 |
 | 6.0.2 | 2025-09-12 | [65947](https://github.com/airbytehq/airbyte/pull/65947) | Set fallback target type to 'string' for numbers and booleans |
 | 6.0.1 | 2025-09-09 | [66100](https://github.com/airbytehq/airbyte/pull/66100) | Update dependencies |
 | 6.0.0 | 2025-08-28 | [65100](https://github.com/airbytehq/airbyte/pull/65100) | Migrate Marketing Emails stream from deprecated v1 API to v3 API. Breaking change requires stream reset. This change also enables incremental syncs for `marketing_emails` stream. |


### PR DESCRIPTION
## What
- We don't have an immediate solution to enable multiple datatypes for dynamic fields, and given that the previous solution caused issues with at least some users, we will permanently remove this troublesome code and return the connector to the same state it was in as 6.0.1.
- Increments patch version to 6.0.3

### Note
The only changes since 6.0.1 were:
* fix(source-hubspot): set schema to include string for numbers and booleans  - https://github.com/airbytehq/airbyte/commit/87186a88205ec49f640db06c9e6d018e68c0d012
* fix(source-hubspot): rollback version on cloud  - https://github.com/airbytehq/airbyte/commit/5adac878db79a11e27a80332dca5d9d408c4b38d
