### PR TITLE
feat: add destination postgres schema propagation operation

### DIFF
--- a/airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/client/PostgresAirbyteClient.kt
+++ b/airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/client/PostgresAirbyteClient.kt
@@ -207,6 +207,6 @@ class PostgresAirbyteClient(
         }
     }
 
-    internal fun execute(query: String) =
+    private fun execute(query: String) =
         dataSource.connection.use { connection -> connection.createStatement().use { it.execute(query) }}
 }

--- a/airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/client/PostgresAirbyteClient.kt
+++ b/airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/client/PostgresAirbyteClient.kt
@@ -10,9 +10,11 @@ import io.airbyte.cdk.load.component.TableSchemaEvolutionClient
 import io.airbyte.cdk.load.message.Meta.Companion.COLUMN_NAME_AB_GENERATION_ID
 import io.airbyte.cdk.load.table.ColumnNameMapping
 import io.airbyte.cdk.load.table.TableName
+import io.airbyte.integrations.destination.postgres.sql.Column
 import io.airbyte.integrations.destination.postgres.sql.PostgresDirectLoadSqlGenerator
 import io.github.oshai.kotlinlogging.KotlinLogging
 import jakarta.inject.Singleton
+import java.sql.ResultSet
 import javax.sql.DataSource
 
 private val log = KotlinLogging.logger {}
