### PR TITLE
docs: Remove future promise from Java destinations update

### DIFF
--- a/docs/platform/connector-development/testing-connectors/README.md
+++ b/docs/platform/connector-development/testing-connectors/README.md
@@ -40,7 +40,9 @@ poetry run pytest
 ### ☕ Java connectors
 
 :::warning
-Airbyte is revamping its core Java destinations codebase. We're not reviewing/accepting new Java connectors at this time.
+Airbyte is undergoing a major revamp of the shared core Java destinations codebase, with plans to release a new CDK in 2024.
+We are actively working on improving usability, speed (through asynchronous loading), and implementing [Typing and Deduplication](/platform/using-airbyte/core-concepts/typing-deduping) (Destinations V2).
+For this reason, Airbyte is not reviewing/accepting new Java connectors for now.
 :::
 
 We run Java connector tests with gradle.

--- a/docs/platform/connector-development/testing-connectors/README.md
+++ b/docs/platform/connector-development/testing-connectors/README.md
@@ -40,9 +40,7 @@ poetry run pytest
 ### ☕ Java connectors
 
 :::warning
-Airbyte is undergoing a major revamp of the shared core Java destinations codebase, with plans to release a new CDK in 2024.
-We are actively working on improving usability, speed (through asynchronous loading), and implementing [Typing and Deduplication](/platform/using-airbyte/core-concepts/typing-deduping) (Destinations V2).
-For this reason, Airbyte is not reviewing/accepting new Java connectors for now.
+Airbyte is revamping its core Java destinations codebase. We're not reviewing/accepting new Java connectors at this time.
 :::
 
 We run Java connector tests with gradle.

--- a/docs/platform/contributing-to-airbyte/README.md
+++ b/docs/platform/contributing-to-airbyte/README.md
@@ -25,8 +25,7 @@ Airbyte evaluates contributions outside this scope on a case-by-case basis. Reac
 Contributions to Airbyte connectors may take some time to review, as they can affect many users. To assist us during code review, include as much information as possible in your pull request, including examples, use cases, documentation links, and more.
 
 :::warning
-Airbyte is undergoing a major revamp of the shared core Java destinations codebase, with plans to release a new CDK in April 2025.
-We are actively working on improving usability, speed (through asynchronous loading), and implementing [Typing and Deduplication](/platform/using-airbyte/core-concepts/typing-deduping) (Destinations V2). We're not actively reviewing/accepting new Java connectors for now.
+Airbyte is revamping its core Java destinations codebase. We're not reviewing/accepting new Java connectors at this time.
 :::
 
 ### Contributions we don't accept

--- a/docs/platform/contributing-to-airbyte/README.md
+++ b/docs/platform/contributing-to-airbyte/README.md
@@ -25,7 +25,8 @@ Airbyte evaluates contributions outside this scope on a case-by-case basis. Reac
 Contributions to Airbyte connectors may take some time to review, as they can affect many users. To assist us during code review, include as much information as possible in your pull request, including examples, use cases, documentation links, and more.
 
 :::warning
-Airbyte is revamping its core Java destinations codebase. We're not reviewing/accepting new Java connectors at this time.
+Airbyte is undergoing a major revamp of the shared core Java destinations codebase, with plans to release a new CDK in April 2025.
+We are actively working on improving usability, speed (through asynchronous loading), and implementing [Typing and Deduplication](/platform/using-airbyte/core-concepts/typing-deduping) (Destinations V2). We're not actively reviewing/accepting new Java connectors for now.
 :::
 
 ### Contributions we don't accept

--- a/docusaurus/platform_versioned_docs/version-1.6/connector-development/testing-connectors/README.md
+++ b/docusaurus/platform_versioned_docs/version-1.6/connector-development/testing-connectors/README.md
@@ -39,7 +39,9 @@ poetry run pytest
 ### ☕ Java connectors
 
 :::warning
