### PR TITLE
docs: update guidance around 2.0 deployment to use Helm chart version

### DIFF
--- a/docs/platform/access-management/sso-providers/azure-entra-id.md
+++ b/docs/platform/access-management/sso-providers/azure-entra-id.md
@@ -280,6 +280,5 @@ In your command-line tool, deploy Airbyte using your updated values file.
 helm upgrade airbyte-enterprise airbyte-v2/airbyte \
   --namespace airbyte-v2 \       # Target Kubernetes namespace
   --values ./values.yaml \       # Custom configuration values
-  --version 2.0.3 \              # Helm chart version to use
-  --set global.image.tag=1.7.0   # Airbyte version to use
+  --version 2.x.x                # Helm chart version to use
 ```

--- a/docs/platform/access-management/sso-providers/okta.md
+++ b/docs/platform/access-management/sso-providers/okta.md
@@ -300,6 +300,5 @@ helm upgrade -i \
 --values ./values.yaml \
 airbyte \
 airbyte-v2/airbyte \
---version 2.0.3 \
---set global.image.tag=1.7.0
+--version 2.x.x
 ```

--- a/docs/platform/connector-development/connector-builder-ui/custom-components.md
+++ b/docs/platform/connector-development/connector-builder-ui/custom-components.md
@@ -150,8 +150,7 @@ If you're deploying Airbyte using public Helm charts without abctl, follow the s
     helm upgrade airbyte airbyte-v2/airbyte \
       --namespace airbyte-v2 \       # Target Kubernetes namespace
       --values ./values.yaml \       # Custom configuration values
-      --version 2.0.3 \              # Helm chart version to use
-      --set global.image.tag=1.7.0   # Airbyte version to use
+      --version 2.x.x                # Helm chart version to use
     ```
 
     </TabItem>

--- a/docs/platform/deploying-airbyte/chart-v2-community.mdx
+++ b/docs/platform/deploying-airbyte/chart-v2-community.mdx
@@ -131,13 +131,9 @@ If you're not using an external database, skip this step. At deployment time, yo
 
 ### Add V2 chart repo
 
-Helm chart V2 uses a different repo URL than V1 did. In your command line tool, add this repo and index it.
+Helm chart V2 uses a different repo URL (`/charts`) than V1 did (`/helm-charts`). In your command line tool, add this repo and index it.
 
 ```bash
-# Helm chart V1
-# helm repo add airbyte https://airbytehq.github.io/helm-charts
-
-# Helm chart V2
 helm repo add airbyte-v2 https://airbytehq.github.io/charts
 helm repo update
 ```
@@ -387,15 +383,46 @@ workloadLauncher:
 <Tabs groupId="external-db">
 <TabItem value='db-yes' label='External database' default>
 
-Deploy Airbyte. Here is an example of how to deploy version 1.7.0 of Airbyte using the latest Helm chart V2 values. Normally the Helm chart version is identical to the Airbyte version. Since using this chart version is optional, the Helm chart and Airbyte have different, but compatible, versions.
+1. Identify the Helm chart version that corresponds to the platform version you want to run. Most Helm chart versions are designed to work with one Airbyte version, and they don't necessarily have the same version number.
 
-```bash
-helm install airbyte airbyte-v2/airbyte \
-  --namespace airbyte-v2 \       # Target Kubernetes namespace
-  --values ./values.yaml \       # Custom configuration values
-  --version 2.0.3 \              # Helm chart version to use
-  --set global.image.tag=1.7.0   # Airbyte version to use
-```
+    ```bash
+    helm search repo airbyte-v2 --versions
+    ```
+
+    You should see something like this:
+
+    ```text
+    NAME                            CHART VERSION   APP VERSION     DESCRIPTION
+    airbyte-v2/airbyte              2.0.18          2.0.0           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.17          1.8.5           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.16          1.8.4           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.15          1.8.4           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.14          1.8.4           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.13          1.8.3           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.12          1.8.2           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.11          1.8.2           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.10          1.8.1           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.9           1.8.0           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.8           1.8.0           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.7           1.7.1           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.6           1.7.1           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.5           1.7.0           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.4           1.6.3           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.3           1.6.2           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.2           1.6.2           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.1           1.6.1           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.0           1.6.0           Helm chart to deploy airbyte
+    airbyte-v2/airbyte-data-plane   2.0.0           2.0.0           A Helm chart for installing an Airbyte Data Plane.
+    ```
+
+2. Install Airbyte into your Helm chart V2 namespace. In this example, you install Airbyte version 2.0.
+
+    ```bash
+    helm install airbyte airbyte-v2/airbyte \
+      --namespace airbyte-v2 \       # Target Kubernetes namespace
+      --values ./values.yaml \       # Custom configuration values
+      --version 2.0.18               # Helm chart version to use
+    ```
 
 </TabItem>
 <TabItem value='db-no' label='No external database' default>
@@ -410,21 +437,52 @@ Do not proceed if you have not backed up Airbyte's internal Postgres database.
     helm uninstall airbyte -n airbyte
     ```
 
