### PR TITLE
[source-s3] add external id parameter

### DIFF
--- a/airbyte-integrations/connectors/source-s3/integration_tests/cloud_spec.json
+++ b/airbyte-integrations/connectors/source-s3/integration_tests/cloud_spec.json
@@ -437,6 +437,12 @@
         "order": 6,
         "type": "string"
       },
+      "external_id": {
+        "title": "AWS External ID",
+        "description": "Specifies the External ID to be used when assuming the provided `role_arn`. This can be left null and fallback to AWS_ASSUME_ROLE_EXTERNAL_ID",
+        "order": 7,
+        "type": "string"
+      },
       "aws_secret_access_key": {
         "title": "AWS Secret Access Key",
         "description": "In order to access private Buckets stored on AWS S3, this connector requires credentials with the proper permissions. If accessing publicly available data, this field is not necessary.",
@@ -700,6 +706,13 @@
             "description": "Specifies the Amazon Resource Name (ARN) of an IAM role that you want to use to perform operations requested using this profile. Set the External ID to the Airbyte workspace ID, which can be found in the URL of this page.",
             "always_show": true,
             "order": 7,
+            "type": "string"
+          },
+          "external_id": {
+            "title": "AWS Role External ID",
+            "description": "Specifies the External ID to be used when assuming the provided `role_arn`. This can be left null and fallback to AWS_ASSUME_ROLE_EXTERNAL_ID",
+            "always_show": true,
+            "order": 8,
             "type": "string"
           },
           "path_prefix": {

--- a/airbyte-integrations/connectors/source-s3/integration_tests/spec.json
+++ b/airbyte-integrations/connectors/source-s3/integration_tests/spec.json
@@ -437,6 +437,12 @@
         "order": 6,
         "type": "string"
       },
+      "external_id": {
+        "title": "AWS External ID",
+        "description": "Specifies the External ID to be used when assuming the provided `role_arn`. This can be left null and fallback to AWS_ASSUME_ROLE_EXTERNAL_ID",
+        "order": 7,
+        "type": "string"
+      },
       "aws_secret_access_key": {
         "title": "AWS Secret Access Key",
         "description": "In order to access private Buckets stored on AWS S3, this connector requires credentials with the proper permissions. If accessing publicly available data, this field is not necessary.",
@@ -699,6 +705,13 @@
             "description": "Specifies the Amazon Resource Name (ARN) of an IAM role that you want to use to perform operations requested using this profile. Set the External ID to the Airbyte workspace ID, which can be found in the URL of this page.",
             "always_show": true,
             "order": 7,
+            "type": "string"
+          },
+          "external_id": {
+            "title": "AWS Role External ID",
+            "description": "Specifies the External ID to be used when assuming the provided `role_arn`. This can be left null and fallback to AWS_ASSUME_ROLE_EXTERNAL_ID",
+            "always_show": true,
+            "order": 8,
             "type": "string"
           },
           "path_prefix": {

--- a/airbyte-integrations/connectors/source-s3/metadata.yaml
+++ b/airbyte-integrations/connectors/source-s3/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: file
   connectorType: source
   definitionId: 69589781-7828-43c5-9f63-8925b1c1ccc2
-  dockerImageTag: 4.14.5
+  dockerImageTag: 4.14.6
   dockerRepository: airbyte/source-s3
   documentationUrl: https://docs.airbyte.com/integrations/sources/s3
   githubIssueLabel: source-s3

--- a/airbyte-integrations/connectors/source-s3/pyproject.toml
+++ b/airbyte-integrations/connectors/source-s3/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "4.14.5"
+version = "4.14.6"
 name = "source-s3"
 description = "Source implementation for S3."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-s3/source_s3/source.py
+++ b/airbyte-integrations/connectors/source-s3/source_s3/source.py
@@ -46,6 +46,14 @@ class SourceS3Spec(SourceFilesAbstractSpec, BaseModel):
             always_show=True,
             order=7,
         )
+        external_id: Optional[str] = Field(
+            title=f"AWS Role External ID",
+            default=None,
+            description="Specifies the External ID to be used when assuming the provided `role_arn`. "
+            f"This can be left null and fallback to AWS_ASSUME_ROLE_EXTERNAL_ID",
+            always_show=True,
+            order=8,
+        )
         path_prefix: str = Field(
             default="",
             description="By providing a path-like prefix (e.g. myFolder/thisTable/) under which all the relevant files sit, "

--- a/airbyte-integrations/connectors/source-s3/source_s3/v4/config.py
+++ b/airbyte-integrations/connectors/source-s3/source_s3/v4/config.py
@@ -41,6 +41,14 @@ class Config(AbstractFileBasedSpec):
         order=6,
     )
 
