### PR TITLE
Bulk CDK: better test retry config

### DIFF
--- a/buildSrc/src/main/groovy/airbyte-bulk-connector.gradle
+++ b/buildSrc/src/main/groovy/airbyte-bulk-connector.gradle
@@ -239,6 +239,16 @@ class AirbyteBulkConnectorPlugin implements Plugin<Project> {
                     // If a test fails, but succeeds on retry - don't fail the task
                     failOnPassedAfterRetry = false
                 }
+                reports {
+                    junitXml {
+                        // Without this flag, the generated test report will list each test attempt.
+                        // This would cause Github to see the report as containing "failed tests,"
+                        // even though the test eventually succeeded.
+                        // So we tell gradle to merge those attempts together, which should tell Github
+                        // to view the overall run as successful.
+                        mergeReruns = true
+                    }
+                }
 
                 // Always re-run integration tests no matter what.
                 outputs.upToDateWhen { false }


### PR DESCRIPTION
## What
Correctly ignore previous failed test attempts if we eventually succeeded. See e.g. https://github.com/airbytehq/airbyte/runs/52648135211 for an example incorrect failure - the test ran twice and succeeded on the second attempt, but the overall PR check was still marked as failed.

## How
Enable the flag to tell gradle to do a smarter thing.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
