### PR TITLE
dummy-pr(do not merge): Explore `SimpleBidirectionalRetriever` as `base_retriever` for Stripe API

### DIFF
--- a/airbyte-integrations/connectors/source-stripe/manifest.yaml
+++ b/airbyte-integrations/connectors/source-stripe/manifest.yaml
@@ -54,17 +54,17 @@ definitions:
     operation_overrides:
       read_many: {} # No overrides needed.
       read_one: {} # No overrides needed.
-      create_one: {}
+      create_one:
         requester_overrides:
           http_method: POST
           path_suffix: ""  # POST to the 'read_many' endpoint.
           request_body_json: "{{ record }}"
-      update_one: {}
+      update_one:
         requester_overrides:
           http_method: POST
           path_suffix: "/{{ record.id }}"
           request_body_json: "{{ record }}"
-      delete_one: {}
+      delete_one:
         requester_overrides:
           http_method: DELETE
           path_suffix: "/{{ record.id }}"

--- a/airbyte-integrations/connectors/source-stripe/manifest.yaml
+++ b/airbyte-integrations/connectors/source-stripe/manifest.yaml
@@ -59,21 +59,16 @@ definitions:
     ## - REST_CRUDL_POST_1999: Uses POST for updates (RFC 2616, 1999)
     ## - REST_CRUDL_PATCH_2010: Uses PATCH for updates (RFC 5789, 2010)
     ## When not set, users define interactions directly. Users can always override defaults even when set. (important-comment)
-
-    supported_operations:
-      # read_one:     True    ## Matches REST CRUDL defaults.
-      # read_many:    True    ## Matches REST CRUDL defaults.
-      # create_one:   True    ## Matches REST CRUDL defaults.
-      # create_many:  False   ## Default, falls back to `create_one` in a loop.
-      # update_one:   True    ## Matches REST CRUDL defaults.
-      # update_many:  False   ## Default, falls back to `update_one` in a loop.
-      # delete_one:   True    ## Matches REST CRUDL defaults.
-      # delete_many:  False   ## Default, falls back to `delete_one` in a loop.
-      # replace_many: False   ## Default, falls back to `replace_one` in a loop.
-
-      ## Only one override needed for Stripe's operation semantics:
-      replace_one:  False     ## Stripe doesn't support `PUT` full replacement.
-                              ## CDK will fall back to read_only+update_one with patch applied over most-recent record data.
+    
+    ## Filter which operation types to enable (applies on top of profile defaults):
+    standard_operations_subset: [read, create, update, delete]
+    ## Subset options: read, create, update, replace, delete
+    ## - read: Enables read_many and read_one
+    ## - create: Enables create_one (create_many falls back to create_one loop) (important-comment)
+    ## - update: Enables update_one (update_many falls back to update_one loop) (important-comment)
+    ## - replace: Enables replace_one (replace_many falls back to replace_one loop) (important-comment)
+    ## - delete: Enables delete_one (delete_many falls back to delete_one loop) (important-comment)
+    ## Note: 'replace' is omitted for Stripe since it doesn't support PUT full replacement. (important-comment)
 
 
     ## Standard REST CRUDL profile defaults:

--- a/airbyte-integrations/connectors/source-stripe/manifest.yaml
+++ b/airbyte-integrations/connectors/source-stripe/manifest.yaml
@@ -17,11 +17,15 @@ definitions:
   base_retriever:
     type: SimpleBidirectionalRetriever
 
-    # Opt into standard REST API conventions by setting this profile.
-    # When set to 'rest_crudl_v1' (or other future enum values), the bidirectional
-    # retriever inherits applicable defaults for all operations. When not set, users
-    # define interactions directly. Users can always override defaults even when set.
-    standard_rest_api_profile: rest_crudl_v1
+    # Opt into standard REST API conventions by setting this profile. (important-comment)
+    # When set to REST_CRUDL_POST_1999 or REST_CRUDL_PATCH_2010 (or other future enum values), (important-comment)
+    # the bidirectional retriever inherits applicable defaults for all operations.
+    # When not set, users define interactions directly. Users can always override defaults even when set. (important-comment)
+    #
+    # Profile options:
+    # - REST_CRUDL_POST_1999: Uses POST for updates (pre-PATCH, RFC 2616 HTTP/1.1 from 1999)
+    # - REST_CRUDL_PATCH_2010: Uses PATCH for updates (RFC 5789 from March 2010)
+    standard_operations_profile: REST_CRUDL_POST_1999
 
     base_requester:
       $ref: "#/definitions/base_requester"
@@ -83,13 +87,23 @@ definitions:
     #   the provided record as-is and let the API's PUT semantics handle clearing.
     #   Connectors can opt into explicit null clearing via replace_unset_strategy.
     #
-    # Standard REST CRUDL profile defaults (standard_rest_api_profile: rest_crudl_v1):
+    # Standard REST CRUDL profile defaults: (important-comment)
+    #
+    # REST_CRUDL_POST_1999 (pre-PATCH era, RFC 2616 HTTP/1.1 from 1999):
     # - read_many: GET /collection
     # - read_one: GET /collection/{id}
     # - create_one: POST /collection
-    # - update_one: PATCH /collection/{id} (partial update)
-    # - replace_one: PUT /collection/{id} (full replacement)
-    # - delete_one: DELETE /collection/{id}
+    # - update_one: POST /collection/{id} (partial update) (important-comment)
+    # - replace_one: PUT /collection/{id} (full replacement) (important-comment)
+    # - delete_one: DELETE /collection/{id} (important-comment)
+    #
+    # REST_CRUDL_PATCH_2010 (modern, RFC 5789 from March 2010):
+    # - read_many: GET /collection
+    # - read_one: GET /collection/{id}
+    # - create_one: POST /collection
+    # - update_one: PATCH /collection/{id} (partial update) (important-comment)
+    # - replace_one: PUT /collection/{id} (full replacement) (important-comment)
+    # - delete_one: DELETE /collection/{id} (important-comment)
     operation_overrides:
       read_many: {} # No overrides needed - uses profile defaults.
       read_one: {} # No overrides needed - uses profile defaults.
@@ -102,11 +116,10 @@ definitions:
             type: RequestBodyJsonObject
             value: "{{ record }}"
       update_one:
