### PR TITLE
source-mssql: Add SQL Server identifier quoting to fix reserved keyword issues

### DIFF
--- a/airbyte-integrations/connectors/source-mssql/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mssql/metadata.yaml
@@ -9,7 +9,7 @@ data:
   connectorSubtype: database
   connectorType: source
   definitionId: b5ea17b1-f170-46dc-bc31-cc744ca984c1
-  dockerImageTag: 4.3.0-rc.4
+  dockerImageTag: 4.3.0-rc.5
   dockerRepository: airbyte/source-mssql
   documentationUrl: https://docs.airbyte.com/integrations/sources/mssql
   githubIssueLabel: source-mssql

--- a/airbyte-integrations/connectors/source-mssql/src/test/kotlin/io/airbyte/integrations/source/mssql/MsSqlServerSourceSelectQueryGeneratorTest.kt
+++ b/airbyte-integrations/connectors/source-mssql/src/test/kotlin/io/airbyte/integrations/source/mssql/MsSqlServerSourceSelectQueryGeneratorTest.kt
@@ -40,7 +40,7 @@ class MsSqlServerSourceSelectQueryGeneratorTest {
                 From("users", "dbo"),
                 limit = Limit(0),
             )
-            .assertSqlEquals("""SELECT TOP 0 id, name FROM dbo.users""")
+            .assertSqlEquals("""SELECT TOP 0 [id], [name] FROM [dbo].[users]""")
     }
 
     @Test
@@ -49,7 +49,7 @@ class MsSqlServerSourceSelectQueryGeneratorTest {
                 SelectColumnMaxValue(Field("updated_at", OffsetDateTimeFieldType)),
                 From("orders", "dbo"),
             )
-            .assertSqlEquals("""SELECT MAX(updated_at) FROM dbo.orders""")
+            .assertSqlEquals("""SELECT MAX([updated_at]) FROM [dbo].[orders]""")
     }
 
     @Test
@@ -63,7 +63,7 @@ class MsSqlServerSourceSelectQueryGeneratorTest {
                 ),
                 From("products", "dbo"),
             )
-            .assertSqlEquals("""SELECT id, description FROM dbo.products""")
+            .assertSqlEquals("""SELECT [id], [description] FROM [dbo].[products]""")
     }
 
     @Test
@@ -90,11 +90,11 @@ class MsSqlServerSourceSelectQueryGeneratorTest {
                 Limit(1000),
             )
             .assertSqlEquals(
-                """SELECT TOP 1000 pk1, pk2, pk3, data FROM """ +
-                    """dbo.composite_table WHERE (pk1 > ?) OR """ +
-                    """((pk1 = ?) AND (pk2 > ?)) OR """ +
-                    """((pk1 = ?) AND (pk2 = ?) AND (pk3 > ?)) """ +
-                    """ORDER BY pk1, pk2, pk3""",
+                """SELECT TOP 1000 [pk1], [pk2], [pk3], [data] FROM """ +
+                    """[dbo].[composite_table] WHERE ([pk1] > ?) OR """ +
+                    """(([pk1] = ?) AND ([pk2] > ?)) OR """ +
+                    """(([pk1] = ?) AND ([pk2] = ?) AND ([pk3] > ?)) """ +
+                    """ORDER BY [pk1], [pk2], [pk3]""",
                 v1 to IntFieldType,
                 v1 to IntFieldType,
                 v2 to IntFieldType,
@@ -117,9 +117,9 @@ class MsSqlServerSourceSelectQueryGeneratorTest {
                 Limit(500),
             )
             .assertSqlEquals(
-                """SELECT TOP 500 content, last_modified FROM """ +
-                    """dbo.documents """ +
-                    """WHERE (last_modified > ?) AND (last_modified <= ?) ORDER BY last_modified""",
+                """SELECT TOP 500 [content], [last_modified] FROM """ +
+                    """[dbo].[documents] """ +
+                    """WHERE ([last_modified] > ?) AND ([last_modified] <= ?) ORDER BY [last_modified]""",
                 lb to DoubleFieldType,
                 ub to DoubleFieldType,
             )
@@ -140,7 +140,7 @@ class MsSqlServerSourceSelectQueryGeneratorTest {
                 From("employees", "hr"),
             )
             .assertSqlEquals(
-                """SELECT employee_id, org_node.ToString(), employee_name FROM hr.employees"""
+                """SELECT [employee_id], [org_node].ToString(), [employee_name] FROM [hr].[employees]"""
             )
     }
 
@@ -157,7 +157,7 @@ class MsSqlServerSourceSelectQueryGeneratorTest {
                 From("simple_table", null),
                 limit = Limit(10),
             )
-            .assertSqlEquals("""SELECT TOP 10 col1, col2 FROM simple_table""")
+            .assertSqlEquals("""SELECT TOP 10 [col1], [col2] FROM [simple_table]""")
     }
 
     @Test
@@ -173,7 +173,7 @@ class MsSqlServerSourceSelectQueryGeneratorTest {
                 Limit(10000),
             )
             .assertSqlEquals(
-                """SELECT TOP 10000 sequence_id, payload FROM dbo.events WHERE sequence_id > ? ORDER BY sequence_id""",
+                """SELECT TOP 10000 [sequence_id], [payload] FROM [dbo].[events] WHERE [sequence_id] > ? ORDER BY [sequence_id]""",
                 startValue to LongFieldType,
             )
     }
@@ -201,10 +201,27 @@ class MsSqlServerSourceSelectQueryGeneratorTest {
                 Limit(100),
             )
             .assertSqlEquals(
-                """SELECT TOP 100 id, created_at, updated_at FROM dbo.records """ +
-                    """WHERE (created_at > ?) AND (updated_at <= ?) ORDER BY created_at, updated_at""",
+                """SELECT TOP 100 [id], [created_at], [updated_at] FROM [dbo].[records] """ +
+                    """WHERE ([created_at] > ?) AND ([updated_at] <= ?) ORDER BY [created_at], [updated_at]""",
                 createdAfter to OffsetDateTimeFieldType,
                 updatedBefore to OffsetDateTimeFieldType,
+            )
+    }
+
+    @Test
+    fun testSelectWithReservedKeywords() {
+        // Test with reserved SQL Server keywords as column names (e.g., "End", "Start")
+        val endField = Field("End", OffsetDateTimeFieldType)
+        val startField = Field("Start", OffsetDateTimeFieldType)
+        val orderField = Field("Order", IntFieldType)
+
+        SelectQuerySpec(
+                SelectColumns(listOf(Field("Id", IntFieldType), startField, endField, orderField)),
+                From("CustomerAgreementProfiles", "dbo"),
+                limit = Limit(100),
+            )
+            .assertSqlEquals(
+                """SELECT TOP 100 [Id], [Start], [End], [Order] FROM [dbo].[CustomerAgreementProfiles]"""
             )
     }
 

--- a/docs/integrations/sources/mssql.md
+++ b/docs/integrations/sources/mssql.md
@@ -454,6 +454,7 @@ WHERE actor_definition_id ='b5ea17b1-f170-46dc-bc31-cc744ca984c1' AND (configura
 
 | Version    | Date       | Pull Request                                                                                                      | Subject                                                                                                                                         |
 |:-----------|:-----------|:------------------------------------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------|
+| 4.3.0-rc.5 | 2025-11-08 | [69248](https://github.com/airbytehq/airbyte/pull/69248) | Add SQL Server identifier quoting to fix reserved keyword issues |
 | 4.3.0-rc.4 | 2025-11-05 | [69194](https://github.com/airbytehq/airbyte/pull/69194) | Fix composite primary key discovery to show all PK columns; separate PK discovery from sync strategy |
 | 4.3.0-rc.3 | 2025-10-31 | [69097](https://github.com/airbytehq/airbyte/pull/69097) | Fix connector state value type from string to json object                                                                                                  |
 | 4.3.0-rc.2 | 2025-10-29 | [69093](https://github.com/airbytehq/airbyte/pull/69093) | Fix state parsing error for integer and number                                                                                                  |


### PR DESCRIPTION
## What
This PR fixes a critical bug in the MSSQL source connector where SQL Server reserved keywords used as column or table names would cause SQL syntax errors during sync operations.

## Problem
Tables with columns named after SQL Server reserved keywords (e.g., `End`, `Start`, `Order`) would fail with errors like:
```
SQLServerException: Incorrect syntax near the keyword 'End'.
```

## Solution
Added proper SQL Server identifier quoting using square brackets `[]` to protect against reserved keywords and special characters.

### Changes
1. **Added `String.quoted()` helper function** (`MsSqlSourceOperations.kt:305`)
   - Wraps identifiers in square brackets `[]`
   - Properly escapes closing brackets within identifiers (`]` becomes `]]`)

2. **Updated `Field.sql()` function** (`MsSqlSourceOperations.kt:307-308`)
   - All column names are now quoted with brackets
   - Maintains special handling for hierarchyid fields: `[column_name].ToString()`

3. **Updated `FromNode.sql()` function** (`MsSqlSourceOperations.kt:310-330`)
   - Table names and schema names are now quoted with brackets
   - Applies to both regular `FROM` clauses and `FromSample` clauses

4. **Updated all test cases** (`MsSqlServerSourceSelectQueryGeneratorTest.kt`)
   - Updated expected SQL queries to include bracket-quoted identifiers
   - Added new test `testSelectWithReservedKeywords()` specifically testing columns named "End", "Start", and "Order"

## Example

**Before (broken):**
```sql
SELECT Id, End, Start FROM dbo.Customer
```
❌ Error: "Incorrect syntax near the keyword 'End'"

**After (fixed):**
```sql
SELECT [Id], [End], [Start] FROM [dbo].[Customer]
```
✅ Works correctly

## Testing
- ✅ All existing unit tests pass
- ✅ Added new test `testSelectWithReservedKeywords()` verifies the fix
- ✅ Follows SQL Server best practices for identifier quoting

## Impact
- Fixes syncs for any MSSQL tables with reserved keyword column names
- Protects against future SQL Server versions introducing new reserved words
- No breaking changes - quoted identifiers work the same as unquoted ones in SQL Server

🤖 Generated with [Claude Code](https://claude.com/claude-code)

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._