### PR TITLE
Fix type definition for property value in manifest.yaml

### DIFF
--- a/airbyte-integrations/connectors/source-jira/manifest.yaml
+++ b/airbyte-integrations/connectors/source-jira/manifest.yaml
@@ -10121,6 +10121,9 @@ definitions:
             readOnly: true
           value:
             description: The value of the property. Required on create and update.
+            type:
+            - 'null'
+            - string
           isdefault:
             description: Indicates if the property is the default property.
             type:


### PR DESCRIPTION
issue_properties type was "Unknown"

## What
Fixes the missing type definition for the `value` field in the `issue_properties` stream schema, which causes sync failures when using Snowflake destination v4.x.


## How
Added explicit type definition to the `value` field in the `issue_properties_stream` schema within `manifest.yaml`:
```yaml
value:
  description: The value of the property. Required on create and update.
  type:
    - 'null'
    - string
```

## Review guide
1. `manifest.yaml` - Review the `issue_properties_stream` schema definition, specifically the `value` field type addition
2. Verify the type definition follows the same pattern as other nullable string fields in the schema (e.g., `issueId`)

## User Impact
- Fixes sync failures for users syncing `issue_properties` to Snowflake destination v4.x
- No breaking changes - existing syncs will continue to work

## Can this PR be safely reverted and rolled back?

- [X] YES 💚
- [ ] NO ❌
