### PR TITLE
destination-redshift: Remove memory limits to improve performance

### DIFF
--- a/airbyte-integrations/connectors/destination-redshift/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-redshift/metadata.yaml
@@ -41,7 +41,7 @@ data:
             type: GSM
   connectorType: destination
   definitionId: f7a7d195-377f-cf5b-70a5-be6b819019dc
-  dockerImageTag: 3.5.3
+  dockerImageTag: 3.5.4
   dockerRepository: airbyte/destination-redshift
   documentationUrl: https://docs.airbyte.com/integrations/destinations/redshift
   githubIssueLabel: destination-redshift
@@ -84,7 +84,6 @@ data:
     jobSpecific:
       - jobType: sync
         resourceRequirements:
-          memory_limit: 1Gi
           memory_request: 1Gi
   supportLevel: certified
   supportsDbt: true

--- a/docs/integrations/destinations/redshift.md
+++ b/docs/integrations/destinations/redshift.md
@@ -222,7 +222,7 @@ Each stream will be output into its own raw table in Redshift. Each table will c
 
 | Version | Date       | Pull Request                                               | Subject                                                                                                                                                                                                          |
 | :------ | :--------- | :--------------------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 3.5.4 | 2025-10-07 | [XXXXX](https://github.com/airbytehq/airbyte/pull/XXXXX) | Remove memory limit for sync jobs to improve performance and resource utilization. |
+| 3.5.4 | 2025-10-07 | [67484](https://github.com/airbytehq/airbyte/pull/67484) | Remove memory limit for sync jobs to improve performance and resource utilization. |
 | 3.5.3 | 2025-03-24 | [56355](https://github.com/airbytehq/airbyte/pull/56355) | Upgrade to airbyte/java-connector-base:2.0.1 to be M4 compatible. |
 | 3.5.2 | 2025-01-10 | [51500](https://github.com/airbytehq/airbyte/pull/51500) | Use a non root base image |
 | 3.5.1 | 2024-12-18 | [49903](https://github.com/airbytehq/airbyte/pull/49903) | Use a base image: airbyte/java-connector-base:1.0.0 |

--- a/docs/integrations/destinations/redshift.md
+++ b/docs/integrations/destinations/redshift.md
@@ -222,6 +222,7 @@ Each stream will be output into its own raw table in Redshift. Each table will c
 
 | Version | Date       | Pull Request                                               | Subject                                                                                                                                                                                                          |
 | :------ | :--------- | :--------------------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 3.5.4 | 2025-10-07 | [XXXXX](https://github.com/airbytehq/airbyte/pull/XXXXX) | Remove memory limit for sync jobs to improve performance and resource utilization. |
 | 3.5.3 | 2025-03-24 | [56355](https://github.com/airbytehq/airbyte/pull/56355) | Upgrade to airbyte/java-connector-base:2.0.1 to be M4 compatible. |
 | 3.5.2 | 2025-01-10 | [51500](https://github.com/airbytehq/airbyte/pull/51500) | Use a non root base image |
 | 3.5.1 | 2024-12-18 | [49903](https://github.com/airbytehq/airbyte/pull/49903) | Use a base image: airbyte/java-connector-base:1.0.0 |


### PR DESCRIPTION
## Summary
- Remove `memory_limit` from sync job resource requirements for destination-redshift
- Update version to 3.5.4
- Add changelog entry

## Motivation
Removing hard memory limits allows the connector to utilize available resources more efficiently, improving performance and resource utilization for large syncs.

## Changes
- Removed `memory_limit: 1Gi` from metadata.yaml, keeping `memory_request: 1Gi`
- Bumped version from 3.5.3 to 3.5.4
- Added changelog entry documenting the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._