### PR TITLE
chore(ci): Update non-privileged CI check titles with slash command hint

### DIFF
--- a/.github/workflows/connector-ci-checks.yml
+++ b/.github/workflows/connector-ci-checks.yml
@@ -192,12 +192,12 @@ jobs:
           airbyte-cdk secrets fetch ${{ matrix.connector }} \
             --print-ci-secrets-masks
 
-      - name: Run Unit Tests ${{ needs.generate-matrix.outputs.creds-available == 'false' && '[Unprivileged, Executed from Fork]' || '' }}
+      - name: Run Unit Tests ${{ needs.generate-matrix.outputs.creds-available == 'false' && '[Non-Blocking (Unprivileged) Test From Fork]' || '' }}
         if: matrix.connector
         working-directory: airbyte-integrations/connectors/${{ matrix.connector }}
         run: poe test-unit-tests
 
-      - name: Run Integration Tests ${{ needs.generate-matrix.outputs.creds-available == 'false' && '[Unprivileged, Executed from Fork]' || '' }}
+      - name: Run Integration Tests ${{ needs.generate-matrix.outputs.creds-available == 'false' && '[Non-Blocking (Unprivileged) Test From Fork]' || '' }}
         if: matrix.connector
         working-directory: airbyte-integrations/connectors/${{ matrix.connector }}
         run: poe test-integration-tests
@@ -290,12 +290,12 @@ jobs:
           airbyte-cdk secrets fetch ${{ matrix.connector }} \
             --print-ci-secrets-masks
 
-      - name: Run Unit Tests ${{ needs.generate-matrix.outputs.creds-available == 'false' && '[Unprivileged, Executed from Fork]' || '' }}
+      - name: Run Unit Tests ${{ needs.generate-matrix.outputs.creds-available == 'false' && '[Non-Blocking (Unprivileged) Test From Fork]' || '' }}
         if: matrix.connector
         working-directory: airbyte-integrations/connectors/${{ matrix.connector }}
         run: poe test-unit-tests
 
-      - name: Run Integration Tests ${{ needs.generate-matrix.outputs.creds-available == 'false' && '[Unprivileged, Executed from Fork]' || '' }}
+      - name: Run Integration Tests ${{ needs.generate-matrix.outputs.creds-available == 'false' && '[Non-Blocking (Unprivileged) Test From Fork]' || '' }}
         if: matrix.connector
         working-directory: airbyte-integrations/connectors/${{ matrix.connector }}
         run: poe test-integration-tests

--- a/.github/workflows/connector-ci-checks.yml
+++ b/.github/workflows/connector-ci-checks.yml
@@ -192,12 +192,12 @@ jobs:
           airbyte-cdk secrets fetch ${{ matrix.connector }} \
             --print-ci-secrets-masks
 
-      - name: Run Unit Tests ${{ needs.generate-matrix.outputs.creds-available == 'false' && '[Non-Blocking (Unprivileged) Test From Fork]' || '' }}
+      - name: Run Unit Tests ${{ needs.generate-matrix.outputs.creds-available == 'false' && '[Non-Blocking (Unprivileged) Test From Fork, pls run `/run-connector-tests`]' || '' }}
         if: matrix.connector
         working-directory: airbyte-integrations/connectors/${{ matrix.connector }}
         run: poe test-unit-tests
 
-      - name: Run Integration Tests ${{ needs.generate-matrix.outputs.creds-available == 'false' && '[Non-Blocking (Unprivileged) Test From Fork]' || '' }}
+      - name: Run Integration Tests ${{ needs.generate-matrix.outputs.creds-available == 'false' && '[Non-Blocking (Unprivileged) Test From Fork, pls run `/run-connector-tests`]' || '' }}
         if: matrix.connector
         working-directory: airbyte-integrations/connectors/${{ matrix.connector }}
         run: poe test-integration-tests
@@ -290,12 +290,12 @@ jobs:
           airbyte-cdk secrets fetch ${{ matrix.connector }} \
             --print-ci-secrets-masks
 
-      - name: Run Unit Tests ${{ needs.generate-matrix.outputs.creds-available == 'false' && '[Non-Blocking (Unprivileged) Test From Fork]' || '' }}
+      - name: Run Unit Tests ${{ needs.generate-matrix.outputs.creds-available == 'false' && '[Non-Blocking (Unprivileged) Test From Fork, pls run `/run-connector-tests`]' || '' }}
         if: matrix.connector
         working-directory: airbyte-integrations/connectors/${{ matrix.connector }}
         run: poe test-unit-tests
 
-      - name: Run Integration Tests ${{ needs.generate-matrix.outputs.creds-available == 'false' && '[Non-Blocking (Unprivileged) Test From Fork]' || '' }}
+      - name: Run Integration Tests ${{ needs.generate-matrix.outputs.creds-available == 'false' && '[Non-Blocking (Unprivileged) Test From Fork, pls run `/run-connector-tests`]' || '' }}
         if: matrix.connector
         working-directory: airbyte-integrations/connectors/${{ matrix.connector }}
         run: poe test-integration-tests


### PR DESCRIPTION
## What

Updates the display names of non-privileged CI check titles in the connector CI workflow to include "Non-Blocking" and provide actionable guidance via slash commands.

When contributors submit PRs from forks, certain test steps run in an unprivileged mode without access to secrets. This change makes it clearer in the GitHub UI that these checks are non-blocking and provides users with the `/run-connector-tests` slash command they can use to trigger the full privileged tests.

**Requested by:** @aaronsteers  
**Slack thread:** https://airbytehq-team.slack.com/archives/C08PWJ16LUC/p1759864974450959

## How

Modified the test step names in `.github/workflows/connector-ci-checks.yml` to change the suffix from:
- `[Unprivileged, Executed from Fork]` 

To:
- `[Non-Blocking (Unprivileged) Test From Fork, pls run `/run-connector-tests`]`

This affects 4 test steps total:
- Unit and Integration tests in the `jvm-connectors-test` job (lines 195, 200)
- Unit and Integration tests in the `non-jvm-connectors-test` job (lines 293, 298)

The conditional logic remains unchanged - the suffix only appears when `needs.generate-matrix.outputs.creds-available == 'false'`.

## Review guide

1. `.github/workflows/connector-ci-checks.yml` - Verify YAML syntax is correct, especially the backticks around the slash command
2. Check that all 4 test step locations were updated consistently
3. Confirm that the conditional logic `needs.generate-matrix.outputs.creds-available == 'false'` remains unchanged

## User Impact

**Positive:**
- Clearer indication in GitHub UI that unprivileged tests are non-blocking
- Provides actionable guidance via `/run-connector-tests` slash command
- Reduces confusion for fork contributors about test failures

**Negative:** 
- Longer test step names may be truncated in some GitHub UI views

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

This change only affects display text and can be safely reverted without impacting functionality.

---

**Link to Devin session:** https://app.devin.ai/sessions/67080d0df8af414c81cfc74dcd9f50cd

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._