### PR TITLE
Timeout for inactive DB during CDC sync

### DIFF
--- a/airbyte-cdk/bulk/changelog.md
+++ b/airbyte-cdk/bulk/changelog.md
@@ -1,3 +1,9 @@
+## Version 0.1.55
+
+**Extract CDK**
+
+* **Changed:** Timeout in case of no event comes back from dbz.
+
 ## Version 0.1.54
 
 Update temporal type representation for proto format

--- a/airbyte-cdk/bulk/version.properties
+++ b/airbyte-cdk/bulk/version.properties
@@ -1,1 +1,1 @@
-version=0.1.54
+version=0.1.55


### PR DESCRIPTION
## What
When a DB is inactive, dbz won't initialize the heartbeat event to us so there was no way to have a good control on the timeout. This change enables us to timeout dbz connection when nothing comes back from dbz

## How
We added a background watchdog coroutine that runs independently of Debezium's event stream:

  1. New tracking fields
    - lastEventTime: Tracks when the last event was received from Debezium
    - watchdogJob: Reference to the background watchdog coroutine
    - watchdogShouldStop: Flag to gracefully stop the watchdog
  2. Watchdog coroutine
    - Runs at the timeout seconds in config setup checking if timeout has been exceeded
    - Monitors time since last event (any event, not just heartbeats)
    - Forcefully closes Debezium engine if timeout expires
    - Logs helpful diagnostic information
  3. Event timestamp tracking
    - Updates lastEventTime whenever ANY event is received from Debezium
    - Ensures watchdog knows the database is active
  4. Watchdog lifecycle management
    - Starts watchdog when AIRBYTE_HEARTBEAT_TIMEOUT_SECONDS is configured
    - Properly cancels watchdog when engine stops
  5. New CloseReason
    - WATCHDOG_TIMEOUT: Indicates timeout triggered by watchdog

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduces Extract CDK.
  - Adds a configurable watchdog timeout for change data capture: if no events arrive within the set period, processing shuts down gracefully to avoid hangs and surface idle connections.

- Documentation
  - Adds changelog entry for version 0.1.52.

- Chores
  - Bumps CDK version to 0.1.52.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->