### PR TITLE
Some polish for data activation general availability

### DIFF
--- a/docs/integrations/destinations/customer-io.md
+++ b/docs/integrations/destinations/customer-io.md
@@ -1,26 +1,46 @@
-# Customer IO
+# Customer.io
 
-This page contains the setup guide and reference information for the Customer IO destination connector.
-
-:::info
-Data activation is in **early access**. Try it today with the HubSpot and Customer.io destinations in Airbyte Cloud or Self-Managed version 1.8 and later. If you'd like to be an early adopter, chat with the team, and share feedback, [fill out this form](https://form.typeform.com/to/STc7a0jx).
-:::
+This page contains the setup guide and reference information for the Customer.io destination connector.
 
 ## Overview
 
-The Customer IO destination connector allows you to sync data to Customer IO, a customer data management platform. This connector supports [data activation](/platform/next/move-data/elt-data-activation) and requires Airbyte version 1.8 or later.
+The Customer.io destination connector allows you to sync data to Customer.io, a customer data management platform. This connector supports [data activation](/platform/next/move-data/elt-data-activation).
 
 ## Prerequisites
 
-- Customer IO Account
-- Airbyte version 1.8 or later is required to use this connector
+- A Customer.io Account
+- Airbyte version 1.8 or later, or Airbyte Cloud
 
