### PR TITLE
🐛 Source Square: Add truncated date format for Square connector

### DIFF
--- a/airbyte-integrations/connectors/source-square/manifest.yaml
+++ b/airbyte-integrations/connectors/source-square/manifest.yaml
@@ -351,6 +351,7 @@ definitions:
         cursor_field: updated_at
         cursor_datetime_formats:
           - "%Y-%m-%dT%H:%M:%S.%fZ"
+          - "%Y-%m-%dT%H:%M:%SZ"
         datetime_format: "%Y-%m-%dT%H:%M:%S.%fZ"
         start_datetime:
           type: MinMaxDatetime
@@ -440,6 +441,7 @@ definitions:
         cursor_field: updated_at
         cursor_datetime_formats:
           - "%Y-%m-%dT%H:%M:%S.%fZ"
+          - "%Y-%m-%dT%H:%M:%SZ"
         datetime_format: "%Y-%m-%dT%H:%M:%S.%fZ"
         start_datetime:
           type: MinMaxDatetime
@@ -529,6 +531,7 @@ definitions:
         cursor_field: updated_at
         cursor_datetime_formats:
           - "%Y-%m-%dT%H:%M:%S.%fZ"
+          - "%Y-%m-%dT%H:%M:%SZ"
         datetime_format: "%Y-%m-%dT%H:%M:%S.%fZ"
         start_datetime:
           type: MinMaxDatetime
@@ -618,6 +621,7 @@ definitions:
         cursor_field: updated_at
         cursor_datetime_formats:
           - "%Y-%m-%dT%H:%M:%S.%fZ"
+          - "%Y-%m-%dT%H:%M:%SZ"
         datetime_format: "%Y-%m-%dT%H:%M:%S.%fZ"
         start_datetime:
           type: MinMaxDatetime
@@ -707,6 +711,7 @@ definitions:
         cursor_field: updated_at
         cursor_datetime_formats:
           - "%Y-%m-%dT%H:%M:%S.%fZ"
+          - "%Y-%m-%dT%H:%M:%SZ"
         datetime_format: "%Y-%m-%dT%H:%M:%S.%fZ"
         start_datetime:
           type: MinMaxDatetime
@@ -797,6 +802,7 @@ definitions:
         cursor_field: created_at
         cursor_datetime_formats:
           - "%Y-%m-%dT%H:%M:%S.%fZ"
+          - "%Y-%m-%dT%H:%M:%SZ"
         datetime_format: "%Y-%m-%dT%H:%M:%S.%fZ"
         start_datetime:
           type: MinMaxDatetime
@@ -937,6 +943,7 @@ definitions:
         cursor_field: created_at
         cursor_datetime_formats:
           - "%Y-%m-%dT%H:%M:%S.%fZ"
+          - "%Y-%m-%dT%H:%M:%SZ"
         datetime_format: "%Y-%m-%dT%H:%M:%S.%fZ"
         start_datetime:
           type: MinMaxDatetime
@@ -1027,6 +1034,7 @@ definitions:
         cursor_field: updated_at
         cursor_datetime_formats:
           - "%Y-%m-%dT%H:%M:%S.%fZ"
+          - "%Y-%m-%dT%H:%M:%SZ"
         datetime_format: "%Y-%m-%dT%H:%M:%S.%fZ"
         start_datetime:
           type: MinMaxDatetime

--- a/airbyte-integrations/connectors/source-square/metadata.yaml
+++ b/airbyte-integrations/connectors/source-square/metadata.yaml
@@ -11,7 +11,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 77225a51-cd15-4a13-af02-65816bd0ecf4
-  dockerImageTag: 1.7.7
+  dockerImageTag: 1.7.8
   dockerRepository: airbyte/source-square
   documentationUrl: https://docs.airbyte.com/integrations/sources/square
   githubIssueLabel: source-square


### PR DESCRIPTION
https://github.com/airbytehq/airbyte/issues/68147

## What
I copied the changes from https://github.com/airbytehq/airbyte/pull/35269 in hopes that they will solve a very similar issue I'm having with Square. 

I think Square, like OpsGenie, will truncate the updated_at timestamp of alerts where the timestamp falls exactly on the second.

This change extends the list of accepted cursor-based timestamp formats to include a format without fractions of seconds to correctly handle the response in this circumstance.

Disclaimer - I am still pretty new to airbyte and this is a guess at a solution based on pattern matching...


## How
Adding "%Y-%m-%dT%H:%M:%SZ" as a secondary accepted format to cursor_datetime_formats for the connector will allow the parser to correctly parse this alternative timestamp from the API.

## Review guide
1. `manifest.yaml`

## User Impact
No more "No format in ['%Y-%m-%dT%H:%M:%S.%fZ'] matching [truncated date]" error, hopefully?

## Can this PR be safely reverted and rolled back?
* If unsure, leave it blank.
- [ ] YES 💚
- [ ] NO ❌
