### PR TITLE
Support Glue catalogs using S3 Table Buckets

### DIFF
--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/IcebergTableCleaner.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/IcebergTableCleaner.kt
@@ -36,7 +36,12 @@ class IcebergTableCleaner(private val icebergUtil: IcebergUtil) {
         io: FileIO,
         tableLocation: String
     ) {
-        catalog.dropTable(identifier, true)
+        try {
+            catalog.dropTable(identifier, true)
+        } catch (_: Exception) {
+            // S3 Table Bucket doesn't support purge
+            catalog.dropTable(identifier, false)
+        }
         if (io is SupportsPrefixOperations) {
             io.deletePrefix(tableLocation)
         }


### PR DESCRIPTION
Iceburg in traditional s3 buckets can have deletion calls, but if the glue catalog is pointing to an S3 Table Bucket the purge=true fails

## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
https://github.com/airbytehq/airbyte/issues/69087
-->

## How
<!--
* Describe how code changes achieve the solution.
It falls back on a compatible deletion method
-->

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
You can use the S3 Data Lake connector with a glue catalog backed by an S3 Table Bucket
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [X] YES 💚
- [ ] NO ❌