+    external_id: Optional[str] = Field(
+        title=f"AWS Role External ID",
+        default=None,
+        description="Specifies the External ID to be used when assuming the provided `role_arn`. "
+        f"This can be left null and fallback to AWS_ASSUME_ROLE_EXTERNAL_ID",
+        order=7,
+    )
+
     aws_secret_access_key: Optional[str] = Field(
         title="AWS Secret Access Key",
         default=None,
@@ -89,6 +97,14 @@ class Config(AbstractFileBasedSpec):
             if endpoint:
                 if endpoint.startswith("http://"):  # ignore-https-check
                     raise ValidationError("The endpoint must be a secure HTTPS endpoint.", model=Config)
+                
+        role_arn = values.get("role_arn")
+        external_id = values.get("external_id")
+
+        if external_id and not role_arn:
+            raise ValidationError(
+                "`role_arn` must be provided if setting `external_id`.", model=Config
+            )
 
         return values
 

--- a/airbyte-integrations/connectors/source-s3/source_s3/v4/config.py
+++ b/airbyte-integrations/connectors/source-s3/source_s3/v4/config.py
@@ -102,9 +102,7 @@ class Config(AbstractFileBasedSpec):
         external_id = values.get("external_id")
 
         if external_id and not role_arn:
-            raise ValidationError(
-                "`role_arn` must be provided if setting `external_id`.", model=Config
-            )
+            raise ValidationError("`role_arn` must be provided if setting `external_id`.", model=Config)
 
         return values
 

--- a/docs/integrations/sources/s3.md
+++ b/docs/integrations/sources/s3.md
@@ -356,6 +356,7 @@ This connector utilizes the open source [Unstructured](https://unstructured-io.g
 
 | Version     | Date       | Pull Request                                                                                                    | Subject                                                                                                              |
 |:------------|:-----------|:----------------------------------------------------------------------------------------------------------------|:---------------------------------------------------------------------------------------------------------------------|
+| 4.14.6 | 2025-10-08 | [](fixme) | Allow passing in external ID |
 | 4.14.5 | 2025-10-08 | [67494](https://github.com/airbytehq/airbyte/pull/67494) | Fix utf_8_sig encoding for zip files |
 | 4.14.4 | 2025-09-30 | [60547](https://github.com/airbytehq/airbyte/pull/60547) | Update dependencies |
 | 4.14.3 | 2025-09-10 | [66023](https://github.com/airbytehq/airbyte/pull/66023) | Update to CDK v7 |

--- a/docs/integrations/sources/s3.md
+++ b/docs/integrations/sources/s3.md
@@ -356,7 +356,7 @@ This connector utilizes the open source [Unstructured](https://unstructured-io.g
 
 | Version     | Date       | Pull Request                                                                                                    | Subject                                                                                                              |
 |:------------|:-----------|:----------------------------------------------------------------------------------------------------------------|:---------------------------------------------------------------------------------------------------------------------|
-| 4.14.6 | 2025-10-08 | [](fixme) | Allow passing in external ID |
+| 4.14.6 | 2025-10-08 | [67567](https://github.com/airbytehq/airbyte/pull/67567) | Allow passing in external ID |
 | 4.14.5 | 2025-10-08 | [67494](https://github.com/airbytehq/airbyte/pull/67494) | Fix utf_8_sig encoding for zip files |
 | 4.14.4 | 2025-09-30 | [60547](https://github.com/airbytehq/airbyte/pull/60547) | Update dependencies |
 | 4.14.3 | 2025-09-10 | [66023](https://github.com/airbytehq/airbyte/pull/66023) | Update to CDK v7 |


### PR DESCRIPTION
## What
https://github.com/airbytehq/airbyte/issues/34582

Fixes the above issue by allowing users to pass in an external ID parameter.  Previously the s3 connector was unusable with organizations that have a requirement to use a role with an external ID since the external_id did not work in this connector.  This also prevents users just not using an external ID which would make them to be susceptible to the [confused deputy problem](https://docs.aws.amazon.com/IAM/latest/UserGuide/confused-deputy.html).

It also allows users to decide what they want to set the external id rather than using the workspace ID(which I believe was the original intent of what `AWS_ASSUME_ROLE_EXTERNAL_ID` was going to be set to)

## How
There is a bug where `AWS_ASSUME_ROLE_EXTERNAL_ID` environment variable is not set.  This bypasses that issue by allowing users to set their own external_id for a connector.

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
None, the connector will work as it did before.  The only change occurs when passing in a external ID

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
