### PR TITLE
fix(destination-s3-data-lake): use unique table name in check operation

### DIFF
--- a/airbyte-integrations/connectors/destination-s3-data-lake/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/metadata.yaml
@@ -32,7 +32,7 @@ data:
             alias: airbyte-connector-testing-secret-store
   connectorType: destination
   definitionId: 716ca874-520b-4902-9f80-9fad66754b89
-  dockerImageTag: 0.3.36
+  dockerImageTag: 0.3.37
   dockerRepository: airbyte/destination-s3-data-lake
   documentationUrl: https://docs.airbyte.com/integrations/destinations/s3-data-lake
   githubIssueLabel: destination-s3-data-lake

--- a/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/S3DataLakeChecker.kt
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/S3DataLakeChecker.kt
@@ -14,6 +14,7 @@ import io.airbyte.cdk.load.toolkits.iceberg.parquet.io.IcebergTableCleaner
 import io.airbyte.cdk.load.toolkits.iceberg.parquet.io.IcebergUtil
 import io.airbyte.integrations.destination.s3_data_lake.io.S3DataLakeUtil
 import jakarta.inject.Singleton
+import java.util.UUID
 import org.apache.iceberg.Schema
 import org.apache.iceberg.types.Types
 
@@ -40,7 +41,10 @@ class S3DataLakeChecker(
                     is RestCatalogConfiguration -> it.namespace
                 }
             }
-        val testTableIdentifier = DestinationStream.Descriptor(defaultNamespace, TEST_TABLE)
+
+        // Use a unique table name to avoid conflicts with existing tables or stale metadata
+        val uniqueTestTableName = "${TEST_TABLE}_${UUID.randomUUID().toString().replace("-", "_")}"
+        val testTableIdentifier = DestinationStream.Descriptor(defaultNamespace, uniqueTestTableName)
 
         val testTableSchema =
             Schema(
@@ -48,6 +52,7 @@ class S3DataLakeChecker(
                 Types.NestedField.optional(2, "data", Types.StringType.get()),
             )
         s3DataLakeUtil.createNamespaceWithGlueHandling(testTableIdentifier, catalog)
+
         val table =
             icebergUtil.createTable(
                 testTableIdentifier,

--- a/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/S3DataLakeChecker.kt
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/S3DataLakeChecker.kt
@@ -53,18 +53,24 @@ class S3DataLakeChecker(
             )
         s3DataLakeUtil.createNamespaceWithGlueHandling(testTableIdentifier, catalog)
 
-        val table =
-            icebergUtil.createTable(
-                testTableIdentifier,
-                catalog,
-                testTableSchema,
-            )
-
-        icebergTableCleaner.clearTable(
-            catalog,
-            tableIdGenerator.toTableIdentifier(testTableIdentifier),
-            table.io(),
-            table.location()
-        )
+        var table: org.apache.iceberg.Table? = null
+        try {
+            table =
+                icebergUtil.createTable(
+                    testTableIdentifier,
+                    catalog,
+                    testTableSchema,
+                )
+        } finally {
+            // Always cleanup test table, even if creation or validation fails
+            table?.let {
+                icebergTableCleaner.clearTable(
+                    catalog,
+                    tableIdGenerator.toTableIdentifier(testTableIdentifier),
+                    it.io(),
+                    it.location()
+                )
+            }
+        }
     }
 }

--- a/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/S3DataLakeChecker.kt
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/S3DataLakeChecker.kt
@@ -44,7 +44,8 @@ class S3DataLakeChecker(
 
         // Use a unique table name to avoid conflicts with existing tables or stale metadata
         val uniqueTestTableName = "${TEST_TABLE}_${UUID.randomUUID().toString().replace("-", "_")}"
-        val testTableIdentifier = DestinationStream.Descriptor(defaultNamespace, uniqueTestTableName)
+        val testTableIdentifier =
+            DestinationStream.Descriptor(defaultNamespace, uniqueTestTableName)
 
         val testTableSchema =
             Schema(

--- a/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/S3DataLakeChecker.kt
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/S3DataLakeChecker.kt
@@ -47,11 +47,12 @@ class S3DataLakeChecker(
     /**
      * Validates catalog connectivity by creating a temporary test table and cleaning it up.
      *
-     * Creates a uniquely-named test table in the configured namespace, then immediately
-     * cleans it up. The cleanup is guaranteed via try-finally to prevent orphaned resources.
+     * Creates a uniquely-named test table in the configured namespace, then immediately cleans it
+     * up. The cleanup is guaranteed via try-finally to prevent orphaned resources.
      *
      * @param config The S3 Data Lake destination configuration
-     * @throws Exception if catalog validation fails (e.g., invalid credentials, missing permissions)
+     * @throws Exception if catalog validation fails (e.g., invalid credentials, missing
+     * permissions)
      */
     private fun catalogValidation(config: S3DataLakeConfiguration) {
         val catalogProperties = s3DataLakeUtil.toCatalogProperties(config)

--- a/docs/integrations/destinations/s3-data-lake.md
+++ b/docs/integrations/destinations/s3-data-lake.md
@@ -338,6 +338,7 @@ Now, you can identify the latest version of the 'Alice' record by querying wheth
 
 | Version | Date       | Pull Request                                               | Subject                                                                                                                         |
 |:--------|:-----------|:-----------------------------------------------------------|:--------------------------------------------------------------------------------------------------------------------------------|
+| 0.3.37  | 2025-10-07 | [67150](https://github.com/airbytehq/airbyte/pull/67150)   | Fix check operation to use unique table names, preventing conflicts with stale metadata and concurrent operations              |
 | 0.3.36  | 2025-09-25 | [66711](https://github.com/airbytehq/airbyte/pull/66711)   | CHECK operation uses configured default dataset instead of `airbyte_test_namespace`                                             |
 | 0.3.35  | 2025-07-23 | [63746](https://github.com/airbytehq/airbyte/pull/63746)   | Remove unnecessary properties from table                                                                                        |
 | 0.3.34  | 2025-07-11 | [62952](https://github.com/airbytehq/airbyte/pull/62952)   | Update CDK version                                                                                                              |


### PR DESCRIPTION
## What
Use UUID-based table names for check operation test tables to prevent conflicts with:

Stale metadata from previous check runs
Concurrent check operations
User tables named airbyte_test_table
This fixes the integration test failure caused by corrupted Glue catalog metadata pointing to non-existent S3 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## How
As description. This is what is currently breaking the S3 Data Lake tests.

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._