### PR TITLE
docs: Link to PyAirbyte MCP docs instead of duplicating content

### DIFF
--- a/docs/ai-agents/pyairbyte-mcp.md
+++ b/docs/ai-agents/pyairbyte-mcp.md
@@ -16,6 +16,7 @@ For complete setup instructions, troubleshooting guidance, and detailed document
 **[PyAirbyte MCP Server Documentation](https://airbytehq.github.io/PyAirbyte/airbyte/mcp.html)**
 
 The PyAirbyte documentation includes:
+
 - Step-by-step setup instructions
 - Environment configuration requirements
 - Security model and safety features

--- a/docs/ai-agents/pyairbyte-mcp.md
+++ b/docs/ai-agents/pyairbyte-mcp.md
@@ -34,6 +34,16 @@ To get started with the PyAirbyte MCP server:
 
 For detailed instructions on each step, see the [PyAirbyte MCP documentation](https://airbytehq.github.io/PyAirbyte/airbyte/mcp.html).
 
+## Helpful Prompts
+
+Here are some things you can do with the PyAirbyte MCP server, across local and Airbyte Cloud use cases:
+
+1. "Use your MCP tools to list all available Airbyte connectors."
+2. "Use your MCP tools to get information about the Airbyte Stripe connector."
+3. "Use your MCP tools to list all variables you have access to in the dotenv secrets file."
+4. "Use your MCP tools to check your connection to your Airbyte Cloud workspace."
+5. "Use your MCP tools to list all available destinations in my Airbyte Cloud workspace."
+
 ## Contributing to the Airbyte MCP Server
 
 - [PyAirbyte Contributing Guide](https://github.com/airbytehq/PyAirbyte/blob/main/docs/CONTRIBUTING.md)

--- a/docs/ai-agents/pyairbyte-mcp.md
+++ b/docs/ai-agents/pyairbyte-mcp.md
@@ -9,90 +9,30 @@ products: embedded
 
 The PyAirbyte MCP (Model Context Protocol) server provides a standardized interface for managing Airbyte connectors through MCP-compatible clients. This experimental feature allows you to list connectors, validate configurations, and run sync operations using the MCP protocol.
 
-## Getting Started with PyAirbyte MCP
+## Documentation
 
-To get started with the PyAirbyte MCP server, follow these steps:
+For complete setup instructions, troubleshooting guidance, and detailed documentation, please refer to the authoritative PyAirbyte MCP documentation:
 
-1. Create a Dotenv secrets file.
-2. Register the MCP server with your MCP client.
-3. Test the MCP server connection using your MCP client.
+**[PyAirbyte MCP Server Documentation](https://airbytehq.github.io/PyAirbyte/airbyte/mcp.html)**
 
-### Step 1: Generate a Dotenv Secrets File
+The PyAirbyte documentation includes:
+- Step-by-step setup instructions
+- Environment configuration requirements
+- Security model and safety features
+- Troubleshooting guide with common issues and solutions
+- Architecture overview
+- Prerequisites checklist
 
-To get started with the PyAirbyte MCP server, you will need to create a dotenv file containing your Airbyte Cloud credentials, as well as credentials for any third-party services you wish to connect to via Airbyte.
+## Quick Start
 
-Create a file named `~/.mcp/airbyte_mcp.env` with the following content:
+To get started with the PyAirbyte MCP server:
 
-```ini
-# Airbyte Project Artifacts Directory
-AIRBYTE_PROJECT_DIR=/path/to/any/writeable/project-dir
+1. Install `uv`: `brew install uv`
+2. Create a dotenv secrets file with your Airbyte Cloud credentials and connector configurations
+3. Register the MCP server with your MCP client using `uvx --from=airbyte@latest airbyte-mcp`
+4. Test the connection using your MCP client
 
-# Airbyte Cloud Credentials (Required for Airbyte Cloud Operations)
-AIRBYTE_CLOUD_CLIENT_ID=your_api_key
-AIRBYTE_CLOUD_CLIENT_SECRET=your_api_secret
-AIRBYTE_CLOUD_WORKSPACE_ID=your_workspace_id
-
-# API-Specific Credentials (Optional, depending on your connectors)
-
-# For example, for a PostgreSQL source connector:
-# POSTGRES_HOST=your_postgres_host
-# POSTGRES_PORT=5432
-# POSTGRES_DB=your_database_name
-# POSTGRES_USER=your_database_user
-# POSTGRES_PASSWORD=your_database_password
-
-# For example, for a Stripe source connector:
-# STRIPE_API_KEY=your_stripe_api_key
-# STRIPE_API_SECRET=your_stripe_api_secret
-# STRIPE_WEBHOOK_SECRET=your_stripe_webhook_secret
-```
-
-Note:
-
-1. You can add more environment variables to this file as needed for different connectors. To start, you only need to create the file and pass it to the MCP server.
-2. Ensure that this file is kept secure, as it contains sensitive information. Your LLM *should never* be given direct access to this file or its contents.
-3. The MCP tools will give your LLM the ability to view *which* variables are available, but it does not give access to their values.
-4. The `AIRBYTE_PROJECT_DIR` variable specifies a directory where the MCP server can store temporary project files. Ensure this directory is writable by the user running the MCP server.
-
-### Step 2: Registering the MCP Server
-
-First install `uv` (`brew install uv`).
-
-Then, create a file named `server_config.json` (or the file name required by your MCP client) with the following content. This uses `uvx` (from `brew install uv`) to run the MCP server. If a matching version Python is not yet installed, a `uv`-managed Python version will be installed automatically. This will also auto-update to use the "latest" Airbyte MCP release at time of launch. You can alternatively pin to a specific version of Python and/or of the Airbyte library if you have special requirements.
-
-```json
-{
-  "mcpServers": {
-    "airbyte": {
-      "command": "uvx",
-      "args": [
-        "--python=3.11",
-        "--from=airbyte@latest",
-        "airbyte-mcp"
-      ],
-      "env": {
-        "AIRBYTE_MCP_ENV_FILE": "/path/to/my/.mcp/airbyte_mcp.env"
-      }
-    }
-  }
-}
-```
-
-Note:
-
-- Replace `/path/to/my/.mcp/airbyte_mcp.env` with the absolute path to your dotenv file created in Step 1.
-
-### Step 3: Testing the MCP Server Connection
-
-You can test the MCP server connection using your MCP client.
-
-Helpful prompts to try:
-
-1. "Use your MCP tools to list all available Airbyte connectors."
-2. "Use your MCP tools to get information about the Airbyte Stripe connector."
-3. "Use your MCP tools to list all variables you have access to in the dotenv secrets file."
-4. "Use your MCP tools to check your connection to your Airbyte Cloud workspace."
-5. "Use your MCP tools to list all available destinations in my Airbyte Cloud workspace."
+For detailed instructions on each step, see the [PyAirbyte MCP documentation](https://airbytehq.github.io/PyAirbyte/airbyte/mcp.html).
 
 ## Contributing to the Airbyte MCP Server
 

--- a/docs/ai-agents/pyairbyte-mcp.md
+++ b/docs/ai-agents/pyairbyte-mcp.md
@@ -29,7 +29,7 @@ To get started with the PyAirbyte MCP server:
 
 1. Install `uv`: `brew install uv`
 2. Create a dotenv secrets file with your Airbyte Cloud credentials and connector configurations
-3. Register the MCP server with your MCP client using `uvx --from=airbyte@latest airbyte-mcp`
+3. Register the MCP server with your MCP client using `uvx --python=3.11 --from=airbyte@latest airbyte-mcp`
 4. Test the connection using your MCP client
 
 For detailed instructions on each step, see the [PyAirbyte MCP documentation](https://airbytehq.github.io/PyAirbyte/airbyte/mcp.html).


### PR DESCRIPTION
## What

This PR deduplicates PyAirbyte MCP documentation by removing detailed setup instructions from the Airbyte docs and linking to the authoritative PyAirbyte documentation instead. This addresses feedback to establish PyAirbyte docs as the single source of truth for MCP setup and troubleshooting.

Related to work in https://github.com/airbytehq/PyAirbyte/pull/853 which adds troubleshooting guidance to the PyAirbyte MCP docs.

## How

- Removed ~80 lines of duplicated setup instructions (Step 1-3) from `docs/ai-agents/pyairbyte-mcp.md`
- Added prominent link to authoritative PyAirbyte MCP documentation (https://airbytehq.github.io/PyAirbyte/airbyte/mcp.html)
- Replaced detailed steps with high-level Quick Start that provides enough context while directing users to complete docs
- Kept the experimental notice and overview to provide immediate context

## Review guide

1. **Verify link accuracy**: Check that https://airbytehq.github.io/PyAirbyte/airbyte/mcp.html is the correct URL and will remain stable
2. **Content completeness**: Review whether the Quick Start section provides enough context for users to get started
3. **Documentation flow**: Ensure the structure makes sense - users should understand they need to follow the link for detailed instructions

Key areas to review:
- Line 16: PyAirbyte docs link - verify this is correct
- Lines 18-24: List of what's in PyAirbyte docs - verify this accurately reflects the content
- Lines 28-35: Quick Start - verify this provides enough context without duplicating PyAirbyte docs

## User Impact

**Positive**:
- Single source of truth for PyAirbyte MCP documentation, reducing maintenance burden
- Users always get the most up-to-date information from PyAirbyte docs
- Clearer separation between Airbyte overview and detailed PyAirbyte setup instructions

**Potential negative**:
- Users need to click through to PyAirbyte docs for detailed instructions (requires extra navigation)
- If the PyAirbyte docs link breaks, users will be unable to access setup instructions

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌

This is a documentation-only change with no code impact. Reverting would restore the duplicated content.

---

**Link to Devin run**: https://app.devin.ai/sessions/8a43ba8eec154b378267455794da19c7  
**Requested by**: AJ Steers (@aaronsteers)

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._

> [!NOTE]
> **Auto-merge may have been disabled. Please check the PR status to confirm.**