### PR TITLE
fix(source-google-ads): Fix schema loader for `custom_queries` streams 

### DIFF
--- a/airbyte-integrations/connectors/source-google-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-ads/metadata.yaml
@@ -11,7 +11,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 253487c0-2246-43ba-a21f-5116b20a2c50
-  dockerImageTag: "4.1.0-rc.6"
+  dockerImageTag: "4.1.0-rc.7"
   dockerRepository: airbyte/source-google-ads
   documentationUrl: https://docs.airbyte.com/integrations/sources/google-ads
   githubIssueLabel: source-google-ads

--- a/airbyte-integrations/connectors/source-google-ads/pyproject.toml
+++ b/airbyte-integrations/connectors/source-google-ads/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "4.1.0-rc.6"
+version = "4.1.0-rc.7"
 name = "source-google-ads"
 description = "Source implementation for Google Ads."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-google-ads/source_google_ads/components.py
+++ b/airbyte-integrations/connectors/source-google-ads/source_google_ads/components.py
@@ -6,9 +6,9 @@ import json
 import logging
 import re
 import threading
-from dataclasses import dataclass
+from dataclasses import InitVar, dataclass
 from itertools import groupby
-from typing import Any, Callable, Dict, Iterable, List, Mapping, MutableMapping, Optional, Tuple, Union
+from typing import Any, Callable, Dict, Generator, Iterable, List, Mapping, MutableMapping, Optional, Tuple, Union
 
 import anyascii
 import requests
@@ -25,6 +25,8 @@ from airbyte_cdk.sources.declarative.transformations import RecordTransformation
 from airbyte_cdk.sources.streams.concurrent.default_stream import DefaultStream
 from airbyte_cdk.sources.types import Config, Record, StreamSlice, StreamState
 from airbyte_cdk.sources.utils.transform import TransformConfig, TypeTransformer
+from airbyte_cdk.sources.declarative.decoders.decoder import Decoder
+
 
 from .google_ads import GoogleAds
 
@@ -284,6 +286,10 @@ class GoogleAdsHttpRequester(HttpRequester):
     """
 
     schema_loader: InlineSchemaLoader = None
+
+    def __post_init__(self, parameters: Mapping[str, Any]) -> None:
+        super().__post_init__(parameters)
+        self.stream_response = True
 
     def get_request_body_json(
         self,
@@ -889,3 +895,146 @@ class CustomGAQuerySchemaLoader(SchemaLoader):
                 internal_message=f"The provided query is invalid: {query}. Please refer to the Google Ads API documentation for the correct syntax: https://developers.google.com/google-ads/api/fields/v20/overview and test validate your query using the Google Ads Query Builder: https://developers.google.com/google-ads/api/fields/v20/query_validator",
                 message=f"The provided query is invalid: {query}. Please refer to the Google Ads API documentation for the correct syntax: https://developers.google.com/google-ads/api/fields/v20/overview and test validate your query using the Google Ads Query Builder: https://developers.google.com/google-ads/api/fields/v20/query_validator",
             )
+
+
+@dataclass
+class RowsStreamingDecoder(Decoder):
+    parameters: InitVar[Mapping[str, Any]]
+
+    def is_stream_response(self) -> bool:
+        return True
+
+    def decode(
+        self, response: requests.Response
+    ) -> Generator[MutableMapping[str, Any], None, None]:
+        for row in self._iter_rows_from_bytes(response.iter_content(chunk_size=128)):
+            yield {"results": [row]}
+
+    def _iter_rows_from_bytes(self, byte_iter: Iterable[bytes], encoding: str = "utf-8") -> Generator[Dict[str, Any], None, None]:
+        """
+        Incrementally scan the searchStream response and yield each object from the
+        top-level "results" array as soon as that object is complete, without waiting
+        for the enclosing message object to finish.
+
+        This is a character-level state machine:
+          - Handles split chunks and concatenated JSON objects
+          - Tracks strings/escapes so braces inside strings don't confuse depth
+          - Detects the `"results": [` array and streams its items one-by-one
+        """
+        # Global scanning state
+        depth = 0
+        in_str = False
+        esc = False
+
+        # Detect the "results" array
+        last_string = None  # last completed JSON string token
+        awaiting_results_array = False
+        results_array_depth = None  # the depth level of the '[' that starts the array
+
+        # Per-item buffering state
+        collecting_item = False
+        item_buf = []  # characters of the current item
+        item_depth = 0  # nesting within the item (starts at 1 when we see '{')
+
+        # Temp buffer for current string token
+        str_buf = []
+
+        def finish_item():
+            nonlocal item_buf, collecting_item, item_depth
+            obj_text = "".join(item_buf).strip()
+            item_buf = []
+            collecting_item = False
+            item_depth = 0
+            if obj_text:
+                return json.loads(obj_text)
+
+        for chunk in byte_iter:
+            text = chunk.decode(encoding, errors="replace")
+            for ch in text:
+
+                # Always feed characters to item buffer if we're inside an item
+                if collecting_item:
+                    item_buf.append(ch)
+
+                # --- String handling (so braces inside strings are ignored) ---
+                if in_str:
+                    if esc:
+                        esc = False
+                        continue
+                    if ch == "\\":
+                        esc = True
+                        continue
+                    if ch == '"':
+                        # string ended
+                        in_str = False
+                        last_string = "".join(str_buf)
+                        str_buf = []
+                    else:
+                        str_buf.append(ch)
+                    continue
+
+                if ch == '"':
+                    in_str = True
+                    str_buf = []
+                    # If we are collecting an item, we already appended the quote to item_buf above
+                    continue
+
+                # --- Structural characters outside strings ---
+                if ch in "{[":
+                    depth += 1
+
+                    # Detect the start of the "results" array: we just saw '[' after key "results": ...
+                    if ch == "[" and awaiting_results_array and results_array_depth is None:
+                        results_array_depth = depth  # this '[' depth
+                        awaiting_results_array = False
+
+                    # Detect the start of an item object directly inside "results"
+                    if (
+                            ch == "{"
+                            and results_array_depth is not None
+                            and not collecting_item
+                            and depth == results_array_depth + 1
+                    ):
+                        collecting_item = True
+                        item_buf = ["{"]  # start buffer anew
+                        item_depth = 1
+                    elif collecting_item and ch in "{[":
+                        # Nested structure inside item
+                        item_depth += 1
+
+                    continue
+
+                if ch in "}]":
+                    # If we're collecting an item, adjust its own nesting counter
+                    if collecting_item:
+                        item_depth -= 1
+                        if item_depth == 0:
+                            # Item just finished -> emit it immediately
+                            item = finish_item()
+                            if item is not None:
+                                yield item
+                            # Note: we do NOT 'continue' here; we still need to update global depth below
+
+                    depth -= 1
+
+                    # If we closed the results array, reset array tracking
+                    if (
+                            ch == "]"
+                            and results_array_depth is not None
+                            and depth < results_array_depth
+                    ):
+                        results_array_depth = None
+                    continue
+
+                # Detect `"results":` key just seen (outside strings)
+                if ch == ":" and last_string == "results" and results_array_depth is None:
+                    awaiting_results_array = True
+
+                # Commas/whitespace are irrelevant; any other chars just pass through
+
+        # End of stream: if we somehow have a finished item without seeing the closing bracket
+        # (rare, but be defensive), try to flush.
+        if collecting_item and item_depth == 0:
+            item = finish_item()
+            if item is not None:
+                yield item

--- a/airbyte-integrations/connectors/source-google-ads/source_google_ads/manifest.yaml
+++ b/airbyte-integrations/connectors/source-google-ads/source_google_ads/manifest.yaml
@@ -56,7 +56,7 @@ definitions:
         action: IGNORE
         http_codes:
           - 403
-#        error_message_contains: "The customer account can\\'t be accessed because it is not yet enabled or has been deactivated."
+  #        error_message_contains: "The customer account can\\'t be accessed because it is not yet enabled or has been deactivated."
 
   base_selector:
     type: RecordSelector

--- a/airbyte-integrations/connectors/source-google-ads/source_google_ads/manifest.yaml
+++ b/airbyte-integrations/connectors/source-google-ads/source_google_ads/manifest.yaml
@@ -401,7 +401,7 @@ definitions:
         class_name: "source_google_ads.components.CustomGAQueryHttpRequester"
         authenticator:
           $ref: "#/definitions/authenticator"
-        url_base: "https://googleads.googleapis.com/v20/{{ stream_partition['customer_id'] }}/googleAds:search"
+        url_base: "https://googleads.googleapis.com/v20/{{ stream_partition['customer_id'] }}/googleAds:searchStream"
         http_method: POST
         error_handler:
           $ref: "#/definitions/base_error_handler"
@@ -420,8 +420,11 @@ definitions:
             parent_key: "clientCustomer"
             partition_field: "customer_id"
             stream: "#/definitions/customer_client"
+      decoder:
+        type: CustomDecoder
+        class_name: "source_google_ads.components.GoogleAdsStreamingDecoder"
       paginator:
-        $ref: "#/definitions/cursor_paginator"
+        type: NoPagination
     transformations:
       - type: CustomTransformation
         class_name: "source_google_ads.components.KeysToSnakeCaseGoogleAdsTransformation"
@@ -488,7 +491,7 @@ definitions:
         type: NoPagination
       decoder:
         type: CustomDecoder
-        class_name: "source_google_ads.components.RowsStreamingDecoder"
+        class_name: "source_google_ads.components.GoogleAdsStreamingDecoder"
     name: ad_group_ad
     primary_key:
       - ad_group.id

--- a/airbyte-integrations/connectors/source-google-ads/source_google_ads/manifest.yaml
+++ b/airbyte-integrations/connectors/source-google-ads/source_google_ads/manifest.yaml
@@ -38,7 +38,7 @@ definitions:
         $ref: "#/schemas"
     authenticator:
       $ref: "#/definitions/authenticator"
-    url_base: "https://googleads.googleapis.com/v20/{{ stream_partition['customer_id'] }}/googleAds:search"
+    url_base: "https://googleads.googleapis.com/v20/{{ stream_partition['customer_id'] }}/googleAds:searchStream"
     http_method: POST
     error_handler:
       $ref: "#/definitions/base_error_handler"
@@ -56,7 +56,7 @@ definitions:
         action: IGNORE
         http_codes:
           - 403
-        error_message_contains: "The customer account can\\'t be accessed because it is not yet enabled or has been deactivated."
+#        error_message_contains: "The customer account can\\'t be accessed because it is not yet enabled or has been deactivated."
 
   base_selector:
     type: RecordSelector
@@ -482,6 +482,13 @@ definitions:
 
   ad_group_ad_stream:
     $ref: "#/definitions/incremental_stream_base"
+    retriever:
+      $ref: "#/definitions/incremental_stream_base/retriever"
+      paginator:
+        type: NoPagination
+      decoder:
+        type: CustomDecoder
+        class_name: "source_google_ads.components.RowsStreamingDecoder"
     name: ad_group_ad
     primary_key:
       - ad_group.id

--- a/airbyte-integrations/connectors/source-google-ads/source_google_ads/manifest.yaml
+++ b/airbyte-integrations/connectors/source-google-ads/source_google_ads/manifest.yaml
@@ -5,7 +5,7 @@ type: DeclarativeSource
 check:
   type: CheckStream
   stream_names:
-    - campaign
+    - customer
 
 definitions:
   # Authenticator Definitions

--- a/airbyte-integrations/connectors/source-google-ads/unit_tests/conftest.py
+++ b/airbyte-integrations/connectors/source-google-ads/unit_tests/conftest.py
@@ -134,3 +134,8 @@ def additional_customers(config, customers):
 @pytest.fixture
 def customers_manager(config):
     return [CustomerModel(id=_id, time_zone="local", is_manager_account=True) for _id in config["customer_id"].split(",")]
+
+
+class Obj:
+    def __init__(self, **entries):
+        self.__dict__.update(entries)

--- a/airbyte-integrations/connectors/source-google-ads/unit_tests/test_components.py
+++ b/airbyte-integrations/connectors/source-google-ads/unit_tests/test_components.py
@@ -3,9 +3,12 @@
 #
 
 from unittest.mock import MagicMock, Mock
+import json
+from dataclasses import dataclass
+from typing import List
 
-import pytest
-from source_google_ads.components import ClickViewHttpRequester, CustomGAQueryHttpRequester, CustomGAQuerySchemaLoader
+
+from source_google_ads.components import ClickViewHttpRequester, CustomGAQueryHttpRequester, CustomGAQuerySchemaLoader, RowsStreamingDecoder
 
 from airbyte_cdk import AirbyteTracedException
 from airbyte_cdk.sources.declarative.schema import InlineSchemaLoader
@@ -173,3 +176,207 @@ class TestClickViewHttpRequester:
         assert request_body == {
             "query": "SELECT ad_group.name, click_view.gclid, click_view.ad_group_ad, segments.date FROM click_view WHERE segments.date = '2025-07-18'"
         }
+
+
+class TestRowsStreamingDecoder:
+    @dataclass
+    class _FakeResponse:
+        chunks: List[bytes]
+        status: int = 200
+
+        def iter_content(self, chunk_size=1):
+            # Ignore chunk_size; we already control chunking via self.chunks
+            for c in self.chunks:
+                yield c
+
+        def raise_for_status(self):
+            if self.status >= 400:
+                raise Exception(f"HTTP {self.status}")
+
+    @staticmethod
+    def _decode_all(decoder: RowsStreamingDecoder, resp: "_FakeResponse"):
+        return list(decoder.decode(resp))
+
+    # --- Tests ---------------------------------------------------------------
+
+    def test_is_stream_response_true(self):
+        d = RowsStreamingDecoder(parameters={})
+        assert d.is_stream_response() is True
+
+    def test_emits_each_row_from_single_message(self):
+        """One server message with two results; delivered as a single chunk."""
+        msg = {
+            "results": [
+                {"campaign": {"id": "1", "name": "A"}},
+                {"campaign": {"id": "2", "name": "B"}},
+            ],
+            "fieldMask": "campaign.id,campaign.name",
+        }
+        raw = json.dumps(msg).encode("utf-8")
+        print(raw)
+
+        resp = self._FakeResponse(chunks=[raw])
+        d = RowsStreamingDecoder(parameters={})
+
+        out = self._decode_all(d, resp)
+        assert out == [
+            {"results": [msg["results"][0]]},
+            {"results": [msg["results"][1]]},
+        ]
+
+    def test_handles_chunk_boundaries_inside_item_and_between_objects(self):
+        """The object is split across arbitrary byte boundaries, including within strings."""
+        msg = {
+            "results": [
+                {"segments": {"date": "2025-10-01"}, "metrics": {"clicks": 1}},
+                {"segments": {"date": "2025-10-02"}, "metrics": {"clicks": 2}},
+            ]
+        }
+        s = json.dumps(msg)
+
+        # Split deliberately in awkward places (inside keys/values)
+        chunks = [
+            s[:23].encode(),   # '{"results": [{"segments":'
+            s[23:40].encode(), # ' {"date": "2025-10-01"'
+            s[40:63].encode(), # '}, "metrics": {"clicks": '
+            s[63:65].encode(), # '1'
+            s[65:88].encode(), # '}}, {"segments": {"date"'
+            s[88:110].encode(),# ': "2025-10-02"}, "metric'
+            s[110:].encode(),  # 's": {"clicks": 2}}]}'
+        ]
+
+        resp = self._FakeResponse(chunks=chunks)
+        d = RowsStreamingDecoder(parameters={})
+
+        out = self._decode_all(d, resp)
+        assert out == [
+            {"results": [msg["results"][0]]},
+            {"results": [msg["results"][1]]},
+        ]
+
+    def test_concatenated_messages_without_newlines(self):
+        """Two top-level server messages concatenated back-to-back."""
+        msg1 = {"results": [{"x": 1}]}
+        msg2 = {"results": [{"x": 2}, {"x": 3}]}
+        raw = (json.dumps(msg1) + json.dumps(msg2)).encode("utf-8")
+
+        resp = self._FakeResponse(chunks=[raw])
+        d = RowsStreamingDecoder(parameters={})
+
+        out = self._decode_all(d, resp)
+        assert out == [
+            {"results": [msg1["results"][0]]},
+            {"results": [msg2["results"][0]]},
+            {"results": [msg2["results"][1]]},
+        ]
+
+    def test_braces_inside_strings_do_not_confuse_depth(self):
+        """Braces and brackets inside string values must not break item boundary tracking."""
+        tricky_text = 'note: has braces { like this } and [also arrays]'
+        msg = {
+            "results": [
+                {"ad": {"id": "42"}, "desc": tricky_text},
+                {"ad": {"id": "43"}, "desc": tricky_text},
+            ],
+            "fieldMask": "ad.id,desc",
+        }
+        raw = json.dumps(msg).encode("utf-8")
+
+        # Split to ensure the string spans chunks
+        resp = self._FakeResponse(chunks=[raw[:40], raw[40:120], raw[120:]])
+        d = RowsStreamingDecoder(parameters={})
+
+        out = self._decode_all(d, resp)
+        assert out == [
+            {"results": [msg["results"][0]]},
+            {"results": [msg["results"][1]]},
+        ]
+
+    def test_nested_objects_and_arrays_within_row(self):
+        """A row containing nested dicts and arrays; ensures per-item depth is tracked correctly."""
+        row = {
+            "campaign": {"id": "9", "labels": [{"id": 1}, {"id": 2}]},
+            "metrics": {"conversions": [0.1, 0.2, 0.3]},
+        }
+        msg = {"results": [row]}
+        raw = json.dumps(msg).encode("utf-8")
+
+        # Split across array/object boundaries
+        resp = self._FakeResponse(chunks=[raw[:15], raw[15:35], raw[35:60], raw[60:]])
+        d = RowsStreamingDecoder(parameters={})
+
+        out = self._decode_all(d, resp)
+        assert out == [{"results": [row]}]
+
+    def test_empty_results_array_yields_nothing(self):
+        msg = {"results": []}
+        raw = json.dumps(msg).encode("utf-8")
+
+        resp = self._FakeResponse(chunks=[raw])
+        d = RowsStreamingDecoder(parameters={})
+
+        out = self._decode_all(d, resp)
+        assert out == []
+
+    def test_ignores_messages_without_results_key(self):
+        msg = {"fieldMask": "whatever", "requestId": "abc"}
+        raw = json.dumps(msg).encode("utf-8")
+
+        resp = self._FakeResponse(chunks=[raw])
+        d = RowsStreamingDecoder(parameters={})
+
+        out = self._decode_all(d, resp)
+        assert out == []
+
+    def test_multiple_messages_mixed_empty_and_nonempty(self):
+        m1 = {"results": [{"a": 1}]}
+        m2 = {"results": []}
+        m3 = {"results": [{"a": 2}, {"a": 3}]}
+        raw = (json.dumps(m1) + json.dumps(m2) + json.dumps(m3)).encode("utf-8")
+
+        # Force a few smaller chunks
+        resp = self._FakeResponse(chunks=[raw[:20], raw[20:55], raw[55:]])
+        d = RowsStreamingDecoder(parameters={})
+
+        out = self._decode_all(d, resp)
+        assert out == [
+            {"results": [m1["results"][0]]},
+            {"results": [m3["results"][0]]},
+            {"results": [m3["results"][1]]},
+        ]
+
+    def test_brackets_inside_strings_are_ignored_for_item_boundaries(self):
+        """
+        Ensure [square] and {curly} brackets that appear inside quoted strings
+        do NOT affect depth tracking and that rows are emitted correctly.
+        Also covers escaped quotes and backslashes inside the same strings,
+        with splits across chunk boundaries.
+        """
+        tricky1 = r'line with [brackets] and {braces} and escaped quote \" and backslash \\'
+        tricky2 = r'second line with [more] {stuff} \" \\ and , commas'
+
+        msg = {
+            "results": [
+                {"ad": {"id": "101"}, "text": tricky1},
+                {"ad": {"id": "102"}, "text": tricky2},
+            ],
+            "fieldMask": "ad.id,text",
+        }
+        raw = json.dumps(msg).encode("utf-8")
+
+        # Split deliberately so the tricky strings are cut across chunk boundaries
+        splits = [35, 70, 105, 160, 220, len(raw)]
+        chunks = []
+        start = 0
+        for end in splits:
+            chunks.append(raw[start:end])
+            start = end
+
+        resp = self._FakeResponse(chunks=chunks)
+        d = RowsStreamingDecoder(parameters={})
+
+        out = self._decode_all(d, resp)
+        assert out == [
+            {"results": [msg["results"][0]]},
+            {"results": [msg["results"][1]]},
+        ]

--- a/airbyte-integrations/connectors/source-google-ads/unit_tests/test_components.py
+++ b/airbyte-integrations/connectors/source-google-ads/unit_tests/test_components.py
@@ -2,11 +2,10 @@
 # Copyright (c) 2025 Airbyte, Inc., all rights reserved.
 #
 
-from unittest.mock import MagicMock, Mock
 import json
 from dataclasses import dataclass
 from typing import List
-
+from unittest.mock import MagicMock, Mock
 
 from source_google_ads.components import ClickViewHttpRequester, CustomGAQueryHttpRequester, CustomGAQuerySchemaLoader, RowsStreamingDecoder
 
@@ -197,8 +196,6 @@ class TestRowsStreamingDecoder:
     def _decode_all(decoder: RowsStreamingDecoder, resp: "_FakeResponse"):
         return list(decoder.decode(resp))
 
-    # --- Tests ---------------------------------------------------------------
-
     def test_is_stream_response_true(self):
         d = RowsStreamingDecoder(parameters={})
         assert d.is_stream_response() is True
@@ -213,7 +210,6 @@ class TestRowsStreamingDecoder:
             "fieldMask": "campaign.id,campaign.name",
         }
         raw = json.dumps(msg).encode("utf-8")
-        print(raw)
 
         resp = self._FakeResponse(chunks=[raw])
         d = RowsStreamingDecoder(parameters={})
@@ -236,12 +232,12 @@ class TestRowsStreamingDecoder:
 
         # Split deliberately in awkward places (inside keys/values)
         chunks = [
-            s[:23].encode(),   # '{"results": [{"segments":'
-            s[23:40].encode(), # ' {"date": "2025-10-01"'
-            s[40:63].encode(), # '}, "metrics": {"clicks": '
-            s[63:65].encode(), # '1'
-            s[65:88].encode(), # '}}, {"segments": {"date"'
-            s[88:110].encode(),# ': "2025-10-02"}, "metric'
+            s[:23].encode(),  # '{"results": [{"segments":'
+            s[23:40].encode(),  # ' {"date": "2025-10-01"'
+            s[40:63].encode(),  # '}, "metrics": {"clicks": '
+            s[63:65].encode(),  # '1'
+            s[65:88].encode(),  # '}}, {"segments": {"date"'
+            s[88:110].encode(),  # ': "2025-10-02"}, "metric'
             s[110:].encode(),  # 's": {"clicks": 2}}]}'
         ]
 
@@ -272,7 +268,7 @@ class TestRowsStreamingDecoder:
 
     def test_braces_inside_strings_do_not_confuse_depth(self):
         """Braces and brackets inside string values must not break item boundary tracking."""
-        tricky_text = 'note: has braces { like this } and [also arrays]'
+        tricky_text = "note: has braces { like this } and [also arrays]"
         msg = {
             "results": [
                 {"ad": {"id": "42"}, "desc": tricky_text},
@@ -352,8 +348,8 @@ class TestRowsStreamingDecoder:
         Also covers escaped quotes and backslashes inside the same strings,
         with splits across chunk boundaries.
         """
-        tricky1 = r'line with [brackets] and {braces} and escaped quote \" and backslash \\'
-        tricky2 = r'second line with [more] {stuff} \" \\ and , commas'
+        tricky1 = r"line with [brackets] and {braces} and escaped quote \" and backslash \\"
+        tricky2 = r"second line with closing brackets ]} \} \] \" \\ and , commas"
 
         msg = {
             "results": [

--- a/airbyte-integrations/connectors/source-google-ads/unit_tests/test_empty_streams.py
+++ b/airbyte-integrations/connectors/source-google-ads/unit_tests/test_empty_streams.py
@@ -72,7 +72,7 @@ def test_query_shopping_performance_view_stream(customers, config, requests_mock
 
     request_history = requests_mock.register_uri(
         "POST",
-        "https://googleads.googleapis.com/v20/customers/123/googleAds:search",
+        "https://googleads.googleapis.com/v20/customers/123/googleAds:searchStream",
         shopping_performance_view_response,
     )
 
@@ -209,7 +209,7 @@ def test_custom_query_stream(customers, config_for_custom_query_tests, requests_
 
     request_history = requests_mock.register_uri(
         "POST",
-        "https://googleads.googleapis.com/v20/customers/123/googleAds:search",
+        "https://googleads.googleapis.com/v20/customers/123/googleAds:searchStream",
         custom_query_response,
     )
 

--- a/airbyte-integrations/connectors/source-google-ads/unit_tests/test_empty_streams.py
+++ b/airbyte-integrations/connectors/source-google-ads/unit_tests/test_empty_streams.py
@@ -1,16 +1,15 @@
 # Copyright (c) 2023 Airbyte, Inc., all rights reserved.
 
 import json
-from unittest.mock import patch
+from unittest.mock import MagicMock
 
 import pytest
 from source_google_ads.components import GAQL
 from source_google_ads.source import SourceGoogleAds
 
-from .conftest import find_stream, get_source, read_full_refresh
+from .conftest import Obj, find_stream, get_source, read_full_refresh
 
 
-@patch.object(SourceGoogleAds, "get_customers", return_value=[])
 def test_query_shopping_performance_view_stream(customers, config, requests_mock):
     config["end_date"] = "2021-01-10"
     config["conversion_window_days"] = 3
@@ -108,8 +107,7 @@ def test_query_shopping_performance_view_stream(customers, config, requests_mock
     assert request_json["query"] == expected_query
 
 
-@patch.object(SourceGoogleAds, "get_customers", return_value=[])
-def test_custom_query_stream(customers, config_for_custom_query_tests, requests_mock):
+def test_custom_query_stream(customers, config_for_custom_query_tests, requests_mock, mocker):
     config_for_custom_query_tests["end_date"] = "2021-01-10"
     config_for_custom_query_tests["conversion_window_days"] = 1
     config_for_custom_query_tests["credentials"]["access_token"] = "access_token"
@@ -170,63 +168,38 @@ def test_custom_query_stream(customers, config_for_custom_query_tests, requests_
 
     # Register mocks
     requests_mock.register_uri("POST", "https://www.googleapis.com/oauth2/v3/token", access_token_response)
-    requests_mock.get(
-        "https://googleads.googleapis.com/v20/googleAdsFields/campaign_budget.name",
-        json={
-            "resourceName": "googleAdsFields/campaign_budget.name",
-            "category": "ATTRIBUTE",
-            "dataType": "STRING",
-            "name": "campaign_budget.name",
-            "selectable": True,
-            "filterable": True,
-            "sortable": True,
-            "typeUrl": "",
-            "isRepeated": False,
-        },
+
+    query_object = MagicMock(
+        return_value={
+            "campaign_budget.name": Obj(data_type=Obj(name="STRING"), is_repeated=False),
+            "campaign.name": Obj(data_type=Obj(name="STRING"), is_repeated=False),
+            "metrics.interaction_event_types": Obj(
+                data_type=Obj(name="ENUM"),
+                is_repeated=True,
+                enum_values=["UNSPECIFIED", "UNKNOWN", "CLICK", "ENGAGEMENT", "VIDEO_VIEW", "NONE"],
+            ),
+            "segments.date": Obj(data_type=Obj(name="DATE"), is_repeated=False),
+        }
     )
-    requests_mock.get(
-        "https://googleads.googleapis.com/v20/googleAdsFields/campaign.name",
-        json={
-            "resourceName": "googleAdsFields/campaign.name",
-            "category": "ATTRIBUTE",
-            "dataType": "STRING",
-            "name": "campaign.name",
-            "selectable": True,
-            "filterable": True,
-            "sortable": True,
-            "typeUrl": "",
-            "isRepeated": False,
-        },
+    mocker.patch(
+        "source_google_ads.components.CustomGAQuerySchemaLoader.google_ads_client", return_value=Obj(get_fields_metadata=query_object)
     )
-    requests_mock.get(
-        "https://googleads.googleapis.com/v20/googleAdsFields/metrics.interaction_event_types",
-        json={
-            "resourceName": "googleAdsFields/metrics.interaction_event_types",
-            "category": "METRIC",
-            "dataType": "ENUM",
-            "name": "metrics.interaction_event_types",
-            "selectable": True,
-            "filterable": True,
-            "sortable": False,
-            "enumValues": ["UNSPECIFIED", "UNKNOWN", "CLICK", "ENGAGEMENT", "VIDEO_VIEW", "NONE"],
-            "typeUrl": "google.ads.googleads.v20.enums.InteractionEventTypeEnum.InteractionEventType",
-            "isRepeated": True,
+
+    assert stream.get_json_schema() == {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+            "campaign_budget.name": {"type": ["string", "null"]},
+            "campaign.name": {"type": ["string", "null"]},
+            "metrics.interaction_event_types": {
+                "type": ["null", "array"],
+                "items": {"type": "string", "enum": ["UNSPECIFIED", "UNKNOWN", "CLICK", "ENGAGEMENT", "VIDEO_VIEW", "NONE"]},
+            },
+            "segments.date": {"type": ["string", "null"], "format": "date"},
         },
-    )
-    requests_mock.get(
-        "https://googleads.googleapis.com/v20/googleAdsFields/segments.date",
-        json={
-            "resourceName": "googleAdsFields/segments.date",
-            "category": "SEGMENT",
-            "dataType": "DATE",
-            "name": "segments.date",
-            "selectable": True,
-            "filterable": True,
-            "sortable": True,
-            "typeUrl": "",
-            "isRepeated": False,
-        },
-    )
+        "additionalProperties": True,
+    }
+
     requests_mock.register_uri(
         "GET", "https://googleads.googleapis.com/v20/customers:listAccessibleCustomers", accessible_customers_response
     )
@@ -289,58 +262,8 @@ def test_custom_query_stream_with_different_queries(query, expected_incremental_
     config = config_for_custom_query_tests
     config["custom_queries_array"][0]["query"] = query
 
-    requests_mock.register_uri("POST", "https://googleads.googleapis.com/v20/customers/123/googleAds:search", json={})
-
     streams = get_source(config=config).streams(config=config)
     stream = next(filter(lambda s: s.name == "custom_ga_query", streams))
-
-    access_token_response = [{"json": {"access_token": "access_token"}, "status_code": 200}]
-
-    accessible_customers_response = [
-        {
-            "json": {"resourceNames": ["customers/1234567890"]},
-            "status_code": 200,
-        }
-    ]
-
-    customers_response = [
-        {
-            "json": {
-                "results": [
-                    {
-                        "customerClient": {
-                            "clientCustomer": "customers/123",
-                            "manager": False,
-                            "status": "ENABLED",
-                            "id": "123",
-                        }
-                    }
-                ]
-            },
-            "status_code": 200,
-        }
-    ]
-
-    for field in GAQL.parse(query).fields:
-        requests_mock.get(
-            f"https://googleads.googleapis.com/v20/googleAdsFields/{field}",
-            json={
-                "resourceName": f"googleAdsFields/{field}",
-                "category": "ATTRIBUTE",
-                "dataType": "STRING",
-                "name": field,
-                "selectable": True,
-                "isRepeated": False,
-            },
-        )
-
-    requests_mock.register_uri("POST", "https://www.googleapis.com/oauth2/v3/token", access_token_response)
-    requests_mock.register_uri(
-        "GET", "https://googleads.googleapis.com/v20/customers:listAccessibleCustomers", accessible_customers_response
-    )
-    requests_mock.register_uri(
-        "POST", "https://googleads.googleapis.com/v20/customers/1234567890/googleAds:searchStream", customers_response
-    )
 
     # Verify that the regex matching in the manifest correctly applies incremental sync
     # by checking the stream_cursor_field which is set by the ComponentMappingDefinition

--- a/airbyte-integrations/connectors/source-google-ads/unit_tests/test_streams.py
+++ b/airbyte-integrations/connectors/source-google-ads/unit_tests/test_streams.py
@@ -116,7 +116,6 @@ class MockGoogleAdsFailsOneDate(MockGoogleAds):
         return mock_response_fails_one_date()
 
 
-@patch.object(SourceGoogleAds, "get_customers", return_value=[])
 def test_read_records_unauthenticated(mocker, customers, config):
     credentials = config["credentials"]
     api = GoogleAds(credentials=credentials)

--- a/docs/integrations/sources/google-ads.md
+++ b/docs/integrations/sources/google-ads.md
@@ -335,16 +335,17 @@ Due to a limitation in the Google Ads API which does not allow getting performan
 
 | Version     | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |:------------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 4.1.0-rc.6 | 2025-09-25 | [66701](https://github.com/airbytehq/airbyte/pull/66701) | Enables progressive rollouts |
-| 4.1.0-rc.5 | 2025-09-25 | [66569](https://github.com/airbytehq/airbyte/pull/66569) | Bumps to CDK v7, adds retry/backoff logic to custom schema loader |
-| 4.1.0-rc.4 | 2025-09-18 | [66522](https://github.com/airbytehq/airbyte/pull/66522) | Revert to CDK v6.60.12 |
-| 4.1.0-rc.3 | 2025-09-17 | [65535](https://github.com/airbytehq/airbyte/pull/65535) | Update custom query dynamic streams to use regex for conditional incremental sync component mapping |
-| 4.1.0-rc.2 | 2025-08-22 | [65149](https://github.com/airbytehq/airbyte/pull/65149) | Update custom query URL to use Google Ads API v20 |
-| 4.1.0-rc.1 | 2025-08-19 | [63344](https://github.com/airbytehq/airbyte/pull/63344) | Migrate `custom_queries` streams to low-code           |
-| 4.0.2 | 2025-08-16 | [64987](https://github.com/airbytehq/airbyte/pull/64987) | Update dependencies |
-| 4.0.1 | 2025-08-09 | [64612](https://github.com/airbytehq/airbyte/pull/64612) | Update dependencies |
-| 4.0.0 | 2025-08-06 | [64512](https://github.com/airbytehq/airbyte/pull/64512) | Update API version to v20 |
-| 3.15.0 | 2025-08-04 | [64495](https://github.com/airbytehq/airbyte/pull/64495) | Promoting release candidate 3.15.0-rc.1 to a main version. |
+| 4.1.0-rc.7  | 2025-10-16 | [68030](https://github.com/airbytehq/airbyte/pull/68030) | Fix schema loader for `custom_queries` streams                                                                                                                         |
+| 4.1.0-rc.6  | 2025-09-25 | [66701](https://github.com/airbytehq/airbyte/pull/66701) | Enables progressive rollouts                                                                                                                                           |
+| 4.1.0-rc.5  | 2025-09-25 | [66569](https://github.com/airbytehq/airbyte/pull/66569) | Bumps to CDK v7, adds retry/backoff logic to custom schema loader                                                                                                      |
+| 4.1.0-rc.4  | 2025-09-18 | [66522](https://github.com/airbytehq/airbyte/pull/66522) | Revert to CDK v6.60.12                                                                                                                                                 |
+| 4.1.0-rc.3  | 2025-09-17 | [65535](https://github.com/airbytehq/airbyte/pull/65535) | Update custom query dynamic streams to use regex for conditional incremental sync component mapping                                                                    |
+| 4.1.0-rc.2  | 2025-08-22 | [65149](https://github.com/airbytehq/airbyte/pull/65149) | Update custom query URL to use Google Ads API v20                                                                                                                      |
+| 4.1.0-rc.1  | 2025-08-19 | [63344](https://github.com/airbytehq/airbyte/pull/63344) | Migrate `custom_queries` streams to low-code                                                                                                                           |
+| 4.0.2       | 2025-08-16 | [64987](https://github.com/airbytehq/airbyte/pull/64987) | Update dependencies                                                                                                                                                    |
+| 4.0.1       | 2025-08-09 | [64612](https://github.com/airbytehq/airbyte/pull/64612) | Update dependencies                                                                                                                                                    |
+| 4.0.0       | 2025-08-06 | [64512](https://github.com/airbytehq/airbyte/pull/64512) | Update API version to v20                                                                                                                                              |
+| 3.15.0      | 2025-08-04 | [64495](https://github.com/airbytehq/airbyte/pull/64495) | Promoting release candidate 3.15.0-rc.1 to a main version.                                                                                                             |
 | 3.15.0-rc.1 | 2025-07-20 | [64124](https://github.com/airbytehq/airbyte/pull/64124) | Switch all streams to paginated endpoints for improved reliability                                                                                                     |
 | 3.14.2      | 2025-07-28 | [63753](https://github.com/airbytehq/airbyte/pull/63753) | Switching `click_view` to paginated endpoint for improved reliability                                                                                                  |
 | 3.14.1      | 2025-07-26 | [61472](https://github.com/airbytehq/airbyte/pull/61472) | Update dependencies                                                                                                                                                    |


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->
Fix several issues related to custom query support and memory performance:

- Refactor schema loading for custom queries to avoid low REST rate limits
- Switch the check stream from `campaign` to `customer` to reduce memory usage in Cloud environments
- Change endpoint for all streams from `search` to `searchStream`
- Add a streaming decoder to process `searchStream` responses incrementally, preventing large in-memory buffers

These improvements collectively reduce memory spikes during syncs and avoid hitting API rate limits on field metadata retrieval. Resolves: https://github.com/airbytehq/oncall/issues/9105

## How
<!--
* Describe how code changes achieve the solution.
-->

- Refactored the schema loader for custom queries to use the official google-ads Python client instead of the REST metadata endpoint, avoiding its very low global rate limit (1,000 requests per app across all users)
- Updated the check stream to `customer`, which returns minimal rows while still validating API access and reducing memory pressure in Cloud environment
- Introduced a character-level streaming decoder that yields rows as soon as they are parsed from `searchStream`, significantly lowering peak memory usage for large streams

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
