### PR TITLE
[GCS-DL] More CDK changes on the IcebergTableSynchronizer

### DIFF
--- a/airbyte-cdk/bulk/changelog.md
+++ b/airbyte-cdk/bulk/changelog.md
@@ -9,7 +9,7 @@
 **Extract CDK**
 
 * Fix case sensitivity for table filtering.
-* 
+
 ## Version 0.1.71
 
 **Load CDK**

--- a/airbyte-cdk/bulk/changelog.md
+++ b/airbyte-cdk/bulk/changelog.md
@@ -1,9 +1,15 @@
+## Version 0.1.73    
+
+**Load CDK**
+
+* More changes to `IcebergTableSynchronizer` to get BigLake working
+
 ## Version 0.1.72
 
 **Extract CDK**
 
 * Fix case sensitivity for table filtering.
-
+* 
 ## Version 0.1.71
 
 **Load CDK**

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/IcebergTableSynchronizer.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/IcebergTableSynchronizer.kt
@@ -200,7 +200,6 @@ class IcebergTableSynchronizer(
         // committed schema). We commit the delete first, then create the add operation.
         if (requireSeparateCommitsForColumnReplace && columnsToReplaceInSecondCommit.isNotEmpty()) {
             // Commit the delete operation immediately
-            update.apply()
             update.commit()
             table.refresh()
 

--- a/airbyte-cdk/bulk/version.properties
+++ b/airbyte-cdk/bulk/version.properties
@@ -1,1 +1,1 @@
-version=0.1.72
+version=0.1.73


### PR DESCRIPTION
## What

Fix schema evolution for BigLake with column type changes (OVERWRITE mode)

  Problem

  When using ColumnTypeChangeBehavior.OVERWRITE with requireSeparateCommitsForColumnReplace=true (required by BigLake), the connector was failing with:

  IllegalArgumentException: Cannot add column, name already exists: to_change

  This occurred because Iceberg's UpdateSchema API is stateless—each call to table.updateSchema() creates a fresh update based on the current committed schema. When attempting to replace a column (delete + add with same name) in deferred
  commit mode:

  1. First UpdateSchema was created with a delete operation
  2. Second UpdateSchema was immediately created to add the column back
  3. Since the delete wasn't committed yet, Iceberg still saw the column as existing
  4. The add operation failed because the column name already existed

  Solution

  When requireSeparateCommitsForColumnReplace is enabled and columns need to be replaced:

  1. Always commit the delete operation immediately (line 203), even in deferred mode
    - This is required because BigLake needs separate transactions for delete/add operations
    - It also ensures the committed schema reflects the deleted column before we create the add operation
  2. Refresh the table (line 205) to get the updated schema after the delete commit
  3. Create the add operation based on the now-committed schema (lines 210-217)
    - In immediate mode: commit the add operation right away
    - In deferred mode: return it as a pending update to be committed later

  This hybrid approach satisfies both requirements:
  - ✅ BigLake's requirement for separate commits (delete and add are in different transactions)
  - ✅ Deferred commit behavior (the add operation can still be deferred for validation before final commit)

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [X] NO ❌

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._