### PR TITLE
ci: add github actions workflow to check that cdk version is not set to local

### DIFF
--- a/.github/workflows/connectors-cdk-version-check.yml
+++ b/.github/workflows/connectors-cdk-version-check.yml
@@ -1,0 +1,41 @@
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - "airbyte-integrations/connectors/*/gradle.properties"
+
+jobs:
+  connectors-cdk-version-check:
+    name: Connectors CDK Version Check
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout Airbyte
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
+        with:
+          submodules: true # Needed for airbyte-enterprise connectors (no-op otherwise)
+
+      - name: Setup Java
+        uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 #v5.0.0
+        with:
+          distribution: "zulu"
+          java-version: "21"
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@748248ddd2a24f49513d8f472f81c3a07d4d50e1 #v4.4.4
+        with:
+          gradle-version: "8.14"
+
+      - name: Check no connectors set CDK version to 'local'
+        run: |
+          set -euo pipefail
+          # connectors that set cdk version to 'local' (should be none)
+          connectors="$(./gradlew getCdkVersion | awk '/local/ {print prev} {prev=$0}' | cut -d: -f4)"
+          
+          if [[ -z "$connectors" ]]; then
+            echo "No connectors are setting CDK version to 'local'."
+            exit 0
+          else
+            echo "ERROR: Invalid CDK version. One or more connectors set CDK version to 'local' (should be none). See the list below:"
+            printf '%s\n' "$connectors"
+            exit 1
+          fi

--- a/.github/workflows/connectors-cdk-version-check.yml
+++ b/.github/workflows/connectors-cdk-version-check.yml
@@ -32,7 +32,6 @@ jobs:
           set -euo pipefail
           # connectors that set cdk version to 'local' (should be none)
           connectors="$(./gradlew getCdkVersion | awk '/local/ {print prev} {prev=$0}' | cut -d: -f4)"
-          
           if [[ -z "$connectors" ]]; then
             echo "No connectors are setting CDK version to 'local'."
             exit 0

--- a/.github/workflows/connectors-cdk-version-check.yml
+++ b/.github/workflows/connectors-cdk-version-check.yml
@@ -1,3 +1,5 @@
+name: Connectors CDK Version Check
+
 on:
   pull_request:
     types: [opened, synchronize, reopened]

--- a/airbyte-integrations/connectors/destination-dev-null/gradle.properties
+++ b/airbyte-integrations/connectors/destination-dev-null/gradle.properties
@@ -1,1 +1,1 @@
-cdkVersion=local
+cdkVersion=0.1.42

--- a/airbyte-integrations/connectors/destination-dev-null/gradle.properties
+++ b/airbyte-integrations/connectors/destination-dev-null/gradle.properties
@@ -1,1 +1,1 @@
-cdkVersion=0.1.42
+cdkVersion=local


### PR DESCRIPTION
## What
https://github.com/airbytehq/airbyte-internal-issues/issues/14311

We need a way to enforce that connectors are not setting their CDK version to `local`, we want them to be pinned to a specific version instead.

## How
Added a github actions workflow that checks if there are any connectors setting the cdk version to `local`. This workflow is triggered when the `gradle.properties` file of a connector is changed (which is where the bluk cdk version is set).

Note: once merged, we need to add this workflow as a required check for branches merging into master.

## How did I test this?
I tested this in this same PR by changing the `destination-dev-null` cdk version to `local`. This is the workflow that was triggered https://github.com/airbytehq/airbyte/actions/runs/18108003731/job/51527259546

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
