### PR TITLE
fix: Handle empty connector matrices correctly in CI workflow

### DIFF
--- a/.github/workflows/connector-ci-checks.yml
+++ b/.github/workflows/connector-ci-checks.yml
@@ -123,6 +123,7 @@ jobs:
 
   jvm-connectors-test:
     needs: [generate-matrix]
+    if: ${{ !contains(needs.generate-matrix.outputs.jvm-connectors-matrix, '"connector":[]') }}
     runs-on: ${{ needs.generate-matrix.outputs.jvm-runner-type }} # Custom runner, defined in GitHub org settings
     env:
       GCP_GSM_CREDENTIALS: ${{ secrets.GCP_GSM_CREDENTIALS }}
@@ -215,6 +216,7 @@ jobs:
 
   non-jvm-connectors-test:
     needs: [generate-matrix]
+    if: ${{ !contains(needs.generate-matrix.outputs.non-jvm-connectors-matrix, '"connector":[]') }}
     runs-on: ubuntu-24.04
     env:
       GCP_GSM_CREDENTIALS: ${{ secrets.GCP_GSM_CREDENTIALS }}
@@ -322,7 +324,7 @@ jobs:
   connectors-lint:
     needs: [generate-matrix]
     runs-on: ubuntu-24.04
-    if: ${{ needs.generate-matrix.outputs.connectors-matrix }}
+    if: ${{ !contains(needs.generate-matrix.outputs.connectors-matrix, '"connector":[]') }}
     strategy:
       matrix: ${{ fromJson(needs.generate-matrix.outputs.connectors-matrix) }}
       max-parallel: 10 # Limit number of parallel jobs
@@ -410,7 +412,7 @@ jobs:
         continue-on-error: true
 
   pre-release-checks:
-    if: github.event.pull_request.draft == false
+    if: github.event.pull_request.draft == false && !contains(needs.generate-matrix.outputs.connectors-matrix, '"connector":[]')
     needs: [generate-matrix]
     strategy:
       matrix: ${{ fromJson(needs.generate-matrix.outputs.connectors-matrix) }}
@@ -474,9 +476,10 @@ jobs:
       - name: Evaluate Status
         id: evaluate-status
         run: |
-          if [[ "${{ needs.jvm-connectors-test.result }}" == "success" &&
-                "${{ needs.non-jvm-connectors-test.result }}" == "success" &&
-                "${{ needs.connectors-lint.result }}" == "success" ]]; then
+          if [[ "${{ needs.jvm-connectors-test.result }}" =~ ^(success|skipped)$ &&
+                "${{ needs.non-jvm-connectors-test.result }}" =~ ^(success|skipped)$ &&
+                "${{ needs.connectors-lint.result }}" =~ ^(success|skipped)$ &&
+                "${{ needs.pre-release-checks.result }}" =~ ^(success|skipped)$ ]]; then
             echo "result=success" | tee -a $GITHUB_OUTPUT
           else
             echo "result=failure" | tee -a $GITHUB_OUTPUT

--- a/.github/workflows/connector-ci-checks.yml
+++ b/.github/workflows/connector-ci-checks.yml
@@ -123,7 +123,7 @@ jobs:
 
   jvm-connectors-test:
     needs: [generate-matrix]
-    if: ${{ !contains(needs.generate-matrix.outputs.jvm-connectors-matrix, '"connector":[]') }}
+    if: ${{ needs.generate-matrix.outputs.jvm-connectors-matrix != '' }}
     runs-on: ${{ needs.generate-matrix.outputs.jvm-runner-type }} # Custom runner, defined in GitHub org settings
     env:
       GCP_GSM_CREDENTIALS: ${{ secrets.GCP_GSM_CREDENTIALS }}
@@ -216,7 +216,7 @@ jobs:
 
   non-jvm-connectors-test:
     needs: [generate-matrix]
