### PR TITLE
fix: sonar operator mcp docs not appearing in sidebar

### DIFF
--- a/docusaurus/sidebar-ai-agents.js
+++ b/docusaurus/sidebar-ai-agents.js
@@ -41,7 +41,13 @@ export default {
             "embedded/api/configuring-sources",
           ]
         },
-
+        {
+          type: "category",
+          label: "Operator MCP",
+          items: [
+            "embedded/operator-mcp/README",
+          ]
+        },
           ]
         },
         {


### PR DESCRIPTION
## What
<img width="303" height="224" alt="Screenshot 2025-10-16 at 11 03 29 AM" src="https://github.com/user-attachments/assets/6ed60108-97ca-4586-b1a2-d08741010af1" />

but

https://docs.airbyte.com/ai-agents/embedded/operator-mcp