### PR TITLE
Fix broken companies/scroll pagination

### DIFF
--- a/airbyte-integrations/connectors/source-intercom/manifest.yaml
+++ b/airbyte-integrations/connectors/source-intercom/manifest.yaml
@@ -243,10 +243,14 @@ definitions:
         type: CustomRetriever
         class_name: "source_declarative_manifest.components.IntercomScrollRetriever"
         requester:
+          type: CustomRequester
+          class_name: source_declarative_manifest.components.NoCacheRequester
           $parameters:
             name: "companies"
-          $ref: "#/definitions/base_requester"
+          url_base: https://api.intercom.io/
           path: "companies/scroll"
+          authenticator:
+            $ref: "#/definitions/base_requester/authenticator"
           request_headers:
             Accept: "application/json"
             Intercom-Version: "2.11"

--- a/airbyte-integrations/connectors/source-intercom/metadata.yaml
+++ b/airbyte-integrations/connectors/source-intercom/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: d8313939-3782-41b0-be29-b3ca20d8dd3a
-  dockerImageTag: 0.13.13
+  dockerImageTag: 0.13.14
   dockerRepository: airbyte/source-intercom
   documentationUrl: https://docs.airbyte.com/integrations/sources/intercom
   githubIssueLabel: source-intercom

--- a/docs/integrations/sources/intercom.md
+++ b/docs/integrations/sources/intercom.md
@@ -96,6 +96,7 @@ The Intercom connector should not run into Intercom API limitations under normal
 
 | Version    | Date       | Pull Request                                             | Subject                                                                                                                          |
 |:-----------|:-----------|:---------------------------------------------------------|:---------------------------------------------------------------------------------------------------------------------------------|
+| 0.13.14 | 2025-11-10 | [69151](https://github.com/airbytehq/airbyte/pull/69151) | Fix pagination for `companies` |
 | 0.13.13 | 2025-10-29 | [68767](https://github.com/airbytehq/airbyte/pull/68767) | Update dependencies |
 | 0.13.12 | 2025-10-21 | [68477](https://github.com/airbytehq/airbyte/pull/68477) | Update dependencies |
 | 0.13.11 | 2025-10-14 | [67933](https://github.com/airbytehq/airbyte/pull/67933) | Update dependencies |


### PR DESCRIPTION
## What
The companies sync is currently only syncing as many as 200 results due to broken pagination. The previous code made the incorrect assumption that each page would return a different token, but the behavior is the opposite.

## How
The companies/scroll API actually provides the same token in every page, so the previous mechanism of stopping pagination when the same token was observed was always limiting results to 2 pages (200 records). Instead, rely on receiving an empty `data` array, which is what occurs when the previous page was the last one.

Doing that actually exposed a new issue. Every page now is requested with exactly the same URL. It appears that the HttpRequester instance is created with use_cache=True, so starting on page 3, every response is returned from cache, with always the same records from page 2, which creates an infinite loop due to never receiving an empty array. To fix this, this commit creates a NoCacheRequester that forces use_cache=False for this particular endpoint.

I tested these changes running Airbyte locally (using `abctl`), plus executing the source in isolation via Docker command.

## Review guide
The description above seems sufficient to understand the problem and the solution. The [Intercom docs](https://developers.intercom.com/docs/references/rest-api/api.intercom.io/companies/scrolloverallcompanies) describe the behavior of the scroll parameter well too. 

## User Impact
This fixes the companies sync, which is otherwise limited to 200 results (broken).

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