### PR TITLE
Support nano sec to preserve precision in TimeAccessor

### DIFF
--- a/airbyte-cdk/bulk/changelog.md
+++ b/airbyte-cdk/bulk/changelog.md
@@ -1,3 +1,9 @@
+## Version 0.1.49
+
+**Extract CDK**
+
+* **Changed:** Support nano sec to preserve precision in TimeAccessor.
+
 ## Version 0.1.48
 
 **Extract CDK**

--- a/airbyte-cdk/bulk/toolkits/extract-jdbc/src/main/kotlin/io/airbyte/cdk/jdbc/JdbcAccessor.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-jdbc/src/main/kotlin/io/airbyte/cdk/jdbc/JdbcAccessor.kt
@@ -321,7 +321,7 @@ data object TimeAccessor : JdbcAccessor<LocalTime> {
     override fun get(
         rs: ResultSet,
         colIdx: Int,
-    ): LocalTime? = rs.getTime(colIdx)?.takeUnless { rs.wasNull() }?.toLocalTime()
+    ): LocalTime? = rs.getObject(colIdx, LocalTime::class.java)?.takeUnless { rs.wasNull() }
 
     override fun set(
         stmt: PreparedStatement,

--- a/airbyte-cdk/bulk/version.properties
+++ b/airbyte-cdk/bulk/version.properties
@@ -1,1 +1,1 @@
-version=0.1.48
+version=0.1.49


### PR DESCRIPTION
## What
As title. Need this for mssql data type

## How
<!--
* Describe how code changes achieve the solution.
-->

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._