### PR TITLE
[GCS-DL] Make getOperation in iceberg public

### DIFF
--- a/airbyte-cdk/bulk/changelog.md
+++ b/airbyte-cdk/bulk/changelog.md
@@ -1,3 +1,9 @@
+## Version 0.1.70
+
+**Load CDK**
+
+* Changed: Make getOperation in icebergUtil public
+
 ## Version 0.1.69
 
 **Load CDK**

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/IcebergUtil.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/IcebergUtil.kt
@@ -243,7 +243,7 @@ class IcebergUtil(private val tableIdGenerator: TableIdGenerator) {
         return builder.build()
     }
 
-    private fun getOperation(
+    fun getOperation(
         record: EnrichedDestinationRecordAirbyteValue,
         importType: ImportType,
     ): Operation =

--- a/airbyte-cdk/bulk/version.properties
+++ b/airbyte-cdk/bulk/version.properties
@@ -1,1 +1,1 @@
-version=0.1.69
+version=0.1.70


### PR DESCRIPTION
## What

Make the `getOperation` method from `IcebergUtil` public to allow us to use it in GCS data lake

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [X] NO ❌
