### PR TITLE
Fetch the startup LSN exactly once

### DIFF
--- a/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/cdc/PostgresDebeziumStateUtil.java
+++ b/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/cdc/PostgresDebeziumStateUtil.java
@@ -219,11 +219,16 @@ public class PostgresDebeziumStateUtil implements DebeziumStateUtil {
   /**
    * Method to construct initial Debezium state which can be passed onto Debezium engine to make it
    * process WAL from a specific LSN and skip snapshot phase
+   *
+   * @param database the database
+   * @param dbName the database name
+   * @param lsn the LSN to use (must be provided to ensure consistency across CDC operations)
+   * @return the initial Debezium state
    */
-  public JsonNode constructInitialDebeziumState(final JdbcDatabase database, final String dbName) {
+  public JsonNode constructInitialDebeziumState(final JdbcDatabase database, final String dbName, final long lsn) {
     if (initialState.get() == null) {
       try {
-        final JsonNode asJson = format(currentXLogLocation(database), currentTransactionId(database), dbName, Instant.now());
+        final JsonNode asJson = format(lsn, currentTransactionId(database), dbName, Instant.now());
         initialState.set(asJson);
       } catch (SQLException e) {
         throw new RuntimeException(e);

--- a/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/CdcPostgresSourceTest.java
+++ b/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/CdcPostgresSourceTest.java
@@ -500,7 +500,11 @@ public class CdcPostgresSourceTest extends CdcSourceTest<PostgresSource, Postgre
                 config().get(JdbcUtils.PORT_KEY).asInt(),
                 config().get(JdbcUtils.DATABASE_KEY).asText())));
 
-    return PostgresCdcTargetPosition.targetPosition(database);
+    try {
+      return PostgresCdcTargetPosition.targetPosition(io.airbyte.cdk.db.PostgresUtils.getLsn(database).asLong());
+    } catch (java.sql.SQLException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   @Override

--- a/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/PostgresDebeziumStateUtilTest.java
+++ b/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/PostgresDebeziumStateUtilTest.java
@@ -224,7 +224,7 @@ public class PostgresDebeziumStateUtilTest {
   }
 
   @Test
-  public void debeziumInitialStateConstructTest() {
+  public void debeziumInitialStateConstructTest() throws SQLException {
     final DockerImageName myImage = DockerImageName.parse("debezium/postgres:13-alpine").asCompatibleSubstituteFor("postgres");
     final String dbName = Strings.addRandomSuffix("db", "_", 10).toLowerCase();
     try (final PostgreSQLContainer<?> container = new PostgreSQLContainer<>(myImage)) {
@@ -249,7 +249,8 @@ public class PostgresDebeziumStateUtilTest {
               databaseConfig.get(JdbcUtils.JDBC_URL_KEY)));
 
       final PostgresDebeziumStateUtil postgresDebeziumStateUtil = new PostgresDebeziumStateUtil();
-      final JsonNode debeziumState = postgresDebeziumStateUtil.constructInitialDebeziumState(database, dbName);
+      final long currentLsn = PostgresUtils.getLsn(database).asLong();
+      final JsonNode debeziumState = postgresDebeziumStateUtil.constructInitialDebeziumState(database, dbName, currentLsn);
       final Map<String, String> stateAsMap = Jsons.object(debeziumState, Map.class);
       Assertions.assertEquals(1, stateAsMap.size());
       Assertions.assertTrue(stateAsMap.containsKey("[\"" + dbName + "\",{\"server\":\"" + dbName + "\"}]"));


### PR DESCRIPTION
WIP

## What
Fix issue in source-postgres where we may commit a too-far-forward LSN to the replication slot when snapshotting a database which is active but has no changes to tracked tables:
https://github.com/airbytehq/airbyte/issues/49803

## How
Fetch the startup LSN exactly once.

## Review guide
TBD.

## User Impact
Should fix the bug described in the linked issue above

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌
