### PR TITLE
Introduce extract-trigger toolkit

### DIFF
--- a/airbyte-cdk/bulk/changelog.md
+++ b/airbyte-cdk/bulk/changelog.md
@@ -1,3 +1,7 @@
+## Version 0.1.63
+
+introduce extract-trigger toolkit for trigger-based CDC
+
 ## Version 0.1.62
 
 load cdk: correctly parse empty schemas

--- a/airbyte-cdk/bulk/toolkits/extract-trigger/build.gradle
+++ b/airbyte-cdk/bulk/toolkits/extract-trigger/build.gradle
@@ -1,0 +1,14 @@
+dependencies {
+    // TODO: Currently prints warning:
+    //  The dependency resolution engine wasn't able to find a version of module org.jetbrains.kotlin:kotlin-stdlib
+    //  which satisfied all requirements because the graph wasn't stable enough. The highest version was selected in
+    //  order to stabilize selection. Features available in a stable graph like version alignment are not guaranteed
+    //  in this case.
+
+    // TODO: Currently transitive:
+    //  Airbyte Protocol v18.  Check other toolkits for same issue.
+    //  Jakarta
+    implementation project(':airbyte-cdk:bulk:core:bulk-cdk-core-base')
+    implementation project(':airbyte-cdk:bulk:core:bulk-cdk-core-extract')
+    implementation project(':airbyte-cdk:bulk:toolkits:bulk-cdk-toolkit-extract-jdbc')
+}

--- a/airbyte-cdk/bulk/toolkits/extract-trigger/src/main/kotlin/io/airbyte/cdk/DeleteQuerier.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-trigger/src/main/kotlin/io/airbyte/cdk/DeleteQuerier.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk
+
+import io.airbyte.cdk.jdbc.JdbcConnectionFactory
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.micronaut.context.annotation.DefaultImplementation
+import jakarta.inject.Singleton
+import java.sql.Connection
+import java.sql.PreparedStatement
+
+/** Interface for executing delete queries against a database. */
+@DefaultImplementation(JdbcDeleteQuerier::class)
+interface DeleteQuerier {
+    /**
+     * Executes a DELETE query against the database.
+     *
+     * @param sql The SQL DELETE query to execute
+     * @return The number of rows affected by the delete operation
+     */
+    fun executeDelete(
+        sql: String,
+    ): Int
+}
+
+/** Default implementation of [DeleteQuerier] for JDBC connections. */
+@Singleton
+class JdbcDeleteQuerier(private val jdbcConnectionFactory: JdbcConnectionFactory) : DeleteQuerier {
+    private val log = KotlinLogging.logger {}
+
+    override fun executeDelete(
+        sql: String,
+    ): Int {
+        log.info { "Executing delete query: $sql" }
+        var conn: Connection? = null
+        var stmt: PreparedStatement? = null
+
+        try {
+            conn = jdbcConnectionFactory.get()
+            conn.isReadOnly = false
+            stmt = conn.prepareStatement(sql)
+
+            // Execute the delete statement and return the count of affected rows
+            val rowsAffected = stmt.executeUpdate()
+            log.info { "Delete query affected $rowsAffected rows" }
+            return rowsAffected
+        } finally {
+            try {
+                stmt?.close()
+            } finally {
+                conn?.close()
+            }
+        }
+    }
+}

