### PR TITLE
ci: add cdk connector compatibility workflow

### DIFF
--- a/.github/workflows/cdk-connector-compatibility-test.yml
+++ b/.github/workflows/cdk-connector-compatibility-test.yml
@@ -3,10 +3,10 @@ name: CDK Connector Compatibility Test
 on:
   pull_request:
     paths:
-      - 'airbyte-cdk/java/**/*'
-      - 'airbyte-cdk/bulk/**/*'
+      - "airbyte-cdk/java/**/*"
+      - "airbyte-cdk/bulk/**/*"
   schedule:
-    - cron: '0 12 * * *'
+    - cron: "0 12 * * *"
 
 jobs:
   generate-matrix:

--- a/.github/workflows/cdk-connector-compatibility-test.yml
+++ b/.github/workflows/cdk-connector-compatibility-test.yml
@@ -1,0 +1,134 @@
+name: CDK Connector Compatibility Test
+
+on:
+  pull_request:
+    paths:
+      - 'airbyte-cdk/java/**/*'
+      - 'airbyte-cdk/bulk/**/*'
+  schedule:
+    - cron: '0 12 * * *'
+
+jobs:
+  generate-matrix:
+    name: Generate Connector Matrix
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout Airbyte
+        uses: actions/checkout@v4
+        with:
+          submodules: true # Needed for airbyte-enterprise connectors (no-op otherwise)
+          fetch-depth: 0
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: "zulu"
+          java-version: "21"
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: "8.14"
+
+      - name: Trigger changes on all connectors using bulk cdk # this is just an easy way to get a list of all bulk cdk connectors
+        run: ./gradlew upgradeCdk --cdkVersion=local
+
+      - name: Generate Connector Matrix from Changes
+        id: generate-matrix
+        run: echo "connectors_matrix=$(./poe-tasks/get-modified-connectors.sh --json --local-cdk)" | tee -a $GITHUB_OUTPUT
+
+    outputs:
+      connectors-matrix: ${{ steps.generate-matrix.outputs.connectors_matrix }}
+
+  connectors-test:
+    name: Test ${{ matrix.connector }} Connector
+    needs: [generate-matrix]
+    runs-on: linux-24.04-large
+    env:
+      GCP_GSM_CREDENTIALS: ${{ secrets.GCP_GSM_CREDENTIALS }}
+      GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID || vars.GCP_PROJECT_ID }}
+      DD_TAGS: "connector.name:${{ matrix.connector }}"
+
+    strategy:
+      matrix: ${{ fromJson(needs.generate-matrix.outputs.connectors-matrix) }}
+      max-parallel: 5 # Limit number of parallel jobs
+      fail-fast: false # Don't stop on first failure
+    steps:
+      - name: Checkout Airbyte
+        if: matrix.connector
+        id: checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: true # Needed for airbyte-enterprise connectors (no-op otherwise)
+
+      # Java deps
+      - uses: actions/setup-java@v4
+        if: matrix.connector
+        with:
+          distribution: zulu
+          java-version: 21
+          cache: gradle
+
+      # The default behaviour is read-only on PR branches and read/write on master.
+      # See https://github.com/gradle/actions/blob/main/docs/setup-gradle.md#using-the-cache-read-only.
+      - uses: gradle/actions/setup-gradle@v4
+        if: matrix.connector
+        with:
+          gradle-version: "8.14"
+
+      # TODO: We can delete this step once Airbyte-CI is removed from Java integration tests.
+      - name: Set up Python (For Airbyte-CI)
+        if: matrix.connector
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          check-latest: true
+          update-environment: true
+
+      - name: Install the latest version of uv
+        if: matrix.connector
+        uses: astral-sh/setup-uv@v6
+
+      - name: Install Poe
+        if: matrix.connector
+        run: |
+          # Install Poe so we can run the connector tasks:
+          uv tool install poethepoet
+
+      - name: Install connector dependencies
+        if: matrix.connector
+        working-directory: airbyte-integrations/connectors/${{ matrix.connector }}
+        run: poe install
+
+      - name: Fetch connector secrets
+        # This will be skipped if the repo or fork does not set GCP_PROJECT_ID, or if it is set to an empty value.
+        # Later integration tests will likely fail in this case, but we at least let them run.
+        if: matrix.connector && (vars.GCP_PROJECT_ID != '')
+        run: |
+          airbyte-cdk secrets fetch ${{ matrix.connector }}
+
+      - name: Run CDK upgrade # Run tests against local CDK version
+        if: matrix.connector
+        run: ./gradlew upgradeCdk --cdkVersion=local
+
+      - name: Run Unit Tests
+        id: run-unit-tests
+        if: matrix.connector
+        working-directory: airbyte-integrations/connectors/${{ matrix.connector }}
+        run: poe test-unit-tests
+
+      - name: Run Integration Tests
+        id: run-integration-tests
+        if: matrix.connector
+        working-directory: airbyte-integrations/connectors/${{ matrix.connector }}
+        run: poe test-integration-tests
+
+      - name: Slack Notification on Failure
+        if: github.event_name == 'schedule' && failure() && (steps.run-unit-tests.outcome == 'failure' || steps.run-integration-tests.outcome == 'failure')
+        uses: slackapi/slack-github-action@v2.1.1
+        with:
+          token: ${{ secrets.SLACK_BOT_TOKEN_AIRBYTE_TEAM }}
+          method: chat.postMessage
+          payload: |
+            channel: C09H56MT8J2 # jose-alert-test channel. The use of this channel is meant to be temporary while we evaluate the usefulness of these notifications.
+            text: "`${{ matrix.connector }}` connector tests failed when using local CDK! <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|View Test Logs>"

--- a/.github/workflows/cdk-connector-compatibility-test.yml
+++ b/.github/workflows/cdk-connector-compatibility-test.yml
@@ -3,7 +3,6 @@ name: CDK Connector Compatibility Test
 on:
   pull_request:
     paths:
-      - "airbyte-cdk/java/**/*"
       - "airbyte-cdk/bulk/**/*"
   schedule:
     - cron: "0 12 * * *"

--- a/.github/workflows/cdk-connector-compatibility-test.yml
+++ b/.github/workflows/cdk-connector-compatibility-test.yml
@@ -75,15 +75,6 @@ jobs:
         with:
           gradle-version: "8.14"
 
-      # TODO: We can delete this step once Airbyte-CI is removed from Java integration tests.
-      - name: Set up Python (For Airbyte-CI)
-        if: matrix.connector
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-          check-latest: true
-          update-environment: true
-
       - name: Install the latest version of uv
         if: matrix.connector
         uses: astral-sh/setup-uv@v6


### PR DESCRIPTION
## What
Currently, when making CDK changes it is easy to break a connector without noticing since connectors are pinned to a CDK version.

We need a way to 
1. When making a change to the CDK, identify if the changes would break any connector. This shouldn't block us from merging the change though since connectors will still work since they are pinned 
2. Once a day, check if the latest CDK version would break any connector. This should somehow alert us so that we can keep track of which connectors need to be fixed.

## How
We are adding a github actions workflow that runs tests on all connectors using the bulk CDK. Before running the test the CDK version is set to `local` so that we run the tests with the most recent CDK changes. The workflow is triggered in two scenarios:
1. As a non-blocking PR check whenever a CDK change is made
2. As a cron, once a day. When running as a cron we send a slack message on a given channel so that we can keep track of broken connectors.

## How did I test this?
Tested from [this](https://github.com/airbytehq/airbyte/pull/66707) PR. You can see the workflow runs I used for testing here https://github.com/airbytehq/airbyte/actions/workflows/cdk-connector-compatibility-test.yml

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