@@ -89,7 +91,81 @@ class PostgresAirbyteClient(
         stream: DestinationStream,
         tableName: TableName,
         columnNameMapping: ColumnNameMapping
-    ) = Unit
+    ) {
+        val columnsInDb = getColumnsFromDb(tableName)
+        val columnsInStream = getColumnsFromStream(stream, columnNameMapping)
+        val (addedColumns, deletedColumns, modifiedColumns) =
+            generateSchemaChanges(columnsInDb, columnsInStream)
+
+        if (
+            addedColumns.isNotEmpty() || deletedColumns.isNotEmpty() || modifiedColumns.isNotEmpty()
+        ) {
+            log.info { "Summary of the table alterations:" }
+            log.info { "Added columns: $addedColumns" }
+            log.info { "Deleted columns: $deletedColumns" }
+            log.info { "Modified columns: $modifiedColumns" }
+            sqlGenerator
+                .matchSchemas(tableName, addedColumns, deletedColumns, modifiedColumns)
+                .forEach { execute(it) }
+        }
+    }
+
+    internal fun getColumnsFromDb(tableName: TableName): Set<Column> {
+        val sql =
+            sqlGenerator.getTableSchema(tableName)
+        dataSource.connection.use { connection ->
+            val statement = connection.createStatement()
+            return statement.use {
+                val rs: ResultSet = it.executeQuery(sql)
+                val columnsInDb: MutableSet<Column> = mutableSetOf()
+                val defaultColumnNames = sqlGenerator.getDefaultColumnNames()
+                while (rs.next()) {
+                    //TODO: extract column_name and data_type as constants
+                    val columnName = rs.getString("column_name")
+
+                    // Filter out airbyte columns
+                    if (defaultColumnNames.contains(columnName)) {
+                        continue
+                    }
+                    val dataType = rs.getString("data_type")
+
+                    columnsInDb.add(Column(columnName, dataType))
+                }
+
+                columnsInDb
+            }
+        }
+    }
+
+    internal fun getColumnsFromStream(
+        stream: DestinationStream,
+        columnNameMapping: ColumnNameMapping
+    ): Set<Column> {
+        val defaultColumnNames = sqlGenerator.getDefaultColumnNames()
+        return sqlGenerator.columnsAndTypes(stream, columnNameMapping)
+            .filter { columnAndType -> columnAndType.columnName !in defaultColumnNames }
+            .toSet()
+    }
+
+    internal fun generateSchemaChanges(
+        columnsInDb: Set<Column>,
+        columnsInStream: Set<Column>
+    ): Triple<Set<Column>, Set<Column>, Set<Column>> {
+        val addedColumns =
+            columnsInStream.filter { it.columnName !in columnsInDb.map { col -> col.columnName } }.toSet()
+        val deletedColumns =
+            columnsInDb.filter { it.columnName !in columnsInStream.map { col -> col.columnName } }.toSet()
+        val commonColumns =
+            columnsInStream.filter { it.columnName in columnsInDb.map { col -> col.columnName } }.toSet()
+        val modifiedColumns =
+            commonColumns
+                .filter {
+                    val dbType = columnsInDb.find { column -> it.columnName == column.columnName }?.columnTypeName
+                    it.columnTypeName != dbType
+                }
+                .toSet()
+        return Triple(addedColumns, deletedColumns, modifiedColumns)
+    }
 
     override suspend fun getGenerationId(tableName: TableName): Long =
         try {
@@ -111,9 +187,10 @@ class PostgresAirbyteClient(
     fun describeTable(tableName: TableName): List<String> =
         dataSource.connection.use { connection ->
             val resultSet =
-                connection.createStatement().executeQuery(sqlGenerator.showColumns(tableName))
+                connection.createStatement().executeQuery(sqlGenerator.getTableSchema(tableName))
             val columns = mutableListOf<String>()
             while (resultSet.next()) {
+                //TODO: extract column_name as a constant
                 columns.add(resultSet.getString("column_name"))
             }
             return columns

--- a/airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/sql/PostgresDirectLoadSqlGenerator.kt
+++ b/airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/sql/PostgresDirectLoadSqlGenerator.kt
@@ -40,23 +40,23 @@ class PostgresDirectLoadSqlGenerator {
     companion object {
         internal val DEFAULT_COLUMNS =
             listOf(
-                ColumnAndType(
+                Column(
                     columnName = COLUMN_NAME_AB_RAW_ID,
                     columnTypeName = PostgresDataType.VARCHAR.typeName,
                     nullable = false
 
                 ),
-                ColumnAndType(
+                Column(
                     columnName = COLUMN_NAME_AB_EXTRACTED_AT,
                     columnTypeName = PostgresDataType.TIMESTAMP_WITH_TIMEZONE.typeName,
                     nullable = false
                 ),
-                ColumnAndType(
+                Column(
                     columnName = COLUMN_NAME_AB_META,
                     columnTypeName = PostgresDataType.JSONB.typeName,
                     nullable = false
                 ),
-                ColumnAndType(
+                Column(
                     columnName = COLUMN_NAME_AB_GENERATION_ID,
                     columnTypeName = PostgresDataType.BIGINT.typeName,
                     nullable = false
@@ -209,7 +209,7 @@ class PostgresDirectLoadSqlGenerator {
         }
 }
 
-data class ColumnAndType(val columnName: String, val columnTypeName: String, val nullable: Boolean = false) {
+data class Column(val columnName: String, val columnTypeName: String, val nullable: Boolean = true) {
     override fun toString(): String {
         val isNullableSuffix = if (nullable) "" else "NOT NULL"
         return "\"$columnName\" $columnTypeName $isNullableSuffix".trim()

--- a/airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/sql/PostgresDirectLoadSqlGenerator.kt
+++ b/airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/sql/PostgresDirectLoadSqlGenerator.kt
@@ -196,6 +196,9 @@ class PostgresDirectLoadSqlGenerator {
     private fun getName(tableName: TableName): String =
         "\"${tableName.name}\""
 
+    private fun getName(column: Column): String =
+        "\"${column.columnName}\""
+
     fun AirbyteType.toDialectType(): String =
         when (this) {
             BooleanType -> PostgresDataType.BOOLEAN.typeName

--- a/airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/sql/PostgresDirectLoadSqlGenerator.kt
+++ b/airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/sql/PostgresDirectLoadSqlGenerator.kt
@@ -172,14 +172,13 @@ class PostgresDirectLoadSqlGenerator {
     fun getGenerationId(tableName: TableName): String =
         "SELECT \"${COLUMN_NAME_AB_GENERATION_ID}\" FROM ${getFullyQualifiedName(tableName)} LIMIT 1;".andLog()
 
-    fun showColumns(tableName: TableName): String =
+    fun getTableSchema(tableName: TableName): String =
         """
-        SELECT column_name
+        SELECT column_name, data_type
         FROM information_schema.columns
         WHERE table_schema = '${tableName.namespace}'
-          AND table_name = '${tableName.name}'
-        ORDER BY ordinal_position
-        """.trimIndent()
+        AND table_name = '${tableName.name}';
+        """.trimIndent().andLog()
 
     fun copyFromCsv(tableName: TableName): String =
         """

--- a/airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/sql/PostgresDirectLoadSqlGenerator.kt
+++ b/airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/sql/PostgresDirectLoadSqlGenerator.kt
@@ -143,7 +143,11 @@ class PostgresDirectLoadSqlGenerator {
     }
 
     private fun getTargetColumnNames(columnNameMapping: ColumnNameMapping): List<String> =
-        DEFAULT_COLUMNS.map { "\"${it.columnName}\"" } + columnNameMapping.map { (_, targetName) -> "\"${targetName}\"" }
+        getDefaultColumnNames() + columnNameMapping.map { (_, targetName) -> "\"${targetName}\"" }
+
+    //TODO: this is out of place, move to its own column class
+    fun getDefaultColumnNames(): List<String> =
+        DEFAULT_COLUMNS.map { "\"${it.columnName}\"" }
 
     @Suppress("UNUSED_PARAMETER")
     fun upsertTable(

--- a/airbyte-integrations/connectors/destination-postgres/src/test/kotlin/io/airbyte/integrations/destination/postgres/client/PostgresAirbyteClientTest.kt
+++ b/airbyte-integrations/connectors/destination-postgres/src/test/kotlin/io/airbyte/integrations/destination/postgres/client/PostgresAirbyteClientTest.kt
@@ -1,0 +1,280 @@
+/*
+ * Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination.postgres.client
+
+import io.airbyte.cdk.load.command.DestinationStream
+import io.airbyte.cdk.load.table.ColumnNameMapping
+import io.airbyte.cdk.load.table.TableName
+import io.airbyte.integrations.destination.postgres.sql.PostgresDirectLoadSqlGenerator
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
+import java.sql.Connection
+import java.sql.ResultSet
+import java.sql.SQLException
+import java.sql.Statement
+import javax.sql.DataSource
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class PostgresAirbyteClientTest {
+
+    private lateinit var client: PostgresAirbyteClient
+    private lateinit var dataSource: DataSource
+    private lateinit var sqlGenerator: PostgresDirectLoadSqlGenerator
+
+    companion object {
+        private const val MOCK_SQL_QUERY = "MOCK_SQL_QUERY"
+    }
+
+    @BeforeEach
+    fun setup() {
+        dataSource = mockk()
+        sqlGenerator = mockk()
+        client = PostgresAirbyteClient(dataSource, sqlGenerator)
+    }
+
+    @Test
+    fun testCountTable() {
+        val tableName = TableName(namespace = "namespace", name = "name")
+        val resultSet =
+            mockk<ResultSet> {
+                every { next() } returns true andThen false
+                every { getLong(COUNT_TOTAL_ALIAS) } returns 42L
+            }
+        val statement =
+            mockk<Statement> {
+                every { executeQuery(any()) } returns resultSet
+                every { close() } just Runs
+            }
+        val mockConnection =
+            mockk<Connection> {
+                every { close() } just Runs
+                every { createStatement() } returns statement
+            }
+
+        every { dataSource.connection } returns mockConnection
+
+        runBlocking {
+            val result = client.countTable(tableName)
+            assertEquals(42L, result)
+            verify(exactly = 1) { mockConnection.close() }
+        }
+    }
+
+    @Test
+    fun testCountTableNoResults() {
+        val tableName = TableName(namespace = "namespace", name = "name")
+        val resultSet = mockk<ResultSet> { every { next() } returns false }
+        val statement =
+            mockk<Statement> {
+                every { executeQuery(any()) } returns resultSet
+                every { close() } just Runs
+            }
+        val mockConnection =
+            mockk<Connection> {
+                every { close() } just Runs
+                every { createStatement() } returns statement
+            }
+
+        every { dataSource.connection } returns mockConnection
+        every { sqlGenerator.countTable(tableName) } returns MOCK_SQL_QUERY
+
+        runBlocking {
+            val result = client.countTable(tableName)
+            assertEquals(0L, result)
+            verify(exactly = 1) { mockConnection.close() }
+        }
+    }
+
+    @Test
+    fun testCountMissingTable() {
+        val tableName = TableName(namespace = "namespace", name = "name")
+        val statement =
+            mockk<Statement> { every { executeQuery(any()) } throws SQLException("table does not exist") }
+        val mockConnection =
+            mockk<Connection> {
+                every { close() } just Runs
+                every { createStatement() } returns statement
+            }
+
+        every { dataSource.connection } returns mockConnection
+
+        runBlocking {
+            val result = client.countTable(tableName)
+            assertNull(result)
+            verify(exactly = 1) { mockConnection.close() }
+        }
+    }
+
+    @Test
+    fun testCreateNamespace() {
+        val namespace = "test_namespace"
+        val statement =
+            mockk<Statement> {
+                every { execute(any()) } returns true
+                every { close() } just Runs
+            }
+        val mockConnection =
+            mockk<Connection> {
+                every { close() } just Runs
+                every { createStatement() } returns statement
+            }
+
+        every { dataSource.connection } returns mockConnection
+        every { sqlGenerator.createNamespace(namespace) } returns MOCK_SQL_QUERY
+
+        runBlocking {
+            client.createNamespace(namespace)
+            verify(exactly = 1) { statement.execute(MOCK_SQL_QUERY) }
+            verify(exactly = 1) { mockConnection.close() }
+        }
+    }
+
+    @Test
+    fun testCreateTable() {
+        val stream = mockk<DestinationStream>()
+        val tableName = TableName(namespace = "namespace", name = "name")
+        val columnNameMapping = mockk<ColumnNameMapping>(relaxed = true)
+        val statement =
+            mockk<Statement> {
+                every { execute(any()) } returns true
+                every { close() } just Runs
+            }
+        val mockConnection =
+            mockk<Connection> {
+                every { close() } just Runs
+                every { createStatement() } returns statement
+            }
+
+        every { dataSource.connection } returns mockConnection
+        every { sqlGenerator.createTable(stream, tableName, columnNameMapping, true) } returns MOCK_SQL_QUERY
+
+        runBlocking {
+            client.createTable(
+                stream = stream,
+                tableName = tableName,
+                columnNameMapping = columnNameMapping,
+                replace = true
+            )
+            verify(exactly = 1) { statement.execute(MOCK_SQL_QUERY) }
+            verify(exactly = 1) { mockConnection.close() }
+        }
+    }
+
+    @Test
+    fun testOverwriteTable() {
+        val sourceTableName = TableName(namespace = "source_ns", name = "source")
+        val targetTableName = TableName(namespace = "target_ns", name = "target")
+        val statement =
+            mockk<Statement> {
+                every { execute(any()) } returns true
+                every { close() } just Runs
+            }
+        val mockConnection =
+            mockk<Connection> {
+                every { close() } just Runs
+                every { createStatement() } returns statement
+            }
+
+        every { dataSource.connection } returns mockConnection
+        every { sqlGenerator.overwriteTable(sourceTableName, targetTableName) } returns MOCK_SQL_QUERY
+
+        runBlocking {
+            client.overwriteTable(sourceTableName, targetTableName)
+            verify(exactly = 1) { statement.execute(MOCK_SQL_QUERY) }
+            verify(exactly = 1) { mockConnection.close() }
+        }
+    }
+
+    @Test
+    fun testCopyTable() {
+        val columnNameMapping = mockk<ColumnNameMapping>(relaxed = true)
+        val sourceTableName = TableName(namespace = "namespace", name = "source")
+        val targetTableName = TableName(namespace = "namespace", name = "target")
+        val statement =
+            mockk<Statement> {
+                every { execute(any()) } returns true
+                every { close() } just Runs
+            }
+
+        val mockConnection =
+            mockk<Connection> {
+                every { close() } just Runs
+                every { createStatement() } returns statement
+            }
+        every { dataSource.connection } returns mockConnection
+        every { sqlGenerator.copyTable(columnNameMapping, sourceTableName, targetTableName) } returns MOCK_SQL_QUERY
+
+        runBlocking {
+            client.copyTable(
+                columnNameMapping = columnNameMapping,
+                sourceTableName = sourceTableName,
+                targetTableName = targetTableName
+            )
+            verify(exactly = 1) { mockConnection.close() }
+        }
+    }
+
+    @Test
+    fun testUpsertTable() {
+        val stream = mockk<DestinationStream>()
+        val columnNameMapping = mockk<ColumnNameMapping>(relaxed = true)
+        val sourceTableName = TableName(namespace = "namespace", name = "source")
+        val targetTableName = TableName(namespace = "namespace", name = "target")
+        val statement =
+            mockk<Statement> {
+                every { execute(any()) } returns true
+                every { close() } just Runs
+            }
+        val mockConnection =
+            mockk<Connection> {
+                every { close() } just Runs
+                every { createStatement() } returns statement
+            }
+
+        every { dataSource.connection } returns mockConnection
+        every { sqlGenerator.upsertTable(stream, columnNameMapping, sourceTableName, targetTableName) } returns MOCK_SQL_QUERY
+
+        runBlocking {
+            client.upsertTable(
+                stream = stream,
+                columnNameMapping = columnNameMapping,
+                sourceTableName = sourceTableName,
+                targetTableName = targetTableName
+            )
+            verify(exactly = 1) { mockConnection.close() }
+        }
+    }
+
+    @Test
+    fun testDropTable() {
+        val tableName = TableName(namespace = "namespace", name = "name")
+        val statement =
+            mockk<Statement> {
+                every { execute(any()) } returns true
+                every { close() } just Runs
+            }
+        val mockConnection =
+            mockk<Connection> {
+                every { close() } just Runs
+                every { createStatement() } returns statement
+            }
+
+        every { dataSource.connection } returns mockConnection
+        every { sqlGenerator.dropTable(tableName) } returns MOCK_SQL_QUERY
+
+        runBlocking {
+            client.dropTable(tableName)
+            verify(exactly = 1) { statement.execute(MOCK_SQL_QUERY) }
+            verify(exactly = 1) { mockConnection.close() }
+        }
+    }
+}

--- a/airbyte-integrations/connectors/destination-postgres/src/test/kotlin/io/airbyte/integrations/destination/postgres/sql/PostgresDirectLoadSqlGeneratorTest.kt
+++ b/airbyte-integrations/connectors/destination-postgres/src/test/kotlin/io/airbyte/integrations/destination/postgres/sql/PostgresDirectLoadSqlGeneratorTest.kt
@@ -253,13 +253,13 @@ internal class PostgresDirectLoadSqlGeneratorTest {
 
     @Test
     fun testColumnAndTypeToString() {
-        val notNullColumn = ColumnAndType("column", "varchar", nullable = false)
+        val notNullColumn = Column("column", "varchar", nullable = false)
         assertEquals("\"column\" varchar NOT NULL", notNullColumn.toString())
     }
 
     @Test
     fun testNullableColumnAndTypeToString() {
-        val nullableColumn = ColumnAndType("column", "varchar", nullable = true)
+        val nullableColumn = Column("column", "varchar", nullable = true)
         assertEquals("\"column\" varchar", nullableColumn.toString())
     }
 }


### PR DESCRIPTION
## What
https://github.com/airbytehq/airbyte-internal-issues/issues/14725

Adding the schema propagation operation (i.e. `ensureSchemaMatches`) for destination postgres. Added a bunch of unit tests and confirmed that `testAppendSchemaEvolution` acceptance test works: 
<img width="567" height="893" alt="Screenshot 2025-10-20 at 3 52 18 PM" src="https://github.com/user-attachments/assets/481ccb63-61a3-45e5-9c5c-88195d4d623e" />


