### PR TITLE
source-uptick: bump to 0.3.6

### DIFF
--- a/airbyte-integrations/connectors/source-uptick/manifest.yaml
+++ b/airbyte-integrations/connectors/source-uptick/manifest.yaml
@@ -5382,7 +5382,7 @@ streams:
         request_parameters:
           ordering: -updated
           show_deleted: "true"
-          fields[TaskSession]: id,created,updated,trashed,submitted,is_approved,is_submitted,type,started,finished,started_coord_lat,started_coord_lng,finished_coord_lat,finished_coord_lng,original_started,original_finished,description,rate,timezone,multiplier,multiplier_label,sell_rate,hours,cost,sell,submitted_at,approved_at,task,technician,sell_product,submitted_by,approved_by,sell_hours,duration,duration_hours,status,payroll_date,appointment_attendance,is_suspicious_started,is_suspicious_finished
+          fields[TaskSession]: id,created,updated,trashed,submitted,is_approved,is_submitted,type,started,finished,started_coord_lat,started_coord_lng,finished_coord_lat,finished_coord_lng,original_started,original_finished,description,rate,timezone,multiplier,multiplier_label,sell_rate,cost,sell,submitted_at,approved_at,task,technician,sell_product,submitted_by,approved_by,duration,duration_hours,status,payroll_date
     schema_loader:
       type: InlineSchemaLoader
       schema:
@@ -5487,11 +5487,6 @@ streams:
               - string
               - "null"
             format: decimal
-          hours:
-            type:
-              - string
-              - "null"
-            format: decimal
           cost:
             type:
               - string
@@ -5534,9 +5529,6 @@ streams:
             type:
               - string
               - "null"
-          sell_hours:
-            type:
-              - string
           duration:
             type:
               - integer
@@ -5555,16 +5547,6 @@ streams:
               - string
               - "null"
             format: date
-          appointment_attendance:
-            type:
-              - string
-              - "null"
-          is_suspicious_started:
-            type:
-              - boolean
-          is_suspicious_finished:
-            type:
-              - boolean
     transformations:
       - type: AddFields
         fields:
@@ -5658,10 +5640,6 @@ streams:
             value: '{{ record["attributes"]["sell_rate"] or "None"}}'
           - type: AddedFieldDefinition
             path:
-              - hours
-            value: '{{ record["attributes"]["hours"] or "None"}}'
-          - type: AddedFieldDefinition
-            path:
               - cost
             value: '{{ record["attributes"]["cost"] or "None"}}'
           - type: AddedFieldDefinition
@@ -5698,10 +5676,6 @@ streams:
             value: '{{ record["relationships"]["approved_by"]["data"]["id"] or "None"}}'
           - type: AddedFieldDefinition
             path:
-              - sell_hours
-            value: '{{ record["attributes"]["sell_hours"] }}'
-          - type: AddedFieldDefinition
-            path:
               - duration
             value: '{{ record["attributes"]["duration"] or "None"}}'
           - type: AddedFieldDefinition
@@ -5716,18 +5690,6 @@ streams:
             path:
               - payroll_date
             value: '{{ record["attributes"]["payroll_date"] or "None"}}'
-          - type: AddedFieldDefinition
-            path:
-              - appointment_attendance
-            value: '{{ record["attributes"]["appointment_attendance"] or "None"}}'
-          - type: AddedFieldDefinition
-            path:
-              - is_suspicious_started
-            value: '{{ record["attributes"]["is_suspicious_started"] }}'
-          - type: AddedFieldDefinition
-            path:
-              - is_suspicious_finished
-            value: '{{ record["attributes"]["is_suspicious_finished"] }}'
   - type: DeclarativeStream
     name: contractors
     primary_key:

--- a/airbyte-integrations/connectors/source-uptick/manifest.yaml
+++ b/airbyte-integrations/connectors/source-uptick/manifest.yaml
@@ -27,7 +27,7 @@ definitions:
           - type: WaitTimeFromHeader
             header: Retry-After
       request_headers:
-        User-Agent: Airbyte (Connector Version 0.3.5)
+        User-Agent: Airbyte (Connector Version 0.3.6)
     SimpleRetriever:
       requester:
         $ref: "#/definitions/linked/HttpRequester"

--- a/airbyte-integrations/connectors/source-uptick/metadata.yaml
+++ b/airbyte-integrations/connectors/source-uptick/metadata.yaml
@@ -33,7 +33,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 54c75c42-df4a-4f3e-a5f3-d50cf80f1649
-  dockerImageTag: 0.3.5
+  dockerImageTag: 0.3.6
   dockerRepository: airbyte/source-uptick
   githubIssueLabel: source-uptick
   icon: icon.svg

--- a/docs/integrations/sources/uptick.md
+++ b/docs/integrations/sources/uptick.md
@@ -117,6 +117,7 @@ The Uptick connector syncs data from the following streams, organized by functio
 
 | Version          | Date              | Pull Request | Subject        |
 |------------------|-------------------|--------------|----------------|
+| 0.3.6 | 2025-10-20 | [67585](https://github.com/airbytehq/airbyte/pull/67585) | Remove expensive calculation fields from tasksessions |
 | 0.3.5 | 2025-10-17 | [67585](https://github.com/airbytehq/airbyte/pull/67585) | Remove projectsectiontask and add more incremental sync streams |
 | 0.3.4 | 2025-10-14 | [67855](https://github.com/airbytehq/airbyte/pull/67855) | Update dependencies |
 | 0.3.3 | 2025-10-07 | [67515](https://github.com/airbytehq/airbyte/pull/67515) | Update dependencies |


### PR DESCRIPTION
## What
- Removes expensive to calculate fields from tasksession stream so that the sync works reliably

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
