### PR TITLE
not for merge: replacing check w/ an automatic success

### DIFF
--- a/airbyte-integrations/connectors/source-sftp-bulk/source_sftp_bulk/source.py
+++ b/airbyte-integrations/connectors/source-sftp-bulk/source_sftp_bulk/source.py
@@ -26,3 +26,13 @@ class SourceSFTPBulk(FileBasedSource):
             state=state,
             cursor_cls=DefaultFileBasedCursor,
         )
+
+    def check_connection(self, logger: logging.Logger, config: Mapping[str, Any]) -> tuple[bool, Optional[Any]]:
+        """
+        WARNING: This is a temporary workaround where we effectively skip the check operation because the memory
+        of the footprint for very large file stores.
+        :param logger:
+        :param config:
+        :return:
+        """
+        return True, None


### PR DESCRIPTION
DO NOT MERGE.

This is a temporary workaround to effectively skip the check for `source-sftp-bulk` sources whose file extract is too memory intensive to do on a container w/ less memory provisioned