### PR TITLE
source-postgres: support all types as cursors

### DIFF
--- a/airbyte-integrations/connectors/source-postgres/src/main/kotlin/io/airbyte/integrations/source/postgres/operations/types/HstoreFieldType.kt
+++ b/airbyte-integrations/connectors/source-postgres/src/main/kotlin/io/airbyte/integrations/source/postgres/operations/types/HstoreFieldType.kt
@@ -4,30 +4,32 @@
 
 package io.airbyte.integrations.source.postgres.operations.types
 
+import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.node.TextNode
-import io.airbyte.cdk.data.JsonEncoder
+import io.airbyte.cdk.data.JsonCodec
 import io.airbyte.cdk.data.LeafAirbyteSchemaType
-import io.airbyte.cdk.jdbc.JdbcFieldType
-import io.airbyte.cdk.jdbc.JdbcGetter
+import io.airbyte.cdk.jdbc.JdbcAccessor
+import io.airbyte.cdk.jdbc.SymmetricJdbcFieldType
 import io.airbyte.cdk.output.sockets.ConnectorJsonEncoder
 import io.airbyte.cdk.output.sockets.ProtoEncoder
+import java.sql.PreparedStatement
 import java.sql.ResultSet
 
-// In Postgres, hstore is like Map<String, String>. We output it as stringified json.
+// In Postgres, hstore is like Map<String, String?>?. We output it as stringified json.
 object HstoreFieldType :
-    JdbcFieldType<Map<String, String?>>(
+    SymmetricJdbcFieldType<Map<String, String?>>(
         LeafAirbyteSchemaType.STRING,
-        HstoreGetter,
-        HstoreEncoder,
+        HstoreAccessor,
+        HstoreCodec,
     )
 
-object HstoreGetter : JdbcGetter<Map<String, String?>> {
-    override fun get(rs: ResultSet, colIdx: Int): Map<String, String?> {
-        return rs.getString(colIdx)
-            .split(",")
-            .map { it.split("=>", limit = 2) } // split key => value
+object HstoreAccessor : JdbcAccessor<Map<String, String?>> {
+    override fun get(rs: ResultSet, colIdx: Int): Map<String, String?>? {
+        val str = rs.getString(colIdx) ?: return null
+        return str.split(",")
+            .map { it.split("=>", limit = 2) } // "key => value" to ["key", "value"]
             .associate { parts ->
                 val key = parts[0].trim().removeSurrounding("\"")
                 val rawValue = parts[1].trim()
@@ -35,15 +37,36 @@ object HstoreGetter : JdbcGetter<Map<String, String?>> {
                 key to value
             }
     }
+    override fun set(stmt: PreparedStatement, paramIdx: Int, value: Map<String, String?>) {
+        stmt.setString(
+            paramIdx,
+            value
+                .map {
+                    if (it.value == null) {
+                        "'${it.key}',NULL"
+                    } else {
+                        "'${it.key}','${it.value}'"
+                    }
+                }
+                .joinToString(",", prefix = "hstore(", postfix = ")")
+        )
+    }
 }
 
-object HstoreEncoder : JsonEncoder<Map<String, String?>>, ConnectorJsonEncoder {
+object HstoreCodec : JsonCodec<Map<String, String?>>, ConnectorJsonEncoder {
     override fun encode(decoded: Map<String, String?>): JsonNode {
         return TextNode(nullValuePreservingObjectMapper.writeValueAsString(decoded))
     }
 
     override fun toProtobufEncoder(): ProtoEncoder<*> {
         return HstoreProtoEncoder()
+    }
+
+    override fun decode(encoded: JsonNode): Map<String, String?> {
+        return nullValuePreservingObjectMapper.readValue(
+            encoded.asText(),
+            object : TypeReference<Map<String, String?>>() {}
+        )
     }
 }
 

--- a/airbyte-integrations/connectors/source-postgres/src/main/kotlin/io/airbyte/integrations/source/postgres/operations/types/InfFieldType.kt
+++ b/airbyte-integrations/connectors/source-postgres/src/main/kotlin/io/airbyte/integrations/source/postgres/operations/types/InfFieldType.kt
@@ -122,11 +122,11 @@ private constructor(
     companion object {
         fun <T> make(rs: ResultSet, colIdx: Int, baseGetter: JdbcGetter<T>): InfWrapper<T> {
             val str = rs.getString(colIdx) ?: return InfWrapper(ValueType.NULL)
-            return if (str.lowercase() == "infinity") {
+            return if (str.equals(ValueType.INF.placeholder, ignoreCase = true)) {
                 InfWrapper(ValueType.INF)
-            } else if (str.lowercase() == "-infinity") {
+            } else if (str.equals(ValueType.MINUS_INF.placeholder, ignoreCase = true)) {
                 InfWrapper(ValueType.MINUS_INF)
-            } else if (str.lowercase() == "nan") {
+            } else if (str.equals(ValueType.NAN.placeholder, ignoreCase = true)) {
                 InfWrapper(ValueType.NAN)
             } else {
                 InfWrapper(ValueType.NORMAL, baseGetter.get(rs, colIdx))
@@ -139,17 +139,17 @@ private constructor(
             }
             if (encoded.isTextual) {
                 val str = encoded.asText()
-                return if (str == "Infinity") {
-                    InfWrapper(InfWrapper.ValueType.INF)
-                } else if (str == "-Infinity") {
-                    InfWrapper(InfWrapper.ValueType.MINUS_INF)
-                } else if (str == "NaN") {
-                    InfWrapper(InfWrapper.ValueType.NAN)
+                return if (str.equals(ValueType.INF.placeholder, ignoreCase = true)) {
+                    InfWrapper(ValueType.INF)
+                } else if (str.equals(ValueType.MINUS_INF.placeholder, ignoreCase = true)) {
+                    InfWrapper(ValueType.MINUS_INF)
+                } else if (str.equals(ValueType.NAN.placeholder, ignoreCase = true)) {
+                    InfWrapper(ValueType.NAN)
                 } else {
-                    InfWrapper(InfWrapper.ValueType.NORMAL, base.decode(encoded))
+                    InfWrapper(ValueType.NORMAL, base.decode(encoded))
                 }
             }
-            return InfWrapper(InfWrapper.ValueType.NORMAL, base.decode(encoded))
+            return InfWrapper(ValueType.NORMAL, base.decode(encoded))
         }
     }
 

--- a/airbyte-integrations/connectors/source-postgres/src/test/kotlin/io/airbyte/integrations/source/postgres/PostgresContainerFactory.kt
+++ b/airbyte-integrations/connectors/source-postgres/src/test/kotlin/io/airbyte/integrations/source/postgres/PostgresContainerFactory.kt
@@ -5,6 +5,7 @@
 package io.airbyte.integrations.source.postgres
 
 import io.airbyte.cdk.testcontainers.TestContainerFactory
+import io.airbyte.integrations.source.postgres.config.EncryptionDisable
 import io.airbyte.integrations.source.postgres.config.PostgresSourceConfigurationSpecification
 import io.airbyte.integrations.source.postgres.config.StandardReplicationMethodConfigurationSpecification
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -134,6 +135,7 @@ object PostgresContainerFactory {
             username = postgresContainer.username
             password = postgresContainer.password
             jdbcUrlParams = ""
+            encryptionJson = EncryptionDisable
             database = "test"
             this.schemas = schemas
             checkpointTargetIntervalSeconds = 60


### PR DESCRIPTION
Use symmetric JDBC types to allow any of the Postgres-specific column types to be used as a cursor.


## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
