### PR TITLE
Destination Snowflake: fix typo

### DIFF
--- a/airbyte-integrations/connectors/destination-snowflake/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-snowflake/metadata.yaml
@@ -6,7 +6,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: 424892c4-daac-4491-b35d-c6688ba547ba
-  dockerImageTag: 4.0.26
+  dockerImageTag: 4.0.27
   dockerRepository: airbyte/destination-snowflake
   documentationUrl: https://docs.airbyte.com/integrations/destinations/snowflake
   githubIssueLabel: destination-snowflake

--- a/airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/client/SnowflakeAirbyteClient.kt
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/client/SnowflakeAirbyteClient.kt
@@ -281,7 +281,7 @@ class SnowflakeAirbyteClient(
             .associate { column ->
                 // columnsAndTypes returns types as either `FOO` or `FOO NOT NULL`.
                 // so check for that suffix.
-                val nullable = column.columnType.endsWith(NOT_NULL)
+                val nullable = !column.columnType.endsWith(NOT_NULL)
                 val type =
                     column.columnType
                         .takeWhile { char ->

--- a/airbyte-integrations/connectors/destination-snowflake/src/test/kotlin/io/airbyte/integrations/destination/snowflake/client/SnowflakeAirbyteClientTest.kt
+++ b/airbyte-integrations/connectors/destination-snowflake/src/test/kotlin/io/airbyte/integrations/destination/snowflake/client/SnowflakeAirbyteClientTest.kt
@@ -625,8 +625,8 @@ internal class SnowflakeAirbyteClientTest {
 
         val expectedColumns =
             mapOf(
-                "COL1_MAPPED" to ColumnType("VARCHAR", false),
-                "COL2_MAPPED" to ColumnType("NUMBER", false),
+                "COL1_MAPPED" to ColumnType("VARCHAR", true),
+                "COL2_MAPPED" to ColumnType("NUMBER", true),
             )
 
         assertEquals(expectedColumns, result)

--- a/docs/integrations/destinations/snowflake.md
+++ b/docs/integrations/destinations/snowflake.md
@@ -251,7 +251,8 @@ desired namespace.
 
 | Version         | Date       | Pull Request                                                        | Subject                                                                                                                                                                                |
 |:----------------|:-----------|:--------------------------------------------------------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 4.0.26          | 2025-11-11 | [69117](https://github.com/airbytehq/airbyte/pull/69117)  | Upgrade fo CDK 0.1.74 (internal code changes for schema evolution) |
+| 4.0.27          | 2025-11-11 | [69285](https://github.com/airbytehq/airbyte/pull/69285)  | Remove spurious log messages |
+| 4.0.26          | 2025-11-11 | [69117](https://github.com/airbytehq/airbyte/pull/69117)  | Upgrade to CDK 0.1.74 (internal code changes for schema evolution) |
 | 4.0.25          | 2025-11-06 | [69226](https://github.com/airbytehq/airbyte/pull/69226)  | Improved additional statistics handling                                        |
 | 4.0.24          | 2025-11-05 | [69200](https://github.com/airbytehq/airbyte/pull/69200/)           | Add support for observability metrics                                          |
 | 4.0.23          | 2025-11-03 | [69153](https://github.com/airbytehq/airbyte/pull/69153)            | Fix bug in connector spec |


### PR DESCRIPTION
derp. Fortunately, the sqlgenerator explicitly excludes alterations to make columns become `NOT NULL` - https://github.com/airbytehq/airbyte/blob/47b04408a10b9a3f8a1ab1a079a760e9c03edc48/airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/sql/SnowflakeDirectLoadSqlGenerator.kt#L436

so this doesn't have any real impact, other than some spurious "schema change detected" log messages.

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._