-        # Stripe-specific override: Stripe uses POST for updates instead of standard PATCH.
-        # The CDK default (from standard_rest_api_profile: rest_crudl_v1) would be PATCH.
+        # With REST_CRUDL_POST_1999 profile, POST is already the default for update_one.
+        # No http_method override needed - only path and body configuration required.
         requester:
           $ref: "#/definitions/base_requester"
-          http_method: POST  # Stripe-specific (CDK default: PATCH)
           # Can override `path` or `path_suffix` as needed.
           # In this case, we only want to append to the existing `path':
           path_suffix: "/{{ record.id }}"

--- a/airbyte-integrations/connectors/source-stripe/manifest.yaml
+++ b/airbyte-integrations/connectors/source-stripe/manifest.yaml
@@ -27,7 +27,7 @@ definitions:
       $ref: "#/definitions/base_requester"
 
     # New `single_record_selector` is default for individual record operations,
-    # including `read_one`, `create_one`, and `update_one`.
+    # including `read_one`, `create_one`, `update_one`, and `replace_one`.
     # Below is the default behavior and therefore optional to specify:
     single_record_selector:
       type: RecordSelector
@@ -57,6 +57,8 @@ definitions:
       - create_many  # Fall back to `create_one` in a loop.
       - update_many  # Fall back to `update_one` in a loop.
       - delete_many  # Fall back to `delete_one` in a loop.
+      - replace_one  # Stripe only supports partial updates (update_one), not full replacement.
+      - replace_many  # Stripe only supports partial updates (update_many), not full replacement.
 
     # Note on $ref merge semantics: Using $ref with inline field overrides performs
     # shallow merge. Overriding nested dicts (e.g., request_headers, error_handler)
@@ -70,6 +72,24 @@ definitions:
     # Note on primary key injection: A planned pk() macro will allow {{ pk(record) }}
     # to automatically extract the primary key value without hardcoding field names.
     # For now, use {{ record.id }} explicitly.
+    #
+    # Note on update_one vs replace_one semantics: (important-comment)
+    # - update_one: Partial update (PATCH semantics). Only provided fields change;
+    #   unspecified fields are preserved. Maps to PATCH by default, or POST with
+    #   partial update semantics (like Stripe).
+    # - replace_one: Full replacement (PUT semantics). The supplied record is the
+    #   entire new resource; unspecified fields are cleared per API rules. Maps to
+    #   PUT by default. By default, we do NOT auto-null unspecified fields; we send
+    #   the provided record as-is and let the API's PUT semantics handle clearing.
+    #   Connectors can opt into explicit null clearing via replace_unset_strategy.
+    #
+    # Standard REST CRUDL profile defaults (standard_rest_api_profile: rest_crudl_v1):
+    # - read_many: GET /collection
+    # - read_one: GET /collection/{id}
+    # - create_one: POST /collection
+    # - update_one: PATCH /collection/{id} (partial update)
+    # - replace_one: PUT /collection/{id} (full replacement)
+    # - delete_one: DELETE /collection/{id}
     operation_overrides:
       read_many: {} # No overrides needed - uses profile defaults.
       read_one: {} # No overrides needed - uses profile defaults.

--- a/airbyte-integrations/connectors/source-stripe/manifest.yaml
+++ b/airbyte-integrations/connectors/source-stripe/manifest.yaml
@@ -55,15 +55,16 @@ definitions:
       read_many: {} # No overrides needed.
       read_one: {} # No overrides needed.
       create_one:
-        requester_overrides:
+        requester:
+          $ref: "#/definitions/base_requester"
           http_method: POST
-          # Intentionally not overriding `path` here:
-          # path: ..  # POST to the 'read_many' endpoint.
+          # Intentionally not overriding `path` here - POST to the 'read_many' endpoint.
           request_body:
             type: RequestBodyJsonObject
             value: "{{ record }}"
       update_one:
-        requester_overrides:
+        requester:
+          $ref: "#/definitions/base_requester"
           http_method: POST
           # Can override `path` or `path_suffix` as needed.
           # In this case, we only want to append to the existing `path':
@@ -72,7 +73,8 @@ definitions:
             type: RequestBodyJsonObject
             value: "{{ record }}"
       delete_one:
-        requester_overrides:
+        requester:
+          $ref: "#/definitions/base_requester"
           http_method: DELETE
           path_suffix: "/{{ record.id }}"
 

--- a/airbyte-integrations/connectors/source-stripe/manifest.yaml
+++ b/airbyte-integrations/connectors/source-stripe/manifest.yaml
@@ -20,17 +20,17 @@ definitions:
     base_requester:
       $ref: "#/definitions/base_requester"
 
-    # New singleton record selector for individual object retrievals.
-    # This is the default selector used in 'fetch', 'create', and 'update' operations.
-    # Below the default behavior and therefore optional to specify:
-    singleton_record_selector:
+    # New `single_record_selector` is default for individual record operations,
+    # including `read_one`, `create_one`, and `update_one`.
+    # Below is the default behavior and therefore optional to specify:
+    single_record_selector:
       type: RecordSelector
       extractor:
         type: DpathExtractor
         field_path: []  # Single object response
       schema_normalization: Default
 
-    # Previous 'record_selector' renamed to `multi_record_selector` for clarity:
+    # Previous 'record_selector' simply renamed to `multi_record_selector` for clarity:
     multi_record_selector:
       type: RecordSelector
       extractor:
@@ -40,7 +40,7 @@ definitions:
       transform_before_filtering: true
       schema_normalization: Default
 
-    # Only really used for 'read_many' operations.
+    # Paginator used for 'read_many' operations. (No change.)
     paginator:
       $ref: "#/definitions/base_paginator"
 

--- a/airbyte-integrations/connectors/source-stripe/manifest.yaml
+++ b/airbyte-integrations/connectors/source-stripe/manifest.yaml
@@ -57,13 +57,16 @@ definitions:
       create_one:
         requester_overrides:
           http_method: POST
-          path_suffix: ""  # POST to the 'read_many' endpoint.
+          # Intentionally not overriding `path` here:
+          # path: ..  # POST to the 'read_many' endpoint.
           request_body:
             type: RequestBodyJsonObject
             value: "{{ record }}"
       update_one:
         requester_overrides:
           http_method: POST
+          # Can override `path` or `path_suffix` as needed.
+          # In this case, we only want to append to the existing `path':
           path_suffix: "/{{ record.id }}"
           request_body:
             type: RequestBodyJsonObject

--- a/airbyte-integrations/connectors/source-stripe/manifest.yaml
+++ b/airbyte-integrations/connectors/source-stripe/manifest.yaml
@@ -17,12 +17,14 @@ definitions:
   base_retriever:
     type: SimpleBidirectionalRetriever
 
+    operation_profile: rest_crudl_v1
+
     base_requester:
       $ref: "#/definitions/base_requester"
 
     # New singleton record selector for individual object retrievals.
-    # This is the default selector used in 'fetch', 'create', and 'update' operations.
-    # Below the default behavior and therefore optional to specify:
+    # This is the default selector used in 'read_one', 'create_one', and 'update_one' operations.
+    # Below shows the default behavior and is therefore optional to specify:
     singleton_record_selector:
       type: RecordSelector
       extractor:
@@ -30,7 +32,8 @@ definitions:
         field_path: []  # Single object response
       schema_normalization: Default
 
-    # Previous 'record_selector' renamed to `multi_record_selector` for clarity:
+    # Previous 'record_selector' renamed to `multi_record_selector` for clarity.
+    # Used for 'read_many' operations:
     multi_record_selector:
       type: RecordSelector
       extractor:
@@ -51,9 +54,21 @@ definitions:
       - update_many  # Fall back to `update_one` in a loop.
       - delete_many  # Fall back to `delete_one` in a loop.
 
+    # Note on $ref merge semantics: Using $ref with inline field overrides performs
+    # shallow merge. Overriding nested dicts (e.g., request_headers, error_handler)
+    # replaces the entire dict, not deep-merge. To preserve base values, don't override
+    # or repeat them explicitly.
+    #
+    # Note on path_suffix: This is a planned CDK feature for ergonomic path appending.
+    # When implemented, it will handle trailing/leading slash normalization and URL encoding.
+    # Until then, use full path overrides: path: "{{ base_path }}/{{ record.id }}" (important-comment)
+    #
+    # Note on primary key injection: A planned pk() macro will allow {{ pk(record) }}
+    # to automatically extract the primary key value without hardcoding field names.
+    # For now, use {{ record.id }} explicitly.
     operation_overrides:
-      read_many: {} # No overrides needed.
-      read_one: {} # No overrides needed.
+      read_many: {} # No overrides needed - uses profile defaults.
+      read_one: {} # No overrides needed - uses profile defaults.
       create_one:
         requester:
           $ref: "#/definitions/base_requester"
@@ -63,9 +78,11 @@ definitions:
             type: RequestBodyJsonObject
             value: "{{ record }}"
       update_one:
+        # Stripe-specific override: Stripe uses POST for updates instead of standard PATCH.
+        # The CDK default (from rest_crudl_v1 profile) would be PATCH.
         requester:
           $ref: "#/definitions/base_requester"
-          http_method: POST
+          http_method: POST  # Stripe-specific (CDK default: PATCH)
           # Can override `path` or `path_suffix` as needed.
           # In this case, we only want to append to the existing `path':
           path_suffix: "/{{ record.id }}"
@@ -77,6 +94,8 @@ definitions:
           $ref: "#/definitions/base_requester"
           http_method: DELETE
           path_suffix: "/{{ record.id }}"
+        # No record_selector by default - many APIs return 204 No Content.
+        # Stripe may return an object; opt-in to singleton_record_selector if needed. (important-comment)
 
   base_requester:
     type: HttpRequester

--- a/airbyte-integrations/connectors/source-stripe/manifest.yaml
+++ b/airbyte-integrations/connectors/source-stripe/manifest.yaml
@@ -15,19 +15,53 @@ definitions:
       $ref: "#/definitions/base_retriever"
 
   base_retriever:
-    type: SimpleRetriever
-    requester:
+    type: SimpleBidirectionalRetriever
+    
+    base_requester:
       $ref: "#/definitions/base_requester"
-    record_selector:
-      type: RecordSelector
-      extractor:
-        type: DpathExtractor
-        field_path:
-          - data
-      transform_before_filtering: true
-      schema_normalization: Default
-    paginator:
-      $ref: "#/definitions/base_paginator"
+    
+    list:
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path:
+            - data
+        transform_before_filtering: true
+        schema_normalization: Default
+      paginator:
+        $ref: "#/definitions/base_paginator"
+    
+    fetch:
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path: []  # Single object, not wrapped in "data"
+        schema_normalization: Default
+    
+    create:
+      requester:
+        http_method: POST
+        request_body_json: "{{ record }}"
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path: []  # Single object response
+        schema_normalization: Default
+    
+    update:
+      requester:
+        path: "{{ stream_slice.get('path') or parameters.get('path') }}/{{ record.id }}"
+        http_method: POST
+        request_body_json: "{{ record }}"
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path: []  # Single object response
+        schema_normalization: Default
 
   base_requester:
     type: HttpRequester

--- a/airbyte-integrations/connectors/source-stripe/manifest.yaml
+++ b/airbyte-integrations/connectors/source-stripe/manifest.yaml
@@ -16,52 +16,58 @@ definitions:
 
   base_retriever:
     type: SimpleBidirectionalRetriever
-    
+
     base_requester:
       $ref: "#/definitions/base_requester"
