### PR TITLE
docs: Improve $parameters documentation with automatic propagation details

### DIFF
--- a/docs/platform/connector-development/config-based/advanced-topics/parameters.md
+++ b/docs/platform/connector-development/config-based/advanced-topics/parameters.md
@@ -11,6 +11,8 @@ Schema:
   additionalProperties: true
 ```
 
+## Basic Usage
+
 Example:
 
 ```yaml
@@ -21,7 +23,7 @@ outer:
     k2: v2
 ```
 
-This the example above, if both outer and inner are types with a "MyKey" field, both of them will evaluate to "MyValue".
+In the example above, if both outer and inner are types with a "MyKey" field, both of them will evaluate to "MyValue".
 
 These parameters can be overwritten by subcomponents as a form of specialization:
 
@@ -48,3 +50,75 @@ outer:
 ```
 
 In this example, outer.inner.k2 will evaluate to "MyKey is MyValue"
+
+## Automatic Parameter Propagation
+
+Parameters are automatically applied to component fields when those fields are not explicitly set. This happens recursively through nested components, allowing you to define parameters at a high level (like a stream) and have them automatically flow down to deeply nested components (like a requester inside a retriever).
+
+### How It Works
+
+When a component is processed:
+1. Parameters from parent components are merged with the current component's parameters
+2. Each parameter key is checked against the component's fields
+3. If a field with that name exists and is not already set (or is falsy), the parameter value is assigned to that field
+4. The merged parameters are then passed down to all child components recursively
+
+### Precedence Rules
+
+- **Explicit values win**: If a field is explicitly set on a component, parameters will not override it
+- **Child parameters override parent parameters**: Parameters defined on a child component take precedence over those from parent components
+- **Exclusion rule**: When descending into a nested component, any parameter whose key matches the component's field name is temporarily excluded from propagation to avoid circular references
+
+### Real-World Example
+
+In the Stripe connector, multiple streams share the same base configuration but differ only in their API path. Here's how parameters enable this:
+
+```yaml
+definitions:
+  base_stream:
+    type: DeclarativeStream
+    retriever:
+      $ref: "#/definitions/base_retriever"
+    # ... other common configuration
+
+  base_retriever:
+    type: SimpleRetriever
+    requester:
+      $ref: "#/definitions/base_requester"
+    # ... other retriever configuration
+
+  base_requester:
+    type: HttpRequester
+    url_base: "https://api.stripe.com/v1"
+    # Note: no 'path' field defined here
+
+streams:
+  shipping_rates:
+    $ref: "#/definitions/base_stream"
+    $parameters:
+      path: shipping_rates
+      name: shipping_rates
+    schema_loader:
+      # ... schema configuration
+
+  file_links:
+    $ref: "#/definitions/base_stream"
+    $parameters:
+      path: file_links
+      name: file_links
+    schema_loader:
+      # ... schema configuration
+```
+
+In this example:
+- Both streams reference the same `base_stream` definition
+- Each stream provides different `$parameters` values for `path` and `name`
+- These parameters automatically propagate down through the component hierarchy: stream → retriever → requester
+- The `path` parameter automatically sets the `requester.path` field, even though it's nested two levels deep
+- The `name` parameter sets the `stream.name` field
+
+This pattern eliminates repetition and makes it easy to create multiple similar streams that differ only in a few key values.
+
+### Technical Details
+
+The parameter propagation mechanism is implemented in the `ManifestComponentTransformer.propagate_types_and_parameters` method in the CDK. For more details, see the [CDK source code](https://github.com/airbytehq/airbyte-python-cdk/blob/main/airbyte_cdk/sources/declarative/parsers/manifest_component_transformer.py).

--- a/docs/platform/connector-development/config-based/advanced-topics/parameters.md
+++ b/docs/platform/connector-development/config-based/advanced-topics/parameters.md
@@ -23,7 +23,7 @@ outer:
     k2: v2
 ```
 
-In the example above, if both outer and inner are types with a "MyKey" field, both of them will evaluate to "MyValue".
+In this example, if both outer and inner are types with a "MyKey" field, both of them evaluate to "MyValue."
 
 These parameters can be overwritten by subcomponents as a form of specialization:
 
@@ -37,7 +37,7 @@ outer:
     k2: v2
 ```
 
-In this example, "outer.MyKey" will evaluate to "MyValue", and "inner.MyKey" will evaluate to "YourValue".
+In this example, "outer.MyKey" evaluates to "MyValue," and "inner.MyKey" evaluates to "YourValue."
 
 The value can also be used for string interpolation:
 
@@ -49,7 +49,7 @@ outer:
     k2: "MyKey is {{ parameters['MyKey'] }}"
 ```
 
-In this example, outer.inner.k2 will evaluate to "MyKey is MyValue"
+In this example, outer.inner.k2 evaluates to "MyKey is MyValue."
 
 ## Automatic Parameter Propagation
 
@@ -58,14 +58,15 @@ Parameters are automatically applied to component fields when those fields are n
 ### How It Works
 
 When a component is processed:
+
 1. Parameters from parent components are merged with the current component's parameters
 2. Each parameter key is checked against the component's fields
-3. If a field with that name exists and is not already set (or is falsy), the parameter value is assigned to that field
+3. If a field with that name exists and is not already set (or evaluates to false), the parameter value is assigned to that field
 4. The merged parameters are then passed down to all child components recursively
 
 ### Precedence Rules
 
-- **Explicit values win**: If a field is explicitly set on a component, parameters will not override it
+- **Explicit values win**: If a field is explicitly set on a component, parameters do not override it
 - **Child parameters override parent parameters**: Parameters defined on a child component take precedence over those from parent components
 - **Exclusion rule**: When descending into a nested component, any parameter whose key matches the component's field name is temporarily excluded from propagation to avoid circular references
 
@@ -111,6 +112,7 @@ streams:
 ```
 
 In this example:
+
 - Both streams reference the same `base_stream` definition
 - Each stream provides different `$parameters` values for `path` and `name`
 - These parameters automatically propagate down through the component hierarchy: stream → retriever → requester

--- a/docusaurus/platform_versioned_docs/version-2.0/connector-development/config-based/advanced-topics/parameters.md
+++ b/docusaurus/platform_versioned_docs/version-2.0/connector-development/config-based/advanced-topics/parameters.md
@@ -11,6 +11,8 @@ Schema:
   additionalProperties: true
 ```
 
+## Basic Usage
+
 Example:
 
 ```yaml
@@ -21,7 +23,7 @@ outer:
     k2: v2
 ```
 
-This the example above, if both outer and inner are types with a "MyKey" field, both of them will evaluate to "MyValue".
+In the example above, if both outer and inner are types with a "MyKey" field, both of them will evaluate to "MyValue".
 
 These parameters can be overwritten by subcomponents as a form of specialization:
 
@@ -48,3 +50,75 @@ outer:
 ```
 
 In this example, outer.inner.k2 will evaluate to "MyKey is MyValue"
+
+## Automatic Parameter Propagation
+
+Parameters are automatically applied to component fields when those fields are not explicitly set. This happens recursively through nested components, allowing you to define parameters at a high level (like a stream) and have them automatically flow down to deeply nested components (like a requester inside a retriever).
+
+### How It Works
+
+When a component is processed:
+1. Parameters from parent components are merged with the current component's parameters
+2. Each parameter key is checked against the component's fields
+3. If a field with that name exists and is not already set (or is falsy), the parameter value is assigned to that field
+4. The merged parameters are then passed down to all child components recursively
+
+### Precedence Rules
+
+- **Explicit values win**: If a field is explicitly set on a component, parameters will not override it
+- **Child parameters override parent parameters**: Parameters defined on a child component take precedence over those from parent components
+- **Exclusion rule**: When descending into a nested component, any parameter whose key matches the component's field name is temporarily excluded from propagation to avoid circular references
+
+### Real-World Example
+
+In the Stripe connector, multiple streams share the same base configuration but differ only in their API path. Here's how parameters enable this:
+
+```yaml
+definitions:
+  base_stream:
+    type: DeclarativeStream
+    retriever:
+      $ref: "#/definitions/base_retriever"
+    # ... other common configuration
+
+  base_retriever:
+    type: SimpleRetriever
+    requester:
+      $ref: "#/definitions/base_requester"
+    # ... other retriever configuration
+
+  base_requester:
+    type: HttpRequester
+    url_base: "https://api.stripe.com/v1"
+    # Note: no 'path' field defined here
+
+streams:
+  shipping_rates:
+    $ref: "#/definitions/base_stream"
+    $parameters:
+      path: shipping_rates
+      name: shipping_rates
+    schema_loader:
+      # ... schema configuration
+
+  file_links:
+    $ref: "#/definitions/base_stream"
+    $parameters:
+      path: file_links
+      name: file_links
+    schema_loader:
+      # ... schema configuration
+```
+
+In this example:
+- Both streams reference the same `base_stream` definition
+- Each stream provides different `$parameters` values for `path` and `name`
+- These parameters automatically propagate down through the component hierarchy: stream → retriever → requester
+- The `path` parameter automatically sets the `requester.path` field, even though it's nested two levels deep
+- The `name` parameter sets the `stream.name` field
+
+This pattern eliminates repetition and makes it easy to create multiple similar streams that differ only in a few key values.
+
+### Technical Details
+
+The parameter propagation mechanism is implemented in the `ManifestComponentTransformer.propagate_types_and_parameters` method in the CDK. For more details, see the [CDK source code](https://github.com/airbytehq/airbyte-python-cdk/blob/main/airbyte_cdk/sources/declarative/parsers/manifest_component_transformer.py).

--- a/docusaurus/platform_versioned_docs/version-2.0/connector-development/config-based/advanced-topics/parameters.md
+++ b/docusaurus/platform_versioned_docs/version-2.0/connector-development/config-based/advanced-topics/parameters.md
@@ -23,7 +23,7 @@ outer:
     k2: v2
 ```
 
-In the example above, if both outer and inner are types with a "MyKey" field, both of them will evaluate to "MyValue".
+In this example, if both outer and inner are types with a "MyKey" field, both of them evaluate to "MyValue."
 
 These parameters can be overwritten by subcomponents as a form of specialization:
 
@@ -37,7 +37,7 @@ outer:
     k2: v2
 ```
 
-In this example, "outer.MyKey" will evaluate to "MyValue", and "inner.MyKey" will evaluate to "YourValue".
+In this example, "outer.MyKey" evaluates to "MyValue," and "inner.MyKey" evaluates to "YourValue."
 
 The value can also be used for string interpolation:
 
@@ -49,7 +49,7 @@ outer:
     k2: "MyKey is {{ parameters['MyKey'] }}"
 ```
 
-In this example, outer.inner.k2 will evaluate to "MyKey is MyValue"
+In this example, outer.inner.k2 evaluates to "MyKey is MyValue."
 
 ## Automatic Parameter Propagation
 
@@ -58,14 +58,15 @@ Parameters are automatically applied to component fields when those fields are n
 ### How It Works
 
 When a component is processed:
+
 1. Parameters from parent components are merged with the current component's parameters
 2. Each parameter key is checked against the component's fields
-3. If a field with that name exists and is not already set (or is falsy), the parameter value is assigned to that field
+3. If a field with that name exists and is not already set (or evaluates to false), the parameter value is assigned to that field
 4. The merged parameters are then passed down to all child components recursively
 
 ### Precedence Rules
 
-- **Explicit values win**: If a field is explicitly set on a component, parameters will not override it
+- **Explicit values win**: If a field is explicitly set on a component, parameters do not override it
 - **Child parameters override parent parameters**: Parameters defined on a child component take precedence over those from parent components
 - **Exclusion rule**: When descending into a nested component, any parameter whose key matches the component's field name is temporarily excluded from propagation to avoid circular references
 
@@ -111,6 +112,7 @@ streams:
 ```
 
 In this example:
+
 - Both streams reference the same `base_stream` definition
 - Each stream provides different `$parameters` values for `path` and `name`
 - These parameters automatically propagate down through the component hierarchy: stream → retriever → requester


### PR DESCRIPTION
## What

Improves the `$parameters` documentation to explain the automatic parameter propagation mechanism that was previously undocumented. This addresses a documentation gap where users could see `$parameters` being used in connectors but the automatic field assignment behavior was not explained.

**Context:** While investigating how `$parameters` works in the declarative CDK, we discovered that parameters automatically propagate to component fields when those fields are not explicitly set. This powerful feature was being used throughout connectors (like Stripe) but was not documented anywhere.

## How

Added a new "Automatic Parameter Propagation" section to the parameters documentation that includes:

1. **How It Works**: Step-by-step explanation of the propagation mechanism
2. **Precedence Rules**: Documents three key rules:
   - Explicit values win over parameters
   - Child parameters override parent parameters  
   - Exclusion rule for nested components
3. **Real-World Example**: Uses the Stripe connector to show how `shipping_rates` and `file_links` streams differ only in `$parameters` values, yet the `path` parameter automatically sets `requester.path` despite being nested two levels deep
4. **Technical Details**: Links to the CDK source code implementation

Also fixed a typo: "This the example" → "In the example"

Updated both:
- `docs/platform/connector-development/config-based/advanced-topics/parameters.md` (main docs)
- `docusaurus/platform_versioned_docs/version-2.0/connector-development/config-based/advanced-topics/parameters.md` (versioned docs)

## Review guide

1. **Verify accuracy of automatic propagation explanation** - The mechanism description is based on code analysis of `ManifestComponentTransformer.propagate_types_and_parameters`. Please confirm this accurately describes the behavior.

2. **Validate the Stripe example** - Confirm that `shipping_rates` and `file_links` streams in the Stripe connector actually work as described (differ only in `$parameters` and the path propagates automatically).

3. **Check precedence rules** - Especially the "exclusion rule" which states that parameters matching child field names are excluded during descent. This is a subtle behavior that should be verified.

4. **Versioned docs update** - Confirm that version-2.0 docs should be updated identically to main docs.

## User Impact

**Positive:**
- Connector developers will now understand how `$parameters` automatically propagates to nested components
- Reduces confusion about why parameters work without explicit Jinja interpolation
- Provides a clear pattern for creating multiple similar streams with minimal repetition

**Negative:**
- None expected - this is purely additive documentation

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

This is documentation-only with no code changes. Reverting would simply remove the new documentation section.

---

**Related work:**
- Follow-up PR needed to airbyte-python-cdk to add inline description to the JSON schema
- This is part of a broader effort to improve `$parameters` documentation

**Requested by:** AJ Steers (@aaronsteers)  
**Session:** https://app.devin.ai/sessions/dc10fcdabf624323a9bef22bae444da8