-    if: ${{ !contains(needs.generate-matrix.outputs.non-jvm-connectors-matrix, '"connector":[]') }}
+    if: ${{ needs.generate-matrix.outputs.non-jvm-connectors-matrix != '' }}
     runs-on: ubuntu-24.04
     env:
       GCP_GSM_CREDENTIALS: ${{ secrets.GCP_GSM_CREDENTIALS }}
@@ -324,7 +324,7 @@ jobs:
   connectors-lint:
     needs: [generate-matrix]
     runs-on: ubuntu-24.04
-    if: ${{ !contains(needs.generate-matrix.outputs.connectors-matrix, '"connector":[]') }}
+    if: ${{ needs.generate-matrix.outputs.connectors-matrix != '' }}
     strategy:
       matrix: ${{ fromJson(needs.generate-matrix.outputs.connectors-matrix) }}
       max-parallel: 10 # Limit number of parallel jobs
@@ -412,7 +412,7 @@ jobs:
         continue-on-error: true
 
   pre-release-checks:
-    if: github.event.pull_request.draft == false && !contains(needs.generate-matrix.outputs.connectors-matrix, '"connector":[]')
+    if: github.event.pull_request.draft == false && needs.generate-matrix.outputs.connectors-matrix != ''
     needs: [generate-matrix]
     strategy:
       matrix: ${{ fromJson(needs.generate-matrix.outputs.connectors-matrix) }}
@@ -479,9 +479,9 @@ jobs:
           # When no connectors are modified, all matrix jobs are skipped via their if conditions. (important-comment)
           # GitHub Actions reports such skipped jobs as "failure" to dependent jobs, so we check (important-comment)
           # if matrices are empty first to handle this case explicitly. (important-comment)
-          if [[ '${{ needs.generate-matrix.outputs.jvm-connectors-matrix }}' == '{"connector": []}' &&
-                '${{ needs.generate-matrix.outputs.non-jvm-connectors-matrix }}' == '{"connector": []}' &&
-                '${{ needs.generate-matrix.outputs.connectors-matrix }}' == '{"connector": []}' ]]; then
+          if [[ -z '${{ needs.generate-matrix.outputs.jvm-connectors-matrix }}' &&
+                -z '${{ needs.generate-matrix.outputs.non-jvm-connectors-matrix }}' &&
+                -z '${{ needs.generate-matrix.outputs.connectors-matrix }}' ]]; then
             echo "No connectors modified, all checks passed"
             echo "result=success" | tee -a $GITHUB_OUTPUT
           elif [[ "${{ needs.jvm-connectors-test.result }}" =~ ^(success|skipped)$ &&

--- a/.github/workflows/connector-ci-checks.yml
+++ b/.github/workflows/connector-ci-checks.yml
@@ -479,9 +479,9 @@ jobs:
           # When no connectors are modified, all matrix jobs are skipped via their if conditions. (important-comment)
           # GitHub Actions reports such skipped jobs as "failure" to dependent jobs, so we check (important-comment)
           # if matrices are empty first to handle this case explicitly. (important-comment)
-          if [[ '${{ needs.generate-matrix.outputs.jvm-connectors-matrix }}' == '{"connector":[]}' &&
-                '${{ needs.generate-matrix.outputs.non-jvm-connectors-matrix }}' == '{"connector":[]}' &&
-                '${{ needs.generate-matrix.outputs.connectors-matrix }}' == '{"connector":[]}' ]]; then
+          if [[ '${{ needs.generate-matrix.outputs.jvm-connectors-matrix }}' == '{"connector": []}' &&
+                '${{ needs.generate-matrix.outputs.non-jvm-connectors-matrix }}' == '{"connector": []}' &&
+                '${{ needs.generate-matrix.outputs.connectors-matrix }}' == '{"connector": []}' ]]; then
             echo "No connectors modified, all checks passed"
             echo "result=success" | tee -a $GITHUB_OUTPUT
           elif [[ "${{ needs.jvm-connectors-test.result }}" =~ ^(success|skipped)$ &&

--- a/.github/workflows/connector-ci-checks.yml
+++ b/.github/workflows/connector-ci-checks.yml
@@ -476,10 +476,18 @@ jobs:
       - name: Evaluate Status
         id: evaluate-status
         run: |
-          if [[ "${{ needs.jvm-connectors-test.result }}" =~ ^(success|skipped)$ &&
-                "${{ needs.non-jvm-connectors-test.result }}" =~ ^(success|skipped)$ &&
-                "${{ needs.connectors-lint.result }}" =~ ^(success|skipped)$ &&
-                "${{ needs.pre-release-checks.result }}" =~ ^(success|skipped)$ ]]; then
+          # When no connectors are modified, all matrix jobs are skipped via their if conditions. (important-comment)
+          # GitHub Actions reports such skipped jobs as "failure" to dependent jobs, so we check (important-comment)
+          # if matrices are empty first to handle this case explicitly. (important-comment)
+          if [[ '${{ needs.generate-matrix.outputs.jvm-connectors-matrix }}' == '{"connector":[]}' &&
+                '${{ needs.generate-matrix.outputs.non-jvm-connectors-matrix }}' == '{"connector":[]}' &&
+                '${{ needs.generate-matrix.outputs.connectors-matrix }}' == '{"connector":[]}' ]]; then
+            echo "No connectors modified, all checks passed"
+            echo "result=success" | tee -a $GITHUB_OUTPUT
+          elif [[ "${{ needs.jvm-connectors-test.result }}" =~ ^(success|skipped)$ &&
+                  "${{ needs.non-jvm-connectors-test.result }}" =~ ^(success|skipped)$ &&
+                  "${{ needs.connectors-lint.result }}" =~ ^(success|skipped)$ &&
+                  "${{ needs.pre-release-checks.result }}" =~ ^(success|skipped)$ ]]; then
             echo "result=success" | tee -a $GITHUB_OUTPUT
           else
             echo "result=failure" | tee -a $GITHUB_OUTPUT

--- a/docs/ai-agents/embedded/operator-mcp/README.md
+++ b/docs/ai-agents/embedded/operator-mcp/README.md
@@ -1,0 +1,30 @@
+# Overview
+
+The Embedded Operator MCP is a remote MCP server providing tools that enable managing embedded configurations and the resulting pipelines. Users can create connection and source templates, securely create sources, query API and File Storage sources, monitor connections and jobs, and more.
+
+# Installation
+
+To install, follow the instructions for adding remote MCP servers to your client.
+
+For Claude Desktop, visit Settings > Connectors > Add Custom Connector. Name the server "Airbyte Embedded Operator MCP" and enter the following URL:
+```
+https://mcp.airbyte.ai/sonar
+```
+
+For Claude Code, run the following in your terminal (not in the Claude Code CLI):
+```bash
+claude mcp add -t http sonar https://mcp.airbyte.ai/sonar
+```
+
+# Authentication
+
+The Embedded Operator MCP adheres to the MCP OAuth 2.0 specification. This specification is evolving and may not be stable. In particular, Claude Desktop may require a few attempts to successfully connect.
+
+To connect with Claude Desktop, press the `Connect` button that appears when you first add the server. A browser window will open and prompt you to enter your Airbyte Client ID and Secret. (Be sure that the window opens in a browser where you are logged into Claude Web using the same account as Claude Desktop.)
+
+To connect with Claude Code, run the following in the Claude Code CLI
+```
+/mcp reconnect sonar
+```
+
+TODO: CALLOUT: Your credentials must reference an organization that has been enabled for Airbyte Embedded. Contact michel@airbyte.io or teo@airbyte.io to enable Airbyte Embedded on your account.

--- a/poe-tasks/get-modified-connectors.sh
+++ b/poe-tasks/get-modified-connectors.sh
@@ -77,12 +77,10 @@ fi
 # 4) merge into one list
 all_changes=$(printf '%s\n%s\n%s\n%s' "$committed" "$staged" "$unstaged" "$untracked")
 
-# 4.5) Define helper function to return empty JSON when no connectors are found
+# 4.5) Define helper function to return empty string when no connectors are found
 return_empty_json() {
-  if [ "$JSON" = true ]; then
-    # When the list is empty and JSON is requested, return an empty array.
-    echo '{"connector": []}'
-  fi
+  # When the list is empty, return nothing (empty string).
+  # The workflow will check for empty strings and skip matrix jobs accordingly.
   exit 0
 }
 

--- a/poe-tasks/get-modified-connectors.sh
+++ b/poe-tasks/get-modified-connectors.sh
@@ -80,16 +80,16 @@ all_changes=$(printf '%s\n%s\n%s\n%s' "$committed" "$staged" "$unstaged" "$untra
 # 4.5) Define helper function to return empty JSON when no connectors are found
 return_empty_json() {
   if [ "$JSON" = true ]; then
-    # When the list is empty and JSON is requested, send one item as empty string.
-    # This allows the matrix to run once as a no-op, and be marked as complete for purposes
-    # of required checks.
-    echo '{"connector": [""]}'
+    # When the list is empty and JSON is requested, return an empty array.
+    echo '{"connector": []}'
   fi
   exit 0
 }
 
 # 5) drop ignored files
+set +e # Allow grep to return no matches without exiting
 filtered=$(printf '%s\n' "$all_changes" | grep -v -E "/${ignore_globs}")
+set -e # Re-enable exit on error
 if [ -z "$filtered" ]; then
   echo "⚠️ Warning: No files remaining after filtering. Returning empty connector list." >&2
   return_empty_json


### PR DESCRIPTION
## What

Fixes CI failure in "Connector CI Checks Summary" step when no connectors are modified (e.g., docs-only PRs). Previously, the `get-modified-connectors.sh` script would exit early and return an empty string instead of valid JSON, causing matrix jobs to fail and the summary check to report failure even though no connector testing was needed.

This PR targets the following PR:
- #67001

## How

**Script fixes (`poe-tasks/get-modified-connectors.sh`)**:
- Added `set +e` / `set -e` around grep command to prevent script from exiting when no matches are found
- Changed `return_empty_json()` to output empty string instead of any JSON when no connectors found

**Workflow fixes (`.github/workflows/connector-ci-checks.yml`)**:
- Added `if` conditions to all matrix jobs (`jvm-connectors-test`, `non-jvm-connectors-test`, `connectors-lint`, `pre-release-checks`) to skip when matrices are empty using `!= ''` checks
- Updated summary evaluation to:
  1. Check for empty matrices first using bash `-z` test and return success immediately 
  2. Accept both "success" and "skipped" as valid job results using regex `^(success|skipped)$`
  3. Include `pre-release-checks` in the evaluation (was missing before)

## Review guide

1. **`poe-tasks/get-modified-connectors.sh`** - Verify the `set +e` / `set -e` placement around grep (lines 90-92) won't mask other legitimate errors
2. **`.github/workflows/connector-ci-checks.yml`** - Focus on:
   - Empty string detection logic in summary evaluation (lines 482-484) using `-z` test
   - Consistency of skip conditions across all 4 matrix jobs (lines 126, 219, 327, 415) 
   - Regex patterns `^(success|skipped)$` are correct for job result matching (lines 487-490)
   - **Critical**: Test with actual connector changes to ensure jobs still run when they should

## User Impact

**Positive**: Docs-only PRs and other changes that don't modify connectors will now pass CI instead of failing on the "Connector CI Checks Summary" step.

**Risk**: If there are bugs in the skip conditions or empty matrix detection, real connector changes could be incorrectly skipped or fail unexpectedly. The bash string comparison logic is critical to get right.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

This only adds skip conditions and improves error handling. Reverting would restore the previous behavior where docs-only PRs fail CI, but wouldn't break connector testing for actual connector changes.

---

Link to Devin run: https://app.devin.ai/sessions/f632f2dec86848798f680033942f17e2

Requested by: @aaronsteers