### PR TITLE
Update data-plane-util.md

### DIFF
--- a/docs/platform/enterprise-flex/data-plane-util.md
+++ b/docs/platform/enterprise-flex/data-plane-util.md
@@ -20,6 +20,8 @@ Before you begin, ensure you satisfy all of these requirements.
 
 - An active subscription to Airbyte Enterprise Flex
 - You must be an organization Admin to manage data planes
+- You need to use a [secrets manager](https://docs.airbyte.com/platform/deploying-airbyte/integrations/secrets) for the connections on your data plane. Modifying the configuration of connector secret storage will cause all existing connectors to fail, so we recommend only using newly created workspaces on the data plane.
+
 
 ### Infrastructure requirements
 


### PR DESCRIPTION
Include pre-req for secret manager in Airbox

## What
Include reference to the fact that a secrets manager must be setup for Airbox. We mention this on the k8s data plane docs, but not for airbox

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌
