### PR TITLE
chore(source-xero): Enable connector for Cloud deployment (do not merge)

### DIFF
--- a/airbyte-integrations/connectors/source-xero/metadata.yaml
+++ b/airbyte-integrations/connectors/source-xero/metadata.yaml
@@ -6,7 +6,7 @@ data:
     oss:
       enabled: true
     cloud:
-      enabled: false
+      enabled: true
   remoteRegistries:
     pypi:
       enabled: false
@@ -31,7 +31,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 6fd1e833-dd6e-45ec-a727-ab917c5be892
-  dockerImageTag: 2.1.4
+  dockerImageTag: 2.1.5
   dockerRepository: airbyte/source-xero
   githubIssueLabel: source-xero
   icon: xero.svg

--- a/docs/integrations/sources/xero.md
+++ b/docs/integrations/sources/xero.md
@@ -121,6 +121,7 @@ If you are upgrading from a previous version of the connector, please refer to t
 
 | Version | Date       | Pull Request                                             | Subject                                                   |
 |:--------|:-----------|:---------------------------------------------------------|:----------------------------------------------------------|
+| 2.1.5 | 2025-10-16 | [68140](https://github.com/airbytehq/airbyte/pull/68140) | Enable connector for Cloud deployment |
 | 2.1.4 | 2025-03-01 | [55142](https://github.com/airbytehq/airbyte/pull/55142) | Update dependencies |
 | 2.1.3 | 2025-02-22 | [54526](https://github.com/airbytehq/airbyte/pull/54526) | Update dependencies |
 | 2.1.2 | 2025-02-15 | [54042](https://github.com/airbytehq/airbyte/pull/54042) | Update dependencies |


### PR DESCRIPTION
## What
Enables the Xero source connector for Airbyte Cloud deployment by updating the registry configuration and bumping the patch version.

Related request: https://airbytehq-team.slack.com/archives/C08BHPUMEPJ/p1760633516580449

## How
- Changed `cloud.enabled` from `false` to `true` in `metadata.yaml`
- Bumped `dockerImageTag` from `2.1.4` to `2.1.5` to trigger connector publish

## Review guide
1. **metadata.yaml** - Main change enabling Cloud deployment
2. **Acceptance tests** - Note that acceptance tests are currently disabled (lines 52-60 in metadata.yaml) with comment "No/Low Airbyte Cloud Usage". Should these be enabled before Cloud deployment?
3. **Authentication** - This connector has complex auth (OAuth + Access Token) based on breaking changes history. Verify Cloud OAuth flows will work properly.
4. **Documentation** - Consider whether connector docs at `docs/integrations/sources/xero.md` need updates to reflect Cloud availability.

## User Impact
- Xero connector will become available for Cloud users
- Users can now create Xero source connections in Airbyte Cloud

**Potential concerns:**
- Acceptance tests are currently disabled - unknown if this connector has been validated for Cloud use
- OAuth authentication complexity may need Cloud-specific verification

## Can this PR be safely reverted and rolled back?
- [x] YES 💚

Reverting would simply disable the connector for Cloud again by changing the configuration back.

---

**Link to Devin run:** https://app.devin.ai/sessions/d27659b6ccce485badeb30c4bbe44a86  
**Requested by:** AJ Steers (@aaronsteers)