### PR TITLE
CH: Properly scale decimals before validating size.

### DIFF
--- a/airbyte-integrations/connectors/destination-clickhouse/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-clickhouse/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: ce0d828e-1dc4-496c-b122-2da42e637e48
-  dockerImageTag: 2.1.9
+  dockerImageTag: 2.1.10
   dockerRepository: airbyte/destination-clickhouse
   githubIssueLabel: destination-clickhouse
   icon: clickhouse.svg

--- a/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/write/transform/ClickhouseCoercer.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/write/transform/ClickhouseCoercer.kt
@@ -117,12 +117,12 @@ class ClickhouseCoercer : ValueCoercer {
         val INT64_MIN = BigInteger(Long.MIN_VALUE.toString())
 
         // below are copied from "deprecated" but still actively used
-        // com.clickhouse.data.format.BinaryStreamUtils.DECIMAL64_MAX
+        // com.clickhouse.data.format.BinaryStreamUtils
         // we can't directly use them because the deprecated status causes a
         // compiler warning which we don't tolerate in CI :smithers:
         //
-        // We further scale them by -9 (our defined scale for decimals) to mimic their scaling
-        // without the overhead (they multiply every value by the scale before comparison).
+        // Further scale the CH defined limits by -9 (our defined scale for decimals) to mimic their
+        // scaling without the overhead (they multiply every value by the scale before comparison).
         val DECIMAL128_MAX = BigDecimal("100000000000000000000000000000")
         val DECIMAL128_MIN = BigDecimal("-100000000000000000000000000000")
 

--- a/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/write/transform/ClickhouseCoercer.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/write/transform/ClickhouseCoercer.kt
@@ -26,7 +26,6 @@ import io.airbyte.integrations.destination.clickhouse.write.transform.Clickhouse
 import io.airbyte.integrations.destination.clickhouse.write.transform.ClickhouseCoercer.Constants.DATETIME64_MIN
 import io.airbyte.integrations.destination.clickhouse.write.transform.ClickhouseCoercer.Constants.DECIMAL128_MAX
 import io.airbyte.integrations.destination.clickhouse.write.transform.ClickhouseCoercer.Constants.DECIMAL128_MIN
-import io.airbyte.integrations.destination.clickhouse.write.transform.ClickhouseCoercer.Constants.DECIMAL_SCALE_MULTIPLIER
 import io.airbyte.integrations.destination.clickhouse.write.transform.ClickhouseCoercer.Constants.INT64_MAX
 import io.airbyte.integrations.destination.clickhouse.write.transform.ClickhouseCoercer.Constants.INT64_MIN
 import io.airbyte.protocol.models.v0.AirbyteRecordMessageMetaChange
@@ -70,14 +69,12 @@ class ClickhouseCoercer : ValueCoercer {
 
     override fun validate(value: EnrichedAirbyteValue): EnrichedAirbyteValue {
         when (val abValue = value.abValue) {
-            is NumberValue -> {
-                val scaled = abValue.value.multiply(DECIMAL_SCALE_MULTIPLIER)
-                if (scaled <= DECIMAL128_MIN || scaled >= DECIMAL128_MAX) {
+            is NumberValue ->
+                if (abValue.value <= DECIMAL128_MIN || abValue.value >= DECIMAL128_MAX) {
                     value.nullify(
                         AirbyteRecordMessageMetaChange.Reason.DESTINATION_FIELD_SIZE_LIMITATION
                     )
                 }
-            }
             is IntegerValue ->
                 if (abValue.value < INT64_MIN || abValue.value > INT64_MAX) {
                     value.nullify(
@@ -123,11 +120,11 @@ class ClickhouseCoercer : ValueCoercer {
         // com.clickhouse.data.format.BinaryStreamUtils.DECIMAL64_MAX
         // we can't directly use them because the deprecated status causes a
         // compiler warning which we don't tolerate in CI :smithers:
-        val DECIMAL128_MAX = BigDecimal("100000000000000000000000000000000000000")
-        val DECIMAL128_MIN = BigDecimal("-100000000000000000000000000000000000000")
-
-        // 9 is the scale we set for all decimals
-        val DECIMAL_SCALE_MULTIPLIER = BigDecimal.TEN.pow(9)
+        //
+        // We further scale them by -9 (our defined scale for decimals) to mimic their scaling
+        // without the overhead (they multiply every value by the scale before comparison).
+        val DECIMAL128_MAX = BigDecimal("100000000000000000000000000000")
+        val DECIMAL128_MIN = BigDecimal("-100000000000000000000000000000")
 
         // used by both date 32 and date time 64
         val DATE32_MAX_RAW = LocalDate.of(2299, 12, 31)

--- a/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/write/transform/ClickhouseCoercer.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/write/transform/ClickhouseCoercer.kt
@@ -126,6 +126,7 @@ class ClickhouseCoercer : ValueCoercer {
         val DECIMAL128_MAX = BigDecimal("100000000000000000000000000000000000000")
         val DECIMAL128_MIN = BigDecimal("-100000000000000000000000000000000000000")
 
+        // 9 is the scale we set for all decimals
         val DECIMAL_SCALE_MULTIPLIER = BigDecimal.TEN.pow(9)
 
         // used by both date 32 and date time 64

--- a/airbyte-integrations/connectors/destination-clickhouse/src/test/kotlin/io/airbyte/integrations/destination/clickhouse/write/transform/ClickhouseCoercerTest.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/test/kotlin/io/airbyte/integrations/destination/clickhouse/write/transform/ClickhouseCoercerTest.kt
@@ -24,7 +24,6 @@ import io.airbyte.integrations.destination.clickhouse.write.transform.Clickhouse
 import io.airbyte.integrations.destination.clickhouse.write.transform.ClickhouseCoercer.Constants.DATE32_MIN
 import io.airbyte.integrations.destination.clickhouse.write.transform.ClickhouseCoercer.Constants.DECIMAL128_MAX
 import io.airbyte.integrations.destination.clickhouse.write.transform.ClickhouseCoercer.Constants.DECIMAL128_MIN
-import io.airbyte.integrations.destination.clickhouse.write.transform.ClickhouseCoercer.Constants.DECIMAL_SCALE_MULTIPLIER
 import io.airbyte.integrations.destination.clickhouse.write.transform.ClickhouseCoercer.Constants.INT64_MAX
 import io.airbyte.integrations.destination.clickhouse.write.transform.ClickhouseCoercer.Constants.INT64_MIN
 import io.airbyte.integrations.destination.clickhouse.write.transform.ClickhouseCoercerTest.Fixtures.toAirbyteDateValue
@@ -234,16 +233,8 @@ class ClickhouseCoercerTest {
                 Arguments.of("42"),
                 Arguments.of("-10000000000000000.33"),
                 Arguments.of("100000000000000000.3"),
-                Arguments.of(
-                    DECIMAL128_MIN.divide(DECIMAL_SCALE_MULTIPLIER)
-                        .add(BigDecimal.valueOf(1))
-                        .toString()
-                ),
-                Arguments.of(
-                    DECIMAL128_MAX.divide(DECIMAL_SCALE_MULTIPLIER)
-                        .subtract(BigDecimal.valueOf(1))
-                        .toString()
-                ),
+                Arguments.of(DECIMAL128_MIN.add(BigDecimal.valueOf(1)).toString()),
+                Arguments.of(DECIMAL128_MAX.subtract(BigDecimal.valueOf(1)).toString()),
                 Arguments.of("1"),
                 Arguments.of("80327031.865312"),
                 Arguments.of("-80327031.8954"),

--- a/airbyte-integrations/connectors/destination-clickhouse/src/test/kotlin/io/airbyte/integrations/destination/clickhouse/write/transform/ClickhouseCoercerTest.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/test/kotlin/io/airbyte/integrations/destination/clickhouse/write/transform/ClickhouseCoercerTest.kt
@@ -24,6 +24,7 @@ import io.airbyte.integrations.destination.clickhouse.write.transform.Clickhouse
 import io.airbyte.integrations.destination.clickhouse.write.transform.ClickhouseCoercer.Constants.DATE32_MIN
 import io.airbyte.integrations.destination.clickhouse.write.transform.ClickhouseCoercer.Constants.DECIMAL128_MAX
 import io.airbyte.integrations.destination.clickhouse.write.transform.ClickhouseCoercer.Constants.DECIMAL128_MIN
+import io.airbyte.integrations.destination.clickhouse.write.transform.ClickhouseCoercer.Constants.DECIMAL_SCALE_MULTIPLIER
 import io.airbyte.integrations.destination.clickhouse.write.transform.ClickhouseCoercer.Constants.INT64_MAX
 import io.airbyte.integrations.destination.clickhouse.write.transform.ClickhouseCoercer.Constants.INT64_MIN
 import io.airbyte.integrations.destination.clickhouse.write.transform.ClickhouseCoercerTest.Fixtures.toAirbyteDateValue
@@ -41,8 +42,8 @@ import java.time.LocalDateTime
 import java.time.LocalTime
 import java.time.OffsetTime
 import java.time.ZoneOffset
-import kotlin.test.Test
 import kotlin.test.assertEquals
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
@@ -233,8 +234,16 @@ class ClickhouseCoercerTest {
                 Arguments.of("42"),
                 Arguments.of("-10000000000000000.33"),
                 Arguments.of("100000000000000000.3"),
-                Arguments.of(DECIMAL128_MIN.add(BigDecimal.valueOf(1)).toString()),
-                Arguments.of(DECIMAL128_MAX.subtract(BigDecimal.valueOf(1)).toString()),
+                Arguments.of(
+                    DECIMAL128_MIN.divide(DECIMAL_SCALE_MULTIPLIER)
+                        .add(BigDecimal.valueOf(1))
+                        .toString()
+                ),
+                Arguments.of(
+                    DECIMAL128_MAX.divide(DECIMAL_SCALE_MULTIPLIER)
+                        .subtract(BigDecimal.valueOf(1))
+                        .toString()
+                ),
                 Arguments.of("1"),
                 Arguments.of("80327031.865312"),
                 Arguments.of("-80327031.8954"),
@@ -250,6 +259,7 @@ class ClickhouseCoercerTest {
                 Arguments.of("100000000000000000000000000000000000001"),
                 Arguments.of("999999999999999999999999999999999999999.9"),
                 Arguments.of("-999999999999999999999999999999999999999.12"),
+                Arguments.of("3.4028234663852886E+37"),
             )
 
         @JvmStatic

--- a/docs/integrations/destinations/clickhouse.md
+++ b/docs/integrations/destinations/clickhouse.md
@@ -104,7 +104,7 @@ You can also use a pre-existing user but we highly recommend creating a dedicate
 
 | Version    | Date       | Pull Request                                               | Subject                                                                        |
 |:-----------|:-----------|:-----------------------------------------------------------|:-------------------------------------------------------------------------------|
-| 2.1.10     | 2025-11-03 | [99999](https://github.com/airbytehq/airbyte/pull/99999)   | Fix decimal validation                                                         |
+| 2.1.10     | 2025-11-03 | [69154](https://github.com/airbytehq/airbyte/pull/69154)   | Fix decimal validation                                                         |
 | 2.1.9      | 2025-10-30 | [69100](https://github.com/airbytehq/airbyte/pull/69100)   | Upgrade to CDK 0.1.61 to fix state index bug                                   |
 | 2.1.8      | 2025-10-28 | [68186](https://github.com/airbytehq/airbyte/pull/68186)   | Upgrade to CDK 0.1.59                                                          |
 | 2.1.7      | 2025-10-21 | [67153](https://github.com/airbytehq/airbyte/pull/67153)   | Implement new proto schema implementation                                      |

--- a/docs/integrations/destinations/clickhouse.md
+++ b/docs/integrations/destinations/clickhouse.md
@@ -104,6 +104,7 @@ You can also use a pre-existing user but we highly recommend creating a dedicate
 
 | Version    | Date       | Pull Request                                               | Subject                                                                        |
 |:-----------|:-----------|:-----------------------------------------------------------|:-------------------------------------------------------------------------------|
+| 2.1.10     | 2025-11-03 | [99999](https://github.com/airbytehq/airbyte/pull/99999)   | Fix decimal validation                                                         |
 | 2.1.9      | 2025-10-30 | [69100](https://github.com/airbytehq/airbyte/pull/69100)   | Upgrade to CDK 0.1.61 to fix state index bug                                   |
 | 2.1.8      | 2025-10-28 | [68186](https://github.com/airbytehq/airbyte/pull/68186)   | Upgrade to CDK 0.1.59                                                          |
 | 2.1.7      | 2025-10-21 | [67153](https://github.com/airbytehq/airbyte/pull/67153)   | Implement new proto schema implementation                                      |


### PR DESCRIPTION
## What
Fixes issue where decimals weren't properly coerced

## How
Copies internal CH logic where values are first scaled before they are validated