-2. Reinstall Airbyte into the same namespace as before. Here is an example of how to deploy version 1.7.0 of Airbyte using the latest Helm chart V2 values. Normally the Helm chart version is identical to the Airbyte version. Since using this chart version is optional, the Helm chart and Airbyte have different, but compatible, versions.
+2. Identify the Helm chart version that corresponds to the platform version you want to run. Most Helm chart versions are designed to work with one Airbyte version, but they don't necessarily have the same version number as the Airbyte platform.
+
+    ```bash
+    helm search repo airbyte-v2 --versions
+    ```
+
+    You see something like this:
+
+    ```text
+    NAME                            CHART VERSION   APP VERSION     DESCRIPTION
+    airbyte-v2/airbyte              2.0.18          2.0.0           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.17          1.8.5           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.16          1.8.4           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.15          1.8.4           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.14          1.8.4           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.13          1.8.3           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.12          1.8.2           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.11          1.8.2           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.10          1.8.1           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.9           1.8.0           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.8           1.8.0           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.7           1.7.1           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.6           1.7.1           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.5           1.7.0           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.4           1.6.3           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.3           1.6.2           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.2           1.6.2           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.1           1.6.1           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.0           1.6.0           Helm chart to deploy airbyte
+    airbyte-v2/airbyte-data-plane   2.0.0           2.0.0           A Helm chart for installing an Airbyte Data Plane.
+    ```
+
+3. Reinstall Airbyte into the same namespace as before. In this example, you install Airbyte version 2.0 using the Helm chart version 2.0.18.
 
     ```bash
     helm install airbyte airbyte-v2/airbyte \
     --namespace airbyte \          # Target Kubernetes namespace
     --values ./values.yaml \       # Custom configuration values
-    --version 2.0.3 \              # Helm chart version to use
-    --set global.image.tag=1.7.0   # Airbyte version to use
+    --version 2.0.18 \             # Helm chart version to use
     ```
 
 Airbyte continues in this namespace as before, now running on Helm Chart V2.
 
 #### Restore your database
 
-You do not need to restore your database except in exceptional circumstances. Only restore your database if there is an issue with your deployment that isn't related to your configurations. The restoration process is essentially the reverse of the backup process you went through above.
+You only need to restore your database in exceptional circumstances. Only restore your database if there is an issue with your deployment that isn't related to your configurations. The restoration process is essentially the reverse of the backup process you went through above.
 
 These examples assume your namespace is still `airbyte` and your database pod name is still `airbyte-db-0`.
 

--- a/docs/platform/deploying-airbyte/deploying-airbyte.md
+++ b/docs/platform/deploying-airbyte/deploying-airbyte.md
@@ -171,13 +171,46 @@ helm install airbyte airbyte/airbyte \
 </TabItem>
 <TabItem value='helm-2' label='Helm chart V2' default>
 
-```bash
-helm install airbyte airbyte-v2/airbyte \
-  --namespace airbyte-v2 \          # Target Kubernetes namespace
-  --values ./values.yaml \       # Custom configuration values
-  --version 2.0.3 \              # Helm chart version to use
-  --set global.image.tag=1.7.0   # Airbyte version to use
-```
+1. Identify the Helm chart version that corresponds to the platform version you want to run. Most Helm chart versions are designed to work with one Airbyte version, and they don't necessarily have the same version number.
+
+    ```bash
+    helm search repo airbyte-v2 --versions
+    ```
+
+    You should see something like this:
+
+    ```text
+    NAME                            CHART VERSION   APP VERSION     DESCRIPTION
+    airbyte-v2/airbyte              2.0.18          2.0.0           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.17          1.8.5           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.16          1.8.4           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.15          1.8.4           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.14          1.8.4           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.13          1.8.3           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.12          1.8.2           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.11          1.8.2           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.10          1.8.1           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.9           1.8.0           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.8           1.8.0           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.7           1.7.1           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.6           1.7.1           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.5           1.7.0           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.4           1.6.3           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.3           1.6.2           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.2           1.6.2           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.1           1.6.1           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.0           1.6.0           Helm chart to deploy airbyte
+    airbyte-v2/airbyte-data-plane   2.0.0           2.0.0           A Helm chart for installing an Airbyte Data Plane.
+    ```
+
+2. Install Airbyte into your Helm chart V2 namespace. In this example, you install Airbyte version 2.0.
+
+    ```bash
+    helm install airbyte airbyte-v2/airbyte \
+      --namespace airbyte-v2 \       # Target Kubernetes namespace
+      --values ./values.yaml \       # Custom configuration values
+      --version 2.0.18               # Helm chart version to use
+    ```
 
 </TabItem>
 </Tabs>

