### PR TITLE
ci: always run connectors cdk version check workflow

### DIFF
--- a/.github/workflows/connectors-cdk-version-check.yml
+++ b/.github/workflows/connectors-cdk-version-check.yml
@@ -17,7 +17,7 @@ jobs:
             cdk-version:
               - "airbyte-integrations/connectors/*/gradle.properties"
     outputs:
-      changed: ${{ steps.detect-changes.outputs.cdk-version }}
+      changed: ${{ steps.connector-cdk-version-changes.outputs.cdk-version }}
 
   connectors-cdk-version-check:
     name: Connectors CDK Version Check

--- a/.github/workflows/connectors-cdk-version-check.yml
+++ b/.github/workflows/connectors-cdk-version-check.yml
@@ -3,13 +3,27 @@ name: Connectors CDK Version Check
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-    paths:
-      - "airbyte-integrations/connectors/*/gradle.properties"
 
 jobs:
+  detect-changes:
+    name: Detect Connector CDK Version Changes
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Detect Connector CDK Version Changes
+        id: connector-cdk-version-changes
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 #v3.0.2
+        with:
+          filters: |
+            cdk-version:
+              - "airbyte-integrations/connectors/*/gradle.properties"
+    outputs:
+      changed: ${{ steps.detect-changes.outputs.cdk-version }}
+
   connectors-cdk-version-check:
     name: Connectors CDK Version Check
     runs-on: ubuntu-24.04
+    needs: detect-changes
+    if: needs.detect-changes.outputs.changed == 'true'
     steps:
       - name: Checkout Airbyte
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0

--- a/airbyte-integrations/connectors/destination-clickhouse/gradle.properties
+++ b/airbyte-integrations/connectors/destination-clickhouse/gradle.properties
@@ -1,1 +1,1 @@
-cdkVersion=local
+cdkVersion=0.1.43

--- a/airbyte-integrations/connectors/destination-clickhouse/gradle.properties
+++ b/airbyte-integrations/connectors/destination-clickhouse/gradle.properties
@@ -1,1 +1,1 @@
-cdkVersion=0.1.45
+cdkVersion=local

--- a/airbyte-integrations/connectors/destination-clickhouse/gradle.properties
+++ b/airbyte-integrations/connectors/destination-clickhouse/gradle.properties
@@ -1,1 +1,1 @@
-cdkVersion=0.1.43
+cdkVersion=0.1.44

--- a/airbyte-integrations/connectors/destination-clickhouse/gradle.properties
+++ b/airbyte-integrations/connectors/destination-clickhouse/gradle.properties
@@ -1,1 +1,1 @@
-cdkVersion=0.1.44
+cdkVersion=0.1.45


### PR DESCRIPTION
## What
https://github.com/airbytehq/airbyte/pull/66752 follow up

The workflow that checks if the cdk version used by a connector is set to `local` must be a required PR check. The problem is that I made the workflow only run when a `gradle.properties` file of a connector changes, meaning that the required workflow will not always run (blocking merging PRs when we shouldn't).

## How
Instead of only triggering the workflow when there are connector cdk version changes in a PR, detect within the workflow if there are changes to connector cdk versions.

## How did I test this?
Tested in this same PR by making changes to a gradle.properties file
- workflow when setting version to `local` https://github.com/airbytehq/airbyte/actions/runs/18167420106/job/51713233216
- workflow when changing the version but not setting it to `local` https://github.com/airbytehq/airbyte/actions/runs/18167568315/job/51713743225

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