-    
-    list:
-      record_selector:
-        type: RecordSelector
-        extractor:
-          type: DpathExtractor
-          field_path:
-            - data
-        transform_before_filtering: true
-        schema_normalization: Default
-      paginator:
-        $ref: "#/definitions/base_paginator"
-    
-    fetch:
-      record_selector:
-        type: RecordSelector
-        extractor:
-          type: DpathExtractor
-          field_path: []  # Single object, not wrapped in "data"
-        schema_normalization: Default
-    
-    create:
-      requester:
-        http_method: POST
-        request_body_json: "{{ record }}"
-      record_selector:
-        type: RecordSelector
-        extractor:
-          type: DpathExtractor
-          field_path: []  # Single object response
-        schema_normalization: Default
-    
-    update:
-      requester:
-        path: "{{ stream_slice.get('path') or parameters.get('path') }}/{{ record.id }}"
-        http_method: POST
-        request_body_json: "{{ record }}"
-      record_selector:
-        type: RecordSelector
-        extractor:
-          type: DpathExtractor
-          field_path: []  # Single object response
-        schema_normalization: Default
+
+    # New singleton record selector for individual object retrievals.
+    # This is the default selector used in 'fetch', 'create', and 'update' operations.
+    # Below the default behavior and therefor optional to specify:
+    singleton_record_selector:
+      type: RecordSelector
+      extractor:
+        type: DpathExtractor
+        field_path: []  # Single object response
+      schema_normalization: Default
+
+    # Previous 'record_selector' renamed to `multi_record_selector` for clarity:
+    multi_record_selector:
+      type: RecordSelector
+      extractor:
+        type: DpathExtractor
+        field_path:
+          - data
+      transform_before_filtering: true
+      schema_normalization: Default
+
+    # Only really used for 'read_many' operations.
+    paginator:
+      $ref: "#/definitions/base_paginator"
+
+    unsupported_operations:
+      # With the exception of `read_many`, unsupported 'many' operations fall
+      # back to sequential 'one' operations:
+      - create_many  # Fall back to `create_one` in a loop.
+      - update_many  # Fall back to `update_one` in a loop.
+      - delete_many  # Fall back to `delete_one` in a loop.
+
+    operation_overrides:
+      read_many: {} # No overrides needed.
+      read_one: {} # No overrides needed.
+      create_one: {}
+        requester_overrides:
+          http_method: POST
+          path_suffix: ""  # POST to the 'read_many' endpoint.
+          request_body_json: "{{ record }}"
+      update_one: {}
+        requester_overrides:
+          http_method: POST
+          path_suffix: "/{{ record.id }}"
+          request_body_json: "{{ record }}"
+      delete_one: {}
+        requester_overrides:
+          http_method: DELETE
+          path_suffix: "/{{ record.id }}"
 
   base_requester:
     type: HttpRequester
@@ -98,8 +104,8 @@ definitions:
               http_codes:
                 - 404
               error_message: >-
-                Data was not found. Error message: {{ response['error']['message'] }} If this is a path for getting 
-                child attributes like /v1/checkout/sessions/<session_id>/line_items when running the incremental sync, 
+                Data was not found. Error message: {{ response['error']['message'] }} If this is a path for getting
+                child attributes like /v1/checkout/sessions/<session_id>/line_items when running the incremental sync,
                 you may safely ignore this warning.
   bearer_authenticator:
     type: BearerAuthenticator
@@ -892,7 +898,7 @@ definitions:
       $parameters:
         name: setup_intents
       full_refresh_stream:
-        $ref: "#/definitions/entity_stream"   
+        $ref: "#/definitions/entity_stream"
         retriever:
           $ref: "#/definitions/base_retriever"
           $parameters:

--- a/airbyte-integrations/connectors/source-stripe/manifest.yaml
+++ b/airbyte-integrations/connectors/source-stripe/manifest.yaml
@@ -17,31 +17,11 @@ definitions:
   base_retriever:
     type: SimpleBidirectionalRetriever
 
-    # Opt into standard REST API conventions by setting this profile. (important-comment)
-    # When set to REST_CRUDL_POST_1999 or REST_CRUDL_PATCH_2010 (or other future enum values), (important-comment)
-    # the bidirectional retriever inherits applicable defaults for all operations.
-    # When not set, users define interactions directly. Users can always override defaults even when set. (important-comment)
-    #
-    # Profile options:
-    # - REST_CRUDL_POST_1999: Uses POST for updates (pre-PATCH, RFC 2616 HTTP/1.1 from 1999)
-    # - REST_CRUDL_PATCH_2010: Uses PATCH for updates (RFC 5789 from March 2010)
-    standard_operations_profile: REST_CRUDL_POST_1999
-
     base_requester:
       $ref: "#/definitions/base_requester"
 
-    # New `single_record_selector` is default for individual record operations,
-    # including `read_one`, `create_one`, `update_one`, and `replace_one`.
-    # Below is the default behavior and therefore optional to specify:
-    single_record_selector:
-      type: RecordSelector
-      extractor:
-        type: DpathExtractor
-        field_path: []  # Single object response
-      schema_normalization: Default
-
-    # Previous 'record_selector' simply renamed to `multi_record_selector` for clarity.
-    # Used for 'read_many' operations:
+    ## The 'record_selector' field is renamed to `multi_record_selector` for clarity.
+    ## Used for 'read_many' operations:
     multi_record_selector:
       type: RecordSelector
       extractor:
@@ -51,88 +31,89 @@ definitions:
       transform_before_filtering: true
       schema_normalization: Default
 
-    # Paginator used for 'read_many' operations. (No change.)
+    ## Paginator used for 'read_many' operations. (No change.)
     paginator:
       $ref: "#/definitions/base_paginator"
 
-    unsupported_operations:
-      # With the exception of `read_many`, unsupported 'many' operations fall
-      # back to sequential 'one' operations:
-      - create_many  # Fall back to `create_one` in a loop.
-      - update_many  # Fall back to `update_one` in a loop.
-      - delete_many  # Fall back to `delete_one` in a loop.
-      - replace_one  # Stripe only supports partial updates (update_one), not full replacement.
-      - replace_many  # Stripe only supports partial updates (update_many), not full replacement.
+    ## ------------------------------------------------
+    ## -- NEW: `single_record_selector` Configuration --
+    ## ------------------------------------------------
+    ## This is the default for individual record operations that return a
+    ## single object, including `read_one`, `create_one`, `update_one`,
+    ## and `replace_one`.
+    ## Below is the default behavior and therefore optional to specify:
+    # single_record_selector:
+    #   type: RecordSelector
+    #   extractor:
+    #     type: DpathExtractor
+    #     field_path: []  ## Single object response
+    #   schema_normalization: Default
 
