### PR TITLE
Fix(Source-Monday): 'data' Key Error - Add API Budget

### DIFF
--- a/airbyte-integrations/connectors/source-monday/manifest.yaml
+++ b/airbyte-integrations/connectors/source-monday/manifest.yaml
@@ -413,6 +413,15 @@ spec:
         default: 4
         examples: [1, 2, 3]
         description: The number of worker threads to use for the sync.
+      account_plan:
+        type: string
+        title: Monday.com Account Plan
+        description: "Your Monday.com account plan. This is used to set the appropriate API rate limits (750 for Enterprise, 500 for Pro, 250 for all other plans requests/minute)."
+        default: "Other"
+        enum:
+          - "Enterprise"
+          - "Pro"
+          - "Other"
   advanced_auth:
     auth_flow_type: oauth2.0
     predicate_key: ["credentials", "auth_type"]
@@ -460,11 +469,37 @@ check:
   stream_names:
     - "users"
 
-# The smallest limit for 1 minute is 250 queries, so set the default number of workers to 4. https://developer.monday.com/api-reference/docs/rate-limits#minute-limit
+# Use account plan to determine the rate limit and concurrency limits
+# https://developer.monday.com/api-reference/docs/rate-limits#minute-limit
 concurrency_level:
   type: ConcurrencyLevel
   default_concurrency: "{{ config.get('num_workers', 4) }}"
-  max_concurrency: 40 # Monday concurrency limit for lowest tier is 40. https://developer.monday.com/api-reference/docs/rate-limits#concurrency-limit
+  # Monday concurrency limit is set based on account plan
+  # Enterprise: 250 concurrent requests
+  # Pro: 100 concurrent requests
+  # Other plans: 40 concurrent requests
+  max_concurrency: "{{ 250 if config.get('account_plan', 'Other') == 'Enterprise' else 100 if config.get('account_plan', 'Other') == 'Pro' else 40 }}"
+
+# Define API budget based on the account plan
+api_budget:
+  type: HTTPAPIBudget
+  policies:
+    - type: MovingWindowCallRatePolicy
+      # Monday.com API has different rate limits based on account plan
+      # https://developer.monday.com/api-reference/docs/rate-limits#minute-limit
+      # Enterprise: 750 requests per minute
+      # Pro: 500 requests per minute 
+      # Other: 250 requests per minute
+      #
+      # NOTE: The official docs contain an error showing incorrectly reversed limits:
+      # Enterprise: 1000, Pro: 2,500, Other: 5,000 (This makes no sense since enterprise should have the highest limit)
+      # Kappa.AI (Monday's AI docs assistant) confirmed these are incorrect,
+      # and the values listed above are the correct ones
+      rates:
+        - limit: "{{ 750 if config.get('account_plan', 'Other') == 'Enterprise' else 500 if config.get('account_plan', 'Other') == 'Pro' else 250 }}"
+          interval: "PT1M"  # 1 minute window
+      matchers:
+        - url_base: "https://api.monday.com"  # Match all requests to Monday.com API
 
 schemas:
   activity_logs:

--- a/airbyte-integrations/connectors/source-monday/manifest.yaml
+++ b/airbyte-integrations/connectors/source-monday/manifest.yaml
@@ -13,7 +13,7 @@ definitions:
 
   requester:
     type: CustomRequester
-    class_name: "components.MondayGraphqlRequester"
+    class_name: "source_declarative_manifest.components.MondayGraphqlRequester"
     http_method: POST
     schema_loader:
       type: InlineSchemaLoader
@@ -133,13 +133,13 @@ definitions:
   double_paginator:
     $ref: "#/definitions/default_paginator"
     pagination_strategy:
-      class_name: "components.ItemPaginationStrategy"
+      class_name: "source_declarative_manifest.components.ItemPaginationStrategy"
       type: "CustomPaginationStrategy"
 
   cursor_paginator:
     $ref: "#/definitions/default_paginator"
     pagination_strategy:
-      class_name: "components.ItemCursorPaginationStrategy"
+      class_name: "source_declarative_manifest.components.ItemCursorPaginationStrategy"
       type: "CustomPaginationStrategy"
 
   activity_logs_stream:
@@ -153,7 +153,7 @@ definitions:
       record_selector:
         $ref: "#/definitions/selector"
         extractor:
-          class_name: "components.MondayActivityExtractor"
+          class_name: "source_declarative_manifest.components.MondayActivityExtractor"
       paginator:
         $ref: "#/definitions/double_paginator"
     $parameters:
