### PR TITLE
docs: update Java connector note to remove delivery date

### DIFF
--- a/docs/platform/contributing-to-airbyte/README.md
+++ b/docs/platform/contributing-to-airbyte/README.md
@@ -25,8 +25,7 @@ Airbyte evaluates contributions outside this scope on a case-by-case basis. Reac
 Contributions to Airbyte connectors may take some time to review, as they can affect many users. To assist us during code review, include as much information as possible in your pull request, including examples, use cases, documentation links, and more.
 
 :::warning
-Airbyte is undergoing a major revamp of the shared core Java destinations codebase, with plans to release a new CDK in April 2025.
-We are actively working on improving usability, speed (through asynchronous loading), and implementing [Typing and Deduplication](/platform/using-airbyte/core-concepts/typing-deduping) (Destinations V2). We're not actively reviewing/accepting new Java connectors for now.
+Airbyte is revamping its shared core Java destinations codebase. We're not accepting or reviewing new Java connectors at this time.
 :::
 
 ### Contributions we don't accept

--- a/docusaurus/platform_versioned_docs/version-1.6/contributing-to-airbyte/README.md
+++ b/docusaurus/platform_versioned_docs/version-1.6/contributing-to-airbyte/README.md
@@ -27,9 +27,7 @@ If you see an issue that isn't tagged that you're interested in, post a comment 
 Please be aware that contributions to Airbyte Connectors may take some time to review, as they can affect many users. We appreciate your patience and encourage you to include as much information as possible to assist reviewers. Please add examples, use cases, documentation links, and more.
 
 :::warning
-Airbyte is undergoing a major revamp of the shared core Java destinations codebase, with plans to release a new CDK in April 2025.
-We are actively working on improving usability, speed (through asynchronous loading), and implementing [Typing and Deduplication](/platform/using-airbyte/core-concepts/typing-deduping) (Destinations V2).
-We're not actively reviewing/accepting new Java connectors for now.
+Airbyte is revamping its shared core Java destinations codebase. We're not accepting or reviewing new Java connectors at this time.
 :::
 
 #### The usual workflow of code contribution is:

--- a/docusaurus/platform_versioned_docs/version-1.7/contributing-to-airbyte/README.md
+++ b/docusaurus/platform_versioned_docs/version-1.7/contributing-to-airbyte/README.md
@@ -27,9 +27,7 @@ If you see an issue that isn't tagged that you're interested in, post a comment 
 Please be aware that contributions to Airbyte Connectors may take some time to review, as they can affect many users. We appreciate your patience and encourage you to include as much information as possible to assist reviewers. Please add examples, use cases, documentation links, and more.
 
 :::warning
-Airbyte is undergoing a major revamp of the shared core Java destinations codebase, with plans to release a new CDK in April 2025.
-We are actively working on improving usability, speed (through asynchronous loading), and implementing [Typing and Deduplication](/platform/using-airbyte/core-concepts/typing-deduping) (Destinations V2).
-We're not actively reviewing/accepting new Java connectors for now.
+Airbyte is revamping its shared core Java destinations codebase. We're not accepting or reviewing new Java connectors at this time.
 :::
 
 #### The usual workflow of code contribution is:

--- a/docusaurus/platform_versioned_docs/version-1.8/contributing-to-airbyte/README.md
+++ b/docusaurus/platform_versioned_docs/version-1.8/contributing-to-airbyte/README.md
@@ -25,8 +25,7 @@ Airbyte evaluates contributions outside this scope on a case-by-case basis. Reac
 Contributions to Airbyte connectors may take some time to review, as they can affect many users. To assist us during code review, include as much information as possible in your pull request, including examples, use cases, documentation links, and more.
 
 :::warning
-Airbyte is undergoing a major revamp of the shared core Java destinations codebase, with plans to release a new CDK in April 2025.
-We are actively working on improving usability, speed (through asynchronous loading), and implementing [Typing and Deduplication](/platform/using-airbyte/core-concepts/typing-deduping) (Destinations V2). We're not actively reviewing/accepting new Java connectors for now.
+Airbyte is revamping its shared core Java destinations codebase. We're not accepting or reviewing new Java connectors at this time.
 :::
 
 ### Contributions we don't accept

--- a/docusaurus/platform_versioned_docs/version-2.0/contributing-to-airbyte/README.md
+++ b/docusaurus/platform_versioned_docs/version-2.0/contributing-to-airbyte/README.md
@@ -25,8 +25,7 @@ Airbyte evaluates contributions outside this scope on a case-by-case basis. Reac
 Contributions to Airbyte connectors may take some time to review, as they can affect many users. To assist us during code review, include as much information as possible in your pull request, including examples, use cases, documentation links, and more.
 
 :::warning
-Airbyte is undergoing a major revamp of the shared core Java destinations codebase, with plans to release a new CDK in April 2025.
-We are actively working on improving usability, speed (through asynchronous loading), and implementing [Typing and Deduplication](/platform/using-airbyte/core-concepts/typing-deduping) (Destinations V2). We're not actively reviewing/accepting new Java connectors for now.
+Airbyte is revamping its shared core Java destinations codebase. We're not accepting or reviewing new Java connectors at this time.
 :::
 
 ### Contributions we don't accept


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->

Removes passed delivery date for a new Java destination CDK. Also removes some specifics from what it is to focus on the fact that we're not accepting new contributions.

## How
<!--
* Describe how code changes achieve the solution.
-->

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