-    # Note on $ref merge semantics: Using $ref with inline field overrides performs
-    # shallow merge. Overriding nested dicts (e.g., request_headers, error_handler)
-    # replaces the entire dict, not deep-merge. To preserve base values, don't override
-    # or repeat them explicitly.
-    #
-    # Note on path_suffix: This is a planned CDK feature for ergonomic path appending.
-    # When implemented, it will handle trailing/leading slash normalization and URL encoding.
-    # Until then, use full path overrides: path: "{{ base_path }}/{{ record.id }}" (important-comment)
-    #
-    # Note on primary key injection: A planned pk() macro will allow {{ pk(record) }}
-    # to automatically extract the primary key value without hardcoding field names.
-    # For now, use {{ record.id }} explicitly.
-    #
-    # Note on update_one vs replace_one semantics: (important-comment)
-    # - update_one: Partial update (PATCH semantics). Only provided fields change;
-    #   unspecified fields are preserved. Maps to PATCH by default, or POST with
-    #   partial update semantics (like Stripe).
-    # - replace_one: Full replacement (PUT semantics). The supplied record is the
-    #   entire new resource; unspecified fields are cleared per API rules. Maps to
-    #   PUT by default. By default, we do NOT auto-null unspecified fields; we send
-    #   the provided record as-is and let the API's PUT semantics handle clearing.
-    #   Connectors can opt into explicit null clearing via replace_unset_strategy.
-    #
-    # Standard REST CRUDL profile defaults: (important-comment)
-    #
-    # REST_CRUDL_POST_1999 (pre-PATCH era, RFC 2616 HTTP/1.1 from 1999):
-    # - read_many: GET /collection
-    # - read_one: GET /collection/{id}
-    # - create_one: POST /collection
-    # - update_one: POST /collection/{id} (partial update) (important-comment)
-    # - replace_one: PUT /collection/{id} (full replacement) (important-comment)
-    # - delete_one: DELETE /collection/{id} (important-comment)
-    #
-    # REST_CRUDL_PATCH_2010 (modern, RFC 5789 from March 2010):
-    # - read_many: GET /collection
-    # - read_one: GET /collection/{id}
-    # - create_one: POST /collection
-    # - update_one: PATCH /collection/{id} (partial update) (important-comment)
-    # - replace_one: PUT /collection/{id} (full replacement) (important-comment)
-    # - delete_one: DELETE /collection/{id} (important-comment)
-    operation_overrides:
-      read_many: {} # No overrides needed - uses profile defaults.
-      read_one: {} # No overrides needed - uses profile defaults.
-      create_one:
-        requester:
-          $ref: "#/definitions/base_requester"
-          http_method: POST
-          # Intentionally not overriding `path` here - POST to the 'read_many' endpoint.
-          request_body:
-            type: RequestBodyJsonObject
-            value: "{{ record }}"
-      update_one:
-        # With REST_CRUDL_POST_1999 profile, POST is already the default for update_one.
-        # No http_method override needed - only path and body configuration required.
-        requester:
-          $ref: "#/definitions/base_requester"
-          # Can override `path` or `path_suffix` as needed.
-          # In this case, we only want to append to the existing `path':
-          path_suffix: "/{{ record.id }}"
-          request_body:
-            type: RequestBodyJsonObject
-            value: "{{ record }}"
-      delete_one:
-        requester:
-          $ref: "#/definitions/base_requester"
-          http_method: DELETE
-          path_suffix: "/{{ record.id }}"
-        # No record_selector by default - many APIs return 204 No Content.
-        # Stripe may return an object; opt-in to singleton_record_selector if needed. (important-comment)
+    ## ----------------------------------
+    ## -- NEW: Operation Configurations --
+    ## ----------------------------------
+
+    ## Opt into standard REST API conventions by setting this profile:
+    standard_operations_profile: REST_CRUDL_POST_1999
+    ## Profile options:
+    ## - REST_CRUDL_POST_1999: Uses POST for updates (RFC 2616, 1999)
+    ## - REST_CRUDL_PATCH_2010: Uses PATCH for updates (RFC 5789, 2010)
+    ## When not set, users define interactions directly. Users can always override defaults even when set. (important-comment)
+
+    supported_operations:
+      # read_one:     True    ## Matches REST CRUDL defaults.
+      # read_many:    True    ## Matches REST CRUDL defaults.
+      # create_one:   True    ## Matches REST CRUDL defaults.
+      # create_many:  False   ## Default, falls back to `create_one` in a loop.
+      # update_one:   True    ## Matches REST CRUDL defaults.
+      # update_many:  False   ## Default, falls back to `update_one` in a loop.
+      # delete_one:   True    ## Matches REST CRUDL defaults.
+      # delete_many:  False   ## Default, falls back to `delete_one` in a loop.
+      # replace_many: False   ## Default, falls back to `replace_one` in a loop.
+
+      ## Only one override needed for Stripe's operation semantics:
+      replace_one:  False     ## Stripe doesn't support `PUT` full replacement.
+                              ## CDK will fall back to read_only+update_one with patch applied over most-recent record data.
+
+
+    ## Standard REST CRUDL profile defaults:
+    ##
+    ## REST_CRUDL_POST_1999 (RFC 2616 HTTP/1.1 circa 1999):
+    ## - read_many: GET /collection
+    ## - read_one: GET /collection/{id}
+    ## - create_one: POST /collection
+    ## - update_one: POST /collection/{id}
+    ## - replace_one: PUT /collection/{id}
+    ## - delete_one: DELETE /collection/{id}
+    ##
+    ## REST_CRUDL_PATCH_2010 (RFC 5789 circa 2010) Adds PATCH support:
+    ## - update_one: PATCH /collection/{id}
+
+    # operation_overrides:
+    #   ## Below are inherited from `REST_CRUDL_POST_1999`, shown for clarity:
+    #   read_many: {}  ## Use default `base_requestor`, `multi_record_selector`, and `paginator`
+    #   read_one: {}   ## Use default `base_requestor`, `single_record_selector`
+    #   create_one:
+    #     requester:
+    #       $ref: "#/definitions/base_requester"
+    #       http_method: POST
+    #       ## No need to override `path`, POST to the 'read_many' endpoint.
+    #       request_body:
+    #         type: RequestBodyJsonObject
+    #         value: "{{ record }}"
+    #   update_one:
+    #     requester:
+    #       $ref: "#/definitions/base_requester"
+    #       ## Override `path_suffix` (new) instead of `path` to keep things DRY:
+    #       path_suffix: "/{{ record.id }}"
+    #       request_body:
+    #         type: RequestBodyJsonObject
+    #         value: "{{ record }}"
+    #   delete_one:
+    #     requester:
+    #       $ref: "#/definitions/base_requester"
+    #       http_method: DELETE
+    #       path_suffix: "/{{ record.id }}"
 
   base_requester:
     type: HttpRequester

--- a/airbyte-integrations/connectors/source-stripe/manifest.yaml
+++ b/airbyte-integrations/connectors/source-stripe/manifest.yaml
@@ -17,7 +17,11 @@ definitions:
   base_retriever:
     type: SimpleBidirectionalRetriever
 
-    operation_profile: rest_crudl_v1
+    # Opt into standard REST API conventions by setting this profile.
+    # When set to 'rest_crudl_v1' (or other future enum values), the bidirectional
+    # retriever inherits applicable defaults for all operations. When not set, users
+    # define interactions directly. Users can always override defaults even when set.
+    standard_rest_api_profile: rest_crudl_v1
 
     base_requester:
       $ref: "#/definitions/base_requester"
@@ -79,7 +83,7 @@ definitions:
             value: "{{ record }}"
       update_one:
         # Stripe-specific override: Stripe uses POST for updates instead of standard PATCH.
-        # The CDK default (from rest_crudl_v1 profile) would be PATCH.
+        # The CDK default (from standard_rest_api_profile: rest_crudl_v1) would be PATCH.
         requester:
           $ref: "#/definitions/base_requester"
           http_method: POST  # Stripe-specific (CDK default: PATCH)

--- a/airbyte-integrations/connectors/source-stripe/manifest.yaml
+++ b/airbyte-integrations/connectors/source-stripe/manifest.yaml
@@ -358,6 +358,11 @@ definitions:
         type: InlineSchemaLoader
         schema:
           $ref: "#/schemas/events"
+      retriever:
+        $ref: "#/definitions/base_retriever"
+        $parameters:
+          path: events
+        http_deep_link_pattern: "https://dashboard.stripe.com/events/{id}"
       $parameters:
         path: events
         name: events
@@ -376,6 +381,11 @@ definitions:
         type: InlineSchemaLoader
         schema:
           $ref: "#/schemas/balance_transactions"
+      retriever:
+        $ref: "#/definitions/base_retriever"
+        $parameters:
+          path: balance_transactions
+        http_deep_link_pattern: "https://dashboard.stripe.com/balance/transactions/{id}"
       $parameters:
         path: balance_transactions
         name: balance_transactions
@@ -385,6 +395,11 @@ definitions:
         type: InlineSchemaLoader
         schema:
           $ref: "#/schemas/files"
+      retriever:
+        $ref: "#/definitions/base_retriever"
+        $parameters:
+          path: files
+        http_deep_link_pattern: "https://dashboard.stripe.com/files/{id}"
       $parameters:
         path: files
         name: files
@@ -408,6 +423,7 @@ definitions:
           $ref: "#/definitions/base_retriever"
           $parameters:
             path: customers
+          http_deep_link_pattern: "https://dashboard.stripe.com/customers/{id}"
         schema_loader:
           type: InlineSchemaLoader
           schema:
@@ -434,6 +450,7 @@ definitions:
           $ref: "#/definitions/base_retriever"
           $parameters:
             path: subscriptions
+          http_deep_link_pattern: "https://dashboard.stripe.com/subscriptions/{id}"
           requester:
             $ref: "#/definitions/base_requester"
             request_parameters:
@@ -464,6 +481,7 @@ definitions:
           $ref: "#/definitions/base_retriever"
           $parameters:
             path: invoices
+          http_deep_link_pattern: "https://dashboard.stripe.com/invoices/{id}"
           requester:
             $ref: "#/definitions/base_requester"
             request_parameters:
@@ -494,6 +512,7 @@ definitions:
           $ref: "#/definitions/base_retriever"
           $parameters:
             path: transfers
+          http_deep_link_pattern: "https://dashboard.stripe.com/transfers/{id}"
         schema_loader:
           type: InlineSchemaLoader
           schema:
@@ -520,6 +539,7 @@ definitions:
           $ref: "#/definitions/base_retriever"
           $parameters:
             path: refunds
+          http_deep_link_pattern: "https://dashboard.stripe.com/payments/{charge}"
         schema_loader:
           type: InlineSchemaLoader
           schema:
@@ -598,6 +618,7 @@ definitions:
           $ref: "#/definitions/base_retriever"
           $parameters:
             path: charges
+          http_deep_link_pattern: "https://dashboard.stripe.com/payments/{id}"
           requester:
             $ref: "#/definitions/base_requester"
             request_parameters:
@@ -628,6 +649,7 @@ definitions:
           $ref: "#/definitions/base_retriever"
           $parameters:
             path: coupons
+          http_deep_link_pattern: "https://dashboard.stripe.com/coupons/{id}"
         schema_loader:
           type: InlineSchemaLoader
           schema:
@@ -654,6 +676,7 @@ definitions:
           $ref: "#/definitions/base_retriever"
           $parameters:
             path: disputes
+          http_deep_link_pattern: "https://dashboard.stripe.com/disputes/{id}"
         schema_loader:
           type: InlineSchemaLoader
           schema:
@@ -732,6 +755,7 @@ definitions:
           $ref: "#/definitions/base_retriever"
           $parameters:
             path: payouts
+          http_deep_link_pattern: "https://dashboard.stripe.com/payouts/{id}"
         schema_loader:
           type: InlineSchemaLoader
           schema:
@@ -814,6 +838,7 @@ definitions:
           $ref: "#/definitions/base_retriever"
           $parameters:
             path: products
+          http_deep_link_pattern: "https://dashboard.stripe.com/products/{id}"
         schema_loader:
           type: InlineSchemaLoader
           schema:
@@ -840,6 +865,7 @@ definitions:
           $ref: "#/definitions/base_retriever"
           $parameters:
             path: reviews
+          http_deep_link_pattern: "https://dashboard.stripe.com/reviews/{id}"
         schema_loader:
           type: InlineSchemaLoader
           schema:
@@ -892,6 +918,7 @@ definitions:
           $ref: "#/definitions/base_retriever"
           $parameters:
             path: payment_intents