-Airbyte is revamping its core Java destinations codebase. We're not reviewing/accepting new Java connectors at this time.
+Airbyte is undergoing a major revamp of the shared core Java destinations codebase, with plans to release a new CDK in 2024.
+We are actively working on improving usability, speed (through asynchronous loading), and implementing [Typing and Deduplication](/platform/using-airbyte/core-concepts/typing-deduping) (Destinations V2).
+For this reason, Airbyte is not reviewing/accepting new Java connectors for now.
 :::
 
 We run Java connector tests with gradle.

--- a/docusaurus/platform_versioned_docs/version-1.6/connector-development/testing-connectors/README.md
+++ b/docusaurus/platform_versioned_docs/version-1.6/connector-development/testing-connectors/README.md
@@ -39,9 +39,7 @@ poetry run pytest
 ### ☕ Java connectors
 
 :::warning
-Airbyte is undergoing a major revamp of the shared core Java destinations codebase, with plans to release a new CDK in 2024.
-We are actively working on improving usability, speed (through asynchronous loading), and implementing [Typing and Deduplication](/platform/using-airbyte/core-concepts/typing-deduping) (Destinations V2).
-For this reason, Airbyte is not reviewing/accepting new Java connectors for now.
+Airbyte is revamping its core Java destinations codebase. We're not reviewing/accepting new Java connectors at this time.
 :::
 
 We run Java connector tests with gradle.

--- a/docusaurus/platform_versioned_docs/version-1.6/contributing-to-airbyte/README.md
+++ b/docusaurus/platform_versioned_docs/version-1.6/contributing-to-airbyte/README.md
@@ -27,7 +27,9 @@ If you see an issue that isn't tagged that you're interested in, post a comment 
 Please be aware that contributions to Airbyte Connectors may take some time to review, as they can affect many users. We appreciate your patience and encourage you to include as much information as possible to assist reviewers. Please add examples, use cases, documentation links, and more.
 
 :::warning
-Airbyte is revamping its core Java destinations codebase. We're not reviewing/accepting new Java connectors at this time.
+Airbyte is undergoing a major revamp of the shared core Java destinations codebase, with plans to release a new CDK in April 2025.
+We are actively working on improving usability, speed (through asynchronous loading), and implementing [Typing and Deduplication](/platform/using-airbyte/core-concepts/typing-deduping) (Destinations V2).
+We're not actively reviewing/accepting new Java connectors for now.
 :::
 
 #### The usual workflow of code contribution is:

--- a/docusaurus/platform_versioned_docs/version-1.6/contributing-to-airbyte/README.md
+++ b/docusaurus/platform_versioned_docs/version-1.6/contributing-to-airbyte/README.md
@@ -27,9 +27,7 @@ If you see an issue that isn't tagged that you're interested in, post a comment 
 Please be aware that contributions to Airbyte Connectors may take some time to review, as they can affect many users. We appreciate your patience and encourage you to include as much information as possible to assist reviewers. Please add examples, use cases, documentation links, and more.
 
 :::warning
-Airbyte is undergoing a major revamp of the shared core Java destinations codebase, with plans to release a new CDK in April 2025.
-We are actively working on improving usability, speed (through asynchronous loading), and implementing [Typing and Deduplication](/platform/using-airbyte/core-concepts/typing-deduping) (Destinations V2).
-We're not actively reviewing/accepting new Java connectors for now.
+Airbyte is revamping its core Java destinations codebase. We're not reviewing/accepting new Java connectors at this time.
 :::
 
 #### The usual workflow of code contribution is:

--- a/docusaurus/platform_versioned_docs/version-1.7/connector-development/testing-connectors/README.md
+++ b/docusaurus/platform_versioned_docs/version-1.7/connector-development/testing-connectors/README.md
@@ -40,7 +40,9 @@ poetry run pytest
 ### ☕ Java connectors
 
 :::warning
-Airbyte is revamping its core Java destinations codebase. We're not reviewing/accepting new Java connectors at this time.
+Airbyte is undergoing a major revamp of the shared core Java destinations codebase, with plans to release a new CDK in 2024.
+We are actively working on improving usability, speed (through asynchronous loading), and implementing [Typing and Deduplication](/platform/using-airbyte/core-concepts/typing-deduping) (Destinations V2).
+For this reason, Airbyte is not reviewing/accepting new Java connectors for now.
 :::
 
 We run Java connector tests with gradle.

