### PR TITLE
Upgrade develocity plugin; disable failOnSkippedAfterRetry

### DIFF
--- a/airbyte-integrations/connectors/destination-dev-null/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-dev-null/metadata.yaml
@@ -38,4 +38,3 @@ data:
   tags:
     - language:java
 metadataSpecVersion: "1.0"
-# trigger CI

--- a/airbyte-integrations/connectors/destination-dev-null/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-dev-null/metadata.yaml
@@ -38,3 +38,4 @@ data:
   tags:
     - language:java
 metadataSpecVersion: "1.0"
+# trigger CI

--- a/buildSrc/src/main/groovy/airbyte-bulk-connector.gradle
+++ b/buildSrc/src/main/groovy/airbyte-bulk-connector.gradle
@@ -226,18 +226,20 @@ class AirbyteBulkConnectorPlugin implements Plugin<Project> {
                     showStandardStreams = true
                 }
 
-                retry {
-                    // If running in CI, enable retries to mitigate flakiness
-                    if (System.getenv().containsKey("CI")) {
-                        // Run each test method up to three times
-                        maxRetries = 3
-                        // If any test method fails, disable retries for the other tests
-                        // (unintuitive: if you set this to 1, then as soon as a test case fails, it will disable retries, including for itself.
-                        // So we set to 2, which means: a test case failing will retry itself. If, after three retries, it still fails, then we disable retries globally.)
-                        maxFailures = 2
+                develocity {
+                    testRetry {
+                        // If running in CI, enable retries to mitigate flakiness
+                        if (System.getenv().containsKey("CI")) {
+                            // Run each test method up to three times
+                            maxRetries = 3
+                            // If any test method fails, disable retries for the other tests
+                            // (unintuitive: if you set this to 1, then as soon as a test case fails, it will disable retries, including for itself.
+                            // So we set to 2, which means: a test case failing will retry itself. If, after three retries, it still fails, then we disable retries globally.)
+                            maxFailures = 2
+                        }
+                        // If a test fails, but succeeds on retry - don't fail the task
+                        failOnPassedAfterRetry = false
                     }
-                    // If a test fails, but succeeds on retry - don't fail the task
-                    failOnPassedAfterRetry = false
                 }
                 reports {
                     junitXml {

--- a/buildSrc/src/main/groovy/airbyte-bulk-connector.gradle
+++ b/buildSrc/src/main/groovy/airbyte-bulk-connector.gradle
@@ -239,6 +239,9 @@ class AirbyteBulkConnectorPlugin implements Plugin<Project> {
                         }
                         // If a test fails, but succeeds on retry - don't fail the task
                         failOnPassedAfterRetry = false
+                        // If a test fails, but is skipped on retry (e.g., due to failed assumptions) - don't fail the task.
+                        // This handles cases where tests use Assumptions.assumeTrue() to conditionally skip themselves.
+                        failOnSkippedAfterRetry = false
                     }
                 }
                 reports {

--- a/settings.gradle
+++ b/settings.gradle
@@ -20,7 +20,7 @@ pluginManagement {
 // Configure the gradle enterprise plugin to enable build scans. Enabling the plugin at the top of the settings file allows the build scan to record
 // as much information as possible.
 plugins {
-    id "com.gradle.enterprise" version "3.15.1"
+    id "com.gradle.develocity" version "3.19.2"
     id 'com.github.burrunan.s3-build-cache' version "1.8.1"
 }
 
@@ -114,10 +114,10 @@ dependencyResolutionManagement {
     }
 }
 
-gradleEnterprise {
+develocity {
     buildScan {
-        termsOfServiceUrl = "https://gradle.com/terms-of-service"
-        termsOfServiceAgree = "yes"
+        termsOfUseUrl = "https://gradle.com/terms-of-service"
+        termsOfUseAgree = "yes"
         uploadInBackground = !isCI // Disable in CI or scan URLs may not work.
         buildScanPublished { PublishedBuildScan scan ->
             file("scan-journal.log") << "${new Date()} - ${scan.buildScanId} - ${scan.buildScanUri}\n"


### PR DESCRIPTION
Two commits to do the two things in the title. `failOnSkippedAfterRetry` isn't available in com.gradle.enterprise 3.15, so I had to upgrade, and that turned into a whole thing.

`failOnSkippedAfterRetry` makes it so that if a test fails on attempt 1, and is then skipped on attempt 2, the overall task is still marked successful - which should solve the thing we saw in https://github.com/airbytehq/airbyte-internal-issues/issues/15104.

I'll put up a PR for airbyte-enterprise to do the enterprise->develocity upgrade in a minute.