### PR TITLE
fix(tiktok-marketing): reduce concurrency again to reduce rate limit issues

### DIFF
--- a/airbyte-integrations/connectors/source-tiktok-marketing/manifest.yaml
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/manifest.yaml
@@ -5903,7 +5903,7 @@ spec:
 # If time allows it, we can definitely try to scope this number a bit better empirically.
 concurrency_level:
   type: ConcurrencyLevel
-  default_concurrency: "{{ config.get('concurrency_level', 2) }}"
+  default_concurrency: "{{ config.get('concurrency_level', 1) }}"
   max_concurrency: 20
 
 metadata:

--- a/airbyte-integrations/connectors/source-tiktok-marketing/metadata.yaml
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/metadata.yaml
@@ -11,7 +11,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 4bfac00d-ce15-44ff-95b9-9e3c3e8fbd35
-  dockerImageTag: 4.8.6
+  dockerImageTag: 4.8.7
   dockerRepository: airbyte/source-tiktok-marketing
   documentationUrl: https://docs.airbyte.com/integrations/sources/tiktok-marketing
   githubIssueLabel: source-tiktok-marketing

--- a/docs/integrations/sources/tiktok-marketing.md
+++ b/docs/integrations/sources/tiktok-marketing.md
@@ -147,6 +147,7 @@ The connector is restricted by [requests limitation](https://business-api.tiktok
 
 | Version    | Date       | Pull Request                                              | Subject                                                                                                                                                                |
 |:-----------|:-----------|:----------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 4.8.7      | 2025-10-29 | [69081](https://github.com/airbytehq/airbyte/pull/69081) | Reduce concurrency |
 | 4.8.6      | 2025-10-29 | [69075](https://github.com/airbytehq/airbyte/pull/69075) | Add API Budget |
 | 4.8.5      | 2025-10-29 | [69074](https://github.com/airbytehq/airbyte/pull/69074) | Improving on rate limiting issue. |
 | 4.8.4      | 2025-10-08 | [67432](https://github.com/airbytehq/airbyte/pull/67432) | Promoting release candidate 4.8.4 to a main version. |


### PR DESCRIPTION
## What
This will increase the risk of deadlock on `pixel_events_statistics` so this stream might have to be disable if there are too many entries in the parent streams

## How
<!--
* Describe how code changes achieve the solution.
-->

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