--- a/docusaurus/platform_versioned_docs/version-1.7/connector-development/testing-connectors/README.md
+++ b/docusaurus/platform_versioned_docs/version-1.7/connector-development/testing-connectors/README.md
@@ -40,9 +40,7 @@ poetry run pytest
 ### ☕ Java connectors
 
 :::warning
-Airbyte is undergoing a major revamp of the shared core Java destinations codebase, with plans to release a new CDK in 2024.
-We are actively working on improving usability, speed (through asynchronous loading), and implementing [Typing and Deduplication](/platform/using-airbyte/core-concepts/typing-deduping) (Destinations V2).
-For this reason, Airbyte is not reviewing/accepting new Java connectors for now.
+Airbyte is revamping its core Java destinations codebase. We're not reviewing/accepting new Java connectors at this time.
 :::
 
 We run Java connector tests with gradle.

--- a/docusaurus/platform_versioned_docs/version-1.7/contributing-to-airbyte/README.md
+++ b/docusaurus/platform_versioned_docs/version-1.7/contributing-to-airbyte/README.md
@@ -27,7 +27,9 @@ If you see an issue that isn't tagged that you're interested in, post a comment 
 Please be aware that contributions to Airbyte Connectors may take some time to review, as they can affect many users. We appreciate your patience and encourage you to include as much information as possible to assist reviewers. Please add examples, use cases, documentation links, and more.
 
 :::warning
-Airbyte is revamping its core Java destinations codebase. We're not reviewing/accepting new Java connectors at this time.
+Airbyte is undergoing a major revamp of the shared core Java destinations codebase, with plans to release a new CDK in April 2025.
+We are actively working on improving usability, speed (through asynchronous loading), and implementing [Typing and Deduplication](/platform/using-airbyte/core-concepts/typing-deduping) (Destinations V2).
+We're not actively reviewing/accepting new Java connectors for now.
 :::
 
 #### The usual workflow of code contribution is:

--- a/docusaurus/platform_versioned_docs/version-1.7/contributing-to-airbyte/README.md
+++ b/docusaurus/platform_versioned_docs/version-1.7/contributing-to-airbyte/README.md
@@ -27,9 +27,7 @@ If you see an issue that isn't tagged that you're interested in, post a comment 
 Please be aware that contributions to Airbyte Connectors may take some time to review, as they can affect many users. We appreciate your patience and encourage you to include as much information as possible to assist reviewers. Please add examples, use cases, documentation links, and more.
 
 :::warning
-Airbyte is undergoing a major revamp of the shared core Java destinations codebase, with plans to release a new CDK in April 2025.
-We are actively working on improving usability, speed (through asynchronous loading), and implementing [Typing and Deduplication](/platform/using-airbyte/core-concepts/typing-deduping) (Destinations V2).
-We're not actively reviewing/accepting new Java connectors for now.
+Airbyte is revamping its core Java destinations codebase. We're not reviewing/accepting new Java connectors at this time.
 :::
 
 #### The usual workflow of code contribution is:

--- a/docusaurus/platform_versioned_docs/version-1.8/connector-development/testing-connectors/README.md
+++ b/docusaurus/platform_versioned_docs/version-1.8/connector-development/testing-connectors/README.md
@@ -40,7 +40,9 @@ poetry run pytest
 ### ☕ Java connectors
 
 :::warning
-Airbyte is revamping its core Java destinations codebase. We're not reviewing/accepting new Java connectors at this time.
+Airbyte is undergoing a major revamp of the shared core Java destinations codebase, with plans to release a new CDK in 2024.
+We are actively working on improving usability, speed (through asynchronous loading), and implementing [Typing and Deduplication](/platform/using-airbyte/core-concepts/typing-deduping) (Destinations V2).
+For this reason, Airbyte is not reviewing/accepting new Java connectors for now.
 :::
 
 We run Java connector tests with gradle.

