### PR TITLE
Update MySQL docs to reflect timeout variable changes in version 8.0.26+

### DIFF
--- a/docs/integrations/sources/mysql/mysql-troubleshooting.md
+++ b/docs/integrations/sources/mysql/mysql-troubleshooting.md
@@ -95,9 +95,8 @@ set global slave_net_timeout = 120;
 set global thread_pool_idle_timeout = 120;
 ```
 
-:::note `slave_net_timeout` was renamed to `replica_net_timeout` in MySQL 8.0.26. Use the appropriate variable depending on your MySQL version. 
+:::note `slave_net_timeout` was renamed to `replica_net_timeout` in MySQL 8.0.26. Use the appropriate variable depending on your MySQL version.
 :::
-
 
 ### (Advanced) Enable GTIDs
 

--- a/docs/integrations/sources/mysql/mysql-troubleshooting.md
+++ b/docs/integrations/sources/mysql/mysql-troubleshooting.md
@@ -90,7 +90,7 @@ SET GLOBAL thread_pool_idle_timeout = 120;
 
 **For MySQL versions before 8.0.26:**
 
-```sql 
+```sql
 SET GLOBAL slave_net_timeout = 120;
 SET GLOBAL thread_pool_idle_timeout = 120;
 ```

--- a/docs/integrations/sources/mysql/mysql-troubleshooting.md
+++ b/docs/integrations/sources/mysql/mysql-troubleshooting.md
@@ -95,7 +95,7 @@ SET GLOBAL slave_net_timeout = 120;
 SET GLOBAL thread_pool_idle_timeout = 120;
 ```
 
-:::note 
+:::note
 `slave_net_timeout` was renamed to `replica_net_timeout` in MySQL 8.0.26. Use the appropriate variable depending on your MySQL version.
 :::
 

--- a/docs/integrations/sources/mysql/mysql-troubleshooting.md
+++ b/docs/integrations/sources/mysql/mysql-troubleshooting.md
@@ -82,16 +82,19 @@ When a sync runs for the first time using CDC, Airbyte performs an initial consi
 If seeing `EventDataDeserializationException` errors intermittently with root cause `EOFException` or `SocketException`, you may need to extend the following _MySql server_ timeout values by running:
 
 **For MySQL 8.0.26 and later:**
+
 ```
 SET GLOBAL replica_net_timeout = 120;
 SET GLOBAL thread_pool_idle_timeout = 120;
 ```
+
 **For MySQL versions before 8.0.26:**
 
 ```
 set global slave_net_timeout = 120;
 set global thread_pool_idle_timeout = 120;
 ```
+
 :::note `slave_net_timeout` was renamed to `replica_net_timeout` in MySQL 8.0.26. Use the appropriate variable depending on your MySQL version. :::
 
 ### (Advanced) Enable GTIDs

--- a/docs/integrations/sources/mysql/mysql-troubleshooting.md
+++ b/docs/integrations/sources/mysql/mysql-troubleshooting.md
@@ -95,7 +95,9 @@ set global slave_net_timeout = 120;
 set global thread_pool_idle_timeout = 120;
 ```
 
-:::note `slave_net_timeout` was renamed to `replica_net_timeout` in MySQL 8.0.26. Use the appropriate variable depending on your MySQL version. :::
+:::note `slave_net_timeout` was renamed to `replica_net_timeout` in MySQL 8.0.26. Use the appropriate variable depending on your MySQL version. 
+:::
+
 
 ### (Advanced) Enable GTIDs
 

--- a/docs/integrations/sources/mysql/mysql-troubleshooting.md
+++ b/docs/integrations/sources/mysql/mysql-troubleshooting.md
@@ -81,10 +81,18 @@ When a sync runs for the first time using CDC, Airbyte performs an initial consi
 
 If seeing `EventDataDeserializationException` errors intermittently with root cause `EOFException` or `SocketException`, you may need to extend the following _MySql server_ timeout values by running:
 
+**For MySQL 8.0.26 and later:**
+```
+SET GLOBAL replica_net_timeout = 120;
+SET GLOBAL thread_pool_idle_timeout = 120;
+```
+**For MySQL versions before 8.0.26:**
+
 ```
 set global slave_net_timeout = 120;
 set global thread_pool_idle_timeout = 120;
 ```
+:::note `slave_net_timeout` was renamed to `replica_net_timeout` in MySQL 8.0.26. Use the appropriate variable depending on your MySQL version. :::
 
 ### (Advanced) Enable GTIDs
 

--- a/docs/integrations/sources/mysql/mysql-troubleshooting.md
+++ b/docs/integrations/sources/mysql/mysql-troubleshooting.md
@@ -83,19 +83,20 @@ If seeing `EventDataDeserializationException` errors intermittently with root ca
 
 **For MySQL 8.0.26 and later:**
 
-```
+```sql
 SET GLOBAL replica_net_timeout = 120;
 SET GLOBAL thread_pool_idle_timeout = 120;
 ```
 
 **For MySQL versions before 8.0.26:**
 
-```
-set global slave_net_timeout = 120;
-set global thread_pool_idle_timeout = 120;
+```sql 
+SET GLOBAL slave_net_timeout = 120;
+SET GLOBAL thread_pool_idle_timeout = 120;
 ```
 
-:::note `slave_net_timeout` was renamed to `replica_net_timeout` in MySQL 8.0.26. Use the appropriate variable depending on your MySQL version.
+:::note 
+`slave_net_timeout` was renamed to `replica_net_timeout` in MySQL 8.0.26. Use the appropriate variable depending on your MySQL version.
 :::
 
 ### (Advanced) Enable GTIDs


### PR DESCRIPTION
- Added version-specific guidance for MySQL timeout variables:
  - `replica_net_timeout` for MySQL 8.0.26 and later
  - `slave_net_timeout` for earlier versions
- Highlighted the deprecation of `slave_net_timeout` and provided clear, version-aware instructions.

Reference: https://dev.mysql.com/doc/mysql-replication-excerpt/8.0/en/replication-options-replica.html#sysvar_replica_net_timeout