### PR TITLE
Source Jira: Add type definition for issue_properties value field

### DIFF
--- a/airbyte-integrations/connectors/source-jira/manifest.yaml
+++ b/airbyte-integrations/connectors/source-jira/manifest.yaml
@@ -10121,6 +10121,14 @@ definitions:
             readOnly: true
           value:
             description: The value of the property. Required on create and update.
+            type:
+            - 'null'
+            - string
+            - number
+            - integer
+            - boolean
+            - object
+            - array
           isdefault:
             description: Indicates if the property is the default property.
             type:

--- a/airbyte-integrations/connectors/source-jira/metadata.yaml
+++ b/airbyte-integrations/connectors/source-jira/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 68e63de2-bb83-4c7e-93fa-a8a9051e3993
-  dockerImageTag: 4.3.5
+  dockerImageTag: 4.3.6
   dockerRepository: airbyte/source-jira
   documentationUrl: https://docs.airbyte.com/integrations/sources/jira
   erdUrl: https://dbdocs.io/airbyteio/source-jira?view=relationships

--- a/docs/integrations/sources/jira.md
+++ b/docs/integrations/sources/jira.md
@@ -169,6 +169,7 @@ The Jira connector should not run into Jira API limitations under normal usage. 
 
 | Version    | Date       | Pull Request                                               | Subject                                                                                                                                                                |
 |:-----------|:-----------|:-----------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 4.3.6 | 2025-10-24 | [68478](https://github.com/airbytehq/airbyte/pull/TBA) | Add type definition for issue_properties value field |
 | 4.3.5 | 2025-10-21 | [68478](https://github.com/airbytehq/airbyte/pull/68478) | Update dependencies |
 | 4.3.4 | 2025-10-14 | [67962](https://github.com/airbytehq/airbyte/pull/67962) | Update dependencies |
 | 4.3.3 | 2025-10-07 | [67375](https://github.com/airbytehq/airbyte/pull/67375) | Update dependencies |

--- a/docs/integrations/sources/jira.md
+++ b/docs/integrations/sources/jira.md
@@ -169,7 +169,7 @@ The Jira connector should not run into Jira API limitations under normal usage. 
 
 | Version    | Date       | Pull Request                                               | Subject                                                                                                                                                                |
 |:-----------|:-----------|:-----------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 4.3.6 | 2025-10-24 | [68634](https://github.com/airbytehq/airbyte/pull/68634) | Add type definition for issue_properties value field |
+| 4.3.6 | 2025-10-24 | [68634](https://github.com/airbytehq/airbyte/pull/68634) | Add type definition for `issue_properties` value field |
 | 4.3.5 | 2025-10-21 | [68478](https://github.com/airbytehq/airbyte/pull/68478) | Update dependencies |
 | 4.3.4 | 2025-10-14 | [67962](https://github.com/airbytehq/airbyte/pull/67962) | Update dependencies |
 | 4.3.3 | 2025-10-07 | [67375](https://github.com/airbytehq/airbyte/pull/67375) | Update dependencies |

--- a/docs/integrations/sources/jira.md
+++ b/docs/integrations/sources/jira.md
@@ -169,7 +169,7 @@ The Jira connector should not run into Jira API limitations under normal usage. 
 
 | Version    | Date       | Pull Request                                               | Subject                                                                                                                                                                |
 |:-----------|:-----------|:-----------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 4.3.6 | 2025-10-24 | [68478](https://github.com/airbytehq/airbyte/pull/TBA) | Add type definition for issue_properties value field |
+| 4.3.6 | 2025-10-24 | [68634](https://github.com/airbytehq/airbyte/pull/68634) | Add type definition for issue_properties value field |
 | 4.3.5 | 2025-10-21 | [68478](https://github.com/airbytehq/airbyte/pull/68478) | Update dependencies |
 | 4.3.4 | 2025-10-14 | [67962](https://github.com/airbytehq/airbyte/pull/67962) | Update dependencies |
 | 4.3.3 | 2025-10-07 | [67375](https://github.com/airbytehq/airbyte/pull/67375) | Update dependencies |


### PR DESCRIPTION
## What
Adds type definition for the `value` field in the `issue_properties` stream schema.

**Problem**: The `value` field in `issue_properties` stream has no type definition, causing Airbyte to infer it as `UNKNOWN` type. When syncing to Snowflake destination v4.0+, this results in errors like:

```
net.snowflake.client.jdbc.SnowflakeSQLException: Failed to cast variant value "2024-06-04T12:50:17+0530" to OBJECT
net.snowflake.client.jdbc.SnowflakeSQLException: Failed to cast variant value 1735880410400 to OBJECT
net.snowflake.client.jdbc.SnowflakeSQLException: Failed to cast variant value [{"entryIndex":0...}] to OBJECT
```

- Snowflake destination v4.x (Direct-Load) attempts to cast `UNKNOWN` types to `OBJECT`
- The actual data in the `value` field can be strings, numbers, booleans, objects, or arrays ([per Jira API spec](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-properties/#api-rest-api-3-issue-issueidorkey-properties-propertykey-get-response): `value: any`)
- This mismatch causes cast failures

## How
Added explicit type definition to the value field in the `issue_properties` stream schema within manifest.yaml:
```
value:
  description: The value of the property. Required on create and update.
  type:
  - 'null'
  - string
  - number
  - integer
  - boolean
  - object
  - array
```

An alternative, more conservative approach would be to use only ["null", "string"] to force all values to be stringified, which guarantees no casting errors but loses native type information. The integration team should validate that union types work correctly with Snowflake destination v4.x.

## Review guide

- `manifest.yaml` - Review the `issue_properties` stream schema definition, specifically the value field type addition


## User Impact

- Fixes sync failures for users syncing issue_properties to Snowflake destination v4.x
- Accurately represents Jira API specification (value: any)
- Preserves native data types where possible (numbers, booleans, objects, arrays)

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [X] YES 💚
- [ ] NO ❌