--- a/docusaurus/platform_versioned_docs/version-1.8/connector-development/testing-connectors/README.md
+++ b/docusaurus/platform_versioned_docs/version-1.8/connector-development/testing-connectors/README.md
@@ -40,9 +40,7 @@ poetry run pytest
 ### ☕ Java connectors
 
 :::warning
-Airbyte is undergoing a major revamp of the shared core Java destinations codebase, with plans to release a new CDK in 2024.
-We are actively working on improving usability, speed (through asynchronous loading), and implementing [Typing and Deduplication](/platform/using-airbyte/core-concepts/typing-deduping) (Destinations V2).
-For this reason, Airbyte is not reviewing/accepting new Java connectors for now.
+Airbyte is revamping its core Java destinations codebase. We're not reviewing/accepting new Java connectors at this time.
 :::
 
 We run Java connector tests with gradle.

--- a/docusaurus/platform_versioned_docs/version-1.8/contributing-to-airbyte/README.md
+++ b/docusaurus/platform_versioned_docs/version-1.8/contributing-to-airbyte/README.md
@@ -25,8 +25,7 @@ Airbyte evaluates contributions outside this scope on a case-by-case basis. Reac
 Contributions to Airbyte connectors may take some time to review, as they can affect many users. To assist us during code review, include as much information as possible in your pull request, including examples, use cases, documentation links, and more.
 
 :::warning
-Airbyte is undergoing a major revamp of the shared core Java destinations codebase, with plans to release a new CDK in April 2025.
-We are actively working on improving usability, speed (through asynchronous loading), and implementing [Typing and Deduplication](/platform/using-airbyte/core-concepts/typing-deduping) (Destinations V2). We're not actively reviewing/accepting new Java connectors for now.
+Airbyte is revamping its core Java destinations codebase. We're not reviewing/accepting new Java connectors at this time.
 :::
 
 ### Contributions we don't accept

--- a/docusaurus/platform_versioned_docs/version-1.8/contributing-to-airbyte/README.md
+++ b/docusaurus/platform_versioned_docs/version-1.8/contributing-to-airbyte/README.md
@@ -25,7 +25,8 @@ Airbyte evaluates contributions outside this scope on a case-by-case basis. Reac
 Contributions to Airbyte connectors may take some time to review, as they can affect many users. To assist us during code review, include as much information as possible in your pull request, including examples, use cases, documentation links, and more.
 
 :::warning
-Airbyte is revamping its core Java destinations codebase. We're not reviewing/accepting new Java connectors at this time.
+Airbyte is undergoing a major revamp of the shared core Java destinations codebase, with plans to release a new CDK in April 2025.
+We are actively working on improving usability, speed (through asynchronous loading), and implementing [Typing and Deduplication](/platform/using-airbyte/core-concepts/typing-deduping) (Destinations V2). We're not actively reviewing/accepting new Java connectors for now.
 :::
 
 ### Contributions we don't accept

--- a/docusaurus/platform_versioned_docs/version-2.0/connector-development/testing-connectors/README.md
+++ b/docusaurus/platform_versioned_docs/version-2.0/connector-development/testing-connectors/README.md
@@ -40,7 +40,9 @@ poetry run pytest
 ### ☕ Java connectors
 
 :::warning
-Airbyte is revamping its core Java destinations codebase. We're not reviewing/accepting new Java connectors at this time.
+Airbyte is undergoing a major revamp of the shared core Java destinations codebase, with plans to release a new CDK in 2024.
+We are actively working on improving usability, speed (through asynchronous loading), and implementing [Typing and Deduplication](/platform/using-airbyte/core-concepts/typing-deduping) (Destinations V2).
+For this reason, Airbyte is not reviewing/accepting new Java connectors for now.
 :::
 
 We run Java connector tests with gradle.

--- a/docusaurus/platform_versioned_docs/version-2.0/connector-development/testing-connectors/README.md
+++ b/docusaurus/platform_versioned_docs/version-2.0/connector-development/testing-connectors/README.md
@@ -40,9 +40,7 @@ poetry run pytest
 ### ☕ Java connectors
 
 :::warning
