### PR TITLE
ci - non-master prs can modify both cdk and connector

### DIFF
--- a/.github/workflows/jvm-connector-pr-structure.yml
+++ b/.github/workflows/jvm-connector-pr-structure.yml
@@ -7,6 +7,7 @@ jobs:
   enforce-pr-structure:
     name: Enforce PR structure
     runs-on: ubuntu-24.04
+    if: github.base_ref == 'master' && github.repository == 'airbytehq/airbyte'
     steps:
       - name: Check for changes in bulk CDK
         uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62 # v47


### PR DESCRIPTION
## What
We recently added a check to CI to enforce that PRs either modify the bulk CDK or connectors, but not both. This is good hygiene for master, but adds an unnecessary hurdle when using feature branches. Let's enforce this only on our master branch.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌
