### PR TITLE
fix(metadata models): correct SecretStore required fields and BreakingChanges const usage

### DIFF
--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/src/ConnectorBreakingChanges.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/src/ConnectorBreakingChanges.yaml
@@ -55,7 +55,7 @@ definitions:
       - impactedScopes
     properties:
       scopeType:
-        type: const
+        type: string
         const: stream
       impactedScopes:
         description: List of streams that are impacted by the breaking change.

--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/src/Secret.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/src/Secret.yaml
@@ -1,6 +1,6 @@
 ---
 "$schema": http://json-schema.org/draft-07/schema#
-"$id": https://github.com/airbytehq/airbyte/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/src/TestSecret.yaml
+"$id": https://github.com/airbytehq/airbyte/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/src/Secret.yaml
 title: Secret
 description: An object describing a secret's metadata
 type: object

--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/src/SecretStore.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/src/SecretStore.yaml
@@ -4,9 +4,6 @@
 title: SecretStore
 description: An object describing a secret store metadata
 type: object
-required:
-  - type
-  - alias
 additionalProperties: false
 properties:
   alias:

--- a/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/src/SecretStore.yaml
+++ b/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/src/SecretStore.yaml
@@ -1,12 +1,12 @@
 ---
 "$schema": http://json-schema.org/draft-07/schema#
-"$id": https://github.com/airbytehq/airbyte/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/src/TestSecret.yaml
+"$id": https://github.com/airbytehq/airbyte/airbyte-ci/connectors/metadata_service/lib/metadata_service/models/src/SecretStore.yaml
 title: SecretStore
 description: An object describing a secret store metadata
 type: object
 required:
-  - name
-  - secretStore
+  - type
+  - alias
 additionalProperties: false
 properties:
   alias:


### PR DESCRIPTION
## What

Fixes critical bugs in metadata service model source YAML files that were preventing validation of connector metadata.yaml files. These bugs were discovered during validation testing for [airbyte-python-cdk PR 807](https://github.com/airbytehq/airbyte-python-cdk/pull/807) which adds JSON schema validation for metadata.yaml files.

**Issues fixed:**
1. Invalid `type: const` syntax in ConnectorBreakingChanges.yaml (JSON Schema Draft 7 does not support `const` as a type value)
2. Incorrect required fields in SecretStore.yaml (copied from Secret.yaml but should match SecretStore's actual properties)
3. Copy-paste errors in `$id` references (both Secret.yaml and SecretStore.yaml pointed to non-existent TestSecret.yaml)

## How

**ConnectorBreakingChanges.yaml**
- Replaced `type: const` with `type: string` alongside `const: stream`
- JSON Schema Draft 7 treats `const` as a validation keyword, not a type
- This was causing validation to fail with "Unknown type 'const'" error

**SecretStore.yaml**
- Changed `required: [name, secretStore]` to `required: [type, alias]`
- Original required fields were incorrectly copied from Secret.yaml
- SecretStore's actual properties are `type` (enum: ["GSM"]) and `alias` (string)
- Verified all 304 connectors with secretStore entries have both `type` and `alias` fields
- Fixed `$id` to point to SecretStore.yaml instead of TestSecret.yaml

**Secret.yaml**
- Fixed `$id` to point to Secret.yaml instead of TestSecret.yaml
- No other changes needed (this file's required fields were correct)

## Review guide

1. **ConnectorBreakingChanges.yaml:58** - Verify `type: string` + `const: stream` is valid JSON Schema Draft 7 syntax
2. **SecretStore.yaml:7-9** - Confirm that SecretStore's properties are actually `type` and `alias` (not `name` and `secretStore`) by checking actual connector metadata.yaml files
3. **SecretStore.yaml:3 and Secret.yaml:3** - Verify $id fixes point to correct files

**Note:** These source YAML files are combined into a JSON schema in [airbyte-python-cdk](https://github.com/airbytehq/airbyte-python-cdk). After this PR merges, the schema will need to be regenerated in PR 807 for the fixes to take effect.

## User Impact

**Before:** Validation of connector metadata.yaml files failed for all 10 tested certified connectors due to schema bugs
**After:** Once schema is regenerated in airbyte-python-cdk, metadata.yaml validation will work correctly

**No immediate user impact** - these are source schema definition files. Changes only take effect after regeneration in the CDK repo.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

These are source YAML files that need regeneration to take effect. Reverting would simply restore the buggy state before any downstream regeneration occurs.

---

**Link to Devin run:** https://app.devin.ai/sessions/0078df9742174c169753b2c4c4d247da  
**Requested by:** AJ Steers (@aaronsteers)