-Airbyte is undergoing a major revamp of the shared core Java destinations codebase, with plans to release a new CDK in 2024.
-We are actively working on improving usability, speed (through asynchronous loading), and implementing [Typing and Deduplication](/platform/using-airbyte/core-concepts/typing-deduping) (Destinations V2).
-For this reason, Airbyte is not reviewing/accepting new Java connectors for now.
+Airbyte is revamping its core Java destinations codebase. We're not reviewing/accepting new Java connectors at this time.
 :::
 
 We run Java connector tests with gradle.

--- a/docusaurus/platform_versioned_docs/version-2.0/contributing-to-airbyte/README.md
+++ b/docusaurus/platform_versioned_docs/version-2.0/contributing-to-airbyte/README.md
@@ -25,8 +25,7 @@ Airbyte evaluates contributions outside this scope on a case-by-case basis. Reac
 Contributions to Airbyte connectors may take some time to review, as they can affect many users. To assist us during code review, include as much information as possible in your pull request, including examples, use cases, documentation links, and more.
 
 :::warning
-Airbyte is undergoing a major revamp of the shared core Java destinations codebase, with plans to release a new CDK in April 2025.
-We are actively working on improving usability, speed (through asynchronous loading), and implementing [Typing and Deduplication](/platform/using-airbyte/core-concepts/typing-deduping) (Destinations V2). We're not actively reviewing/accepting new Java connectors for now.
+Airbyte is revamping its core Java destinations codebase. We're not reviewing/accepting new Java connectors at this time.
 :::
 
 ### Contributions we don't accept

--- a/docusaurus/platform_versioned_docs/version-2.0/contributing-to-airbyte/README.md
+++ b/docusaurus/platform_versioned_docs/version-2.0/contributing-to-airbyte/README.md
@@ -25,7 +25,8 @@ Airbyte evaluates contributions outside this scope on a case-by-case basis. Reac
 Contributions to Airbyte connectors may take some time to review, as they can affect many users. To assist us during code review, include as much information as possible in your pull request, including examples, use cases, documentation links, and more.
 
 :::warning
-Airbyte is revamping its core Java destinations codebase. We're not reviewing/accepting new Java connectors at this time.
+Airbyte is undergoing a major revamp of the shared core Java destinations codebase, with plans to release a new CDK in April 2025.
+We are actively working on improving usability, speed (through asynchronous loading), and implementing [Typing and Deduplication](/platform/using-airbyte/core-concepts/typing-deduping) (Destinations V2). We're not actively reviewing/accepting new Java connectors for now.
 :::
 
 ### Contributions we don't accept

--- a/poe-tasks/get-modified-connectors.sh
+++ b/poe-tasks/get-modified-connectors.sh
@@ -51,7 +51,7 @@ git fetch --quiet "$REMOTE" "$DEFAULT_BRANCH"
 ignore_patterns=(
   '.coveragerc'
   'poe_tasks.toml'
-  'README.md'
+  'airbyte-integrations/connectors/[^/]+/README.md'
 )
 # join with | into a grouped regex
 ignore_globs="($(IFS='|'; echo "${ignore_patterns[*]}"))$"
@@ -89,7 +89,7 @@ return_empty_json() {
 }
 
 # 5) drop ignored files
-filtered=$(printf '%s\n' "$all_changes" | grep -v -E "/${ignore_globs}")
+filtered=$(printf '%s\n' "$all_changes" | grep -v -E "(/${ignore_globs}|^${ignore_globs})")
 if [ -z "$filtered" ]; then
   echo "⚠️ Warning: No files remaining after filtering. Returning empty connector list." >&2
   return_empty_json


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->

- Remove future promise from contribution documentation. Aside from missing this deadline, we should not, as a matter of policy, make future promises in documentation.
- Updated get-modified-connectors.sh to stop ignoring files called "README.md" that are outside connector folders. If a change contained only docs files called README.md, CI fails. This prevented this change from ever passing CI, because all files were called README.md.

## How
<!--
* Describe how code changes achieve the solution.
-->

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