+### S3 prerequisites for rejected records
+
+If you're using an S3 bucket to store rejected records, you also need the following.
+
+1. Allow connections from Airbyte to your AWS S3/Minio S3 cluster (if they exist in separate VPCs).
+2. [Enforce encryption of data in transit](https://docs.aws.amazon.com/AmazonS3/latest/userguide/security-best-practices.html#transit).
+3. An S3 bucket with credentials, a Role ARN, or an instance profile with read/write permissions configured for the host (EC2, EKS).
+
+    - These fields are always required:
+
+      - **S3 Bucket Name**
+      - **S3 Bucket Region**
+      - **Prefix Path in the Bucket**
+
+    - If you are using STS Assume Role, you must provide:
+
+      - **Role ARN**
+
+    - If you are using AWS credentials, you must provide:
+
+      - **Access Key ID**
+      - **Secret Access Key**
+
+    - If you are using an Instance Profile, you may omit the Access Key ID, Secret Access Key, and Role ARN.
 
 ### Destination Objects + Operations
 
 Here are the destination objects and their respective operations that are currently supported:
 * [Person](https://docs.customer.io/journeys/create-update-person/): Identifies a person and assigns traits to them.
-* [Person Events](https://docs.customer.io/journeys/events/): Track an event for a user that is known or not by Customer IO. Required fields: `person_email`, `event_name`. Optional fields: `event_id` (for event deduplication), `timestamp`.
+* [Person Events](https://docs.customer.io/journeys/events/): Track an event for a user that is known or not by Customer.io. Required fields: `person_email`, `event_name`. Optional fields: `event_id` (for event deduplication), `timestamp`.
 
 ### Features
 
@@ -34,7 +54,7 @@ Here are the destination objects and their respective operations that are curren
 ### Restrictions
 
 * Each entry sent to the API needs to be 32kb or smaller
-* Customer IO allows you to send unstructured attributes. Those attributes are subject to the following restrictions:
+* Customer.io allows you to send unstructured attributes. Those attributes are subject to the following restrictions:
     * Max number of attributes allowed per object is 300
     * Max size of all attributes is 100kb
     * The attributes name is 150 bytes or smaller
@@ -45,9 +65,9 @@ Here are the destination objects and their respective operations that are curren
 
 ### Setup guide
 
-In order to configure this connector, you need to generate your Track API Key and obtain your Site ID from Customer IO (Workspace Settings → API and webhook credentials → Create Track API Key). Once this is done, provide both the Site ID and API Key in the connector's configuration and you are good to go.
+In order to configure this connector, you need to generate your Track API Key and obtain your Site ID from Customer.io (Workspace Settings → API and webhook credentials → Create Track API Key). Once this is done, provide both the Site ID and API Key in the connector's configuration and you are good to go.
 
-**Object Storage for Rejected Records**: This connector supports data activation and can optionally store [rejected records](/platform/next/move-data/rejected-records) in object storage (such as S3). Configure object storage in the connector settings to capture records that couldn't be synced to Customer IO due to schema validation issues or other errors.
+**Object Storage for Rejected Records**: This connector supports data activation and can optionally store [rejected records](/platform/next/move-data/rejected-records) in object storage (such as S3). Configure object storage in the connector settings to capture records that couldn't be synced to Customer.io due to schema validation issues or other errors.
 
 ## Changelog
 
@@ -59,4 +79,4 @@ In order to configure this connector, you need to generate your Track API Key an
 | 0.0.4   | 2025-08-20 | [#65113](https://github.com/airbytehq/airbyte/pull/65113) | Update logo                                               |
 | 0.0.3   | 2025-07-08 | [#62848](https://github.com/airbytehq/airbyte/pull/62848) | Improve UX on connector configuration                     |
 | 0.0.2   | 2025-07-08 | [#62843](https://github.com/airbytehq/airbyte/pull/62843) | Checker should validate DLQ                               |
-| 0.0.1   | 2025-07-07 | [#62083](https://github.com/airbytehq/airbyte/pull/62083) | Initial release of the Customer IO destination connector  |
+| 0.0.1   | 2025-07-07 | [#62083](https://github.com/airbytehq/airbyte/pull/62083) | Initial release of the Customer.io destination connector  |

--- a/docs/integrations/destinations/customer-io.md
+++ b/docs/integrations/destinations/customer-io.md
@@ -39,8 +39,9 @@ If you're using an S3 bucket to store rejected records, you also need the follow
 ### Destination Objects + Operations
 
 Here are the destination objects and their respective operations that are currently supported:
-* [Person](https://docs.customer.io/journeys/create-update-person/): Identifies a person and assigns traits to them.
-* [Person Events](https://docs.customer.io/journeys/events/): Track an event for a user that is known or not by Customer.io. Required fields: `person_email`, `event_name`. Optional fields: `event_id` (for event deduplication), `timestamp`.
+
+- [Person](https://docs.customer.io/journeys/create-update-person/): Identifies a person and assigns traits to them.
+- [Person Events](https://docs.customer.io/journeys/events/): Track an event for a user that is known or not by Customer.io. Required fields: `person_email`, `event_name`. Optional fields: `event_id` (for event deduplication), `timestamp`.
 
 ### Features
 
@@ -53,13 +54,13 @@ Here are the destination objects and their respective operations that are curren
 
 ### Restrictions
 
-* Each entry sent to the API needs to be 32kb or smaller
-* Customer.io allows you to send unstructured attributes. Those attributes are subject to the following restrictions:
-    * Max number of attributes allowed per object is 300
-    * Max size of all attributes is 100kb
-    * The attributes name is 150 bytes or smaller
-    * The value of attributes is 1000 bytes or smaller
-* Event names are 100 bytes or smaller
+- Each entry sent to the API needs to be 32kb or smaller
+- Customer.io allows you to send unstructured attributes. Those attributes are subject to the following restrictions:
+    - Max number of attributes allowed per object is 300
+    - Max size of all attributes is 100kb
+    - The attributes name is 150 bytes or smaller
+    - The value of attributes is 1000 bytes or smaller
+- Event names are 100 bytes or smaller
 
 ## Getting started
 

--- a/docs/integrations/destinations/hubspot.md
+++ b/docs/integrations/destinations/hubspot.md
@@ -6,14 +6,35 @@ dockerRepository: airbyte/destination-hubspot
 
 This page guides you through the process of setting up the [HubSpot](https://www.hubspot.com/) destination connector. This connector supports [data activation](/platform/next/move-data/elt-data-activation) for operational workflows.
 
-:::info
-Data activation is in **early access**. Try it today with the HubSpot and Customer.io destinations in Airbyte Cloud or Self-Managed version 1.8 and later. If you'd like to be an early adopter, chat with the team, and share feedback, [fill out this form](https://form.typeform.com/to/STc7a0jx).
-:::
-
 ## Prerequisites
 
-- HubSpot Account
-- A version of the Airbyte platform version to be at least 1.8 or cloud
+- A HubSpot account
+- Airbyte version 1.8 or later, or Airbyte Cloud
+
+### S3 prerequisites for rejected records
+
+If you're using an S3 bucket to store rejected records, you also need the following.
+
+1. Allow connections from Airbyte to your AWS S3/Minio S3 cluster (if they exist in separate VPCs).
+2. [Enforce encryption of data in transit](https://docs.aws.amazon.com/AmazonS3/latest/userguide/security-best-practices.html#transit).
+3. An S3 bucket with credentials, a Role ARN, or an instance profile with read/write permissions configured for the host (EC2, EKS).
+
+    - These fields are always required:
+
+      - **S3 Bucket Name**
+      - **S3 Bucket Region**
+      - **Prefix Path in the Bucket**
+
+    - If you are using STS Assume Role, you must provide:
+
+      - **Role ARN**
+
+    - If you are using AWS credentials, you must provide:
+
+      - **Access Key ID**
+      - **Secret Access Key**
+
+    - If you are using an Instance Profile, you may omit the Access Key ID, Secret Access Key, and Role ARN.
 
 ## Setup guide
 

--- a/docs/integrations/destinations/s3.md
+++ b/docs/integrations/destinations/s3.md
@@ -4,31 +4,26 @@ This page guides you through the process of setting up the S3 destination connec
 
 ## Prerequisites
 
-List of required fields:
+1. Allow connections from Airbyte to your AWS S3/Minio S3 cluster (if they exist in separate VPCs).
+2. [Enforce encryption of data in transit](https://docs.aws.amazon.com/AmazonS3/latest/userguide/security-best-practices.html#transit).
+3. An S3 bucket with credentials, a Role ARN, or an instance profile with read/write permissions configured for the host (EC2, EKS).
 
-- **S3 Bucket Name**
-- **S3 Bucket Path**
-- **S3 Bucket Region**
+    - These fields are always required:
 
-If you are using STS Assume Role, you must provide the following:
+      - **S3 Bucket Name**
+      - **S3 Bucket Path**
+      - **S3 Bucket Region**
 
-- **Role ARN**
+    - If you are using STS Assume Role, you must provide:
 
-Otherwise, if you are using AWS credentials you must provide the following:
+      - **Role ARN**
 
-- **Access Key ID**
-- **Secret Access Key**
+    - If you are using AWS credentials, you must provide:
 
-If you are using an Instance Profile, you may omit the Access Key ID and Secret Access Key,
-as well as, the Role ARN.
+      - **Access Key ID**
+      - **Secret Access Key**
 
-Additionally the following prerequisites are required:
-
-1. Allow connections from Airbyte server to your AWS S3/ Minio S3 cluster \(if they exist in
-   separate VPCs\).
-2. An S3 bucket with credentials, a Role ARN, or an instance profile with read/write permissions configured for
-   the host (ec2, eks).
-3. [Enforce encryption of data in transit](https://docs.aws.amazon.com/AmazonS3/latest/userguide/security-best-practices.html#transit)
+    - If you are using an Instance Profile, you may omit the Access Key ID, Secret Access Key, and Role ARN.
 
 ## Setup guide
 

--- a/docs/integrations/enterprise-connectors/destination-salesforce.md
+++ b/docs/integrations/enterprise-connectors/destination-salesforce.md
@@ -3,17 +3,13 @@ dockerRepository: airbyte/destination-salesforce
 enterprise-connector: true
 ---
 
-# Salesforce Destination
+# Salesforce destination
 
 The Salesforce destination connector enables [data activation](/platform/next/move-data/elt-data-activation) by syncing data from your data warehouse to Salesforce objects. This connector is designed for operational workflows where you need to deliver modeled data directly to your CRM for sales, marketing, and customer success teams.
 
-:::info
-Data activation is in **early access**. Try it today with the HubSpot and Customer.io destinations in Airbyte Cloud or Self-Managed version 1.8 and later. If you'd like to be an early adopter, chat with the team, and share feedback, [fill out this form](https://form.typeform.com/to/STc7a0jx).
-:::
-
 The connector uses the [Salesforce Bulk API v62.0](https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/asynch_api_intro.htm) for efficient data loading and supports OAuth 2.0 authentication with comprehensive error handling through [rejected records](/platform/next/move-data/rejected-records) functionality.
 
-### Key Features
+## Key features
 
 - **Data Activation Support**: Sync enriched customer data, lead scores, and product usage metrics from your warehouse to Salesforce
 - **Bulk API Integration**: Uses Salesforce Bulk API v62.0 for high-performance data loading with 100MB batch processing
@@ -21,23 +17,43 @@ The connector uses the [Salesforce Bulk API v62.0](https://developer.salesforce.
 - **OAuth 2.0 Authentication**: Secure authentication with support for both sandbox and production environments
 - **CSV Format Processing**: Data is processed in CSV format for optimal compatibility with Salesforce Bulk API
 
-
 ## Prerequisites
 
-- [Salesforce Account](https://login.salesforce.com/) with Enterprise access or API quota purchased
-- A version of the Airbyte platform to be at least 1.8 or cloud
-- Salesforce developer application with OAuth 2.0 credentials (Client ID and Client Secret)
-- (Recommended) Dedicated Salesforce user with appropriate object permissions
+- A [Salesforce account](https://login.salesforce.com/) with one of the following subscriptions:
+    - Enterprise Edition
+    - Professional Edition with API access purchased as an add-on
+- Airbyte version 1.8 or later, or Airbyte Cloud
+- A Salesforce developer application with OAuth 2.0 credentials (Client ID and Client Secret)
+- Recommended: a dedicated Salesforce user with appropriate object permissions
 
-:::tip
+### S3 prerequisites for rejected records
 
-To use this connector, you'll need at least the Enterprise edition of Salesforce or the Professional Edition with API access purchased as an add-on. Reference the [Salesforce docs about API access](https://help.salesforce.com/s/articleView?id=000385436&type=1) for more information.
+If you're using an S3 bucket to store rejected records, you also need the following.
 
-:::
+1. Allow connections from Airbyte to your AWS S3/Minio S3 cluster (if they exist in separate VPCs).
+2. [Enforce encryption of data in transit](https://docs.aws.amazon.com/AmazonS3/latest/userguide/security-best-practices.html#transit).
+3. An S3 bucket with credentials, a Role ARN, or an instance profile with read/write permissions configured for the host (EC2, EKS).
+
+    - These fields are always required:
+
+      - **S3 Bucket Name**
+      - **S3 Bucket Region**
+      - **Prefix Path in the Bucket**
+
+    - If you are using STS Assume Role, you must provide:
+
+      - **Role ARN**
+
+    - If you are using AWS credentials, you must provide:
+
+      - **Access Key ID**
+      - **Secret Access Key**
+
+    - If you are using an Instance Profile, you may omit the Access Key ID, Secret Access Key, and Role ARN.
 
 ## Setup guide
 
-### Step 1: Create a Salesforce Connected App
+### Step 1: Create a Salesforce connected app
 
 Before setting up the Airbyte connector, you need to create a Connected App in Salesforce to obtain OAuth 2.0 credentials.
 
@@ -46,7 +62,7 @@ Before setting up the Airbyte connector, you need to create a Connected App in S
 3. Click **New Connected App**
 4. Fill in the basic information:
    - **Connected App Name**: "Airbyte Data Sync" (or your preferred name)
-   - **API Name**: Will auto-populate
+   - **API Name**: Auto-populates
    - **Contact Email**: Your email address
 5. Enable OAuth Settings:
    - Check **Enable OAuth Settings**
@@ -55,49 +71,54 @@ Before setting up the Airbyte connector, you need to create a Connected App in S
 6. Click **Save** and then **Continue**
 7. Note the **Consumer Key** (Client ID) and **Consumer Secret** (Client Secret) for later use
 
-### Step 2: (Optional, Recommended) Create a dedicated Salesforce user
+### Step 2: Create a dedicated Salesforce user (optional but recommended)
 
 Follow the instructions below to create a profile and assign custom permission sets to grant the new user the write access needed for data you want to access with Airbyte.
 
 [Log in to Salesforce](https://login.salesforce.com/) with an admin account.
 
-#### 1. Create a new User:
--  On the top right of the screen, click the gear icon and then click **Setup**.
--  In the left navigation bar, under Administration, click **Users** > **Users**. Create a new User, entering details for the user's first name, last name, alias, and email. Filling in the email field will auto-populate the username field and nickname.
+#### 1. Create a new User
+
+- On the top right of the screen, click the gear icon and then click **Setup**.
+- In the left navigation bar, under Administration, click **Users** > **Users**. Create a new User, entering details for the user's first name, last name, alias, and email. Filling in the email field auto-populates the username field and nickname.
       - Leave `role` unspecified
       - Select `Salesforce Platform` for the User License
       - Select `Standard Platform User` for Profile.
       - Decide whether to generate a new password and notify the user.
       - Select `save`
-#### 2. Create a new Permission Set:
--  Using the left navigation bar, select **Users** > **Permission Sets**
+
+#### 2. Create a new permission set
+
+- Using the left navigation bar, select **Users** > **Permission Sets**
 - Click `New` to create a new Permission Set.
 - Give your permission set a descriptive label name (e.g., "Airbyte Data Activation"). The API name will autopopulate based on the label you give the permission set.
-- For licence, leave this set to` –None—` and click `save`.
+- For licence, leave this set to `–None—` and click `save`.
 - Now that you see the permission set is created, define the permissions via Object Settings.
    - Click "Object Settings."
    - Select the `Object Name` for each object you want the user to have write access to (e.g., Accounts, Contacts, Opportunities).
    - Select "Edit" and check all the object permissions under "Object Permissions"
    - Click `Save`
    - Continue to add permissions for any objects you want Airbyte to have access to.
-#### 3. Assign the Permission Set to the new User
+
+#### 3. Assign the permission set to the new user
+
 - From the Permission Sets page, click "Manage Assignments" next to the read-only permission set you just created.
 - Click "Add Assignments."
 - Find and select the user you created in Step 1.
 - Click `Assign`
 
-Log into the email you used above and verify your new Salesforce account user. You'll need to set a password as part of this process. Keep this password accessible.
+Log into the email you used in the preceding steps and verify your new Salesforce account user. You'll need to set a password as part of this process. Keep this password accessible.
 
 :::info
-**Profile vs. Permission Set:** Remember that the user's profile will provide their baseline permissions. The permission set adds or restricts permissions on top of that.
-**Object-Level vs. Field-Level Security:** This guide focuses on object-level read-only access. While setting up your permission set, you can stick with object-level security or define more granular controls by scrolling down within each object settings page to select read access for only needed fields.
+**Profile vs. Permission Set**: remember that the user's profile provides their baseline permissions. The permission set adds or restricts permissions on top of that.
+**Object-Level vs. Field-Level Security**: this guide focuses on object-level read-only access. While setting up your permission set, you can stick with object-level security or define more granular controls by scrolling down within each object settings page to select read access for only needed fields.
 :::
 
 ### Step 3: Set up the Salesforce connector in Airbyte
 
 <!-- env:cloud -->
 
-#### For Airbyte Cloud:
+#### For Airbyte Cloud
 
 1. [Log into your Airbyte Cloud](https://cloud.airbyte.com/workspaces) account
 2. Click **Destinations** and then click **+ New destination**
@@ -114,9 +135,9 @@ Log into the email you used above and verify your new Salesforce account user. Y
 
 <!-- env:oss -->
 
-#### For Self-Managed Airbyte:
+#### For Self-Managed Airbyte
 
-1. Navigate to your Airbyte instance (e.g., `http://localhost:8000`)
+1. Navigate to your Airbyte instance (for example, `http://localhost:8000`)
 2. Click **Destinations** and then click **+ New destination**
 3. Select **Salesforce** from the destination type dropdown
 4. Enter a name for the Salesforce connector
@@ -133,7 +154,7 @@ Log into the email you used above and verify your new Salesforce account user. Y
 
 The connector uses OAuth 2.0 authentication with your Salesforce Connected App credentials. Make sure to set the **Is Sandbox** option correctly before authenticating, as this determines which Salesforce environment you connect to.
 
-## Supported Sync Modes
+## Supported sync modes
 
 The Salesforce destination currently supports:
 
@@ -145,34 +166,33 @@ While the underlying implementation supports additional operations (update, upse
 
 :::
 
+## Limitations and considerations
 
-## Limitations and Considerations
+- **API Limits**: respect Salesforce API limits based on your edition and purchased API calls
+- **Field Mapping**: ensure source data types are compatible with target Salesforce field types
+- **Object Permissions**: the authenticated user must have appropriate permissions on target objects
+- **Bulk API Quotas**: monitor your Bulk API usage as it counts against your daily limits
 
-- **API Limits**: Respect Salesforce API limits based on your edition and purchased API calls
-- **Field Mapping**: Ensure source data types are compatible with target Salesforce field types
-- **Object Permissions**: The authenticated user must have appropriate permissions on target objects
-- **Bulk API Quotas**: Monitor your Bulk API usage as it counts against your daily limits
-
-### Error Handling
+### Error handling
 
 - Failed records are automatically captured for troubleshooting
 - Monitor sync status through the Airbyte UI for detailed error information
 
 ## Troubleshooting
 
-### Authentication Issues
+### Authentication issues
 
 - **Invalid Client Credentials**: Verify your Connected App's Consumer Key and Consumer Secret
 - **Refresh Token Expired**: Re-authenticate through the Airbyte UI to generate a new refresh token
 - **Sandbox vs Production**: Ensure the "Is Sandbox" setting matches your Salesforce environment. Changing this setting requires redoing authentication.
 
-### Permission Issues
+### Permission issues
 
 - **Insufficient Object Permissions**: Verify the authenticated user has Create/Edit permissions on target objects
 - **Field-Level Security**: Check that required fields are accessible to the user
 - **API Access**: Confirm your Salesforce edition includes API access
 
-### Data Issues
+### Data issues
 
 - **Field Type Mismatches**: Ensure source data types are compatible with Salesforce field types
 - **Required Field Validation**: Check that all required Salesforce fields are populated
@@ -203,7 +223,7 @@ For programmatic configuration, use these parameter names:
 }
 ```
 
-## Related Documentation
+## Related documentation
 
 - [Data Activation Overview](/platform/next/move-data/elt-data-activation)
 - [Salesforce Bulk API Documentation](https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/asynch_api_intro.htm)

--- a/docs/platform/move-data/add-connection.md
+++ b/docs/platform/move-data/add-connection.md
@@ -59,10 +59,6 @@ Follow these steps to create a connection to a database, warehouse, lake, or sim
 
 ## Create a data activation connection
 
-:::info
-Data activation is in **early access**. Try it today with the HubSpot and Customer.io destinations in Airbyte Cloud or Self-Managed version 1.8 and later. If you'd like to be an early adopter, chat with the team, and share feedback, [fill out this form](https://form.typeform.com/to/STc7a0jx).
-:::
-
 Follow these steps to create a connection to a data activation destination.
 
 ### Step 1: Choose your connectors

--- a/docs/platform/move-data/elt-data-activation.md
+++ b/docs/platform/move-data/elt-data-activation.md
@@ -4,10 +4,6 @@ products: all
 
 # Data activation (reverse ETL)
 
-:::info
-Data activation is in **early access**. Try it today with the HubSpot and Customer.io destinations in Airbyte Cloud or Self-Managed version 1.8 and later. If you'd like to be an early adopter, chat with the team, and share feedback, [fill out this form](https://form.typeform.com/to/STc7a0jx).
-:::
-
 Data activation enables you to move data out of your data warehouse and into the operational tools where work happens, like CRMs, marketing platforms, and support systems. With this capability, you can deliver modeled data directly to points of action and systems people already use, helping your organization respond faster and more effectively.
 
 This page introduces the concept of data activation, outlines how it works within the Airbyte platform, and describes common use cases.
@@ -87,9 +83,9 @@ Teams in sales, marketing, support, and finance often rely on operational system
 
 To start activating your data with Airbyte, see the following topics.
 
-- [Set up a source](../using-airbyte/getting-started/add-a-source)
-- [Set up a destination](../using-airbyte/getting-started/add-a-destination)
-- [Set up a connection](add-connection)
+- [Set up a source](../using-airbyte/getting-started/add-a-source): The data warehouse or other source you're syncing data from.
+- [Set up a destination](../using-airbyte/getting-started/add-a-destination): The CRM, marketing platform, or support system you're syncing data to.
+- [Set up a connection](add-connection): Learn how to create a connection to a data activation destination and map fields from your source to your destination.
 
 More resources:
 

--- a/docs/platform/using-airbyte/mappings.md
+++ b/docs/platform/using-airbyte/mappings.md
@@ -8,7 +8,9 @@ Use mappings to hash, encrypt, and rename fields, and filter rows. You set up ma
 
 ![Screenshot of mappings feature showing several streams with mappings applied](images/mappings.png)
 
-## More about mapping in Airbyte 
+If you're doing [data activation](../move-data/elt-data-activation), a similar mapping concept applies when you map fields from a source to a destination. [Learn more](../move-data/add-connection).
+
+## More about mapping in Airbyte
 
 It’s often the case that you want to move data from a source to a destination in a non-literal way, obscuring sensitive information and improving the consistency and usability of that data in its destination. Mapping allows you to match a field from your source to your destination and sync data in a way that is still accurate, but also more meaningful and appropriate for your needs.
 


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->

- Added more complete requirements for S3 buckets in data activation destinations (Nourien's request).
- Clarified Salesforce subscription requirements, as there were previously two mutually exclusive statements.
- Some linting, and minor edits based on feedback from sales team.
- Removed early access banners now that data activation is in GA

## How
<!--
* Describe how code changes achieve the solution.
-->

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
