### PR TITLE
chore(source-pokeapi): CDK prerelease proof test (InferredSchemaLoader) (do not merge)

### DIFF
--- a/airbyte-integrations/connectors/source-pokeapi/manifest.yaml
+++ b/airbyte-integrations/connectors/source-pokeapi/manifest.yaml
@@ -26,9 +26,19 @@ definitions:
             type: DpathExtractor
             field_path: []
       schema_loader:
-        type: InlineSchemaLoader
-        schema:
-          $ref: "#/schemas/pokemon"
+        type: InferredSchemaLoader
+        record_sample_size: 1
+        retriever:
+          type: SimpleRetriever
+          requester:
+            $ref: "#/definitions/base_requester"
+            path: /{{config['pokemon_name']}}
+            http_method: GET
+          record_selector:
+            type: RecordSelector
+            extractor:
+              type: DpathExtractor
+              field_path: []
   base_requester:
     type: HttpRequester
     url_base: https://pokeapi.co/api/v2/pokemon

--- a/airbyte-integrations/connectors/source-pokeapi/manifest.yaml
+++ b/airbyte-integrations/connectors/source-pokeapi/manifest.yaml
@@ -27,18 +27,7 @@ definitions:
             field_path: []
       schema_loader:
         type: InferredSchemaLoader
-        record_sample_size: 1
-        retriever:
-          type: SimpleRetriever
-          requester:
-            $ref: "#/definitions/base_requester"
-            path: /{{config['pokemon_name']}}
-            http_method: GET
-          record_selector:
-            type: RecordSelector
-            extractor:
-              type: DpathExtractor
-              field_path: []
+        record_sample_size: 50
   base_requester:
     type: HttpRequester
     url_base: https://pokeapi.co/api/v2/pokemon

--- a/airbyte-integrations/connectors/source-pokeapi/metadata.yaml
+++ b/airbyte-integrations/connectors/source-pokeapi/metadata.yaml
@@ -15,7 +15,7 @@ data:
     # Please update to the latest version of the connector base image.
     # https://hub.docker.com/r/airbyte/python-connector-base
     # Please use the full address with sha256 hash to guarantee build reproducibility.
-    baseImage: docker.io/airbyte/source-declarative-manifest:7.4.1@sha256:71df19e2ee555ca5b14abbec01d50104c79c9b84cb9cc323284d24333361900a
+    baseImage: docker.io/airbyte/source-declarative-manifest:7.4.2.post15.dev19207237224@sha256:758d68ad5800a4c7de218be0b611156a1aef577953ef599c5725c780d6004aaa
   connectorSubtype: api
   connectorType: source
   definitionId: 6371b14b-bc68-4236-bfbd-468e8df8e968


### PR DESCRIPTION
## What

This is a **proof-of-concept PR** to test the new `InferredSchemaLoader` feature from Python CDK prerelease version `7.4.2.post15.dev19207237224`. This PR demonstrates end-to-end functionality by switching source-pokeapi to use runtime schema inference instead of a static schema.

**⚠️ DO NOT MERGE** - This is a research/testing PR only.

**Related:**
- CDK PR: airbytehq/airbyte-python-cdk#831 (adds InferredSchemaLoader feature)
- CDK Issue: airbytehq/airbyte-python-cdk#714 (survey of manifest-only connectors)
- Requested by: @aaronsteers (aj@airbyte.io)
- Devin session: https://app.devin.ai/sessions/6fbe7bb84c894b32b04196b00c9db457

## How

**Three-commit strategy:**
1. **Commit 1**: Bump base Docker image to prerelease CDK version `7.4.2.post15.dev19207237224`
2. **Commit 2**: Replace `InlineSchemaLoader` with `InferredSchemaLoader` on the pokemon stream (initial attempt with configuration error)
3. **Commit 3**: Fix manifest configuration - remove incorrectly nested retriever from schema_loader

**Key changes:**
- `metadata.yaml`: Updated baseImage from `7.4.1` to prerelease `7.4.2.post15.dev19207237224`
- `manifest.yaml`: Switched pokemon stream from InlineSchemaLoader (static schema reference) to InferredSchemaLoader (runtime inference)
- InferredSchemaLoader configured with `record_sample_size: 50` to infer schema from up to 50 sample records

**Configuration Fix (Commit 3):**
The initial InferredSchemaLoader configuration incorrectly nested a `retriever` inside the `schema_loader`, causing JSON schema validation errors. InferredSchemaLoader should reuse the stream's existing retriever, not embed a new one.

## Review guide

**Critical items to verify:**

1. **CI Test Results** - Standard tests may fail with schema validation errors if the test harness uses a stable airbyte-cdk that doesn't include InferredSchemaLoader. This is expected for a prerelease POC. Check if:
   - Container-level `discover` and `check` commands work (they use the prerelease CDK in the image)
   - Standard tests fail only on schema validation, not on functional issues

2. **Schema Quality** - Compare the inferred schema against the original static schema:
   - `airbyte-integrations/connectors/source-pokeapi/manifest.yaml` (lines 28-30): New InferredSchemaLoader config
   - Original schema was at `#/schemas/pokemon` (removed in this PR)
   - Expected differences: Genson may produce nullable unions like `["string", "null"]`
   - **Risk**: With `record_sample_size: 50` and PokeAPI returning single records, the inferred schema may miss optional fields

3. **Single Record Limitation** - PokeAPI's pokemon endpoint (`/{{config['pokemon_name']}}`) returns a single Pokemon by name, not a list. This means:
   - The "sample" is effectively one record, making `record_sample_size: 50` somewhat meaningless
   - Schema inference is based on ONE Pokemon's structure
   - Fields that are optional or vary by Pokemon type may be missing from the inferred schema
   - This is acceptable for POC but would need adjustment for production

**Files to review:**
1. `airbyte-integrations/connectors/source-pokeapi/metadata.yaml` - CDK version bump (line 18)
2. `airbyte-integrations/connectors/source-pokeapi/manifest.yaml` - Schema loader replacement (lines 28-30)

## User Impact

**For this proof-of-concept:**
- No user impact - this PR should not be merged

**If this approach were adopted in production:**
- Schema would be dynamically inferred at discover time instead of being statically defined
- Schema may differ from current schema (nullable unions, potentially missing optional fields)
- Discover operation would make additional API calls to fetch sample records
- For connectors with single-record endpoints like PokeAPI, schema quality may be reduced

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

This is a proof-of-concept PR on a single connector with no production impact. The changes are isolated to source-pokeapi and use a prerelease CDK version.