### PR TITLE
feat: add upsert with dedup and cdc deletes

### DIFF
--- a/airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/client/PostgresAirbyteClient.kt
+++ b/airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/client/PostgresAirbyteClient.kt
@@ -107,7 +107,7 @@ class PostgresAirbyteClient(
         columnNameMapping: ColumnNameMapping
     ) {
         val columnsInDb = getColumnsFromDb(tableName)
-        val defaultColumnNames = postgresColumnUtils.defaultColumns().map { it.columnName }
+        val defaultColumnNames = postgresColumnUtils.defaultColumns().map { it.columnName }.toSet()
         val columnsInStream = postgresColumnUtils.getTargetColumns(stream, columnNameMapping)
             .filter { it.columnName !in defaultColumnNames }
             .toSet()
@@ -135,7 +135,7 @@ class PostgresAirbyteClient(
             return statement.use {
                 val rs: ResultSet = it.executeQuery(sql)
                 val columnsInDb: MutableSet<Column> = mutableSetOf()
-                val defaultColumnNames = postgresColumnUtils.defaultColumns().map { it.columnName }
+                val defaultColumnNames = postgresColumnUtils.defaultColumns().map { it.columnName }.toSet()
                 while (rs.next()) {
                     //TODO: extract column_name and data_type as constants
                     val columnName = rs.getString("column_name")

--- a/airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/client/PostgresAirbyteClient.kt
+++ b/airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/client/PostgresAirbyteClient.kt
@@ -10,6 +10,7 @@ import io.airbyte.cdk.load.component.TableSchemaEvolutionClient
 import io.airbyte.cdk.load.message.Meta.Companion.COLUMN_NAME_AB_GENERATION_ID
 import io.airbyte.cdk.load.table.ColumnNameMapping
 import io.airbyte.cdk.load.table.TableName
+import io.airbyte.integrations.destination.postgres.sql.COUNT_TOTAL_ALIAS
 import io.airbyte.integrations.destination.postgres.sql.Column
 import io.airbyte.integrations.destination.postgres.sql.PostgresDirectLoadSqlGenerator
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -19,7 +20,6 @@ import javax.sql.DataSource
 
 private val log = KotlinLogging.logger {}
 
-internal const val COUNT_TOTAL_ALIAS = "total"
 
 @Singleton
 class PostgresAirbyteClient(

--- a/airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/sql/PostgresColumnUtils.kt
+++ b/airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/sql/PostgresColumnUtils.kt
@@ -4,6 +4,7 @@
 
 package io.airbyte.integrations.destination.postgres.sql
 
+import com.google.common.annotations.VisibleForTesting
 import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.data.AirbyteType
 import io.airbyte.cdk.load.data.ArrayType
@@ -40,11 +41,11 @@ class PostgresColumnUtils(
 ) {
     companion object {
         //Default columns that are always present in both raw and typed tables.
-        internal val DEFAULT_COLUMNS =
+        private val DEFAULT_COLUMNS =
             listOf(
                 Column(
                     columnName = COLUMN_NAME_AB_RAW_ID,
-                    columnTypeName = "${PostgresDataType.VARCHAR.typeName}",
+                    columnTypeName = PostgresDataType.VARCHAR.typeName,
                     nullable = false
                 ),
                 Column(
@@ -65,7 +66,7 @@ class PostgresColumnUtils(
             )
 
         // Columns that are only present in raw (legacy) tables.
-        internal val RAW_COLUMNS =
+        private val RAW_COLUMNS =
             listOf(
                 Column(
                     columnName = COLUMN_NAME_AB_LOADED_AT,
@@ -85,7 +86,7 @@ class PostgresColumnUtils(
      * - Raw table mode: includes _airbyte_data column for storing raw JSON
      * - Typed table mode: excludes _airbyte_data, schema columns stored separately
      */
-    fun defaultColumns(): List<Column> =
+    internal fun defaultColumns(): List<Column> =
         if (postgresConfiguration.legacyRawTablesOnly == true) {
             DEFAULT_COLUMNS + RAW_COLUMNS
         } else {
@@ -97,7 +98,7 @@ class PostgresColumnUtils(
      * - Raw table mode: Only returns system columns (including _airbyte_data), user columns are ignored
      * - Typed table mode: Returns system columns + mapped user columns
      */
-    fun getTargetColumns(
+    internal fun getTargetColumns(
         stream: DestinationStream,
         columnNameMapping: ColumnNameMapping
     ): List<Column> =
@@ -131,7 +132,8 @@ class PostgresColumnUtils(
         columnNameMapping[streamColumnName] ?: streamColumnName
 
     // Converts Airbyte types to PostgreSQL column types.
-    private fun toDialectType(type: AirbyteType): String =
+    @VisibleForTesting
+    internal fun toDialectType(type: AirbyteType): String =
         when (type) {
             BooleanType -> PostgresDataType.BOOLEAN.typeName
             DateType -> PostgresDataType.DATE.typeName

--- a/airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/sql/PostgresDirectLoadSqlGenerator.kt
+++ b/airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/sql/PostgresDirectLoadSqlGenerator.kt
@@ -320,8 +320,8 @@ class PostgresDirectLoadSqlGenerator(
         primaryKeyTargetColumns: List<String>,
         cdcHardDeleteEnabled: Boolean
     ): String {
-        val pkConditions = primaryKeyTargetColumns.joinToString(" AND ") { pk ->
-            "${getFullyQualifiedName(targetTableName)}.$pk = $dedupTableAlias.$pk"
+        val primaryKeysConditions = primaryKeyTargetColumns.joinToString(" AND ") { primaryKey ->
+            "${getFullyQualifiedName(targetTableName)}.$primaryKey = $dedupTableAlias.$primaryKey"
         }
 
         val skipCdcDeletedClause = if(cdcHardDeleteEnabled) "AND $dedupTableAlias.${getDeletedAtColumnName()} IS NULL" else ""
@@ -337,7 +337,7 @@ class PostgresDirectLoadSqlGenerator(
               NOT EXISTS (
                 SELECT 1
                 FROM ${getFullyQualifiedName(targetTableName)}
-                WHERE $pkConditions
+                WHERE $primaryKeysConditions
               )
               $skipCdcDeletedClause
         """.trimIndent()
@@ -349,8 +349,8 @@ class PostgresDirectLoadSqlGenerator(
                                    primaryKeyTargetColumns: List<String>,
                                    cursorTargetColumn: String?,
                                    cdcHardDeleteEnabled: Boolean): String {
-        val primaryKeysMatches = primaryKeyTargetColumns.joinToString(" AND ") { pk ->
-            "${getFullyQualifiedName(targetTableName)}.$pk = $dedupTableAlias.$pk"
+        val primaryKeysMatches = primaryKeyTargetColumns.joinToString(" AND ") { primaryKey ->
+            "${getFullyQualifiedName(targetTableName)}.$primaryKey = $dedupTableAlias.$primaryKey"
         }
 
         val cursorComparison = buildCursorComparison(cursorTargetColumn, targetTableName, dedupTableAlias)
@@ -383,8 +383,8 @@ class PostgresDirectLoadSqlGenerator(
             return ""
         }
 
-        val primaryKeysMatchingCondition = primaryKeyTargetColumns.joinToString(" AND ") { pk ->
-            "${getFullyQualifiedName(targetTableName)}.$pk = $dedupTableAlias.$pk"
+        val primaryKeysMatchingCondition = primaryKeyTargetColumns.joinToString(" AND ") { primaryKey ->
+            "${getFullyQualifiedName(targetTableName)}.$primaryKey = $dedupTableAlias.$primaryKey"
         }
 
         // ensure we only delete if the deletion is newer

--- a/airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/sql/PostgresDirectLoadSqlGenerator.kt
+++ b/airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/sql/PostgresDirectLoadSqlGenerator.kt
@@ -240,6 +240,18 @@ class PostgresDirectLoadSqlGenerator(
     fun getDefaultColumnNames(): List<String> =
         DEFAULT_COLUMNS.map { "\"${it.columnName}\"" }
 
+    /**
+     * Generates an SQL statement that upserts (merge) data from a source staging table into a target table.
+     *
+     * The generated SQL performs the following operations in a single statement:
+     * 1. **Deduplication CTE**: Deduplicates the source data based on primary keys
+     * 2. **CDC Delete CTE**: If CDC hard delete is enabled and the stream contains CDC deleted records,
+     *    this CTE deletes rows from the target table.
+     * 3. **Update CTE**: Updates existing rows in the target table with newer data from the source
+     * 4. **Insert Statement**: Inserts new rows from the source that don't exist in the target table.
+     *
+     * @throws IllegalArgumentException if the stream's import type does not contain a primary key.
+     */
     fun upsertTable(
         stream: DestinationStream,
         columnNameMapping: ColumnNameMapping,

--- a/airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/sql/PostgresDirectLoadSqlGenerator.kt
+++ b/airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/sql/PostgresDirectLoadSqlGenerator.kt
@@ -153,7 +153,7 @@ class PostgresDirectLoadSqlGenerator(
     ): String? {
         return cursor
             .firstOrNull()
-            ?.let { columnName -> getTargetColumnNameSafe(columnName, columnNameMapping) }
+            ?.let { columnName -> getQuotedTargetColumnName(columnName, columnNameMapping) }
     }
 
     private fun getCursorColumnName(stream: DestinationStream, columnNameMapping: ColumnNameMapping): String? {
@@ -224,7 +224,7 @@ class PostgresDirectLoadSqlGenerator(
     }
 
     private fun getTargetColumnNames(stream: DestinationStream, columnNameMapping: ColumnNameMapping): List<String> {
-        return columnsAndTypes(stream, columnNameMapping).map { getTargetColumnNameSafe(it.columnName, columnNameMapping) }
+        return columnsAndTypes(stream, columnNameMapping).map { getQuotedTargetColumnName(it.columnName, columnNameMapping) }
     }
 
     private fun getTargetColumnNames(columnNameMapping: ColumnNameMapping): List<String> =
@@ -233,7 +233,7 @@ class PostgresDirectLoadSqlGenerator(
     private fun getTargetColumnName(streamColumnName : String, columnNameMapping: ColumnNameMapping): String =
         columnNameMapping[streamColumnName] ?: streamColumnName
 
-    private fun getTargetColumnNameSafe(streamColumnName: String, columnNameMapping: ColumnNameMapping): String {
+    private fun getQuotedTargetColumnName(streamColumnName: String, columnNameMapping: ColumnNameMapping): String {
         return "\"${getTargetColumnName(streamColumnName, columnNameMapping)}\""
     }
 

--- a/airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/sql/PostgresDirectLoadSqlGenerator.kt
+++ b/airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/sql/PostgresDirectLoadSqlGenerator.kt
@@ -286,6 +286,20 @@ class PostgresDirectLoadSqlGenerator(
             primaryKeyTargetColumns = primaryKeyTargetColumns,
             cdcHardDeleteEnabled = cdcHardDeleteEnabled
         )
+
+        return """
+            WITH $DEDUPED_TABLE_ALIAS AS (
+              $selectDedupedQuery
+            ),
+
+            $cdcDeleteQuery
+
+            updates AS (
+              $updateExistingRowsQuery
+            )
+
+            $insertNewRowsQuery
+            """.trimIndent().andLog()
     }
 
     private fun insertNewRows(

--- a/airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/sql/PostgresDirectLoadSqlGenerator.kt
+++ b/airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/sql/PostgresDirectLoadSqlGenerator.kt
@@ -4,6 +4,7 @@
 
 package io.airbyte.integrations.destination.postgres.sql
 
+import com.google.common.annotations.VisibleForTesting
 import io.airbyte.cdk.load.command.Dedupe
 import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.data.AirbyteType
@@ -323,6 +324,7 @@ class PostgresDirectLoadSqlGenerator(
      * Uses NOT EXISTS to check for existing records by primary key. If CDC hard delete is enabled,
      * filters out records marked as deleted.
      */
+    @VisibleForTesting
     internal fun insertNewRows(
         dedupTableAlias: String,
         targetTableName: TableName,
@@ -359,6 +361,7 @@ class PostgresDirectLoadSqlGenerator(
      * Rows are matched by primary key and only updated if the source data is newer (determined by cursor
      * or extracted_at comparison). If CDC hard delete is enabled, skips records marked as deleted.
      */
+    @VisibleForTesting
     internal fun updateExistingRows(dedupTableAlias: String,
                                    targetTableName: TableName,
                                    allTargetColumns: List<String>,
@@ -394,6 +397,7 @@ class PostgresDirectLoadSqlGenerator(
      * Deletes rows from the target table where the source has a CDC deletion marker and the deletion
      * is newer than the target record (based on cursor or extracted_at).
      */
+    @VisibleForTesting
     internal fun cdcDelete(
         dedupTableAlias: String,
         cursorTargetColumn: String?,
@@ -459,6 +463,7 @@ class PostgresDirectLoadSqlGenerator(
      * Partitions by primary key and orders by cursor (if present) then extracted_at, keeping only
      * the most recent record for each unique primary key.
      */
+    @VisibleForTesting
     internal fun selectDeduped(
         primaryKeyTargetColumns: List<String>,
         cursorTargetColumn: String?,

--- a/airbyte-integrations/connectors/destination-postgres/src/test/kotlin/io/airbyte/integrations/destination/postgres/client/PostgresAirbyteClientTest.kt
+++ b/airbyte-integrations/connectors/destination-postgres/src/test/kotlin/io/airbyte/integrations/destination/postgres/client/PostgresAirbyteClientTest.kt
@@ -5,8 +5,6 @@
 package io.airbyte.integrations.destination.postgres.client
 
 import io.airbyte.cdk.load.command.DestinationStream
-import io.airbyte.cdk.load.data.FieldType
-import io.airbyte.cdk.load.data.ObjectType
 import io.airbyte.cdk.load.message.Meta.Companion.COLUMN_NAME_AB_GENERATION_ID
 import io.airbyte.cdk.load.table.ColumnNameMapping
 import io.airbyte.cdk.load.table.TableName
@@ -24,7 +22,6 @@ import java.sql.Connection
 import java.sql.ResultSet
 import java.sql.SQLException
 import java.sql.Statement
-import java.util.LinkedHashMap
 import javax.sql.DataSource
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -438,51 +435,6 @@ internal class PostgresAirbyteClientTest {
 
         assertEquals(expectedColumns, result)
     }
-
-//    @Test
-//    fun testGetColumnsFromStream() {
-//        val defaultColumnName = "default_column_name"
-//        every { postgresColumnUtils.defaultColumns() } returns
-//            listOf(Column(defaultColumnName, "varchar", false))
-//        every { postgresConfiguration.legacyRawTablesOnly } returns false
-//
-//        val properties = LinkedHashMap<String, FieldType>()
-//        val objectType = mockk<ObjectType>()
-//        every { objectType.properties } returns properties
-//
-//        val stream = mockk<DestinationStream>()
-//        every { stream.schema } returns objectType
-//
-//        val columnNameMapping = mockk<ColumnNameMapping>(relaxed = true)
-//
-//        every { postgresColumnUtils.columnsAndTypes(properties, columnNameMapping) } returns
-//            listOf(
-//                Column(defaultColumnName, "varchar", false),
-//                Column("col1", "text", false)
-//            )
-//
-//        val result = client.getColumnsFromStream(stream, columnNameMapping)
-//
-//        val expectedColumns =
-//            setOf(
-//                Column("col1", "text", false),
-//            )
-//
-//        assertEquals(expectedColumns, result)
-//    }
-//
-//    @Test
-//    fun testGetColumnsFromStreamRawTableMode() {
-//        every { postgresConfiguration.legacyRawTablesOnly } returns true
-//
-//        val stream = mockk<DestinationStream>()
-//        val columnNameMapping = mockk<ColumnNameMapping>(relaxed = true)
-//
-//        val result = client.getColumnsFromStream(stream, columnNameMapping)
-//
-//        // In raw table mode, there are no user columns to track
-//        assertEquals(emptySet<Column>(), result)
-//    }
 
     @Test
     fun testGenerateSchemaChanges() {

--- a/airbyte-integrations/connectors/destination-postgres/src/test/kotlin/io/airbyte/integrations/destination/postgres/client/PostgresAirbyteClientTest.kt
+++ b/airbyte-integrations/connectors/destination-postgres/src/test/kotlin/io/airbyte/integrations/destination/postgres/client/PostgresAirbyteClientTest.kt
@@ -8,6 +8,7 @@ import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.message.Meta.Companion.COLUMN_NAME_AB_GENERATION_ID
 import io.airbyte.cdk.load.table.ColumnNameMapping
 import io.airbyte.cdk.load.table.TableName
+import io.airbyte.integrations.destination.postgres.sql.COUNT_TOTAL_ALIAS
 import io.airbyte.integrations.destination.postgres.sql.Column
 import io.airbyte.integrations.destination.postgres.sql.PostgresDirectLoadSqlGenerator
 import io.mockk.Runs

--- a/airbyte-integrations/connectors/destination-postgres/src/test/kotlin/io/airbyte/integrations/destination/postgres/sql/PostgresColumnUtilsTest.kt
+++ b/airbyte-integrations/connectors/destination-postgres/src/test/kotlin/io/airbyte/integrations/destination/postgres/sql/PostgresColumnUtilsTest.kt
@@ -1,0 +1,230 @@
+/*
+ * Copyright (c) 2025 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination.postgres.sql
+
+import com.fasterxml.jackson.databind.JsonNode
+import io.airbyte.cdk.load.command.DestinationStream
+import io.airbyte.cdk.load.data.ArrayType
+import io.airbyte.cdk.load.data.ArrayTypeWithoutSchema
+import io.airbyte.cdk.load.data.BooleanType
+import io.airbyte.cdk.load.data.DateType
+import io.airbyte.cdk.load.data.FieldType
+import io.airbyte.cdk.load.data.IntegerType
+import io.airbyte.cdk.load.data.NumberType
+import io.airbyte.cdk.load.data.ObjectType
+import io.airbyte.cdk.load.data.ObjectTypeWithEmptySchema
+import io.airbyte.cdk.load.data.ObjectTypeWithoutSchema
+import io.airbyte.cdk.load.data.StringType
+import io.airbyte.cdk.load.data.TimeTypeWithTimezone
+import io.airbyte.cdk.load.data.TimeTypeWithoutTimezone
+import io.airbyte.cdk.load.data.TimestampTypeWithTimezone
+import io.airbyte.cdk.load.data.TimestampTypeWithoutTimezone
+import io.airbyte.cdk.load.data.UnionType
+import io.airbyte.cdk.load.data.UnknownType
+import io.airbyte.cdk.load.message.Meta.Companion.COLUMN_NAME_AB_EXTRACTED_AT
+import io.airbyte.cdk.load.message.Meta.Companion.COLUMN_NAME_AB_GENERATION_ID
+import io.airbyte.cdk.load.message.Meta.Companion.COLUMN_NAME_AB_LOADED_AT
+import io.airbyte.cdk.load.message.Meta.Companion.COLUMN_NAME_AB_META
+import io.airbyte.cdk.load.message.Meta.Companion.COLUMN_NAME_AB_RAW_ID
+import io.airbyte.cdk.load.message.Meta.Companion.COLUMN_NAME_DATA
+import io.airbyte.cdk.load.table.ColumnNameMapping
+import io.airbyte.integrations.destination.postgres.spec.PostgresConfiguration
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+internal class PostgresColumnUtilsTest {
+
+    @Test
+    fun testDefaultColumns() {
+        val config = mockk<PostgresConfiguration> {
+            every { legacyRawTablesOnly } returns false
+        }
+        val columnUtils = PostgresColumnUtils(config)
+
+        val columns = columnUtils.defaultColumns()
+
+        assertEquals(4, columns.size)
+        assertTrue(columns.any { it.columnName == COLUMN_NAME_AB_RAW_ID })
+        assertTrue(columns.any { it.columnName == COLUMN_NAME_AB_EXTRACTED_AT })
+        assertTrue(columns.any { it.columnName == COLUMN_NAME_AB_META })
+        assertTrue(columns.any { it.columnName == COLUMN_NAME_AB_GENERATION_ID })
+        assertFalse(columns.any { it.columnName == COLUMN_NAME_AB_LOADED_AT })
+        assertFalse(columns.any { it.columnName == COLUMN_NAME_DATA })
+    }
+
+    @Test
+    fun testDefaultColumnsForRawTables() {
+        val config = mockk<PostgresConfiguration> {
+            every { legacyRawTablesOnly } returns true
+        }
+        val columnUtils = PostgresColumnUtils(config)
+
+        val columns = columnUtils.defaultColumns()
+
+        assertEquals(6, columns.size)
+        assertTrue(columns.any { it.columnName == COLUMN_NAME_AB_RAW_ID })
+        assertTrue(columns.any { it.columnName == COLUMN_NAME_AB_EXTRACTED_AT })
+        assertTrue(columns.any { it.columnName == COLUMN_NAME_AB_META })
+        assertTrue(columns.any { it.columnName == COLUMN_NAME_AB_GENERATION_ID })
+        assertTrue(columns.any { it.columnName == COLUMN_NAME_AB_LOADED_AT })
+        assertTrue(columns.any { it.columnName == COLUMN_NAME_DATA })
+    }
+
+    @Test
+    fun testGetTargetColumns() {
+        // In typed mode, user columns should be included
+        val config = mockk<PostgresConfiguration> {
+            every { legacyRawTablesOnly } returns false
+        }
+        val columnUtils = PostgresColumnUtils(config)
+
+        val stream = mockk<DestinationStream> {
+            every { schema } returns ObjectType(
+                properties = linkedMapOf(
+                    "id" to FieldType(IntegerType, nullable = false),
+                    "name" to FieldType(StringType, nullable = true)
+                )
+            )
+        }
+        val columnNameMapping = ColumnNameMapping(
+            mapOf(
+                "id" to "targetId"
+            )
+        )
+
+        val columns = columnUtils.getTargetColumns(stream, columnNameMapping)
+
+        // Should return default columns (4) + user columns (2) = 6
+        assertEquals(6, columns.size)
+        assertTrue(columns.any { it.columnName == COLUMN_NAME_AB_RAW_ID })
+        assertTrue(columns.any { it.columnName == COLUMN_NAME_AB_EXTRACTED_AT })
+        assertTrue(columns.any { it.columnName == COLUMN_NAME_AB_META })
+        assertTrue(columns.any { it.columnName == COLUMN_NAME_AB_GENERATION_ID })
+
+        val idColumn = columns.find { it.columnName == "targetId" }!!
+        assertEquals("bigint", idColumn.columnTypeName)
+        assertFalse(idColumn.nullable)
+
+        val nameColumn = columns.find { it.columnName == "name" }!!
+        assertEquals("varchar", nameColumn.columnTypeName)
+        assertTrue(nameColumn.nullable)
+    }
+
+    @Test
+    fun testGetTargetColumnsInRawMode() {
+        // In raw mode, user columns should be ignored
+        val config = mockk<PostgresConfiguration> {
+            every { legacyRawTablesOnly } returns true
+        }
+        val columnUtils = PostgresColumnUtils(config)
+
+        val stream = mockk<DestinationStream> {
+            every { schema } returns ObjectType(
+                properties = linkedMapOf(
+                    "id" to FieldType(IntegerType, nullable = false),
+                    "name" to FieldType(StringType, nullable = true),
+                    "email" to FieldType(StringType, nullable = false)
+                )
+            )
+        }
+        val columnNameMapping = ColumnNameMapping(emptyMap())
+
+        val columns = columnUtils.getTargetColumns(stream, columnNameMapping)
+
+        // Should only return default columns (6 in raw mode), no user columns
+        assertEquals(6, columns.size)
+        assertTrue(columns.any { it.columnName == COLUMN_NAME_AB_RAW_ID })
+        assertTrue(columns.any { it.columnName == COLUMN_NAME_AB_EXTRACTED_AT })
+        assertTrue(columns.any { it.columnName == COLUMN_NAME_AB_META })
+        assertTrue(columns.any { it.columnName == COLUMN_NAME_AB_GENERATION_ID })
+        assertTrue(columns.any { it.columnName == COLUMN_NAME_AB_LOADED_AT })
+        assertTrue(columns.any { it.columnName == COLUMN_NAME_DATA })
+    }
+
+    @Test
+    fun testGetTargetColumnsWithEmptySchema() {
+        val config = mockk<PostgresConfiguration> {
+            every { legacyRawTablesOnly } returns false
+        }
+        val columnUtils = PostgresColumnUtils(config)
+
+        val stream = mockk<DestinationStream> {
+            every { schema } returns ObjectTypeWithEmptySchema
+        }
+        val columnNameMapping = ColumnNameMapping(emptyMap())
+
+        val columns = columnUtils.getTargetColumns(stream, columnNameMapping)
+
+        // Should only return default columns
+        assertEquals(4, columns.size)
+        assertTrue(columns.any { it.columnName == COLUMN_NAME_AB_RAW_ID })
+        assertTrue(columns.any { it.columnName == COLUMN_NAME_AB_EXTRACTED_AT })
+        assertTrue(columns.any { it.columnName == COLUMN_NAME_AB_META })
+        assertTrue(columns.any { it.columnName == COLUMN_NAME_AB_GENERATION_ID })
+    }
+
+    @Test
+    fun testGetTargetColumnName() {
+        val config = mockk<PostgresConfiguration> (relaxed = true)
+        val columnUtils = PostgresColumnUtils(config)
+
+        val columnNameMapping = ColumnNameMapping(
+            mapOf(
+                "sourceId" to "targetId"
+            )
+        )
+
+        assertEquals("targetId", columnUtils.getTargetColumnName("sourceId", columnNameMapping))
+        assertEquals("sourceName", columnUtils.getTargetColumnName("sourceName", columnNameMapping))
+    }
+
+    @Test
+    fun testToDialectTypeMapping() {
+        val config = mockk<PostgresConfiguration> (relaxed = true)
+        val columnUtils = PostgresColumnUtils(config)
+
+        assertEquals("boolean", columnUtils.toDialectType(BooleanType))
+        assertEquals("date", columnUtils.toDialectType(DateType))
+        assertEquals("bigint", columnUtils.toDialectType(IntegerType))
+        assertEquals("decimal", columnUtils.toDialectType(NumberType))
+        assertEquals("varchar", columnUtils.toDialectType(StringType))
+        assertEquals("time with time zone", columnUtils.toDialectType(TimeTypeWithTimezone))
+        assertEquals("time", columnUtils.toDialectType(TimeTypeWithoutTimezone))
+        assertEquals("timestamp with time zone", columnUtils.toDialectType(TimestampTypeWithTimezone))
+        assertEquals("timestamp", columnUtils.toDialectType(TimestampTypeWithoutTimezone))
+
+        assertEquals("jsonb", columnUtils.toDialectType(ArrayType(items = FieldType(StringType, false))))
+        assertEquals("jsonb", columnUtils.toDialectType(ArrayTypeWithoutSchema))
+        assertEquals("jsonb", columnUtils.toDialectType(ObjectType(linkedMapOf())))
+        assertEquals("jsonb", columnUtils.toDialectType(ObjectTypeWithEmptySchema))
+        assertEquals("jsonb", columnUtils.toDialectType(ObjectTypeWithoutSchema))
+        assertEquals("jsonb", columnUtils.toDialectType(UnknownType(mockk<JsonNode>())))
+    }
+
+    @Test
+    fun testToDialectTypeMappingUnions() {
+        val config = mockk<PostgresConfiguration> (relaxed = true)
+        val columnUtils = PostgresColumnUtils(config)
+
+        val unionWithStruct = UnionType(
+            options = setOf(
+                StringType,
+                ObjectType(linkedMapOf("field" to FieldType(StringType, nullable = false)))
+            ),
+            isLegacyUnion = true
+        )
+        assertEquals("jsonb", columnUtils.toDialectType(unionWithStruct))
+
+        val unionWithBasicTypes = UnionType(
+            options = setOf(StringType, IntegerType),
+            isLegacyUnion = true
+        )
+        assertEquals("jsonb", columnUtils.toDialectType(unionWithBasicTypes))
+    }
+}

--- a/airbyte-integrations/connectors/destination-postgres/src/test/kotlin/io/airbyte/integrations/destination/postgres/sql/PostgresColumnUtilsTest.kt
+++ b/airbyte-integrations/connectors/destination-postgres/src/test/kotlin/io/airbyte/integrations/destination/postgres/sql/PostgresColumnUtilsTest.kt
@@ -33,20 +33,28 @@ import io.airbyte.cdk.load.table.ColumnNameMapping
 import io.airbyte.integrations.destination.postgres.spec.PostgresConfiguration
 import io.mockk.every
 import io.mockk.mockk
+import org.junit.Before
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 internal class PostgresColumnUtilsTest {
 
+    private lateinit var config: PostgresConfiguration
+    private lateinit var columnUtils: PostgresColumnUtils
+
+
+    @BeforeEach
+    fun setUp() {
+        config = mockk()
+        columnUtils = PostgresColumnUtils(config)
+    }
+
     @Test
     fun testDefaultColumns() {
-        val config = mockk<PostgresConfiguration> {
-            every { legacyRawTablesOnly } returns false
-        }
-        val columnUtils = PostgresColumnUtils(config)
-
+        every { config.legacyRawTablesOnly } returns false
         val columns = columnUtils.defaultColumns()
 
         assertEquals(4, columns.size)
@@ -60,11 +68,7 @@ internal class PostgresColumnUtilsTest {
 
     @Test
     fun testDefaultColumnsForRawTables() {
-        val config = mockk<PostgresConfiguration> {
-            every { legacyRawTablesOnly } returns true
-        }
-        val columnUtils = PostgresColumnUtils(config)
-
+        every { config.legacyRawTablesOnly } returns true
         val columns = columnUtils.defaultColumns()
 
         assertEquals(6, columns.size)
@@ -78,11 +82,7 @@ internal class PostgresColumnUtilsTest {
 
     @Test
     fun testGetTargetColumns() {
-        // In typed mode, user columns should be included
-        val config = mockk<PostgresConfiguration> {
-            every { legacyRawTablesOnly } returns false
-        }
-        val columnUtils = PostgresColumnUtils(config)
+        every { config.legacyRawTablesOnly } returns false
 
         val stream = mockk<DestinationStream> {
             every { schema } returns ObjectType(
@@ -118,11 +118,7 @@ internal class PostgresColumnUtilsTest {
 
     @Test
     fun testGetTargetColumnsInRawMode() {
-        // In raw mode, user columns should be ignored
-        val config = mockk<PostgresConfiguration> {
-            every { legacyRawTablesOnly } returns true
-        }
-        val columnUtils = PostgresColumnUtils(config)
+        every { config.legacyRawTablesOnly } returns true
 
         val stream = mockk<DestinationStream> {
             every { schema } returns ObjectType(
@@ -149,10 +145,7 @@ internal class PostgresColumnUtilsTest {
 
     @Test
     fun testGetTargetColumnsWithEmptySchema() {
-        val config = mockk<PostgresConfiguration> {
-            every { legacyRawTablesOnly } returns false
-        }
-        val columnUtils = PostgresColumnUtils(config)
+        every { config.legacyRawTablesOnly } returns false
 
         val stream = mockk<DestinationStream> {
             every { schema } returns ObjectTypeWithEmptySchema
@@ -171,9 +164,6 @@ internal class PostgresColumnUtilsTest {
 
     @Test
     fun testGetTargetColumnName() {
-        val config = mockk<PostgresConfiguration> (relaxed = true)
-        val columnUtils = PostgresColumnUtils(config)
-
         val columnNameMapping = ColumnNameMapping(
             mapOf(
                 "sourceId" to "targetId"
@@ -186,9 +176,6 @@ internal class PostgresColumnUtilsTest {
 
     @Test
     fun testToDialectTypeMapping() {
-        val config = mockk<PostgresConfiguration> (relaxed = true)
-        val columnUtils = PostgresColumnUtils(config)
-
         assertEquals("boolean", columnUtils.toDialectType(BooleanType))
         assertEquals("date", columnUtils.toDialectType(DateType))
         assertEquals("bigint", columnUtils.toDialectType(IntegerType))
@@ -209,9 +196,6 @@ internal class PostgresColumnUtilsTest {
 
     @Test
     fun testToDialectTypeMappingUnions() {
-        val config = mockk<PostgresConfiguration> (relaxed = true)
-        val columnUtils = PostgresColumnUtils(config)
-
         val unionWithStruct = UnionType(
             options = setOf(
                 StringType,

--- a/airbyte-integrations/connectors/destination-postgres/src/test/kotlin/io/airbyte/integrations/destination/postgres/sql/PostgresDirectLoadSqlGeneratorTest.kt
+++ b/airbyte-integrations/connectors/destination-postgres/src/test/kotlin/io/airbyte/integrations/destination/postgres/sql/PostgresDirectLoadSqlGeneratorTest.kt
@@ -249,7 +249,7 @@ internal class PostgresDirectLoadSqlGeneratorTest {
                 options = setOf(StringType, IntegerType),
                 isLegacyUnion = true
             )
-            assertEquals("varchar", unionWithBasicTypes.toDialectType())
+            assertEquals("jsonb", unionWithBasicTypes.toDialectType())
         }
     }
 

--- a/airbyte-integrations/connectors/destination-postgres/src/test/kotlin/io/airbyte/integrations/destination/postgres/sql/PostgresDirectLoadSqlGeneratorTest.kt
+++ b/airbyte-integrations/connectors/destination-postgres/src/test/kotlin/io/airbyte/integrations/destination/postgres/sql/PostgresDirectLoadSqlGeneratorTest.kt
@@ -273,48 +273,6 @@ internal class PostgresDirectLoadSqlGeneratorTest {
         )
     }
 
-//    @Test
-//    fun testToDialectTypeMapping() {
-//        with(postgresDirectLoadSqlGenerator) {
-//            assertEquals("boolean", BooleanType.toDialectType())
-//            assertEquals("date", DateType.toDialectType())
-//            assertEquals("bigint", IntegerType.toDialectType())
-//            assertEquals("decimal", NumberType.toDialectType())
-//            assertEquals("varchar", StringType.toDialectType())
-//            assertEquals("time with time zone", TimeTypeWithTimezone.toDialectType())
-//            assertEquals("time", TimeTypeWithoutTimezone.toDialectType())
-//            assertEquals("timestamp with time zone", TimestampTypeWithTimezone.toDialectType())
-//            assertEquals("timestamp", TimestampTypeWithoutTimezone.toDialectType())
-//
-//            assertEquals("jsonb", ArrayType(items = FieldType(StringType, false)).toDialectType())
-//            assertEquals("jsonb", ArrayTypeWithoutSchema.toDialectType())
-//            assertEquals("jsonb", ObjectType(linkedMapOf()).toDialectType())
-//            assertEquals("jsonb", ObjectTypeWithEmptySchema.toDialectType())
-//            assertEquals("jsonb", ObjectTypeWithoutSchema.toDialectType())
-//            assertEquals("jsonb", UnknownType(mockk<JsonNode>()).toDialectType())
-//        }
-//    }
-//
-//    @Test
-//    fun testToDialectTypeMappingUnions() {
-//        with(postgresDirectLoadSqlGenerator) {
-//            val unionWithStruct = UnionType(
-//                options = setOf(
-//                    StringType,
-//                    ObjectType(linkedMapOf("field" to FieldType(StringType, nullable = false)))
-//                ),
-//                isLegacyUnion = true
-//            )
-//            assertEquals("jsonb", unionWithStruct.toDialectType())
-//
-//            val unionWithBasicTypes = UnionType(
-//                options = setOf(StringType, IntegerType),
-//                isLegacyUnion = true
-//            )
-//            assertEquals("jsonb", unionWithBasicTypes.toDialectType())
-//        }
-//    }
-
     @Test
     fun testColumnAndTypeToString() {
         with(postgresDirectLoadSqlGenerator) {


### PR DESCRIPTION
## What

https://github.com/airbytehq/airbyte-internal-issues/issues/14726
https://github.com/airbytehq/airbyte-internal-issues/issues/14882

Adding upsert table function that includes both the dedup and cdc deletes logic. Also added indexes that should make the queries done in upsert faster.
