### PR TITLE
Bump cdk for CH and release.

### DIFF
--- a/airbyte-integrations/connectors/destination-clickhouse/gradle.properties
+++ b/airbyte-integrations/connectors/destination-clickhouse/gradle.properties
@@ -1,1 +1,1 @@
-cdkVersion=0.1.44
+cdkVersion=0.1.50

--- a/airbyte-integrations/connectors/destination-clickhouse/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-clickhouse/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: ce0d828e-1dc4-496c-b122-2da42e637e48
-  dockerImageTag: 2.1.4
+  dockerImageTag: 2.1.5
   dockerRepository: airbyte/destination-clickhouse
   githubIssueLabel: destination-clickhouse
   icon: clickhouse.svg

--- a/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/config/ClickhouseBeanFactory.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/config/ClickhouseBeanFactory.kt
@@ -7,7 +7,7 @@ package io.airbyte.integrations.destination.clickhouse.config
 import com.clickhouse.client.api.Client
 import com.clickhouse.client.api.internal.ServerSettings
 import io.airbyte.cdk.command.ConfigurationSpecificationSupplier
-import io.airbyte.cdk.load.dataflow.config.MemoryAndParallelismConfig
+import io.airbyte.cdk.load.dataflow.config.AggregatePublishingConfig
 import io.airbyte.cdk.load.orchestration.db.DefaultTempTableNameGenerator
 import io.airbyte.cdk.load.orchestration.db.TempTableNameGenerator
 import io.airbyte.cdk.ssh.SshConnectionOptions
@@ -87,9 +87,8 @@ class ClickhouseBeanFactory {
     fun tempTableNameGenerator(): TempTableNameGenerator = DefaultTempTableNameGenerator()
 
     @Singleton
-    fun getConfig(clickhouseConfiguration: ClickhouseConfiguration): MemoryAndParallelismConfig {
-        return MemoryAndParallelismConfig(
+    fun aggregatePublishingConfig(clickhouseConfiguration: ClickhouseConfiguration) =
+        AggregatePublishingConfig(
             maxRecordsPerAgg = clickhouseConfiguration.resolvedRecordWindowSize,
         )
-    }
 }

--- a/docs/integrations/destinations/clickhouse.md
+++ b/docs/integrations/destinations/clickhouse.md
@@ -104,8 +104,9 @@ You can also use a pre-existing user but we highly recommend creating a dedicate
 
 | Version    | Date       | Pull Request                                               | Subject                                                                        |
 |:-----------|:-----------|:-----------------------------------------------------------|:-------------------------------------------------------------------------------|
-| 2.1.4      | 2025-09-29 | [66743](https://github.com/airbytehq/airbyte/pull/66743) | Activate speed mode.                                                           |
-| 2.1.3      | 2025-09-29 | [66743](https://github.com/airbytehq/airbyte/pull/66743) | Promoting release candidate 2.1.3-rc.1 to a main version.                      |
+| 2.1.5      | 2025-10-09 | [99999](https://github.com/airbytehq/airbyte/pull/99999)   | Improve handling of heavily interleaved streams.                               |
+| 2.1.4      | 2025-09-29 | [66743](https://github.com/airbytehq/airbyte/pull/66743)   | Activate speed mode.                                                           |
+| 2.1.3      | 2025-09-29 | [66743](https://github.com/airbytehq/airbyte/pull/66743)   | Promoting release candidate 2.1.3-rc.1 to a main version.                      |
 | 2.1.3-rc.1 | 2025-09-25 | [66699](https://github.com/airbytehq/airbyte/pull/66699)   | Prepare for speed mode. Fix interleaved stream state handling.                 |
 | 2.1.2      | 2025-09-09 | [66143](https://github.com/airbytehq/airbyte/pull/66143)   | Improve schema propagation.                                                    |
 | 2.1.1      | 2025-09-09 | [66134](https://github.com/airbytehq/airbyte/pull/66134)   | Update the type we are setting for the number type to `Decimal(38, 9)`.        |

--- a/docs/integrations/destinations/clickhouse.md
+++ b/docs/integrations/destinations/clickhouse.md
@@ -104,7 +104,7 @@ You can also use a pre-existing user but we highly recommend creating a dedicate
 
 | Version    | Date       | Pull Request                                               | Subject                                                                        |
 |:-----------|:-----------|:-----------------------------------------------------------|:-------------------------------------------------------------------------------|
-| 2.1.5      | 2025-10-09 | [99999](https://github.com/airbytehq/airbyte/pull/99999)   | Improve handling of heavily interleaved streams.                               |
+| 2.1.5      | 2025-10-09 | [67598](https://github.com/airbytehq/airbyte/pull/67598)   | Improve handling of heavily interleaved streams.                               |
 | 2.1.4      | 2025-09-29 | [66743](https://github.com/airbytehq/airbyte/pull/66743)   | Activate speed mode.                                                           |
 | 2.1.3      | 2025-09-29 | [66743](https://github.com/airbytehq/airbyte/pull/66743)   | Promoting release candidate 2.1.3-rc.1 to a main version.                      |
 | 2.1.3-rc.1 | 2025-09-25 | [66699](https://github.com/airbytehq/airbyte/pull/66699)   | Prepare for speed mode. Fix interleaved stream state handling.                 |


### PR DESCRIPTION
## What
Brings CH to the latest CDK

## User Impact
We won't immediately evict aggregates if over some static number of interleaved-ness. We secondarily check the size of all active aggregates and only evict if over the configured size.