--- a/airbyte-cdk/bulk/toolkits/extract-trigger/src/main/kotlin/io/airbyte/cdk/DeleteQuerier.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-trigger/src/main/kotlin/io/airbyte/cdk/DeleteQuerier.kt
@@ -43,7 +43,7 @@ class JdbcDeleteQuerier(private val jdbcConnectionFactory: JdbcConnectionFactory
             stmt = conn.prepareStatement(sql)
 
             // Execute the delete statement and return the count of affected rows
-            val rowsAffected = stmt.executeUpdate()
+            val rowsAffected: Int = stmt.executeUpdate()
             log.info { "Delete query affected $rowsAffected rows" }
             return rowsAffected
         } finally {

--- a/airbyte-cdk/bulk/toolkits/extract-trigger/src/main/kotlin/io/airbyte/cdk/TriggerCdcMetaFields.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-trigger/src/main/kotlin/io/airbyte/cdk/TriggerCdcMetaFields.kt
@@ -15,6 +15,9 @@ import kotlin.text.lowercase
 enum class TriggerCdcMetaFields(
     override val type: FieldType,
 ) : MetaField {
+    // TODO: For speed mode, this should be changed to CdcOffsetDateTimeStringMetaFieldType.
+    //  For json, this works because dates are string in json.
+    //  For protobuf, this causes a bug since the type will cause it to convert differently.
     CHANGE_TIME(CdcStringMetaFieldType);
 
     override val id: String

--- a/airbyte-cdk/bulk/toolkits/extract-trigger/src/main/kotlin/io/airbyte/cdk/TriggerCdcMetaFields.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-trigger/src/main/kotlin/io/airbyte/cdk/TriggerCdcMetaFields.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk
+
+import io.airbyte.cdk.discover.CdcStringMetaFieldType
+import io.airbyte.cdk.discover.FieldType
+import io.airbyte.cdk.discover.MetaField
+import kotlin.text.lowercase
+
+/* We shouldn't have to create this but destination can't recognize this column if passed as field
+ * type. This is to be used as CURSOR_FIELD in TriggerTableConfig.
+ */
+enum class TriggerCdcMetaFields(
+    override val type: FieldType,
+) : MetaField {
+    CHANGE_TIME(CdcStringMetaFieldType);
+
+    override val id: String
+        get() = TriggerTableConfig.TRIGGER_TABLE_PREFIX + name.lowercase()
+}

--- a/airbyte-cdk/bulk/toolkits/extract-trigger/src/main/kotlin/io/airbyte/cdk/TriggerPartition.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-trigger/src/main/kotlin/io/airbyte/cdk/TriggerPartition.kt
@@ -1,0 +1,395 @@
+/*
+ * Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.node.ObjectNode
+import io.airbyte.cdk.command.OpaqueStateValue
+import io.airbyte.cdk.discover.Field
+import io.airbyte.cdk.read.And
+import io.airbyte.cdk.read.Equal
+import io.airbyte.cdk.read.From
+import io.airbyte.cdk.read.FromSample
+import io.airbyte.cdk.read.Greater
+import io.airbyte.cdk.read.GreaterOrEqual
+import io.airbyte.cdk.read.JdbcCursorPartition
+import io.airbyte.cdk.read.JdbcPartition
+import io.airbyte.cdk.read.JdbcSplittablePartition
+import io.airbyte.cdk.read.Lesser
+import io.airbyte.cdk.read.LesserOrEqual
+import io.airbyte.cdk.read.Limit
+import io.airbyte.cdk.read.Or
+import io.airbyte.cdk.read.OrderBy
+import io.airbyte.cdk.read.SelectColumnMaxValue
+import io.airbyte.cdk.read.SelectColumns
+import io.airbyte.cdk.read.SelectQuery
+import io.airbyte.cdk.read.SelectQueryGenerator
+import io.airbyte.cdk.read.SelectQuerySpec
+import io.airbyte.cdk.read.Stream
+import io.airbyte.cdk.read.Where
+import io.airbyte.cdk.read.WhereClauseLeafNode
+import io.airbyte.cdk.read.WhereClauseNode
+import io.airbyte.cdk.read.optimize
+import io.airbyte.cdk.util.Jsons
+import kotlin.collections.distinct
+import kotlin.collections.map
+import kotlin.collections.mapIndexed
+import kotlin.collections.plus
+import kotlin.collections.take
+import kotlin.collections.zip
+import kotlin.let
+
+sealed class TriggerPartition(
+    val selectQueryGenerator: SelectQueryGenerator,
+    final override val streamState: TriggerStreamState,
+    protected val config: TriggerTableConfig,
+) : JdbcPartition<TriggerStreamState> {
+    val stream: Stream = streamState.stream
+    val from = From(stream.name, stream.namespace)
+}
+
+/** Base class for trigger-based implementations of [JdbcPartition] for unsplittable partitions. */
+sealed class TriggerUnsplittablePartition(
+    selectQueryGenerator: SelectQueryGenerator,
+    streamState: TriggerStreamState,
+    config: TriggerTableConfig,
+) : TriggerPartition(selectQueryGenerator, streamState, config) {
+
+    override val nonResumableQuery: SelectQuery
+        get() = selectQueryGenerator.generate(nonResumableQuerySpec.optimize())
+
+    val nonResumableQuerySpec = SelectQuerySpec(SelectColumns(stream.fields), from)
+
+    override fun samplingQuery(sampleRateInvPow2: Int): SelectQuery {
+        val sampleSize: Int = streamState.sharedState.maxSampleSize
+        val querySpec =
+            SelectQuerySpec(
+                SelectColumns(stream.fields),
+                FromSample(stream.name, stream.namespace, sampleRateInvPow2, sampleSize),
+            )
+        return selectQueryGenerator.generate(querySpec.optimize())
+    }
+}
+
+/** Trigger-based implementation of a [JdbcPartition] for an unsplittable snapshot partition. */
+class TriggerUnsplittableSnapshotPartition(
+    selectQueryGenerator: SelectQueryGenerator,
+    streamState: TriggerStreamState,
+    config: TriggerTableConfig,
+) : TriggerUnsplittablePartition(selectQueryGenerator, streamState, config) {
+
+    override val completeState: OpaqueStateValue = TriggerStreamStateValue.snapshotCompleted
+}
+
+/**
+ * Trigger-based implementation of a [JdbcPartition] for an unsplittable snapshot partition
+ * preceding a cursor-based incremental sync.
+ */
+class TriggerUnsplittableSnapshotWithCursorPartition(
+    selectQueryGenerator: SelectQueryGenerator,
+    streamState: TriggerStreamState,
+    val cursor: Field,
+    config: TriggerTableConfig,
+) :
+    TriggerUnsplittablePartition(selectQueryGenerator, streamState, config),
+    JdbcCursorPartition<TriggerStreamState> {
+
+    override val completeState: OpaqueStateValue
+        get() =
+            TriggerStreamStateValue.cursorIncrementalCheckpoint(
+                cursor,
+                cursorCheckpoint = streamState.cursorUpperBound!!,
+            )
+
+    override val cursorUpperBoundQuery: SelectQuery
+        get() = selectQueryGenerator.generate(cursorUpperBoundQuerySpec.optimize())
+
+    val cursorUpperBoundQuerySpec = SelectQuerySpec(SelectColumnMaxValue(cursor), from)
+}
+
+/** Base class for trigger-based implementations of [JdbcPartition] for splittable partitions. */
+sealed class TriggerSplittablePartition(
+    selectQueryGenerator: SelectQueryGenerator,
+    streamState: TriggerStreamState,
+    config: TriggerTableConfig,
+    val checkpointColumns: List<Field>,
+    val triggerCdcPartitionState: TriggerCdcPartitionState? = null,
+) :
+    TriggerPartition(selectQueryGenerator, streamState, config),
+    JdbcSplittablePartition<TriggerStreamState> {
+
+    init {
+        streamState.isReadingFromTriggerTable =
+            triggerCdcPartitionState == TriggerCdcPartitionState.INCREMENTAL
+    }
+
+    abstract val lowerBound: List<JsonNode>?
+    abstract val upperBound: List<JsonNode>?
+
+    override val nonResumableQuery: SelectQuery
+        get() = selectQueryGenerator.generate(nonResumableQuerySpec.optimize())
+
+    val queryTableColumns =
+        if (triggerCdcPartitionState == TriggerCdcPartitionState.INCREMENTAL)
+            config.getTriggerTableSchemaFromStream(stream)
+        else stream.fields
+    val triggerTableName =
+        TriggerTableConfig.TRIGGER_TABLE_PREFIX + stream.namespace + '_' + stream.name
+    val queryTableFrom =
+        if (triggerCdcPartitionState == TriggerCdcPartitionState.INCREMENTAL)
+            From(
+                triggerTableName,
+                TriggerTableConfig.TRIGGER_TABLE_NAMESPACE,
+            )
+        else from
+    val nonResumableQuerySpec: SelectQuerySpec
+        get() = SelectQuerySpec(SelectColumns(queryTableColumns), queryTableFrom, where)
+
+    override fun resumableQuery(limit: Long): SelectQuery {
+        val querySpec =
+            SelectQuerySpec(
+                SelectColumns((queryTableColumns + checkpointColumns).distinct()),
+                queryTableFrom,
+                where,
+                OrderBy(checkpointColumns),
+                Limit(limit),
+            )
+        return selectQueryGenerator.generate(querySpec.optimize())
+    }
+
+    override fun samplingQuery(sampleRateInvPow2: Int): SelectQuery {
+        val samplingTableName =
+            if (triggerCdcPartitionState == TriggerCdcPartitionState.INCREMENTAL) triggerTableName
+            else stream.name
+        val samplingNamespace =
+            if (triggerCdcPartitionState == TriggerCdcPartitionState.INCREMENTAL)
+                TriggerTableConfig.TRIGGER_TABLE_NAMESPACE
+            else stream.namespace
+        val sampleSize: Int = streamState.sharedState.maxSampleSize
+        val querySpec =
+            SelectQuerySpec(
+                SelectColumns((queryTableColumns + checkpointColumns).distinct()),
+                FromSample(samplingTableName, samplingNamespace, sampleRateInvPow2, sampleSize),
+                where,
+                OrderBy(checkpointColumns),
+            )
+        return selectQueryGenerator.generate(querySpec.optimize())
+    }
+
+    val where: Where
+        get() {
+            val zippedLowerBound: List<Pair<Field, JsonNode>> =
+                lowerBound?.let { checkpointColumns.zip(it) } ?: listOf()
+            val lowerBoundDisj: List<WhereClauseNode> =
+                zippedLowerBound.mapIndexed { idx: Int, (gtCol: Field, gtValue: JsonNode) ->
+                    val lastLeaf: WhereClauseLeafNode =
+                        if (isLowerBoundIncluded && idx == checkpointColumns.size - 1) {
+                            GreaterOrEqual(gtCol, gtValue)
+                        } else {
+                            Greater(gtCol, gtValue)
+                        }
+                    And(
+                        zippedLowerBound.take(idx).map { (eqCol: Field, eqValue: JsonNode) ->
+                            Equal(eqCol, eqValue)
+                        } + listOf(lastLeaf),
+                    )
+                }
+            val zippedUpperBound: List<Pair<Field, JsonNode>> =
+                upperBound?.let { checkpointColumns.zip(it) } ?: listOf()
+            val upperBoundDisj: List<WhereClauseNode> =
+                zippedUpperBound.mapIndexed { idx: Int, (leqCol: Field, leqValue: JsonNode) ->
+                    val lastLeaf: WhereClauseLeafNode =
+                        if (idx < zippedUpperBound.size - 1) {
+                            Lesser(leqCol, leqValue)
+                        } else {
+                            LesserOrEqual(leqCol, leqValue)
+                        }
+                    And(
+                        zippedUpperBound.take(idx).map { (eqCol: Field, eqValue: JsonNode) ->
+                            Equal(eqCol, eqValue)
+                        } + listOf(lastLeaf),
+                    )
+                }
+            return Where(And(Or(lowerBoundDisj), Or(upperBoundDisj)))
+        }
+
+    open val isLowerBoundIncluded: Boolean = false
+}
+
+/** Default implementation of a [JdbcPartition] for a splittable snapshot partition. */
+class TriggerSplittableSnapshotPartition(
+    selectQueryGenerator: SelectQueryGenerator,
+    streamState: TriggerStreamState,
+    config: TriggerTableConfig,
+    primaryKey: List<Field>,
+    triggerCdcPartitionState: TriggerCdcPartitionState? = null,
+    override val lowerBound: List<JsonNode>?,
+    override val upperBound: List<JsonNode>?,
+) :
+    TriggerSplittablePartition(
+        selectQueryGenerator,
+        streamState,
+        config,
+        primaryKey,
+        triggerCdcPartitionState,
+    ) {
+
+    override val completeState: OpaqueStateValue
+        get() =
+            when (upperBound) {
+                null -> TriggerStreamStateValue.snapshotCompleted
+                else ->
+                    TriggerStreamStateValue.snapshotCheckpoint(
+                        primaryKey = checkpointColumns,
+                        primaryKeyCheckpoint = upperBound,
+                    )
+            }
+
+    override fun incompleteState(lastRecord: ObjectNode): OpaqueStateValue =
+        TriggerStreamStateValue.snapshotCheckpoint(
+            primaryKey = checkpointColumns,
+            primaryKeyCheckpoint = checkpointColumns.map { lastRecord[it.id] ?: Jsons.nullNode() },
+        )
+}
+
+/**
+ * Default implementation of a [JdbcPartition] for a splittable partition involving cursor columns.
+ */
+sealed class TriggerCursorPartition(
+    selectQueryGenerator: SelectQueryGenerator,
+    streamState: TriggerStreamState,
+    config: TriggerTableConfig,
+    checkpointColumns: List<Field>,
+    triggerCdcPartitionState: TriggerCdcPartitionState? = null,
+    val cursor: Field,
+    private val explicitCursorUpperBound: JsonNode?,
+) :
+    TriggerSplittablePartition(
+        selectQueryGenerator,
+        streamState,
+        config,
+        checkpointColumns,
+        triggerCdcPartitionState,
+    ),
+    JdbcCursorPartition<TriggerStreamState> {
+
+    val cursorUpperBound: JsonNode
+        get() = explicitCursorUpperBound ?: streamState.cursorUpperBound!!
+    val cursorUpperBoundFrom: From =
+        if (triggerCdcPartitionState == null) from
+        else
+            From(
+                triggerTableName,
+                TriggerTableConfig.TRIGGER_TABLE_NAMESPACE,
+            )
+
+    override val cursorUpperBoundQuery: SelectQuery
+        get() = selectQueryGenerator.generate(cursorUpperBoundQuerySpec.optimize())
+
+    val cursorUpperBoundQuerySpec =
+        SelectQuerySpec(SelectColumnMaxValue(cursor), cursorUpperBoundFrom)
+}
+
+/**
+ * Trigger-based implementation of a [JdbcPartition] for a splittable snapshot partition preceding a
+ * cursor-based incremental sync.
+ */
+class TriggerSplittableSnapshotWithCursorPartition(
+    selectQueryGenerator: SelectQueryGenerator,
+    streamState: TriggerStreamState,
+    config: TriggerTableConfig,
+    primaryKey: List<Field>,
+    triggerCdcPartitionState: TriggerCdcPartitionState? = null,
+    override val lowerBound: List<JsonNode>?,
+    override val upperBound: List<JsonNode>?,
+    cursor: Field,
+    cursorUpperBound: JsonNode?,
+) :
+    TriggerCursorPartition(
+        selectQueryGenerator,
+        streamState,
+        config,
+        primaryKey,
+        triggerCdcPartitionState,
+        cursor,
+        cursorUpperBound,
+    ) {
+
+    override val completeState: OpaqueStateValue
+        get() =
+            when (upperBound) {
+                null ->
+                    TriggerStreamStateValue.cursorIncrementalCheckpoint(
+                        cursor,
+                        cursorUpperBound,
+                    )
+                else ->
+                    TriggerStreamStateValue.snapshotWithCursorCheckpoint(
+                        primaryKey = checkpointColumns,
+                        primaryKeyCheckpoint = upperBound,
+                        cursor,
+                        cursorUpperBound,
+                    )
+            }
+
+    override fun incompleteState(lastRecord: ObjectNode): OpaqueStateValue =
+        TriggerStreamStateValue.snapshotWithCursorCheckpoint(
+            primaryKey = checkpointColumns,
+            primaryKeyCheckpoint = checkpointColumns.map { lastRecord[it.id] ?: Jsons.nullNode() },
+            cursor,
+            cursorUpperBound,
+        )
+}
+
+/**
+ * Trigger-based implementation of a [JdbcPartition] for a cursor incremental partition. These are
+ * always splittable.
+ */
+class TriggerCursorIncrementalPartition(
+    selectQueryGenerator: SelectQueryGenerator,
+    streamState: TriggerStreamState,
+    config: TriggerTableConfig,
+    cursor: Field,
+    triggerCdcPartitionState: TriggerCdcPartitionState? = null,
+    val cursorLowerBound: JsonNode,
+    override val isLowerBoundIncluded: Boolean,
+    cursorUpperBound: JsonNode?,
+) :
+    TriggerCursorPartition(
+        selectQueryGenerator,
+        streamState,
+        config,
+        listOf(cursor),
+        triggerCdcPartitionState,
+        cursor,
+        cursorUpperBound,
+    ) {
+
+    override val lowerBound: List<JsonNode> = listOf(cursorLowerBound)
+    override val upperBound: List<JsonNode>
+        get() = listOf(cursorUpperBound)
+
+    override val completeState: OpaqueStateValue
+        get() =
+            TriggerStreamStateValue.cursorIncrementalCheckpoint(
+                cursor,
+                cursorCheckpoint = cursorUpperBound,
+            )
+
+    override fun incompleteState(lastRecord: ObjectNode): OpaqueStateValue =
+        TriggerStreamStateValue.cursorIncrementalCheckpoint(
+            cursor,
+            cursorCheckpoint = lastRecord[cursor.id] ?: Jsons.nullNode(),
+        )
+}
+
+// SNAPSHOT indicates the stream hasn't had a snapshot completed yet and the partition need to read
+// data from the source table.
+// INCREMENTAL indicates the stream has had a snapshot completed and the partition need to read
+// change from trigger table.
+enum class TriggerCdcPartitionState {
+    SNAPSHOT,
+    INCREMENTAL,
+}

--- a/airbyte-cdk/bulk/toolkits/extract-trigger/src/main/kotlin/io/airbyte/cdk/TriggerPartitionFactory.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-trigger/src/main/kotlin/io/airbyte/cdk/TriggerPartitionFactory.kt
@@ -1,0 +1,318 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk
+
+import com.fasterxml.jackson.databind.JsonNode
+import io.airbyte.cdk.command.OpaqueStateValue
+import io.airbyte.cdk.discover.Field
+import io.airbyte.cdk.discover.FieldOrMetaField
+import io.airbyte.cdk.output.CatalogValidationFailureHandler
+import io.airbyte.cdk.output.InvalidCursor
+import io.airbyte.cdk.output.InvalidPrimaryKey
+import io.airbyte.cdk.output.ResetStream
+import io.airbyte.cdk.read.ConfiguredSyncMode
+import io.airbyte.cdk.read.DefaultJdbcSharedState
+import io.airbyte.cdk.read.JdbcPartitionFactory
+import io.airbyte.cdk.read.SelectQueryGenerator
+import io.airbyte.cdk.read.Stream
+import io.airbyte.cdk.read.StreamFeedBootstrap
+import io.airbyte.cdk.util.Jsons
+import io.micronaut.context.annotation.Primary
+import jakarta.inject.Singleton
+import java.util.concurrent.ConcurrentHashMap
+import kotlin.collections.associateWith
+import kotlin.collections.find
+import kotlin.collections.first
+import kotlin.collections.getOrPut
+import kotlin.collections.isNotEmpty
+import kotlin.collections.map
+import kotlin.collections.mapIndexed
+import kotlin.collections.mapNotNull
+import kotlin.collections.plus
+import kotlin.collections.toList
+import kotlin.collections.toSet
+import kotlin.collections.zip
+import kotlin.jvm.java
+import kotlin.run
+import kotlin.to
+
+@Primary
+@Singleton
+class TriggerPartitionFactory(
+    override val sharedState: DefaultJdbcSharedState,
+    val handler: CatalogValidationFailureHandler,
+    val selectQueryGenerator: SelectQueryGenerator,
+    private val config: TriggerTableConfig,
+) :
+    JdbcPartitionFactory<
+        DefaultJdbcSharedState,
+        TriggerStreamState,
+        TriggerPartition,
+    > {
+
+    private val streamStates = ConcurrentHashMap<StreamIdentifier, TriggerStreamState>()
+
+    override fun streamState(streamFeedBootstrap: StreamFeedBootstrap): TriggerStreamState =
+        streamStates.getOrPut(streamFeedBootstrap.feed.id) {
+            TriggerStreamState(sharedState, streamFeedBootstrap)
+        }
+
+    override fun create(streamFeedBootstrap: StreamFeedBootstrap): TriggerPartition? {
+        val stream: Stream = streamFeedBootstrap.feed
+        val streamState: TriggerStreamState = streamState(streamFeedBootstrap)
+        val opaqueStateValue: OpaqueStateValue? = streamFeedBootstrap.currentState
+        if (opaqueStateValue == null) {
+            return coldStart(streamState)
+        }
+        val sv: TriggerStreamStateValue =
+            Jsons.treeToValue(opaqueStateValue, TriggerStreamStateValue::class.java)
+        val pkMap: Map<Field, JsonNode> =
+            sv.pkMap(stream)
+                ?: run {
+                    handler.accept(ResetStream(stream.id))
+                    streamState.reset()
+                    return coldStart(streamState)
+                }
+        val cursorPair: Pair<Field, JsonNode>? =
+            if (sv.cursors.isEmpty()) {
+                null
+            } else {
+                sv.cursorPair(stream)
+                    ?: run {
+                        handler.accept(ResetStream(stream.id))
+                        streamState.reset()
+                        return coldStart(streamState)
+                    }
+            }
+
+        // Incremental sync applies to CDC or user defined cursor based incremental.
+        val isIncrementalSync: Boolean = stream.configuredSyncMode == ConfiguredSyncMode.INCREMENTAL
+
+        return if (cursorPair == null) {
+            if (isIncrementalSync) {
+                handler.accept(ResetStream(stream.id))
+                streamState.reset()
+                coldStart(streamState)
+            } else if (pkMap.isEmpty()) {
+                // Snapshot complete.
+                null
+            } else {
+                // Snapshot ongoing.
+                TriggerSplittableSnapshotPartition(
+                    selectQueryGenerator,
+                    streamState,
+                    config,
+                    primaryKey = pkMap.keys.toList(),
+                    lowerBound = pkMap.values.toList(),
+                    upperBound = null,
+                )
+            }
+        } else {
+            val (cursor: Field, cursorCheckpoint: JsonNode) = cursorPair
+            val triggerCdcPartitionState =
+                if (cursor.id == config.CURSOR_FIELD.id) TriggerCdcPartitionState.INCREMENTAL
+                else null
+
+            if (!isIncrementalSync) {
+                handler.accept(ResetStream(stream.id))
+                streamState.reset()
+                coldStart(streamState)
+            } else if (pkMap.isNotEmpty()) {
+                // Snapshot ongoing.
+                TriggerSplittableSnapshotWithCursorPartition(
+                    selectQueryGenerator,
+                    streamState,
+                    config,
+                    primaryKey = pkMap.keys.toList(),
+                    triggerCdcPartitionState,
+                    lowerBound = pkMap.values.toList(),
+                    upperBound = null,
+                    cursor,
+                    cursorUpperBound = cursorCheckpoint,
+                )
+            } else if (cursorCheckpoint == streamState.cursorUpperBound) {
+                // Incremental sync complete.
+                null
+            } else {
+                // Incremental sync ongoing.
+                TriggerCursorIncrementalPartition(
+                    selectQueryGenerator,
+                    streamState,
+                    config,
+                    cursor,
+                    triggerCdcPartitionState,
+                    cursorLowerBound = cursorCheckpoint,
+                    isLowerBoundIncluded = true,
+                    cursorUpperBound = streamState.cursorUpperBound,
+                )
+            }
+        }
+    }
+
+    private fun TriggerStreamStateValue.pkMap(stream: Stream): Map<Field, JsonNode>? {
+        if (primaryKey.isEmpty()) {
+            return mapOf()
+        }
+        val fields: List<Field> = stream.configuredPrimaryKey ?: listOf()
+        if (primaryKey.keys != fields.map { it.id }.toSet()) {
+            handler.accept(
+                InvalidPrimaryKey(stream.id, primaryKey.keys.toList()),
+            )
+            return null
+        }
+        return fields.associateWith { primaryKey[it.id]!! }
+    }
+
+    private fun TriggerStreamStateValue.cursorPair(stream: Stream): Pair<Field, JsonNode>? {
+        if (cursors.size > 1) {
+            handler.accept(
+                InvalidCursor(stream.id, cursors.keys.toString()),
+            )
+            return null
+        }
+        val cursorLabel: String = cursors.keys.first()
+        val cursor: FieldOrMetaField? =
+            stream.schema.find { it.id == cursorLabel }
+                ?: config.COMMON_FIELDS.find { it.id == cursorLabel }
+        if (cursor !is Field) {
+            handler.accept(
+                InvalidCursor(stream.id, cursorLabel),
+            )
+            return null
+        }
+        if (stream.configuredCursor != cursor) {
+            handler.accept(
+                InvalidCursor(stream.id, cursorLabel),
+            )
+            return null
+        }
+        return cursor to cursors[cursorLabel]!!
+    }
+
+    private fun coldStart(streamState: TriggerStreamState): TriggerPartition {
+        val stream: Stream = streamState.stream
+        val pkChosenFromCatalog: List<Field> = stream.configuredPrimaryKey ?: listOf()
+        if (stream.configuredSyncMode == ConfiguredSyncMode.FULL_REFRESH) {
+            if (pkChosenFromCatalog.isEmpty()) {
+                return TriggerUnsplittableSnapshotPartition(
+                    selectQueryGenerator,
+                    streamState,
+                    config,
+                )
+            }
+            return TriggerSplittableSnapshotPartition(
+                selectQueryGenerator,
+                streamState,
+                config,
+                pkChosenFromCatalog,
+                lowerBound = null,
+                upperBound = null,
+            )
+        }
+        val cursorChosenFromCatalog: Field =
+            stream.configuredCursor as? Field ?: throw ConfigErrorException("no cursor")
+        if (pkChosenFromCatalog.isEmpty()) {
+            return TriggerUnsplittableSnapshotWithCursorPartition(
+                selectQueryGenerator,
+                streamState,
+                cursorChosenFromCatalog,
+                config,
+            )
+        }
+        val triggerCdcPartitionState =
+            if (config.cdcEnabled) TriggerCdcPartitionState.SNAPSHOT else null
+        return TriggerSplittableSnapshotWithCursorPartition(
+            selectQueryGenerator,
+            streamState,
+            config,
+            pkChosenFromCatalog,
+            triggerCdcPartitionState,
+            lowerBound = null,
+            upperBound = null,
+            cursorChosenFromCatalog,
+            cursorUpperBound = null,
+        )
+    }
+
+    override fun split(
+        unsplitPartition: TriggerPartition,
+        opaqueStateValues: List<OpaqueStateValue>
+    ): List<TriggerPartition> {
+        val splitPartitionBoundaries: List<TriggerStreamStateValue> by lazy {
+            opaqueStateValues.map { Jsons.treeToValue(it, TriggerStreamStateValue::class.java) }
+        }
+        return when (unsplitPartition) {
+            is TriggerSplittableSnapshotPartition ->
+                unsplitPartition.split(splitPartitionBoundaries)
+            is TriggerSplittableSnapshotWithCursorPartition ->
+                unsplitPartition.split(splitPartitionBoundaries)
+            is TriggerCursorIncrementalPartition -> unsplitPartition.split(splitPartitionBoundaries)
+            is TriggerUnsplittableSnapshotPartition -> listOf(unsplitPartition)
+            is TriggerUnsplittableSnapshotWithCursorPartition -> listOf(unsplitPartition)
+        }
+    }
+
+    private fun TriggerSplittableSnapshotPartition.split(
+        splitPointValues: List<TriggerStreamStateValue>
+    ): List<TriggerSplittableSnapshotPartition> {
+        val inners: List<List<JsonNode>> =
+            splitPointValues.mapNotNull { it.pkMap(streamState.stream)?.values?.toList() }
+        val lbs: List<List<JsonNode>?> = listOf(lowerBound) + inners
+        val ubs: List<List<JsonNode>?> = inners + listOf(upperBound)
+        return lbs.zip(ubs).map { (lowerBound, upperBound) ->
+            TriggerSplittableSnapshotPartition(
+                selectQueryGenerator,
+                streamState,
+                config,
+                primaryKey = checkpointColumns,
+                triggerCdcPartitionState,
+                lowerBound,
+                upperBound,
+            )
+        }
+    }
+
+    private fun TriggerSplittableSnapshotWithCursorPartition.split(
+        splitPointValues: List<TriggerStreamStateValue>
+    ): List<TriggerSplittableSnapshotWithCursorPartition> {
+        val inners: List<List<JsonNode>> =
+            splitPointValues.mapNotNull { it.pkMap(streamState.stream)?.values?.toList() }
+        val lbs: List<List<JsonNode>?> = listOf(lowerBound) + inners
+        val ubs: List<List<JsonNode>?> = inners + listOf(upperBound)
+        return lbs.zip(ubs).map { (lowerBound, upperBound) ->
+            TriggerSplittableSnapshotWithCursorPartition(
+                selectQueryGenerator,
+                streamState,
+                config,
+                primaryKey = checkpointColumns,
+                triggerCdcPartitionState,
+                lowerBound,
+                upperBound,
+                cursor,
+                cursorUpperBound,
+            )
+        }
+    }
+
+    private fun TriggerCursorIncrementalPartition.split(
+        splitPointValues: List<TriggerStreamStateValue>
+    ): List<TriggerCursorIncrementalPartition> {
+        val inners: List<JsonNode> = splitPointValues.mapNotNull { it.cursorPair(stream)?.second }
+        val lbs: List<JsonNode> = listOf(cursorLowerBound) + inners
+        val ubs: List<JsonNode> = inners + listOf(cursorUpperBound)
+        return lbs.zip(ubs).mapIndexed { idx: Int, (lowerBound, upperBound) ->
+            TriggerCursorIncrementalPartition(
+                selectQueryGenerator,
+                streamState,
+                config,
+                cursor,
+                triggerCdcPartitionState,
+                lowerBound,
+                isLowerBoundIncluded = idx == 0,
+                upperBound,
+            )
+        }
+    }
+}

--- a/airbyte-cdk/bulk/toolkits/extract-trigger/src/main/kotlin/io/airbyte/cdk/TriggerPartitionReader.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-trigger/src/main/kotlin/io/airbyte/cdk/TriggerPartitionReader.kt
@@ -26,8 +26,6 @@ import io.airbyte.cdk.read.Stream
 import io.airbyte.cdk.read.UnlimitedTimePartitionReader
 import io.airbyte.protocol.models.v0.AirbyteStateMessage
 import io.airbyte.protocol.models.v0.AirbyteStreamStatusTraceMessage
-import java.time.Duration
-import java.time.Instant
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.atomic.AtomicReference

--- a/airbyte-cdk/bulk/toolkits/extract-trigger/src/main/kotlin/io/airbyte/cdk/TriggerPartitionReader.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-trigger/src/main/kotlin/io/airbyte/cdk/TriggerPartitionReader.kt
@@ -1,0 +1,238 @@
+/*
+ * Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+ */
+package io.airbyte.cdk
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
+import io.airbyte.cdk.data.NullCodec
+import io.airbyte.cdk.discover.CommonMetaField
+import io.airbyte.cdk.discover.Field
+import io.airbyte.cdk.discover.FieldOrMetaField
+import io.airbyte.cdk.output.DataChannelMedium.SOCKET
+import io.airbyte.cdk.output.DataChannelMedium.STDIO
+import io.airbyte.cdk.output.OutputMessageRouter
+import io.airbyte.cdk.output.sockets.FieldValueEncoder
+import io.airbyte.cdk.output.sockets.NativeRecordPayload
+import io.airbyte.cdk.read.FieldValueChange
+import io.airbyte.cdk.read.JdbcPartition
+import io.airbyte.cdk.read.JdbcPartitionReader
+import io.airbyte.cdk.read.JdbcSharedState
+import io.airbyte.cdk.read.JdbcStreamState
+import io.airbyte.cdk.read.PartitionReadCheckpoint
+import io.airbyte.cdk.read.PartitionReader
+import io.airbyte.cdk.read.ResourceType
+import io.airbyte.cdk.read.SelectQuerier
+import io.airbyte.cdk.read.Stream
+import io.airbyte.protocol.models.v0.AirbyteStateMessage
+import io.airbyte.protocol.models.v0.AirbyteStreamStatusTraceMessage
+import java.time.Duration
+import java.time.Instant
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.AtomicReference
+
+/** Base class for Trigger-based CDC implementations of [PartitionReader] using JDBC. */
+@SuppressFBWarnings(value = ["NP_NONNULL_RETURN_VIOLATION"], justification = "lateinit usage")
+abstract class TriggerPartitionReader<P : JdbcPartition<*>>(
+    val partition: P,
+    protected val config: TriggerTableConfig,
+) : PartitionReader {
+    private val nullValueEncoder = FieldValueEncoder(null, NullCodec)
+
+    lateinit var outputMessageRouter: OutputMessageRouter
+    lateinit var outputRoute: ((NativeRecordPayload, Map<Field, FieldValueChange>?) -> Unit)
+    private val charPool: List<Char> = ('a'..'z') + ('A'..'Z') + ('0'..'9')
+
+    private fun generatePartitionId(length: Int): String =
+        (1..length).map { charPool.random() }.joinToString("")
+
+    protected var partitionId: String = generatePartitionId(4)
+    val streamState: JdbcStreamState<*> = partition.streamState
+    val stream: Stream = streamState.stream
+    val sharedState: JdbcSharedState = streamState.sharedState
+    val selectQuerier: SelectQuerier = sharedState.selectQuerier
+
+    private val acquiredResources =
+        AtomicReference<Map<ResourceType, JdbcPartitionReader.AcquiredResource>>()
+
+    override fun tryAcquireResources(): PartitionReader.TryAcquireResourcesStatus {
+        val resourceTypes =
+            when (streamState.streamFeedBootstrap.dataChannelMedium) {
+                STDIO -> listOf(ResourceType.RESOURCE_DB_CONNECTION)
+                SOCKET ->
+                    listOf(ResourceType.RESOURCE_DB_CONNECTION, ResourceType.RESOURCE_OUTPUT_SOCKET)
+            }
+        val resources: Map<ResourceType, JdbcPartitionReader.AcquiredResource> =
+            partition.tryAcquireResourcesForReader(resourceTypes)
+                ?: return PartitionReader.TryAcquireResourcesStatus.RETRY_LATER
+        acquiredResources.set(resources)
+
+        outputMessageRouter =
+            OutputMessageRouter(
+                streamState.streamFeedBootstrap.dataChannelMedium,
+                streamState.streamFeedBootstrap.dataChannelFormat,
+                streamState.streamFeedBootstrap.outputConsumer,
+                mapOf("partition_id" to partitionId),
+                streamState.streamFeedBootstrap,
+                acquiredResources
+                    .get()
+                    .filter { it.value.resource != null }
+                    .map { it.key to it.value.resource!! }
+                    .toMap()
+            )
+        outputRoute = outputMessageRouter.recordAcceptors[stream.id]!!
+
+        return PartitionReader.TryAcquireResourcesStatus.READY_TO_RUN
+    }
+
+    fun out(row: SelectQuerier.ResultRow) {
+        val db2StreamState = streamState as TriggerStreamState
+        if (db2StreamState.isReadingFromTriggerTable) {
+            val decoratedPayload = decorateTriggerBasedCdcRecord(row)
+            outputRoute(decoratedPayload, emptyMap())
+        } else {
+            outputRoute(row.data, row.changes)
+        }
+    }
+
+    override fun releaseResources() {
+        if (::outputMessageRouter.isInitialized) {
+            outputMessageRouter.close()
+        }
+        acquiredResources.getAndSet(null)?.forEach { it.value.close() }
+        partitionId = generatePartitionId(4)
+    }
+
+    /** If configured max feed read time elapsed we exit with a transient error */
+    protected fun checkMaxReadTimeElapsed() {
+        sharedState.configuration.maxSnapshotReadDuration?.let {
+            if (Duration.between(sharedState.snapshotReadStartTime, Instant.now()) > it) {
+                throw TransientErrorException("Shutting down snapshot reader: max duration elapsed")
+            }
+        }
+    }
+
+    protected fun outputPendingMessages() {
+        if (streamState.streamFeedBootstrap.dataChannelMedium == STDIO) {
+            return
+        }
+        while (PartitionReader.pendingStates.isNotEmpty()) {
+            var pendingMessage = PartitionReader.pendingStates.poll() ?: break
+            when (pendingMessage) {
+                is AirbyteStateMessage -> {
+                    outputMessageRouter.acceptNonRecord(pendingMessage)
+                }
+                is AirbyteStreamStatusTraceMessage -> {
+                    outputMessageRouter.acceptNonRecord(pendingMessage)
+                }
+            }
+        }
+    }
+
+    private fun decorateTriggerBasedCdcRecord(row: SelectQuerier.ResultRow): NativeRecordPayload {
+        val isDelete: Boolean =
+            (row.data[TriggerTableConfig.OPERATION_TYPE_FIELD.id]!!.fieldValue as? String)
+                ?.uppercase() == "DELETE"
+        val data = createChangePayload(row.data, isDelete)
+        val validatedRecord = validateDataFieldName(data, stream.schema)
+        val transactionTimestamp = row.data[config.CURSOR_FIELD.id]
+        validatedRecord[CommonMetaField.CDC_UPDATED_AT.id] = transactionTimestamp!!
+        validatedRecord[CommonMetaField.CDC_DELETED_AT.id] =
+            if (isDelete) transactionTimestamp else nullValueEncoder
+        validatedRecord[config.CURSOR_FIELD.id] = transactionTimestamp
+        return validatedRecord
+    }
+
+    private fun createChangePayload(
+        data: NativeRecordPayload,
+        isDelete: Boolean,
+    ): NativeRecordPayload {
+        val payload: NativeRecordPayload = mutableMapOf()
+        val suffix = if (isDelete) "_before" else "_after"
+        stream.schema.forEach {
+            val fieldName = TriggerTableConfig.TRIGGER_TABLE_PREFIX + it.id + suffix
+            payload[it.id] = data[fieldName]!!
+        }
+        return payload
+    }
+
+    // Validate the data field name with the schema field name so they have the same case.
+    private fun validateDataFieldName(
+        payload: NativeRecordPayload,
+        schema: Set<FieldOrMetaField>,
+    ): NativeRecordPayload {
+        val validatedPayload: NativeRecordPayload = mutableMapOf()
+        for (field in schema) {
+            val value =
+                payload.keys.find { it.equals(field.id, ignoreCase = true) }?.let { payload[it] }
+                    ?: throw IllegalArgumentException("Field '${field.id}' not found")
+            validatedPayload[field.id] = value
+        }
+        return validatedPayload
+    }
+}
+
+/**
+ * Trigger-based implementation of [PartitionReader] which reads the [partition] in its entirety.
+ */
+class TriggerNonResumablePartitionReader<P : JdbcPartition<*>>(
+    partition: P,
+    config: TriggerTableConfig,
+    val deleteQuerier: DeleteQuerier
+) : TriggerPartitionReader<P>(partition, config) {
+    val runComplete = AtomicBoolean(false)
+    val numRecords = AtomicLong()
+
+    override suspend fun run() {
+        outputPendingMessages()
+        /* Don't start read if we've gone over max duration.
+        We check for elapsed duration before reading and not while because
+        existing exiting with an exception skips checkpoint(), so any work we
+        did before time has elapsed will be wasted. */
+        checkMaxReadTimeElapsed()
+
+        // Check if partition is for trigger based CDC. We don't do cleanup for user defined cursor
+        if (
+            partition is TriggerCursorIncrementalPartition &&
+                partition.triggerCdcPartitionState == TriggerCdcPartitionState.INCREMENTAL
+        ) {
+            val latestCheckpoint = partition.cursorLowerBound.asText()
+            val namespace = TriggerTableConfig.TRIGGER_TABLE_NAMESPACE
+            val fullyQualifiedName = "\"${namespace}\".\"${partition.triggerTableName}\""
+            val whereClause = "\"${config.CURSOR_FIELD.id}\" < '${latestCheckpoint}'"
+            deleteQuerier.executeDelete("DELETE FROM $fullyQualifiedName WHERE $whereClause")
+        }
+
+        selectQuerier
+            .executeQuery(
+                q = partition.nonResumableQuery,
+                parameters =
+                    SelectQuerier.Parameters(
+                        reuseResultObject = true,
+                        fetchSize = streamState.fetchSize,
+                    ),
+            )
+            .use { result: SelectQuerier.Result ->
+                for (row in result) {
+                    out(row)
+                    numRecords.incrementAndGet()
+                }
+            }
+        runComplete.set(true)
+    }
+
+    override fun checkpoint(): PartitionReadCheckpoint {
+        // Sanity check.
+        if (!runComplete.get()) throw RuntimeException("cannot checkpoint non-resumable read")
+        // The run method executed to completion without a LIMIT clause.
+        // This implies that the partition boundary has been reached.
+        return PartitionReadCheckpoint(
+            partition.completeState,
+            numRecords.get(),
+            when (streamState.streamFeedBootstrap.dataChannelMedium) {
+                SOCKET -> partitionId
+                STDIO -> null
+            }
+        )
+    }
+}

--- a/airbyte-cdk/bulk/toolkits/extract-trigger/src/main/kotlin/io/airbyte/cdk/TriggerPartitionReader.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-trigger/src/main/kotlin/io/airbyte/cdk/TriggerPartitionReader.kt
@@ -86,8 +86,8 @@ abstract class TriggerPartitionReader<P : JdbcPartition<*>>(
     }
 
     fun out(row: SelectQuerier.ResultRow) {
-        val db2StreamState = streamState as TriggerStreamState
-        if (db2StreamState.isReadingFromTriggerTable) {
+        val triggerStreamState = streamState as TriggerStreamState
+        if (triggerStreamState.isReadingFromTriggerTable) {
             val decoratedPayload = decorateTriggerBasedCdcRecord(row)
             outputRoute(decoratedPayload, emptyMap())
         } else {

--- a/airbyte-cdk/bulk/toolkits/extract-trigger/src/main/kotlin/io/airbyte/cdk/TriggerPartitionReader.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-trigger/src/main/kotlin/io/airbyte/cdk/TriggerPartitionReader.kt
@@ -23,6 +23,7 @@ import io.airbyte.cdk.read.PartitionReader
 import io.airbyte.cdk.read.ResourceType
 import io.airbyte.cdk.read.SelectQuerier
 import io.airbyte.cdk.read.Stream
+import io.airbyte.cdk.read.UnlimitedTimePartitionReader
 import io.airbyte.protocol.models.v0.AirbyteStateMessage
 import io.airbyte.protocol.models.v0.AirbyteStreamStatusTraceMessage
 import java.time.Duration
@@ -36,7 +37,7 @@ import java.util.concurrent.atomic.AtomicReference
 abstract class TriggerPartitionReader<P : JdbcPartition<*>>(
     val partition: P,
     protected val config: TriggerTableConfig,
-) : PartitionReader {
+) : UnlimitedTimePartitionReader {
     private val nullValueEncoder = FieldValueEncoder(null, NullCodec)
 
     lateinit var outputMessageRouter: OutputMessageRouter

--- a/airbyte-cdk/bulk/toolkits/extract-trigger/src/main/kotlin/io/airbyte/cdk/TriggerPartitionsCreator.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-trigger/src/main/kotlin/io/airbyte/cdk/TriggerPartitionsCreator.kt
@@ -1,0 +1,217 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.node.ObjectNode
+import io.airbyte.cdk.command.OpaqueStateValue
+import io.airbyte.cdk.output.sockets.toJson
+import io.airbyte.cdk.read.JdbcCursorPartition
+import io.airbyte.cdk.read.JdbcPartition
+import io.airbyte.cdk.read.JdbcPartitionFactory
+import io.airbyte.cdk.read.JdbcPartitionsCreator
+import io.airbyte.cdk.read.JdbcSharedState
+import io.airbyte.cdk.read.JdbcSplittablePartition
+import io.airbyte.cdk.read.JdbcStreamState
+import io.airbyte.cdk.read.PartitionReadCheckpoint
+import io.airbyte.cdk.read.PartitionReader
+import io.airbyte.cdk.read.PartitionsCreator
+import io.airbyte.cdk.read.Sample
+import io.airbyte.cdk.read.SelectQuerier
+import io.airbyte.cdk.read.SelectQuery
+import io.airbyte.cdk.read.Stream
+import io.airbyte.cdk.util.Jsons
+import io.github.oshai.kotlinlogging.KotlinLogging
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.collections.distinct
+import kotlin.collections.filter
+import kotlin.collections.map
+import kotlin.collections.mapNotNull
+import kotlin.collections.sum
+import kotlin.random.Random
+import kotlin.ranges.coerceAtLeast
+import kotlin.sequences.asSequence
+import kotlin.sequences.firstOrNull
+import kotlin.to
+import kotlin.use
+
+/** Concurrent Trigger-based implementation of [PartitionsCreator]. */
+class TriggerPartitionsCreator<
+    A : JdbcSharedState,
+    S : JdbcStreamState<A>,
+    P : JdbcPartition<S>,
+>(
+    val partition: P,
+    val partitionFactory: JdbcPartitionFactory<A, S, P>,
+    val config: TriggerTableConfig,
+    val deleteQuerier: DeleteQuerier,
+) : PartitionsCreator {
+    private val log = KotlinLogging.logger {}
+
+    val streamState: S = partition.streamState
+    val stream: Stream = streamState.stream
+    val sharedState: A = streamState.sharedState
+    val selectQuerier: SelectQuerier = sharedState.selectQuerier
+
+    private val acquiredResources = AtomicReference<JdbcPartitionsCreator.AcquiredResources>()
+
+    // A reader that only checkpoints the complete state of a partition
+    // used for empty tables
+    inner class CheckpointOnlyPartitionReader() : PartitionReader {
+        override fun tryAcquireResources(): PartitionReader.TryAcquireResourcesStatus =
+            PartitionReader.TryAcquireResourcesStatus.READY_TO_RUN
+
+        override suspend fun run() {}
+
+        override fun checkpoint(): PartitionReadCheckpoint =
+            PartitionReadCheckpoint(partition.completeState, 0)
+
+        override fun releaseResources() {}
+    }
+
+    override fun tryAcquireResources(): PartitionsCreator.TryAcquireResourcesStatus {
+        val acquiredResources: JdbcPartitionsCreator.AcquiredResources =
+            partition.tryAcquireResourcesForCreator()
+                ?: return PartitionsCreator.TryAcquireResourcesStatus.RETRY_LATER
+        this.acquiredResources.set(acquiredResources)
+        return PartitionsCreator.TryAcquireResourcesStatus.READY_TO_RUN
+    }
+
+    override fun releaseResources() {
+        acquiredResources.getAndSet(null)?.close()
+    }
+
+    fun ensureCursorUpperBound() {
+        val cursorUpperBoundQuery: SelectQuery =
+            (partition as JdbcCursorPartition<*>).cursorUpperBoundQuery
+        if (streamState.cursorUpperBound != null) {
+            return
+        }
+        log.info { "Querying maximum cursor column value." }
+        val record: ObjectNode? =
+            selectQuerier.executeQuery(cursorUpperBoundQuery).use {
+                if (it.hasNext()) it.next().data.toJson() else null
+            }
+        if (record == null) {
+            streamState.cursorUpperBound = Jsons.nullNode()
+            return
+        }
+        val cursorUpperBound: JsonNode? = record.fields().asSequence().firstOrNull()?.value
+        if (cursorUpperBound == null) {
+            log.warn { "No cursor column value found in '${stream.label}'." }
+            return
+        }
+        if (cursorUpperBound.isNull) {
+            log.warn { "Maximum cursor column value in '${stream.label}' is NULL." }
+            return
+        }
+        log.info { "Maximum cursor column value in '${stream.label}' is '$cursorUpperBound'." }
+        streamState.cursorUpperBound = cursorUpperBound
+    }
+
+    /** Collects a sample of rows in the unsplit partition. */
+    fun <T> collectSample(
+        recordMapper: (ObjectNode) -> T,
+    ): Sample<T> {
+        val values = mutableListOf<T>()
+        var previousWeight = 0L
+        for (sampleRateInvPow2 in listOf(16, 8, 0)) {
+            val sampleRateInv: Long = 1L shl sampleRateInvPow2
+            log.info { "Sampling stream '${stream.label}' at rate 1 / $sampleRateInv." }
+            // First, try sampling the table at a rate of one every 2^16 = 65_536 rows.
+            // If that's not enough to produce the desired number of sampled rows (1024 by default)
+            // then try sampling at a higher rate of one every 2^8 = 256 rows.
+            // If that's still not enough, don't sample at all.
+            values.clear()
+            val samplingQuery: SelectQuery = partition.samplingQuery(sampleRateInvPow2)
+            selectQuerier.executeQuery(samplingQuery).use {
+                for (row in it) {
+                    values.add(recordMapper(row.data.toJson()))
+                }
+            }
+            if (values.size < sharedState.maxSampleSize) {
+                previousWeight = sampleRateInv * values.size / sharedState.maxSampleSize
+                continue
+            }
+            val kind: Sample.Kind =
+                when (sampleRateInvPow2) {
+                    16 -> Sample.Kind.LARGE
+                    8 -> Sample.Kind.MEDIUM
+                    else -> Sample.Kind.SMALL
+                }
+            log.info { "Sampled ${values.size} rows in ${kind.name} stream '${stream.label}'." }
+            return Sample(values, kind, previousWeight.coerceAtLeast(sampleRateInv))
+        }
+        val kind: Sample.Kind = if (values.isEmpty()) Sample.Kind.EMPTY else Sample.Kind.TINY
+        log.info { "Sampled ${values.size} rows in ${kind.name} stream '${stream.label}'." }
+        return Sample(values, kind, if (values.isEmpty()) 0L else 1L)
+    }
+
+    override suspend fun run(): List<PartitionReader> {
+        // Ensure that the cursor upper bound is known, if required.
+        if (partition is JdbcCursorPartition<*>) {
+            ensureCursorUpperBound()
+            if (
+                streamState.cursorUpperBound == null || streamState.cursorUpperBound?.isNull == true
+            ) {
+                log.info { "Maximum cursor column value query found that the table was empty." }
+                return listOf(CheckpointOnlyPartitionReader())
+            }
+        }
+        // Handle edge case where the table can't be sampled.
+        if (!sharedState.withSampling) {
+            log.warn {
+                "Table cannot be read by concurrent partition readers because it cannot be sampled."
+            }
+            // TODO: adaptive fetchSize computation?
+            return listOf(TriggerNonResumablePartitionReader(partition, config, deleteQuerier))
+        }
+        // Sample the table for partition split boundaries and for record byte sizes.
+        val sample: Sample<Pair<OpaqueStateValue?, Long>> = collectSample { record: ObjectNode ->
+            val boundary: OpaqueStateValue? =
+                (partition as? JdbcSplittablePartition<*>)?.incompleteState(record)
+            val rowByteSize: Long = sharedState.rowByteSizeEstimator().apply(record)
+            boundary to rowByteSize
+        }
+        if (sample.kind == Sample.Kind.EMPTY) {
+            log.info { "Sampling query found that the table was empty." }
+            return listOf(CheckpointOnlyPartitionReader())
+        }
+        val rowByteSizeSample: Sample<Long> = sample.map { (_, rowByteSize: Long) -> rowByteSize }
+        streamState.fetchSize = sharedState.jdbcFetchSizeEstimator().apply(rowByteSizeSample)
+        val expectedTableByteSize: Long = rowByteSizeSample.sampledValues.sum() * sample.valueWeight
+        log.info { "Table memory size estimated at ${expectedTableByteSize shr 20} MiB." }
+        // Handle edge case where the table can't be split.
+        if (partition !is JdbcSplittablePartition<*>) {
+            log.warn {
+                "Table cannot be read by concurrent partition readers because it cannot be split."
+            }
+            return listOf(TriggerNonResumablePartitionReader(partition, config, deleteQuerier))
+        }
+        // Happy path.
+        log.info { "Target partition size is ${sharedState.targetPartitionByteSize shr 20} MiB." }
+        val secondarySamplingRate: Double =
+            if (expectedTableByteSize <= sharedState.targetPartitionByteSize) {
+                0.0
+            } else {
+                val expectedPartitionByteSize: Long =
+                    expectedTableByteSize / sharedState.maxSampleSize
+                if (expectedPartitionByteSize < sharedState.targetPartitionByteSize) {
+                    expectedPartitionByteSize.toDouble() / sharedState.targetPartitionByteSize
+                } else {
+                    1.0
+                }
+            }
+        val random = Random(expectedTableByteSize) // RNG output is repeatable.
+        val splitBoundaries: List<OpaqueStateValue> =
+            sample.sampledValues
+                .filter { random.nextDouble() < secondarySamplingRate }
+                .mapNotNull { (splitBoundary: OpaqueStateValue?, _) -> splitBoundary }
+                .distinct()
+        val partitions: List<JdbcPartition<*>> = partitionFactory.split(partition, splitBoundaries)
+        log.info { "Table will be read by ${partitions.size} concurrent partition reader(s)." }
+        return partitions.map { TriggerNonResumablePartitionReader(it, config, deleteQuerier) }
+    }
+}

--- a/airbyte-cdk/bulk/toolkits/extract-trigger/src/main/kotlin/io/airbyte/cdk/TriggerPartitionsCreatorFactory.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-trigger/src/main/kotlin/io/airbyte/cdk/TriggerPartitionsCreatorFactory.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk
+
+import io.airbyte.cdk.jdbc.JDBC_PROPERTY_PREFIX
+import io.airbyte.cdk.read.CreateNoPartitions
+import io.airbyte.cdk.read.FeedBootstrap
+import io.airbyte.cdk.read.JdbcPartition
+import io.airbyte.cdk.read.JdbcPartitionFactory
+import io.airbyte.cdk.read.JdbcSharedState
+import io.airbyte.cdk.read.JdbcStreamState
+import io.airbyte.cdk.read.PartitionsCreator
+import io.airbyte.cdk.read.PartitionsCreatorFactory
+import io.airbyte.cdk.read.StreamFeedBootstrap
+import io.micronaut.context.annotation.Requires
+import jakarta.inject.Singleton
+
+/** Concurrent JDBC implementation of [PartitionsCreatorFactory]. Support trigger based CDC only */
+@Singleton
+@Requires(property = MODE_PROPERTY, value = "concurrent_with_cdc")
+class TriggerPartitionsCreatorFactory<
+    A : JdbcSharedState,
+    S : JdbcStreamState<A>,
+    P : JdbcPartition<S>,
+>(
+    val partitionFactory: JdbcPartitionFactory<A, S, P>,
+    val config: TriggerTableConfig,
+    val deleteQuerier: DeleteQuerier,
+) : PartitionsCreatorFactory {
+
+    override fun make(feedBootstrap: FeedBootstrap<*>): PartitionsCreator? {
+        if (feedBootstrap !is StreamFeedBootstrap) return null
+        val partition: P = partitionFactory.create(feedBootstrap) ?: return CreateNoPartitions
+        return TriggerPartitionsCreator(partition, partitionFactory, config, deleteQuerier)
+    }
+}
+
+private const val MODE_PROPERTY = "$JDBC_PROPERTY_PREFIX.mode"

--- a/airbyte-cdk/bulk/toolkits/extract-trigger/src/main/kotlin/io/airbyte/cdk/TriggerPartitionsCreatorFactorySupplier.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-trigger/src/main/kotlin/io/airbyte/cdk/TriggerPartitionsCreatorFactorySupplier.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2024 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk
+
+import io.airbyte.cdk.read.JdbcPartition
+import io.airbyte.cdk.read.JdbcSharedState
+import io.airbyte.cdk.read.JdbcStreamState
+import io.airbyte.cdk.read.MODE_PROPERTY
+import io.airbyte.cdk.read.PartitionsCreatorFactorySupplier
+import io.micronaut.context.annotation.Primary
+import io.micronaut.context.annotation.Requires
+import jakarta.inject.Singleton
+
+@Singleton
+@Primary
+@Requires(property = MODE_PROPERTY, value = "concurrent_with_cdc")
+class TriggerPartitionsCreatorFactorySupplier<
+    A : JdbcSharedState,
+    S : JdbcStreamState<A>,
+    P : JdbcPartition<S>,
+>(private val factory: TriggerPartitionsCreatorFactory<A, S, P>) :
+    PartitionsCreatorFactorySupplier<TriggerPartitionsCreatorFactory<A, S, P>> {
+
+    override fun get(): TriggerPartitionsCreatorFactory<A, S, P> {
+        return factory
+    }
+}

--- a/airbyte-cdk/bulk/toolkits/extract-trigger/src/main/kotlin/io/airbyte/cdk/TriggerStreamState.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-trigger/src/main/kotlin/io/airbyte/cdk/TriggerStreamState.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk
+
+import com.fasterxml.jackson.databind.JsonNode
+import io.airbyte.cdk.read.DefaultJdbcSharedState
+import io.airbyte.cdk.read.JdbcStreamState
+import io.airbyte.cdk.read.LimitState
+import io.airbyte.cdk.read.StreamFeedBootstrap
+import java.util.concurrent.atomic.AtomicReference
+
+/** Implementation of [JdbcStreamState] for Trigger-based CDC. */
+class TriggerStreamState(
+    override val sharedState: DefaultJdbcSharedState,
+    override val streamFeedBootstrap: StreamFeedBootstrap,
+) : JdbcStreamState<DefaultJdbcSharedState> {
+
+    override var cursorUpperBound: JsonNode?
+        get() = transient.get().cursorUpperBound
+        set(value) {
+            transient.updateAndGet { it.copy(cursorUpperBound = value) }
+        }
+
+    override var fetchSize: Int?
+        get() = transient.get().fetchSize
+        set(value) {
+            transient.updateAndGet { it.copy(fetchSize = value) }
+        }
+
+    override val fetchSizeOrDefault: Int
+        get() = fetchSize ?: sharedState.constants.defaultFetchSize
+
+    override val limit: Long
+        get() = fetchSizeOrDefault * transient.get().limitState.current
+
+    private val transient = AtomicReference(Transient.initial)
+
+    var isReadingFromTriggerTable: Boolean = false
+
+    override fun updateLimitState(fn: (LimitState) -> LimitState) {
+        transient.updateAndGet { it.copy(limitState = fn(it.limitState)) }
+    }
+
+    override fun reset() {
+        transient.set(Transient.initial)
+    }
+
+    private data class Transient(
+        val fetchSize: Int?,
+        val limitState: LimitState,
+        val cursorUpperBound: JsonNode?,
+    ) {
+        companion object {
+            val initial = Transient(fetchSize = null, LimitState.minimum, cursorUpperBound = null)
+        }
+    }
+}

--- a/airbyte-cdk/bulk/toolkits/extract-trigger/src/main/kotlin/io/airbyte/cdk/TriggerStreamStateValue.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-trigger/src/main/kotlin/io/airbyte/cdk/TriggerStreamStateValue.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.databind.JsonNode
+import io.airbyte.cdk.command.OpaqueStateValue
+import io.airbyte.cdk.discover.Field
+import io.airbyte.cdk.util.Jsons
+import kotlin.collections.map
+import kotlin.collections.toMap
+import kotlin.collections.zip
+import kotlin.to
+
+class TriggerStreamStateValue(
+    @JsonProperty("primary_key") val primaryKey: Map<String, JsonNode> = mapOf(),
+    @JsonProperty("cursors") val cursors: Map<String, JsonNode> = mapOf(),
+) {
+    companion object {
+        /** Empty json representing the completion of a FULL_REFRESH snapshot. */
+        val snapshotCompleted: OpaqueStateValue
+            get() = Jsons.valueToTree(TriggerStreamStateValue())
+
+        /** Value representing the progress of an ongoing snapshot not involving cursor columns. */
+        fun snapshotCheckpoint(
+            primaryKey: List<Field>,
+            primaryKeyCheckpoint: List<JsonNode>,
+        ): OpaqueStateValue =
+            Jsons.valueToTree(
+                TriggerStreamStateValue(
+                    primaryKey = primaryKey.map { it.id }.zip(primaryKeyCheckpoint).toMap(),
+                )
+            )
+
+        /** Value representing the progress of an ongoing snapshot involving cursor columns. */
+        fun snapshotWithCursorCheckpoint(
+            primaryKey: List<Field>,
+            primaryKeyCheckpoint: List<JsonNode>,
+            cursor: Field,
+            cursorUpperBound: JsonNode,
+        ): OpaqueStateValue =
+            Jsons.valueToTree(
+                TriggerStreamStateValue(
+                    primaryKey = primaryKey.map { it.id }.zip(primaryKeyCheckpoint).toMap(),
+                    cursors = mapOf(cursor.id to cursorUpperBound),
+                )
+            )
+
+        /** Value representing the progress of an ongoing incremental cursor read. */
+        fun cursorIncrementalCheckpoint(
+            cursor: Field,
+            cursorCheckpoint: JsonNode,
+        ): OpaqueStateValue =
+            Jsons.valueToTree(
+                TriggerStreamStateValue(
+                    cursors = mapOf(cursor.id to cursorCheckpoint),
+                )
+            )
+    }
+}

--- a/airbyte-cdk/bulk/toolkits/extract-trigger/src/main/kotlin/io/airbyte/cdk/TriggerTableConfig.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-trigger/src/main/kotlin/io/airbyte/cdk/TriggerTableConfig.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk
+
+import io.airbyte.cdk.discover.Field
+import io.airbyte.cdk.discover.FieldType
+import io.airbyte.cdk.jdbc.BigIntegerFieldType
+import io.airbyte.cdk.jdbc.StringFieldType
+import io.airbyte.cdk.read.Stream
+
+/**
+ * Trigger table related constants, schema etc. Trigger table naming convention:
+ * TRIGGER_TABLE_PREFIX + <schema_name> + <table_name>.
+ */
+abstract class TriggerTableConfig() {
+
+    abstract val cursorFieldType: FieldType
+    abstract val cdcEnabled: Boolean
+
+    val CURSOR_FIELD: Field
+        get() =
+            Field(
+                id = TRIGGER_TABLE_PREFIX + "change_time",
+                type = cursorFieldType,
+            )
+
+    val COMMON_FIELDS: List<Field>
+        get() =
+            listOf(
+                CHANGE_ID_FIELD,
+                CURSOR_FIELD,
+                OPERATION_TYPE_FIELD,
+            )
+
+    fun getTriggerTableSchemaFromStream(stream: Stream): List<Field> {
+        val result = mutableListOf<Field>()
+
+        stream.schema.forEach { field ->
+            result.add(Field(id = TRIGGER_TABLE_PREFIX + field.id + "_before", type = field.type))
+            result.add(Field(id = TRIGGER_TABLE_PREFIX + field.id + "_after", type = field.type))
+        }
+        return COMMON_FIELDS + result
+    }
+
+    companion object {
+        const val TRIGGER_TABLE_PREFIX = "_ab_trigger_"
+        const val TRIGGER_TABLE_NAMESPACE = "_ab_cdc"
+        val CHANGE_ID_FIELD =
+            Field(
+                id = TRIGGER_TABLE_PREFIX + "change_id",
+                type = BigIntegerFieldType,
+            )
+        val OPERATION_TYPE_FIELD =
+            Field(
+                id = TRIGGER_TABLE_PREFIX + "operation_type",
+                type = StringFieldType,
+            )
+    }
+}

--- a/airbyte-cdk/bulk/toolkits/extract-trigger/src/main/kotlin/io/airbyte/cdk/operations/TriggerStreamFactory.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-trigger/src/main/kotlin/io/airbyte/cdk/operations/TriggerStreamFactory.kt
@@ -1,0 +1,64 @@
+/* Copyright (c) 2025 Airbyte, Inc., all rights reserved. */
+package io.airbyte.cdk.operations
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.node.ObjectNode
+import io.airbyte.cdk.TriggerCdcMetaFields
+import io.airbyte.cdk.TriggerTableConfig
+import io.airbyte.cdk.command.OpaqueStateValue
+import io.airbyte.cdk.data.NullCodec
+import io.airbyte.cdk.discover.CommonMetaField
+import io.airbyte.cdk.discover.FieldOrMetaField
+import io.airbyte.cdk.discover.JdbcAirbyteStreamFactory
+import io.airbyte.cdk.discover.MetaField
+import io.airbyte.cdk.output.sockets.FieldValueEncoder
+import io.airbyte.cdk.output.sockets.NativeRecordPayload
+import io.airbyte.cdk.read.Stream
+import io.micronaut.context.annotation.Primary
+import jakarta.inject.Singleton
+import java.time.OffsetDateTime
+
+@Singleton
+@Primary
+class TriggerStreamFactory(private val config: TriggerTableConfig) : JdbcAirbyteStreamFactory {
+
+    override val globalCursor: FieldOrMetaField = config.CURSOR_FIELD
+
+    override val globalMetaFields: Set<MetaField> =
+        setOf(
+            TriggerCdcMetaFields.CHANGE_TIME,
+            CommonMetaField.CDC_UPDATED_AT,
+            CommonMetaField.CDC_DELETED_AT,
+        )
+
+    override fun decorateRecordData(
+        timestamp: OffsetDateTime,
+        globalStateValue: OpaqueStateValue?,
+        stream: Stream,
+        recordData: ObjectNode
+    ) {
+        recordData.set<JsonNode>(
+            CommonMetaField.CDC_UPDATED_AT.id,
+            null,
+        )
+        recordData.set<JsonNode>(
+            CommonMetaField.CDC_DELETED_AT.id,
+            null,
+        )
+        recordData.set<JsonNode>(
+            config.CURSOR_FIELD.id,
+            null,
+        )
+    }
+
+    override fun decorateRecordData(
+        timestamp: OffsetDateTime,
+        globalStateValue: OpaqueStateValue?,
+        stream: Stream,
+        recordData: NativeRecordPayload
+    ) {
+        recordData[CommonMetaField.CDC_UPDATED_AT.id] = FieldValueEncoder(null, NullCodec)
+        recordData[CommonMetaField.CDC_DELETED_AT.id] = FieldValueEncoder(null, NullCodec)
+        recordData[config.CURSOR_FIELD.id] = FieldValueEncoder(null, NullCodec)
+    }
+}

--- a/airbyte-cdk/bulk/version.properties
+++ b/airbyte-cdk/bulk/version.properties
@@ -1,1 +1,1 @@
-version=0.1.62
+version=0.1.63


### PR DESCRIPTION
Move the trigger-based functionality from some enterprise connectors into a new toolkit in the CDK where it can be better maintained.

## Review guide
It seemed impossible for a reviewer to understand what was just moved from the connectors verbatim and what was modified, so I generated this report:
[cdk-migration-diff.html](https://github.com/user-attachments/files/23007681/cdk-migration-diff.html)

## User Impact
No behavior change

## Can this PR be safely reverted and rolled back?
- [x] YES 💚 - but only until one or both of the enterprise connectors with this functionality start using it
- [ ] NO ❌
