### PR TITLE
Allow no op summary step to complete on forks

### DIFF
--- a/.github/workflows/connector-ci-checks.yml
+++ b/.github/workflows/connector-ci-checks.yml
@@ -500,7 +500,7 @@ jobs:
       - name: Create Check Status
         if: >
           always() && !cancelled() &&
-          steps.get-app-token.outcome == 'success'
+          steps.get-app-token.conclusion == 'success'
         uses: LouisBrunner/checks-action@v2.0.0
         with:
           name: "Connector CI Checks Summary" # << Name of the 'Required' check


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->

This should fix https://github.com/airbytehq/airbyte/issues/66742, which prevented CI from completing on docs PRs from forked repos.

## How
<!--
* Describe how code changes achieve the solution.
-->

The `Authenticate as GitHub App` step continues-on-error on forked repos because the needed secrets aren't available.

The `Create Check Status` then runs on the `outcome == success` condition, but outcome is always `failure` after a continue-on-error. Following [GitHub's documentation](https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#steps-context), I've changed `outcome` to `conclusion`, which runs after continue-on-error, and should evaluate to `success` and allow the step to complete.

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

Forked repo contributions can succeed.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
