### PR TITLE
Remove incorrect validation from api_url setting in source-plausible

### DIFF
--- a/airbyte-integrations/connectors/source-plausible/manifest.yaml
+++ b/airbyte-integrations/connectors/source-plausible/manifest.yaml
@@ -179,7 +179,6 @@ spec:
         description: >-
           The API URL of your plausible instance.
           Change this if you self-host plausible. The default is https://plausible.io/api/v1/stats
-        pattern: ^[A-Za-z0-9-.]+\.[A-Z-a-z0-9-.]+
         examples:
           - https://plausible.example.com/api/v1/stats
         order: 2

--- a/airbyte-integrations/connectors/source-plausible/metadata.yaml
+++ b/airbyte-integrations/connectors/source-plausible/metadata.yaml
@@ -16,7 +16,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 603ba446-3d75-41d7-92f3-aba901f8b897
-  dockerImageTag: 0.2.14
+  dockerImageTag: 0.2.15
   dockerRepository: airbyte/source-plausible
   githubIssueLabel: source-plausible
   icon: plausible.svg


### PR DESCRIPTION
## What
Resolves https://github.com/airbytehq/airbyte/issues/67791 which prevents source-plausible from running

## How
Removes validation from the `api_url` setting. This seems to align with other sources in the repo where URLs are not validated.

## Can this PR be safely reverted and rolled back?
- [X] YES 💚
- [ ] NO ❌
