### PR TITLE
Move last 2 inlined dispatchers into bean factory

### DIFF
--- a/airbyte-cdk/bulk/changelog.md
+++ b/airbyte-cdk/bulk/changelog.md
@@ -1,3 +1,7 @@
+## Version 0.1.46
+
+Noop: Move stream lifecyle dispatchers to bean factory.
+
 ## Version 0.1.45
 
 Noop release. 0.1.44 suspected to have a bad publish.

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/DestinationLifecycle.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/DestinationLifecycle.kt
@@ -5,15 +5,14 @@
 package io.airbyte.cdk.load.dataflow
 
 import io.airbyte.cdk.load.command.DestinationCatalog
-import io.airbyte.cdk.load.dataflow.config.MemoryAndParallelismConfig
 import io.airbyte.cdk.load.dataflow.finalization.StreamCompletionTracker
 import io.airbyte.cdk.load.dataflow.pipeline.PipelineRunner
 import io.airbyte.cdk.load.write.DestinationWriter
 import io.airbyte.cdk.load.write.StreamLoader
 import io.github.oshai.kotlinlogging.KotlinLogging
+import jakarta.inject.Named
 import jakarta.inject.Singleton
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -25,7 +24,8 @@ class DestinationLifecycle(
     private val destinationCatalog: DestinationCatalog,
     private val pipeline: PipelineRunner,
     private val completionTracker: StreamCompletionTracker,
-    private val memoryAndParallelismConfig: MemoryAndParallelismConfig,
+    @Named("streamInitDispatcher") private val streamInitDispatcher: CoroutineDispatcher,
+    @Named("streamFinalizeDispatcher") private val streamFinalizeDispatcher: CoroutineDispatcher,
 ) {
     private val log = KotlinLogging.logger {}
 
@@ -56,16 +56,11 @@ class DestinationLifecycle(
 
     @OptIn(ExperimentalCoroutinesApi::class)
     private fun initializeIndividualStreams(): List<StreamLoader> {
-        val initDispatcher: CoroutineDispatcher =
-            Dispatchers.Default.limitedParallelism(
-                memoryAndParallelismConfig.maxConcurrentLifecycleOperations
-            )
-
         return runBlocking {
             val result =
                 destinationCatalog.streams
                     .map {
-                        async(initDispatcher) {
+                        async(streamInitDispatcher) {
                             log.info {
                                 "Starting stream loader for stream ${it.mappedDescriptor.namespace}:${it.mappedDescriptor.name}"
                             }
@@ -91,15 +86,10 @@ class DestinationLifecycle(
             }
         }
 
-        val finalizeDispatcher: CoroutineDispatcher =
-            Dispatchers.Default.limitedParallelism(
-                memoryAndParallelismConfig.maxConcurrentLifecycleOperations
-            )
-
         runBlocking {
             streamLoaders
                 .map {
-                    async(finalizeDispatcher) {
+                    async(streamFinalizeDispatcher) {
                         log.info {
                             "Finalizing stream ${it.stream.mappedDescriptor.namespace}:${it.stream.mappedDescriptor.name}"
                         }

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/config/DispatcherBeanFactory.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/config/DispatcherBeanFactory.kt
@@ -11,6 +11,7 @@ import java.util.concurrent.Executors
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.asCoroutineDispatcher
 
 /** The dispatchers (think views of thread pools) and static scopes we use for dataflow. */
@@ -41,4 +42,18 @@ class DispatcherBeanFactory {
     fun stateDispatcher(
         @Named("stateReconcilerDispatcher") dispatcher: CoroutineDispatcher,
     ) = CoroutineScope(dispatcher)
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Named("streamInitDispatcher")
+    @Singleton
+    fun streamInitDispatcher(
+        memConfig: MemoryAndParallelismConfig,
+    ) = Dispatchers.Default.limitedParallelism(memConfig.maxConcurrentLifecycleOperations)
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Named("streamFinalizeDispatcher")
+    @Singleton
+    fun streamFinalizeDispatcher(
+        memConfig: MemoryAndParallelismConfig,
+    ) = Dispatchers.Default.limitedParallelism(memConfig.maxConcurrentLifecycleOperations)
 }

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/dataflow/DestinationLifecycleTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/dataflow/DestinationLifecycleTest.kt
@@ -6,7 +6,6 @@ package io.airbyte.cdk.load.dataflow
 
 import io.airbyte.cdk.load.command.DestinationCatalog
 import io.airbyte.cdk.load.command.DestinationStream
-import io.airbyte.cdk.load.dataflow.config.MemoryAndParallelismConfig
 import io.airbyte.cdk.load.dataflow.finalization.StreamCompletionTracker
 import io.airbyte.cdk.load.dataflow.pipeline.PipelineRunner
 import io.airbyte.cdk.load.write.DestinationWriter
@@ -15,6 +14,7 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
@@ -24,8 +24,8 @@ class DestinationLifecycleTest {
     private val destinationCatalog: DestinationCatalog = mockk(relaxed = true)
     private val pipeline: PipelineRunner = mockk(relaxed = true)
     private val completionTracker: StreamCompletionTracker = mockk(relaxed = true)
-    private val memoryAndParallelismConfig: MemoryAndParallelismConfig =
-        MemoryAndParallelismConfig(maxOpenAggregates = 1, maxBufferedAggregates = 1)
+    private val streamInitDispatcher = Dispatchers.Default
+    private val streamFinalizeDispatcher = Dispatchers.Default
 
     private val destinationLifecycle =
         DestinationLifecycle(
@@ -33,7 +33,8 @@ class DestinationLifecycleTest {
             destinationCatalog,
             pipeline,
             completionTracker,
-            memoryAndParallelismConfig,
+            streamInitDispatcher,
+            streamFinalizeDispatcher,
         )
 
     @Test

--- a/airbyte-cdk/bulk/version.properties
+++ b/airbyte-cdk/bulk/version.properties
@@ -1,1 +1,1 @@
-version=0.1.45
+version=0.1.46


### PR DESCRIPTION
## What
Moves the last 2 inlined dispatchers to the DispatcherBeanFactory

## Why
Keeping all the thread pool / dispatcher logic colocated makes it easier to tune / understand thread usage at a glance. 
