### PR TITLE
Prevent automatic major version bumps in up-to-date pipeline

### DIFF
--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/steps/base_image.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/steps/base_image.py
@@ -103,6 +103,10 @@ class UpdateBaseImageMetadata(StepModifyingFiles):
                     )
                 except (ValueError, IndexError) as e:
                     self.context.logger.warning(f"Could not parse current base image version from '{current_base_image}': {e}")
+            else:
+                self.context.logger.warning(
+                    "No baseImage found in metadata.yaml connectorBuildOptions, proceeding without major version constraint"
+                )
 
             latest_tag = self._parse_latest_stable_tag(tags, max_major_version=max_major_version)
             if latest_tag:

--- a/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/steps/base_image.py
+++ b/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/steps/base_image.py
@@ -51,14 +51,24 @@ class UpdateBaseImageMetadata(StepModifyingFiles):
         else:
             raise NotImplementedError(f"Registry for language {language} is not implemented yet.")
 
-    def _parse_latest_stable_tag(self, tags: List[str]) -> Optional[str]:
-        """Parse tags to find latest stable (non-prerelease) version."""
+    def _parse_latest_stable_tag(self, tags: List[str], max_major_version: Optional[int] = None) -> Optional[str]:
+        """Parse tags to find latest stable (non-prerelease) version.
+
+        Args:
+            tags: List of available tags
+            max_major_version: Maximum major version to include (e.g., 6 will exclude version 7.x.x and above)
+
+        Returns:
+            Latest stable version string, constrained by max_major_version if provided
+        """
         valid_versions = []
         for tag in tags:
             try:
                 version = semver.VersionInfo.parse(tag)
                 if not version.prerelease:  # Exclude pre-release versions
-                    valid_versions.append(version)
+                    # If max_major_version is set, only include versions up to that major version
+                    if max_major_version is None or version.major <= max_major_version:
+                        valid_versions.append(version)
             except ValueError:
                 continue  # Skip non-semver tags
 
@@ -78,7 +88,23 @@ class UpdateBaseImageMetadata(StepModifyingFiles):
             tags_output = await crane_container.with_exec(["crane", "ls", f"docker.io/{repository}"]).stdout()
             tags = [tag.strip() for tag in tags_output.strip().split("\n") if tag.strip()]
 
-            latest_tag = self._parse_latest_stable_tag(tags)
+            # Extract current major version from connector's base image to prevent major version bumps
+            max_major_version = None
+            current_base_image = self.context.connector.metadata.get("connectorBuildOptions", {}).get("baseImage")
+            if current_base_image:
+                # Extract version from base image string (e.g., "docker.io/airbyte/source-declarative-manifest:6.60.16@sha256...")
+                try:
+                    # Parse version between ':' and '@' (or end of string if no digest)
+                    version_part = current_base_image.split(":")[-1].split("@")[0]
+                    current_version = semver.VersionInfo.parse(version_part)
+                    max_major_version = current_version.major
+                    self.context.logger.info(
+                        f"Current base image version: {version_part}, constraining to major version {max_major_version}"
+                    )
+                except (ValueError, IndexError) as e:
+                    self.context.logger.warning(f"Could not parse current base image version from '{current_base_image}': {e}")
+
+            latest_tag = self._parse_latest_stable_tag(tags, max_major_version=max_major_version)
             if latest_tag:
                 # Get the digest for the specific tag to ensure immutable reference
                 digest_output = await crane_container.with_exec(["crane", "digest", f"docker.io/{repository}:{latest_tag}"]).stdout()

--- a/airbyte-ci/connectors/pipelines/tests/test_steps/test_base_image.py
+++ b/airbyte-ci/connectors/pipelines/tests/test_steps/test_base_image.py
@@ -1,0 +1,97 @@
+# Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+
+import pytest
+from connector_ops.utils import ConnectorLanguage
+
+from pipelines.airbyte_ci.steps.base_image import UpdateBaseImageMetadata
+
+
+class TestUpdateBaseImageMetadata:
+    """Test suite for UpdateBaseImageMetadata step, focusing on major version constraint behavior."""
+
+    @pytest.fixture
+    def mock_context(self, mocker):
+        """Create a mock connector context."""
+        context = mocker.Mock()
+        context.connector = mocker.Mock()
+        context.connector.language = ConnectorLanguage.MANIFEST_ONLY
+        context.connector.metadata = {
+            "connectorBuildOptions": {"baseImage": "docker.io/airbyte/source-declarative-manifest:6.60.16@sha256:abc123"}
+        }
+        context.logger = mocker.Mock()
+        return context
+
+    @pytest.fixture
+    def mock_connector_directory(self, mocker):
+        """Create a mock connector directory."""
+        return mocker.Mock()
+
+    @pytest.fixture
+    def update_step(self, mock_context, mock_connector_directory):
+        """Create an UpdateBaseImageMetadata instance."""
+        return UpdateBaseImageMetadata(mock_context, mock_connector_directory)
+
+    @pytest.mark.parametrize(
+        "tags,max_major_version,expected_result,description",
+        [
+            # Test without constraint - should return latest stable version
+            (
+                ["5.0.0", "6.0.0", "6.1.0", "6.60.16", "7.0.0", "7.1.0", "8.0.0-rc.1"],
+                None,
+                "7.1.0",
+                "without constraint returns latest stable",
+            ),
+            # Test with constraint - should respect major version limit
+            (["5.0.0", "6.0.0", "6.1.0", "6.60.16", "7.0.0", "7.1.0"], 6, "6.60.16", "with constraint returns latest within major version"),
+            # Test pre-release exclusion
+            (["6.0.0", "6.1.0", "6.2.0-rc.1", "6.2.0-beta.1"], 6, "6.1.0", "excludes pre-release versions"),
+            # Test no valid versions within constraint
+            (["7.0.0", "8.0.0", "9.0.0"], 6, None, "returns None when no versions match constraint"),
+            # Test invalid tags are skipped
+            (["invalid", "not-a-version", "6.0.0", "6.1.0", "latest", "main"], 6, "6.1.0", "skips invalid semver tags"),
+            # Test empty list
+            ([], 6, None, "returns None for empty tag list"),
+            # Test patch version comparison
+            (["6.60.14", "6.60.15", "6.60.16", "6.60.17", "7.0.0"], 6, "6.60.17", "correctly compares patch versions"),
+        ],
+    )
+    def test_parse_latest_stable_tag(self, update_step, tags, max_major_version, expected_result, description):
+        """Test _parse_latest_stable_tag with various scenarios."""
+        result = update_step._parse_latest_stable_tag(tags, max_major_version=max_major_version)
+
+        assert result == expected_result, f"Failed: {description}"
+
+    @pytest.mark.parametrize(
+        "base_image,expected_major",
+        [
+            ("docker.io/airbyte/source-declarative-manifest:6.60.16@sha256:abc", 6),
+            ("docker.io/airbyte/source-declarative-manifest:7.1.0", 7),
+            ("docker.io/airbyte/python-connector-base:1.2.3@sha256:def", 1),
+            ("airbyte/java-connector-base:2.0.0", 2),
+            ("docker.io/repo:10.5.3@sha256:xyz", 10),
+            ("registry.example.com:5000/repo:3.14.159@sha256:abc123", 3),
+        ],
+    )
+    def test_extract_major_version_from_base_image_success(self, update_step, base_image, expected_major):
+        """Test that major version is correctly extracted from various base image formats."""
+        result = update_step._extract_major_version_from_base_image(base_image)
+
+        assert result == expected_major
+
+    @pytest.mark.parametrize(
+        "invalid_base_image",
+        [
+            "docker.io/airbyte/source-declarative-manifest:invalid-version",
+            "docker.io/airbyte/source-declarative-manifest:latest",
+            "docker.io/airbyte/source-declarative-manifest",  # No version
+            "docker.io/airbyte/source-declarative-manifest:",  # Empty version
+            "not-a-valid-image-string",
+        ],
+    )
+    def test_extract_major_version_from_base_image_invalid(self, update_step, invalid_base_image):
+        """Test that invalid base images return None and log a warning."""
+        result = update_step._extract_major_version_from_base_image(invalid_base_image)
+
+        assert result is None
+        # Verify warning was logged
+        update_step.context.logger.warning.assert_called()


### PR DESCRIPTION
## Summary

This PR modifies the `up-to-date` pipeline to prevent automatic major version bumps for base images (manifest-only, Python, and Java connectors).

### Changes

- **Updated `_parse_latest_stable_tag()`** to accept an optional `max_major_version` parameter that constrains which versions are considered
- **Modified `get_latest_base_image_address()`** to:
  - Extract the current major version from the connector's `baseImage` in `metadata.yaml`
  - Pass this as a constraint to `_parse_latest_stable_tag()`
  - Log the constraint being applied for visibility

### Behavior

**Before:** A connector with `baseImage: "docker.io/airbyte/source-declarative-manifest:6.60.16@sha256..."` would automatically update to version `7.0.0` when available.

**After:** The same connector will only update to the latest `6.x.x` version and will NOT automatically bump to `7.x.x`.

### Scope

This change affects:
- ✅ Manifest-only connectors (using `source-declarative-manifest` base image)
- ✅ Python connectors (using `python-connector-base` base image) 
- ✅ Java connectors (using `java-connector-base` base image)

Note: For Python connectors with `pyproject.toml`, major version bumps can also be prevented by pinning the CDK version constraint (e.g., `airbyte-cdk = "^6.0.0, <7.0.0"`).

### Testing

- Code changes respect existing error handling for unparseable versions
- Falls back gracefully to unconstrained updates if current version cannot be determined
- Logs provide visibility into version constraint decisions

## Test plan

- [ ] Verify the `up-to-date` workflow continues to work correctly
- [ ] Confirm manifest-only connectors update to latest minor/patch but not major versions
- [ ] Check logs show the version constraint being applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)