### PR TITLE
fix(source-hubspot): unpin the previous versions on oss and cloud

### DIFF
--- a/airbyte-integrations/connectors/source-hubspot/metadata.yaml
+++ b/airbyte-integrations/connectors/source-hubspot/metadata.yaml
@@ -36,10 +36,8 @@ data:
   registryOverrides:
     cloud:
       enabled: true
-      dockerImageTag: 6.0.5
     oss:
       enabled: true
-      dockerImageTag: 6.0.5
   releaseStage: generally_available
   releases:
     rolloutConfiguration:


### PR DESCRIPTION
forgot to unpin the versions in the previous PR so can't do the progressive rollout until this is removed