+          http_deep_link_pattern: "https://dashboard.stripe.com/payments/{id}"
         schema_loader:
           type: InlineSchemaLoader
           schema:
@@ -918,6 +945,7 @@ definitions:
           $ref: "#/definitions/base_retriever"
           $parameters:
             path: promotion_codes
+          http_deep_link_pattern: "https://dashboard.stripe.com/promotion_codes/{id}"
         schema_loader:
           type: InlineSchemaLoader
           schema:
@@ -1022,6 +1050,7 @@ definitions:
           $ref: "#/definitions/base_retriever"
           $parameters:
             path: topups
+          http_deep_link_pattern: "https://dashboard.stripe.com/topups/{id}"
         schema_loader:
           type: InlineSchemaLoader
           schema:
@@ -1074,6 +1103,7 @@ definitions:
           $ref: "#/definitions/base_retriever"
           $parameters:
             path: checkout/sessions
+          http_deep_link_pattern: "https://dashboard.stripe.com/checkout/sessions/{id}"
         schema_loader:
           type: InlineSchemaLoader
           schema:

--- a/airbyte-integrations/connectors/source-stripe/manifest.yaml
+++ b/airbyte-integrations/connectors/source-stripe/manifest.yaml
@@ -22,7 +22,7 @@ definitions:
 
     # New singleton record selector for individual object retrievals.
     # This is the default selector used in 'fetch', 'create', and 'update' operations.
-    # Below the default behavior and therefor optional to specify:
+    # Below the default behavior and therefore optional to specify:
     singleton_record_selector:
       type: RecordSelector
       extractor:
@@ -58,12 +58,16 @@ definitions:
         requester_overrides:
           http_method: POST
           path_suffix: ""  # POST to the 'read_many' endpoint.
-          request_body_json: "{{ record }}"
+          request_body:
+            type: RequestBodyJsonObject
+            value: "{{ record }}"
       update_one:
         requester_overrides:
           http_method: POST
           path_suffix: "/{{ record.id }}"
-          request_body_json: "{{ record }}"
+          request_body:
+            type: RequestBodyJsonObject
+            value: "{{ record }}"
       delete_one:
         requester_overrides:
           http_method: DELETE

--- a/airbyte-integrations/connectors/source-stripe/manifest.yaml
+++ b/airbyte-integrations/connectors/source-stripe/manifest.yaml
@@ -362,6 +362,7 @@ definitions:
         $ref: "#/definitions/base_retriever"
         $parameters:
           path: events
+        standard_operations_subset: [read]
         http_deep_link_pattern: "https://dashboard.stripe.com/events/{id}"
       $parameters:
         path: events
@@ -385,6 +386,7 @@ definitions:
         $ref: "#/definitions/base_retriever"
         $parameters:
           path: balance_transactions
+        standard_operations_subset: [read]
         http_deep_link_pattern: "https://dashboard.stripe.com/balance/transactions/{id}"
       $parameters:
         path: balance_transactions
@@ -399,6 +401,7 @@ definitions:
         $ref: "#/definitions/base_retriever"
         $parameters:
           path: files
+        standard_operations_subset: [read]
         http_deep_link_pattern: "https://dashboard.stripe.com/files/{id}"
       $parameters:
         path: files
@@ -423,6 +426,7 @@ definitions:
           $ref: "#/definitions/base_retriever"
           $parameters:
             path: customers
+          standard_operations_subset: [read, create, update, delete]
           http_deep_link_pattern: "https://dashboard.stripe.com/customers/{id}"
         schema_loader:
           type: InlineSchemaLoader
@@ -450,6 +454,7 @@ definitions:
           $ref: "#/definitions/base_retriever"
           $parameters:
             path: subscriptions
+          standard_operations_subset: [read, create, update, delete]
           http_deep_link_pattern: "https://dashboard.stripe.com/subscriptions/{id}"
           requester:
             $ref: "#/definitions/base_requester"
@@ -481,6 +486,7 @@ definitions:
           $ref: "#/definitions/base_retriever"
           $parameters:
             path: invoices
+          standard_operations_subset: [read, create, update]
           http_deep_link_pattern: "https://dashboard.stripe.com/invoices/{id}"
           requester:
             $ref: "#/definitions/base_requester"
@@ -512,6 +518,7 @@ definitions:
           $ref: "#/definitions/base_retriever"
           $parameters:
             path: transfers
+          standard_operations_subset: [read, create, update]
           http_deep_link_pattern: "https://dashboard.stripe.com/transfers/{id}"
         schema_loader:
           type: InlineSchemaLoader
@@ -539,6 +546,7 @@ definitions:
           $ref: "#/definitions/base_retriever"
           $parameters:
             path: refunds
+          standard_operations_subset: [read, create, update]
           http_deep_link_pattern: "https://dashboard.stripe.com/payments/{charge}"
         schema_loader:
           type: InlineSchemaLoader
@@ -618,6 +626,7 @@ definitions:
           $ref: "#/definitions/base_retriever"
           $parameters:
             path: charges
+          standard_operations_subset: [read, create, update]
           http_deep_link_pattern: "https://dashboard.stripe.com/payments/{id}"
           requester:
             $ref: "#/definitions/base_requester"
@@ -649,6 +658,7 @@ definitions:
           $ref: "#/definitions/base_retriever"
           $parameters:
             path: coupons
+          standard_operations_subset: [read, create, update, delete]
           http_deep_link_pattern: "https://dashboard.stripe.com/coupons/{id}"
         schema_loader:
           type: InlineSchemaLoader
@@ -676,6 +686,7 @@ definitions:
           $ref: "#/definitions/base_retriever"
           $parameters:
             path: disputes
+          standard_operations_subset: [read, update]
           http_deep_link_pattern: "https://dashboard.stripe.com/disputes/{id}"
         schema_loader:
           type: InlineSchemaLoader
@@ -755,6 +766,7 @@ definitions:
           $ref: "#/definitions/base_retriever"
           $parameters:
             path: payouts
+          standard_operations_subset: [read, create, update]
           http_deep_link_pattern: "https://dashboard.stripe.com/payouts/{id}"
         schema_loader:
           type: InlineSchemaLoader
@@ -838,6 +850,7 @@ definitions:
           $ref: "#/definitions/base_retriever"
           $parameters:
             path: products
