### PR TITLE
feat: add response_type parameter to connector configuration

### DIFF
--- a/airbyte-integrations/connectors/source-typeform/manifest.yaml
+++ b/airbyte-integrations/connectors/source-typeform/manifest.yaml
@@ -984,6 +984,7 @@ streams:
         http_method: GET
         request_parameters:
           sort: "{{ 'submitted_at,asc' if not next_page_token else '' }}"
+          response_type: started,partial,completed
         request_headers: {}
         error_handler:
           type: CompositeErrorHandler

--- a/airbyte-integrations/connectors/source-typeform/metadata.yaml
+++ b/airbyte-integrations/connectors/source-typeform/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: e7eff203-90bf-43e5-a240-19ea3056c474
-  dockerImageTag: 1.4.3
+  dockerImageTag: 1.4.4
   dockerRepository: airbyte/source-typeform
   documentationUrl: https://docs.airbyte.com/integrations/sources/typeform
   githubIssueLabel: source-typeform

--- a/docs/integrations/sources/typeform.md
+++ b/docs/integrations/sources/typeform.md
@@ -101,6 +101,7 @@ API rate limits \(2 requests per second\): [https://developer.typeform.com/get-s
 
 | Version | Date       | Pull Request                                             | Subject                                                                                         |
 |:--------|:-----------|:---------------------------------------------------------|:------------------------------------------------------------------------------------------------|
+| 1.4.4 | 2025-10-16 | [68133](https://github.com/airbytehq/airbyte/pull/68133) | Include all response_types |
 | 1.4.3 | 2025-09-11 | [66140](https://github.com/airbytehq/airbyte/pull/66140) | Update to CDK v7 |
 | 1.4.2 | 2025-05-31 | [53033](https://github.com/airbytehq/airbyte/pull/53033) | Update dependencies |
 | 1.4.1 | 2025-02-26 | [54690](https://github.com/airbytehq/airbyte/pull/54690) | Fix missing records for non `image` streams & formatting |


### PR DESCRIPTION
## What
The default behaviour of Typeform's Response API only retrieves `completed` responses. This PR adds `started` and `partial` response types to the request parameters to ensure they're retrieved.

## How
Added `response_type` parameter to the Typeform connector implementation with all of the possible values in Typeform's Response API: started, partial and completed


## Review guide
[Typeform's documentation for this particular issue](https://www.typeform.com/developers/responses/reference/retrieve-responses/#:~:text=from%20the%20response.-,response_type,.,-completed)

## User Impact
- This change is internal and does not modify the connector's user-facing spec.
- The user will only see additional rows if they have set up [Partial Submit Points](https://help.typeform.com/hc/en-us/articles/21102221958676-Collect-partial-responses) in their forms. And if they have, they certainly want to get them via Airbyte.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌
