### PR TITLE
feat(connectors): Add externalDocumentationUrls to connector metadata (do not merge)

### DIFF
--- a/airbyte-integrations/connectors/source-monday/metadata.yaml
+++ b/airbyte-integrations/connectors/source-monday/metadata.yaml
@@ -32,6 +32,16 @@ data:
               ]
   dockerRepository: airbyte/source-monday
   documentationUrl: https://docs.airbyte.com/integrations/sources/monday
+  externalDocumentationUrls:
+    - title: Changelog
+      url: https://developer.monday.com/api-reference/changelog
+      type: api_release_history
+    - title: API Versioning
+      url: https://developer.monday.com/api-reference/docs/api-versioning#making-a-request
+      type: api_reference
+    - title: Release notes
+      url: https://developer.monday.com/api-reference/docs/release-notes
+      type: api_release_history
   githubIssueLabel: source-monday
   icon: monday.svg
   license: ELv2

--- a/airbyte-integrations/connectors/source-shopify/metadata.yaml
+++ b/airbyte-integrations/connectors/source-shopify/metadata.yaml
@@ -14,6 +14,20 @@ data:
   dockerImageTag: 3.0.13
   dockerRepository: airbyte/source-shopify
   documentationUrl: https://docs.airbyte.com/integrations/sources/shopify
+  externalDocumentationUrls:
+    - title: Versioning docs
+      url: https://shopify.dev/docs/api/usage/versioning
+      type: api_reference
+    - title: Changelog
+      url: https://shopify.dev/changelog
+      type: api_release_history
+    - title: Deprecated API calls made by Airbyte
+      url: https://dev.shopify.com/dashboard/129006130/apps/5841799/monitoring/api_health
+      type: api_deprecations
+      requiresLogin: true
+    - title: API versions overview
+      url: https://shopify.dev/docs/api/admin-rest
+      type: api_reference
   erdUrl: https://dbdocs.io/airbyteio/source-shopify?view=relationships
   githubIssueLabel: source-shopify
   icon: shopify.svg

--- a/airbyte-integrations/connectors/source-stripe/metadata.yaml
+++ b/airbyte-integrations/connectors/source-stripe/metadata.yaml
@@ -13,6 +13,13 @@ data:
   dockerImageTag: 5.15.11
   dockerRepository: airbyte/source-stripe
   documentationUrl: https://docs.airbyte.com/integrations/sources/stripe
+  externalDocumentationUrls:
+    - title: Versioning docs
+      url: https://stripe.com/docs/api/versioning
+      type: api_reference
+    - title: Changelog
+      url: https://stripe.com/docs/changelog
+      type: api_release_history
   erdUrl: https://dbdocs.io/airbyteio/source-stripe?view=relationships
   githubIssueLabel: source-stripe
   icon: stripe.svg

--- a/airbyte-integrations/connectors/source-zendesk-support/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zendesk-support/metadata.yaml
@@ -14,6 +14,12 @@ data:
   dockerImageTag: 4.10.15
   dockerRepository: airbyte/source-zendesk-support
   documentationUrl: https://docs.airbyte.com/integrations/sources/zendesk-support
+  externalDocumentationUrls:
+    - title: Developer Updates
+      url: https://support.zendesk.com/hc/en-us/sections/4405298889242-Developer-updates
+    - title: Changelog
+      url: https://developer.zendesk.com/api-reference/changelog/changelog/
+      type: api_release_history
   githubIssueLabel: source-zendesk-support
   icon: zendesk-support.svg
   license: ELv2


### PR DESCRIPTION
## What

This PR adds a new `externalDocumentationUrls` field to connector metadata.yaml files to track vendor API documentation links (changelogs, versioning docs, deprecation notices, etc.). 

**This is a pilot implementation** with only 4 connectors updated to validate the structure before scaling to 35+ additional connectors. The PR is marked as draft and should not be merged until:
1. The metadata schema is confirmed to support this field
2. The structure is validated by reviewers
3. All remaining connectors are updated

**Link to Devin run**: https://app.devin.ai/sessions/ee9bbdfed34a416c9acd24ae1755f722

**Requested by**: AJ Steers (@aaronsteers)

## How

Added a new `externalDocumentationUrls` array field to metadata.yaml files, positioned adjacent to the existing `documentationUrl` field. Each entry contains:
- `title`: Human-readable label for the link
- `url`: The documentation URL
- `type` (optional): Categorization - `api_release_history`, `api_reference`, or `api_deprecations`
- `requiresLogin` (optional): Boolean flag for authenticated-only resources

The field was extracted from a spreadsheet of vendor documentation links and categorized based on URL patterns and labels.

## Review guide

**Critical items to verify:**
1. **Metadata schema validation**: Does the metadata schema allow arbitrary fields under `data:`? Will this break connector validation or publishing?
2. **Field structure**: Confirm the structure (title, url, type, requiresLogin) matches requirements and won't cause issues downstream
3. **Type values**: Are `api_release_history`, `api_reference`, `api_deprecations` appropriate? Do they need to be defined in an enum somewhere?
4. **Platform integration**: Does any platform code need to be updated to consume/display these URLs, or is this purely additive metadata?

**Files to review:**
1. `airbyte-integrations/connectors/source-shopify/metadata.yaml` - Most complex example with 4 links including requiresLogin flag
2. `airbyte-integrations/connectors/source-stripe/metadata.yaml` - Simple 2-link example
3. `airbyte-integrations/connectors/source-monday/metadata.yaml` - Multiple links of same type
4. `airbyte-integrations/connectors/source-zendesk-support/metadata.yaml` - Link without type categorization

## User Impact

**Positive:**
- Provides structured access to vendor API documentation for connector users
- Enables platform to surface relevant vendor docs (changelogs, deprecations) alongside Airbyte docs

**Potential negative:**
- If metadata schema validation fails, this could break connector publishing
- If platform code doesn't handle this field gracefully, it could cause errors

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

This only adds metadata fields and doesn't modify any functional code. Reverting would simply remove the new documentation links from metadata files.