### PR TITLE
postgres misc fixes

### DIFF
--- a/airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/PostgresSQLNameTransformer.kt
+++ b/airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/PostgresSQLNameTransformer.kt
@@ -28,8 +28,8 @@ class PostgresSQLNameTransformer : StandardNameTransformer() {
     // migration
     @Deprecated("") // Overriding a deprecated method is, itself, a warning
     @Suppress("deprecation")
-    override fun getRawTableName(streamName: String): String {
-        return convertStreamName("_airbyte_raw_" + streamName.lowercase(Locale.getDefault()))
+    override fun getRawTableName(name: String): String {
+        return convertStreamName("_airbyte_raw_" + name.lowercase(Locale.getDefault()))
     }
 
     /**

--- a/airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/typing_deduping/PostgresGenerationIdMigrator.kt
+++ b/airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/typing_deduping/PostgresGenerationIdMigrator.kt
@@ -44,13 +44,13 @@ class PostgresGenerationIdMigration(
 
             if (existingRawTable.columns[JavaBaseConstants.COLUMN_NAME_AB_GENERATION_ID] != null) {
                 // The raw table already has the _airbyte_meta column. No migration necessary.
-                logger.info(
+                logger.info {
                     "Skipping migration for ${stream.id.rawNamespace}.${stream.id.rawName}'s raw table because the generation_id column is already present"
-                )
+                }
             } else {
-                logger.info(
+                logger.info {
                     "Executing migration for ${stream.id.rawNamespace}.${stream.id.rawName}'s raw table for real"
-                )
+                }
 
                 needsStateRefresh = true
                 destinationHandler.execute(
@@ -74,9 +74,9 @@ class PostgresGenerationIdMigration(
                 stream.id.finalName
             )
         if (maybeExistingFinalTable.isEmpty) {
-            logger.info(
+            logger.info {
                 "Stopping migration for ${stream.id.originalNamespace}.${stream.id.originalName} because the final table doesn't exist"
-            )
+            }
             return Migration.MigrationResult(
                 state.destinationState.copy(isAirbyteGenerationIdPresent = true),
                 needsStateRefresh
@@ -86,13 +86,13 @@ class PostgresGenerationIdMigration(
         if (existingFinalTable.columns[JavaBaseConstants.COLUMN_NAME_AB_GENERATION_ID] != null) {
             // The raw table already has the _airbyte_meta column. No migration necessary. Update
             // the state.
-            logger.info(
+            logger.info {
                 "Skipping migration for ${stream.id.finalNamespace}.${stream.id.finalName} because the generation_id column is already present"
-            )
+            }
         } else {
-            logger.info(
+            logger.info {
                 "Executing migration for ${stream.id.finalNamespace}.${stream.id.finalName} for real"
-            )
+            }
 
             needsStateRefresh = true
             destinationHandler.execute(

--- a/airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/typing_deduping/PostgresSqlGenerator.kt
+++ b/airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/typing_deduping/PostgresSqlGenerator.kt
@@ -327,21 +327,19 @@ class PostgresSqlGenerator(
             .and(jsonTypeof(extractColumnAsJson(cdcDeletedAtColumn)).ne("null"))
     }
 
-    override fun getRowNumber(primaryKeys: List<ColumnId>, cursor: Optional<ColumnId>): Field<Int> {
+    override fun getRowNumber(primaryKey: List<ColumnId>, cursorField: Optional<ColumnId>): Field<Int> {
         // literally identical to redshift's getRowNumber implementation, changes here probably
         // should
         // be reflected there
         val primaryKeyFields =
-            if (primaryKeys != null)
-                primaryKeys
-                    .stream()
-                    .map { columnId: ColumnId -> DSL.field(DSL.quotedName(columnId.name)) }
-                    .collect(Collectors.toList())
-            else ArrayList()
+            primaryKey
+                .stream()
+                .map { columnId: ColumnId -> DSL.field(DSL.quotedName(columnId.name)) }
+                .collect(Collectors.toList())
         val orderedFields: MutableList<Field<*>> = ArrayList()
         // We can still use Jooq's field to get the quoted name with raw sql templating.
         // jooq's .desc returns SortField<?> instead of Field<?> and NULLS LAST doesn't work with it
-        cursor.ifPresent { columnId: ColumnId ->
+        cursorField.ifPresent { columnId: ColumnId ->
             orderedFields.add(
                 DSL.field("{0} desc NULLS LAST", DSL.field(DSL.quotedName(columnId.name)))
             )

--- a/airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/write/transform/PostgresValueCoercer.kt
+++ b/airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/write/transform/PostgresValueCoercer.kt
@@ -13,6 +13,7 @@ import io.airbyte.cdk.load.data.TimestampWithTimezoneValue
 import io.airbyte.cdk.load.data.TimestampWithoutTimezoneValue
 import io.airbyte.cdk.load.data.UnionType
 import io.airbyte.cdk.load.data.UnknownType
+import io.airbyte.cdk.load.dataflow.transform.ValidationResult
 import io.airbyte.cdk.load.dataflow.transform.ValueCoercer
 import io.airbyte.cdk.load.util.serializeToString
 import io.airbyte.protocol.models.v0.AirbyteRecordMessageMetaChange
@@ -64,23 +65,23 @@ class PostgresValueCoercer : ValueCoercer {
         return value
     }
 
-    override fun validate(value: EnrichedAirbyteValue): EnrichedAirbyteValue {
+    override fun validate(value: EnrichedAirbyteValue): ValidationResult =
         when (val abValue = value.abValue) {
             is IntegerValue -> {
                 // Validate against BIGINT range
                 if (abValue.value !in BIGINT_RANGE) {
-                    value.nullify(
+                    ValidationResult.ShouldNullify(
                         AirbyteRecordMessageMetaChange.Reason.DESTINATION_FIELD_SIZE_LIMITATION
                     )
-                }
+                } else ValidationResult.Valid
             }
             is NumberValue -> {
                 // Validate against NUMERIC range
                 if (abValue.value < NUMERIC_MIN || abValue.value > NUMERIC_MAX) {
-                    value.nullify(
+                    ValidationResult.ShouldNullify(
                         AirbyteRecordMessageMetaChange.Reason.DESTINATION_FIELD_SIZE_LIMITATION
                     )
-                }
+                } else ValidationResult.Valid
             }
             is StringValue -> {
                 // PostgreSQL doesn't allow null bytes (\u0000) in text fields
@@ -95,32 +96,30 @@ class PostgresValueCoercer : ValueCoercer {
                 // PostgreSQL uses UTF-8, so we check character count * 4 (max bytes per UTF-8 char)
                 val currentValue = (value.abValue as StringValue).value
                 if (currentValue.length * 4 > TEXT_LIMIT_BYTES) {
-                    value.nullify(
+                    ValidationResult.ShouldNullify(
                         AirbyteRecordMessageMetaChange.Reason.DESTINATION_FIELD_SIZE_LIMITATION
                     )
-                }
+                } else ValidationResult.Valid
             }
             is TimestampWithTimezoneValue -> {
                 val seconds = abValue.value.toEpochSecond()
                 if (seconds < TIMESTAMP_MIN_EPOCH_SECONDS || seconds > TIMESTAMP_MAX_EPOCH_SECONDS) {
-                    value.nullify(
+                    ValidationResult.ShouldNullify(
                         AirbyteRecordMessageMetaChange.Reason.DESTINATION_FIELD_SIZE_LIMITATION
                     )
-                }
+                } else ValidationResult.Valid
             }
             is TimestampWithoutTimezoneValue -> {
                 val seconds = abValue.value.toEpochSecond(java.time.ZoneOffset.UTC)
                 if (seconds < TIMESTAMP_MIN_EPOCH_SECONDS || seconds > TIMESTAMP_MAX_EPOCH_SECONDS) {
-                    value.nullify(
+                    ValidationResult.ShouldNullify(
                         AirbyteRecordMessageMetaChange.Reason.DESTINATION_FIELD_SIZE_LIMITATION
                     )
-                }
+                } else ValidationResult.Valid
             }
             else -> {
-                // Other types don't need validation
+                ValidationResult.Valid
             }
         }
 
-        return value
-    }
 }

--- a/airbyte-integrations/connectors/destination-postgres/src/test-integration/kotlin/io/airbyte/integrations/destination/postgres/write/PostgresRawDataDumper.kt
+++ b/airbyte-integrations/connectors/destination-postgres/src/test-integration/kotlin/io/airbyte/integrations/destination/postgres/write/PostgresRawDataDumper.kt
@@ -241,10 +241,15 @@ class PostgresRawDataDumper(
 
                 // The internal schema (airbyte_internal) is used for raw tables
                 // Use "airbyte_internal" as the default if internalTableSchema is not set
-                val rawNamespace = config.internalTableSchema ?: "airbyte_internal"
-                val rawName = TypingDedupingUtil.concatenateRawTableName(sourceNamespace, sourceName)
-                    .toPostgresCompatibleName()
-                val quotedTableName = "\"$rawNamespace\".\"$rawName\""
+                val rawNamespace = config.internalTableSchema?.lowercase()?.toPostgresCompatibleName()
+                    ?: "airbyte_internal"
+
+                val rawName =
+                    TypingDedupingUtil.concatenateRawTableName(sourceNamespace, sourceName)
+                        .lowercase()
+                        .toPostgresCompatibleName()
+
+                val fullyQualifiedTableName = "$rawNamespace.$rawName"
 
                 // Check if table exists first
                 val tableExistsQuery = """
@@ -264,15 +269,15 @@ class PostgresRawDataDumper(
                     return output
                 }
 
-                val resultSet = statement.executeQuery("SELECT * FROM $quotedTableName")
+                val resultSet = statement.executeQuery("SELECT * FROM $fullyQualifiedTableName")
 
                 // Check if the table has the _airbyte_data column (legacy raw table mode)
                 // or individual typed columns (typed table mode)
                 val hasDataColumn = try {
                     resultSet.metaData.getColumnCount() > 0 &&
-                    (1..resultSet.metaData.getColumnCount()).any {
-                        resultSet.metaData.getColumnName(it) == Meta.COLUMN_NAME_DATA
-                    }
+                        (1..resultSet.metaData.getColumnCount()).any {
+                            resultSet.metaData.getColumnName(it) == Meta.COLUMN_NAME_DATA
+                        }
                 } catch (e: Exception) {
                     false
                 }

--- a/airbyte-integrations/connectors/destination-postgres/src/test/kotlin/io/airbyte/integrations/destination/postgres/write/transform/PostgresValueCoercerTest.kt
+++ b/airbyte-integrations/connectors/destination-postgres/src/test/kotlin/io/airbyte/integrations/destination/postgres/write/transform/PostgresValueCoercerTest.kt
@@ -23,8 +23,8 @@ import io.airbyte.cdk.load.data.TimestampTypeWithoutTimezone
 import io.airbyte.cdk.load.data.TimestampWithTimezoneValue
 import io.airbyte.cdk.load.data.TimestampWithoutTimezoneValue
 import io.airbyte.cdk.load.data.UnionType
+import io.airbyte.cdk.load.dataflow.transform.ValidationResult
 import io.airbyte.protocol.models.v0.AirbyteRecordMessageMetaChange
-import io.airbyte.protocol.models.v0.AirbyteRecordMessageMetaChange.Change
 import java.math.BigDecimal
 import java.math.BigInteger
 import java.time.OffsetDateTime
@@ -89,7 +89,7 @@ internal class PostgresValueCoercerTest {
                 airbyteMetaField = null,
             )
         val result = coercer.validate(airbyteValue)
-        assertEquals(airbyteValue, result)
+        assertEquals(ValidationResult.Valid, result)
     }
 
     @Test
@@ -120,7 +120,7 @@ internal class PostgresValueCoercerTest {
             )
 
         val result = coercer.validate(airbyteValue)
-        assertEquals(airbyteValue, result)
+        assertEquals(ValidationResult.Valid, result)
     }
 
     @Test
@@ -136,7 +136,7 @@ internal class PostgresValueCoercerTest {
             )
 
         val result = coercer.validate(airbyteValue)
-        assertEquals(airbyteValue, result)
+        assertEquals(ValidationResult.Valid, result)
     }
 
     @Test
@@ -152,12 +152,10 @@ internal class PostgresValueCoercerTest {
             )
 
         val result = coercer.validate(airbyteValue)
-        assertEquals(NullValue, result.abValue)
-        assertEquals(1, result.changes.size)
-        assertEquals(Change.NULLED, result.changes.first().change)
+        assertEquals(ValidationResult.ShouldNullify::class, result::class)
         assertEquals(
             AirbyteRecordMessageMetaChange.Reason.DESTINATION_FIELD_SIZE_LIMITATION,
-            result.changes.first().reason
+            (result as ValidationResult.ShouldNullify).reason
         )
     }
 
@@ -174,12 +172,10 @@ internal class PostgresValueCoercerTest {
             )
 
         val result = coercer.validate(airbyteValue)
-        assertEquals(NullValue, result.abValue)
-        assertEquals(1, result.changes.size)
-        assertEquals(Change.NULLED, result.changes.first().change)
+        assertEquals(ValidationResult.ShouldNullify::class, result::class)
         assertEquals(
             AirbyteRecordMessageMetaChange.Reason.DESTINATION_FIELD_SIZE_LIMITATION,
-            result.changes.first().reason
+            (result as ValidationResult.ShouldNullify).reason
         )
     }
 
@@ -196,7 +192,7 @@ internal class PostgresValueCoercerTest {
             )
 
         val result = coercer.validate(airbyteValue)
-        assertEquals(airbyteValue, result)
+        assertEquals(ValidationResult.Valid, result)
     }
 
     @Test
@@ -212,12 +208,10 @@ internal class PostgresValueCoercerTest {
             )
 
         val result = coercer.validate(airbyteValue)
-        assertEquals(NullValue, result.abValue)
-        assertEquals(1, result.changes.size)
-        assertEquals(Change.NULLED, result.changes.first().change)
+        assertEquals(ValidationResult.ShouldNullify::class, result::class)
         assertEquals(
             AirbyteRecordMessageMetaChange.Reason.DESTINATION_FIELD_SIZE_LIMITATION,
-            result.changes.first().reason
+            (result as ValidationResult.ShouldNullify).reason
         )
     }
 
@@ -234,12 +228,10 @@ internal class PostgresValueCoercerTest {
             )
 
         val result = coercer.validate(airbyteValue)
-        assertEquals(NullValue, result.abValue)
-        assertEquals(1, result.changes.size)
-        assertEquals(Change.NULLED, result.changes.first().change)
+        assertEquals(ValidationResult.ShouldNullify::class, result::class)
         assertEquals(
             AirbyteRecordMessageMetaChange.Reason.DESTINATION_FIELD_SIZE_LIMITATION,
-            result.changes.first().reason
+            (result as ValidationResult.ShouldNullify).reason
         )
     }
 
@@ -256,7 +248,7 @@ internal class PostgresValueCoercerTest {
             )
 
         val result = coercer.validate(airbyteValue)
-        assertEquals(airbyteValue, result)
+        assertEquals(ValidationResult.Valid, result)
     }
 
     @Test
@@ -275,12 +267,10 @@ internal class PostgresValueCoercerTest {
             )
 
         val result = coercer.validate(airbyteValue)
-        assertEquals(NullValue, result.abValue)
-        assertEquals(1, result.changes.size)
-        assertEquals(Change.NULLED, result.changes.first().change)
+        assertEquals(ValidationResult.ShouldNullify::class, result::class)
         assertEquals(
             AirbyteRecordMessageMetaChange.Reason.DESTINATION_FIELD_SIZE_LIMITATION,
-            result.changes.first().reason
+            (result as ValidationResult.ShouldNullify).reason
         )
     }
 
@@ -298,7 +288,7 @@ internal class PostgresValueCoercerTest {
             )
 
         val result = coercer.validate(airbyteValue)
-        assertEquals(airbyteValue, result)
+        assertEquals(ValidationResult.Valid, result)
     }
 
     @Test
@@ -315,7 +305,7 @@ internal class PostgresValueCoercerTest {
             )
 
         val result = coercer.validate(airbyteValue)
-        assertEquals(airbyteValue, result)
+        assertEquals(ValidationResult.Valid, result)
     }
 
     @Test
@@ -332,7 +322,7 @@ internal class PostgresValueCoercerTest {
             )
 
         val result = coercer.validate(airbyteValue)
-        assertEquals(airbyteValue, result)
+        assertEquals(ValidationResult.Valid, result)
     }
 
     @Test
@@ -359,8 +349,8 @@ internal class PostgresValueCoercerTest {
                 airbyteMetaField = null,
             )
 
-        assertEquals(intValue, coercer.validate(intValue))
-        assertEquals(floatValue, coercer.validate(floatValue))
+        assertEquals(ValidationResult.Valid, coercer.validate(intValue))
+        assertEquals(ValidationResult.Valid, coercer.validate(floatValue))
     }
 
     @Test
@@ -376,7 +366,7 @@ internal class PostgresValueCoercerTest {
             )
 
         val result = coercer.validate(airbyteValue)
-        assertEquals(airbyteValue, result)
+        assertEquals(ValidationResult.Valid, result)
     }
 
     @Test
@@ -393,7 +383,7 @@ internal class PostgresValueCoercerTest {
             )
 
         val result = coercer.validate(airbyteValue)
-        assertEquals(airbyteValue, result)
+        assertEquals(ValidationResult.Valid, result)
     }
 
     @Test
@@ -410,7 +400,7 @@ internal class PostgresValueCoercerTest {
             )
 
         val result = coercer.validate(airbyteValue)
-        assertEquals(airbyteValue, result)
+        assertEquals(ValidationResult.Valid, result)
     }
 
     @Test
@@ -427,7 +417,7 @@ internal class PostgresValueCoercerTest {
             )
 
         val result = coercer.validate(airbyteValue)
-        assertEquals(nullValue, result.abValue)
+        assertEquals(ValidationResult.Valid, result)
     }
 
     @Test
@@ -445,7 +435,7 @@ internal class PostgresValueCoercerTest {
             )
 
         val result = coercer.validate(airbyteValue)
-        assertEquals(airbyteValue, result)
+        assertEquals(ValidationResult.Valid, result)
     }
 
     @Test
@@ -467,12 +457,10 @@ internal class PostgresValueCoercerTest {
             )
 
         val result = coercer.validate(airbyteValue)
-        assertEquals(NullValue, result.abValue)
-        assertEquals(1, result.changes.size)
-        assertEquals(Change.NULLED, result.changes.first().change)
+        assertEquals(ValidationResult.ShouldNullify::class, result::class)
         assertEquals(
             AirbyteRecordMessageMetaChange.Reason.DESTINATION_FIELD_SIZE_LIMITATION,
-            result.changes.first().reason
+            (result as ValidationResult.ShouldNullify).reason
         )
     }
 
@@ -495,12 +483,10 @@ internal class PostgresValueCoercerTest {
             )
 
         val result = coercer.validate(airbyteValue)
-        assertEquals(NullValue, result.abValue)
-        assertEquals(1, result.changes.size)
-        assertEquals(Change.NULLED, result.changes.first().change)
+        assertEquals(ValidationResult.ShouldNullify::class, result::class)
         assertEquals(
             AirbyteRecordMessageMetaChange.Reason.DESTINATION_FIELD_SIZE_LIMITATION,
-            result.changes.first().reason
+            (result as ValidationResult.ShouldNullify).reason
         )
     }
 
@@ -519,7 +505,7 @@ internal class PostgresValueCoercerTest {
             )
 
         val result = coercer.validate(airbyteValue)
-        assertEquals(airbyteValue, result)
+        assertEquals(ValidationResult.Valid, result)
     }
 
     @Test
@@ -540,7 +526,7 @@ internal class PostgresValueCoercerTest {
             )
 
         val result = coercer.validate(airbyteValue)
-        assertEquals(airbyteValue, result)
+        assertEquals(ValidationResult.Valid, result)
     }
 
     @Test
@@ -561,7 +547,7 @@ internal class PostgresValueCoercerTest {
             )
 
         val result = coercer.validate(airbyteValue)
-        assertEquals(airbyteValue, result)
+        assertEquals(ValidationResult.Valid, result)
     }
 
     @Test
@@ -579,7 +565,7 @@ internal class PostgresValueCoercerTest {
             )
 
         val result = coercer.validate(airbyteValue)
-        assertEquals(airbyteValue, result)
+        assertEquals(ValidationResult.Valid, result)
     }
 
     @Test
@@ -628,7 +614,7 @@ internal class PostgresValueCoercerTest {
             )
 
         val result = coercer.validate(airbyteValue)
-        assertEquals(airbyteValue, result)
+        assertEquals(ValidationResult.Valid, result)
     }
 
     @Test
@@ -645,7 +631,7 @@ internal class PostgresValueCoercerTest {
             )
 
         val result = coercer.validate(airbyteValue)
-        assertEquals(airbyteValue, result)
+        assertEquals(ValidationResult.Valid, result)
     }
 
     @Test
@@ -662,6 +648,6 @@ internal class PostgresValueCoercerTest {
             )
 
         val result = coercer.validate(airbyteValue)
-        assertEquals(airbyteValue, result)
+        assertEquals(ValidationResult.Valid, result)
     }
 }


### PR DESCRIPTION
## What
A few misc fixes:
1. Fix name warning so that we can publish the connector, otherwise the github action that publishes the connector fails.
2. Update `PostgresRawDataDumper` so that it uses the right table and schema names.
3. Update The value coercer since the interface it implements has changed.
