### PR TITLE
🐛 Source Iterable: Fix schema issues in campaigns, email send, and subscriptions

### DIFF
--- a/airbyte-integrations/connectors/source-iterable/metadata.yaml
+++ b/airbyte-integrations/connectors/source-iterable/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 2e875208-0c0b-4ee4-9e92-1cb3156ea799
-  dockerImageTag: 0.6.50
+  dockerImageTag: 0.6.51
   dockerRepository: airbyte/source-iterable
   documentationUrl: https://docs.airbyte.com/integrations/sources/iterable
   githubIssueLabel: source-iterable

--- a/airbyte-integrations/connectors/source-iterable/pyproject.toml
+++ b/airbyte-integrations/connectors/source-iterable/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "0.6.50"
+version = "0.6.51"
 name = "source-iterable"
 description = "Source implementation for Iterable."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-iterable/source_iterable/schemas/campaigns.json
+++ b/airbyte-integrations/connectors/source-iterable/source_iterable/schemas/campaigns.json
@@ -2,79 +2,142 @@
   "properties": {
     "id": {
       "description": "The unique identifier of the campaign",
-      "type": ["null", "integer"]
+      "type": [
+        "null",
+        "integer"
+      ]
     },
     "createdAt": {
       "description": "The timestamp when the campaign was created",
-      "type": ["null", "integer"]
+      "type": [
+        "null",
+        "integer"
+      ]
     },
     "updatedAt": {
       "description": "The timestamp when the campaign was last updated",
-      "type": ["null", "integer"]
+      "type": [
+        "null",
+        "integer"
+      ]
     },
     "startAt": {
       "description": "The timestamp when the campaign will start",
-      "type": ["null", "integer"]
+      "type": [
+        "null",
+        "integer"
+      ]
     },
     "endedAt": {
       "description": "The timestamp when the campaign ended",
-      "type": ["null", "integer"]
+      "type": [
+        "null",
+        "integer"
+      ]
     },
     "name": {
       "description": "The name of the campaign",
-      "type": ["null", "string"]
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "templateId": {
       "description": "The ID of the template used for the campaign",
-      "type": ["null", "integer"]
+      "type": [
+        "null",
+        "integer"
+      ]
     },
     "messageMedium": {
       "description": "The medium used to deliver the campaign message (e.g., email, SMS)",
-      "type": ["null", "string"]
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "createdByUserId": {
       "description": "The ID of the user who created the campaign",
-      "type": ["null", "string"]
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "updatedByUserId": {
       "description": "The ID of the user who last updated the campaign",
-      "type": ["null", "string"]
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "campaignState": {
       "description": "The current state of the campaign (e.g., draft, active, paused)",
-      "type": ["null", "string"]
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "listIds": {
       "description": "List of IDs of the lists targeted by the campaign",
-      "type": ["null", "array"],
-      "items": {}
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": "integer"
+      }
     },
     "suppressionListIds": {
       "description": "List of IDs of suppression lists for the campaign",
-      "type": ["null", "array"],
-      "items": {}
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": "integer"
+      }
     },
     "sendSize": {
       "description": "The size of the audience targeted by the campaign",
-      "type": ["null", "number"]
+      "type": [
+        "null",
+        "number"
+      ]
     },
     "recurringCampaignId": {
       "description": "If the campaign is recurring, the ID of the parent recurring campaign",
-      "type": ["null", "number"]
+      "type": [
+        "null",
+        "number"
+      ]
     },
     "workflowId": {
       "description": "The ID of the workflow associated with the campaign",
-      "type": ["null", "number"]
+      "type": [
+        "null",
+        "number"
+      ]
     },
     "labels": {
       "description": "List of labels associated with the campaign",
-      "type": ["null", "array"],
-      "items": {}
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": "string"
+      }
     },
     "type": {
       "description": "The type of campaign (e.g., one-time, recurring)",
-      "type": ["null", "string"]
+      "type": [
+        "null",
+        "string"
+      ]
     }
   },
-  "type": ["null", "object"]
+  "type": [
+    "null",
+    "object"
+  ]
 }

--- a/airbyte-integrations/connectors/source-iterable/source_iterable/schemas/campaigns.json
+++ b/airbyte-integrations/connectors/source-iterable/source_iterable/schemas/campaigns.json
@@ -2,142 +2,85 @@
   "properties": {
     "id": {
       "description": "The unique identifier of the campaign",
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     },
     "createdAt": {
       "description": "The timestamp when the campaign was created",
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     },
     "updatedAt": {
       "description": "The timestamp when the campaign was last updated",
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     },
     "startAt": {
       "description": "The timestamp when the campaign will start",
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     },
     "endedAt": {
       "description": "The timestamp when the campaign ended",
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     },
     "name": {
       "description": "The name of the campaign",
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "templateId": {
       "description": "The ID of the template used for the campaign",
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     },
     "messageMedium": {
       "description": "The medium used to deliver the campaign message (e.g., email, SMS)",
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "createdByUserId": {
       "description": "The ID of the user who created the campaign",
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "updatedByUserId": {
       "description": "The ID of the user who last updated the campaign",
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "campaignState": {
       "description": "The current state of the campaign (e.g., draft, active, paused)",
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "listIds": {
       "description": "List of IDs of the lists targeted by the campaign",
-      "type": [
-        "null",
-        "array"
-      ],
+      "type": ["null", "array"],
       "items": {
         "type": "integer"
       }
     },
     "suppressionListIds": {
       "description": "List of IDs of suppression lists for the campaign",
-      "type": [
-        "null",
-        "array"
-      ],
+      "type": ["null", "array"],
       "items": {
         "type": "integer"
       }
     },
     "sendSize": {
       "description": "The size of the audience targeted by the campaign",
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "recurringCampaignId": {
       "description": "If the campaign is recurring, the ID of the parent recurring campaign",
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "workflowId": {
       "description": "The ID of the workflow associated with the campaign",
-      "type": [
-        "null",
-        "number"
-      ]
+      "type": ["null", "number"]
     },
     "labels": {
       "description": "List of labels associated with the campaign",
-      "type": [
-        "null",
-        "array"
-      ],
+      "type": ["null", "array"],
       "items": {
         "type": "string"
       }
     },
     "type": {
       "description": "The type of campaign (e.g., one-time, recurring)",
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     }
   },
-  "type": [
-    "null",
-    "object"
-  ]
+  "type": ["null", "object"]
 }

--- a/airbyte-integrations/connectors/source-iterable/source_iterable/schemas/email_send.json
+++ b/airbyte-integrations/connectors/source-iterable/source_iterable/schemas/email_send.json
@@ -2,289 +2,172 @@
   "properties": {
     "createdAt": {
       "description": "The timestamp when the email was created.",
-      "type": [
-        "null",
-        "string"
-      ],
+      "type": ["null", "string"],
       "format": "date-time"
     },
     "campaignId": {
       "description": "The identifier of the campaign associated with the email_send data.",
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     },
     "itblInternal": {
       "description": "Internal information related to ITBL (Iterable).",
-      "type": [
-        "null",
-        "object"
-      ],
+      "type": ["null", "object"],
       "properties": {
         "documentCreatedAt": {
           "description": "The timestamp when the document was created.",
-          "type": [
-            "null",
-            "string"
-          ],
+          "type": ["null", "string"],
           "format": "date-time"
         },
         "documentUpdatedAt": {
           "description": "The timestamp when the document was last updated.",
-          "type": [
-            "null",
-            "string"
-          ],
+          "type": ["null", "string"],
           "format": "date-time"
         }
       }
     },
     "messageTypeId": {
       "description": "The identifier of the message type associated with the email_send data.",
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     },
     "transactionalData": {
       "description": "Transactional data related to the email_send.",
-      "type": [
-        "null",
-        "object"
-      ],
+      "type": ["null", "object"],
       "properties": {
         "inventory": {
           "description": "The quantity of the product in stock.",
-          "type": [
-            "null",
-            "integer"
-          ]
+          "type": ["null", "integer"]
         },
         "eventName": {
           "description": "The name of the event associated with the transaction.",
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "name": {
           "description": "The name of the product.",
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "sku": {
           "description": "The stock keeping unit (SKU) of the product.",
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "email": {
           "description": "The email address associated with the transaction.",
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "url": {
           "description": "The URL related to the transaction or product.",
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "description": {
           "description": "Description of the product or transaction.",
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "price": {
           "description": "The price of the product.",
-          "type": [
-            "null",
-            "integer"
-          ]
+          "type": ["null", "integer"]
         },
         "product_type": {
           "description": "The type or category of the product.",
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "compare_at_price": {
           "description": "The original price of the product being transacted.",
-          "type": [
-            "null",
-            "number"
-          ]
+          "type": ["null", "number"]
         },
         "id": {
           "description": "The unique identifier of the transactional data.",
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "templateId": {
           "description": "The identifier of the template used for the transactional data.",
-          "type": [
-            "null",
-            "integer"
-          ]
+          "type": ["null", "integer"]
         },
         "product_id": {
           "description": "The identifier of the product.",
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "categories": {
           "description": "Categories related to the transactional data.",
-          "type": [
-            "null",
-            "array"
-          ],
+          "type": ["null", "array"],
           "items": {
             "type": "string"
           }
         },
         "createdAt": {
           "description": "The timestamp when the transactional data was created.",
-          "type": [
-            "null",
-            "string"
-          ],
+          "type": ["null", "string"],
           "format": "date-time"
         },
         "campaignId": {
           "description": "The identifier of the campaign associated with the transactional data.",
-          "type": [
-            "null",
-            "integer"
-          ]
+          "type": ["null", "integer"]
         },
         "vendor": {
           "description": "The vendor or seller of the product.",
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "eventUpdatedAt": {
           "description": "The timestamp when the event was last updated.",
-          "type": [
-            "null",
-            "string"
-          ],
+          "type": ["null", "string"],
           "format": "date-time"
         },
         "discount": {
           "description": "The discount applied to the product.",
-          "type": [
-            "null",
-            "integer"
-          ]
+          "type": ["null", "integer"]
         },
         "imageUrl": {
           "description": "The URL of the image related to the product.",
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "itblInternal": {
           "description": "Internal information related to ITBL (Iterable) for transactional data.",
-          "type": [
-            "null",
-            "object"
-          ],
+          "type": ["null", "object"],
           "properties": {
             "documentCreatedAt": {
               "description": "The timestamp when the document related to transactional data was created.",
-              "type": [
-                "null",
-                "string"
-              ],
+              "type": ["null", "string"],
               "format": "date-time"
             },
             "documentUpdatedAt": {
               "description": "The timestamp when the document related to transactional data was last updated.",
-              "type": [
-                "null",
-                "string"
-              ],
+              "type": ["null", "string"],
               "format": "date-time"
             }
           }
         },
         "handle": {
           "description": "A unique identifier for the transaction or product.",
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         }
       }
     },
     "contentId": {
       "description": "The identifier of the content related to the email being sent.",
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     },
     "messageId": {
       "description": "The unique identifier of the message.",
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "messageBusId": {
       "description": "The identifier of the message bus associated with the email_send data.",
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "templateId": {
       "description": "The identifier of the template used for the email content.",
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     },
     "email": {
       "description": "The email address of the recipient.",
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "userId": {
       "description": "The identifier of the user to whom the email is being sent.",
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "channelId": {
       "description": "The identifier of the channel through which the email was sent.",
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     }
   },
-  "type": [
-    "null",
-    "object"
-  ]
+  "type": ["null", "object"]
 }

--- a/airbyte-integrations/connectors/source-iterable/source_iterable/schemas/email_send.json
+++ b/airbyte-integrations/connectors/source-iterable/source_iterable/schemas/email_send.json
@@ -2,170 +2,289 @@
   "properties": {
     "createdAt": {
       "description": "The timestamp when the email was created.",
-      "type": ["null", "string"],
+      "type": [
+        "null",
+        "string"
+      ],
       "format": "date-time"
     },
     "campaignId": {
       "description": "The identifier of the campaign associated with the email_send data.",
-      "type": ["null", "integer"]
+      "type": [
+        "null",
+        "integer"
+      ]
     },
     "itblInternal": {
       "description": "Internal information related to ITBL (Iterable).",
-      "type": ["null", "object"],
+      "type": [
+        "null",
+        "object"
+      ],
       "properties": {
         "documentCreatedAt": {
           "description": "The timestamp when the document was created.",
-          "type": ["null", "string"],
+          "type": [
+            "null",
+            "string"
+          ],
           "format": "date-time"
         },
         "documentUpdatedAt": {
           "description": "The timestamp when the document was last updated.",
-          "type": ["null", "string"],
+          "type": [
+            "null",
+            "string"
+          ],
           "format": "date-time"
         }
       }
     },
     "messageTypeId": {
       "description": "The identifier of the message type associated with the email_send data.",
-      "type": ["null", "integer"]
+      "type": [
+        "null",
+        "integer"
+      ]
     },
     "transactionalData": {
       "description": "Transactional data related to the email_send.",
-      "type": ["null", "object"],
+      "type": [
+        "null",
+        "object"
+      ],
       "properties": {
         "inventory": {
           "description": "The quantity of the product in stock.",
-          "type": ["null", "integer"]
+          "type": [
+            "null",
+            "integer"
+          ]
         },
         "eventName": {
           "description": "The name of the event associated with the transaction.",
-          "type": ["null", "string"]
+          "type": [
+            "null",
+            "string"
+          ]
         },
         "name": {
           "description": "The name of the product.",
-          "type": ["null", "string"]
+          "type": [
+            "null",
+            "string"
+          ]
         },
         "sku": {
           "description": "The stock keeping unit (SKU) of the product.",
-          "type": ["null", "string"]
+          "type": [
+            "null",
+            "string"
+          ]
         },
         "email": {
           "description": "The email address associated with the transaction.",
-          "type": ["null", "string"]
+          "type": [
+            "null",
+            "string"
+          ]
         },
         "url": {
           "description": "The URL related to the transaction or product.",
-          "type": ["null", "string"]
+          "type": [
+            "null",
+            "string"
+          ]
         },
         "description": {
           "description": "Description of the product or transaction.",
-          "type": ["null", "string"]
+          "type": [
+            "null",
+            "string"
+          ]
         },
         "price": {
           "description": "The price of the product.",
-          "type": ["null", "integer"]
+          "type": [
+            "null",
+            "integer"
+          ]
         },
         "product_type": {
           "description": "The type or category of the product.",
-          "type": ["null", "string"]
+          "type": [
+            "null",
+            "string"
+          ]
         },
         "compare_at_price": {
           "description": "The original price of the product being transacted.",
-          "type": ["null", "number"]
+          "type": [
+            "null",
+            "number"
+          ]
         },
         "id": {
           "description": "The unique identifier of the transactional data.",
-          "type": ["null", "string"]
+          "type": [
+            "null",
+            "string"
+          ]
         },
         "templateId": {
           "description": "The identifier of the template used for the transactional data.",
-          "type": ["null", "integer"]
+          "type": [
+            "null",
+            "integer"
+          ]
         },
         "product_id": {
           "description": "The identifier of the product.",
-          "type": ["null", "string"]
+          "type": [
+            "null",
+            "string"
+          ]
         },
         "categories": {
           "description": "Categories related to the transactional data.",
-          "type": ["null", "array"],
-          "items": {}
+          "type": [
+            "null",
+            "array"
+          ],
+          "items": {
+            "type": "string"
+          }
         },
         "createdAt": {
           "description": "The timestamp when the transactional data was created.",
-          "type": ["null", "string"],
+          "type": [
+            "null",
+            "string"
+          ],
           "format": "date-time"
         },
         "campaignId": {
           "description": "The identifier of the campaign associated with the transactional data.",
-          "type": ["null", "integer"]
+          "type": [
+            "null",
+            "integer"
+          ]
         },
         "vendor": {
           "description": "The vendor or seller of the product.",
-          "type": ["null", "string"]
+          "type": [
+            "null",
+            "string"
+          ]
         },
         "eventUpdatedAt": {
           "description": "The timestamp when the event was last updated.",
-          "type": ["null", "string"],
+          "type": [
+            "null",
+            "string"
+          ],
           "format": "date-time"
         },
         "discount": {
           "description": "The discount applied to the product.",
-          "type": ["null", "integer"]
+          "type": [
+            "null",
+            "integer"
+          ]
         },
         "imageUrl": {
           "description": "The URL of the image related to the product.",
-          "type": ["null", "string"]
+          "type": [
+            "null",
+            "string"
+          ]
         },
         "itblInternal": {
           "description": "Internal information related to ITBL (Iterable) for transactional data.",
-          "type": ["null", "object"],
+          "type": [
+            "null",
+            "object"
+          ],
           "properties": {
             "documentCreatedAt": {
               "description": "The timestamp when the document related to transactional data was created.",
-              "type": ["null", "string"],
+              "type": [
+                "null",
+                "string"
+              ],
               "format": "date-time"
             },
             "documentUpdatedAt": {
               "description": "The timestamp when the document related to transactional data was last updated.",
-              "type": ["null", "string"],
+              "type": [
+                "null",
+                "string"
+              ],
               "format": "date-time"
             }
           }
         },
         "handle": {
           "description": "A unique identifier for the transaction or product.",
-          "type": ["null", "string"]
+          "type": [
+            "null",
+            "string"
+          ]
         }
       }
     },
     "contentId": {
       "description": "The identifier of the content related to the email being sent.",
-      "type": ["null", "integer"]
+      "type": [
+        "null",
+        "integer"
+      ]
     },
     "messageId": {
       "description": "The unique identifier of the message.",
-      "type": ["null", "string"]
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "messageBusId": {
       "description": "The identifier of the message bus associated with the email_send data.",
-      "type": ["null", "string"]
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "templateId": {
       "description": "The identifier of the template used for the email content.",
-      "type": ["null", "integer"]
+      "type": [
+        "null",
+        "integer"
+      ]
     },
     "email": {
       "description": "The email address of the recipient.",
-      "type": ["null", "string"]
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "userId": {
       "description": "The identifier of the user to whom the email is being sent.",
-      "type": ["null", "string"]
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "channelId": {
       "description": "The identifier of the channel through which the email was sent.",
-      "type": ["null", "integer"]
+      "type": [
+        "null",
+        "integer"
+      ]
     }
   },
-  "type": ["null", "object"]
+  "type": [
+    "null",
+    "object"
+  ]
 }

--- a/airbyte-integrations/connectors/source-iterable/source_iterable/schemas/email_send_skip.json
+++ b/airbyte-integrations/connectors/source-iterable/source_iterable/schemas/email_send_skip.json
@@ -2,170 +2,289 @@
   "properties": {
     "reason": {
       "description": "Reason for skipping the email send.",
-      "type": ["null", "string"]
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "createdAt": {
       "description": "Date and time when the email send skip data was created.",
-      "type": ["null", "string"],
+      "type": [
+        "null",
+        "string"
+      ],
       "format": "date-time"
     },
     "campaignId": {
       "description": "Unique identifier for the campaign associated with the email send skip data.",
-      "type": ["null", "integer"]
+      "type": [
+        "null",
+        "integer"
+      ]
     },
     "itblInternal": {
       "description": "Internal iterable properties associated with the email send skip data.",
-      "type": ["null", "object"],
+      "type": [
+        "null",
+        "object"
+      ],
       "properties": {
         "documentCreatedAt": {
           "description": "Date and time when the document was created.",
-          "type": ["null", "string"],
+          "type": [
+            "null",
+            "string"
+          ],
           "format": "date-time"
         },
         "documentUpdatedAt": {
           "description": "Date and time when the document was last updated.",
-          "type": ["null", "string"],
+          "type": [
+            "null",
+            "string"
+          ],
           "format": "date-time"
         }
       }
     },
     "messageTypeId": {
       "description": "Identifier for the type of message sent.",
-      "type": ["null", "integer"]
+      "type": [
+        "null",
+        "integer"
+      ]
     },
     "transactionalData": {
       "description": "Transactional data associated with the email send skip.",
-      "type": ["null", "object"],
+      "type": [
+        "null",
+        "object"
+      ],
       "properties": {
         "inventory": {
           "description": "Inventory details of the transactional data.",
-          "type": ["null", "integer"]
+          "type": [
+            "null",
+            "integer"
+          ]
         },
         "eventName": {
           "description": "Name of the event associated with the transactional data.",
-          "type": ["null", "string"]
+          "type": [
+            "null",
+            "string"
+          ]
         },
         "name": {
           "description": "Name of the product associated with the transactional data.",
-          "type": ["null", "string"]
+          "type": [
+            "null",
+            "string"
+          ]
         },
         "sku": {
           "description": "Stock Keeping Unit (SKU) associated with the transactional data.",
-          "type": ["null", "string"]
+          "type": [
+            "null",
+            "string"
+          ]
         },
         "email": {
           "description": "Email address associated with the transactional data.",
-          "type": ["null", "string"]
+          "type": [
+            "null",
+            "string"
+          ]
         },
         "url": {
           "description": "URL associated with the transactional data.",
-          "type": ["null", "string"]
+          "type": [
+            "null",
+            "string"
+          ]
         },
         "description": {
           "description": "Description of the transactional data.",
-          "type": ["null", "string"]
+          "type": [
+            "null",
+            "string"
+          ]
         },
         "price": {
           "description": "Price of the product in the transactional data.",
-          "type": ["null", "integer"]
+          "type": [
+            "null",
+            "integer"
+          ]
         },
         "product_type": {
           "description": "Type of the product in the transactional data.",
-          "type": ["null", "string"]
+          "type": [
+            "null",
+            "string"
+          ]
         },
         "compare_at_price": {
           "description": "Comparison price for the transactional data.",
-          "type": ["null", "number"]
+          "type": [
+            "null",
+            "number"
+          ]
         },
         "id": {
           "description": "Unique identifier for the transactional data.",
-          "type": ["null", "string"]
+          "type": [
+            "null",
+            "string"
+          ]
         },
         "templateId": {
           "description": "Identifier for the template used for the transactional data.",
-          "type": ["null", "integer"]
+          "type": [
+            "null",
+            "integer"
+          ]
         },
         "product_id": {
           "description": "Identifier for the product associated with the transactional data.",
-          "type": ["null", "string"]
+          "type": [
+            "null",
+            "string"
+          ]
         },
         "categories": {
           "description": "Categories associated with the transactional data.",
-          "type": ["null", "array"],
-          "items": {}
+          "type": [
+            "null",
+            "array"
+          ],
+          "items": {
+            "type": "string"
+          }
         },
         "createdAt": {
           "description": "Date and time when the transactional data was created.",
-          "type": ["null", "string"],
+          "type": [
+            "null",
+            "string"
+          ],
           "format": "date-time"
         },
         "campaignId": {
           "description": "Unique identifier for the campaign associated with the transactional data.",
-          "type": ["null", "integer"]
+          "type": [
+            "null",
+            "integer"
+          ]
         },
         "vendor": {
           "description": "Vendor of the product in the transactional data.",
-          "type": ["null", "string"]
+          "type": [
+            "null",
+            "string"
+          ]
         },
         "eventUpdatedAt": {
           "description": "Date and time when the event was last updated.",
-          "type": ["null", "string"],
+          "type": [
+            "null",
+            "string"
+          ],
           "format": "date-time"
         },
         "discount": {
           "description": "Discount applied in the transactional data.",
-          "type": ["null", "integer"]
+          "type": [
+            "null",
+            "integer"
+          ]
         },
         "imageUrl": {
           "description": "URL for the image associated with the transactional data.",
-          "type": ["null", "string"]
+          "type": [
+            "null",
+            "string"
+          ]
         },
         "itblInternal": {
           "description": "Internal iterable properties associated with the transactional data.",
-          "type": ["null", "object"],
+          "type": [
+            "null",
+            "object"
+          ],
           "properties": {
             "documentCreatedAt": {
               "description": "Date and time when the document was created.",
-              "type": ["null", "string"],
+              "type": [
+                "null",
+                "string"
+              ],
               "format": "date-time"
             },
             "documentUpdatedAt": {
               "description": "Date and time when the document was last updated.",
-              "type": ["null", "string"],
+              "type": [
+                "null",
+                "string"
+              ],
               "format": "date-time"
             }
           }
         },
         "handle": {
           "description": "Handle of the transactional data.",
-          "type": ["null", "string"]
+          "type": [
+            "null",
+            "string"
+          ]
         }
       }
     },
     "contentId": {
       "description": "Identifier for the content associated with the email send skip data.",
-      "type": ["null", "integer"]
+      "type": [
+        "null",
+        "integer"
+      ]
     },
     "messageId": {
       "description": "Unique identifier for the message related to the email send skip data.",
-      "type": ["null", "string"]
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "templateId": {
       "description": "Identifier for the template used in the email send skip data.",
-      "type": ["null", "integer"]
+      "type": [
+        "null",
+        "integer"
+      ]
     },
     "email": {
       "description": "Email address to which the email send skip data corresponds.",
-      "type": ["null", "string"]
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "userId": {
       "description": "Identifier for the user associated with the email send skip data.",
-      "type": ["null", "string"]
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "channelId": {
       "description": "Identifier for the channel through which the email was sent.",
-      "type": ["null", "integer"]
+      "type": [
+        "null",
+        "integer"
+      ]
     }
   },
-  "type": ["null", "object"]
+  "type": [
+    "null",
+    "object"
+  ]
 }

--- a/airbyte-integrations/connectors/source-iterable/source_iterable/schemas/email_send_skip.json
+++ b/airbyte-integrations/connectors/source-iterable/source_iterable/schemas/email_send_skip.json
@@ -2,289 +2,172 @@
   "properties": {
     "reason": {
       "description": "Reason for skipping the email send.",
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "createdAt": {
       "description": "Date and time when the email send skip data was created.",
-      "type": [
-        "null",
-        "string"
-      ],
+      "type": ["null", "string"],
       "format": "date-time"
     },
     "campaignId": {
       "description": "Unique identifier for the campaign associated with the email send skip data.",
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     },
     "itblInternal": {
       "description": "Internal iterable properties associated with the email send skip data.",
-      "type": [
-        "null",
-        "object"
-      ],
+      "type": ["null", "object"],
       "properties": {
         "documentCreatedAt": {
           "description": "Date and time when the document was created.",
-          "type": [
-            "null",
-            "string"
-          ],
+          "type": ["null", "string"],
           "format": "date-time"
         },
         "documentUpdatedAt": {
           "description": "Date and time when the document was last updated.",
-          "type": [
-            "null",
-            "string"
-          ],
+          "type": ["null", "string"],
           "format": "date-time"
         }
       }
     },
     "messageTypeId": {
       "description": "Identifier for the type of message sent.",
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     },
     "transactionalData": {
       "description": "Transactional data associated with the email send skip.",
-      "type": [
-        "null",
-        "object"
-      ],
+      "type": ["null", "object"],
       "properties": {
         "inventory": {
           "description": "Inventory details of the transactional data.",
-          "type": [
-            "null",
-            "integer"
-          ]
+          "type": ["null", "integer"]
         },
         "eventName": {
           "description": "Name of the event associated with the transactional data.",
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "name": {
           "description": "Name of the product associated with the transactional data.",
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "sku": {
           "description": "Stock Keeping Unit (SKU) associated with the transactional data.",
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "email": {
           "description": "Email address associated with the transactional data.",
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "url": {
           "description": "URL associated with the transactional data.",
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "description": {
           "description": "Description of the transactional data.",
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "price": {
           "description": "Price of the product in the transactional data.",
-          "type": [
-            "null",
-            "integer"
-          ]
+          "type": ["null", "integer"]
         },
         "product_type": {
           "description": "Type of the product in the transactional data.",
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "compare_at_price": {
           "description": "Comparison price for the transactional data.",
-          "type": [
-            "null",
-            "number"
-          ]
+          "type": ["null", "number"]
         },
         "id": {
           "description": "Unique identifier for the transactional data.",
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "templateId": {
           "description": "Identifier for the template used for the transactional data.",
-          "type": [
-            "null",
-            "integer"
-          ]
+          "type": ["null", "integer"]
         },
         "product_id": {
           "description": "Identifier for the product associated with the transactional data.",
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "categories": {
           "description": "Categories associated with the transactional data.",
-          "type": [
-            "null",
-            "array"
-          ],
+          "type": ["null", "array"],
           "items": {
             "type": "string"
           }
         },
         "createdAt": {
           "description": "Date and time when the transactional data was created.",
-          "type": [
-            "null",
-            "string"
-          ],
+          "type": ["null", "string"],
           "format": "date-time"
         },
         "campaignId": {
           "description": "Unique identifier for the campaign associated with the transactional data.",
-          "type": [
-            "null",
-            "integer"
-          ]
+          "type": ["null", "integer"]
         },
         "vendor": {
           "description": "Vendor of the product in the transactional data.",
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "eventUpdatedAt": {
           "description": "Date and time when the event was last updated.",
-          "type": [
-            "null",
-            "string"
-          ],
+          "type": ["null", "string"],
           "format": "date-time"
         },
         "discount": {
           "description": "Discount applied in the transactional data.",
-          "type": [
-            "null",
-            "integer"
-          ]
+          "type": ["null", "integer"]
         },
         "imageUrl": {
           "description": "URL for the image associated with the transactional data.",
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         },
         "itblInternal": {
           "description": "Internal iterable properties associated with the transactional data.",
-          "type": [
-            "null",
-            "object"
-          ],
+          "type": ["null", "object"],
           "properties": {
             "documentCreatedAt": {
               "description": "Date and time when the document was created.",
-              "type": [
-                "null",
-                "string"
-              ],
+              "type": ["null", "string"],
               "format": "date-time"
             },
             "documentUpdatedAt": {
               "description": "Date and time when the document was last updated.",
-              "type": [
-                "null",
-                "string"
-              ],
+              "type": ["null", "string"],
               "format": "date-time"
             }
           }
         },
         "handle": {
           "description": "Handle of the transactional data.",
-          "type": [
-            "null",
-            "string"
-          ]
+          "type": ["null", "string"]
         }
       }
     },
     "contentId": {
       "description": "Identifier for the content associated with the email send skip data.",
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     },
     "messageId": {
       "description": "Unique identifier for the message related to the email send skip data.",
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "templateId": {
       "description": "Identifier for the template used in the email send skip data.",
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     },
     "email": {
       "description": "Email address to which the email send skip data corresponds.",
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "userId": {
       "description": "Identifier for the user associated with the email send skip data.",
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "channelId": {
       "description": "Identifier for the channel through which the email was sent.",
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     }
   },
-  "type": [
-    "null",
-    "object"
-  ]
+  "type": ["null", "object"]
 }

--- a/airbyte-integrations/connectors/source-iterable/source_iterable/schemas/email_subscribe.json
+++ b/airbyte-integrations/connectors/source-iterable/source_iterable/schemas/email_subscribe.json
@@ -2,55 +2,93 @@
   "properties": {
     "createdAt": {
       "description": "The timestamp when the email subscription was created",
-      "type": ["null", "string"],
+      "type": [
+        "null",
+        "string"
+      ],
       "format": "date-time"
     },
     "signupSource": {
       "description": "The source where the subscriber signed up for the emails",
-      "type": ["null", "string"]
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "emailListIds": {
       "description": "List of email list identifiers the subscriber belongs to",
-      "type": ["null", "array"],
-      "items": {}
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": "integer"
+      }
     },
     "itblInternal": {
       "description": "Internal properties related to the subscription",
-      "type": ["null", "object"],
+      "type": [
+        "null",
+        "object"
+      ],
       "properties": {
         "documentCreatedAt": {
           "description": "The timestamp when the internal document was created",
-          "type": ["null", "string"],
+          "type": [
+            "null",
+            "string"
+          ],
           "format": "date-time"
         },
         "documentUpdatedAt": {
           "description": "The timestamp when the internal document was last updated",
-          "type": ["null", "string"],
+          "type": [
+            "null",
+            "string"
+          ],
           "format": "date-time"
         }
       }
     },
     "emailListId": {
       "description": "The unique identifier of the email list",
-      "type": ["null", "integer"]
+      "type": [
+        "null",
+        "integer"
+      ]
     },
     "email": {
       "description": "The email address of the subscriber",
-      "type": ["null", "string"]
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "userId": {
       "description": "The unique identifier of the subscriber user",
-      "type": ["null", "string"]
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "profileUpdatedAt": {
       "description": "The timestamp when the subscriber profile was last updated",
-      "type": ["null", "string"],
+      "type": [
+        "null",
+        "string"
+      ],
       "format": "date-time"
     },
     "workflowId": {
       "description": "The identifier of the workflow associated with the subscription",
-      "type": ["null", "integer"]
+      "type": [
+        "null",
+        "integer"
+      ]
     }
   },
-  "type": ["null", "object"]
+  "type": [
+    "null",
+    "object"
+  ]
 }

--- a/airbyte-integrations/connectors/source-iterable/source_iterable/schemas/email_subscribe.json
+++ b/airbyte-integrations/connectors/source-iterable/source_iterable/schemas/email_subscribe.json
@@ -2,93 +2,57 @@
   "properties": {
     "createdAt": {
       "description": "The timestamp when the email subscription was created",
-      "type": [
-        "null",
-        "string"
-      ],
+      "type": ["null", "string"],
       "format": "date-time"
     },
     "signupSource": {
       "description": "The source where the subscriber signed up for the emails",
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "emailListIds": {
       "description": "List of email list identifiers the subscriber belongs to",
-      "type": [
-        "null",
-        "array"
-      ],
+      "type": ["null", "array"],
       "items": {
         "type": "integer"
       }
     },
     "itblInternal": {
       "description": "Internal properties related to the subscription",
-      "type": [
-        "null",
-        "object"
-      ],
+      "type": ["null", "object"],
       "properties": {
         "documentCreatedAt": {
           "description": "The timestamp when the internal document was created",
-          "type": [
-            "null",
-            "string"
-          ],
+          "type": ["null", "string"],
           "format": "date-time"
         },
         "documentUpdatedAt": {
           "description": "The timestamp when the internal document was last updated",
-          "type": [
-            "null",
-            "string"
-          ],
+          "type": ["null", "string"],
           "format": "date-time"
         }
       }
     },
     "emailListId": {
       "description": "The unique identifier of the email list",
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     },
     "email": {
       "description": "The email address of the subscriber",
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "userId": {
       "description": "The unique identifier of the subscriber user",
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "profileUpdatedAt": {
       "description": "The timestamp when the subscriber profile was last updated",
-      "type": [
-        "null",
-        "string"
-      ],
+      "type": ["null", "string"],
       "format": "date-time"
     },
     "workflowId": {
       "description": "The identifier of the workflow associated with the subscription",
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     }
   },
-  "type": [
-    "null",
-    "object"
-  ]
+  "type": ["null", "object"]
 }

--- a/airbyte-integrations/connectors/source-iterable/source_iterable/schemas/email_unsubscribe.json
+++ b/airbyte-integrations/connectors/source-iterable/source_iterable/schemas/email_unsubscribe.json
@@ -2,123 +2,75 @@
   "properties": {
     "unsubSource": {
       "description": "The source from which the email unsubscribe request originated.",
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "createdAt": {
       "description": "The timestamp indicating when the email unsubscribe data was created.",
-      "type": [
-        "null",
-        "string"
-      ],
+      "type": ["null", "string"],
       "format": "date-time"
     },
     "campaignId": {
       "description": "The unique identifier for the campaign associated with the email unsubscribe data.",
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     },
     "itblInternal": {
       "description": "Internal properties specific to Iterable.",
-      "type": [
-        "null",
-        "object"
-      ],
+      "type": ["null", "object"],
       "properties": {
         "documentCreatedAt": {
           "description": "The timestamp indicating when the document was created within Iterable.",
-          "type": [
-            "null",
-            "string"
-          ],
+          "type": ["null", "string"],
           "format": "date-time"
         },
         "documentUpdatedAt": {
           "description": "The timestamp indicating when the document was last updated within Iterable.",
-          "type": [
-            "null",
-            "string"
-          ],
+          "type": ["null", "string"],
           "format": "date-time"
         }
       }
     },
     "emailListId": {
       "description": "The unique identifier for the email list associated with the email unsubscribe data.",
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     },
     "emailListIds": {
       "description": "The list of unique identifiers for multiple email lists associated with the email unsubscribe data.",
-      "type": [
-        "null",
-        "array"
-      ],
+      "type": ["null", "array"],
       "items": {
         "type": "integer"
       }
     },
     "workflowId": {
       "description": "The unique identifier for the workflow associated with the email unsubscribe data.",
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     },
     "messageId": {
       "description": "The unique identifier for the message associated with the email unsubscribe data.",
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "templateId": {
       "description": "The unique identifier for the template associated with the email unsubscribe data.",
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     },
     "channelIds": {
       "description": "The list of unique identifiers for multiple channels associated with the email unsubscribe data.",
-      "type": [
-        "null",
-        "array"
-      ],
+      "type": ["null", "array"],
       "items": {
         "type": "integer"
       }
     },
     "email": {
       "description": "The email address for which the user unsubscribed.",
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "userId": {
       "description": "The unique identifier for the user who unsubscribed from the email list.",
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": ["null", "string"]
     },
     "channelId": {
       "description": "The unique identifier for the channel associated with the email unsubscribe data.",
-      "type": [
-        "null",
-        "integer"
-      ]
+      "type": ["null", "integer"]
     }
   },
-  "type": [
-    "null",
-    "object"
-  ]
+  "type": ["null", "object"]
 }

--- a/airbyte-integrations/connectors/source-iterable/source_iterable/schemas/email_unsubscribe.json
+++ b/airbyte-integrations/connectors/source-iterable/source_iterable/schemas/email_unsubscribe.json
@@ -2,71 +2,123 @@
   "properties": {
     "unsubSource": {
       "description": "The source from which the email unsubscribe request originated.",
-      "type": ["null", "string"]
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "createdAt": {
       "description": "The timestamp indicating when the email unsubscribe data was created.",
-      "type": ["null", "string"],
+      "type": [
+        "null",
+        "string"
+      ],
       "format": "date-time"
     },
     "campaignId": {
       "description": "The unique identifier for the campaign associated with the email unsubscribe data.",
-      "type": ["null", "integer"]
+      "type": [
+        "null",
+        "integer"
+      ]
     },
     "itblInternal": {
       "description": "Internal properties specific to Iterable.",
-      "type": ["null", "object"],
+      "type": [
+        "null",
+        "object"
+      ],
       "properties": {
         "documentCreatedAt": {
           "description": "The timestamp indicating when the document was created within Iterable.",
-          "type": ["null", "string"],
+          "type": [
+            "null",
+            "string"
+          ],
           "format": "date-time"
         },
         "documentUpdatedAt": {
           "description": "The timestamp indicating when the document was last updated within Iterable.",
-          "type": ["null", "string"],
+          "type": [
+            "null",
+            "string"
+          ],
           "format": "date-time"
         }
       }
     },
     "emailListId": {
       "description": "The unique identifier for the email list associated with the email unsubscribe data.",
-      "type": ["null", "integer"]
+      "type": [
+        "null",
+        "integer"
+      ]
     },
     "emailListIds": {
       "description": "The list of unique identifiers for multiple email lists associated with the email unsubscribe data.",
-      "type": ["null", "array"],
-      "items": {}
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": "integer"
+      }
     },
     "workflowId": {
       "description": "The unique identifier for the workflow associated with the email unsubscribe data.",
-      "type": ["null", "integer"]
+      "type": [
+        "null",
+        "integer"
+      ]
     },
     "messageId": {
       "description": "The unique identifier for the message associated with the email unsubscribe data.",
-      "type": ["null", "string"]
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "templateId": {
       "description": "The unique identifier for the template associated with the email unsubscribe data.",
-      "type": ["null", "integer"]
+      "type": [
+        "null",
+        "integer"
+      ]
     },
     "channelIds": {
       "description": "The list of unique identifiers for multiple channels associated with the email unsubscribe data.",
-      "type": ["null", "array"],
-      "items": {}
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": "integer"
+      }
     },
     "email": {
       "description": "The email address for which the user unsubscribed.",
-      "type": ["null", "string"]
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "userId": {
       "description": "The unique identifier for the user who unsubscribed from the email list.",
-      "type": ["null", "string"]
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "channelId": {
       "description": "The unique identifier for the channel associated with the email unsubscribe data.",
-      "type": ["null", "integer"]
+      "type": [
+        "null",
+        "integer"
+      ]
     }
   },
-  "type": ["null", "object"]
+  "type": [
+    "null",
+    "object"
+  ]
 }

--- a/docs/integrations/sources/iterable.md
+++ b/docs/integrations/sources/iterable.md
@@ -83,6 +83,7 @@ The Iterable source connector supports the following [sync modes](https://docs.a
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                                                                    |
 |:--------|:-----------|:---------------------------------------------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 0.6.51 | 2025-10-10 | [67602](https://github.com/airbytehq/airbyte/pull/67602) | Fix array schema definitions |
 | 0.6.50 | 2025-10-07 | [67361](https://github.com/airbytehq/airbyte/pull/67361) | Update dependencies |
 | 0.6.49 | 2025-09-30 | [66798](https://github.com/airbytehq/airbyte/pull/66798) | Update dependencies |
 | 0.6.48 | 2025-09-09 | [66107](https://github.com/airbytehq/airbyte/pull/66107) | Update dependencies |


### PR DESCRIPTION
## What
Fixes array column serialization errors in source-iterable streams by properly defining array item types in JSONSchema definitions.

**Problem:** Array columns (e.g., `campaigns.labels`, `emailListIds`, `channelIds`, `categories`) were being written as null values to the S3 Data Lake destination with `DESTINATION_SERIALIZATION_ERROR` in the `_airbyte_meta` column.

**Root Cause:** Multiple stream schemas had array definitions with empty `items: {}`, which is ambiguous and prevents proper type mapping to destinations like Iceberg/Glue.

**Affected Streams:**
- `email_unsubscribe` (emailListIds, channelIds)
- `email_send` (categories)
- `email_send_skip` (categories)  
- `email_subscribe` (emailListIds)
- `campaigns` (listIds, suppressionListIds, labels)


## How
Updated JSONSchema definitions across affected stream schema files to specify explicit item types for all array fields:

**Before:**

```
"emailListIds": {
  "type": ["null", "array"],
  "items": {}  
}
```

After:

```
"emailListIds": {
  "type": ["null", "array"],
  "items": {
    "type": "integer" 
  }
}
```

## Review guide
source_iterable/schemas/campaigns.json - Check listIds, suppressionListIds, labels
source_iterable/schemas/email_unsubscribe.json - Check emailListIds, channelIds
source_iterable/schemas/email_send.json - Check categories (in transactional data)
source_iterable/schemas/email_send_skip.json - Check categories (in transactional data)
source_iterable/schemas/email_subscribe.json - Check emailListIds

Verify that all "items": {} instances have been replaced with proper type definitions.

## User Impact
None expected - this is a schema clarification that aligns with actual data types.

## Can this PR be safely reverted and rolled back?

- [X] YES 💚
- [ ] NO ❌
