### PR TITLE
docs: Add deprecation notices and official documentation links to MCP server docs

### DIFF
--- a/docs/ai-agents/README.md
+++ b/docs/ai-agents/README.md
@@ -9,9 +9,9 @@ Airbyte provides multiple tools to help you build data applications.
 - **Airbyte Embedded Widget**: App development teams who have signed up for Airbyte Embedded and are looking to get started onboarding customers using the Embedded Widget can follow the get started guide at the bottom of this page, which will step you through a complete sample onboarding app.
 - **Authentication Proxies**: Connect safely to third party APIs using Airbyte's Authentication Proxies.
 - **MCP Servers**: Airbyte provides multiple MCP (Model Context Protocol) servers for different use cases:
-  - [**PyAirbyte MCP**](#pyairbyte-mcp): Local MCP server for managing Airbyte connectors through AI assistants.
-  - [**Connector Builder MCP**](#connector-builder-mcp): AI-assisted connector development - _**coming soon!**_
-  - [**Embedded Operator MCP**](#embedded-operator-mcp): Manage embedded configurations and pipelines.
+  - [**PyAirbyte MCP**](#pyairbyte-mcp): Local MCP server for managing Airbyte connectors through AI assistants. [View official docs →](https://github.com/airbytehq/PyAirbyte)
+  - [**Connector Builder MCP**](#connector-builder-mcp): AI-assisted connector development - _**coming soon!**_ [View official docs →](https://github.com/airbytehq/connector-builder-mcp)
+  - [**Embedded Operator MCP**](#embedded-operator-mcp): Manage embedded configurations and pipelines. [View official docs →](https://github.com/airbytehq/sonar)
   - [**PyAirbyte Fast-Coder MCP**](#pyairbyte-fast-coder-mcp) _(deprecated)_: Remote MCP server for rapid pipeline code generation.
 
 ## Prerequisites
@@ -40,15 +40,25 @@ Airbyte provides multiple MCP (Model Context Protocol) servers to enable AI-assi
 
 [The PyAirbyte MCP server](./pyairbyte-mcp.md) is a local MCP server that provides a standardized interface for managing Airbyte connectors through MCP-compatible clients. It allows you to list connectors, validate configurations, and run sync operations using the MCP protocol. This is the recommended MCP server for most use cases.
 
+**Official Documentation**: [PyAirbyte GitHub Repository](https://github.com/airbytehq/PyAirbyte)
+
 ### Connector Builder MCP
 
 [The Connector Builder MCP server](./connector-builder-mcp.md) (coming soon) will provide AI-assisted capabilities for building and testing Airbyte connectors using the Model Context Protocol.
+
+**Official Documentation**: [Connector Builder MCP GitHub Repository](https://github.com/airbytehq/connector-builder-mcp)
 
 ### Embedded Operator MCP
 
 [The Embedded Operator MCP](./embedded/operator-mcp/README.md) is a remote MCP server providing tools that enable managing embedded configurations and the resulting pipelines. Users can create connection and source templates, securely create sources, query API and File Storage sources, monitor connections and jobs, and more.
 
-### PyAirbyte Fast-Coder MCP
+**Official Documentation**: [Sonar (Embedded) GitHub Repository](https://github.com/airbytehq/sonar)
+
+### PyAirbyte Fast-Coder MCP (Deprecated)
+
+:::warning
+This MCP server has been deprecated and is no longer actively maintained. Please use the [PyAirbyte MCP](#pyairbyte-mcp) instead.
+:::
 
 [The PyAirbyte Fast-Coder MCP](./pyairbyte-fast-coder-mcp.md) is a remote MCP server that provides the ability for data engineers to generate a data pipeline in Python using a single prompt. It is currently designed to work within Cursor, with broader support coming in the near future.
 

--- a/docs/ai-agents/connector-builder-mcp.md
+++ b/docs/ai-agents/connector-builder-mcp.md
@@ -16,3 +16,7 @@ This MCP server is under active development. Check back for updates.
 ## Early Access Preview
 
 If you are an active Airbyte customer interested in early access to the **Connector Builder MCP** server, please reach out to your sales representative to request early access.
+
+## Official Documentation
+
+For the latest information and updates, visit the [Connector Builder MCP GitHub Repository](https://github.com/airbytehq/connector-builder-mcp).

--- a/docs/ai-agents/embedded/operator-mcp/README.md
+++ b/docs/ai-agents/embedded/operator-mcp/README.md
@@ -28,3 +28,7 @@ To connect with Claude Code, run the following in the Claude Code CLI
 ```
 
 TODO: CALLOUT: Your credentials must reference an organization that has been enabled for Airbyte Embedded. Contact michel@airbyte.io or teo@airbyte.io to enable Airbyte Embedded on your account.
+
+## Official Documentation
+
+For more information about Airbyte Embedded and the Operator MCP server, visit the [Sonar (Airbyte Embedded) GitHub Repository](https://github.com/airbytehq/sonar).

--- a/docs/ai-agents/pyairbyte-fast-coder-mcp.md
+++ b/docs/ai-agents/pyairbyte-fast-coder-mcp.md
@@ -5,7 +5,11 @@ products: embedded
 # PyAirbyte Fast-Coder MCP (Deprecated)
 
 :::warning
-The PyAirbyte Fast-Coder MCP has been deprecated and is no longer actively maintained. If you would like to see continued development on this tool, please let us know by adding feedback on the related GitHub Discussion.
+**This MCP server has been deprecated and is no longer actively maintained.**
+
+Please use the [PyAirbyte MCP](./pyairbyte-mcp.md) instead, which provides a local MCP server for managing Airbyte connectors through AI assistants.
+
+If you would like to see continued development on this tool, please let us know by adding feedback on the [PyAirbyte GitHub Discussions](https://github.com/airbytehq/PyAirbyte/discussions).
 :::
 
 The PyAirbyte Fast-Coder MCP is a remote MCP server that provides the ability for data engineers to generate a data pipeline in Python using a single prompt. It is currently designed to work within Cursor, with broader support coming in the near future.

--- a/docs/ai-agents/pyairbyte-fast-coder-mcp.md
+++ b/docs/ai-agents/pyairbyte-fast-coder-mcp.md
@@ -9,7 +9,7 @@ products: embedded
 
 Please use the [PyAirbyte MCP](./pyairbyte-mcp.md) instead, which provides a local MCP server for managing Airbyte connectors through AI assistants.
 
-If you would like to see continued development on this tool, please let us know by adding feedback on the [PyAirbyte GitHub Discussions](https://github.com/airbytehq/PyAirbyte/discussions).
+If you would like to see continued development on this tool, please share feedback on the [PyAirbyte GitHub Discussions](https://github.com/airbytehq/PyAirbyte/discussions).
 :::
 
 The PyAirbyte Fast-Coder MCP is a remote MCP server that provides the ability for data engineers to generate a data pipeline in Python using a single prompt. It is currently designed to work within Cursor, with broader support coming in the near future.


### PR DESCRIPTION
## What

Improves the recently merged AI agents and MCP server documentation by:
1. Adding prominent deprecation notices for the PyAirbyte Fast-Coder MCP server
2. Adding links to official GitHub repositories for all MCP servers
3. Making it easier for users to find the authoritative documentation for each MCP server

Requested by AJ Steers (@aaronsteers) in [this Devin session](https://app.devin.ai/sessions/a94ac8e829794379a96130133dc45bed).

**Problem**: The deprecated PyAirbyte Fast-Coder MCP server was not properly marked as deprecated in all important locations (headers, section descriptions), and none of the MCP servers had links back to their official documentation repositories.

## How

### Deprecation Improvements
- Added "(Deprecated)" suffix to the Fast-Coder MCP section header in README.md
- Enhanced the deprecation warning box with:
  - Bold text emphasizing deprecation status
  - Direct link to the recommended alternative (PyAirbyte MCP)
  - Link to GitHub Discussions for feedback

### Official Documentation Links
- Added repository links to each MCP server in the bullet point list at the top of README.md
- Added "Official Documentation" sections to each individual MCP server page:
  - PyAirbyte MCP → https://github.com/airbytehq/PyAirbyte
  - Connector Builder MCP → https://github.com/airbytehq/connector-builder-mcp
  - Embedded Operator MCP → https://github.com/airbytehq/sonar
  - Fast-Coder MCP → Links to PyAirbyte repo discussions for feedback

## Review guide

1. **`docs/ai-agents/README.md`** - Verify:
   - Deprecation notice is prominent in the Fast-Coder MCP section (line 57-63)
   - Repository links are correct in the bullet points (lines 12-15)
   - "Official Documentation" sections are added for each MCP server

2. **`docs/ai-agents/pyairbyte-fast-coder-mcp.md`** - Verify:
   - Enhanced deprecation warning clearly directs users to the alternative (lines 7-13)
   - Link to GitHub Discussions works

3. **`docs/ai-agents/connector-builder-mcp.md`** - Verify:
   - Official documentation section added (lines 20-22)

4. **`docs/ai-agents/embedded/operator-mcp/README.md`** - Verify:
   - Official documentation section added (lines 32-34)

5. **Test all GitHub repository links** to ensure they're accessible and point to the correct repositories

## User Impact

**Positive:**
- Users can easily find the official documentation for each MCP server
- Clear guidance that the Fast-Coder MCP is deprecated and what to use instead
- Reduced confusion about which MCP server to use

**No negative side effects** - purely additive documentation improvements.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

This is purely documentation changes with no code or infrastructure modifications. Rolling back would simply restore the previous documentation state.