### PR TITLE
chore: Allow for setting control version on github action

### DIFF
--- a/.github/workflows/regression_tests.yml
+++ b/.github/workflows/regression_tests.yml
@@ -138,8 +138,8 @@ jobs:
       - name: Setup Control Version
         if: github.event_name == 'workflow_dispatch'
         run: |
-          if ${{ github.event.inputs.control_version }}; then
-            echo "CONTROL_VERSION=--connector_live_tests.control_version=${{ github.event.inputs.control_version }}" >> $GITHUB_ENV
+          if [ -n "${{ github.event.inputs.control_version }}" ]; then
+            echo "CONTROL_VERSION=--connector_live_tests.control-version=${{ github.event.inputs.control_version }}" >> $GITHUB_ENV
           else
             echo "CONTROL_VERSION=" >> $GITHUB_ENV
           fi

--- a/.github/workflows/regression_tests.yml
+++ b/.github/workflows/regression_tests.yml
@@ -46,6 +46,10 @@ on:
         options:
           - sandboxes
           - all
+      control_version:
+        description: The version to use as a control version. This is useful when the version defined in the cloud registry does not have a lot of usage (either because a progressive rollout is underway or because a new version has just been released).
+        required: false
+        type: string
 
 jobs:
   regression_tests:
@@ -131,6 +135,15 @@ jobs:
         run: |
           echo "CONNECTION_SUBSET=--connector_live_tests.connection-subset=${{ github.event.inputs.connection_subset }}" >> $GITHUB_ENV
 
+      - name: Setup Control Version
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          if ${{ github.event.inputs.control_version }}; then
+            echo "CONTROL_VERSION=--connector_live_tests.control_version=${{ github.event.inputs.control_version }}" >> $GITHUB_ENV
+          else
+            echo "CONTROL_VERSION=" >> $GITHUB_ENV
+          fi
+
       # NOTE: We still use a PAT here (rather than a GitHub App) because the workflow needs
       # permissions to add commits to our main repo as well as forks. This will only work on
       # forks if the user installs the app into their fork. Until we document this as a clear
@@ -151,4 +164,4 @@ jobs:
           github_token: ${{ secrets.GH_PAT_MAINTENANCE_OSS }}
           s3_build_cache_access_key_id: ${{ secrets.SELF_RUNNER_AWS_ACCESS_KEY_ID }}
           s3_build_cache_secret_key: ${{ secrets.SELF_RUNNER_AWS_SECRET_ACCESS_KEY }}
-          subcommand: connectors ${{ env.USE_LOCAL_CDK_FLAG }} --name ${{ github.event.inputs.connector_name }} test --only-step connector_live_tests --connector_live_tests.test-suite=regression --connector_live_tests.connection-id=${{ github.event.inputs.connection_id }} --connector_live_tests.pr-url=${{ github.event.inputs.pr_url }} ${{ env.READ_WITH_STATE_FLAG }} ${{ env.DISABLE_PROXY_FLAG }} ${{ env.STREAM_PARAMS }} ${{ env.CONNECTION_SUBSET }} --global-status-check-context="Regression Tests" --global-status-check-description='Running regression tests'
+          subcommand: connectors ${{ env.USE_LOCAL_CDK_FLAG }} --name ${{ github.event.inputs.connector_name }} test --only-step connector_live_tests --connector_live_tests.test-suite=regression --connector_live_tests.connection-id=${{ github.event.inputs.connection_id }} --connector_live_tests.pr-url=${{ github.event.inputs.pr_url }} ${{ env.READ_WITH_STATE_FLAG }} ${{ env.DISABLE_PROXY_FLAG }} ${{ env.STREAM_PARAMS }} ${{ env.CONNECTION_SUBSET }} ${{ env.CONTROL_VERSION }} --global-status-check-context="Regression Tests" --global-status-check-description='Running regression tests'


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->
In some cases (recent release or progressive rollout), there were no syncs with the most recent version of the connector. We still want to be able to run regression tests.

## How
<!--
* Describe how code changes achieve the solution.
-->
We will allow this by adding an optional input in the GitHub action. 

Other solutions that were discarded:
* Find the version released before the one active in prod. This is not easily possible as we use [the cloud registry](https://storage.googleapis.com/prod-airbyte-cloud-connector-metadata-service/registries/v0/cloud_registry.json) in order to be able to know the version and there is only the most recent version
* Try to get the previous version based on the version there was an attempt on. For example, if the version is 2.1.1, we would check for 2.1.0. There are a couple of problems with this:
    * if the patch version is 0, we don't know what is the patch version from the previous version
    * this assume that the previous released was active a bit and generated syncs

Note that the above are not mutually exclusive so we could have the second option work with the solution in this PR so maybe this is another way to alleviate the problem in the future.

You can see the parameter beings passed [here](https://github.com/airbytehq/airbyte/actions/runs/18538584966/job/52840046885) when added to the GitHub action and is not passed when not added [here](https://github.com/airbytehq/airbyte/actions/runs/18540377411/job/52846048671)

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