+          standard_operations_subset: [read, create, update, delete]
           http_deep_link_pattern: "https://dashboard.stripe.com/products/{id}"
         schema_loader:
           type: InlineSchemaLoader
@@ -865,6 +878,7 @@ definitions:
           $ref: "#/definitions/base_retriever"
           $parameters:
             path: reviews
+          standard_operations_subset: [read, update]
           http_deep_link_pattern: "https://dashboard.stripe.com/reviews/{id}"
         schema_loader:
           type: InlineSchemaLoader
@@ -918,6 +932,7 @@ definitions:
           $ref: "#/definitions/base_retriever"
           $parameters:
             path: payment_intents
+          standard_operations_subset: [read, create, update]
           http_deep_link_pattern: "https://dashboard.stripe.com/payments/{id}"
         schema_loader:
           type: InlineSchemaLoader
@@ -945,6 +960,7 @@ definitions:
           $ref: "#/definitions/base_retriever"
           $parameters:
             path: promotion_codes
+          standard_operations_subset: [read, create, update]
           http_deep_link_pattern: "https://dashboard.stripe.com/promotion_codes/{id}"
         schema_loader:
           type: InlineSchemaLoader
@@ -1050,6 +1066,7 @@ definitions:
           $ref: "#/definitions/base_retriever"
           $parameters:
             path: topups
+          standard_operations_subset: [read, create]
           http_deep_link_pattern: "https://dashboard.stripe.com/topups/{id}"
         schema_loader:
           type: InlineSchemaLoader
@@ -1103,6 +1120,7 @@ definitions:
           $ref: "#/definitions/base_retriever"
           $parameters:
             path: checkout/sessions
+          standard_operations_subset: [read, create]
           http_deep_link_pattern: "https://dashboard.stripe.com/checkout/sessions/{id}"
         schema_loader:
           type: InlineSchemaLoader


### PR DESCRIPTION
## What

This is a **design mockup PR** demonstrating how the proposed `SimpleBidirectionalRetriever` would be applied to the Stripe connector's `base_retriever` definition. This PR is related to the epic for adding fetch/create/update operations to the declarative CDK: airbytehq/airbyte-python-cdk#833

**Note:** `SimpleBidirectionalRetriever` does not exist in the CDK yet - this is purely a YAML specification to guide implementation. CI failures are expected and should be ignored.

## How

The changes transform the existing `SimpleRetriever` into a `SimpleBidirectionalRetriever` with support for CRUDL operations (Create, Read-one, Update, Delete, List):

1. **Profile-based defaults**: Added `standard_operations_profile: REST_CRUDL_POST_1999` to opt into standard REST API conventions
   - `REST_CRUDL_POST_1999`: Uses POST for updates (pre-PATCH era, RFC 2616 HTTP/1.1 from 1999)
   - `REST_CRUDL_PATCH_2010`: Uses PATCH for updates (RFC 5789 from March 2010)
   - Stripe uses the POST variant since it uses POST for updates (with partial update semantics)

2. **Operation overrides**: Defined `read_many`, `read_one`, `create_one`, `update_one`, `delete_one` with Stripe-specific customizations
   - Uses `$ref: "#/definitions/base_requester"` with inline field overrides (shallow merge semantics)
   - `update_one` no longer needs `http_method: POST` override since it's inherited from the profile

3. **Unsupported operations**: Explicitly listed operations Stripe doesn't support:
   - Bulk operations: `create_many`, `update_many`, `delete_many` (fall back to sequential single operations)
   - Replace operations: `replace_one`, `replace_many` (Stripe only supports partial updates)

4. **Selector refactoring**: 
   - Renamed `record_selector` → `multi_record_selector` (for list operations)
   - Added `single_record_selector` (for individual record operations)

5. **Comprehensive documentation**: Added extensive comments explaining:
   - Profile options and their HTTP spec history
   - update_one vs replace_one semantics (PATCH vs PUT)
   - Planned features: `path_suffix`, `pk()` macro, `replace_unset_strategy`
   - $ref merge semantics (shallow, not deep)

## Review guide

**Key areas to review:**

1. **Profile naming and structure** (lines 20-28): 
   - Is `standard_operations_profile` a good field name?
   - Are `REST_CRUDL_POST_1999` and `REST_CRUDL_PATCH_2010` clear enum values?
   - Should we tie naming to HTTP spec years (1999/2010) or use simpler v1/v2?

2. **Profile defaults documentation** (lines 90-106):
   - Are the operation mappings accurate for both profiles?
   - Is the distinction between POST (1999) and PATCH (2010) clear?

3. **Operation overrides structure** (lines 107-145):
   - Does the `operation_overrides` structure make sense?
   - Is the `$ref` pattern with inline overrides intuitive?
   - Are Stripe-specific overrides correct?

4. **update_one vs replace_one semantics** (lines 76-88):
   - Is the distinction between partial update (PATCH) and full replacement (PUT) clear?
   - Is the "no auto-null" default for replace operations correct?

5. **Unsupported operations** (lines 54-61):
   - Is the list complete for Stripe?
   - Are the fallback behaviors (sequential single operations) documented clearly?

6. **Selector naming** (lines 29-48):
   - Is `single_record_selector` vs `multi_record_selector` clear?
   - Should these be named differently?

7. **Planned features documentation** (lines 63-88):
   - Are planned features (`path_suffix`, `pk()` macro, `replace_unset_strategy`) clearly marked as not-yet-implemented?

## User Impact

**This PR has no user impact** - it's a design mockup for discussion and refinement. The actual implementation will happen in the airbyte-python-cdk repository.

When eventually implemented, users will be able to:
- Define write operations (create/update/delete) declaratively in YAML
- Opt into standard REST conventions via `standard_operations_profile`
- Choose between POST-based (1999) or PATCH-based (2010) update semantics
- Override specific operations per connector needs

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

This is a design mockup with no functional changes. `SimpleBidirectionalRetriever` doesn't exist in the CDK, so this PR cannot be merged as-is. It's purely for design discussion and documentation.

---

**Requested by:** AJ Steers (@aaronsteers)  
**Devin session:** https://app.devin.ai/sessions/dc10fcdabf624323a9bef22bae444da8  
**Related epic:** airbytehq/airbyte-python-cdk#833