### PR TITLE
always run the "enforce 2-PRs" workflow

### DIFF
--- a/.github/workflows/jvm-connector-pr-structure.yml
+++ b/.github/workflows/jvm-connector-pr-structure.yml
@@ -2,9 +2,6 @@ name: PR cannot modify both bulk CDK and connectors
 
 on:
   pull_request:
-    paths:
-      - "airbyte-cdk/bulk/**/*"
-      - "airbyte-integrations/connectors/**/*"
 
 jobs:
   enforce-pr-structure:


### PR DESCRIPTION
for https://github.com/airbytehq/airbyte-internal-issues/issues/14639. Same as all the other PRs you submitted to deal with this exact problem.

workflow is literally just `if path1Changed && path2Changed: fail`, so it's already doing the right things.