### PR TITLE
Fix(Source-Intercom): Heartbeat Timeout - Increase Threshold

### DIFF
--- a/airbyte-integrations/connectors/source-intercom/metadata.yaml
+++ b/airbyte-integrations/connectors/source-intercom/metadata.yaml
@@ -10,13 +10,13 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: d8313939-3782-41b0-be29-b3ca20d8dd3a
-  dockerImageTag: 0.13.8
+  dockerImageTag: 0.13.9
   dockerRepository: airbyte/source-intercom
   documentationUrl: https://docs.airbyte.com/integrations/sources/intercom
   githubIssueLabel: source-intercom
   icon: intercom.svg
   license: ELv2
-  maxSecondsBetweenMessages: 60
+  maxSecondsBetweenMessages: 21600
   name: Intercom
   remoteRegistries:
     pypi:

--- a/docs/integrations/sources/intercom.md
+++ b/docs/integrations/sources/intercom.md
@@ -96,7 +96,7 @@ The Intercom connector should not run into Intercom API limitations under normal
 
 | Version    | Date       | Pull Request                                             | Subject                                                                                                                          |
 |:-----------|:-----------|:---------------------------------------------------------|:---------------------------------------------------------------------------------------------------------------------------------|
-| 0.13.9 | 2025-10-06 | [XXXXX](https://github.com/airbytehq/airbyte/pull/XXXXX) | Increase Heartbeat Timeout to Account for cursor based streams with client side incremental and large record counts.|
+| 0.13.9 | 2025-10-06 | [67104](https://github.com/airbytehq/airbyte/pull/67104) | Increase Heartbeat Timeout to Account for cursor based streams with client side incremental and large record counts for a given day.|
 | 0.13.8 | 2025-09-30 | [66789](https://github.com/airbytehq/airbyte/pull/66789) | Update dependencies |
 | 0.13.7 | 2025-09-25 | [66665](https://github.com/airbytehq/airbyte/pull/66665) | Fix Typo on Error Message |
 | 0.13.6 | 2025-09-09 | [66056](https://github.com/airbytehq/airbyte/pull/66056) | Update dependencies |

--- a/docs/integrations/sources/intercom.md
+++ b/docs/integrations/sources/intercom.md
@@ -96,6 +96,7 @@ The Intercom connector should not run into Intercom API limitations under normal
 
 | Version    | Date       | Pull Request                                             | Subject                                                                                                                          |
 |:-----------|:-----------|:---------------------------------------------------------|:---------------------------------------------------------------------------------------------------------------------------------|
+| 0.13.9 | 2025-10-06 | [XXXXX](https://github.com/airbytehq/airbyte/pull/XXXXX) | Increase Heartbeat Timeout to Account for cursor based streams with client side incremental and large record counts.|
 | 0.13.8 | 2025-09-30 | [66789](https://github.com/airbytehq/airbyte/pull/66789) | Update dependencies |
 | 0.13.7 | 2025-09-25 | [66665](https://github.com/airbytehq/airbyte/pull/66665) | Fix Typo on Error Message |
 | 0.13.6 | 2025-09-09 | [66056](https://github.com/airbytehq/airbyte/pull/66056) | Update dependencies |


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->
OC Issue: 
https://github.com/airbytehq/oncall/issues/8421

Users will get this error:
```
Airbyte detected that the Source didn't send any records in the last 1 hour 31 minutes 7 seconds, exceeding the configured 1 hour 30 minutes threshold. Airbyte will try reading again on the next sync. Please see https://docs.airbyte.com/understanding-airbyte/heartbeats for more info.
```


We identify the impacted streams that use cursor-based pagination and client-side incremental. 

They use client-side, because for a given day, the API will return all records with no hourly or second granularity.  This prevents us from emitting duplicate records for a given day if the cursor value is the 14th hour of the day. (We would skip hours 0-14, and only emit 15-23)


Cursor-based pagination means we cannot filter by a specific page; we must start from the first and read it sequentially, which means syncs will take longer as there is no possibility for parallelism. 

The issue occurs if the user has a large number of records, and their cursor is positioned at a later hour for a given day; in this case, we won't emit records from previous hours. By the time we reach the new records in pagination, we hit the heartbeat timeout, as we haven't emitted anything the whole time.


## How
<!--
* Describe how code changes achieve the solution.
-->

Given the API limitation, the only option we have that won't have a negative impact on the user is to increase the threshold. 

We may need to tinker with the values, but below is how we determined to raise it to 6 hours.

In the most extreme case we saw, we completed 610 pages in 90 minutes out of a total of 1,797 pages. At that rate, it would take approximately 4 hours and 25 minutes to reach the end of pagination.

We change the `maxSecondsBetweenMessages` to 21600, which is 6HRs. This will increase the HB timeout.

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [X ] YES 💚
- [ ] NO ❌
