### PR TITLE
ci: allow workflow call on connectors cdk version check workflow

### DIFF
--- a/.github/workflows/connectors-cdk-version-check.yml
+++ b/.github/workflows/connectors-cdk-version-check.yml
@@ -3,6 +3,7 @@ name: Connectors CDK Version Check
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+  workflow_dispatch:
 
 jobs:
   detect-changes:

--- a/.github/workflows/connectors-cdk-version-check.yml
+++ b/.github/workflows/connectors-cdk-version-check.yml
@@ -3,7 +3,7 @@ name: Connectors CDK Version Check
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-  workflow_dispatch:
+  workflow_call:
 
 jobs:
   detect-changes:


### PR DESCRIPTION
## What
We have a github actions workflow in this repo to check that connectors are not setting their cdk version to `local`. We would like to make this workflow reusable to so that we can call it from our enterprise repo.

## How
enable workflow call on connectors cdk version check workflow

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
