### PR TITLE
Fix broken companies/scroll pagination

### DIFF
--- a/airbyte-integrations/connectors/source-intercom/components.py
+++ b/airbyte-integrations/connectors/source-intercom/components.py
@@ -10,6 +10,7 @@ from typing import Any, Callable, Dict, Iterable, Mapping, Optional, Union
 import requests
 
 from airbyte_cdk.sources.declarative.migrations.state_migration import StateMigration
+from airbyte_cdk.sources.declarative.requesters.http_requester import HttpRequester
 from airbyte_cdk.sources.declarative.requesters.error_handlers import DefaultErrorHandler
 from airbyte_cdk.sources.declarative.requesters.paginators.strategies import CursorPaginationStrategy
 from airbyte_cdk.sources.declarative.retrievers.simple_retriever import SimpleRetriever
@@ -18,6 +19,20 @@ from airbyte_cdk.sources.types import Record, StreamSlice
 
 
 RequestInput = Union[str, Mapping[str, str]]
+
+
+class NoCacheRequester(HttpRequester):
+    """
+    The companies scroll API requires hitting the same endpoint
+    multiple times to get all the data,
+    but somehow HttpRequester is getting configured with use_cache=True,
+    so we need to override it to False.
+    Changing the option in the manifest.yaml is not working,
+    so we need to override it here.
+    """
+    def __init__(self, *args, **kwargs):
+        kwargs["use_cache"] = False
+        super().__init__(*args, **kwargs)
 
 
 @dataclass
@@ -334,28 +349,12 @@ class IntercomScrollRetriever(SimpleRetriever):
 
         yield from []
 
-
 class IntercomScrollPagination(CursorPaginationStrategy):
     """
-    Custom pagination strategy for Intercom's companies stream. Only compatible with streams that sync using
-    a single date time window instead of multiple windows when the step is defined. This is okay for the companies stream
-    since it only allows for single-threaded processing.
+    Pagination strategy for Intercom's /companies/scroll endpoint.
 
-    The only change is the stop condtion logic, which is done by comparing the
-    token value with the last page token value. If they are equal, we stop the pagination. This is needed since the Intercom API does not
-    have any clear stop condition for pagination, and we need to rely on the token value to determine when to stop.
-
-    As of 5/12/25 - they have some fields used for pagination stop conditons but they always result in null values, so we cannot rely on them.
-    Ex:
-    {
-        "type": "list",
-        "data": [
-            {...}
-        ],
-        "pages": null,
-        "total_count": null,
-        "scroll_param": "6287df44-6323-4dfa-8d19-eae43fdc4ab2" <- The scroll param also remains even if there are no more pages; leading to infinite pagination.
-    }
+    Intercom returns the same scroll_param for the entire scroll session.
+    The proper stop condition is when the response 'data' array is empty.
     """
 
     def next_page_token(
@@ -366,10 +365,14 @@ class IntercomScrollPagination(CursorPaginationStrategy):
         last_page_token_value: Optional[Any] = None,
     ) -> Optional[Any]:
         decoded_response = next(self.decoder.decode(response))
-        # The default way that link is presented in requests.Response is a string of various links (last, next, etc). This
-        # is not indexable or useful for parsing the cursor, so we replace it with the link dictionary from response.links
         headers: Dict[str, Any] = dict(response.headers)
         headers["link"] = response.links
+
+        # Stop if no records left
+        data = decoded_response.get("data", [])
+        if not data:
+            return None
+
         token = self._cursor_value.eval(
             config=self.config,
             response=decoded_response,
@@ -377,8 +380,5 @@ class IntercomScrollPagination(CursorPaginationStrategy):
             last_record=last_record,
             last_page_size=last_page_size,
         )
-
-        if token == last_page_token_value:
-            return None  # stop pagination
 
         return token if token else None

--- a/airbyte-integrations/connectors/source-intercom/manifest.yaml
+++ b/airbyte-integrations/connectors/source-intercom/manifest.yaml
@@ -243,10 +243,14 @@ definitions:
         type: CustomRetriever
         class_name: "source_declarative_manifest.components.IntercomScrollRetriever"
         requester:
+          type: CustomRequester
+          class_name: source_declarative_manifest.components.NoCacheRequester
           $parameters:
             name: "companies"
-          $ref: "#/definitions/base_requester"
+          url_base: https://api.intercom.io/
           path: "companies/scroll"
+          authenticator:
+            $ref: "#/definitions/base_requester/authenticator"
           request_headers:
             Accept: "application/json"
             Intercom-Version: "2.11"


### PR DESCRIPTION
## What
The companies sync is currently only syncing as many as 200 results due to broken pagination. The previous code made the incorrect assumption that each page would return a different token, but the behavior is the opposite.

## How
The companies/scroll API actually provides the same token in every page, so the previous mechanism of stopping pagination when the same token was observed was always limiting results to 2 pages (200 records). Instead, rely on receiving an empty `data` array, which is what occurs when the previous page was the last one.

Doing that actually exposed a new issue. Every page now is requested with exactly the same URL. It appears that the HttpRequester instance is created with use_cache=True, so starting on page 3, every response is returned from cache, with always the same records from page 2, which creates an infinite loop due to never receiving an empty array. To fix this, this commit creates a NoCacheRequester that forces use_cache=False for this particular endpoint.

I tested these changes running Airbyte locally (using `abctl`), plus executing the source in isolation via Docker command.

## Review guide
The description above seems sufficient to understand the problem and the solution. The [Intercom docs](https://developers.intercom.com/docs/references/rest-api/api.intercom.io/companies/scrolloverallcompanies) describe the behavior of the scroll parameter well too. 

## User Impact
This fixes the companies sync, which is otherwise limited to 200 results (broken).

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌
