### PR TITLE
Query table metadata per schema

### DIFF
--- a/airbyte-cdk/bulk/changelog.md
+++ b/airbyte-cdk/bulk/changelog.md
@@ -1,3 +1,7 @@
+## Version 0.1.65
+
+extract cdk: fix bug when getting table metadata that cause timeout
+
 ## Version 0.1.64
 
 extract cdk: add table filtering to jdbc connectors

--- a/airbyte-cdk/bulk/version.properties
+++ b/airbyte-cdk/bulk/version.properties
@@ -1,1 +1,1 @@
-version=0.1.64
+version=0.1.65


### PR DESCRIPTION
## What
In `JdbcMetadataQuerier` we thought we improved the `memoizedColumnMetadata` query by eliminating tables outside the table filter, but we introduced overhead of making individual request to get each table's metadata. 

## How
Now we query table metadata per schema + per filter (if any) instead of per table

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
