### PR TITLE
Finalize Clickhouse 2.1.3 rollout.

### DIFF
--- a/airbyte-integrations/connectors/destination-clickhouse/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-clickhouse/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: ce0d828e-1dc4-496c-b122-2da42e637e48
-  dockerImageTag: 2.1.3-rc.1
+  dockerImageTag: 2.1.3
   dockerRepository: airbyte/destination-clickhouse
   githubIssueLabel: destination-clickhouse
   icon: clickhouse.svg
@@ -18,7 +18,7 @@ data:
   releaseStage: generally_available
   releases:
     rolloutConfiguration:
-      enableProgressiveRollout: true
+      enableProgressiveRollout: false
     breakingChanges:
       2.0.0:
         message: "This connector has been re-written from scratch. Data will now be typed and stored in final (non-raw) tables. The connector may require changes to its configuration to function properly and downstream pipelines may be affected. Warning: SSH tunneling is in Beta."

--- a/docs/integrations/destinations/clickhouse.md
+++ b/docs/integrations/destinations/clickhouse.md
@@ -94,7 +94,7 @@ You can also use a pre-existing user but we highly recommend creating a dedicate
 
 | Version    | Date       | Pull Request                                               | Subject                                                                        |
 |:-----------|:-----------|:-----------------------------------------------------------|:-------------------------------------------------------------------------------|
-| 2.1.3      | 2025-09-29 | [\#TBD99](https://github.com/airbytehq/airbyte/pull/TBD99) | Finalize speed preparation.                                                    |
+| 2.1.3      | 2025-09-29 | [\#66746](https://github.com/airbytehq/airbyte/pull/66746) | Finalize speed preparation.                                                    |
 | 2.1.3-rc.1 | 2025-09-25 | [\#66699](https://github.com/airbytehq/airbyte/pull/66699) | Prepare for speed mode. Fix interleaved stream state handling.                 |
 | 2.1.2      | 2025-09-09 | [\#66143](https://github.com/airbytehq/airbyte/pull/66143) | Improve schema propagation.                                                    |
 | 2.1.1      | 2025-09-09 | [\#66134](https://github.com/airbytehq/airbyte/pull/66134) | Update the type we are setting for the number type to `Decimal(38, 9)`.        |

--- a/docs/integrations/destinations/clickhouse.md
+++ b/docs/integrations/destinations/clickhouse.md
@@ -94,10 +94,11 @@ You can also use a pre-existing user but we highly recommend creating a dedicate
 
 | Version    | Date       | Pull Request                                               | Subject                                                                        |
 |:-----------|:-----------|:-----------------------------------------------------------|:-------------------------------------------------------------------------------|
-| 2.1.3-rc.1 | 2025-09-25 | [66699](https://github.com/airbytehq/airbyte/pull/66699)   | Prepare for speed mode. Fix interleaved stream state handling.                 |
-| 2.1.2      | 2025-09-09 | [66143](https://github.com/airbytehq/airbyte/pull/66143)   | Improve schema propagation.                                                    |
-| 2.1.1      | 2025-09-09 | [66134](https://github.com/airbytehq/airbyte/pull/66134)   | Update the type we are setting for the number type to `Decimal(38, 9)`.        |
-| 2.1.0      | 2025-09-03 | [65929](https://github.com/airbytehq/airbyte/pull/65929)   | Promoting release candidate 2.1.0-rc.2 to a main version.                      |
+| 2.1.3      | 2025-09-29 | [\#TBD99](https://github.com/airbytehq/airbyte/pull/TBD99) | Finalize speed preparation.                                                    |
+| 2.1.3-rc.1 | 2025-09-25 | [\#66699](https://github.com/airbytehq/airbyte/pull/66699) | Prepare for speed mode. Fix interleaved stream state handling.                 |
+| 2.1.2      | 2025-09-09 | [\#66143](https://github.com/airbytehq/airbyte/pull/66143) | Improve schema propagation.                                                    |
+| 2.1.1      | 2025-09-09 | [\#66134](https://github.com/airbytehq/airbyte/pull/66134) | Update the type we are setting for the number type to `Decimal(38, 9)`.        |
+| 2.1.0      | 2025-09-03 | [\#65929](https://github.com/airbytehq/airbyte/pull/65929) | Promoting release candidate 2.1.0-rc.2 to a main version.                      |
 | 2.1.0-rc.2 | 2025-08-29 | [\#65626](https://github.com/airbytehq/airbyte/pull/65626) | Pick up CDK fix for rare array OOB exception.                                  |
 | 2.1.0-rc.1 | 2025-08-21 | [\#65144](https://github.com/airbytehq/airbyte/pull/65144) | Migrate to dataflow model.                                                     |
 | 2.0.13     | 2025-08-20 | [\#65125](https://github.com/airbytehq/airbyte/pull/65125) | Update docs permissioning advice.                                              |


### PR DESCRIPTION
## What
Finalizes ClickHouse 2.1.3 rollout

## Why
The rollout tool appears to be choking.
