### PR TITLE
Fix widget token request URL in quickstart guide

### DIFF
--- a/docs/ai-agents/embedded/widget/quickstart.md
+++ b/docs/ai-agents/embedded/widget/quickstart.md
@@ -50,7 +50,7 @@ curl -X POST https://api.airbyte.ai/api/v1/account/applications/token \
 **2. Add a way to request a widget token:** a widget token is a string that contains an encoded version of both a JWT and the URL the widget uses to open. To request a widget token, make a request like the following:
 
 ```bash title="Request a widget token"
-curl -X POST https://api.airbyte.ai/api/v1/embedded/widget_token \
+curl -X POST https://api.airbyte.ai/api/v1/embedded/widget-token \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer YOUR_APPLICATION_TOKEN" \
   -d '{


### PR DESCRIPTION
Corrected the endpoint URL for requesting a widget token in the documentation.

## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->

## How
<!--
* Describe how code changes achieve the solution.
-->

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._