@@ -178,7 +178,7 @@ definitions:
         partition_field: "ids"
 
   incremental_extractor:
-    class_name: "components.MondayIncrementalItemsExtractor"
+    class_name: "source_declarative_manifest.components.MondayIncrementalItemsExtractor"
 
   # Boards Stream: Split into full refresh and incremental, then combine with StateDelegatingStream
   boards_stream:
@@ -201,7 +201,7 @@ definitions:
               - updated_at_int
             value: "{{ timestamp(record.get('updated_at')) | int if record.get('updated_at') else 1 }}" # updated_at_int is cursor field so in cannot be None
       - type: CustomTransformation
-        class_name: components.MondayTransformation
+        class_name: source_declarative_manifest.components.MondayTransformation
 
     incremental_sync:
       type: DatetimeBasedCursor
@@ -264,7 +264,7 @@ definitions:
         deduplicate: true
     state_migrations:
       - type: CustomStateMigration
-        class_name: components.MondayStateMigration
+        class_name: source_declarative_manifest.components.MondayStateMigration
 
   items_stream:
     type: StateDelegatingStream
@@ -326,7 +326,7 @@ definitions:
         deduplicate: true
     state_migrations:
       - type: CustomStateMigration
-        class_name: components.MondayStateMigration
+        class_name: source_declarative_manifest.components.MondayStateMigration
 streams:
   - "#/definitions/items_stream"
   - "#/definitions/boards_stream"
@@ -409,7 +409,7 @@ spec:
         type: integer
         title: Number of concurrent workers
         minimum: 2
-        maximum: 50
+        maximum: 250
         default: 4
         examples: [1, 2, 3]
         description: The number of worker threads to use for the sync.
@@ -473,12 +473,15 @@ check:
 # https://developer.monday.com/api-reference/docs/rate-limits#minute-limit
 concurrency_level:
   type: ConcurrencyLevel
+
+  #Ideally, we would have set this based on the account plan but since num_workers is user configurable we will use it instead
   default_concurrency: "{{ config.get('num_workers', 4) }}"
-  # Monday concurrency limit is set based on account plan
   # Enterprise: 250 concurrent requests
   # Pro: 100 concurrent requests
   # Other plans: 40 concurrent requests
-  max_concurrency: 250  # Using highest value as default, will be limited at runtime
+  # max_concurrency cannot be set with a Jinja expression because it is used to validate default_concurrency.
+  # due to this we will use the static max_concurrency of 250 which is the max allowed by Monday.com
+  max_concurrency: 250
 
 # Define API budget based on the account plan
 api_budget:
@@ -496,7 +499,7 @@ api_budget:
       # Kappa.AI (Monday's AI docs assistant) confirmed these are incorrect,
       # and the values listed above are the correct ones
       rates:
-        - limit: 750  # Using highest value as default, will be limited at runtime
+        - limit: "{{ 750 if config.get('account_plan', 'Other') == 'Enterprise' else 500 if config.get('account_plan', 'Other') == 'Pro' else 250 }}"
           interval: "PT1M"  # 1 minute window
       matchers:
         - url_base: "https://api.monday.com"  # Match all requests to Monday.com API

--- a/airbyte-integrations/connectors/source-monday/manifest.yaml
+++ b/airbyte-integrations/connectors/source-monday/manifest.yaml
@@ -13,7 +13,7 @@ definitions:
 
   requester:
     type: CustomRequester
-    class_name: "source_declarative_manifest.components.MondayGraphqlRequester"
+    class_name: "components.MondayGraphqlRequester"
     http_method: POST
     schema_loader:
       type: InlineSchemaLoader
@@ -133,13 +133,13 @@ definitions:
   double_paginator:
     $ref: "#/definitions/default_paginator"
     pagination_strategy:
-      class_name: "source_declarative_manifest.components.ItemPaginationStrategy"
+      class_name: "components.ItemPaginationStrategy"
       type: "CustomPaginationStrategy"
 
   cursor_paginator:
     $ref: "#/definitions/default_paginator"
     pagination_strategy:
-      class_name: "source_declarative_manifest.components.ItemCursorPaginationStrategy"
+      class_name: "components.ItemCursorPaginationStrategy"
       type: "CustomPaginationStrategy"
 
   activity_logs_stream:
@@ -153,7 +153,7 @@ definitions:
       record_selector:
         $ref: "#/definitions/selector"
         extractor:
-          class_name: "source_declarative_manifest.components.MondayActivityExtractor"
+          class_name: "components.MondayActivityExtractor"
       paginator:
         $ref: "#/definitions/double_paginator"
     $parameters:
@@ -178,7 +178,7 @@ definitions:
         partition_field: "ids"
 
   incremental_extractor:
-    class_name: "source_declarative_manifest.components.MondayIncrementalItemsExtractor"
+    class_name: "components.MondayIncrementalItemsExtractor"
 
   # Boards Stream: Split into full refresh and incremental, then combine with StateDelegatingStream
   boards_stream:
@@ -201,7 +201,7 @@ definitions:
               - updated_at_int
             value: "{{ timestamp(record.get('updated_at')) | int if record.get('updated_at') else 1 }}" # updated_at_int is cursor field so in cannot be None
       - type: CustomTransformation
-        class_name: source_declarative_manifest.components.MondayTransformation
+        class_name: components.MondayTransformation
 
     incremental_sync:
       type: DatetimeBasedCursor
@@ -264,7 +264,7 @@ definitions:
         deduplicate: true
     state_migrations:
       - type: CustomStateMigration
-        class_name: source_declarative_manifest.components.MondayStateMigration
+        class_name: components.MondayStateMigration
 
   items_stream:
     type: StateDelegatingStream
@@ -326,7 +326,7 @@ definitions:
         deduplicate: true
     state_migrations:
       - type: CustomStateMigration
-        class_name: source_declarative_manifest.components.MondayStateMigration
+        class_name: components.MondayStateMigration
 streams:
   - "#/definitions/items_stream"
   - "#/definitions/boards_stream"
@@ -478,7 +478,7 @@ concurrency_level:
   # Enterprise: 250 concurrent requests
   # Pro: 100 concurrent requests
   # Other plans: 40 concurrent requests
-  max_concurrency: "{{ 250 if config.get('account_plan', 'Other') == 'Enterprise' else 100 if config.get('account_plan', 'Other') == 'Pro' else 40 }}"
+  max_concurrency: 250  # Using highest value as default, will be limited at runtime
 
 # Define API budget based on the account plan
 api_budget:
@@ -496,7 +496,7 @@ api_budget:
       # Kappa.AI (Monday's AI docs assistant) confirmed these are incorrect,
       # and the values listed above are the correct ones
       rates:
-        - limit: "{{ 750 if config.get('account_plan', 'Other') == 'Enterprise' else 500 if config.get('account_plan', 'Other') == 'Pro' else 250 }}"
+        - limit: 750  # Using highest value as default, will be limited at runtime
           interval: "PT1M"  # 1 minute window
       matchers:
         - url_base: "https://api.monday.com"  # Match all requests to Monday.com API

--- a/airbyte-integrations/connectors/source-monday/metadata.yaml
+++ b/airbyte-integrations/connectors/source-monday/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 80a54ea2-9959-4040-aac1-eee42423ec9b
-  dockerImageTag: 2.4.6
+  dockerImageTag: 2.4.7
   releases:
     rolloutConfiguration:
       enableProgressiveRollout: false

--- a/docs/integrations/sources/monday-migrations.md
+++ b/docs/integrations/sources/monday-migrations.md
@@ -1,5 +1,7 @@
 # Monday Migration Guide
 
+import MigrationGuide from '@site/static/_migration_guides_upgrade_guide.md';
+
 ## Upgrading to 2.0.0
 
 Source Monday has deprecated API version 2023-07. We have upgraded the connector to the latest API version 2024-01. In this new version, the Id field has changed from an integer to a string in the streams Boards, Items, Tags, Teams, Updates, Users and Workspaces. Please reset affected streams.

--- a/docs/integrations/sources/monday-migrations.md
+++ b/docs/integrations/sources/monday-migrations.md
@@ -1,5 +1,3 @@
-import MigrationGuide from '@site/static/_migration_guides_upgrade_guide.md';
-
 # Monday Migration Guide
 
 ## Upgrading to 2.0.0

--- a/docs/integrations/sources/monday.md
+++ b/docs/integrations/sources/monday.md
@@ -74,13 +74,15 @@ The Monday connector should not run into Monday API limitations under normal usa
 
 ## Account Plan Configuration
 
-The connector now supports specifying your Monday.com account plan type, which optimizes API usage based on your subscription tier:
+The connector now supports specifying your Monday.com account plan type, which optimizes API rate limits based on your subscription tier:
 
