### PR TITLE
bulk load CDK auto upgrade cron: use app token instead of GITHUB_TOKEN

### DIFF
--- a/.github/workflows/auto-upgrade-certified-connectors-cdk.yml
+++ b/.github/workflows/auto-upgrade-certified-connectors-cdk.yml
@@ -32,7 +32,7 @@ jobs:
         id: list-connectors
         run: |
           json_array=$(tools/bin/bulk-cdk/get-certified-connectors.sh)
-          echo 'connectors=["destination-dev-null"]' >> $GITHUB_OUTPUT
+          echo "connectors=$json_array" >> $GITHUB_OUTPUT
           echo "Found bulk CDK connectors to upgrade: $json_array"
 
   upgrade-connector-cdk:

--- a/.github/workflows/auto-upgrade-certified-connectors-cdk.yml
+++ b/.github/workflows/auto-upgrade-certified-connectors-cdk.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Checkout Airbyte
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           # Needed for when airbyte-enterprise calls this workflow
           submodules: true
 

--- a/.github/workflows/auto-upgrade-certified-connectors-cdk.yml
+++ b/.github/workflows/auto-upgrade-certified-connectors-cdk.yml
@@ -32,7 +32,7 @@ jobs:
         id: list-connectors
         run: |
           json_array=$(tools/bin/bulk-cdk/get-certified-connectors.sh)
-          echo "connectors=$json_array" >> $GITHUB_OUTPUT
+          echo 'connectors=["destination-dev-null"]' >> $GITHUB_OUTPUT
           echo "Found bulk CDK connectors to upgrade: $json_array"
 
   upgrade-connector-cdk:


### PR DESCRIPTION
closes https://github.com/airbytehq/airbyte-internal-issues/issues/15126. GITHUB_TOKEN commits don't trigger CI. Switch to using the app token.

Example PR - https://github.com/airbytehq/airbyte/pull/69182. All checks ran as expected.