### PR TITLE
ci: allow workflow call on cdk connector compatibility workflow

### DIFF
--- a/.github/workflows/cdk-connector-compatibility-test.yml
+++ b/.github/workflows/cdk-connector-compatibility-test.yml
@@ -6,7 +6,7 @@ on:
       - "airbyte-cdk/bulk/**/*"
   schedule:
     - cron: "0 12 * * *"
-  workflow_dispatch:
+  workflow_call:
 
 jobs:
   generate-matrix:

--- a/.github/workflows/cdk-connector-compatibility-test.yml
+++ b/.github/workflows/cdk-connector-compatibility-test.yml
@@ -6,6 +6,7 @@ on:
       - "airbyte-cdk/bulk/**/*"
   schedule:
     - cron: "0 12 * * *"
+  workflow_dispatch:
 
 jobs:
   generate-matrix:


### PR DESCRIPTION
## What
We have a github actions workflow in this repo that checks if the most recent cdk version would break any connectors. We would like to make this workflow reusable to so that we can call it from our enterprise repo.

## How
enable workflow call on cdk connector compatibility workflow

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
