### PR TITLE
Update the IcebergTableSynchronizer.kt to allow us to force commit between schema updates

### DIFF
--- a/airbyte-cdk/bulk/changelog.md
+++ b/airbyte-cdk/bulk/changelog.md
@@ -1,3 +1,9 @@
+## Version 0.1.69
+
+**Load CDK**
+
+* Changed: Update the IcebergTableSynchronizer to allow for individual update operations commit in preparation for BigLake
+
 ## Version 0.1.68
 
 **Load CDK**

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/IcebergTableSynchronizer.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/IcebergTableSynchronizer.kt
@@ -197,7 +197,9 @@ class IcebergTableSynchronizer(
         // If we're doing separate commits for column replacements, commit the delete operations now
         if (requireSeparateCommitsForColumnReplace && columnsToReplaceInSecondCommit.isNotEmpty()) {
             // Commit the first update (with deletes but not adds for replaced columns)
-            update.commit()
+            if (columnTypeChangeBehavior.commitImmediately) {
+                update.commit()
+            }
 
             // Refresh table to get updated schema after delete
             table.refresh()

--- a/airbyte-cdk/bulk/version.properties
+++ b/airbyte-cdk/bulk/version.properties
@@ -1,1 +1,1 @@
-version=0.1.68
+version=0.1.69


### PR DESCRIPTION
## What

BigLake requires that to be a think but we do not want to enforce that the rest of the data lake cotalogs

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [X] YES 💚
- [ ] NO ❌
