### PR TITLE
feat: Support migration guides for enterprise connectors

### DIFF
--- a/docusaurus/sidebar-connectors.js
+++ b/docusaurus/sidebar-connectors.js
@@ -252,8 +252,11 @@ function getSourceConnectors(registry) {
     ["readme"],
   );
   const enterpriseSourcesWithSupportLevel = enterpriseSources
-    .filter((item) => item.id.includes("source"))
-    .map((item) => {
+  .filter((item) => {
+    const itemId = item.id || item.link?.id;
+    return itemId && itemId.includes("source");
+  })
+  .map((item) => {
       return {
         ...item,
         customProps: { ...item.customProps, supportLevel: "enterprise" },
@@ -343,8 +346,11 @@ function getDestinationConnectors(registry) {
     ["readme"],
   );
   const enterpriseDestinationsWithSupportLevel = enterpriseDestinations
-    .filter((item) => item.id.includes("destination"))
-    .map((item) => {
+  .filter((item) => {
+    const itemId = item.id || item.link?.id;
+    return itemId && itemId.includes("destination");
+  })
+  .map((item) => {
       return {
         ...item,
         customProps: {


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->

This PR adds support for migration guides on enterprise connectors.

<img width="1920" height="883" alt="image" src="https://github.com/user-attachments/assets/8a94d7a7-e390-4460-900c-bfaf000e6f0b" />

## How
<!--
* Describe how code changes achieve the solution.
-->

Updated filtering logic to support top-level `id` as well as nested `link.id`.

The existing filtering logic for enterprise connectors in the sidebar did not expect nested migration guides. The reason is because the getFilenamesInDir() function returns two different object structures.

Simple doc (no migration file): { type: "doc", id: "...", label: "..." } - has id at top level
Category with migration doc: { type: "category", label: "...", link: { id: "..." }, items: [...] } - has id nested in link.id

@darynaishchenko discovered during work on https://github.com/airbytehq/airbyte/pull/67214 that all builds failed when a migration guide was added to an enterprise connector.

## Review guide

1. Review the logic in the sidebar filtering code.
2. There is currently no migration guide in master to test this on, but I did test this fix with Darnya's PR and it built correctly with the updated code. You can simulate a migration guide by adding a dummy `<connector_filename>-migrations.md` doc for an enterprise connector. At build time it should nest appropriately under its parent object.

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

Enterprise customers can have migration guides too.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
