### PR TITLE
feat: recreate indexes if cursor/primary keys changed

### DIFF
--- a/airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/client/PostgresAirbyteClient.kt
+++ b/airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/client/PostgresAirbyteClient.kt
@@ -31,10 +31,7 @@ class PostgresAirbyteClient(
 
     override suspend fun countTable(tableName: TableName): Long? =
         try {
-            dataSource.connection.use { connection ->
-                val resultSet =
-                    connection.createStatement().executeQuery(sqlGenerator.countTable(tableName))
-
+            executeQuery(sqlGenerator.countTable(tableName)) { resultSet ->
                 if (resultSet.next()) {
                     resultSet.getLong(COUNT_TOTAL_ALIAS)
                 } else {
@@ -176,9 +173,7 @@ class PostgresAirbyteClient(
 
     override suspend fun getGenerationId(tableName: TableName): Long =
         try {
-            val sql = sqlGenerator.getGenerationId(tableName)
-            dataSource.connection.use { connection ->
-                val resultSet = connection.createStatement().executeQuery(sql)
+            executeQuery(sqlGenerator.getGenerationId(tableName)) { resultSet ->
                 if (resultSet.next()) {
                     resultSet.getLong(COLUMN_NAME_AB_GENERATION_ID)
                 } else {
@@ -192,15 +187,13 @@ class PostgresAirbyteClient(
         }
 
     fun describeTable(tableName: TableName): List<String> =
-        dataSource.connection.use { connection ->
-            val resultSet =
-                connection.createStatement().executeQuery(sqlGenerator.getTableSchema(tableName))
+        executeQuery(sqlGenerator.getTableSchema(tableName)) { resultSet ->
             val columns = mutableListOf<String>()
             while (resultSet.next()) {
                 //TODO: extract column_name as a constant
                 columns.add(resultSet.getString("column_name"))
             }
-            return columns
+            columns
         }
 
     fun copyFromCsv(tableName: TableName, filePath: String) {
@@ -223,4 +216,14 @@ class PostgresAirbyteClient(
         }
     }
 
+    private fun <T> executeQuery(query: String, resultProcessor: (ResultSet) -> T): T {
+        log.info { query.trimIndent() }
+        return dataSource.connection.use { connection ->
+            connection.createStatement().use {
+                it.executeQuery(query).use { resultSet ->
+                    resultProcessor(resultSet)
+                }
+            }
+        }
+    }
 }

--- a/airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/client/PostgresAirbyteClient.kt
+++ b/airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/client/PostgresAirbyteClient.kt
@@ -114,9 +114,6 @@ class PostgresAirbyteClient(
         val (addedColumns, deletedColumns, modifiedColumns) =
             generateSchemaChanges(columnsInDb, columnsInStream)
 
-        if (
-            addedColumns.isNotEmpty() || deletedColumns.isNotEmpty() || modifiedColumns.isNotEmpty()
-        ) {
             log.info { "Summary of the table alterations:" }
             log.info { "Added columns: $addedColumns" }
             log.info { "Deleted columns: $deletedColumns" }
@@ -133,7 +130,6 @@ class PostgresAirbyteClient(
                 recreateCursorIndex =  shouldRecreateCursorIndex(stream, tableName, columnNameMapping),
                 cursorColumnName = postgresColumnUtils.getCursorColumnName(stream, columnNameMapping),
             ))
-        }
     }
 
     /**

--- a/airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/client/PostgresAirbyteClient.kt
+++ b/airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/client/PostgresAirbyteClient.kt
@@ -21,13 +21,16 @@ import javax.sql.DataSource
 
 private val log = KotlinLogging.logger {}
 
-
 @Singleton
 class PostgresAirbyteClient(
     private val dataSource: DataSource,
     private val sqlGenerator: PostgresDirectLoadSqlGenerator,
     private val postgresColumnUtils: PostgresColumnUtils
 ) : TableSchemaEvolutionClient, TableOperationsClient {
+
+    companion object {
+        private const val COLUMN_NAME_COLUMN = "column_name"
+    }
 
     override suspend fun countTable(tableName: TableName): Long? =
         try {
@@ -169,7 +172,7 @@ class PostgresAirbyteClient(
         executeQuery(sql) { resultSet ->
             val columns = mutableListOf<String>()
             while (resultSet.next()) {
-                columns.add(resultSet.getString("column_name"))
+                columns.add(resultSet.getString(COLUMN_NAME_COLUMN))
             }
             columns
         }
@@ -205,8 +208,7 @@ class PostgresAirbyteClient(
             val columnsInDb: MutableSet<Column> = mutableSetOf()
             val defaultColumnNames = postgresColumnUtils.defaultColumns().map { it.columnName }.toSet()
             while (rs.next()) {
-                //TODO: extract column_name and data_type as constants
-                val columnName = rs.getString("column_name")
+                val columnName = rs.getString(COLUMN_NAME_COLUMN)
 
                 // Filter out airbyte columns
                 if (defaultColumnNames.contains(columnName)) {
@@ -260,7 +262,7 @@ class PostgresAirbyteClient(
             val columns = mutableListOf<String>()
             while (resultSet.next()) {
                 //TODO: extract column_name as a constant
-                columns.add(resultSet.getString("column_name"))
+                columns.add(resultSet.getString(COLUMN_NAME_COLUMN))
             }
             columns
         }

--- a/airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/client/PostgresAirbyteClient.kt
+++ b/airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/client/PostgresAirbyteClient.kt
@@ -166,7 +166,7 @@ class PostgresAirbyteClient(
         getIndexColumns(sqlGenerator.getPrimaryKeyIndexColumns(tableName))
 
     private fun getCursorIndexColumn(tableName: TableName): String? =
-        getIndexColumns(sqlGenerator.getCursorColumn(tableName)).firstOrNull()
+        getIndexColumns(sqlGenerator.getCursorIndexColumn(tableName)).firstOrNull()
 
     private fun getIndexColumns(sql: String): List<String> =
         executeQuery(sql) { resultSet ->

--- a/airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/client/PostgresAirbyteClient.kt
+++ b/airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/client/PostgresAirbyteClient.kt
@@ -214,6 +214,13 @@ class PostgresAirbyteClient(
         }
     }
 
-    private fun execute(query: String) =
-        dataSource.connection.use { connection -> connection.createStatement().use { it.execute(query) }}
+    private fun execute(query: String) {
+        log.info { query.trimIndent() }
+        dataSource.connection.use { connection ->
+            connection.createStatement().use {
+                it.execute(query)
+            }
+        }
+    }
+
 }

--- a/airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/sql/PostgresColumnUtils.kt
+++ b/airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/sql/PostgresColumnUtils.kt
@@ -170,6 +170,22 @@ class PostgresColumnUtils(
             getTargetColumnName(primaryKeyColumnName, columnNameMapping )
         }.toList()
     }
+
+    internal fun getCursorColumnName(stream: DestinationStream, columnNameMapping: ColumnNameMapping): String? {
+        return when (stream.importType) {
+            is Dedupe -> getCursorColumnName((stream.importType as Dedupe).cursor, columnNameMapping)
+            else -> null
+        }
+    }
+
+    internal fun getCursorColumnName(
+        cursor: List<String>,
+        columnNameMapping: ColumnNameMapping
+    ): String? {
+        return cursor
+            .firstOrNull()
+            ?.let { columnName -> getTargetColumnName(columnName, columnNameMapping) }
+    }
 }
 
 data class Column(val columnName: String, val columnTypeName: String, val nullable: Boolean = true)

--- a/airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/sql/PostgresColumnUtils.kt
+++ b/airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/sql/PostgresColumnUtils.kt
@@ -32,6 +32,7 @@ import io.airbyte.cdk.load.message.Meta.Companion.COLUMN_NAME_AB_META
 import io.airbyte.cdk.load.message.Meta.Companion.COLUMN_NAME_AB_RAW_ID
 import io.airbyte.cdk.load.message.Meta.Companion.COLUMN_NAME_DATA
 import io.airbyte.cdk.load.table.ColumnNameMapping
+import io.airbyte.cdk.load.table.TableName
 import io.airbyte.integrations.destination.postgres.spec.PostgresConfiguration
 import jakarta.inject.Singleton
 import kotlin.collections.plus
@@ -41,6 +42,8 @@ class PostgresColumnUtils(
     private val postgresConfiguration: PostgresConfiguration
 ) {
     companion object {
+        private const val CURSOR_INDEX_PREFIX = "idx_cursor_"
+        private const val PRIMARY_KEY_INDEX_PREFIX = "idx_pk_"
         //Default columns that are always present in both raw and typed tables.
         private val DEFAULT_COLUMNS =
             listOf(
@@ -186,6 +189,12 @@ class PostgresColumnUtils(
             .firstOrNull()
             ?.let { columnName -> getTargetColumnName(columnName, columnNameMapping) }
     }
+
+    internal fun getCursorIndexName(tableName: TableName): String =
+        CURSOR_INDEX_PREFIX + tableName.name
+
+    internal fun getPrimaryKeyIndexName(tableName: TableName): String =
+        PRIMARY_KEY_INDEX_PREFIX + tableName.name
 }
 
 data class Column(val columnName: String, val columnTypeName: String, val nullable: Boolean = true)

--- a/airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/sql/PostgresDirectLoadSqlGenerator.kt
+++ b/airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/sql/PostgresDirectLoadSqlGenerator.kt
@@ -28,8 +28,6 @@ class PostgresDirectLoadSqlGenerator(
     private val dropTableSuffix: String = if (postgresConfiguration.dropCascade == true) " CASCADE" else ""
 
     companion object {
-        private const val CURSOR_INDEX_PREFIX = "idx_cursor_"
-        private const val PRIMARY_KEY_INDEX_PREFIX = "idx_pk_"
         private const val DEDUPED_TABLE_ALIAS = "deduped_source"
         private val EXTRACTED_AT_COLUMN_NAME = quoteIdentifier(COLUMN_NAME_AB_EXTRACTED_AT)
         private val DELETED_AT_COLUMN_NAME = quoteIdentifier(CDC_DELETED_AT_COLUMN)
@@ -148,10 +146,10 @@ class PostgresDirectLoadSqlGenerator(
     }
 
     private fun getPrimaryKeyIndexName(tableName: TableName): String =
-        quoteIdentifier(PRIMARY_KEY_INDEX_PREFIX + tableName.name)
+        quoteIdentifier(postgresColumnUtils.getPrimaryKeyIndexName(tableName))
 
     private fun getCursorIndexName(tableName: TableName): String =
-        quoteIdentifier(CURSOR_INDEX_PREFIX + tableName.name)
+        quoteIdentifier(postgresColumnUtils.getCursorIndexName(tableName))
 
     fun overwriteTable(
         sourceTableName: TableName,
@@ -468,8 +466,8 @@ class PostgresDirectLoadSqlGenerator(
      */
     fun getPrimaryKeyIndexColumns(tableName: TableName): String =
         getIndexColumns(
-           indexName = getPrimaryKeyIndexName(tableName),
-            namespace = getNamespace(tableName)
+            indexName = postgresColumnUtils.getPrimaryKeyIndexName(tableName),
+            namespace = tableName.namespace
         )
 
     /**
@@ -480,8 +478,8 @@ class PostgresDirectLoadSqlGenerator(
      */
     fun getCursorColumn(tableName: TableName): String =
         getIndexColumns(
-            indexName = getCursorIndexName(tableName),
-            namespace = getNamespace(tableName)
+            indexName = postgresColumnUtils.getCursorIndexName(tableName),
+            namespace = tableName.namespace
         )
 
 

--- a/airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/sql/PostgresDirectLoadSqlGenerator.kt
+++ b/airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/sql/PostgresDirectLoadSqlGenerator.kt
@@ -576,7 +576,7 @@ class PostgresDirectLoadSqlGenerator(
     private fun getName(column: Column): String =
         "\"${column.columnName}\""
 
-    fun Column.toSQLString(): String {
+    internal fun Column.toSQLString(): String {
         val isNullableSuffix = if (nullable) "" else "NOT NULL"
         return "\"$columnName\" $columnTypeName $isNullableSuffix".trim()
     }

--- a/airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/sql/PostgresDirectLoadSqlGenerator.kt
+++ b/airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/sql/PostgresDirectLoadSqlGenerator.kt
@@ -100,7 +100,10 @@ class PostgresDirectLoadSqlGenerator(
         primaryKeyColumnNames: List<String>,
         tableName: TableName
     ): String {
-        val dropPrimaryKeyIndexStatement = dropIndex(getPrimaryKeyIndexName(tableName))
+        val dropPrimaryKeyIndexStatement = dropIndex(
+            indexName = getPrimaryKeyIndexName(tableName),
+            schema = getNamespace(tableName))
+
         val primaryKeyIndexStatement = createPrimaryKeyIndexStatement(primaryKeyColumnNames, tableName)
 
         return """
@@ -124,7 +127,9 @@ class PostgresDirectLoadSqlGenerator(
         cursorColumnName: String?,
         tableName: TableName
     ): String {
-        val dropCursorIndexStatement = dropIndex(getCursorIndexName(tableName))
+        val dropCursorIndexStatement = dropIndex(
+            indexName = getCursorIndexName(tableName),
+            schema = getNamespace(tableName))
         val cursorIndexStatement = createCursorIndexStatement(cursorColumnName, tableName)
 
         return """
@@ -492,8 +497,8 @@ class PostgresDirectLoadSqlGenerator(
         ORDER BY array_position(i.indkey, a.attnum);
         """
 
-    private fun dropIndex(indexName: String): String =
-        "DROP INDEX IF EXISTS ${quoteIdentifier(indexName)};"
+    private fun dropIndex(indexName: String, schema: String): String =
+        "DROP INDEX IF EXISTS $schema.$indexName;"
 
     fun copyFromCsv(tableName: TableName): String =
         """

--- a/airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/sql/PostgresDirectLoadSqlGenerator.kt
+++ b/airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/sql/PostgresDirectLoadSqlGenerator.kt
@@ -14,7 +14,6 @@ import io.airbyte.cdk.load.table.ColumnNameMapping
 import io.airbyte.cdk.load.table.TableName
 import io.airbyte.integrations.destination.postgres.spec.CdcDeletionMode
 import io.airbyte.integrations.destination.postgres.spec.PostgresConfiguration
-import io.github.oshai.kotlinlogging.KotlinLogging
 import jakarta.inject.Singleton
 import kotlin.collections.forEach
 
@@ -476,7 +475,7 @@ class PostgresDirectLoadSqlGenerator(
      * @param tableName The table to query the index for
      * @return SQL query that returns column name in the cursor index
      */
-    fun getCursorColumn(tableName: TableName): String =
+    fun getCursorIndexColumn(tableName: TableName): String =
         getIndexColumns(
             indexName = postgresColumnUtils.getCursorIndexName(tableName),
             namespace = tableName.namespace

--- a/airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/sql/PostgresDirectLoadSqlGenerator.kt
+++ b/airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/sql/PostgresDirectLoadSqlGenerator.kt
@@ -25,7 +25,7 @@ class PostgresDirectLoadSqlGenerator(
     private val postgresColumnUtils: PostgresColumnUtils,
     private val postgresConfiguration: PostgresConfiguration) {
 
-    private val dropTableSuffix: String = if (postgresConfiguration.dropCascade == true) "CASCADE" else ""
+    private val dropTableSuffix: String = if (postgresConfiguration.dropCascade == true) " CASCADE" else ""
 
     companion object {
         private const val CURSOR_INDEX_PREFIX = "idx_cursor_"
@@ -45,7 +45,7 @@ class PostgresDirectLoadSqlGenerator(
         replace: Boolean
     ): String {
         val columnDeclarations = postgresColumnUtils.getTargetColumns(stream, columnNameMapping).joinToString(",\n") {it.toSQLString() }
-        val dropTableIfExistsStatement = if (replace) "DROP TABLE IF EXISTS ${getFullyQualifiedName(tableName)} $dropTableSuffix;" else ""
+        val dropTableIfExistsStatement = if (replace) "DROP TABLE IF EXISTS ${getFullyQualifiedName(tableName)}$dropTableSuffix;" else ""
         val createIndexesStatement = createIndexes(stream, tableName, columnNameMapping)
         return """
             BEGIN TRANSACTION;
@@ -142,7 +142,7 @@ class PostgresDirectLoadSqlGenerator(
     ): String {
         return """
             BEGIN TRANSACTION;
-            DROP TABLE IF EXISTS ${getFullyQualifiedName(targetTableName)} $dropTableSuffix;
+            DROP TABLE IF EXISTS ${getFullyQualifiedName(targetTableName)}$dropTableSuffix;
             ALTER TABLE ${getFullyQualifiedName(sourceTableName)} RENAME TO ${getName(targetTableName)};
             COMMIT;
             """
@@ -421,7 +421,7 @@ class PostgresDirectLoadSqlGenerator(
     }
 
     fun dropTable(tableName: TableName): String =
-        "DROP TABLE IF EXISTS ${getFullyQualifiedName(tableName)} $dropTableSuffix;"
+        "DROP TABLE IF EXISTS ${getFullyQualifiedName(tableName)}$dropTableSuffix;"
 
     fun countTable(tableName: TableName): String {
         return "SELECT COUNT(*) AS \"$COUNT_TOTAL_ALIAS\" FROM ${getFullyQualifiedName(tableName)};"

--- a/airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/sql/PostgresDirectLoadSqlGenerator.kt
+++ b/airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/sql/PostgresDirectLoadSqlGenerator.kt
@@ -507,7 +507,6 @@ class PostgresDirectLoadSqlGenerator(
         WITH (FORMAT csv)
         """
 
-    //should all alters happen in one same tx? probably
     fun matchSchemas(
         tableName: TableName,
         columnsToAdd: Set<Column>,

--- a/airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/sql/PostgresDirectLoadSqlGenerator.kt
+++ b/airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/sql/PostgresDirectLoadSqlGenerator.kt
@@ -442,7 +442,10 @@ class PostgresDirectLoadSqlGenerator(
         FROM information_schema.columns
         WHERE table_schema = '${tableName.namespace}'
         AND table_name = '${tableName.name}';
-        """.trimIndent().andLog()
+        """
+
+    private fun dropIndex(indexName: String): String =
+        "DROP INDEX IF EXISTS ${quoteIdentifier(indexName)};"
 
     fun copyFromCsv(tableName: TableName): String =
         """

--- a/airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/sql/PostgresDirectLoadSqlGenerator.kt
+++ b/airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/sql/PostgresDirectLoadSqlGenerator.kt
@@ -492,8 +492,8 @@ class PostgresDirectLoadSqlGenerator(
         JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = ANY(i.indkey)
         JOIN pg_class c ON c.oid = i.indexrelid
         JOIN pg_namespace n ON n.oid = c.relnamespace
-        WHERE c.relname = $indexName
-        AND n.nspname = $namespace
+        WHERE c.relname = '${indexName}'
+        AND n.nspname = '${namespace}'
         ORDER BY array_position(i.indkey, a.attnum);
         """
 

--- a/airbyte-integrations/connectors/destination-postgres/src/test/kotlin/io/airbyte/integrations/destination/postgres/client/PostgresAirbyteClientTest.kt
+++ b/airbyte-integrations/connectors/destination-postgres/src/test/kotlin/io/airbyte/integrations/destination/postgres/client/PostgresAirbyteClientTest.kt
@@ -57,6 +57,7 @@ internal class PostgresAirbyteClientTest {
             mockk<ResultSet> {
                 every { next() } returns true
                 every { getLong(COUNT_TOTAL_ALIAS) } returns 42L
+                every { close() } just Runs
             }
         val statement =
             mockk<Statement> {
@@ -82,7 +83,12 @@ internal class PostgresAirbyteClientTest {
     @Test
     fun testCountTableNoResults() {
         val tableName = TableName(namespace = "namespace", name = "name")
-        val resultSet = mockk<ResultSet> { every { next() } returns false }
+
+        val resultSet = mockk<ResultSet> {
+            every { next() } returns false
+            every { close()} just Runs
+        }
+
         val statement =
             mockk<Statement> {
                 every { executeQuery(any()) } returns resultSet
@@ -296,6 +302,7 @@ internal class PostgresAirbyteClientTest {
             mockk<ResultSet> {
                 every { next() } returns true
                 every { getLong(COLUMN_NAME_AB_GENERATION_ID) } returns generationId
+                every { close() } just Runs
             }
         val statement =
             mockk<Statement> {
@@ -376,6 +383,7 @@ internal class PostgresAirbyteClientTest {
             mockk<ResultSet> {
                 every { next() } returns true andThen true andThen false
                 every { getString("column_name") } returns column1 andThen column2
+                every { close() } just Runs
             }
         val statement =
             mockk<Statement> {
@@ -401,6 +409,7 @@ internal class PostgresAirbyteClientTest {
         val tableName = TableName(namespace = "test_namespace", name = "test_table")
         val resultSet = mockk<ResultSet>()
         every { resultSet.next() } returns true andThen true andThen true andThen false
+        every { resultSet.close() } just Runs
         val defaultColumnName = "default_column_name"
         every { resultSet.getString("column_name") } returns
             "col1" andThen

--- a/airbyte-integrations/connectors/destination-postgres/src/test/kotlin/io/airbyte/integrations/destination/postgres/client/PostgresAirbyteClientTest.kt
+++ b/airbyte-integrations/connectors/destination-postgres/src/test/kotlin/io/airbyte/integrations/destination/postgres/client/PostgresAirbyteClientTest.kt
@@ -122,6 +122,7 @@ internal class PostgresAirbyteClientTest {
             }
 
         every { dataSource.connection } returns mockConnection
+        every { sqlGenerator.countTable(tableName) } returns MOCK_SQL_QUERY
 
         runBlocking {
             val result = client.countTable(tableName)

--- a/airbyte-integrations/connectors/destination-postgres/src/test/kotlin/io/airbyte/integrations/destination/postgres/client/PostgresAirbyteClientTest.kt
+++ b/airbyte-integrations/connectors/destination-postgres/src/test/kotlin/io/airbyte/integrations/destination/postgres/client/PostgresAirbyteClientTest.kt
@@ -30,7 +30,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 internal class PostgresAirbyteClientTest {
-
     private lateinit var client: PostgresAirbyteClient
     private lateinit var dataSource: DataSource
     private lateinit var sqlGenerator: PostgresDirectLoadSqlGenerator
@@ -491,5 +490,267 @@ internal class PostgresAirbyteClientTest {
         assertEquals(0, added.size)
         assertEquals(0, deleted.size)
         assertEquals(0, modified.size)
+    }
+
+    @Test
+    fun testEnsureSchemaMatchesWithNoChanges() {
+        val stream = mockk<DestinationStream>()
+        val tableName = TableName(namespace = "test_ns", name = "test_table")
+        val columnNameMapping = mockk<ColumnNameMapping>(relaxed = true)
+
+        // Mock getColumnsFromDb
+        val resultSet = mockk<ResultSet>()
+        every { resultSet.next() } returns true andThen true andThen false
+        every { resultSet.getString("column_name") } returns "col1" andThen "col2"
+        every { resultSet.getString("data_type") } returns "text" andThen "integer"
+        every { resultSet.close() } just Runs
+
+        // Mock getPrimaryKeyIndexColumns
+        val pkResultSet = mockk<ResultSet>()
+        every { pkResultSet.next() } returns false
+        every { pkResultSet.close() } just Runs
+
+        // Mock getCursorIndexColumn
+        val cursorResultSet = mockk<ResultSet>()
+        every { cursorResultSet.next() } returns false
+        every { cursorResultSet.close() } just Runs
+
+        val statement = mockk<Statement> {
+            every { executeQuery(any()) } returns resultSet andThen pkResultSet andThen cursorResultSet
+            every { execute(any()) } returns true
+            every { close() } just Runs
+        }
+
+        val connection = mockk<Connection>()
+        every { connection.createStatement() } returns statement
+        every { connection.close() } just Runs
+
+        every { dataSource.connection } returns connection
+        every { sqlGenerator.getTableSchema(tableName) } returns MOCK_SQL_QUERY
+        every { sqlGenerator.getPrimaryKeyIndexColumns(tableName) } returns MOCK_SQL_QUERY
+        every { sqlGenerator.getCursorIndexColumn(tableName) } returns MOCK_SQL_QUERY
+        every { sqlGenerator.matchSchemas(any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns MOCK_SQL_QUERY
+
+        //no column changes
+        every { postgresColumnUtils.defaultColumns() } returns emptyList()
+        every { postgresColumnUtils.getTargetColumns(stream, columnNameMapping) } returns
+            listOf(Column("col1", "text"), Column("col2", "integer"))
+
+        //no index changes
+        every { postgresColumnUtils.getPrimaryKeysColumnNames(stream, columnNameMapping) } returns emptyList()
+        every { postgresColumnUtils.getCursorColumnName(stream, columnNameMapping) } returns null
+
+        runBlocking {
+            client.ensureSchemaMatches(stream, tableName, columnNameMapping)
+            verify(exactly = 1) {
+                sqlGenerator.matchSchemas(
+                    tableName = tableName,
+                    columnsToAdd = emptySet(),
+                    columnsToRemove = emptySet(),
+                    columnsToModify = emptySet(),
+                    columnsInDb = any(),
+                    recreatePrimaryKeyIndex = false,
+                    primaryKeyColumnNames = emptyList(),
+                    recreateCursorIndex = false,
+                    cursorColumnName = null
+                )
+            }
+        }
+    }
+
+    @Test
+    fun testEnsureSchemaMatchesWithColumnChanges() {
+        val stream = mockk<DestinationStream>()
+        val tableName = TableName(namespace = "test_ns", name = "test_table")
+        val columnNameMapping = mockk<ColumnNameMapping>(relaxed = true)
+
+        // Mock getColumnsFromDb
+        val tableColumnsResultSet = mockk<ResultSet>()
+        every { tableColumnsResultSet.next() } returns true andThen false
+        every { tableColumnsResultSet.getString("column_name") } returns "col1"
+        every { tableColumnsResultSet.getString("data_type") } returns "text"
+        every { tableColumnsResultSet.close() } just Runs
+
+        // Mock getPrimaryKeyIndexColumns
+        val pkResultSet = mockk<ResultSet>()
+        every { pkResultSet.next() } returns false
+        every { pkResultSet.close() } just Runs
+
+        // Mock getCursorIndexColumn
+        val cursorResultSet = mockk<ResultSet>()
+        every { cursorResultSet.next() } returns false
+        every { cursorResultSet.close() } just Runs
+
+        val statement = mockk<Statement> {
+            every { executeQuery(any()) } returns tableColumnsResultSet andThen pkResultSet andThen cursorResultSet
+            every { execute(any()) } returns true
+            every { close() } just Runs
+        }
+
+        val connection = mockk<Connection>()
+        every { connection.createStatement() } returns statement
+        every { connection.close() } just Runs
+
+        every { dataSource.connection } returns connection
+        every { sqlGenerator.getTableSchema(tableName) } returns MOCK_SQL_QUERY
+        every { sqlGenerator.getPrimaryKeyIndexColumns(tableName) } returns MOCK_SQL_QUERY
+        every { sqlGenerator.getCursorIndexColumn(tableName) } returns MOCK_SQL_QUERY
+        every { sqlGenerator.matchSchemas(any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns MOCK_SQL_QUERY
+
+        every { postgresColumnUtils.defaultColumns() } returns emptyList()
+        every { postgresColumnUtils.getTargetColumns(stream, columnNameMapping) } returns
+            listOf(Column("col1", "text"), Column("col2", "integer"))
+
+        every { postgresColumnUtils.getPrimaryKeysColumnNames(stream, columnNameMapping) } returns emptyList()
+        every { postgresColumnUtils.getCursorColumnName(stream, columnNameMapping) } returns null
+
+        runBlocking {
+            client.ensureSchemaMatches(stream, tableName, columnNameMapping)
+            verify(exactly = 1) {
+                sqlGenerator.matchSchemas(
+                    tableName = tableName,
+                    columnsToAdd = setOf(Column("col2", "integer")),
+                    columnsToRemove = emptySet(),
+                    columnsToModify = emptySet(),
+                    columnsInDb = any(),
+                    recreatePrimaryKeyIndex = false,
+                    primaryKeyColumnNames = emptyList(),
+                    recreateCursorIndex = false,
+                    cursorColumnName = null
+                )
+            }
+        }
+    }
+
+    @Test
+    fun testEnsureSchemaMatchesWithPrimaryKeyIndexRecreation() {
+        val stream = mockk<DestinationStream>()
+        val tableName = TableName(namespace = "test_ns", name = "test_table")
+        val columnNameMapping = mockk<ColumnNameMapping>(relaxed = true)
+
+        // Mock getColumnsFromDb
+        val resultSet = mockk<ResultSet>()
+        every { resultSet.next() } returns true andThen false
+        every { resultSet.getString("column_name") } returns "col1"
+        every { resultSet.getString("data_type") } returns "text"
+        every { resultSet.close() } just Runs
+
+        // Mock getPrimaryKeyIndexColumns
+        val pkResultSet = mockk<ResultSet>()
+        every { pkResultSet.next() } returns true andThen false
+        every { pkResultSet.getString("column_name") } returns "old_pk"
+        every { pkResultSet.close() } just Runs
+
+        // Mock getCursorIndexColumn
+        val cursorResultSet = mockk<ResultSet>()
+        every { cursorResultSet.next() } returns false
+        every { cursorResultSet.close() } just Runs
+
+        val statement = mockk<Statement> {
+            every { executeQuery(any()) } returns resultSet andThen pkResultSet andThen cursorResultSet
+            every { execute(any()) } returns true
+            every { close() } just Runs
+        }
+
+        val connection = mockk<Connection>()
+        every { connection.createStatement() } returns statement
+        every { connection.close() } just Runs
+
+        every { dataSource.connection } returns connection
+        every { sqlGenerator.getTableSchema(tableName) } returns MOCK_SQL_QUERY
+        every { sqlGenerator.getPrimaryKeyIndexColumns(tableName) } returns MOCK_SQL_QUERY
+        every { sqlGenerator.getCursorIndexColumn(tableName) } returns MOCK_SQL_QUERY
+        every { sqlGenerator.matchSchemas(any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns MOCK_SQL_QUERY
+
+        every { postgresColumnUtils.defaultColumns() } returns emptyList()
+        every { postgresColumnUtils.getTargetColumns(stream, columnNameMapping) } returns
+            listOf(Column("col1", "text"))
+
+        // primary key has changed
+        every { postgresColumnUtils.getPrimaryKeysColumnNames(stream, columnNameMapping) } returns listOf("new_pk")
+        every { postgresColumnUtils.getCursorColumnName(stream, columnNameMapping) } returns null
+
+        runBlocking {
+            client.ensureSchemaMatches(stream, tableName, columnNameMapping)
+            verify(exactly = 1) {
+                sqlGenerator.matchSchemas(
+                    tableName = tableName,
+                    columnsToAdd = emptySet(),
+                    columnsToRemove = emptySet(),
+                    columnsToModify = emptySet(),
+                    columnsInDb = any(),
+                    recreatePrimaryKeyIndex = true,
+                    primaryKeyColumnNames = listOf("new_pk"),
+                    recreateCursorIndex = false,
+                    cursorColumnName = null
+                )
+            }
+        }
+    }
+
+    @Test
+    fun testEnsureSchemaMatchesWithCursorIndexRecreation() {
+        val stream = mockk<DestinationStream>()
+        val tableName = TableName(namespace = "test_ns", name = "test_table")
+        val columnNameMapping = mockk<ColumnNameMapping>(relaxed = true)
+
+        // Mock getColumnsFromDb
+        val resultSet = mockk<ResultSet>()
+        every { resultSet.next() } returns true andThen false
+        every { resultSet.getString("column_name") } returns "col1"
+        every { resultSet.getString("data_type") } returns "text"
+        every { resultSet.close() } just Runs
+
+        // Mock getPrimaryKeyIndexColumns
+        val pkResultSet = mockk<ResultSet>()
+        every { pkResultSet.next() } returns false
+        every { pkResultSet.close() } just Runs
+
+        // Mock getCursorIndexColumn
+        val cursorResultSet = mockk<ResultSet>()
+        every { cursorResultSet.next() } returns true andThen false
+        every { cursorResultSet.getString("column_name") } returns "old_cursor"
+        every { cursorResultSet.close() } just Runs
+
+        val statement = mockk<Statement> {
+            every { executeQuery(any()) } returns resultSet andThen pkResultSet andThen cursorResultSet
+            every { execute(any()) } returns true
+            every { close() } just Runs
+        }
+
+        val connection = mockk<Connection>()
+        every { connection.createStatement() } returns statement
+        every { connection.close() } just Runs
+
+        every { dataSource.connection } returns connection
+        every { sqlGenerator.getTableSchema(tableName) } returns MOCK_SQL_QUERY
+        every { sqlGenerator.getPrimaryKeyIndexColumns(tableName) } returns MOCK_SQL_QUERY
+        every { sqlGenerator.getCursorIndexColumn(tableName) } returns MOCK_SQL_QUERY
+        every { sqlGenerator.matchSchemas(any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns MOCK_SQL_QUERY
+
+        every { postgresColumnUtils.defaultColumns() } returns emptyList()
+        every { postgresColumnUtils.getTargetColumns(stream, columnNameMapping) } returns
+            listOf(Column("col1", "text"))
+
+        every { postgresColumnUtils.getPrimaryKeysColumnNames(stream, columnNameMapping) } returns emptyList()
+        // cursor has changed
+        every { postgresColumnUtils.getCursorColumnName(stream, columnNameMapping) } returns "new_cursor"
+
+        runBlocking {
+            client.ensureSchemaMatches(stream, tableName, columnNameMapping)
+            verify(exactly = 1) {
+                sqlGenerator.matchSchemas(
+                    tableName = tableName,
+                    columnsToAdd = emptySet(),
+                    columnsToRemove = emptySet(),
+                    columnsToModify = emptySet(),
+                    columnsInDb = any(),
+                    recreatePrimaryKeyIndex = false,
+                    primaryKeyColumnNames = emptyList(),
+                    recreateCursorIndex = true,
+                    cursorColumnName = "new_cursor"
+                )
+            }
+        }
     }
 }

--- a/airbyte-integrations/connectors/destination-postgres/src/test/kotlin/io/airbyte/integrations/destination/postgres/sql/PostgresDirectLoadSqlGeneratorTest.kt
+++ b/airbyte-integrations/connectors/destination-postgres/src/test/kotlin/io/airbyte/integrations/destination/postgres/sql/PostgresDirectLoadSqlGeneratorTest.kt
@@ -79,7 +79,7 @@ internal class PostgresDirectLoadSqlGeneratorTest {
             );
             CREATE INDEX ON "namespace"."name" ("_airbyte_extracted_at");
             COMMIT;
-            """.trimIndent()
+            """
 
         assertEqualsIgnoreWhitespace(expected, sql)
     }
@@ -132,7 +132,7 @@ internal class PostgresDirectLoadSqlGeneratorTest {
             );
             CREATE INDEX ON "namespace"."name" ("_airbyte_extracted_at");
             COMMIT;
-            """.trimIndent()
+            """
 
         assertEqualsIgnoreWhitespace(expected, sql)
     }
@@ -178,7 +178,7 @@ internal class PostgresDirectLoadSqlGeneratorTest {
             CREATE INDEX "idx_cursor_test_table" ON "test_schema"."test_table" ("updatedAt");
             CREATE INDEX ON "test_schema"."test_table" ("_airbyte_extracted_at");
             COMMIT;
-            """.trimIndent()
+            """
 
         assertEqualsIgnoreWhitespace(expected, sql)
     }
@@ -380,7 +380,7 @@ internal class PostgresDirectLoadSqlGeneratorTest {
             WHERE "test_schema"."final_table"."id" = deduped_source."id"
             )
             AND deduped_source."_ab_cdc_deleted_at" IS NULL
-            """.trimIndent()
+            """
 
         assertEqualsIgnoreWhitespace(expected, sql)
     }
@@ -436,7 +436,7 @@ internal class PostgresDirectLoadSqlGeneratorTest {
             FROM "test_schema"."staging_table"
             ) AS deduplicated
             WHERE row_number = 1
-            """.trimIndent()
+            """
 
         assertEqualsIgnoreWhitespace(expected, sql)
     }
@@ -466,7 +466,7 @@ internal class PostgresDirectLoadSqlGeneratorTest {
             FROM "test_schema"."staging_table"
             ) AS deduplicated
             WHERE row_number = 1
-            """.trimIndent()
+            """
 
         assertEqualsIgnoreWhitespace(expected, sql)
     }
@@ -497,7 +497,7 @@ internal class PostgresDirectLoadSqlGeneratorTest {
             OR ("test_schema"."final_table".updatedAt IS NULL AND deduped_source.updatedAt IS NOT NULL)
             OR ("test_schema"."final_table".updatedAt IS NULL AND deduped_source.updatedAt IS NULL AND "test_schema"."final_table"."_airbyte_extracted_at" < deduped_source."_airbyte_extracted_at"))
             ),
-            """.trimIndent()
+            """
 
         assertEqualsIgnoreWhitespace(expected, sql)
     }
@@ -524,7 +524,7 @@ internal class PostgresDirectLoadSqlGeneratorTest {
             AND deduped_source."_ab_cdc_deleted_at" IS NOT NULL
             AND ("test_schema"."final_table"."_airbyte_extracted_at" < deduped_source."_airbyte_extracted_at")
             ),
-            """.trimIndent()
+            """
 
         assertEqualsIgnoreWhitespace(expected, sql)
     }
@@ -570,7 +570,7 @@ internal class PostgresDirectLoadSqlGeneratorTest {
             FROM deduped_source
             WHERE "test_schema"."final_table".id = deduped_source.id
             AND ("test_schema"."final_table"."_airbyte_extracted_at" < deduped_source."_airbyte_extracted_at")
-            """.trimIndent()
+            """
 
         assertEqualsIgnoreWhitespace(expected, sql)
     }
@@ -634,7 +634,7 @@ internal class PostgresDirectLoadSqlGeneratorTest {
             WHERE "test_schema"."final_table".id = deduped_source.id
             AND deduped_source."_ab_cdc_deleted_at" IS NULL
             AND ("test_schema"."final_table"."_airbyte_extracted_at" < deduped_source."_airbyte_extracted_at")
-            """.trimIndent()
+            """
 
         assertEqualsIgnoreWhitespace(expected, sql)
     }
@@ -669,7 +669,7 @@ internal class PostgresDirectLoadSqlGeneratorTest {
             FROM "test_schema"."final_table"
             WHERE "test_schema"."final_table".id = deduped_source.id
             )
-            """.trimIndent()
+            """
 
         assertEqualsIgnoreWhitespace(expected, sql)
     }
@@ -705,7 +705,7 @@ internal class PostgresDirectLoadSqlGeneratorTest {
             WHERE "test_schema"."final_table".id = deduped_source.id
             )
             AND deduped_source."_ab_cdc_deleted_at" IS NULL
-            """.trimIndent()
+            """
 
         assertEqualsIgnoreWhitespace(expected, sql)
     }

--- a/airbyte-integrations/connectors/destination-postgres/src/test/kotlin/io/airbyte/integrations/destination/postgres/sql/PostgresDirectLoadSqlGeneratorTest.kt
+++ b/airbyte-integrations/connectors/destination-postgres/src/test/kotlin/io/airbyte/integrations/destination/postgres/sql/PostgresDirectLoadSqlGeneratorTest.kt
@@ -28,14 +28,15 @@ internal class PostgresDirectLoadSqlGeneratorTest {
 
     private lateinit var postgresDirectLoadSqlGenerator: PostgresDirectLoadSqlGenerator
     private lateinit var columnUtils: PostgresColumnUtils
-    private val postgresConfiguration: PostgresConfiguration = mockk()
+    private lateinit var postgresConfiguration: PostgresConfiguration
 
     @BeforeEach
     fun setUp() {
-        val mockConfig = mockk<PostgresConfiguration> {
+        postgresConfiguration = mockk<PostgresConfiguration> {
             every { legacyRawTablesOnly } returns false
+            every { dropCascade } returns false
         }
-        columnUtils = PostgresColumnUtils(mockConfig)
+        columnUtils = PostgresColumnUtils(postgresConfiguration)
         postgresDirectLoadSqlGenerator = PostgresDirectLoadSqlGenerator(columnUtils, postgresConfiguration)
     }
 

--- a/airbyte-integrations/connectors/destination-postgres/src/test/kotlin/io/airbyte/integrations/destination/postgres/sql/PostgresDirectLoadSqlGeneratorTest.kt
+++ b/airbyte-integrations/connectors/destination-postgres/src/test/kotlin/io/airbyte/integrations/destination/postgres/sql/PostgresDirectLoadSqlGeneratorTest.kt
@@ -334,10 +334,12 @@ internal class PostgresDirectLoadSqlGeneratorTest {
             USING deduped_source
             WHERE "test_schema"."final_table"."id" = deduped_source."id"
             AND deduped_source."_ab_cdc_deleted_at" IS NOT NULL
-            AND ("test_schema"."final_table"."updatedAt" < deduped_source."updatedAt"
+            AND (
+            "test_schema"."final_table"."updatedAt" < deduped_source."updatedAt"
             OR ("test_schema"."final_table"."updatedAt" = deduped_source."updatedAt" AND "test_schema"."final_table"."_airbyte_extracted_at" < deduped_source."_airbyte_extracted_at")
             OR ("test_schema"."final_table"."updatedAt" IS NULL AND deduped_source."updatedAt" IS NOT NULL)
-            OR ("test_schema"."final_table"."updatedAt" IS NULL AND deduped_source."updatedAt" IS NULL AND "test_schema"."final_table"."_airbyte_extracted_at" < deduped_source."_airbyte_extracted_at"))
+            OR ("test_schema"."final_table"."updatedAt" IS NULL AND deduped_source."updatedAt" IS NULL AND "test_schema"."final_table"."_airbyte_extracted_at" < deduped_source."_airbyte_extracted_at")
+            )
             ),
 
             updates AS (
@@ -354,10 +356,12 @@ internal class PostgresDirectLoadSqlGeneratorTest {
             FROM deduped_source
             WHERE "test_schema"."final_table"."id" = deduped_source."id"
             AND deduped_source."_ab_cdc_deleted_at" IS NULL
-            AND ("test_schema"."final_table"."updatedAt" < deduped_source."updatedAt"
+            AND (
+            "test_schema"."final_table"."updatedAt" < deduped_source."updatedAt"
             OR ("test_schema"."final_table"."updatedAt" = deduped_source."updatedAt" AND "test_schema"."final_table"."_airbyte_extracted_at" < deduped_source."_airbyte_extracted_at")
             OR ("test_schema"."final_table"."updatedAt" IS NULL AND deduped_source."updatedAt" IS NOT NULL)
-            OR ("test_schema"."final_table"."updatedAt" IS NULL AND deduped_source."updatedAt" IS NULL AND "test_schema"."final_table"."_airbyte_extracted_at" < deduped_source."_airbyte_extracted_at"))
+            OR ("test_schema"."final_table"."updatedAt" IS NULL AND deduped_source."updatedAt" IS NULL AND "test_schema"."final_table"."_airbyte_extracted_at" < deduped_source."_airbyte_extracted_at")
+            )
             )
 
             INSERT INTO "test_schema"."final_table" (
@@ -499,10 +503,12 @@ internal class PostgresDirectLoadSqlGeneratorTest {
             USING deduped_source
             WHERE "test_schema"."final_table".id = deduped_source.id
             AND deduped_source."_ab_cdc_deleted_at" IS NOT NULL
-            AND ("test_schema"."final_table".updatedAt < deduped_source.updatedAt
+            AND (
+            "test_schema"."final_table".updatedAt < deduped_source.updatedAt
             OR ("test_schema"."final_table".updatedAt = deduped_source.updatedAt AND "test_schema"."final_table"."_airbyte_extracted_at" < deduped_source."_airbyte_extracted_at")
             OR ("test_schema"."final_table".updatedAt IS NULL AND deduped_source.updatedAt IS NOT NULL)
-            OR ("test_schema"."final_table".updatedAt IS NULL AND deduped_source.updatedAt IS NULL AND "test_schema"."final_table"."_airbyte_extracted_at" < deduped_source."_airbyte_extracted_at"))
+            OR ("test_schema"."final_table".updatedAt IS NULL AND deduped_source.updatedAt IS NULL AND "test_schema"."final_table"."_airbyte_extracted_at" < deduped_source."_airbyte_extracted_at")
+            )
             ),
             """
 
@@ -607,11 +613,13 @@ internal class PostgresDirectLoadSqlGeneratorTest {
             updatedAt = deduped_source.updatedAt
             FROM deduped_source
             WHERE "test_schema"."final_table".id = deduped_source.id
-            AND ("test_schema"."final_table".updatedAt < deduped_source.updatedAt
+            AND (
+            "test_schema"."final_table".updatedAt < deduped_source.updatedAt
             OR ("test_schema"."final_table".updatedAt = deduped_source.updatedAt AND "test_schema"."final_table"."_airbyte_extracted_at" < deduped_source."_airbyte_extracted_at")
             OR ("test_schema"."final_table".updatedAt IS NULL AND deduped_source.updatedAt IS NOT NULL)
-            OR ("test_schema"."final_table".updatedAt IS NULL AND deduped_source.updatedAt IS NULL AND "test_schema"."final_table"."_airbyte_extracted_at" < deduped_source."_airbyte_extracted_at"))
-            """.trimIndent()
+            OR ("test_schema"."final_table".updatedAt IS NULL AND deduped_source.updatedAt IS NULL AND "test_schema"."final_table"."_airbyte_extracted_at" < deduped_source."_airbyte_extracted_at")
+            )
+            """
 
         assertEqualsIgnoreWhitespace(expected, sql)
     }

--- a/airbyte-integrations/connectors/destination-postgres/src/test/kotlin/io/airbyte/integrations/destination/postgres/sql/PostgresDirectLoadSqlGeneratorTest.kt
+++ b/airbyte-integrations/connectors/destination-postgres/src/test/kotlin/io/airbyte/integrations/destination/postgres/sql/PostgresDirectLoadSqlGeneratorTest.kt
@@ -741,12 +741,17 @@ internal class PostgresDirectLoadSqlGeneratorTest {
             columnsToAdd,
             columnsToRemove,
             columnsToModify,
-            columnsInDb
+            columnsInDb,
+            recreatePrimaryKeyIndex = false,
+            primaryKeyColumnNames = emptyList(),
+            recreateCursorIndex = false,
+            cursorColumnName = null
         )
 
-        assertEquals(2, sql.size)
-        assert(sql.any { it.contains("ADD COLUMN \"new_column1\" varchar") })
-        assert(sql.any { it.contains("ADD COLUMN \"new_column2\" bigint") })
+        assert(sql.contains("BEGIN TRANSACTION;"))
+        assert(sql.contains("COMMIT;"))
+        assert(sql.contains("ADD COLUMN \"new_column1\" varchar"))
+        assert(sql.contains("ADD COLUMN \"new_column2\" bigint"))
     }
 
     @Test
@@ -768,12 +773,17 @@ internal class PostgresDirectLoadSqlGeneratorTest {
             columnsToAdd,
             columnsToRemove,
             columnsToModify,
-            columnsInDb
+            columnsInDb,
+            recreatePrimaryKeyIndex = false,
+            primaryKeyColumnNames = emptyList(),
+            recreateCursorIndex = false,
+            cursorColumnName = null
         )
 
-        assertEquals(2, sql.size)
-        assert(sql.any { it.contains("DROP COLUMN \"old_column1\"") })
-        assert(sql.any { it.contains("DROP COLUMN \"old_column2\"") })
+        assert(sql.contains("BEGIN TRANSACTION;"))
+        assert(sql.contains("COMMIT;"))
+        assert(sql.contains("DROP COLUMN \"old_column1\""))
+        assert(sql.contains("DROP COLUMN \"old_column2\""))
     }
 
     @Test
@@ -793,13 +803,15 @@ internal class PostgresDirectLoadSqlGeneratorTest {
             columnsToAdd,
             columnsToRemove,
             columnsToModify,
-            columnsInDb
+            columnsInDb,
+            recreatePrimaryKeyIndex = false,
+            primaryKeyColumnNames = emptyList(),
+            recreateCursorIndex = false,
+            cursorColumnName = null
         )
 
-        assertEquals(1, sql.size)
-        val alterStatement = sql.first()
-        assert(alterStatement.contains("ALTER COLUMN \"column_a\" TYPE jsonb"))
-        assert(alterStatement.contains("USING to_jsonb(\"column_a\")"))
+        assert(sql.contains("ALTER COLUMN \"column_a\" TYPE jsonb"))
+        assert(sql.contains("USING to_jsonb(\"column_a\")"))
     }
 
     @Test
@@ -819,13 +831,15 @@ internal class PostgresDirectLoadSqlGeneratorTest {
             columnsToAdd,
             columnsToRemove,
             columnsToModify,
-            columnsInDb
+            columnsInDb,
+            recreatePrimaryKeyIndex = false,
+            primaryKeyColumnNames = emptyList(),
+            recreateCursorIndex = false,
+            cursorColumnName = null
         )
 
-        assertEquals(1, sql.size)
-        val alterStatement = sql.first()
-        assert(alterStatement.contains("ALTER COLUMN \"column_b\" TYPE varchar"))
-        assert(alterStatement.contains("USING \"column_b\" #>> '{}'"))
+        assert(sql.contains("ALTER COLUMN \"column_b\" TYPE varchar"))
+        assert(sql.contains("USING \"column_b\" #>> '{}'"))
     }
 
     @Test
@@ -845,13 +859,15 @@ internal class PostgresDirectLoadSqlGeneratorTest {
             columnsToAdd,
             columnsToRemove,
             columnsToModify,
-            columnsInDb
+            columnsInDb,
+            recreatePrimaryKeyIndex = false,
+            primaryKeyColumnNames = emptyList(),
+            recreateCursorIndex = false,
+            cursorColumnName = null
         )
 
-        assertEquals(1, sql.size)
-        val alterStatement = sql.first()
-        assert(alterStatement.contains("ALTER COLUMN \"column_c\" TYPE character varying"))
-        assert(alterStatement.contains("USING \"column_c\" #>> '{}'"))
+        assert(sql.contains("ALTER COLUMN \"column_c\" TYPE character varying"))
+        assert(sql.contains("USING \"column_c\" #>> '{}'"))
     }
 
     @Test
@@ -871,13 +887,15 @@ internal class PostgresDirectLoadSqlGeneratorTest {
             columnsToAdd,
             columnsToRemove,
             columnsToModify,
-            columnsInDb
+            columnsInDb,
+            recreatePrimaryKeyIndex = false,
+            primaryKeyColumnNames = emptyList(),
+            recreateCursorIndex = false,
+            cursorColumnName = null
         )
 
-        assertEquals(1, sql.size)
-        val alterStatement = sql.first()
-        assert(alterStatement.contains("ALTER COLUMN \"column_d\" TYPE varchar"))
-        assert(alterStatement.contains("USING \"column_d\"::varchar"))
+        assert(sql.contains("ALTER COLUMN \"column_d\" TYPE varchar"))
+        assert(sql.contains("USING \"column_d\"::varchar"))
     }
 
     @Test
@@ -902,7 +920,11 @@ internal class PostgresDirectLoadSqlGeneratorTest {
             columnsToAdd,
             columnsToRemove,
             columnsToModify,
-            columnsInDb
+            columnsInDb,
+            recreatePrimaryKeyIndex = false,
+            primaryKeyColumnNames = emptyList(),
+            recreateCursorIndex = false,
+            cursorColumnName = null
         )
 
         assertEquals(3, sql.size)

--- a/airbyte-integrations/connectors/destination-postgres/src/test/kotlin/io/airbyte/integrations/destination/postgres/sql/PostgresDirectLoadSqlGeneratorTest.kt
+++ b/airbyte-integrations/connectors/destination-postgres/src/test/kotlin/io/airbyte/integrations/destination/postgres/sql/PostgresDirectLoadSqlGeneratorTest.kt
@@ -194,9 +194,16 @@ internal class PostgresDirectLoadSqlGeneratorTest {
             DROP TABLE IF EXISTS "namespace"."target";
             ALTER TABLE "namespace"."source" RENAME TO "target";
             COMMIT;
-        """.trimIndent()
+        """
 
-        assertEquals(expected, sql)
+        assertEqualsWithTrimIndent(expected, sql)
+    }
+
+    private fun assertEqualsWithTrimIndent(expected: String, actual: String) {
+        assertEquals(
+            expected.trimIndent(),
+            actual.trimIndent()
+        )
     }
 
     @Test
@@ -219,9 +226,9 @@ internal class PostgresDirectLoadSqlGeneratorTest {
             INSERT INTO "namespace"."target" ("_airbyte_raw_id","_airbyte_extracted_at","_airbyte_meta","_airbyte_generation_id","targetId")
             SELECT "_airbyte_raw_id","_airbyte_extracted_at","_airbyte_meta","_airbyte_generation_id","targetId"
             FROM "namespace"."source";
-        """.trimIndent()
+        """
 
-        assertEquals(expected, sql)
+        assertEqualsWithTrimIndent(expected, sql)
     }
 
     @Test

--- a/airbyte-integrations/connectors/destination-postgres/src/test/kotlin/io/airbyte/integrations/destination/postgres/sql/PostgresDirectLoadSqlGeneratorTest.kt
+++ b/airbyte-integrations/connectors/destination-postgres/src/test/kotlin/io/airbyte/integrations/destination/postgres/sql/PostgresDirectLoadSqlGeneratorTest.kt
@@ -4,27 +4,14 @@
 
 package io.airbyte.integrations.destination.postgres.sql
 
-import com.fasterxml.jackson.databind.JsonNode
 import io.airbyte.cdk.load.command.Append
 import io.airbyte.cdk.load.command.Dedupe
 import io.airbyte.cdk.load.command.DestinationStream
-import io.airbyte.cdk.load.data.ArrayType
-import io.airbyte.cdk.load.data.ArrayTypeWithoutSchema
-import io.airbyte.cdk.load.data.BooleanType
-import io.airbyte.cdk.load.data.DateType
 import io.airbyte.cdk.load.data.FieldType
 import io.airbyte.cdk.load.data.IntegerType
-import io.airbyte.cdk.load.data.NumberType
 import io.airbyte.cdk.load.data.ObjectType
-import io.airbyte.cdk.load.data.ObjectTypeWithEmptySchema
-import io.airbyte.cdk.load.data.ObjectTypeWithoutSchema
 import io.airbyte.cdk.load.data.StringType
-import io.airbyte.cdk.load.data.TimeTypeWithTimezone
-import io.airbyte.cdk.load.data.TimeTypeWithoutTimezone
 import io.airbyte.cdk.load.data.TimestampTypeWithTimezone
-import io.airbyte.cdk.load.data.TimestampTypeWithoutTimezone
-import io.airbyte.cdk.load.data.UnionType
-import io.airbyte.cdk.load.data.UnknownType
 import io.airbyte.cdk.load.table.CDC_DELETED_AT_COLUMN
 import io.airbyte.cdk.load.table.ColumnNameMapping
 import io.airbyte.cdk.load.table.TableName


### PR DESCRIPTION
## What
I noticed that we were not recreating the cursor/primary key indexes when these have changed. This PR addresses that by recreating the indexes when calling `ensureSchemaMatches`