-- **Enterprise**: 750 requests per minute, 250 concurrent requests
-- **Pro**: 500 requests per minute, 100 concurrent requests
-- **Other Plans**: 250 requests per minute, 40 concurrent requests
+- **Enterprise**: 750 requests per minute
+- **Pro**: 500 requests per minute
+- **Other Plans**: 250 requests per minute
 
 Setting your account plan correctly helps the connector respect Monday.com's rate limits and optimize performance during syncs.
+
+**Concurrency Configuration**: The number of concurrent requests can be controlled using the `num_workers` configuration parameter (default: 4). The maximum allowed concurrency is 250, allowing higher-tier users to scale up performance as needed.
 
 
 ## Changelog

--- a/docs/integrations/sources/monday.md
+++ b/docs/integrations/sources/monday.md
@@ -15,7 +15,9 @@ You can get the API token for Monday by going to Profile picture (bottom left co
 1. [Log into your Airbyte Cloud](https://cloud.airbyte.com/workspaces) account.
 2. In the left navigation bar, click **Sources**. In the top-right corner, click **+new source**.
 3. On the Set up the source page, enter the name for the Monday connector and select **Monday** from the Source type dropdown.
-4. Fill in your API Key or authenticate using OAuth and then click **Set up source**.
+4. Fill in your API Key or authenticate using OAuth.
+5. (Optional) Select your Monday.com account plan (Enterprise, Pro, or Other) to optimize API usage.
+6. Click **Set up source**.
 
 ### Connect using `OAuth 2.0` option
 
@@ -70,6 +72,17 @@ Important Notes:
 
 The Monday connector should not run into Monday API limitations under normal usage. Please [create an issue](https://github.com/airbytehq/airbyte/issues) if you see any rate limit issues that are not automatically retried successfully.
 
+## Account Plan Configuration
+
+The connector now supports specifying your Monday.com account plan type, which optimizes API usage based on your subscription tier:
+
+- **Enterprise**: 750 requests per minute, 250 concurrent requests
+- **Pro**: 500 requests per minute, 100 concurrent requests
+- **Other Plans**: 250 requests per minute, 40 concurrent requests
+
+Setting your account plan correctly helps the connector respect Monday.com's rate limits and optimize performance during syncs.
+
+
 ## Changelog
 
 <details>
@@ -77,6 +90,7 @@ The Monday connector should not run into Monday API limitations under normal usa
 
 | Version    | Date       | Pull Request                                              | Subject                                                                                                                                                                |
 |:-----------|:-----------|:----------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 2.4.7 | 2025-09-30 | [XXXXX](https://github.com/airbytehq/airbyte/pull/XXXXX) | Add API Budget with Plan options |
 | 2.4.6 | 2025-09-09 | [65884](https://github.com/airbytehq/airbyte/pull/65884) | Update dependencies |
 | 2.4.5 | 2025-08-23 | [64705](https://github.com/airbytehq/airbyte/pull/64705) | Update dependencies |
 | 2.4.4 | 2025-08-11 | [64878](https://github.com/airbytehq/airbyte/pull/64878) | Pass query in json body of request instead of query params. |

--- a/docs/integrations/sources/monday.md
+++ b/docs/integrations/sources/monday.md
@@ -90,7 +90,7 @@ Setting your account plan correctly helps the connector respect Monday.com's rat
 
 | Version    | Date       | Pull Request                                              | Subject                                                                                                                                                                |
 |:-----------|:-----------|:----------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 2.4.7 | 2025-09-30 | [XXXXX](https://github.com/airbytehq/airbyte/pull/XXXXX) | Add API Budget with Plan options |
+| 2.4.7 | 2025-09-30 | [66724](https://github.com/airbytehq/airbyte/pull/66724) | Add API Budget with Plan options |
 | 2.4.6 | 2025-09-09 | [65884](https://github.com/airbytehq/airbyte/pull/65884) | Update dependencies |
 | 2.4.5 | 2025-08-23 | [64705](https://github.com/airbytehq/airbyte/pull/64705) | Update dependencies |
 | 2.4.4 | 2025-08-11 | [64878](https://github.com/airbytehq/airbyte/pull/64878) | Pass query in json body of request instead of query params. |


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->
OC Issue: https://github.com/airbytehq/oncall/issues/7817

Users get a KeyError when syncing due to ratelimit backoffs causing the paginator cursor to expire. Monday, then will send us a 200 response with an error message (saying the cursor is expired and to retry the pagination), leading to the 'data' KeyError.

## How
<!--
* Describe how code changes achieve the solution.
-->

This fix will implement the API budget based on the Plan, which should prevent the error from happening. 

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ X] YES 💚
- [ ] NO ❌
