### PR TITLE
source-mysql: fix CDC null primary key validation error

### DIFF
--- a/airbyte-integrations/connectors/source-mysql/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mysql/metadata.yaml
@@ -9,7 +9,7 @@ data:
   connectorSubtype: database
   connectorType: source
   definitionId: 435bb9a5-7887-4809-aa58-28c27df0d7ad
-  dockerImageTag: 3.50.9
+  dockerImageTag: 3.50.10
   dockerRepository: airbyte/source-mysql
   documentationUrl: https://docs.airbyte.com/integrations/sources/mysql
   githubIssueLabel: source-mysql

--- a/airbyte-integrations/connectors/source-mysql/src/main/kotlin/io/airbyte/integrations/source/mysql/MySqlSourceDebeziumOperations.kt
+++ b/airbyte-integrations/connectors/source-mysql/src/main/kotlin/io/airbyte/integrations/source/mysql/MySqlSourceDebeziumOperations.kt
@@ -99,6 +99,8 @@ class MySqlSourceDebeziumOperations(
         // Turn string representations of numbers into BigDecimals.
 
         val resultRow: NativeRecordPayload = mutableMapOf()
+        // Extract primary key field IDs to ensure they're always included in the payload,
+        // even when null, to prevent "All the defined primary keys are null" validation errors.
         val primaryKeyFields = stream.configuredPrimaryKey?.map { it.id }?.toSet() ?: emptySet()
 
         for (field in stream.schema) {

--- a/airbyte-integrations/connectors/source-mysql/src/main/kotlin/io/airbyte/integrations/source/mysql/MySqlSourceDebeziumOperations.kt
+++ b/airbyte-integrations/connectors/source-mysql/src/main/kotlin/io/airbyte/integrations/source/mysql/MySqlSourceDebeziumOperations.kt
@@ -100,7 +100,7 @@ class MySqlSourceDebeziumOperations(
 
         val resultRow: NativeRecordPayload = mutableMapOf()
         val primaryKeyFields = stream.configuredPrimaryKey?.map { it.id }?.toSet() ?: emptySet()
-        
+
         for (field in stream.schema) {
             when (field.type.airbyteSchemaType) {
                 LeafAirbyteSchemaType.INTEGER,
@@ -126,9 +126,10 @@ class MySqlSourceDebeziumOperations(
             if (fieldValue == null && !primaryKeyFields.contains(field.id)) {
                 continue
             }
-            
+
             when (fieldValue) {
-                null, is NullNode -> {
+                null,
+                is NullNode -> {
                     resultRow[field.id] = FieldValueEncoder(null, NullCodec)
                 }
                 else -> {

--- a/docs/integrations/sources/mysql.md
+++ b/docs/integrations/sources/mysql.md
@@ -230,6 +230,7 @@ Any database or table encoding combination of charset and collation is supported
 
 | Version     | Date       | Pull Request                                               | Subject                                                                                                                                         |
 |:------------|:-----------|:-----------------------------------------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------|
+| 3.50.10     | 2025-10-17 | [#67711](https://github.com/airbytehq/airbyte/issues/67711) | Fix CDC replication error where null primary keys were incorrectly skipped during record deserialization                                        |
 | 3.50.9      | 2025-10-06  | [67151](https://github.com/airbytehq/airbyte/pull/66515)   | Fix CDC decorating fields encoding to Protobuf                                                                                                  |
 | 3.50.8      | 2025-09-18 | [66515](https://github.com/airbytehq/airbyte/pull/66515)   | Fix division by zero in partition creation when sampling produces no split boundaries.                                                          |
 | 3.50.7      | 2025-09-10 | [66179](https://github.com/airbytehq/airbyte/pull/66179)   | Bump to the latest CDK fixing protobuf encoding of certain column types                                                                         |


### PR DESCRIPTION
- Ensure primary key fields are always included in record payload, even when null
- Prevent 'All the defined primary keys are null' error during CDC replication
- Modified deserializeRecord to identify and preserve primary key fields
- Fixes issue #67711
- Version bump to 3.50.10

## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->
This PR fixes a critical bug in MySQL CDC replication where records with null or missing primary key values in the Debezium payload were incorrectly causing sync failures with the error: "All the defined primary keys are null, the primary keys are: {field_name}".
Root Cause:
In `MySqlSourceDebeziumOperations.kt` (line 122), the code used data[field.id] ?: continue which unconditionally skipped any field that was null or missing from the Debezium record. When a primary key field came as null from Debezium (a valid scenario in CDC), it was completely omitted from the resultRow map. This caused Airbyte's BasicAirbyteMessageValidator to fail validation because it couldn't find the primary key field in the record payload.
Why This Happens in CDC:
MySQL CDC via Debezium can produce records where primary key fields are null or missing in scenarios such as:
Primary key columns that allow NULL in the database schema
Debezium's before or after objects not containing certain fields due to connector configuration
Schema evolution or type conversion edge cases
DELETE operations where after is null and before contains the data
Closes #67711

## How
<!--
* Describe how code changes achieve the solution.
-->
The fix modifies the deserializeRecord method in `MySqlSourceDebeziumOperations.kt` to:
1. Identify Primary Keys: Extract configured primary key field IDs from stream.configuredPrimaryKey into a Set for O(1) lookup
```
   val primaryKeyFields = stream.configuredPrimaryKey?.map { it.id }?.toSet() ?: emptySet()
```
2. Conditional Skipping Logic: Replace the blanket continue with conditional logic:
- Before: `data[field.id] ?: continue` → skipped ALL null fields
- After: Skip only non-primary-key fields that are null; always process primary key fields
```
   val fieldValue = data[field.id]
   if (fieldValue == null && !primaryKeyFields.contains(field.id)) {
       continue  // Only skip non-PK null fields
   }
```
3. Explicit Null Handling: Update the when expression to handle both `null` and `NullNode`:
```
   when (fieldValue) {
       null, is NullNode -> {
           resultRow[field.id] = FieldValueEncoder(null, NullCodec)
       }
       // ... rest of the logic
   }
```
This ensures primary key fields are always included in the record payload with proper null encoding, allowing the validator to see them and proceed with validation.
Backward Compatibility: The change maintains existing behavior for non-primary-key fields (they continue to be skipped when null) while only modifying behavior for primary key fields.

## Review guide
<!--
1. `x.py`
3. `y.py`
-->
### Key Files to Review:
1. `airbyte-integrations/connectors/source-mysql/src/main/kotlin/io/airbyte/integrations/source/mysql/MySqlSourceDebeziumOperations.kt`
- Lines 102-103: Primary key field identification
- Lines 124-151: Modified field processing logic with conditional skipping
- Focus on the logic that differentiates between PK and non-PK fields

2. `airbyte-integrations/connectors/source-mysql/metadata.yaml`
- Line 12: Version bump to 3.50.10

3. docs/integrations/sources/mysql.md
- Line 233: Changelog entry

### Testing Recommendations:
- Verify that CDC sync with records containing null PKs now succeeds
- Confirm that non-PK null fields continue to be handled as before
- Test with composite primary keys where some components are null
- Validate that DELETE operations (where `after` is null) still work correctly

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->
### Positive Impact:
- Users experiencing MySQL CDC sync failures with "All the defined primary keys are null" error will now have successful syncs
- Enables CDC replication for tables with nullable primary key columns
- More robust handling of Debezium payload variations
- Prevents data loss from failed syncs due to null PK validation

### No Negative Impact:
- The change is surgical and only affects how primary key fields are processed
- Non-primary-key fields maintain their existing behavior
- No schema changes or breaking changes to the connector API
- Performance impact is negligible (single Set lookup per field)

### Affected Scenarios:
- MySQL CDC connections experiencing the specific error in issue #67711
- Tables with nullable primary keys
- Complex CDC scenarios with schema evolution

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [X] YES 💚
- [ ] NO ❌

### Rationale:
- This is a pure bug fix with no schema changes or state format modifications
- The change is isolated to record deserialization logic
- Rolling back would return to the previous behavior where null PKs cause validation errors
- No data corruption risk - the worst case of revert is returning to the previous error state
- No database schema or Airbyte state changes involved
