### PR TITLE
ci: checkout submodules in update connector cdk command workflow

### DIFF
--- a/.github/workflows/update-connector-cdk-version-command.yml
+++ b/.github/workflows/update-connector-cdk-version-command.yml
@@ -45,6 +45,8 @@ jobs:
 
       - name: Checkout Airbyte
         uses: actions/checkout@v4
+        with:
+          submodules: true # Needed for airbyte-enterprise connectors (no-op otherwise)
 
       - name: Validate connector
         id: validate-connector


### PR DESCRIPTION
## What
We want to reuse the github actions workflow that updates the cdk version of a connector for enterprise connectors, but we can't in its current state since submodules are not being checked out, which enterprise connectors need.

## How
Changing the workflow so that it checks out submodules too.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
