### PR TITLE
Publish docker image to dockerRepository from metadata.yaml

### DIFF
--- a/buildSrc/src/main/groovy/airbyte-connector-docker-convention.gradle
+++ b/buildSrc/src/main/groovy/airbyte-connector-docker-convention.gradle
@@ -5,6 +5,7 @@ import org.gradle.api.Task
 import org.gradle.api.file.RegularFile
 import org.gradle.api.plugins.ExtensionAware
 import org.gradle.api.provider.Provider
+import org.yaml.snakeyaml.Yaml
 
 class AirbyteConnectorDockerConventionPlugin implements Plugin<Project> {
     private static final String SHARED_DOCKERFILE = 'docker-images/Dockerfile.java-connector-non-airbyte-ci'
@@ -28,10 +29,27 @@ class AirbyteConnectorDockerConventionPlugin implements Plugin<Project> {
             }
 
             /* ------------------------------------------------------------
-             * 1. imageName default = project.name (if not already set)
+             * 1. imageName default = dockerRepository from metadata.yaml (if not already set)
+             *    Falls back to project.name if dockerRepository is not in metadata.yaml
              * ------------------------------------------------------------ */
             if (!dockerExt.imageName.present) {
-                dockerExt.imageName.convention(project.name)
+                def metadataFile = project.layout.projectDirectory.file('metadata.yaml').asFile
+                if (metadataFile.exists()) {
+                    def yaml = new Yaml()
+                    def metadata = metadataFile.withInputStream { yaml.load(it) }
+                    def dockerRepo = metadata?.data?.dockerRepository
+
+                    if (dockerRepo) {
+                        // Extract image name from repository (everything after last /)
+                        def imageName = dockerRepo.split('/').last()
+                        dockerExt.imageName.convention(imageName)
+                        project.logger.info("Using dockerRepository from metadata.yaml: ${dockerRepo} -> imageName: ${imageName}")
+                    } else {
+                        dockerExt.imageName.convention(project.name)
+                    }
+                } else {
+                    dockerExt.imageName.convention(project.name)
+                }
             }
 
             /* ------------------------------------------------------------

--- a/poe-tasks/build-and-publish-java-connectors-with-tag.sh
+++ b/poe-tasks/build-and-publish-java-connectors-with-tag.sh
@@ -84,6 +84,12 @@ if [[ -z "$base_tag" || "$base_tag" == "null" ]]; then
   exit 1
 fi
 
+docker_repository=$(yq -r '.data.dockerRepository' "$meta")
+if [[ -z "$docker_repository" || "$docker_repository" == "null" ]]; then
+  echo "Error:  dockerRepository missing in ${meta}" >&2
+  exit 1
+fi
+
 if [[ "$publish_mode" == "main-release" ]]; then
   docker_tag="$base_tag"
 else
@@ -91,14 +97,14 @@ else
 fi
 
 if $do_publish; then
-  echo "Building & publishing ${connector} with tag ${docker_tag}"
+  echo "Building & publishing ${connector} to ${docker_repository} with tag ${docker_tag}"
 
-  if dockerhub_tag_exists "airbyte/${connector}" "$docker_tag"; then
-    echo "ℹ️  Skipping publish — tag airbyte/${connector}:${docker_tag} already exists."
+  if dockerhub_tag_exists "${docker_repository}" "$docker_tag"; then
+    echo "ℹ️  Skipping publish — tag ${docker_repository}:${docker_tag} already exists."
     exit
   fi
 
-  echo "airbyte/${connector}:${docker_tag} image does not exists on Docker. Publishing..."
+  echo "${docker_repository}:${docker_tag} image does not exists on Docker. Publishing..."
   ./gradlew -Pdocker.publish \
             -DciMode=true \
             -Psbom=false \


### PR DESCRIPTION
## What
Currently the connector image publishing flow use project name/connector directory to construct the repo name in dockerhub and ignoring the repo defined in metadata.yml file. It creates inconsistency between publishing the pulling image flow. This PR is to fix the issue

## How
<!--
* Describe how code changes achieve the solution.
-->

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