--- a/docs/platform/enterprise-setup/audit-logging.md
+++ b/docs/platform/enterprise-setup/audit-logging.md
@@ -104,8 +104,7 @@ Choose a new blob storage bucket with your chosen cloud provider (for example, A
     helm upgrade airbyte airbyte-v2/airbyte \
       --namespace airbyte-v2 \       # Target Kubernetes namespace
       --values ./values.yaml \       # Custom configuration values
-      --version 2.0.3 \              # Helm chart version to use
-      --set global.image.tag=1.7.0   # Airbyte version to use
+      --version 2.x.x                # Helm chart version to use
     ```
 
     </TabItem>

--- a/docs/platform/enterprise-setup/chart-v2-enterprise.mdx
+++ b/docs/platform/enterprise-setup/chart-v2-enterprise.mdx
@@ -71,7 +71,7 @@ kubectl create namespace airbyte-v2
 
 ### Add and index the repo
 
-Helm chart V2 uses a separate repo than V1 did. In your command line tool, add this repo and index it.
+Helm chart V2 uses a different repo URL (`/charts`) than V1 did (`/helm-charts`). In your command line tool, add this repo and index it.
 
 ```bash
 helm repo add airbyte-v2 https://airbytehq.github.io/charts
@@ -412,14 +412,43 @@ workloadLauncher:
 
 ### Deploy Airbyte {#deploy-airbyte}
 
-Here is an example of how to deploy version 1.7.0 of Airbyte using the latest Helm chart V2 values. Normally, in V1, the Helm chart version is identical to the Airbyte version. Since using this chart version is optional, the Helm chart and Airbyte have different, but compatible, versions.
+1. Identify the Helm chart version that corresponds to the platform version you want to run. Most Helm chart versions are designed to work with one Airbyte version, and they don't necessarily have the same version number.
 
-```bash
-helm install airbyte-enterprise airbyte-v2/airbyte \
-  --namespace airbyte-v2 \       # Target Kubernetes namespace
-  --values ./values.yaml \       # Custom configuration values
-  --version 2.0.3 \              # Helm chart version to use
-  --set global.image.tag=1.7.0   # Airbyte version to use
-```
+    ```bash
+    helm search repo airbyte-v2 --versions
+    ```
 
-<!-- I am realizing the decoupling the chart from the platform may create weird scenarios where it's unclear which version/chart combination to use. -->
+    You should see something like this:
+
+    ```text
+    NAME                            CHART VERSION   APP VERSION     DESCRIPTION
+    airbyte-v2/airbyte              2.0.18          2.0.0           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.17          1.8.5           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.16          1.8.4           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.15          1.8.4           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.14          1.8.4           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.13          1.8.3           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.12          1.8.2           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.11          1.8.2           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.10          1.8.1           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.9           1.8.0           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.8           1.8.0           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.7           1.7.1           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.6           1.7.1           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.5           1.7.0           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.4           1.6.3           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.3           1.6.2           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.2           1.6.2           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.1           1.6.1           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.0           1.6.0           Helm chart to deploy airbyte
+    airbyte-v2/airbyte-data-plane   2.0.0           2.0.0           A Helm chart for installing an Airbyte Data Plane.
+    ```
+
+2. Install Airbyte into your Helm chart V2 namespace. In this example, you install Airbyte version 2.0.
+
+    ```bash
+    helm install airbyte airbyte-v2/airbyte \
+      --namespace airbyte-v2 \       # Target Kubernetes namespace
+      --values ./values.yaml \       # Custom configuration values
+      --version 2.0.18               # Helm chart version to use
+    ```

--- a/docs/platform/enterprise-setup/implementation-guide.md
+++ b/docs/platform/enterprise-setup/implementation-guide.md
@@ -957,13 +957,46 @@ helm install airbyte-enterprise airbyte/airbyte \
 </TabItem>
 <TabItem value='helm-2' label='Helm chart V2' default>
 
-```bash
-helm install airbyte-enterprise airbyte-v2/airbyte \
-  --namespace airbyte-v2 \       # Target Kubernetes namespace
-  --values ./values.yaml \       # Custom configuration values
-  --version 2.0.3 \              # Helm chart version to use
-  --set global.image.tag=1.7.0   # Airbyte version to use
-```
+1. Identify the Helm chart version that corresponds to the platform version you want to run. Most Helm chart versions are designed to work with one Airbyte version, and they don't necessarily have the same version number.
+
+    ```bash
+    helm search repo airbyte-v2 --versions
+    ```
+
+    You should see something like this:
+
+    ```text
+    NAME                            CHART VERSION   APP VERSION     DESCRIPTION
+    airbyte-v2/airbyte              2.0.18          2.0.0           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.17          1.8.5           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.16          1.8.4           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.15          1.8.4           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.14          1.8.4           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.13          1.8.3           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.12          1.8.2           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.11          1.8.2           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.10          1.8.1           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.9           1.8.0           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.8           1.8.0           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.7           1.7.1           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.6           1.7.1           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.5           1.7.0           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.4           1.6.3           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.3           1.6.2           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.2           1.6.2           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.1           1.6.1           Helm chart to deploy airbyte
+    airbyte-v2/airbyte              2.0.0           1.6.0           Helm chart to deploy airbyte
+    airbyte-v2/airbyte-data-plane   2.0.0           2.0.0           A Helm chart for installing an Airbyte Data Plane.
+    ```
+
+2. Install Airbyte into your Helm chart V2 namespace. In this example, you install Airbyte version 2.0.
+
+    ```bash
+    helm install airbyte airbyte-v2/airbyte \
+      --namespace airbyte-v2 \       # Target Kubernetes namespace
+      --values ./values.yaml \       # Custom configuration values
+      --version 2.0.18               # Helm chart version to use
+    ```
 
 </TabItem>
 </Tabs>
@@ -990,11 +1023,10 @@ Upgrade Airbyte Self-Managed Enterprise by:
     <TabItem value='helm-2' label='Helm chart V2' default>
 
     ```bash
-    helm upgrade airbyte-enterprise airbyte-v2/airbyte \
+    helm upgrade airbyte airbyte-v2/airbyte \
       --namespace airbyte-v2 \       # Target Kubernetes namespace
       --values ./values.yaml \       # Custom configuration values
-      --version 2.0.3 \              # Helm chart version to use
-      --set global.image.tag=1.7.0   # Airbyte version to use
+      --version 2.x.x                # Helm chart version to use
     ```
 
     </TabItem>
@@ -1022,8 +1054,7 @@ After specifying your own configuration, run the following command:
     helm upgrade airbyte-enterprise airbyte-v2/airbyte \
       --namespace airbyte-v2 \       # Target Kubernetes namespace
       --values ./values.yaml \       # Custom configuration values
-      --version 2.0.3 \              # Helm chart version to use
-      --set global.image.tag=1.7.0   # Airbyte version to use
+      --version 2.x.x                # Helm chart version to use
     ```
 
     </TabItem>

--- a/docs/platform/enterprise-setup/upgrading-from-community.md
+++ b/docs/platform/enterprise-setup/upgrading-from-community.md
@@ -55,8 +55,7 @@ Update your `values.yaml` file as explained in the [Self-Managed Enterprise impl
     helm upgrade airbyte airbyte-v2/airbyte \
       --namespace airbyte-v2 \       # Target Kubernetes namespace
       --values ./values.yaml \       # Custom configuration values
-      --version 2.0.3 \              # Helm chart version to use
-      --set global.image.tag=1.7.0   # Airbyte version to use
+      --version 2.x.x                # Helm chart version to use
     ```
 
     </TabItem>

--- a/docs/platform/operator-guides/upgrading-airbyte.md
+++ b/docs/platform/operator-guides/upgrading-airbyte.md
@@ -41,8 +41,7 @@ Upgrade by updating your `values.yaml` file and redeploying Airbyte. If you're n
    helm upgrade airbyte airbyte-v2/airbyte \
    --namespace airbyte-v2 \       # Target Kubernetes namespace
    --values ./values.yaml \       # Custom configuration values
-   --version 2.0.3 \              # Helm chart version to use
-   --set global.image.tag=1.7.0   # Airbyte version to use
+   --version 2.x.x                # Helm chart version to use
    ```
 
    </TabItem>


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->

This PR replaces guidance on deployments in the Helm chart V2 conversion guides. Previously we asked them to set both the helm chart version and the platform version. This was probably a mistake, as some people are getting themselves into trouble using incompatible chart and platform versions.

This update changes deployment instructions and indicates that they should run `helm search repo airbyte-v2 --versions` to divine the Helm chart version for the platform version they want to deploy, then provides a deployment command sample using only the Helm chart without the `--set global.image.tag` flag.

It also makes companion changes in other deployment samples around the site, which also no longer use the `--set` flag.

I also cleaned up a couple of other random statements or samples that seemed less than clear in hindsight.

## How
<!--
* Describe how code changes achieve the solution.
-->

- Updates Cloud/Next version.
- Once merged, I'll use Devin to regenerate the 2.0 docs too.

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

No particular reading order. The main thing to check is:

- The general deployment narrative remains correct.
- No more use of the `--set` flag in Helm V2 deployment commands.

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
